### PR TITLE
[batch] wait unless we have more work

### DIFF
--- a/batch/batch/driver/instance_collection/job_private.py
+++ b/batch/batch/driver/instance_collection/job_private.py
@@ -143,9 +143,8 @@ WHERE name = %s;
         log.info(f'starting scheduling jobs for {self}')
         waitable_pool = WaitableSharedPool(self.async_worker_pool)
 
-        should_wait = True
-
-        n_scheduled = 0
+        n_records_seen = 0
+        max_records = 300
 
         async for record in self.db.select_and_fetchall(
             '''
@@ -160,9 +159,9 @@ WHERE batches.state = 'running'
   AND jobs.inst_coll = %s
   AND instances.`state` = 'active'
 ORDER BY instances.time_activated ASC
-LIMIT 300;
+LIMIT %s;
 ''',
-            (self.name,),
+            (self.name, max_records),
         ):
             batch_id = record['batch_id']
             job_id = record['job_id']
@@ -171,8 +170,7 @@ LIMIT 300;
             log.info(f'scheduling job {id}')
 
             instance = self.name_instance[instance_name]
-            n_scheduled += 1
-            should_wait = False
+            n_records_seen += 1
 
             async def schedule_with_error_handling(app, record, id, instance):
                 try:
@@ -184,8 +182,9 @@ LIMIT 300;
 
         await waitable_pool.wait()
 
-        log.info(f'scheduled {n_scheduled} jobs for {self}')
+        log.info(f'attempted to schedule {n_records_seen} jobs for {self}')
 
+        should_wait = n_records_seen < max_records
         return should_wait
 
     def max_instances_to_create(self):

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -459,7 +459,6 @@ LIMIT %s;
                     instance.adjust_free_cores_in_memory(-record['cores_mcpu'])
                     scheduled_cores_mcpu += record['cores_mcpu']
                     n_scheduled += 1
-                    should_wait = False
 
                     async def schedule_with_error_handling(app, record, id, instance):
                         try:
@@ -471,11 +470,12 @@ LIMIT %s;
 
                 remaining.value -= 1
                 if remaining.value <= 0:
+                    should_wait = False
                     break
 
         await waitable_pool.wait()
 
         end = time_msecs()
-        log.info(f'schedule: scheduled {n_scheduled} jobs in {end - start}ms for {self.pool}')
+        log.info(f'schedule: attemptd to schedule {n_scheduled} jobs in {end - start}ms for {self.pool}')
 
         return should_wait

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -476,6 +476,6 @@ LIMIT %s;
         await waitable_pool.wait()
 
         end = time_msecs()
-        log.info(f'schedule: attemptd to schedule {n_scheduled} jobs in {end - start}ms for {self.pool}')
+        log.info(f'schedule: attempted to schedule {n_scheduled} jobs in {end - start}ms for {self.pool}')
 
         return should_wait


### PR DESCRIPTION
The return value of these functions indicates if the containing loop
should wait or if we should immediately re-call the function. This
is intended to be used to allow functions which *know* they have more
work to eagerly invoke themselves again.

The use of this variable seems to have been changed to basically always
eagerly re-run during the Azure work.

This change restores the original behavior:
1. Do not wait in job private if we saw 300 records (seems likely there were
   301 or more records in the db).
2. Do not wait in pool scheduler if we exhaust a user's share. I do not
   fully follow the pool scheduler's logic. There might be something
   smarter we can do. I think we should really only re-call if we believe
   the db contains more ready jobs and we have available cores.