### PR TITLE
[batch] fix flaky test

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1294,7 +1294,7 @@ class DockerJob(Job):
                     self.output_volume_mounts.append(volume_mount)
 
         # create containers
-        containers = {}
+        containers: Dict[str, Container] = {}
 
         if input_files:
             containers['input'] = copy_container(

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -57,7 +57,7 @@ def test_job_running_logs(client: BatchClient):
         status = j.status()
         if status['state'] == 'Running':
             log = j.log()
-            if log is not None:
+            if log is not None and log != '':
                 assert log['main'] == 'test\n', str((log, b.debug_info()))
                 break
         delay = sync_sleep_and_backoff(delay)

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -57,7 +57,7 @@ def test_job_running_logs(client: BatchClient):
         status = j.status()
         if status['state'] == 'Running':
             log = j.log()
-            if log is not None and log != '':
+            if log is not None and log['main'] != '':
                 assert log['main'] == 'test\n', str((log, b.debug_info()))
                 break
         delay = sync_sleep_and_backoff(delay)


### PR DESCRIPTION
Saw this in https://ci.azure.hail.is/batches/38760/jobs/99.

I think the log of a container is actually never None any more. It can
be empty if bash has started but the echo command has not yet run.