### PR TITLE
[query] ggplot redo scales and stores groups in Dataframe.attrs

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -282,11 +282,11 @@ def geom_col(mapping=aes(), *, fill=None, color=None, alpha=None, position="stac
 class GeomHistogram(Geom):
 
     aes_to_arg = {
-        "fill": ("marker_color", "black", False),
-        "color": ("marker_line_color", None, True),
-        "tooltip": ("hovertext", None, False),
-        "fill_legend": ("name", None, True),
-        "alpha": ("marker_opacity", None, False)
+        "fill": ("marker_color", "black"),
+        "color": ("marker_line_color", None),
+        "tooltip": ("hovertext", None),
+        "fill_legend": ("name", None),
+        "alpha": ("marker_opacity", None)
     }
 
     def __init__(self, aes, min_val=None, max_val=None, bins=None, fill=None, color=None, alpha=None, position='stack', size=None):
@@ -335,14 +335,13 @@ class GeomHistogram(Geom):
                     "<extra></extra>",
             }
 
-            for aes_name, (plotly_name, default, take_one) in self.aes_to_arg.items():
+            for aes_name, (plotly_name, default) in self.aes_to_arg.items():
                 if hasattr(self, aes_name) and getattr(self, aes_name) is not None:
                     bar_args[plotly_name] = getattr(self, aes_name)
+                elif aes_name in df.attrs:
+                    bar_args[plotly_name] = df.attrs[aes_name]
                 elif aes_name in df.columns:
-                    if take_one:
-                        bar_args[plotly_name] = df[aes_name].iloc[0]
-                    else:
-                        bar_args[plotly_name] = df[aes_name]
+                    bar_args[plotly_name] = df[aes_name]
                 elif default is not None:
                     bar_args[plotly_name] = default
 
@@ -497,11 +496,9 @@ class GeomTile(Geom):
                     "y0": y_center - height / 2,
                     "x1": x_center + width / 2,
                     "y1": y_center + height / 2,
-                    "fillcolor": "black" if "fill" not in row else row["fill"],
+                    "fillcolor": "black" if "fill" not in df.attrs else df.attrs["fill"],
                     "opacity": row.get('alpha', 1.0)
                 }
-                if "color" in row:
-                    shape_args["line_color"] = row["color"]
                 fig_so_far.add_shape(**shape_args)
 
         for group_df in grouped_data:

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -309,11 +309,11 @@ class GeomHistogram(Geom):
 
         num_groups = len(grouped_data)
 
-        def plot_group(df):
+        def plot_group(df, idx):
             left_xs = df.x
 
             if self.position == "dodge":
-                x = left_xs + bin_width * (2 * df.group + 1) / (2 * num_groups)
+                x = left_xs + bin_width * (2 * idx + 1) / (2 * num_groups)
                 bar_width = bin_width / num_groups
 
             elif self.position in {"stack", "identity"}:
@@ -347,8 +347,8 @@ class GeomHistogram(Geom):
 
             fig_so_far.add_bar(**bar_args)
 
-        for group_df in grouped_data:
-            plot_group(group_df)
+        for idx, group_df in enumerate(grouped_data):
+            plot_group(group_df, idx)
 
         fig_so_far.update_layout(barmode=bar_position_plotly_to_gg(self.position))
 

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -85,7 +85,7 @@ class GeomPoint(Geom):
         self.alpha = alpha
 
     def apply_to_fig(self, parent, grouped_data, fig_so_far, precomputed, num_groups):
-        def plot_group(group_constants, df):
+        def plot_group(df):
             scatter_args = {
                 "x": df.x,
                 "y": df.y,
@@ -95,8 +95,8 @@ class GeomPoint(Geom):
             for aes_name, (plotly_name, default) in self.aes_to_arg.items():
                 if hasattr(self, aes_name) and getattr(self, aes_name) is not None:
                     scatter_args[plotly_name] = getattr(self, aes_name)
-                elif aes_name in group_constants:
-                    scatter_args[plotly_name] = group_constants[aes_name]
+                elif aes_name in df.attrs:
+                    scatter_args[plotly_name] = df.attrs[aes_name]
                 elif aes_name in df.columns:
                     scatter_args[plotly_name] = df[aes_name]
                 elif default is not None:
@@ -104,8 +104,8 @@ class GeomPoint(Geom):
 
             fig_so_far.add_scatter(**scatter_args)
 
-        for group_constants, group_df in grouped_data.items():
-            plot_group(group_constants, group_df)
+        for group_df in grouped_data:
+            plot_group(group_df)
 
     def get_stat(self):
         return StatIdentity()

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -179,22 +179,24 @@ class GGPlot:
         discrete_aesthetics_to_possible_values = defaultdict(lambda: set())
         # Discrete scales only first:
         for _, _, grouped_dfs in geoms_and_grouped_dfs:
-            distinct_structs = grouped_dfs.keys()
+            distinct_discrete_fields = [df.attrs for df in grouped_dfs]
             # Now want to identify full space of discrete variables in here.
-            for struct in distinct_structs:
-                for aesthetic_name, value in struct.items():
+            for attrs in distinct_discrete_fields:
+                for aesthetic_name, value in attrs.items():
                     discrete_aesthetics_to_possible_values[aesthetic_name].add(value)
 
-        for geom, geom_label, grouped_dfs in geoms_and_grouped_dfs:
+        print(discrete_aesthetics_to_possible_values)
 
+        for geom, geom_label, grouped_dfs in geoms_and_grouped_dfs:
             total_groups = len(grouped_dfs)
-            scaled_grouped_dfs = {}
-            for group_fields, df in grouped_dfs.items():
-                relevant_aesthetics = [scale_name for scale_name in df.columns if scale_name in self.scales]
+            scaled_grouped_dfs = []
+            for df in grouped_dfs:
+                scales_to_consider = list(df.columns) + list(df.attrs)
+                relevant_aesthetics = [scale_name for scale_name in scales_to_consider if scale_name in self.scales]
                 scaled_df = df
                 for relevant_aesthetic in relevant_aesthetics:
                     scaled_df = self.scales[relevant_aesthetic].transform_data_local(scaled_df, self)
-                scaled_grouped_dfs[group_fields] = scaled_df
+                scaled_grouped_dfs.append(scaled_df)
 
             geom.apply_to_fig(self, scaled_grouped_dfs, fig, precomputed[geom_label], total_groups)
 

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -2,7 +2,6 @@ import plotly
 import plotly.graph_objects as go
 
 from pprint import pprint
-from collections import defaultdict
 
 import hail as hl
 
@@ -13,7 +12,7 @@ from .scale import Scale, ScaleContinuous, ScaleDiscrete, scale_x_continuous, sc
     scale_x_discrete, scale_y_discrete, scale_color_discrete, scale_color_continuous, scale_fill_discrete, \
     scale_fill_continuous
 from .aes import Aesthetic, aes
-from .utils import is_continuous_type, is_genomic_type, check_scale_continuity, should_use_scale_for_grouping
+from .utils import is_continuous_type, is_genomic_type, check_scale_continuity
 
 
 class GGPlot:

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -171,8 +171,21 @@ class GGPlot:
 
         fig = go.Figure()
 
-        for geom, (geom_label, agg_result) in zip(self.geoms, aggregated.items()):
-            grouped_dfs = labels_to_stats[geom_label].listify(agg_result)
+        geoms_and_grouped_dfs = [(geom, geom_label, labels_to_stats[geom_label].listify(agg_result)) for geom, (geom_label, agg_result) in zip(self.geoms, aggregated.items())]
+
+        # Problem: Need to get full range of local values to scale them properly. Also need to get full range of continuous
+        # values to scale them properly.
+
+        discrete_aesthetics_to_possible_values = defaultdict(lambda: set())
+        # Discrete scales only first:
+        for _, _, grouped_dfs in geoms_and_grouped_dfs:
+            distinct_structs = grouped_dfs.keys()
+            # Now want to identify full space of discrete variables in here.
+            for struct in distinct_structs:
+                for aesthetic_name, value in struct.items():
+                    discrete_aesthetics_to_possible_values[aesthetic_name].add(value)
+
+        for geom, geom_label, grouped_dfs in geoms_and_grouped_dfs:
 
             total_groups = len(grouped_dfs)
             scaled_grouped_dfs = {}

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -179,7 +179,6 @@ class GGPlot:
             transformers[scale.aesthetic_name] = scale.create_local_transformer([x for _, _, x in geoms_and_grouped_dfs], self)
 
         for geom, geom_label, grouped_dfs in geoms_and_grouped_dfs:
-            total_groups = len(grouped_dfs)
             scaled_grouped_dfs = []
             for df in grouped_dfs:
                 scales_to_consider = list(df.columns) + list(df.attrs)

--- a/hail/python/hail/ggplot/scale.py
+++ b/hail/python/hail/ggplot/scale.py
@@ -14,9 +14,6 @@ class Scale(FigureAttribute):
     def transform_data(self, field_expr):
         pass
 
-    def transform_data_local(self, data, parent):
-        return data
-
     def create_local_transformer(self, groups_of_dfs, parent):
         return lambda x: x
 
@@ -152,18 +149,6 @@ class ScaleDiscrete(Scale):
 
 class ScaleColorDiscrete(ScaleDiscrete):
 
-
-    def transform_data_local(self, df, parent):
-        categorical_strings = set(df[self.aesthetic_name])
-        unique_color_mapping = categorical_strings_to_colors(categorical_strings, parent)
-
-        new_column_name = f"{self.aesthetic_name}_legend"
-        new_df = df.assign(**{new_column_name: df[self.aesthetic_name]})
-
-        new_df[self.aesthetic_name] = new_df[self.aesthetic_name].map(unique_color_mapping)
-
-        return new_df
-
     def create_local_transformer(self, groups_of_dfs, parent):
         categorical_strings = set()
         for group_of_dfs in groups_of_dfs:
@@ -182,19 +167,38 @@ class ScaleColorDiscrete(ScaleDiscrete):
 
 
 class ScaleColorContinuous(ScaleContinuous):
-    def transform_data_local(self, df, parent):
-        color_series = df[self.aesthetic_name]
-        color_mapping = continuous_nums_to_colors(color_series, parent.continuous_color_scale)
 
-        df[self.aesthetic_name] = df[self.aesthetic_name].map(lambda i: color_mapping[i])
+    def create_local_transformer(self, groups_of_dfs, parent):
+        overall_min = None
+        overall_max = None
+        for group_of_dfs in groups_of_dfs:
+            for df in group_of_dfs:
+                if self.aesthetic_name in df.columns:
+                    series = df[self.aesthetic_name]
+                    series_min = series.min()
+                    series_max = series.max()
+                    if overall_min is None:
+                        overall_min = series_min
+                    else:
+                        overall_min = min(series_min, overall_min)
 
-        return df
+                    if overall_max is None:
+                        overall_max = series_max
+                    else:
+                        overall_max = max(series_max, overall_max)
+
+        color_mapping = continuous_nums_to_colors(overall_min, overall_max, parent.continuous_color_scale)
+
+        def transform(df):
+            df[self.aesthetic_name] = df[self.aesthetic_name].map(lambda i: color_mapping(i))
+            return df
+
+        return transform
 
 
 # Legend names messed up for scale color identity
 class ScaleColorDiscreteIdentity(ScaleDiscrete):
-    def transform_data_local(self, data, parent):
-        return data
+    pass
 
 
 def scale_x_log10(name=None):

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -26,7 +26,7 @@ class StatIdentity(Stat):
     def make_agg(self, mapping, precomputed):
         grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys()
                               if should_use_for_grouping(aes_key, mapping[aes_key].dtype)}
-        non_grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys() if not aes_key in grouping_variables}
+        non_grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys() if aes_key not in grouping_variables}
         return hl.agg.group_by(hl.struct(**grouping_variables), hl.agg.collect(hl.struct(**non_grouping_variables)))
 
     def listify(self, agg_result):

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -23,9 +23,6 @@ class Stat:
 
 class StatIdentity(Stat):
 
-    def __init__(self, downsample=False):
-        self.downsample = downsample
-
     def make_agg(self, mapping, precomputed):
         grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys()
                               if should_use_for_grouping(aes_key, mapping[aes_key].dtype)}

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -54,9 +54,9 @@ class StatFunction(StatIdentity):
     def __init__(self, fun):
         self.fun = fun
 
-    def make_agg(self, combined, precomputed):
-        with_y_value = combined.annotate(y=self.fun(combined.x))
-        return hl.agg.collect(with_y_value)
+    def make_agg(self, mapping, precomputed):
+        with_y_value = mapping.annotate(y=self.fun(mapping.x))
+        return super().make_agg(with_y_value, precomputed)
 
 
 class StatNone(Stat):
@@ -75,6 +75,7 @@ class StatCount(Stat):
         return hl.agg.group_by(hl.struct(**grouping_variables), hl.agg.count())
 
     def listify(self, agg_result):
+        # Slightly tricky, want to know the grouping as though it weren't by `x`. Nested group bys?
         unflattened_items = agg_result.items()
         data = []
         for grouping_variables, count in unflattened_items:

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -22,8 +22,14 @@ class Stat:
 
 
 class StatIdentity(Stat):
+
+    def __init__(self, downsample=False):
+        self.downsample = downsample
+
     def make_agg(self, mapping, precomputed):
-        return hl.agg.collect(mapping)
+        grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys()
+                              if should_use_for_grouping(aes_key, mapping[aes_key].dtype)}
+        return hl.agg.group_by(hl.struct(**grouping_variables), hl.agg.collect(mapping))
 
     def listify(self, agg_result):
         columns = list(agg_result[0].keys())

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -34,7 +34,7 @@ class StatIdentity(Stat):
 
     def listify(self, agg_result):
         # agg result is a dict of struct to collected list.
-        result = {}
+        result = []
         for grouped_struct, collected in agg_result.items():
             columns = list(collected[0].keys())
             data_dict = {}
@@ -43,8 +43,9 @@ class StatIdentity(Stat):
                 col_data = [row[column] for row in collected]
                 data_dict[column] = pd.Series(col_data)
 
-            result[grouped_struct] = pd.DataFrame(data_dict)
-        import pdb; pdb.set_trace()
+            df = pd.DataFrame(data_dict)
+            df.attrs.update(**grouped_struct)
+            result.append(df)
         return result
 
 

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -22,7 +22,7 @@ def is_discrete_type(dtype):
     return dtype in [hl.tstr]
 
 
-excluded_from_grouping = {"tooltip", "label"}
+excluded_from_grouping = {"x", "tooltip", "label"}
 
 
 def should_use_for_grouping(name, type):

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -22,7 +22,7 @@ def is_discrete_type(dtype):
     return dtype in [hl.tstr]
 
 
-excluded_from_grouping = {"tooltip"}
+excluded_from_grouping = {"tooltip", "label"}
 
 
 def should_use_for_grouping(name, type):

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -46,15 +46,13 @@ def categorical_strings_to_colors(string_set, parent_plot):
     return parent_plot.discrete_color_dict
 
 
-def continuous_nums_to_colors(input_color_nums, continuous_color_scale):
-    min_color = min(input_color_nums)
-    max_color = max(input_color_nums)
-
+def continuous_nums_to_colors(min_color, max_color, continuous_color_scale):
     def adjust_color(input_color):
         return (input_color - min_color) / max_color - min_color
 
-    color_mapping = plotly.colors.sample_colorscale(continuous_color_scale, [adjust_color(input_color) for input_color in input_color_nums])
-    return color_mapping
+    def transform_color(input_color):
+        return plotly.colors.sample_colorscale(continuous_color_scale, adjust_color(input_color))[0]
+    return transform_color
 
 
 def bar_position_plotly_to_gg(plotly_pos):

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -36,9 +36,9 @@ def test_histogram():
     ht = hl.utils.range_table(10)
     for position in ["stack", "dodge", "identity"]:
         fig = (ggplot(ht, aes(x=ht.idx)) +
-               geom_histogram(alpha=0.5, position)
+               geom_histogram(alpha=0.5, position=position)
                )
-    fig.to_plotly()
+        fig.to_plotly()
 
 
 def test_separate_traces_per_group():

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -34,9 +34,10 @@ def test_manhattan_plot():
 @fails_service_backend()
 def test_histogram():
     ht = hl.utils.range_table(10)
-    fig = (ggplot(ht, aes(x=ht.idx)) +
-           geom_histogram(alpha=0.5)
-           )
+    for position in ["stack", "dodge", "identity"]:
+        fig = (ggplot(ht, aes(x=ht.idx)) +
+               geom_histogram(alpha=0.5, position)
+               )
     fig.to_plotly()
 
 

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -1,11 +1,12 @@
 # These tests only check that the functions don't error out, they don't check what the output plot looks like.
 import hail as hl
 from hail.ggplot import *
+import numpy as np
 import math
 from ..helpers import fails_service_backend
 
 
-def test_geom_point_line_text_col():
+def test_geom_point_line_text_col_area():
     ht = hl.utils.range_table(20)
     ht = ht.annotate(double=ht.idx * 2)
     ht = ht.annotate(triple=ht.idx * 3)
@@ -15,6 +16,7 @@ def test_geom_point_line_text_col():
            geom_line(aes(y=ht.triple)) +
            geom_text(aes(label=hl.str(ht.idx))) +
            geom_col(aes(y=ht.triple + ht.double)) +
+           geom_area(aes(y=ht.triple - ht.double)) +
            coord_cartesian((0, 100), (0, 80)) +
            xlab("my_x") +
            ylab("my_y") +
@@ -28,17 +30,30 @@ def test_manhattan_plot():
     ht = mt.rows()
     ht = ht.annotate(pval=.02)
     fig = ggplot(ht, aes(x=ht.locus, y=-hl.log10(ht.pval))) + geom_point() + geom_hline(yintercept=-math.log10(5e-8))
-    fig.to_plotly()
-
+    pfig = fig.to_plotly()
+    expected_ticks = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', 'X', 'Y')
+    assert pfig.layout.xaxis.ticktext == expected_ticks
 
 @fails_service_backend()
 def test_histogram():
-    ht = hl.utils.range_table(10)
+    num_rows = 101
+    num_groups = 5
+    ht = hl.utils.range_table(num_rows)
+    ht = ht.annotate(mod_3=hl.str(ht.idx % num_groups))
     for position in ["stack", "dodge", "identity"]:
         fig = (ggplot(ht, aes(x=ht.idx)) +
-               geom_histogram(alpha=0.5, position=position)
+               geom_histogram(aes(fill=ht.mod_3), alpha=0.5, position=position, bins=10)
                )
-        fig.to_plotly()
+        pfig = fig.to_plotly()
+        assert len(pfig.data) == num_groups
+        for idx, bar in enumerate(pfig.data):
+            if position in {"stack", "identity"}:
+                assert (bar.x == [float(e) for e in range(num_groups, num_rows-1, num_groups*2)]).all()
+            else:
+                dist_between_bars_in_one_group = (num_rows - 1) / (num_groups * 2)
+                single_bar_width = (dist_between_bars_in_one_group / num_groups)
+                first_bar_start = single_bar_width / 2 + idx * single_bar_width
+                assert (bar.x == np.arange(first_bar_start, num_rows - 1, dist_between_bars_in_one_group)).all()
 
 
 def test_separate_traces_per_group():


### PR DESCRIPTION
Turns out pandas dataframes have an `.attrs` field to store "globals". So now I group by discrete values and collect them as globals, and I get one pandas dataframe per group of discrete values. This makes things a bit less complicated I think. 

As part of this change, I now create scales based on looking at all the collected data, not just one particular geom's data. This is more correct for things like continuous color, where if I have one geom that has points in color range 0 - .5, and another geom that has points in color range .5-1, there should be a continuous color gradient between 0 and 1, not two separate ones from 0 - .5 and .5 - 1. 

This will also allow me to support things like `scale_color_hue`, which is the default R way of picking discrete colors by choosing evenly spaced points on a color wheel. I can't pick evenly spaced points if I don't know how many discrete values of `color` I have across all geoms.

Summary of actual code changes:

1. Don't flatten out grouped data. Stats use `group_by` to group by discrete aesthetics, but prior to this PR they would just forget that grouping information and flatten out the data, only to redetermine the grouping information later. This prevents that entirely by storing the per group information in a dataframes `attrs`. 
2. Update geoms to reflect they are getting data in this form. This simplifies away the need to have a specified `take_one` boolean for each aesthetic a geom supports that said whether it's a per data point or per group field.
3. Replace `Scale.transform_local_data` with `Scale.create_local_transformer`. This takes in all the data and returns a lambda to map over the data. This is part of the "scales looking at all collect data" change mentioned above.