### PR TITLE
[batch] Add `/version` endpoint (originally in [query])

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -33,7 +33,7 @@ from gear import (
 )
 from gear.clients import get_cloud_async_fs
 from gear.database import CallError
-from hailtop import aiotools, dictfix, httpx
+from hailtop import aiotools, dictfix, httpx, version
 from hailtop.batch_client.parse import parse_cpu_in_mcpu, parse_memory_in_bytes, parse_storage_in_bytes
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
@@ -172,6 +172,11 @@ def web_billing_project_users_only(redirect=True):
 @routes.get('/healthcheck')
 async def get_healthcheck(request):  # pylint: disable=W0613
     return web.Response()
+
+
+@routes.get('/api/v1alpha/version')
+async def rest_get_version(request):  # pylint: disable=W0613
+    return web.Response(text=version())
 
 
 async def _handle_ui_error(session, f, *args, **kwargs):


### PR DESCRIPTION
The endpoint was originally added into the Query service in https://github.com/hail-is/hail/pull/10085, but it disappeared after the Query service was removed. Re-adding it into Batch.

Let me know if it better belongs somewhere else. Our use case was to request the version of currently running Batch service, so adding it into Batch made sense.)