### PR TITLE
[ci] use two-level header for more succinct table

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -72,7 +72,6 @@ async def pr_config(app, pr: PR) -> PRConfig:
     build_state = pr.build_state if await pr.authorized(app['dbpool']) else 'unauthorized'
     if build_state is None and batch_id is not None:
         build_state = 'building'
-
     return {
         'number': pr.number,
         'title': pr.title,

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -72,6 +72,7 @@ async def pr_config(app, pr: PR) -> PRConfig:
     build_state = pr.build_state if await pr.authorized(app['dbpool']) else 'unauthorized'
     if build_state is None and batch_id is not None:
         build_state = 'building'
+
     return {
         'number': pr.number,
         'title': pr.title,
@@ -97,6 +98,7 @@ class WatchedBranchConfig(TypedDict):
     deploy_state: Optional[str]
     repo: str
     prs: List[PRConfig]
+    gh_status_names: Set[str]
 
 
 async def watched_branch_config(app, wb: WatchedBranch, index: int) -> WatchedBranchConfig:
@@ -105,6 +107,11 @@ async def watched_branch_config(app, wb: WatchedBranch, index: int) -> WatchedBr
     else:
         pr_configs = []
     # FIXME recent deploy history
+    gh_status_names = {
+        k
+        for pr in pr_configs
+        for k in pr['gh_statuses'].keys()
+    }
     return {
         'index': index,
         'branch': wb.branch.short_str(),
@@ -114,6 +121,7 @@ async def watched_branch_config(app, wb: WatchedBranch, index: int) -> WatchedBr
         'deploy_state': wb.deploy_state,
         'repo': wb.branch.repo.short_str(),
         'prs': pr_configs,
+        'gh_status_names': gh_status_names,
     }
 
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -106,11 +106,7 @@ async def watched_branch_config(app, wb: WatchedBranch, index: int) -> WatchedBr
     else:
         pr_configs = []
     # FIXME recent deploy history
-    gh_status_names = {
-        k
-        for pr in pr_configs
-        for k in pr['gh_statuses'].keys()
-    }
+    gh_status_names = {k for pr in pr_configs for k in pr['gh_statuses'].keys()}
     return {
         'index': index,
         'branch': wb.branch.short_str(),

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -38,7 +38,7 @@
       </td>
       {% for name in wb.gh_status_names %}
       <td>{{ pr['gh_statuses'][name] | default("") }}</td>
-      {% endfor $}
+      {% endfor %}
       <td>
         {{ pr.labels|join(", ") }}
       </td>

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -37,7 +37,7 @@
         {% endif %}
       </td>
       {% for name in wb.gh_status_names %}
-      <td>pr['gh_statuses'][name] | default("")(</td>
+      <td>{{ pr['gh_statuses'][name] | default("") }}</td>
       {% endfor $}
       <td>
         {{ pr.labels|join(", ") }}

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -15,7 +15,7 @@
     <tr>
       {% for name in wb.gh_status_names %}
       <th>{{ name }}</th>
-      {% endfor $}
+      {% endfor %}
     </tr>
   </thead>
   <tbody>

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -4,13 +4,18 @@
   <table id="{{ id }}" class="data-table">
   <thead>
     <tr>
-      <th>PR</th>
-      <th>Build State</th>
-      <th>Github Statuses</th>
-      <th>Labels</th>
-      <th>Branch</th>
-      <th>Review State</th>
-      <th>Author</th>
+      <th rowspan="2">PR</th>
+      <th rowspan="2">Build State</th>
+      <th colspan="{{ wb.gh_status_names | length }}">GitHub Statuses</th>
+      <th rowspan="2">Labels</th>
+      <th rowspan="2">Branch</th>
+      <th rowspan="2">Review State</th>
+      <th rowspan="2">Author</th>
+    </tr>
+    <tr>
+      {% for name in wb.gh_status_names %}
+      <th>{{ name }}</th>
+      {% endfor $}
     </tr>
   </thead>
   <tbody>
@@ -31,13 +36,9 @@
           *
         {% endif %}
       </td>
-      <td>
-        <ol>
-          {% for context, status in pr['gh_statuses'].items() %}
-          <li>{{ context }}: {{ status }}</li>
-          {% endfor %}
-        </ol>
-      </td>
+      {% for name in wb.gh_status_names %}
+      <td>pr['gh_statuses'][name] | default("")(</td>
+      {% endfor $}
       <td>
         {{ pr.labels|join(", ") }}
       </td>


### PR DESCRIPTION
The margins around the list are kind of annoying and make the table really big.

An example of how two row headers look:

```
<table>
  <thead>
    <tr>
      <th rowspan="2">PR</th>
      <th rowspan="2">Build State</th>
      <th colspan="3">GitHub Statuses</th>
      <th rowspan="2">Labels</th>
      <th rowspan="2">Branch</th>
      <th rowspan="2">Review State</th>
      <th rowspan="2">Author</th>
    </tr>
    <tr>
      <th>gcp ci</th>
      <th>aws ci</th>
      <th>azure ci</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>123</td>
      <td>failing</td>
      <td>fail</td>
      <td>success</td>
      <td>fail</td>
      <td></td>
      <td>my-branch</td>
      <td>approved</td>
      <td>danking</td>
    </tr>
  </tbody>
</table>
```

<img width="718" alt="Screen Shot 2022-03-02 at 12 05 19 PM" src="https://user-images.githubusercontent.com/106194/156411331-0541f8b5-3255-44e3-83b3-f2838f449b92.png">
