### PR TITLE
[gear] Remove broken and unused Transaction functions

### DIFF
--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -180,22 +180,6 @@ class Transaction:
         # await shield becuase we want to wait for commit/rollback to finish
         await asyncio.shield(self._aexit_1(exc_type))
 
-    async def commit(self):
-        assert self.conn
-        self.conn.commit()
-        self.conn = None
-
-        await aexit(self.conn_context_manager)
-        self.conn_context_manager = None
-
-    async def rollback(self):
-        assert self.conn
-        self.conn.rollback()
-        self.conn = None
-
-        await aexit(self.conn_context_manager)
-        self.conn_context_manager = None
-
     async def just_execute(self, sql, args=None):
         assert self.conn
         async with self.conn.cursor() as cursor:


### PR DESCRIPTION
I was confused at how these could work because `self.conn.commit` and `self.conn.rollback` are async functions, but then I couldn't find any invocations of these methods.