### PR TITLE
[query/service] automatically determine JAR url based on SHA

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1578,9 +1578,8 @@ class JVMJob(Job):
             raise Exception("i/o not supported")
 
         self.user_command_string = job_spec['process']['command']
-        assert len(self.user_command_string) >= 3, self.user_command_string
-        self.revision = self.user_command_string[1]
-        self.jar_url = self.user_command_string[2]
+        assert len(self.user_command_string) >= 2, self.user_command_string
+        self.jar_url = self.user_command_string[1]
 
         self.timings = Timings()
         self.state = 'pending'
@@ -1607,8 +1606,9 @@ class JVMJob(Job):
         return f'{self.scratch}/secrets/{secret["mount_path"]}'
 
     async def download_jar(self):
-        async with self.worker.jar_download_locks[self.revision]:
-            local_jar_location = f'/hail-jars/{self.revision}.jar'
+        async with self.worker.jar_download_locks[self.jar_url]:
+            unique_key = self.jar_url.replace('_', '__').replace('/', '_')
+            local_jar_location = f'/hail-jars/{unique_key}.jar'
             if not os.path.isfile(local_jar_location):
                 self.verify_is_acceptable_query_jar_url(self.jar_url)
                 temporary_file = tempfile.NamedTemporaryFile(delete=False)  # pylint: disable=consider-using-with

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -49,7 +49,8 @@ JAR_DEBUG_CLASSES := $(addprefix $(BUILD_DEBUG_PREFIX)/, $(JAR_DEBUG_SOURCES:src
 PY_FILES := $(shell git ls-files python)
 
 INIT_SCRIPTS := python/hailtop/hailctl/deploy.yaml
-PYTHON_VERSION_INFO := python/hail/hail_version
+PYTHON_VERSION_INFO := python/hail/hail_revision
+PYTHON_VERSION_INFO += python/hail/hail_version
 PYTHON_VERSION_INFO += python/hail/hail_pip_version
 PYTHON_VERSION_INFO += python/hailtop/hail_version
 PYTHON_VERSION_INFO += python/hail/docs/_static/hail_version.js
@@ -118,6 +119,9 @@ src/main/resources/build-info.properties: Makefile
 
 .PHONY: python-version-info
 python-version-info: $(PYTHON_VERSION_INFO)
+
+python/hail/hail_revision: env/REVISION
+	echo $(REVISION) > $@
 
 python/hail/hail_version: env/SHORT_REVISION env/HAIL_PIP_VERSION
 	echo $(HAIL_VERSION) > $@

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import pkg_resources
 import sys
 import asyncio
@@ -135,7 +136,8 @@ del builtins
 ir.register_functions()
 ir.register_aggregators()
 
-__version__ = None  # set in hail.init()
+__version__: Optional[str] = None  # set by hail.version()
+__revision__: Optional[str] = None  # set by hail.revision()
 
 import warnings  # noqa: E402
 

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -379,8 +379,8 @@ def init_local(
         global_seed, backend)
 
 
-def version():
-    """Get the installed hail version.
+def version() -> str:
+    """Get the installed Hail version.
 
     Returns
     -------
@@ -390,6 +390,19 @@ def version():
         # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
         hail.__version__ = pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
     return hail.__version__
+
+
+def revision() -> str:
+    """Get the installed Hail git revision.
+
+    Returns
+    -------
+    str
+    """
+    if hail.__revision__ is None:
+        # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
+        hail.__revision__ = pkg_resources.resource_string(__name__, 'hail_revision').decode().strip()
+    return hail.__revision__
 
 
 def _hail_cite_url():

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -61,7 +61,6 @@ class User(
   val fs: GoogleStorageFS)
 
 class ServiceBackend(
-  val revision: String,
   val jarLocation: String,
   var name: String,
   val theHailClassLoader: HailClassLoader,
@@ -153,7 +152,6 @@ class ServiceBackend(
         "process" -> JObject(
           "command" -> JArray(List(
             JString(Main.WORKER),
-            JString(revision),
             JString(jarLocation),
             JString(root),
             JString(s"$i"))),
@@ -467,15 +465,14 @@ object ServiceBackendSocketAPI2 {
     val logFile = argv(1)
     val kind = argv(2)
     assert(kind == Main.DRIVER)
-    val revision = argv(3)
-    val jarLocation = argv(4)
-    val name = argv(5)
-    val input = argv(6)
-    val output = argv(7)
+    val jarLocation = argv(3)
+    val name = argv(4)
+    val input = argv(5)
+    val output = argv(6)
 
     // FIXME: when can the classloader be shared? (optimizer benefits!)
     val backend = new ServiceBackend(
-      revision, jarLocation, name, new HailClassLoader(getClass().getClassLoader()), scratchDir)
+      jarLocation, name, new HailClassLoader(getClass().getClassLoader()), scratchDir)
     if (HailContext.isInitialized) {
       HailContext.get.backend = backend
     } else {

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -61,7 +61,6 @@ object Worker {
     val logFile = argv(1)
     val kind = argv(2)
     assert(kind == Main.WORKER)
-    val revision = argv(3)
     val jarGCSPath = argv(4)
     val root = argv(5)
     val i = argv(6).toInt
@@ -115,11 +114,11 @@ object Worker {
     timer.start("executeFunction")
 
     if (HailContext.isInitialized) {
-      HailContext.get.backend = new ServiceBackend(null, null, null, new HailClassLoader(getClass().getClassLoader()))
+      HailContext.get.backend = new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()))
     } else {
       HailContext(
         // FIXME: workers should not have backends, but some things do need hail contexts
-        new ServiceBackend(null, null, null, new HailClassLoader(getClass().getClassLoader())), skipLoggingConfiguration = true, quiet = true)
+        new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader())), skipLoggingConfiguration = true, quiet = true)
     }
     val htc = new ServiceTaskContext(i)
     val result = f(context, htc, theHailClassLoader, fs)

--- a/query/Makefile
+++ b/query/Makefile
@@ -19,11 +19,11 @@ HAIL_REVISION := $(shell git rev-parse HEAD)
 ifeq ($(NAMESPACE),default)
 JAR_LOCATION := gs://hail-query/jars/$(HAIL_TEST_GCS_TOKEN)/$(HAIL_REVISION).jar
 else
-JAR_LOCATION := gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/jars/$(HAIL_REVISION).jar
+JAR_LOCATION := gs://hail-test-dmk9z/$(NAMESPACE)/jars/$(HAIL_REVISION).jar
 endif
 
-.PHONY: push-jar
-push-jar: jar
+.PHONY: upload-query-jar
+upload-query-jar: jar
 	gsutil cp ./hail.jar "$(JAR_LOCATION)"
 	echo >last_uploaded_jar "$(JAR_LOCATION)"
 
@@ -32,7 +32,7 @@ upload-resources-dir:
 	touch upload-resources-dir
 
 .PHONY: test
-test: push-jar upload-resources-dir
+test: upload-query-jar upload-resources-dir
 	HAIL_QUERY_BACKEND=service \
 	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
 	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
@@ -40,7 +40,7 @@ test: push-jar upload-resources-dir
 	$(MAKE) -C ../hail pytest
 
 .PHONY: ipython
-ipython: push-jar
+ipython: upload-query-jar
 	HAIL_QUERY_BACKEND=service \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	ipython

--- a/query/Makefile
+++ b/query/Makefile
@@ -36,14 +36,12 @@ test: push-jar upload-resources-dir
 	HAIL_QUERY_BACKEND=service \
 	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
 	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	$(MAKE) -C ../hail pytest
 
 .PHONY: ipython
 ipython: push-jar
 	HAIL_QUERY_BACKEND=service \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	ipython
 
@@ -52,13 +50,11 @@ test-no-deps:
 	HAIL_QUERY_BACKEND=service \
 	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
 	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	$(MAKE) -C ../hail pytest
 
 .PHONY: ipython-no-deps
 ipython-no-deps:
 	HAIL_QUERY_BACKEND=service \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	ipython


### PR DESCRIPTION
Alright, so the goal of this PR is to make this work:

```
HAIL_QUERY_BACKEND=service \
  python3 -c 'import hail as hl; hl.utils.range_table(10).write("gs://foo/bar.t")`
```

In particular, the Hail Query JAR is stored in a well known location. If we know the desired git revision, (we do, it should be the same git revision as our wheel), then we can deduce the JAR URL for the user. Moreover, if we're pointed at a namespace, we can still determine the correct location [1].

This PR provides three escape hatches to this behavior:
1. Specify the `jar_url` parameter to `ServiceBackend`.
2. Specify the `HAIL_JAR_URL` environment variable.
3. Specify a JAR url in the user config: `hailctl config set query/jar_url gs://...`.


This PR is unfortunately entangled with one other minor change. In `main`, we send the git revision *and* the JAR URL to the driver and the worker as a part of the "command string" (the JVMEntryway passes this array of strings to the `main` method of `ServiceBackendSocketAPI2` or `Worker`. After this change, the backend does not necessarily know the git revision. That's fine. The git revision was only ever used as:
1. a cache key for the JAR cache, and
2. a unique name for the JAR
Both of these uses are buggy anyway! If you re-use a HAIL_SHA with a different HAIL_JAR_URL and you land on a worker that previously pulled that HAIL_SHA, you'll get the previously pulled JAR, not the newly specified one. Instead I use the JAR URL directly as a cache key and unique name.

---

[1] Odds are good that the developer has not uploaded a JAR to this location, but they can do so by dev deploying `upload_query_jar` or by running `make -C query push-jar`.