### PR TITLE
[compiler] fix sexpr style IR printer

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -457,7 +457,7 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
       }
       list(fillSep(text(prettyClass(ir)) +: pt ++ header(ir, elideLiterals)) +: body)
       */
-      list(fillSep(text(Pretty.prettyClass(ir)) +: header(ir, elideLiterals)) +: body)
+      list(fillSep(text(Pretty.prettyClass(ir)) +: header(ir)) +: body)
     }
 
     pretty(ir).render(width, ribbonWidth, maxLen)


### PR DESCRIPTION
Fixes a bug where identifiers for bound variables were not being printed by the sexpr style pretty printer.