### PR TITLE
[query] Improve Makefile Compatibility

### DIFF
--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -1,8 +1,9 @@
 from typing import List, Optional, Dict
-import json
-import asyncio
-import logging
 import argparse
+import asyncio
+import json
+import logging
+import sys
 import uvloop
 from concurrent.futures import ThreadPoolExecutor
 
@@ -81,8 +82,8 @@ async def main() -> None:
     parser = argparse.ArgumentParser(description='Hail copy tool')
     parser.add_argument('requester_pays_project', type=str,
                         help='a JSON string indicating the Google project to which to charge egress costs')
-    parser.add_argument('files', type=str,
-                        help='a JSON array of JSON objects indicating from where and to where to copy files')
+    parser.add_argument('files', type=str, nargs='?',
+                        help='a JSON array of JSON objects indicating from where and to where to copy files. If empty or "-", read the array from standard input instead')
     parser.add_argument('--max-simultaneous-transfers', type=int,
                         help='The limit on the number of simultaneous transfers. Large files are uploaded as multiple transfers. This parameter sets an upper bound on the number of open source and destination files.')
     parser.add_argument('-v', '--verbose', action='store_const',
@@ -95,6 +96,8 @@ async def main() -> None:
         logging.root.setLevel(logging.INFO)
 
     requester_pays_project = json.loads(args.requester_pays_project)
+    if args.files is None or args.files == '-':
+        args.files = sys.stdin.read()
     files = json.loads(args.files)
     gcs_kwargs = {'project': requester_pays_project}
 

--- a/query/Makefile
+++ b/query/Makefile
@@ -12,6 +12,9 @@ jar:
 	cp ../hail/build/libs/hail-all-spark.jar ./hail.jar
 
 HAIL_TEST_GCS_TOKEN := $(shell whoami)
+HAIL_TEST_RESOURCES_PREFIX := gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources
+HAIL_TEST_RESOURCES_DIR := $(HAIL_TEST_RESOURCES_PREFIX)/test/resources/
+HAIL_DOCTEST_DATA_DIR := $(HAIL_TEST_RESOURCES_PREFIX)/doctest/data/
 HAIL_REVISION := $(shell git rev-parse HEAD)
 ifeq ($(NAMESPACE),default)
 JAR_LOCATION := gs://hail-query/jars/$(HAIL_TEST_GCS_TOKEN)/$(HAIL_REVISION).jar
@@ -25,41 +28,37 @@ push-jar: jar
 	echo >last_uploaded_jar "$(JAR_LOCATION)"
 
 upload-resources-dir:
-	python3 -m hailtop.aiotools.copy 'null' '[ \
-{"from": "../hail/src/test/resources/", \
- "to": "gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources/test/resources/"}, \
-{"from": "../hail/python/hail/docs/data/", \
- "to": "gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources/doctest/data/"}]'
+	python3 -m hailtop.aiotools.copy 'null' '[{"from":"../hail/src/test/resources","to":"$(HAIL_TEST_RESOURCES_DIR)"},{"from":"../hail/python/hail/docs/data","to":"$(HAIL_DOCTEST_DATA_DIR)"}]'
 	touch upload-resources-dir
 
 .PHONY: test
 test: push-jar upload-resources-dir
-	HAIL_QUERY_BACKEND=serivce \
-	  HAIL_TEST_RESOURCES_DIR='gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources/test/resources/' \
-    HAIL_DOCTEST_DATA_DIR='gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources/doctest/data/' \
-    HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
-    HAIL_JAR_URL=$$(cat last_uploaded_jar) \
-    $(MAKE) -C ../hail pytest
+	HAIL_QUERY_BACKEND=service \
+	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
+	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
+	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
+	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
+	$(MAKE) -C ../hail pytest
 
 .PHONY: ipython
 ipython: push-jar
-	HAIL_QUERY_BACKEND=serivce \
-    HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
-    HAIL_JAR_URL=$$(cat last_uploaded_jar) \
-    ipython
+	HAIL_QUERY_BACKEND=service \
+	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
+	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
+	ipython
 
 .PHONY: test-no-deps
 test-no-deps:
 	HAIL_QUERY_BACKEND=service \
-    HAIL_TEST_RESOURCES_DIR='gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources/test/resources/' \
-    HAIL_DOCTEST_DATA_DIR='gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources/doctest/data/' \
-    HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
-    HAIL_JAR_URL=$$(cat last_uploaded_jar) \
-    $(MAKE) -C ../hail pytest
+	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
+	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
+	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
+	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
+	$(MAKE) -C ../hail pytest
 
 .PHONY: ipython-no-deps
 ipython-no-deps:
 	HAIL_QUERY_BACKEND=service \
-    HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
-    HAIL_JAR_URL=$$(cat last_uploaded_jar) \
-    ipython
+	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
+	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
+	ipython


### PR DESCRIPTION
When using GNU Make 4.3, the slashes in the json string in
query/Makefile were being passed unmodified as arguments to the python
copy process. In order to fix this, I had to put the json input on one
line. Furthermore, I converted all indents to tabs for consistency.

I also modified hailtop.aiotools.copy to read from standard input if '-'
or no 'files' argument is provided. I belive this will allow easier use
of the copy tool by end users, for example, using [jo], the copy
invocation looks like:

```make
	jo -a \
		$$(jo from=../hail/src/test/resources to=$(HAIL_TEST_RESOURCES_DIR)) \
		$$(jo from=../hail/python/hail/docs/data to=$(HAIL_DOCTEST_DATA_DIR)) | \
		python3 -m hailtop.aiotools.copy 'null'
```

[jo]: https://jpmens.net/2016/03/05/a-shell-command-to-create-json-jo/