### PR TITLE
[query/service] properly implement Backend.stop for ServiceBackend

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -178,9 +178,9 @@ class ServiceBackend(Backend):
     def logger(self):
         return log
 
-    @property
     def stop(self):
-        pass
+        async_to_blocking(self._async_fs.close())
+        async_to_blocking(self.async_bc.close())
 
     def render(self, ir):
         r = CSERenderer()


### PR DESCRIPTION
It is not a property. We can clean up some async resources as well.