### PR TITLE
[batch] Turn GCP worker vm image targets into bash script

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -43,15 +43,3 @@ deploy: build
 	  python3 ../ci/jinja2_render.py $$E service-account.yaml service-account.yaml.out
 	kubectl -n $(NAMESPACE) apply -f service-account.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out
-
-.PHONY: gcp-create-build-worker-image-instance
-gcp-create-build-worker-image-instance:
-	-gcloud -q compute --project $(PROJECT) instances delete --zone=$(ZONE) build-batch-worker-image
-	python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"$(DOCKER_ROOT_IMAGE)"}}' build-batch-worker-image-startup-gcp.sh build-batch-worker-image-startup-gcp.sh.out
-	gcloud -q compute --project $(PROJECT) instances create --zone=$(ZONE) build-batch-worker-image --machine-type=n1-standard-1 --network=default --network-tier=PREMIUM --metadata-from-file startup-script=build-batch-worker-image-startup-gcp.sh.out --no-restart-on-failure --maintenance-policy=MIGRATE --scopes=https://www.googleapis.com/auth/cloud-platform --image=$$(gcloud compute images list --standard-images --filter 'family="ubuntu-minimal-2004-lts"' --format='value(name)') --image-project=ubuntu-os-cloud --boot-disk-size=10GB --boot-disk-type=pd-ssd
-
-.PHONY: gcp-create-worker-image
-gcp-create-worker-image:
-	-gcloud -q compute --project $(PROJECT) images delete batch-worker-12
-	gcloud -q compute --project $(PROJECT) images create batch-worker-12 --source-disk=build-batch-worker-image --source-disk-zone=$(ZONE)
-	gcloud -q compute --project $(PROJECT) instances delete --zone=$(ZONE) build-batch-worker-image

--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+source $HAIL/devbin/functions.sh
+
+PROJECT=$(get_global_config_field gcp_project)
+ZONE=$(get_global_config_field gcp_zone)
+DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image)
+
+WORKER_IMAGE_VERSION=12
+BUILDER=build-batch-worker-image
+
+create_build_image_instance() {
+    gcloud -q compute --project ${PROJECT} instances delete \
+        --zone=${ZONE} ${BUILDER} || true
+
+    python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"'${DOCKER_ROOT_IMAGE}'"}}' \
+        build-batch-worker-image-startup-gcp.sh build-batch-worker-image-startup-gcp.sh.out
+
+    UBUNTU_IMAGE=$(gcloud compute images list \
+        --standard-images \
+        --filter 'family="ubuntu-minimal-2004-lts"' \
+        --format='value(name)')
+
+    gcloud -q compute instances create ${BUILDER} \
+        --project ${PROJECT}  \
+        --zone=${ZONE} \
+        --machine-type=n1-standard-1 \
+        --network=default \
+        --network-tier=PREMIUM \
+        --metadata-from-file startup-script=build-batch-worker-image-startup-gcp.sh.out \
+        --no-restart-on-failure \
+        --maintenance-policy=MIGRATE \
+        --scopes=https://www.googleapis.com/auth/cloud-platform \
+        --image=${UBUNTU_IMAGE} \
+        --image-project=ubuntu-os-cloud \
+        --boot-disk-size=10GB \
+        --boot-disk-type=pd-ssd
+}
+
+create_worker_image() {
+	gcloud -q compute images delete batch-worker-${WORKER_IMAGE_VERSION} \
+        --project ${PROJECT} || true
+
+	gcloud -q compute images create batch-worker-${WORKER_IMAGE_VERSION} \
+        --project ${PROJECT} \
+        --source-disk-zone=${ZONE} \
+        --source-disk=${BUILDER}
+
+	gcloud -q compute instances delete ${BUILDER} \
+        --project ${PROJECT} \
+        --zone=${ZONE}
+}
+
+main() {
+    set -x
+    create_build_image_instance
+    while [ "$(gcloud compute instances describe ${BUILDER} --project ${PROJECT} --zone ${ZONE} --format='value(status)')" != "TERMINATED" ];
+    do
+        sleep 5
+    done
+    create_worker_image
+}
+
+confirm "Building image with properties:\n Version: ${WORKER_IMAGE_VERSION}\n Project: ${PROJECT}\n Zone: ${ZONE}" && main

--- a/config.mk
+++ b/config.mk
@@ -1,13 +1,9 @@
-PROJECT := hail-vdc
 DOCKER_PREFIX := gcr.io/$(PROJECT)
 DOCKER_ROOT_IMAGE := $(DOCKER_PREFIX)/ubuntu:20.04
-HAIL_TEST_GCS_BUCKET := hail-test-dmk9z
 DOMAIN := hail.is
 INTERNAL_IP := 10.128.0.57
 IP := 35.188.91.25
 KUBERNETES_SERVER_URL := https://104.198.230.143
-REGION := us-central1
-ZONE := us-central1-a
 
 ifeq ($(NAMESPACE),default)
 SCOPE = deploy

--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
-DOCKER_PREFIX := gcr.io/$(PROJECT)
+DOCKER_PREFIX := gcr.io/hail-vdc
 DOCKER_ROOT_IMAGE := $(DOCKER_PREFIX)/ubuntu:20.04
 DOMAIN := hail.is
 INTERNAL_IP := 10.128.0.57

--- a/devbin/functions.sh
+++ b/devbin/functions.sh
@@ -212,3 +212,20 @@ azsshworker() {
 
     ssh -i ~/.ssh/batch_worker_ssh_rsa batch-worker@$worker_ip
 }
+
+get_global_config_field() {
+    kubectl get secret global-config --template={{.data.$1}} | base64 --decode
+}
+
+confirm() {
+    printf "$1\n"
+    read -r -p "Are you sure? [y/N] " response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            true
+            ;;
+        *)
+            false
+            ;;
+    esac
+}

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -149,13 +149,7 @@ You can now install Hail:
 - Create the batch worker VM image. Run:
 
   ```
-  make -C $HAIL/batch gcp-create-build-worker-image-instance
-  ```
-
-  Wait for the `build-batch-worker-image` instance to be stopped. Then run:
-
-  ```
-  make -C $HAIL/batch gcp-create-worker-image
+  $HAIL/batch/gcp-create-worker-image.sh
   ```
 
 - Download the global-config to be used by `bootstrap.py`.


### PR DESCRIPTION
Part 1 of chipping away at config.mk. This puts the two make targets for building the vm image in GCP into a single script. It loads variables that used to come from config.mk from kubernetes. Added a convenience function to offer a confirmation prompt before running the script. Here's an example:

```
(hailenv) dgoldste@wmce3-cb7 hail % $HAIL/batch/gcp-create-worker-image.sh
Building image with properties:
 Version: 12
 Project: hail-vdc
 Zone: us-central1-a
Are you sure? [y/N] n
(hailenv) dgoldste@wmce3-cb7 hail %
```
