### PR TITLE
Test missingness comparisons for distinctly keyed

### DIFF
--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -773,7 +773,9 @@ class TableIRSuite extends HailSuite {
       "idx" -> idxRef,
       "const" -> 5,
       "half" ->  idxRef.floorDiv(2),
-      "oneRepeat" -> If(idxRef ceq I32(10), I32(9), idxRef)
+      "oneRepeat" -> If(idxRef ceq I32(10), I32(9), idxRef),
+      "oneMissing" -> If(idxRef ceq I32(4), NA(TInt32), idxRef),
+      "twoMissing" -> If((idxRef ceq 10) || (idxRef ceq 2), NA(TInt32), idxRef),
     )))
     val keyedByConst = TableKeyBy(at, IndexedSeq("const"))
     val pathConst = ctx.createTmpPath("test-table-write-distinctness", "ht")
@@ -798,6 +800,18 @@ class TableIRSuite extends HailSuite {
     Interpret[Unit](ctx, TableWrite(keyedByOneRepeat, TableNativeWriter(pathOneRepeat)))
     val readOneRepeat = TableIR.read(fs, pathOneRepeat)
     assert(!readOneRepeat.isDistinctlyKeyed)
+
+    val keyedByOneMissing = TableKeyBy(at, IndexedSeq("oneMissing"))
+    val pathOneMissing = ctx.createTmpPath("test-table-write-distinctness", "ht")
+    Interpret[Unit](ctx, TableWrite(keyedByOneMissing, TableNativeWriter(pathOneMissing)))
+    val readOneMissing = TableIR.read(fs, pathOneMissing)
+    assert(readOneMissing.isDistinctlyKeyed)
+
+    val keyedByTwoMissing = TableKeyBy(at, IndexedSeq("twoMissing"))
+    val pathTwoMissing = ctx.createTmpPath("test-table-write-distinctness", "ht")
+    Interpret[Unit](ctx, TableWrite(keyedByTwoMissing, TableNativeWriter(pathTwoMissing)))
+    val readTwoMissing = TableIR.read(fs, pathTwoMissing)
+    assert(!readTwoMissing.isDistinctlyKeyed)
   }
 
   @Test def testPartitionCountsWithDropRows() {

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -775,7 +775,7 @@ class TableIRSuite extends HailSuite {
       "half" ->  idxRef.floorDiv(2),
       "oneRepeat" -> If(idxRef ceq I32(10), I32(9), idxRef),
       "oneMissing" -> If(idxRef ceq I32(4), NA(TInt32), idxRef),
-      "twoMissing" -> If((idxRef ceq 10) || (idxRef ceq 2), NA(TInt32), idxRef),
+      "twoMissing" -> If((idxRef ceq 10) || (idxRef ceq 2), NA(TInt32), idxRef)
     )))
     val keyedByConst = TableKeyBy(at, IndexedSeq("const"))
     val pathConst = ctx.createTmpPath("test-table-write-distinctness", "ht")


### PR DESCRIPTION
I had a brief worry that the key distinctness analysis didn't handle missing keys correctly, so I added some tests. It does seem to work so that's good. 