### PR TITLE
[auth] Add rest endpoint and cli for create / delete users

### DIFF
--- a/auth/auth/exceptions.py
+++ b/auth/auth/exceptions.py
@@ -1,0 +1,65 @@
+from aiohttp import web
+
+
+class AuthUserError(Exception):
+    def __init__(self, message, severity):
+        super().__init__(message)
+        self.message = message
+        self.ui_error_type = severity
+
+    def http_response(self):
+        return web.HTTPBadRequest(reason=self.message)
+
+
+class EmptyLoginID(AuthUserError):
+    def __init__(self, username):
+        super().__init__(f"Login id for user '{username}' must be a non-empty string.", 'error')
+
+
+class DuplicateLoginID(AuthUserError):
+    def __init__(self, username, login_id):
+        super().__init__(f"Login id '{login_id}' already exists for user '{username}'.", 'error')
+
+
+class DuplicateUsername(AuthUserError):
+    def __init__(self, username, login_id):
+        super().__init__(f"Username '{username}' already exists with login id '{login_id}'.", 'error')
+
+
+class InvalidUsername(AuthUserError):
+    def __init__(self, username):
+        super().__init__(f"Invalid username '{username}'. Must be a non-empty alphanumeric string.", 'error')
+
+
+class InvalidType(AuthUserError):
+    def __init__(self, field_name, input, expected_type):
+        super().__init__(f"Expected '{field_name}' is of type {expected_type}. Found type {type(input)}", 'error')
+
+
+class MultipleUserTypes(AuthUserError):
+    def __init__(self, username):
+        super().__init__(f"User '{username}' cannot be both a developer and a service account.", 'error')
+
+
+class MultipleExistingUsers(AuthUserError):
+    def __init__(self, username, login_id):
+        super().__init__(
+            f"Multiple users with user name '{username}' and login id '{login_id}' appear in the database.",
+            'error',
+        )
+
+    def http_response(self):
+        return web.HTTPInternalServerError(reason=self.message)
+
+
+class UnknownUser(AuthUserError):
+    def __init__(self, username):
+        super().__init__(f"Unknown user '{username}'.", 'error')
+
+    def http_response(self):
+        return web.HTTPNotFound(reason=self.message)
+
+
+class PreviouslyDeletedUser(AuthUserError):
+    def __init__(self, username):
+        super().__init__(f"User '{username}' has already been deleted.", 'error')

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -10,13 +10,14 @@ from .auth import (
 )
 from .auth_utils import create_session, insert_user
 from .csrf import check_csrf_token, new_csrf_token
-from .database import Database, create_database_pool, transaction
+from .database import Database, Transaction, create_database_pool, transaction
 from .metrics import monitor_endpoints_middleware
 from .session import setup_aiohttp_session
 
 __all__ = [
     'create_database_pool',
     'Database',
+    'Transaction',
     'setup_aiohttp_session',
     'userdata_from_web_request',
     'userdata_from_rest_request',

--- a/hail/python/hailtop/auth/__init__.py
+++ b/hail/python/hailtop/auth/__init__.py
@@ -3,11 +3,15 @@ from .tokens import (get_tokens, session_id_encode_to_str,
                      session_id_decode_from_str)
 from .auth import (
     async_get_userinfo, get_userinfo, namespace_auth_headers,
-    service_auth_headers, copy_paste_login, async_copy_paste_login)
+    service_auth_headers, copy_paste_login, async_copy_paste_login,
+    async_create_user, async_delete_user, async_get_user)
 
 __all__ = [
     'get_tokens',
     'async_get_userinfo',
+    'async_create_user',
+    'async_delete_user',
+    'async_get_user',
     'get_userinfo',
     'namespace_auth_headers',
     'service_auth_headers',

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
 import os
 import aiohttp
 from hailtop.config import get_deploy_config, DeployConfig
@@ -6,6 +6,43 @@ from hailtop.utils import async_to_blocking, request_retry_transient_errors
 from hailtop import httpx
 
 from .tokens import get_tokens
+
+
+def namespace_auth_headers(deploy_config: DeployConfig,
+                           ns: str,
+                           authorize_target: bool = True,
+                           *,
+                           token_file: Optional[str] = None
+                           ) -> Dict[str, str]:
+    headers = {}
+    if authorize_target:
+        headers['Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error(ns)}'
+    if deploy_config.location() == 'external' and ns != 'default':
+        headers['X-Hail-Internal-Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error("default")}'
+    return headers
+
+
+def service_auth_headers(deploy_config: DeployConfig,
+                         service: str,
+                         authorize_target: bool = True,
+                         *,
+                         token_file: Optional[str] = None
+                         ) -> Dict[str, str]:
+    ns = deploy_config.service_ns(service)
+    return namespace_auth_headers(deploy_config, ns, authorize_target, token_file=token_file)
+
+
+def deploy_config_and_headers_from_namespace(namespace: Optional[str] = None, *, authorize_target: bool = True) -> Tuple[DeployConfig, Dict[str, str], str]:
+    deploy_config = get_deploy_config()
+
+    if namespace is not None:
+        deploy_config = deploy_config.with_default_namespace(namespace)
+    else:
+        namespace = deploy_config.default_namespace()
+
+    headers = namespace_auth_headers(deploy_config, namespace, authorize_target=authorize_target)
+
+    return (deploy_config, headers, namespace)
 
 
 async def async_get_userinfo(*,
@@ -44,44 +81,12 @@ def get_userinfo(deploy_config=None, session_id=None, client_session=None):
         client_session=client_session))
 
 
-def namespace_auth_headers(deploy_config: DeployConfig,
-                           ns: str,
-                           authorize_target: bool = True,
-                           *,
-                           token_file: Optional[str] = None
-                           ) -> Dict[str, str]:
-    headers = {}
-    if authorize_target:
-        headers['Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error(ns)}'
-    if deploy_config.location() == 'external' and ns != 'default':
-        headers['X-Hail-Internal-Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error("default")}'
-    return headers
-
-
-def service_auth_headers(deploy_config: DeployConfig,
-                         service: str,
-                         authorize_target: bool = True,
-                         *,
-                         token_file: Optional[str] = None
-                         ) -> Dict[str, str]:
-    ns = deploy_config.service_ns(service)
-    return namespace_auth_headers(deploy_config, ns, authorize_target, token_file=token_file)
-
-
-def copy_paste_login(copy_paste_token, namespace=None):
+def copy_paste_login(copy_paste_token: str, namespace: Optional[str] = None):
     return async_to_blocking(async_copy_paste_login(copy_paste_token, namespace))
 
 
-async def async_copy_paste_login(copy_paste_token, namespace=None):
-    deploy_config = get_deploy_config()
-
-    if namespace is not None:
-        deploy_config = deploy_config.with_default_namespace(namespace)
-    else:
-        namespace = deploy_config.default_namespace()
-
-    headers = namespace_auth_headers(deploy_config, namespace, authorize_target=False)
-
+async def async_copy_paste_login(copy_paste_token: str, namespace: Optional[str] = None):
+    deploy_config, headers, namespace = deploy_config_and_headers_from_namespace(namespace, authorize_target=False)
     async with aiohttp.ClientSession(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=5),
@@ -101,3 +106,57 @@ async def async_copy_paste_login(copy_paste_token, namespace=None):
     tokens.write()
 
     return namespace, username
+
+
+def get_user(username: str, namespace: Optional[str] = None) -> dict:
+    return async_to_blocking(async_get_user(username, namespace))
+
+
+async def async_get_user(username: str, namespace: Optional[str] = None) -> dict:
+    deploy_config, headers, _ = deploy_config_and_headers_from_namespace(namespace)
+
+    async with aiohttp.ClientSession(
+            raise_for_status=True,
+            timeout=aiohttp.ClientTimeout(total=30),
+            headers=headers) as session:
+        resp = await request_retry_transient_errors(
+            session, 'GET', deploy_config.url('auth', f'/api/v1alpha/users/{username}')
+        )
+        return await resp.json()
+
+
+def create_user(username: str, login_id: str, is_developer: bool, is_service_account: bool, namespace: Optional[str] = None):
+    return async_to_blocking(async_create_user(username, login_id, is_developer, is_service_account, namespace=namespace))
+
+
+async def async_create_user(username: str, login_id: str, is_developer: bool, is_service_account: bool, namespace: Optional[str] = None):
+    deploy_config, headers, _ = deploy_config_and_headers_from_namespace(namespace)
+
+    body = {
+        'login_id': login_id,
+        'is_developer': is_developer,
+        'is_service_account': is_service_account,
+    }
+
+    async with aiohttp.ClientSession(
+            raise_for_status=True,
+            timeout=aiohttp.ClientTimeout(total=30),
+            headers=headers) as session:
+        await request_retry_transient_errors(
+            session, 'POST', deploy_config.url('auth', f'/api/v1alpha/users/{username}/create'), json=body
+        )
+
+
+def delete_user(username: str, namespace: Optional[str] = None):
+    return async_to_blocking(async_delete_user(username, namespace=namespace))
+
+
+async def async_delete_user(username: str, namespace: Optional[str] = None):
+    deploy_config, headers, _ = deploy_config_and_headers_from_namespace(namespace)
+    async with aiohttp.ClientSession(
+            raise_for_status=True,
+            timeout=aiohttp.ClientTimeout(total=300),
+            headers=headers) as session:
+        await request_retry_transient_errors(
+            session, 'DELETE', deploy_config.url('auth', f'/api/v1alpha/users/{username}')
+        )

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -6,6 +6,8 @@ from . import logout
 from . import auth_list
 from . import copy_paste_login
 from . import user
+from . import create_user
+from . import delete_user
 
 
 def parser():
@@ -33,7 +35,17 @@ def parser():
     user_parser = subparsers.add_parser(
         'user',
         help='Get Hail user information.',
-        description='Get Hail user information'
+        description='Get Hail user information.'
+    )
+    create_user_parser = subparsers.add_parser(
+        'create-user',
+        help='Create a new Hail user.',
+        description='Create a new Hail user.'
+    )
+    delete_user_parser = subparsers.add_parser(
+        'delete-user',
+        help='Delete a Hail user.',
+        description='Delete a Hail user.'
     )
 
     login_parser.set_defaults(module='login')
@@ -51,6 +63,12 @@ def parser():
     user_parser.set_defaults(module='user')
     user.init_parser(user_parser)
 
+    create_user_parser.set_defaults(module='create-user')
+    create_user.init_parser(create_user_parser)
+
+    delete_user_parser.set_defaults(module='delete-user')
+    delete_user.init_parser(delete_user_parser)
+
     return main_parser
 
 
@@ -64,6 +82,8 @@ def main(args):
         'logout': logout,
         'list': auth_list,
         'user': user,
+        'create-user': create_user,
+        'delete-user': delete_user,
     }
 
     args, pass_through_args = parser().parse_known_args(args=args)

--- a/hail/python/hailtop/hailctl/auth/create_user.py
+++ b/hail/python/hailtop/hailctl/auth/create_user.py
@@ -1,0 +1,46 @@
+import asyncio
+
+from hailtop.utils import sleep_and_backoff
+from hailtop.auth import async_create_user, async_get_user
+
+
+def init_parser(parser):
+    parser.add_argument("username", type=str,
+                        help="User name to create.")
+    parser.add_argument("login_id", type=str,
+                        help="Login ID to be used with OAuth. This is the object ID in Azure and the email address in GCP.")
+    parser.add_argument("--developer", default=False, action='store_true',
+                        help="User should be a developer.")
+    parser.add_argument("--service-account", default=False, action='store_true',
+                        help="User should be a service account.")
+    parser.add_argument("--namespace", "-n", type=str,
+                        help="Specify namespace for auth server.  (default: from deploy configuration)")
+    parser.add_argument("--wait", default=False, action='store_true',
+                        help="Wait for the creation of the user to finish")
+
+
+async def async_main(args):
+    try:
+        await async_create_user(args.username, args.login_id, args.developer, args.service_account, args.namespace)
+
+        if not args.wait:
+            return
+
+        async def _poll():
+            delay = 5
+            while True:
+                user = await async_get_user(args.username, args.namespace)
+                if user['state'] == 'active':
+                    print(f"Created user '{args.username}'")
+                    return
+                assert user['state'] == 'creating'
+                delay = await sleep_and_backoff(delay)
+
+        await _poll()
+    except Exception as e:
+        raise Exception(f"Error while creating user '{args.username}'") from e
+
+
+def main(args, pass_through_args):  # pylint: disable=unused-argument
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_main(args))

--- a/hail/python/hailtop/hailctl/auth/delete_user.py
+++ b/hail/python/hailtop/hailctl/auth/delete_user.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from hailtop.utils import sleep_and_backoff
+from hailtop.auth import async_delete_user, async_get_user
+
+
+def init_parser(parser):
+    parser.add_argument("username", type=str,
+                        help="User name to delete.")
+    parser.add_argument("--namespace", "-n", type=str,
+                        help="Specify namespace for auth server.  (default: from deploy configuration)")
+    parser.add_argument("--wait", default=False, action='store_true',
+                        help="Wait for the creation of the user to finish")
+
+
+async def async_main(args):
+    try:
+        await async_delete_user(args.username, args.namespace)
+
+        if not args.wait:
+            return
+
+        async def _poll():
+            delay = 5
+            while True:
+                user = await async_get_user(args.username, args.namespace)
+                if user['state'] == 'deleted':
+                    print(f"Deleted user '{args.username}'")
+                    return
+                assert user['state'] == 'deleting'
+                delay = await sleep_and_backoff(delay)
+
+        await _poll()
+    except Exception as e:
+        raise Exception(f"Error while deleting user '{args.username}'") from e
+
+
+def main(args, pass_through_args):  # pylint: disable=unused-argument
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_main(args))


### PR DESCRIPTION
I wanted to get this feature done quickly for Michael. But I do think we should think about having consistency in route names across services. Like when do we have `/delete` in the route name versus a 'DELETE' request or both?

Another question is whether to add the polling / waiting for the user to be created and if so, where should the polling go? I put it in the auth service for now rather than the CLI because I don't think we expose the state of the user in our API.

I tested this as much as I could in my namespace.

The most important thing is to make sure the decorators are correct and only developers can create / delete users. I want to add auth tests that make sure the routes are protected, but that's more work than I wanted to do in this PR. 