### PR TITLE
[batch] load credentials from file once instead of thrice

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -27,7 +27,7 @@ import async_timeout
 from aiodocker.exceptions import DockerError  # type: ignore
 from aiohttp import web
 
-from gear.clients import get_cloud_async_fs, get_compute_client, get_cloud_credentials_from_data
+from gear.clients import get_cloud_async_fs, get_cloud_credentials_from_data, get_compute_client
 from hailtop import aiotools, httpx
 from hailtop.aiotools import LocalAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS

--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from gear.cloud_config import get_azure_config, get_gcp_config, get_global_config
-from hailtop.aiocloud import aioazure, aiogoogle, CloudCredentials
+from hailtop.aiocloud import aioazure, aiogoogle, common
 from hailtop.aiotools.fs import AsyncFS, AsyncFSFactory
 
 
@@ -38,7 +38,7 @@ def get_compute_client(*args, **kwargs):
     return aiogoogle.GoogleComputeClient(project, *args, **kwargs)
 
 
-def get_cloud_credentials_from_data(data, *args, **kwargs) -> CloudCredentials:
+def get_cloud_credentials_from_data(data, *args, **kwargs) -> common.CloudCredentials:
     cloud = get_global_config()['cloud']
 
     if cloud == 'azure':

--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from gear.cloud_config import get_azure_config, get_gcp_config, get_global_config
-from hailtop.aiocloud import aioazure, aiogoogle
+from hailtop.aiocloud import aioazure, aiogoogle, CloudCredentials
 from hailtop.aiotools.fs import AsyncFS, AsyncFSFactory
 
 
@@ -23,32 +23,42 @@ def get_identity_client(credentials_file: Optional[str] = None):
     return aiogoogle.GoogleIAmClient(project, credentials_file=credentials_file)
 
 
-def get_compute_client(credentials_file: Optional[str] = None):
-    if credentials_file is None:
-        credentials_file = '/gsa-key/key.json'
+def get_compute_client(*args, **kwargs):
+    if kwargs.get('credentials_file') is None and kwargs.get('credentials') is None:
+        kwargs['credentials_file'] = '/gsa-key/key.json'
 
     cloud = get_global_config()['cloud']
 
     if cloud == 'azure':
         azure_config = get_azure_config()
-        return aioazure.AzureComputeClient(azure_config.subscription_id, azure_config.resource_group)
+        return aioazure.AzureComputeClient(azure_config.subscription_id, azure_config.resource_group, *args, **kwargs)
 
     assert cloud == 'gcp', cloud
     project = get_gcp_config().project
-    return aiogoogle.GoogleComputeClient(project, credentials_file=credentials_file)
+    return aiogoogle.GoogleComputeClient(project, *args, **kwargs)
 
 
-def get_cloud_async_fs(credentials_file: Optional[str] = None) -> AsyncFS:
-    if credentials_file is None:
-        credentials_file = '/gsa-key/key.json'
+def get_cloud_credentials_from_data(data, *args, **kwargs) -> CloudCredentials:
+    cloud = get_global_config()['cloud']
+
+    if cloud == 'azure':
+        return aioazure.AzureCredentials.from_credentials_data(data, *args, **kwargs)
+
+    assert cloud == 'gcp', cloud
+    return aiogoogle.GoogleCredentials.from_credentials_data(data, *args, **kwargs)
+
+
+def get_cloud_async_fs(*args, **kwargs) -> AsyncFS:
+    if kwargs.get('credentials_file') is None and kwargs.get('credentials') is None:
+        kwargs['credentials_file'] = '/gsa-key/key.json'
 
     cloud = get_global_config()['cloud']
 
     if cloud == 'azure':
-        return aioazure.AzureAsyncFS(credential_file=credentials_file)
+        return aioazure.AzureAsyncFS(*args, **kwargs)
 
     assert cloud == 'gcp', cloud
-    return aiogoogle.GoogleStorageAsyncFS(credentials_file=credentials_file)
+    return aiogoogle.GoogleStorageAsyncFS(*args, **kwargs)
 
 
 def get_cloud_async_fs_factory() -> AsyncFSFactory:

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -438,6 +438,7 @@ class AzureAsyncFS(AsyncFS):
 
         if self._blob_service_clients:
             await asyncio.wait([client.close() for client in self._blob_service_clients.values()])
+            self._blob_service_clients = {}
 
 
 class AzureAsyncFSFactory(AsyncFSFactory[AzureAsyncFS]):


### PR DESCRIPTION
I'm also not sure how the Azure compute client ever worked, it never received the credentials_file argument.