### PR TITLE
[devbin] do not authenticate everytime I change projects

### DIFF
--- a/devbin/functions.sh
+++ b/devbin/functions.sh
@@ -182,7 +182,6 @@ gcpsetcluster() {
     fi
 
     gcloud config set project $1
-    gcloud auth application-default login
     gcloud container clusters get-credentials --zone us-central1-a vdc
 }
 


### PR DESCRIPTION
I really do not think this should be necessary. The ADC is my *user* credentials. If I can
access the given project then I do not see why I need to regenerate my ADC creds.