### PR TITLE
[batch] db must rollback if spec write fails or is cancelled

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1033,7 +1033,7 @@ VALUES (%s, %s, %s);
             # must rollback. See https://github.com/hail-is/hail-production-issues/issues/9
             await asyncio.gather(write_spec_to_cloud(), insert_jobs_into_db(tx))
 
-        write_and_insert()  # pylint: disable=no-value-for-parameter
+        await write_and_insert()  # pylint: disable=no-value-for-parameter
     return web.Response()
 
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -36,7 +36,7 @@ orjson==3.6.4
 # importlib-metadata<4: in dev-requirements, jupyter depends on (an unpinned) ipykernel which needs importlib-metadata<4
 importlib-metadata<4
 janus==0.6.1
-Jinja2==2.11.3
+Jinja2==3.0.3
 # keyrings.alt>3.1: https://bugs.launchpad.net/usd-importer/+bug/1794041/comments/6
 keyrings.alt>=3.1
 kubernetes-asyncio==9.1.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -20,9 +20,9 @@ dictdiffer==0.8.1
 dill>=0.3.1.1,<0.4
 docker==5.0.3
 flake8==3.8.3
-Flask-Cors==3.0.9
+Flask-Cors==3.0.10
 Flask-Sockets==0.2.1
-Flask==1.0.3
+Flask==2.0.3
 # https://github.com/dask/gcsfs/issues/372
 gcsfs==0.8.0
 # https://github.com/dask/gcsfs/issues/372

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -68,7 +68,6 @@ tqdm==4.42.1
 twine>=1.11.0
 urllib3==1.26.5
 uvloop==0.14.0
-Werkzeug==0.15.4
 wheel>=0.31.0
 # yarl 1.6.0 broke query string parsing in aiohttp 3.6.[012] https://github.com/aio-libs/aiohttp/issues/4972#issuecomment-700290809
 yarl<1.6.0


### PR DESCRIPTION
Closes hail-is/hail-production-issues#9

Details [here](https://github.com/hail-is/hail-production-issues/issues/9#issuecomment-1049356188).

This is my bad. One of the query service PRs allowed spec writing to happen in
parallel with DB insertion (which reduces latency a bit), but if the spec fails
to write or is cancelled, then the DB has a spec token that points at a
cloud object which does not necessarily exist.

I think we do not need the spec token, but removing it does not seem likely
to improve performance much. We still need to hit the DB to get the start_job_id.
There was some discussion about the necessity of the token [here](https://github.com/hail-is/hail/pull/7949#discussion_r370406517).
I think that discussion came to the wrong conclusion. GCS is atomic and globally
consistent. Writing to an already present spec object is atomic. The only issue
I forsee is the possibility that the spec is different the second time. The spec
should have the same semantic content, but if the characters are different the
spec index could be very briefly wrong. We could fix this by storing both the
spec and the index in one GCS file.

cc: @jigold 