### PR TITLE
[query] Use RFC3339/ISO8601 for Py4jUtils.stat data

### DIFF
--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -69,7 +69,9 @@ trait Py4jUtils {
       "is_dir" -> JBool(fs.isDirectory),
       "modification_time" ->
         (if (fs.getModificationTime != null)
-          JString(new java.util.Date(fs.getModificationTime).toString)
+          JString(
+            new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ").format(
+              new java.util.Date(fs.getModificationTime)))
         else
           JNull),
       "owner" -> (


### PR DESCRIPTION
This is a sane choice, and while I do not expect java to ever change the
toString of Date, it's better to have a consistent format across all
file systems and interfaces.