### PR TITLE
[compiler] lowered TableIntervalJoin

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -860,8 +860,6 @@ Caused by: java.lang.ClassCastException: __C2308collect_distributed_array cannot
                 rt['value'] == "IB",
                 hl.is_missing(rt['value']))))
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_interval_join(self):
         left = hl.utils.range_matrix_table(50, 1, n_partitions=10)
         intervals = hl.utils.range_table(4)
@@ -1545,8 +1543,6 @@ Caused by: is.hail.utils.HailException: Premature end of file: expected 4 bytes,
 
         self.assertTrue(matrix1.union_cols(matrix2)._same(expected))
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_row_joins_into_table(self):
         rt = hl.utils.range_matrix_table(9, 13, 3)
         mt1 = rt.key_rows_by(idx=rt.row_idx)

--- a/hail/python/test/hail/methods/test_misc.py
+++ b/hail/python/test/hail/methods/test_misc.py
@@ -28,8 +28,6 @@ class Tests(unittest.TestCase):
             'foo'
         )['foo'].dtype == hl.tstr
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_annotate_intervals(self):
         ds = get_dataset()
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1678,8 +1678,6 @@ def test_maybe_flexindex_table_by_expr_prefix_match():
     assert t1._maybe_flexindex_table_by_expr((hl.str(mt1.row_idx), mt1.row_idx)) is None
 
 
-@fails_service_backend()
-@fails_local_backend()
 def test_maybe_flexindex_table_by_expr_direct_interval_match():
     t1 = hl.utils.range_table(1)
     t1 = t1.key_by(interval=hl.interval(t1.idx, t1.idx+1))
@@ -1700,8 +1698,6 @@ def test_maybe_flexindex_table_by_expr_direct_interval_match():
     assert t1._maybe_flexindex_table_by_expr(hl.str(mt1.row_key)) is None
 
 
-@fails_service_backend()
-@fails_local_backend()
 def test_maybe_flexindex_table_by_expr_prefix_interval_match():
     t1 = hl.utils.range_table(1)
     t1 = t1.key_by(interval=hl.interval(t1.idx, t1.idx+1))

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -482,8 +482,6 @@ Caused by: java.lang.AssertionError: assertion failed
         ht = hl.import_vcf(resource('sample.vcf')).rows()
         assert ht.filter(ht.locus > hl.locus('20', 17434581)).count() == 100
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_interval_join(self):
         left = hl.utils.range_table(50, n_partitions=10)
         intervals = hl.utils.range_table(4)

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -163,8 +163,6 @@ def test_filter_samples_and_merge():
     assert merged.variant_data._same(vds.variant_data)
 
 
-@fails_local_backend
-@fails_service_backend
 def test_segment_intervals():
     vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
 
@@ -197,8 +195,6 @@ def test_segment_intervals():
     assert before_coverage == after_coverage
 
 
-@fails_local_backend
-@fails_service_backend
 def test_interval_coverage():
     vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
 
@@ -252,7 +248,6 @@ def test_interval_coverage():
         pytest.approx(obs.mean_dp, exp.mean_dp)
 
 
-@fails_local_backend
 @skip_when_service_backend(message='''
 hangs >=9 minutes after "optimize optimize: darrayLowerer, initial IR ..."
 with no calls to parallelizeAndComputeWithIndex

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
@@ -49,7 +49,8 @@ object CanLowerEfficiently {
         case t: TableHead =>
         case t: TableTail =>
         case t: TableJoin =>
-        case t: TableIntervalJoin => fail(s"TableIntervalJoin has no lowered implementation")
+        case TableIntervalJoin(_, _, _, true) => fail("TableIntervalJoin with \"product=true\" has no lowered implementation")
+        case TableIntervalJoin(_, _, _, false) =>
         case t: TableLeftJoinRightDistinct =>
         case t: TableMapPartitions =>
         case t: TableMapRows =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -402,12 +402,12 @@ class TableStage(
     require(rightKeyType.isInstanceOf[TInterval])
     require(rightKeyType.asInstanceOf[TInterval].pointType == kType.types.head)
 
-    val irPartitioner = partitioner.partitionBoundsIRRepresentation
+    val irPartitioner = partitioner.coarsen(1).partitionBoundsIRRepresentation
 
     val rightWithPartNums = right.mapPartition(None) { partStream =>
       flatMapIR(partStream) { row =>
         val interval = bindIR(GetField(row, right.key.head)) { interval =>
-          invoke("Interval", TInterval(TTuple(kType, TInt32)),
+          invoke("Interval", TInterval(TTuple(kType.typeAfterSelect(Array(0)), TInt32)),
             MakeTuple.ordered(FastSeq(MakeStruct(FastSeq(kType.fieldNames.head -> invoke("start", kType.types.head, interval))), I32(1))),
             MakeTuple.ordered(FastSeq(MakeStruct(FastSeq(kType.fieldNames.head -> invoke("end", kType.types.head, interval))), I32(1))),
             invoke("includesStart", TBoolean, interval),

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -357,11 +357,7 @@ class TableStage(
 
     val newKey = kType.fieldNames ++ right.kType.fieldNames.drop(joinKey)
 
-    val leftKeyToRightKeyMap = kType.fieldNames.zip(right.kType.fieldNames).toMap
-    val newRightPartitioner = newPartitioner.coarsen(joinKey).strictify.rename(leftKeyToRightKeyMap)
-    val repartitionedRight = right.repartitionNoShuffle(newRightPartitioner)
-
-    repartitionedLeft.zipPartitions(repartitionedRight, globalJoiner, partitionJoiner)
+    repartitionedLeft.alignAndZipPartitions(right, joinKey, globalJoiner, partitionJoiner)
       .extendKeyPreservesPartitioning(newKey)
   }
 
@@ -382,10 +378,61 @@ class TableStage(
     require(joinKey <= kType.size)
     require(joinKey <= right.kType.size)
 
-    val leftKeyToRightKeyMap = kType.fieldNames.zip(right.kType.fieldNames).toMap
+    val leftKeyToRightKeyMap = (kType.fieldNames.take(joinKey), right.kType.fieldNames.take(joinKey)).zipped.toMap
     val newRightPartitioner = partitioner.coarsen(joinKey).strictify.rename(leftKeyToRightKeyMap)
     val repartitionedRight = right.repartitionNoShuffle(newRightPartitioner)
     zipPartitions(repartitionedRight, globalJoiner, joiner)
+  }
+
+  // Like alignAndZipPartitions, when 'right' is keyed by intervals.
+  // 'joiner' is called once for each partition of 'this', as in
+  // alignAndZipPartitions, but now the second iterator will contain all rows
+  // of 'that' whose key is an interval overlapping the range bounds of the
+  // current partition of 'this', in standard interval ordering.
+  def intervalAlignAndZipPartitions(
+    ctx: ExecuteContext,
+    right: TableStage,
+    rightRowRType: RStruct,
+    relationalLetsAbove: Map[String, IR],
+    globalJoiner: (IR, IR) => IR,
+    joiner: (IR, IR) => IR
+  ): TableStage = {
+    require(right.kType.size == 1)
+    val rightKeyType = right.kType.fields.head.typ
+    require(rightKeyType.isInstanceOf[TInterval])
+    require(rightKeyType.asInstanceOf[TInterval].pointType == kType.fields.head.typ)
+
+    val irPartitioner = partitioner.partitionBoundsIRRepresentation
+
+    val rightWithPartNums = right.mapPartition(None) { partStream =>
+      flatMapIR(partStream) { row =>
+        val interval = GetField(row, right.key.head)
+        bindIR(invoke("partitionerFindIntervalRange", TTuple(TInt32, TInt32), irPartitioner, interval)) { range =>
+          val rangeStream = rangeIR(GetTupleElement(range, 0), GetTupleElement(range, 1))
+          mapIR(rangeStream) { partNum =>
+            InsertFields(row, FastIndexedSeq("__partNum" -> partNum))
+          }
+        }
+      }
+    }
+    val sorted = ctx.backend.lowerDistributedSort(ctx,
+      rightWithPartNums,
+      SortField("__partNum", Ascending) +: right.key.map(k => SortField(k, Ascending)),
+      relationalLetsAbove,
+      rightRowRType)
+    assert(sorted.kType.fieldNames.sameElements("__partNum" +: right.key))
+    val newRightPartitioner = new RVDPartitioner(
+      Some(1),
+      TStruct.concat(TStruct("__partNum" -> TInt32), right.kType),
+      Array.tabulate[Interval](partitioner.numPartitions)(i => Interval(Row(i), Row(i), true, true))
+      )
+    val repartitioned = sorted.repartitionNoShuffle(newRightPartitioner)
+      .mapPartition(None) { part =>
+        mapIR(part) { row =>
+          SelectFields(row, right.rowType.fieldNames)
+        }
+      }
+    zipPartitions(repartitioned, globalJoiner, joiner)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1391,7 +1391,7 @@ object LowerTableIR {
 
         loweredLeft.intervalAlignAndZipPartitions(ctx,
           loweredRight,
-          r.lookup(right).asInstanceOf[RTable].rowType,
+          analyses.requirednessAnalysis.lookup(right).asInstanceOf[RTable].rowType,
           relationalLetsAbove,
           (lGlobals, _) => lGlobals,
           partitionJoiner)


### PR DESCRIPTION
Closes hail-is/hail-tasks#13

~Stacked on #11375~

Currently only supports `product = false`