### PR TITLE
[query] upgrade pandas to >=1.3.0,<1.4.0

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -19,7 +19,7 @@ janus>=0.6,<0.7
 nest_asyncio==1.5.4
 numpy<2
 orjson==3.6.4
-pandas>=1.1.0,<1.1.5
+pandas>=1.3.0,<1.4.0
 parsimonious<0.9
 PyJWT
 pyspark>=3.1.1,<3.2.0


### PR DESCRIPTION
Pandas 1.4 drops support for Python versions before 3.8.

As a user of python 3.10, having no pre-built pandas or pandas that did
not compile due to changes in the python c-api was very painful.