### PR TITLE
[batch] Fix cancel orphaned attempts query

### DIFF
--- a/batch/batch/driver/canceller.py
+++ b/batch/batch/driver/canceller.py
@@ -355,7 +355,7 @@ INNER JOIN jobs ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.
 LEFT JOIN instances ON attempts.instance_name = instances.name
 WHERE attempts.start_time IS NOT NULL
   AND attempts.end_time IS NULL
-  AND (jobs.state != 'Running' OR jobs.attempt_id != attempts.attempt_id)
+  AND ((jobs.state != 'Running' AND jobs.state != 'Creating') OR jobs.attempt_id != attempts.attempt_id)
   AND instances.`state` = 'active'
 ORDER BY attempts.start_time ASC
 LIMIT 300;


### PR DESCRIPTION
We were not accounting for jobs that could be in the Creating state before a job has been scheduled on an active instance.