### PR TITLE
[infra] Double cores and memory for GCP database

### DIFF
--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -216,9 +216,9 @@ resource "google_sql_database_instance" "db" {
   depends_on = [google_service_networking_connection.private_vpc_connection]
 
   settings {
-    # Second-generation instance tiers are based on the machine
-    # type. See argument reference below.
-    tier = "db-n1-standard-1"
+    # 4 vCPU and 15360 MB
+    # https://cloud.google.com/sql/docs/mysql/instance-settings
+    tier = "db-custom-4-15360"
 
     ip_configuration {
       ipv4_enabled = false


### PR DESCRIPTION
I currently have a PR up to change the Azure database so I'll make the equivalent change there.

If you click into the link I included you'll see that the naming scheme we're currently using is now considered Legacy, and they're moving to a scheme that doesn't use machine type, instead just resource specs