### PR TITLE
[query] Fix MatrixPlinkReader's `lowerGlobals`

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -712,6 +712,7 @@ class VCFTests(unittest.TestCase):
             mt = hl.import_vcf([resource('different_info_test1.vcf'), resource('different_info_test2.vcf')])
             mt.rows()._force_count()
 
+
 class PLINKTests(unittest.TestCase):
     @fails_service_backend()
     def test_import_fam(self):
@@ -841,6 +842,11 @@ class PLINKTests(unittest.TestCase):
                                 reference_genome=None)
         self.assertEqual(plink.locus.dtype,
                          hl.tstruct(contig=hl.tstr, position=hl.tint32))
+
+    def test_import_plink_and_ignore_rows(self):
+        bfile = doctest_resource('ldsc')
+        plink = hl.import_plink(bfile + '.bed', bfile + '.bim', bfile + '.fam', block_size=16)
+        self.assertEqual(plink.aggregate_cols(hl.agg.count()), 489)
 
     @fails_service_backend()
     @fails_local_backend()

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -462,7 +462,8 @@ class MatrixPLINKReader(
     executeGeneric(ctx).toTableValue(ctx, tr.typ)
 
   override def lowerGlobals(ctx: ExecuteContext, requestedGlobalsType: TStruct): IR = {
-    val subset = fullMatrixType.globalType.valueSubsetter(requestedGlobalsType)
+    val tt = fullMatrixType.toTableType(LowerMatrixIR.entriesFieldName, LowerMatrixIR.colsFieldName)
+    val subset = tt.globalType.valueSubsetter(requestedGlobalsType)
     val globals = Row(sampleInfo)
     Literal(requestedGlobalsType, subset(globals).asInstanceOf[Row])
   }


### PR DESCRIPTION
`lowerGlobals` is only used by `lowerTableIR`, we have to have the lowered globals at this point, not the matrix globals. 