### PR TITLE
[query] New Shuffler with Arbitrary Sort Order

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -67,7 +67,7 @@ object Children {
       Array(start, stop, step)
     case SeqSample(totalRange, numToSample, _) =>
       Array(totalRange, numToSample)
-    case StreamDistribute(child, pivots, path, _) =>
+    case StreamDistribute(child, pivots, path, _, _) =>
       Array(child, pivots, path)
     case ArrayZeros(length) =>
       Array(length)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -90,8 +90,8 @@ object Copy {
       case SeqSample(_, _, requiresMemoryManagementPerElement) =>
         assert(newChildren.length == 2)
         SeqSample(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], requiresMemoryManagementPerElement)
-      case StreamDistribute(_, _, _, spec) =>
-        StreamDistribute(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR], spec)
+      case StreamDistribute(_, _, _, op, spec) =>
+        StreamDistribute(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR], op, spec)
       case ArrayZeros(_) =>
         assert(newChildren.length == 1)
         ArrayZeros(newChildren(0).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1285,11 +1285,11 @@ class Emit[C](
           }
         }
 
-      case StreamDistribute(child, pivots, path, spec) =>
+      case StreamDistribute(child, pivots, path, comparisonOp, spec) =>
         emitI(path).flatMap(cb) { pathValue =>
           emitI(pivots).flatMap(cb) { case pivotsVal: SIndexableValue =>
             emitStream(child, cb, region).map(cb) { case childStream: SStreamValue =>
-              EmitStreamDistribute.emit(cb, region, pivotsVal, childStream, pathValue, spec)
+              EmitStreamDistribute.emit(cb, region, pivotsVal, childStream, pathValue, comparisonOp, spec)
             }
           }
         }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -29,10 +29,6 @@ object EmitStreamDistribute {
       val rhs = relt.map(cb)(_.asBaseStruct.subset(keyFieldNames: _*))
       val codeOrdering = comparisonOp.codeOrdering(cb.emb.ecb, lhs.st.asInstanceOf[SBaseStruct], rhs.st.asInstanceOf[SBaseStruct])
       codeOrdering(cb, lhs, rhs).asInstanceOf[Value[Int]]
-//      val oldCodeOrdering = StructOrdering.make(lhs.st.asInstanceOf[SBaseStruct], rhs.st.asInstanceOf[SBaseStruct],
-//        cb.emb.ecb, missingFieldsEqual = true)
-//
-//      oldCodeOrdering.compare(cb, lhs, rhs, missingEqual = true)
     }
 
     def equal(cb: EmitCodeBuilder, lelt: EmitValue, relt: EmitValue): Code[Boolean] = compare(cb, lelt, relt) ceq 0

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -15,7 +15,7 @@ import is.hail.utils._
 
 object EmitStreamDistribute {
 
-  def emit(cb: EmitCodeBuilder, region: Value[Region], requestedSplittersAndEndsVal: SIndexableValue, childStream: SStreamValue, pathVal: SValue, spec: AbstractTypedCodecSpec): SIndexableValue = {
+  def emit(cb: EmitCodeBuilder, region: Value[Region], requestedSplittersAndEndsVal: SIndexableValue, childStream: SStreamValue, pathVal: SValue, comparisonOp: ComparisonOp[_], spec: AbstractTypedCodecSpec): SIndexableValue = {
     val mb = cb.emb
     val pivotsPType = requestedSplittersAndEndsVal.st.storageType().asInstanceOf[PCanonicalArray]
     val requestedSplittersVal = requestedSplittersAndEndsVal.sliceArray(cb, region, pivotsPType, 1, requestedSplittersAndEndsVal.loadLength() - 1)
@@ -27,9 +27,12 @@ object EmitStreamDistribute {
     def compare(cb: EmitCodeBuilder, lelt: EmitValue, relt: EmitValue): Code[Int] = {
       val lhs = lelt.map(cb)(_.asBaseStruct.subset(keyFieldNames: _*))
       val rhs = relt.map(cb)(_.asBaseStruct.subset(keyFieldNames: _*))
-      StructOrdering.make(lhs.st.asInstanceOf[SBaseStruct], rhs.st.asInstanceOf[SBaseStruct],
-        cb.emb.ecb, missingFieldsEqual = true)
-        .compare(cb, lhs, rhs, missingEqual = true)
+      val codeOrdering = comparisonOp.codeOrdering(cb.emb.ecb, lhs.st.asInstanceOf[SBaseStruct], rhs.st.asInstanceOf[SBaseStruct])
+      codeOrdering(cb, lhs, rhs).asInstanceOf[Value[Int]]
+//      val oldCodeOrdering = StructOrdering.make(lhs.st.asInstanceOf[SBaseStruct], rhs.st.asInstanceOf[SBaseStruct],
+//        cb.emb.ecb, missingFieldsEqual = true)
+//
+//      oldCodeOrdering.compare(cb, lhs, rhs, missingEqual = true)
     }
 
     def equal(cb: EmitCodeBuilder, lelt: EmitValue, relt: EmitValue): Code[Boolean] = compare(cb, lelt, relt) ceq 0

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -302,7 +302,7 @@ final case class SeqSample(totalRange: IR, numToSample: IR, requiresMemoryManage
 
 // Take the child stream and sort each element into buckets based on the provided pivots. The first and last elements of
 // pivots are the endpoints of the first and last interval respectively, should not be contained in the dataset.
-final case class StreamDistribute(child: IR, pivots: IR, path: IR, spec: AbstractTypedCodecSpec) extends IR
+final case class StreamDistribute(child: IR, pivots: IR, path: IR, comparisonOp: ComparisonOp[_],spec: AbstractTypedCodecSpec) extends IR
 
 object ArrayZipBehavior extends Enumeration {
   type ArrayZipBehavior = Value

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -491,12 +491,16 @@ final case class ApplyAggOp(initOpArgs: IndexedSeq[IR], seqOpArgs: IndexedSeq[IR
 
 object AggFold {
 
-  def min(element: IR, keyType: TStruct): IR = {
-    minAndMaxHelper(element, keyType, LT(keyType))
+  def min(element: IR, sortFields: IndexedSeq[SortField]): IR = {
+    val elementType = element.typ.asInstanceOf[TStruct]
+    val keyType = elementType.select(sortFields.map(_.field))._1
+    minAndMaxHelper(element, keyType, StructLT(keyType, sortFields))
   }
 
-  def max(element: IR, keyType: TStruct): IR = {
-    minAndMaxHelper(element, keyType, GT(keyType))
+  def max(element: IR, sortFields: IndexedSeq[SortField]): IR = {
+    val elementType = element.typ.asInstanceOf[TStruct]
+    val keyType = elementType.select(sortFields.map(_.field))._1
+    minAndMaxHelper(element, keyType, StructGT(keyType, sortFields))
   }
 
   def all(element: IR): IR = {
@@ -507,7 +511,7 @@ object AggFold {
 
   private def minAndMaxHelper(element: IR, keyType: TStruct, comp: ComparisonOp[Boolean]): IR = {
     val keyFields = keyType.fields.map(_.name)
-    // Folding for Min
+
     val minAndMaxZero = NA(keyType)
     val aggFoldMinAccumName1 = genUID()
     val aggFoldMinAccumName2 = genUID()

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -139,7 +139,7 @@ object InferType {
         assert(body.typ == zero.typ)
         zero.typ
       case StreamFold2(_, _, _, _, result) => result.typ
-      case StreamDistribute(child, pivots, pathPrefix, _) =>
+      case StreamDistribute(child, pivots, pathPrefix, _, _) =>
         val keyType = pivots.typ.asInstanceOf[TContainer].elementType
         TArray(TStruct(("interval", TInterval(keyType)), ("fileName", TString), ("numElements", TInt32)))
       case StreamScan(a, zero, accumName, valueName, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -162,7 +162,7 @@ object TypeCheck {
       case SeqSample(totalRange, numToSample, _) =>
         assert(totalRange.typ == TInt32)
         assert(numToSample.typ == TInt32)
-      case StreamDistribute(child, pivots, path, _) =>
+      case StreamDistribute(child, pivots, path, _, _) =>
         assert(path.typ == TString)
         assert(child.typ.isInstanceOf[TStream])
         assert(pivots.typ.isInstanceOf[TArray])

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -283,7 +283,6 @@ object LowerDistributedSort {
           val newSegmentIndices = priorIndices :+ newIndex
           SegmentResult(newSegmentIndices, interval, chunks)
         }
-        print("anchor")
 
         // Now I need to figure out how many partitions to allocate to each segment.
         dataPerSegment.partition { sr =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -247,7 +247,7 @@ object LowerDistributedSort {
           val partitionStream = flatMapIR(ToStream(filenames)) { fileName =>
             ReadPartition(fileName, spec._vType, reader)
           }
-          MakeTuple.ordered(IndexedSeq(segmentIdx, StreamDistribute(partitionStream, ArrayRef(pivotsWithEndpointsGroupedBySegmentIdx, indexIntoPivotsArray), path, ???, spec)))
+          MakeTuple.ordered(IndexedSeq(segmentIdx, StreamDistribute(partitionStream, ArrayRef(pivotsWithEndpointsGroupedBySegmentIdx, indexIntoPivotsArray), path, StructCompare(newKType, newKType, sortFields.toArray), spec)))
         }
 
         val (Some(PTypeReferenceSingleCodeType(resultPType)), f) = ctx.timer.time("LowerDistributedSort.distributedSort.compile")(Compile[AsmFunction1RegionLong](ctx,

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -247,7 +247,7 @@ object LowerDistributedSort {
           val partitionStream = flatMapIR(ToStream(filenames)) { fileName =>
             ReadPartition(fileName, spec._vType, reader)
           }
-          MakeTuple.ordered(IndexedSeq(segmentIdx, StreamDistribute(partitionStream, ArrayRef(pivotsWithEndpointsGroupedBySegmentIdx, indexIntoPivotsArray), path, spec)))
+          MakeTuple.ordered(IndexedSeq(segmentIdx, StreamDistribute(partitionStream, ArrayRef(pivotsWithEndpointsGroupedBySegmentIdx, indexIntoPivotsArray), path, ???, spec)))
         }
 
         val (Some(PTypeReferenceSingleCodeType(resultPType)), f) = ctx.timer.time("LowerDistributedSort.distributedSort.compile")(Compile[AsmFunction1RegionLong](ctx,
@@ -283,6 +283,7 @@ object LowerDistributedSort {
           val newSegmentIndices = priorIndices :+ newIndex
           SegmentResult(newSegmentIndices, interval, chunks)
         }
+        print("anchor")
 
         // Now I need to figure out how many partitions to allocate to each segment.
         dataPerSegment.partition { sr =>

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
@@ -44,6 +44,8 @@ object CodeOrdering {
 
   final case class StructGt(missingEqual: Boolean = true) extends BooleanOp
 
+  final case class StructCompare(missingEqual: Boolean = true) extends BooleanOp
+
   type F[R] = (EmitCodeBuilder, EmitValue, EmitValue) => Value[R]
 
   def makeOrdering(t1: SType, t2: SType, ecb: EmitClassBuilder[_]): CodeOrdering = {

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
@@ -38,6 +38,12 @@ object CodeOrdering {
 
   final case class Neq(missingEqual: Boolean = true) extends BooleanOp
 
+  final case class StructLt(missingEqual: Boolean = true) extends BooleanOp
+
+  final case class StructLteq(missingEqual: Boolean = true) extends BooleanOp
+
+  final case class StructGt(missingEqual: Boolean = true) extends BooleanOp
+
   type F[R] = (EmitCodeBuilder, EmitValue, EmitValue) => Value[R]
 
   def makeOrdering(t1: SType, t2: SType, ecb: EmitClassBuilder[_]): CodeOrdering = {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3581,7 +3581,7 @@ class IRSuite extends HailSuite {
     val child = ToStream(MakeArray(data.map(makeRowStruct):_*))
     val pivots = MakeArray(splitters.map(makeKeyStruct):_*)
     val spec = TypedCodecSpec(PCanonicalStruct(("rowIdx", PInt32Required), ("extraInfo", PInt32Required)), BufferSpec.default)
-    val dist = StreamDistribute(child, pivots, Str(ctx.localTmpdir), LT(pivots.typ.asInstanceOf[TArray].elementType), spec)
+    val dist = StreamDistribute(child, pivots, Str(ctx.localTmpdir), Compare(pivots.typ.asInstanceOf[TArray].elementType), spec)
     val result = eval(dist).asInstanceOf[IndexedSeq[Row]].map(row => (row(0).asInstanceOf[Interval], row(1).asInstanceOf[String], row(2).asInstanceOf[Int]))
     val kord: ExtendedOrdering = PartitionBoundOrdering(pivots.typ.asInstanceOf[TArray].elementType)
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3581,7 +3581,7 @@ class IRSuite extends HailSuite {
     val child = ToStream(MakeArray(data.map(makeRowStruct):_*))
     val pivots = MakeArray(splitters.map(makeKeyStruct):_*)
     val spec = TypedCodecSpec(PCanonicalStruct(("rowIdx", PInt32Required), ("extraInfo", PInt32Required)), BufferSpec.default)
-    val dist = StreamDistribute(child, pivots, Str(ctx.localTmpdir), spec)
+    val dist = StreamDistribute(child, pivots, Str(ctx.localTmpdir), LT(pivots.typ.asInstanceOf[TArray].elementType), spec)
     val result = eval(dist).asInstanceOf[IndexedSeq[Row]].map(row => (row(0).asInstanceOf[Interval], row(1).asInstanceOf[String], row(2).asInstanceOf[Int]))
     val kord: ExtendedOrdering = PartitionBoundOrdering(pivots.typ.asInstanceOf[TArray].elementType)
 

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
@@ -52,7 +52,11 @@ class LowerDistributedSortSuite extends HailSuite {
       var i = 0
       while (i < sortFields.size) {
         if (leftKey(i).asInstanceOf[Int] != rightKey(i).asInstanceOf[Int]) {
-          ans = leftKey(i).asInstanceOf[Int] < rightKey(i).asInstanceOf[Int]
+          if (sortFields(i).sortOrder == Ascending) {
+            ans = leftKey(i).asInstanceOf[Int] < rightKey(i).asInstanceOf[Int]
+          } else {
+            ans = leftKey(i).asInstanceOf[Int] > rightKey(i).asInstanceOf[Int]
+          }
           i = sortFields.size
         }
         i += 1
@@ -75,10 +79,10 @@ class LowerDistributedSortSuite extends HailSuite {
       ))
     )
 
-//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("foo", Ascending), SortField("idx", Ascending)))
-//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("idx", Ascending)))
-//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("backwards", Ascending)))
-//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("const", Ascending)))
+    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("foo", Ascending), SortField("idx", Ascending)))
+    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("idx", Ascending)))
+    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("backwards", Ascending)))
+    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("const", Ascending)))
     testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("idx", Descending)))
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.lowering
 
 import is.hail.TestUtils.assertEvalsTo
 import is.hail.expr.ir.functions.IRRandomness
-import is.hail.expr.ir.{Apply, ApplyBinaryPrimOp, Ascending, ErrorIDs, GetField, I32, IR, Literal, MakeStruct, Ref, Requiredness, RequirednessAnalysis, SelectFields, SortField, TableIR, TableMapRows, TableRange, ToArray, ToStream, mapIR}
+import is.hail.expr.ir.{Apply, ApplyBinaryPrimOp, Ascending, Descending, ErrorIDs, GetField, I32, IR, Literal, MakeStruct, Ref, Requiredness, RequirednessAnalysis, SelectFields, SortField, TableIR, TableMapRows, TableRange, ToArray, ToStream, mapIR}
 import is.hail.{ExecStrategy, HailContext, HailSuite, TestUtils}
 import is.hail.expr.ir.lowering.LowerDistributedSort.samplePartition
 import is.hail.types.RTable
@@ -19,7 +19,7 @@ class LowerDistributedSortSuite extends HailSuite {
     val data1 = ToStream(Literal(TArray(elementType), dataKeys.map{ case (k1, k2) => Row(k1, k2, k1 * k1)}))
     val sampleSeq = ToStream(Literal(TArray(TInt32), IndexedSeq(0, 2, 3, 7)))
 
-    val sampled = samplePartition(mapIR(data1)(s => SelectFields(s, IndexedSeq("key1", "key2"))), sampleSeq)
+    val sampled = samplePartition(mapIR(data1)(s => SelectFields(s, IndexedSeq("key1", "key2"))), sampleSeq, IndexedSeq(SortField("key1", Ascending), SortField("key2", Ascending)))
 
     assertEvalsTo(sampled, Row(Row(0, -1), Row(9, 1), IndexedSeq( Row(0, 0), Row(1, 4), Row(2, 8), Row(6, 9)), false))
 
@@ -27,22 +27,21 @@ class LowerDistributedSortSuite extends HailSuite {
     val elementType2 = TStruct(("key1", TInt32), ("key2", TInt32))
     val data2 = ToStream(Literal(TArray(elementType2), dataKeys2.map{ case (k1, k2) => Row(k1, k2)}))
     val sampleSeq2 = ToStream(Literal(TArray(TInt32), IndexedSeq(0)))
-    val sampled2 = samplePartition(mapIR(data2)(s => SelectFields(s, IndexedSeq("key2", "key1"))), sampleSeq2)
+    val sampled2 = samplePartition(mapIR(data2)(s => SelectFields(s, IndexedSeq("key2", "key1"))), sampleSeq2, IndexedSeq(SortField("key2", Ascending), SortField("key1", Ascending)))
     assertEvalsTo(sampled2, Row(Row(0, 0), Row(3, 3), IndexedSeq( Row(0, 0)), false))
   }
 
 
   // Only does ascending for now
-  def testDistributedSortHelper(myTable: TableIR, sortFieldNames: IndexedSeq[String]): Unit = {
+  def testDistributedSortHelper(myTable: TableIR, sortFields: IndexedSeq[SortField]): Unit = {
     HailContext.setFlag("shuffle_cutoff_to_local_sort", "6")
     val req: RequirednessAnalysis = Requiredness(myTable, ctx)
     val rowType = req.lookup(myTable).asInstanceOf[RTable].rowType
     val stage = LowerTableIR.applyTable(myTable, DArrayLowering.All, ctx, req, Map.empty[String, IR])
-    val sortFields = sortFieldNames.map(x => SortField(x, Ascending) )
     val sortedTs = LowerDistributedSort.distributedSort(ctx, stage, sortFields, Map.empty[String, IR], rowType)
     val res = TestUtils.eval(sortedTs.mapCollect(Map.empty[String, IR])(x => ToArray(x))).asInstanceOf[IndexedSeq[IndexedSeq[Row]]].flatten
 
-    val rowFunc = myTable.typ.rowType.select(sortFieldNames)._2
+    val rowFunc = myTable.typ.rowType.select(sortFields.map(_.field))._2
     val unsortedCollect = is.hail.expr.ir.TestUtils.collect(myTable)
     val unsortedReq = Requiredness(unsortedCollect, ctx)
     val unsorted = TestUtils.eval(LowerTableIR.apply(unsortedCollect, DArrayLowering.All, ctx, unsortedReq, Map.empty[String, IR])).asInstanceOf[Row](0).asInstanceOf[IndexedSeq[Row]]
@@ -51,10 +50,10 @@ class LowerDistributedSortSuite extends HailSuite {
       val rightKey = rowFunc(r)
       var ans = false
       var i = 0
-      while (i < sortFieldNames.size) {
+      while (i < sortFields.size) {
         if (leftKey(i).asInstanceOf[Int] != rightKey(i).asInstanceOf[Int]) {
           ans = leftKey(i).asInstanceOf[Int] < rightKey(i).asInstanceOf[Int]
-          i = sortFieldNames.size
+          i = sortFields.size
         }
         i += 1
       }
@@ -76,9 +75,10 @@ class LowerDistributedSortSuite extends HailSuite {
       ))
     )
 
-    testDistributedSortHelper(tableWithExtraField, IndexedSeq("foo", "idx"))
-    testDistributedSortHelper(tableWithExtraField, IndexedSeq("idx"))
-    testDistributedSortHelper(tableWithExtraField, IndexedSeq("backwards"))
-    testDistributedSortHelper(tableWithExtraField, IndexedSeq("const"))
+//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("foo", Ascending), SortField("idx", Ascending)))
+//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("idx", Ascending)))
+//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("backwards", Ascending)))
+//    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("const", Ascending)))
+    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("idx", Descending)))
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
@@ -84,5 +84,6 @@ class LowerDistributedSortSuite extends HailSuite {
     testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("backwards", Ascending)))
     testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("const", Ascending)))
     testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("idx", Descending)))
+    testDistributedSortHelper(tableWithExtraField, IndexedSeq(SortField("foo", Descending), SortField("idx", Ascending)))
   }
 }


### PR DESCRIPTION
This PR:

- Introduces `StructComparisonOp`, a subclass of `ComparisonOp` that is just for comparing structs. They have an array of sort fields for this purpose.
- Extends `StreamDistribute` to take in a `ComparisonOp`, so that it doesn't just assume data sorted in ascending order.
- Updates `LowerDistributedSort.scala` to actually use the `SortFields` that get passed into it, allowing for arbitrary sort orders. 
