### PR TITLE
[query] from_pandas needs to support Pandas missing types and support numpy nums better

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -1,5 +1,6 @@
 from typing import Tuple, Mapping
 import numpy as np
+import pandas as pd
 
 import hail
 import hail as hl
@@ -217,7 +218,7 @@ def _impute_type(x, partial_type):
     elif isinstance(x, np.ndarray):
         element_type = from_numpy(x.dtype)
         return tndarray(element_type, x.ndim)
-    elif x is None:
+    elif x is None or pd.isna(x):
         return partial_type
     elif isinstance(x, (hl.expr.builders.CaseBuilder, hl.expr.builders.SwitchBuilder)):
         raise ExpressionException("'switch' and 'case' expressions must end with a call to either"

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -21,7 +21,7 @@ from hail.expr.expressions import (Expression, ArrayExpression, SetExpression,
 from hail.expr.types import (HailType, hail_type, tint32, tint64, tfloat32,
                              tfloat64, tstr, tbool, tarray, tset, tdict,
                              tstruct, tlocus, tinterval, tcall, ttuple,
-                             tndarray, is_primitive, is_numeric)
+                             tndarray, is_primitive, is_numeric, is_int32, is_int64, is_float32, is_float64)
 from hail.genetics.reference_genome import reference_genome_type, ReferenceGenome
 import hail.ir as ir
 from hail.typecheck import (typecheck, nullable, anytype, enumeration, tupleof,
@@ -261,18 +261,18 @@ def literal(x: Any, dtype: Optional[Union[HailType, str]] = None):
         return hl.missing(dtype)
     elif is_primitive(dtype):
         if dtype == tint32:
-            assert isinstance(x, builtins.int)
+            assert is_int32(x)
             assert tint32.min_value <= x <= tint32.max_value
             return construct_expr(ir.I32(x), tint32)
         elif dtype == tint64:
-            assert isinstance(x, builtins.int)
+            assert is_int64(x)
             assert tint64.min_value <= x <= tint64.max_value
             return construct_expr(ir.I64(x), tint64)
         elif dtype == tfloat32:
-            assert isinstance(x, (builtins.float, builtins.int))
+            assert is_float32(x)
             return construct_expr(ir.F32(x), tfloat32)
         elif dtype == tfloat64:
-            assert isinstance(x, (builtins.float, builtins.int))
+            assert is_float64(x)
             return construct_expr(ir.F64(x), tfloat64)
         elif dtype == tbool:
             assert isinstance(x, builtins.bool)

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -3,6 +3,7 @@ import json
 import math
 from collections.abc import Mapping, Sequence
 import pprint
+import builtins
 
 import numpy as np
 import pandas as pd
@@ -350,7 +351,7 @@ class _tint32(HailType):
 
     def _typecheck_one_level(self, annotation):
         if annotation is not None:
-            if not isinstance(annotation, int):
+            if not is_int32(annotation):
                 raise TypeError("type 'tint32' expected Python 'int', but found type '%s'" % type(annotation))
             elif not self.min_value <= annotation <= self.max_value:
                 raise TypeError(f"Value out of range for 32-bit integer: "
@@ -405,7 +406,7 @@ class _tint64(HailType):
 
     def _typecheck_one_level(self, annotation):
         if annotation is not None:
-            if not isinstance(annotation, int):
+            if not is_int64(annotation):
                 raise TypeError("type 'int64' expected Python 'int', but found type '%s'" % type(annotation))
             if not self.min_value <= annotation <= self.max_value:
                 raise TypeError(f"Value out of range for 64-bit integer: "
@@ -457,7 +458,7 @@ class _tfloat32(HailType):
         super(_tfloat32, self).__init__()
 
     def _typecheck_one_level(self, annotation):
-        if annotation is not None and not isinstance(annotation, (float, int)):
+        if annotation is not None and not is_float32(annotation):
             raise TypeError("type 'float32' expected Python 'float', but found type '%s'" % type(annotation))
 
     def __str__(self):
@@ -507,7 +508,7 @@ class _tfloat64(HailType):
         super(_tfloat64, self).__init__()
 
     def _typecheck_one_level(self, annotation):
-        if annotation is not None and not isinstance(annotation, (float, int)):
+        if annotation is not None and not is_float64(annotation):
             raise TypeError("type 'float64' expected Python 'float', but found type '%s'" % type(annotation))
 
     def __str__(self):
@@ -2022,6 +2023,22 @@ def is_compound(t) -> bool:
 def types_match(left, right) -> bool:
     return (len(left) == len(right)
             and all(map(lambda lr: lr[0].dtype == lr[1].dtype, zip(left, right))))
+
+
+def is_int32(x):
+    return isinstance(x, (builtins.int, np.int32))
+
+
+def is_int64(x):
+    return isinstance(x, (builtins.int, np.int64))
+
+
+def is_float32(x):
+    return isinstance(x, (builtins.float, builtins.int, np.float32))
+
+
+def is_float64(x):
+    return isinstance(x, (builtins.float, builtins.int, np.float64))
 
 
 def from_numpy(np_dtype):

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -2060,10 +2060,11 @@ def dtypes_from_pandas(pd_dtype):
 
     if type(pd_dtype) == pd.StringDtype:
         return hl.tstr
-    elif pd_dtype == np.int32:
-        return hl.tint32
-    elif pd_dtype == np.int64:
+    elif pd.api.types.is_int64_dtype(pd_dtype):
         return hl.tint64
+    # For some reason pandas doesn't have `is_int32_dtype`, so we use `is_integer_dtype` if first branch failed.
+    elif pd.api.types.is_integer_dtype(pd_dtype):
+        return hl.tint32
     elif pd_dtype == np.float32:
         return hl.tfloat32
     elif pd_dtype == np.float64:

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3354,8 +3354,14 @@ class Table(ExprContainer):
         for data_idx in range(len(columns[fields[0]])):
             for field in fields:
                 cur_val = columns[field][data_idx]
+
                 if pandas.isna(cur_val):
-                    fixed_val = None
+                    if isinstance(cur_val, float):
+                        fixed_val = cur_val
+                    elif isinstance(cur_val, np.floating):
+                        fixed_val = cur_val.item()
+                    else:
+                        fixed_val = None
                 elif isinstance(cur_val, np.number):
                     fixed_val = cur_val.item()
                 else:

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3355,7 +3355,8 @@ class Table(ExprContainer):
             for field in fields:
                 cur_val = columns[field][data_idx]
 
-                if pandas.isna(cur_val):
+                # Can't call isna on a collection or it will implicitly broadcast
+                if pandas.api.types.is_numeric_dtype(df[field].dtype) and pandas.isna(cur_val):
                     if isinstance(cur_val, float):
                         fixed_val = cur_val
                     elif isinstance(cur_val, np.floating):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1,6 +1,7 @@
 import collections
 import itertools
 import pandas
+import numpy as np
 import pyspark
 from typing import Optional, Dict, Callable
 
@@ -3352,7 +3353,14 @@ class Table(ExprContainer):
 
         for data_idx in range(len(columns[fields[0]])):
             for field in fields:
-                data[data_idx][field] = columns[field][data_idx]
+                cur_val = columns[field][data_idx]
+                if pandas.isna(cur_val):
+                    fixed_val = None
+                elif isinstance(cur_val, np.number):
+                    fixed_val = cur_val.item()
+                else:
+                    fixed_val = cur_val
+                data[data_idx][field] = fixed_val
 
         for data_idx, field in enumerate(fields):
             type_hint = dtypes_from_pandas(pd_dtypes[field])

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -759,6 +759,11 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
 
         self.assertTrue(t._same(t2))
 
+    def test_from_pandas_missing_ints(self):
+        df = pd.DataFrame({"x": pd.Series([1, 2, None, 4], dtype=pd.Int64Dtype())})
+        ht = hl.Table.from_pandas(df)
+        assert [s.x for s in ht.collect()] == [1, 2, None, 4]
+
     def test_from_pandas_mismatched_object_rows(self):
         d = {'a': [[1, 2], {1, 2}]}
         df = pd.DataFrame(data=d)


### PR DESCRIPTION
Pandas missingness is crazy. `pd.isna` tells you if something is "missing", which means either `NaN`, or a special `NA` sentinel value. For floats they use `NaN`, and specifically for the pandas special `Int64DType` and `Int32DType` and nothing else they use this `NA` value.

They don't have an easy way to distinguish between `NA` and `NaN`, so I first check if something `isna`, then check if it's a `float` to differentiate between the cases. 

They also don't have a way to test if something is a `Int32DType` for some reason. So I use `is_int64_dtype`, and if that fails I fall back to `is_integer_dtype`, which is true for both `Int64DType` and `Int32DType`.