### PR TITLE
[ci] Run five PRs simultaneously

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -37,7 +37,7 @@ if os.path.exists("/zulip-config/.zuliprc"):
 
 TRACKED_PRS = pc.Gauge('ci_tracked_prs', 'PRs currently being monitored by CI', ['build_state', 'review_state'])
 
-MAX_CONCURRENT_PR_BATCHES = 3
+MAX_CONCURRENT_PR_BATCHES = 5
 
 
 class GithubStatus(Enum):


### PR DESCRIPTION
I don't think this will be too much on the database, but even if it is I feel like mitigating that will be less effort than it is currently trying to nudge CI towards getting PRs in quickly.