### PR TITLE
[batch] Add metrics for scheduling loop queries

### DIFF
--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -316,6 +316,7 @@ GROUP BY user
 HAVING n_ready_jobs + n_running_jobs > 0;
 ''',
             (self.pool.name,),
+            "compute_fair_share",
         )
 
         async for record in records:
@@ -392,13 +393,14 @@ HAVING n_ready_jobs + n_running_jobs > 0;
         async def user_runnable_jobs(user, remaining):
             async for batch in self.db.select_and_fetchall(
                 '''
-SELECT batches.id,  batches_cancelled.id IS NOT NULL AS cancelled, userdata, user, format_version
+SELECT batches.id, batches_cancelled.id IS NOT NULL AS cancelled, userdata, user, format_version
 FROM batches
 LEFT JOIN batches_cancelled
        ON batches.id = batches_cancelled.id
 WHERE user = %s AND `state` = 'running';
 ''',
                 (user,),
+                "user_runnable_jobs__select_running_batches",
             ):
                 async for record in self.db.select_and_fetchall(
                     '''
@@ -408,6 +410,7 @@ WHERE batch_id = %s AND state = 'Ready' AND always_run = 1 AND inst_coll = %s
 LIMIT %s;
 ''',
                     (batch['id'], self.pool.name, remaining.value),
+                    "user_runnable_jobs__select_ready_always_run_jobs",
                 ):
                     record['batch_id'] = batch['id']
                     record['userdata'] = batch['userdata']
@@ -423,6 +426,7 @@ WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND inst_coll = %s AN
 LIMIT %s;
 ''',
                         (batch['id'], self.pool.name, remaining.value),
+                        "user_runnable_jobs__select_ready_jobs_batch_not_cancelled",
                     ):
                         record['batch_id'] = batch['id']
                         record['userdata'] = batch['userdata']


### PR DESCRIPTION
After do_handshake, [schedule_loop_body](https://github.com/hail-is/hail/blob/2d019337114a972016ad843baabe76814dc8ad10/batch/batch/driver/instance_collection/pool.py#L371) is our biggest offender on the profiler. That in itself is not a bad thing, ideally we want the scheduling loop to be running as much as possible to give us the highest throughput, but the loop should still be efficient. All the queries in `user_runnable_jobs` show up the same on the profiler, since they are the same function call-stack just with different arguments. This should give us finer granularity into what's taking up our time.