### PR TITLE
[query] Relocate Breeze

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -781,7 +781,7 @@ steps:
       - hail_build_image
       - merge_code
   - kind: runImage
-    name: build_hail_spark2.4.5
+    name: build_hail_spark2.4.8
     image:
       valueFrom: hail_build_image.image
     resources:
@@ -792,7 +792,7 @@ steps:
       cd /io/repo/hail
       chmod 755 ./gradlew
       time retry ./gradlew --version
-      export SPARK_VERSION="2.4.5" SCALA_VERSION="2.11.12"
+      export SPARK_VERSION="2.4.8" SCALA_VERSION="2.12.12"
       time retry make jars python-version-info wheel
     inputs:
       - from: /repo

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -40,7 +40,7 @@ tasks.withType(JavaCompile) {
 }
 
 project.ext {
-    cachedBreezeVersion = null
+    breezeVersion = "1.1"
 
     sparkVersion = System.getProperty("spark.version", "3.1.2")
 
@@ -83,41 +83,14 @@ compileScala {
     }
 }
 
-String breezeVersion() {
-  if (cachedBreezeVersion == null) {
-    def artifacts = configurations.justSpark.getResolvedConfiguration().getResolvedArtifacts()
-    artifacts.each { ResolvedArtifact artifact ->
-	def module = artifact.getModuleVersion().getId()
-	if (module.getGroup() == 'org.scalanlp'
-	  && module.getName() == 'breeze_' + scalaMajorVersion) {
-	    cachedBreezeVersion = module.getVersion()
-	}
-    }
-    if (cachedBreezeVersion == null) {
-      throw new RuntimeException('Unable to determine breeze library version')
-    }
-  }
-  return cachedBreezeVersion
-}
-
 configurations {
     justSpark
 
     all {
         resolutionStrategy {
-            componentSelection {
-                withModule('org.scalanlp:breeze-natives_' + scalaMajorVersion) { ComponentSelection selection ->
-                    if (selection.candidate.getVersion() != breezeVersion()) {
-                        selection.reject()
-                    }
-                }
-	        }
             eachDependency { DependencyResolveDetails details ->
                 if (details.requested.group == 'org.apache.spark') {
                     details.useVersion(sparkVersion)
-                } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
-                    // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
-                    details.useVersion('1.1')
                 }
             }
 	    }
@@ -160,10 +133,11 @@ dependencies {
     bundled 'org.lz4:lz4-java:1.8.0'
 
     // Breeze 1.0 has a known bug (https://github.com/scalanlp/breeze/issues/772)
-    unbundled 'org.scalanlp:breeze-natives_' + scalaMajorVersion + ':' + breezeVersion()
-    bundled('org.scalanlp:breeze-natives_' + scalaMajorVersion + ':' + breezeVersion()) {
+    unbundled 'org.scalanlp:breeze-natives_' + scalaMajorVersion + ':' + breezeVersion
+    bundled('org.scalanlp:breeze-natives_' + scalaMajorVersion + ':' + breezeVersion) {
         exclude module: 'commons-math3'
     }
+    bundled 'org.scalanlp:breeze_' + scalaMajorVersion + ':' + breezeVersion
 
     bundled 'com.github.fommil.netlib:all:1.1.2'
     bundled('com.github.samtools:htsjdk:2.24.1') {
@@ -353,6 +327,9 @@ tasks.withType(ShadowJar) {
     relocate 'org.freemarker', 'is.hail.relocated.org.freemarker'
     relocate 'org.json4s', 'is.hail.relocated.org.json4s'
     relocate 'org.elasticsearch', 'is.hail.relocated.org.elasticsearch'
+
+    // Breeze 1.0 is broken, it is never ok to use Breeze 1.0 or earlier.
+    relocate 'org.scalanlp', 'is.hail.relocated.org.scalanlp'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -331,7 +331,7 @@ tasks.withType(ShadowJar) {
     relocate 'org.elasticsearch', 'is.hail.relocated.org.elasticsearch'
 
     // Breeze 1.0 is broken, it is never ok to use Breeze 1.0 or earlier.
-    relocate 'org.scalanlp', 'is.hail.relocated.org.scalanlp'
+    relocate 'breeze', 'is.hail.relocated.breeze'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -111,7 +111,9 @@ configurations {
 }
 
 dependencies {
-    justSpark 'org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion
+    justSpark('org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion) {
+        exclude group: 'org.scalanlp'
+    }
 
     unbundled 'org.scala-lang:scala-library:' + scalaVersion
     unbundled 'org.scala-lang:scala-reflect:' + scalaVersion

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -49,6 +49,7 @@ project.ext {
     }
     scalaVersion = System.getProperty("scala.version", "2.12.13")
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
+    assert(scalaMajorVersion == "2.12")
 }
 
 compileScala {
@@ -154,7 +155,6 @@ dependencies {
     }
 
     if (sparkVersion.startsWith("3.")) {
-        assert(scalaMajorVersion == "2.12")
         if (elasticMajorVersion == "8") {
             bundled 'org.elasticsearch:elasticsearch-spark-30_2.12:8.0.0'
         }
@@ -163,9 +163,8 @@ dependencies {
         }
     }
     else if (sparkVersion.startsWith("2.4.")) {
-        assert(scalaMajorVersion == "2.11")
         assert(elasticMajorVersion == "7")
-        bundled 'org.elasticsearch:elasticsearch-spark-20_2.11:7.8.1'
+        bundled 'org.elasticsearch:elasticsearch-spark-20_2.12:7.8.1'
     }
     else {
         throw new UnsupportedOperationException("Couldn't pick a valid elasticsearch.")

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     }
     else if (sparkVersion.startsWith("2.4.")) {
         assert(elasticMajorVersion == "7")
-        bundled 'org.elasticsearch:elasticsearch-spark-20_2.12:7.8.1'
+        bundled 'org.elasticsearch:elasticsearch-spark-20_2.12:7.17.1'
     }
     else {
         throw new UnsupportedOperationException("Couldn't pick a valid elasticsearch.")

--- a/hail/python/cluster-tests/block_matrix_from_numpy.py
+++ b/hail/python/cluster-tests/block_matrix_from_numpy.py
@@ -1,0 +1,8 @@
+import hail as hl
+import numpy as np
+
+x = np.random.randn(100, 100)
+x_bm = hl.linalg.BlockMatrix.from_numpy(x, 8)
+x_round_trip = x_bm.to_numpy()
+
+assert np.allclose(x, x_round_trip)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -5,12 +5,10 @@ import is.hail.types.{BlockMatrixSparsity, BlockMatrixType}
 import is.hail.types.virtual.{TArray, TBaseStruct, TFloat64, TInt32, TInt64, TNDArray, TString, TTuple, Type}
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata}
 import is.hail.utils._
-import breeze.linalg
 import breeze.linalg.DenseMatrix
 import breeze.numerics
 import is.hail.annotations.{NDArray, Region}
 import is.hail.backend.{BackendContext, ExecuteContext}
-import is.hail.backend.spark.SparkBackend
 import is.hail.expr.Nat
 import is.hail.expr.ir.lowering.{BlockMatrixStage, LowererUnsupportedOperation}
 import is.hail.io.TypedCodecSpec
@@ -19,7 +17,6 @@ import is.hail.types.encoded.{EBlockMatrixNDArray, EFloat64}
 
 import scala.collection.mutable.ArrayBuffer
 import is.hail.utils.richUtils.RichDenseMatrixDouble
-import org.apache.spark.sql.Row
 import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
 
 import scala.collection.immutable.NumericRange


### PR DESCRIPTION
Spark 3.1 still relies on Breeze 1.0, which is very broken: https://github.com/scalanlp/breeze/issues/772

We can never allow use of Breeze 1.0. 

To fix, I have hard coded the insistence that we use Breeze 1.1, relocated it into our hail jar. In the process, I also made it so that we don't support building with Scala 2.11 anymore, but that doesn't preclude us from still building with Spark 2.4.8 for now. 

Our old "fix" in the build.gradle that said to change Spark 1.0 to 1.1 was actually making things more confusing. It was making it so that when we pulled down Spark and Breeze from Maven ourselves we'd switch out Breeze 1.0 for Breeze 1.1. However, it had no effect on what happened in dataproc, when breeze and Spark are provided on the classpath and we just use what's available. 

I also added a dataproc test to catch this behavior. 