### PR TITLE
[hailctl] Use a unique temp dir for starting browser in connect

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/connect.py
+++ b/hail/python/hailtop/hailctl/dataproc/connect.py
@@ -4,6 +4,8 @@ import shutil
 import subprocess
 import tempfile
 
+from hailtop.utils import secret_alnum_string
+
 from . import gcloud
 
 
@@ -93,12 +95,13 @@ async def main(args, pass_through_args):  # pylint: disable=unused-argument
         chrome = os.environ.get('HAILCTL_CHROME') or get_chrome_path()
 
         # open Chrome with SOCKS proxy configuration
-        with open(os.devnull, 'w') as f:
-            subprocess.Popen([
-                chrome,
-                'http://localhost:{}'.format(connect_port_and_path),
-                '--proxy-server=socks5://localhost:{}'.format(args.port),
-                '--host-resolver-rules=MAP * 0.0.0.0 , EXCLUDE localhost',
-                '--proxy-bypass-list=<-loopback>',  # https://chromium.googlesource.com/chromium/src/+/da790f920bbc169a6805a4fb83b4c2ab09532d91
-                '--user-data-dir={}'.format(tempfile.gettempdir())
-            ], stdout=f, stderr=f)
+        subprocess.Popen([
+            chrome,
+            'http://localhost:{}'.format(connect_port_and_path),
+            '--proxy-server=socks5://localhost:{}'.format(args.port),
+            '--host-resolver-rules=MAP * 0.0.0.0 , EXCLUDE localhost',
+            '--proxy-bypass-list=<-loopback>',  # https://chromium.googlesource.com/chromium/src/+/da790f920bbc169a6805a4fb83b4c2ab09532d91
+            '--user-data-dir={}'.format(
+                os.path.join(tempfile.gettempdir(),
+                             'hailctl-dataproc-connect-' + secret_alnum_string(6)))
+        ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
gettempdir returns the system/Python temporary directory. If multiple
chromium processes are launched with the same user data directory, the
the process is reused. Because of this, new proxy settings won't be
picked up if the directory is reused. So we use a random identifier for
the chromium data directory.

Co-Authored-By: Dan King <daniel.zidan.king@gmail.com>