### PR TITLE
[compiler] fix lowered join where join key is prefix of left key

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1764,6 +1764,18 @@ def create_width_scale_files():
         write_file(w)
 
 
+def test_join_with_key_prefix():
+    t = hl.utils.range_table(20, 2)
+    t = t.annotate(pk=1)
+    t = t.key_by('pk', 'idx')
+    t2 = hl.utils.range_table(20, 2)
+    t2 = t2.annotate(foo=t2.idx)
+    t.show()
+    t2.show()
+    t = t.annotate(foo=t2[t.pk].foo)
+    assert t.aggregate(hl.agg.all(t.foo == 1))
+    assert t.n_partitions() == 2
+
 def test_join_distinct_preserves_count():
     left_pos = [1, 2, 4, 4, 5, 5, 9, 13, 13, 14, 15]
     right_pos = [1, 1, 1, 3, 4, 4, 6, 6, 8, 9, 13, 15]

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1770,8 +1770,6 @@ def test_join_with_key_prefix():
     t = t.key_by('pk', 'idx')
     t2 = hl.utils.range_table(20, 2)
     t2 = t2.annotate(foo=t2.idx)
-    t.show()
-    t2.show()
     t = t.annotate(foo=t2[t.pk].foo)
     assert t.aggregate(hl.agg.all(t.foo == 1))
     assert t.n_partitions() == 2


### PR DESCRIPTION
This fixes a bug in joins where:
* The join key is a prefix of the left key
* Values of the join key in the left table span multiple partitions

For example, say the left table is `{[(0, 0), (0, 1)], [(0, 2), (1, 0)]}`, where the two lists of tuples are the two partitions, and the key is the entire tuple, and the join key is just the first field.

Then in the old code
```
        val loweredLeft = lower(left).strictify()
        val leftKeyToRightKeyMap = left.typ.keyType.fieldNames.zip(right.typ.keyType.fieldNames).toMap
        val newRightPartitioner = loweredLeft.partitioner.coarsen(commonKeyLength)
          .rename(leftKeyToRightKeyMap)
        val loweredRight = lower(right).repartitionNoShuffle(newRightPartitioner)
```
the left partitioner is coarsened to `[(0), (0)], [(0), (1)]` in the third line, and the `repartitionNoShuffle` in the fourth line fails because rows with key `(0)` are split across both partitions.

One possible fix would be to strictify the coarsened partitioner, which in this case would force the left table to one partition. But this seems dangerous performance-wise. Instead, this PR makes the lowered behavior match the old behavior, which is to "repartition" the right to the invalid partitioner `[(0), (0)], [(0), (1)]`, meaning rows with key `(0)` get duplicated into both partitions. This is exactly the intended semantics of `alignAndZipPartitions` as described in the code:
> The partitioner of the result will be the left partitioner. Each partition will be computed by 'joiner', with corresponding partition of 'this' as first iterator, and with all rows of 'that' whose 'joinKey' might match something in partition as the second iterator.

This behavior is implemented with a flag `allowDuplication` on `repartitionNoShuffle`. This simply omits the assertion on the new partitioner that guarantees each incoming row ends up in at most one result partition.