### PR TITLE
[query] Properly handling pandas strings which can be NA 

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3363,7 +3363,7 @@ class Table(ExprContainer):
                         fixed_val = cur_val.item()
                     else:
                         fixed_val = None
-                elif isinstance(df[field].dtype, pandas.StringDtype) and pandas.isna(cur_val): # No NaN to worry about
+                elif isinstance(df[field].dtype, pandas.StringDtype) and pandas.isna(cur_val):  # No NaN to worry about
                     fixed_val = None
                 elif isinstance(cur_val, np.number):
                     fixed_val = cur_val.item()

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3363,6 +3363,8 @@ class Table(ExprContainer):
                         fixed_val = cur_val.item()
                     else:
                         fixed_val = None
+                elif isinstance(df[field].dtype, pandas.StringDtype) and pandas.isna(cur_val): # No NaN to worry about
+                    fixed_val = None
                 elif isinstance(cur_val, np.number):
                     fixed_val = cur_val.item()
                 else:

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -765,14 +765,15 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         df = pd.DataFrame({
             "x": pd.Series([None, 1, 2, None, 4], dtype=pd.Int64Dtype()),
             "y": pd.Series([None, 1, 2, None, 4], dtype=pd.Int32Dtype()),
-            "z": pd.Series([np.nan, 1.0, 3.0, 4.0, np.nan])
+            "z": pd.Series([np.nan, 1.0, 3.0, 4.0, np.nan]),
+            "s": pd.Series([None, "cat", None, "fox", "dog"], dtype=pd.StringDtype())
         })
         ht = hl.Table.from_pandas(df)
         collected = ht.collect()
 
         assert [s.x for s in collected] == [None, 1, 2, None, 4]
-
         assert [s.y for s in collected] == [None, 1, 2, None, 4]
+        assert [s.s for s in collected] == [None, "cat", None, "fox", "dog"]
 
         assert np.isnan(collected[0].z)
         assert np.isnan(collected[-1].z)


### PR DESCRIPTION
As far as I can tell, pandas integers and strings specifically can be this special pandas `NA` value, whereas floats use `NaN` for missing and `object` just uses `None`. Here I specifically watch out for these special pandas values and turn them into `None`s. 