### PR TITLE
[infra] Remove hard-coded values from config.mk

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -7,6 +7,7 @@ BATCH_WORKER_IMAGE := $(DOCKER_PREFIX)/batch-worker:$(TOKEN)
 
 EXTRA_PYTHONPATH := ../hail/python:../gear:../web_common
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
+CLOUD := $(shell kubectl get secret global-config --template={{.data.cloud}} | base64 --decode)
 
 BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -31,6 +31,7 @@ cleanup_image:
 PROJECT := hail-vdc
 BENCHMARK_DOCKER_TAG := benchmark_$(shell whoami)
 BENCHMARK_REPO_BASE = $(DOCKER_PREFIX)/$(BENCHMARK_DOCKER_TAG)
+DOCKER_ROOT_IMAGE := $(shell kubectl get secret global-config --template={{.data.docker_root_image}} | base64 --decode)
 
 ifndef HAIL_WHEEL
 image_sha:

--- a/bootstrap-gateway/Makefile
+++ b/bootstrap-gateway/Makefile
@@ -5,6 +5,7 @@ include ../config.mk
 TOKEN = $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
 
 GATEWAY_IMAGE := $(DOCKER_PREFIX)/gateway:$(TOKEN)
+IP := $(shell kubectl get secret global-config --template={{.data.ip}} | base64 --decode)
 
 build:
 	$(MAKE) -C ../docker hail-ubuntu

--- a/config.mk
+++ b/config.mk
@@ -1,10 +1,5 @@
-DOCKER_PREFIX := gcr.io/hail-vdc
-DOCKER_ROOT_IMAGE := $(DOCKER_PREFIX)/ubuntu:20.04
-DOMAIN := hail.is
-INTERNAL_IP := 10.128.0.57
-IP := 35.188.91.25
-KUBERNETES_SERVER_URL := https://104.198.230.143
-CLOUD := gcp
+DOCKER_PREFIX := $(shell kubectl get secret global-config --template={{.data.docker_prefix}} | base64 --decode)
+DOMAIN := $(shell kubectl get secret global-config --template={{.data.domain}} | base64 --decode)
 
 ifeq ($(NAMESPACE),default)
 SCOPE = deploy

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -5,6 +5,7 @@ include ../config.mk
 TOKEN = $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
 
 GATEWAY_IMAGE := $(DOCKER_PREFIX)/gateway:$(TOKEN)
+IP := $(shell kubectl get secret global-config --template={{.data.ip}} | base64 --decode)
 
 build:
 	$(MAKE) -C ../docker hail-ubuntu

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -7,29 +7,6 @@ fi
 
 source $HAIL/devbin/functions.sh
 
-render_config_mk() {
-    DOCKER_PREFIX=$(get_global_config_field docker_prefix)
-    INTERNAL_IP=$(get_global_config_field internal_ip)
-    IP=$(get_global_config_field ip)
-    DOMAIN=$(get_global_config_field domain)
-    CLOUD=$(get_global_config_field cloud)
-    cat >$HAIL/config.mk <<EOF
-DOCKER_PREFIX := $DOCKER_PREFIX
-INTERNAL_IP := $INTERNAL_IP
-IP := $IP
-DOMAIN := $DOMAIN
-CLOUD := $CLOUD
-
-ifeq (\$(NAMESPACE),default)
-SCOPE = deploy
-DEPLOY = true
-else
-SCOPE = dev
-DEPLOY = false
-endif
-EOF
-}
-
 copy_images() {
     cd $HAIL/docker/third-party
     DOCKER_PREFIX=$(get_global_config_field docker_prefix)
@@ -72,7 +49,6 @@ generate_ssl_certs() {
 deploy_unmanaged() {
     make -C $HAIL/hail python/hailtop/hail_version
 
-    render_config_mk
     copy_images
     generate_ssl_certs
 

--- a/internal-gateway/Makefile
+++ b/internal-gateway/Makefile
@@ -5,6 +5,7 @@ include ../config.mk
 TOKEN = $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
 
 INTERNAL_GATEWAY_IMAGE := $(DOCKER_PREFIX)/internal-gateway:$(TOKEN)
+INTERNAL_IP := $(shell kubectl get secret global-config --template={{.data.internal_ip}} | base64 --decode)
 
 build:
 	$(MAKE) -C ../docker hail-ubuntu


### PR DESCRIPTION
I was hoping that a greater restructure would lead to a more elegant solution, but after so many footguns it just felt worth making this change. The main point is shelling out in the Makefiles to ask Kubernetes directly for what the global config values are instead of hard-coding them. Specifically, the changes are:

- `KUBERNETES_SERVER_URL` was simply not used anymore in the Makefiles so I deleted it.
- `DOCKER_ROOT_IMAGE`, `INTERNAL_IP`, `IP` and `CLOUD` were only used in a couple Makefiles so I moved the `kubectl` invocation into where they're used so that Makefiles that don't depend on those variables won't incur the cost of querying them
- `DOCKER_PREFIX` and `DOMAIN` were used pretty widely, so I kept them in config.mk because most Makefiles will need to query those values anyway. The added startup time for `make deploy` feels pretty insignificant.
- With this change in place, there's no need to render config.mk anymore so I deleted the shell function for doing so