### PR TITLE
[query/service] implement the function registry in the ServiceBackend

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -1,7 +1,8 @@
-from typing import Mapping, List, Dict, Optional, Any
+from typing import Mapping, List, Union, Tuple, Dict, Optional, Any
 import abc
 from ..fs.fs import FS
 from ..expr import Expression
+from ..expr.types import HailType
 from ..ir import BaseIR
 from ..utils.java import FatalError, HailUserError
 
@@ -142,7 +143,13 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def register_ir_function(self, name, type_parameters, argument_names, argument_types, return_type, body):
+    def register_ir_function(self,
+                             name: str,
+                             type_parameters: Union[Tuple[HailType, ...], List[HailType]],
+                             value_parameter_names: Union[Tuple[str, ...], List[str]],
+                             value_parameter_types: Union[Tuple[HailType, ...], List[HailType]],
+                             return_type: HailType,
+                             body: Expression):
         pass
 
     @abc.abstractmethod

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -84,7 +84,7 @@ class Py4JBackend(Backend):
 
         Env.hail().expr.ir.functions.IRFunctionRegistry.pyRegisterIR(
             name,
-            [ta._parsable_string() for ta in type_parameter],
+            [ta._parsable_string() for ta in type_parameters],
             value_parameter_names,
             [pt._parsable_string() for pt in value_parameter_types],
             return_type._parsable_string(),

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from typing import Mapping, Union, Tuple, List
 import abc
 
 import py4j
@@ -10,6 +10,8 @@ from hail.ir import JavaIR
 from hail.ir.renderer import CSERenderer
 from hail.utils.java import FatalError, Env
 from .backend import Backend, fatal_error_from_java_error_triplet
+from ..expr import Expression
+from ..expr.types import HailType
 
 
 def handle_java_exception(f):
@@ -70,19 +72,19 @@ class Py4JBackend(Backend):
         pass
 
     def register_ir_function(self,
-                             name,
-                             type_parameter_names,
-                             value_parameter_names,
-                             value_parameter_types,
-                             return_type,
-                             body):
+                             name: str,
+                             type_parameters: Union[Tuple[HailType, ...], List[HailType]],
+                             value_parameter_names: Union[Tuple[str, ...], List[str]],
+                             value_parameter_types: Union[Tuple[HailType, ...], List[HailType]],
+                             return_type: HailType,
+                             body: Expression):
         r = CSERenderer(stop_at_jir=True)
         code = r(body._ir)
         jbody = (self._parse_value_ir(code, ref_map=dict(zip(value_parameter_names, value_parameter_types)), ir_map=r.jirs))
 
         Env.hail().expr.ir.functions.IRFunctionRegistry.pyRegisterIR(
             name,
-            [ta._parsable_string() for ta in type_parameter_names],
+            [ta._parsable_string() for ta in type_parameter],
             value_parameter_names,
             [pt._parsable_string() for pt in value_parameter_types],
             return_type._parsable_string(),

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -69,15 +69,22 @@ class Py4JBackend(Backend):
     def _to_java_value_ir(self, ir):
         pass
 
-    def register_ir_function(self, name, type_parameters, argument_names, argument_types, return_type, body):
+    def register_ir_function(self,
+                             name,
+                             type_parameter_names,
+                             value_parameter_names,
+                             value_parameter_types,
+                             return_type,
+                             body):
         r = CSERenderer(stop_at_jir=True)
         code = r(body._ir)
-        jbody = (self._parse_value_ir(code, ref_map=dict(zip(argument_names, argument_types)), ir_map=r.jirs))
+        jbody = (self._parse_value_ir(code, ref_map=dict(zip(value_parameter_names, value_parameter_types)), ir_map=r.jirs))
 
         Env.hail().expr.ir.functions.IRFunctionRegistry.pyRegisterIR(
             name,
-            [ta._parsable_string() for ta in type_parameters],
-            argument_names, [pt._parsable_string() for pt in argument_types],
+            [ta._parsable_string() for ta in type_parameter_names],
+            value_parameter_names,
+            [pt._parsable_string() for pt in value_parameter_types],
             return_type._parsable_string(),
             jbody)
 

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -216,7 +216,7 @@ class HailType(object):
         b.append(str(self))
 
     @abc.abstractmethod
-    def _parsable_string(self):
+    def _parsable_string(self) -> str:
         pass
 
     def typecheck(self, value):

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -118,7 +118,6 @@ class Tests(unittest.TestCase):
 
 
     @pytest.mark.unchecked_allocator
-    @skip_when_service_backend('hangs >5 minutes; last message is "all results compelte" in ServiceBackend.parallelizeAndComputeWithIndex')
     def test_ld_score_regression(self):
 
         ht_scores = hl.import_table(
@@ -295,7 +294,6 @@ class Tests(unittest.TestCase):
               .drop('a_index', 'was_split').select_entries(*expected_split_mt.entry.keys()))
         assert mt._same(expected_split_mt)
 
-    @fails_service_backend()
     def test_define_function(self):
         f1 = hl.experimental.define_function(
             lambda a, b: (a + 7) * b, hl.tint32, hl.tint32)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3630,7 +3630,6 @@ Caused by: java.lang.AssertionError: assertion failed
         self.assert_evals_to(hl.set([1, 2, 3]) ^ set([3, 4, 5]), set([1, 2, 4, 5]))
         self.assert_evals_to(set([1, 2, 3]) ^ hl.set([3, 4, 5]), set([1, 2, 4, 5]))
 
-    @fails_service_backend()
     def test_uniroot(self):
         tol = 1.220703e-4
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1377,13 +1377,11 @@ Caused by: is.hail.utils.HailException: Premature end of file: expected 4 bytes,
             self.assertTrue(r.sum_x == -15 and r.sum_y == 10 and r.sum_empty == 0 and
                             r.prod_x == -120 and r.prod_y == 0 and r.prod_empty == 1)
 
-    @fails_service_backend
     def test_aggregators_hist(self):
         table = hl.utils.range_table(11)
         r = table.aggregate(hl.agg.hist(table.idx - 1, 0, 8, 4))
         self.assertTrue(r.bin_edges == [0, 2, 4, 6, 8] and r.bin_freq == [2, 2, 2, 3] and r.n_smaller == 1 and r.n_larger == 1)
 
-    @fails_service_backend()
     def test_aggregators_hist_neg0(self):
         table = hl.utils.range_table(32)
         table = table.annotate(d=hl.if_else(table.idx == 11, -0.0, table.idx / 3))
@@ -1393,7 +1391,6 @@ Caused by: is.hail.utils.HailException: Premature end of file: expected 4 bytes,
         self.assertEqual(r.n_smaller, 0)
         self.assertEqual(r.n_larger, 1)
 
-    @fails_service_backend()
     def test_aggregators_hist_nan(self):
         ht = hl.utils.range_table(3).annotate(x=hl.float('nan'))
         r = ht.aggregate(hl.agg.hist(ht.x, 0, 10, 2))
@@ -1429,7 +1426,6 @@ Caused by: is.hail.utils.HailException: Premature end of file: expected 4 bytes,
     # r2adj = sumfit$adj.r.squared
     # f = sumfit$fstatistic
     # p = pf(f[1],f[2],f[3],lower.tail=F)
-    @fails_service_backend()
     def test_aggregators_linreg(self):
         t = hl.Table.parallelize([
             {"y": None, "x": 1.0},
@@ -1487,7 +1483,6 @@ Caused by: is.hail.utils.HailException: Premature end of file: expected 4 bytes,
         self.assertAlmostEqual(r.multiple_p_value, 0.56671386)
         self.assertAlmostEqual(r.n, 5)
 
-    @fails_service_backend()
     def test_linreg_no_data(self):
         ht = hl.utils.range_table(1).filter(False)
         r = ht.aggregate(hl.agg.linreg(ht.idx, 0))
@@ -2559,7 +2554,6 @@ Caused by: java.lang.AssertionError: assertion failed
             (hl.literal(None, dtype='int32'), None),
             (hl.literal(None, dtype='int64'), None)])
 
-    @fails_service_backend()
     def test_is_transition(self):
         _test_many_equal([
             (hl.is_transition("A", "G"), True),
@@ -2569,7 +2563,6 @@ Caused by: java.lang.AssertionError: assertion failed
             (hl.is_transition("ACA", "AGA"), False),
             (hl.is_transition("A", "T"), False)])
 
-    @fails_service_backend()
     def test_is_transversion(self):
         _test_many_equal([
             (hl.is_transversion("A", "T"), True),
@@ -2578,7 +2571,6 @@ Caused by: java.lang.AssertionError: assertion failed
             (hl.is_transversion("AA", "T"), False),
             (hl.is_transversion("ACCC", "ACCT"), False)])
 
-    @fails_service_backend()
     def test_is_snp(self):
         _test_many_equal([
             (hl.is_snp("A", "T"), True),
@@ -2588,36 +2580,30 @@ Caused by: java.lang.AssertionError: assertion failed
             (hl.is_snp("AT", "AG"), True),
             (hl.is_snp("ATCCC", "AGCCC"), True)])
 
-    @fails_service_backend()
     def test_is_mnp(self):
         _test_many_equal([
             (hl.is_mnp("ACTGAC", "ATTGTT"), True),
             (hl.is_mnp("CA", "TT"), True)])
 
-    @fails_service_backend()
     def test_is_insertion(self):
         _test_many_equal([
             (hl.is_insertion("A", "ATGC"), True),
             (hl.is_insertion("ATT", "ATGCTT"), True)])
 
-    @fails_service_backend()
     def test_is_deletion(self):
         self.assertTrue(hl.eval(hl.is_deletion("ATGC", "A")))
         self.assertTrue(hl.eval(hl.is_deletion("GTGTA", "GTA")))
 
-    @fails_service_backend()
     def test_is_indel(self):
         self.assertTrue(hl.eval(hl.is_indel("A", "ATGC")))
         self.assertTrue(hl.eval(hl.is_indel("ATT", "ATGCTT")))
         self.assertTrue(hl.eval(hl.is_indel("ATGC", "A")))
         self.assertTrue(hl.eval(hl.is_indel("GTGTA", "GTA")))
 
-    @fails_service_backend()
     def test_is_complex(self):
         self.assertTrue(hl.eval(hl.is_complex("CTA", "ATTT")))
         self.assertTrue(hl.eval(hl.is_complex("A", "TATGC")))
 
-    @fails_service_backend()
     def test_is_star(self):
         self.assertTrue(hl.eval(hl.is_star("ATC", "*")))
         self.assertTrue(hl.eval(hl.is_star("A", "*")))
@@ -2626,7 +2612,6 @@ Caused by: java.lang.AssertionError: assertion failed
         self.assertTrue(hl.eval(hl.is_strand_ambiguous("A", "T")))
         self.assertFalse(hl.eval(hl.is_strand_ambiguous("G", "T")))
 
-    @fails_service_backend()
     def test_allele_type(self):
         self.assertEqual(
             hl.eval(hl.tuple((

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -33,7 +33,6 @@ def test_manhattan_plot():
     expected_ticks = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', 'X', 'Y')
     assert pfig.layout.xaxis.ticktext == expected_ticks
 
-@fails_service_backend()
 def test_histogram():
     num_rows = 101
     num_groups = 5

--- a/hail/python/test/hail/methods/test_family_methods.py
+++ b/hail/python/test/hail/methods/test_family_methods.py
@@ -99,7 +99,6 @@ class Tests(unittest.TestCase):
         hl.trio_matrix(mt, ped, complete_trios=False)
 
 
-    @fails_service_backend()
     def test_mendel_errors(self):
         mt = hl.import_vcf(resource('mendel.vcf'))
         ped = hl.Pedigree.read(resource('mendel.fam'))
@@ -215,7 +214,6 @@ class Tests(unittest.TestCase):
             bad.order_by(hl.asc(bad.v)).show()
             self.fail('Found rows in violation of the predicate (see show output)')
 
-    @fails_service_backend()
     def test_de_novo(self):
         mt = hl.import_vcf(resource('denovo.vcf'))
         mt = mt.filter_rows(mt.locus.in_y_par(), keep=False)  # de_novo_finder doesn't know about y PAR

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -460,7 +460,6 @@ class VCFTests(unittest.TestCase):
         self.assertEqual(len(parts), comb.n_partitions())
         comb._force_count_rows()
 
-    @fails_service_backend()
     def test_haploid_combiner_ok(self):
         from hail.experimental.vcf_combiner.vcf_combiner import transform_gvcf
         # make a combiner table

--- a/hail/python/test/hail/methods/test_misc.py
+++ b/hail/python/test/hail/methods/test_misc.py
@@ -259,7 +259,6 @@ E                   	at java.lang.Thread.run(Thread.java:748)''')
                                  hl.Struct(locus=hl.Locus('20', 10644700), alleles=['A', 'T']))]
         self.assertEqual(hl.filter_intervals(ds, intervals).count_rows(), 3)
 
-    @fails_service_backend()
     def test_summarize_variants(self):
         mt = hl.utils.range_matrix_table(3, 3)
         variants = hl.literal({0: hl.Struct(locus=hl.Locus('1', 1), alleles=['A', 'T', 'C']),

--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -285,26 +285,21 @@ def spectra_and_moments_helper(spec_func):
         np.testing.assert_allclose(moments, true_moments, rtol=1e-04)
 
 
-@skip_when_service_backend(message='intermittently hangs')
 def test_spectra_and_moments_1():
     spectra_and_moments_helper(spec1)
 
 
-@skip_when_service_backend(message='intermittently hangs')
 def test_spectra_and_moments_2():
     spectra_and_moments_helper(spec2)
 
 
-@skip_when_service_backend(message='intermittently hangs')
 def test_spectra_and_moments_3():
     spectra_and_moments_helper(spec3)
 
 
-@skip_when_service_backend(message='intermittently hangs')
 def test_spectra_and_moments_4():
     spectra_and_moments_helper(spec4)
 
 
-@skip_when_service_backend(message='intermittently hangs')
 def test_spectra_and_moments_5():
     spectra_and_moments_helper(spec5)

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -9,7 +9,6 @@ tearDownModule = stopTestHailContext
 
 
 class Tests(unittest.TestCase):
-    @fails_service_backend()
     def test_sample_qc(self):
         data = [
             {'v': '1:1:A:T', 's': '1', 'GT': hl.Call([0, 0]), 'GQ': 10, 'DP': 0},
@@ -276,7 +275,6 @@ Caused by: java.lang.ClassCastException: __C2860collect_distributed_array cannot
                 ._same(hl.import_vcf(resource('filter_alleles/keep_allele2_downcode.vcf')))
         )
 
-    @fails_service_backend()
     def test_sample_and_variant_qc_call_rate(self):
         mt = hl.import_vcf(resource('sample.vcf'))
 
@@ -287,7 +285,6 @@ Caused by: java.lang.ClassCastException: __C2860collect_distributed_array cannot
         assert mt.aggregate_cols(hl.agg.all(hl.approx_equal(mt.sample_qc.call_rate, mt.sample_qc.n_called / n_rows)))
         assert mt.aggregate_rows(hl.agg.all(hl.approx_equal(mt.variant_qc.call_rate, mt.variant_qc.n_called / n_cols)))
 
-    @fails_service_backend()
     def test_summarize_variants_ti_tv(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         # check that summarize can run with the print control flow

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -466,7 +466,6 @@ class Tests(unittest.TestCase):
     # Outside the spark backend, "logistic_regression_rows" automatically defers to the _ version.
     logreg_functions = [hl.logistic_regression_rows, hl._logistic_regression_rows_nd] if backend_name == "spark" else [hl.logistic_regression_rows]
 
-    @fails_service_backend(reason='not implemented error: register_ir_function')
     def test_weighted_linear_regression(self):
         covariates = hl.import_table(resource('regressionLinear.cov'),
                                      key='Sample',
@@ -1611,7 +1610,6 @@ class Tests(unittest.TestCase):
                 covariates=[1.0, ds.cov.Cov1, ds.cov.Cov2],
                 logistic=True)._force_count()
 
-    @fails_service_backend()
     def test_de_novo(self):
         mt = hl.import_vcf(resource('denovo.vcf'))
         mt = mt.filter_rows(mt.locus.in_y_par(), keep=False)  # de_novo_finder doesn't know about y PAR
@@ -1638,7 +1636,6 @@ class Tests(unittest.TestCase):
         j = r.join(truth, how='outer')
         self.assertTrue(j.all((j.confidence == j.confidence_1) & (hl.abs(j.p_de_novo - j.p_de_novo_1) < 1e-4)))
 
-    @fails_service_backend()
     def test_de_novo_error(self):
         mt = hl.import_vcf(resource('denovo.vcf'))
         ped = hl.Pedigree.read(resource('denovo.fam'))
@@ -1646,7 +1643,6 @@ class Tests(unittest.TestCase):
         with pytest.raises(Exception, match='pop_frequency_prior'):
             hl.de_novo(mt, ped, pop_frequency_prior=2.0).count()
 
-    @fails_service_backend()
     def test_de_novo_ignore_computed_af_runs(self):
         mt = hl.import_vcf(resource('denovo.vcf'))
         ped = hl.Pedigree.read(resource('denovo.fam'))

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1127,7 +1127,6 @@ Caused by: java.lang.NullPointerException
         self.assertTrue(t1.key_by().union(t2.key_by(), t3.key_by())
                         ._same(hl.utils.range_table(15).key_by()))
 
-    @skip_when_service_backend(message='very slow')
     def test_nested_union(self):
         N = 10
         M = 200

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1127,6 +1127,7 @@ Caused by: java.lang.NullPointerException
         self.assertTrue(t1.key_by().union(t2.key_by(), t3.key_by())
                         ._same(hl.utils.range_table(15).key_by()))
 
+    @fails_service_backend()
     def test_nested_union(self):
         N = 10
         M = 200

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1127,7 +1127,7 @@ Caused by: java.lang.NullPointerException
         self.assertTrue(t1.key_by().union(t2.key_by(), t3.key_by())
                         ._same(hl.utils.range_table(15).key_by()))
 
-    @fails_service_backend()
+    @skip_when_service_backend('intermittent failure due to too large code')
     def test_nested_union(self):
         N = 10
         M = 200

--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -9,7 +9,6 @@ tearDownModule = stopTestHailContext
 
 
 class Tests(unittest.TestCase):
-    @fails_service_backend()
     def test_init_hail_context_twice(self):
         hl.init(idempotent=True)  # Should be no error
         hl.stop()

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -92,7 +92,6 @@ def test_conversion_equivalence():
     assert svcr._same(svcr_readback)
 
 
-@fails_service_backend(reason='register_ir_function')
 def test_sampleqc_old_new_equivalence():
     vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
     sqc = hl.vds.sample_qc(vds)
@@ -124,7 +123,6 @@ def test_sampleqc_old_new_equivalence():
     ))
 
 
-@skip_when_service_backend()
 def test_sampleqc_gq_dp():
     vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
     sqc = hl.vds.sample_qc(vds)
@@ -137,7 +135,6 @@ def test_sampleqc_gq_dp():
                                 bases_over_dp_threshold=(334822, 10484, 388, 111, 52))
 
 
-@fails_service_backend(reason='persist')
 def test_filter_samples_and_merge():
     vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
 

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -580,7 +580,7 @@ class ServiceBackendSocketAPI2(
           val code = readString()
           val token = readString()
           withExecuteContext("ServiceBackend.execute", { ctx =>
-            withIRFunctionsReadFromInput {
+            withIRFunctionsReadFromInput(ctx) {
               backend.execute(ctx, code, token)
             }
           })
@@ -660,7 +660,7 @@ class ServiceBackendSocketAPI2(
     }
   }
 
-  def withIRFunctionsReadFromInput(body: () => String): String = {
+  def withIRFunctionsReadFromInput(ctx: ExecuteContext)(body: () => String): String = {
     try {
       var nFunctionsRemaining = readInt()
       while (nFunctionsRemaining > 0) {

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -580,7 +580,7 @@ class ServiceBackendSocketAPI2(
           val code = readString()
           val token = readString()
           withExecuteContext("ServiceBackend.execute", { ctx =>
-            withIRFunctionsReadFromInput(ctx) {
+            withIRFunctionsReadFromInput(ctx) { () =>
               backend.execute(ctx, code, token)
             }
           })


### PR DESCRIPTION
This PR keeps a list of registered function client-side. When we send
an execute operation, we also send all the functions with the IR-to-execute.

The bulk of the deletions are removing fails_service_backend markers.
