### PR TITLE
properly import submodules from kubernetes_asyncio

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -9,7 +9,8 @@ import signal
 import dictdiffer
 from aiohttp import web
 import aiohttp_session
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.config
+import kubernetes_asyncio.client
 from prometheus_async.aio.web import server_stats
 import prometheus_client as pc  # type: ignore
 from gear import (
@@ -1138,8 +1139,8 @@ async def on_startup(app):
 
     app['client_session'] = httpx.client_session()
 
-    kube.config.load_incluster_config()
-    app['k8s_client'] = kube.client.CoreV1Api()
+    kubernetes_asyncio.config.load_incluster_config()
+    app['k8s_client'] = kubernetes_asyncio.client.CoreV1Api()
     app['k8s_cache'] = K8sCache(app['k8s_client'])
 
     db = Database()
@@ -1226,7 +1227,7 @@ async def on_cleanup(app):
                                 app['async_worker_pool'].shutdown()
                             finally:
                                 try:
-                                    k8s_client: kube.client.CoreV1Api = app['k8s_client']
+                                    k8s_client: kubernetes_asyncio.client.CoreV1Api = app['k8s_client']
                                     await k8s_client.api_client.rest_client.pool_manager.close()
                                 finally:
                                     await asyncio.gather(

--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -6,7 +6,8 @@ import base64
 import asyncio
 import argparse
 
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.client
+import kubernetes_asyncio.config
 
 from hailtop.utils import check_shell_output
 
@@ -173,7 +174,7 @@ class LocalBatchBuilder:
                 # Note, that is in the kubenetes-client repo, the
                 # kubernetes_asyncio.  I'm assuming it has the same
                 # issue.
-                k8s_client = kube.client.CoreV1Api()
+                k8s_client = kubernetes_asyncio.client.CoreV1Api()
                 try:
                     k8s_cache = K8sCache(k8s_client)
 
@@ -343,7 +344,7 @@ git checkout {shq(self._sha)}
 
 
 async def main():
-    await kube.config.load_kube_config()
+    await kubernetes_asyncio.config.load_kube_config()
 
     parser = argparse.ArgumentParser(description='Bootstrap a Hail as a service installation.')
 

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -1,7 +1,8 @@
 import os
 import base64
 import json
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.config
+import kubernetes_asyncio.client
 from hailtop.utils import async_to_blocking
 from gear import Database, transaction
 from gear.cloud_config import get_global_config
@@ -85,8 +86,8 @@ async def main():
     app['db_instance'] = db_instance
 
     # kube.config.load_incluster_config()
-    await kube.config.load_kube_config()
-    k8s_client = kube.client.CoreV1Api()
+    await kubernetes_asyncio.config.load_kube_config()
+    k8s_client = kubernetes_asyncio.client.CoreV1Api()
     try:
         app['k8s_client'] = k8s_client
 

--- a/ci/create_initial_account.py
+++ b/ci/create_initial_account.py
@@ -1,7 +1,8 @@
 import argparse
 import base64
 import json
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.config
+import kubernetes_asyncio.client
 import os
 
 from hailtop.utils import async_to_blocking
@@ -13,15 +14,15 @@ NAMESPACE = os.environ['NAMESPACE']
 
 async def copy_identity_from_default(hail_credentials_secret_name: str) -> str:
     cloud = os.environ['CLOUD']
-    await kube.config.load_kube_config()
-    k8s_client = kube.client.CoreV1Api()
+    await kubernetes_asyncio.config.load_kube_config()
+    k8s_client = kubernetes_asyncio.client.CoreV1Api()
 
     secret = await k8s_client.read_namespaced_secret(hail_credentials_secret_name, 'default')
 
     await k8s_client.create_namespaced_secret(
         NAMESPACE,
-        kube.client.V1Secret(
-            metadata=kube.client.V1ObjectMeta(name=hail_credentials_secret_name),
+        kubernetes_asyncio.client.V1Secret(
+            metadata=kubernetes_asyncio.client.V1ObjectMeta(name=hail_credentials_secret_name),
             data=secret.data,
         ),
     )

--- a/devbin/rotate_keys.py
+++ b/devbin/rotate_keys.py
@@ -9,7 +9,8 @@ from typing import List, Tuple, Generator, Optional, TextIO
 from enum import Enum
 import warnings
 import sys
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.config
+import kubernetes_asyncio.client
 from hailtop.aiocloud.aiogoogle import GoogleIAmClient
 from hailtop.utils import retry_transient_errors
 
@@ -274,9 +275,9 @@ async def main():
     iam_client = GoogleIAmClient(project)
     iam_manager = IAMManager(iam_client)
 
-    await kube.config.load_kube_config()  # type: ignore
-    k8s_client = kube.client.CoreV1Api()
-    k8s_manager = KubeSecretManager(k8s_client)  # type: ignore
+    await kubernetes_asyncio.config.load_kube_config()
+    k8s_client = kubernetes_asyncio.client.CoreV1Api()
+    k8s_manager = KubeSecretManager(k8s_client)
 
     try:
         service_accounts = await iam_manager.get_all_service_accounts()

--- a/devbin/sync.py
+++ b/devbin/sync.py
@@ -10,7 +10,8 @@ from threading import Thread
 import os
 import argparse
 import asyncio
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.config
+import kubernetes_asyncio.client
 import logging
 import re
 import sys
@@ -68,8 +69,8 @@ class Sync:
         log.info(f'initialized {pod}@{namespace}')
 
     async def monitor_pods(self, apps, namespace):
-        await kube.config.load_kube_config()
-        k8s = kube.client.CoreV1Api()
+        await kubernetes_asyncio.config.load_kube_config()
+        k8s = kubernetes_asyncio.client.CoreV1Api()
         try:
             while True:
                 log.info('monitor_pods: start loop')

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -7,7 +7,8 @@ import os
 import uvloop
 import signal
 from aiohttp import web
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.config
+import kubernetes_asyncio.client
 from prometheus_async.aio.web import server_stats  # type: ignore
 from collections import defaultdict
 
@@ -150,8 +151,8 @@ async def on_startup(app):
     app['files_in_progress'] = dict()
     app['users'] = {}
     app['userlocks'] = defaultdict(asyncio.Lock)
-    kube.config.load_incluster_config()
-    k8s_client = kube.client.CoreV1Api()
+    kubernetes_asyncio.config.load_incluster_config()
+    k8s_client = kubernetes_asyncio.client.CoreV1Api()
     app['k8s_client'] = k8s_client
     app['redis_pool']: aioredis.ConnectionsPool = await aioredis.create_pool(socket)
 

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -8,7 +8,6 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session
 import aiohttp_session.cookie_storage
-from kubernetes_asyncio import client, config
 import kubernetes_asyncio.config
 import kubernetes_asyncio.client
 import kubernetes_asyncio.client.rest
@@ -731,10 +730,10 @@ async def workshop_get_error(request, userdata):
 
 async def on_startup(app):
     if 'BATCH_USE_KUBE_CONFIG' in os.environ:
-        await config.load_kube_config()
+        await kubernetes_asyncio.config.load_kube_config()
     else:
-        config.load_incluster_config()
-    app['k8s_client'] = client.CoreV1Api()
+        kubernetes_asyncio.config.load_incluster_config()
+    app['k8s_client'] = kubernetes_asyncio.client.CoreV1Api()
 
     app['dbpool'] = await create_database_pool()
 

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -9,7 +9,9 @@ from aiohttp import web
 import aiohttp_session
 import aiohttp_session.cookie_storage
 from kubernetes_asyncio import client, config
-import kubernetes_asyncio as kube
+import kubernetes_asyncio.config
+import kubernetes_asyncio.client
+import kubernetes_asyncio.client.rest
 from prometheus_async.aio.web import server_stats  # type: ignore
 
 from hailtop.config import get_deploy_config
@@ -118,27 +120,33 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
 
         image = DEFAULT_WORKER_IMAGE
 
-        env = [kube.client.V1EnvVar(name='HAIL_DEPLOY_CONFIG_FILE', value='/deploy-config/deploy-config.json')]
+        env = [
+            kubernetes_asyncio.client.V1EnvVar(
+                name='HAIL_DEPLOY_CONFIG_FILE', value='/deploy-config/deploy-config.json'
+            )
+        ]
 
         tokens_secret_name = userdata['tokens_secret_name']
         hail_credentials_secret_name = userdata['hail_credentials_secret_name']
         volumes = [
-            kube.client.V1Volume(
-                name='deploy-config', secret=kube.client.V1SecretVolumeSource(secret_name='deploy-config')
+            kubernetes_asyncio.client.V1Volume(
+                name='deploy-config', secret=kubernetes_asyncio.client.V1SecretVolumeSource(secret_name='deploy-config')
             ),
-            kube.client.V1Volume(
-                name='gsa-key', secret=kube.client.V1SecretVolumeSource(secret_name=hail_credentials_secret_name)
+            kubernetes_asyncio.client.V1Volume(
+                name='gsa-key',
+                secret=kubernetes_asyncio.client.V1SecretVolumeSource(secret_name=hail_credentials_secret_name),
             ),
-            kube.client.V1Volume(
-                name='user-tokens', secret=kube.client.V1SecretVolumeSource(secret_name=tokens_secret_name)
+            kubernetes_asyncio.client.V1Volume(
+                name='user-tokens',
+                secret=kubernetes_asyncio.client.V1SecretVolumeSource(secret_name=tokens_secret_name),
             ),
         ]
         volume_mounts = [
-            kube.client.V1VolumeMount(mount_path='/deploy-config', name='deploy-config', read_only=True),
-            kube.client.V1VolumeMount(mount_path='/gsa-key', name='gsa-key', read_only=True),
-            kube.client.V1VolumeMount(mount_path='/user-tokens', name='user-tokens', read_only=True),
+            kubernetes_asyncio.client.V1VolumeMount(mount_path='/deploy-config', name='deploy-config', read_only=True),
+            kubernetes_asyncio.client.V1VolumeMount(mount_path='/gsa-key', name='gsa-key', read_only=True),
+            kubernetes_asyncio.client.V1VolumeMount(mount_path='/user-tokens', name='user-tokens', read_only=True),
         ]
-        resources = kube.client.V1ResourceRequirements(requests={'cpu': '1.601', 'memory': '1.601G'})
+        resources = kubernetes_asyncio.client.V1ResourceRequirements(requests={'cpu': '1.601', 'memory': '1.601G'})
     else:
         workshop = userdata['workshop']
 
@@ -150,20 +158,20 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
 
         cpu = workshop['cpu']
         memory = workshop['memory']
-        resources = kube.client.V1ResourceRequirements(
+        resources = kubernetes_asyncio.client.V1ResourceRequirements(
             requests={'cpu': cpu, 'memory': memory}, limits={'cpu': cpu, 'memory': memory}
         )
 
-    pod_spec = kube.client.V1PodSpec(
+    pod_spec = kubernetes_asyncio.client.V1PodSpec(
         node_selector={'preemptible': 'false'},
         service_account_name=service_account_name,
         containers=[
-            kube.client.V1Container(
+            kubernetes_asyncio.client.V1Container(
                 command=command,
                 name='default',
                 image=image,
                 env=env,
-                ports=[kube.client.V1ContainerPort(container_port=POD_PORT)],
+                ports=[kubernetes_asyncio.client.V1ContainerPort(container_port=POD_PORT)],
                 resources=resources,
                 volume_mounts=volume_mounts,
             )
@@ -172,8 +180,8 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
     )
 
     user_id = str(userdata['id'])
-    pod_template = kube.client.V1Pod(
-        metadata=kube.client.V1ObjectMeta(
+    pod_template = kubernetes_asyncio.client.V1Pod(
+        metadata=kubernetes_asyncio.client.V1ObjectMeta(
             generate_name='notebook-worker-', labels={'app': 'notebook-worker', 'user_id': user_id}
         ),
         spec=pod_spec,
@@ -207,7 +215,7 @@ async def k8s_notebook_status_from_notebook(k8s, notebook):
             name=notebook['pod_name'], namespace=NOTEBOOK_NAMESPACE, _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
         )
         return notebook_status_from_pod(pod)
-    except kube.client.rest.ApiException as e:
+    except kubernetes_asyncio.client.rest.ApiException as e:
         if e.status == 404:
             log.exception(f"404 for pod: {notebook['pod_name']}")
             return None
@@ -274,7 +282,7 @@ async def get_user_notebook(dbpool, user_id):
 async def delete_worker_pod(k8s, pod_name):
     try:
         await k8s.delete_namespaced_pod(pod_name, NOTEBOOK_NAMESPACE, _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
-    except kube.client.rest.ApiException as e:
+    except kubernetes_asyncio.client.rest.ApiException as e:
         log.info(f'pod {pod_name} already deleted {e}')
 
 


### PR DESCRIPTION
I use `pyright` as my LSP server and it gets mad at me with our old form of importing saying that `client is not a known member of kubernetes_asyncio`,  which as far as I can tell is because they don't actually use `__all__` and just import their submodules in their init? Anyway this seemed better to me and allows me to actually get the LSP hints for this library now, but let me know if this is just a Me thing or if I don't understand python modules