### PR TITLE
[ci] Support optional secrets in createNamespace steps

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -664,15 +664,10 @@ kubectl -n {self.namespace_name} get -o json secret global-config \
 '''
 
             for s in self.secrets:
-                if isinstance(s, str):
+                name = s['name']
+                if s.get('clouds') is None or CLOUD in s['clouds']:
                     script += f'''
-kubectl -n {self.namespace_name} get -o json secret {s} | jq 'del(.metadata) | .metadata.name = "{s}"' | kubectl -n {self._name} apply -f -
-'''
-                else:
-                    clouds = s.get('clouds')
-                    if clouds is None or CLOUD in clouds:
-                        script += f'''
-kubectl -n {self.namespace_name} get -o json secret {s["name"]} | jq 'del(.metadata) | .metadata.name = "{s["name"]}"' | kubectl -n {self._name} apply -f -
+kubectl -n {self.namespace_name} get -o json secret {name} | jq 'del(.metadata) | .metadata.name = "{name}"' | kubectl -n {self._name} apply -f - { '|| true' if s.get('optional') is True else ''}
 '''
 
         script += '''

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -3,6 +3,9 @@ steps:
     name: default_ns
     namespaceName: default
     public: true
+    secrets:
+      - name: doesnotexist
+        optional: true
   - kind: buildImage2
     name: git_make_bash_image
     dockerFile:


### PR DESCRIPTION
- Ignore missing secrets when they are optional. The test is a bit weak but hopefully enough to guard against crashing entirely.
- No longer need to support secrets as just string names in `createNamespace` steps