### PR TITLE
[batch] Simplify iptables rules for worker network namespaces

### DIFF
--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -202,6 +202,8 @@ iptables --append FORWARD --destination $IP_ADDRESS --jump ACCEPT
 # Forbid outgoing requests to cluster-internal IP addresses
 INTERNET_INTERFACE=eth0
 iptables --append FORWARD --out-interface $INTERNET_INTERFACE ! --destination 10.128.0.0/16 --jump ACCEPT
+# Allow incoming packets to job network namespaces only from the internet
+iptables --append FORWARD --in-interface $INTERNET_INTERFACE --destination 172.20.0.0/15 --jump ACCEPT
 
 cat >> /etc/hosts <<EOF
 $INTERNAL_GATEWAY_IP batch-driver.hail
@@ -237,7 +239,6 @@ docker run \
 -e MAX_IDLE_TIME_MSECS=$MAX_IDLE_TIME_MSECS \
 -e BATCH_WORKER_IMAGE=$BATCH_WORKER_IMAGE \
 -e BATCH_WORKER_IMAGE_ID=$BATCH_WORKER_IMAGE_ID \
--e INTERNET_INTERFACE=$INTERNET_INTERFACE \
 -e UNRESERVED_WORKER_DATA_DISK_SIZE_GB=$UNRESERVED_WORKER_DATA_DISK_SIZE_GB \
 -e INTERNAL_GATEWAY_IP=$INTERNAL_GATEWAY_IP \
 -v /var/run/docker.sock:/var/run/docker.sock \

--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -174,6 +174,7 @@ CORES=$(nproc)
 NAMESPACE=$(jq -r '.namespace' userdata)
 ACTIVATION_TOKEN=$(jq -r '.activation_token' userdata)
 IP_ADDRESS=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2021-02-01&format=text")
+EXTERNAL_IP_ADDRESS=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
 
 BATCH_LOGS_STORAGE_URI=$(jq -r '.batch_logs_storage_uri' userdata)
 INSTANCE_ID=$(jq -r '.instance_id' userdata)
@@ -228,6 +229,7 @@ docker run \
 -e NAMESPACE=$NAMESPACE \
 -e ACTIVATION_TOKEN=$ACTIVATION_TOKEN \
 -e IP_ADDRESS=$IP_ADDRESS \
+-e EXTERNAL_IP_ADDRESS=$EXTERNAL_IP_ADDRESS \
 -e BATCH_LOGS_STORAGE_URI=$BATCH_LOGS_STORAGE_URI \
 -e INSTANCE_ID=$INSTANCE_ID \
 -e SUBSCRIPTION_ID=$SUBSCRIPTION_ID \

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -166,6 +166,7 @@ CORES=$(nproc)
 NAMESPACE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/namespace")
 ACTIVATION_TOKEN=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/activation_token")
 IP_ADDRESS=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip")
+EXTERNAL_IP_ADDRESS=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip")
 PROJECT=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/project/project-id")
 
 BATCH_LOGS_STORAGE_URI=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/batch_logs_storage_uri")
@@ -277,6 +278,7 @@ docker run \
 -e NAMESPACE=$NAMESPACE \
 -e ACTIVATION_TOKEN=$ACTIVATION_TOKEN \
 -e IP_ADDRESS=$IP_ADDRESS \
+-e EXTERNAL_IP_ADDRESS=$EXTERNAL_IP_ADDRESS \
 -e BATCH_LOGS_STORAGE_URI=$BATCH_LOGS_STORAGE_URI \
 -e INSTANCE_ID=$INSTANCE_ID \
 -e PROJECT=$PROJECT \

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -196,6 +196,8 @@ iptables --append FORWARD --destination $IP_ADDRESS --jump ACCEPT
 # Forbid outgoing requests to cluster-internal IP addresses
 INTERNET_INTERFACE=$(ip link list | grep ens | awk -F": " '{{ print $2 }}')
 iptables --append FORWARD --out-interface $INTERNET_INTERFACE ! --destination 10.128.0.0/16 --jump ACCEPT
+# Allow incoming packets to job network namespaces only from the internet
+iptables --append FORWARD --in-interface $INTERNET_INTERFACE --destination 172.20.0.0/15 --jump ACCEPT
 
 
 # Setup fluentd
@@ -285,7 +287,6 @@ docker run \
 -e MAX_IDLE_TIME_MSECS=$MAX_IDLE_TIME_MSECS \
 -e BATCH_WORKER_IMAGE=$BATCH_WORKER_IMAGE \
 -e BATCH_WORKER_IMAGE_ID=$BATCH_WORKER_IMAGE_ID \
--e INTERNET_INTERFACE=$INTERNET_INTERFACE \
 -e UNRESERVED_WORKER_DATA_DISK_SIZE_GB=$UNRESERVED_WORKER_DATA_DISK_SIZE_GB \
 -e INTERNAL_GATEWAY_IP=$INTERNAL_GATEWAY_IP \
 -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
# Commit 1

This rule that we add per job network namespace

> iptables -w {IPTABLES_WAIT_TIMEOUT_SECS} --append FORWARD --out-interface {self.veth_host} --in-interface {self.internet_interface} --jump ACCEPT

is functionally equivalent to this single line 

> iptables --append FORWARD --in-interface $INTERNET_INTERFACE --destination 172.20.0.0/15 --jump ACCEPT

so better have 1 rule than O(slots) rules.

It would be nice to eliminate the one remaining rule that we append per-network namespace. Without that rule [this test](https://github.com/hail-is/hail/blob/9da1c759efe9fcbbd9ad02ee7c8bf725974270e9/batch/test/test_dag.py#L117) will fail because the iptables rules won't allow `curl $HAIL_BATCH_WORKER_IP:$HAIL_BATCH_WORKER_PORT` from inside the job container. The request leaves the job's network namespace to the host (whose IP it is), and then returns right back to the network namespace. I have this strict rule such that jobs cannot communicate with each other, but so far don't know how in iptables to specify that the sending/receiving interfaces or IPs must match without listing them explicitly.

That being said, this is also a side-effect of `HAIL_BATCH_WORKER_IP` being an in-cluster ip address `10.128.x.x` and thus known to the host. I believe if we made this the public IP (forcing the request to leave through the ethernet device I think) the test could work without this rule. Jobs can still communicate with themselves within their own network namespace (localhost still works fine), and we strictly prohibit workers talking to each other, so I don't see any reason why we shouldn't go the public ip approach.


# Commit 2
This gives the external ip address to a job container that opens a port instead of using the private one. This just seems to make more sense to me and also allows us to delete that iptables rule. This ensures that iptables rules don't grow linearly with number of jobs (they'll be 1:1 with jobs that open ports but that makes more sense).