### PR TITLE
[query] Simplify Elasticsearch Dependencies

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -66,9 +66,6 @@ GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION)
 .PHONY: shadowJar
 shadowJar: $(SHADOW_JAR)
 
-$(JAR_SOURCES): $(ELASTICSEARCH_311_JAR)
-$(JAR_TEST_SOURCES): $(ELASTICSEARCH_311_JAR)
-
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_JAR): native-lib-prebuilt
 endif

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -60,16 +60,8 @@ SHADOW_TEST_JAR := build/libs/hail-all-spark-test.jar
 PYTHON_JAR := python/hail/backend/hail-all-spark.jar
 WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 EGG := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3.6.egg
-ELASTICSEARCH_311_JAR := libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar
 
 GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION) -Delasticsearch.major-version=$(ELASTIC_MAJOR_VERSION)
-
-.PHONY: elasticsearchJar
-elasticsearchJar: $(ELASTICSEARCH_311_JAR)
-
-$(ELASTICSEARCH_311_JAR):
-	@mkdir -p libs
-	curl https://storage.googleapis.com/hail-common/elasticsearch-libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar >  libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar
 
 .PHONY: shadowJar
 shadowJar: $(SHADOW_JAR)

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -215,7 +215,7 @@ dependencies {
 
     unbundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     bundled group: 'commons-codec', name: 'commons-codec', version: '1.11'
-    bundled group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
+    bundled group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
     bundled(group: 'org.apache.avro', name: 'avro', version: '1.10.2') {
         exclude group: 'com.fasterxml.jackson.core'
     }

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -16,9 +16,6 @@ plugins {
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 repositories {
-    flatDir {
-        dirs 'libs'
-    }
     mavenCentral()
     maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
 }
@@ -175,21 +172,22 @@ dependencies {
     bundled group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
     def elasticMajorVersion = System.getProperty("elasticsearch.major-version", "7")
-    if (elasticMajorVersion != "7") {
-        throw new UnsupportedOperationException("elasticsearch.major-version must be 7")
+    if (elasticMajorVersion != "7" && elasticMajorVersion != "8") {
+        throw new UnsupportedOperationException("elasticsearch.major-version must be 7 or 8")
     }
 
-    if (sparkVersion.startsWith("3.1.")) {
-        // This comes from a local libs directory, see Makefile
+    if (sparkVersion.startsWith("3.")) {
         assert(scalaMajorVersion == "2.12")
-        bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311'
-    }
-    else if (sparkVersion.startsWith("3.0.")) {
-        assert(scalaMajorVersion == "2.12")
-        bundled 'org.elasticsearch:elasticsearch-spark-30_2.12:7.13.1'
+        if (elasticMajorVersion == "8") {
+            bundled 'org.elasticsearch:elasticsearch-spark-30_2.12:8.0.0'
+        }
+        else if (elasticMajorVersion == "7") {
+            bundled 'org.elasticsearch:elasticsearch-spark-30_2.12:7.17.0'
+        }
     }
     else if (sparkVersion.startsWith("2.4.")) {
         assert(scalaMajorVersion == "2.11")
+        assert(elasticMajorVersion == "7")
         bundled 'org.elasticsearch:elasticsearch-spark-20_2.11:7.8.1'
     }
     else {


### PR DESCRIPTION
This PR drastically simplifies the hail/elasticsearch story. We no longer require any special custom built JAR from google cloud (was necessary because there was a time when Spark 3 compatible ES wasn't on Maven). Also allow ES version 7 or 8 when on Spark 3, and don't require that it's Spark 3.1