### PR TITLE
[infra] teach create_bootstrap_vm.sh to use random names

### DIFF
--- a/infra/azure/create_bootstrap_vm.sh
+++ b/infra/azure/create_bootstrap_vm.sh
@@ -10,7 +10,7 @@ fi
 RESOURCE_GROUP=$1
 
 SUBSCRIPTION_ID=$(az account list | jq -rj '.[0].id')
-VM_NAME=bootstrap-vm
+VM_NAME=bootstrap-vm-$(cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
 
 ip=$(az vm create \
     --name $VM_NAME \


### PR DESCRIPTION
In the unlikely change that the user already has a VM whose prefix is boostrap-vm, this will significantly reduce the likelihood of a name-clash.