### PR TITLE
[batch] use a filesystem that still exists

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -471,8 +471,6 @@ class Container:
 
         self.overlay_mounted = False
 
-        self.fs = LocalAsyncFS(self.worker.pool)
-
         self.container_name = f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}'
 
         self.netns: Optional[NetworkNamespace] = None
@@ -940,10 +938,6 @@ class Container:
             network_allocator.free(self.netns)
             self.netns = None
 
-        if self.fs is not None:
-            await self.fs.close()
-            self.fs = None
-
     async def delete(self):
         log.info(f'deleting {self}')
         self.deleted_event.set()
@@ -1010,9 +1004,7 @@ class Container:
 
     async def get_log(self):
         if os.path.exists(self.log_path):
-            stream = await self.fs.open(self.log_path)
-            async with stream:
-                return (await stream.read()).decode()
+            return (await self.worker.fs.read(self.log_path)).decode()
         return ''
 
     def __str__(self):
@@ -1620,7 +1612,6 @@ class JVMJob(Job):
         self.jvm: Optional[JVM] = None
         self.jvm_name: Optional[str] = None
 
-        self.fs = LocalAsyncFS(self.worker.pool)
         self.log_file = f'{self.scratch}/log'
 
     def step(self, name):
@@ -1733,14 +1724,10 @@ class JVMJob(Job):
             raise
         except Exception:
             log.exception('while deleting volumes')
-        finally:
-            if self.fs is not None:
-                await self.fs.close()
-                self.fs = None
 
     async def _get_log(self):
         if os.path.exists(self.log_file):
-            return (await self.fs.read(self.log_file)).decode()
+            return (await self.worker.fs.read(self.log_file)).decode()
         return ''
 
     async def get_log(self):


### PR DESCRIPTION
A front_end may request a log as long as the job state is "Running". Ergo, we
must have a valid FS until after the job complete HTTP request to
the driver completes successfully. Seems easiest to just use the
worker's file system which can read local as well as remote files.