### PR TITLE
[batch] Don't do O(jobs) logging in scheduling loop when no machines found

### DIFF
--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -159,11 +159,6 @@ WHERE removed = 0 AND inst_coll = %s;
             if user != 'ci' or (user == 'ci' and instance.location == self._default_location()):
                 return instance
             i += 1
-        histogram = collections.defaultdict(int)
-        for instance in self.healthy_instances_by_free_cores:
-            histogram[instance.free_cores_mcpu] += 1
-        log.info(f'schedule {self}: no viable instances for {cores_mcpu}: {histogram}')
-
         return None
 
     async def create_instance(
@@ -440,8 +435,6 @@ LIMIT %s;
 
             scheduled_cores_mcpu = 0
             share = user_share[user]
-
-            log.info(f'schedule {self.pool}: user-share: {user}: {allocated_cores_mcpu} {share}')
 
             remaining = Box(share)
             async for record in user_runnable_jobs(user, remaining):

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -3,7 +3,6 @@ import sortedcontainers
 import logging
 import asyncio
 import random
-import collections
 
 from gear import Database
 from hailtop import aiotools


### PR DESCRIPTION
I'm happy to see if I can replace this with a more efficient observability solution, but according to the profiler these lines combined can take up to 8% of the driver's overall CPU time, which just seems like something we shouldn't do. The `get_instance` logging will be especially bad with big clusters because it builds up a whole histogram which then needs to get formatted and printed.

I'm not sure how useful these log statements currently are. I never look at them but maybe others do.

cc: @danking 