### PR TITLE
[docker] remove Authlib

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -10,7 +10,6 @@ async-timeout==4.0.2
 asyncinit==0.2.4
 azure-identity==1.6.0
 azure-storage-blob==12.8.1
-Authlib==0.11
 black==22.1.0
 boto3==1.17.54
 botocore==1.20.54


### PR DESCRIPTION
This was used a very long time ago for authentication (e.g. see notebook2 in commit aa937bd3414481998e522832336ab618a8cf756d).