### PR TITLE
[query/service] fix calculation of number of flags

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -204,7 +204,7 @@ class ServiceBackend(Backend):
         with TemporaryDirectory(ensure_exists=False) as _:
             with timings.step("write input"):
                 async with await self._async_fs.create(iodir + '/in') as infile:
-                    nonnull_flag_count = len(v is not None for v in self.flags.values())
+                    nonnull_flag_count = len([v is not None for v in self.flags.values()])
                     await write_int(infile, nonnull_flag_count)
                     for k, v in self.flags.items():
                         if v is not None:

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -204,7 +204,8 @@ class ServiceBackend(Backend):
         with TemporaryDirectory(ensure_exists=False) as _:
             with timings.step("write input"):
                 async with await self._async_fs.create(iodir + '/in') as infile:
-                    await write_int(infile, len(self.flags))
+                    nonnull_flag_count = len(v is not None for v in self.flags.values())
+                    await write_int(infile, nonnull_flag_count)
                     for k, v in self.flags.items():
                         if v is not None:
                             await write_str(infile, k)


### PR DESCRIPTION
We do not send flags set to None, so we should not include them in the count of flags.

Yes, I agree, I should have used JSON for this. I will fix that post-haste after March 28th