### PR TITLE
[query/service] use error id to raise user-friendly errors

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -2,6 +2,22 @@ from typing import Mapping, List, Dict, Optional
 import abc
 from ..fs.fs import FS
 from ..expr import Expression
+from ..expr.types import HailType
+from ..ir import BaseIR
+from ..utils.java import FatalError, HailUserError
+
+
+def fatal_error_from_java_error_triplet(short_message, expanded_message, error_id):
+    from .. import __version__
+    if error_id != -1:
+        return FatalError(f'Error summary: {short_message}', error_id)
+    return FatalError(f'''{short_message}
+
+Java stack trace:
+{expanded_message}
+Hail version: {__version__}
+Error summary: {short_message}''',
+                      error_id)
 
 
 class Backend(abc.ABC):
@@ -10,7 +26,7 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def execute(self, ir, timed=False):
+    def execute(self, ir: BaseIR, timed: bool = False) -> Any:
         pass
 
     @abc.abstractmethod
@@ -143,3 +159,19 @@ class Backend(abc.ABC):
     def get_flags(self, *flags) -> Mapping[str, str]:
         """Mapping of Hail flags."""
         pass
+
+    def _handle_fatal_error_from_backend(self, err: FatalError, ir: BaseIR):
+        if err._error_id is None:
+            raise err
+
+        error_sources = ir.base_search(lambda x: x._error_id == err._error_id)
+        if len(error_sources) == 0:
+            raise err
+
+        better_stack_trace = error_sources[0]._stack_trace
+        error_message = str(err)
+        message_and_trace = (f'{error_message}\n'
+                             '------------\n'
+                             'Hail stack trace:\n'
+                             f'{better_stack_trace}')
+        raise HailUserError(message_and_trace) from None

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -1,8 +1,7 @@
-from typing import Mapping, List, Dict, Optional
+from typing import Mapping, List, Dict, Optional, Any
 import abc
 from ..fs.fs import FS
 from ..expr import Expression
-from ..expr.types import HailType
 from ..ir import BaseIR
 from ..utils.java import FatalError, HailUserError
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -199,7 +199,6 @@ class Tests(unittest.TestCase):
             else:
                 self.assertEqual(v, result[k], msg=k)
 
-    @fails_service_backend(reason='need to convert errors to HailUserError')
     def test_array_slicing(self):
         schema = hl.tstruct(a=hl.tarray(hl.tint32))
         rows = [{'a': [1, 2, 3, 4, 5]}]
@@ -267,7 +266,6 @@ class Tests(unittest.TestCase):
 
         self.assertDictEqual(result, expected)
 
-    @fails_service_backend(reason='need to convert errors to HailUserError')
     def test_dict_missing_error(self):
         d = hl.dict({'a': 2, 'b': 3})
         with pytest.raises(hl.utils.HailUserError, match='Key NA not found in dictionary'):
@@ -1606,7 +1604,6 @@ Caused by: is.hail.utils.HailException: Premature end of file: expected 4 bytes,
         table2 = hl.utils.range_table(10)
         self.assertEqual(table.aggregate(hl.agg.count_where(hl.is_defined(table2[table.idx]))), 10)
 
-    @fails_service_backend()
     def test_switch(self):
         x = hl.literal('1')
         na = hl.missing(tint32)
@@ -1651,7 +1648,6 @@ Caused by: is.hail.utils.HailException: Premature end of file: expected 4 bytes,
             hl.eval(hl.switch(x).when('0', 0).or_error("foo"))
         assert '.or_error("foo")' in str(exc.value)
 
-    @fails_service_backend()
     def test_case(self):
         def make_case(x):
             x = hl.literal(x)
@@ -4128,7 +4124,6 @@ E                   	at java.lang.Thread.run(Thread.java:748)
         assert hl.eval(hl.bit_rshift(hl.int64(-1), 64)) == -1
         assert hl.eval(hl.bit_rshift(hl.int64(-11), 64, logical=True)) == 0
 
-    @fails_service_backend()
     def test_bit_shift_errors(self):
         with pytest.raises(hl.utils.HailUserError):
             hl.eval(hl.bit_lshift(1, -1))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -64,7 +64,6 @@ class Tests(unittest.TestCase):
         test_random_function(lambda: hl.rand_cat(hl.array([1, 1, 1, 1])))
         test_random_function(lambda: hl.rand_dirichlet(hl.array([1, 1, 1, 1])))
 
-    @fails_service_backend(reason='need to convert errors to HailUserError')
     def test_range(self):
         def same_as_python(*args):
             self.assertEqual(hl.eval(hl.range(*args)), list(range(*args)))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -26,7 +26,6 @@ def assert_ndarrays_almost_eq(*expr_and_expected):
     assert_ndarrays(np.allclose, expr_and_expected)
 
 
-@fails_service_backend()
 def test_ndarray_ref():
 
     scalar = 5.0
@@ -62,7 +61,6 @@ def test_ndarray_ref():
     assert "Index 4 is out of bounds for axis 0 with size 3" in str(exc.value)
 
 
-@skip_when_service_backend('slow >800s')
 def test_ndarray_slice():
     np_rect_prism = np.arange(24).reshape((2, 3, 4))
     rect_prism = hl.nd.array(np_rect_prism)
@@ -204,7 +202,6 @@ def test_ndarray_transposed_slice():
     )
 
 
-@fails_service_backend()
 def test_ndarray_eval():
     data_list = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     mishapen_data_list1 = [[4], [1, 2, 3]]
@@ -288,7 +285,6 @@ def test_ndarray_shape():
     )
 
 
-@fails_service_backend(reason='need to convert errors to HailUserError')
 def test_ndarray_reshape():
     np_single = np.array([8])
     single = hl.nd.array([8])
@@ -555,7 +551,6 @@ def test_ndarray_transpose():
         cube.transpose((1, 1, 1))
     assert "Axes cannot contain duplicates" in str(exc.value)
 
-@fails_service_backend(reason='need to convert errors to HailUserError')
 def test_ndarray_matmul():
     np_v = np.array([1, 2])
     np_y = np.array([1, 1, 1])
@@ -681,7 +676,6 @@ def test_ndarray_full():
     assert hl.eval(hl.nd.full((5, 6, 7), hl.int32(3), dtype=hl.tfloat64)).dtype, np.float64
 
 
-@fails_service_backend(reason='need to convert errors to HailUserError')
 def test_ndarray_arange():
     assert_ndarrays_eq(
         (hl.nd.arange(40), np.arange(40)),
@@ -723,7 +717,6 @@ def test_ndarray_diagonal():
     assert "2 dimensional" in str(exc.value)
 
 
-@fails_service_backend(reason='need to convert errors to HailUserError')
 def test_ndarray_solve_triangular():
     a = hl.nd.array([[1, 1], [0, 1]])
     b = hl.nd.array([2, 1])
@@ -742,7 +735,6 @@ def test_ndarray_solve_triangular():
         hl.eval(hl.nd.solve_triangular(a_sing, b_sing))
     assert "singular" in str(exc.value), str(exc.value)
 
-@fails_service_backend(reason='need to convert errors to HailUserError')
 def test_ndarray_solve():
     a = hl.nd.array([[1, 2], [3, 5]])
     b = hl.nd.array([1, 2])

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1054,7 +1054,6 @@ Caused by: java.lang.AssertionError: assertion failed
         f = hl._locus_windows_per_contig([[1.0, 3.0, 4.0], [2.0, 2.0], [5.0]], 1.0)
         assert hl.eval(f) == ([0, 1, 1, 3, 3, 5], [1, 3, 3, 5, 5, 6])
 
-    @fails_service_backend()
     def test_locus_windows(self):
         def assert_eq(a, b):
             assert np.array_equal(a, np.array(b)), f"a={a}, b={b}"

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -2117,7 +2117,6 @@ Caused by: java.lang.ClassCastException: __C2829collect_distributed_array cannot
         ht2 = hl.import_table(resource('sampleAnnotations.tsv'))
         assert ht._same(ht2)
 
-    @fails_service_backend()
     def test_error_with_context(self):
         with pytest.raises(FatalError, match='For input string:'):
             ht = hl.import_table(resource('tsv_errors.tsv'), types={'col1': 'int32'})

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -850,8 +850,6 @@ class PLINKTests(unittest.TestCase):
         plink = hl.import_plink(bfile + '.bed', bfile + '.bim', bfile + '.fam', block_size=16)
         self.assertEqual(plink.aggregate_cols(hl.agg.count()), 489)
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_import_plink_skip_invalid_loci(self):
         mt = hl.import_plink(resource('skip_invalid_loci.bed'),
                              resource('skip_invalid_loci.bim'),

--- a/hail/python/test/hail/methods/test_misc.py
+++ b/hail/python/test/hail/methods/test_misc.py
@@ -272,7 +272,6 @@ E                   	at java.lang.Thread.run(Thread.java:748)''')
         self.assertEqual(r.allele_types, {'SNP': 2, 'MNP': 1, 'Unknown': 1, 'Insertion': 1})
         self.assertEqual(r.allele_counts, {2: 1, 3: 2})
 
-    @fails_service_backend()
     def test_verify_biallelic(self):
         mt = hl.import_vcf(resource('sample2.vcf'))  # has multiallelics
         with self.assertRaises(hl.utils.HailUserError):

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -176,20 +176,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(s.annotate(**{'a': 5, 'x': 10, 'y': 15}),
                          Struct(a=5, b=2, c=3, x=10, y=15))
 
-    @fails_service_backend(reason='''worker error not propagated to client.
-
-falsCaused by: is.hail.utils.HailException: array index out of bounds: index=5, length=2
-	at __C23409collect_distributed_array.__m23435arrayref_bounds_check(Unknown Source)
-	at __C23409collect_distributed_array.__m23417split_StreamLen(Unknown Source)
-	at __C23409collect_distributed_array.apply(Unknown Source)
-	at __C23409collect_distributed_array.apply(Unknown Source)
-	at is.hail.backend.BackendUtils.$anonfun$collectDArray$2(BackendUtils.scala:31)
-	at is.hail.utils.package$.using(package.scala:627)
-	at is.hail.annotations.RegionPool.scopedRegion(RegionPool.scala:144)
-	at is.hail.backend.BackendUtils.$anonfun$collectDArray$1(BackendUtils.scala:30)
-	at is.hail.backend.service.Worker$.main(Worker.scala:120)
-	at is.hail.backend.service.Worker.main(Worker.scala)
-	... 11 more''')
     def test_expr_exception_results_in_hail_user_error(self):
         df = range_table(10)
         df = df.annotate(x=[1, 2])

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -51,6 +51,12 @@ object Worker {
   private[this] implicit val ec = ExecutionContext.fromExecutorService(
     javaConcurrent.Executors.newCachedThreadPool())
 
+  private[this] def writeString(out: DataOutputStream, s: String): Unit = {
+    val bytes = s.getBytes(StandardCharsets.UTF_8)
+    out.writeInt(bytes.length)
+    out.write(bytes)
+  }
+
   def main(argv: Array[String]): Unit = {
     val theHailClassLoader = new HailClassLoader(getClass().getClassLoader())
 
@@ -122,14 +128,34 @@ object Worker {
         new ServiceBackend(null, null, null, new HailClassLoader(getClass().getClassLoader())), skipLoggingConfiguration = true, quiet = true)
     }
     val htc = new ServiceTaskContext(i)
-    val result = f(context, htc, theHailClassLoader, fs)
+    var result: Array[Byte] = null
+    var userError: HailException = null
+    try {
+      result = f(context, htc, theHailClassLoader, fs)
+    } catch {
+      case err: HailException => userError = err
+    }
     htc.finish()
 
     timer.end("executeFunction")
     timer.start("writeOutputs")
 
     using(fs.createCachedNoCompression(s"$root/result.$i")) { os =>
-      os.write(result)
+      val dos = new DataOutputStream(os)
+      if (result != null) {
+        assert(userError == null)
+
+        dos.writeBoolean(true)
+        dos.write(result)
+      } else {
+        assert(userError != null)
+        val (shortMessage, expandedMessage, errorId) = handleForPython(userError)
+
+        dos.writeBoolean(false)
+        writeString(dos, shortMessage)
+        writeString(dos, expandedMessage)
+        dos.writeInt(errorId)
+      }
     }
     timer.end("writeOutputs")
     timer.end(s"Job $i")

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -289,7 +289,8 @@ class PlinkVariant(
   val index: Int,
   val locusAlleles: Any,
   val cmPos: Double,
-  val rsid: String)
+  val rsid: String
+) extends Serializable
 
 class MatrixPLINKReader(
   val params: MatrixPLINKReaderParameters,
@@ -315,8 +316,6 @@ class MatrixPLINKReader(
   }
 
   def executeGeneric(ctx: ExecuteContext): GenericTableValue = {
-    val fsBc = ctx.fsBc
-
     val localA2Reference = params.a2Reference
     val variantsBc = ctx.backend.broadcast(variants)
     val localNSamples = nSamples
@@ -361,9 +360,11 @@ class MatrixPLINKReader(
 
         val rvb = new RegionValueBuilder(region)
 
-        val is = fsBc.value.open(bed)
-        TaskContext.get.addTaskCompletionListener[Unit] { (context: TaskContext) =>
-          is.close()
+        val is = fs.open(bed)
+        if (TaskContext.get != null) {
+          TaskContext.get.addTaskCompletionListener[Unit] { (context: TaskContext) =>
+            is.close()
+          }
         }
         var offset: Long = 0
 

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -7,6 +7,12 @@ class HailException(val msg: String, val logMsg: Option[String], cause: Throwabl
   def this(msg: String, errorId: Int) = this(msg, None, null, errorId)
 }
 
+class HailWorkerException(
+  val shortMessage: String,
+  val expandedMessage: String,
+  val errorId: Int
+) extends RuntimeException(shortMessage)
+
 trait ErrorHandling {
   def fatal(msg: String): Nothing = throw new HailException(msg)
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -93,7 +93,6 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
   ): Array[FileWriteMetadata] = {
     val localTmpdir = ctx.localTmpdir
     val fs = ctx.fs
-    val fsBc = ctx.fsBc
 
     fs.mkDir(path + "/parts")
     if (idxRelPath != null)


### PR DESCRIPTION
The main change is to the communication protocol between the client and
the driver and between the driver and the worker.

In main, both the driver and the client send messages back to the client
and driver (respectively) by writing to a file in cloud storage. In both
cases, the file (in main) has one of these two structures:

    0x00                  # is_success (False)
    UTF-8 encoded string  # the stack trace

    0x01                  # is_success (True)
    UTF-8 encoded string  # JSON message to send back to the client or driver

In this PR, the success case does not change. The failure case becomes:

    0x00                  # is_sucess (False)
    UTF-8 encoded string  # short message
    UTF-8 encoded string  # expanded message
    4-byte signed integer # error id

The Python client (in `service_backend.py`) and the Driver (in
`ServiceBackendSocketAPI2`) changes to read this and raise the right error if
an error id is present.

I also uncovered three unrelated problems that are fixed in this PR:
1. PlinkVariant needs to be serializable because it is broadcasted.
2. We open an input stream in LoadPlink which ought to be closed, but there is no mechanism to do so in the ServiceBackend. I just ignore it for now. cc: @tpoterba, I'm not sure what the right answer is here.
3. Two uses of the broadcasted file system that should use the ExecuteContext's file system.
