### PR TITLE
[build.yaml] Fix jvm entryway and wheel for azure steps

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -842,6 +842,7 @@ steps:
     dependsOn:
       - hail_build_image
       - merge_code
+  - kind: runImage
     name: compile_batch_worker_jvm_entryway
     image:
       valueFrom: base_image.image


### PR DESCRIPTION
I believe this missing line basically erased all of the above `build_wheel_for_azure` step and the cloud optional changes I put our build system think a missing step is ok. If you look at the most recent deploy it doesn't include `build_wheel_for_azure` even though the `deploy` step depends on it. I'll separately make a fix for that