### PR TITLE
[query] Update deploy to depend on new test dataprocs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4063,7 +4063,8 @@ steps:
       - deploy
       - dev
     dependsOn:
-      - test_dataproc
+      - test_dataproc-37
+      - test_dataproc-38
       - default_ns
       - ci_utils_image
       - build_hail


### PR DESCRIPTION
Correcting an oversight from #11273 

Probably we should test that all build.yaml dependencies exist in the future (Services team seems to be replacing build.yaml with something new?)