### PR TITLE
[compiler] First pieces of infrastructure for reproducible randomness

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -241,7 +241,8 @@ class ClassBuilder[C](
 
   val lazyFieldMemo: mutable.Map[Any, Value[_]] = mutable.Map.empty
 
-  val lInit = lclass.newMethod("<init>", FastIndexedSeq(), UnitInfo)
+  val lInitBuilder = new MethodBuilder[C](this, "<init>", FastIndexedSeq(), UnitInfo)
+  val lInit = lInitBuilder.lmethod
 
   var initBody: Code[Unit] = {
     val L = new lir.Block()
@@ -263,6 +264,11 @@ class ClassBuilder[C](
 
   def emitInit(c: Code[Unit]): Unit = {
     initBody = Code(initBody, c)
+  }
+
+  def emitInitI(f: CodeBuilder => Unit): Unit = {
+    val body = CodeBuilder.scopedVoid(lInitBuilder)(f)
+    emitInit(body)
   }
 
   def emitClinit(c: Code[Unit]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/Random.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Random.scala
@@ -1,0 +1,481 @@
+package is.hail.expr.ir
+
+import is.hail.asm4s._
+import is.hail.types.physical.stypes.concrete.SRNGState
+import is.hail.utils.FastIndexedSeq
+import net.sourceforge.jdistlib.rng.RandomEngine
+
+object Threefry {
+  val keyConst = 0x1BD11BDAA9FC1A22L
+
+  val rotConsts = Array(
+    Array(14, 16),
+    Array(52, 57),
+    Array(23, 40),
+    Array( 5, 37),
+    Array(25, 33),
+    Array(46, 12),
+    Array(58, 22),
+    Array(32, 32))
+
+  val defaultNumRounds = 20
+
+  def expandKey(k: IndexedSeq[Long]): IndexedSeq[Long] = {
+    assert(k.length == 4)
+    val k4 = k(0) ^ k(1) ^ k(2) ^ k(3) ^ keyConst
+    k :+ k4
+  }
+
+  def rotL(i: Value[Long], n: Value[Int]): Code[Long] = {
+    (i << n) | (i >>> -n)
+  }
+
+  def mix(cb: CodeBuilderLike, x0: Settable[Long], x1: Settable[Long], n: Int): Unit = {
+    cb.assign(x0, x0 + x1)
+    cb.assign(x1, rotL(x1, n))
+    cb.assign(x1, x0 ^ x1)
+  }
+
+  def injectKey(key: IndexedSeq[Long], tweak: Long, block: Array[Long], s: Int): Unit = {
+    val tweakExt = Array[Long](tweak, 0, tweak)
+    block(0) += key(s % 5)
+    block(1) += key((s + 1) % 5) + tweakExt(s % 3)
+    block(2) += key((s + 2) % 5) + tweakExt((s + 1) % 3)
+    block(3) += key((s + 3) % 5) + s.toLong
+  }
+
+  def injectKey(cb: CodeBuilderLike,
+    key: IndexedSeq[Long],
+    tweak: Value[Long],
+    block: IndexedSeq[Settable[Long]],
+    s: Int
+  ): Unit = {
+    val tweakExt = Array[Value[Long]](tweak, const(0), tweak)
+    cb.assign(block(0), block(0) + key(s % 5))
+    cb.assign(block(1), block(1) + const(key((s + 1) % 5)) + tweakExt(s % 3))
+    cb.assign(block(2), block(2) + const(key((s + 2) % 5)) + tweakExt((s + 1) % 3))
+    cb.assign(block(3), block(3) + const(key((s + 3) % 5)) + const(s.toLong))
+  }
+
+  def permute(x: Array[Settable[Long]]): Unit = {
+    val tmp = x(1)
+    x(1) = x(3)
+    x(3) = tmp
+  }
+
+  def encryptUnrolled(k0: Long, k1: Long, k2: Long, k3: Long, t: Long, _x0: Long, _x1: Long, _x2: Long, _x3: Long): Unit = {
+    import java.lang.Long.rotateLeft
+    var x0 = _x0
+    var x1 = _x1
+    var x2 = _x2
+    var x3 = _x3
+    val k4 = k0 ^ k1 ^ k2 ^ k3 ^ keyConst
+    // d = 0
+    // injectKey s = 0
+    x0 += k0; x1 += k1 + t; x2 += k2; x3 += k3
+    x0 += x1; x1 = rotateLeft(x1, 14); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 16); x3 ^= x2
+    // d = 1
+    x0 += x3; x3 = rotateLeft(x3, 52); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 57); x1 ^= x2
+    // d = 2
+    x0 += x1; x1 = rotateLeft(x1, 23); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 40); x3 ^= x2
+    // d = 3
+    x0 += x3; x3 = rotateLeft(x3, 5); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 37); x1 ^= x2
+    // d = 4
+    // injectKey s = 1
+    x0 += k1; x1 += k2; x2 += k3 + t; x3 += k4 + 1
+    x0 += x1; x1 = rotateLeft(x1, 25); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 33); x3 ^= x2
+    // d = 5
+    x0 += x3; x3 = rotateLeft(x3, 46); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 12); x1 ^= x2
+    // d = 6
+    x0 += x1; x1 = rotateLeft(x1, 58); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 22); x3 ^= x2
+    // d = 7
+    x0 += x3; x3 = rotateLeft(x3, 32); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 32); x1 ^= x2
+    // d = 8
+    // injectKey s = 2
+    x0 += k2; x1 += k3 + t; x2 += k4 + t; x3 += k0 + 2
+    x0 += x1; x1 = rotateLeft(x1, 14); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 16); x3 ^= x2
+    // d = 9
+    x0 += x3; x3 = rotateLeft(x3, 52); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 57); x1 ^= x2
+    // d = 10
+    x0 += x1; x1 = rotateLeft(x1, 23); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 40); x3 ^= x2
+    // d = 11
+    x0 += x3; x3 = rotateLeft(x3, 5); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 37); x1 ^= x2
+    // d = 12
+    // injectKey s = 3
+    x0 += k3; x1 += k4 + t; x2 += k0; x3 += k1 + 3
+    x0 += x1; x1 = rotateLeft(x1, 25); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 33); x3 ^= x2
+    // d = 13
+    x0 += x3; x3 = rotateLeft(x3, 46); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 12); x1 ^= x2
+    // d = 14
+    x0 += x1; x1 = rotateLeft(x1, 58); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 22); x3 ^= x2
+    // d = 15
+    x0 += x3; x3 = rotateLeft(x3, 32); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 32); x1 ^= x2
+    // d = 16
+    // injectKey s = 4
+    x0 += k4; x1 += k0; x2 += k1 + t; x3 += k2 + 4
+    x0 += x1; x1 = rotateLeft(x1, 14); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 16); x3 ^= x2
+    // d = 17
+    x0 += x3; x3 = rotateLeft(x3, 52); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 57); x1 ^= x2
+    // d = 18
+    x0 += x1; x1 = rotateLeft(x1, 23); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 40); x3 ^= x2
+    // d = 19
+    x0 += x3; x3 = rotateLeft(x3, 5); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 37); x1 ^= x2
+    // d = 20
+    // injectKey s = 5
+    x0 += k0; x1 += k1 + t; x2 += k2 + t; x3 += k3 + 5
+  }
+
+  def encrypt(k: IndexedSeq[Long], t: Long, x: Array[Long]): Unit =
+    encrypt(k, t, x, defaultNumRounds)
+
+  def encrypt(k: IndexedSeq[Long], t: Long, x: Array[Long], rounds: Int): Unit = {
+    assert(k.length == 5)
+    assert(x.length == 4)
+
+    for (d <- 0 until rounds) {
+      if (d % 4 == 0)
+        injectKey(k, t, x, d / 4)
+
+      x(0) += x(1)
+      x(1) = java.lang.Long.rotateLeft(x(1), rotConsts(d % 8)(0))
+      x(1) ^= x(0)
+      x(2) += x(3)
+      x(3) = java.lang.Long.rotateLeft(x(3), rotConsts(d % 8)(1))
+      x(3) ^= x(2)
+
+      val tmp = x(1)
+      x(1) = x(3)
+      x(3) = tmp
+    }
+
+    if (rounds % 4 == 0)
+      injectKey(k, t, x, rounds / 4)
+  }
+
+  def encrypt(cb: CodeBuilderLike,
+    k: IndexedSeq[Long],
+    t: Value[Long],
+    x: IndexedSeq[Settable[Long]]
+  ): Unit =
+    encrypt(cb, k, t, x, defaultNumRounds)
+
+  def encrypt(cb: CodeBuilderLike,
+    k: IndexedSeq[Long],
+    t: Value[Long],
+    _x: IndexedSeq[Settable[Long]],
+    rounds: Int
+  ): Unit = {
+    assert(k.length == 5)
+    assert(_x.length == 4)
+    val x = _x.toArray
+
+    for (d <- 0 until rounds) {
+      if (d % 4 == 0)
+        injectKey(cb, k, t, x, d / 4)
+
+      for (j <- 0 until 2)
+        mix(cb, x(2*j), x(2*j+1), rotConsts(d % 8)(j))
+
+      permute(x)
+    }
+
+    if (rounds % 4 == 0)
+      injectKey(cb, k, t, x, rounds / 4)
+  }
+
+  def debugPrint(cb: EmitCodeBuilder, x: IndexedSeq[Settable[Long]], info: String) {
+    cb.println(s"[$info]=\n\t", x(0).toString, "  ", x(1).toString, "  ", x(2).toString, "  ", x(3).toString)
+  }
+
+  def apply(k: IndexedSeq[Long]): AsmFunction2[Array[Long], Long, Unit] = {
+    val f = FunctionBuilder[Array[Long], Long, Unit]("Threefry")
+    f.mb.emitWithBuilder { cb =>
+      val xArray = f.mb.getArg[Array[Long]](1)
+      val t = f.mb.getArg[Long](2)
+      val x = Array.tabulate[Settable[Long]](4)(i => cb.newLocal[Long](s"x$i", xArray(i)))
+      encrypt(cb, expandKey(k), t, x)
+      for (i <- 0 until 4) cb += (xArray(i) = x(i))
+      Code._empty
+    }
+    f.result()()
+  }
+}
+
+class RNGState {
+  val staticAcc: Array[Long] = Array.fill(4)(0)
+  val staticIdx: Int = 0
+  val staticOpen: Array[Long] = Array.fill(4)(0)
+  val staticOpenLen: Int = 0
+  val dynAcc: Array[Long] = Array.fill(4)(0)
+  val dynIdx: Int = 0
+  val dynOpen: Array[Long] = Array.fill(4)(0)
+  val dynOpenLen: Int = 0
+}
+
+object ThreefryRandomEngine {
+  def apply(
+    k1: Long, k2: Long, k3: Long, k4: Long,
+    h1: Long, h2: Long, h3: Long, h4: Long,
+    x1: Long, x2: Long, x3: Long
+  ): ThreefryRandomEngine = {
+    new ThreefryRandomEngine(
+      Threefry.expandKey(FastIndexedSeq(k1, k2, k3, k4)),
+      Array(h1 ^ x1, h2 ^ x2, h3 ^ x3, h4),
+      0)
+  }
+
+  def apply(): ThreefryRandomEngine = {
+    val rand = new java.util.Random()
+    new ThreefryRandomEngine(
+      Threefry.expandKey(Array.fill(4)(rand.nextLong())),
+      Array.fill(4)(rand.nextLong()),
+      0)
+  }
+}
+
+class ThreefryRandomEngine(
+  val key: IndexedSeq[Long],
+  val state: Array[Long],
+  var counter: Long,
+  val tweak: Long = SRNGState.finalBlockNoPadTweak
+) extends RandomEngine {
+  val buffer: Array[Long] = Array.ofDim[Long](4)
+  var usedInts: Int = 8
+  var hasBufferedGaussian: Boolean = false
+  var bufferedGaussian: Double = 0.0
+
+  override def clone(): ThreefryRandomEngine = ???
+
+  private def fillBuffer(): Unit = {
+    import java.lang.Long.rotateLeft
+    var x0 = state(0)
+    var x1 = state(1)
+    var x2 = state(2)
+    var x3 = state(3) ^ counter
+    val k0 = key(0); val k1 = key(1); val k2 = key(2); val k3 = key(3)
+    val k4 = k0 ^ k1 ^ k2 ^ k3 ^ Threefry.keyConst
+    val t = tweak
+    // d = 0
+    // injectKey s = 0
+    x0 += k0; x1 += k1 + t; x2 += k2; x3 += k3
+    x0 += x1; x1 = rotateLeft(x1, 14); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 16); x3 ^= x2
+    // d = 1
+    x0 += x3; x3 = rotateLeft(x3, 52); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 57); x1 ^= x2
+    // d = 2
+    x0 += x1; x1 = rotateLeft(x1, 23); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 40); x3 ^= x2
+    // d = 3
+    x0 += x3; x3 = rotateLeft(x3, 5); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 37); x1 ^= x2
+    // d = 4
+    // injectKey s = 1
+    x0 += k1; x1 += k2; x2 += k3 + t; x3 += k4 + 1
+    x0 += x1; x1 = rotateLeft(x1, 25); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 33); x3 ^= x2
+    // d = 5
+    x0 += x3; x3 = rotateLeft(x3, 46); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 12); x1 ^= x2
+    // d = 6
+    x0 += x1; x1 = rotateLeft(x1, 58); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 22); x3 ^= x2
+    // d = 7
+    x0 += x3; x3 = rotateLeft(x3, 32); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 32); x1 ^= x2
+    // d = 8
+    // injectKey s = 2
+    x0 += k2; x1 += k3 + t; x2 += k4 + t; x3 += k0 + 2
+    x0 += x1; x1 = rotateLeft(x1, 14); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 16); x3 ^= x2
+    // d = 9
+    x0 += x3; x3 = rotateLeft(x3, 52); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 57); x1 ^= x2
+    // d = 10
+    x0 += x1; x1 = rotateLeft(x1, 23); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 40); x3 ^= x2
+    // d = 11
+    x0 += x3; x3 = rotateLeft(x3, 5); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 37); x1 ^= x2
+    // d = 12
+    // injectKey s = 3
+    x0 += k3; x1 += k4 + t; x2 += k0; x3 += k1 + 3
+    x0 += x1; x1 = rotateLeft(x1, 25); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 33); x3 ^= x2
+    // d = 13
+    x0 += x3; x3 = rotateLeft(x3, 46); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 12); x1 ^= x2
+    // d = 14
+    x0 += x1; x1 = rotateLeft(x1, 58); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 22); x3 ^= x2
+    // d = 15
+    x0 += x3; x3 = rotateLeft(x3, 32); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 32); x1 ^= x2
+    // d = 16
+    // injectKey s = 4
+    x0 += k4; x1 += k0; x2 += k1 + t; x3 += k2 + 4
+    x0 += x1; x1 = rotateLeft(x1, 14); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 16); x3 ^= x2
+    // d = 17
+    x0 += x3; x3 = rotateLeft(x3, 52); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 57); x1 ^= x2
+    // d = 18
+    x0 += x1; x1 = rotateLeft(x1, 23); x1 ^= x0
+    x2 += x3; x3 = rotateLeft(x3, 40); x3 ^= x2
+    // d = 19
+    x0 += x3; x3 = rotateLeft(x3, 5); x3 ^= x0
+    x2 += x1; x1 = rotateLeft(x1, 37); x1 ^= x2
+    // d = 20
+    // injectKey s = 5
+    x0 += k0; x1 += k1 + t; x2 += k2 + t; x3 += k3 + 5
+
+    buffer(0) = x0; buffer(1) = x1; buffer(2) = x2; buffer(3) = x3
+    counter += 1
+    usedInts = 0
+  }
+
+  override def setSeed(seed: Long): Unit = ???
+
+  override def getSeed: Long = ???
+
+  override def nextLong(): Long = {
+    usedInts += usedInts & 1 // round up to multiple of 2
+    if (usedInts >= 8) fillBuffer()
+    val result = buffer(usedInts >> 1)
+    usedInts += 2
+    result
+  }
+
+  override def nextInt(): Int = {
+    if (usedInts >= 8) fillBuffer()
+    val result = buffer(usedInts >> 1)
+    usedInts += 1
+    val parity = usedInts & 1
+    val shift = parity << 5 // either 0 or 32
+    (result >>> shift).toInt // either first or second 32 bits
+  }
+
+  // Uses approach from https://github.com/apple/swift/pull/39143
+  override def nextInt(n: Int): Int = {
+    val nL = n.toLong
+    val mult = nL * (nextInt().toLong & 0xFFFFFFFFL)
+    val result = (mult >>> 32).toInt
+    val fraction = mult & 0xFFFFFFFFL
+
+    // optional early return, benchmark to decide if it helps
+    if (fraction < ((1L << 32) - nL)) return result
+
+    val multHigh = (((nL * (nextInt().toLong & 0xFFFFFFFFL)) >>> 32) + (nL * (nextInt().toLong & 0xFFFFFFFFL))) >>> 32
+    val sum = fraction + multHigh
+    val carry = (sum >>> 32).toInt
+    result + carry
+  }
+
+  // Uses standard Java approach. We could use the same approach as for ints,
+  // but that requires full-width multiplication of two longs, which adds some
+  // complexity.
+  override def nextLong(l: Long): Long = {
+    var x = nextLong() >>> 1
+    var r = x % l
+    while (x - r + (l - 1) < 0) {
+      x = nextLong() >>> 1
+      r = x % l
+    }
+    r
+  }
+
+  override def nextGaussian(): Double = {
+    if (hasBufferedGaussian) {
+      hasBufferedGaussian = false
+      return bufferedGaussian
+    }
+
+    var v1 = 2 * nextDouble() - 1 // between -1 and 1
+    var v2 = 2 * nextDouble() - 1
+    var s = v1 * v1 + v2 * v2
+    while (s >= 1 || s == 0) {
+      v1 = 2 * nextDouble() - 1 // between -1 and 1
+      v2 = 2 * nextDouble() - 1
+      s = v1 * v1 + v2 * v2
+    }
+    val multiplier = StrictMath.sqrt(-2 * StrictMath.log(s) / s)
+    bufferedGaussian = v2 * multiplier
+    hasBufferedGaussian = true
+    v1 * multiplier
+  }
+
+  // Equivalent to generating an infinite-precision real number in [0, 1),
+  // represented as an infinitely long bitstream, and rounding down to the
+  // nearest representable floating point number.
+  // In contrast, the standard Java and jdistlib generators sample uniformly
+  // from a sequence of equidistant floating point numbers in [0, 1), using
+  // (nextLong() >>> 11).toDouble / (1L << 53)
+  //
+  // Intuitively, the algorithm is:
+  // * lazily generate an infinite string of random bits, interpreted as
+  //   the binary expansion of a real number in [0, 1), i.e. `0.${bits}`
+  // * convert to floating point representation: the exponent is -n, where n is
+  //   the number of 0s before the first 1, and the significand is the first 1
+  //   followed by the next 52 bits.
+  override def nextDouble(): Double = {
+    // first generate random bits until we get the first 1, counting the number
+    // of zeroes
+    var bits: Long = nextLong()
+    // the exponent starts at 1022 and subtracts the number of leading zeroes,
+    // to account for the exponent bias in IEE754
+    var exponent: Int = 1022
+    while (bits == 0) {
+      bits = nextLong()
+      exponent -= 64
+    }
+    // use trailing zeroes instead of leading zeroes as slight optimization,
+    // but probabilistically equivalent
+    val e = java.lang.Long.numberOfTrailingZeros(bits)
+    exponent -= e
+    // If there are at least 52 bits before the trailing 1, use those
+    val significand = (if (e < 12) bits else nextLong()) >>> 12
+    val result = (exponent.toLong << 52) | significand
+    java.lang.Double.longBitsToDouble(result)
+  }
+
+  override def nextFloat(): Float = {
+    // first generate random bits until we get the first 1, counting the number
+    // of zeroes
+    var bits: Int = nextInt()
+    // the exponent starts at 126 and subtracts the number of leading zeroes,
+    // to account for the exponent bias in IEE754
+    var exponent: Int = 126
+    while (bits == 0) {
+      bits = nextInt()
+      exponent -= 32
+    }
+    // use trailing zeroes instead of leading zeroes as slight optimization,
+    // but probabilistically equivalent
+    val e = java.lang.Long.numberOfTrailingZeros(bits)
+    exponent -= e
+    // If there are at least 23 bits before the trailing 1, use those
+    val significand = (if (e < 9) bits else nextInt()) >>> 9
+    val result = (exponent << 23) | significand
+    java.lang.Float.intBitsToFloat(result)
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/Random.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Random.scala
@@ -217,7 +217,7 @@ object Threefry {
       for (i <- 0 until 4) cb += (xArray(i) = x(i))
       Code._empty
     }
-    f.result()()
+    f.result()(new HailClassLoader(getClass.getClassLoader))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Random.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Random.scala
@@ -217,7 +217,7 @@ object Threefry {
       for (i <- 0 until 4) cb += (xArray(i) = x(i))
       Code._empty
     }
-    f.result()(new HailClassLoader(getClass.getClassLoader))
+    f.result(false)(new HailClassLoader(getClass.getClassLoader))
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -3,6 +3,7 @@ package is.hail.types.physical.stypes
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.concrete.SRNGStateValue
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives._
 
@@ -88,6 +89,8 @@ trait SValue {
   def asCall: SCallValue = asInstanceOf[SCallValue]
 
   def asStream: SStreamValue = asInstanceOf[SStreamValue]
+
+  def asRNGState: SRNGStateValue = asInstanceOf[SRNGStateValue]
 
   def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: SType): SValue =
     castTo(cb, region, destType, false)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
@@ -78,6 +78,8 @@ final case class SRNGStateValue(
   override def valueTuple: IndexedSeq[Value[_]] =
     dynBlocksSum ++ lastDynBlock
 
+  override def sizeToStoreInBytes(cb: EmitCodeBuilder) = ???
+
   def splitStatic(bitstring: Bitstring): SRNGStateValue = {
     val appendedBlock = lastStaticBlock ++ bitstring
     if (appendedBlock.length < 256) {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
@@ -7,7 +7,7 @@ import is.hail.types.TypeWithRequiredness
 import is.hail.types.physical.PType
 import is.hail.types.physical.stypes.{SSettable, SType, SValue}
 import is.hail.types.virtual.{TRNGState, Type}
-import is.hail.utils.{FastIndexedSeq, toRichIterable}
+import is.hail.utils.{Bitstring, toRichIterable}
 
 import scala.collection.mutable
 
@@ -45,93 +45,6 @@ final case class SRNGState(
   override protected[stypes] def _typeWithRequiredness: TypeWithRequiredness = ???
 
   override def containsPointers: Boolean = false
-}
-
-object Bitstring {
-  def apply(string: String): Bitstring = {
-    assert(string.forall(c => c == '0' || c == '1'))
-    val bitstring = mutable.ArrayBuilder.make[Long]()
-    var pos: Int = 0
-    while (string.length - pos > 64) {
-      bitstring += java.lang.Long.parseUnsignedLong(string.slice(pos, pos + 64), 2)
-      pos += 64
-    }
-    val lastWord = java.lang.Long.parseUnsignedLong(string.slice(pos, string.length))
-    val bitsInLastWord = string.length - pos
-    bitstring += (lastWord << (64 - bitsInLastWord))
-    new Bitstring(bitstring.result(), bitsInLastWord)
-  }
-}
-
-case class Bitstring(contents: IndexedSeq[Long], bitsInLastWord: Int) {
-  def numWords = contents.length
-  def length = (contents.length - 1) * 64 + bitsInLastWord
-
-  override def toString: String = {
-    if (contents.isEmpty) return "Bitstring()"
-    val result = new mutable.StringBuilder("Bitstring(")
-    var i = 0
-    while (i < contents.length - 1) {
-      result ++= contents(i).toBinaryString
-      i += 1
-    }
-    i = 0
-    var lastWord = contents.last
-    val bits = Array('0', '1')
-    while (i < bitsInLastWord) {
-      result += bits((lastWord >>> 63).toInt)
-      lastWord <<= 1
-      i += 1
-    }
-    result += ')'
-    result.result
-  }
-
-  def ++(rhs: Bitstring): Bitstring = {
-    if (length == 0) return rhs
-    if (rhs.length == 0) return this
-    if (bitsInLastWord < 64) {
-      val newNumWords = (length + rhs.length + 63) >> 6
-      val newContents = Array.ofDim[Long](newNumWords)
-      for (i <- 0 until (numWords - 2)) {
-        newContents(i) = contents(i)
-      }
-      newContents(numWords - 1) = contents.last & (rhs.contents.head >>> bitsInLastWord)
-      for (i <- 0 until (rhs.numWords - 2)) {
-        newContents(numWords + i) =
-          (rhs.contents(i) << (64 - bitsInLastWord)) &
-          (rhs.contents(i + 1) >>> bitsInLastWord)
-      }
-      var newBitsInLastWord = bitsInLastWord + rhs.bitsInLastWord
-      if (newBitsInLastWord > 64) {
-        newContents(numWords + rhs.numWords - 1) = rhs.contents.last << (64 - bitsInLastWord)
-        newBitsInLastWord = newBitsInLastWord - 64
-      }
-      new Bitstring(newContents, newBitsInLastWord)
-    } else {
-      new Bitstring(contents ++ rhs.contents, rhs.bitsInLastWord)
-    }
-  }
-
-  def popWords(n: Int): (Array[Long], Bitstring) = {
-    assert(n < numWords || (n == numWords && bitsInLastWord == 64))
-    val result = contents.slice(0, n).toArray
-    val newContents = contents.slice(n, numWords)
-    val newBitsInLastWord = if (n < numWords) bitsInLastWord else 0
-    (result, new Bitstring(newContents, newBitsInLastWord))
-  }
-
-  def padTo(n: Int): Array[Long] = {
-    assert(n > numWords || (n == numWords && bitsInLastWord < 64))
-    val result = Array.ofDim[Long](n)
-    Array.copy(contents, 0, result, 0, numWords)
-    if (bitsInLastWord == 64) {
-      result(numWords) = 1L << 63
-    } else {
-      result(numWords - 1) = result(numWords - 1) & (1L << (63 - bitsInLastWord))
-    }
-    result
-  }
 }
 
 object SRNGStateValue {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
@@ -1,0 +1,222 @@
+package is.hail.types.physical.stypes.concrete
+
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.expr.ir.{EmitCodeBuilder, Threefry}
+import is.hail.types.TypeWithRequiredness
+import is.hail.types.physical.PType
+import is.hail.types.physical.stypes.{SSettable, SType, SValue}
+import is.hail.types.virtual.{TRNGState, Type}
+import is.hail.utils.{FastIndexedSeq, toRichIterable}
+
+import scala.collection.mutable
+
+object SRNGState {
+  val staticTweakMask = 0L
+  val dynTweakMask = 1L << 63
+  val finalBlockNoPadTweak = -1L >>> 1
+  val finalBlockPaddedTweak = -1L
+}
+
+final case class SRNGState(
+  key: IndexedSeq[Long],
+  numWordsInLastDynBlock: Int
+) extends SType {
+  assert(key.length == 4)
+  assert(numWordsInLastDynBlock <= 4 && numWordsInLastDynBlock >= 0)
+
+  def virtualType: Type = TRNGState
+
+  override protected[stypes] def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): SValue = ???
+
+  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] =
+    Array.fill(4 + numWordsInLastDynBlock)(typeInfo[Long])
+
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = ???
+
+  override def fromValues(values: IndexedSeq[Value[_]]): SValue = ???
+
+  override def storageType(): PType = ???
+
+  override def copiedType: SType = ???
+
+  override def castRename(t: Type): SType = ???
+
+  override protected[stypes] def _typeWithRequiredness: TypeWithRequiredness = ???
+
+  override def containsPointers: Boolean = false
+}
+
+object Bitstring {
+  def apply(string: String): Bitstring = {
+    assert(string.forall(c => c == '0' || c == '1'))
+    val bitstring = mutable.ArrayBuilder.make[Long]()
+    var pos: Int = 0
+    while (string.length - pos > 64) {
+      bitstring += java.lang.Long.parseUnsignedLong(string.slice(pos, pos + 64), 2)
+      pos += 64
+    }
+    val lastWord = java.lang.Long.parseUnsignedLong(string.slice(pos, string.length))
+    val bitsInLastWord = string.length - pos
+    bitstring += (lastWord << (64 - bitsInLastWord))
+    new Bitstring(bitstring.result(), bitsInLastWord)
+  }
+}
+
+case class Bitstring(contents: IndexedSeq[Long], bitsInLastWord: Int) {
+  def numWords = contents.length
+  def length = (contents.length - 1) * 64 + bitsInLastWord
+
+  override def toString: String = {
+    if (contents.isEmpty) return "Bitstring()"
+    val result = new mutable.StringBuilder("Bitstring(")
+    var i = 0
+    while (i < contents.length - 1) {
+      result ++= contents(i).toBinaryString
+      i += 1
+    }
+    i = 0
+    var lastWord = contents.last
+    val bits = Array('0', '1')
+    while (i < bitsInLastWord) {
+      result += bits((lastWord >>> 63).toInt)
+      lastWord <<= 1
+      i += 1
+    }
+    result += ')'
+    result.result
+  }
+
+  def ++(rhs: Bitstring): Bitstring = {
+    if (length == 0) return rhs
+    if (rhs.length == 0) return this
+    if (bitsInLastWord < 64) {
+      val newNumWords = (length + rhs.length + 63) >> 6
+      val newContents = Array.ofDim[Long](newNumWords)
+      for (i <- 0 until (numWords - 2)) {
+        newContents(i) = contents(i)
+      }
+      newContents(numWords - 1) = contents.last & (rhs.contents.head >>> bitsInLastWord)
+      for (i <- 0 until (rhs.numWords - 2)) {
+        newContents(numWords + i) =
+          (rhs.contents(i) << (64 - bitsInLastWord)) &
+          (rhs.contents(i + 1) >>> bitsInLastWord)
+      }
+      var newBitsInLastWord = bitsInLastWord + rhs.bitsInLastWord
+      if (newBitsInLastWord > 64) {
+        newContents(numWords + rhs.numWords - 1) = rhs.contents.last << (64 - bitsInLastWord)
+        newBitsInLastWord = newBitsInLastWord - 64
+      }
+      new Bitstring(newContents, newBitsInLastWord)
+    } else {
+      new Bitstring(contents ++ rhs.contents, rhs.bitsInLastWord)
+    }
+  }
+
+  def popWords(n: Int): (Array[Long], Bitstring) = {
+    assert(n < numWords || (n == numWords && bitsInLastWord == 64))
+    val result = contents.slice(0, n).toArray
+    val newContents = contents.slice(n, numWords)
+    val newBitsInLastWord = if (n < numWords) bitsInLastWord else 0
+    (result, new Bitstring(newContents, newBitsInLastWord))
+  }
+
+  def padTo(n: Int): Array[Long] = {
+    assert(n > numWords || (n == numWords && bitsInLastWord < 64))
+    val result = Array.ofDim[Long](n)
+    Array.copy(contents, 0, result, 0, numWords)
+    if (bitsInLastWord == 64) {
+      result(numWords) = 1L << 63
+    } else {
+      result(numWords - 1) = result(numWords - 1) & (1L << (63 - bitsInLastWord))
+    }
+    result
+  }
+}
+
+object SRNGStateValue {
+  def apply(cb: EmitCodeBuilder, key: IndexedSeq[Long]): SRNGStateValue = {
+    val typ = SRNGState(key, 0)
+    new SRNGStateValue(
+      typ,
+      Array.fill[Value[Long]](4)(0),
+      Array[Value[Long]](),
+      Array.fill[Long](4)(0),
+      Bitstring(""),
+      0,
+      0)
+  }
+}
+
+final case class SRNGStateValue(
+  st: SRNGState,
+  dynBlocksSum: IndexedSeq[Value[Long]],
+  lastDynBlock: IndexedSeq[Value[Long]],
+  staticBlocksSum: IndexedSeq[Long],
+  lastStaticBlock: Bitstring,
+  numStaticBlocks: Int,
+  numDynBlocks: Int,
+) extends SValue {
+  assert(staticBlocksSum.length == 4)
+  assert(lastStaticBlock.numWords <= 4)
+  assert(dynBlocksSum.length == 4)
+  assert(lastDynBlock.length == st.numWordsInLastDynBlock)
+
+  override def valueTuple: IndexedSeq[Value[_]] =
+    dynBlocksSum ++ lastDynBlock
+
+  def splitStatic(bitstring: Bitstring): SRNGStateValue = {
+    val appendedBlock = lastStaticBlock ++ bitstring
+    if (appendedBlock.length < 256) {
+      return copy(lastStaticBlock = appendedBlock)
+    }
+    val (fullBlock, newLastStaticBlock) = appendedBlock.popWords(4)
+    Threefry.encrypt(st.key, numStaticBlocks.toLong & SRNGState.staticTweakMask, fullBlock)
+    for (i <- fullBlock.indices) fullBlock(i) ^= staticBlocksSum(i)
+    copy(
+      staticBlocksSum = fullBlock,
+      lastStaticBlock = newLastStaticBlock,
+      numStaticBlocks = numStaticBlocks + 1)
+  }
+
+  def splitDyn(cb: EmitCodeBuilder, idx: Value[Long]): SRNGStateValue = {
+    if (st.numWordsInLastDynBlock < 4) {
+      return copy(
+        st = st.copy(numWordsInLastDynBlock = st.numWordsInLastDynBlock + 1),
+        lastDynBlock = lastDynBlock :+ idx)
+    }
+    val x = Array.tabulate[Settable[Long]](4)(i => cb.newLocal[Long](s"splitDyn_x$i", lastDynBlock(i)))
+    Threefry.encrypt(cb, st.key, numDynBlocks.toLong & SRNGState.dynTweakMask, x)
+    for (i <- 0 until 4) cb.assign(x(i), x(i) ^ dynBlocksSum(i))
+    copy(
+      st = st.copy(numWordsInLastDynBlock = 1),
+      dynBlocksSum = x,
+      lastDynBlock = Array(idx),
+      numDynBlocks = numDynBlocks + 1)
+  }
+
+  def rand(cb: EmitCodeBuilder): IndexedSeq[Value[Long]] = {
+    val finalStaticBlocksSum = if (lastStaticBlock.length == 0) {
+      staticBlocksSum
+    } else {
+      val padded = lastStaticBlock.padTo(4)
+      Threefry.encrypt(st.key, numStaticBlocks.toLong & SRNGState.staticTweakMask, padded)
+      Array.tabulate(4)(i => staticBlocksSum(i) ^ padded(i)).toFastIndexedSeq
+    }
+    if (st.numWordsInLastDynBlock == 0) {
+      val x = Array(finalStaticBlocksSum: _*)
+      Threefry.encrypt(st.key, SRNGState.finalBlockNoPadTweak, x)
+      return x.map(const)
+    }
+    val x = Array.tabulate[Settable[Long]](4)(i => cb.newLocal[Long](s"rand_x$i", finalStaticBlocksSum(i)))
+    if (st.numWordsInLastDynBlock == 4) {
+      for (i <- lastDynBlock.indices) cb.assign(x(i), x(i) ^ lastDynBlock(i))
+      Threefry.encrypt(cb, st.key, SRNGState.finalBlockNoPadTweak, x)
+    } else {
+      for (i <- lastDynBlock.indices) cb.assign(x(i), x(i) ^ lastDynBlock(i))
+      cb.assign(x(lastDynBlock.size), x(lastDynBlock.size) ^ (1L << 63))
+      Threefry.encrypt(cb, st.key, SRNGState.finalBlockPaddedTweak, x)
+    }
+    x
+  }
+}

--- a/hail/src/main/scala/is/hail/types/virtual/TRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TRNGState.scala
@@ -1,0 +1,12 @@
+package is.hail.types.virtual
+
+case object TRNGState extends Type {
+  override def _toPretty = "RNGState"
+
+  override def pyString(sb: StringBuilder): Unit = {
+    sb.append("rng_state")
+  }
+  def _typeCheck(a: Any): Boolean = ???
+  def mkOrdering(missingEqual: Boolean): is.hail.annotations.ExtendedOrdering = ???
+  def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] = ???
+}

--- a/hail/src/main/scala/is/hail/utils/Bitstring.scala
+++ b/hail/src/main/scala/is/hail/utils/Bitstring.scala
@@ -1,0 +1,90 @@
+package is.hail.utils
+
+import scala.collection.mutable
+
+object Bitstring {
+  def apply(string: String): Bitstring = {
+    assert(string.forall(c => c == '0' || c == '1'))
+    val bitstring = mutable.ArrayBuilder.make[Long]()
+    var pos: Int = 0
+    while (string.length - pos > 64) {
+      bitstring += java.lang.Long.parseUnsignedLong(string.slice(pos, pos + 64), 2)
+      pos += 64
+    }
+    val lastWord = java.lang.Long.parseUnsignedLong(string.slice(pos, string.length))
+    val bitsInLastWord = string.length - pos
+    bitstring += (lastWord << (64 - bitsInLastWord))
+    new Bitstring(bitstring.result(), bitsInLastWord)
+  }
+}
+
+case class Bitstring(contents: IndexedSeq[Long], bitsInLastWord: Int) {
+  def numWords = contents.length
+  def length = (contents.length - 1) * 64 + bitsInLastWord
+
+  override def toString: String = {
+    if (contents.isEmpty) return "Bitstring()"
+    val result = new mutable.StringBuilder("Bitstring(")
+    var i = 0
+    while (i < contents.length - 1) {
+      result ++= contents(i).toBinaryString
+      i += 1
+    }
+    i = 0
+    var lastWord = contents.last
+    val bits = Array('0', '1')
+    while (i < bitsInLastWord) {
+      result += bits((lastWord >>> 63).toInt)
+      lastWord <<= 1
+      i += 1
+    }
+    result += ')'
+    result.result
+  }
+
+  def ++(rhs: Bitstring): Bitstring = {
+    if (length == 0) return rhs
+    if (rhs.length == 0) return this
+    if (bitsInLastWord < 64) {
+      val newNumWords = (length + rhs.length + 63) >> 6
+      val newContents = Array.ofDim[Long](newNumWords)
+      for (i <- 0 until (numWords - 2)) {
+        newContents(i) = contents(i)
+      }
+      newContents(numWords - 1) = contents.last & (rhs.contents.head >>> bitsInLastWord)
+      for (i <- 0 until (rhs.numWords - 2)) {
+        newContents(numWords + i) =
+          (rhs.contents(i) << (64 - bitsInLastWord)) &
+            (rhs.contents(i + 1) >>> bitsInLastWord)
+      }
+      var newBitsInLastWord = bitsInLastWord + rhs.bitsInLastWord
+      if (newBitsInLastWord > 64) {
+        newContents(numWords + rhs.numWords - 1) = rhs.contents.last << (64 - bitsInLastWord)
+        newBitsInLastWord = newBitsInLastWord - 64
+      }
+      new Bitstring(newContents, newBitsInLastWord)
+    } else {
+      new Bitstring(contents ++ rhs.contents, rhs.bitsInLastWord)
+    }
+  }
+
+  def popWords(n: Int): (Array[Long], Bitstring) = {
+    assert(n < numWords || (n == numWords && bitsInLastWord == 64))
+    val result = contents.slice(0, n).toArray
+    val newContents = contents.slice(n, numWords)
+    val newBitsInLastWord = if (n < numWords) bitsInLastWord else 0
+    (result, new Bitstring(newContents, newBitsInLastWord))
+  }
+
+  def padTo(n: Int): Array[Long] = {
+    assert(n > numWords || (n == numWords && bitsInLastWord < 64))
+    val result = Array.ofDim[Long](n)
+    Array.copy(contents, 0, result, 0, numWords)
+    if (bitsInLastWord == 64) {
+      result(numWords) = 1L << 63
+    } else {
+      result(numWords - 1) = result(numWords - 1) & (1L << (63 - bitsInLastWord))
+    }
+    result
+  }
+}

--- a/hail/src/test/scala/is/hail/expr/ir/RandomSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomSuite.scala
@@ -1,0 +1,106 @@
+package is.hail.expr.ir
+
+import is.hail.HailSuite
+import org.apache.commons.math3.distribution.ChiSquaredDistribution
+import org.testng.annotations.Test
+
+class RandomSuite extends HailSuite {
+  @Test def testThreefry() {
+    val k = Array.fill[Long](4)(0)
+    val tf = Threefry(k)
+    val x = Array.fill[Long](4)(0)
+    val expected = Array(
+      0x09218EBDE6C85537L,
+      0x55941F5266D86105L,
+      0x4BD25E16282434DCL,
+      0xEE29EC846BD2E40BL
+    )
+    tf(x, 0)
+    assert(x sameElements expected)
+
+    val rand = new ThreefryRandomEngine(k, Array.fill(4)(0L), 0, tweak = 0)
+    val y = Array.fill(4)(rand.nextLong())
+    assert(y sameElements expected)
+  }
+
+  def runChiSquareTest(samples: Int, buckets: Int)(sample: => Int) {
+    val chiSquareDist = new ChiSquaredDistribution(buckets - 1)
+    val expected = samples.toDouble / buckets
+    var numRuns = 0
+    val passThreshold = 0.1
+    val failThreshold = 1e-6
+    var geometricMean = failThreshold
+
+    while (geometricMean >= failThreshold && geometricMean < passThreshold) {
+      val counts = Array.ofDim[Int](buckets)
+      for (_ <- 0 until samples) counts(sample) += 1
+      val chisquare = counts.map(observed => math.pow(observed - expected, 2) / expected).sum
+      val pvalue = 1 - chiSquareDist.cumulativeProbability(chisquare)
+      numRuns += 1
+      geometricMean = math.pow(geometricMean, (numRuns - 1).toDouble / numRuns) * math.pow(pvalue, 1.0 / numRuns)
+    }
+    assert(geometricMean >= passThreshold, s"failed after $numRuns runs with pvalue $geometricMean")
+    println(s"passed after $numRuns runs with pvalue $geometricMean")
+  }
+
+  @Test def testRandomInt() {
+    val n = 1 << 25
+    val k = 1 << 15
+    val rand = ThreefryRandomEngine()
+    runChiSquareTest(n, k) {
+      rand.nextInt() & (k - 1)
+    }
+  }
+
+  @Test def testBoundedUniformInt() {
+    var n = 1 << 25
+    var k = 1 << 15
+    val rand = ThreefryRandomEngine()
+    runChiSquareTest(n, k) {
+      rand.nextInt(k)
+    }
+
+    n = 30000000
+    k = math.pow(n, 3.0/5).toInt
+    runChiSquareTest(n, k) {
+      rand.nextInt(k)
+    }
+  }
+
+  @Test def testBoundedUniformLong() {
+    var n = 1 << 25
+    var k = 1 << 15
+    val rand = ThreefryRandomEngine()
+    runChiSquareTest(n, k) {
+      rand.nextLong(k).toInt
+    }
+
+    n = 30000000
+    k = math.pow(n, 3.0/5).toInt
+    runChiSquareTest(n, k) {
+      rand.nextLong(k).toInt
+    }
+  }
+
+  @Test def testUniformDouble() {
+    val n = 1 << 25
+    val k = 1 << 15
+    val rand = ThreefryRandomEngine()
+    runChiSquareTest(n, k) {
+      val r = rand.nextDouble()
+      assert(r >= 0.0 && r < 1.0, r)
+      (r * k).toInt
+    }
+  }
+
+  @Test def testUniformFloat() {
+    val n = 1 << 25
+    val k = 1 << 15
+    val rand = ThreefryRandomEngine()
+    runChiSquareTest(n, k) {
+      val r = rand.nextFloat()
+      assert(r >= 0.0 && r < 1.0, r)
+      (r * k).toInt
+    }
+  }
+}


### PR DESCRIPTION
This PR begins to implement the infrastructure needed for reproducible randomness.

The main components are:
* An implementation of the Threefish block cipher, reduced to 20 rounds as in Threefry [1], but keeping the tweak from Threefish (really just the first 64 bits, the second 64 bits are always 0). The specification for Threefish can be found in [2].
* An implementation of the `jdistlib.RandomEngine` interface using Threefish, so that we can continue using the `jdistlib` implementations of sampling from various distributions.
  * This has some improvements over the standard Java RNG implementations of random floating point numbers, and of random integers from a specified interval. See comments in the code for details.
* The beginnings of a new type `(S/T)RNGState`. This implements a splittable RNG interface, similarly to [3], but instead of the cascade construction, we use a modification of PMAC [4] to build a psuedo-random function from a blockcipher. This allows us to reorder the processing of blocks of the input, in particular moving computation to compile time as much as possible.
* A simple test suite for the new RNG using a chi-square test.

[1] "Parallel random numbers: as easy as 1, 2, 3", http://www.thesalmons.org/john/random123/papers/random123sc11.pdf
[2] "The Skein Hash Function Family", https://www.schneier.com/wp-content/uploads/2015/01/skein.pdf
[3] "Splittable pseudorandom number generators using cryptographic hashing", https://publications.lib.chalmers.se/records/fulltext/183348/local_183348.pdf
[4] "Efficient Instantiations of Tweakable Blockciphers and Refinements to Modes OCB and PMAC", https://www.cs.ucdavis.edu/~rogaway/papers/offsets.pdf