### PR TITLE
[java-services] add new transient error

### DIFF
--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -13,6 +13,7 @@ import scala.util.Random
 import java.io._
 import com.google.cloud.storage.StorageException
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.client.http.HttpResponseException
 
 package object services {
   lazy val log: Logger = LogManager.getLogger("is.hail.services")
@@ -35,6 +36,8 @@ package object services {
     e match {
       case e: NoHttpResponseException =>
         true
+      case e: HttpResponseException =>
+        RETRYABLE_HTTP_STATUS_CODES.contains(e.getStatusCode())
       case e: ClientResponseException =>
         RETRYABLE_HTTP_STATUS_CODES.contains(e.status)
       case e: GoogleJsonResponseException =>


### PR DESCRIPTION
See https://ci.hail.is/batches/532603/jobs/112.

We encounter a `is.hail.relocated.com.google.cloud.storage.StorageException` which is caused by a
`com.google.api.client.http.HttpResponseException`. The latter exception is not currently
considered a transient error. This PR changes isTransientError to recognize `HttpResponseException`
as a transient error.