### PR TITLE
[infra] Install skopeo on bootstrap vm

### DIFF
--- a/infra/install_bootstrap_dependencies.sh
+++ b/infra/install_bootstrap_dependencies.sh
@@ -3,8 +3,13 @@ echo 'export HAIL=$HOME/hail' >> ~/.profile
 echo 'source $HAIL/devbin/functions.sh' >> ~/.profile
 umask 022
 
+# Necessary to install Skopeo on 20.04 (can be removed on 20.10)
+. /etc/os-release
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+
 sudo apt update
-sudo apt install -y docker.io python3-pip openjdk-8-jre-headless jq
+sudo apt install -y docker.io python3-pip openjdk-8-jre-headless jq skopeo
 sudo snap install --classic kubectl
 sudo usermod -a -G docker $USER
 


### PR DESCRIPTION
Allows `skopeo` to be used instead of docker when copying third-party images, which should substantially speed up the bootstrap process.