### PR TITLE
[query] Clear TableKeyByAndAggregate context region in SeqOp

### DIFF
--- a/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
@@ -378,3 +378,10 @@ def mt_localize_and_collect(mt_path):
     mt = hl.read_matrix_table(mt_path)
     ht = mt.localize_entries("ent")
     collected = ht.head(150).collect()
+
+
+@benchmark(args=random_doubles.handle("mt"))
+def mt_group_by_memory_usage(mt_path):
+    mt = hl.read_matrix_table(mt_path)
+    mt = mt.group_rows_by(new_idx=mt.row_idx % 3).aggregate(x = hl.agg.mean(mt.x))
+    mt._force_count_rows()

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -2602,6 +2602,7 @@ case class TableKeyByAndAggregate(
             f.setAggState(agg.region, agg.offset)
             f(ctx.region, globals, ptr)
             agg.setOffset(f.getAggOffset())
+            ctx.region.clear()
           }
         }
         val serializeAndCleanupAggs = { rv: RegionValue =>


### PR DESCRIPTION
Tested using code from [zulip].

After this change, the same pipeline went from 135 MiB peak usage per
partition, to 808 KiB.

[zulip]: https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query.200.2E2.20support/topic/Hail.20off-heap.20memory/near/270245855