### PR TITLE
[build] Parallelize test-dataproc

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3905,7 +3905,7 @@ steps:
       - blog_nginx_image
       - create_certs
   - kind: runImage
-    name: test_dataproc
+    name: test_dataproc-37
     image:
       valueFrom: ci_utils_image.image
     script: |
@@ -3926,7 +3926,50 @@ steps:
       cd hail
       chmod 755 ./gradlew
       time retry ./gradlew --version
-      make test-dataproc DEV_CLARIFIER=ci_test_dataproc
+      make test-dataproc-37 DEV_CLARIFIER=ci_test_dataproc
+    timeout: 7200
+    dependsOn:
+      - ci_utils_image
+      - default_ns
+      - merge_code
+    inputs:
+      - from: /hail_pip_version
+        to: /io/hail_pip_version
+      - from: /repo
+        to: /io/repo
+    secrets:
+      - name: test-dataproc-service-account-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-dataproc-service-account-key
+    scopes:
+      - deploy
+      - dev
+    clouds:
+      - gcp
+  - kind: runImage
+    name: test_dataproc-38
+    image:
+      valueFrom: ci_utils_image.image
+    script: |
+      set -ex
+
+      cd /io/repo
+
+      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
+      gcloud config set project hail-vdc
+      gcloud config set dataproc/region us-central1
+
+      if git ls-remote --exit-code --tags origin $(cat /io/hail_pip_version)
+      then
+          echo "tag $HAIL_PIP_VERSION already exists"
+          exit 0
+      fi
+
+      cd hail
+      chmod 755 ./gradlew
+      time retry ./gradlew --version
+      make test-dataproc-38 DEV_CLARIFIER=ci_test_dataproc
     timeout: 7200
     dependsOn:
       - ci_utils_image

--- a/build.yaml
+++ b/build.yaml
@@ -3927,7 +3927,6 @@ steps:
       chmod 755 ./gradlew
       time retry ./gradlew --version
       make test-dataproc-37 DEV_CLARIFIER=ci_test_dataproc
-    timeout: 7200
     dependsOn:
       - ci_utils_image
       - default_ns
@@ -3970,7 +3969,6 @@ steps:
       chmod 755 ./gradlew
       time retry ./gradlew --version
       make test-dataproc-38 DEV_CLARIFIER=ci_test_dataproc
-    timeout: 7200
     dependsOn:
       - ci_utils_image
       - default_ns

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -270,6 +270,14 @@ install-hailctl: install upload-artifacts
 test-dataproc: install-hailctl
 	bash scripts/test-dataproc.sh
 
+.PHONY: test-dataproc-37
+test-dataproc-37: install-hailctl
+	bash scripts/test-dataproc.sh "GRCh37"
+
+.PHONY: test-dataproc-38
+test-dataproc-38: install-hailctl
+	bash scripts/test-dataproc.sh "GRCh38"
+
 # install skopeo
 # use curl version >=7.55.0
 #

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -266,10 +266,6 @@ install-on-cluster: $(WHEEL)
 .PHONY: install-hailctl
 install-hailctl: install upload-artifacts
 
-.PHONY: test-dataproc
-test-dataproc: install-hailctl
-	bash scripts/test-dataproc.sh
-
 .PHONY: test-dataproc-37
 test-dataproc-37: install-hailctl
 	bash scripts/test-dataproc.sh "GRCh37"

--- a/hail/scripts/test-dataproc.sh
+++ b/hail/scripts/test-dataproc.sh
@@ -32,6 +32,7 @@ hailctl dataproc \
         --max-idle 10m \
         --max-age 120m \
         --vep $1 \
+        --num-preemptible-workers=4 \
         --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_test_files
 do

--- a/hail/scripts/test-dataproc.sh
+++ b/hail/scripts/test-dataproc.sh
@@ -2,46 +2,40 @@
 
 set -ex
 
-cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
-cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
+cluster_name=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 
 stop_dataproc () {
     exit_code=$?
 
     set +e
 
-    hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
-    hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
+    hailctl dataproc stop $cluster_name || true  # max-idle or max-age will delete it
 
     exit $exit_code
 }
 trap stop_dataproc EXIT
 
-cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh38.py')
-cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')
+if [ $1 == "GRCh37" ]
+then
+    EXCLUDE="GRCh38"
+fi
+
+if [ $1 == "GRCh38" ]
+then
+    EXCLUDE="GRCh37"
+fi
+
+cluster_test_files=$(ls python/cluster-tests/*.py | grep -ve "python/cluster-tests/cluster-vep-check-$EXCLUDE.py")
 
 hailctl dataproc \
-        start $cluster_name_37 \
+        start $cluster_name \
         --max-idle 10m \
         --max-age 120m \
-        --vep GRCh37 \
+        --vep $1 \
         --requester-pays-allow-buckets hail-us-vep
-for file in $cluster_37_test_files
+for file in $cluster_test_files
 do
     hailctl dataproc \
             submit \
-            $cluster_name_37 $file
-done
-
-hailctl dataproc \
-        start $cluster_name_38 \
-        --max-idle 10m \
-        --max-age 120m \
-        --vep GRCh38 \
-        --requester-pays-allow-buckets hail-us-vep
-for file in $cluster_38_test_files
-do
-    hailctl dataproc \
-            submit \
-            $cluster_name_38 $file
+            $cluster_name $file
 done


### PR DESCRIPTION
test-dataproc was taking over an hour, for two reasons:

1. Starting two vep clusters sequentially is slow.
2. A very small cluster was working on submits that sometimes had 10k partitions.

To solve this, I've:

1. Split test-dataproc into test-dataproc-37 and test-dataproc-38
2. Added a few preemptibles to cluster create script.