### PR TITLE
[hailctl] Move aiohttp imports in deploy_config out of top level

### DIFF
--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -1,10 +1,8 @@
 from typing import List, Tuple, Dict
-import aiohttp
 import random
 import os
 import json
 import logging
-from aiohttp import web
 from ..utils import retry_transient_errors, first_extant_file
 from ..tls import internal_client_ssl_context
 
@@ -108,6 +106,7 @@ class DeployConfig:
         return f'{base_scheme}s://internal.{self._domain}/{ns}/{service}{path}'
 
     def prefix_application(self, app, service, **kwargs):
+        from aiohttp import web # pylint: disable=import-outside-toplevel
         base_path = self.base_path(service)
         if not base_path:
             return app
@@ -131,6 +130,7 @@ class DeployConfig:
 
     async def addresses(self, service: str) -> List[Tuple[str, int]]:
         from ..auth import service_auth_headers  # pylint: disable=cyclic-import,import-outside-toplevel
+        import aiohttp  # pylint: disable=import-outside-toplevel
         namespace = self.service_ns(service)
         headers = service_auth_headers(self, namespace)
         async with aiohttp.ClientSession(

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -106,7 +106,7 @@ class DeployConfig:
         return f'{base_scheme}s://internal.{self._domain}/{ns}/{service}{path}'
 
     def prefix_application(self, app, service, **kwargs):
-        from aiohttp import web # pylint: disable=import-outside-toplevel
+        from aiohttp import web  # pylint: disable=import-outside-toplevel
         base_path = self.base_path(service)
         if not base_path:
             return app


### PR DESCRIPTION
Python CLI tools like `hailctl` suffer from slow startup times, which infuriate me. This is in part because the first thing that happens is python has to recursively load all imported packages, since imports are traditionally done at the top-level. Very conveniently, setting the `PYTHONPROFILEIMPORTTIME` environment variable will cause python to emit a profile to stderr, which you can visualize with tools like [tuna](https://github.com/nschloe/tuna). So running

```
PYTHONPROFILEIMPORTTIME=1 hailctl dev config show 2> profile.log
tuna profile.log
```

gave me this

<img width="1576" alt="Screen Shot 2022-01-28 at 2 58 28 PM" src="https://user-images.githubusercontent.com/24440116/151614364-d57a4478-1516-4397-ac72-4f2b9c6c081b.png">

showing that importing `aiohttp` is responsible for half the time it takes me to run `hailctl dev config show`, which is literally just printing a local file!! There's no reason this shouldn't be instantaneous, but reducing it to ~300ms, which this change did, is fine enough for me for now. Generally people don't care about import time because most applications are long-lived and what does a few seconds matter, so `pylint` by default wants us to put imports at the top level. I would say this is a valid exception.
