### PR TITLE
[infra] always use valid storage account names

### DIFF
--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -19,10 +19,24 @@ Every resource in Azure must belong to a Resource Group. First, obtain
 a resource group and make sure you have Owner permissions for that
 resource group.
 
-Create a `global.tfvars` file with the necessary variables
-from $HAIL/infra/azure/variables.tf.
+You will also need a storage account and container for remotely storing
+terraform state. The following command creates these and stores their names in
+`remote_storage.tfvars`:
 
-To setup and run the terraform, run
+```
+./bootstrap.sh create_terraform_remote_storage <RESOURCE_GROUP>
+```
+
+Initialize terraform:
+
+```
+./bootstrap.sh init_terraform <RESOURCE_GROUP>
+```
+
+Create a `global.tfvars` file with the necessary variables from
+$HAIL/infra/azure/variables.tf.
+
+Setup and run terraform:
 
 ```
 ./bootstrap.sh run_terraform <RESOURCE_GROUP>

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -36,10 +36,10 @@ Initialize terraform:
 Create a `global.tfvars` file with the necessary variables from
 $HAIL/infra/azure/variables.tf.
 
-Setup and run terraform:
+Run terraform:
 
 ```
-./bootstrap.sh run_terraform <RESOURCE_GROUP>
+terraform apply -var-file=global.tfvars
 ```
 
 Once terraform has completed successfully, note the `gateway_ip` in the

--- a/infra/azure/bootstrap.sh
+++ b/infra/azure/bootstrap.sh
@@ -16,50 +16,53 @@ setup_az() {
     az login --identity
 }
 
-setup_terraform_backend() {
-    RESOURCE_GROUP=$1
-    STORAGE_CONTAINER_NAME="tfstate"
+create_terraform_remote_storage() {
+    RESOURCE_GROUP=${RESOURCE_GROUP:-$1}
+    STORAGE_CONTAINER_NAME=${STORAGE_CONTAINER_NAME:-"tfstate"}
 
-    if [ -e backend-config.tfvars ]
-    then
-        echo "Found backend-config.tfvars. I assume storage account and container for terraform are already created."
-    else
-        echo "No backend-config.tfvars found. I will create storage account and container for terraform."
-        # NOTE: This name is assumed to be globally unique
-        # NOTE: must be 3-24 lowercase letters and numbers only
-        possibly_invalid_storage_account_name="$(cat /dev/urandom | LC_ALL=C tr -dc '0-9' | head -c 4)${RESOURCE_GROUP}"
-        STORAGE_ACCOUNT_NAME=$(LC_ALL=C tr -dc 'a-z0-9' <<< "${possibly_invalid_storage_account_name}" | head -c 24)
+    # NOTE: This name is assumed to be globally unique
+    # NOTE: must be 3-24 lowercase letters and numbers only
+    possibly_invalid_storage_account_name="$(cat /dev/urandom | LC_ALL=C tr -dc '0-9' | head -c 4)${RESOURCE_GROUP}"
+    STORAGE_ACCOUNT_NAME=$(LC_ALL=C tr -dc 'a-z0-9' <<< "${possibly_invalid_storage_account_name}" | head -c 24)
 
-        # This storage account/container will be created if it does not already exist
-        az storage account create -n $STORAGE_ACCOUNT_NAME -g $RESOURCE_GROUP
-        STORAGE_ACCOUNT_KEY=$(az storage account keys list \
-            -g $RESOURCE_GROUP \
-            --account-name $STORAGE_ACCOUNT_NAME \
-            | jq -rj '.[0].value'
-        )
-        az storage container create -n $STORAGE_CONTAINER_NAME \
-            --account-name $STORAGE_ACCOUNT_NAME \
-            --account-key $STORAGE_ACCOUNT_KEY
-
-        cat >backend-config.tfvars <<EOF
+    # This storage account/container will be created if it does not already exist
+    az storage account create -n $STORAGE_ACCOUNT_NAME -g $RESOURCE_GROUP
+    STORAGE_ACCOUNT_KEY=$(az storage account keys list \
+        -g $RESOURCE_GROUP \
+        --account-name $STORAGE_ACCOUNT_NAME \
+        | jq -rj '.[0].value'
+    )
+    az storage container create -n $STORAGE_CONTAINER_NAME \
+        --account-name $STORAGE_ACCOUNT_NAME \
+        --account-key $STORAGE_ACCOUNT_KEY
+    cat >remote_storage.tfvars <<EOF
 storage_account_name = "$STORAGE_ACCOUNT_NAME"
 container_name       = "$STORAGE_CONTAINER_NAME"
-access_key           = "$STORAGE_ACCOUNT_KEY"
 key                  = "haildev.tfstate"
 EOF
+}
 
-    fi
-    terraform init -backend-config=backend-config.tfvars
+init_terraform() {
+    RESOURCE_GROUP=${RESOURCE_GROUP:-$1}
+    STORAGE_CONTAINER_NAME=${STORAGE_CONTAINER_NAME:-"tfstate"}
+
+    STORAGE_ACCOUNT_KEY=$(az storage account keys list \
+        -g $RESOURCE_GROUP \
+        --account-name $STORAGE_ACCOUNT_NAME \
+        | jq -rj '.[0].value'
+    )
+    remote_storage_access_key="$(mktemp)"
+    trap 'rm -f -- "$backend_config_file"' EXIT
+
+    cat >$remote_storage_access_key <<EOF
+access_key           = "$STORAGE_ACCOUNT_KEY"
+EOF
+
+    terraform init -backend-config=$remote_storage_access_key -backend-config=remote_storage.tfvars
 }
 
 run_terraform() {
-    if [ -z "$1" ]; then
-        echo "Arguments not supplied: <RESOURCE_GROUP>"
-        return
-    fi
-
     set -e
-    setup_terraform_backend "$@"
     terraform apply -var-file=global.tfvars
 }
 

--- a/infra/azure/bootstrap.sh
+++ b/infra/azure/bootstrap.sh
@@ -52,7 +52,7 @@ init_terraform() {
         | jq -rj '.[0].value'
     )
     remote_storage_access_key="$(mktemp)"
-    trap 'rm -f -- "$backend_config_file"' EXIT
+    trap 'rm -f -- "$remote_storage_access_key"' EXIT
 
     cat >$remote_storage_access_key <<EOF
 access_key           = "$STORAGE_ACCOUNT_KEY"

--- a/infra/azure/bootstrap.sh
+++ b/infra/azure/bootstrap.sh
@@ -61,9 +61,4 @@ EOF
     terraform init -backend-config=$remote_storage_access_key -backend-config=remote_storage.tfvars
 }
 
-run_terraform() {
-    set -e
-    terraform apply -var-file=global.tfvars
-}
-
 $@


### PR DESCRIPTION
Resource groups are permitted to use dashes, underscores, uppercase letters,
and probably other characters not permitted in storage account names. This
PR cahanges `bootstrap.sh` to:

1. Ignore invalid characters in the resouce group.

2. Ensure (via randomness) that the generated name is unique.

3. Do not try to create a new storage account if `backend-config.tfvars` exists.

I lightly tested this. Here is an example of how it sanitizes a resource group name:

```
RESOURCE_GROUP=bu__ild-batch-worker-i32mage
possibly_invalid_storage_account_name="$(cat /dev/urandom | LC_ALL=C tr -dc 0-9 | head -c 4)${RESOURCE_GROUP}"
STORAGE_ACCOUNT_NAME=$(LC_ALL=C tr -dc a-z0-9 <<< "${possibly_invalid_storage_account_name}" | head -c 24)
echo $STORAGE_ACCOUNT_NAME
7241buildbatchworkeri32m
```