### PR TITLE
[query/service] automatically determine JAR url based on SHA

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -672,8 +672,7 @@ NON_HEX_DIGIT = re.compile('[^A-Fa-f0-9]')
 
 def assert_is_sha_1_hex_string(revision: str):
     if len(revision) != 40 or NON_HEX_DIGIT.search(revision):
-        raise web.HTTPBadRequest(
-            reason=f'revision must be 40 character hexadecimal encoded SHA-1, got: {revision}')
+        raise web.HTTPBadRequest(reason=f'revision must be 40 character hexadecimal encoded SHA-1, got: {revision}')
 
 
 async def _create_jobs(userdata: dict, job_specs: dict, batch_id: int, app: aiohttp.web.Application):

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -787,7 +787,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         assert spec['process']['jar_spec']['type'] == 'jar_url'
                         jar_url = spec['process']['jar_spec']['value']
                         if not jar_url.startswith(ACCEPTABLE_QUERY_JAR_URL_PREFIX):
-                            raise HTTPBadRequest(reason=f'unacceptable JAR url: {jar_url}')
+                            raise web.HTTPBadRequest(reason=f'unacceptable JAR url: {jar_url}')
 
                 req_memory_bytes: Optional[int]
                 if machine_type is None:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -56,7 +56,6 @@ from web_common import render_template, set_message, setup_aiohttp_jinja2, setup
 from ..batch import batch_record_to_dict, cancel_batch_in_db, job_record_to_dict
 from ..batch_configuration import BATCH_STORAGE_URI, CLOUD, DEFAULT_NAMESPACE, SCOPE
 from ..batch_format_version import BatchFormatVersion
-from ..cloud.utils import ACCEPTABLE_QUERY_JAR_URL_PREFIX
 from ..cloud.resource_utils import (
     cores_mcpu_to_memory_bytes,
     cost_from_msec_mcpu,
@@ -64,6 +63,7 @@ from ..cloud.resource_utils import (
     memory_to_worker_type,
     valid_machine_types,
 )
+from ..cloud.utils import ACCEPTABLE_QUERY_JAR_URL_PREFIX
 from ..exceptions import (
     BatchOperationAlreadyCompletedError,
     BatchUserError,

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -783,6 +783,11 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         assert_is_sha_1_hex_string(revision)
                         spec['process']['jar_spec']['type'] = 'jar_url'
                         spec['process']['jar_spec']['value'] = ACCEPTABLE_QUERY_JAR_URL_PREFIX + '/' + revision + '.jar'
+                    else:
+                        assert spec['process']['jar_spec']['type'] == 'jar_url'
+                        jar_url = spec['process']['jar_spec']['value']
+                        if not jar_url.startswith(ACCEPTABLE_QUERY_JAR_URL_PREFIX):
+                            raise HTTPBadRequest(reason=f'unacceptable JAR url: {jar_url}')
 
                 req_memory_bytes: Optional[int]
                 if machine_type is None:

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -71,7 +71,13 @@ job_validator = keyed(
                     required('image'): image_str,
                     required('mount_docker_socket'): bool_type,
                 },
-                'jvm': {required('command'): listof(str_type)},
+                'jvm': {
+                    required('jar_spec'): keyed({
+                        required('type'): oneof('git_revision', 'jar_url'),
+                        required('value'): str_type
+                    }),
+                    required('command'): listof(str_type)
+                },
             },
         ),
         'requester_pays_project': str_type,

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -72,11 +72,10 @@ job_validator = keyed(
                     required('mount_docker_socket'): bool_type,
                 },
                 'jvm': {
-                    required('jar_spec'): keyed({
-                        required('type'): oneof('git_revision', 'jar_url'),
-                        required('value'): str_type
-                    }),
-                    required('command'): listof(str_type)
+                    required('jar_spec'): keyed(
+                        {required('type'): oneof('git_revision', 'jar_url'), required('value'): str_type}
+                    ),
+                    required('command'): listof(str_type),
                 },
             },
         ),

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -72,10 +72,11 @@ job_validator = keyed(
                     required('mount_docker_socket'): bool_type,
                 },
                 'jvm': {
-                    required('jar_spec'): keyed(
-                        {required('type'): oneof('git_revision', 'jar_url'), required('value'): str_type}
-                    ),
-                    required('command'): listof(str_type),
+                    required('jar_spec'): keyed({
+                        required('type'): oneof('git_revision', 'jar_url'),
+                        required('value'): str_type
+                    }),
+                    required('command'): listof(str_type)
                 },
             },
         ),

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1597,11 +1597,6 @@ class JVMJob(Job):
     async def run_until_done_or_deleted(self, f: Callable[..., Awaitable[Any]], *args, **kwargs):
         return await run_until_done_or_deleted(self.deleted_event, f, *args, **kwargs)
 
-    def verify_is_acceptable_query_jar_url(self, url: str):
-        if not url.startswith(ACCEPTABLE_QUERY_JAR_URL_PREFIX):
-            log.error(f'user submitted unacceptable JAR url: {url} for {self}. {ACCEPTABLE_QUERY_JAR_URL_PREFIX}')
-            raise ValueError(f'unacceptable JAR url: {url}')
-
     def secret_host_path(self, secret):
         return f'{self.scratch}/secrets/{secret["mount_path"]}'
 
@@ -1610,7 +1605,7 @@ class JVMJob(Job):
             unique_key = self.jar_url.replace('_', '__').replace('/', '_')
             local_jar_location = f'/hail-jars/{unique_key}.jar'
             if not os.path.isfile(local_jar_location):
-                self.verify_is_acceptable_query_jar_url(self.jar_url)
+                assert self.jar_url.startswith(ACCEPTABLE_QUERY_JAR_URL_PREFIX)
                 temporary_file = tempfile.NamedTemporaryFile(delete=False)  # pylint: disable=consider-using-with
                 try:
                     async with await self.worker.fs.open(self.jar_url) as jar_data:

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1579,7 +1579,7 @@ class JVMJob(Job):
 
         assert job_spec['process']['jar_spec']['type'] == 'jar_url'
         self.jar_url = job_spec['process']['jar_spec']['value']
-        self.argv = job_spec['process']['argv']
+        self.argv = job_spec['process']['command']
 
         self.timings = Timings()
         self.state = 'pending'

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1577,10 +1577,9 @@ class JVMJob(Job):
         if input_files or output_files:
             raise Exception("i/o not supported")
 
-        self.user_command_string = job_spec['process']['command']
-        assert len(self.user_command_string) >= 3, self.user_command_string
-        self.revision = self.user_command_string[1]
-        self.jar_url = self.user_command_string[2]
+        assert job_spec['process']['jar_spec']['type'] == 'jar_url'
+        self.jar_url = job_spec['process']['jar_spec']['value']
+        self.argv = job_spec['process']['argv']
 
         self.timings = Timings()
         self.state = 'pending'
@@ -1607,8 +1606,9 @@ class JVMJob(Job):
         return f'{self.scratch}/secrets/{secret["mount_path"]}'
 
     async def download_jar(self):
-        async with self.worker.jar_download_locks[self.revision]:
-            local_jar_location = f'/hail-jars/{self.revision}.jar'
+        async with self.worker.jar_download_locks[self.jar_url]:
+            unique_key = self.jar_url.replace('_', '__').replace('/', '_')
+            local_jar_location = f'/hail-jars/{unique_key}.jar'
             if not os.path.isfile(local_jar_location):
                 self.verify_is_acceptable_query_jar_url(self.jar_url)
                 temporary_file = tempfile.NamedTemporaryFile(delete=False)  # pylint: disable=consider-using-with
@@ -1663,7 +1663,7 @@ class JVMJob(Job):
 
                 log.info(f'{self}: running jvm process')
                 with self.step('running'):
-                    await self.jvm.execute(local_jar_location, self.scratch, self.log_file, self.user_command_string)
+                    await self.jvm.execute(local_jar_location, self.scratch, self.log_file, self.jar_url, self.argv)
 
                 self.state = 'succeeded'
                 log.info(f'{self} main: {self.state}')
@@ -1974,7 +1974,7 @@ class JVM:
     def close(self):
         self.process.close()
 
-    async def execute(self, classpath: str, scratch_dir: str, log_file: str, command_string: List[str]):
+    async def execute(self, classpath: str, scratch_dir: str, log_file: str, jar_url: str, argv: List[str]):
         assert worker is not None
 
         log.info(f'{self}: execute')
@@ -1986,12 +1986,12 @@ class JVM:
             stack.callback(writer.close)
             log.info(f'{self}: connection acquired')
 
-            command_string = [classpath, 'is.hail.backend.service.Main', scratch_dir, log_file, *command_string]
+            command = [classpath, 'is.hail.backend.service.Main', scratch_dir, log_file, jar_url, *argv]
 
-            write_int(writer, len(command_string))
-            for arg in command_string:
-                assert isinstance(arg, str)
-                write_str(writer, arg)
+            write_int(writer, len(command))
+            for part in command:
+                assert isinstance(part, str)
+                write_str(writer, part)
             await writer.drain()
 
             wait_for_message_from_process: asyncio.Future = asyncio.ensure_future(read_int(reader))

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -309,15 +309,7 @@ spec:
                key: query_storage_uri
          - name: HAIL_QUERY_ACCEPTABLE_JAR_SUBFOLDER
            value: "/jars"
-{% elif scope == "test" %}
-         - name: HAIL_QUERY_STORAGE_URI
-           valueFrom:
-             secretKeyRef:
-               name: global-config
-               key: test_storage_uri
-         - name: HAIL_QUERY_ACCEPTABLE_JAR_SUBFOLDER
-           value: "/{{ token }}/jars"
-{% elif scope == "dev" %}
+{% elif scope == "test" or scope == "dev" %}
          - name: HAIL_QUERY_STORAGE_URI
            valueFrom:
              secretKeyRef:

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -127,15 +127,7 @@ spec:
                key: query_storage_uri
          - name: HAIL_QUERY_ACCEPTABLE_JAR_SUBFOLDER
            value: "/jars"
-{% elif scope == "test" %}
-         - name: HAIL_QUERY_STORAGE_URI
-           valueFrom:
-             secretKeyRef:
-               name: global-config
-               key: test_storage_uri
-         - name: HAIL_QUERY_ACCEPTABLE_JAR_SUBFOLDER
-           value: "/{{ token }}/jars"
-{% elif scope == "dev" %}
+{% elif scope == "test" or scope == "dev" %}
          - name: HAIL_QUERY_STORAGE_URI
            valueFrom:
              secretKeyRef:

--- a/build.yaml
+++ b/build.yaml
@@ -703,6 +703,11 @@ steps:
       time retry ./gradlew --version
       time retry make shadowJar wheel
       (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
+
+      cat Makefile
+      make python/hail/hail_revision
+      ls python/hail/
+      cat python/hail/hail_revision
     inputs:
       - from: /repo
         to: /io/repo

--- a/build.yaml
+++ b/build.yaml
@@ -703,11 +703,6 @@ steps:
       time retry ./gradlew --version
       time retry make shadowJar wheel
       (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
-
-      cat Makefile
-      make python/hail/hail_revision
-      ls python/hail/
-      cat python/hail/hail_revision
     inputs:
       - from: /repo
         to: /io/repo

--- a/build.yaml
+++ b/build.yaml
@@ -3108,9 +3108,7 @@ steps:
 
       {% if scope == "deploy" %}
       HAIL_JAR_URL={{ global.query_storage_uri }}
-      {% elif scope == "test" %}
-      HAIL_JAR_URL={{ global.test_storage_uri }}/{{ deploy_batch.token }}
-      {% elif scope == "dev" %}
+      {% elif scope == "test" or scope == "dev" %}
       HAIL_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
       {% else %}
       echo "!!! unexpected scope {{ scope }} !!!"
@@ -3165,19 +3163,6 @@ steps:
 
       cd /io/repo/hail/python
 
-      export HAIL_SHA="$(cat /io/git_version)"
-      {% if scope == "deploy" %}
-      export HAIL_JAR_URL={{ global.query_storage_uri }}
-      {% elif scope == "test" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ deploy_batch.token }}
-      {% elif scope == "dev" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
-      {% else %}
-      echo "!!! unexpected scope {{ scope }} !!!"
-      exit 1
-      {% endif %}
-      export HAIL_JAR_URL=${HAIL_JAR_URL}/jars/$(cat /io/git_version).jar
-
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
@@ -3206,8 +3191,6 @@ steps:
         to: /io/wheel-container.tar
       - from: /repo/hail/python/test
         to: /io/repo/hail/python/test
-      - from: /git_version
-        to: /io/git_version
     secrets:
       - name: test-gsa-key
         namespace:
@@ -3251,19 +3234,6 @@ steps:
 
       cd /io/repo/hail/python
 
-      export HAIL_SHA="$(cat /io/git_version)"
-      {% if scope == "deploy" %}
-      export HAIL_JAR_URL={{ global.query_storage_uri }}
-      {% elif scope == "test" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ deploy_batch.token }}
-      {% elif scope == "dev" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
-      {% else %}
-      echo "!!! unexpected scope {{ scope }} !!!"
-      exit 1
-      {% endif %}
-      export HAIL_JAR_URL=${HAIL_JAR_URL}/jars/$(cat /io/git_version).jar
-
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
@@ -3292,8 +3262,6 @@ steps:
         to: /io/wheel-container.tar
       - from: /repo/hail/python/test
         to: /io/repo/hail/python/test
-      - from: /git_version
-        to: /io/git_version
     secrets:
       - name: test-gsa-key
         namespace:
@@ -3337,19 +3305,6 @@ steps:
 
       cd /io/repo/hail/python
 
-      export HAIL_SHA="$(cat /io/git_version)"
-      {% if scope == "deploy" %}
-      export HAIL_JAR_URL={{ global.query_storage_uri }}
-      {% elif scope == "test" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ deploy_batch.token }}
-      {% elif scope == "dev" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
-      {% else %}
-      echo "!!! unexpected scope {{ scope }} !!!"
-      exit 1
-      {% endif %}
-      export HAIL_JAR_URL=${HAIL_JAR_URL}/jars/$(cat /io/git_version).jar
-
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
@@ -3378,8 +3333,6 @@ steps:
         to: /io/wheel-container.tar
       - from: /repo/hail/python/test
         to: /io/repo/hail/python/test
-      - from: /git_version
-        to: /io/git_version
     secrets:
       - name: test-gsa-key
         namespace:
@@ -3423,19 +3376,6 @@ steps:
 
       cd /io/repo/hail/python
 
-      export HAIL_SHA="$(cat /io/git_version)"
-      {% if scope == "deploy" %}
-      export HAIL_JAR_URL={{ global.query_storage_uri }}
-      {% elif scope == "test" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ deploy_batch.token }}
-      {% elif scope == "dev" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
-      {% else %}
-      echo "!!! unexpected scope {{ scope }} !!!"
-      exit 1
-      {% endif %}
-      export HAIL_JAR_URL=${HAIL_JAR_URL}/jars/$(cat /io/git_version).jar
-
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
@@ -3464,8 +3404,6 @@ steps:
         to: /io/wheel-container.tar
       - from: /repo/hail/python/test
         to: /io/repo/hail/python/test
-      - from: /git_version
-        to: /io/git_version
     secrets:
       - name: test-gsa-key
         namespace:
@@ -3509,19 +3447,6 @@ steps:
 
       cd /io/repo/hail/python
 
-      export HAIL_SHA="$(cat /io/git_version)"
-      {% if scope == "deploy" %}
-      export HAIL_JAR_URL={{ global.query_storage_uri }}
-      {% elif scope == "test" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ deploy_batch.token }}
-      {% elif scope == "dev" %}
-      export HAIL_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
-      {% else %}
-      echo "!!! unexpected scope {{ scope }} !!!"
-      exit 1
-      {% endif %}
-      export HAIL_JAR_URL=${HAIL_JAR_URL}/jars/$(cat /io/git_version).jar
-
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
@@ -3550,8 +3475,6 @@ steps:
         to: /io/wheel-container.tar
       - from: /repo/hail/python/test
         to: /io/repo/hail/python/test
-      - from: /git_version
-        to: /io/git_version
     secrets:
       - name: test-gsa-key
         namespace:

--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -3,6 +3,7 @@ python/README.md
 python/dist
 python/hail.egg-info
 python/hail/backend/hail-all-spark.jar
+python/hail/hail_revision
 python/hail/hail_pip_version
 python/hail/docs/change_log.rst
 python/hail/docs/_build/*

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -49,7 +49,8 @@ JAR_DEBUG_CLASSES := $(addprefix $(BUILD_DEBUG_PREFIX)/, $(JAR_DEBUG_SOURCES:src
 PY_FILES := $(shell git ls-files python)
 
 INIT_SCRIPTS := python/hailtop/hailctl/deploy.yaml
-PYTHON_VERSION_INFO := python/hail/hail_version
+PYTHON_VERSION_INFO := python/hail/hail_revision
+PYTHON_VERSION_INFO += python/hail/hail_version
 PYTHON_VERSION_INFO += python/hail/hail_pip_version
 PYTHON_VERSION_INFO += python/hailtop/hail_version
 PYTHON_VERSION_INFO += python/hail/docs/_static/hail_version.js
@@ -118,6 +119,9 @@ src/main/resources/build-info.properties: Makefile
 
 .PHONY: python-version-info
 python-version-info: $(PYTHON_VERSION_INFO)
+
+python/hail/hail_revision: env/REVISION
+	echo $(REVISION) > $@
 
 python/hail/hail_version: env/SHORT_REVISION env/HAIL_PIP_VERSION
 	echo $(HAIL_VERSION) > $@

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import pkg_resources
 import sys
 import asyncio
@@ -135,7 +136,8 @@ del builtins
 ir.register_functions()
 ir.register_aggregators()
 
-__version__ = None  # set in hail.init()
+__version__: Optional[str] = None  # set by hail.version()
+__revision__: Optional[str] = None  # set by hail.revision()
 
 import warnings  # noqa: E402
 

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -1,4 +1,5 @@
 from typing import Dict, Optional, Callable, Awaitable, Mapping, Any, List
+import abc
 import asyncio
 import struct
 import os
@@ -8,7 +9,7 @@ import re
 import yaml
 from pathlib import Path
 
-from hail.context import TemporaryDirectory, tmp_dir, TemporaryFilename
+from hail.context import TemporaryDirectory, tmp_dir, TemporaryFilename, revision
 from hail.utils import FatalError
 from hail.expr.types import dtype
 from hail.expr.table_type import ttable
@@ -17,7 +18,7 @@ from hail.expr.blockmatrix_type import tblockmatrix
 from hail.experimental import write_expression, read_expression
 from hail.ir.renderer import CSERenderer
 
-from hailtop.config import get_user_config, get_user_local_cache_dir, get_remote_tmpdir
+from hailtop.config import (get_user_config, get_user_local_cache_dir, get_remote_tmpdir)
 from hailtop.utils import async_to_blocking, secret_alnum_string, TransientError, Timings
 from hailtop.batch_client import client as hb
 from hailtop.batch_client import aioclient as aiohb
@@ -104,6 +105,45 @@ def yaml_literally_shown_str_representer(dumper, data):
 yaml.add_representer(yaml_literally_shown_str, yaml_literally_shown_str_representer)
 
 
+class JarSpec(abc.ABC):
+    @abc.abstractmethod
+    def to_dict(self) -> Dict[str, str]:
+        raise NotImplementedError
+
+
+class JarUrl(JarSpec):
+    def __init__(self, url):
+        self.url = url
+
+    def to_dict(self) -> Dict[str, str]:
+        return {'type': 'jar_url', 'value': self.url}
+
+    def __repr__(self):
+        return f'JarUrl({self.url})'
+
+
+class GitRevision(JarSpec):
+    def __init__(self, revision):
+        self.revision = revision
+
+    def to_dict(self) -> Dict[str, str]:
+        return {'type': 'git_revision', 'value': self.revision}
+
+    def __repr__(self):
+        return f'GitRevision({self.revision})'
+
+
+def _get_jar_specification(jar_url: Optional[str]) -> JarSpec:
+    user_config = get_user_config()
+
+    jar_url = jar_url or os.environ.get('HAIL_JAR_URL')
+    jar_url = jar_url or user_config.get('query', 'jar_url', fallback=None)
+
+    if jar_url is not None:
+        return JarUrl(jar_url)
+    return GitRevision(revision())
+
+
 class ServiceBackend(Backend):
     HAIL_BATCH_FAILURE_EXCEPTION_MESSAGE_RE = re.compile("is.hail.backend.service.HailBatchFailure: ([0-9]+)\n")
 
@@ -131,7 +171,8 @@ class ServiceBackend(Backend):
                      skip_logging_configuration: Optional[bool] = None,
                      disable_progress_bar: bool = True,
                      remote_tmpdir: Optional[str] = None,
-                     flags: Optional[Dict[str, str]] = None):
+                     flags: Optional[Dict[str, str]] = None,
+                     jar_url: Optional[str] = None):
         del skip_logging_configuration
 
         if billing_project is None:
@@ -152,6 +193,7 @@ class ServiceBackend(Backend):
         user_local_reference_cache_dir = Path(get_user_local_cache_dir(), 'references', version())
         os.makedirs(user_local_reference_cache_dir, exist_ok=True)
         remote_tmpdir = get_remote_tmpdir('ServiceBackend', remote_tmpdir=remote_tmpdir)
+        jar_spec = _get_jar_specification(jar_url)
 
         return ServiceBackend(
             billing_project=billing_project,
@@ -163,6 +205,7 @@ class ServiceBackend(Backend):
             user_local_reference_cache_dir=user_local_reference_cache_dir,
             remote_tmpdir=remote_tmpdir,
             flags=flags or {},
+            jar_spec=jar_spec
         )
 
     def __init__(self,
@@ -174,7 +217,8 @@ class ServiceBackend(Backend):
                  batch_attributes: Dict[str, str],
                  user_local_reference_cache_dir: Path,
                  remote_tmpdir: str,
-                 flags: Dict[str, str]):
+                 flags: Dict[str, str],
+                 jar_spec: JarSpec):
         self.billing_project = billing_project
         self._sync_fs = sync_fs
         self._async_fs = async_fs
@@ -185,13 +229,14 @@ class ServiceBackend(Backend):
         self.user_local_reference_cache_dir = user_local_reference_cache_dir
         self.remote_tmpdir = remote_tmpdir
         self.flags = flags
+        self.jar_spec = jar_spec
+
         if "use_new_shuffle" not in self.flags:
             self.flags["use_new_shuffle"] = "1"
 
     def debug_info(self) -> Dict[str, Any]:
         return {
-            'hail_sha': os.environ['HAIL_SHA'],
-            'hail_jar_url': os.environ['HAIL_JAR_URL'],
+            'jar_spec': str(self.jar_spec),
             'billing_project': self.billing_project,
             'batch_attributes': self.batch_attributes,
             'user_local_reference_cache_dir': str(self.user_local_reference_cache_dir),
@@ -240,12 +285,13 @@ class ServiceBackend(Backend):
                 bb = self.async_bc.create_batch(token=token, attributes=batch_attributes)
 
                 j = bb.create_jvm_job([
-                    ServiceBackend.DRIVER,
-                    os.environ['HAIL_SHA'],
-                    os.environ['HAIL_JAR_URL'],
-                    batch_attributes['name'],
-                    iodir + '/in',
-                    iodir + '/out',
+                    jar_spec=self.jar_spec.to_dict(),
+                    argv=[
+                        ServiceBackend.DRIVER,
+                        batch_attributes['name'],
+                        iodir + '/in',
+                        iodir + '/out'
+                    ]
                 ], mount_tokens=True, resources={'preemptible': False, 'memory': 'standard'})
                 b = await bb.submit(disable_progress_bar=self.disable_progress_bar)
 

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -284,15 +284,17 @@ class ServiceBackend(Backend):
                     batch_attributes = {**batch_attributes, 'name': name}
                 bb = self.async_bc.create_batch(token=token, attributes=batch_attributes)
 
-                j = bb.create_jvm_job([
+                j = bb.create_jvm_job(
                     jar_spec=self.jar_spec.to_dict(),
                     argv=[
                         ServiceBackend.DRIVER,
                         batch_attributes['name'],
                         iodir + '/in',
                         iodir + '/out'
-                    ]
-                ], mount_tokens=True, resources={'preemptible': False, 'memory': 'standard'})
+                    ],
+                    mount_tokens=True,
+                    resources={'preemptible': False, 'memory': 'standard'}
+                )
                 b = await bb.submit(disable_progress_bar=self.disable_progress_bar)
 
             with timings.step("wait batch"):

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -379,8 +379,8 @@ def init_local(
         global_seed, backend)
 
 
-def version():
-    """Get the installed hail version.
+def version() -> str:
+    """Get the installed Hail version.
 
     Returns
     -------
@@ -390,6 +390,19 @@ def version():
         # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
         hail.__version__ = pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
     return hail.__version__
+
+
+def revision() -> str:
+    """Get the installed Hail git revision.
+
+    Returns
+    -------
+    str
+    """
+    if hail.__revision__ is None:
+        # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
+        hail.__revision__ = pkg_resources.resource_string(__name__, 'hail_revision').decode().strip()
+    return hail.__revision__
 
 
 def _hail_cite_url():

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -431,8 +431,8 @@ class BatchBuilder:
             {'command': command, 'image': image, 'mount_docker_socket': mount_docker_socket, 'type': 'docker'}, **kwargs
         )
 
-    def create_jvm_job(self, command: List[str], **kwargs):
-        return self._create_job({'command': command, 'type': 'jvm'}, **kwargs)
+    def create_jvm_job(self, jar_spec: Dict[str, str], argv: List[str], **kwargs):
+        return self._create_job({'type': 'jvm', 'jar_spec': jar_spec, 'argv': argv}, **kwargs)
 
     def _create_job(self,
                     process: dict,

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -432,7 +432,7 @@ class BatchBuilder:
         )
 
     def create_jvm_job(self, jar_spec: Dict[str, str], argv: List[str], **kwargs):
-        return self._create_job({'type': 'jvm', 'jar_spec': jar_spec, 'argv': argv}, **kwargs)
+        return self._create_job({'type': 'jvm', 'jar_spec': jar_spec, 'command': argv}, **kwargs)
 
     def _create_job(self,
                     process: dict,

--- a/hail/python/setup.py
+++ b/hail/python/setup.py
@@ -47,6 +47,7 @@ setup(
     package_data={
         'hail': ['hail_pip_version',
                  'hail_version',
+                 'hail_revision',
                  'experimental/datasets.json'],
         'hail.backend': ['hail-all-spark.jar'],
         'hailtop': ['hail_version', 'py.typed'],

--- a/hail/src/main/scala/is/hail/backend/service/Main.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Main.scala
@@ -28,7 +28,7 @@ object Main {
     val logFile = argv(1)
     configureLogging(logFile)
 
-    argv(2) match {
+    argv(3) match {
       case WORKER => Worker.main(argv)
       case DRIVER => ServiceBackendSocketAPI2.main(argv)
       case kind => throw new RuntimeException(s"unknown kind: ${kind}")

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -363,7 +363,7 @@ class HailBatchFailure(message: String) extends RuntimeException(message)
 
 object ServiceBackendSocketAPI2 {
   def main(argv: Array[String]): Unit = {
-    assert(argv.length == 8, argv.toFastIndexedSeq)
+    assert(argv.length == 7, argv.toFastIndexedSeq)
 
     val scratchDir = argv(0)
     val logFile = argv(1)

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -146,7 +146,7 @@ class ServiceBackend(
             "type" -> JString("jar_url"),
             "value" -> JString(jarLocation)
           ),
-          "argv" -> JArray(List(
+          "command" -> JArray(List(
             JString(Main.WORKER),
             JString(root),
             JString(s"$i"))),

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -59,7 +59,6 @@ object ServiceBackend {
 }
 
 class ServiceBackend(
-  val revision: String,
   val jarLocation: String,
   var name: String,
   val theHailClassLoader: HailClassLoader,
@@ -143,10 +142,12 @@ class ServiceBackend(
         "job_id" -> JInt(i + 1),
         "parent_ids" -> JArray(List()),
         "process" -> JObject(
-          "command" -> JArray(List(
+          "jar_spec" -> JObject(
+            "type" -> JString("jar_url"),
+            "value" -> JString(jarLocation)
+          ),
+          "argv" -> JArray(List(
             JString(Main.WORKER),
-            JString(revision),
-            JString(jarLocation),
             JString(root),
             JString(s"$i"))),
           "type" -> JString("jvm")),
@@ -366,17 +367,16 @@ object ServiceBackendSocketAPI2 {
 
     val scratchDir = argv(0)
     val logFile = argv(1)
-    val kind = argv(2)
+    val jarLocation = argv(2)
+    val kind = argv(3)
     assert(kind == Main.DRIVER)
-    val revision = argv(3)
-    val jarLocation = argv(4)
-    val name = argv(5)
-    val input = argv(6)
-    val output = argv(7)
+    val name = argv(4)
+    val input = argv(5)
+    val output = argv(6)
 
     // FIXME: when can the classloader be shared? (optimizer benefits!)
     val backend = new ServiceBackend(
-      revision, jarLocation, name, new HailClassLoader(getClass().getClassLoader()), scratchDir)
+      jarLocation, name, new HailClassLoader(getClass().getClassLoader()), scratchDir)
     if (HailContext.isInitialized) {
       HailContext.get.backend = backend
     } else {

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -54,7 +54,7 @@ object Worker {
   def main(argv: Array[String]): Unit = {
     val theHailClassLoader = new HailClassLoader(getClass().getClassLoader())
 
-    if (argv.length != 7) {
+    if (argv.length != 6) {
       throw new IllegalArgumentException(s"expected seven arguments, not: ${ argv.length }")
     }
     val scratchDir = argv(0)

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -114,11 +114,11 @@ object Worker {
     timer.start("executeFunction")
 
     if (HailContext.isInitialized) {
-      HailContext.get.backend = new ServiceBackend(null, null, null, new HailClassLoader(getClass().getClassLoader()))
+      HailContext.get.backend = new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()))
     } else {
       HailContext(
         // FIXME: workers should not have backends, but some things do need hail contexts
-        new ServiceBackend(null, null, null, new HailClassLoader(getClass().getClassLoader())), skipLoggingConfiguration = true, quiet = true)
+        new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader())), skipLoggingConfiguration = true, quiet = true)
     }
     val htc = new ServiceTaskContext(i)
     val result = f(context, htc, theHailClassLoader, fs)

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -59,12 +59,11 @@ object Worker {
     }
     val scratchDir = argv(0)
     val logFile = argv(1)
-    val kind = argv(2)
+    var jarLocation = argv(2)
+    val kind = argv(3)
     assert(kind == Main.WORKER)
-    val revision = argv(3)
-    val jarGCSPath = argv(4)
-    val root = argv(5)
-    val i = argv(6).toInt
+    val root = argv(4)
+    val i = argv(5).toInt
     val timer = new WorkerTimer()
 
     val deployConfig = DeployConfig.fromConfigFile(

--- a/query/Makefile
+++ b/query/Makefile
@@ -31,9 +31,6 @@ else
 JAR_LOCATION := $(TEST_STORAGE_URI)/$(NAMESPACE)/jars/$(HAIL_REVISION).jar
 endif
 
-foo:
-	echo $(JAR_LOCATION)
-
 .PHONY: upload-query-jar
 upload-query-jar: jar
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default

--- a/query/Makefile
+++ b/query/Makefile
@@ -1,5 +1,8 @@
 include ../config.mk
 
+QUERY_STORAGE_URI := $(shell kubectl get secret global-config --template={{.data.query_storage_uri}} | base64 --decode)
+TEST_STORAGE_URI := $(shell kubectl get secret global-config --template={{.data.test_storage_uri}} | base64 --decode)
+
 EXTRA_PYTHONPATH := ../hail/python:../gear
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 
@@ -12,15 +15,24 @@ jar:
 	cp ../hail/build/libs/hail-all-spark.jar ./hail.jar
 
 HAIL_TEST_GCS_TOKEN := $(shell whoami)
-HAIL_TEST_RESOURCES_PREFIX := gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources
+HAIL_TEST_RESOURCES_PREFIX := $(TEST_STORAGE_URI)/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources
 HAIL_TEST_RESOURCES_DIR := $(HAIL_TEST_RESOURCES_PREFIX)/test/resources/
 HAIL_DOCTEST_DATA_DIR := $(HAIL_TEST_RESOURCES_PREFIX)/doctest/data/
 HAIL_REVISION := $(shell git rev-parse HEAD)
 ifeq ($(NAMESPACE),default)
-JAR_LOCATION := gs://hail-query/jars/$(HAIL_TEST_GCS_TOKEN)/$(HAIL_REVISION).jar
+ifeq ($(DEPLOY_JAR_FOR_PUBLIC_USE),true)
+# This should only be used if the normal CI deploy process fails and you need to upload a JAR to the
+# expected location for our users.
+JAR_LOCATION := $(QUERY_STORAGE_URI)/jars/$(HAIL_REVISION).jar
 else
-JAR_LOCATION := gs://hail-test-dmk9z/$(NAMESPACE)/jars/$(HAIL_REVISION).jar
+JAR_LOCATION := $(QUERY_STORAGE_URI)/jars/$(HAIL_TEST_GCS_TOKEN)/$(HAIL_REVISION).jar
 endif
+else
+JAR_LOCATION := $(TEST_STORAGE_URI)/$(NAMESPACE)/jars/$(HAIL_REVISION).jar
+endif
+
+foo:
+	echo $(JAR_LOCATION)
 
 .PHONY: upload-query-jar
 upload-query-jar: jar
@@ -29,6 +41,7 @@ upload-query-jar: jar
 	echo >last_uploaded_jar "$(JAR_LOCATION)"
 
 upload-resources-dir:
+	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	python3 -m hailtop.aiotools.copy 'null' '[{"from":"../hail/src/test/resources","to":"$(HAIL_TEST_RESOURCES_DIR)"},{"from":"../hail/python/hail/docs/data","to":"$(HAIL_DOCTEST_DATA_DIR)"}]'
 	touch upload-resources-dir
 

--- a/query/Makefile
+++ b/query/Makefile
@@ -19,11 +19,12 @@ HAIL_REVISION := $(shell git rev-parse HEAD)
 ifeq ($(NAMESPACE),default)
 JAR_LOCATION := gs://hail-query/jars/$(HAIL_TEST_GCS_TOKEN)/$(HAIL_REVISION).jar
 else
-JAR_LOCATION := gs://hail-test-dmk9z/$(HAIL_TEST_GCS_TOKEN)/jars/$(HAIL_REVISION).jar
+JAR_LOCATION := gs://hail-test-dmk9z/$(NAMESPACE)/jars/$(HAIL_REVISION).jar
 endif
 
-.PHONY: push-jar
-push-jar: jar
+.PHONY: upload-query-jar
+upload-query-jar: jar
+	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	gsutil cp ./hail.jar "$(JAR_LOCATION)"
 	echo >last_uploaded_jar "$(JAR_LOCATION)"
 
@@ -32,18 +33,16 @@ upload-resources-dir:
 	touch upload-resources-dir
 
 .PHONY: test
-test: push-jar upload-resources-dir
+test: upload-query-jar upload-resources-dir
 	HAIL_QUERY_BACKEND=service \
 	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
 	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	$(MAKE) -C ../hail pytest
 
 .PHONY: ipython
-ipython: push-jar
+ipython: upload-query-jar
 	HAIL_QUERY_BACKEND=service \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	ipython
 
@@ -52,13 +51,11 @@ test-no-deps:
 	HAIL_QUERY_BACKEND=service \
 	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
 	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	$(MAKE) -C ../hail pytest
 
 .PHONY: ipython-no-deps
 ipython-no-deps:
 	HAIL_QUERY_BACKEND=service \
-	HAIL_SHA='$(HAIL_REVISION)-$(TOKEN)' \
 	HAIL_JAR_URL=$$(cat last_uploaded_jar) \
 	ipython


### PR DESCRIPTION
Apologies, this spiraled into a big PR. Hopefully the large set of changes actually improves everyone's understanding of this.

---

The goal of this PR is to make this work:

```
HAIL_QUERY_BACKEND=service \
  python3 -c 'import hail as hl; hl.utils.range_table(10).write("gs://foo/bar.t")`
```

In particular, a normal user should not need to know the location of a Hail Query JAR. Currently, you must specify two environment variables: `HAIL_SHA` and `HAIL_JAR_URL`.

This PR takes advantage of the well known location of a Hail Query JAR [1]. We use the newly introduced `hl.revision()` to determine the SHA-1 of the currently installed Hail. This PR includes the revision in the driver job spec. The front end has been modified to convert the revision into a cloud storage URL.

This PR also provides three escape hatches to the aforementioned default behavior. These escape hatches should more or less only be used by developers. They're specified from highest priority to lowest.
1. Specify the `jar_url` parameter to `ServiceBackend`.
2. Specify the `HAIL_JAR_URL` environment variable.
3. Specify a JAR url in the user config: `hailctl config set query/jar_url gs://...`.

While writing this PR, I decided to clean up five bits of cruft I left when I first built the service backend.

First, I took the JAR URL out of the "command" of the job spec. This "command" is just an array of strings. The fact that certain parts of that array *must* be the JAR URL and the SHA-1 is confusing. Instead, there are now two keys in a JVM process specification:
1. `jar_spec`, which may be either `{"type": "jar_url", "value": "gs://..../abc123....jar"}` or `{"type":"git_revision", "value": "abc123..."}`.
2. `argv`, an opaque list of strings which are passed, by the JVMEntryway, along with a few more args, to `is.hail.backend.service.Main`. The `Main` class dispatches to either `ServiceBackendSocketAPI2` or the `Worker` based on the first element of `argv`. Each class expects different contents in `argv` that suits its needs.

Second, I completely eliminated the HAIL_SHA/revision from the Worker and Hail Query Java code. This was only ever used as unique name for the JAR. Instead, I just use the full JAR URL as a unique name for the JAR. If you need to defeat the cache, just create a new git commit before running `make -C query ipython`. If defeating the cache becomes a common problem, we can add a "reload_jar" parameter or similar to the job spec.

Third, I renamed `push-jar` in `query/Makefile` to `upload-query-jar` to mirror the build.yaml step.

Fourth, I embraced the use of `NAMEPSACE` in `query/Makefile` instead of relying on the minor hack that our laptop usernames match our namespace names. This does mean you need to always specify NAMESPACE when uploading a jar.

Finally, a pleasant outcome of this change is the elimination of a bunch of conditional build.yaml logic in the service backend tests!

I think this will simplify the use of Hail Query by Australia et al. because I've isolated the use of hail-specific data to `query/Makefile`. If there's a way to access the relevant global-config variables from `query/Makefile`, I can also fix the `query/Makefile` to be deployment-independent.

cc: @lgruen @illusional @tpoterba 


[1] For our default namespace deployment, `gs://hail-query/jars/{GIT_REVISION}.jar`. In general, `{HAIL_QUERY_STORAGE_URI}{HAIL_QUERY_ACCEPTABLE_JAR_SUBFOLDER}/{GIT_REVISION}.jar`.

