### PR TITLE
[compiler] generic staged binary search utils

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
@@ -98,6 +98,12 @@ trait CodeBuilderLike {
     define(Lafter)
   }
 
+  def loop(emitBody: CodeLabel => Unit): Unit = {
+    val Lstart = CodeLabel()
+    define(Lstart)
+    emitBody(Lstart)
+  }
+
   def whileLoop(c: => Code[Boolean], emitBody: (CodeLabel) => Unit): Unit = {
     val Lstart = CodeLabel()
     val Lbody = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -213,24 +213,28 @@ object BinarySearch {
     // - range [right, end) is > needle
     // - left <= right
     // terminates b/c (right - left) strictly decreases each iteration
-    cb.whileLoop(left < right, break => {
+    cb.loop { recur =>
+      cb.ifx(left < right, {
       val mid = cb.memoize((left + right) >>> 1) // works even when sum overflows
       compare(cb, haystack.loadElement(cb, mid), {
         // range [start, mid] is < needle
         cb.assign(left, mid + 1)
+          cb.goto(recur)
       }, {
         // range [mid, end) is > needle
         cb.assign(right, mid)
+          cb.goto(recur)
       }, {
         // haystack(mid) is incomparable to needle
         found(left, mid, right)
-        cb.goto(break)
-      })
     })
+      }, {
     // now loop invariants hold, with left = right, so
     // - range [start, left) is < needle
     // - range [left, end) is > needle
     notFound(left)
+      })
+    }
   }
 
   private def runSearchUnit(

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -8,67 +8,301 @@ import is.hail.utils.FastIndexedSeq
 
 import scala.language.existentials
 
-class BinarySearch[C](mb: EmitMethodBuilder[C], containerType: SContainer, eltType: EmitType, keyOnly: Boolean) {
-
-  val containerElementType: EmitType = containerType.elementEmitType
-
-  val (compare: CodeOrdering.F[Int], equiv: CodeOrdering.F[Boolean], findElt: EmitMethodBuilder[C]) = if (keyOnly) {
-    val kt: EmitType = containerElementType.st match {
-      case s: SBaseStruct =>
-        require(s.size == 2)
-        s.fieldEmitTypes(0)
-      case interval: SInterval =>
-        interval.pointEmitType
+object BinarySearch {
+  object Comparator {
+    def fromLtGt(
+      ltNeedle: IEmitCode => Code[Boolean],
+      gtNeedle: IEmitCode => Code[Boolean]
+    ): Comparator = new Comparator {
+      def apply(cb: EmitCodeBuilder, elt: IEmitCode, ifLtNeedle: => Unit, ifGtNeedle: => Unit, ifNeither: => Unit): Unit = {
+        val eltVal = cb.memoize(elt)
+        cb.ifx(ltNeedle(eltVal.loadI(cb)),
+          ifLtNeedle,
+          cb.ifx(gtNeedle(eltVal.loadI(cb)),
+            ifGtNeedle,
+            ifNeither))
+      }
     }
-    val findMB = mb.genEmitMethod("findElt", FastIndexedSeq[ParamType](containerType.paramType, eltType.paramType), typeInfo[Int])
 
-    val comp: CodeOrdering.F[Int] = {
-      (cb: EmitCodeBuilder, ec1: EmitValue, _ec2: EmitValue) =>
-        val ec2 = cb.memoize(EmitCode.fromI(cb.emb) { cb =>
-          _ec2.toI(cb).flatMap(cb) {
-            case v2: SBaseStructValue =>
-              v2.loadField(cb, 0)
-            case v2: SIntervalValue =>
-              v2.loadStart(cb)
-          }
-        })
-        findMB.ecb.getOrderingFunction(eltType.st, kt.st, CodeOrdering.Compare())(cb, ec1, ec2)
+    def fromCompare(compare: IEmitCode => Code[Int]): Comparator = new Comparator {
+      def apply(cb: EmitCodeBuilder, elt: IEmitCode, ifLtNeedle: => Unit, ifGtNeedle: => Unit, ifNeither: => Unit): Unit = {
+        val c = compare(elt)
+        cb.ifx(c < 0,
+          ifLtNeedle,
+          cb.ifx(c > 0,
+            ifGtNeedle,
+            ifNeither))
+      }
     }
-    val ceq: CodeOrdering.F[Boolean] = {
-      (cb: EmitCodeBuilder, ec1: EmitValue, _ec2: EmitValue) =>
-        val ec2 = cb.memoize(EmitCode.fromI(cb.emb) { cb =>
-          _ec2.toI(cb).flatMap(cb) {
-            case v2: SBaseStructValue =>
-              v2.loadField(cb, 0)
-            case v2: SIntervalValue =>
-              v2.loadStart(cb)
-          }
-        })
-      findMB.ecb.getOrderingFunction(eltType.st, kt.st, CodeOrdering.Equiv())(cb, ec1, ec2)
+
+    def fromPred(pred: IEmitCode => Code[Boolean]): Comparator = new Comparator {
+      def apply(cb: EmitCodeBuilder, elt: IEmitCode, ifLtNeedle: => Unit, ifGtNeedle: => Unit, ifNeither: => Unit): Unit = {
+        cb.ifx(pred(elt), ifGtNeedle, ifLtNeedle)
+      }
     }
-    (comp, ceq, findMB)
-  } else
-    (mb.ecb.getOrderingFunction(eltType.st, containerElementType.st, CodeOrdering.Compare()),
-      mb.ecb.getOrderingFunction(eltType.st, containerElementType.st, CodeOrdering.Equiv()),
-      mb.genEmitMethod("findElt", FastIndexedSeq[ParamType](containerType.paramType, eltType.paramType), typeInfo[Int]))
+  }
 
-  // Returns smallest i, 0 <= i < n, for which a(i) >= key, or returns n if a(i) < key for all i
-  findElt.emitWithBuilder[Int] { cb =>
-    val indexable = findElt.getSCodeParam(1).asIndexable
+  /** Represents a discriminator of values of some type into one of three
+    * mutually exclusive categories:
+    * - less than the needle (whatever is being searched for)
+    * - greater than the needle
+    * - neither (interpretation depends on the application, e.g. "equals needle",
+    *   "contains needle", "contained in needle")
+    */
+  abstract class Comparator {
+    def apply(cb: EmitCodeBuilder, elt: IEmitCode, ltNeedle: => Unit, gtNeedle: => Unit, neither: => Unit): Unit
+  }
 
-    val elt = findElt.getEmitParam(cb, 2, null) // no streams
+  /** Returns true if haystack contains an element x such that !ltNeedle(x)
+    * and !gtNeedle(x), false otherwise.
+    */
+  def containsOrdered(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    ltNeedle: IEmitCode => Code[Boolean],
+    gtNeedle: IEmitCode => Code[Boolean]
+  ): Value[Boolean] =
+    runSearch[Boolean](cb, haystack, Comparator.fromLtGt(ltNeedle, gtNeedle), (_, _, _) => true, (_) => false)
 
-    val low = cb.newLocal("findelt_low", 0)
-    val high = cb.newLocal("findelt_high", indexable.loadLength())
+  /** Returns true if haystack contains an element x such that !lt(x, needle)
+    * and !lt(needle, x), false otherwise.
+    */
+  def containsOrdered(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    needle: EmitValue,
+    lt: (IEmitCode, IEmitCode) => Code[Boolean],
+    key: IEmitCode => IEmitCode
+  ): Value[Boolean] =
+    containsOrdered(cb, haystack, x => lt(key(x), needle.loadI(cb)), x => lt(needle.loadI(cb), key(x)))
 
-    cb.whileLoop(low < high, {
-      val i = cb.newLocal("findelt_i", (low + high) / 2)
-      cb.ifx(compare(cb, elt, cb.memoize(indexable.loadElement(cb, i))) <= 0,
-        cb.assign(high, i),
-        cb.assign(low, i + 1)
-      )
+  /** Returns (l, u) such that
+    * - range [0, l) is < needle
+    * - range [l, u) is incomparable ("equal") to needle
+    * - range [u, size) is > needle
+    *
+    * Assumes comparator separates haystack into < needle, followed by
+    * incomparable to needle, followed by > needle.
+    */
+  def equalRange(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    compare: Comparator,
+    ltNeedle: IEmitCode => Code[Boolean],
+    gtNeedle: IEmitCode => Code[Boolean],
+    start: Value[Int],
+    end: Value[Int]
+  ): (Value[Int], Value[Int]) = {
+    val l = cb.newLocal[Int]("equalRange_l")
+    val u = cb.newLocal[Int]("equalRange_u")
+    runSearchBoundedUnit(cb, haystack, compare, start, end,
+      (curL, m, curU) => {
+        // [start, curL) is < needle
+        // [start, m] is <= needle
+        // [m, end) is >= needle
+        // [curR, end) is > needle
+        cb.assign(l,
+          lowerBound(cb, haystack, ltNeedle, curL, m))
+        // [curL, l) is < needle
+        // [l, m) is >= needle
+        cb.assign(u,
+          upperBound(cb, haystack, gtNeedle, cb.memoize(m + 1), curU))
+        // [m+1, u) is <= needle
+        // [u, curU) is > needle
+      }, m => {
+        // [start, m) is < needle
+        // [m, end) is > needle
+        cb.assign(l, m)
+        cb.assign(u, m)
+      })
+    (l, u)
+  }
+
+  /** Returns i in ['start', 'end'] such that
+    * - range [start, i) is < needle
+    * - range [i, end) is >= needle
+    *
+    * Assumes ltNeedle is down-closed, i.e. all trues precede all falses
+    */
+  def lowerBound(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    ltNeedle: IEmitCode => Code[Boolean],
+    start: Value[Int],
+    end: Value[Int]
+  ): Value[Int] =
+    partitionPoint(cb, haystack, x => !ltNeedle(x), start, end)
+
+  def lowerBound(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    ltNeedle: IEmitCode => Code[Boolean]
+  ): Value[Int] =
+    lowerBound(cb, haystack, ltNeedle, 0, haystack.loadLength())
+
+  /** Returns i in ['start', 'end'] such that
+    * - range [start, i) is <= needle
+    * - range [i, end) is > needle
+    *
+    * Assumes gtNeedle is up-closed, i.e. all falses precede all trues
+    */
+  def upperBound(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    gtNeedle: IEmitCode => Code[Boolean],
+    start: Value[Int],
+    end: Value[Int]
+  ): Value[Int] =
+    partitionPoint(cb, haystack, x => gtNeedle(x), start, end)
+
+  /** Returns 'start' <= i <= 'end' such that
+    * - pred is false on range [start, i), and
+    * - pred is true on range [i, end).
+    *
+    * Assumes pred partitions a, i.e. for all 0 <= i <= j < haystack.size,
+    * if pred(i) then pred(j), i.e. all falses precede all trues.
+    */
+  def partitionPoint(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    pred: IEmitCode => Code[Boolean],
+    start: Value[Int],
+    end: Value[Int]
+  ): Value[Int] = {
+    var i: Value[Int] = null
+    runSearchBoundedUnit(cb, haystack, Comparator.fromPred(pred), start, end,
+      (_, _, _) => {}, // unreachable
+      _i => i = _i)
+    i
+  }
+
+  def partitionPoint(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    pred: IEmitCode => Code[Boolean]
+  ): Value[Int] =
+    partitionPoint(cb, haystack, pred, const(0), haystack.loadLength())
+
+  /** Perform binary search until either
+    * - an index m is found for which haystack(i) is incomparable with the needle,
+    *   i.e. neither ltNeedle(m) nor gtNeedle(m).
+    *   In this case, call found(l, m, u), where
+    *   - haystack(m) is incomparable to needle
+    *   - range [start, l) is < needle
+    *   - range [r, end) is > needle
+    * - it is certain that no such m exists. In this case, call notFound(j), where
+    *   - range [start, j) is < needle
+    *   - range [j, end) is > needle
+    *
+    * Assumes comparator separates haystack into < needle, followed by
+    * incomparable to needle, followed by > needle.
+    */
+  private def runSearchBoundedUnit(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    compare: Comparator,
+    start: Value[Int],
+    end: Value[Int],
+    found: (Value[Int], Value[Int], Value[Int]) => Unit,
+    notFound: Value[Int] => Unit
+  ): Unit = {
+    val left = cb.newLocal[Int]("left", start)
+    val right = cb.newLocal[Int]("right", end)
+    // loop invariants:
+    // - range [start, left) is < needle
+    // - range [right, end) is > needle
+    // - left <= right
+    // terminates b/c (right - left) strictly decreases each iteration
+    cb.whileLoop(left < right, break => {
+      val mid = cb.memoize((left + right) >>> 1) // works even when sum overflows
+      compare(cb, haystack.loadElement(cb, mid), {
+        // range [start, mid] is < needle
+        cb.assign(left, mid + 1)
+      }, {
+        // range [mid, end) is > needle
+        cb.assign(right, mid)
+      }, {
+        // haystack(mid) is incomparable to needle
+        found(left, mid, right)
+        cb.goto(break)
+      })
     })
-    low
+    // now loop invariants hold, with left = right, so
+    // - range [start, left) is < needle
+    // - range [left, end) is > needle
+    notFound(left)
+  }
+
+  private def runSearchUnit(
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    compare: Comparator,
+    found: (Value[Int], Value[Int], Value[Int]) => Unit,
+    notFound: Value[Int] => Unit
+  ): Unit =
+    runSearchBoundedUnit(cb, haystack, compare, 0, haystack.loadLength(), found, notFound)
+
+  private def runSearchBounded[T: TypeInfo](
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    compare: Comparator,
+    start: Value[Int],
+    end: Value[Int],
+    found: (Value[Int], Value[Int], Value[Int]) => Code[T],
+    notFound: Value[Int] => Code[T]
+  ): Value[T] = {
+    val ret = cb.newLocal[T]("runSearch_ret")
+    runSearchBoundedUnit(cb, haystack, compare, start, end,
+      (l, m, r) => cb.assign(ret, found(l, m, r)),
+      i => cb.assign(ret, notFound(i)))
+    ret
+  }
+
+  private def runSearch[T: TypeInfo](
+    cb: EmitCodeBuilder,
+    haystack: SIndexableValue,
+    compare: Comparator,
+    found: (Value[Int], Value[Int], Value[Int]) => Code[T],
+    notFound: Value[Int] => Code[T]
+  ): Value[T] =
+    runSearchBounded[T](cb, haystack, compare, 0, haystack.loadLength(), found, notFound)
+}
+
+class BinarySearch[C](mb: EmitMethodBuilder[C], containerType: SContainer, eltType: EmitType, keyOnly: Boolean) {
+  val containerElementType: EmitType = containerType.elementEmitType
+  val findElt = mb.genEmitMethod("findElt", FastIndexedSeq[ParamType](containerType.paramType, eltType.paramType), typeInfo[Int])
+
+  // Returns i in [0, n] such that a(j) < key for j in [0, i), and a(j) >= key
+  // for j in [i, n)
+  findElt.emitWithBuilder[Int] { cb =>
+    val haystack = findElt.getSCodeParam(1).asIndexable
+    val needle = findElt.getEmitParam(cb, 2, null) // no streams
+
+    def ltNeedle(x: IEmitCode): Code[Boolean] = if (keyOnly) {
+      val kt: EmitType = containerElementType.st match {
+        case s: SBaseStruct =>
+          require(s.size == 2)
+          s.fieldEmitTypes(0)
+        case interval: SInterval =>
+          interval.pointEmitType
+      }
+
+      val keyLT = mb.ecb.getOrderingFunction(eltType.st, kt.st, CodeOrdering.Lt())
+
+      val key = cb.memoize(x.flatMap(cb) {
+        case x: SBaseStructValue =>
+          x.loadField(cb, 0)
+        case x: SIntervalValue =>
+          x.loadStart(cb)
+      })
+
+      keyLT(cb, key, needle)
+    } else {
+      val lt = mb.ecb.getOrderingFunction(eltType.st, containerElementType.st, CodeOrdering.Lt())
+      lt(cb, cb.memoize(x), needle)
+    }
+
+    BinarySearch.lowerBound(cb, haystack, ltNeedle)
   }
 
   // check missingness of v before calling

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -287,7 +287,7 @@ class BinarySearch[C](mb: EmitMethodBuilder[C], containerType: SContainer, eltTy
           interval.pointEmitType
       }
 
-      val keyLT = mb.ecb.getOrderingFunction(eltType.st, kt.st, CodeOrdering.Lt())
+      val keyLT = mb.ecb.getOrderingFunction(kt.st, eltType.st, CodeOrdering.Lt())
 
       val key = cb.memoize(x.flatMap(cb) {
         case x: SBaseStructValue =>
@@ -298,7 +298,7 @@ class BinarySearch[C](mb: EmitMethodBuilder[C], containerType: SContainer, eltTy
 
       keyLT(cb, key, needle)
     } else {
-      val lt = mb.ecb.getOrderingFunction(eltType.st, containerElementType.st, CodeOrdering.Lt())
+      val lt = mb.ecb.getOrderingFunction(containerElementType.st, eltType.st, CodeOrdering.Lt())
       lt(cb, cb.memoize(x), needle)
     }
 


### PR DESCRIPTION
This ports and cleans up the binary search library methods in `RichIndexedSeq`. I very carefully documented general pre-/post-conditions and invariants, because binary search implementations are notorious for hiding bugs, and because these will be used in cases where both haystack and needle are intervals, where the typical formulation of binary search involving a well-behaved ordering doesn't apply.