### PR TITLE
[infra] Raise azure db max_connections to 1k

### DIFF
--- a/infra/azure/modules/db/main.tf
+++ b/infra/azure/modules/db/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_mysql_configuration" "max_connections" {
   name                = "max_connections"
   resource_group_name = var.resource_group.name
   server_name         = azurerm_mysql_server.db.name
-  value               = 500
+  value               = 1000
 }
 
 data "http" "db_ca_cert" {


### PR DESCRIPTION
We had a couple PRs fail because the database reached its [max connections](https://portal.azure.com/#@haildev.onmicrosoft.com/resource/subscriptions/22cd45fe-f996-4c51-af67-ef329d977519/resourceGroups/haildev/providers/Microsoft.DBforMySQL/servers/db-393222c4/metrics). We should probably be resilient to this, but I figured we should be able to handle our normal PR load. I also checked GCP and their default is 4k. Azure sets its cap at 1250.

I haven't applied any terraform since you've made your changes. Is that safe to do?