### PR TITLE
[query/fs] fix LocalFS when given a single file to list & when globbing

### DIFF
--- a/hail/python/hail/fs/local_fs.py
+++ b/hail/python/hail/fs/local_fs.py
@@ -3,6 +3,7 @@ import gzip
 import io
 import os
 from shutil import copy2, rmtree
+import glob
 
 from .fs import FS
 from .stat_result import StatResult
@@ -52,8 +53,19 @@ class LocalFS(FS):
         return StatResult.from_os_stat_result(path, os.stat(path))
 
     def ls(self, path: str) -> List[StatResult]:
-        return [self.stat(os.path.join(path, file))
-                for file in os.listdir(path)]
+        if glob.escape(path) == path:
+            return self._ls_no_glob(path)
+        return [
+            result_path
+            for globbed_path in glob.glob(path)
+            for result_path in self._ls_no_glob(globbed_path)
+        ]
+
+    def _ls_no_glob(self, path: str) -> List[StatResult]:
+        if os.path.isdir(path):
+            return [self.stat(os.path.join(path, file))
+                    for file in os.listdir(path)]
+        return [self.stat(path)]
 
     def mkdir(self, path: str):
         os.mkdir(path)

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -114,7 +114,6 @@ class Tests(unittest.TestCase):
         self.assertTrue('path' in stat2)
 
     @fails_service_backend()
-    @fails_local_backend()
     def test_hadoop_ls(self):
         path1 = resource('ls_test/f_50')
         ls1 = hl.hadoop_ls(path1)
@@ -136,7 +135,7 @@ class Tests(unittest.TestCase):
         ls3 = hl.hadoop_ls(path3)
         assert len(ls3) == 2, ls3
 
-        with self.assertRaisesRegex(Exception, "FileNotFound"):
+        with self.assertRaisesRegex(Exception, "FileNotFound|No such file or directory"):
             hl.hadoop_ls('a_file_that_does_not_exist')
 
     def test_linked_list(self):


### PR DESCRIPTION
This test tests a lot of functionality. Two different things were failing, both of which are fixed here:

1. When you list a file (as opposed to a directory) you should get a size one list containing the stat for that file. Previously, `LocalFS.ls` would raise a NotADirectoryError.
2. `LocalFS.ls` does not support the globbing that `HadoopFS` supports. I fixed that.