### PR TITLE
[batch] Dont block on all netns creation on startup

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2256,7 +2256,8 @@ class Worker:
         await site.start()
 
         try:
-            await asyncio.wait_for(self.activate(), MAX_IDLE_TIME_MSECS / 1000)
+            startup_tasks = asyncio.gather(self.activate(), network_allocator.reserve())
+            await asyncio.wait_for(startup_tasks, MAX_IDLE_TIME_MSECS / 1000)
         except asyncio.TimeoutError:
             log.exception(f'could not activate after trying for {MAX_IDLE_TIME_MSECS} ms, exiting')
             return

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2465,7 +2465,6 @@ async def async_main():
     network_allocator = NetworkAllocator()
 
     worker = Worker(httpx.client_session())
-    worker.task_manager.ensure_future(network_allocator.reserve())
     try:
         await worker.run()
     finally:

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2462,9 +2462,9 @@ async def async_main():
 
     port_allocator = PortAllocator()
     network_allocator = NetworkAllocator()
-    await network_allocator.reserve()
 
     worker = Worker(httpx.client_session())
+    worker.task_manager.ensure_future(network_allocator.reserve())
     try:
         await worker.run()
     finally:


### PR DESCRIPTION
`NetworkAllocator.reserve` creates a bunch of network namespaces on startup and adds them to an `asyncio.Queue`. There's no reason to wait for all of them before accepting jobs.