### PR TITLE
[query] Lower TextTableWriter

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -2067,13 +2067,14 @@ Caused by: java.lang.ClassCastException: __C2829collect_distributed_array cannot
             'struct{A:int64, B:int32}')
 
     def test_import_export_identity(self):
+        fs = hl.current_backend().fs
         ht = hl.import_table(resource('sampleAnnotations.tsv'))
         f = new_temp_file()
         ht.export(f)
 
-        with open(resource('sampleAnnotations.tsv'), 'r') as i1:
+        with fs.open(resource('sampleAnnotations.tsv'), 'r') as i1:
             expected = list(line.strip() for line in i1)
-        with open(uri_path(f), 'r') as i2:
+        with fs.open(uri_path(f), 'r') as i2:
             observed = list(line.strip() for line in i2)
 
         assert expected == observed

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1640,7 +1640,7 @@ class LocusIntervalTests(unittest.TestCase):
         nint = t.count()
 
         i = 0
-        with open(interval_file) as f:
+        with hl.current_backend().fs.open(interval_file) as f:
             for line in f:
                 if len(line.strip()) != 0:
                     i += 1

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -2016,12 +2016,13 @@ class ImportLinesTest(unittest.TestCase):
 
 class ImportTableTests(unittest.TestCase):
     def test_import_table_force_bgz(self):
+        fs = hl.current_backend().fs
         f = new_temp_file(extension="bgz")
         t = hl.utils.range_table(10, 5)
         t.export(f)
 
         f2 = new_temp_file(extension="gz")
-        run_command(["cp", uri_path(f), uri_path(f2)])
+        fs.copy(f, f2)
         t2 = hl.import_table(f2, force_bgz=True, impute=True).key_by('idx')
         self.assertTrue(t._same(t2))
 

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1634,8 +1634,6 @@ class GENTests(unittest.TestCase):
 
 
 class LocusIntervalTests(unittest.TestCase):
-    @fails_service_backend()
-    @fails_local_backend()
     def test_import_locus_intervals(self):
         interval_file = resource('annotinterall.interval_list')
         t = hl.import_locus_intervals(interval_file, reference_genome='GRCh37')
@@ -2017,8 +2015,6 @@ class ImportLinesTest(unittest.TestCase):
 
 
 class ImportTableTests(unittest.TestCase):
-    @fails_service_backend()
-    @fails_local_backend()
     def test_import_table_force_bgz(self):
         f = new_temp_file(extension="bgz")
         t = hl.utils.range_table(10, 5)
@@ -2070,8 +2066,6 @@ Caused by: java.lang.ClassCastException: __C2829collect_distributed_array cannot
         assert ht.row.dtype == hl.dtype(
             'struct{A:int64, B:int32}')
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_import_export_identity(self):
         ht = hl.import_table(resource('sampleAnnotations.tsv'))
         f = new_temp_file()

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -2075,7 +2075,7 @@ Caused by: java.lang.ClassCastException: __C2829collect_distributed_array cannot
 
         with fs.open(resource('sampleAnnotations.tsv'), 'r') as i1:
             expected = list(line.strip() for line in i1)
-        with fs.open(uri_path(f), 'r') as i2:
+        with fs.open(f, 'r') as i2:
             observed = list(line.strip() for line in i2)
 
         assert expected == observed

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -938,8 +938,6 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         with pytest.raises(ValueError):
             t.explode(t.foo.bar, name='baz')
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_export(self):
         t = hl.utils.range_table(1).annotate(foo=3)
         tmp_file = new_temp_file()
@@ -948,8 +946,6 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         with hl.hadoop_open(tmp_file, 'r') as f_in:
             assert f_in.read() == 'idx\tfoo\n0\t3\n'
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_export_delim(self):
         t = hl.utils.range_table(1).annotate(foo = 3)
         tmp_file = new_temp_file()
@@ -977,8 +973,6 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
     def test_min_partitions(self):
         assert hl.import_table(resource('variantAnnotations.tsv'), min_partitions=50).n_partitions() == 50
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_read_back_same_as_exported(self):
         t, _ = create_all_values_datasets()
         tmp_file = new_temp_file(prefix="test", extension=".tsv")

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -439,10 +439,9 @@ case class TableTextWriter(
 
   def apply(ctx: ExecuteContext, tv: TableValue): Unit = tv.export(ctx, path, typesFile, header, exportType, delimiter)
 
-  override def canLowerEfficiently: Boolean = true
+  override def canLowerEfficiently: Boolean = exportType != ExportType.PARALLEL_COMPOSABLE
   override def lower(ctx: ExecuteContext, ts: TableStage, t: TableIR, r: RTable, relationalLetsAbove: Map[String, IR]): IR = {
-    if (exportType == ExportType.PARALLEL_COMPOSABLE)
-      throw new LowererUnsupportedOperation(s"cannot lower parallel_composable export")
+    require(exportType != ExportType.PARALLEL_COMPOSABLE)
 
     val ext = ctx.fs.getCodecExtension(path)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -6,6 +6,8 @@ import is.hail.GenericIndexedSeqSerializer
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
+import is.hail.expr.TableAnnotationImpex
+import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage}
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.io.fs.FS
@@ -16,7 +18,8 @@ import is.hail.types.encoded.EType
 import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SContainer, SStringValue, SVoidValue}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.EmitType
-import is.hail.types.physical.stypes.concrete.SStackStruct
+import is.hail.types.physical.stypes.concrete.{SStackStruct, SJavaArrayString, SJavaArrayStringValue}
+import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.{SBooleanValue, SInt64Value}
 import is.hail.types.virtual._
 import is.hail.types.{RIterable, RStruct, RTable, TableType, TypeWithRequiredness}
@@ -433,7 +436,115 @@ case class TableTextWriter(
   exportType: String = ExportType.CONCATENATED,
   delimiter: String
 ) extends TableWriter {
+
   def apply(ctx: ExecuteContext, tv: TableValue): Unit = tv.export(ctx, path, typesFile, header, exportType, delimiter)
+
+  override def canLowerEfficiently: Boolean = true
+  override def lower(ctx: ExecuteContext, ts: TableStage, t: TableIR, r: RTable, relationalLetsAbove: Map[String, IR]): IR = {
+    if (exportType == ExportType.PARALLEL_COMPOSABLE)
+      throw new LowererUnsupportedOperation(s"cannot lower parallel_composable export")
+
+    val ext = ctx.fs.getCodecExtension(path)
+
+    val folder = if (exportType == ExportType.CONCATENATED)
+      ctx.createTmpPath("write-table-concatenated")
+    else
+      path
+    val lineWriter = TableTextPartitionWriter(ts.rowType, delimiter, writeHeader = exportType == ExportType.PARALLEL_HEADER_IN_SHARD)
+
+    ts.mapContexts { oldCtx =>
+      val d = digitsNeeded(ts.numPartitions)
+      val partFiles = Literal(TArray(TString), Array.tabulate(ts.numPartitions)(i => s"$folder/${ partFile(d, i) }$ext").toFastIndexedSeq)
+
+      zip2(oldCtx, ToStream(partFiles), ArrayZipBehavior.AssertSameLength) { (ctxElt, pf) =>
+        MakeStruct(FastSeq(
+          "oldCtx" -> ctxElt,
+          "partFile" -> pf))
+      }
+    }(GetField(_, "oldCtx")).mapCollectWithContextsAndGlobals(relationalLetsAbove) { (rows, ctxRef) =>
+      val file = GetField(ctxRef, "partFile")
+      WritePartition(rows, file, lineWriter)
+    } { (parts, _) =>
+      val commit = TableTextFinalizer(path, ts.rowType, delimiter, header, exportType)
+      Begin(FastIndexedSeq(WriteMetadata(parts, commit)))
+    }
+  }
+}
+
+case class TableTextPartitionWriter(rowType: TStruct, delimiter: String, writeHeader: Boolean) extends SimplePartitionWriter {
+  lazy val headerStr = rowType.fields.map(_.name).mkString(delimiter)
+
+  override def preConsume(cb: EmitCodeBuilder, os: Value[OutputStream]): Unit = if (writeHeader) {
+    cb += os.invoke[Array[Byte], Unit]("write", const(headerStr).invoke[Array[Byte]]("getBytes"))
+    cb += os.invoke[Int, Unit]("write", '\n')
+  }
+
+  def consumeElement(cb: EmitCodeBuilder, element: EmitCode, os: Value[OutputStream], region: Value[Region]): Unit = {
+    require(element.st.virtualType == rowType)
+    val delimBytes: Value[Array[Byte]] = cb.memoize(cb.emb.getObject(delimiter.getBytes))
+
+    element.toI(cb).consume(cb, { cb._fatal("stream element can not be missing!") }, { case sv: SBaseStructValue =>
+      // I hope we're buffering our writes correctly!
+      (0 until sv.st.size).foreachBetween { i =>
+        val f = sv.loadField(cb, i)
+        val annotation = f.consumeCode[AnyRef](cb, Code._null[AnyRef],
+          { sv => StringFunctions.svalueToJavaValue(cb, region, sv) })
+        val str = Code.invokeScalaObject2[Any, Type, String](TableAnnotationImpex.getClass, "exportAnnotation",
+          annotation, cb.emb.getType(f.st.virtualType))
+        cb += os.invoke[Array[Byte], Unit]("write", str.invoke[Array[Byte]]("getBytes"))
+      }(cb += os.invoke[Array[Byte], Unit]("write", delimBytes))
+      cb += os.invoke[Int, Unit]("write", '\n')
+    })
+  }
+}
+
+case class TableTextFinalizer(outputPath: String, rowType: TStruct, delimiter: String,
+    header: Boolean = true, exportType: String = ExportType.CONCATENATED) extends MetadataWriter {
+  def annotationType: Type = TArray(TString)
+  def writeMetadata(writeAnnotations: => IEmitCode, cb: EmitCodeBuilder, region: Value[Region]): Unit = {
+    val ctx: ExecuteContext = cb.emb.ctx
+    val ext = ctx.fs.getCodecExtension(outputPath)
+    val partPaths = writeAnnotations.get(cb, "write annotations cannot be missing!")
+    exportType match {
+      case ExportType.CONCATENATED =>
+        val files = partPaths.castTo(cb, region, SJavaArrayString(true), false)
+        val jFiles = if (header) {
+          val headerFilePath = ctx.createTmpPath("header", ext)
+          val headerStr = rowType.fields.map(_.name).mkString(delimiter)
+          val os = cb.memoize(cb.emb.create(const(headerFilePath)))
+          cb += os.invoke[Array[Byte], Unit]("write", const(headerStr).invoke[Array[Byte]]("getBytes"))
+          cb += os.invoke[Int, Unit]("write", '\n')
+          cb += os.invoke[Unit]("close")
+
+          val jFiles = files.asInstanceOf[SJavaArrayStringValue].array
+          val allFiles = cb.memoize(Code.newArray[String](jFiles.length + 1))
+          cb += (allFiles(0) = const(headerFilePath))
+          cb += Code.invokeStatic5[System, Any, Int, Any, Int, Int, Unit](
+            "arraycopy", jFiles /*src*/, 0 /*srcPos*/, allFiles /*dest*/, 1 /*destPos*/, jFiles.length /*len*/)
+          allFiles
+        } else {
+          files.asInstanceOf[SJavaArrayStringValue].array
+        }
+
+        cb += cb.emb.getFS.invoke[Array[String], String, Unit]("concatenateFiles", jFiles, const(outputPath))
+        // can I rely on context managers to clean up?
+
+      case ExportType.PARALLEL_HEADER_IN_SHARD =>
+        cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
+
+      case ExportType.PARALLEL_SEPARATE_HEADER =>
+        if (header) {
+          val headerFilePath = s"outputPath/header$ext"
+          val headerStr = rowType.fields.map(_.name).mkString(delimiter)
+          val os = cb.memoize(cb.emb.create(const(headerFilePath)))
+          cb += os.invoke[Array[Byte], Unit]("write", const(headerStr).invoke[Array[Byte]]("getBytes"))
+          cb += os.invoke[Int, Unit]("write", '\n')
+          cb += os.invoke[Unit]("close")
+        }
+
+        cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
+    }
+  }
 }
 
 object WrappedMatrixNativeMultiWriter {

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -526,7 +526,11 @@ case class TableTextFinalizer(outputPath: String, rowType: TStruct, delimiter: S
         }
 
         cb += cb.emb.getFS.invoke[Array[String], String, Unit]("concatenateFiles", jFiles, const(outputPath))
-        // can I rely on context managers to clean up?
+
+        val i = cb.newLocal[Int]("i")
+        cb.forLoop(cb.assign(i, 0), i.lt(jFiles.length), cb.assign(i, i + 1), {
+          cb += cb.emb.getFS.invoke[String, Boolean, Unit]("delete", jFiles(i), const(false))
+        })
 
       case ExportType.PARALLEL_HEADER_IN_SHARD =>
         cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -528,7 +528,7 @@ case class TableTextFinalizer(outputPath: String, rowType: TStruct, delimiter: S
         cb += cb.emb.getFS.invoke[Array[String], String, Unit]("concatenateFiles", jFiles, const(outputPath))
 
         val i = cb.newLocal[Int]("i")
-        cb.forLoop(cb.assign(i, 0), i.lt(jFiles.length), cb.assign(i, i + 1), {
+        cb.forLoop(cb.assign(i, 0), i < jFiles.length, cb.assign(i, i + 1), {
           cb += cb.emb.getFS.invoke[String, Boolean, Unit]("delete", jFiles(i), const(false))
         })
 

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -314,6 +314,17 @@ trait FS extends Serializable {
     }
   }
 
+  def concatenateFiles(sourceNames: Array[String], destFilename: String): Unit = {
+    val fileStatuses = sourceNames.map(fileStatus(_))
+
+    info(s"merging ${ fileStatuses.length } files totalling " +
+      s"${ readableBytes(fileStatuses.map(_.getLen).sum) }...")
+
+    val (_, timing) = time(copyMergeList(fileStatuses, destFilename, deleteSource = false))
+
+    info(s"while writing:\n    $destFilename\n  merge time: ${ formatTime(timing) }")
+  }
+
   def touch(filename: String): Unit = {
     using(createNoCompression(filename))(_ => ())
   }


### PR DESCRIPTION
To do this add an intermidiate abstract PartitionWriter,
SimplePartitionWriter, and extend it with TextTablePartitionWriter.

SimplePartitionWriter manages the output stream for its subclasses. The
subclasses need to implement consumeElement, and optionally preConsume
and postConsume.

TextTablePartitionWriter handles the delimiter delimited writing per
element item and the line delimited writing per element of the stream.
It will also optionally write the header if ExportType.PARALLEL_HEADER_IN_SHARD
has been requested.

TextTableFinalizer is the 'MetadataWriter' (name change pending), for
TextTableWriter. That's where the header is written for
PARALLEL_SEPARATE_HEADER and CONCATENATED, and files are merged for
CONCATENATED.

There are currently a few idosyncracies that don't replicate bug-for-bug
compatibility with the non-lowered version.

    1. We avoid the use of fs.copyMerge, as such, we don't check for the
       existence of the _SUCCESS file (even though we create it).
    2. ExportType.PARALLEL_COMPOSABLE is unsupported.
    3. We rely on the temporary file cleaner to clean up the files
       created for CONCATENATED export, rather than deleting them
       explicitly.
