### PR TITLE
[query] Refactor ggplot to use pandas, support alpha on histograms and bar charts

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -391,6 +391,8 @@ def geom_histogram(mapping=aes(), *, min_val=None, max_val=None, bins=None, fill
         A single fill color for all bars of histogram, overrides ``fill`` aesthetic.
     color:
         A single outline color for all bars of histogram, overrides ``color`` aesthetic.
+    alpha: `float`
+        A measure of transparency between 0 and 1.
     position: :class:`str`
         Tells how to deal with different groups of data at same point. Options are "stack" and "dodge".
 

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -194,12 +194,13 @@ def geom_text(mapping=aes(), *, color=None):
 
 class GeomBar(Geom):
 
-    def __init__(self, aes, fill=None, color=None, position="stack", size=None, stat=None):
+    def __init__(self, aes, fill=None, color=None, alpha=None, position="stack", size=None, stat=None):
         super().__init__(aes)
         self.fill = fill
         self.color = color
         self.position = position
         self.size = size
+        self.alpha = alpha
 
         if stat is None:
             stat = StatCount()
@@ -232,6 +233,9 @@ class GeomBar(Geom):
             if self.size is not None:
                 bar_args["marker_line_width"] = self.size
 
+            if self.alpha is not None:
+                bar_args["marker_opacity"] = self.alpha
+
             fig_so_far.add_bar(**bar_args)
 
         groups = set(agg_result["group"])
@@ -246,7 +250,7 @@ class GeomBar(Geom):
         return self.stat
 
 
-def geom_bar(mapping=aes(), *, fill=None, color=None, position="stack", size=None):
+def geom_bar(mapping=aes(), *, fill=None, color=None, alpha=None, position="stack", size=None):
     """Create a bar chart that counts occurrences of the various values of the ``x`` aesthetic.
 
     Supported aesthetics: ``x``, ``color``, ``fill``
@@ -257,10 +261,10 @@ def geom_bar(mapping=aes(), *, fill=None, color=None, position="stack", size=Non
         The geom to be applied.
     """
 
-    return GeomBar(mapping, fill=fill, color=color, position=position, size=size)
+    return GeomBar(mapping, fill=fill, color=color, alpha=alpha, position=position, size=size)
 
 
-def geom_col(mapping=aes(), *, fill=None, color=None, position="stack", size=None):
+def geom_col(mapping=aes(), *, fill=None, color=None, alpha=None, position="stack", size=None):
     """Create a bar chart that uses bar heights specified in y aesthetic.
 
     Supported aesthetics: ``x``, ``y``, ``color``, ``fill``
@@ -270,18 +274,19 @@ def geom_col(mapping=aes(), *, fill=None, color=None, position="stack", size=Non
     :class:`FigureAttribute`
         The geom to be applied.
     """
-    return GeomBar(mapping, stat=StatIdentity(), fill=fill, color=color, position=position, size=size)
+    return GeomBar(mapping, stat=StatIdentity(), fill=fill, color=color, alpha=alpha, position=position, size=size)
 
 
 class GeomHistogram(Geom):
 
-    def __init__(self, aes, min_val=None, max_val=None, bins=None, fill=None, color=None, position='stack', size=None):
+    def __init__(self, aes, min_val=None, max_val=None, bins=None, fill=None, color=None, alpha=None, position='stack', size=None):
         super().__init__(aes)
         self.min_val = min_val
         self.max_val = max_val
         self.bins = bins
         self.fill = fill
         self.color = color
+        self.alpha = alpha
         self.position = position
         self.size = size
 
@@ -330,6 +335,9 @@ class GeomHistogram(Geom):
             if self.size is not None:
                 hist_args["marker_line_width"] = self.size
 
+            if self.alpha is not None:
+                hist_args["marker_opacity"] = self.alpha
+
             if "fill_legend" in df.columns:
                 hist_args["name"] = df.fill_legend.iloc[0]
 
@@ -350,7 +358,7 @@ class GeomHistogram(Geom):
         return StatBin(self.min_val, self.max_val, self.bins)
 
 
-def geom_histogram(mapping=aes(), *, min_val=None, max_val=None, bins=None, fill=None, color=None, position='stack',
+def geom_histogram(mapping=aes(), *, min_val=None, max_val=None, bins=None, fill=None, color=None, alpha=None, position='stack',
                    size=None):
     """Creates a histogram.
 
@@ -374,14 +382,13 @@ def geom_histogram(mapping=aes(), *, min_val=None, max_val=None, bins=None, fill
         A single outline color for all bars of histogram, overrides ``color`` aesthetic.
     position: :class:`str`
         Tells how to deal with different groups of data at same point. Options are "stack" and "dodge".
-    size
 
     Returns
     -------
     :class:`FigureAttribute`
         The geom to be applied.
     """
-    return GeomHistogram(mapping, min_val, max_val, bins, fill, color, position, size)
+    return GeomHistogram(mapping, min_val=min_val, max_val=max_val, bins=bins, fill=fill, color=color, alpha=alpha, position=position, size=size)
 
 
 linetype_dict = {

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -29,28 +29,29 @@ class GeomLineBasic(Geom):
 
     def apply_to_fig(self, parent, agg_result, fig_so_far, precomputed):
 
-        def plot_group(data, color):
+        def plot_group(df, color):
             scatter_args = {
-                "x": [element["x"] for element in data],
-                "y": [element["y"] for element in data],
+                "x": df.x,
+                "y": df.y,
                 "mode": "lines",
                 "line_color": color
 
             }
-            if "color_legend" in data[0]:
-                scatter_args["name"] = data[0]["color_legend"]
+            if "color_legend" in df.columns:
+                scatter_args["name"] = df.color_legend.iloc[0]
 
             if "tooltip" in parent.aes or "tooltip" in self.aes:
-                scatter_args["hovertext"] = [element["tooltip"] for element in data]
+                scatter_args["hovertext"] = df.tooltip
             fig_so_far.add_scatter(**scatter_args)
 
         if self.color is not None:
             plot_group(agg_result, self.color)
         elif "color" in parent.aes or "color" in self.aes:
-            groups = set([element["group"] for element in agg_result])
+            groups = set(agg_result["group"])
             for group in groups:
-                just_one_group = [element for element in agg_result if element["group"] == group]
-                plot_group(just_one_group, just_one_group[0]["color"])
+                rows_for_this_group = agg_result["group"] == group
+                just_one_group = agg_result[rows_for_this_group]
+                plot_group(just_one_group)
         else:
             plot_group(agg_result, "black")
 
@@ -66,29 +67,30 @@ class GeomPoint(Geom):
         self.color = color
 
     def apply_to_fig(self, parent, agg_result, fig_so_far, precomputed):
-        def plot_group(data, color=None):
+        def plot_group(df, color=None):
             scatter_args = {
-                "x": [element["x"] for element in data],
-                "y": [element["y"] for element in data],
+                "x": df["x"],
+                "y": df["y"],
                 "mode": "markers",
-                "marker_color": color if color is not None else [element["color"] for element in data]
+                "marker_color": color if color is not None else df["color"]
             }
 
-            if "color_legend" in data[0]:
-                scatter_args["name"] = data[0]["color_legend"]
+            if "color_legend" in df.columns:
+                scatter_args["name"] = df["color_legend"].iloc[0]
 
             if "size" in parent.aes or "size" in self.aes:
-                scatter_args["marker_size"] = [element["size"] for element in data]
+                scatter_args["marker_size"] = df["size"]
             if "tooltip" in parent.aes or "tooltip" in self.aes:
-                scatter_args["hovertext"] = [element["tooltip"] for element in data]
+                scatter_args["hovertext"] = df["tooltip"]
             fig_so_far.add_scatter(**scatter_args)
 
         if self.color is not None:
             plot_group(agg_result, self.color)
         elif "color" in parent.aes or "color" in self.aes:
-            groups = set([element["group"] for element in agg_result])
+            groups = set(agg_result["group"])
             for group in groups:
-                just_one_group = [element for element in agg_result if element["group"] == group]
+                rows_for_this_group = agg_result["group"] == group
+                just_one_group = agg_result[rows_for_this_group]
                 plot_group(just_one_group)
         else:
             plot_group(agg_result, "black")
@@ -143,32 +145,33 @@ class GeomText(Geom):
         self.color = color
 
     def apply_to_fig(self, parent, agg_result, fig_so_far, precomputed):
-        def plot_group(data, color=None):
+        def plot_group(df, color=None):
             scatter_args = {
-                "x": [element["x"] for element in data],
-                "y": [element["y"] for element in data],
-                "text": [element["label"] for element in data],
+                "x": df.x,
+                "y": df.y,
+                "text": df.label,
                 "mode": "text",
                 "textfont_color": color
             }
 
-            if "color_legend" in data[0]:
-                scatter_args["name"] = data[0]["color_legend"]
+            if "color_legend" in df.columns:
+                scatter_args["name"] = df.color_legend.iloc[0]
 
             if "tooltip" in parent.aes or "tooltip" in self.aes:
-                scatter_args["hovertext"] = [element["tooltip"] for element in data]
+                scatter_args["hovertext"] = df.tooltip
 
             if "size" in parent.aes or "size" in self.aes:
-                scatter_args["marker_size"] = [element["size"] for element in data]
+                scatter_args["marker_size"] = df.size
             fig_so_far.add_scatter(**scatter_args)
 
         if self.color is not None:
             plot_group(agg_result, self.color)
         elif "color" in parent.aes or "color" in self.aes:
-            groups = set([element["group"] for element in agg_result])
+            groups = set(agg_result["group"])
             for group in groups:
-                just_one_group = [element for element in agg_result if element["group"] == group]
-                plot_group(just_one_group, just_one_group[0]["color"])
+                rows_for_this_group = agg_result["group"] == group
+                just_one_group = agg_result[rows_for_this_group]
+                plot_group(just_one_group)
         else:
             plot_group(agg_result, "black")
 
@@ -203,25 +206,26 @@ class GeomBar(Geom):
         self.stat = stat
 
     def apply_to_fig(self, parent, agg_result, fig_so_far, precomputed):
-        def plot_group(data):
+        def plot_group(df):
             if self.fill is None:
-                if "fill" in data[0]:
-                    fill = [element["fill"] for element in data]
+                if "fill" in df.columns:
+                    fill = df.fill
                 else:
                     fill = "black"
             else:
                 fill = self.fill
 
             bar_args = {
-                "x": [element["x"] for element in data],
-                "y": [element["y"] for element in data],
+                "x": df.x,
+                "y": df.y,
                 "marker_color": fill
             }
-            if "color_legend" in data[0]:
-                bar_args["name"] = data[0]["color_legend"]
 
-            if self.color is None and "color" in data[0]:
-                bar_args["marker_line_color"] = [element["color"] for element in data]
+            if "color_legend" in df.columns:
+                bar_args["name"] = df.color_legend.iloc[0]
+
+            if self.color is None and "color" in df.columns:
+                bar_args["marker_line_color"] = df.color
             elif self.color is not None:
                 bar_args["marker_line_color"] = self.color
 
@@ -230,9 +234,10 @@ class GeomBar(Geom):
 
             fig_so_far.add_bar(**bar_args)
 
-        groups = set([element["group"] for element in agg_result])
+        groups = set(agg_result["group"])
         for group in groups:
-            just_one_group = [element for element in agg_result if element["group"] == group]
+            rows_for_this_group = agg_result["group"] == group
+            just_one_group = agg_result[rows_for_this_group]
             plot_group(just_one_group)
 
         ggplot_to_plotly = {'dodge': 'group', 'stack': 'stack'}

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -74,12 +74,15 @@ class GeomPoint(Geom):
         "color": ("marker_color", "black", False),
         "size": ("marker_size", None, False),
         "tooltip": ("hovertext", None, False),
-        "color_legend": ("name", None, True)
+        "color_legend": ("name", None, True),
+        "alpha": ("marker_opacity", None, False)
     }
 
-    def __init__(self, aes, color=None):
+    def __init__(self, aes, color=None, size=None, alpha=None):
         super().__init__(aes)
         self.color = color
+        self.size = size
+        self.alpha = alpha
 
     def apply_to_fig(self, parent, agg_result, fig_so_far, precomputed, num_groups):
         def plot_group(df):
@@ -111,7 +114,7 @@ class GeomPoint(Geom):
         return StatIdentity()
 
 
-def geom_point(mapping=aes(), *, color=None):
+def geom_point(mapping=aes(), *, color=None, size=None, alpha=None):
     """Create a scatter plot.
 
     Supported aesthetics: ``x``, ``y``, ``color``, ``tooltip``
@@ -121,7 +124,7 @@ def geom_point(mapping=aes(), *, color=None):
     :class:`FigureAttribute`
         The geom to be applied.
     """
-    return GeomPoint(mapping, color=color)
+    return GeomPoint(mapping, color=color, size=size, alpha=alpha)
 
 
 class GeomLine(GeomLineBasic):
@@ -137,7 +140,7 @@ class GeomLine(GeomLineBasic):
         return StatIdentity()
 
 
-def geom_line(mapping=aes(), *, color=None):
+def geom_line(mapping=aes(), *, color=None, size=None, alpha=None):
     """Create a line plot.
 
     Supported aesthetics: ``x``, ``y``, ``color``, ``tooltip``
@@ -156,11 +159,14 @@ class GeomText(Geom):
         "size": ("marker_size", None, False),
         "tooltip": ("hovertext", None, False),
         "color_legend": ("name", None, True),
+        "alpha": ("marker_opacity", None, False)
     }
 
-    def __init__(self, aes, color=None):
+    def __init__(self, aes, color=None, size=None, alpha=None):
         super().__init__(aes)
         self.color = color
+        self.size = size
+        self.alpha = alpha
 
     def apply_to_fig(self, parent, agg_result, fig_so_far, precomputed, num_groups):
         def plot_group(df, color=None):
@@ -194,7 +200,7 @@ class GeomText(Geom):
         return StatIdentity()
 
 
-def geom_text(mapping=aes(), *, color=None):
+def geom_text(mapping=aes(), *, color=None, size=None, alpha=None):
     """Create a scatter plot where each point is text from the ``text`` aesthetic.
 
     Supported aesthetics: ``x``, ``y``, ``label``, ``color``, ``tooltip``
@@ -204,7 +210,7 @@ def geom_text(mapping=aes(), *, color=None):
     :class:`FigureAttribute`
         The geom to be applied.
     """
-    return GeomText(mapping, color=color)
+    return GeomText(mapping, color=color, size=size, alpha=alpha)
 
 
 class GeomBar(Geom):

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -2,7 +2,7 @@ import abc
 
 from .aes import aes
 from .stats import StatCount, StatIdentity, StatBin, StatNone, StatFunction
-
+from .utils import bar_position_plotly_to_gg
 
 class FigureAttribute(abc.ABC):
     pass
@@ -240,8 +240,7 @@ class GeomBar(Geom):
             just_one_group = agg_result[rows_for_this_group]
             plot_group(just_one_group)
 
-        ggplot_to_plotly = {'dodge': 'group', 'stack': 'stack'}
-        fig_so_far.update_layout(barmode=ggplot_to_plotly[self.position])
+        fig_so_far.update_layout(barmode=bar_position_plotly_to_gg(self.position))
 
     def get_stat(self):
         return self.stat
@@ -345,8 +344,7 @@ class GeomHistogram(Geom):
             just_one_group = agg_result[rows_for_this_group]
             plot_group(just_one_group, len(groups))
 
-        ggplot_to_plotly = {'dodge': 'group', 'stack': 'stack'}
-        fig_so_far.update_layout(barmode=ggplot_to_plotly[self.position])
+        fig_so_far.update_layout(barmode=bar_position_plotly_to_gg(self.position))
 
     def get_stat(self):
         return StatBin(self.min_val, self.max_val, self.bins)

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -117,7 +117,7 @@ class GeomPoint(Geom):
 def geom_point(mapping=aes(), *, color=None, size=None, alpha=None):
     """Create a scatter plot.
 
-    Supported aesthetics: ``x``, ``y``, ``color``, ``tooltip``
+    Supported aesthetics: ``x``, ``y``, ``color``, ``alpha``, ``tooltip``
 
     Returns
     -------

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -326,9 +326,13 @@ class GeomHistogram(Geom):
 
             if self.position == "dodge":
                 x = left_xs + bin_width * (2 * df.group + 1) / (2 * num_groups)
+                bar_width = bin_width / num_groups
 
-            elif self.position == "stack":
+            elif self.position in {"stack", "identity"}:
                 x = left_xs + bin_width / 2
+                bar_width = bin_width
+            else:
+                raise ValueError(f"Histogram does not support position = {self.position}")
 
             right_xs = left_xs + bin_width
 
@@ -336,14 +340,12 @@ class GeomHistogram(Geom):
                 "x": x,
                 "y": df.y,
                 "customdata": list(zip(left_xs, right_xs)),
+                "width": bar_width,
                 "hovertemplate":
                     "Range: [%{customdata[0]:.3f}-%{customdata[1]:.3f})<br>"
                     "Count: %{y}<br>"
                     "<extra></extra>",
             }
-
-            width = bin_width if self.position == 'stack' else bin_width / num_groups
-            bar_args["width"] = [width] * len(df)
 
             for aes_name, (plotly_name, default, take_one) in self.aes_to_arg.items():
                 if hasattr(self, aes_name) and getattr(self, aes_name) is not None:

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -183,7 +183,6 @@ class GGPlot:
 
                 subsetted_to_discrete = listified_agg_result[discrete_aesthetics]
 
-
                 group_counter = 0
 
                 def increment_and_return_old():
@@ -193,7 +192,7 @@ class GGPlot:
                 numberer = defaultdict(increment_and_return_old)
                 listified_agg_result["group"] = [numberer[tuple(x)] for _, x in subsetted_to_discrete.iterrows()]
 
-            geom.apply_to_fig(self, listified_agg_result, fig, precomputed[geom_label])
+            geom.apply_to_fig(self, listified_agg_result, fig, precomputed[geom_label], group_counter)
 
         # Important to update axes after labels, axes names take precedence.
         self.labels.apply_to_fig(fig)

--- a/hail/python/hail/ggplot/scale.py
+++ b/hail/python/hail/ggplot/scale.py
@@ -148,34 +148,29 @@ class ScaleDiscrete(Scale):
 
 
 class ScaleColorDiscrete(ScaleDiscrete):
-    def transform_data_local(self, data, parent):
-        categorical_strings = set([element[self.aesthetic_name] for element in data])
+    def transform_data_local(self, df, parent):
+        categorical_strings = set(df[self.aesthetic_name])
         unique_color_mapping = categorical_strings_to_colors(categorical_strings, parent)
 
-        updated_data = []
-        for category in categorical_strings:
-            for data_entry in data:
-                if data_entry[self.aesthetic_name] == category:
-                    annotate_args = {
-                        self.aesthetic_name: unique_color_mapping[category],
-                        f"{self.aesthetic_name}_legend": category
-                    }
-                    updated_data.append(data_entry.annotate(**annotate_args))
-        return updated_data
+        new_column_name = f"{self.aesthetic_name}_legend"
+        new_df = df.assign(**{new_column_name: df[self.aesthetic_name]})
+
+        new_df[self.aesthetic_name] = new_df[self.aesthetic_name].map(unique_color_mapping)
+
+        return new_df
 
 
 class ScaleColorContinuous(ScaleContinuous):
-    def transform_data_local(self, data, parent):
-        color_list = [element[self.aesthetic_name] for element in data]
-        color_mapping = continuous_nums_to_colors(color_list, parent.continuous_color_scale)
-        updated_data = []
-        for data_idx, data_entry in enumerate(data):
-            annotate_args = {
-                self.aesthetic_name: color_mapping[data_idx],
-                "color_legend": data_entry[self.aesthetic_name]
-            }
-            updated_data.append(data_entry.annotate(**annotate_args))
-        return updated_data
+    def transform_data_local(self, df, parent):
+        color_series = df[self.aesthetic_name]
+        color_mapping = continuous_nums_to_colors(color_series, parent.continuous_color_scale)
+
+        new_column_name = f"{self.aesthetic_name}_legend"
+        new_df = df.assign(**{new_column_name: df[self.aesthetic_name]})
+
+        new_df[self.aesthetic_name] = new_df[self.aesthetic_name].map(lambda i: color_mapping[i])
+
+        return new_df
 
 
 # Legend names messed up for scale color identity

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 import hail as hl
 from hail.utils.java import warning
-from .utils import is_continuous_type, should_use_for_grouping
+from .utils import should_use_for_grouping
 
 
 class Stat:
@@ -115,5 +115,5 @@ class StatBin(Stat):
             y_values = hist.bin_freq
             for i, x in enumerate(x_edges[:num_edges - 1]):
                 x_value = x
-                data_rows.append({"x": x_value, "y":y_values[i], **key})
+                data_rows.append({"x": x_value, "y": y_values[i], **key})
         return pd.DataFrame.from_records(data_rows)

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -26,8 +26,6 @@ class StatIdentity(Stat):
         return hl.agg.collect(mapping)
 
     def listify(self, agg_result):
-        # Collect aggregator returns a list, nothing to do.
-
         columns = list(agg_result[0].keys())
         data_dict = {}
 
@@ -36,8 +34,6 @@ class StatIdentity(Stat):
             data_dict[column] = pd.Series(col_data)
 
         return pd.DataFrame(data_dict)
-
-        return agg_result
 
 
 class StatFunction(StatIdentity):

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -49,3 +49,14 @@ def continuous_nums_to_colors(input_color_nums, continuous_color_scale):
 def bar_position_plotly_to_gg(plotly_pos):
     ggplot_to_plotly = {'dodge': 'group', 'stack': 'stack', 'identity': 'overlay'}
     return ggplot_to_plotly[plotly_pos]
+
+
+def linetype_plotly_to_gg(plotly_linetype):
+    linetype_dict = {
+        "solid": "solid",
+        "dashed": "dash",
+        "dotted": "dot",
+        "longdash": "longdash",
+        "dotdash": "dashdot"
+    }
+    return linetype_dict[plotly_linetype]

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -22,6 +22,16 @@ def is_discrete_type(dtype):
     return dtype in [hl.tstr]
 
 
+excluded_from_grouping = {"tooltip"}
+
+
+def should_use_for_grouping(name, type):
+    return (name not in excluded_from_grouping) and is_discrete_type(type)
+
+
+def should_use_scale_for_grouping(scale):
+    return (scale.aesthetic_name not in excluded_from_grouping) and scale.is_discrete()
+
 # Map strings to numbers that will index into a color scale.
 def categorical_strings_to_colors(string_set, parent_plot):
 

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -44,3 +44,8 @@ def continuous_nums_to_colors(input_color_nums, continuous_color_scale):
 
     color_mapping = plotly.colors.sample_colorscale(continuous_color_scale, [adjust_color(input_color) for input_color in input_color_nums])
     return color_mapping
+
+
+def bar_position_plotly_to_gg(plotly_pos):
+    ggplot_to_plotly = {'dodge': 'group', 'stack': 'stack', 'identity': 'overlay'}
+    return ggplot_to_plotly[plotly_pos]

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -32,6 +32,7 @@ def should_use_for_grouping(name, type):
 def should_use_scale_for_grouping(scale):
     return (scale.aesthetic_name not in excluded_from_grouping) and scale.is_discrete()
 
+
 # Map strings to numbers that will index into a color scale.
 def categorical_strings_to_colors(string_set, parent_plot):
 

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -13,7 +13,11 @@ def test_geom_point_line_text_col():
            geom_point() +
            geom_line(aes(y=ht.triple)) +
            geom_text(aes(label=hl.str(ht.idx))) +
-           geom_col(aes(y=ht.triple + ht.double))
+           geom_col(aes(y=ht.triple + ht.double)) +
+           coord_cartesian((0, 100), (0, 80)) +
+           xlab("my_x") +
+           ylab("my_y") +
+           ggtitle("Title")
            )
     fig.to_plotly()
 
@@ -29,6 +33,6 @@ def test_manhattan_plot():
 def test_histogram():
     ht = hl.utils.range_table(10)
     fig = (ggplot(ht, aes(x=ht.idx)) +
-           geom_histogram()
+           geom_histogram(alpha=0.5)
            )
     fig.to_plotly()


### PR DESCRIPTION
This PR:

1. Refactors `listify` to return pandas dataframes, and every geom to take in pandas dataframes. This significantly simplifies the code and should also speed things up.
2. Refactors the `apply_to_fig` method of most of the geoms to rely on a specification dict and then just loop over that. This simplifies adding a new argument / aesthethic. In the future, it may be best to just make all of the geoms take `**kwargs` so that arguments added to that dict will immediately be used for plotting, as right now I have to add something to `geom_bar`, `GeomBar.__init__`, and that dictionary for it to start showing up in plots. 
3. Adds `identity` as a bar position, which means to plot bars on top of each other. This is useful along with the `alpha` argument added to bars and histograms, which sets transparency of points. 