### PR TITLE
[query/service] implement globbing for RouterFS

### DIFF
--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -283,6 +283,8 @@ class RouterFS(FS):
             suffix = ''
         else:
             suffix = '/' + '/'.join(running_prefix)
+
+        cumulative_prefixes = []
         if len(glob_components) > 0:
             first_component_prefix, first_component_pattern = glob_components[0]
             first_component_prefix_url = str(url.with_path('/'.join(first_component_prefix)))

--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -11,7 +11,7 @@ import fnmatch
 from hailtop.aiotools.fs import Copier, Transfer, FileListEntry, ReadableStream, WritableStream
 from hailtop.aiotools.local_fs import LocalAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.utils import OnlineBoundedGather2, async_to_blocking
+from hailtop.utils import bounded_gather, async_to_blocking
 
 from .fs import FS
 from .stat_result import FileType, StatResult

--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -319,7 +319,7 @@ class RouterFS(FS):
             file_stat = _stat_result(False, maybe_size, path)
             if maybe_contents is not None:
                 if error_when_file_and_directory:
-                    raise ValueError(f'{path} is both a file a directory')
+                    raise ValueError(f'{path} is both a file and a directory')
                 return [file_stat, *maybe_contents]
             return [file_stat]
         if maybe_contents is None:

--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -280,7 +280,7 @@ class RouterFS(FS):
                 running_prefix = []
 
         suffix_components: List[str] = running_prefix
-        first_prefix = '/'.join([url.scheme +':', '', *url.bucket_parts])
+        first_prefix = '/'.join([url.scheme + ':', '', *url.bucket_parts])
         cumulative_prefixes = [first_prefix]
 
         for intervening_components, single_component_glob_pattern in glob_components:
@@ -288,9 +288,8 @@ class RouterFS(FS):
                 stat.path
                 for cumulative_prefix in cumulative_prefixes
                 for stat in await ls_no_glob('/'.join([cumulative_prefix, *intervening_components]))
-                if fnmatch.fnmatch(
-                        stat.path,
-                        '/'.join([cumulative_prefix, *intervening_components, single_component_glob_pattern]))
+                if fnmatch.fnmatch(stat.path,
+                                   '/'.join([cumulative_prefix, *intervening_components, single_component_glob_pattern]))
             ]
 
         return [stat

--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -1,10 +1,9 @@
-from typing import List, AsyncContextManager, BinaryIO, Optional, Tuple
+from typing import List, AsyncContextManager, BinaryIO, Optional
 import asyncio
 import io
 import nest_asyncio
 import os
 import functools
-from urllib.parse import urlparse
 import glob
 import fnmatch
 
@@ -287,10 +286,7 @@ class RouterFS(FS):
                 stat.path
                 for cumulative_prefix in cumulative_prefixes
                 for stat in await ls_no_glob('/'.join([cumulative_prefix, *component_prefix]))
-                if fnmatch.fnmatch(
-                        stat.path,
-                        '/'.join([cumulative_prefix, *component_prefix, pattern])
-                )
+                if fnmatch.fnmatch(stat.path, '/'.join([cumulative_prefix, *component_prefix, pattern]))
             ]
 
         return [stat

--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -280,7 +280,10 @@ class RouterFS(FS):
                 running_prefix = []
 
         suffix_components: List[str] = running_prefix
-        first_prefix = '/'.join([url.scheme + ':', '', *url.bucket_parts])
+        if len(url.bucket_parts) > 0:
+            first_prefix = '/'.join([url.scheme + ':', '', *url.bucket_parts])
+        else:
+            first_prefix = url.scheme + ':'
         cumulative_prefixes = [first_prefix]
 
         for intervening_components, single_component_glob_pattern in glob_components:

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -261,6 +261,10 @@ class S3AsyncFSURL(AsyncFSURL):
     def path(self) -> str:
         return self._path
 
+    @property
+    def scheme(self) -> str:
+        return 's3:'
+
     def with_path(self, path) -> 'S3AsyncFSURL':
         return S3AsyncFSURL(self._bucket, path)
 

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -263,7 +263,7 @@ class S3AsyncFSURL(AsyncFSURL):
 
     @property
     def scheme(self) -> str:
-        return 's3:'
+        return 's3'
 
     def with_path(self, path) -> 'S3AsyncFSURL':
         return S3AsyncFSURL(self._bucket, path)

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -294,7 +294,7 @@ class S3AsyncFS(AsyncFS):
         return (parsed.netloc, name)
 
     async def open(self, url: str) -> ReadableStream:
-        bucket, name = self._get_bucket_name(url)
+        bucket, name = self.get_bucket_name(url)
         try:
             resp = await blocking_to_async(self._thread_pool, self._s3.get_object,
                                            Bucket=bucket,
@@ -304,7 +304,7 @@ class S3AsyncFS(AsyncFS):
             raise FileNotFoundError(url) from e
 
     async def open_from(self, url: str, start: int) -> ReadableStream:
-        bucket, name = self._get_bucket_name(url)
+        bucket, name = self.get_bucket_name(url)
         try:
             resp = await blocking_to_async(self._thread_pool, self._s3.get_object,
                                            Bucket=bucket,
@@ -355,7 +355,7 @@ class S3AsyncFS(AsyncFS):
         # interface.  This has the disadvantage that the read must
         # complete before the write can begin (unlike the current
         # code, that copies 128MB parts in 256KB chunks).
-        bucket, name = self._get_bucket_name(url)
+        bucket, name = self.get_bucket_name(url)
         return S3CreateManager(self, bucket, name)
 
     async def multi_part_create(
@@ -363,7 +363,7 @@ class S3AsyncFS(AsyncFS):
             sema: asyncio.Semaphore,
             url: str,
             num_parts: int) -> MultiPartCreate:
-        bucket, name = self._get_bucket_name(url)
+        bucket, name = self.get_bucket_name(url)
         return S3MultiPartCreate(sema, self, bucket, name, num_parts)
 
     async def mkdir(self, url: str) -> None:
@@ -373,7 +373,7 @@ class S3AsyncFS(AsyncFS):
         pass
 
     async def statfile(self, url: str) -> FileStatus:
-        bucket, name = self._get_bucket_name(url)
+        bucket, name = self.get_bucket_name(url)
         try:
             resp = await blocking_to_async(self._thread_pool, self._s3.head_object,
                                            Bucket=bucket,
@@ -410,7 +410,7 @@ class S3AsyncFS(AsyncFS):
                         recursive: bool = False,
                         exclude_trailing_slash_files: bool = True
                         ) -> AsyncIterator[FileListEntry]:
-        bucket, name = self._get_bucket_name(url)
+        bucket, name = self.get_bucket_name(url)
         if name and not name.endswith('/'):
             name += '/'
         if recursive:
@@ -454,7 +454,7 @@ class S3AsyncFS(AsyncFS):
 
     async def isfile(self, url: str) -> bool:
         try:
-            bucket, name = self._get_bucket_name(url)
+            bucket, name = self.get_bucket_name(url)
             await blocking_to_async(self._thread_pool, self._s3.head_object,
                                     Bucket=bucket,
                                     Key=name)
@@ -474,7 +474,7 @@ class S3AsyncFS(AsyncFS):
 
     async def remove(self, url: str) -> None:
         try:
-            bucket, name = self._get_bucket_name(url)
+            bucket, name = self.get_bucket_name(url)
             await blocking_to_async(self._thread_pool, self._s3.delete_object,
                                     Bucket=bucket,
                                     Key=name)

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -263,7 +263,7 @@ class AzureAsyncFSURL(AsyncFSURL):
 
     @property
     def scheme(self) -> str:
-        return 'hail-az:'
+        return 'hail-az'
 
     def with_path(self, path) -> 'AzureAsyncFSURL':
         return AzureAsyncFSURL(self._account, self._container, path)

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -261,6 +261,10 @@ class AzureAsyncFSURL(AsyncFSURL):
     def path(self) -> str:
         return self._path
 
+    @property
+    def scheme(self) -> str:
+        return 'hail-az:'
+
     def with_path(self, path) -> 'AzureAsyncFSURL':
         return AzureAsyncFSURL(self._account, self._container, path)
 

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -291,10 +291,10 @@ class AzureAsyncFS(AsyncFS):
         self._blob_service_clients: Dict[str, BlobServiceClient] = {}
 
     def parse_url(self, url: str) -> AzureAsyncFSURL:
-        return AzureAsyncFSURL(*self.get_account_container_name(url))
+        return AzureAsyncFSURL(*self.get_account_container_and_name(url))
 
     @staticmethod
-    def get_account_container_name(url: str) -> Tuple[str, str, str]:
+    def get_account_container_and_name(url: str) -> Tuple[str, str, str]:
         parsed = urllib.parse.urlparse(url)
 
         if parsed.scheme != 'hail-az':
@@ -321,12 +321,12 @@ class AzureAsyncFS(AsyncFS):
         return self._blob_service_clients[account]
 
     def get_blob_client(self, url: str) -> BlobClient:
-        account, container, name = AzureAsyncFS.get_account_container_name(url)
+        account, container, name = AzureAsyncFS.get_account_container_and_name(url)
         blob_service_client = self.get_blob_service_client(account)
         return blob_service_client.get_blob_client(container, name)
 
     def get_container_client(self, url: str) -> ContainerClient:
-        account, container, _ = AzureAsyncFS.get_account_container_name(url)
+        account, container, _ = AzureAsyncFS.get_account_container_and_name(url)
         blob_service_client = self.get_blob_service_client(account)
         return blob_service_client.get_container_client(container)
 
@@ -353,7 +353,7 @@ class AzureAsyncFS(AsyncFS):
         return AzureMultiPartCreate(sema, client, num_parts)
 
     async def isfile(self, url: str) -> bool:
-        _, _, name = self.get_account_container_name(url)
+        _, _, name = self.get_account_container_and_name(url)
         # if name is empty, get_object_metadata behaves like list objects
         # the urls are the same modulo the object name
         if not name:
@@ -362,7 +362,7 @@ class AzureAsyncFS(AsyncFS):
         return await self.get_blob_client(url).exists()
 
     async def isdir(self, url: str) -> bool:
-        _, _, name = self.get_account_container_name(url)
+        _, _, name = self.get_account_container_and_name(url)
         assert not name or name.endswith('/'), name
         client = self.get_container_client(url)
         async for _ in client.walk_blobs(name_starts_with=name,
@@ -411,7 +411,7 @@ class AzureAsyncFS(AsyncFS):
                         recursive: bool = False,
                         exclude_trailing_slash_files: bool = True
                         ) -> AsyncIterator[FileListEntry]:
-        _, _, name = self.get_account_container_name(url)
+        _, _, name = self.get_account_container_and_name(url)
         if name and not name.endswith('/'):
             name = f'{name}/'
 

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -317,12 +317,12 @@ class AzureAsyncFS(AsyncFS):
         return self._blob_service_clients[account]
 
     def get_blob_client(self, url: str) -> BlobClient:
-        account, container, name = AzureAsyncFS._get_account_container_name(url)
+        account, container, name = AzureAsyncFS.get_account_container_name(url)
         blob_service_client = self.get_blob_service_client(account)
         return blob_service_client.get_blob_client(container, name)
 
     def get_container_client(self, url: str) -> ContainerClient:
-        account, container, _ = AzureAsyncFS._get_account_container_name(url)
+        account, container, _ = AzureAsyncFS.get_account_container_name(url)
         blob_service_client = self.get_blob_service_client(account)
         return blob_service_client.get_container_client(container)
 
@@ -349,7 +349,7 @@ class AzureAsyncFS(AsyncFS):
         return AzureMultiPartCreate(sema, client, num_parts)
 
     async def isfile(self, url: str) -> bool:
-        _, _, name = self._get_account_container_name(url)
+        _, _, name = self.get_account_container_name(url)
         # if name is empty, get_object_metadata behaves like list objects
         # the urls are the same modulo the object name
         if not name:
@@ -358,7 +358,7 @@ class AzureAsyncFS(AsyncFS):
         return await self.get_blob_client(url).exists()
 
     async def isdir(self, url: str) -> bool:
-        _, _, name = self._get_account_container_name(url)
+        _, _, name = self.get_account_container_name(url)
         assert not name or name.endswith('/'), name
         client = self.get_container_client(url)
         async for _ in client.walk_blobs(name_starts_with=name,
@@ -407,7 +407,7 @@ class AzureAsyncFS(AsyncFS):
                         recursive: bool = False,
                         exclude_trailing_slash_files: bool = True
                         ) -> AsyncIterator[FileListEntry]:
-        _, _, name = self._get_account_container_name(url)
+        _, _, name = self.get_account_container_name(url)
         if name and not name.endswith('/'):
             name = f'{name}/'
 

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -301,7 +301,6 @@ class GoogleStorageClient(GoogleBaseClient):
             params['uploadType'] = upload_type
 
         if upload_type == 'media':
-            print(('media', f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o', kwargs))
             it: FeedableAsyncIterable[bytes] = FeedableAsyncIterable()
             kwargs['data'] = aiohttp.AsyncIterablePayload(it)
             request_task = asyncio.ensure_future(self._session.post(
@@ -319,7 +318,6 @@ class GoogleStorageClient(GoogleBaseClient):
             f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o',
             **kwargs)
         session_url = resp.headers['Location']
-        print(('else', f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o', kwargs, session_url, resp))
         return ResumableInsertObjectStream(self._session, session_url, chunk_size)
 
     async def get_object(self, bucket: str, name: str, **kwargs) -> GetObjectStream:

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -558,10 +558,6 @@ class GoogleStorageAsyncFS(AsyncFS):
         bucket = rest[2:end_of_bucket]
         name = rest[(end_of_bucket + 1):]
 
-        if name:
-            assert name[0] == '/'
-            name = name[1:]
-
         return (bucket, name)
 
     async def open(self, url: str) -> ReadableStream:

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -548,9 +548,9 @@ class GoogleStorageAsyncFS(AsyncFS):
         if parsed.scheme != 'gs':
             raise ValueError(f"invalid scheme, expected gs: {parsed.scheme}")
 
-        # FIXME: what to do here about ? in bucket paths
         name = parsed.path
         if parsed.query:
+            # gs:// URLs don't have query parameters, so just include it as part of the object name
             name += '?' + parsed.query
         if name:
             assert name[0] == '/'

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -550,13 +550,13 @@ class GoogleStorageAsyncFS(AsyncFS):
         if scheme != 'gs':
             raise ValueError(f'invalid scheme, expected gs: {scheme}')
 
-        rest = url[(colon_index+1):]
+        rest = url[(colon_index + 1):]
         if not rest.startswith('//'):
             raise ValueError(f'Google Cloud Storage URI must be of the form: gs://bucket/path, found: {url}')
 
         end_of_bucket = rest.find('/', 2)
         bucket = rest[2:end_of_bucket]
-        name = rest[(end_of_bucket+1):]
+        name = rest[(end_of_bucket + 1):]
 
         if name:
             assert name[0] == '/'

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -288,7 +288,7 @@ class GoogleStorageClient(GoogleBaseClient):
             params = {}
             kwargs['params'] = params
         assert 'name' not in params
-        params['name'] = urllib.parse.quote(name, safe="")
+        params['name'] = name
 
         if 'data' in params:
             return await self._session.post(

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -414,7 +414,7 @@ class GoogleStorageMultiPartCreate(MultiPartCreate):
         self._fs = fs
         self._dest_url = dest_url
         self._num_parts = num_parts
-        bucket, dest_name = fs.get_bucket_name(dest_url)
+        bucket, dest_name = fs.get_bucket_and_name(dest_url)
         self._bucket = bucket
         self._dest_name = dest_name
 
@@ -538,10 +538,10 @@ class GoogleStorageAsyncFS(AsyncFS):
         self._storage_client = storage_client
 
     def parse_url(self, url: str) -> GoogleStorageAsyncFSURL:
-        return GoogleStorageAsyncFSURL(*self.get_bucket_name(url))
+        return GoogleStorageAsyncFSURL(*self.get_bucket_and_name(url))
 
     @staticmethod
-    def get_bucket_name(url: str) -> Tuple[str, str]:
+    def get_bucket_and_name(url: str) -> Tuple[str, str]:
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme != 'gs':
             raise ValueError(f"invalid scheme, expected gs: {parsed.scheme}")
@@ -557,16 +557,16 @@ class GoogleStorageAsyncFS(AsyncFS):
         return (parsed.netloc, name)
 
     async def open(self, url: str) -> ReadableStream:
-        bucket, name = self.get_bucket_name(url)
+        bucket, name = self.get_bucket_and_name(url)
         return await self._storage_client.get_object(bucket, name)
 
     async def open_from(self, url: str, start: int) -> ReadableStream:
-        bucket, name = self.get_bucket_name(url)
+        bucket, name = self.get_bucket_and_name(url)
         return await self._storage_client.get_object(
             bucket, name, headers={'Range': f'bytes={start}-'})
 
     async def create(self, url: str, *, retry_writes: bool = True) -> WritableStream:
-        bucket, name = self.get_bucket_name(url)
+        bucket, name = self.get_bucket_and_name(url)
         params = {
             'uploadType': 'resumable' if retry_writes else 'media'
         }
@@ -590,7 +590,7 @@ class GoogleStorageAsyncFS(AsyncFS):
 
     async def statfile(self, url: str) -> GetObjectFileStatus:
         try:
-            bucket, name = self.get_bucket_name(url)
+            bucket, name = self.get_bucket_and_name(url)
             return GetObjectFileStatus(await self._storage_client.get_object_metadata(bucket, name))
         except aiohttp.ClientResponseError as e:
             if e.status == 404:
@@ -635,7 +635,7 @@ class GoogleStorageAsyncFS(AsyncFS):
                         recursive: bool = False,
                         exclude_trailing_slash_files: bool = True
                         ) -> AsyncIterator[FileListEntry]:
-        bucket, name = self.get_bucket_name(url)
+        bucket, name = self.get_bucket_and_name(url)
         if name and not name.endswith('/'):
             name = f'{name}/'
 
@@ -677,7 +677,7 @@ class GoogleStorageAsyncFS(AsyncFS):
 
     async def isfile(self, url: str) -> bool:
         try:
-            bucket, name = self.get_bucket_name(url)
+            bucket, name = self.get_bucket_and_name(url)
             # if name is empty, get_object_metadata behaves like list objects
             # the urls are the same modulo the object name
             if not name:
@@ -690,7 +690,7 @@ class GoogleStorageAsyncFS(AsyncFS):
             raise
 
     async def isdir(self, url: str) -> bool:
-        bucket, name = self.get_bucket_name(url)
+        bucket, name = self.get_bucket_and_name(url)
         assert not name or name.endswith('/'), name
         params = {
             'prefix': name,
@@ -705,7 +705,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         assert False  # unreachable
 
     async def remove(self, url: str) -> None:
-        bucket, name = self.get_bucket_name(url)
+        bucket, name = self.get_bucket_and_name(url)
         try:
             await self._storage_client.delete_object(bucket, name)
         except aiohttp.ClientResponseError as e:

--- a/hail/python/hailtop/aiotools/fs/__init__.py
+++ b/hail/python/hailtop/aiotools/fs/__init__.py
@@ -1,10 +1,11 @@
-from .fs import AsyncFS, AsyncFSFactory, MultiPartCreate, FileListEntry, FileStatus
+from .fs import AsyncFS, AsyncFSURL, AsyncFSFactory, MultiPartCreate, FileListEntry, FileStatus
 from .copier import Copier, CopyReport, SourceCopier, SourceReport, Transfer, TransferReport
 from .exceptions import UnexpectedEOFError, FileAndDirectoryError
 from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
 
 __all__ = [
     'AsyncFS',
+    'AsyncFSURL',
     'AsyncFSFactory',
     'Copier',
     'CopyReport',

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -1,5 +1,5 @@
 from typing import (Any, AsyncContextManager, Optional, Type, Set, AsyncIterator, Callable, TypeVar,
-                    Generic)
+                    Generic, List)
 from types import TracebackType
 import abc
 import asyncio
@@ -61,6 +61,24 @@ class MultiPartCreate(abc.ABC):
         pass
 
 
+class AsyncFSURL(abc.ABC):
+    @abc.abstractproperty
+    def bucket_parts(self) -> List[str]:
+        pass
+
+    @abc.abstractproperty
+    def path(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def with_path(self, path) -> 'AsyncFSURL':
+        pass
+
+    @abc.abstractmethod
+    def __str__(self) -> str:
+        pass
+
+
 class AsyncFS(abc.ABC):
     FILE = 'file'
     DIR = 'dir'
@@ -68,6 +86,10 @@ class AsyncFS(abc.ABC):
     @property
     @abc.abstractmethod
     def schemes(self) -> Set[str]:
+        pass
+
+    @abc.abstractmethod
+    def parse_url(self, url: str) -> AsyncFSURL:
         pass
 
     @abc.abstractmethod

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -62,11 +62,13 @@ class MultiPartCreate(abc.ABC):
 
 
 class AsyncFSURL(abc.ABC):
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def bucket_parts(self) -> List[str]:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def path(self) -> str:
         pass
 

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -72,6 +72,11 @@ class AsyncFSURL(abc.ABC):
     def path(self) -> str:
         pass
 
+    @property
+    @abc.abstractmethod
+    def scheme(self) -> str:
+        pass
+
     @abc.abstractmethod
     def with_path(self, path) -> 'AsyncFSURL':
         pass

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -81,6 +81,9 @@ class AsyncFSURL(abc.ABC):
     def with_path(self, path) -> 'AsyncFSURL':
         pass
 
+    def with_new_path_component(self, new_path_component) -> 'AsyncFSURL':
+        return self.with_path(self.path + '/' + new_path_component)
+
     @abc.abstractmethod
     def __str__(self) -> str:
         pass

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
 
 from ..utils import blocking_to_async, OnlineBoundedGather2
-from .fs import (FileStatus, FileListEntry, MultiPartCreate, AsyncFS,
+from .fs import (FileStatus, FileListEntry, MultiPartCreate, AsyncFS, AsyncFSURL,
                  ReadableStream, WritableStream, blocking_readable_stream_to_async,
                  blocking_writable_stream_to_async)
 
@@ -87,6 +87,25 @@ class LocalMultiPartCreate(MultiPartCreate):
                 pass
 
 
+class LocalAsyncFSURL(AsyncFSURL):
+    def __init__(self, path: str):
+        self._path = path
+
+    @property
+    def bucket_parts(self) -> List[str]:
+        return []
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    def with_path(self, path) -> 'LocalAsyncFSURL':
+        return LocalAsyncFSURL(path)
+
+    def __str__(self) -> str:
+        return 'file:' + self._path
+
+
 class LocalAsyncFS(AsyncFS):
     schemes: Set[str] = {'file'}
 
@@ -94,6 +113,9 @@ class LocalAsyncFS(AsyncFS):
         if not thread_pool:
             thread_pool = ThreadPoolExecutor(max_workers=max_workers)
         self._thread_pool = thread_pool
+
+    def parse_url(self, url: str) -> LocalAsyncFSURL:
+        return LocalAsyncFSURL(self._get_path(url))
 
     @staticmethod
     def _get_path(url):

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -99,6 +99,10 @@ class LocalAsyncFSURL(AsyncFSURL):
     def path(self) -> str:
         return self._path
 
+    @property
+    def scheme(self) -> str:
+        return 'file:'
+
     def with_path(self, path) -> 'LocalAsyncFSURL':
         return LocalAsyncFSURL(path)
 

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -101,7 +101,7 @@ class LocalAsyncFSURL(AsyncFSURL):
 
     @property
     def scheme(self) -> str:
-        return 'file:'
+        return 'file'
 
     def with_path(self, path) -> 'LocalAsyncFSURL':
         return LocalAsyncFSURL(path)

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -3,7 +3,8 @@ import asyncio
 import urllib.parse
 
 from ..aiocloud import aioaws, aioazure, aiogoogle
-from .fs import AsyncFS, MultiPartCreate, FileStatus, FileListEntry, ReadableStream, WritableStream
+from .fs import (AsyncFS, MultiPartCreate, FileStatus, FileListEntry, ReadableStream,
+                 WritableStream, AsyncFSURL)
 from .local_fs import LocalAsyncFS
 
 
@@ -33,6 +34,9 @@ class RouterAsyncFS(AsyncFS):
         self._gcs_kwargs = gcs_kwargs or {}
         self._azure_kwargs = azure_kwargs or {}
         self._s3_kwargs = s3_kwargs or {}
+
+    def parse_url(self, url: str) -> AsyncFSURL:
+        return self._get_fs(url).parse_url(url)
 
     @property
     def schemes(self) -> Set[str]:

--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -37,7 +37,6 @@ class Tests(unittest.TestCase):
     def test_write(self):
         create_backward_compatibility_files()
 
-    @fails_service_backend()
     def test_backward_compatability(self):
         import os
 

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -171,15 +171,23 @@ class Tests(unittest.TestCase):
 
         with hl.TemporaryDirectory() as dirname:
             touch(dirname + '/abc/ghi/123')
+            touch(dirname + '/abc/ghi/!23')
+            touch(dirname + '/abc/ghi/?23')
             touch(dirname + '/abc/ghi/456')
             touch(dirname + '/abc/ghi/78')
             touch(dirname + '/abc/jkl/123')
+            touch(dirname + '/abc/jkl/!23')
+            touch(dirname + '/abc/jkl/?23')
             touch(dirname + '/abc/jkl/456')
             touch(dirname + '/abc/jkl/78')
             touch(dirname + '/def/ghi/123')
+            touch(dirname + '/def/ghi/!23')
+            touch(dirname + '/def/ghi/?23')
             touch(dirname + '/def/ghi/456')
             touch(dirname + '/def/ghi/78')
             touch(dirname + '/def/jkl/123')
+            touch(dirname + '/def/jkl/!23')
+            touch(dirname + '/def/jkl/?23')
             touch(dirname + '/def/jkl/456')
             touch(dirname + '/def/jkl/78')
             dirname = self.normalize_path(dirname)
@@ -222,9 +230,20 @@ class Tests(unittest.TestCase):
             assert set(actual) == set(expected)
 
             expected = [dirname + '/abc/ghi/123',
+                        dirname + '/abc/ghi/!23',
+                        dirname + '/abc/ghi/?23',
                         dirname + '/abc/ghi/456',
                         dirname + '/abc/ghi/78']
             actual = [x['path'] for x in hl.hadoop_ls(dirname + '/abc/[g][h][i]/*')]
+            assert set(actual) == set(expected)
+
+            expected = [dirname + '/abc/ghi/123',
+                        dirname + '/abc/ghi/?23']
+            actual = [x['path'] for x in hl.hadoop_ls(dirname + '/abc/ghi/[!1]23')]
+            assert set(actual) == set(expected)
+
+            expected = [dirname + '/abc/ghi/?23']
+            actual = [x['path'] for x in hl.hadoop_ls(dirname + '/abc/ghi/[?]23')]
             assert set(actual) == set(expected)
 
     def test_linked_list(self):

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -112,6 +112,14 @@ class Tests(unittest.TestCase):
         self.assertEqual(stat2['is_dir'], False)
         self.assertTrue('path' in stat2)
 
+    def test_hadoop_ls_simple(self):
+        with hl.TemporaryDirectory() as dirname:
+            touch(dirname + 'a')
+            touch(dirname + '?')
+            dirname = self.normalize_path(dirname)
+
+        
+
     def test_hadoop_ls(self):
         path1 = resource('ls_test/f_50')
         ls1 = hl.hadoop_ls(path1)
@@ -150,6 +158,8 @@ class Tests(unittest.TestCase):
             hl.hadoop_ls(resource('foo[/]bar'))
         except ValueError as err:
             assert 'glob groups must not include forward slashes' in err.args[0]
+        except FatalError as err:
+            assert 'PatternSyntaxException: error parsing regexp: Unclosed character class at pos 4' in err.args[0]
         else:
             assert False
 

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -178,6 +178,7 @@ class Tests(unittest.TestCase):
             results[0]['path'] == dirname + '/?'
 
     @fails_local_backend()
+    @fails_service_backend()
     def test_hadoop_ls_glob_empty_group_matches_empty_string(self):
         with hl.TemporaryDirectory() as dirname:
             with fs.open(dirname + '/a', 'w') as fobj:

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -177,18 +177,6 @@ class Tests(unittest.TestCase):
             assert len(results) == 1
             results[0]['path'] == dirname + '/?'
 
-    @fails_local_backend()
-    @fails_service_backend()
-    def test_hadoop_ls_glob_empty_group_matches_empty_string(self):
-        with hl.TemporaryDirectory() as dirname:
-            with hl.current_backend().fs.open(dirname + '/a', 'w') as fobj:
-                fobj.write('hello world')
-            dirname = self.normalize_path(dirname)
-
-            results = hl.hadoop_ls(dirname + '/[]a')
-            assert len(results) == 1
-            results[0]['path'] == dirname + '/a'
-
     def test_hadoop_ls_glob_1(self):
         expected = [self.normalize_path(resource('ls_test/f_100'))]
         actual = [x['path'] for x in hl.hadoop_ls(resource('l?_t?st/f*00'))]

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -114,7 +114,7 @@ class Tests(unittest.TestCase):
 
     def test_hadoop_ls_simple(self):
         with hl.TemporaryDirectory() as dirname:
-            with fs.open(dirname + '/a', 'w') as fobj:
+            with hl.current_backend().fs.open(dirname + '/a', 'w') as fobj:
                 fobj.write('hello world')
             dirname = self.normalize_path(dirname)
 
@@ -169,7 +169,7 @@ class Tests(unittest.TestCase):
     @fails_spark_backend()
     def test_hadoop_ls_glob_question_mark_in_group(self):
         with hl.TemporaryDirectory() as dirname:
-            with fs.open(dirname + '/?', 'w') as fobj:
+            with hl.current_backend().fs.open(dirname + '/?', 'w') as fobj:
                 fobj.write('hello world')
             dirname = self.normalize_path(dirname)
 
@@ -181,7 +181,7 @@ class Tests(unittest.TestCase):
     @fails_service_backend()
     def test_hadoop_ls_glob_empty_group_matches_empty_string(self):
         with hl.TemporaryDirectory() as dirname:
-            with fs.open(dirname + '/a', 'w') as fobj:
+            with hl.current_backend().fs.open(dirname + '/a', 'w') as fobj:
                 fobj.write('hello world')
             dirname = self.normalize_path(dirname)
 
@@ -202,7 +202,7 @@ class Tests(unittest.TestCase):
     def test_hadoop_ls_glob_3(self):
         fs = hl.current_backend().fs
         def touch(filename):
-            with fs.open(filename, 'w') as fobj:
+            with hl.current_backend().fs.open(filename, 'w') as fobj:
                 fobj.write('hello world')
 
         with hl.TemporaryDirectory() as dirname:

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -121,11 +121,14 @@ class Tests(unittest.TestCase):
         self.assertEqual(stat2['is_dir'], False)
         self.assertTrue('path' in stat2)
 
+    @fails_local_backend()
     def test_hadoop_no_glob_in_bucket(self):
         try:
             hl.hadoop_ls('gs://glob*bucket')
         except ValueError as err:
             assert 'glob pattern only allowed in path (e.g. not in bucket): gs://glob*bucket' in err.args[0]
+        except FatalError as err:
+            assert "Invalid bucket name 'glob*bucket': bucket name must contain only 'a-z0-9_.-' characters." in err.args[0]
         else:
             assert False
 

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -237,13 +237,17 @@ class Tests(unittest.TestCase):
             actual = [x['path'] for x in hl.hadoop_ls(dirname + '/abc/[g][h][i]/*')]
             assert set(actual) == set(expected)
 
-            expected = [dirname + '/abc/ghi/123',
+            expected = [dirname + '/abc/ghi/!23',
                         dirname + '/abc/ghi/?23']
             actual = [x['path'] for x in hl.hadoop_ls(dirname + '/abc/ghi/[!1]23')]
             assert set(actual) == set(expected)
 
             expected = [dirname + '/abc/ghi/?23']
             actual = [x['path'] for x in hl.hadoop_ls(dirname + '/abc/ghi/[?]23')]
+            assert set(actual) == set(expected)
+
+            expected = [dirname + '/abc/ghi/123']
+            actual = [x['path'] for x in hl.hadoop_ls(dirname + '/abc/ghi/[]123')]
             assert set(actual) == set(expected)
 
     def test_linked_list(self):

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -128,3 +128,27 @@ async def test_multi_part_create_many_two_level_merge(gs_filesystem):
         assert expected == actual
     except (concurrent.futures._base.CancelledError, asyncio.CancelledError) as err:
         raise AssertionError('uncaught cancelled error') from err
+
+async def test_weird_urls(gs_filesystem):
+    _, fs, base = gs_filesystem
+
+    await fs.write(base + '?', b'contents of ?')
+    assert await fs.read(base + '?') == b'contents of ?'
+
+    await fs.write(base + '?a', b'contents of ?a')
+    assert await fs.read(base + '?') == b'contents of ?a'
+
+    await fs.write(base + '?a#b', b'contents of ?a#b')
+    assert await fs.read(base + '?a#b') == b'contents of ?a#b'
+
+    await fs.write(base + '#b?a', b'contents of #b?a')
+    assert await fs.read(base + '#b?a') == b'contents of #b?a'
+
+    await fs.write(base + '?a#b@c', b'contents of ?a#b@c')
+    assert await fs.read(base + '?a#b@c') == b'contents of ?a#b@c'
+
+    await fs.write(base + '#b', b'contents of #b')
+    assert await fs.read(base + '#b') == b'contents of #b'
+
+    await fs.write(base + '???', b'contents of ???')
+    assert await fs.read(base + '???') == b'contents of ???'

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -39,7 +39,7 @@ async def gs_filesystem(request):
 
 @pytest.fixture
 def bucket_and_temporary_file():
-    bucket, prefix = GoogleStorageAsyncFS.get_bucket_name(os.environ['HAIL_TEST_STORAGE_URI'])
+    bucket, prefix = GoogleStorageAsyncFS.get_bucket_and_name(os.environ['HAIL_TEST_STORAGE_URI'])
     return bucket, prefix + '/' + secrets.token_hex(16)
 
 


### PR DESCRIPTION
The `hadoop_ls` interface has traditionally supported globbing. This improves the service backend to also support Python-style globbing. The strategy is straightforward:
1. Break the object name into components (the bits between `/`s)
2. Find the components with glob patterns. Call these pattern-components.
3. For each pattern-component, list the files in its `dirname`. Find entries which match the pattern-component.

cc: @tpoterba @chrisvittal , y'all have a vested interest in the Query Python FS API.