### PR TITLE
[infra] Update k8s to 8-core nodes

### DIFF
--- a/dev-docs/kubernetes-operations.md
+++ b/dev-docs/kubernetes-operations.md
@@ -2,6 +2,8 @@
 
 ## Altering a Node Pool
 
+### When managing node pools manually
+
 We will have the old node pool and the new node pool active simultaneously. We will use `cordon` and
 `drain` to move all load from the old node pool to the new node pool. Then we will delete the old
 node pool.

--- a/dev-docs/kubernetes-operations.md
+++ b/dev-docs/kubernetes-operations.md
@@ -8,7 +8,7 @@ node pool.
 
 1. Add a new node pool to the cluster. You can use the UI or `gcloud`. We have two kinds of node
    pools: non-preemptible and preemptible, their names should always be non-preemptible-pool-N and
-   prremptible-pool-N, respectively. When you re-create the nodepool, increment the number by
+   preemptible-pool-N, respectively. When you re-create the nodepool, increment the number by
    one. Take care to copy the taints and tags correctly.
 
 2. Wait for the new nodepool to be ready.
@@ -47,3 +47,48 @@ kubectl drain --delete-emptydir-data --ignore-daemonsets --selector="cloud.googl
 ```
 gcloud container node-pools delete $OLD_POOL_NAME --cluster $CLUSTER_NAME
 ```
+
+### When using terraform
+If using terraform to manage the node pools, we use terraform to create and delete
+the pools. Assume we are replacing a pool whose terraform resource name is
+`vdc_preemptible_pool`. NOTE: the following names apply to the *terraform resource*,
+not the names of the node pools themselves, which should adhere to the naming
+conventions outlined above and specified as terraform variables.
+
+To complete step 1, copy the existing node pool resource
+under a new name, `vdc_preemptible_pool_2`, make the desired changes to the new
+resource and apply the terraform. This should not alter existing node pools.
+
+Once draining is complete, take the following steps to remove the old node pool
+and restore a clean terraform state:
+1. Delete the resource `vdc_preemptible_pool` and apply. This should delete the old node pool.
+2. Move the state of the new resource into the old one. For example, if in Azure, run
+
+```
+terraform state mv \
+module.vdc.azurerm_kubernetes_cluster_node_pool.vdc_preemptible_pool_2 \
+module.vdc.azurerm_kubernetes_cluster_node_pool.vdc_preemptible_pool
+```
+
+3. Rename `vdc_preemptible_pool_2` to `vdc_preemptible_pool`. If you try
+to `terraform apply`, there should be no planned changes and the git history
+should be clean.
+
+
+## Troubleshooting
+
+### Terraform Kubernetes provider dialing localhost
+Occasionally, the `kubernetes` provider can initialize before fetching necessary
+state (as the credentials are themselves terraform resources) and fall back to
+dialing localhost. This can occur if you are switching between Hail installations
+and the local mirror of the terraform state needs to be sync'd from remote storage
+at the start of `terraform apply`.
+
+As of writing, this
+[remains an issue](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1028)
+with the kubernetes provider. A workaround to fully initialize the state is instead
+of just running `terraform apply` for the entire module, to instead target just
+the resources that generate the kubernetes configuration but do not themselves
+rely on the kubernetes provider. Run `terraform apply -var-file=global.tfvars -target=module.vdc`
+to correctly sync local terraform state, and subsequent invocations of `terraform apply`
+should work as expected.

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.97.0"
+      version = "=2.99.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azuread"
       version = "=2.7.0"
     }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "2.8.0"
+    }
     http = {
       source = "hashicorp/http"
       version = "2.1.0"

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -60,7 +60,11 @@ module "vdc" {
 
   resource_group        = data.azurerm_resource_group.rg
   container_registry_id = azurerm_container_registry.acr.id
-  k8s_machine_type      = var.k8s_machine_type
+
+  k8s_default_node_pool_machine_type = var.k8s_default_node_pool_machine_type
+  k8s_user_pool_machine_type         = var.k8s_user_pool_machine_type
+  k8s_preemptible_node_pool_name     = var.k8s_preemptible_node_pool_name
+  k8s_nonpreemptible_node_pool_name  = var.k8s_nonpreemptible_node_pool_name
 }
 
 module "db" {

--- a/infra/azure/modules/batch/main.tf
+++ b/infra/azure/modules/batch/main.tf
@@ -55,6 +55,10 @@ resource "azurerm_storage_account" "batch" {
   location                 = var.resource_group.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  blob_properties {
+    last_access_time_enabled = true
+  }
 }
 
 resource "azurerm_storage_container" "batch_logs" {
@@ -75,6 +79,10 @@ resource "azurerm_storage_account" "test" {
   location                 = var.resource_group.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  blob_properties {
+    last_access_time_enabled = true
+  }
 }
 
 resource "azurerm_storage_container" "test" {
@@ -91,7 +99,7 @@ resource "azurerm_storage_management_policy" "test" {
     enabled = true
     filters {
       prefix_match = [azurerm_storage_container.test.name]
-      blob_types   = ["blockBlob", "appendBlob"]
+      blob_types   = ["blockBlob"]
     }
     actions {
       base_blob {

--- a/infra/azure/modules/ci/main.tf
+++ b/infra/azure/modules/ci/main.tf
@@ -4,6 +4,10 @@ resource "azurerm_storage_account" "ci" {
   location                 = var.resource_group.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  blob_properties {
+    last_access_time_enabled = true
+  }
 }
 
 resource "azurerm_storage_container" "ci_artifacts" {
@@ -20,7 +24,7 @@ resource "azurerm_storage_management_policy" "ci" {
     enabled = true
     filters {
       prefix_match = [azurerm_storage_container.ci_artifacts.name]
-      blob_types   = ["blockBlob", "appendBlob"]
+      blob_types   = ["blockBlob"]
     }
     actions {
       base_blob {

--- a/infra/azure/modules/vdc/main.tf
+++ b/infra/azure/modules/vdc/main.tf
@@ -52,13 +52,13 @@ resource "azurerm_kubernetes_cluster" "vdc" {
 
   default_node_pool {
     name           = "nonpreempt"
-    vm_size        = var.k8s_machine_type
+    vm_size        = var.k8s_default_node_pool_machine_type
     vnet_subnet_id = azurerm_subnet.k8s_subnet.id
 
     enable_auto_scaling = true
 
     min_count = 1
-    max_count = 200
+    max_count = 5
 
     node_labels = {
       "preemptible" = "false"
@@ -82,10 +82,32 @@ resource "azurerm_kubernetes_cluster" "vdc" {
   }
 }
 
-resource "azurerm_kubernetes_cluster_node_pool" "vdc_preemptible_pool" {
-  name                  = "preempt"
+resource "azurerm_kubernetes_cluster_node_pool" "vdc_nonpreemptible_pool" {
+  name                  = var.k8s_nonpreemptible_node_pool_name
   kubernetes_cluster_id = azurerm_kubernetes_cluster.vdc.id
-  vm_size               = var.k8s_machine_type
+  vm_size               = var.k8s_user_pool_machine_type
+  vnet_subnet_id        = azurerm_subnet.k8s_subnet.id
+
+  enable_auto_scaling = true
+
+  min_count = 0
+  max_count = 200
+
+  node_labels = {
+    "preemptible" = "false"
+  }
+
+  lifecycle {
+    # Ignore if the node count has natually changed since last apply
+    # due to autoscaling
+    ignore_changes = [node_count]
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "vdc_preemptible_pool" {
+  name                  = var.k8s_preemptible_node_pool_name
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.vdc.id
+  vm_size               = var.k8s_user_pool_machine_type
   vnet_subnet_id        = azurerm_subnet.k8s_subnet.id
 
   enable_auto_scaling = true

--- a/infra/azure/modules/vdc/variables.tf
+++ b/infra/azure/modules/vdc/variables.tf
@@ -5,7 +5,19 @@ variable resource_group {
   })
 }
 
-variable k8s_machine_type {
+variable k8s_default_node_pool_machine_type {
+  type = string
+}
+
+variable k8s_user_pool_machine_type {
+  type = string
+}
+
+variable k8s_preemptible_node_pool_name {
+  type = string
+}
+
+variable k8s_nonpreemptible_node_pool_name {
   type = string
 }
 

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -7,18 +7,33 @@ variable domain {
 }
 
 variable acr_name {
-  type = string
+  type    = string
   default = ""
 }
 
 variable acr_sku {
-  type = string
+  type    = string
   default = "Premium"
 }
 
-variable k8s_machine_type {
-  type = string
-  default = "Standard_D2_v2"
+variable k8s_default_node_pool_machine_type {
+  type    = string
+  default = "Standard_D2_v2"  # 2 vCPU
+}
+
+variable k8s_user_pool_machine_type {
+  type    = string
+  default = "Standard_D4_v2"  # 8 vCPU
+}
+
+variable k8s_preemptible_node_pool_name {
+  type    = string
+  default = "preempt1"
+}
+
+variable k8s_nonpreemptible_node_pool_name {
+  type    = string
+  default = "nonpreempt1"
 }
 
 variable organization_domain {
@@ -37,6 +52,6 @@ variable "ci_config" {
 }
 
 variable oauth2_developer_redirect_uris {
-  type = list(string)
+  type    = list(string)
   default = []
 }

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "1.13.3"
+      version = "2.8.0"
     }
   }
 }

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -11,6 +11,14 @@ terraform {
   }
 }
 
+variable "k8s_preemptible_node_pool_name" {
+  type    = string
+  default = "preemptible-pool"
+}
+variable "k8s_nonpreemptible_node_pool_name" {
+  type    = string
+  default = "nonpreemptible-pool"
+}
 variable "batch_gcp_regions" {}
 variable "gcp_project" {}
 variable "batch_logs_bucket_location" {}
@@ -111,9 +119,9 @@ resource "google_container_cluster" "vdc" {
 }
 
 resource "google_container_node_pool" "vdc_preemptible_pool" {
-  name = "preemptible-pool"
+  name     = var.k8s_preemptible_node_pool_name
   location = var.gcp_zone
-  cluster = google_container_cluster.vdc.name
+  cluster  = google_container_cluster.vdc.name
 
   # Allocate at least one node, so that autoscaling can take place.
   initial_node_count = 1
@@ -125,7 +133,7 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
 
   node_config {
     preemptible = true
-    machine_type = "n1-standard-2"
+    machine_type = "n1-standard-8"
 
     labels = {
       "preemptible" = "true"
@@ -148,9 +156,9 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
 }
 
 resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
-  name = "nonpreemptible-pool"
+  name     = var.k8s_nonpreemptible_node_pool_name
   location = var.gcp_zone
-  cluster = google_container_cluster.vdc.name
+  cluster  = google_container_cluster.vdc.name
 
   # Allocate at least one node, so that autoscaling can take place.
   initial_node_count = 1
@@ -162,7 +170,7 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
 
   node_config {
     preemptible = false
-    machine_type = "n1-standard-2"
+    machine_type = "n1-standard-8"
 
     labels = {
       preemptible = "false"


### PR DESCRIPTION
There's a few things happening here:

### Node pool updates through terraform
I extended the node pool update documentation with how to deal with terraform-managed node pools. This is what I did on Azure and worked fine. The only real change in terraform other than changing the machine type is making the node pool name configurable to adhere to the naming guidelines and allow us to do a rolling migration.

### Updated the kubernetes and azurerm providers
I updated the azurerm provider without thinking much about it and even though it's a minor version had some breaking changes that after a half-successful `apply` made it hard to downgrade. So I decided just to appease the breaking change and leave us at the new version, which is what all the `blob_properties` changes are for. They are in no way related to the node pools.

### Troubleshooting
I added a section for a bug that I've seen a couple of times (and encountered again today) but never documented how I got around it.