### PR TITLE
[batch] Use nginx reverse proxy to terminate TLS for batch-driver

### DIFF
--- a/batch/Dockerfile.driver-nginx
+++ b/batch/Dockerfile.driver-nginx
@@ -1,0 +1,12 @@
+FROM {{ hail_ubuntu_image.image }}
+
+RUN hail-apt-get-install nginx
+
+RUN rm -f /etc/nginx/sites-enabled/default && \
+    rm -f /etc/nginx/nginx.conf
+ADD driver-nginx.conf /etc/nginx/nginx.conf
+
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -5,6 +5,8 @@ TOKEN = $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
 BATCH_IMAGE := $(DOCKER_PREFIX)/batch:$(TOKEN)
 BATCH_WORKER_IMAGE := $(DOCKER_PREFIX)/batch-worker:$(TOKEN)
 
+BATCH_DRIVER_NGINX_IMAGE := $(DOCKER_PREFIX)/batch-driver-nginx:$(TOKEN)
+
 EXTRA_PYTHONPATH := ../hail/python:../gear:../web_common
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 CLOUD := $(shell kubectl get secret global-config --template={{.data.cloud}} | base64 --decode)
@@ -34,15 +36,20 @@ jars/junixsocket-selftest-2.3.3-jar-with-dependencies.jar:
 src/main/java/is/hail/JVMEntryway.class: src/main/java/is/hail/JVMEntryway.java jars/junixsocket-selftest-2.3.3-jar-with-dependencies.jar
 	javac -cp jars/junixsocket-selftest-2.3.3-jar-with-dependencies.jar $<
 
+.PHONY: build-batch-driver-nginx
+build-batch-driver-nginx:
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../docker/hail-ubuntu-image-ref)'"}}' Dockerfile.driver-nginx Dockerfile.driver-nginx.out
+	../docker-build.sh . Dockerfile.driver-nginx.out $(BATCH_DRIVER_NGINX_IMAGE)
+
 .PHONY: build-worker
 build-worker: src/main/java/is/hail/JVMEntryway.class
 	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../docker/hail-ubuntu-image-ref)'"},"global":{"cloud":"$(CLOUD)"}}' Dockerfile.worker Dockerfile.worker.out
 	../docker-build.sh .. batch/Dockerfile.worker.out $(BATCH_WORKER_IMAGE)
 
 .PHONY: build
-build: build-batch build-worker
+build: build-batch build-batch-driver-nginx build-worker
 
-JINJA_ENVIRONMENT = '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"batch_image":{"image":"$(BATCH_IMAGE)"},"batch_worker_image":{"image":"$(BATCH_WORKER_IMAGE)"},"default_ns":{"name":"$(NAMESPACE)"},"batch_database":{"user_secret_name":"sql-batch-user-config"},"scope":"$(SCOPE)"}'
+JINJA_ENVIRONMENT = '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"batch_image":{"image":"$(BATCH_IMAGE)"},"batch_worker_image":{"image":"$(BATCH_WORKER_IMAGE)"},"default_ns":{"name":"$(NAMESPACE)"},"batch_database":{"user_secret_name":"sql-batch-user-config"},"scope":"$(SCOPE)","batch_driver_nginx_image":{"image":"$(BATCH_DRIVER_NGINX_IMAGE)"}}'
 
 .PHONY: deploy
 deploy: build

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 import sortedcontainers
 
+import prometheus_client as pc
+
 from gear import Database
 from hailtop import aiotools
 from hailtop.utils import (
@@ -27,6 +29,8 @@ from ..resource_manager import CloudResourceManager
 from .base import InstanceCollection, InstanceCollectionManager
 
 log = logging.getLogger('pool')
+
+SCHEDULING_LOOP_RUNS = pc.Counter('scheduling_loop_runs', '')
 
 
 class Pool(InstanceCollection):
@@ -373,6 +377,7 @@ HAVING n_ready_jobs + n_running_jobs > 0;
 
         log.info(f'schedule {self.pool}: starting')
         start = time_msecs()
+        SCHEDULING_LOOP_RUNS.inc()
         n_scheduled = 0
 
         user_resources = await self.compute_fair_share()

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -29,7 +29,11 @@ from .base import InstanceCollection, InstanceCollectionManager
 
 log = logging.getLogger('pool')
 
-SCHEDULING_LOOP_RUNS = pc.Counter('scheduling_loop_runs', '')
+SCHEDULING_LOOP_RUNS = pc.Counter(
+    'scheduling_loop_runs',
+    'Number of scheduling loop executions per pool',
+    ['pool_name'],
+)
 
 
 class Pool(InstanceCollection):
@@ -376,7 +380,7 @@ HAVING n_ready_jobs + n_running_jobs > 0;
 
         log.info(f'schedule {self.pool}: starting')
         start = time_msecs()
-        SCHEDULING_LOOP_RUNS.inc()
+        SCHEDULING_LOOP_RUNS.labels(pool_name=self.pool.name).inc()
         n_scheduled = 0
 
         user_resources = await self.compute_fair_share()

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -3,9 +3,8 @@ import logging
 import random
 from typing import Optional
 
-import sortedcontainers
-
 import prometheus_client as pc
+import sortedcontainers
 
 from gear import Database
 from hailtop import aiotools

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -46,6 +46,7 @@ WHERE batches.id = %s AND NOT deleted AND callback IS NOT NULL AND
 GROUP BY batches.id;
 ''',
         (batch_id,),
+        'notify_batch_job_complete',
     )
 
     if not record:
@@ -85,6 +86,7 @@ VALUES (%s, %s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE quantity = quantity;
 ''',
                 resource_args,
+                'add_attempt_resources',
             )
         except Exception:
             log.exception(f'error while inserting resources for job {job_id}, attempt {attempt_id}')

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -30,7 +30,6 @@ from gear.clients import get_cloud_async_fs
 from hailtop import aiotools, httpx
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import AsyncWorkerPool, Notice, dump_all_stacktraces, periodically_call, serialization, time_msecs
 from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
@@ -1261,5 +1260,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=internal_server_ssl_context(),
     )

--- a/batch/batch/spec_writer.py
+++ b/batch/batch/spec_writer.py
@@ -36,6 +36,7 @@ ORDER BY start_job_id DESC
 LIMIT 1;
 ''',
             (batch_id, job_id),
+            'get_token_start_id',
         )
         token = bunch_record['token']
         start_job_id = bunch_record['start_job_id']

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -34,6 +34,26 @@ spec:
          value: "spot"
 {% endif %}
       containers:
+      - name: nginx
+        image: {{ batch_driver_nginx_image.image }}
+        resources:
+          requests:
+            cpu: "4"
+            memory: "2G"
+          limits:
+            cpu: "4.5"
+            memory: "4G"
+        ports:
+         - containerPort: 443
+        volumeMounts:
+         - name: ssl-config-batch-driver-nginx
+           mountPath: /ssl-config
+           readOnly: true
+        readinessProbe:
+          tcpSocket:
+            port: 443
+          initialDelaySeconds: 5
+          periodSeconds: 5
       - name: batch-driver
         image: {{ batch_image.image }}
         command:
@@ -45,10 +65,10 @@ spec:
          - batch.driver
         resources:
           requests:
-            cpu: "600m"
+            cpu: "1"
             memory: "2G"
           limits:
-            cpu: "1"
+            cpu: "1.5"
             memory: "2.5G"
         env:
          - name: HAIL_DOMAIN
@@ -150,8 +170,6 @@ spec:
          - name: HAIL_SHOULD_CHECK_INVARIANTS
            value: "1"
 {% endif %}
-        ports:
-         - containerPort: 5000
         volumeMounts:
          - name: deploy-config
            mountPath: /deploy-config
@@ -199,6 +217,10 @@ spec:
          secret:
            optional: false
            secretName: ssl-config-batch-driver
+       - name: ssl-config-batch-driver-nginx
+         secret:
+           optional: false
+           secretName: ssl-config-batch-driver-nginx
        - name: ssh-public-key
          secret:
            secretName: batch-worker-ssh-public-key
@@ -441,6 +463,6 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 5000
+    targetPort: 443
   selector:
     app: batch-driver

--- a/batch/driver-nginx.conf
+++ b/batch/driver-nginx.conf
@@ -1,0 +1,78 @@
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+  worker_connections 768;
+}
+
+http {
+
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  server_names_hash_bucket_size 128;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_prefer_server_ciphers on;
+
+  log_format json-log escape=json '{'
+   '"message":"$scheme $request done in ${request_time}s: $status",'
+   '"response_status":$status,'
+   '"request_duration":$request_time,'
+   '"remote_address":"$remote_addr",'
+   '"x_real_ip":"$http_x_real_ip",'
+   '"request_start_time":"$time_local",'
+   '"body_bytes_sent":"$body_bytes_sent",'
+   '"http_referer":"$http_referer",'
+   '"http_user_agent":"$http_user_agent"'
+ '}';
+
+  access_log /var/log/nginx/access.log json-log;
+  error_log /var/log/nginx/error.log;
+
+  gzip on;
+
+  include /ssl-config/ssl-config-http.conf;
+  map $http_x_forwarded_proto $updated_scheme {
+       default $http_x_forwarded_proto;
+       '' $scheme;
+  }
+  map $http_x_forwarded_host $updated_host {
+       default $http_x_forwarded_host;
+       '' $http_host;
+  }
+  map $http_upgrade $connection_upgrade {
+      default upgrade;
+      ''      close;
+  }
+
+  server {
+    server_name batch-driver.*;
+
+    location = /healthcheck {
+        return 204;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:5000/;
+
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host  $updated_host;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Real-IP         $http_x_real_ip;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+  }
+}

--- a/build.yaml
+++ b/build.yaml
@@ -571,6 +571,17 @@ steps:
       - service_base_image
       - merge_code
   - kind: buildImage2
+    name: batch_driver_nginx_image
+    dockerFile: /io/batch/Dockerfile.driver-nginx
+    contextPath: /io/batch
+    publishAs: batch-driver-nginx
+    inputs:
+      - from: /repo/batch
+        to: /io/batch
+    dependsOn:
+      - hail_ubuntu_image
+      - merge_code
+  - kind: buildImage2
     name: batch_image
     dockerFile: /io/batch/Dockerfile
     contextPath: /io/batch/
@@ -2976,6 +2987,7 @@ steps:
       - create_accounts
       - batch_image
       - batch_worker_image
+      - batch_driver_nginx_image
       - batch_database
       - deploy_auth
       - create_certs

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -9,7 +9,7 @@ from typing import Optional
 import aiomysql
 import pymysql
 
-from gear.metrics import DB_CONNECTION_QUEUE_SIZE, PrometheusSQLTimer
+from gear.metrics import DB_CONNECTION_QUEUE_SIZE, SQL_TRANSACTIONS, PrometheusSQLTimer
 from hailtop.auth.sql_config import SQLConfig
 from hailtop.utils import sleep_and_backoff
 
@@ -159,6 +159,7 @@ class Transaction:
         try:
             self.conn_context_manager = db_pool.acquire()
             DB_CONNECTION_QUEUE_SIZE.inc()
+            SQL_TRANSACTIONS.inc()
             self.conn = await aenter(self.conn_context_manager)
             DB_CONNECTION_QUEUE_SIZE.dec()
             async with self.conn.cursor() as cursor:

--- a/gear/gear/metrics.py
+++ b/gear/gear/metrics.py
@@ -6,6 +6,7 @@ REQUEST_TIME = pc.Summary('http_request_latency_seconds', 'Endpoint latency in s
 REQUEST_COUNT = pc.Counter('http_request_count', 'Number of HTTP requests', ['endpoint', 'verb', 'status'])
 CONCURRENT_REQUESTS = pc.Gauge('http_concurrent_requests', 'Number of in progress HTTP requests', ['endpoint', 'verb'])
 
+SQL_TRANSACTIONS = pc.Counter('sql_transactions', 'Number of SQL transactions')
 SQL_QUERY_COUNT = pc.Counter('sql_query_count', 'Number of SQL Queries', ['query_name'])
 SQL_QUERY_LATENCY = pc.Summary('sql_query_latency_seconds', 'SQL Query latency in seconds', ['query_name'])
 DB_CONNECTION_QUEUE_SIZE = pc.Gauge('sql_connection_queue_size', 'Number of coroutines waiting for a connection')

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -837,6 +837,7 @@ async def run_if_changed(changed, f, *args, **kwargs):
     while True:
         changed.clear()
         should_wait = await f(*args, **kwargs)
+        await asyncio.sleep(0.5)
         if should_wait:
             await changed.wait()
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -837,7 +837,8 @@ async def run_if_changed(changed, f, *args, **kwargs):
     while True:
         changed.clear()
         should_wait = await f(*args, **kwargs)
-        # Require half a second between iterations to avoid
+        # 0.5 is arbitrary, but should be short enough not to greatly
+        # increase latency and long enough to reduce the impact of
         # wasteful spinning when `should_wait` is always true and the
         # event is constantly being set. This was instated to
         # avoid wasteful repetition of scheduling loops, but

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -837,6 +837,11 @@ async def run_if_changed(changed, f, *args, **kwargs):
     while True:
         changed.clear()
         should_wait = await f(*args, **kwargs)
+        # Require half a second between iterations to avoid
+        # wasteful spinning when `should_wait` is always true and the
+        # event is constantly being set. This was instated to
+        # avoid wasteful repetition of scheduling loops, but
+        # might not always be desirable, especially in very low-latency batches.
         await asyncio.sleep(0.5)
         if should_wait:
             await changed.wait()

--- a/internal-gateway/internal-gateway.nginx.conf
+++ b/internal-gateway/internal-gateway.nginx.conf
@@ -13,7 +13,7 @@ map $service $batch_driver_limit_key {
     default "";  # no key => no limit
 }
 
-limit_req_zone $batch_driver_limit_key zone=batch_driver:1m rate=18r/s;
+limit_req_zone $batch_driver_limit_key zone=batch_driver:1m rate=60r/s;
 
 server {
     server_name internal.hail;

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -19,6 +19,10 @@ principals:
   domains:
     - batch-driver
   kind: json
+- name: batch-driver-nginx
+  domains:
+    - batch-driver
+  kind: nginx
 - name: ci
   domains:
     - ci


### PR DESCRIPTION
This change adds an nginx sidecar to the batch-driver pod for terminating TLS. TLS negotiation has proven a major bottleneck to scheduling performance, as the batch-driver currently spends up to 60% of its CPU time in handshakes with workers. Moving TLS termination into a sidecar that can leverage additional cores both reduced CPU pressure on the driver and allowed for a 3-4x increase in job-scheduling throughput.

##  Benchmarking
Below are before-and-after profiles of the same benchmark (30,000 1s jobs) under the proposed higher rate limit, showing CPU time:
<img width="1889" alt="Screen Shot 2022-03-21 at 5 10 13 PM" src="https://user-images.githubusercontent.com/24440116/159364769-6fd60840-5745-40ab-802e-68b8d4f32078.png">
<img width="1885" alt="Screen Shot 2022-03-21 at 5 12 33 PM" src="https://user-images.githubusercontent.com/24440116/159364787-ca7ec307-877d-479c-9c19-8746b5e82eab.png">

Looking at Wall time, the before profile is nearly identical because at the current rate limit the driver uses 100% of its CPU shares under this benchmark. On this branch, CPU utilization drops to 40-60%, giving the following wall time profile:
<img width="1879" alt="Screen Shot 2022-03-21 at 5 30 39 PM" src="https://user-images.githubusercontent.com/24440116/159367182-0830d6ff-3b6f-4fa7-8004-0fc43283ec4a.png">

So we can be confident that driver CPU is no longer a bottleneck even in the increased rate limit.


## So what's the bottleneck now?
Since the higher rate limit still leaves the driver plenty of CPU room (I've seen it peak at 60% of a vCPU), why not crank it higher? Well, we're increasing concurrency so latent deadlocks start to be a bigger issue again. We start to see tens of deadlocks per second in the proposed rate limit and hundreds at higher rate limits. As a result, we're spending more cycles repeating queries instead of actually scheduling faster. Next steps should focus on eliminating deadlocks before we can continue to max out CPU use.


## Miscellaneous
We've lumped in a few other monitoring changes that were helpful in this process and tried to leave the commits tidy. The one potentially rude change is enforcing a minimum wait time of half a second for `run_if_changed` loops. This dramatically reduced the number of scheduling loop invocations we were executing, greatly reducing the number of `compute_fair_share` queries, while maintaining the same scheduling ability. This feels like a fine requirement, but I'm unfamiliar with other use cases and can introduce a less invasive change if desired.

cc @vrautela 