### PR TITLE
[batch] demote callback failure to info

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -66,7 +66,7 @@ GROUP BY batches.id;
     except asyncio.CancelledError:
         raise
     except Exception:
-        log.exception(f'callback for batch {batch_id} failed, will not retry.')
+        log.info(f'callback for batch {batch_id} failed, will not retry.')
 
 
 async def add_attempt_resources(db, batch_id, job_id, attempt_id, resources):


### PR DESCRIPTION
This is not a real error. It is not the fault of batch that the other
end of the connection did not respond. If batch is having general
network connectivity issues, I would expect to see many other
error log statements.