### PR TITLE
[batch] ensure cost is up-to-date when a batch is marked complete

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -130,6 +130,7 @@ async def mark_job_complete(
             raise
         await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
         return rv
+
     rv = mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     scheduler_state_changed.notify()
@@ -186,6 +187,7 @@ CALL mark_job_started(%s, %s, %s, %s, %s);
             raise
         await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
         return rv
+
     rv = mjs_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
@@ -221,6 +223,7 @@ CALL mark_job_creating(%s, %s, %s, %s, %s);
             raise
         await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
         return rv
+
     rv = mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'pending':

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -9,7 +9,7 @@ import traceback
 from hailtop.aiotools import BackgroundTaskManager
 from hailtop.utils import time_msecs, Notice, retry_transient_errors
 from hailtop import httpx
-from gear import Database
+from gear import Database, transaction, Transaction
 
 from ..batch import batch_record_to_dict
 from ..globals import complete_states, tasks, STATUS_FORMAT_VERSION
@@ -69,14 +69,14 @@ GROUP BY batches.id;
         log.exception(f'callback for batch {batch_id} failed, will not retry.')
 
 
-async def add_attempt_resources(db, batch_id, job_id, attempt_id, resources):
+async def add_attempt_resources(tx: Transaction, batch_id, job_id, attempt_id, resources):
     if attempt_id:
         try:
             resource_args = [
                 (batch_id, job_id, attempt_id, resource['name'], resource['quantity']) for resource in resources
             ]
 
-            await db.execute_many(
+            await tx.execute_many(
                 '''
 INSERT INTO `attempt_resources` (batch_id, job_id, attempt_id, resource, quantity)
 VALUES (%s, %s, %s, %s, %s)
@@ -106,26 +106,31 @@ async def mark_job_complete(
 
     now = time_msecs()
 
-    try:
-        rv = await db.execute_and_fetchone(
-            'CALL mark_job_complete(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);',
-            (
-                batch_id,
-                job_id,
-                attempt_id,
-                instance_name,
-                new_state,
-                json.dumps(status) if status is not None else None,
-                start_time,
-                end_time,
-                reason,
-                now,
-            ),
-            'mark_job_complete',
-        )
-    except Exception:
-        log.exception(f'error while marking job {id} complete on instance {instance_name}')
-        raise
+    @transaction(db)
+    async def mjc_and_add_attempt_resources(tx: Transaction) -> dict:
+        try:
+            rv = await tx.execute_and_fetchone(
+                'CALL mark_job_complete(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);',
+                (
+                    batch_id,
+                    job_id,
+                    attempt_id,
+                    instance_name,
+                    new_state,
+                    json.dumps(status) if status is not None else None,
+                    start_time,
+                    end_time,
+                    reason,
+                    now,
+                ),
+                'mark_job_complete',
+            )
+        except Exception:
+            log.exception(f'error while marking job {id} complete on instance {instance_name}')
+            raise
+        await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
+        return rv
+    rv = mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     scheduler_state_changed.notify()
     cancel_ready_state_changed.set()
@@ -140,8 +145,6 @@ async def mark_job_complete(
                 instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])
         else:
             log.warning(f'mark_complete for job {id} from unknown {instance}')
-
-    await add_attempt_resources(db, batch_id, job_id, attempt_id, resources)
 
     if rv['rc'] != 0:
         log.info(f'mark_job_complete returned {rv} for job {id}')
@@ -168,22 +171,25 @@ async def mark_job_started(app, batch_id, job_id, attempt_id, instance, start_ti
 
     log.info(f'mark job {id} started')
 
-    try:
-        rv = await db.execute_and_fetchone(
-            '''
+    @transaction(db)
+    async def mjs_and_add_attempt_resources(tx: Transaction) -> dict:
+        try:
+            rv = await tx.execute_and_fetchone(
+                '''
 CALL mark_job_started(%s, %s, %s, %s, %s);
 ''',
-            (batch_id, job_id, attempt_id, instance.name, start_time),
-            'mark_job_started',
-        )
-    except Exception:
-        log.info(f'error while marking job {id} started on {instance}')
-        raise
+                (batch_id, job_id, attempt_id, instance.name, start_time),
+                'mark_job_started',
+            )
+        except Exception:
+            log.info(f'error while marking job {id} started on {instance}')
+            raise
+        await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
+        return rv
+    rv = mjs_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
         instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])
-
-    await add_attempt_resources(db, batch_id, job_id, attempt_id, resources)
 
 
 async def mark_job_creating(
@@ -201,22 +207,24 @@ async def mark_job_creating(
 
     log.info(f'mark job {id} creating')
 
-    try:
-        rv = await db.execute_and_fetchone(
-            '''
+    @transaction(db)
+    async def mjc_and_add_attempt_resources(tx: Transaction) -> dict:
+        try:
+            rv = await tx.execute_and_fetchone(
+                '''
 CALL mark_job_creating(%s, %s, %s, %s, %s);
 ''',
-            (batch_id, job_id, attempt_id, instance.name, start_time),
-        )
-    except Exception:
-        log.info(f'error while marking job {id} creating on {instance}')
-        raise
+                (batch_id, job_id, attempt_id, instance.name, start_time),
+            )
+        except Exception:
+            log.info(f'error while marking job {id} creating on {instance}')
+            raise
+        await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
+        return rv
+    rv = mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
-    log.info(rv)
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'pending':
         instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])
-
-    await add_attempt_resources(db, batch_id, job_id, attempt_id, resources)
 
 
 async def unschedule_job(app, record):

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -131,7 +131,7 @@ async def mark_job_complete(
         await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
         return rv
 
-    rv = mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
+    rv = await mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     scheduler_state_changed.notify()
     cancel_ready_state_changed.set()
@@ -188,7 +188,7 @@ CALL mark_job_started(%s, %s, %s, %s, %s);
         await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
         return rv
 
-    rv = mjs_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
+    rv = await mjs_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
         instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])
@@ -224,7 +224,7 @@ CALL mark_job_creating(%s, %s, %s, %s, %s);
         await add_attempt_resources(tx, batch_id, job_id, attempt_id, resources)
         return rv
 
-    rv = mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
+    rv = await mjc_and_add_attempt_resources()  # pylint: disable=no-value-for-parameter
 
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'pending':
         instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -1,4 +1,4 @@
-from .database import create_database_pool, Database, transaction
+from .database import create_database_pool, Database, transaction, Transaction
 from .session import setup_aiohttp_session
 from .auth import (
     userdata_from_web_request,
@@ -30,6 +30,7 @@ __all__ = [
     'insert_user',
     'create_session',
     'transaction',
+    'Transaction',
     'maybe_parse_bearer_header',
     'monitor_endpoints_middleware',
 ]


### PR DESCRIPTION
Closes hail-is/hail-production-issues#3

Details [here](https://github.com/hail-is/hail-production-issues/issues/3).

The high-level takeaway is that if the system is moving quite fast MJS
can happen *after* MJC. When MJC happens first, there are not yet any
resources. As a result, the state of a batch is observable as
`complete` *before* the resources are present. A lack of
resources implies an incorrect total cost for a batch. Linking
resource insertion with MJC ensures a batch may be complete if-and-only-if
the cost of the batch is accurate.