### PR TITLE
[azure] Dont assume resource_group is the name of the ACR

### DIFF
--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -212,7 +212,7 @@ EOF
 {make_global_config_str}
 
 # retry once
-az acr login --name $RESOURCE_GROUP
+az acr login --name $DOCKER_PREFIX
 docker pull $BATCH_WORKER_IMAGE || \
 (echo 'pull failed, retrying' && sleep 15 && docker pull $BATCH_WORKER_IMAGE)
 

--- a/devbin/functions.sh
+++ b/devbin/functions.sh
@@ -171,6 +171,10 @@ upload-secret() {
 	      | kubectl apply -f -
 }
 
+get_global_config_field() {
+    kubectl get secret global-config --template={{.data.$1}} | base64 --decode
+}
+
 gcpsetcluster() {
     if [ -z "$1" ]; then
         echo "Usage: gcpsetcluster <PROJECT>"
@@ -190,7 +194,7 @@ azsetcluster() {
 
     RESOURCE_GROUP=$1
     az aks get-credentials --name vdc --resource-group $RESOURCE_GROUP
-    az acr login --name $(az acr list -g $RESOURCE_GROUP | jq -j '.[0].name')
+    az acr login --name $(get_global_config_field docker_prefix)
 }
 
 azsshworker() {

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -5,9 +5,7 @@ if [[ -z "$HAIL" ]]; then
     exit 1
 fi
 
-get_global_config_field() {
-    kubectl get secret global-config --template={{.data.$1}} | base64 --decode
-}
+source $HAIL/devbin/functions.sh
 
 render_config_mk() {
     DOCKER_PREFIX=$(get_global_config_field docker_prefix)


### PR DESCRIPTION
docker_prefix is not exactly the "registry name" in azure's definition, but it is `<registry_name>.azurecr.io` which `az acr login` accepts alternatively to just the registry name. Didn't seem worth adding a mostly redundant config field.