### PR TITLE
[gear] Add metric for number of queries waiting on a connection

### DIFF
--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -9,7 +9,7 @@ from typing import Optional
 import aiomysql
 import pymysql
 
-from gear.metrics import PrometheusSQLTimer, DB_CONNECTION_QUEUE_SIZE
+from gear.metrics import DB_CONNECTION_QUEUE_SIZE, PrometheusSQLTimer
 from hailtop.auth.sql_config import SQLConfig
 from hailtop.utils import sleep_and_backoff
 

--- a/gear/gear/metrics.py
+++ b/gear/gear/metrics.py
@@ -5,8 +5,10 @@ from prometheus_async.aio import time as prom_async_time  # type: ignore
 REQUEST_TIME = pc.Summary('http_request_latency_seconds', 'Endpoint latency in seconds', ['endpoint', 'verb'])
 REQUEST_COUNT = pc.Counter('http_request_count', 'Number of HTTP requests', ['endpoint', 'verb', 'status'])
 CONCURRENT_REQUESTS = pc.Gauge('http_concurrent_requests', 'Number of in progress HTTP requests', ['endpoint', 'verb'])
+
 SQL_QUERY_COUNT = pc.Counter('sql_query_count', 'Number of SQL Queries', ['query_name'])
 SQL_QUERY_LATENCY = pc.Summary('sql_query_latency_seconds', 'SQL Query latency in seconds', ['query_name'])
+DB_CONNECTION_QUEUE_SIZE = pc.Gauge('sql_connection_queue_size', 'Number of coroutines waiting for a connection')
 
 
 @web.middleware


### PR DESCRIPTION
Added a panel for it [here](https://grafana.hail.is/d/TVytxvb7z/batch-driver-performance?orgId=1&var-namespace=dgoldste&from=1646327460490&to=1646328244432). I was kind of surprised to see that we don't have a queue building up, but the back-pressure could be somewhere else. I can also bring up the rate limit now that the DB can handle it