### PR TITLE
[query] LowerDistributedSort cutoff based on bytes not rows

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -161,6 +161,8 @@ object EmitStreamDistribute {
 
     val outputBuffers = cb.memoize[Array[OutputBuffer]](Code.newArray[OutputBuffer](numFilesToWrite))
     val numElementsPerFile = cb.memoize[Array[Int]](Code.newArray[Int](numFilesToWrite))
+    val numBytesPerFile = cb.memoize[Array[Long]](Code.newArray[Long](numFilesToWrite))
+
     val fileArrayIdx = cb.newLocal[Int]("stream_dist_file_array_idx")
 
     def makeFileName(cb: EmitCodeBuilder, fileIdx: Value[Int]): Value[String] = {
@@ -172,6 +174,7 @@ object EmitStreamDistribute {
       val ob = cb.memoize(spec.buildCodeOutputBuffer(mb.create(fileName)))
       cb += outputBuffers.update(fileArrayIdx, ob)
       cb += numElementsPerFile.update(fileArrayIdx, 0)
+      cb += numBytesPerFile.update(fileArrayIdx, 0)
     })
     // The element classifying algorithm acts as though there are identity buckets for every splitter. We only use identity buckets for elements that repeat
     // in splitters list. Since We don't want many empty files, we need to make an array mapping output buckets to files.
@@ -196,8 +199,10 @@ object EmitStreamDistribute {
       val ob = cb.memoize[OutputBuffer](outputBuffers(fileToUse))
 
       cb += ob.writeByte(1.asInstanceOf[Byte])
-      encoder(cb, current.get(cb), ob)
+      val curSV = current.get(cb)
+      encoder(cb, curSV, ob)
       cb += numElementsPerFile.update(fileToUse, numElementsPerFile(fileToUse) + 1)
+      cb += numBytesPerFile.update(fileToUse, numBytesPerFile(fileToUse) + curSV.sizeInBytes(cb).value)
     }
 
     cb.forLoop(cb.assign(fileArrayIdx, 0), fileArrayIdx < numFilesToWrite, cb.assign(fileArrayIdx, fileArrayIdx + 1), {
@@ -207,7 +212,7 @@ object EmitStreamDistribute {
     })
 
     val intervalType = PCanonicalInterval(keyPType.setRequired(false), true)
-    val returnType = PCanonicalArray(PCanonicalStruct(("interval", intervalType), ("fileName", PCanonicalStringRequired), ("numElements", PInt32Required)), true)
+    val returnType = PCanonicalArray(PCanonicalStruct(("interval", intervalType), ("fileName", PCanonicalStringRequired), ("numElements", PInt32Required), ("numBytes", PInt64Required)), true)
 
     val min = requestedSplittersAndEndsVal.loadElement(cb, 0).memoize(cb, "stream_dist_min")
     val firstSplitter = paddedSplitters.loadElement(cb, 0).memoize(cb, "stream_dist_first_splitter")
@@ -237,7 +242,8 @@ object EmitStreamDistribute {
       pushElement(cb, IEmitCode.present(cb, new SStackStructValue(stackStructType, IndexedSeq(
         EmitValue.present(firstInterval),
         EmitValue.present(SJavaString.construct(cb, makeFileName(cb, 0))),
-        EmitValue.present(primitive(cb.memoize(numElementsPerFile(0))))
+        EmitValue.present(primitive(cb.memoize(numElementsPerFile(0)))),
+        EmitValue.present(primitive(cb.memoize(numBytesPerFile(0))))
       ))))
     })
 
@@ -253,7 +259,8 @@ object EmitStreamDistribute {
         pushElement(cb, IEmitCode.present(cb, new SStackStructValue(stackStructType, IndexedSeq(
           EmitValue.present(intervalFromLastToThis),
           EmitValue.present(SJavaString.construct(cb, makeFileName(cb, fileArrayIdx))),
-          EmitValue.present(primitive(cb.memoize(numElementsPerFile(fileArrayIdx))))
+          EmitValue.present(primitive(cb.memoize(numElementsPerFile(fileArrayIdx)))),
+          EmitValue.present(primitive(cb.memoize(numBytesPerFile(fileArrayIdx))))
         ))))
 
         cb.assign(fileArrayIdx, fileArrayIdx + 1)
@@ -271,7 +278,8 @@ object EmitStreamDistribute {
         pushElement(cb, IEmitCode.present(cb, new SStackStructValue(stackStructType, IndexedSeq(
           EmitValue.present(identityInterval),
           EmitValue.present(SJavaString.construct(cb, makeFileName(cb, fileArrayIdx))),
-          EmitValue.present(primitive(cb.memoize(numElementsPerFile(fileArrayIdx))))
+          EmitValue.present(primitive(cb.memoize(numElementsPerFile(fileArrayIdx)))),
+          EmitValue.present(primitive(cb.memoize(numBytesPerFile(fileArrayIdx))))
         ))))
 
         cb.assign(fileArrayIdx, fileArrayIdx + 1)
@@ -290,7 +298,8 @@ object EmitStreamDistribute {
       pushElement(cb, IEmitCode.present(cb, new SStackStructValue(stackStructType, IndexedSeq(
         EmitValue.present(lastInterval),
         EmitValue.present(SJavaString.construct(cb, makeFileName(cb, fileArrayIdx))),
-        EmitValue.present(primitive(cb.memoize(numElementsPerFile(fileArrayIdx))))
+        EmitValue.present(primitive(cb.memoize(numElementsPerFile(fileArrayIdx)))),
+        EmitValue.present(primitive(cb.memoize(numBytesPerFile(fileArrayIdx))))
       ))))
     })
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -202,7 +202,7 @@ object EmitStreamDistribute {
       val curSV = current.get(cb)
       encoder(cb, curSV, ob)
       cb += numElementsPerFile.update(fileToUse, numElementsPerFile(fileToUse) + 1)
-      cb += numBytesPerFile.update(fileToUse, numBytesPerFile(fileToUse) + curSV.sizeInBytes(cb).value)
+      cb += numBytesPerFile.update(fileToUse, numBytesPerFile(fileToUse) + curSV.sizeToStoreInBytes(cb).value)
     }
 
     cb.forLoop(cb.assign(fileArrayIdx, 0), fileArrayIdx < numFilesToWrite, cb.assign(fileArrayIdx, fileArrayIdx + 1), {

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -147,7 +147,7 @@ object InferType {
       case StreamFold2(_, _, _, _, result) => result.typ
       case StreamDistribute(child, pivots, pathPrefix, _, _) =>
         val keyType = pivots.typ.asInstanceOf[TContainer].elementType
-        TArray(TStruct(("interval", TInterval(keyType)), ("fileName", TString), ("numElements", TInt32)))
+        TArray(TStruct(("interval", TInterval(keyType)), ("fileName", TString), ("numElements", TInt32), ("numBytes", TInt64)))
       case StreamScan(a, zero, accumName, valueName, body) =>
         assert(body.typ == zero.typ)
         TStream(zero.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -282,7 +282,8 @@ object LowerDistributedSort {
       loopState = LoopState(newBigUnsortedSegments, loopState.largeSortedSegments ++ sortedSegments, loopState.smallSegments ++ newSmallSegments)
       i = i + 1
 
-      if (i > 100) {
+      if (i > 40) {
+        val debugCheck = CompileAndEvaluate[Annotation](ctx, ToArray(ReadPartition(Str(newBigUnsortedSegments(0).chunks(0).filename), spec._vType, PartitionNativeReader(spec))))
         println("Check in")
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -194,7 +194,6 @@ object LowerDistributedSort {
             bindIR(sortedOversampling) { sortedOversampling =>
               bindIR(ArrayLen(sortedOversampling)) { numSamples =>
                 val branchingFactor = UtilFunctions.intMin(I32(defaultBranchingFactor), numSamples)
-                // range(1, branchingFactor, 1).map { i => floor(i * ((numSamples + 1) / branchFactor)) - 1 }
                 val sortedSampling = ToArray(mapIR(StreamRange(I32(1), branchingFactor, I32(1))) { idx =>
                   ArrayRef(sortedOversampling, Apply("floor", Seq(), IndexedSeq(idx.toD * ((numSamples + 1) / branchingFactor)), TFloat64, ErrorIDs.NO_ERROR).toI - 1)
                 })

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -287,11 +287,6 @@ object LowerDistributedSort {
       } else { (IndexedSeq.empty[SegmentResult], IndexedSeq.empty[SegmentResult]) }
       loopState = LoopState(newBigUnsortedSegments, loopState.largeSortedSegments ++ sortedSegments, loopState.smallSegments ++ newSmallSegments)
       i = i + 1
-
-      if (i > 40) {
-        val debugCheck = CompileAndEvaluate[Annotation](ctx, ToArray(ReadPartition(Str(newBigUnsortedSegments(0).chunks(0).filename), spec._vType, PartitionNativeReader(spec))))
-        println("Check in")
-      }
     }
 
     val needSortingFilenames = loopState.smallSegments.map(_.chunks.map(_.filename))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -101,7 +101,7 @@ trait SValue {
 
   def hash(cb: EmitCodeBuilder): SInt32Value = throw new UnsupportedOperationException(s"Stype ${st} has no hashcode")
 
-  def sizeInBytes(cb: EmitCodeBuilder): SInt64Value
+  def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value
 }
 
 
@@ -120,6 +120,6 @@ object SSettable {
 }
 
 trait SUnrealizableValue extends SValue {
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value =
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value =
     throw new UnsupportedOperationException(s"Unrealizable SValue has no size in bytes.")
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -119,4 +119,7 @@ object SSettable {
   }
 }
 
-trait SUnrealizableValue extends SValue
+trait SUnrealizableValue extends SValue {
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value =
+    throw new UnsupportedOperationException(s"Unrealizable SValue has no size in bytes.")
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -100,6 +100,8 @@ trait SValue {
     destType.coerceOrCopy(cb, region, this, deepCopy = true)
 
   def hash(cb: EmitCodeBuilder): SInt32Value = throw new UnsupportedOperationException(s"Stype ${st} has no hashcode")
+
+  def sizeInBytes(cb: EmitCodeBuilder): SInt64Value
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructSettable, SBaseStructValue}
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
 import is.hail.types.physical.{PBaseStruct, PType}
 import is.hail.types.virtual.{TBaseStruct, Type}
@@ -65,6 +66,23 @@ class SBaseStructPointerValue(
 
   override def isFieldMissing(cb: EmitCodeBuilder, fieldIdx: Int): Value[Boolean] = {
     pt.isFieldMissing(cb, a, fieldIdx)
+  }
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    // Size in bytes of the struct that must represent this thing, plus recursive call on any non-missing children.
+    val pStructSize = this.st.storageType().byteSize
+    val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pStructSize)
+    (0 until st.size).foreach { idx =>
+      if (!this.st.fieldTypes(idx).isPrimitive) {
+        val sizeAtThisIdx: Value[Long] = this.loadField(cb, idx).consumeCode(cb, {
+          const(0L)
+        }, { sv =>
+          sv.sizeInBytes(cb).value
+        })
+        cb.assign(sizeSoFar, sizeSoFar + sizeAtThisIdx)
+      }
+    }
+    new SInt64Value(sizeSoFar)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -67,23 +67,6 @@ class SBaseStructPointerValue(
   override def isFieldMissing(cb: EmitCodeBuilder, fieldIdx: Int): Value[Boolean] = {
     pt.isFieldMissing(cb, a, fieldIdx)
   }
-
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
-    // Size in bytes of the struct that must represent this thing, plus recursive call on any non-missing children.
-    val pStructSize = this.st.storageType().byteSize
-    val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pStructSize)
-    (0 until st.size).foreach { idx =>
-      if (!this.st.fieldTypes(idx).isPrimitive) {
-        val sizeAtThisIdx: Value[Long] = this.loadField(cb, idx).consumeCode(cb, {
-          const(0L)
-        }, { sv =>
-          sv.sizeInBytes(cb).value
-        })
-        cb.assign(sizeSoFar, sizeSoFar + sizeAtThisIdx)
-      }
-    }
-    new SInt64Value(sizeSoFar)
-  }
 }
 
 object SBaseStructPointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -140,7 +140,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
     new SCanonicalCallValue(repr)
   }
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(this.pt.byteSize)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(this.pt.byteSize)
 }
 
 object SCanonicalCallSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces.{SCall, SCallValue, SIndexableValue}
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PCall, PCanonicalCall, PType}
 import is.hail.types.virtual.{TCall, Type}
@@ -138,6 +139,8 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
     )
     new SCanonicalCallValue(repr)
   }
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(this.pt.byteSize)
 }
 
 object SCanonicalCallSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -6,6 +6,7 @@ import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.stypes._
 import is.hail.types.physical.stypes.interfaces.{SContainer, SIndexableValue}
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
 
@@ -104,6 +105,19 @@ class SIndexablePointerValue(
         })
       case _ => super.forEachDefined(cb)(f)
     }
+  }
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", pt.nMissingBytes(this.length).toL)
+    if (this.st.elementType.containsPointers) {
+      this.forEachDefined(cb) { (cb, _, element) =>
+        cb.assign(totalSize, totalSize + element.sizeInBytes(cb).value)
+      }
+    } else {
+      cb.assign(totalSize, totalSize + (this.length.toL * this.pt.elementByteSize))
+    }
+
+    new SInt64Value(totalSize)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -106,19 +106,6 @@ class SIndexablePointerValue(
       case _ => super.forEachDefined(cb)(f)
     }
   }
-
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
-    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", pt.nMissingBytes(this.length).toL)
-    if (this.st.elementType.containsPointers) {
-      this.forEachDefined(cb) { (cb, _, element) =>
-        cb.assign(totalSize, totalSize + element.sizeInBytes(cb).value)
-      }
-    } else {
-      cb.assign(totalSize, totalSize + (this.length.toL * this.pt.elementByteSize))
-    }
-
-    new SInt64Value(totalSize)
-  }
 }
 
 object SIndexablePointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
@@ -61,7 +61,7 @@ class SJavaStringValue(val s: Value[String]) extends SStringValue {
   override def toBytes(cb: EmitCodeBuilder): SBinaryValue =
     new SJavaBytesValue(cb.memoize(s.invoke[Array[Byte]]("getBytes")))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val lengthInBytes: Value[Int] = cb.memoize(s.invoke[Array[Byte]]("getBytes").length())
     val storageTypeString = this.st.storageType().asInstanceOf[PCanonicalString]
     val contentsSize = storageTypeString.binaryRepresentation.contentByteSize(lengthInBytes)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
@@ -1,7 +1,7 @@
 package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{toCodeObject, _}
+import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.SInt64Value
@@ -62,8 +62,10 @@ class SJavaStringValue(val s: Value[String]) extends SStringValue {
     new SJavaBytesValue(cb.memoize(s.invoke[Array[Byte]]("getBytes")))
 
   override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
-    val lengthInBytes = cb.memoize(s.invoke[Array[Byte]]("getBytes").invoke[Int]("getLength").toL)
-    new SInt64Value(lengthInBytes)
+    val lengthInBytes: Value[Int] = cb.memoize(s.invoke[Array[Byte]]("getBytes").length())
+    val storageTypeString = this.st.storageType().asInstanceOf[PCanonicalString]
+    val contentsSize = storageTypeString.binaryRepresentation.contentByteSize(lengthInBytes)
+    new SInt64Value(cb.memoize(contentsSize + storageTypeString.byteSize))
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
@@ -65,7 +65,7 @@ class SJavaStringValue(val s: Value[String]) extends SStringValue {
     val lengthInBytes: Value[Int] = cb.memoize(s.invoke[Array[Byte]]("getBytes").length())
     val storageTypeString = this.st.storageType().asInstanceOf[PCanonicalString]
     val contentsSize = storageTypeString.binaryRepresentation.contentByteSize(lengthInBytes)
-    new SInt64Value(cb.memoize(contentsSize + storageTypeString.byteSize))
+    new SInt64Value(cb.memoize(contentsSize))
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
@@ -1,9 +1,10 @@
 package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
-import is.hail.asm4s._
+import is.hail.asm4s.{toCodeObject, _}
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces._
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PCanonicalString, PType}
 import is.hail.types.virtual.{TString, Type}
@@ -59,6 +60,11 @@ class SJavaStringValue(val s: Value[String]) extends SStringValue {
 
   override def toBytes(cb: EmitCodeBuilder): SBinaryValue =
     new SJavaBytesValue(cb.memoize(s.invoke[Array[Byte]]("getBytes")))
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    val lengthInBytes = cb.memoize(s.invoke[Array[Byte]]("getBytes").invoke[Int]("getLength").toL)
+    new SInt64Value(lengthInBytes)
+  }
 }
 
 object SJavaStringSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -4,8 +4,9 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces._
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
-import is.hail.types.physical.{PCanonicalNDArray, PType}
+import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils.{FastIndexedSeq, toRichIterable}
 
@@ -103,6 +104,12 @@ class SNDArrayPointerValue(
       }
       pt.elementType.storeAtAddress(cb, ptrs.head, region, body(codes), deepCopy)
     }
+  }
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    val storageType = st.storageType().asInstanceOf[PNDArray]
+    storageType.byteSize
+    new SInt64Value(???)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -105,12 +105,6 @@ class SNDArrayPointerValue(
       pt.elementType.storeAtAddress(cb, ptrs.head, region, body(codes), deepCopy)
     }
   }
-
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
-    val storageType = st.storageType().asInstanceOf[PNDArray]
-    storageType.byteSize
-    new SInt64Value(???)
-  }
 }
 
 object SNDArrayPointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -4,9 +4,8 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
-import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
+import is.hail.types.physical.{PCanonicalNDArray, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils.{FastIndexedSeq, toRichIterable}
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
@@ -1,7 +1,6 @@
 package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Settable, TypeInfo, Value, const}
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitSettable, EmitValue, IEmitCode}
 import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructSettable, SBaseStructValue}
 import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -62,7 +62,7 @@ class SStringPointerValue(val st: SStringPointer, val a: Value[Long]) extends SS
   def toBytes(cb: EmitCodeBuilder): SBinaryPointerValue =
     new SBinaryPointerValue(SBinaryPointer(pt.binaryRepresentation), a)
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = this.binaryRepr().sizeInBytes(cb)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = this.binaryRepr().sizeToStoreInBytes(cb)
 }
 
 object SStringPointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s.{Code, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces.{SString, SStringValue}
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PString, PType}
 import is.hail.types.virtual.Type
@@ -60,6 +61,8 @@ class SStringPointerValue(val st: SStringPointer, val a: Value[Long]) extends SS
 
   def toBytes(cb: EmitCodeBuilder): SBinaryPointerValue =
     new SBinaryPointerValue(SBinaryPointer(pt.binaryRepresentation), a)
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = this.binaryRepr().sizeInBytes(cb)
 }
 
 object SStringPointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -5,6 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitValue, IEmitCode}
 import is.hail.types.physical.stypes._
 import is.hail.types.physical.stypes.interfaces._
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
 import is.hail.types.virtual._
 import is.hail.utils.FastIndexedSeq
@@ -56,6 +57,8 @@ abstract class SUnreachableValue extends SSettable {
   override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq()
 
   override def store(cb: EmitCodeBuilder, v: SValue): Unit = {}
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(-1L)
 }
 
 case class SUnreachableStruct(virtualType: TBaseStruct) extends SUnreachable with SBaseStruct {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -58,7 +58,7 @@ abstract class SUnreachableValue extends SSettable {
 
   override def store(cb: EmitCodeBuilder, v: SValue): Unit = {}
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(-1L)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(-1L)
 }
 
 case class SUnreachableStruct(virtualType: TBaseStruct) extends SUnreachable with SBaseStruct {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -6,7 +6,7 @@ import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitValue, IEmitCode}
 import is.hail.types.physical.PCanonicalStruct
 import is.hail.types.physical.stypes._
 import is.hail.types.physical.stypes.concrete._
-import is.hail.types.physical.stypes.primitives.SInt32Value
+import is.hail.types.physical.stypes.primitives.{SInt32Value, SInt64Value}
 import is.hail.types.virtual.{TBaseStruct, TStruct, TTuple}
 import is.hail.types.{RField, RStruct, RTuple, TypeWithRequiredness}
 import is.hail.utils._
@@ -55,6 +55,23 @@ trait SBaseStructValue extends SValue {
         {field => cb.assign(hash_result, (hash_result * 31) + field.hash(cb).value)})
     })
     new SInt32Value(hash_result)
+  }
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    // Size in bytes of the struct that must represent this thing, plus recursive call on any non-missing children.
+    val pStructSize = this.st.storageType().byteSize
+    val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pStructSize)
+    (0 until st.size).foreach { idx =>
+      if (!this.st.fieldTypes(idx).isPrimitive) {
+        val sizeAtThisIdx: Value[Long] = this.loadField(cb, idx).consumeCode(cb, {
+          const(0L)
+        }, { sv =>
+          sv.sizeInBytes(cb).value
+        })
+        cb.assign(sizeSoFar, sizeSoFar + sizeAtThisIdx)
+      }
+    }
+    new SInt64Value(sizeSoFar)
   }
 
   protected[stypes] def _insert(newType: TStruct, fields: (String, EmitValue)*): SBaseStructValue = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -57,7 +57,7 @@ trait SBaseStructValue extends SValue {
     new SInt32Value(hash_result)
   }
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     // Size in bytes of the struct that must represent this thing, plus recursive call on any non-missing children.
     val pStructSize = this.st.storageType().byteSize
     val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pStructSize)
@@ -66,7 +66,7 @@ trait SBaseStructValue extends SValue {
         val sizeAtThisIdx: Value[Long] = this.loadField(cb, idx).consumeCode(cb, {
           const(0L)
         }, { sv =>
-          sv.sizeInBytes(cb).value
+          sv.sizeToStoreInBytes(cb).value
         })
         cb.assign(sizeSoFar, sizeSoFar + sizeAtThisIdx)
       }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -62,7 +62,7 @@ trait SBaseStructValue extends SValue {
     val pStructSize = this.st.storageType().byteSize
     val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pStructSize)
     (0 until st.size).foreach { idx =>
-      if (!this.st.fieldTypes(idx).isPrimitive) {
+      if (!this.st.fieldTypes(idx).containsPointers) {
         val sizeAtThisIdx: Value[Long] = this.loadField(cb, idx).consumeCode(cb, {
           const(0L)
         }, { sv =>

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -62,7 +62,7 @@ trait SBaseStructValue extends SValue {
     val pStructSize = this.st.storageType().byteSize
     val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pStructSize)
     (0 until st.size).foreach { idx =>
-      if (!this.st.fieldTypes(idx).containsPointers) {
+      if (this.st.fieldTypes(idx).containsPointers) {
         val sizeAtThisIdx: Value[Long] = this.loadField(cb, idx).consumeCode(cb, {
           const(0L)
         }, { sv =>

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical.stypes.interfaces
 import is.hail.asm4s.Code.invokeStatic1
 import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.primitives.SInt32Value
+import is.hail.types.physical.stypes.primitives.{SInt32Value, SInt64Value}
 import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.{RPrimitive, TypeWithRequiredness}
 
@@ -20,4 +20,7 @@ trait SBinaryValue extends SValue {
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.util.Arrays, Array[Byte], Int]("hashCode", loadBytes(cb))))
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value =
+    new SInt64Value(cb.memoize(this.loadLength(cb).toL))
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
@@ -22,7 +22,7 @@ trait SBinaryValue extends SValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.util.Arrays, Array[Byte], Int]("hashCode", loadBytes(cb))))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val binaryStorageType = this.st.storageType().asInstanceOf[PCanonicalBinary]
     val contentsByteSize = binaryStorageType.contentByteSize(this.loadLength(cb))
     new SInt64Value(cb.memoize(contentsByteSize))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
@@ -1,7 +1,7 @@
 package is.hail.types.physical.stypes.interfaces
 
 import is.hail.asm4s.Code.invokeStatic1
-import is.hail.asm4s.{Code, Value}
+import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.PCanonicalBinary
 import is.hail.types.physical.stypes.primitives.{SInt32Value, SInt64Value}
@@ -25,6 +25,6 @@ trait SBinaryValue extends SValue {
   override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val binaryStorageType = this.st.storageType().asInstanceOf[PCanonicalBinary]
     val contentsByteSize = binaryStorageType.contentByteSize(this.loadLength(cb))
-    new SInt64Value(cb.memoize(contentsByteSize + binaryStorageType.byteSize))
+    new SInt64Value(cb.memoize(contentsByteSize))
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
@@ -3,6 +3,7 @@ package is.hail.types.physical.stypes.interfaces
 import is.hail.asm4s.Code.invokeStatic1
 import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.PCanonicalBinary
 import is.hail.types.physical.stypes.primitives.{SInt32Value, SInt64Value}
 import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.{RPrimitive, TypeWithRequiredness}
@@ -21,6 +22,9 @@ trait SBinaryValue extends SValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.util.Arrays, Array[Byte], Int]("hashCode", loadBytes(cb))))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value =
-    new SInt64Value(cb.memoize(this.loadLength(cb).toL))
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    val binaryStorageType = this.st.storageType().asInstanceOf[PCanonicalBinary]
+    val contentsByteSize = binaryStorageType.contentByteSize(this.loadLength(cb))
+    new SInt64Value(cb.memoize(contentsByteSize + binaryStorageType.byteSize))
+  }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -3,8 +3,8 @@ package is.hail.types.physical.stypes.interfaces
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.PCanonicalArray
-import is.hail.types.physical.stypes.primitives.SInt32Value
+import is.hail.types.physical.{PCanonicalArray, PContainer}
+import is.hail.types.physical.stypes.primitives.{SInt32Value, SInt64Value}
 import is.hail.types.physical.stypes.{EmitType, SType, SValue}
 import is.hail.types.{RIterable, TypeWithRequiredness}
 
@@ -76,5 +76,20 @@ trait SIndexableValue extends SValue {
     pt.constructFromElements(cb, region, cb.newLocal[Int]("slice_length", end - startMemo), deepCopy){ (cb, idx) =>
       this.loadElement(cb, idx + startMemo)
     }
+  }
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    val storageType = this.st.storageType().asInstanceOf[PContainer]
+    val length = this.loadLength()
+    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.nMissingBytes(length).toL)
+    if (this.st.elementType.containsPointers) {
+      this.forEachDefined(cb) { (cb, _, element) =>
+        cb.assign(totalSize, totalSize + element.sizeInBytes(cb).value)
+      }
+    } else {
+      cb.assign(totalSize, totalSize + (length.toL * storageType.elementByteSize))
+    }
+
+    new SInt64Value(totalSize)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -78,13 +78,13 @@ trait SIndexableValue extends SValue {
     }
   }
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val storageType = this.st.storageType().asInstanceOf[PContainer]
     val length = this.loadLength()
     val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.elementsOffset(length).toL)
     if (this.st.elementType.containsPointers) {
       this.forEachDefined(cb) { (cb, _, element) =>
-        cb.assign(totalSize, totalSize + element.sizeInBytes(cb).value)
+        cb.assign(totalSize, totalSize + element.sizeToStoreInBytes(cb).value)
       }
     } else {
       cb.assign(totalSize, totalSize + (length.toL * storageType.elementByteSize))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -81,7 +81,7 @@ trait SIndexableValue extends SValue {
   override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val storageType = this.st.storageType().asInstanceOf[PContainer]
     val length = this.loadLength()
-    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.nMissingBytes(length).toL)
+    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.elementsOffset(length).toL)
     if (this.st.elementType.containsPointers) {
       this.forEachDefined(cb) { (cb, _, element) =>
         cb.assign(totalSize, totalSize + element.sizeInBytes(cb).value)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -4,6 +4,7 @@ import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
 import is.hail.types.{RInterval, TypeWithRequiredness}
 import is.hail.types.physical.PInterval
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
 
 trait SInterval extends SType {
@@ -31,4 +32,21 @@ trait SIntervalValue extends SValue {
   def endDefined(cb: EmitCodeBuilder): Value[Boolean]
 
   def isEmpty(cb: EmitCodeBuilder): Value[Boolean]
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    val storageType = st.storageType().asInstanceOf[PInterval]
+
+    val pIntervalSize = this.st.storageType().byteSize
+    val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pIntervalSize)
+
+    loadStart(cb).consume(cb, {}, {sv =>
+      sv.sizeInBytes(cb)
+    })
+
+    loadEnd(cb).consume(cb, {}, {sv =>
+      sv.sizeInBytes(cb)
+    })
+
+    new SInt64Value(???)
+  }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -33,18 +33,18 @@ trait SIntervalValue extends SValue {
 
   def isEmpty(cb: EmitCodeBuilder): Value[Boolean]
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val storageType = st.storageType().asInstanceOf[PInterval]
 
     val pIntervalSize = this.st.storageType().byteSize
     val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pIntervalSize)
 
     loadStart(cb).consume(cb, {}, {sv =>
-      sv.sizeInBytes(cb)
+      sv.sizeToStoreInBytes(cb)
     })
 
     loadEnd(cb).consume(cb, {}, {sv =>
-      sv.sizeInBytes(cb)
+      sv.sizeToStoreInBytes(cb)
     })
 
     new SInt64Value(???)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -1,11 +1,11 @@
 package is.hail.types.physical.stypes.interfaces
 
-import is.hail.asm4s.{Code, Value}
+import is.hail.asm4s.{Value}
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
 import is.hail.types.{RInterval, TypeWithRequiredness}
-import is.hail.types.physical.PInterval
 import is.hail.types.physical.stypes.primitives.SInt64Value
-import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
+import is.hail.types.physical.stypes.{EmitType, SType, SValue}
+import is.hail.asm4s._
 
 trait SInterval extends SType {
   def pointType: SType
@@ -34,19 +34,17 @@ trait SIntervalValue extends SValue {
   def isEmpty(cb: EmitCodeBuilder): Value[Boolean]
 
   override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
-    val storageType = st.storageType().asInstanceOf[PInterval]
-
     val pIntervalSize = this.st.storageType().byteSize
     val sizeSoFar = cb.newLocal[Long]("sstackstruct_size_in_bytes", pIntervalSize)
 
     loadStart(cb).consume(cb, {}, {sv =>
-      sv.sizeToStoreInBytes(cb)
+      cb.assign(sizeSoFar, sizeSoFar + sv.sizeToStoreInBytes(cb).value)
     })
 
     loadEnd(cb).consume(cb, {}, {sv =>
-      sv.sizeToStoreInBytes(cb)
+      cb.assign(sizeSoFar, sizeSoFar + sv.sizeToStoreInBytes(cb).value)
     })
 
-    new SInt64Value(???)
+    new SInt64Value(sizeSoFar)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
@@ -2,7 +2,7 @@ package is.hail.types.physical.stypes.interfaces
 
 import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.primitives.SInt32Value
+import is.hail.types.physical.stypes.primitives.{SInt32Value, SInt64Value}
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
 import is.hail.types.{RPrimitive, TypeWithRequiredness}
 import is.hail.variant.{Locus, ReferenceGenome}
@@ -30,4 +30,6 @@ trait SLocusValue extends SValue {
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     structRepr(cb).hash(cb)
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = structRepr(cb).sizeInBytes(cb)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
@@ -31,5 +31,5 @@ trait SLocusValue extends SValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     structRepr(cb).hash(cb)
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = structRepr(cb).sizeInBytes(cb)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = structRepr(cb).sizeToStoreInBytes(cb)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -5,6 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.linalg.{BLAS, LAPACK}
 import is.hail.types.physical.stypes.concrete.{SNDArraySlice, SNDArraySliceValue}
+import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.physical.stypes.{EmitType, SSettable, SType, SValue}
 import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
 import is.hail.types.{RNDArray, TypeWithRequiredness}
@@ -729,6 +730,22 @@ trait SNDArrayValue extends SValue {
     val newSType = SNDArraySlice(PCanonicalNDArray(st.pType.elementType, newShape.size, st.pType.required))
 
     new SNDArraySliceValue(newSType, newShape, newStrides, newFirstDataAddress)
+  }
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+    val storageType = st.storageType().asInstanceOf[PNDArray]
+    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.byteSize)
+
+    if (storageType.elementType.containsPointers) {
+      SNDArray.coiterate(cb, (this, "A")){
+        case Seq(elt) =>
+          cb.assign(totalSize, totalSize + elt.sizeInBytes(cb).value)
+      }
+    } else {
+      val numElements = SNDArray.numElements(this.shapes)
+      cb.assign(totalSize, totalSize + (numElements * storageType.elementType.byteSize))
+    }
+    new SInt64Value(totalSize)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -732,14 +732,14 @@ trait SNDArrayValue extends SValue {
     new SNDArraySliceValue(newSType, newShape, newStrides, newFirstDataAddress)
   }
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = {
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val storageType = st.storageType().asInstanceOf[PNDArray]
     val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.byteSize)
 
     if (storageType.elementType.containsPointers) {
       SNDArray.coiterate(cb, (this, "A")){
         case Seq(elt) =>
-          cb.assign(totalSize, totalSize + elt.sizeInBytes(cb).value)
+          cb.assign(totalSize, totalSize + elt.sizeToStoreInBytes(cb).value)
       }
     } else {
       val numElements = SNDArray.numElements(this.shapes)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -52,7 +52,7 @@ class SBooleanValue(val value: Value[Boolean]) extends SPrimitiveValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(value.toI))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(pt.byteSize)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(pt.byteSize)
 }
 
 object SBooleanSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -51,6 +51,8 @@ class SBooleanValue(val value: Value[Boolean]) extends SPrimitiveValue {
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(value.toI))
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(pt.byteSize)
 }
 
 object SBooleanSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -50,7 +50,7 @@ class SFloat32Value(val value: Value[Float]) extends SPrimitiveValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(Code.invokeStatic1[java.lang.Float, Float, Int]("floatToIntBits", value)))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(4L)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(4L)
 }
 
 object SFloat32Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -49,6 +49,8 @@ class SFloat32Value(val value: Value[Float]) extends SPrimitiveValue {
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(Code.invokeStatic1[java.lang.Float, Float, Int]("floatToIntBits", value)))
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(4L)
 }
 
 object SFloat32Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -54,6 +54,8 @@ class SFloat64Value(val value: Value[Double]) extends SPrimitiveValue {
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.lang.Double, Double, Int]("hashCode", value)))
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(8L)
 }
 
 object SFloat64Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -55,7 +55,7 @@ class SFloat64Value(val value: Value[Double]) extends SPrimitiveValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.lang.Double, Double, Int]("hashCode", value)))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(8L)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(8L)
 }
 
 object SFloat64Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -49,6 +49,8 @@ class SInt32Value(val value: Value[Int]) extends SPrimitiveValue {
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(value)
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(4L)
 }
 
 object SInt32Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -50,7 +50,7 @@ class SInt32Value(val value: Value[Int]) extends SPrimitiveValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(value)
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(4L)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(4L)
 }
 
 object SInt32Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -51,7 +51,7 @@ class SInt64Value(val value: Value[Long]) extends SPrimitiveValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.lang.Long, Long, Int]("hashCode", value)))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(this.st.storageType().asInstanceOf[PInt64].byteSize)
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(this.st.storageType().asInstanceOf[PInt64].byteSize)
 }
 
 object SInt64Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -51,7 +51,7 @@ class SInt64Value(val value: Value[Long]) extends SPrimitiveValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.lang.Long, Long, Int]("hashCode", value)))
 
-  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(8L)
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(this.st.storageType().asInstanceOf[PInt64].byteSize)
 }
 
 object SInt64Settable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -50,6 +50,8 @@ class SInt64Value(val value: Value[Long]) extends SPrimitiveValue {
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.lang.Long, Long, Int]("hashCode", value)))
+
+  override def sizeInBytes(cb: EmitCodeBuilder): SInt64Value = new SInt64Value(8L)
 }
 
 object SInt64Settable {

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -32,9 +32,11 @@ class CodeSuite extends HailSuite {
     val int64 = new SInt64Value(5L)
     val int32 = new SInt32Value(2)
     val struct = new SStackStructValue(SStackStruct(TStruct("x" -> TInt64, "y" -> TInt32), IndexedSeq(EmitType(SInt64, true), EmitType(SInt32, false))), IndexedSeq(EmitValue(None, int64), EmitValue(Some(false), int32)))
+    val str = new SJavaStringValue(const("cat"))
     assert(testSizeHelper(int64) == 8L)
     assert(testSizeHelper(int32) == 4L)
     assert(testSizeHelper(struct) == 16L) // 1 missing byte that gets 4 byte aligned, 8 bytes for long, 4 bytes for missing int
+    assert(testSizeHelper(str) == 15L) // 8 byte pointer, 4 byte header, 3 bytes for the 3 letters.
   }
 
   def testSizeHelper(v: SValue): Long = {
@@ -43,7 +45,7 @@ class CodeSuite extends HailSuite {
     mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
       v.sizeInBytes(cb).value
     })
-    fb.result()()()
+    fb.result()(theHailClassLoader)()
   }
 
   @Test def testHash() {

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -38,7 +38,7 @@ class CodeSuite extends HailSuite {
       val fb = EmitFunctionBuilder[Long](ctx, "test_size_in_bytes")
       val mb = fb.apply_method
       mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
-        v.sizeInBytes(cb).value
+        v.sizeToStoreInBytes(cb).value
       })
       fb.result()(theHailClassLoader)()
     }
@@ -59,7 +59,7 @@ class CodeSuite extends HailSuite {
       val sarray = ptype.constructFromElements(cb, region, 5, true) { (cb, idx) =>
         cb.ifx(idx ceq 2, { IEmitCode.missing(cb, stype.elementType.defaultValue)}, { IEmitCode.present(cb, new SInt32Value(idx))})
       }
-      sarray.sizeInBytes(cb).value
+      sarray.sizeToStoreInBytes(cb).value
     })
     assert(fb.result()(theHailClassLoader)(ctx.r) == 28L) // 2 missing bytes 4 byte aligned + 4 header bytes + 5 elements * 4 bytes for ints.
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3572,12 +3572,12 @@ class IRSuite extends HailSuite {
     val pivots = MakeArray(splitters.map(makeKeyStruct):_*)
     val spec = TypedCodecSpec(PCanonicalStruct(("rowIdx", PInt32Required), ("extraInfo", PInt32Required)), BufferSpec.default)
     val dist = StreamDistribute(child, pivots, Str(ctx.localTmpdir), Compare(pivots.typ.asInstanceOf[TArray].elementType), spec)
-    val result = eval(dist).asInstanceOf[IndexedSeq[Row]].map(row => (row(0).asInstanceOf[Interval], row(1).asInstanceOf[String], row(2).asInstanceOf[Int]))
+    val result = eval(dist).asInstanceOf[IndexedSeq[Row]].map(row => (row(0).asInstanceOf[Interval], row(1).asInstanceOf[String], row(2).asInstanceOf[Int], row(3).asInstanceOf[Long]))
     val kord: ExtendedOrdering = PartitionBoundOrdering(pivots.typ.asInstanceOf[TArray].elementType)
 
     var dataIdx = 0
 
-    result.foreach { case (interval, path, elementCount) =>
+    result.foreach { case (interval, path, elementCount, numBytes) =>
       val reader = PartitionNativeReader(spec)
       val read = ToArray(ReadPartition(Str(path), spec._vType, reader))
       val rowsFromDisk = eval(read).asInstanceOf[IndexedSeq[Row]]

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3553,31 +3553,25 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testStreamDistribute(): Unit =  {
-//    val data1 = IndexedSeq(0, 1, 1, 2, 4, 7, 7, 7, 9, 11, 15, 20, 22, 28, 50, 100)
-//    val pivots1 = IndexedSeq(-10, 1, 7, 7, 15, 22, 50, 200)
-//    val pivots2 = IndexedSeq(-10, 1, 1, 7, 9, 28, 50, 200)
-//    val pivots3 = IndexedSeq(-3, 0, 20, 100, 200)
-//    val pivots4 = IndexedSeq(-8, 4, 7, 7, 150)
-//    val pivots5 = IndexedSeq(0, 1, 4, 15, 200)
-//    val pivots6 = IndexedSeq(0, 7, 20, 100)
-//
-//    runStreamDistTest(data1, pivots1)
-//    runStreamDistTest(data1, pivots2)
-//    runStreamDistTest(data1, pivots3)
-//    runStreamDistTest(data1, pivots4)
-//    runStreamDistTest(data1, pivots5)
-//    runStreamDistTest(data1, pivots6)
+    val data1 = IndexedSeq(0, 1, 1, 2, 4, 7, 7, 7, 9, 11, 15, 20, 22, 28, 50, 100)
+    val pivots1 = IndexedSeq(-10, 1, 7, 7, 15, 22, 50, 200)
+    val pivots2 = IndexedSeq(-10, 1, 1, 7, 9, 28, 50, 200)
+    val pivots3 = IndexedSeq(-3, 0, 20, 100, 200)
+    val pivots4 = IndexedSeq(-8, 4, 7, 7, 150)
+    val pivots5 = IndexedSeq(0, 1, 4, 15, 200)
+    val pivots6 = IndexedSeq(0, 7, 20, 100)
+
+    runStreamDistTest(data1, pivots1)
+    runStreamDistTest(data1, pivots2)
+    runStreamDistTest(data1, pivots3)
+    runStreamDistTest(data1, pivots4)
+    runStreamDistTest(data1, pivots5)
+    runStreamDistTest(data1, pivots6)
 
     val data2 = IndexedSeq(0, 2)
     val pivots11 = IndexedSeq(0, 0, 2)
-    val pivots12 = IndexedSeq(0, 2, 2)
 
-//    runStreamDistTest(data2, pivots11)
-    runStreamDistTest(data2, pivots12)
-
-//    val data3 = IndexedSeq(0, 0, 0, 0)
-//    val pivots21 = IndexedSeq(0, 0, 0)
-//    runStreamDistTest(data3, pivots21)
+    runStreamDistTest(data2, pivots11)
   }
 
   def runStreamDistTest(data: IndexedSeq[Int], splitters: IndexedSeq[Int]): Unit = {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3553,16 +3553,31 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testStreamDistribute(): Unit =  {
-    val data1 = IndexedSeq(0, 1, 1, 2, 4, 7, 7, 7, 9, 11, 15, 20, 22, 28, 50, 100)
-    val pivots1 = IndexedSeq(-10, 1, 7, 7, 15, 22, 50, 200)
-    val pivots2 = IndexedSeq(-10, 1, 1, 7, 9, 28, 50, 200)
-    val pivots3 = IndexedSeq(-3, 0, 20, 100, 200)
-    val pivots4 = IndexedSeq(-8, 4, 7, 7, 150)
+//    val data1 = IndexedSeq(0, 1, 1, 2, 4, 7, 7, 7, 9, 11, 15, 20, 22, 28, 50, 100)
+//    val pivots1 = IndexedSeq(-10, 1, 7, 7, 15, 22, 50, 200)
+//    val pivots2 = IndexedSeq(-10, 1, 1, 7, 9, 28, 50, 200)
+//    val pivots3 = IndexedSeq(-3, 0, 20, 100, 200)
+//    val pivots4 = IndexedSeq(-8, 4, 7, 7, 150)
+//    val pivots5 = IndexedSeq(0, 1, 4, 15, 200)
+//    val pivots6 = IndexedSeq(0, 7, 20, 100)
+//
+//    runStreamDistTest(data1, pivots1)
+//    runStreamDistTest(data1, pivots2)
+//    runStreamDistTest(data1, pivots3)
+//    runStreamDistTest(data1, pivots4)
+//    runStreamDistTest(data1, pivots5)
+//    runStreamDistTest(data1, pivots6)
 
-    runStreamDistTest(data1, pivots1)
-    runStreamDistTest(data1, pivots2)
-    runStreamDistTest(data1, pivots3)
-    runStreamDistTest(data1, pivots4)
+    val data2 = IndexedSeq(0, 2)
+    val pivots11 = IndexedSeq(0, 0, 2)
+    val pivots12 = IndexedSeq(0, 2, 2)
+
+//    runStreamDistTest(data2, pivots11)
+    runStreamDistTest(data2, pivots12)
+
+//    val data3 = IndexedSeq(0, 0, 0, 0)
+//    val pivots21 = IndexedSeq(0, 0, 0)
+//    runStreamDistTest(data3, pivots21)
   }
 
   def runStreamDistTest(data: IndexedSeq[Int], splitters: IndexedSeq[Int]): Unit = {

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
@@ -38,6 +38,7 @@ class LowerDistributedSortSuite extends HailSuite {
     val analyses: Analyses = Analyses.apply(myTable, ctx)
     val rowType = analyses.requirednessAnalysis.lookup(myTable).asInstanceOf[RTable].rowType
     val stage = LowerTableIR.applyTable(myTable, DArrayLowering.All, ctx, analyses, Map.empty[String, IR])
+
     val sortedTs = LowerDistributedSort.distributedSort(ctx, stage, sortFields, Map.empty[String, IR], rowType)
     val res = TestUtils.eval(sortedTs.mapCollect(Map.empty[String, IR])(x => ToArray(x))).asInstanceOf[IndexedSeq[IndexedSeq[Row]]].flatten
 

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
@@ -34,7 +34,7 @@ class LowerDistributedSortSuite extends HailSuite {
 
   // Only does ascending for now
   def testDistributedSortHelper(myTable: TableIR, sortFields: IndexedSeq[SortField]): Unit = {
-    HailContext.setFlag("shuffle_cutoff_to_local_sort", "6")
+    HailContext.setFlag("shuffle_cutoff_to_local_sort", "40")
     val analyses: Analyses = Analyses.apply(myTable, ctx)
     val rowType = analyses.requirednessAnalysis.lookup(myTable).asInstanceOf[RTable].rowType
     val stage = LowerTableIR.applyTable(myTable, DArrayLowering.All, ctx, analyses, Map.empty[String, IR])


### PR DESCRIPTION
With this, we should theoretically be able to arbitrarily sized rows.