### PR TITLE
Changed y_min and y_max to ymin and ymax for geom_ribbon

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -641,7 +641,7 @@ class GeomRibbon(Geom):
 
             scatter_args_bottom = {
                 "x": df.x,
-                "y": df.y_min,
+                "y": df.ymin,
                 "mode": "lines",
                 "showlegend": False
             }
@@ -649,7 +649,7 @@ class GeomRibbon(Geom):
 
             scatter_args_top = {
                 "x": df.x,
-                "y": df.y_max,
+                "y": df.ymax,
                 "mode": "lines",
                 "fill": 'tonexty'
             }
@@ -668,9 +668,9 @@ class GeomRibbon(Geom):
 
 
 def geom_ribbon(mapping=aes(), fill=None, color=None):
-    """Creates filled in area between two lines specified by x, y_min, and y_max
+    """Creates filled in area between two lines specified by x, ymin, and ymax
 
-    Supported aesthetics: ``x``, ``y_min``, ``y_max``, ``color``, ``fill``, ``tooltip``
+    Supported aesthetics: ``x``, ``ymin``, ``ymax``, ``color``, ``fill``, ``tooltip``
 
     Parameters
     ----------

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -46,3 +46,9 @@ def test_separate_traces_per_group():
            geom_bar(aes(fill=hl.str(ht.idx)))
            )
     assert len(fig.to_plotly().data) == 30
+
+
+def test_geom_ribbon():
+    ht = hl.utils.range_table(20)
+    fig = ggplot(ht, aes(x=ht.idx, ymin=ht.idx * 2, ymax=ht.idx * 3)) + geom_ribbon()
+    fig.to_plotly()


### PR DESCRIPTION
R uses `ymin` and `ymax`. This was added after last release so isn't a user exposed bug yet.