### PR TITLE
[query] Generate infinite discrete colors

### DIFF
--- a/hail/python/hail/docs/ggplot/index.rst
+++ b/hail/python/hail/docs/ggplot/index.rst
@@ -73,9 +73,13 @@ currently uses plotly to generate plots, as opposed to ``hl.plot``, which uses b
     scale_y_reverse
     scale_color_continuous
     scale_color_discrete
+    scale_color_hue
+    scale_color_manual
     scale_color_identity
     scale_fill_continuous
     scale_fill_discrete
+    scale_fill_hue
+    scale_fill_manual
     scale_fill_identity
 
 .. autofunction:: scale_x_continuous
@@ -89,9 +93,13 @@ currently uses plotly to generate plots, as opposed to ``hl.plot``, which uses b
 .. autofunction:: scale_y_reverse
 .. autofunction:: scale_color_continuous
 .. autofunction:: scale_color_discrete
+.. autofunction:: scale_color_hue
+.. autofunction:: scale_color_manual
 .. autofunction:: scale_color_identity
 .. autofunction:: scale_fill_continuous
 .. autofunction:: scale_fill_discrete
+.. autofunction:: scale_fill_hue
+.. autofunction:: scale_fill_manual
 .. autofunction:: scale_fill_identity
 
 .. rubric:: Labels

--- a/hail/python/hail/ggplot/__init__.py
+++ b/hail/python/hail/ggplot/__init__.py
@@ -6,7 +6,8 @@ from .geoms import FigureAttribute, geom_line, geom_point, geom_text, geom_bar, 
 from .labels import ggtitle, xlab, ylab
 from .scale import scale_x_continuous, scale_y_continuous, scale_x_discrete, scale_y_discrete, scale_x_genomic, \
     scale_x_log10, scale_y_log10, scale_x_reverse, scale_y_reverse, scale_color_discrete, scale_color_hue, scale_color_identity,\
-    scale_color_continuous, scale_fill_discrete, scale_fill_hue, scale_fill_identity, scale_fill_continuous
+    scale_color_manual, scale_color_continuous, scale_fill_discrete, scale_fill_hue, scale_fill_identity, scale_fill_continuous,\
+    scale_fill_manual
 
 __all__ = [
     "aes",
@@ -40,8 +41,10 @@ __all__ = [
     "scale_color_identity",
     "scale_color_discrete",
     "scale_color_hue",
+    "scale_color_manual",
     "scale_fill_continuous",
     "scale_fill_identity",
     "scale_fill_discrete",
     "scale_fill_hue",
+    "scale_fill_manual"
 ]

--- a/hail/python/hail/ggplot/__init__.py
+++ b/hail/python/hail/ggplot/__init__.py
@@ -5,8 +5,8 @@ from .geoms import FigureAttribute, geom_line, geom_point, geom_text, geom_bar, 
     geom_hline, geom_vline, geom_tile, geom_col, geom_area, geom_ribbon # noqa F401
 from .labels import ggtitle, xlab, ylab
 from .scale import scale_x_continuous, scale_y_continuous, scale_x_discrete, scale_y_discrete, scale_x_genomic, \
-    scale_x_log10, scale_y_log10, scale_x_reverse, scale_y_reverse, scale_color_discrete, scale_color_identity,\
-    scale_color_continuous, scale_fill_discrete, scale_fill_identity, scale_fill_continuous
+    scale_x_log10, scale_y_log10, scale_x_reverse, scale_y_reverse, scale_color_discrete, scale_color_hue, scale_color_identity,\
+    scale_color_continuous, scale_fill_discrete, scale_fill_hue, scale_fill_identity, scale_fill_continuous
 
 __all__ = [
     "aes",
@@ -39,7 +39,9 @@ __all__ = [
     "scale_color_continuous",
     "scale_color_identity",
     "scale_color_discrete",
+    "scale_color_hue",
     "scale_fill_continuous",
     "scale_fill_identity",
     "scale_fill_discrete",
+    "scale_fill_hue",
 ]

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -1,4 +1,3 @@
-import plotly
 import plotly.graph_objects as go
 
 from pprint import pprint

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -25,8 +25,7 @@ class GGPlot:
     .. automethod:: write_image
     """
 
-    def __init__(self, ht, aes, geoms=[], labels=Labels(), coord_cartesian=None, scales=None,
-                 discrete_color_scale=plotly.colors.qualitative.D3, continuous_color_scale=plotly.colors.sequential.Viridis):
+    def __init__(self, ht, aes, geoms=[], labels=Labels(), coord_cartesian=None, scales=None):
         if scales is None:
             scales = {}
 
@@ -36,10 +35,6 @@ class GGPlot:
         self.labels = labels
         self.coord_cartesian = coord_cartesian
         self.scales = scales
-        self.discrete_color_scale = discrete_color_scale
-        self.discrete_color_dict = {}
-        self.discrete_color_idx = 0
-        self.continuous_color_scale = continuous_color_scale
 
         self.add_default_scales(aes)
 
@@ -99,8 +94,7 @@ class GGPlot:
                         self.scales[aesthetic_str] = ScaleDiscrete(aesthetic_str)
 
     def copy(self):
-        return GGPlot(self.ht, self.aes, self.geoms[:], self.labels, self.coord_cartesian, self.scales,
-                      self.discrete_color_scale, self.continuous_color_scale)
+        return GGPlot(self.ht, self.aes, self.geoms[:], self.labels, self.coord_cartesian, self.scales)
 
     def verify_scales(self):
         for geom_idx, geom in enumerate(self.geoms):
@@ -175,7 +169,7 @@ class GGPlot:
         # Create scaling functions based on all the data:
         transformers = {}
         for scale in self.scales.values():
-            transformers[scale.aesthetic_name] = scale.create_local_transformer([x for _, _, x in geoms_and_grouped_dfs], self)
+            transformers[scale.aesthetic_name] = scale.create_local_transformer([x for _, _, x in geoms_and_grouped_dfs])
 
         for geom, geom_label, grouped_dfs in geoms_and_grouped_dfs:
             scaled_grouped_dfs = []

--- a/hail/python/hail/ggplot/scale.py
+++ b/hail/python/hail/ggplot/scale.py
@@ -400,10 +400,12 @@ def scale_color_discrete():
     :class:`.FigureAttribute`
         The scale to be applied.
     """
-    return ScaleColorDiscrete("color")
+    return scale_color_hue()
+
 
 def scale_color_hue():
     return ScaleColorHue("color")
+
 
 def scale_color_continuous():
     """The default continuous color scale. This linearly interpolates colors between the min and max observed values.
@@ -435,7 +437,7 @@ def scale_fill_discrete():
     :class:`.FigureAttribute`
         The scale to be applied.
     """
-    return ScaleColorDiscrete("fill")
+    return scale_fill_hue()
 
 
 def scale_fill_continuous():
@@ -458,6 +460,7 @@ def scale_fill_identity():
         The scale to be applied.
     """
     return ScaleColorDiscreteIdentity("fill")
+
 
 def scale_fill_hue():
     return ScaleColorHue("fill")

--- a/hail/python/hail/ggplot/scale.py
+++ b/hail/python/hail/ggplot/scale.py
@@ -149,7 +149,10 @@ class ScaleDiscrete(Scale):
         return False
 
 
-class ScaleColorDiscrete(ScaleDiscrete):
+class ScaleColorManual(ScaleDiscrete):
+
+    def __init__(self, values):
+        self.values = values
 
     def create_local_transformer(self, groups_of_dfs, parent):
         categorical_strings = set()
@@ -158,7 +161,7 @@ class ScaleColorDiscrete(ScaleDiscrete):
                 if self.aesthetic_name in df.attrs:
                     categorical_strings.add(df.attrs[self.aesthetic_name])
 
-        unique_color_mapping = categorical_strings_to_colors(categorical_strings, parent)
+        unique_color_mapping = categorical_strings_to_colors(categorical_strings, self.values)
 
         def transform(df):
             df.attrs[f"{self.aesthetic_name}_legend"] = df.attrs[self.aesthetic_name]

--- a/hail/python/hail/ggplot/scale.py
+++ b/hail/python/hail/ggplot/scale.py
@@ -6,6 +6,7 @@ from hail.context import get_reference
 from .utils import categorical_strings_to_colors, continuous_nums_to_colors
 
 import plotly.express as px
+import plotly
 
 
 class Scale(FigureAttribute):
@@ -16,7 +17,7 @@ class Scale(FigureAttribute):
     def transform_data(self, field_expr):
         pass
 
-    def create_local_transformer(self, groups_of_dfs, parent):
+    def create_local_transformer(self, groups_of_dfs):
         return lambda x: x
 
     @abc.abstractmethod
@@ -155,7 +156,7 @@ class ScaleColorManual(ScaleDiscrete):
         super().__init__(aesthetic_name)
         self.values = values
 
-    def create_local_transformer(self, groups_of_dfs, parent):
+    def create_local_transformer(self, groups_of_dfs):
         categorical_strings = set()
         for group_of_dfs in groups_of_dfs:
             for df in group_of_dfs:
@@ -174,7 +175,7 @@ class ScaleColorManual(ScaleDiscrete):
 
 class ScaleColorContinuous(ScaleContinuous):
 
-    def create_local_transformer(self, groups_of_dfs, parent):
+    def create_local_transformer(self, groups_of_dfs):
         overall_min = None
         overall_max = None
         for group_of_dfs in groups_of_dfs:
@@ -193,7 +194,7 @@ class ScaleColorContinuous(ScaleContinuous):
                     else:
                         overall_max = max(series_max, overall_max)
 
-        color_mapping = continuous_nums_to_colors(overall_min, overall_max, parent.continuous_color_scale)
+        color_mapping = continuous_nums_to_colors(overall_min, overall_max, plotly.colors.sequential.Viridis)
 
         def transform(df):
             df[self.aesthetic_name] = df[self.aesthetic_name].map(lambda i: color_mapping(i))
@@ -203,7 +204,7 @@ class ScaleColorContinuous(ScaleContinuous):
 
 
 class ScaleColorHue(ScaleDiscrete):
-    def create_local_transformer(self, groups_of_dfs, parent):
+    def create_local_transformer(self, groups_of_dfs):
         categorical_strings = set()
         for group_of_dfs in groups_of_dfs:
             for df in group_of_dfs:

--- a/hail/python/hail/ggplot/scale.py
+++ b/hail/python/hail/ggplot/scale.py
@@ -151,7 +151,8 @@ class ScaleDiscrete(Scale):
 
 class ScaleColorManual(ScaleDiscrete):
 
-    def __init__(self, values):
+    def __init__(self, aesthetic_name, values):
+        super().__init__(aesthetic_name)
         self.values = values
 
     def create_local_transformer(self, groups_of_dfs, parent):
@@ -396,7 +397,7 @@ def scale_x_genomic(reference_genome, name=None):
 
 
 def scale_color_discrete():
-    """The default discrete color scale. This maps each discrete value to a color.
+    """The default discrete color scale. This maps each discrete value to a color. Equivalent to scale_color_hue.
 
     Returns
     -------
@@ -407,6 +408,14 @@ def scale_color_discrete():
 
 
 def scale_color_hue():
+    """Map discrete colors to evenly placed positions around the color wheel.
+
+    Returns
+    -------
+    :class:`.FigureAttribute`
+        The scale to be applied.
+
+    """
     return ScaleColorHue("color")
 
 
@@ -430,6 +439,23 @@ def scale_color_identity():
         The scale to be applied.
     """
     return ScaleColorDiscreteIdentity("color")
+
+
+def scale_color_manual(*, values):
+    """A color scale that assigns strings to colors using the pool of colors specified as `values`.
+
+
+    Parameters
+    ----------
+    values: :class:`list` of :class:`str`
+        The colors to choose when assigning values to colors.
+
+    Returns
+    -------
+    :class:`.FigureAttribute`
+        The scale to be applied.
+    """
+    return ScaleColorManual("color", values=values)
 
 
 def scale_fill_discrete():
@@ -466,4 +492,29 @@ def scale_fill_identity():
 
 
 def scale_fill_hue():
+    """Map discrete fill colors to evenly placed positions around the color wheel.
+
+    Returns
+    -------
+    :class:`.FigureAttribute`
+        The scale to be applied.
+
+    """
     return ScaleColorHue("fill")
+
+
+def scale_fill_manual(*, values):
+    """A color scale that assigns strings to fill colors using the pool of colors specified as `values`.
+
+
+    Parameters
+    ----------
+    values: :class:`list` of :class:`str`
+        The colors to choose when assigning values to colors.
+
+    Returns
+    -------
+    :class:`.FigureAttribute`
+        The scale to be applied.
+    """
+    return ScaleColorManual("fill", values=values)

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -34,16 +34,20 @@ def should_use_scale_for_grouping(scale):
 
 
 # Map strings to numbers that will index into a color scale.
-def categorical_strings_to_colors(string_set, parent_plot):
+def categorical_strings_to_colors(string_set, color_values):
 
-    color_dict = parent_plot.discrete_color_dict
+    if isinstance(color_values, list):
+        if len(string_set) > len(color_values):
+            print(f"Not enough colors specified. Found {len(string_set)} distinct values of color aesthetic and only {len(color_values)} colors were provided.")
+        color_dict = {}
+        for idx, element in enumerate(string_set):
+            if element not in color_dict:
+                color_dict[element] = color_values[idx]
 
-    for element in string_set:
-        if element not in color_dict:
-            color_dict[element] = parent_plot.discrete_color_scale[parent_plot.discrete_color_idx % len(parent_plot.discrete_color_scale)]
-            parent_plot.discrete_color_idx += 1
+    else:
+        color_dict = color_values
 
-    return parent_plot.discrete_color_dict
+    return color_dict
 
 
 def continuous_nums_to_colors(min_color, max_color, continuous_color_scale):

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -81,4 +81,10 @@ def test_default_scale_no_repeat_colors():
 
 
 def test_scale_color_manual():
-    ...
+    num_rows = 4
+    colors = set(["red", "blue"])
+    ht = hl.utils.range_table(num_rows)
+    fig = ggplot(ht, aes(x=ht.idx, y=ht.idx, color=hl.str(ht.idx % 2))) + geom_point() + scale_color_manual(values=list(colors))
+    pfig = fig.to_plotly()
+
+    assert set([scatter.marker.color for scatter in pfig.data]) == colors

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -78,3 +78,7 @@ def test_default_scale_no_repeat_colors():
     scatter_colors = [scatter['marker']['color'] for scatter in pfig['data']]
     num_unique_colors = len(set(scatter_colors))
     assert num_unique_colors == num_rows
+
+
+def test_scale_color_manual():
+    ...

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -1,4 +1,3 @@
-# These tests only check that the functions don't error out, they don't check what the output plot looks like.
 import hail as hl
 from hail.ggplot import *
 import numpy as np
@@ -68,3 +67,14 @@ def test_geom_ribbon():
     ht = hl.utils.range_table(20)
     fig = ggplot(ht, aes(x=ht.idx, ymin=ht.idx * 2, ymax=ht.idx * 3)) + geom_ribbon()
     fig.to_plotly()
+
+
+def test_default_scale_no_repeat_colors():
+    num_rows = 20
+    ht = hl.utils.range_table(num_rows)
+    fig = ggplot(ht, aes(x=ht.idx, y=ht.idx, color=hl.str(ht.idx))) + geom_point()
+    pfig = fig.to_plotly()
+
+    scatter_colors = [scatter['marker']['color'] for scatter in pfig['data']]
+    num_unique_colors = len(set(scatter_colors))
+    assert num_unique_colors == num_rows


### PR DESCRIPTION
Prior to this PR, when someone specified they'd like to color a plot by a discrete variable, we used a predetermined list of 10 colors to assign colors. If something used more than 10 colors, it'd wrap around. 

This PR changes `scale_color_discrete` to be an alias for `scale_color_hue`, as it is in ggplot. `scale_color_hue` works by sampling evenly spaced points around a color wheel to create a set of maximally distant colors. 

The old behavior is now achievable by using `scale_color_manual`, which takes in a list of colors and assigns colors based on that list. 