### PR TITLE
[copier] retry file listing if it fails

### DIFF
--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, List, Union, Dict, Callable, AsyncIterator, Awaitable
+from typing import Any, AsyncIterator, Awaitable, Optional, List, Union, Dict, Callable
 import os
 import os.path
 import asyncio

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, List, Union, Dict, Callable
+from typing import Any, Optional, List, Union, Dict, Callable, AsyncIterator, Awaitable
 import os
 import os.path
 import asyncio
@@ -10,7 +10,7 @@ from ...utils import (retry_transient_errors, url_basename, url_join, bounded_ga
                       humanize_timedelta_msecs)
 from ..weighted_semaphore import WeightedSemaphore
 from .exceptions import FileAndDirectoryError, UnexpectedEOFError
-from .fs import MultiPartCreate, FileStatus, AsyncFS
+from .fs import MultiPartCreate, FileStatus, AsyncFS, FileListEntry
 
 
 class Transfer:
@@ -286,7 +286,8 @@ class SourceCopier:
             srcfile: str,
             srcstat: FileStatus,
             destfile: str,
-            return_exceptions: bool):
+            return_exceptions: bool
+    ) -> None:
         source_report.start_files(1)
         source_report.start_bytes(await srcstat.size())
         success = False
@@ -351,13 +352,16 @@ class SourceCopier:
         await self._copy_file_multi_part(sema, source_report, src, srcstat, full_dest, return_exceptions)
 
     async def copy_as_dir(self, sema: asyncio.Semaphore, source_report: SourceReport, return_exceptions: bool):
+        async def files_iterator() -> AsyncIterator[FileListEntry]:
+            return await self.router_fs.listfiles(src, recursive=True)
+
         try:
             src = self.src
             if not src.endswith('/'):
                 src = src + '/'
 
             try:
-                srcentries = await self.router_fs.listfiles(src, recursive=True)
+                srcentries: Optional[AsyncIterator[FileListEntry]] = await files_iterator()
             except (NotADirectoryError, FileNotFoundError):
                 self.src_is_dir = False
                 return
@@ -376,7 +380,7 @@ class SourceCopier:
         if full_dest_type == AsyncFS.FILE:
             raise NotADirectoryError(full_dest)
 
-        async def copy_source(srcentry):
+        async def copy_source(srcentry: FileListEntry) -> None:
             srcfile = srcentry.url_maybe_trailing_slash()
             assert srcfile.startswith(src)
 
@@ -389,9 +393,20 @@ class SourceCopier:
 
             await self._copy_file_multi_part(sema, source_report, srcfile, await srcentry.status(), url_join(full_dest, relsrcfile), return_exceptions)
 
-        await bounded_gather2(sema, *[
-            functools.partial(copy_source, srcentry)
-            async for srcentry in srcentries], cancel_on_error=True)
+        async def create_copies() -> List[Callable[[], Awaitable[None]]]:
+            nonlocal srcentries
+            if srcentries is None:
+                srcentries = await files_iterator()
+            try:
+                return [
+                    functools.partial(copy_source, srcentry)
+                    async for srcentry in srcentries]
+            finally:
+                srcentries = None
+
+        copies = await retry_transient_errors(create_copies)
+
+        await bounded_gather2(sema, *copies, cancel_on_error=True)
 
     async def copy(self, sema: asyncio.Semaphore, source_report: SourceReport, return_exceptions: bool):
         try:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -451,7 +451,10 @@ class OnlineBoundedGather2:
             raise self._exception
 
 
-async def bounded_gather2_return_exceptions(sema: asyncio.Semaphore, *pfs):
+async def bounded_gather2_return_exceptions(
+        sema: asyncio.Semaphore,
+        *pfs: Callable[[], Awaitable[T]]
+) -> List[T]:
     '''Run the partial functions `pfs` as tasks with parallelism bounded
     by `sema`, which should be `asyncio.Semaphore` whose initial value
     is the desired level of parallelism.
@@ -474,7 +477,11 @@ async def bounded_gather2_return_exceptions(sema: asyncio.Semaphore, *pfs):
         return await asyncio.gather(*tasks)
 
 
-async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *pfs, cancel_on_error: bool = False):
+async def bounded_gather2_raise_exceptions(
+        sema: asyncio.Semaphore,
+        *pfs: Callable[[], Awaitable[T]],
+        cancel_on_error: bool = False
+) -> List[T]:
     '''Run the partial functions `pfs` as tasks with parallelism bounded
     by `sema`, which should be `asyncio.Semaphore` whose initial value
     is the level of parallelism.
@@ -513,7 +520,12 @@ async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *pfs, cancel
                     await asyncio.wait(tasks)
 
 
-async def bounded_gather2(sema: asyncio.Semaphore, *pfs, return_exceptions: bool = False, cancel_on_error: bool = False):
+async def bounded_gather2(
+        sema: asyncio.Semaphore,
+        *pfs: Callable[[], Awaitable[T]],
+        return_exceptions: bool = False,
+        cancel_on_error: bool = False
+) -> List[T]:
     if return_exceptions:
         return await bounded_gather2_return_exceptions(sema, *pfs)
     return await bounded_gather2_raise_exceptions(sema, *pfs, cancel_on_error=cancel_on_error)


### PR DESCRIPTION
I saw an error in a CI job that was copying in some files. To be clear,
this change would not restart a copy of the entire directory. It just
retries the directory listing. We currently use O(N_FILES) memory to
store the list of files in a directory *before* we start copying.

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/copy.py", line 110, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1501, in uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/copy.py", line 104, in main
    files=files
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/copy.py", line 76, in copy_from_dict
    transfers=transfers
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/copy.py", line 50, in copy
    bytes_listener=make_tqdm_listener(byte_pbar))
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 439, in copy
    await copier._copy(sema, copy_report, transfer, return_exceptions)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 532, in _copy
    raise e
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 527, in _copy
    ], return_exceptions=return_exceptions, cancel_on_error=True)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/utils/utils.py", line 519, in bounded_gather2
    return await bounded_gather2_raise_exceptions(sema, *pfs, cancel_on_error=cancel_on_error)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/utils/utils.py", line 504, in bounded_gather2_raise_exceptions
    return await asyncio.gather(*tasks)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/utils/utils.py", line 494, in run_with_sema
    return await pf()
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 509, in _copy_one_transfer
    raise e
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 488, in _copy_one_transfer
    await self.copy_source(sema, transfer, src_report, src, dest_type_task, return_exceptions)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 474, in copy_source
    await src_copier.copy(sema, source_report, return_exceptions)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 419, in copy
    raise e
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 408, in copy
    raise result
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/copier.py", line 360, in copy_as_dir
    srcentries = await self.router_fs.listfiles(src, recursive=True)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/router_fs.py", line 104, in listfiles
    return await fs.listfiles(url, recursive, exclude_trailing_slash_files)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiocloud/aiogoogle/client/storage_client.py", line 619, in listfiles
    first_entry = await it.__anext__()
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiocloud/aiogoogle/client/storage_client.py", line 575, in _listfiles_recursive
    async for page in await self._storage_client.list_objects(bucket, params=params):
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiocloud/aiogoogle/client/storage_client.py", line 45, in __anext__
    self._page = await self._client.get(self._path, params=self._request_params, **self._request_kwargs)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiocloud/common/base_client.py", line 24, in get
    return await resp.json()
  File "/usr/local/lib/python3.7/dist-packages/aiohttp/client_reqrep.py", line 1098, in json
    await self.read()
  File "/usr/local/lib/python3.7/dist-packages/aiohttp/client_reqrep.py", line 1036, in read
    self._body = await self.content.read()
  File "/usr/local/lib/python3.7/dist-packages/aiohttp/streams.py", line 375, in read
    block = await self.readany()
  File "/usr/local/lib/python3.7/dist-packages/aiohttp/streams.py", line 397, in readany
    await self._wait("readany")
  File "/usr/local/lib/python3.7/dist-packages/aiohttp/streams.py", line 304, in _wait
    await waiter
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed
```