### PR TITLE
[query] ssa style IR in logs

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -483,7 +483,8 @@ object HailFeatureFlags {
     ("method_split_ir_limit", ("HAIL_DEV_METHOD_SPLIT_LIMIT" -> "16")),
     ("use_new_shuffle", ("HAIL_USE_NEW_SHUFFLE" -> null)),
     ("shuffle_cutoff_to_local_sort", ("HAIL_SHUFFLE_CUTOFF" -> null)),
-    ("grouped_aggregate_buffer_size", ("HAIL_GROUPED_AGGREGATE_BUFFER_SIZE" -> "50"))
+    ("grouped_aggregate_buffer_size", ("HAIL_GROUPED_AGGREGATE_BUFFER_SIZE" -> "50")),
+    ("use_ssa_logs", "HAIL_USE_SSA_LOGS" -> null),
   )
 }
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -484,7 +484,7 @@ object HailFeatureFlags {
     ("use_new_shuffle", ("HAIL_USE_NEW_SHUFFLE" -> null)),
     ("shuffle_cutoff_to_local_sort", ("HAIL_SHUFFLE_CUTOFF" -> null)),
     ("grouped_aggregate_buffer_size", ("HAIL_GROUPED_AGGREGATE_BUFFER_SIZE" -> "50")),
-    ("use_ssa_logs", "HAIL_USE_SSA_LOGS" -> null),
+    ("use_ssa_logs", "HAIL_USE_SSA_LOGS" -> null)
   )
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -1,13 +1,18 @@
 package is.hail.expr.ir
 
+import is.hail.{HailContext, HailFeatureFlags}
 import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.Bindings.empty
 import is.hail.expr.ir.agg.{AggElementsAggSig, AggStateSig, ArrayLenAggSig, FoldStateSig, GroupedAggSig, PhysicalAggSig}
 import is.hail.expr.ir.functions.RelationalFunctions
-import is.hail.types.virtual.{TArray, TInterval, Type}
+import is.hail.types.TableType
+import is.hail.types.virtual.{TArray, TInt32, TInt64, TInterval, TNDArray, TStream, TStruct, TTuple, Type}
 import is.hail.utils.{space => _, _}
 import is.hail.utils.prettyPrint._
 import is.hail.utils.richUtils.RichIterable
 import org.json4s.jackson.{JsonMethods, Serialization}
+
+import scala.collection.mutable
 
 object Pretty {
 
@@ -112,7 +117,7 @@ object Pretty {
 
   def single(d: Doc): Iterable[Doc] = RichIterable.single(d)
 
-  def header(ir: BaseIR, elideLiterals: Boolean): Iterable[Doc] = ir match {
+  def header(ir: BaseIR, elideLiterals: Boolean, elideBindings: Boolean = false): Iterable[Doc] = ir match {
     case ApplyAggOp(initOpArgs, seqOpArgs, aggSig) => single(prettyClass(aggSig.op))
     case ApplyScanOp(initOpArgs, seqOpArgs, aggSig) => single(prettyClass(aggSig.op))
     case InitOp(i, args, aggSig) => FastSeq(i.toString, prettyPhysicalAggSig(aggSig))
@@ -146,14 +151,24 @@ object Pretty {
         else
           "<literal value>")
     case EncodedLiteral(codec, _) => single(codec.encodedVirtualType.parsableString())
-    case Let(name, _, _) => single(prettyIdentifier(name))
-    case AggLet(name, _, _, isScan) => FastSeq(prettyIdentifier(name), prettyBooleanLiteral(isScan))
-    case TailLoop(name, args, _) => FastSeq(prettyIdentifier(name), prettyIdentifiers(args.map(_._1).toFastIndexedSeq))
-    case Recur(name, _, t) => FastSeq(prettyIdentifier(name), t.parsableString())
+    case Let(name, _, _) if !elideBindings => single(prettyIdentifier(name))
+    case AggLet(name, _, _, isScan) => if (elideBindings)
+      single(prettyBooleanLiteral(isScan))
+    else
+      FastSeq(prettyIdentifier(name), prettyBooleanLiteral(isScan))
+    case TailLoop(name, args, _) if !elideBindings =>
+      FastSeq(prettyIdentifier(name), prettyIdentifiers(args.map(_._1).toFastIndexedSeq))
+    case Recur(name, _, t) => if (elideBindings)
+      single(t.parsableString())
+    else
+      FastSeq(prettyIdentifier(name), t.parsableString())
 //    case Ref(name, t) if t != null => FastSeq(prettyIdentifier(name), t.parsableString())  // For debug purposes
     case Ref(name, _) => single(prettyIdentifier(name))
-    case RelationalRef(name, t) => FastSeq(prettyIdentifier(name), t.parsableString())
-    case RelationalLet(name, _, _) => single(prettyIdentifier(name))
+    case RelationalRef(name, t) => if (elideBindings)
+      single(t.parsableString())
+    else
+      FastSeq(prettyIdentifier(name), t.parsableString())
+    case RelationalLet(name, _, _) if !elideBindings => single(prettyIdentifier(name))
     case ApplyBinaryPrimOp(op, _, _) => single(prettyClass(op))
     case ApplyUnaryPrimOp(op, _) => single(prettyClass(op))
     case ApplyComparisonOp(op, _, _) => single(op.render())
@@ -166,37 +181,58 @@ object Pretty {
     case StreamIota(_, _, requiresMemoryManagementPerElement) => FastSeq(prettyBooleanLiteral(requiresMemoryManagementPerElement))
     case StreamRange(_, _, _, requiresMemoryManagementPerElement, errorID) => FastSeq(errorID.toString, prettyBooleanLiteral(requiresMemoryManagementPerElement))
     case ToStream(_, requiresMemoryManagementPerElement) => single(prettyBooleanLiteral(requiresMemoryManagementPerElement))
-    case StreamMap(_, name, _) => single(prettyIdentifier(name))
-    case StreamZip(_, names, _, behavior, errorID) => FastSeq(errorID.toString, behavior match {
+    case StreamMap(_, name, _) if !elideBindings => single(prettyIdentifier(name))
+    case StreamZip(_, names, _, behavior, errorID) => if (elideBindings)
+      FastSeq(errorID.toString, behavior match {
+        case ArrayZipBehavior.AssertSameLength => "AssertSameLength"
+        case ArrayZipBehavior.TakeMinLength => "TakeMinLength"
+        case ArrayZipBehavior.ExtendNA => "ExtendNA"
+        case ArrayZipBehavior.AssumeSameLength => "AssumeSameLength"
+      })
+    else
+      FastSeq(errorID.toString, behavior match {
       case ArrayZipBehavior.AssertSameLength => "AssertSameLength"
       case ArrayZipBehavior.TakeMinLength => "TakeMinLength"
       case ArrayZipBehavior.ExtendNA => "ExtendNA"
       case ArrayZipBehavior.AssumeSameLength => "AssumeSameLength"
     }, prettyIdentifiers(names))
-    case StreamZipJoin(_, key, curKey, curVals, _) =>
+    case StreamZipJoin(_, key, curKey, curVals, _) if !elideBindings =>
       FastSeq(prettyIdentifiers(key), prettyIdentifier(curKey), prettyIdentifier(curVals))
     case StreamMultiMerge(_, key) => single(prettyIdentifiers(key))
-    case StreamFilter(_, name, _) => single(prettyIdentifier(name))
-    case StreamTakeWhile(_, name, _) => single(prettyIdentifier(name))
-    case StreamDropWhile(_, name, _) => single(prettyIdentifier(name))
-    case StreamFlatMap(_, name, _) => single(prettyIdentifier(name))
-    case StreamFold(_, _, accumName, valueName, _) => FastSeq(prettyIdentifier(accumName), prettyIdentifier(valueName))
-    case StreamFold2(_, acc, valueName, _, _) => FastSeq(prettyIdentifiers(acc.map(_._1)), prettyIdentifier(valueName))
-    case StreamScan(_, _, accumName, valueName, _) => FastSeq(prettyIdentifier(accumName), prettyIdentifier(valueName))
-    case StreamJoinRightDistinct(_, _, lKey, rKey, l, r, _, joinType) =>
+    case StreamFilter(_, name, _) if !elideBindings => single(prettyIdentifier(name))
+    case StreamTakeWhile(_, name, _) if !elideBindings => single(prettyIdentifier(name))
+    case StreamDropWhile(_, name, _) if !elideBindings => single(prettyIdentifier(name))
+    case StreamFlatMap(_, name, _) if !elideBindings => single(prettyIdentifier(name))
+    case StreamFold(_, _, accumName, valueName, _) if !elideBindings => FastSeq(prettyIdentifier(accumName), prettyIdentifier(valueName))
+    case StreamFold2(_, acc, valueName, _, _) if !elideBindings => FastSeq(prettyIdentifiers(acc.map(_._1)), prettyIdentifier(valueName))
+    case StreamScan(_, _, accumName, valueName, _) if !elideBindings => FastSeq(prettyIdentifier(accumName), prettyIdentifier(valueName))
+    case StreamJoinRightDistinct(_, _, lKey, rKey, l, r, _, joinType) => if (elideBindings)
+      FastSeq(prettyIdentifiers(lKey), prettyIdentifiers(rKey), joinType)
+    else
       FastSeq(prettyIdentifiers(lKey), prettyIdentifiers(rKey), prettyIdentifier(l), prettyIdentifier(r), joinType)
-    case StreamFor(_, valueName, _) => single(prettyIdentifier(valueName))
-    case StreamAgg(a, name, query) => single(prettyIdentifier(name))
-    case StreamAggScan(a, name, query) => single(prettyIdentifier(name))
+    case StreamFor(_, valueName, _) if !elideBindings => single(prettyIdentifier(valueName))
+    case StreamAgg(a, name, query) if !elideBindings => single(prettyIdentifier(name))
+    case StreamAggScan(a, name, query) if !elideBindings => single(prettyIdentifier(name))
     case StreamGroupByKey(a, key) => single(prettyIdentifiers(key))
-    case AggFold(_, _, _, accumName, otherAccumName, isScan) => FastSeq(prettyIdentifier(accumName), prettyIdentifier(otherAccumName), prettyBooleanLiteral(isScan))
-    case AggExplode(_, name, _, isScan) => FastSeq(prettyIdentifier(name), prettyBooleanLiteral(isScan))
+    case AggFold(_, _, _, accumName, otherAccumName, isScan) => if (elideBindings)
+      single(prettyBooleanLiteral(isScan))
+    else
+      FastSeq(prettyIdentifier(accumName), prettyIdentifier(otherAccumName), prettyBooleanLiteral(isScan))
+    case AggExplode(_, name, _, isScan) => if (elideBindings)
+      single(prettyBooleanLiteral(isScan))
+    else
+      FastSeq(prettyIdentifier(name), prettyBooleanLiteral(isScan))
     case AggFilter(_, _, isScan) => single(prettyBooleanLiteral(isScan))
     case AggGroupBy(_, _, isScan) => single(prettyBooleanLiteral(isScan))
-    case AggArrayPerElement(_, elementName, indexName, _, knownLength, isScan) =>
+    case AggArrayPerElement(_, elementName, indexName, _, knownLength, isScan) => if (elideBindings)
+      FastSeq(prettyBooleanLiteral(isScan), prettyBooleanLiteral(knownLength.isDefined))
+    else
       FastSeq(prettyIdentifier(elementName), prettyIdentifier(indexName), prettyBooleanLiteral(isScan), prettyBooleanLiteral(knownLength.isDefined))
-    case NDArrayMap(_, name, _) => single(prettyIdentifier(name))
-    case NDArrayMap2(_, _, lName, rName, _, errorID) => FastSeq(s"$errorID", prettyIdentifier(lName), prettyIdentifier(rName))
+    case NDArrayMap(_, name, _) if !elideBindings => single(prettyIdentifier(name))
+    case NDArrayMap2(_, _, lName, rName, _, errorID) => if (elideBindings)
+      single(s"$errorID")
+    else
+      FastSeq(s"$errorID", prettyIdentifier(lName), prettyIdentifier(rName))
     case NDArrayReindex(_, indexExpr) => single(prettyInts(indexExpr, elideLiterals))
     case NDArrayConcat(_, axis) => single(axis.toString)
     case NDArrayAgg(_, axes) => single(prettyInts(axes, elideLiterals))
@@ -206,7 +242,7 @@ object Pretty {
     case NDArrayQR(_, mode, errorID) => FastSeq(errorID.toString, mode)
     case NDArraySVD(_, fullMatrices, computeUV, errorID) => FastSeq(errorID.toString, fullMatrices.toString, computeUV.toString)
     case NDArrayInv(_, errorID) => single(s"$errorID")
-    case ArraySort(_, l, r, _) => FastSeq(prettyIdentifier(l), prettyIdentifier(r))
+    case ArraySort(_, l, r, _) if !elideBindings => FastSeq(prettyIdentifier(l), prettyIdentifier(r))
     case ArrayRef(_,_, errorID) => single(s"$errorID")
     case ApplyIR(function, typeArgs, _, errorID) => FastSeq(s"$errorID", prettyIdentifier(function), prettyTypes(typeArgs), ir.typ.parsableString())
     case Apply(function, typeArgs, _, t, errorID) => FastSeq(s"$errorID", prettyIdentifier(function), prettyTypes(typeArgs), t.parsableString())
@@ -216,7 +252,7 @@ object Pretty {
     case LowerBoundOnOrderedCollection(_, _, onKey) => single(prettyBooleanLiteral(onKey))
     case In(i, typ) => FastSeq(typ.toString, i.toString)
     case Die(message, typ, errorID) => FastSeq(typ.parsableString(), errorID.toString)
-    case CollectDistributedArray(_, _, cname, gname, _, _) =>
+    case CollectDistributedArray(_, _, cname, gname, _, _) if !elideBindings =>
       FastSeq(prettyIdentifier(cname), prettyIdentifier(gname))
     case MatrixRead(typ, dropCols, dropRows, reader) =>
       FastSeq(if (typ == reader.fullMatrixType) "None" else typ.parsableString(),
@@ -251,9 +287,13 @@ object Pretty {
         prettyBooleanLiteral(gaussian),
         prettyLongs(shape, elideLiterals),
         blockSize.toString)
-    case BlockMatrixMap(_, name, _, needsDense) =>
+    case BlockMatrixMap(_, name, _, needsDense) => if (elideBindings)
+      single(prettyBooleanLiteral(needsDense))
+    else
       FastSeq(prettyIdentifier(name), prettyBooleanLiteral(needsDense))
-    case BlockMatrixMap2(_, _, lName, rName, _, sparsityStrategy) =>
+    case BlockMatrixMap2(_, _, lName, rName, _, sparsityStrategy) => if (elideBindings)
+      single(prettyClass(sparsityStrategy))
+    else
       FastSeq(prettyIdentifier(lName), prettyIdentifier(rName), prettyClass(sparsityStrategy))
     case MatrixRowsHead(_, n) => single(n.toString)
     case MatrixColsHead(_, n) => single(n.toString)
@@ -359,6 +399,9 @@ object Pretty {
   }
 
   def apply(ir: BaseIR, width: Int = 100, ribbonWidth: Int = 50, elideLiterals: Boolean = true, maxLen: Int = -1): String = {
+    if (HailContext.getFlag("use_ssa_logs") != null)
+      return ssaStyle(ir, width, ribbonWidth, elideLiterals, maxLen)
+
     def prettySeq(xs: Seq[BaseIR]): Doc =
       list(xs.view.map(pretty))
 
@@ -394,5 +437,260 @@ object Pretty {
     }
 
     pretty(ir).render(width, ribbonWidth, maxLen)
+  }
+
+  def ssaStyle(ir: BaseIR, width: Int = 100, ribbonWidth: Int = 100, elideLiterals: Boolean = true, maxLen: Int = -1): String = {
+    def childIsStrict(ir: BaseIR, i: Int): Boolean = blockArgs(ir, i).isEmpty
+
+    def blockArgs(ir: BaseIR, i: Int): Option[IndexedSeq[(String, String)]] = ir match {
+      case If(_, _, _) =>
+        if (i > 0) Some(FastIndexedSeq()) else None
+      case TailLoop(name, args, body) => if (i == args.length)
+        Some(args.map { case (name, ir) => name -> "loopvar" } :+
+          name -> "loop") else None
+      case StreamMap(a, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case StreamZip(as, names, _, _, _) =>
+        if (i == as.length) Some(names.map(_ -> "elt")) else None
+      case StreamZipJoin(as, key, curKey, curVals, _) =>
+        if (i == as.length)
+          Some(Array(curKey -> "key", curVals -> "elts"))
+        else
+          None
+      case StreamFor(a, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case StreamFlatMap(a, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case StreamFilter(a, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case StreamTakeWhile(a, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case StreamDropWhile(a, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case StreamFold(a, zero, accumName, valueName, _) =>
+        if (i == 2) Some(Array(accumName -> "accum", valueName -> "elt")) else None
+      case StreamFold2(a, accum, valueName, seq, result) =>
+        if (i <= accum.length)
+          None
+        else if (i < 2 * accum.length + 1)
+          Some(Array(valueName -> "elt") ++ accum.map { case (name, value) => name -> "accum" })
+        else
+          Some(accum.map { case (name, value) => name -> "accum" })
+      case RunAggScan(a, name, _, _, _, _) =>
+        if (i == 2 || i == 3) Some(Array(name -> "elt")) else None
+      case StreamScan(a, zero, accumName, valueName, _) =>
+        if (i == 2) Some(Array(accumName -> "accum", valueName -> "elt")) else None
+      case StreamAggScan(a, name, _) =>
+        if (i == 1) Some(FastIndexedSeq(name -> "elt")) else None
+      case StreamJoinRightDistinct(ll, rr, _, _, l, r, _, _) =>
+        if (i == 2) Some(Array(l -> "l_elt", r -> "r_elt")) else None
+      case ArraySort(a, left, right, _) =>
+        if (i == 1) Some(Array(left -> "l", right -> "r")) else None
+      case AggArrayPerElement(_, elementName, indexName, _, _, _) =>
+        if (i == 1) Some(Array(elementName -> "elt", indexName -> "idx")) else None
+      case AggFold(zero, seqOp, combOp, accumName, otherAccumName, _) => {
+        if (i == 1) Some(Array(accumName -> "accum"))
+        else if (i == 2) Some(Array(accumName -> "l", otherAccumName -> "r"))
+        else None
+      }
+      case NDArrayMap(nd, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case NDArrayMap2(l, r, lName, rName, _, _) => if (i == 2)
+        Some(Array(lName -> "l_elt", rName -> "r_elt"))
+      else
+        None
+      case CollectDistributedArray(contexts, globals, cname, gname, _, _) =>
+        if (i == 2) Some(Array(cname -> "ctx", gname -> "g")) else None
+      case TableAggregate(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "row" -> "row")) else None
+      case MatrixAggregate(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "sa" -> "col", "va" -> "row", "g" -> "entry")) else None
+      case TableFilter(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "row" -> "row")) else None
+      case TableMapGlobals(child, _) =>
+        if (i == 1) Some(Array("global" -> "g")) else None
+      case TableMapRows(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "row" -> "row")) else None
+      case TableAggregateByKey(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "row" -> "row")) else None
+      case TableKeyByAndAggregate(child, _, _, _, _) =>
+        if (i == 1 || i == 2)
+          Some(Array("global" -> "g", "row" -> "row"))
+        else None
+      case TableMapPartitions(child, g, p, _) =>
+        if (i == 1) Some(Array(g -> "g", p -> "part")) else None
+      case MatrixMapRows(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "va" -> "row", "sa" -> "col", "g" -> "entry", "n_cols" -> "n_cols")) else None
+      case MatrixFilterRows(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "va" -> "row")) else None
+      case MatrixMapCols(child, _, _) =>
+        if (i == 1) Some(Array("global" -> "g", "va" -> "row", "sa" -> "col", "g" -> "entry", "n_rows" -> "n_rows")) else None
+      case MatrixFilterCols(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "sa" -> "col")) else None
+      case MatrixMapEntries(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "sa" -> "col", "va" -> "row", "g" -> "entry")) else None
+      case MatrixFilterEntries(child, _) =>
+        if (i == 1) Some(Array("global" -> "g", "sa" -> "col", "va" -> "row", "g" -> "entry")) else None
+      case MatrixMapGlobals(child, _) =>
+        if (i == 1) Some(Array("global" -> "g")) else None
+      case MatrixAggregateColsByKey(child, _, _) =>
+        if (i == 1)
+          Some(Array("global" -> "g", "va" -> "row", "sa" -> "col", "g" -> "entry"))
+        else if (i == 2)
+          Some(Array("global" -> "g", "sa" -> "col"))
+        else
+          None
+      case MatrixAggregateRowsByKey(child, _, _) =>
+        if (i == 1)
+          Some(Array("global" -> "g", "va" -> "row", "sa" -> "col", "g" -> "entry"))
+        else if (i == 2)
+          Some(Array("global" -> "g", "va" -> "row"))
+        else
+          None
+      case BlockMatrixMap(_, eltName, _, _) =>
+        if (i == 1) Some(Array(eltName -> "elt")) else None
+      case BlockMatrixMap2(_, _, lName, rName, _, _) =>
+        if (i == 2) Some(Array(lName -> "l", rName -> "r")) else None
+      case AggLet(name, _, _, _) =>
+        if (i == 1) Some(Array(name -> "")) else None
+      case AggExplode(_, name, _, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case StreamAgg(_, name, _) =>
+        if (i == 1) Some(Array(name -> "elt")) else None
+      case _ =>
+        None
+    }
+
+    var identCounter: Int = 0
+    val idents = collection.mutable.Map.empty[String, Int]
+    def getIdentBase(ir: BaseIR): String = ir match {
+      case True() => "true"
+      case False() => "false"
+      case I32(i) => s"c$i"
+      case stream if stream.typ.isInstanceOf[TStream] => "s"
+      case table if table.typ.isInstanceOf[TableType] => "ht"
+      case mt if mt.typ.isInstanceOf[TableType] => "mt"
+      case _ => ""
+    }
+    def uniqueify(base: String): String = {
+      if (idents.contains(base)) {
+        idents(base) += 1
+        if (base.last.isDigit)
+          s"${base}_${idents(base)}"
+        else
+          s"${base}${idents(base)}"
+      } else {
+        idents(base) = 1
+        base
+      }
+    }
+    def getResultIdent(ir: BaseIR): String = {
+      val base = getIdentBase(ir)
+      if (base.isEmpty) {
+        identCounter += 1
+        identCounter.toString
+      } else {
+        uniqueify(base)
+      }
+    }
+
+    def prettyWithIdent(ir: BaseIR, bindings: Env[String], prefix: String): (Doc, String) = {
+      val (pre, body) = pretty(ir, bindings)
+      val ident = prefix + getResultIdent(ir)
+      val doc = vsep(pre, hsep(text(ident), "=", body))
+      (doc, ident)
+    }
+
+    def prettyBlock(ir: BaseIR, newBindings: IndexedSeq[(String, String)], bindings: Env[String]): Doc = {
+      val args = newBindings.map { case (name, base) => name -> s"%${uniqueify(base)}" }
+      val blockBindings = bindings.bindIterable(args)
+      val (pre, body) = pretty(ir, blockBindings)
+      val openBlock = if (args.isEmpty)
+        text("{")
+      else
+        concat("{", softline, args.map(_._2).mkString("(", ", ", ") =>"))
+      concat(openBlock, nest(2, vsep(pre, body)), line, "}")
+    }
+
+    def pretty(ir: BaseIR, bindings: Env[String]): (Doc, Doc) = ir match {
+      case Let(name, value, body) =>
+        val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
+        val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
+        (vsep(valueDoc, bodyPre), bodyHead)
+      case RelationalLet(name, value, body) =>
+        val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
+        val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
+        (vsep(valueDoc, bodyPre), bodyHead)
+      case RelationalLetTable(name, value, body) =>
+        val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
+        val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
+        (vsep(valueDoc, bodyPre), bodyHead)
+      case RelationalLetMatrixTable(name, value, body) =>
+        val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
+        val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
+        (vsep(valueDoc, bodyPre), bodyHead)
+      case RelationalLetBlockMatrix(name, value, body) =>
+        val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
+        val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
+        (vsep(valueDoc, bodyPre), bodyHead)
+      case _ =>
+        val strictChildBodies = mutable.ArrayBuilder.make[Doc]()
+        val strictChildIdents = for {
+          i <- ir.children.indices
+          if childIsStrict(ir, i)
+        } yield {
+          val child = ir.children(i)
+          child match {
+            case Ref(name, _) => bindings.lookup(name)
+            case _ =>
+              val (body, ident) = prettyWithIdent(ir.children(i), bindings, "!")
+              strictChildBodies += body
+              ident
+          }
+        }
+
+        val nestedBlocks = for {
+          i <- ir.children.indices
+          if !childIsStrict(ir, i)
+        } yield prettyBlock(ir.children(i), blockArgs(ir, i).get, bindings)
+
+        val attsIterable = header(ir, elideLiterals, elideBindings = true)
+        val attributes = if (attsIterable.isEmpty) Iterable.empty else
+          RichIterable.single(concat(attsIterable.intersperse[Doc]("[", ", ", "]")))
+
+        def standardArgs = if (strictChildIdents.isEmpty)
+          ""
+        else
+          strictChildIdents.mkString("(", ", ", ")")
+
+        val head = ir match {
+          case MakeStruct(fields) =>
+            val args = (fields.map(_._1), strictChildIdents).zipped.map { (field, value) =>
+              s"$field: $value"
+            }.mkString("(", ", ", ")")
+            hsep(text(prettyClass(ir) + args) +: (attributes ++ nestedBlocks))
+          case InsertFields(_, fields, _) =>
+            val newFields = (fields.map(_._1), strictChildIdents.tail).zipped.map { (field, value) =>
+              s"$field: $value"
+            }.mkString("(", ", ", ")")
+            val args = s" ${strictChildIdents.head} $newFields"
+            hsep(text(prettyClass(ir) + args) +: (attributes ++ nestedBlocks))
+          case ir: If =>
+            hsep(
+              text(s"${prettyClass(ir)} ${strictChildIdents.head}"),
+              text("then"),
+              nestedBlocks(0),
+              text("else"),
+              nestedBlocks(1))
+          case _ =>
+            val args = strictChildIdents.mkString("(", ", ", ")")
+            hsep(text(prettyClass(ir) + standardArgs) +: (attributes ++ nestedBlocks))
+        }
+
+        (hsep(strictChildBodies.result()), head)
+    }
+
+    val (pre, head) = pretty(ir, Env.empty)
+    vsep(pre, head, empty).render(width, ribbonWidth, maxLen)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3068,7 +3068,7 @@ class IRSuite extends HailSuite {
       "bin" -> TBinary,
       "x" -> TInt32))
 
-    val s = Pretty(x, elideLiterals = false)
+    val s = Pretty.sexprStyle(x, elideLiterals = false)
 
     val x2 = IRParser.parse_value_ir(s, env)
 
@@ -3077,21 +3077,21 @@ class IRSuite extends HailSuite {
 
   @Test(dataProvider = "tableIRs")
   def testTableIRParser(x: TableIR) {
-    val s = Pretty(x, elideLiterals = false)
+    val s = Pretty.sexprStyle(x, elideLiterals = false)
     val x2 = IRParser.parse_table_ir(ctx, s)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "matrixIRs")
   def testMatrixIRParser(x: MatrixIR) {
-    val s = Pretty(x, elideLiterals = false)
+    val s = Pretty.sexprStyle(x, elideLiterals = false)
     val x2 = IRParser.parse_matrix_ir(ctx, s)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "blockMatrixIRs")
   def testBlockMatrixIRParser(x: BlockMatrixIR) {
-    val s = Pretty(x, elideLiterals = false)
+    val s = Pretty.sexprStyle(x, elideLiterals = false)
     val x2 = IRParser.parse_blockmatrix_ir(ctx, s)
     assert(x2 == x)
   }
@@ -3101,7 +3101,7 @@ class IRSuite extends HailSuite {
     backend.persist(ctx.backendContext, "x", bm, "MEMORY_ONLY")
     val persist = BlockMatrixRead(BlockMatrixPersistReader("x", BlockMatrixType.fromBlockMatrix(bm)))
 
-    val s = Pretty(persist, elideLiterals = false)
+    val s = Pretty.sexprStyle(persist, elideLiterals = false)
     val x2 = IRParser.parse_blockmatrix_ir(ctx, s)
     assert(x2 == persist)
     backend.unpersist(ctx.backendContext, "x")
@@ -3358,7 +3358,7 @@ class IRSuite extends HailSuite {
     val lit = Literal(t, Row(1L))
 
     assert(IRParser.parseType(t.parsableString()) == t)
-    assert(IRParser.parse_value_ir(ctx, Pretty(lit, elideLiterals = false)) == lit)
+    assert(IRParser.parse_value_ir(ctx, Pretty.sexprStyle(lit, elideLiterals = false)) == lit)
   }
 
   def regressionTestUnifyBug(): Unit = {


### PR DESCRIPTION
This adds a new IR pretty-printer that uses an mlir inspired printed form. It is currently not rigorously tested, so using the new format in logs is gated behind the flag `HAIL_USE_SSA_LOGS`.