### PR TITLE
[query] refactor primitive SValue -> Value accessor

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Casts.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Casts.scala
@@ -11,20 +11,20 @@ import scala.language.existentials
 object Casts {
   private val casts: Map[(Type, Type), (EmitCodeBuilder, SValue) => SValue] = Map(
     (TInt32, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => x),
-    (TInt32, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asInt.intCode(cb).toL))),
-    (TInt32, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asInt.intCode(cb).toF))),
-    (TInt32, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asInt.intCode(cb).toD))),
-    (TInt64, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asLong.longCode(cb).toI))),
+    (TInt32, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asInt.value.toL))),
+    (TInt32, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asInt.value.toF))),
+    (TInt32, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asInt.value.toD))),
+    (TInt64, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asLong.value.toI))),
     (TInt64, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => x),
-    (TInt64, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asLong.longCode(cb).toF))),
-    (TInt64, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asLong.longCode(cb).toD))),
-    (TFloat32, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asFloat.floatCode(cb).toI))),
-    (TFloat32, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asFloat.floatCode(cb).toL))),
+    (TInt64, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asLong.value.toF))),
+    (TInt64, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asLong.value.toD))),
+    (TFloat32, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asFloat.value.toI))),
+    (TFloat32, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asFloat.value.toL))),
     (TFloat32, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => x),
-    (TFloat32, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asFloat.floatCode(cb).toD))),
-    (TFloat64, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asDouble.doubleCode(cb).toI))),
-    (TFloat64, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asDouble.doubleCode(cb).toL))),
-    (TFloat64, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asDouble.doubleCode(cb).toF))),
+    (TFloat32, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asFloat.value.toD))),
+    (TFloat64, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asDouble.value.toI))),
+    (TFloat64, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asDouble.value.toL))),
+    (TFloat64, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => primitive(cb.memoize(x.asDouble.value.toF))),
     (TFloat64, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => x))
 
   def get(from: Type, to: Type): (EmitCodeBuilder, SValue) => SValue =

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -618,7 +618,7 @@ class Emit[C](
       case If(cond, cnsq, altr) =>
         assert(cnsq.typ == TVoid && altr.typ == TVoid)
 
-        emitI(cond).consume(cb, {}, m => cb.ifx(m.asBoolean.boolCode(cb), emitVoid(cnsq), emitVoid(altr)))
+        emitI(cond).consume(cb, {}, m => cb.ifx(m.asBoolean.value, emitVoid(cnsq), emitVoid(altr)))
 
       case Let(name, value, body) =>
         val xVal = if (value.typ.isInstanceOf[TStream]) emitStream(value, region) else emit(value)
@@ -884,7 +884,7 @@ class Emit[C](
           val Lmissing = CodeLabel()
           val Ldefined = CodeLabel()
           val out = mb.newPLocal(outType)
-          cb.ifx(condValue.boolCode(cb), {
+          cb.ifx(condValue.value, {
             codeCnsq.toI(cb).consume(cb,
               {
                 cb.goto(Lmissing)
@@ -970,7 +970,7 @@ class Emit[C](
         emitI(length).map(cb) { case n: SInt32Value =>
           val outputPType = PCanonicalArray(PInt32Required)
           val elementSize = outputPType.elementByteSize
-          val numElements = n.intCode(cb)
+          val numElements = n.value
           val arrayAddress = cb.newLocal[Long]("array_addr", outputPType.allocate(region, numElements))
           outputPType.stagedInitialize(cb, arrayAddress, numElements)
           cb += Region.setMemory(outputPType.firstElementOffset(arrayAddress), numElements.toL * elementSize, 0.toByte)
@@ -999,7 +999,7 @@ class Emit[C](
 
         emitI(a).flatMap(cb) { case av: SIndexableValue =>
           emitI(i).flatMap(cb) { case ic: SInt32Value =>
-            val iv = ic.intCode(cb)
+            val iv = ic.value
             boundsCheck(cb, iv, av.loadLength())
             av.loadElement(cb, iv)
           }
@@ -1009,7 +1009,7 @@ class Emit[C](
           emitI(start).flatMap(cb) { startCode =>
             emitI(step).flatMap(cb) { stepCode =>
               val arrayLength = arrayValue.loadLength()
-              val realStep = cb.newLocal[Int]("array_slice_requestedStep", stepCode.asInt.intCode(cb))
+              val realStep = cb.newLocal[Int]("array_slice_requestedStep", stepCode.asInt.value)
 
               cb.ifx(realStep ceq const(0), cb._fatalWithError(const(errorID), const("step cannot be 0 for array slice")))
 
@@ -1023,7 +1023,7 @@ class Emit[C](
 
               val stopI = stop.map(emitI(_)).getOrElse(IEmitCode.present(cb, new SInt32Value(noneStop)))
               stopI.map(cb) { stopCode =>
-                val requestedStart = cb.newLocal[Int]("array_slice_requestedStart", startCode.asInt.intCode(cb))
+                val requestedStart = cb.newLocal[Int]("array_slice_requestedStart", startCode.asInt.value)
                 val realStart = cb.newLocal[Int]("array_slice_realStart")
                 cb.ifx(requestedStart >= arrayLength,
                   cb.assign(realStart, maxBound),
@@ -1032,7 +1032,7 @@ class Emit[C](
                       cb.assign(realStart, arrayLength + requestedStart),
                       cb.assign(realStart, minBound))))
 
-                val requestedStop = cb.newLocal[Int]("array_slice_requestedStop", stopCode.asInt.intCode(cb))
+                val requestedStop = cb.newLocal[Int]("array_slice_requestedStop", stopCode.asInt.value)
                 val realStop = cb.newLocal[Int]("array_slice_realStop")
                 cb.ifx(requestedStop > arrayLength,
                   cb.assign(realStop, maxBound),
@@ -1322,7 +1322,7 @@ class Emit[C](
                     cb.newLocalAny[Long](s"make_ndarray_shape_${ i }", shape.code)
                   }
 
-                  cb.ifx(isRowMajorCode.asBoolean.boolCode(cb), {
+                  cb.ifx(isRowMajorCode.asBoolean.value, {
                     val strides = xP.makeRowMajorStrides(shapeValues, region, cb)
 
                     stridesSettables.zip(strides).foreach { case (settable, stride) =>
@@ -1350,10 +1350,10 @@ class Emit[C](
                       val stridesSettables = (0 until nDims).map(i => cb.newLocal[Long](s"make_ndarray_stride_$i"))
 
                       val shapeValues = (0 until nDims).map { i =>
-                        cb.newLocal[Long](s"make_ndarray_shape_${i}", shapeTupleValue.loadField(cb, i).get(cb).asLong.longCode(cb))
+                        cb.newLocal[Long](s"make_ndarray_shape_${i}", shapeTupleValue.loadField(cb, i).get(cb).asLong.value)
                       }
 
-                      cb.ifx(isRowMajorCode.asBoolean.boolCode(cb), {
+                      cb.ifx(isRowMajorCode.asBoolean.value, {
                         val strides = xP.makeRowMajorStrides(shapeValues, region, cb)
 
 
@@ -1410,7 +1410,7 @@ class Emit[C](
           val indexEmitCodes = idxs.map(idx => EmitCode.fromI(cb.emb)(emitInNewBuilder(_, idx)))
           IEmitCode.multiMapEmitCodes(cb, indexEmitCodes) { idxPCodes: IndexedSeq[SValue] =>
             val idxValues = idxPCodes.zipWithIndex.map { case (pc, idx) =>
-              pc.asInt64.longCode(cb)
+              pc.asInt64.value
             }
 
             ndValue.assertInBounds(idxValues, cb, errorId)
@@ -1563,13 +1563,13 @@ class Emit[C](
                   def multiply(l: SValue, r: SValue): Code[_] = {
                     (l.st, r.st) match {
                       case (SInt32, SInt32) =>
-                        l.asInt.intCode(cb) * r.asInt.intCode(cb)
+                        l.asInt.value * r.asInt.value
                       case (SInt64, SInt64) =>
-                        l.asLong.longCode(cb) * r.asLong.longCode(cb)
+                        l.asLong.value * r.asLong.value
                       case (SFloat32, SFloat32) =>
-                        l.asFloat.floatCode(cb) * r.asFloat.floatCode(cb)
+                        l.asFloat.value * r.asFloat.value
                       case (SFloat64, SFloat64) =>
-                        l.asDouble.doubleCode(cb) * r.asDouble.doubleCode(cb)
+                        l.asDouble.value * r.asDouble.value
                     }
                   }
 
@@ -1891,7 +1891,7 @@ class Emit[C](
                 cb.append(Region.storeDouble(
                   curWriteAddress,
                   (currCol >= currRow).mux(
-                    h.loadElement(IndexedSeq(currCol, currRow), cb).asDouble.doubleCode(cb),
+                    h.loadElement(IndexedSeq(currCol, currRow), cb).asDouble.value,
                     0.0
                   )
                 ))
@@ -2584,7 +2584,7 @@ class Emit[C](
       }
 
       val iec = emitter.emitI(ir, cb, newEnv, None)
-      iec.get(cb, "Result of sorting function cannot be missing").asBoolean.boolCode(cb)
+      iec.get(cb, "Result of sorting function cannot be missing").asBoolean.value
     }
     (cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]) => cb.memoize(cb.invokeCode[Boolean](sort, region, l, r))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -218,7 +218,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
 
   // for debugging
   def strValue(sc: SValue): Code[String] = {
-    StringFunctions.scodeToJavaValue(this, emb.partitionRegion, sc).invoke[String]("toString")
+    StringFunctions.svalueToJavaValue(this, emb.partitionRegion, sc).invoke[String]("toString")
   }
 
   def strValue(ec: EmitCode): Code[String] = {

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -44,7 +44,7 @@ class PartitionIteratorLongReader(
     val mb = cb.emb
 
     context.toI(cb).map(cb) { contextPC =>
-      val ctxJavaValue = UtilFunctions.scodeToJavaValue(cb, partitionRegion, contextPC)
+      val ctxJavaValue = UtilFunctions.svalueToJavaValue(cb, partitionRegion, contextPC)
       val region = mb.genFieldThisRef[Region]("pilr_region")
       val it = mb.genFieldThisRef[Iterator[java.lang.Long]]("pilr_it")
       val rv = mb.genFieldThisRef[Long]("pilr_rv")

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -368,11 +368,11 @@ case class MatrixSpecWriter(path: String, typ: MatrixType, rowRelPath: String, g
     cb.assign(partCounts, Code.newArray[Long](n))
     cb.whileLoop(i < n, {
       val count = a.loadElement(cb, i).get(cb, "part count can't be missing!")
-      cb += partCounts.update(i, count.asInt64.longCode(cb))
+      cb += partCounts.update(i, count.asInt64.value)
       cb.assign(i, i + 1)
     })
     cb += cb.emb.getObject(new MatrixSpecHelper(path, rowRelPath, globalRelPath, colRelPath, entryRelPath, refRelPath, typ, log))
-      .invoke[FS, Long, Array[Long], Unit]("write", cb.emb.getFS, c.loadField(cb, "cols").get(cb).asInt64.longCode(cb), partCounts)
+      .invoke[FS, Long, Array[Long], Unit]("write", cb.emb.getFS, c.loadField(cb, "cols").get(cb).asInt64.value, partCounts)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -66,7 +66,7 @@ case class StringTablePartitionReader(lines: GenericLines) extends PartitionRead
          override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
          override def initialize(cb: EmitCodeBuilder): Unit = {
-           val contextAsJavaValue = coerce[Any](StringFunctions.scodeToJavaValue(cb, partitionRegion, partitionContext))
+           val contextAsJavaValue = coerce[Any](StringFunctions.svalueToJavaValue(cb, partitionRegion, partitionContext))
 
            cb.assign(fileName, partitionContext.loadField(cb, "file").get(cb).asString.loadString(cb))
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -518,7 +518,7 @@ case class PartitionRVDReader(rvd: RVD) extends PartitionReader {
 
         override def initialize(cb: EmitCodeBuilder): Unit = {
           cb.assign(iterator, broadcastRVD.invoke[Int, Region, Region, Iterator[Long]](
-            "computePartition", EmitCodeBuilder.scopedCode[Int](mb)(idx.asInt.intCode(_)), region, partitionRegion))
+            "computePartition", EmitCodeBuilder.scopedCode[Int](mb)((cb: EmitCodeBuilder) => idx.asInt.value), region, partitionRegion))
           cb.assign(upcastF, Code.checkcast[AsmFunction2RegionLongLong](upcastCode.invoke[AnyRef, AnyRef, AnyRef, AnyRef]("apply", cb.emb.ecb.emodb.getFS, Code.boxInt(0), partitionRegion)))
         }
         override val elementRegion: Settable[Region] = region
@@ -866,7 +866,7 @@ case class PartitionZippedIndexedNativeReader(specLeft: AbstractTypedCodecSpec, 
         Code.invokeScalaObject1[AnyRef, Interval](
           PartitionBoundOrdering.getClass,
           "partitionBoundToInterval",
-          StringFunctions.scodeToJavaValue(cb, region, ctxMemo.loadField(cb, "interval").get(cb)))
+          StringFunctions.svalueToJavaValue(cb, region, ctxMemo.loadField(cb, "interval").get(cb)))
       }
 
       val indexReader = cb.emb.genFieldThisRef[IndexReader]("idx_reader")

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -370,7 +370,7 @@ case class TableSpecWriter(path: String, typ: TableType, rowRelPath: String, glo
     cb.assign(partCounts, Code.newArray[Long](n))
     cb.whileLoop(i < n, {
       val curElement =  a.loadElement(cb, i).get(cb, "writeMetadata annotation can't be missing").asBaseStruct
-      val count = curElement.asBaseStruct.loadField(cb, "partitionCounts").get(cb, "part count can't be missing!").asLong.longCode(cb)
+      val count = curElement.asBaseStruct.loadField(cb, "partitionCounts").get(cb, "part count can't be missing!").asLong.value
 
       if (hasKey) {
         // Only nonempty partitions affect first, last, and distinctlyKeyed.
@@ -380,7 +380,7 @@ case class TableSpecWriter(path: String, typ: TableType, rowRelPath: String, glo
           val comparator = NEQ(lastSeenSettable.emitType.virtualType).codeOrdering(cb.emb.ecb, lastSeenSettable.st, curFirst.st)
           val notEqualToLast = comparator(cb, lastSeenSettable, EmitValue.present(curFirst)).asInstanceOf[Value[Boolean]]
 
-          val partWasDistinctlyKeyed = curElement.loadField(cb, "distinctlyKeyed").get(cb).asBoolean.boolCode(cb)
+          val partWasDistinctlyKeyed = curElement.loadField(cb, "distinctlyKeyed").get(cb).asBoolean.value
           cb.assign(distinctlyKeyed, distinctlyKeyed && partWasDistinctlyKeyed && notEqualToLast)
           cb.assign(lastSeenSettable, curElement.loadField(cb, "lastKey"))
         })

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -121,7 +121,7 @@ class ApproxCDFAggregator extends StagedAggregator {
     k.toI(cb)
       .consume(cb,
         cb += Code._fatal[Unit]("approx_cdf: 'k' may not be missing"),
-        pv => state.init(cb, pv.asInt.intCode(cb)))
+        pv => state.init(cb, pv.asInt.value))
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
@@ -129,7 +129,7 @@ class ApproxCDFAggregator extends StagedAggregator {
     x.toI(cb)
       .consume(cb,
         {},
-        pv => state.seq(cb, pv.asDouble.doubleCode(cb))
+        pv => state.seq(cb, pv.asDouble.value)
       )
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -179,7 +179,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
       val Array(len, inits) = init
       state.init(cb, cb => cb += inits.asVoid, initLen = false)
       len.toI(cb).consume(cb, cb._fatal("Array length can't be missing"),
-        len => state.initLength(cb, len.asInt32.intCode(cb)))
+        len => state.initLength(cb, len.asInt32.value))
     } else {
       val Array(inits) = init
       state.init(cb, cb => cb += inits.asVoid, initLen = true)
@@ -195,10 +195,10 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
       /* do nothing */
     }, { len =>
       if (!knownLength) {
-        val v = cb.newLocal("aelca_seqop_len", len.asInt.intCode(cb))
+        val v = cb.newLocal("aelca_seqop_len", len.asInt.value)
         cb.ifx(state.lenRef < 0, state.initLength(cb, v), state.checkLength(cb, v))
       } else {
-        state.checkLength(cb, len.asInt.intCode(cb))
+        state.checkLength(cb, len.asInt.value)
       }
     })
   }
@@ -280,7 +280,7 @@ class ArrayElementwiseOpAggregator(nestedAggs: Array[StagedAggregator]) extends 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(eltIdx, seqOps) = seq
     eltIdx.toI(cb).consume(cb, {}, { idx =>
-      cb.assign(state.idx, idx.asInt32.intCode(cb))
+      cb.assign(state.idx, idx.asInt32.value)
       cb.ifx(state.idx > state.lenRef || state.idx < 0, {
         cb._fatal("element idx out of bounds")
       }, {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -120,7 +120,7 @@ class CallStatsAggregator extends StagedAggregator {
       .consume(cb,
         cb += Code._fatal[Unit]("call_stats: n_alleles may not be missing"),
         { sc =>
-          cb.assign(n, sc.asInt.intCode(cb))
+          cb.assign(n, sc.asInt.value)
           cb.assign(state.nAlleles, n)
           cb.assign(state.off, state.region.allocate(CallStatsState.stateType.alignment, CallStatsState.stateType.byteSize))
           cb.assign(addr, CallStatsState.callStatsInternalArrayType.allocate(state.region, n))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -29,14 +29,14 @@ object CountAggregator extends StagedAggregator {
     assert(seq.length == 0)
     assert(state.vtypes.head.r.required)
     val ev = state.fields(0)
-    cb.assign(ev, EmitCode.present(cb.emb, primitive(cb.memoize(ev.pv.asInt64.longCode(cb) + 1L))))
+    cb.assign(ev, EmitCode.present(cb.emb, primitive(cb.memoize(ev.pv.asInt64.value + 1L))))
   }
 
   protected def _combOp(ctx: ExecuteContext, cb: EmitCodeBuilder, state: PrimitiveRVAState, other: PrimitiveRVAState): Unit = {
     assert(state.vtypes.head.r.required)
     val v1 = state.fields(0)
     val v2 = other.fields(0)
-    cb.assign(v1, EmitCode.present(cb.emb, primitive(cb.memoize(v1.pv.asInt64.longCode(cb) + v2.pv.asInt64.longCode(cb)))))
+    cb.assign(v1, EmitCode.present(cb.emb, primitive(cb.memoize(v1.pv.asInt64.value + v2.pv.asInt64.value))))
   }
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -155,7 +155,7 @@ class DensifyAggregator(val arrayVType: VirtualTypeWithReq) extends StagedAggreg
     sizeTriplet.toI(cb)
       .consume(cb,
         cb += Code._fatal[Unit](s"argument 'n' for 'hl.agg.densify' may not be missing"),
-        sc => state.init(cb, sc.asInt.intCode(cb))
+        sc => state.init(cb, sc.asInt.value)
       )
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -26,7 +26,7 @@ class DownsampleBTreeKey(binType: PBaseStruct, pointType: PBaseStruct, kb: EmitC
   private val kcomp = kb.getOrderingFunction(binType.sType, CodeOrdering.Compare())
 
   override def isEmpty(cb: EmitCodeBuilder, off: Code[Long]): Value[Boolean] =
-    PBooleanRequired.loadCheapSCode(cb, storageType.loadField(off, "empty")).boolCode(cb)
+    PBooleanRequired.loadCheapSCode(cb, storageType.loadField(off, "empty")).value
 
   override def initializeEmpty(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += Region.storeBoolean(storageType.fieldOffset(off, "empty"), true)
 
@@ -363,8 +363,8 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         cb.whileLoop(i < buffer.size,
           {
             buffer.loadElement(cb, i).toI(cb).consume(cb, {}, { case point: SBaseStructValue =>
-              val x = point.loadField(cb, "x").get(cb).asFloat64.doubleCode(cb)
-              val y = point.loadField(cb, "y").get(cb).asFloat64.doubleCode(cb)
+              val x = point.loadField(cb, "x").get(cb).asFloat64.value
+              val y = point.loadField(cb, "y").get(cb).asFloat64.value
               val pointc = coerce[Long](SingleCodeSCode.fromSCode(cb, point, region).code)
               insertIntoTree(cb, xBinCoordinate(cb, x), yBinCoordinate(cb, y), pointc, deepCopy = true)
             })
@@ -449,9 +449,9 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         val y = mb.getSCodeParam(2)
         val l = mb.getEmitParam(cb, 3, region)
 
-        def xx = x.asDouble.doubleCode(cb)
+        def xx = x.asDouble.value
 
-        def yy = y.asDouble.doubleCode(cb)
+        def yy = y.asDouble.value
 
         cb.ifx((!(isFinite(xx) && isFinite(yy))), cb += Code._return[Unit](Code._empty))
         cb.assign(pointStaging, storageType.loadField(off, "pointStaging"))
@@ -555,7 +555,7 @@ class DownsampleAggregator(arrayType: VirtualTypeWithReq) extends StagedAggregat
     nDivisions.toI(cb)
       .consume(cb,
         cb += Code._fatal[Unit]("downsample: n_divisions may not be missing"),
-        sc => state.init(cb, sc.asInt.intCode(cb))
+        sc => state.init(cb, sc.asInt.value)
       )
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
@@ -66,7 +66,7 @@ object ImputeTypeState {
 }
 
 class ImputeTypeState(kb: EmitClassBuilder[_]) extends PrimitiveRVAState(Array(VirtualTypeWithReq(TInt32,RPrimitive()).setRequired(true)), kb) {
-  private def repr: Code[Int] = _repr.pv.asInt32.intCode(null) // hack, emitcodebuilder unused in this function
+  private def repr: Code[Int] = _repr.pv.asInt32.value
   private val _repr = fields(0)
 
   def getAnyNonMissing: Code[Boolean] = (repr & 1).cne(0)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -126,7 +126,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
               {
                 cb += Code._fatal[Unit]("linreg: init args may not be missing")
               },
-              k0tCode => initOpF(state)(cb, ktCode.asInt.intCode(cb), k0tCode.asInt.intCode(cb))
+              k0tCode => initOpF(state)(cb, ktCode.asInt.value, k0tCode.asInt.value)
             )
         })
   }
@@ -185,7 +185,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
           case _ =>
             cb.whileLoop(i < k,
               {
-                cb += Region.storeDouble(sptr, Region.loadDouble(sptr) + x.loadElement(cb, i).get(cb).asDouble.doubleCode(cb) * y)
+                cb += Region.storeDouble(sptr, Region.loadDouble(sptr) + x.loadElement(cb, i).get(cb).asDouble.value * y)
                 cb.assign(i, i + 1)
                 cb.assign(sptr, sptr + scalar.byteSize)
               })
@@ -200,7 +200,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
                   {
                     // add x[i] * x[j] to the value at sptr
                     cb += Region.storeDouble(sptr, Region.loadDouble(sptr) +
-                      (x.loadElement(cb, i).get(cb).asDouble.doubleCode(cb) * x.loadElement(cb, j).get(cb).asDouble.doubleCode(cb)))
+                      (x.loadElement(cb, i).get(cb).asDouble.value * x.loadElement(cb, j).get(cb).asDouble.value))
                     cb.assign(j, j + 1)
                     cb.assign(sptr, sptr + scalar.byteSize)
                   })
@@ -219,7 +219,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
           x.toI(cb)
             .consume(cb,
               {},
-              xCode => seqOpF(state)(cb, yCode.asDouble.doubleCode(cb), xCode.asIndexable)
+              xCode => seqOpF(state)(cb, yCode.asDouble.value, xCode.asIndexable)
             )
         })
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -114,7 +114,7 @@ class TakeAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
     sizeTriplet.toI(cb)
       .consume(cb,
         cb += Code._fatal[Unit](s"argument 'n' for 'hl.agg.take' may not be missing"),
-        sc => state.init(cb, sc.asInt.intCode(cb))
+        sc => state.init(cb, sc.asInt.value)
       )
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -556,7 +556,7 @@ class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithRe
     sizeTriplet.toI(cb)
       .consume(cb,
         cb += Code._fatal[Unit](s"argument 'n' for 'hl.agg.take' may not be missing"),
-        sc => state.initialize(cb, sc.asInt.intCode(cb)))
+        sc => state.initialize(cb, sc.asInt.value))
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -289,8 +289,8 @@ object ArrayFunctions extends RegistryFunctions {
             cb.forLoop(cb.assign(i, 0), i < l1, cb.assign(i, i + 1), {
               pv1.loadElement(cb, i).consume(cb, {}, { xc =>
                 pv2.loadElement(cb, i).consume(cb, {}, { yc =>
-                  val x = cb.newLocal[Double]("x", xc.asDouble.doubleCode(cb))
-                  val y = cb.newLocal[Double]("y", yc.asDouble.doubleCode(cb))
+                  val x = cb.newLocal[Double]("x", xc.asDouble.value)
+                  val y = cb.newLocal[Double]("y", yc.asDouble.value)
                   cb.assign(xSum, xSum + x)
                   cb.assign(xSqSum, xSqSum + x * x)
                   cb.assign(ySum, ySum + y)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -16,31 +16,39 @@ object CallFunctions extends RegistryFunctions {
     registerWrappedScalaFunction1("Call", TString, TCall, (rt: Type, st: SType) => SCanonicalCall)(Call.getClass, "parse")
 
     registerSCode1("callFromRepr", TInt32, TCall, (rt: Type, _: SType) => SCanonicalCall) {
-      case (er, cb, rt, repr, _) => SCanonicalCall.constructFromIntRepr(cb, repr.asInt.intCode(cb))
+      case (er, cb, rt, repr, _) => SCanonicalCall.constructFromIntRepr(cb, repr.asInt.value)
     }
 
     registerSCode1("Call", TBoolean, TCall, (rt: Type, _: SType) => SCanonicalCall) {
       case (er, cb, rt, phased, _) =>
         SCanonicalCall.constructFromIntRepr(cb, Code.invokeScalaObject[Int](
-          Call0.getClass, "apply", Array(classTag[Boolean].runtimeClass), Array(phased.asBoolean.boolCode(cb))))
+          Call0.getClass, "apply",
+          Array(classTag[Boolean].runtimeClass),
+          Array(phased.asBoolean.value)))
     }
 
     registerSCode2("Call", TInt32, TBoolean, TCall, (rt: Type, _: SType, _: SType) => SCanonicalCall) {
       case (er, cb, rt, a1, phased, _) =>
         SCanonicalCall.constructFromIntRepr(cb, Code.invokeScalaObject[Int](
-          Call1.getClass, "apply", Array(classTag[Int].runtimeClass, classTag[Boolean].runtimeClass), Array(a1.asInt.intCode(cb), phased.asBoolean.boolCode(cb))))
+          Call1.getClass, "apply",
+          Array(classTag[Int].runtimeClass, classTag[Boolean].runtimeClass),
+          Array(a1.asInt.value, phased.asBoolean.value)))
     }
 
     registerSCode3("Call", TInt32, TInt32, TBoolean, TCall, (rt: Type, _: SType, _: SType, _: SType) => SCanonicalCall) {
       case (er, cb, rt, a1, a2, phased, _) =>
         SCanonicalCall.constructFromIntRepr(cb, Code.invokeScalaObject[Int](
-          Call2.getClass, "apply", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass, classTag[Boolean].runtimeClass), Array(a1.asInt.intCode(cb), a2.asInt.intCode(cb), phased.asBoolean.boolCode(cb))))
+          Call2.getClass, "apply",
+          Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass, classTag[Boolean].runtimeClass),
+          Array(a1.asInt.value, a2.asInt.value, phased.asBoolean.value)))
     }
 
     registerSCode1("UnphasedDiploidGtIndexCall", TInt32, TCall, (rt: Type, _: SType) => SCanonicalCall) {
       case (er, cb, rt, x, _) =>
         SCanonicalCall.constructFromIntRepr(cb, Code.invokeScalaObject[Int](
-          Call2.getClass, "fromUnphasedDiploidGtIndex", Array(classTag[Int].runtimeClass), Array(x.asInt.intCode(cb))))
+          Call2.getClass, "fromUnphasedDiploidGtIndex",
+          Array(classTag[Int].runtimeClass),
+          Array(x.asInt.value)))
     }
 
 
@@ -71,7 +79,7 @@ object CallFunctions extends RegistryFunctions {
 
     registerSCode2("containsAllele", TCall, TInt32, TBoolean, (rt: Type, _: SType, _: SType) => SBoolean) {
       case (er, cb, rt, call, allele, _) =>
-        primitive(call.asCall.containsAllele(cb, allele.asInt.intCode(cb)))
+        primitive(call.asCall.containsAllele(cb, allele.asInt.value))
     }
 
     registerSCode1("nNonRefAlleles", TCall, TInt32, (rt: Type, _: SType) => SInt32) {
@@ -89,14 +97,14 @@ object CallFunctions extends RegistryFunctions {
     registerSCode2("index", TCall, TInt32, TInt32, (rt: Type, _: SType, _: SType) => SInt32) {
       case (er, cb, rt, call, idx, _) =>
         primitive(cb.memoize(Code.invokeScalaObject[Int](
-          Call.getClass, "alleleByIndex", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass), Array(call.asCall.canonicalCall(cb), idx.asInt.intCode(cb)))))
+          Call.getClass, "alleleByIndex", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass), Array(call.asCall.canonicalCall(cb), idx.asInt.value))))
     }
 
 
     registerSCode2("downcode", TCall, TInt32, TCall, (rt: Type, _: SType, _: SType) => SCanonicalCall) {
       case (er, cb, rt, call, downcodedAllele, _) =>
         SCanonicalCall.constructFromIntRepr(cb, Code.invokeScalaObject[Int](
-          Call.getClass, "downcode", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass), Array(call.asCall.canonicalCall(cb), downcodedAllele.asInt.intCode(cb))))
+          Call.getClass, "downcode", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass), Array(call.asCall.canonicalCall(cb), downcodedAllele.asInt.value)))
     }
 
     registerSCode2("lgt_to_gt", TCall, TArray(TInt32), TCall, { case (rt: Type, sc: SCall, _:SType) => sc }) {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -262,13 +262,13 @@ abstract class RegistryFunctions {
     case _ => classInfo[AnyRef]
   }
 
-  def scodeToJavaValue(cb: EmitCodeBuilder, r: Value[Region], sc: SValue): Value[AnyRef] = {
+  def svalueToJavaValue(cb: EmitCodeBuilder, r: Value[Region], sc: SValue): Value[AnyRef] = {
     sc.st match {
-      case SInt32 => cb.memoize(Code.boxInt(sc.asInt32.intCode(cb)))
-      case SInt64 => cb.memoize(Code.boxLong(sc.asInt64.longCode(cb)))
-      case SFloat32 => cb.memoize(Code.boxFloat(sc.asFloat32.floatCode(cb)))
-      case SFloat64 => cb.memoize(Code.boxDouble(sc.asFloat64.doubleCode(cb)))
-      case SBoolean => cb.memoize(Code.boxBoolean(sc.asBoolean.boolCode(cb)))
+      case SInt32 => cb.memoize(Code.boxInt(sc.asInt32.value))
+      case SInt64 => cb.memoize(Code.boxLong(sc.asInt64.value))
+      case SFloat32 => cb.memoize(Code.boxFloat(sc.asFloat32.value))
+      case SFloat64 => cb.memoize(Code.boxDouble(sc.asFloat64.value))
+      case SBoolean => cb.memoize(Code.boxBoolean(sc.asBoolean.value))
       case _: SCall => cb.memoize(Code.boxInt(sc.asCall.canonicalCall(cb)))
       case _: SString => sc.asString.loadString(cb)
       case _: SLocus => sc.asLocus.getLocusObj(cb)
@@ -464,7 +464,7 @@ abstract class RegistryFunctions {
           }
           arr
       }
-      case _ => scodeToJavaValue(cb, r, code)
+      case _ => svalueToJavaValue(cb, r, code)
     }
 
     registerSCode(name, valueParameterTypes, returnType, calculateReturnType) { case (r, cb, _, rt, args, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -18,7 +18,7 @@ object GenotypeFunctions extends RegistryFunctions {
 
       cb.whileLoop(i < pl.loadLength(), {
         val value = pl.loadElement(cb, i).get(cb, "PL cannot have missing elements.", errorID)
-        val pli = cb.newLocal[Int]("pli", value.asInt.intCode(cb))
+        val pli = cb.newLocal[Int]("pli", value.asInt.value)
         cb.ifx(pli < m, {
           cb.assign(m2, m)
           cb.assign(m, pli)
@@ -41,7 +41,7 @@ object GenotypeFunctions extends RegistryFunctions {
 
         gpv.loadElement(cb, 1).flatMap(cb) { _1 =>
           gpv.loadElement(cb, 2).map(cb) { _2 =>
-            primitive(cb.memoize(_1.asDouble.doubleCode(cb) + _2.asDouble.doubleCode(cb) * 2.0))
+            primitive(cb.memoize(_1.asDouble.value + _2.asDouble.value * 2.0))
           }
         }
       }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -29,9 +29,8 @@ object IntervalFunctions extends RegistryFunctions {
             pt.constructFromCodes(cb, r,
               start,
               end,
-              cb.memoize(includesStart.asBoolean.boolCode(cb)),
-              cb.memoize(includesEnd.asBoolean.boolCode(cb))
-            )
+              includesStart.asBoolean.value,
+              includesEnd.asBoolean.value)
           }
         }
     }
@@ -130,7 +129,7 @@ object IntervalFunctions extends RegistryFunctions {
     registerSCode3("partitionIntervalEndpointGreaterThan", endpointT, tv("T"), TBoolean, TBoolean, (_, _, _, _) => SBoolean) {
       case (_, cb, _, leftPartitionEndpoint: SBaseStructValue, point: SBaseStructValue, containsStart: SBooleanValue, _) =>
         val left = leftPartitionEndpoint.loadField(cb, 0).get(cb).asBaseStruct
-        val leftLen = cb.newLocal[Int]("partitionInterval_leftlen", leftPartitionEndpoint.loadField(cb, 1).get(cb).asInt.intCode(cb))
+        val leftLen = leftPartitionEndpoint.loadField(cb, 1).get(cb).asInt.value
 
         val c = cb.newLocal[Int]("partitionInterval_c", 0)
         (0 until left.st.size).foreach { idx =>
@@ -144,7 +143,7 @@ object IntervalFunctions extends RegistryFunctions {
 
         val isContained = cb.newLocal[Boolean]("partitionInterval_b")
         cb.ifx(c.ceq(0),
-          cb.assign(isContained, containsStart.boolCode(cb)),
+          cb.assign(isContained, containsStart.value),
           cb.assign(isContained, c < 0))
 
         primitive(isContained)
@@ -153,7 +152,7 @@ object IntervalFunctions extends RegistryFunctions {
     registerSCode3("partitionIntervalEndpointLessThan", endpointT, tv("T"), TBoolean, TBoolean, (_, _, _, _) => SBoolean) {
       case (_, cb, _, rightPartitionEndpoint: SBaseStructValue, point: SBaseStructValue, containsEnd: SBooleanValue, _) =>
         val right = rightPartitionEndpoint.loadField(cb, 0).get(cb).asBaseStruct
-        val rightLen = cb.newLocal[Int]("partitionInterval_rightlen", rightPartitionEndpoint.loadField(cb, 1).get(cb).asInt.intCode(cb))
+        val rightLen = rightPartitionEndpoint.loadField(cb, 1).get(cb).asInt.value
 
         val c = cb.newLocal[Int]("partitionInterval_c", 0)
         (0 until right.st.size).foreach { idx =>
@@ -167,7 +166,7 @@ object IntervalFunctions extends RegistryFunctions {
 
         val isContained = cb.newLocal[Boolean]("partitionInterval_b")
         cb.ifx(c.ceq(0),
-          cb.assign(isContained, containsEnd.boolCode(cb)),
+          cb.assign(isContained, containsEnd.value),
           cb.assign(isContained, c > 0))
 
         primitive(isContained)
@@ -183,7 +182,7 @@ object IntervalFunctions extends RegistryFunctions {
         val leftTuple = interval.loadField(cb, "left").get(cb).asBaseStruct
 
         val left = leftTuple.loadField(cb, 0).get(cb).asBaseStruct
-        val leftLen = cb.newLocal[Int]("partitionInterval_leftlen", leftTuple.loadField(cb, 1).get(cb).asInt.intCode(cb))
+        val leftLen = leftTuple.loadField(cb, 1).get(cb).asInt.value
 
         (0 until left.st.size).foreach { idx =>
           cb.ifx(c.ceq(0) && const(idx) < leftLen, {
@@ -196,7 +195,7 @@ object IntervalFunctions extends RegistryFunctions {
 
         val isContained = cb.newLocal[Boolean]("partitionInterval_b")
         cb.ifx(c.ceq(0),
-          cb.assign(isContained, interval.loadField(cb, "includesLeft").get(cb).asBoolean.boolCode(cb)),
+          cb.assign(isContained, interval.loadField(cb, "includesLeft").get(cb).asBoolean.value),
           cb.assign(isContained, c < 0))
 
         cb.ifx(isContained, {
@@ -204,7 +203,7 @@ object IntervalFunctions extends RegistryFunctions {
           val rightTuple = interval.loadField(cb, "right").get(cb).asBaseStruct
 
           val right = rightTuple.loadField(cb, 0).get(cb).asBaseStruct
-          val rightLen = cb.newLocal[Int]("partitionInterval_leftlen", rightTuple.loadField(cb, 1).get(cb).asInt.intCode(cb))
+          val rightLen = rightTuple.loadField(cb, 1).get(cb).asInt.value
 
           cb.assign(c, 0)
           (0 until right.st.size).foreach { idx =>
@@ -217,7 +216,7 @@ object IntervalFunctions extends RegistryFunctions {
           }
 
           cb.ifx(c.ceq(0),
-            cb.assign(isContained, interval.loadField(cb, "includesRight").get(cb).asBoolean.boolCode(cb)),
+            cb.assign(isContained, interval.loadField(cb, "includesRight").get(cb).asBoolean.value),
             cb.assign(isContained, c > 0))
         })
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -123,7 +123,7 @@ object LocusFunctions extends RegistryFunctions {
         val variantTuple = Code.invokeScalaObject2[Locus, IndexedSeq[String], (Locus, IndexedSeq[String])](
           VariantMethods.getClass, "minRep",
           locus.getLocusObj(cb),
-          Code.checkcast[IndexedSeq[String]](scodeToJavaValue(cb, r.region, alleles)))
+          Code.checkcast[IndexedSeq[String]](svalueToJavaValue(cb, r.region, alleles)))
 
         emitVariant(cb, r.region, variantTuple, rt)
     }
@@ -133,7 +133,7 @@ object LocusFunctions extends RegistryFunctions {
         PCanonicalTuple(false, PCanonicalArray(PInt32(true), true), PCanonicalArray(PInt32(true), true)).sType
     }) {
       case (r: EmitRegion, cb: EmitCodeBuilder, SBaseStructPointer(rt: PCanonicalTuple), grouped: SIndexableValue, radiusVal: SFloat64Value, errorID) =>
-        val radius = radiusVal.doubleCode(cb)
+        val radius = radiusVal.value
         val ncontigs = grouped.loadLength()
         val totalLen = cb.newLocal[Int]("locuswindows_totallen", 0)
 
@@ -164,14 +164,14 @@ object LocusFunctions extends RegistryFunctions {
             val len = coords.loadLength()
             cb.ifx(len.ceq(0),
               cb.assign(lastCoord, 0.0),
-              cb.assign(lastCoord, coords.loadElement(cb, 0).get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.doubleCode(cb)))
+              cb.assign(lastCoord, coords.loadElement(cb, 0).get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value))
             cb.whileLoop(i < len, {
 
               coords.loadElement(cb, i).consume(cb,
                 cb._fatalWithError(errorID, const("locus_windows: missing value for 'coord_expr' at row ")
                     .concat((offset + i).toS)),
                 { sc =>
-                  val currentCoord = cb.newLocal[Double]("locuswindows_coord_i", sc.asDouble.doubleCode(cb))
+                  val currentCoord = cb.newLocal[Double]("locuswindows_coord_i", sc.asDouble.value)
                   cb.ifx(lastCoord > currentCoord,
                     cb._fatalWithError(errorID, "locus_windows: 'coord_expr' must be in ascending order within each contig."),
                     cb.assign(lastCoord, currentCoord)
@@ -210,14 +210,14 @@ object LocusFunctions extends RegistryFunctions {
         rt.constructFromFields(cb, r.region,
           FastIndexedSeq[EmitCode](
             EmitCode.fromI(cb.emb)(cb => addIdxWithCondition(cb) { case (cb, i, idx, coords) => coords.loadElement(cb, i)
-              .get(cb, "locus_windows: missing value for 'coord_expr'")
-              .asDouble.doubleCode(cb) > (coords.loadElement(cb, idx)
-              .get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.doubleCode(cb) + radius)
+                          .get(cb, "locus_windows: missing value for 'coord_expr'")
+                          .asDouble.value > (coords.loadElement(cb, idx)
+                                        .get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value + radius)
             }),
             EmitCode.fromI(cb.emb)(cb => addIdxWithCondition(cb) { case (cb, i, idx, coords) => coords.loadElement(cb, i)
-              .get(cb, "locus_windows: missing value for 'coord_expr'")
-              .asDouble.doubleCode(cb) >= (coords.loadElement(cb, idx)
-              .get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.doubleCode(cb) - radius)
+                          .get(cb, "locus_windows: missing value for 'coord_expr'")
+                          .asDouble.value >= (coords.loadElement(cb, idx)
+                                        .get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value - radius)
             })
           ), deepCopy = false)
     }
@@ -237,8 +237,8 @@ object LocusFunctions extends RegistryFunctions {
       (returnType: Type, _: SType, _: SType) => PCanonicalLocus(returnType.asInstanceOf[TLocus].rg).sType
     }) {
       case (r, cb, SCanonicalLocusPointer(rt: PCanonicalLocus), contig, pos, _) =>
-        cb += rgCode(r.mb, rt.rg).invoke[String, Int, Unit]("checkLocus", contig.asString.loadString(cb), pos.asInt.intCode(cb))
-        rt.constructFromPositionAndString(cb, r.region, contig.asString.loadString(cb), pos.asInt.intCode(cb))
+        cb += rgCode(r.mb, rt.rg).invoke[String, Int, Unit]("checkLocus", contig.asString.loadString(cb), pos.asInt.value)
+        rt.constructFromPositionAndString(cb, r.region, contig.asString.loadString(cb), pos.asInt.value)
     }
 
     registerSCode1("LocusAlleles", TString, tvariant("T"), {
@@ -277,7 +277,7 @@ object LocusFunctions extends RegistryFunctions {
               locusClass, "parseInterval",
               locusStr.asString.loadString(cb),
               rgCode(cb.emb, plocus.rg),
-              invalidMissing.asBoolean.boolCode(cb)))
+              invalidMissing.asBoolean.value))
 
           cb.ifx(interval.isNull, cb.goto(Lmissing))
 
@@ -319,12 +319,12 @@ object LocusFunctions extends RegistryFunctions {
                       Code.invokeScalaObject7[String, Int, Int, Boolean, Boolean, ReferenceGenome, Boolean, Interval](
                         locusClass, "makeInterval",
                         locusString.asString.loadString(cb),
-                        pos1.asInt.intCode(cb),
-                        pos2.asInt.intCode(cb),
-                        include1.asBoolean.boolCode(cb),
-                        include2.asBoolean.boolCode(cb),
+                        pos1.asInt.value,
+                        pos2.asInt.value,
+                        include1.asBoolean.value,
+                        include2.asBoolean.value,
                         rgCode(cb.emb, plocus.rg),
-                        invalidMissing.asBoolean.boolCode(cb)))
+                        invalidMissing.asBoolean.value))
 
                     cb.ifx(interval.isNull, cb.goto(Lmissing))
 
@@ -345,7 +345,7 @@ object LocusFunctions extends RegistryFunctions {
     }) {
       case (r, cb, SCanonicalLocusPointer(rt: PCanonicalLocus), globalPos, _) =>
         val locus = cb.newLocal[Locus]("global_pos_locus",
-          rgCode(r.mb, rt.rg).invoke[Long, Locus]("globalPosToLocus", globalPos.asLong.longCode(cb)))
+          rgCode(r.mb, rt.rg).invoke[Long, Locus]("globalPosToLocus", globalPos.asLong.value))
         rt.constructFromPositionAndString(cb, r.region, locus.invoke[String]("contig"), locus.invoke[Int]("position"))
     }
 
@@ -376,7 +376,7 @@ object LocusFunctions extends RegistryFunctions {
             val locusObj = loc.getLocusObj(cb)
             val lifted = cb.newLocal[(Locus, Boolean)]("lifterover_locus_ lifted",
               rgCode(cb.emb, srcRG).invoke[String, Locus, Double, (Locus, Boolean)]("liftoverLocus",
-                destRG.name, locusObj, minMatch.asDouble.doubleCode(cb)))
+                destRG.name, locusObj, minMatch.asDouble.value))
 
             cb.ifx(lifted.isNull, cb.goto(Lmissing))
 
@@ -413,10 +413,10 @@ object LocusFunctions extends RegistryFunctions {
             val srcRG = iT.pointType.asInstanceOf[SLocus].rg
             val destRG = rt.types(0).asInstanceOf[PInterval].pointType.asInstanceOf[PLocus].rg
             val er = EmitRegion(cb.emb, r)
-            val intervalObj = Code.checkcast[Interval](scodeToJavaValue(cb, r, interval))
+            val intervalObj = Code.checkcast[Interval](svalueToJavaValue(cb, r, interval))
             val lifted = cb.newLocal[(Interval, Boolean)]("liftover_locus_interval_lifted",
               rgCode(cb.emb, srcRG).invoke[String, Interval, Double, (Interval, Boolean)]("liftoverLocusInterval",
-                destRG.name, intervalObj, minMatch.asDouble.doubleCode(cb)))
+                destRG.name, intervalObj, minMatch.asDouble.value))
 
 
             cb.ifx(lifted.isNull, cb.goto(Lmissing))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -220,10 +220,10 @@ object MathFunctions extends RegistryFunctions {
     ) { case (r, cb, rt, a: SInt32Value, b: SInt32Value, c: SInt32Value, d: SInt32Value, _) =>
       val res = cb.newLocal[Array[Double]]("fisher_exact_test_res",
         Code.invokeScalaObject4[Int, Int, Int, Int, Array[Double]](statsPackageClass, "fisherExactTest",
-          a.intCode(cb),
-          b.intCode(cb),
-          c.intCode(cb),
-          d.intCode(cb)))
+          a.value,
+          b.value,
+          c.value,
+          d.value))
 
       fetStruct.constructFromFields(cb, r.region, FastIndexedSeq(
         EmitValue.present(primitive(cb.memoize(res(0)))),
@@ -238,10 +238,10 @@ object MathFunctions extends RegistryFunctions {
     ) { case (r, cb, rt, a: SInt32Value, b: SInt32Value, c: SInt32Value, d: SInt32Value, _) =>
       val res = cb.newLocal[Array[Double]]("chi_squared_test_res",
         Code.invokeScalaObject4[Int, Int, Int, Int, Array[Double]](statsPackageClass, "chiSquaredTest",
-          a.intCode(cb),
-          b.intCode(cb),
-          c.intCode(cb),
-          d.intCode(cb)))
+          a.value,
+          b.value,
+          c.value,
+          d.value))
 
       chisqStruct.constructFromFields(cb, r.region, FastIndexedSeq(
         EmitValue.present(primitive(cb.memoize(res(0)))),
@@ -254,11 +254,11 @@ object MathFunctions extends RegistryFunctions {
     ) { case (r, cb, rt, a: SInt32Value, b: SInt32Value, c: SInt32Value, d: SInt32Value, mcc: SInt32Value, _) =>
       val res = cb.newLocal[Array[Double]]("contingency_table_test_res",
         Code.invokeScalaObject5[Int, Int, Int, Int, Int, Array[Double]](statsPackageClass, "contingencyTableTest",
-          a.intCode(cb),
-          b.intCode(cb),
-          c.intCode(cb),
-          d.intCode(cb),
-          mcc.intCode(cb)))
+          a.value,
+          b.value,
+          c.value,
+          d.value,
+          mcc.value))
 
       chisqStruct.constructFromFields(cb, r.region, FastIndexedSeq(
         EmitValue.present(primitive(cb.memoize(res(0)))),
@@ -271,10 +271,10 @@ object MathFunctions extends RegistryFunctions {
     ) { case (r, cb, rt, nHomRef: SInt32Value, nHet: SInt32Value, nHomVar: SInt32Value, oneSided: SBooleanValue, _) =>
       val res = cb.newLocal[Array[Double]]("hardy_weinberg_test_res",
         Code.invokeScalaObject4[Int, Int, Int, Boolean, Array[Double]](statsPackageClass, "hardyWeinbergTest",
-          nHomRef.intCode(cb),
-          nHet.intCode(cb),
-          nHomVar.intCode(cb),
-          oneSided.boolCode(cb)))
+          nHomRef.value,
+          nHet.value,
+          nHomVar.value,
+          oneSided.value))
 
       hweStruct.constructFromFields(cb, r.region, FastIndexedSeq(
         EmitValue.present(primitive(cb.memoize(res(0)))),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -48,7 +48,7 @@ object  NDArrayFunctions extends RegistryFunctions {
       cb.ifx(ndCoefRow  cne ndDepRow, cb._fatalWithError(errorID,"hail.nd.solve_triangular: Solve dimensions incompatible"))
 
       val uplo = cb.newLocal[String]("dtrtrs_uplo")
-      cb.ifx(lower.boolCode(cb), cb.assign(uplo, const("L")), cb.assign(uplo, const("U")))
+      cb.ifx(lower.value, cb.assign(uplo, const("L")), cb.assign(uplo, const("U")))
 
       val infoDTRTRSResult = cb.newLocal[Int]("dtrtrs_result")
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -24,7 +24,7 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
     registerSCode2t("isValidLocus", Array(LocusFunctions.tlocus("R")), TString, TInt32, TBoolean, (_: Type, _: SType, _: SType) => SBoolean) {
       case (r, cb, Seq(tlocus: TLocus), _, contig, pos, _) =>
         val scontig = contig.asString.loadString(cb)
-        primitive(cb.memoize(rgCode(r.mb, tlocus.rg).invoke[String, Int, Boolean]("isValidLocus", scontig, pos.asInt.intCode(cb))))
+        primitive(cb.memoize(rgCode(r.mb, tlocus.rg).invoke[String, Int, Boolean]("isValidLocus", scontig, pos.asInt.value)))
     }
 
     registerSCode4t("getReferenceSequenceFromValidLocus",
@@ -36,9 +36,9 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
         unwrapReturn(cb, r.region, st,
           rgCode(cb.emb, typeParam.rg).invoke[String, Int, Int, Int, String]("getSequence",
             scontig,
-            pos.asInt.intCode(cb),
-            before.asInt.intCode(cb),
-            after.asInt.intCode(cb)))
+            pos.asInt.value,
+            before.asInt.value,
+            after.asInt.value))
     }
 
     registerSCode1t("contigLength", Array(LocusFunctions.tlocus("R")), TString, TInt32, (_: Type, _: SType) => SInt32) {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -108,7 +108,7 @@ object StringFunctions extends RegistryFunctions {
       (_: Type, _: SType, _: SType, _: SType) => SJavaString
     }) {
       case (r: EmitRegion, cb, st: SJavaString.type, s, start, end, _) =>
-        val str = s.asString.loadString(cb).invoke[Int, Int, String]("substring", start.asInt.intCode(cb), end.asInt.intCode(cb))
+        val str = s.asString.loadString(cb).invoke[Int, Int, String]("substring", start.asInt.value, end.asInt.value)
         st.construct(cb, str)
     }
 
@@ -141,7 +141,7 @@ object StringFunctions extends RegistryFunctions {
     registerIR2("sliceLeft", TString, TInt32, TString) { (_, s, end, _) => invoke("slice", TString, s, I32(0), end) }
 
     registerSCode1("str", tv("T"), TString, (_: Type, _: SType) => SJavaString) { case (r, cb, st: SJavaString.type, a, _) =>
-      val annotation = scodeToJavaValue(cb, r.region, a)
+      val annotation = svalueToJavaValue(cb, r.region, a)
       val str = cb.emb.getType(a.st.virtualType).invoke[Any, String]("str", annotation)
       st.construct(cb, str)
     }
@@ -152,7 +152,7 @@ object StringFunctions extends RegistryFunctions {
       val jObj = cb.newLocal("showstr_java_obj")(boxedTypeInfo(a.st.virtualType))
       a.toI(cb).consume(cb,
         cb.assignAny(jObj, Code._null(boxedTypeInfo(a.st.virtualType))),
-        sc => cb.assignAny(jObj, scodeToJavaValue(cb, r, sc)))
+        sc => cb.assignAny(jObj, svalueToJavaValue(cb, r, sc)))
 
       val str = cb.emb.getType(a.st.virtualType).invoke[Any, String]("showStr", jObj)
 
@@ -167,9 +167,9 @@ object StringFunctions extends RegistryFunctions {
 
         a.toI(cb).consume(cb,
           cb.assignAny(jObj, Code._null(boxedTypeInfo(a.st.virtualType))),
-          sc => cb.assignAny(jObj, scodeToJavaValue(cb, r, sc)))
+          sc => cb.assignAny(jObj, svalueToJavaValue(cb, r, sc)))
 
-        val str = cb.emb.getType(a.st.virtualType).invoke[Any, Int, String]("showStr", jObj, trunc.asInt.intCode(cb))
+        val str = cb.emb.getType(a.st.virtualType).invoke[Any, Int, String]("showStr", jObj, trunc.asInt.value)
         st.construct(cb, str)
       }
     }
@@ -181,7 +181,7 @@ object StringFunctions extends RegistryFunctions {
         a.toI(cb).consume(cb,
           cb.assignAny(inputJavaValue, Code._null(ti)),
           { sc =>
-            val jv = scodeToJavaValue(cb, r, sc)
+            val jv = svalueToJavaValue(cb, r, sc)
             cb.assignAny(inputJavaValue, jv)
           })
         val json = cb.emb.getType(a.st.virtualType).invoke[Any, JValue]("toJSON", inputJavaValue)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -176,24 +176,24 @@ object UtilFunctions extends RegistryFunctions {
     }) {
       case (er, cb, rt, l, r, tol, abs, _) =>
         assert(l.st.virtualType == r.st.virtualType, s"\n  lt=${ l.st.virtualType }\n  rt=${ r.st.virtualType }")
-        val lb = scodeToJavaValue(cb, er.region, l)
-        val rb = scodeToJavaValue(cb, er.region, r)
-        primitive(cb.memoize(er.mb.getType(l.st.virtualType).invoke[Any, Any, Double, Boolean, Boolean]("valuesSimilar", lb, rb, tol.asDouble.doubleCode(cb), abs.asBoolean.boolCode(cb))))
+        val lb = svalueToJavaValue(cb, er.region, l)
+        val rb = svalueToJavaValue(cb, er.region, r)
+        primitive(cb.memoize(er.mb.getType(l.st.virtualType).invoke[Any, Any, Double, Boolean, Boolean]("valuesSimilar", lb, rb, tol.asDouble.value, abs.asBoolean.value)))
     }
 
     registerCode1("triangle", TInt32, TInt32, (_: Type, _: SType) => SInt32) { case (cb, _, rt, nn) =>
-      val n = nn.asInt.intCode(cb)
+      val n = nn.asInt.value
       cb.memoize((n * (n + 1)) / 2)
     }
 
     registerSCode1("toInt32", TBoolean, TInt32, (_: Type, _: SType) => SInt32) { case (_, cb, _, x, _) =>
-      primitive(cb.memoize(x.asBoolean.boolCode(cb).toI)) }
+      primitive(cb.memoize(x.asBoolean.value.toI)) }
     registerSCode1("toInt64", TBoolean, TInt64, (_: Type, _: SType) => SInt64) { case (_, cb, _, x, _) =>
-      primitive(cb.memoize(x.asBoolean.boolCode(cb).toI.toL)) }
+      primitive(cb.memoize(x.asBoolean.value.toI.toL)) }
     registerSCode1("toFloat32", TBoolean, TFloat32, (_: Type, _: SType) => SFloat32) { case (_, cb, _, x, _) =>
-      primitive(cb.memoize(x.asBoolean.boolCode(cb).toI.toF)) }
+      primitive(cb.memoize(x.asBoolean.value.toI.toF)) }
     registerSCode1("toFloat64", TBoolean, TFloat64, (_: Type, _: SType) => SFloat64) { case (_, cb, _, x, _) =>
-      primitive(cb.memoize(x.asBoolean.boolCode(cb).toI.toD)) }
+      primitive(cb.memoize(x.asBoolean.value.toI.toD)) }
 
     for ((name, t, rpt, ct) <- Seq[(String, Type, SType, ClassTag[_])](
       ("Boolean", TBoolean, SBoolean, implicitly[ClassTag[Boolean]]),
@@ -227,12 +227,12 @@ object UtilFunctions extends RegistryFunctions {
     Array("min", "max").foreach { name =>
       registerCode2(name, TFloat32, TFloat32, TFloat32, (_: Type, _: SType, _: SType) => SFloat32) {
         case (cb, r, rt, v1, v2) =>
-          cb.memoize(Code.invokeStatic2[Math, Float, Float, Float](name, v1.asFloat.floatCode(cb), v2.asFloat.floatCode(cb)))
+          cb.memoize(Code.invokeStatic2[Math, Float, Float, Float](name, v1.asFloat.value, v2.asFloat.value))
       }
 
       registerCode2(name, TFloat64, TFloat64, TFloat64, (_: Type, _: SType, _: SType) => SFloat64) {
         case (cb, r, rt, v1, v2) =>
-          cb.memoize(Code.invokeStatic2[Math, Double, Double, Double](name, v1.asDouble.doubleCode(cb), v2.asDouble.doubleCode(cb)))
+          cb.memoize(Code.invokeStatic2[Math, Double, Double, Double](name, v1.asDouble.value, v2.asDouble.value))
       }
 
       val ignoreMissingName = name + "_ignore_missing"
@@ -241,12 +241,12 @@ object UtilFunctions extends RegistryFunctions {
 
       registerCode2(ignoreNanName, TFloat32, TFloat32, TFloat32, (_: Type, _: SType, _: SType) => SFloat32) {
         case (cb, r, rt, v1, v2) =>
-          cb.memoize(Code.invokeScalaObject2[Float, Float, Float](thisClass, ignoreNanName, v1.asFloat.floatCode(cb), v2.asFloat.floatCode(cb)))
+          cb.memoize(Code.invokeScalaObject2[Float, Float, Float](thisClass, ignoreNanName, v1.asFloat.value, v2.asFloat.value))
       }
 
       registerCode2(ignoreNanName, TFloat64, TFloat64, TFloat64, (_: Type, _: SType, _: SType) => SFloat64) {
         case (cb, r, rt, v1, v2) =>
-          cb.memoize(Code.invokeScalaObject2[Double, Double, Double](thisClass, ignoreNanName, v1.asDouble.doubleCode(cb), v2.asDouble.doubleCode(cb)))
+          cb.memoize(Code.invokeScalaObject2[Double, Double, Double](thisClass, ignoreNanName, v1.asDouble.value, v2.asDouble.value))
       }
 
       def ignoreMissingTriplet[T](cb: EmitCodeBuilder, rt: SType, v1: EmitCode, v2: EmitCode, name: String, f: (Code[T], Code[T]) => Code[T])(implicit ct: ClassTag[T], ti: TypeInfo[T]): IEmitCode = {
@@ -303,7 +303,7 @@ object UtilFunctions extends RegistryFunctions {
 
     registerSCode2("format", TString, tv("T", "tuple"), TString, (_: Type, _: SType, _: SType) => SJavaString) {
       case (r, cb, st: SJavaString.type, format, args, _) =>
-        val javaObjArgs = Code.checkcast[Row](scodeToJavaValue(cb, r.region, args))
+        val javaObjArgs = Code.checkcast[Row](svalueToJavaValue(cb, r.region, args))
         val formatted = Code.invokeScalaObject2[String, Row, String](thisClass, "format", format.asString.loadString(cb), javaObjArgs)
         st.construct(cb, formatted)
     }
@@ -312,8 +312,8 @@ object UtilFunctions extends RegistryFunctions {
       case (cb, _, rt,_ , l, r) =>
         if (l.required && r.required) {
           val result = cb.newLocal[Boolean]("land_result")
-          cb.ifx(l.toI(cb).get(cb).asBoolean.boolCode(cb), {
-            cb.assign(result, r.toI(cb).get(cb).asBoolean.boolCode(cb))
+          cb.ifx(l.toI(cb).get(cb).asBoolean.value, {
+            cb.assign(result, r.toI(cb).get(cb).asBoolean.value)
           }, {
             cb.assign(result, const(false))
           })
@@ -329,7 +329,7 @@ object UtilFunctions extends RegistryFunctions {
           l.toI(cb)
             .consume(cb,
               cb.assign(w, 1),
-              b1 => cb.assign(w, b1.asBoolean.boolCode(cb).mux(const(2), const(0)))
+              b1 => cb.assign(w, b1.asBoolean.value.mux(const(2), const(0)))
             )
 
           cb.ifx(w.cne(0),
@@ -337,7 +337,7 @@ object UtilFunctions extends RegistryFunctions {
               r.toI(cb).consume(cb,
                 cb.assign(w, w | const(4)),
                 { b2 =>
-                  cb.assign(w, w | b2.asBoolean.boolCode(cb).mux(const(8), const(0)))
+                  cb.assign(w, w | b2.asBoolean.value.mux(const(8), const(0)))
                 }
               )
             })
@@ -350,10 +350,10 @@ object UtilFunctions extends RegistryFunctions {
       case (cb, _, rt,_, l, r) =>
         if (l.required && r.required) {
           val result = cb.newLocal[Boolean]("land_result")
-          cb.ifx(l.toI(cb).get(cb).asBoolean.boolCode(cb), {
+          cb.ifx(l.toI(cb).get(cb).asBoolean.value, {
             cb.assign(result, const(true))
           }, {
-            cb.assign(result, r.toI(cb).get(cb).asBoolean.boolCode(cb))
+            cb.assign(result, r.toI(cb).get(cb).asBoolean.value)
           })
 
           IEmitCode.present(cb, primitive(result))
@@ -367,7 +367,7 @@ object UtilFunctions extends RegistryFunctions {
           l.toI(cb)
             .consume(cb,
               cb.assign(w, 1),
-              b1 => cb.assign(w, b1.asBoolean.boolCode(cb).mux(const(2), const(0)))
+              b1 => cb.assign(w, b1.asBoolean.value.mux(const(2), const(0)))
             )
 
           cb.ifx(w.cne(2),
@@ -375,7 +375,7 @@ object UtilFunctions extends RegistryFunctions {
               r.toI(cb).consume(cb,
                 cb.assign(w, w | const(4)),
                 { b2 =>
-                  cb.assign(w, w | b2.asBoolean.boolCode(cb).mux(const(8), const(0)))
+                  cb.assign(w, w | b2.asBoolean.value.mux(const(8), const(0)))
                 }
               )
             })

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/PrimitiveOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/PrimitiveOrdering.scala
@@ -13,22 +13,22 @@ object Int32Ordering {
       override val type2: SInt32.type = t2
 
       override def _compareNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Int] =
-        cb.memoize(Code.invokeStatic2[java.lang.Integer, Int, Int, Int]("compare", x.asInt.intCode(cb), y.asInt.intCode(cb)))
+        cb.memoize(Code.invokeStatic2[java.lang.Integer, Int, Int, Int]("compare", x.asInt.value, y.asInt.value))
 
       override def _ltNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asInt.intCode(cb) < y.asInt.intCode(cb))
+        cb.memoize(x.asInt.value < y.asInt.value)
 
       override def _lteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asInt.intCode(cb) <= y.asInt.intCode(cb))
+        cb.memoize(x.asInt.value <= y.asInt.value)
 
       override def _gtNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asInt.intCode(cb) > y.asInt.intCode(cb))
+        cb.memoize(x.asInt.value > y.asInt.value)
 
       override def _gteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asInt.intCode(cb) >= y.asInt.intCode(cb))
+        cb.memoize(x.asInt.value >= y.asInt.value)
 
       override def _equivNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asInt.intCode(cb).ceq(y.asInt.intCode(cb)))
+        cb.memoize(x.asInt.value.ceq(y.asInt.value))
     }
   }
 }
@@ -42,22 +42,22 @@ object Int64Ordering {
       override val type2: SInt64.type = t2
 
       override def _compareNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Int] =
-        cb.memoize(Code.invokeStatic2[java.lang.Long, Long, Long, Int]("compare", x.asLong.longCode(cb), y.asLong.longCode(cb)))
+        cb.memoize(Code.invokeStatic2[java.lang.Long, Long, Long, Int]("compare", x.asLong.value, y.asLong.value))
 
       override def _ltNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asLong.longCode(cb) < y.asLong.longCode(cb))
+        cb.memoize(x.asLong.value < y.asLong.value)
 
       override def _lteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asLong.longCode(cb) <= y.asLong.longCode(cb))
+        cb.memoize(x.asLong.value <= y.asLong.value)
 
       override def _gtNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asLong.longCode(cb) > y.asLong.longCode(cb))
+        cb.memoize(x.asLong.value > y.asLong.value)
 
       override def _gteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asLong.longCode(cb) >= y.asLong.longCode(cb))
+        cb.memoize(x.asLong.value >= y.asLong.value)
 
       override def _equivNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asLong.longCode(cb).ceq(y.asLong.longCode(cb)))
+        cb.memoize(x.asLong.value.ceq(y.asLong.value))
     }
   }
 }
@@ -70,22 +70,22 @@ object Float32Ordering {
       override val type2: SFloat32.type = t2
 
       override def _compareNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Int] =
-        cb.memoize(Code.invokeStatic2[java.lang.Float, Float, Float, Int]("compare", x.asFloat.floatCode(cb), y.asFloat.floatCode(cb)))
+        cb.memoize(Code.invokeStatic2[java.lang.Float, Float, Float, Int]("compare", x.asFloat.value, y.asFloat.value))
 
       override def _ltNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asFloat.floatCode(cb) < y.asFloat.floatCode(cb))
+        cb.memoize(x.asFloat.value < y.asFloat.value)
 
       override def _lteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asFloat.floatCode(cb) <= y.asFloat.floatCode(cb))
+        cb.memoize(x.asFloat.value <= y.asFloat.value)
 
       override def _gtNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asFloat.floatCode(cb) > y.asFloat.floatCode(cb))
+        cb.memoize(x.asFloat.value > y.asFloat.value)
 
       override def _gteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asFloat.floatCode(cb) >= y.asFloat.floatCode(cb))
+        cb.memoize(x.asFloat.value >= y.asFloat.value)
 
       override def _equivNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asFloat.floatCode(cb).ceq(y.asFloat.floatCode(cb)))
+        cb.memoize(x.asFloat.value.ceq(y.asFloat.value))
     }
   }
 }
@@ -98,22 +98,22 @@ object Float64Ordering {
       override val type2: SFloat64.type = t2
 
       override def _compareNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Int] =
-        cb.memoize(Code.invokeStatic2[java.lang.Double, Double, Double, Int]("compare", x.asDouble.doubleCode(cb), y.asDouble.doubleCode(cb)))
+        cb.memoize(Code.invokeStatic2[java.lang.Double, Double, Double, Int]("compare", x.asDouble.value, y.asDouble.value))
 
       override def _ltNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asDouble.doubleCode(cb) < y.asDouble.doubleCode(cb))
+        cb.memoize(x.asDouble.value < y.asDouble.value)
 
       override def _lteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asDouble.doubleCode(cb) <= y.asDouble.doubleCode(cb))
+        cb.memoize(x.asDouble.value <= y.asDouble.value)
 
       override def _gtNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asDouble.doubleCode(cb) > y.asDouble.doubleCode(cb))
+        cb.memoize(x.asDouble.value > y.asDouble.value)
 
       override def _gteqNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asDouble.doubleCode(cb) >= y.asDouble.doubleCode(cb))
+        cb.memoize(x.asDouble.value >= y.asDouble.value)
 
       override def _equivNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Boolean] =
-        cb.memoize(x.asDouble.doubleCode(cb).ceq(y.asDouble.doubleCode(cb)))
+        cb.memoize(x.asDouble.value.ceq(y.asDouble.value))
     }
   }
 }
@@ -126,7 +126,7 @@ object BooleanOrdering {
       override val type2: SBoolean.type = t2
 
       override def _compareNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Int] =
-        cb.memoize(Code.invokeStatic2[java.lang.Boolean, Boolean, Boolean, Int]("compare", x.asBoolean.boolCode(cb), y.asBoolean.boolCode(cb)))
+        cb.memoize(Code.invokeStatic2[java.lang.Boolean, Boolean, Boolean, Int]("compare", x.asBoolean.value, y.asBoolean.value))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -309,7 +309,7 @@ object EmitStream {
       case x@If(cond, cnsq, altr) =>
         emit(cond, cb).flatMap(cb) { cond =>
           val xCond = mb.genFieldThisRef[Boolean]("stream_if_cond")
-          cb.assign(xCond, cond.asBoolean.boolCode(cb))
+          cb.assign(xCond, cond.asBoolean.value)
 
           val Lmissing = CodeLabel()
           val Lpresent = CodeLabel()
@@ -392,8 +392,8 @@ object EmitStream {
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder): Unit = {
-                val startVar = cb.newLocal[Int]("start", startCode.asInt.intCode(cb))
-                cb.assign(stepVar, stepCode.asInt.intCode(cb))
+                val startVar = startCode.asInt.value
+                cb.assign(stepVar, stepCode.asInt.value)
                 cb.assign(curr, startVar - stepVar)
               }
 
@@ -436,8 +436,8 @@ object EmitStream {
               })
 
               override def initialize(cb: EmitCodeBuilder): Unit = {
-                cb.assign(startVar, startCode.asInt.intCode(cb))
-                cb.assign(stopVar, stopCode.asInt.intCode(cb))
+                cb.assign(startVar, startCode.asInt.value)
+                cb.assign(stopVar, stopCode.asInt.value)
                 start match {
                   case I32(x) if step < 0 && ((x.toLong - Int.MinValue.toLong) / step.toLong + 1) < Int.MaxValue =>
                   case I32(x) if step > 0 && ((Int.MaxValue.toLong - x.toLong) / step.toLong + 1) < Int.MaxValue =>
@@ -491,9 +491,9 @@ object EmitStream {
                 override def initialize(cb: EmitCodeBuilder): Unit = {
                   val llen = cb.newLocal[Long]("streamrange_llen")
 
-                  cb.assign(start, startc.asInt.intCode(cb))
-                  cb.assign(stop, stopc.asInt.intCode(cb))
-                  cb.assign(step, stepc.asInt.intCode(cb))
+                  cb.assign(start, startc.asInt.value)
+                  cb.assign(stop, stopc.asInt.value)
+                  cb.assign(step, stepc.asInt.value)
 
                   cb.ifx(step ceq const(0), cb._fatalWithError(errorID, "Array range cannot have step size 0."))
                   cb.ifx(step < const(0), {
@@ -547,7 +547,7 @@ object EmitStream {
             val len = mb.genFieldThisRef[Int]("seq_sample_len")
             val regionVar = mb.genFieldThisRef[Region]("seq_sample_region")
 
-            val nRemaining = cb.newField[Int]("seq_sample_num_remaining", numToSampleVal.intCode(cb))
+            val nRemaining = cb.newField[Int]("seq_sample_num_remaining", numToSampleVal.value)
             val candidate = cb.newField[Int]("seq_sample_candidate", 0)
             val elementToReturn = cb.newField[Int]("seq_sample_element_to_return", -1) // -1 should never be returned.
 
@@ -555,8 +555,8 @@ object EmitStream {
               override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => len)
 
               override def initialize(cb: EmitCodeBuilder): Unit = {
-                cb.assign(len, numToSampleVal.asInt.intCode(cb))
-                cb.assign(nRemaining, numToSampleVal.intCode(cb))
+                cb.assign(len, numToSampleVal.asInt.value)
+                cb.assign(nRemaining, numToSampleVal.value)
                 cb.assign(candidate, 0)
                 cb.assign(elementToReturn, -1)
               }
@@ -569,11 +569,11 @@ object EmitStream {
                 cb.ifx(nRemaining <= 0, cb.goto(LendOfStream))
 
                 val u = cb.newLocal[Double]("seq_sample_rand_unif", Code.invokeStatic0[Math, Double]("random"))
-                val fC = cb.newLocal[Double]("seq_sample_Fc", (totalSizeVal.intCode(cb) - candidate - nRemaining).toD / (totalSizeVal.intCode(cb) - candidate).toD)
+                val fC = cb.newLocal[Double]("seq_sample_Fc", (totalSizeVal.value - candidate - nRemaining).toD / (totalSizeVal.value - candidate).toD)
 
                 cb.whileLoop(fC > u, {
                   cb.assign(candidate, candidate + 1)
-                  cb.assign(fC, fC * (const(1.0) - (nRemaining.toD / (totalSizeVal.intCode(cb) - candidate).toD)))
+                  cb.assign(fC, fC * (const(1.0) - (nRemaining.toD / (totalSizeVal.value - candidate).toD)))
                 })
                 cb.assign(nRemaining, nRemaining - 1)
                 cb.assign(elementToReturn, candidate)
@@ -625,7 +625,7 @@ object EmitStream {
                   .consume(cb,
                     cb.goto(Lfiltered),
                     { sc =>
-                      cb.ifx(!sc.asBoolean.boolCode(cb), cb.goto(Lfiltered))
+                      cb.ifx(!sc.asBoolean.value, cb.goto(Lfiltered))
                     })
 
                 if (requiresMemoryManagementPerElement)
@@ -666,7 +666,7 @@ object EmitStream {
                   childProducer.length.map(compLen => (cb: EmitCodeBuilder) => compLen(cb).min(n))
 
                 override def initialize(cb: EmitCodeBuilder): Unit = {
-                  cb.assign(n, num.intCode(cb))
+                  cb.assign(n, num.value)
                   cb.ifx(n < 0, cb._fatal(s"stream take: negative number of elements to take: ", n.toS))
                   cb.assign(idx, 0)
                   childProducer.initialize(cb)
@@ -710,7 +710,7 @@ object EmitStream {
                 }
 
                 override def initialize(cb: EmitCodeBuilder): Unit = {
-                  cb.assign(n, num.intCode(cb))
+                  cb.assign(n, num.value)
                   cb.ifx(n < 0, cb._fatal(s"stream drop: negative number of elements to drop: ", n.toS))
                   cb.assign(idx, 0)
                   childProducer.initialize(cb)
@@ -767,7 +767,7 @@ object EmitStream {
                 emit(condIR, cb, region = childProducer.elementRegion, env = env.bind(elt, eltSettable))
                   .consume(cb,
                     cb.goto(LendOfStream),
-                    code => cb.ifx(code.asBoolean.boolCode(cb),
+                    code => cb.ifx(code.asBoolean.value,
                       cb.goto(LproduceElementDone),
                       cb.goto(LendOfStream)))
 
@@ -815,7 +815,7 @@ object EmitStream {
                 emit(condIR, cb, region = childProducer.elementRegion, env = env.bind(elt, eltSettable))
                   .consume(cb,
                     cb.goto(LdoneDropping),
-                    code => cb.ifx(code.asBoolean.boolCode(cb),
+                    code => cb.ifx(code.asBoolean.value,
                       cb.goto(LdropThis),
                       cb.goto(LdoneDropping)))
 
@@ -1867,7 +1867,7 @@ object EmitStream {
                 childProducer.length.map(compL => (cb: EmitCodeBuilder) => ((compL(cb).toL + n.toL - 1L) / n.toL).toI)
 
               override def initialize(cb: EmitCodeBuilder): Unit = {
-                cb.assign(n, groupSize.intCode(cb))
+                cb.assign(n, groupSize.value)
                 cb.ifx(n <= 0, cb._fatal(s"stream grouped: non-positive size: ", n.toS))
                 cb.assign(eos, false)
                 cb.assign(xCounter, n)

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -335,7 +335,7 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
       parentBuilder.loadFrom(cb, utils, 0)
 
       leafBuilder.loadChild(cb, 0)
-      parentBuilder.add(cb, idxOff, leafBuilder.firstIdx(cb).asLong.longCode(cb), leafBuilder.getLoadedChild)
+      parentBuilder.add(cb, idxOff, leafBuilder.firstIdx(cb).asLong.value, leafBuilder.getLoadedChild)
       parentBuilder.store(cb, utils, 0)
       leafBuilder.reset(cb, elementIdx)
       Code._empty

--- a/hail/src/main/scala/is/hail/types/encoded/EBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBoolean.scala
@@ -15,7 +15,7 @@ case object EBooleanRequired extends EBoolean(true)
 
 class EBoolean(override val required: Boolean) extends EType {
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
-    cb += out.writeBoolean(v.asBoolean.boolCode(cb))
+    cb += out.writeBoolean(v.asBoolean.value)
   }
 
   override def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer]): SValue = {

--- a/hail/src/main/scala/is/hail/types/encoded/EFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EFloat32.scala
@@ -15,7 +15,7 @@ case object EFloat32Required extends EFloat32(true)
 
 class EFloat32(override val required: Boolean) extends EType {
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
-    cb += out.writeFloat(v.asFloat.floatCode(cb))
+    cb += out.writeFloat(v.asFloat.value)
   }
 
   override def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer]): SValue = {

--- a/hail/src/main/scala/is/hail/types/encoded/EFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EFloat64.scala
@@ -15,7 +15,7 @@ case object EFloat64Required extends EFloat64(true)
 
 class EFloat64(override val required: Boolean) extends EType {
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
-    cb += out.writeDouble(v.asDouble.doubleCode(cb))
+    cb += out.writeDouble(v.asDouble.value)
   }
 
   override def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer]): SValue = {

--- a/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
@@ -20,7 +20,7 @@ class EInt32(override val required: Boolean) extends EType {
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
     val x = v.st match {
       case _: SCall => v.asInstanceOf[SCallValue].canonicalCall(cb)
-      case SInt32 => v.asInt32.intCode(cb)
+      case SInt32 => v.asInt32.value
     }
     cb += out.writeInt(x)
   }

--- a/hail/src/main/scala/is/hail/types/encoded/EInt64.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EInt64.scala
@@ -15,7 +15,7 @@ case object EInt64Required extends EInt64(true)
 
 class EInt64(override val required: Boolean) extends EType {
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
-    cb += out.writeLong(v.asLong.longCode(cb))
+    cb += out.writeLong(v.asLong.value)
   }
 
   override def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer]): SValue = {

--- a/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
@@ -29,7 +29,7 @@ class PBoolean(override val required: Boolean) extends PType with PPrimitive {
   def sType: SBoolean.type = SBoolean
 
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit = {
-    cb += Region.storeBoolean(addr, value.asBoolean.boolCode(cb))
+    cb += Region.storeBoolean(addr, value.asBoolean.value)
   }
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBooleanValue =

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -42,7 +42,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     assert(settables.length == nDims, s"got ${ settables.length } settables, expect ${ nDims } dims")
     val shapeTuple = shapeType.loadCheapSCode(cb, representation.loadField(addr, "shape"))
     (0 until nDims).foreach { dimIdx =>
-      cb.assign(settables(dimIdx), shapeTuple.loadField(cb, dimIdx).get(cb).asLong.longCode(cb))
+      cb.assign(settables(dimIdx), shapeTuple.loadField(cb, dimIdx).get(cb).asLong.value)
     }
   }
 
@@ -50,7 +50,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     assert(settables.length == nDims)
     val strideTuple = strideType.loadCheapSCode(cb, representation.loadField(addr, "strides"))
     (0 until nDims).foreach { dimIdx =>
-      cb.assign(settables(dimIdx), strideTuple.loadField(cb, dimIdx).get(cb).asLong.longCode(cb))
+      cb.assign(settables(dimIdx), strideTuple.loadField(cb, dimIdx).get(cb).asLong.value)
     }
   }
 
@@ -344,9 +344,9 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SNDArrayPointerValue = {
     val a = cb.memoize(addr)
     val shapeTuple = shapeType.loadCheapSCode(cb, representation.loadField(a, "shape"))
-    val shape = Array.tabulate(nDims)(i => SizeValueDyn(shapeTuple.loadField(cb, i).get(cb).asLong.longCode(cb)))
+    val shape = Array.tabulate(nDims)(i => SizeValueDyn(shapeTuple.loadField(cb, i).get(cb).asLong.value))
     val strideTuple = strideType.loadCheapSCode(cb, representation.loadField(a, "strides"))
-    val strides = Array.tabulate(nDims)(strideTuple.loadField(cb, _).get(cb).asLong.longCode(cb))
+    val strides = Array.tabulate(nDims)(strideTuple.loadField(cb, _).get(cb).asLong.value)
     val firstDataAddress = cb.memoize(dataFirstElementPointer(a))
     new SNDArrayPointerValue(sType, a, shape, strides, firstDataAddress)
   }

--- a/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
@@ -40,7 +40,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
   override def sType: SType = SFloat32
 
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
-    cb.append(Region.storeFloat(addr, value.asFloat.floatCode(cb)))
+    cb.append(Region.storeFloat(addr, value.asFloat.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat32Value =
     new SFloat32Value(cb.memoize(Region.loadFloat(addr)))

--- a/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
@@ -41,7 +41,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
   override def sType: SType = SFloat64
 
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
-    cb.append(Region.storeDouble(addr, value.asDouble.doubleCode(cb)))
+    cb.append(Region.storeDouble(addr, value.asDouble.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat64Value =
     new SFloat64Value(cb.memoize(Region.loadDouble(addr)))

--- a/hail/src/main/scala/is/hail/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt32.scala
@@ -37,7 +37,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
   override def sType: SType = SInt32
 
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
-    cb.append(Region.storeInt(addr, value.asInt.intCode(cb)))
+    cb.append(Region.storeInt(addr, value.asInt.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt32Value =
     new SInt32Value(cb.memoize(Region.loadInt(addr)))

--- a/hail/src/main/scala/is/hail/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt64.scala
@@ -38,7 +38,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
   override def sType: SType = SInt64
 
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
-    cb.append(Region.storeLong(addr, value.asLong.longCode(cb)))
+    cb.append(Region.storeLong(addr, value.asLong.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt64Value =
     new SInt64Value(cb.memoize(Region.loadLong(addr)))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -9,37 +9,37 @@ import is.hail.types.physical.stypes.primitives._
 object SCode {
   def add(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) + right.asInt.intCode(cb)))
-      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) + right.asFloat.floatCode(cb)))
-      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) + right.asLong.longCode(cb)))
-      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) + right.asDouble.doubleCode(cb)))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.value + right.asInt.value))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.value + right.asFloat.value))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.value + right.asLong.value))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.value + right.asDouble.value))
     }
   }
 
   def multiply(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) * right.asInt.intCode(cb)))
-      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) * right.asFloat.floatCode(cb)))
-      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) * right.asLong.longCode(cb)))
-      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) * right.asDouble.doubleCode(cb)))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.value * right.asInt.value))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.value * right.asFloat.value))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.value * right.asLong.value))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.value * right.asDouble.value))
     }
   }
 
   def subtract(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) - right.asInt.intCode(cb)))
-      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) - right.asFloat.floatCode(cb)))
-      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) - right.asLong.longCode(cb)))
-      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) - right.asDouble.doubleCode(cb)))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.value - right.asInt.value))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.value - right.asFloat.value))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.value - right.asLong.value))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.value - right.asDouble.value))
     }
   }
 
   def divide(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) / right.asInt.intCode(cb)))
-      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) / right.asFloat.floatCode(cb)))
-      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) / right.asLong.longCode(cb)))
-      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) / right.asDouble.doubleCode(cb)))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.value / right.asInt.value))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.value / right.asFloat.value))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.value / right.asLong.value))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.value / right.asDouble.value))
     }
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -29,11 +29,11 @@ object SType {
   }
 
   def extractPrimValue(cb: EmitCodeBuilder, x: SValue): Value[_] = x.st.virtualType match {
-    case TInt32 => x.asInt.intCode(cb)
-    case TInt64 => x.asLong.longCode(cb)
-    case TFloat32 => x.asFloat.floatCode(cb)
-    case TFloat64 => x.asDouble.doubleCode(cb)
-    case TBoolean => x.asBoolean.boolCode(cb)
+    case TInt32 => x.asInt.value
+    case TInt64 => x.asLong.value
+    case TFloat32 => x.asFloat.value
+    case TFloat64 => x.asDouble.value
+    case TBoolean => x.asBoolean.value
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
@@ -54,7 +54,7 @@ case object Int32SingleCodeType extends SingleCodeType {
   def virtualType: Type = TInt32
 
   def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean): SingleCodeSCode =
-    SingleCodeSCode(this, pc.asInt.intCode(cb))
+    SingleCodeSCode(this, pc.asInt.value)
 }
 
 case object Int64SingleCodeType extends SingleCodeType {
@@ -67,7 +67,7 @@ case object Int64SingleCodeType extends SingleCodeType {
   def virtualType: Type = TInt64
 
   def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean): SingleCodeSCode =
-    SingleCodeSCode(this, pc.asLong.longCode(cb))
+    SingleCodeSCode(this, pc.asLong.value)
 }
 
 case object Float32SingleCodeType extends SingleCodeType {
@@ -80,7 +80,7 @@ case object Float32SingleCodeType extends SingleCodeType {
   def virtualType: Type = TFloat32
 
   def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean): SingleCodeSCode =
-    SingleCodeSCode(this, pc.asFloat.floatCode(cb))
+    SingleCodeSCode(this, pc.asFloat.value)
 }
 
 case object Float64SingleCodeType extends SingleCodeType {
@@ -93,7 +93,7 @@ case object Float64SingleCodeType extends SingleCodeType {
   def virtualType: Type = TFloat64
 
   def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean): SingleCodeSCode =
-    SingleCodeSCode(this, pc.asDouble.doubleCode(cb))
+    SingleCodeSCode(this, pc.asDouble.value)
 }
 
 case object BooleanSingleCodeType extends SingleCodeType {
@@ -106,7 +106,7 @@ case object BooleanSingleCodeType extends SingleCodeType {
   def virtualType: Type = TBoolean
 
   def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean): SingleCodeSCode =
-    SingleCodeSCode(this, pc.asBoolean.boolCode(cb))
+    SingleCodeSCode(this, pc.asBoolean.value)
 }
 
 case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, eltType: PType) extends SingleCodeType {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -107,7 +107,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
         cb._fatalWithError(errorID,
           s"lgt_to_gt: found allele ", av.toS, ", but there are only ", localAlleles.loadLength().toS, " local alleles"))
       localAlleles.loadElement(cb, av).get(cb, const("lgt_to_gt: found missing value in local alleles at index ").concat(av.toS), errorID = errorID)
-        .asInt.intCode(cb)
+              .asInt.value
     }
 
     val repr = cb.newLocal[Int]("lgt_to_gt_repr")

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -52,7 +52,7 @@ trait SBaseStructValue extends SValue {
     val hash_result = cb.newLocal[Int]("hash_result_struct", 1)
     (0 until st.size).foreach(i => {
       loadField(cb, i).consume(cb, { cb.assign(hash_result, hash_result * 31) },
-        {field => cb.assign(hash_result, (hash_result * 31) + field.hash(cb).intCode(cb))})
+        {field => cb.assign(hash_result, (hash_result * 31) + field.hash(cb).value)})
     })
     new SInt32Value(hash_result)
   }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -66,7 +66,7 @@ trait SIndexableValue extends SValue {
       case (cb, idx) => cb.assign(hash_result, hash_result * 31)
     }, {
       case (cb, idx, element) =>
-        cb.assign(hash_result, hash_result * 31 + element.hash(cb).intCode(cb))
+        cb.assign(hash_result, hash_result * 31 + element.hash(cb).value)
     })
     new SInt32Value(hash_result)
   }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -256,7 +256,7 @@ object SNDArray {
   }
 
   def scale(cb: EmitCodeBuilder, alpha: SValue, X: SNDArrayValue): Unit =
-    scale(cb, alpha.asFloat64.doubleCode(cb), X)
+    scale(cb, alpha.asFloat64.value, X)
 
   def scale(cb: EmitCodeBuilder, alpha: Value[Double], X: SNDArrayValue): Unit = {
     val Seq(n) = X.shapes

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -49,10 +49,8 @@ class SBooleanValue(val value: Value[Boolean]) extends SPrimitiveValue {
 
   override def _primitiveValue: Value[_] = value
 
-  def boolCode(cb: EmitCodeBuilder): Value[Boolean] = value
-
   override def hash(cb: EmitCodeBuilder): SInt32Value =
-    new SInt32Value(cb.memoize(boolCode(cb).toI))
+    new SInt32Value(cb.memoize(value.toI))
 }
 
 object SBooleanSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -47,10 +47,8 @@ class SFloat32Value(val value: Value[Float]) extends SPrimitiveValue {
 
   override def _primitiveValue: Value[_] = value
 
-  def floatCode(cb: EmitCodeBuilder): Value[Float] = value
-
   override def hash(cb: EmitCodeBuilder): SInt32Value =
-    new SInt32Value(cb.memoize(Code.invokeStatic1[java.lang.Float, Float, Int]("floatToIntBits", floatCode(cb))))
+    new SInt32Value(cb.memoize(Code.invokeStatic1[java.lang.Float, Float, Int]("floatToIntBits", value)))
 }
 
 object SFloat32Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -52,10 +52,8 @@ class SFloat64Value(val value: Value[Double]) extends SPrimitiveValue {
 
   override def _primitiveValue: Value[_] = value
 
-  def doubleCode(cb: EmitCodeBuilder): Value[Double] = value
-
   override def hash(cb: EmitCodeBuilder): SInt32Value =
-    new SInt32Value(cb.memoize(invokeStatic1[java.lang.Double, Double, Int]("hashCode", doubleCode(cb))))
+    new SInt32Value(cb.memoize(invokeStatic1[java.lang.Double, Double, Int]("hashCode", value)))
 }
 
 object SFloat64Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -47,10 +47,8 @@ class SInt32Value(val value: Value[Int]) extends SPrimitiveValue {
 
   override def _primitiveValue: Value[_] = value
 
-  def intCode(cb: EmitCodeBuilder): Value[Int] = value
-
   override def hash(cb: EmitCodeBuilder): SInt32Value =
-    new SInt32Value(intCode(cb))
+    new SInt32Value(value)
 }
 
 object SInt32Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -48,10 +48,8 @@ class SInt64Value(val value: Value[Long]) extends SPrimitiveValue {
 
   override def _primitiveValue: Value[_] = value
 
-  def longCode(cb: EmitCodeBuilder): Value[Long] = value
-
   override def hash(cb: EmitCodeBuilder): SInt32Value =
-    new SInt32Value(cb.memoize(invokeStatic1[java.lang.Long, Long, Int]("hashCode", longCode(cb))))
+    new SInt32Value(cb.memoize(invokeStatic1[java.lang.Long, Long, Int]("hashCode", value)))
 }
 
 object SInt64Settable {

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
@@ -60,10 +60,10 @@ class RichCodeOutputBuffer(
     ob.invoke[String, Unit]("writeUTF", s)
 
   def writePrimitive(cb: EmitCodeBuilder, pc: SValue): Unit = pc.st.virtualType match {
-    case TBoolean => cb += writeBoolean(pc.asBoolean.boolCode(cb))
-    case TInt32 => cb += writeInt(pc.asInt.intCode(cb))
-    case TInt64 => cb += writeLong(pc.asLong.longCode(cb))
-    case TFloat32 => cb += writeFloat(pc.asFloat.floatCode(cb))
-    case TFloat64 => cb += writeDouble(pc.asDouble.doubleCode(cb))
+    case TBoolean => cb += writeBoolean(pc.asBoolean.value)
+    case TInt32 => cb += writeInt(pc.asInt.value)
+    case TInt64 => cb += writeLong(pc.asLong.value)
+    case TFloat32 => cb += writeFloat(pc.asFloat.value)
+    case TFloat64 => cb += writeDouble(pc.asDouble.value)
   }
 }

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -44,7 +44,7 @@ class CodeSuite extends HailSuite {
     val mb = fb.apply_method
     mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
       val hash = v.hash(cb)
-      hash.intCode(cb)
+      hash.value
     })
     fb.result()()()
   }
@@ -59,7 +59,7 @@ class CodeSuite extends HailSuite {
       val stringToHash = st.constructFromString(cb, region, toHash)
       val i = stringToHash
       val hash = i.hash(cb)
-      hash.intCode(cb)
+      hash.value
     })
     val region = Region(pool=pool)
     fb.result()()(region)
@@ -73,7 +73,7 @@ class CodeSuite extends HailSuite {
       val arrayPointer = fb.emb.getCodeParam[Long](1)
       val arrayToHash = pArray.loadCheapSCode(cb, arrayPointer)
       val hash = arrayToHash.hash(cb)
-      hash.intCode(cb)
+      hash.value
     })
     val region = Region(pool=pool)
     val arrayPointer = pArray.unstagedStoreJavaObject(toHash, region)
@@ -88,7 +88,7 @@ class CodeSuite extends HailSuite {
       val structPointer = fb.emb.getCodeParam[Long](1)
       val structToHash = pStruct.loadCheapSCode(cb, structPointer)
       val hash = structToHash.hash(cb)
-      hash.intCode(cb)
+      hash.value
     })
     val region = Region(pool=pool)
     val structPointer = pStruct.unstagedStoreJavaObject(toHash, region)

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -33,7 +33,7 @@ object TestRegisterFunctions extends RegistryFunctions {
     registerScalaFunction("foobar1", Array(), TInt32, null)(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", Array(), TInt32, null)(ScalaTestCompanion.getClass, "testFunction")
     registerSCode2("testCodeUnification", tnum("x"), tv("x", "int32"), tv("x"), null) {
-      case (_, cb, rt, a, b, _) => primitive(cb.memoize(a.asInt.intCode(cb) + b.asInt.intCode(cb)))
+      case (_, cb, rt, a, b, _) => primitive(cb.memoize(a.asInt.value + b.asInt.value))
     }
     registerSCode1("testCodeUnification2", tv("x"), tv("x"), null) { case (_, cb, rt, a, _) => a }
   }

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -149,7 +149,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
         val ec = key.loadCompKey(cb, koff)
         cb.ifx(ec.m,
           cb += sab.addMissing(),
-          cb += sab.add(ec.pv.asInt64.longCode(cb)))
+          cb += sab.add(ec.pv.asInt64.value))
       }
       cb += (returnArray := Code.newArray[java.lang.Long](sab.size))
       cb += (idx := 0)
@@ -184,7 +184,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
         val ev = cb.memoize(key.loadCompKey(cb, off), "ev")
         cb += ob.writeBoolean(ev.m)
         cb.ifx(!ev.m, {
-          cb += ob.writeLong(ev.pv.asInt64.longCode(cb))
+          cb += ob.writeLong(ev.pv.asInt64.value)
         })
       }
       ob2.flush()


### PR DESCRIPTION
Stacked on #11241

Replace `SInt32Value.intCode(CodeBuilder)` etc. with `value` field