### PR TITLE
[hailctl dataproc] Address the *third* log4j vulnerability

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -135,7 +135,7 @@ REGION_TO_REPLICATE_MAPPING = {
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us", "hail-datasets-eu", "gnomad-public-requester-pays"]
 
-IMAGE_VERSION = '2.0.27-debian10'
+IMAGE_VERSION = '2.0.29-debian10'
 
 
 def init_parser(parser):


### PR DESCRIPTION
CHANGELOG: hailctl dataproc now produces clusters which are not known to be vulnerable to log4j exploits as of 2022-01-22.

More details at https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-2.0.