### PR TITLE
[prometheus] Update prometheus version

### DIFF
--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 65534
       containers:
        - name: prometheus
-         image: prom/prometheus:v2.19.2
+         image: prom/prometheus:v2.34.0
          imagePullPolicy: Always
          command:
           - "/bin/prometheus"


### PR DESCRIPTION
prometheus was on a crash loop in Azure because it was failing to `mmap` a 0-byte file that the previous pod had created before getting shut down. Turns out this bug was fixed in a more recent version of prometheus so a simple upgrade fixed the issue. This is the most recent release.