### PR TITLE
[query] Rework python FS.stat to return an object

### DIFF
--- a/hail/python/hail/fs/__init__.py
+++ b/hail/python/hail/fs/__init__.py
@@ -1,0 +1,3 @@
+from .stat_result import FileType
+
+__all__ = ['FileType']

--- a/hail/python/hail/fs/fs.py
+++ b/hail/python/hail/fs/fs.py
@@ -1,10 +1,12 @@
 import abc
 import sys
 import os
-from typing import Dict, List
+from typing import List
 
 from hail.utils.java import Env, info
 from hail.utils import local_path_uri
+
+from .stat_result import StatResult
 
 
 class FS(abc.ABC):
@@ -29,11 +31,11 @@ class FS(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def stat(self, path: str) -> Dict:
+    def stat(self, path: str) -> StatResult:
         pass
 
     @abc.abstractmethod
-    def ls(self, path: str) -> List[Dict]:
+    def ls(self, path: str) -> List[StatResult]:
         pass
 
     @abc.abstractmethod

--- a/hail/python/hail/fs/hadoop_fs.py
+++ b/hail/python/hail/fs/hadoop_fs.py
@@ -1,8 +1,25 @@
 import io
 import json
+import time
 from typing import Dict, List
 
+import dateutil
+
 from .fs import FS
+from .stat_result import FileType, StatResult
+
+
+def _stat_dict_to_stat_result(stat: Dict) -> StatResult:
+    dt = dateutil.parser.isoparse(stat['modification_time'])
+    mtime = time.mktime(dt.timetuple())
+    if stat['is_dir']:
+        typ = FileType.DIRECTORY
+    elif stat['is_link']:
+        typ = FileType.SYMLINK
+    else:
+        typ = FileType.FILE
+    return StatResult(path=stat['path'], owner=stat['owner'], size=stat['size'],
+                      typ=typ, modification_time=mtime)
 
 
 class HadoopFS(FS):
@@ -42,11 +59,13 @@ class HadoopFS(FS):
     def is_dir(self, path: str) -> bool:
         return self._jfs.isDir(path)
 
-    def stat(self, path: str) -> Dict:
-        return json.loads(self._utils_package_object.stat(self._jfs, path))
+    def stat(self, path: str) -> StatResult:
+        stat_dict = json.loads(self._utils_package_object.stat(self._jfs, path))
+        return _stat_dict_to_stat_result(stat_dict)
 
-    def ls(self, path: str) -> List[Dict]:
-        return json.loads(self._utils_package_object.ls(self._jfs, path))
+    def ls(self, path: str) -> List[StatResult]:
+        return [_stat_dict_to_stat_result(st)
+                for st in json.loads(self._utils_package_object.ls(self._jfs, path))]
 
     def mkdir(self, path: str) -> None:
         return self._jfs.mkDir(path)

--- a/hail/python/hail/fs/stat_result.py
+++ b/hail/python/hail/fs/stat_result.py
@@ -1,0 +1,40 @@
+import os
+import stat
+
+from enum import Enum, auto
+from typing import Dict, NamedTuple, Optional, Union
+
+import hurry.filesize
+
+
+class FileType(Enum):
+    DIRECTORY = auto()
+    FILE = auto()
+    SYMLINK = auto()
+
+
+class StatResult(NamedTuple):
+    path: str
+    owner: Union[None, str, int]
+    size: int
+    typ: FileType
+    # common point between unix, google, and hadoop filesystems, represented as a unix timestamp
+    modification_time: Optional[float] = None
+
+    def is_dir(self) -> bool:
+        return self.typ is FileType.DIRECTORY
+
+    @staticmethod
+    def from_os_stat_result(path: str, sb: os.stat_result) -> 'StatResult':
+        if stat.S_ISDIR(sb.st_mode):
+            typ = FileType.DIRECTORY
+        elif stat.S_ISLNK(sb.st_mode):
+            typ = FileType.SYMLINK
+        else:
+            typ = FileType.FILE
+        return StatResult(path=path, owner=sb.st_uid, size=sb.st_size, typ=typ,
+                          modification_time=sb.st_mtime)
+
+    def to_legacy_dict(self) -> Dict:
+        return dict(path=self.path, owner=self.owner, is_dir=self.is_dir(), size_bytes=self.size,
+                    size=hurry.filesize.size(self.size), modification_time=self.modification_time)

--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -185,7 +185,7 @@ def hadoop_stat(path: str) -> Dict:
     -------
     :obj:`dict`
     """
-    return Env.fs().stat(path)
+    return Env.fs().stat(path).to_legacy_dict()
 
 
 def hadoop_ls(path: str) -> List[Dict]:
@@ -216,7 +216,7 @@ def hadoop_ls(path: str) -> List[Dict]:
     -------
     :obj:`list` [:obj:`dict`]
     """
-    return Env.fs().ls(path)
+    return [sr.to_legacy_dict() for sr in Env.fs().ls(path)]
 
 
 def hadoop_scheme_supported(scheme: str) -> bool:

--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -75,7 +75,7 @@ Caused by: java.lang.AssertionError: assertion failed
 
         resource_dir = resource('backward_compatability')
         fs = hl.current_backend().fs
-        versions = [os.path.basename(x['path']) for x in fs.ls(resource_dir)]
+        versions = [os.path.basename(x.path) for x in fs.ls(resource_dir)]
 
         n = 0
         for v in versions:

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -36,6 +36,7 @@ trait FileStatus {
   def getModificationTime: java.lang.Long
   def getLen: Long
   def isDirectory: Boolean
+  def isSymlink: Boolean
   def isFile: Boolean
   def getOwner: String
 }

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -96,6 +96,8 @@ class GoogleStorageFileStatus(path: String, modificationTime: java.lang.Long, si
 
   def isFile: Boolean = !isDir
 
+  def isSymlink: Boolean = false
+
   def getOwner: String = null
 }
 

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -20,6 +20,8 @@ class HadoopFileStatus(fs: hadoop.fs.FileStatus) extends FileStatus {
 
   def isFile: Boolean = fs.isFile
 
+  def isSymlink: Boolean = fs.isSymlink
+
   def getOwner: String = fs.getOwner
 }
 

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -64,9 +64,9 @@ trait Py4jUtils {
   private def statusToJson(fs: FileStatus): JObject = {
     JObject(
       "path" -> JString(fs.getPath.toString),
-      "size_bytes" -> JInt(fs.getLen),
-      "size" -> JString(readableBytes(fs.getLen)),
+      "size" -> JInt(fs.getLen),
       "is_dir" -> JBool(fs.isDirectory),
+      "is_link" -> JBool(fs.isSymlink),
       "modification_time" ->
         (if (fs.getModificationTime != null)
           JString(


### PR DESCRIPTION
The new object, a StatResult (analogous to os.stat_result) is minimal
for now. Notably, it uses a fractional UNIX timestamp for modification
time. StatResult should be moderately extensible, but since it
subclasses NamedTuple, care may need to be taken to preserve field
order.
