### PR TITLE
[hail] fix some mypy types

### DIFF
--- a/hail/python/hail/fs/google_fs.py
+++ b/hail/python/hail/fs/google_fs.py
@@ -2,7 +2,7 @@ import os
 import time
 
 from stat import S_ISREG, S_ISDIR
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 from shutil import copy2, rmtree
 
 import dateutil
@@ -86,13 +86,13 @@ class GoogleCloudStorageFS(FS):
         except FileNotFoundError:
             return False
 
-    def stat(self, path: str) -> Dict:
+    def stat(self, path: str) -> StatResult:
         if self._is_local(path):
             return StatResult.from_os_stat_result(path, os.stat(path))
 
         return self._format_stat_gs_file(self.client.info(path), path)
 
-    def _format_stat_gs_file(self, stats: Dict, path: Optional[str] = None) -> StatResult:
+    def _format_stat_gs_file(self, stats: Dict[str, Any], path: Optional[str] = None) -> StatResult:
         path_from_stats = stats.get('name')
         if path_from_stats is not None:
             path_from_stats = self._add_gs_path_prefix(path_from_stats)
@@ -114,7 +114,7 @@ class GoogleCloudStorageFS(FS):
             typ=typ,
             modification_time=modification_time)
 
-    def _stat_is_gs_dir(self, stats: Dict) -> bool:
+    def _stat_is_gs_dir(self, stats: Dict[str, Any]) -> bool:
         return stats['storageClass'] == 'DIRECTORY' or stats['name'].endswith('/')
 
     def ls(self, path: str) -> List[StatResult]:

--- a/hail/python/hail/fs/hadoop_fs.py
+++ b/hail/python/hail/fs/hadoop_fs.py
@@ -1,7 +1,7 @@
 import io
 import json
 import time
-from typing import Dict, List
+from typing import Dict, List, Union, Any
 
 import dateutil
 
@@ -9,7 +9,7 @@ from .fs import FS
 from .stat_result import FileType, StatResult
 
 
-def _stat_dict_to_stat_result(stat: Dict) -> StatResult:
+def _stat_dict_to_stat_result(stat: Dict[str, Any]) -> StatResult:
     dt = dateutil.parser.isoparse(stat['modification_time'])
     mtime = time.mktime(dt.timetuple())
     if stat['is_dir']:
@@ -35,6 +35,7 @@ class HadoopFS(FS):
         return self._open(path, mode, buffer_size, use_codec=True)
 
     def _open(self, path: str, mode: str = 'r', buffer_size: int = 8192, use_codec: bool = False):
+        handle: Union[io.BufferedReader, io.BufferedWriter]
         if 'r' in mode:
             handle = io.BufferedReader(HadoopReader(self, path, buffer_size, use_codec=use_codec), buffer_size=buffer_size)
         elif 'w' in mode:

--- a/hail/python/hail/fs/stat_result.py
+++ b/hail/python/hail/fs/stat_result.py
@@ -2,7 +2,7 @@ import os
 import stat
 
 from enum import Enum, auto
-from typing import Dict, NamedTuple, Optional, Union
+from typing import Dict, NamedTuple, Optional, Union, Any
 
 import hurry.filesize
 
@@ -35,6 +35,6 @@ class StatResult(NamedTuple):
         return StatResult(path=path, owner=sb.st_uid, size=sb.st_size, typ=typ,
                           modification_time=sb.st_mtime)
 
-    def to_legacy_dict(self) -> Dict:
+    def to_legacy_dict(self) -> Dict[str, Any]:
         return dict(path=self.path, owner=self.owner, is_dir=self.is_dir(), size_bytes=self.size,
                     size=hurry.filesize.size(self.size), modification_time=self.modification_time)

--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List, Dict, Any
 from hail.fs.hadoop_fs import HadoopFS
 from hail.utils.java import Env
 from hail.typecheck import typecheck, enumeration
@@ -161,7 +161,7 @@ def hadoop_is_dir(path: str) -> bool:
     return Env.fs().is_dir(path)
 
 
-def hadoop_stat(path: str) -> Dict:
+def hadoop_stat(path: str) -> Dict[str, Any]:
     """Returns information about the file or directory at a given path.
 
     Notes
@@ -188,7 +188,7 @@ def hadoop_stat(path: str) -> Dict:
     return Env.fs().stat(path).to_legacy_dict()
 
 
-def hadoop_ls(path: str) -> List[Dict]:
+def hadoop_ls(path: str) -> List[Dict[str, Any]]:
     """Returns information about files at `path`.
 
     Notes


### PR DESCRIPTION
Dict is generally supposed to have type arguments, we can use `dict`, lowercase, if
we do not want to specify type arguments.