### PR TITLE
[infra] Make zuliprc and ukbb terraform resources optional

### DIFF
--- a/infra/gcp/ci/main.tf
+++ b/infra/gcp/ci/main.tf
@@ -31,12 +31,13 @@ resource "kubernetes_secret" "ci_config" {
 }
 
 resource "kubernetes_secret" "zulip_config" {
+  count = fileexists("~/.hail/.zuliprc") ? 1 : 0
   metadata {
     name = "zulip-config"
   }
 
   data = {
-    ".zuliprc" = file("~/.hail/.zuliprc")
+    ".zuliprc" = fileexists("~/.hail/.zuliprc") ? file("~/.hail/.zuliprc") : ""
   }
 }
 

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -11,7 +11,6 @@ terraform {
   }
 }
 
-variable "gsuite_organization" {}
 variable "batch_gcp_regions" {}
 variable "gcp_project" {}
 variable "batch_logs_bucket_location" {}
@@ -41,6 +40,12 @@ variable "ci_config" {
     github_context = string
   })
   default = null
+}
+
+variable deploy_ukbb {
+  type = bool
+  description = "Run the UKBB Genetic Correlation browser"
+  default = false
 }
 
 locals {
@@ -388,7 +393,8 @@ resource "kubernetes_secret" "registry_push_credentials" {
 }
 
 module "ukbb" {
-  source = "../ukbb"
+  count = var.deploy_ukbb ? 1 : 0
+  source = "../k8s/ukbb"
 }
 
 module "auth_gsa_secret" {

--- a/infra/k8s/ci/main.tf
+++ b/infra/k8s/ci/main.tf
@@ -12,12 +12,13 @@ resource "kubernetes_secret" "ci_config" {
 }
 
 resource "kubernetes_secret" "zulip_config" {
+  count = fileexists("~/.hail/.zuliprc") ? 1 : 0
   metadata {
     name = "zulip-config"
   }
 
   data = {
-    ".zuliprc" = file("~/.hail/.zuliprc")
+    ".zuliprc" = fileexists("~/.hail/.zuliprc") ? file("~/.hail/.zuliprc") : ""
   }
 }
 


### PR DESCRIPTION
The only real bitrot in the GCP terraform was the leftover `gsuite_organization` variable. This fixes that and also makes the zuliprc secret and ukbb module optional. The extra `fileexists` in the data block for the zuliprc is janky, but functions such as `file` are evaluated before the creation of the resource, so terraform will complain that about the file not existing without that extra guard there. I don't love it but ultimately want these to come from a cloud secret vault so it might look different soon enough anyway.