### PR TITLE
[batch] Add option to show docker output when building images

### DIFF
--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -3,7 +3,7 @@ import sys
 import os
 from typing import Optional, List
 
-from ..utils import secret_alnum_string, sync_check_shell
+from ..utils import secret_alnum_string, sync_check_exec
 
 
 def build_python_image(fullname: str,
@@ -82,15 +82,15 @@ RUN pip install --upgrade --no-cache-dir -r requirements.txt && \
     python3 -m pip check
 ''')
 
-            sync_check_exec('docker', 'build', '-t', fullname, docker_path, capture_output=False)
+            sync_check_exec('docker', 'build', '-t', fullname, docker_path, capture_output=(not show_docker_output))
             print(f'finished building image {fullname}')
         else:
-            sync_check_exec('docker', 'pull', base_image, capture_output=False)
-            sync_check_exec('docker', 'tag', base_image, fullname, capture_output=False)
+            sync_check_exec('docker', 'pull', base_image, capture_output=(not show_docker_output))
+            sync_check_exec('docker', 'tag', base_image, fullname, capture_output=(not show_docker_output))
             print(f'finished pulling image {fullname}')
 
         if '/' in fullname:
-            sync_check_shell('docker', 'push', fullname, capture_output=False)
+            sync_check_shell('docker', 'push', fullname, capture_output=(not show_docker_output))
             print(f'finished pushing image {fullname}')
     finally:
         shutil.rmtree(docker_path, ignore_errors=True)

--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -10,6 +10,7 @@ def build_python_image(fullname: str,
                        requirements: Optional[List[str]] = None,
                        python_version: Optional[str] = None,
                        _tmp_dir: str = '/tmp',
+                       *,
                        show_docker_output: bool = False) -> str:
     """
     Build a new Python image with dill and the specified pip packages installed.
@@ -81,15 +82,15 @@ RUN pip install --upgrade --no-cache-dir -r requirements.txt && \
     python3 -m pip check
 ''')
 
-            sync_check_shell(f'docker build -t {fullname} {docker_path}', inherit_std_out_err=show_docker_output)
+            sync_check_exec('docker', 'build', '-t', fullname, docker_path, capture_output=False)
             print(f'finished building image {fullname}')
         else:
-            sync_check_shell(f'docker pull {base_image}', inherit_std_out_err=show_docker_output)
-            sync_check_shell(f'docker tag {base_image} {fullname}', inherit_std_out_err=show_docker_output)
+            sync_check_exec('docker', 'pull', base_image, capture_output=False)
+            sync_check_exec('docker', 'tag', base_image, fullname, capture_output=False)
             print(f'finished pulling image {fullname}')
 
         if '/' in fullname:
-            sync_check_shell(f'docker push {fullname}', inherit_std_out_err=show_docker_output)
+            sync_check_shell('docker', 'push', fullname, capture_output=False)
             print(f'finished pushing image {fullname}')
     finally:
         shutil.rmtree(docker_path, ignore_errors=True)

--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -3,13 +3,14 @@ import sys
 import os
 from typing import Optional, List
 
-from ..utils import secret_alnum_string, sync_check_shell_output
+from ..utils import secret_alnum_string, sync_check_shell
 
 
 def build_python_image(fullname: str,
                        requirements: Optional[List[str]] = None,
                        python_version: Optional[str] = None,
-                       _tmp_dir: str = '/tmp') -> str:
+                       _tmp_dir: str = '/tmp',
+                       show_docker_output: bool = False) -> str:
     """
     Build a new Python image with dill and the specified pip packages installed.
 
@@ -36,6 +37,8 @@ def build_python_image(fullname: str,
         current version of Python that is running.
     _tmp_dir:
         Location to place local temporary files used while building the image.
+    show_docker_output:
+        Print the output from Docker when building / pushing the image.
 
     Returns
     -------
@@ -78,15 +81,15 @@ RUN pip install --upgrade --no-cache-dir -r requirements.txt && \
     python3 -m pip check
 ''')
 
-            sync_check_shell_output(f'docker build -t {fullname} {docker_path}')
+            sync_check_shell(f'docker build -t {fullname} {docker_path}', inherit_std_out_err=show_docker_output)
             print(f'finished building image {fullname}')
         else:
-            sync_check_shell_output(f'docker pull {base_image}')
-            sync_check_shell_output(f'docker tag {base_image} {fullname}')
+            sync_check_shell(f'docker pull {base_image}', inherit_std_out_err=show_docker_output)
+            sync_check_shell(f'docker tag {base_image} {fullname}', inherit_std_out_err=show_docker_output)
             print(f'finished pulling image {fullname}')
 
         if '/' in fullname:
-            sync_check_shell_output(f'docker push {fullname}')
+            sync_check_shell(f'docker push {fullname}', inherit_std_out_err=show_docker_output)
             print(f'finished pushing image {fullname}')
     finally:
         shutil.rmtree(docker_path, ignore_errors=True)

--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -90,7 +90,7 @@ RUN pip install --upgrade --no-cache-dir -r requirements.txt && \
             print(f'finished pulling image {fullname}')
 
         if '/' in fullname:
-            sync_check_shell('docker', 'push', fullname, capture_output=(not show_docker_output))
+            sync_check_exec('docker', 'push', fullname, capture_output=(not show_docker_output))
             print(f'finished pushing image {fullname}')
     finally:
         shutil.rmtree(docker_path, ignore_errors=True)

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -14,7 +14,7 @@ from .utils import (
     retry_all_errors_n_times, Timings)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
-    sync_check_shell, sync_check_shell_output, sync_check_exec, sync_check_exec_output)
+    sync_check_shell, sync_check_shell_output, sync_check_exec)
 from .tqdm import tqdm, TqdmDisableOption
 from .rates import (
     rate_cpu_hour_to_mcpu_msec, rate_gib_hour_to_mib_msec, rate_gib_month_to_mib_msec,
@@ -40,7 +40,6 @@ __all__ = [
     'sync_check_shell',
     'sync_check_shell_output',
     'sync_check_exec',
-    'sync_check_exec_output',
     'bounded_gather',
     'grouped',
     'is_transient_error',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -14,7 +14,7 @@ from .utils import (
     retry_all_errors_n_times, Timings)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
-    sync_check_shell, sync_check_shell_output)
+    sync_check_shell, sync_check_shell_output, sync_check_exec, sync_check_exec_output)
 from .tqdm import tqdm, TqdmDisableOption
 from .rates import (
     rate_cpu_hour_to_mcpu_msec, rate_gib_hour_to_mib_msec, rate_gib_month_to_mib_msec,
@@ -39,6 +39,8 @@ __all__ = [
     'check_exec_output',
     'sync_check_shell',
     'sync_check_shell_output',
+    'sync_check_exec',
+    'sync_check_exec_output',
     'bounded_gather',
     'grouped',
     'is_transient_error',

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -59,4 +59,4 @@ def sync_check_exec(command: str, *args: str, echo: bool = False, capture_output
     try:
         subprocess.run(command_args, check=True, capture_output=capture_output)
     except subprocess.CalledProcessError as e:
-        raise CalledProcessError(command_args, e.returncode, (e.stdout, e.stderr))
+        raise CalledProcessError(command_args, e.returncode, (e.stdout, e.stderr)) from e

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -49,8 +49,8 @@ async def check_shell_output(script: str, echo: bool = False) -> Tuple[bytes, by
     return await check_exec_output('/bin/bash', '-c', script, echo=echo)
 
 
-async def check_shell(script: str, echo: bool = False, inherit_std_out_err: bool = False) -> None:
-    if inherit_std_out_err:
+async def check_shell(script: str, echo: bool = False, capture_output: bool = False) -> None:
+    if capture_output:
         await check_exec_inherit_output_streams('/bin/bash', '-c', script, echo=echo)
     else:
         # Use version that collects stdout/stderr for error reporting
@@ -61,11 +61,12 @@ def sync_check_exec_output(command: str, *args: str, echo: bool = False) -> Tupl
     return async_to_blocking(check_exec_output(command, *args, echo=echo))
 
 
-def sync_check_exec(command: str, *args: str,echo: bool = False):
-    sync_check_exec_output(command, *args, echo=echo)
+def sync_check_exec(command: str, *args: str, echo: bool = False, capture_output: bool = True):
+    if capture_output:
+        check_exec_inherit_output_streams(command, *args, echo=echo, capture_output=capture_output)
 
 
-def sync_check_shell_output(script: str, echo=False) -> Tuple[bytes, bytes]:
+def sync_check_shell_output(script: str, echo: bool = False) -> Tuple[bytes, bytes]:
     return async_to_blocking(check_shell_output(script, echo))
 
 

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -52,11 +52,10 @@ def sync_check_shell(script: str, echo=False) -> None:
     sync_check_shell_output(script, echo)
 
 
-def sync_check_exec(command: str, *args: str, echo: bool = False, capture_output: bool = False) -> None:
-    command_args = [command, *args]
+def sync_check_exec(*command_args: str, echo: bool = False, capture_output: bool = False) -> None:
     if echo:
         print(command_args)
     try:
         subprocess.run(command_args, check=True, capture_output=capture_output)
     except subprocess.CalledProcessError as e:
-        raise CalledProcessError(command_args, e.returncode, (e.stdout, e.stderr)) from e
+        raise CalledProcessError(list(command_args), e.returncode, (e.stdout, e.stderr)) from e

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -57,6 +57,14 @@ async def check_shell(script: str, echo: bool = False, inherit_std_out_err: bool
         await check_shell_output(script, echo=echo)
 
 
+def sync_check_exec_output(command: str, *args: str, echo: bool = False) -> Tuple[bytes, bytes]:
+    return async_to_blocking(check_exec_output(command, *args, echo=echo))
+
+
+def sync_check_exec(command: str, *args: str,echo: bool = False):
+    sync_check_exec_output(command, *args, echo=echo)
+
+
 def sync_check_shell_output(script: str, echo=False) -> Tuple[bytes, bytes]:
     return async_to_blocking(check_shell_output(script, echo))
 

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Optional
+from typing import Tuple, List
 import asyncio
 import subprocess
 

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -51,6 +51,7 @@ def sync_check_shell_output(script: str, echo=False) -> Tuple[bytes, bytes]:
 def sync_check_shell(script: str, echo=False) -> None:
     sync_check_shell_output(script, echo)
 
+
 def sync_check_exec(command: str, *args: str, echo: bool = False, capture_output: bool = False) -> Optional[Tuple[str, str]]:
     command_args = [command, *args]
     if echo:

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -52,7 +52,7 @@ def sync_check_shell(script: str, echo=False) -> None:
     sync_check_shell_output(script, echo)
 
 
-def sync_check_exec(command: str, *args: str, echo: bool = False, capture_output: bool = False) -> Optional[Tuple[str, str]]:
+def sync_check_exec(command: str, *args: str, echo: bool = False, capture_output: bool = False) -> None:
     command_args = [command, *args]
     if echo:
         print(command_args)


### PR DESCRIPTION
This adds support to optionally view the docker output in `build_python_image`. I'm not sure what our general strategy is for adding inputs to user-facing functions. I tried to maintain backwards compatibility, but it feels very weird and similarly wrong to put a normal parameter after an underscore parameter. I feel like it would be best to have `_tmp_dir` be keyword-only. That would also technically be breaking, but does the underscore prefix relinquish us from that responsibility?