### PR TITLE
[hailtop.batch] allow for remote-only dependencies, allow nested reso…

### DIFF
--- a/hail/python/hailtop/batch/__init__.py
+++ b/hail/python/hailtop/batch/__init__.py
@@ -7,7 +7,7 @@ from .backend import LocalBackend, ServiceBackend, Backend
 from .docker import build_python_image
 from .exceptions import BatchException
 from .utils import concatenate, plink_merge
-from .resource import Resource, ResourceFile, ResourceGroup, PythonResult
+from .resource import Resource, ResourceGroup, PythonResult, remote
 
 __all__ = ['Batch',
            'LocalBackend',
@@ -20,8 +20,8 @@ __all__ = ['Batch',
            'plink_merge',
            'PythonResult',
            'Resource',
-           'ResourceFile',
-           'ResourceGroup'
+           'ResourceGroup',
+           'remote'
            ]
 
 nest_asyncio.apply()

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -1,5 +1,6 @@
-from typing import Optional, Dict, Any, TypeVar, Generic, List, Union
+from typing import Optional, Dict, Any, TypeVar, Generic, List, Union, Tuple
 import sys
+import tempfile
 import abc
 import orjson
 import os
@@ -11,14 +12,16 @@ import copy
 from shlex import quote as shq
 import webbrowser
 import warnings
+from io import StringIO
 
+import hailtop
 from hailtop import pip_version
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.utils import parse_docker_image_reference, async_to_blocking, bounded_gather, tqdm, url_scheme
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
+import hailtop.batch_client.aioclient as aiobc
 import hailtop.batch_client.client as bc
-from hailtop.batch_client.client import BatchClient
 from hailtop.aiotools import AsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
 
@@ -46,6 +49,9 @@ class Backend(abc.ABC, Generic[RunningBatchType]):
     """
 
     _closed = False
+
+    def remote_tmpdir(self) -> str:
+        raise NotImplementedError
 
     @abc.abstractmethod
     def _run(self, batch, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs) -> RunningBatchType:
@@ -117,7 +123,8 @@ class LocalBackend(Backend[None]):
                  tmp_dir: str = '/tmp/',
                  gsa_key_file: Optional[str] = None,
                  extra_docker_run_flags: Optional[str] = None):
-        self._tmp_dir = tmp_dir.rstrip('/')
+        self._tmp_dir = tmp_dir.rstrip('/')  # FIXME: what is this for?
+        self._remote_tmpdir = self._get_scratch_dir()
 
         flags = ''
 
@@ -133,6 +140,9 @@ class LocalBackend(Backend[None]):
 
         self._extra_docker_run_flags = flags
         self.__fs: AsyncFS = RouterAsyncFS(default_scheme='file')
+
+    def remote_tmpdir(self) -> str:
+        return self._remote_tmpdir
 
     @property
     def _fs(self):
@@ -162,125 +172,46 @@ class LocalBackend(Backend[None]):
         delete_scratch_on_exit:
             If `True`, delete temporary directories with intermediate files.
         """
+        async_to_blocking(self._async_run(batch, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs))
 
+    async def _async_run(self,
+                         batch: 'batch.Batch',
+                         dry_run: bool,
+                         verbose: bool,
+                         delete_scratch_on_exit: bool,
+                         **backend_kwargs) -> None:  # pylint: disable=R0915
         if backend_kwargs:
             raise ValueError(f'LocalBackend does not support any of these keywords: {backend_kwargs}')
 
-        tmpdir = self._get_scratch_dir()
-
-        def new_code_block():
-            return ['set -e' + ('x' if verbose else ''),
-                    '\n',
-                    '# change cd to tmp directory',
-                    f"cd {tmpdir}",
-                    '\n']
-
-        def run_code(code):
-            code = '\n'.join(code)
-            if dry_run:
-                print(code)
-            else:
-                try:
-                    sp.check_call(code, shell=True)
-                except sp.CalledProcessError as e:
-                    print(e)
-                    print(e.output)
-                    raise
-
-        copied_input_resource_files = set()
-        os.makedirs(tmpdir + '/inputs/', exist_ok=True)
-
         requester_pays_project_json = orjson.dumps(batch.requester_pays_project).decode('utf-8')
 
-        def copy_input(job, r):
-            if isinstance(r, resource.InputResourceFile):
-                if r not in copied_input_resource_files:
-                    copied_input_resource_files.add(r)
-
-                    input_scheme = url_scheme(r._input_path)
-                    if input_scheme != '':
-                        transfers_bytes = orjson.dumps([{"from": r._input_path, "to": r._get_path(tmpdir)}])
-                        transfers = transfers_bytes.decode('utf-8')
-                        return [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}']
-
-                    absolute_input_path = os.path.realpath(os.path.expanduser(r._input_path))
-
-                    dest = r._get_path(os.path.expanduser(tmpdir))
-                    dir = os.path.dirname(dest)
-                    os.makedirs(dir, exist_ok=True)
-
-                    if job._image is not None:  # pylint: disable-msg=W0640
-                        return [f'cp {shq(absolute_input_path)} {shq(dest)}']
-
-                    return [f'ln -sf {shq(absolute_input_path)} {shq(dest)}']
-
-                return []
-
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return []
-
-        def symlink_input_resource_group(r):
-            symlinks = []
-            if isinstance(r, resource.ResourceGroup) and r._source is None:
-                for name, irf in r._resources.items():
-                    src = irf._get_path(tmpdir)
-                    dest = f'{r._get_path(tmpdir)}.{name}'
-                    symlinks.append(f'ln -sf {shq(src)} {shq(dest)}')
-            return symlinks
-
-        def transfer_dicts_for_resource_file(res_file: Union[resource.ResourceFile, resource.PythonResult]) -> List[dict]:
-            if isinstance(res_file, resource.InputResourceFile):
-                source = res_file._input_path
-            else:
-                assert isinstance(res_file, (resource.JobResourceFile, resource.PythonResult))
-                source = res_file._get_path(tmpdir)
-
-            return [{"from": source, "to": dest} for dest in res_file._output_paths]
+        async def generate_job_code(job):
+            main_code, resources_to_download = await job.compile()
+            code = StringIO()
+            for resource in resources_to_download:
+                transfers_bytes = orjson.dumps([{
+                    "from": resource.remote_location(),
+                    "to": resource.local_location()}])
+                transfers = transfers_bytes.decode('utf-8')
+                code.write(
+                    f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}')
+            code.write(main_code)
+            code.getvalue()
 
         try:
-            input_transfer_dicts = [
-                transfer_dict
-                for input_resource in batch._input_resources
-                for transfer_dict in transfer_dicts_for_resource_file(input_resource)]
-
-            if input_transfer_dicts:
-                input_transfers = orjson.dumps(input_transfer_dicts).decode('utf-8')
-                code = new_code_block()
-                code += ["# Write input resources to output destinations"]
-                code += [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(input_transfers)}']
-                code += ['\n']
-                run_code(code)
-
-            for job in batch._jobs:
-                async_to_blocking(job._compile(tmpdir, tmpdir))
-
-                os.makedirs(f'{tmpdir}/{job._dirname}/', exist_ok=True)
-
-                code = new_code_block()
-
-                code.append(f"# {job._job_id}: {job.name if job.name else ''}")
-
-                if job._user_code:
-                    code.append('# USER CODE')
-                    user_code = [f'# {line}' for cmd in job._user_code for line in cmd.split('\n')]
-                    code.append('\n'.join(user_code))
-
-                code += [x for r in job._inputs for x in copy_input(job, r)]
-                code += [x for r in job._mentioned for x in symlink_input_resource_group(r)]
-
-                env = {**job._env, 'BATCH_TMPDIR': tmpdir}
-                env_declarations = [f'export {k}={v}' for k, v in env.items()]
-                joined_env = '; '.join(env_declarations) + '; ' if env else ''
-
-                job_shell = job._shell if job._shell else DEFAULT_SHELL
-
-                cmd = " && ".join(f'{{\n{x}\n}}' for x in job._wrapper_code)
-
-                quoted_job_script = shq(joined_env + cmd)
-
-                if job._image:
-                    cpu = f'--cpus={job._cpu}' if job._cpu else ''
-
+            job_codes = await asyncio.gather(*[generate_job_code(job) for job in batch._jobs])
+            for code, job in zip(job_codes, job):
+                if dry_run:
+                    print(code)
+                elif job._image is None:
+                    with tempfile.TemporaryDirectory() as workdir:
+                        sp.run(
+                            [job._shell, '-c', code],
+                            check=True,
+                            cwd=workdir,
+                            env=job._env  #FIXME: do I need BATCH_TMPDIR ?
+                        )
+                elif job._image:
                     memory = job._memory
                     if memory is not None:
                         memory_ratios = {'lowmem': 1024**3, 'standard': 4 * 1024**3, 'highmem': 7 * 1024**3}
@@ -293,35 +224,31 @@ class LocalBackend(Backend[None]):
                                     raise BatchException(f'invalid value for cpu: {job._cpu}')
                             else:
                                 raise BatchException(f'must specify cpu when using {memory} to specify the memory')
-                        memory = f'-m {memory}' if memory else ''
-                    else:
-                        memory = ''
 
-                    code.append(f"docker run "
-                                "--entrypoint=''"
-                                f"{self._extra_docker_run_flags} "
-                                f"-v {tmpdir}:{tmpdir} "
-                                f"-w {tmpdir} "
-                                f"{memory} "
-                                f"{cpu} "
-                                f"{job._image} "
-                                f"{job_shell} -c {quoted_job_script}")
-                else:
-                    code.append(f"{job_shell} -c {quoted_job_script}")
+                    command = [
+                        'docker',
+                        'run',
+                        '--entrypoint=' + job._shell,
+                        *self._extra_docker_run_flags.split(' '),
+                        '-v', batch._remote_location + ':' + batch._remote_location,
+                    ]
+                    if job._cpu is not None:
+                        command.extend(['--cpus', job._cpu])
+                    if memory is not None:
+                        command.extend(['-m', memory])
+                    command.extend(['--', '-c', code])
 
-                output_transfer_dicts = [
-                    transfer_dict
-                    for output_resource in job._external_outputs
-                    for transfer_dict in transfer_dicts_for_resource_file(output_resource)]
-                output_transfers = orjson.dumps(output_transfer_dicts).decode('utf-8')
+                    with tempfile.TemporaryDirectory() as workdir:
+                        sp.run(command, check=True, cwd=workdir,env=job._env)  #FIXME: do I need BATCH_TMPDIR ?
 
-                code += [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(output_transfers)}']
-                code += ['\n']
-
-                run_code(code)
+                hailtop.aiotools.copy.copy_from_dict(
+                    max_simultaneous_transfers=300,
+                    files=[
+                        {'from': resource.remote_location(), 'to': destination}
+                        for resource, destination in batch._outputs.items()])
         finally:
             if delete_scratch_on_exit:
-                sp.run(f'rm -rf {tmpdir}', shell=True, check=False)
+                sp.run(['rm', '-rf', batch._remote_location], check=False)
 
         print('Batch completed successfully!')
 
@@ -405,8 +332,8 @@ class ServiceBackend(Backend[bc.Batch]):
                 'the billing_project parameter of ServiceBackend must be set '
                 'or run `hailctl config set batch/billing_project '
                 'MY_BILLING_PROJECT`')
-        self._batch_client = BatchClient(billing_project)
 
+        self.batch_client = async_to_blocking(aiobc.BatchClient.create(billing_project))
         user_config = get_user_config()
 
         if bucket is not None:
@@ -440,18 +367,20 @@ class ServiceBackend(Backend[bc.Batch]):
                     f'remote_tmpdir must be a storage uri path like gs://bucket/folder. Possible schemes include {schemes}')
         if remote_tmpdir[-1] != '/':
             remote_tmpdir += '/'
-        self.remote_tmpdir = remote_tmpdir
+        self._remote_tmpdir = remote_tmpdir
 
         gcs_kwargs = {'project': google_project}
         self.__fs: AsyncFS = RouterAsyncFS(default_scheme='file', gcs_kwargs=gcs_kwargs)
+
+    def remote_tmpdir(self) -> str:
+        return self._remote_tmpdir
 
     @property
     def _fs(self):
         return self.__fs
 
     def _close(self):
-        if hasattr(self, '_batch_client'):
-            self._batch_client.close()
+        async_to_blocking(self.batch_client.close())
         async_to_blocking(self._fs.close())
 
     def _run(self,
@@ -513,69 +442,6 @@ class ServiceBackend(Backend[bc.Batch]):
 
         build_dag_start = time.time()
 
-        uid = uuid.uuid4().hex[:6]
-        batch_remote_tmpdir = f'{self.remote_tmpdir}{uid}'
-        local_tmpdir = f'/io/batch/{uid}'
-
-        default_image = 'ubuntu:20.04'
-
-        attributes = copy.deepcopy(batch.attributes)
-        if batch.name is not None:
-            attributes['name'] = batch.name
-
-        bc_batch = self._batch_client.create_batch(attributes=attributes, callback=callback,
-                                                   token=token, cancel_after_n_failures=batch._cancel_after_n_failures)
-
-        n_jobs_submitted = 0
-        used_remote_tmpdir = False
-
-        job_to_client_job_mapping: Dict[_job.Job, bc.Job] = {}
-        jobs_to_command = {}
-        commands = []
-
-        bash_flags = 'set -e' + ('x' if verbose else '')
-
-        def copy_input(r):
-            if isinstance(r, resource.InputResourceFile):
-                return [(r._input_path, r._get_path(local_tmpdir))]
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return [(r._get_path(batch_remote_tmpdir), r._get_path(local_tmpdir))]
-
-        def copy_internal_output(r):
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return [(r._get_path(local_tmpdir), r._get_path(batch_remote_tmpdir))]
-
-        def copy_external_output(r):
-            if isinstance(r, resource.InputResourceFile):
-                return [(r._input_path, dest) for dest in r._output_paths]
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return [(r._get_path(local_tmpdir), dest) for dest in r._output_paths]
-
-        def symlink_input_resource_group(r):
-            symlinks = []
-            if isinstance(r, resource.ResourceGroup) and r._source is None:
-                for name, irf in r._resources.items():
-                    src = irf._get_path(local_tmpdir)
-                    dest = f'{r._get_path(local_tmpdir)}.{name}'
-                    symlinks.append(f'ln -sf {shq(src)} {shq(dest)}')
-            return symlinks
-
-        write_external_inputs = [x for r in batch._input_resources for x in copy_external_output(r)]
-        if write_external_inputs:
-            transfers_bytes = orjson.dumps([
-                {"from": src, "to": dest}
-                for src, dest in write_external_inputs])
-            transfers = transfers_bytes.decode('utf-8')
-            write_cmd = ['python3', '-m', 'hailtop.aiotools.copy', 'null', transfers]
-            if dry_run:
-                commands.append(' '.join(shq(x) for x in write_cmd))
-            else:
-                j = bc_batch.create_job(image=HAIL_GENETICS_HAIL_IMAGE,
-                                        command=write_cmd,
-                                        attributes={'name': 'write_external_inputs'})
-                jobs_to_command[j] = ' '.join(shq(x) for x in write_cmd)
-                n_jobs_submitted += 1
-
         pyjobs = [j for j in batch._jobs if isinstance(j, _job.PythonJob)]
         for job in pyjobs:
             if job._image is None:
@@ -585,65 +451,66 @@ class ServiceBackend(Backend[bc.Batch]):
                         f"You must specify 'image' for Python jobs if you are using a Python version other than 3.6, 3.7, or 3.8 (you are using {version})")
                 job._image = f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
 
+        default_image = 'ubuntu:20.04'
+        attributes = batch.attributes
+        if batch.name is not None:
+            attributes = {'name': batch.name, **attributes}
+        job_to_client_job_mapping: Dict[_job.Job, aiobc.Job] = {}
+        batch_builder = self.batch_client.create_batch(
+            attributes=attributes,
+            callback=callback,
+            token=token,
+            cancel_after_n_failures=batch._cancel_after_n_failures
+        )
+
         with tqdm(total=len(batch._jobs), desc='upload code', disable=disable_progress_bar) as pbar:
-            async def compile_job(job):
-                used_remote_tmpdir = await job._compile(local_tmpdir, batch_remote_tmpdir, dry_run=dry_run)
+            async def compile_job(job: _job.Job) -> Tuple[_job.Job, str, str, List[resource.Resource]]:
+                # FIXME: data type for this triplet
+                code, user_code, resources_to_download = await job.compile(dry_run=dry_run)
                 pbar.update(1)
-                return used_remote_tmpdir
-            used_remote_tmpdir_results = await bounded_gather(*[functools.partial(compile_job, j) for j in batch._jobs], parallelism=150)
-            used_remote_tmpdir |= any(used_remote_tmpdir_results)
+                return job, code, user_code, resources_to_download
+            compiled_jobs = await bounded_gather(*[functools.partial(compile_job, j) for j in batch._jobs], parallelism=150)
 
-        for job in tqdm(batch._jobs, desc='create job objects', disable=disable_progress_bar):
-            inputs = [x for r in job._inputs for x in copy_input(r)]
+        used_remote_tmpdir = any(len(j._need_to_copy_out) > 0 for j in batch._jobs)
 
-            outputs = [x for r in job._internal_outputs for x in copy_internal_output(r)]
-            if outputs:
-                used_remote_tmpdir = True
-            outputs += [x for r in job._external_outputs for x in copy_external_output(r)]
+        for job, code, user_code, resources_to_download in tqdm(compiled_jobs, desc='create job objects', disable=disable_progress_bar):
+            inputs = [(r.remote_location(), r.local_location()) for r in resources_to_download]
 
-            symlinks = [x for r in job._mentioned for x in symlink_input_resource_group(r)]
+            def output_src_dest_pairs(r: resource.Resource) -> List[Tuple[str, str]]:
+                external_locations = batch._outputs[r]
+                if job.resource_defined_remotely(r):
+                    return [(r.remote_location(), dest) for dest in external_locations]
+                return [
+                    (r.local_location(), dest)
+                    for dest in [r.remote_location(), *external_locations]
+                ]
+
+            outputs = [
+                src_dest
+                for r in job._need_to_copy_out
+                for src_dest in output_src_dest_pairs(r)
+            ]
 
             if job._image is None:
                 if verbose:
                     print(f"Using image '{default_image}' since no image was specified.")
 
-            make_local_tmpdir = f'mkdir -p {local_tmpdir}/{job._dirname}'
-
-            job_command = [cmd.strip() for cmd in job._wrapper_code]
-            prepared_job_command = (f'{{\n{x}\n}}' for x in job_command)
-            cmd = f'''
-{bash_flags}
-{make_local_tmpdir}
-{"; ".join(symlinks)}
-{" && ".join(prepared_job_command)}
-'''
-
-            user_code = '\n\n'.join(job._user_code) if job._user_code else None
-
             if dry_run:
-                formatted_command = f'''
+                print('''
 ================================================================================
 # Job {job._job_id} {f": {job.name}" if job.name else ''}
-
---------------------------------------------------------------------------------
-## USER CODE
---------------------------------------------------------------------------------
-{user_code}
-
---------------------------------------------------------------------------------
-## COMMAND
---------------------------------------------------------------------------------
-{cmd}
+''')
+                print(code)
+                print('''
 ================================================================================
-'''
-                commands.append(formatted_command)
+''')
                 continue
 
             parents = [job_to_client_job_mapping[j] for j in job._dependencies]
 
-            attributes = copy.deepcopy(job.attributes) if job.attributes else dict()
+            attributes = job.attributes or dict()
             if job.name:
-                attributes['name'] = job.name
+                attributes = {'name': job.name, **attributes}
 
             resources: Dict[str, Any] = {}
             if job._cpu:
@@ -660,59 +527,46 @@ class ServiceBackend(Backend[bc.Batch]):
             image = job._image if job._image else default_image
             image_ref = parse_docker_image_reference(image)
             if image_ref.hosted_in('dockerhub') and image_ref.name() not in HAIL_GENETICS_IMAGES:
-                warnings.warn(f'Using an image {image} from Docker Hub. '
+                warnings.warn(f'Using an image, {image}, from Docker Hub. '
                               f'Jobs may fail due to Docker Hub rate limits.')
 
-            env = {**job._env, 'BATCH_TMPDIR': local_tmpdir}
+            env = job._env
 
-            j = bc_batch.create_job(image=image,
-                                    command=[job._shell if job._shell else DEFAULT_SHELL, '-c', cmd],
-                                    parents=parents,
-                                    attributes=attributes,
-                                    resources=resources,
-                                    input_files=inputs if len(inputs) > 0 else None,
-                                    output_files=outputs if len(outputs) > 0 else None,
-                                    always_run=job._always_run,
-                                    timeout=job._timeout,
-                                    cloudfuse=job._cloudfuse if len(job._cloudfuse) > 0 else None,
-                                    env=env,
-                                    requester_pays_project=batch.requester_pays_project,
-                                    mount_tokens=True,
-                                    user_code=user_code)
-
-            n_jobs_submitted += 1
+            j = batch_builder.create_job(
+                image=image,
+                command=[job._shell if job._shell else DEFAULT_SHELL, '-c', code],
+                parents=parents,
+                attributes=attributes,
+                resources=resources,
+                input_files=inputs if len(inputs) > 0 else None,
+                output_files=outputs if len(outputs) > 0 else None,
+                always_run=job._always_run,
+                timeout=job._timeout,
+                cloudfuse=job._cloudfuse if len(job._cloudfuse) > 0 else None,
+                env=env,
+                requester_pays_project=batch.requester_pays_project,
+                mount_tokens=True,
+                user_code=user_code
+            )
 
             job_to_client_job_mapping[job] = j
-            jobs_to_command[j] = cmd
-
-        if dry_run:
-            print("\n\n".join(commands))
-            return None
 
         if delete_scratch_on_exit and used_remote_tmpdir:
-            parents = list(jobs_to_command.keys())
-            j = bc_batch.create_job(
+            j = batch_builder.create_job(
                 image=HAIL_GENETICS_HAIL_IMAGE,
-                command=['python3', '-m', 'hailtop.aiotools.delete', batch_remote_tmpdir],
-                parents=parents,
+                command=['python3', '-m', 'hailtop.aiotools.delete', batch._remote_location],
+                parents=batch_builder._jobs,
                 attributes={'name': 'remove_tmpdir'},
                 always_run=True)
-            jobs_to_command[j] = cmd
-            n_jobs_submitted += 1
 
         if verbose:
-            print(f'Built DAG with {n_jobs_submitted} jobs in {round(time.time() - build_dag_start, 3)} seconds.')
+            print(f'Built DAG with {batch_builder.n_jobs} jobs in {round(time.time() - build_dag_start, 3)} seconds.')
 
         submit_batch_start = time.time()
-        batch_handle = bc_batch.submit(disable_progress_bar=disable_progress_bar)
-
-        jobs_to_command = {j.id: cmd for j, cmd in jobs_to_command.items()}
+        batch_handle = await batch_builder.submit(disable_progress_bar=disable_progress_bar)
 
         if verbose:
-            print(f'Submitted batch {batch_handle.id} with {n_jobs_submitted} jobs in {round(time.time() - submit_batch_start, 3)} seconds:')
-            for jid, cmd in jobs_to_command.items():
-                print(f'{jid}: {cmd}')
-            print('')
+            print(f'Submitted batch {batch_handle.id} with {batch_builder.n_jobs} jobs in {round(time.time() - submit_batch_start, 3)} seconds.')
 
         deploy_config = get_deploy_config()
         url = deploy_config.url('batch', f'/batches/{batch_handle.id}')
@@ -722,6 +576,6 @@ class ServiceBackend(Backend[bc.Batch]):
             webbrowser.open(url)
         if wait:
             print(f'Waiting for batch {batch_handle.id}...')
-            status = batch_handle.wait()
+            status = await batch_handle.wait()
             print(f'batch {batch_handle.id} complete: {status["state"]}')
-        return batch_handle
+        return bc.Batch.from_async_batch(batch_handle)

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -1,7 +1,9 @@
+from typing import Optional, Dict, Union, List, Any, Set
 import os
 import warnings
 import re
-from typing import Optional, Dict, Union, List, Any, Set
+import uuid
+from collections import defaultdict
 
 from hailtop.utils import secret_alnum_string, url_scheme
 from hailtop.aiotools import AsyncFS
@@ -113,14 +115,19 @@ class Batch:
                  default_python_image: Optional[str] = None,
                  project: Optional[str] = None,
                  cancel_after_n_failures: Optional[int] = None):
+
         self._jobs: List[job.Job] = []
-        self._resource_map: Dict[str, _resource.Resource] = {}
-        self._allocated_files: Set[str] = set()
-        self._input_resources: Set[_resource.InputResourceFile] = set()
         self._uid = Batch._get_uid()
         self._job_tokens: Set[str] = set()
+        self._input_resources: Set[_resource.Resource] = set()
+        self._outputs: Dict[_resource.Resource, List[str]] = defaultdict(list)
 
         self._backend = backend if backend else _backend.LocalBackend()
+
+        # FIXME: iterate until a truly unique directory
+        uid = uuid.uuid4().hex[:6]
+        self._remote_location = f'{self._backend.remote_tmpdir()}{uid}'
+        self._resource_by_uid: Dict[int, _resource.Resource] = {}
 
         self.name = name
 
@@ -292,48 +299,7 @@ class Batch:
         self._jobs.append(j)
         return j
 
-    def _new_job_resource_file(self, source, value=None):
-        if value is None:
-            value = secret_alnum_string(5)
-        jrf = _resource.JobResourceFile(value, source)
-        self._resource_map[jrf._uid] = jrf  # pylint: disable=no-member
-        return jrf
-
-    def _new_input_resource_file(self, input_path, value=None):
-        if value is None:
-            value = f'{secret_alnum_string(5)}/{os.path.basename(input_path.rstrip("/"))}'
-        irf = _resource.InputResourceFile(value)
-        irf._add_input_path(input_path)
-        self._resource_map[irf._uid] = irf  # pylint: disable=no-member
-        self._input_resources.add(irf)
-        return irf
-
-    def _new_resource_group(self, source, mappings, root=None):
-        assert isinstance(mappings, dict)
-        if root is None:
-            root = secret_alnum_string(5)
-        d = {}
-        new_resource_map = {}
-        for name, code in mappings.items():
-            if not isinstance(code, str):
-                raise BatchException(f"value for name '{name}' is not a string. Found '{type(code)}' instead.")
-            r = self._new_job_resource_file(source=source, value=eval(f'f"""{code}"""'))  # pylint: disable=W0123
-            d[name] = r
-            new_resource_map[r._uid] = r  # pylint: disable=no-member
-
-        self._resource_map.update(new_resource_map)
-        rg = _resource.ResourceGroup(source, root, **d)
-        self._resource_map.update({rg._uid: rg})
-        return rg
-
-    def _new_python_result(self, source, value=None) -> _resource.PythonResult:
-        if value is None:
-            value = secret_alnum_string(5)
-        jrf = _resource.PythonResult(value, source)
-        self._resource_map[jrf._uid] = jrf  # pylint: disable=no-member
-        return jrf
-
-    def read_input(self, path: str) -> _resource.InputResourceFile:
+    def read_input(self, path: str) -> _resource.Resource:
         """
         Create a new input resource file object representing a single file.
 
@@ -362,8 +328,9 @@ class Batch:
             File extension to use.
         """
 
-        irf = self._new_input_resource_file(path)
-        return irf
+        resource = _resource.ExternalResource(path, os.path.basename(path))
+        self._input_resources.add(resource)
+        return resource
 
     def read_input_group(self, **kwargs: str) -> _resource.ResourceGroup:
         """Create a new resource group representing a mapping of identifier to
@@ -424,12 +391,9 @@ class Batch:
             is the file path.
         """
 
-        root = secret_alnum_string(5)
-        new_resources = {name: self._new_input_resource_file(file, value=f'{root}/{os.path.basename(file.rstrip("/"))}')
-                         for name, file in kwargs.items()}
-        rg = _resource.ResourceGroup(None, root, **new_resources)
-        self._resource_map.update({rg._uid: rg})
-        return rg
+        resource = _resource.ExternalResourceGroup(kwargs, f'<ExternalResourceGroup from {self}>')
+        self._input_resources.add(resource)
+        return resource
 
     def write_output(self, resource: _resource.Resource, dest: str):  # pylint: disable=R0201
         """
@@ -488,27 +452,14 @@ class Batch:
 
         if not isinstance(resource, _resource.Resource):
             raise BatchException(f"'write_output' only accepts Resource inputs. Found '{type(resource)}'.")
-        if (isinstance(resource, _resource.JobResourceFile)
-                and isinstance(resource._source, job.BashJob)
-                and resource not in resource._source._mentioned):
-            name = resource._source._resources_inverse[resource]
-            raise BatchException(f"undefined resource '{name}'\n"
-                                 f"Hint: resources must be defined within the "
-                                 f"job methods 'command' or 'declare_resource_group'")
-        if (isinstance(resource, _resource.PythonResult)
-                and isinstance(resource._source, job.PythonJob)
-                and resource not in resource._source._mentioned):
-            name = resource._source._resources_inverse[resource]
-            raise BatchException(f"undefined resource '{name}'\n"
-                                 f"Hint: resources must be bound as a result "
-                                 f"using the PythonJob 'call' method")
-
-        if isinstance(self._backend, _backend.LocalBackend):
-            dest_scheme = url_scheme(dest)
-            if dest_scheme == '':
-                dest = os.path.abspath(os.path.expanduser(dest))
-
-        resource._add_output_path(dest)
+        source = resource.source()
+        if source is not None and resource not in source.defined_resources():
+            raise BatchException(
+                f"undefined resource '{resource.humane_name()}'\n"
+                f"Hint: resources must be defined within the job methods 'BashJob.command' or "
+                f"'BashJob.declare_resource_group' or PythonJob.call")
+        self._outputs[resource].append(dest)
+        source.resource_is_needed(resource)
 
     def select_jobs(self, pattern: str) -> List[job.Job]:
         """

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -64,7 +64,6 @@ class Job(abc.ABC):
 
         self._dependencies: Set['Job'] = set()
         self._produced_resource_by_name: Dict[str, _resource.Resource] = {}
-        # FIXME: why the heck did I use an int? just use the resource
         self._defined_resource_remoteness: Dict[_resource.Resource, bool] = {}
         self._need_to_copy_out: Set[_resource.Resource] = set()
 
@@ -941,7 +940,6 @@ class PythonJob(Job):
         pipe.seek(0)
 
         for resource in pickler.serialized_resources:
-            # FIXME: this should probably happen when you call?
             maybe_source = resource.source()
             if maybe_source is not None:
                 if maybe_source == self:
@@ -952,7 +950,6 @@ class PythonJob(Job):
 
         user_code_builder = StringIO()
         user_code_builder.write(textwrap.dedent(inspect.getsource(unapplied)) + '\n')
-        # FIXME: the repr for a resource does not have any quotes
         args_str = ', '.join([repr(arg) for arg in args])
         kwargs_str = ', '.join([f'{k}={v!r}' for k, v in kwargs.items()])
         separator = ', ' if args and kwargs else ''

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1,3 +1,5 @@
+from typing import Union, Optional, Dict, List, Set, Tuple, Callable, Any, cast, Iterable, KeysView
+import abc
 import re
 
 import warnings
@@ -7,38 +9,36 @@ import functools
 import inspect
 import textwrap
 from shlex import quote as shq
-from io import BytesIO
-from typing import Union, Optional, Dict, List, Set, Tuple, Callable, Any, cast
+from io import BytesIO, StringIO
 
 from . import backend, resource as _resource, batch  # pylint: disable=cyclic-import
 from .exceptions import BatchException
 from .globals import DEFAULT_SHELL
 
 
-def _add_resource_to_set(resource_set, resource, include_rg=True):
-    if isinstance(resource, _resource.ResourceGroup):
-        rg = resource
-        if include_rg:
-            resource_set.add(resource)
-    else:
-        resource_set.add(resource)
-        if isinstance(resource, _resource.ResourceFile) and resource._has_resource_group():
-            rg = resource._get_resource_group()
-        else:
-            rg = None
-
-    if rg is not None:
-        for _, resource_file in rg._resources.items():
-            resource_set.add(resource_file)
-
-
-def opt_str(x):
+def opt_str(x: Optional[Any]) -> Optional[str]:
     if x is None:
         return x
     return str(x)
 
 
-class Job:
+class ResourceToStringPickler(dill.Pickler):
+    def __init__(self, file, **kwargs):
+        super().__init__(file, **kwargs)
+        self.serialized_resources: List[_resource.Resource] = []
+        self.dispatch = {
+            **dill.Pickler.dispatch,
+            **{k: ResourceToStringPickler.save_resource
+           for k in _resource.ALL_RESOURCE_CLASSES}
+        }
+
+    def save_resource(self, obj: _resource.Resource):
+        self.serialized_resources.append(obj)
+        # FIXME: need to fix PythonResult too. We'll need an unpickler that returns the result of as_py
+        return self.save(obj.as_py())
+
+
+class Job(abc.ABC):
     """
     Object representing a single job to execute.
 
@@ -47,16 +47,6 @@ class Job:
     This class should never be created directly by the user. Use :meth:`.Batch.new_job`,
     :meth:`.Batch.new_bash_job`, or :meth:`.Batch.new_python_job` instead.
     """
-
-    _counter = 1
-    _uid_prefix = "__JOB__"
-    _regex_pattern = r"(?P<JOB>{}\d+)".format(_uid_prefix)
-
-    @classmethod
-    def _new_uid(cls):
-        uid = "{}{}".format(cls._uid_prefix, cls._counter)
-        cls._counter += 1
-        return uid
 
     def __init__(self,
                  batch: 'batch.Batch',
@@ -72,56 +62,58 @@ class Job:
         self.name = name
         self.attributes = attributes
 
-        self._cpu: Optional[str] = None
-        self._memory: Optional[str] = None
+        self._dependencies: Set['Job'] = set()
+        self._produced_resource_by_name: Dict[str, _resource.Resource] = {}
+        # FIXME: why the heck did I use an int? just use the resource
+        self._defined_resource_remoteness: Dict[_resource.Resource, bool] = {}
+        self._need_to_copy_out: Set[_resource.Resource] = set()
+
+        self._env: Dict[str, str] = dict()
         self._storage: Optional[str] = None
-        self._image: Optional[str] = None
+        self._memory: Optional[str] = None
+        self._cpu: Optional[str] = None
         self._always_run: bool = False
-        self._preemptible: Optional[bool] = None
-        self._machine_type: Optional[str] = None
         self._timeout: Optional[Union[int, float]] = None
         self._cloudfuse: List[Tuple[str, str, bool]] = []
-        self._env: Dict[str, str] = dict()
-        self._wrapper_code: List[str] = []
-        self._user_code: List[str] = []
+        self._image: Optional[str] = None
 
-        self._resources: Dict[str, _resource.Resource] = {}
-        self._resources_inverse: Dict[_resource.Resource, str] = {}
-        self._uid = Job._new_uid()
-        self._job_id: Optional[int] = None
+        # unused?
+        self._preemptible: Optional[bool] = None
+        self._machine_type: Optional[str] = None
 
-        self._inputs: Set[_resource.Resource] = set()
-        self._internal_outputs: Set[Union[_resource.ResourceFile, _resource.PythonResult]] = set()
-        self._external_outputs: Set[Union[_resource.ResourceFile, _resource.PythonResult]] = set()
-        self._mentioned: Set[_resource.Resource] = set()  # resources used in the command
-        self._valid: Set[_resource.Resource] = set()  # resources declared in the appropriate place
-        self._dependencies: Set[Job] = set()
+    def defined_resources(self) -> KeysView[_resource.Resource]:
+        return self._defined_resource_remoteness.keys()
 
-        def safe_str(s):
-            new_s = []
-            for c in s:
-                if c.isalnum() or c == '-':
-                    new_s.append(c)
-                else:
-                    new_s.append('_')
-            return ''.join(new_s)
+    def resource_defined_remotely(self, resource: _resource.Resource) -> bool:
+        print(resource, self._defined_resource_remoteness, self)
+        return self._defined_resource_remoteness[resource]
 
-        self._dirname = f'{safe_str(name)}-{self._token}' if name else self._token
+    def resource_is_defined(self, resource: _resource.Resource, *, remote: bool = False):
+        if resource.is_remote():
+            return self.resource_is_defined(resource.defining_resource(), remote=True)
+        self._defined_resource_remoteness[resource] = remote
 
-    def _get_resource(self, item: str) -> '_resource.Resource':
-        raise NotImplementedError
+    def resource_is_needed(self, resource: _resource.Resource):
+        if resource.is_remote():
+            return self.resource_is_needed(resource.defining_resource())
+        if self.resource_defined_remotely(resource):
+            return
+        self._need_to_copy_out.add(resource)
 
-    def __getitem__(self, item: str) -> '_resource.Resource':
-        return self._get_resource(item)
+    def __getitem__(self, name: str) -> '_resource.Resource':
+        resource = self._produced_resource_by_name.get(name)
+        if resource is None:
+            resource = _resource.JobResource(self._batch._remote_location, self, name, None)
+            self._produced_resource_by_name[name] = resource
+            self._batch._resource_by_uid[resource.uid()] = resource
+        return resource
 
-    def __getattr__(self, item: str) -> '_resource.Resource':
-        return self._get_resource(item)
+    def __getattr__(self, name: str) -> '_resource.Resource':
+        return self.__getitem__(name)
 
-    def _add_internal_outputs(self, resource: '_resource.Resource') -> None:
-        _add_resource_to_set(self._internal_outputs, resource, include_rg=False)
-
-    def _add_inputs(self, resource: '_resource.Resource') -> None:
-        _add_resource_to_set(self._inputs, resource, include_rg=False)
+    @abc.abstractmethod
+    async def compile(self, *, dry_run=False) -> Tuple[str, str, List['_resource.Resource']]:
+        pass
 
     def depends_on(self, *jobs: 'Job') -> 'Job':
         """
@@ -166,8 +158,7 @@ class Job:
         Same job object with dependencies set.
         """
 
-        for j in jobs:
-            self._dependencies.add(j)
+        self._dependencies.extend(jobs)
         return self
 
     def env(self, variable: str, value: str):
@@ -473,69 +464,33 @@ class Job:
         self._cloudfuse.append((bucket, mount_point, read_only))
         return self
 
-    async def _compile(self, local_tmpdir, remote_tmpdir, *, dry_run=False):
-        raise NotImplementedError
+    def image(self, image: str) -> 'Job':
+        """
+        Set the job's docker image.
 
-    def _interpolate_command(self, command, allow_python_results=False):
-        def handler(match_obj):
-            groups = match_obj.groupdict()
+        Examples
+        --------
 
-            if groups['JOB']:
-                raise BatchException(f"found a reference to a Job object in command '{command}'.")
-            if groups['BATCH']:
-                raise BatchException(f"found a reference to a Batch object in command '{command}'.")
-            if groups['PYTHON_RESULT'] and not allow_python_results:
-                raise BatchException(f"found a reference to a PythonResult object. hint: Use one of the methods `as_str`, `as_json` or `as_repr` on a PythonResult. command: '{command}'")
+        Set the job's docker image to `ubuntu:20.04`:
 
-            assert groups['RESOURCE_FILE'] or groups['RESOURCE_GROUP'] or groups['PYTHON_RESULT']
-            r_uid = match_obj.group()
-            r = self._batch._resource_map.get(r_uid)
+        >>> b = Batch()
+        >>> j = b.new_job()
+        >>> (j.image('ubuntu:20.04')
+        ...   .command(f'echo "hello"'))
+        >>> b.run()  # doctest: +SKIP
 
-            if r is None:
-                raise BatchException(f"undefined resource '{r_uid}' in command '{command}'.\n"
-                                     f"Hint: resources must be from the same batch as the current job.")
+        Parameters
+        ----------
+        image:
+            Docker image to use.
 
-            if r._source != self:
-                self._add_inputs(r)
-                if r._source is not None:
-                    if r not in r._source._valid:
-                        name = r._source._resources_inverse[r]
-                        raise BatchException(f"undefined resource '{name}'\n"
-                                             f"Hint: resources must be defined within "
-                                             f"the job methods 'command' or 'declare_resource_group'")
-                    self._dependencies.add(r._source)
-                    r._source._add_internal_outputs(r)
-            else:
-                _add_resource_to_set(self._valid, r)
+        Returns
+        -------
+        Same job object with docker image set.
+        """
 
-            self._mentioned.add(r)
-            return '${BATCH_TMPDIR}' + shq(r._get_path(''))
-
-        regexes = [_resource.ResourceFile._regex_pattern,
-                   _resource.ResourceGroup._regex_pattern,
-                   _resource.PythonResult._regex_pattern,
-                   Job._regex_pattern,
-                   batch.Batch._regex_pattern]
-
-        subst_command = re.sub('(' + ')|('.join(regexes) + ')',
-                               handler,
-                               command)
-
-        return subst_command
-
-    def _pretty(self):
-        s = f"Job '{self._uid}'" \
-            f"\tName:\t'{self.name}'" \
-            f"\tAttributes:\t'{self.attributes}'" \
-            f"\tImage:\t'{self._image}'" \
-            f"\tCPU:\t'{self._cpu}'" \
-            f"\tMemory:\t'{self._memory}'" \
-            f"\tStorage:\t'{self._storage}'" \
-            f"\tCommand:\t'{self._command}'"
-        return s
-
-    def __str__(self):
-        return self._uid
+        self._image = image
+        return self
 
 
 class BashJob(Job):
@@ -578,15 +533,7 @@ class BashJob(Job):
         super().__init__(batch, token, name=name, attributes=attributes, shell=shell)
         self._command: List[str] = []
 
-    def _get_resource(self, item: str) -> '_resource.Resource':
-        if item not in self._resources:
-            r = self._batch._new_job_resource_file(self, value=item)
-            self._resources[item] = r
-            self._resources_inverse[r] = item
-
-        return self._resources[item]
-
-    def declare_resource_group(self, **mappings: Dict[str, Any]) -> 'BashJob':
+    def declare_resource_group(self, **mappings: Dict[str, str]) -> 'BashJob':
         """Declare a resource group for a job.
 
         Examples
@@ -611,11 +558,17 @@ class BashJob(Job):
         Be careful when specifying the expressions for each file as this is Python
         code that is executed with `eval`!
 
+        # FIXME: !!!!! eval?
+
         Parameters
         ----------
         mappings:
             Keywords (in the above example `tmp1`) are the name(s) of the
-            resource group(s).  File names may contain arbitrary Python
+            resource group(s).
+
+
+            FIXME: woah, eval?
+            File names may contain arbitrary Python
             expressions, which will be evaluated by Python `eval`.  To use the
             keyword as the file name, use `{root}` (in the above example {root}
             will be replaced with `tmp1`).
@@ -625,41 +578,16 @@ class BashJob(Job):
         Same job object with resource groups set.
         """
 
-        for name, d in mappings.items():
-            assert name not in self._resources
-            if not isinstance(d, dict):
-                raise BatchException(f"value for name '{name}' is not a dict. Found '{type(d)}' instead.")
-            rg = self._batch._new_resource_group(self, d, root=name)
-            self._resources[name] = rg
-            _add_resource_to_set(self._valid, rg)
-        return self
+        for name, named_format_strings in mappings.items():
+            rg = _resource.ResourceGroup(
+                self._batch._remote_location,
+                named_format_strings,
+                self,
+                f'ResourceGroup({",".join(mappings.keys())})'
+            )
+            self._produced_resource_by_name[name] = rg
+            self._batch._resource_by_uid[rg.uid()] = rg
 
-    def image(self, image: str) -> 'BashJob':
-        """
-        Set the job's docker image.
-
-        Examples
-        --------
-
-        Set the job's docker image to `ubuntu:20.04`:
-
-        >>> b = Batch()
-        >>> j = b.new_job()
-        >>> (j.image('ubuntu:20.04')
-        ...   .command(f'echo "hello"'))
-        >>> b.run()  # doctest: +SKIP
-
-        Parameters
-        ----------
-        image:
-            Docker image to use.
-
-        Returns
-        -------
-        Same job object with docker image set.
-        """
-
-        self._image = image
         return self
 
     def command(self, command: str) -> 'BashJob':
@@ -735,49 +663,61 @@ class BashJob(Job):
         Same job object with command appended.
         """
 
-        command = self._interpolate_command(command)
+        for mo in re.finditer(_resource.Resource.REGEXP, command):
+            uid = _resource.decode_uid(mo[2])
+            try:
+                resource = self._batch._resource_by_uid[uid]
+            except KeyError as err:
+                raise BatchException(
+                    f"undefined resource '{mo[2]}' in command '{command}'.\n"
+                    f"Hint: resources must be from the same batch as the current job.") from err
+            maybe_source = resource.source()
+            if maybe_source is not None:
+                if maybe_source == self:
+                    self.resource_is_defined(resource)
+                else:
+                    maybe_source.resource_is_needed(resource)
+                    self._dependencies.add(maybe_source)
+
         self._command.append(command)
         return self
 
-    async def _compile(self, local_tmpdir, remote_tmpdir, *, dry_run=False):
-        if len(self._command) == 0:
-            return False
-
+    async def compile(self, *, dry_run=False) -> Tuple[str, str, List['_resource.Resource']]:
         job_shell = self._shell if self._shell else DEFAULT_SHELL
 
-        job_command = [cmd.strip() for cmd in self._command]
-        job_command = [f'{{\n{x}\n}}' for x in job_command]
-        job_command = '\n'.join(job_command)
+        job_command = ['#! ' + job_shell]
+        job_command.extend([
+            'mkdir -p ' + os.path.dirname(resource.local_location())
+            for resource in self.defined_resources()])
+        user_code = [cmd.strip() for cmd in self._command]
+        job_command.extend(user_code)
+        job_command_str = '\n'.join(job_command)
+        user_code_str = '\n'.join(user_code)
+        job_command_bytes = job_command_str.encode('utf-8')
 
-        job_command = f'''
-#! {job_shell}
-{job_command}
-'''
-
-        job_command_bytes = job_command.encode()
+        resources_to_download = []
+        for match in re.finditer(_resource.Resource.REGEXP, job_command_str):
+            assert match[1] in 'LR'
+            is_referenced_remote = match[1] == 'R'
+            uid = _resource.decode_uid(match[2])
+            resource = self._batch._resource_by_uid[uid]
+            if resource not in self.defined_resources() and not is_referenced_remote:
+                resources_to_download.append(resource)
 
         if len(job_command_bytes) <= 10 * 1024:
-            self._wrapper_code.append(job_command)
-            return False
+            return (job_command_str, user_code_str, resources_to_download)
 
-        self._user_code.append(job_command)
-
-        job_path = f'{remote_tmpdir}/{self._dirname}'
-        code_path = f'{job_path}/code.sh'
-        code = self._batch.read_input(code_path)
-
-        wrapper_command = f'''
-chmod u+x {code}
-source {code}
-'''
-        wrapper_command = self._interpolate_command(wrapper_command)
-        self._wrapper_code.append(wrapper_command)
-
+        code_location = self._batch._remote_location + '/' + self._token + '/' + 'code.sh'
         if not dry_run:
-            await self._batch._fs.makedirs(os.path.dirname(code_path), exist_ok=True)
-            await self._batch._fs.write(code_path, job_command_bytes)
+            # FIXME: local fs .create should be responsibile for makedirs
+            await self._batch._fs.makedirs(os.path.dirname(code_location), exist_ok=True)
+            await self._batch._fs.write(code_location, job_command_bytes)
+        code_resource = self._batch.read_input(code_location)
+        resources_to_download.append(code_resource)
 
-        return True
+        job_command_str += f'\nchmod u+x {code_resource}; source {code_resource}'
+
+        return (job_command_str, user_code_str, resources_to_download)
 
 
 class PythonJob(Job):
@@ -826,15 +766,8 @@ class PythonJob(Job):
         super().__init__(batch, token, name=name, attributes=attributes, shell=None)
         self._resources: Dict[str, _resource.Resource] = {}
         self._resources_inverse: Dict[_resource.Resource, str] = {}
-        self._functions: List[Tuple[_resource.PythonResult, Callable, Tuple[Any, ...], Dict[str, Any]]] = []
+        self._functions: List[Tuple[_resource.PythonResult, bytes, str]] = []
         self.n_results = 0
-
-    def _get_resource(self, item: str) -> '_resource.PythonResult':
-        if item not in self._resources:
-            r = self._batch._new_python_result(self, value=item)
-            self._resources[item] = r
-            self._resources_inverse[r] = item
-        return cast(_resource.PythonResult, self._resources[item])
 
     def image(self, image: str) -> 'PythonJob':
         """
@@ -995,103 +928,83 @@ class PythonJob(Job):
             if isinstance(value, Job):
                 raise BatchException('arguments to a PythonJob cannot be other job objects.')
 
-        def handle_arg(r):
-            if r._source != self:
-                self._add_inputs(r)
-                if r._source is not None:
-                    if r not in r._source._valid:
-                        name = r._source._resources_inverse[r]
-                        raise BatchException(f"undefined resource '{name}'\n")
-                    self._dependencies.add(r._source)
-                    r._source._add_internal_outputs(r)
-            else:
-                _add_resource_to_set(self._valid, r)
-
-            self._mentioned.add(r)
-
-        for arg in args:
-            if isinstance(arg, _resource.Resource):
-                handle_arg(arg)
-
-        for value in kwargs.values():
-            if isinstance(value, _resource.Resource):
-                handle_arg(value)
-
         self.n_results += 1
-        result = self._get_resource(f'result{self.n_results}')
-        handle_arg(result)
+        result_name = f'result{self.n_results}'
+        result = _resource.PythonResult(self._batch._remote_location, self, result_name)
+        self._produced_resource_by_name[result_name] = result
+        self._batch._resource_by_uid[result.uid()] = result
+        self.resource_is_defined(result)
 
-        self._functions.append((result, unapplied, args, kwargs))
+        pipe = BytesIO()
+        pickler = ResourceToStringPickler(pipe, recurse=True)
+        pickler.dump(functools.partial(unapplied, *args, **kwargs))
+        pipe.seek(0)
+
+        for resource in pickler.serialized_resources:
+            # FIXME: this should probably happen when you call?
+            maybe_source = resource.source()
+            if maybe_source is not None:
+                if maybe_source == self:
+                    self.resource_is_defined(resource)
+                else:
+                    maybe_source.resource_is_needed(resource)
+                    self._dependencies.add(maybe_source)
+
+        user_code_builder = StringIO()
+        user_code_builder.write(textwrap.dedent(inspect.getsource(unapplied)) + '\n')
+        # FIXME: the repr for a resource does not have any quotes
+        args_str = ', '.join([repr(arg) for arg in args])
+        kwargs_str = ', '.join([f'{k}={v!r}' for k, v in kwargs.items()])
+        separator = ', ' if args and kwargs else ''
+        func_call = f'{unapplied.__name__}({args_str}{separator}{kwargs_str})'
+        user_code_builder.write(func_call + '\n')
+
+        self._functions.append((result, pipe.getvalue(), user_code_builder.getvalue()))
 
         return result
 
-    async def _compile(self, local_tmpdir, remote_tmpdir, *, dry_run=False):
-        for i, (result, unapplied, args, kwargs) in enumerate(self._functions):
-            def prepare_argument_for_serialization(arg):
-                if isinstance(arg, _resource.PythonResult):
-                    return ('py_path', arg._get_path(local_tmpdir))
-                if isinstance(arg, _resource.ResourceFile):
-                    return ('path', arg._get_path(local_tmpdir))
-                if isinstance(arg, _resource.ResourceGroup):
-                    return ('dict_path', {name: resource._get_path(local_tmpdir)
-                                          for name, resource in arg._resources.items()})
-                return ('value', arg)
-
-            def deserialize_argument(arg):
-                typ, val = arg
-                if typ == 'py_path':
-                    return dill.load(open(val, 'rb'))
-                if typ in ('path', 'dict_path'):
-                    return val
-                assert typ == 'value'
-                return val
-
-            def wrap(f):
-                @functools.wraps(f)
-                def wrapped(*args, **kwargs):
-                    args = [deserialize_argument(arg) for arg in args]
-                    kwargs = {kw: deserialize_argument(arg) for kw, arg in kwargs.items()}
-                    return f(*args, **kwargs)
-                return wrapped
-
-            args = [prepare_argument_for_serialization(arg) for arg in args]
-            kwargs = {kw: prepare_argument_for_serialization(arg) for kw, arg in kwargs.items()}
-
-            pipe = BytesIO()
-            dill.dump(functools.partial(wrap(unapplied), *args, **kwargs), pipe, recurse=True)
-            pipe.seek(0)
-
-            job_path = os.path.dirname(result._get_path(remote_tmpdir))
-            code_path = f'{job_path}/code{i}.p'
-
+    async def compile(self, *, dry_run=False) -> Tuple[str, str, List['_resource.Resource']]:
+        resources_to_download: List[_resource.Resource] = []
+        command = StringIO()
+        user_code_builder = StringIO()
+        for i, (result, pickled, user_code) in enumerate(self._functions):
+            user_code_builder.write(user_code)
+            py_code_location = self._batch._remote_location + '/' + self._token + '/' + f'code{i}.dill'
             if not dry_run:
-                await self._batch._fs.makedirs(os.path.dirname(code_path), exist_ok=True)
-                await self._batch._fs.write(code_path, pipe.getvalue())
-
-            code = self._batch.read_input(code_path)
+                # FIXME: local fs .create should be responsibile for makedirs
+                await self._batch._fs.makedirs(os.path.dirname(py_code_location), exist_ok=True)
+                await self._batch._fs.write(py_code_location, pickled)
+            py_code_resource = self._batch.read_input(py_code_location)
+            resources_to_download.append(py_code_resource)
 
             json_write = ''
-            if result._json:
+            if result._as_json:
+                resources_to_download.append(result._as_json)
                 json_write = f'''
-            with open(\\"{result._json}\\", \\"w\\") as out:
+            os.makedirs(os.path.dirname(\\"result._as_json\\"), exist_ok=True)
+            with open(\\"{result._as_json}\\", \\"w\\") as out:
                 out.write(json.dumps(result) + \\"\\n\\")
 '''
 
             str_write = ''
-            if result._str:
+            if result._as_str:
+                resources_to_download.append(result._as_str)
                 str_write = f'''
-            with open(\\"{result._str}\\", \\"w\\") as out:
+            os.makedirs(os.path.dirname(\\"result._as_str\\"), exist_ok=True)
+            with open(\\"{result._as_str}\\", \\"w\\") as out:
                 out.write(str(result) + \\"\\n\\")
 '''
 
             repr_write = ''
-            if result._repr:
+            if result._as_repr:
+                resources_to_download.append(result._as_repr)
                 repr_write = f'''
-            with open(\\"{result._repr}\\", \\"w\\") as out:
+            os.makedirs(os.path.dirname(\\"result._as_repr\\"), exist_ok=True)
+            with open(\\"{result._as_repr}\\", \\"w\\") as out:
                 out.write(repr(result) + \\"\\n\\")
 '''
 
-            wrapper_code = f'''python3 -c "
+            command.write(f'''python3 -c "
 import os
 import base64
 import dill
@@ -1099,9 +1012,10 @@ import traceback
 import json
 import sys
 
+os.makedirs(os.path.dirname(\\"{result}\\"), exist_ok=True)
 with open(\\"{result}\\", \\"wb\\") as dill_out:
     try:
-        with open(\\"{code}\\", \\"rb\\") as f:
+        with open(\\"{py_code_resource}\\", \\"rb\\") as f:
             result = dill.load(f)()
             dill.dump(result, dill_out, recurse=True)
             {json_write}
@@ -1111,16 +1025,6 @@ with open(\\"{result}\\", \\"wb\\") as dill_out:
         traceback.print_exc()
         dill.dump((e, traceback.format_exception(type(e), e, e.__traceback__)), dill_out, recurse=True)
         raise e
-"'''
+"''')
 
-            wrapper_code = self._interpolate_command(wrapper_code, allow_python_results=True)
-            self._wrapper_code.append(wrapper_code)
-
-            self._user_code.append(textwrap.dedent(inspect.getsource(unapplied)))
-            args = ', '.join([f'{arg!r}' for _, arg in args])
-            kwargs = ', '.join([f'{k}={v!r}' for k, (_, v) in kwargs.items()])
-            separator = ', ' if args and kwargs else ''
-            func_call = f'{unapplied.__name__}({args}{separator}{kwargs})'
-            self._user_code.append(self._interpolate_command(func_call, allow_python_results=True))
-
-        return True
+        return command.getvalue(), user_code_builder.getvalue(), resources_to_download

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -1,140 +1,278 @@
+from typing import Optional, Dict, Union
+from typing_extensions import Literal
 import abc
-from typing import Optional, Set, cast
+import dill
+import urllib
+import base64
+import re
+import os
 
-from . import job  # pylint: disable=cyclic-import
+# I need to restore the jobs types without pulling in a ton of dependencies. The dependencies screw
+# with dill serialization.
 from .exceptions import BatchException
 
 
-class Resource:
+_last_used_uid = 0
+
+
+def generate_uid() -> int:
+    global _last_used_uid
+    _last_used_uid += 1
+    return _last_used_uid
+
+
+def encode_uid(uid: int) -> str:
+    return base64.b64encode(uid.to_bytes(8, byteorder='big')).decode('utf-8')
+
+
+def decode_uid(uid_str: str) -> int:
+    try:
+        return int.from_bytes(base64.b64decode(uid_str.encode('utf-8')), byteorder='big')
+    except Exception as err:
+        raise ValueError(f'bad uid: {uid_str}') from err
+
+
+class Resource(abc.ABC):
     """
     Abstract class for resources.
     """
 
-    _uid: str
-    _source: Optional[job.Job]
+    LOCAL_PREFIX =      '/__HAIL_1kh7ah_/L'
+    REMOTE_PREFIX =     '/__HAIL_1kh7ah_/R'
+    # FIXME: should use base63 (no /)
+    REGEXP = re.compile('/__HAIL_1kh7ah_/([LR])([+/0-9A-Za-z]+=*)')
 
+    def uid_remote_path_needle(self):
+        return Resource.REMOTE_PREFIX + encode_uid(self.uid())
+
+    def uid_local_path_needle(self):
+        return Resource.LOCAL_PREFIX + encode_uid(self.uid())
+
+    def local_prefix_from_uid(self):
+        return '/io' + self.uid_local_path_needle()
+
+    # FIXME: do I need this
     @abc.abstractmethod
-    def _get_path(self, directory: str) -> str:
+    def uses_remote_tmpdir(self) -> bool:
         pass
 
-    @abc.abstractmethod
-    def _add_output_path(self, path: str) -> None:
-        pass
+    def as_py(self) -> Union[str, Dict[str, str]]:
+        return self.local_location()
 
+    def is_remote(self) -> bool:
+        return False
 
-class ResourceFile(Resource, str):
-    """
-    Class representing a single file resource. There exist two subclasses:
-    :class:`.InputResourceFile` and :class:`.JobResourceFile`.
-    """
-    _counter = 0
-    _uid_prefix = "__RESOURCE_FILE__"
-    _regex_pattern = r"(?P<RESOURCE_FILE>{}\d+)".format(_uid_prefix)
-
-    @classmethod
-    def _new_uid(cls):
-        uid = "{}{}".format(cls._uid_prefix, cls._counter)
-        cls._counter += 1
-        return uid
-
-    def __new__(cls, *args, **kwargs):  # pylint: disable=W0613
-        uid = ResourceFile._new_uid()
-        r = str.__new__(cls, uid)
-        r._uid = uid
-        return r
-
-    def __init__(self, value: Optional[str]):
-        super().__init__()
-        assert value is None or isinstance(value, str)
-        self._value = value
-        self._source: Optional[job.Job] = None
-        self._output_paths: Set[str] = set()
-        self._resource_group: Optional[ResourceGroup] = None
-
-    def _get_path(self, directory: str):
-        raise NotImplementedError
-
-    def _add_output_path(self, path: str) -> None:
-        self._output_paths.add(path)
-        if self._source is not None:
-            self._source._external_outputs.add(self)
-
-    def _add_resource_group(self, rg: 'ResourceGroup') -> None:
-        self._resource_group = rg
-
-    def _has_resource_group(self) -> bool:
-        return self._resource_group is not None
-
-    def _get_resource_group(self) -> Optional['ResourceGroup']:
-        return self._resource_group
-
-    def __str__(self):
-        return f'{self._uid}'  # pylint: disable=no-member
-
-    def __repr__(self):
-        return self._uid  # pylint: disable=no-member
-
-
-class InputResourceFile(ResourceFile):
-    """
-    Class representing a resource from an input file.
-
-    Examples
-    --------
-    `input` is an :class:`.InputResourceFile` of the batch `b`
-    and is used in job `j`:
-
-    >>> b = Batch()
-    >>> input = b.read_input('data/hello.txt')
-    >>> j = b.new_job(name='hello')
-    >>> j.command(f'cat {input}')
-    >>> b.run()
-    """
-
-    def __init__(self, value):
-        self._input_path = None
-        super().__init__(value)
-
-    def _add_input_path(self, path: str) -> 'InputResourceFile':
-        self._input_path = path
+    def defining_resource(self) -> 'Resource':
         return self
 
-    def _get_path(self, directory: str) -> str:
-        assert self._value is not None
-        return directory + '/inputs/' + self._value
+    @abc.abstractmethod
+    def uid(self) -> int:
+        pass
+
+    @abc.abstractmethod
+    def humane_name(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def source(self):  #  -> Optional[job.Job]
+        pass
+
+    @abc.abstractmethod
+    def remote_location(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def local_location(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def group(self) -> Optional[Union['ResourceGroup', 'ExternalResourceGroup']]:
+        pass
+
+    def __str__(self) -> str:
+        return self.local_location()
+
+    def __repr__(self) -> str:
+        return repr(self.local_location())
 
 
-class JobResourceFile(ResourceFile):
-    """
-    Class representing an intermediate file from a job.
+class RemoteResource(Resource):
+    def __init__(self, resource: Resource):
+        self.resource = resource
+        self._deserialized_remote_location: Optional[str] = None
+        if isinstance(self.resource, PythonResult):
+            raise ValueError('cannot remote resource a PythonResult')
 
-    Examples
-    --------
-    `j.ofile` is a :class:`.JobResourceFile` on the job`j`:
+    def uses_remote_tmpdir(self) -> bool:
+        return False
 
-    >>> b = Batch()
-    >>> j = b.new_job(name='hello-tmp')
-    >>> j.command(f'echo "hello world" > {j.ofile}')
-    >>> b.run()
+    def uid(self) -> int:
+        return self.resource.uid()
 
-    Notes
-    -----
-    All :class:`.JobResourceFile` are temporary files and must be written
-    to a permanent location using :meth:`.Batch.write_output` if the output needs
-    to be saved.
-    """
+    def as_py(self) -> Union[str, Dict[str, str]]:
+        if isinstance(self.resource, ResourceGroup):
+            return {name: m.remote_location() for name, m in self.resource.members_by_name.items()}
+        assert not isinstance(self.resource, PythonResult)
+        return self.resource.remote_location()
 
-    def __init__(self, value, source: job.Job):
-        super().__init__(value)
-        self._has_extension = False
-        self._source: job.Job = source
+    def is_remote(self) -> bool:
+        return True
 
-    def _get_path(self, directory: str) -> str:
-        assert self._source is not None
-        assert self._value is not None
-        return f'{directory}/{self._source._dirname}/{self._value}'
+    def defining_resource(self) -> 'Resource':
+        return self.resource
 
-    def add_extension(self, extension: str) -> 'JobResourceFile':
+    def humane_name(self) -> str:
+        return self.resource.humane_name()
+
+    def source(self):  #  -> Optional[job.Job]
+        return self.resource.source()
+
+    def remote_location(self) -> str:
+        return self._deserialized_remote_location or self.resource.remote_location()
+
+    def local_location(self) -> str:
+        return self._deserialized_remote_location or self.resource.remote_location()
+
+    def group(self) -> Optional[Union['ResourceGroup', 'ExternalResourceGroup']]:
+        return self.resource.group()
+
+
+def remote(resource: Resource) -> RemoteResource:
+    return RemoteResource(resource)
+
+
+class ExternalResource(Resource):
+    def __init__(self, remote_location: str, humane_name: str):
+        self._uid = generate_uid()
+        self._remote_location = remote_location
+        self._local_location = self.local_prefix_from_uid() + '/' + os.path.basename(self._remote_location)
+        self._humane_name = humane_name
+
+    def uid(self) -> int:
+        return self._uid
+
+    def uses_remote_tmpdir(self) -> bool:
+        return False
+
+    def humane_name(self) -> str:
+        return self._humane_name
+
+    def source(self) -> Literal[None]:
+        return None
+
+    def remote_location(self) -> str:
+        return self._remote_location
+
+    def local_location(self) -> str:
+        return self._local_location
+
+    def group(self) -> Literal[None]:
+        return None
+
+
+class ExternalResourceGroupMember(Resource):
+    def __init__(self, group: 'ExternalResourceGroup', remote_location: str, suffix: str, humane_name: str):
+        self._group = group
+        self._remote_location = remote_location
+        self._suffix = suffix
+        self._humane_name = humane_name
+
+    def uid(self) -> int:
+        return self._group.uid()
+
+    def uses_remote_tmpdir(self) -> bool:
+        return False
+
+    def humane_name(self) -> str:
+        return self._humane_name + ' in ' + self._group.humane_name()
+
+    def source(self):  #  -> Optional[job.Job]
+        return self._group.source()
+
+    def remote_location(self) -> str:
+        return self._remote_location
+
+    def local_location(self) -> str:
+        return self._group.local_location() + '/' + self._suffix
+
+    def group(self) -> Optional['ExternalResourceGroup']:
+        return self._group
+
+
+class ExternalResourceGroup(Resource):
+    def __init__(self, named_members: Dict[str, str], humane_name: str):
+        self._uid = generate_uid()
+        parsed = [urllib.parse.urlparse(url) for url in named_members.values()]
+        common_path_prefix = os.path.commonpath([url.path for url in parsed])
+        n = len(common_path_prefix)
+        suffices = [url.path[n:] for url in parsed]
+        self._local_location = self.local_prefix_from_uid() + '/' + common_path_prefix
+        self.members_by_name = {
+            name: ExternalResourceGroupMember(self, remote_location, suffix, name)
+            for (name, remote_location), suffix in zip(named_members.items(), suffices)
+        }
+        self._humane_name = humane_name
+
+    def as_py(self) -> Dict[str, str]:
+        return {name: m.local_location() for name, m in self.members_by_name.items()}
+
+    def uid(self) -> int:
+        return self._uid
+
+    def uses_remote_tmpdir(self) -> bool:
+        return False
+
+    def humane_name(self) -> str:
+        return self._humane_name
+
+    def source(self) -> Literal[None]:
+        return None
+
+    def remote_location(self) -> str:
+        raise ValueError('ExternalResourceGroup has no sensible remote location')
+
+    def local_location(self) -> str:
+        return self._local_location
+
+    def group(self) -> Optional['ResourceGroup']:
+        return None
+
+
+class JobResource(Resource):
+    def __init__(self, remote_dir: str, j, humane_name: str, extension: Optional[str]):
+        self._uid = generate_uid()
+        self._remote_location = remote_dir + self.uid_remote_path_needle()
+        self._extension: Optional[str] = extension
+        self._local_location: Optional[str] = None
+        self._job = j
+        self._humane_name = humane_name
+
+    def uid(self) -> int:
+        return self._uid
+
+    def uses_remote_tmpdir(self) -> bool:
+        return True
+
+    def humane_name(self) -> str:
+        return self._humane_name
+
+    def source(self):  #  -> job.Job
+        return self._job
+
+    def remote_location(self) -> str:
+        return self._remote_location
+
+    def local_location(self) -> str:
+        if self._local_location is None:
+            self._local_location = self.local_prefix_from_uid()
+            if self._extension is not None:
+                self._local_location += self._extension
+        return self._local_location
+
+    def group(self) -> Literal[None]:
+        return None
+
+    def add_extension(self, extension: str) -> 'JobResource':
         """
         Specify the file extension to use.
 
@@ -162,195 +300,123 @@ class JobResourceFile(ResourceFile):
         :class:`.JobResourceFile`
             Same resource file with the extension specified
         """
-        if self._has_extension:
+        if self._extension is not None:
             raise BatchException("Resource already has a file extension added.")
-        assert self._value is not None
-        self._value += extension
-        self._has_extension = True
+        assert self._local_location is None
+        self._extension = extension
         return self
 
 
+class ResourceGroupMember(Resource):
+    def __init__(self, group: 'ResourceGroup', suffix: str, humane_name: str):
+        self._group = group
+        self._suffix = suffix
+        self._humane_name = humane_name
+
+    def uid(self) -> int:
+        return self._group.uid()
+
+    def uses_remote_tmpdir(self) -> bool:
+        return True
+
+    def humane_name(self) -> str:
+        return self._humane_name + ' in ' + self._group.humane_name()
+
+    def source(self):  #  -> Optional[job.Job]
+        return self._group.source()
+
+    def remote_location(self) -> str:
+        return self._group.remote_location() + '/' + self._suffix
+
+    def local_location(self) -> str:
+        return self._group.local_location() + '/' + self._suffix
+
+    def group(self) -> Literal[None]:
+        return self._group
+
+
 class ResourceGroup(Resource):
-    """
-    Class representing a mapping of identifiers to a resource file.
+    def __init__(self, remote_prefix: str, named_format_strings: Dict[str, str], j, humane_name: str):
+        self._uid = generate_uid()
+        self._remote_location = remote_prefix + self.uid_remote_path_needle()
+        self._local_location = self.local_prefix_from_uid() + '/' + os.path.basename(self._remote_location)
+        self._job = j
+        self.members_by_name = {
+            name: ResourceGroupMember(self, format_string.format(root='root'), name)
+            for name, format_string in named_format_strings.items()
+        }
+        self._humane_name = humane_name
 
-    Examples
-    --------
+    def as_py(self) -> Dict[str, str]:
+        return {name: m.local_location() for name, m in self.members_by_name.items()}
 
-    Initialize a batch and create a new job:
+    def uid(self) -> int:
+        return self._uid
 
-    >>> b = Batch()
-    >>> j = b.new_job()
+    def uses_remote_tmpdir(self) -> bool:
+        return True
 
-    Read a set of input files as a resource group:
+    def humane_name(self) -> str:
+        return self._humane_name
 
-    >>> bfile = b.read_input_group(bed='data/example.bed',
-    ...                            bim='data/example.bim',
-    ...                            fam='data/example.fam')
+    def source(self):  #  -> Optional[job.Job]
+        return self._job
 
-    Create a resource group from a job intermediate:
+    def remote_location(self) -> str:
+        return self._remote_location
 
-    >>> j.declare_resource_group(ofile={'bed': '{root}.bed',
-    ...                                 'bim': '{root}.bim',
-    ...                                 'fam': '{root}.fam'})
-    >>> j.command(f'plink --bfile {bfile} --make-bed --out {j.ofile}')
+    def local_location(self) -> str:
+        return self._local_location
 
-    Reference the entire file group:
-
-    >>> j.command(f'plink --bfile {bfile} --geno 0.2 --make-bed --out {j.ofile}')
-
-    Reference a single file:
-
-    >>> j.command(f'wc -l {bfile.fam}')
-
-    Execute the batch:
-
-    >>> b.run() # doctest: +SKIP
-
-    Notes
-    -----
-    All files in the resource group are copied between jobs even if only one
-    file in the resource group is mentioned. This is to account for files that
-    are implicitly assumed to always be together such as a FASTA file and its
-    index.
-    """
-
-    _counter = 0
-    _uid_prefix = "__RESOURCE_GROUP__"
-    _regex_pattern = r"(?P<RESOURCE_GROUP>{}\d+)".format(_uid_prefix)
-
-    @classmethod
-    def _new_uid(cls):
-        uid = "{}{}".format(cls._uid_prefix, cls._counter)
-        cls._counter += 1
-        return uid
-
-    def __init__(self, source: Optional[job.Job], root: str, **values: ResourceFile):
-        self._source = source
-        self._resources = {}  # dict of name to resource uid
-        self._root = root
-        self._uid = ResourceGroup._new_uid()
-
-        for name, resource_file in values.items():
-            assert isinstance(resource_file, ResourceFile)
-            self._resources[name] = resource_file
-            resource_file._add_resource_group(self)
-
-    def _get_path(self, directory: str) -> str:
-        subdir = str(self._source._dirname) if self._source else 'inputs'
-        return directory + '/' + subdir + '/' + self._root
-
-    def _add_output_path(self, path: str) -> None:
-        for name, rf in self._resources.items():
-            rf._add_output_path(path + '.' + name)
-
-    def _get_resource(self, item: str) -> ResourceFile:
-        if item not in self._resources:
-            raise BatchException(f"'{item}' not found in the resource group.\n"
-                                 f"Hint: you must declare each attribute when constructing the resource group.")
-        return self._resources[item]
-
-    def __getitem__(self, item: str) -> ResourceFile:
-        return self._get_resource(item)
-
-    def __getattr__(self, item: str) -> ResourceFile:
-        return self._get_resource(item)
-
-    def __add__(self, other: str):
-        assert isinstance(other, str)
-        return str(self._uid) + other
-
-    def __radd__(self, other: str):
-        assert isinstance(other, str)
-        return other + str(self._uid)
-
-    def __str__(self):
-        return f'{self._uid}'
+    def group(self) -> Optional['ResourceGroup']:
+        return None
 
 
-class PythonResult(Resource, str):
-    """
-    Class representing a result from a Python job.
+class PythonResult(Resource):
+    def __init__(self, remote_dir: str, j, humane_name: str):
+        self._uid = generate_uid()
+        self._remote_location = remote_dir + '/' + encode_uid(self._uid)
+        self._extension: Optional[str] = None
+        self._local_location: Optional[str] = None
+        self._job = j
+        self._humane_name = humane_name
 
-    Examples
-    --------
+        self._remote_dir = remote_dir
+        self._as_json = None
+        self._as_str = None
+        self._as_repr = None
 
-    Add two numbers and then square the result:
+    def as_py(self) -> Dict[str, str]:
+        raise ValueError('hmm')
+        # FIXME: Hmm. how do we do this with RemoteResource
+        return dill.load(open(self.local_location()))
 
-    .. code-block:: python
+    def uid(self) -> int:
+        return self._uid
 
-        def add(x, y):
-            return x + y
+    def uses_remote_tmpdir(self) -> bool:
+        return True
 
-        def square(x):
-            return x ** 2
+    def humane_name(self) -> str:
+        return self._humane_name
 
+    def source(self):  #  -> job.Job
+        return self._job
 
-        b = Batch()
-        j = b.new_python_job(name='add')
-        result = j.call(add, 3, 2)
-        result = j.call(square, result)
-        b.write_output(result.as_str(), 'output/squared.txt')
-        b.run()
+    def remote_location(self) -> str:
+        return self._remote_location
 
-    Notes
-    -----
-    All :class:`.PythonResult` are temporary Python objects and must be written
-    to a permanent location using :meth:`.Batch.write_output` if the output needs
-    to be saved. In most cases, you'll want to convert the :class:`.PythonResult`
-    to a :class:`.JobResourceFile` in a human-readable format.
-    """
-    _counter = 0
-    _uid_prefix = "__PYTHON_RESULT__"
-    _regex_pattern = r"(?P<PYTHON_RESULT>{}\d+)".format(_uid_prefix)
+    def local_location(self) -> str:
+        if self._local_location is None:
+            self._local_location = self.local_prefix_from_uid()+ '/' + os.path.basename(self._remote_location)
+            if self._extension is not None:
+                self._local_location += self._extension
+        return self._local_location
 
-    @classmethod
-    def _new_uid(cls):
-        uid = "{}{}".format(cls._uid_prefix, cls._counter)
-        cls._counter += 1
-        return uid
+    def group(self) -> Literal[None]:
+        return None
 
-    def __new__(cls, *args, **kwargs):  # pylint: disable=W0613
-        uid = PythonResult._new_uid()
-        r = str.__new__(cls, uid)
-        r._uid = uid
-        return r
-
-    def __init__(self, value: str, source: job.PythonJob):
-        super().__init__()
-        assert value is None or isinstance(value, str)
-        self._value = value
-        self._source = source
-        self._output_paths: Set[str] = set()
-        self._json = None
-        self._str = None
-        self._repr = None
-
-    def _get_path(self, directory: str) -> str:
-        assert self._source is not None
-        assert self._value is not None
-        return f'{directory}/{self._source._dirname}/{self._value}'
-
-    def _add_converted_resource(self, value):
-        jrf = self._source._batch._new_job_resource_file(self._source, value)
-        self._source._resources[value] = jrf
-        self._source._resources_inverse[jrf] = value
-        self._source._valid.add(jrf)
-        self._source._mentioned.add(jrf)
-        return jrf
-
-    def _add_output_path(self, path: str) -> None:
-        self._output_paths.add(path)
-        if self._source is not None:
-            self._source._external_outputs.add(self)
-
-    def source(self) -> job.PythonJob:
-        """
-        Get the job that created the Python result.
-        """
-        return cast(job.PythonJob, self._source)
-
-    def as_json(self) -> JobResourceFile:
+    def as_json(self) -> JobResource:
         """
         Convert a Python result to a file with a JSON representation of the object.
 
@@ -375,13 +441,11 @@ class PythonResult(Resource, str):
             A new resource file where the contents are a Python object
             that has been converted to JSON.
         """
-        if self._json is None:
-            jrf = self._add_converted_resource(self._value + '-json')
-            jrf.add_extension('.json')
-            self._json = jrf
-        return cast(JobResourceFile, self._json)
+        if self._as_json is None:
+            self._as_json = JobResource(self._remote_dir, self._job, self._humane_name + '-json', '.json')
+        return self._as_json
 
-    def as_str(self) -> JobResourceFile:
+    def as_str(self) -> Resource:
         """
         Convert a Python result to a file with the str representation of the object.
 
@@ -402,17 +466,15 @@ class PythonResult(Resource, str):
 
         Returns
         -------
-        :class:`.JobResourceFile`
+        :class:`.Resource`
             A new resource file where the contents are the str representation
             of a Python object.
         """
-        if self._str is None:
-            jrf = self._add_converted_resource(self._value + '-str')
-            jrf.add_extension('.txt')
-            self._str = jrf
-        return cast(JobResourceFile, self._str)
+        if self._as_str is None:
+            self._as_str = JobResource(self._remote_dir, self._job, self._humane_name + '-str', '.txt')
+        return self._as_str
 
-    def as_repr(self) -> JobResourceFile:
+    def as_repr(self) -> Resource:
         """
         Convert a Python result to a file with the repr representation of the object.
 
@@ -433,18 +495,21 @@ class PythonResult(Resource, str):
 
         Returns
         -------
-        :class:`.JobResourceFile`
+        :class:`.Resource`
             A new resource file where the contents are the repr representation
             of a Python object.
         """
-        if self._repr is None:
-            jrf = self._add_converted_resource(self._value + '-repr')
-            jrf.add_extension('.txt')
-            self._repr = jrf
-        return cast(JobResourceFile, self._repr)
+        if self._as_repr is None:
+            self._as_repr = JobResource(self._remote_dir, self._job, self._humane_name + '-repr', '.repr')
+        return self._as_repr
 
-    def __str__(self):
-        return f'{self._uid}'  # pylint: disable=no-member
 
-    def __repr__(self):
-        return self._uid  # pylint: disable=no-member
+ALL_RESOURCE_CLASSES = [
+    RemoteResource,
+    ExternalResourceGroupMember,
+    ExternalResourceGroup,
+    JobResource,
+    ResourceGroupMember,
+    ResourceGroup,
+    PythonResult
+]

--- a/hail/python/hailtop/batch/utils.py
+++ b/hail/python/hailtop/batch/utils.py
@@ -5,10 +5,10 @@ from typing import List
 from ..utils.utils import grouped, digits_needed
 from .batch import Batch
 from .exceptions import BatchException
-from .resource import ResourceGroup, ResourceFile
+from .resource import ResourceGroup, Resource
 
 
-def concatenate(b: Batch, files: List[ResourceFile], image: str = None, branching_factor: int = 100) -> ResourceFile:
+def concatenate(b: Batch, files: List[Resource], image: str = None, branching_factor: int = 100) -> Resource:
     """
     Concatenate files using tree aggregation.
 
@@ -53,7 +53,7 @@ def concatenate(b: Batch, files: List[ResourceFile], image: str = None, branchin
     if len(files) == 0:
         raise BatchException('Must have at least one file to concatenate.')
 
-    if not all([isinstance(f, ResourceFile) for f in files]):
+    if not all([isinstance(f, Resource) for f in files]):
         raise BatchException('Invalid input file(s) - all inputs must be resource files.')
 
     return _combine(_concatenate, b, 'concatenate', files, branching_factor=branching_factor)

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1,4 +1,5 @@
 import secrets
+import dill
 import unittest
 import os
 import subprocess as sp
@@ -7,6 +8,7 @@ from shlex import quote as shq
 import uuid
 import re
 
+import hailtop.batch as hb
 from hailtop.batch import Batch, ServiceBackend, LocalBackend
 from hailtop.batch.exceptions import BatchException
 from hailtop.batch.globals import arg_max
@@ -20,7 +22,7 @@ from ..utils import skip_in_azure
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
 PYTHON_DILL_IMAGE = os.environ['PYTHON_DILL_IMAGE']
-
+HAIL_GENETICS_HAIL_IMAGE = os.environ['HAIL_GENETICS_HAIL_IMAGE']
 
 class LocalTests(unittest.TestCase):
     def batch(self, requester_pays_project=None):
@@ -901,3 +903,208 @@ class ServiceTests(unittest.TestCase):
         assert not batch.submission_info.used_fast_create
         batch_status = batch.status()
         assert batch_status['state'] == 'success', str((batch.debug_info()))
+
+    def test_remote_consumer(self):
+        backend = ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files')
+        b = Batch(backend=backend)
+        j1 = b.new_job()
+        j1.command(f'echo hi > {j1.out}')
+        j2 = b.new_job()
+        j2.image(HAIL_GENETICS_HAIL_IMAGE)
+        j2.command(f'python3 -c "import hail as hl; print(hl.hadoop_open(\\"{hb.remote(j1.out)}\\").read())"')
+
+        assert j1._dependencies == []
+        assert j2._dependencies == [j1]
+
+        batch = b.run()
+
+        jobs = list(batch.jobs())
+        assert len(jobs) == 3, jobs
+
+        j2_log = batch.get_job_log(2)
+        assert j2_log == 'hi\n', j2_log
+
+        batch_status = batch.status()
+        assert batch_status['state'] == 'success', str((batch.debug_info()))
+
+    def test_remote_producer(self):
+        backend = ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files')
+        b = Batch(backend=backend)
+        j1 = b.new_job()
+        j1.image(HAIL_GENETICS_HAIL_IMAGE)
+        j1.command(f'python3 -c "import hail as hl; hl.hadoop_open(\\"{hb.remote(j1.out)}\\").write(b\\"hello world\\")"')
+        j2 = b.new_job()
+        j2.image(HAIL_GENETICS_HAIL_IMAGE)
+        j2.command(f'cat {j1.out}')
+
+        assert j1._dependencies == []
+        assert j2._dependencies == [j1]
+
+        batch = b.run()
+
+        jobs = list(batch.jobs())
+        assert len(jobs) == 3, jobs
+
+        j2_log = batch.get_job_log(2)
+        assert j2_log == 'hello world', j2_log
+
+        batch_status = batch.status()
+        assert batch_status['state'] == 'success', str((batch.debug_info()))
+
+    def test_remote_consumer_and_producer(self):
+        backend = ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files')
+        b = Batch(backend=backend)
+        j1 = b.new_job()
+        j1.image(HAIL_GENETICS_HAIL_IMAGE)
+        j1.command(f'python3 -c "import hail as hl; hl.hadoop_open(\\"{hb.remote(j1.out)}\\").write(b\\"hello world\\")"')
+        j2 = b.new_job()
+        j2.image(HAIL_GENETICS_HAIL_IMAGE)
+        j2.command(f'python3 -c "import hail as hl; print(hl.hadoop_open(\\"{hb.remote(j1.out)}\\").read())"')
+
+        assert j1._dependencies == []
+        assert j2._dependencies == [j1]
+
+        batch = b.run()
+
+        jobs = list(batch.jobs())
+        assert len(jobs) == 3, jobs
+
+        j2_log = batch.get_job_log(2)
+        assert j2_log == 'hello world\n', j2_log
+
+        batch_status = batch.status()
+        assert batch_status['state'] == 'success', str((batch.debug_info()))
+
+    # FIXME: need write_output and read_input examples too
+
+    def test_remote_python_consumer(self):
+        backend = hb.ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files')
+        b = hb.Batch(backend=backend)
+        j1 = b.new_job()
+        j1.command(f'echo x y > {j1.out}')
+        j1.command(f'echo 1 2 >> {j1.out}')
+        j1.command(f'echo 3 4 >> {j1.out}')
+
+        def column_means(path):
+            import hail as hl
+            ht = hl.import_table(path, delimiter=' ', impute=True)
+            return ht.aggregate([hl.agg.mean(ht.x), hl.agg.mean(ht.y)])
+
+        j2 = b.new_python_job()
+        j2.image(HAIL_GENETICS_HAIL_IMAGE)
+        result_resource = j2.call(column_means, hb.remote(j1.out))
+
+        token = uuid.uuid4()
+        result_location = self.remote_tmpdir + '/' + token
+        b.write_output(result_resource, result_location)
+
+        b.run()
+
+        async with RouterAsyncFS('gs') as fs:
+            result = dill.loads(fs.read(result_location))
+        assert result == [2.0, 3.0]
+
+    def test_local_python_producer__remote_python_consumer(self):
+        backend = hb.ServiceBackend(billing_project='hail')
+        b = hb.Batch(backend=backend)
+
+        def write_range_table(path):
+            import hail as hl
+            ht = hl.utils.range_table(10)
+            ht = ht.key_by()
+            ht = ht.select(x = ht.idx, y = ht.idx / 2.0)
+            ht.write(path)
+
+        j1 = b.new_python_job()
+        j1.image(HAIL_GENETICS_HAIL_IMAGE)
+        j1.call(write_range_table, j1.ht)
+
+        def column_means(path):
+            import hail as hl
+            ht = hl.read_table(path)
+            return ht.aggregate([hl.agg.mean(ht.x), hl.agg.mean(ht.y)])
+
+        j2 = b.new_python_job()
+        j2.image(HAIL_GENETICS_HAIL_IMAGE)
+        result_resource = j2.call(column_means, hb.remote(j1.ht))
+
+        token = uuid.uuid4()
+        result_location = self.remote_tmpdir + '/' + token
+        b.write_output(result_resource, result_location)
+        b.run()
+
+        async with RouterAsyncFS('gs') as fs:
+            result = dill.loads(fs.read(result_location))
+        assert result == [4.5, 2.25]
+
+    def test_remote_python_producer__remote_python_consumer(self):
+        backend = hb.ServiceBackend(billing_project='hail')
+        b = hb.Batch(backend=backend)
+
+        def write_range_table(path):
+            import hail as hl
+            ht = hl.utils.range_table(10)
+            ht = ht.key_by()
+            ht = ht.select(x = ht.idx, y = ht.idx / 2.0)
+            ht.write(path)
+
+        j1 = b.new_python_job()
+        j1.image(HAIL_GENETICS_HAIL_IMAGE)
+        j1.call(write_range_table, hb.remote(j1.ht))
+
+        def column_means(path):
+            import hail as hl
+            ht = hl.read_table(path)
+            return ht.aggregate([hl.agg.mean(ht.x), hl.agg.mean(ht.y)])
+
+        j2 = b.new_python_job()
+        j2.image(HAIL_GENETICS_HAIL_IMAGE)
+        result_resource = j2.call(column_means, hb.remote(j1.ht))
+
+        token = uuid.uuid4()
+        result_location = self.remote_tmpdir + '/' + token
+        b.write_output(result_resource, result_location)
+        b.run()
+
+        async with RouterAsyncFS('gs') as fs:
+            result = dill.loads(fs.read(result_location))
+        assert result == [4.5, 2.25]
+
+    def test_L_to_R_to_R_to_L(self):
+        def import_table(input: str, out: str):
+            import hail as hl
+            hl.import_table(input).write(out)
+
+        def export_table(input: str, out: str):
+            import hail as hl
+            hl.read_table(input).export(out)
+
+        b = hb.Batch(
+            backend=hb.ServiceBackend(billing_project='hail'),
+            default_python_image=HAIL_GENETICS_HAIL_IMAGE,
+        )
+
+        j0 = b.new_bash_job()
+        j0.command(f'''
+cat >{j0.tsv} <<EOF
+a b c
+1 2 3
+4 5 6
+EOF
+''')
+
+        j1 = b.new_python_job()
+        j1.call(import_table, hb.remote(j0.tsv), hb.remote(j1.ht))
+
+        j2 = b.new_python_job()
+        j2.call(export_table, hb.remote(j1.ht), hb.remote(j2.tsv))
+
+        j3 = b.new_bash_job()
+        j3.command(f'''
+cat {j2.tsv}
+''')
+        batch_handle = b.run()
+        assert batch_handle.get_job_log(4) == '''a b c
+1 2 3
+4 5 6
+'''

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1079,8 +1079,8 @@ class ServiceTests(unittest.TestCase):
             import hail as hl
             hl.read_table(input).export(out)
 
-        b = hb.Batch(
-            backend=hb.ServiceBackend(billing_project='hail'),
+        b = Batch(
+            backend=ServiceBackend(billing_project='hail'),
             default_python_image=HAIL_GENETICS_HAIL_IMAGE,
         )
 


### PR DESCRIPTION
…urces

TJ has raised a bunch of very legitimate concerns about the expressivity of
hailtop.batch. In this PR, I basically rebuilt hailtop.batch from scratch as
a learning exercise. Once I understood how it worked, I added two valuable
features:

1. `hb.remote` creates a "remote" resource which is never localized but still
   creates dependency relationships.

2. `ResourceToStringPickler` which pickles resources appropriately even if
   they are nested within other structures.