### PR TITLE
[query] Shuffler Outputs Approximately Evenly Sized Partitions

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -291,9 +291,8 @@ object LowerDistributedSort {
       WritePartition(sortedStream, UUID4(), writer)
     }
 
-    val myReturn = CompileAndEvaluate[Annotation](ctx, sortedFilenamesIR).asInstanceOf[IndexedSeq[Row]]
-    val mySortedFilenames = myReturn.map(_(0).asInstanceOf[String])
-    val newlySortedSegments = loopState.smallSegments.zip(mySortedFilenames).map { case (sr, newFilename) =>
+    val sortedFilenames = CompileAndEvaluate[Annotation](ctx, sortedFilenamesIR).asInstanceOf[IndexedSeq[Row]].map(_(0).asInstanceOf[String])
+    val newlySortedSegments = loopState.smallSegments.zip(sortedFilenames).map { case (sr, newFilename) =>
       SegmentResult(sr.indices, sr.interval, IndexedSeq(Chunk(initialTmpPath + newFilename, sr.chunks.foldLeft(0)((size, chunk) => size + chunk.size))))
     }
 


### PR DESCRIPTION
This PR makes the following changes:

1. For some reason, I forgot `CompileAndEvaluate` exists, and was separately calling `Compile`, applying it, then doing `SafeRow.read` in two places. Ripped those out in favor of `CompileAndEvaluate`.
2. When all segments are either already sorted or sufficiently small, I now sort and write out all the sufficiently small ones. Now I have a set of files that taken together fully represent the table, and I create a new `TableStage` by assembling those chunks into approximately evenly sized partitions.