### PR TITLE
[lowering] lower vcf export 

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -267,7 +267,7 @@ class LocalBackend(Py4JBackend):
             name, dest_reference_genome)
 
     def parse_vcf_metadata(self, path):
-        return json.loads(self._jhc.pyParseVCFMetadataJSON(self.fs._jfs, path))
+        return json.loads(self._jhc.pyParseVCFMetadataJSON(self._jbackend.fs(), path))
 
     def index_bgen(self, files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci):
         self._jbackend.pyIndexBgen(files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci)

--- a/hail/python/hail/fs/local_fs.py
+++ b/hail/python/hail/fs/local_fs.py
@@ -1,7 +1,5 @@
-from typing import List, BinaryIO
-import gzip
-import io
 import os
+from typing import List
 from shutil import copy2, rmtree
 
 from .fs import FS
@@ -12,26 +10,14 @@ class LocalFS(FS):
     def __init__(self):
         pass
 
-    def open(self, path: str, mode: str = 'r', buffer_size: int = 0):
-        if mode not in ('r', 'rb', 'w', 'wb'):
-            raise ValueError(f'Unsupported mode: {repr(mode)}')
-
-        strm: BinaryIO
-        if mode[0] == 'r':
-            strm = open(path, 'rb')
-        else:
-            assert mode[0] == 'w'
+    def open(self, path: str, mode: str = 'r', buffer_size: int = -1):
+        if 'w' in mode:
             try:
-                strm = open(path, 'wb')
+                return open(path, mode, buffering=buffer_size)
             except FileNotFoundError:
                 os.makedirs(os.path.dirname(path))
-                strm = open(path, 'wb')
-
-        if path[-3:] == '.gz' or path[-4:] == '.bgz':
-            strm = gzip.GzipFile(fileobj=strm, mode=mode)  # type: ignore # GzipFile should be a BinaryIO
-        if 'b' not in mode:
-            strm = io.TextIOWrapper(strm, encoding='utf-8')  # type: ignore # TextIOWrapper should be a BinaryIO
-        return strm
+                return open(path, mode, buffering=buffer_size)
+        return open(path, mode, buffering=buffer_size)
 
     def copy(self, src: str, dest: str):
         dst_w_file = dest

--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -1,6 +1,5 @@
 from typing import List, AsyncContextManager, BinaryIO
 import asyncio
-import gzip
 import io
 import nest_asyncio
 
@@ -175,8 +174,6 @@ class RouterFS(FS):
             assert mode[0] == 'w'
             strm = SyncWritableStream(async_to_blocking(self.afs.create(path)), path)
 
-        if path[-3:] == '.gz' or path[-4:] == '.bgz':
-            strm = gzip.GzipFile(fileobj=strm, mode=mode)
         if 'b' not in mode:
             strm = io.TextIOWrapper(strm, encoding='utf-8')  # type: ignore # typeshed is wrong, this *is* an IOBase
         return strm

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -84,7 +84,6 @@ class VCFTests(unittest.TestCase):
             mt = hl.import_vcf(resource('malformed.vcf'))
             mt._force_count_rows()
 
-    @fails_service_backend(reason="Need to change some service backend errors into FatalError")
     def test_not_identical_headers(self):
         t = new_temp_file(extension='vcf')
         mt = hl.import_vcf(resource('sample.vcf'))

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -20,7 +20,6 @@ tearDownModule = stopTestHailContext
 class Tests(unittest.TestCase):
     @unittest.skipIf('HAIL_TEST_SKIP_PLINK' in os.environ, 'Skipping tests requiring plink')
     @fails_service_backend()
-    @fails_local_backend()
     def test_impute_sex_same_as_plink(self):
         ds = hl.import_vcf(resource('x-chromosome.vcf'))
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -144,9 +144,9 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def addEncodedLiteral(encodedLiteral: EncodedLiteral) = ecb.addEncodedLiteral(encodedLiteral)
 
-  def getPType(t: PType): Code[PType] = ecb.getPType(t)
+  def getPType[T <: PType : TypeInfo](t: T): Code[T] = ecb.getPType(t)
 
-  def getType(t: Type): Code[Type] = ecb.getType(t)
+  def getType[T <: Type : TypeInfo](t: T): Code[T] = ecb.getType(t)
 
   def newEmitMethod(name: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] =
     ecb.newEmitMethod(name, argsInfo, returnInfo)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -747,6 +747,7 @@ object PartitionWriter {
     override val typeHints = ShortTypeHints(List(
       classOf[PartitionNativeWriter],
       classOf[TableTextPartitionWriter],
+      classOf[VCFPartitionWriter],
       classOf[AbstractTypedCodecSpec],
       classOf[TypedCodecSpec]), typeHintFieldName = "name"
     ) + BufferSpec.shortTypeHints
@@ -765,6 +766,7 @@ object MetadataWriter {
       classOf[TableSpecWriter],
       classOf[RelationalWriter],
       classOf[TableTextFinalizer],
+      classOf[VCFExportFinalizer],
       classOf[RVDSpecMaker],
       classOf[AbstractTypedCodecSpec],
       classOf[TypedCodecSpec]),

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -13,19 +13,22 @@ import is.hail.io.fs.FS
 import is.hail.io.gen.{ExportBGEN, ExportGen}
 import is.hail.io.index.StagedIndexWriter
 import is.hail.io.plink.ExportPlink
-import is.hail.io.vcf.ExportVCF
+import is.hail.io.vcf.{ExportVCF, TabixVCF}
 import is.hail.linalg.BlockMatrix
 import is.hail.rvd.{IndexSpec, RVDPartitioner, RVDSpecMaker}
 import is.hail.types.encoded.{EBaseStruct, EBlockMatrixNDArray, EType}
-import is.hail.types.physical.stypes.{EmitType, SCode}
+import is.hail.types.physical.stypes.{EmitType, SValue}
 import is.hail.types.physical.stypes.interfaces._
+import is.hail.types.physical.stypes.primitives._
 import is.hail.types.physical.{PBooleanRequired, PCanonicalBaseStruct, PCanonicalString, PCanonicalStruct, PInt64, PStruct, PType}
 import is.hail.types.virtual._
 import is.hail.types._
-import is.hail.types.physical.stypes.concrete.SStackStruct
+import is.hail.types.physical.stypes.concrete.{SJavaString, SJavaArrayString, SJavaArrayStringValue, SStackStruct}
+import is.hail.types.physical.stypes.interfaces.{SIndexableValue, SBaseStructValue}
 import is.hail.types.physical.stypes.primitives.{SBooleanValue, SInt64Value}
 import is.hail.utils._
 import is.hail.utils.richUtils.ByteTrackingOutputStream
+import is.hail.variant.{ReferenceGenome, Call}
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods
 import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
@@ -385,7 +388,413 @@ case class MatrixVCFWriter(
   metadata: Option[VCFMetadata] = None,
   tabix: Boolean = false
 ) extends MatrixWriter {
-  def apply(ctx: ExecuteContext, mv: MatrixValue): Unit = ExportVCF(ctx, mv, path, append, exportType, metadata, tabix)
+  def apply(ctx: ExecuteContext, mv: MatrixValue): Unit = {
+    val appendStr = getAppendHeaderValue(ctx.fs)
+    ExportVCF(ctx, mv, path, appendStr, exportType, metadata, tabix)
+  }
+
+  override def canLowerEfficiently: Boolean = exportType != ExportType.PARALLEL_COMPOSABLE
+  override def lower(colsFieldName: String, entriesFieldName: String, colKey: IndexedSeq[String],
+      ctx: ExecuteContext, ts: TableStage, t: TableIR, r: RTable, relationalLetsAbove: Map[String, IR]): IR = {
+    require(exportType != ExportType.PARALLEL_COMPOSABLE)
+
+    val tm = MatrixType.fromTableType(t.typ, colsFieldName, entriesFieldName, colKey)
+    tm.requireRowKeyVariant()
+    tm.requireColKeyString()
+    ExportVCF.checkFormatSignature(tm.entryType)
+
+    val ext = ctx.fs.getCodecExtension(path)
+
+    val folder = if (exportType == ExportType.CONCATENATED)
+      ctx.createTmpPath("write-vcf-concatenated")
+    else
+      path
+
+    val appendStr = getAppendHeaderValue(ctx.fs)
+
+    val writeHeader = exportType == ExportType.PARALLEL_HEADER_IN_SHARD
+    val partAppend = appendStr.filter(_ => writeHeader)
+    val partMetadata = metadata.filter(_ => writeHeader)
+    val lineWriter = VCFPartitionWriter(tm, entriesFieldName, writeHeader = exportType == ExportType.PARALLEL_HEADER_IN_SHARD,
+      partAppend, partMetadata, tabix && exportType != ExportType.CONCATENATED)
+
+    ts.mapContexts { oldCtx =>
+      val d = digitsNeeded(ts.numPartitions)
+      val partFiles = Literal(TArray(TString), Array.tabulate(ts.numPartitions)(i => s"$folder/${ partFile(d, i) }$ext").toFastIndexedSeq)
+
+      zip2(oldCtx, ToStream(partFiles), ArrayZipBehavior.AssertSameLength) { (ctxElt, pf) =>
+        MakeStruct(FastSeq(
+          "oldCtx" -> ctxElt,
+          "partFile" -> pf))
+      }
+    }(GetField(_, "oldCtx")).mapCollectWithContextsAndGlobals(relationalLetsAbove) { (rows, ctxRef) =>
+      val ctx = MakeStruct(FastSeq(
+        "cols" -> GetField(ts.globals, colsFieldName),
+        "partFile" -> GetField(ctxRef, "partFile")))
+      WritePartition(rows, ctx, lineWriter)
+    }{ (parts, globals) =>
+      val ctx = MakeStruct(FastSeq("cols" -> GetField(globals, colsFieldName), "partFiles" -> parts))
+      val commit = VCFExportFinalizer(tm, path, appendStr, metadata, exportType, tabix)
+      Begin(FastIndexedSeq(WriteMetadata(ctx, commit)))
+    }
+  }
+
+  private def getAppendHeaderValue(fs: FS): Option[String] = append.map { f =>
+    using(fs.open(f)) { s =>
+      val sb = new StringBuilder
+      scala.io.Source.fromInputStream(s)
+        .getLines()
+        .filterNot(_.isEmpty)
+        .foreach { line =>
+          sb.append(line)
+          sb += '\n'
+        }
+      sb.result()
+    }
+  }
+}
+
+case class VCFPartitionWriter(typ: MatrixType, entriesFieldName: String, writeHeader: Boolean,
+    append: Option[String], metadata: Option[VCFMetadata], tabix: Boolean) extends PartitionWriter {
+  val ctxType: Type = TStruct("cols" -> TArray(typ.colType), "partFile" -> TString)
+
+  if (typ.rowType.hasField("info")) {
+    typ.rowType.field("info").typ match {
+      case _: TStruct =>
+      case t =>
+        warn(s"export_vcf found row field 'info' of type $t, but expected type 'Struct'. Emitting no INFO fields.")
+    }
+  } else {
+    warn(s"export_vcf found no row field 'info'. Emitting no INFO fields.")
+  }
+
+  val formatFieldOrder: Array[Int] = typ.entryType.fieldIdx.get("GT") match {
+    case Some(i) => (i +: typ.entryType.fields.filter(fd => fd.name != "GT").map(_.index)).toArray
+    case None => typ.entryType.fields.indices.toArray
+  }
+  val formatFieldString = formatFieldOrder.map(i => typ.entryType.fields(i).name).mkString(":")
+  val missingFormatStr = if (typ.entryType.size > 0 && typ.entryType.types(formatFieldOrder(0)) == TCall)
+    "./."
+    else
+      "."
+
+  val locusIdx = typ.rowType.fieldIdx("locus")
+  val allelesIdx = typ.rowType.fieldIdx("alleles")
+  val (idExists, idIdx) = ExportVCF.lookupVAField(typ.rowType, "rsid", "ID", Some(TString))
+  val (qualExists, qualIdx) = ExportVCF.lookupVAField(typ.rowType, "qual", "QUAL", Some(TFloat64))
+  val (filtersExists, filtersIdx) = ExportVCF.lookupVAField(typ.rowType, "filters", "FILTERS", Some(TSet(TString)))
+  val (infoExists, infoIdx) = ExportVCF.lookupVAField(typ.rowType, "info", "INFO", None)
+
+  def returnType: Type = TString
+  def unionTypeRequiredness(r: TypeWithRequiredness, ctxType: TypeWithRequiredness, streamType: RIterable): Unit = {
+    r.union(ctxType.required)
+    r.union(streamType.required)
+  }
+
+  final def consumeStream(ctx: ExecuteContext, cb: EmitCodeBuilder, stream: StreamProducer,
+      context: EmitCode, region: Value[Region]): IEmitCode = {
+    val mb = cb.emb
+    context.toI(cb).map(cb) { case ctx: SBaseStructValue =>
+      val filename = ctx.loadField(cb, "partFile").get(cb, "partFile can't be missing").asString.loadString(cb)
+
+      val os = cb.memoize(cb.emb.create(filename))
+      if (writeHeader) {
+        val sampleIds = ctx.loadField(cb, "cols").get(cb).asIndexable
+        val stringSampleIds = cb.memoize(Code.newArray[String](sampleIds.loadLength()))
+        sampleIds.forEachDefined(cb) { case (cb, i, colv: SBaseStructValue) =>
+          val s = colv.subset(typ.colKey: _*).loadField(cb, 0).get(cb).asString
+          cb += (stringSampleIds(i) = s.loadString(cb))
+        }
+
+        val headerStr = Code.invokeScalaObject6[TStruct, TStruct, ReferenceGenome, Option[String], Option[VCFMetadata], Array[String], String](
+          ExportVCF.getClass, "makeHeader",
+          mb.getType[TStruct](typ.rowType), mb.getType[TStruct](typ.entryType),
+          mb.getReferenceGenome(typ.referenceGenome), mb.getObject(append),
+          mb.getObject(metadata), stringSampleIds)
+        cb += os.invoke[Array[Byte], Unit]("write", headerStr.invoke[Array[Byte]]("getBytes"))
+        cb += os.invoke[Int, Unit]("write", '\n')
+      }
+
+      stream.memoryManagedConsume(region, cb) { cb =>
+        consumeElement(cb, stream.element, os, stream.elementRegion)
+      }
+
+      cb += os.invoke[Unit]("close")
+
+      if (tabix) {
+          cb += Code.invokeScalaObject2[FS, String, Unit](TabixVCF.getClass, "apply", cb.emb.getFS, filename)
+      }
+
+      SJavaString.construct(cb, filename)
+    }
+  }
+
+  def consumeElement(cb: EmitCodeBuilder, element: EmitCode, os: Value[OutputStream], region: Value[Region]): Unit = {
+    def _writeC(cb: EmitCodeBuilder, code: Code[Int]) = { cb += os.invoke[Int, Unit]("write", code) }
+    def _writeB(cb: EmitCodeBuilder, code: Code[Array[Byte]]) = { cb += os.invoke[Array[Byte], Unit]("write", code) }
+    def _writeS(cb: EmitCodeBuilder, code: Code[String]) = { _writeB(cb, code.invoke[Array[Byte]]("getBytes")) }
+    def writeValue(cb: EmitCodeBuilder, value: SValue) = value match {
+      case v: SInt32Value => _writeS(cb, v.value.toS)
+      case v: SInt64Value =>
+        cb.ifx(v.value > Int.MaxValue || v.value <  Int.MinValue, cb._fatal(
+          "Cannot convert Long to Int if value is greater than Int.MaxValue (2^31 - 1) ",
+          "or less than Int.MinValue (-2^31). Found ", v.value.toS))
+        _writeS(cb, v.value.toS)
+      case v: SFloat32Value =>
+        cb.ifx(Code.invokeStatic1[java.lang.Float, Float, Boolean]("isNaN", v.value),
+          _writeC(cb, '.'),
+          _writeS(cb, Code.invokeScalaObject2[String, Float, String](ExportVCF.getClass, "fmtFloat", "%.6g", v.value)))
+      case v: SFloat64Value =>
+        cb.ifx(Code.invokeStatic1[java.lang.Double, Double, Boolean]("isNaN", v.value),
+          _writeC(cb, '.'),
+          _writeS(cb, Code.invokeScalaObject2[String, Double, String](ExportVCF.getClass, "fmtDouble", "%.6g", v.value)))
+      case v: SStringValue =>
+        _writeB(cb, v.toBytes(cb).loadBytes(cb))
+      case v: SCallValue =>
+        val ploidy = v.ploidy(cb)
+        val phased = v.isPhased(cb)
+        cb.ifx(ploidy.ceq(0), cb._fatal("VCF spec does not support 0-ploid calls."))
+        cb.ifx(ploidy.ceq(1) , cb._fatal("VCF spec does not support phased haploid calls."))
+        val c = v.canonicalCall(cb)
+        _writeS(cb, Code.invokeScalaObject1[Int, String](Call.getClass, "toString", c))
+      case _ =>
+        fatal(s"VCF does not support ${value.st}")
+    }
+
+    def writeIterable(cb: EmitCodeBuilder, it: SIndexableValue, delim: Int) =
+      it.forEachDefinedOrMissing(cb)({ (cb, i) =>
+        cb.ifx(i.cne(0), _writeC(cb, delim))
+        _writeC(cb, '.')
+      }, { (cb, i, value) =>
+        cb.ifx(i.cne(0), _writeC(cb, delim))
+        writeValue(cb, value)
+      })
+
+    def writeGenotype(cb: EmitCodeBuilder, gt: SBaseStructValue) = {
+      val end = cb.newLocal[Int]("lastDefined", -1)
+      val Lend = CodeLabel()
+      formatFieldOrder.zipWithIndex.reverse.foreach { case (idx, pos) =>
+        cb.ifx(!gt.isFieldMissing(cb, idx), {
+          cb.assign(end, pos)
+          cb.goto(Lend)
+        })
+      }
+
+      cb.define(Lend)
+
+      val Lout = CodeLabel()
+
+      cb.ifx(end < 0, {
+        _writeS(cb, missingFormatStr)
+        cb.goto(Lout)
+      })
+
+      formatFieldOrder.zipWithIndex.foreach { case (idx, pos) =>
+        if (pos != 0)
+          _writeC(cb, ':')
+
+        gt.loadField(cb, idx).consume(cb, {
+          if (gt.st.fieldTypes(idx).virtualType == TCall)
+            _writeS(cb, "./.")
+          else
+            _writeC(cb, '.')
+        }, {
+          case value: SIndexableValue =>
+            writeIterable(cb, value, ',')
+          case value =>
+            writeValue(cb, value)
+        })
+
+        cb.ifx(end.ceq(pos), cb.goto(Lout))
+      }
+
+      cb.define(Lout)
+    }
+
+    def writeC(code: Code[Int]) = _writeC(cb, code)
+    def writeB(code: Code[Array[Byte]]) = _writeB(cb, code)
+    def writeS(code: Code[String]) = _writeS(cb, code)
+
+    val elt = element.toI(cb).get(cb).asBaseStruct
+    val locus = elt.loadField(cb, locusIdx).get(cb).asLocus
+    // CHROM
+    writeB(locus.contig(cb).toBytes(cb).loadBytes(cb))
+    // POS
+    writeC('\t')
+    writeS(locus.position(cb).toS)
+
+    // ID
+    writeC('\t')
+    if (idExists)
+      elt.loadField(cb, idIdx).consume(cb, writeC('.'), { case id: SStringValue =>
+        writeB(id.toBytes(cb).loadBytes(cb))
+      })
+    else
+      writeC('.')
+
+    // REF
+    writeC('\t')
+    val alleles = elt.loadField(cb, allelesIdx).get(cb).asIndexable
+    writeB(alleles.loadElement(cb, 0).get(cb).asString.toBytes(cb).loadBytes(cb))
+
+    // ALT
+    writeC('\t')
+    cb.ifx(alleles.loadLength() > 1,
+      {
+        val i = cb.newLocal[Int]("i")
+        cb.forLoop(cb.assign(i, 1), i < alleles.loadLength(), cb.assign(i, i + 1), {
+          cb.ifx(i.cne(1), writeC(','))
+          writeB(alleles.loadElement(cb, i).get(cb).asString.toBytes(cb).loadBytes(cb))
+        })
+      },
+      writeC('.'))
+
+    // QUAL
+    writeC('\t')
+    if (qualExists)
+      elt.loadField(cb, qualIdx).consume(cb, writeC('.'), { qual =>
+        writeS(Code.invokeScalaObject2[String, Double, String](ExportVCF.getClass, "fmtDouble", "%.2f", qual.asDouble.value))
+      })
+    else
+      writeC('.')
+
+    // FILTER
+    writeC('\t')
+    if (filtersExists)
+      elt.loadField(cb, filtersIdx).consume(cb, writeC('.'), { case filters: SIndexableValue =>
+        cb.ifx(filters.loadLength().ceq(0), writeS("PASS"), {
+          writeIterable(cb, filters, ';')
+        })
+      })
+    else
+      writeC('.')
+
+    // INFO
+    writeC('\t')
+    if (infoExists) {
+      val wroteInfo = cb.newLocal[Boolean]("wroteInfo", false)
+
+      elt.loadField(cb, infoIdx).consume(cb, { /* do nothing */ }, { case info: SBaseStructValue =>
+        var idx = 0
+        while (idx < info.st.size) {
+          val field = info.st.virtualType.fields(idx)
+          info.loadField(cb, idx).consume(cb, { /* do nothing */ }, {
+            case infoArray: SIndexableValue if infoArray.st.elementType.virtualType != TBoolean =>
+              cb.ifx(infoArray.loadLength() > 0, {
+                cb.ifx(wroteInfo, writeC(';'))
+                writeS(field.name)
+                writeC('=')
+                writeIterable(cb, infoArray, ',')
+                cb.assign(wroteInfo, true)
+              })
+            case infoFlag: SBooleanValue =>
+              cb.ifx(infoFlag.value, {
+                cb.ifx(wroteInfo, writeC(';'))
+                writeS(field.name)
+                cb.assign(wroteInfo, true)
+              })
+            case info =>
+              cb.ifx(wroteInfo, writeC(';'))
+              writeS(field.name)
+              writeC('=')
+              writeValue(cb, info)
+              cb.assign(wroteInfo, true)
+          })
+          idx += 1
+        }
+      })
+
+      cb.ifx(!wroteInfo, writeC('.'))
+    } else {
+      writeC('.')
+    }
+
+    // FORMAT
+    val genotypes = elt.loadField(cb, entriesFieldName).get(cb).asIndexable
+    cb.ifx(genotypes.loadLength() > 0, {
+      writeC('\t')
+      writeS(formatFieldString)
+      genotypes.forEachDefinedOrMissing(cb)({ (cb, _) =>
+        _writeC(cb, '\t')
+        _writeS(cb, missingFormatStr)
+      }, { case (cb, _, gt: SBaseStructValue) =>
+        _writeC(cb, '\t')
+        writeGenotype(cb, gt)
+      })
+    })
+
+    writeC('\n')
+  }
+}
+
+case class VCFExportFinalizer(typ: MatrixType, outputPath: String, append: Option[String],
+    metadata: Option[VCFMetadata], exportType: String, tabix: Boolean) extends MetadataWriter {
+  def annotationType: Type = TStruct("cols" -> TArray(typ.colType), "partFiles" -> TArray(TString))
+  private def header(cb: EmitCodeBuilder, annotations: SBaseStructValue): Code[String] = {
+    val mb = cb.emb
+    val sampleIds = annotations.loadField(cb, "cols").get(cb).asIndexable
+    val stringSampleIds = cb.memoize(Code.newArray[String](sampleIds.loadLength()))
+    sampleIds.forEachDefined(cb) { case (cb, i, colv: SBaseStructValue) =>
+      val s = colv.subset(typ.colKey: _*).loadField(cb, 0).get(cb).asString
+      cb += (stringSampleIds(i) = s.loadString(cb))
+    }
+    Code.invokeScalaObject6[TStruct, TStruct, ReferenceGenome, Option[String], Option[VCFMetadata], Array[String], String](
+      ExportVCF.getClass, "makeHeader",
+      mb.getType[TStruct](typ.rowType), mb.getType[TStruct](typ.entryType),
+      mb.getReferenceGenome(typ.referenceGenome), mb.getObject(append),
+      mb.getObject(metadata), stringSampleIds)
+  }
+
+  def writeMetadata(writeAnnotations: => IEmitCode, cb: EmitCodeBuilder, region: Value[Region]): Unit = {
+    val ctx: ExecuteContext = cb.emb.ctx
+    val ext = ctx.fs.getCodecExtension(outputPath)
+
+    val annotations = writeAnnotations.get(cb).asBaseStruct
+
+    exportType match {
+      case ExportType.CONCATENATED =>
+        val headerStr = header(cb, annotations)
+
+        val partPaths = annotations.loadField(cb, "partFiles").get(cb)
+        val files = partPaths.castTo(cb, region, SJavaArrayString(true), false)
+        val headerFilePath = ctx.createTmpPath("header", ext)
+        val os = cb.memoize(cb.emb.create(const(headerFilePath)))
+        cb += os.invoke[Array[Byte], Unit]("write", headerStr.invoke[Array[Byte]]("getBytes"))
+        cb += os.invoke[Int, Unit]("write", '\n')
+        cb += os.invoke[Unit]("close")
+
+        val partFiles = files.asInstanceOf[SJavaArrayStringValue].array
+        val jFiles = cb.memoize(Code.newArray[String](partFiles.length + 1))
+        cb += (jFiles(0) = const(headerFilePath))
+        cb += Code.invokeStatic5[System, Any, Int, Any, Int, Int, Unit](
+          "arraycopy", partFiles /*src*/, 0 /*srcPos*/, jFiles /*dest*/, 1 /*destPos*/, partFiles.length /*len*/)
+
+        cb += cb.emb.getFS.invoke[Array[String], String, Unit]("concatenateFiles", jFiles, const(outputPath))
+
+        val i = cb.newLocal[Int]("i")
+        cb.forLoop(cb.assign(i, 0), i < jFiles.length, cb.assign(i, i + 1), {
+          cb += cb.emb.getFS.invoke[String, Boolean, Unit]("delete", jFiles(i), const(false))
+        })
+
+        if (tabix) {
+          cb += Code.invokeScalaObject2[FS, String, Unit](TabixVCF.getClass, "apply", cb.emb.getFS, const(outputPath))
+        }
+
+      case ExportType.PARALLEL_HEADER_IN_SHARD =>
+        cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
+
+      case ExportType.PARALLEL_SEPARATE_HEADER =>
+        val headerFilePath = s"$outputPath/header$ext"
+        val headerStr = header(cb, annotations)
+
+        val os = cb.memoize(cb.emb.create(const(headerFilePath)))
+        cb += os.invoke[Array[Byte], Unit]("write", headerStr.invoke[Array[Byte]]("getBytes"))
+        cb += os.invoke[Int, Unit]("write", '\n')
+        cb += os.invoke[Unit]("close")
+
+        cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
+    }
+  }
 }
 
 case class MatrixGENWriter(


### PR DESCRIPTION
Re-implement export vcf in generated code.

There is a fair amount of 'duplicated' code here between table export
and vcf export, however, I belive this to be fine. We can always
refactor VCFPartitionWriter to be a subclass of SimplePartitionWriter,
but that would require a little special casing as VCF export needs
access to the column values and SimplePartitionWriter assumes such
a thing is not necessary.

As far as VCF export itself, we simply duplicate the logic present in
ExportVCF but with generated code.