### PR TITLE
[docker] fix curl options, use curl in more places

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -38,7 +38,7 @@ RUN hail-apt-get-install xz-utils libncurses5 && \
     ln -s /opt/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild/bin/* /usr/bin/
 
 # Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
-RUN wget -nv -O ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar
+RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
 
 RUN git clone https://github.com/catchorg/Catch2.git --depth 1 --branch v2.13.3 && \

--- a/docker/hail-ubuntu/curlrc
+++ b/docker/hail-ubuntu/curlrc
@@ -1,7 +1,7 @@
 --connect-timeout 5
 --max-time 10
 --retry 5
---retry-all-errors
+--retry-connrefused
 --retry-max-time 40
 --location
 --fail

--- a/hail/Dockerfile.hail-run-tests
+++ b/hail/Dockerfile.hail-run-tests
@@ -2,7 +2,7 @@ FROM {{ hail_run_image.image }}
 
 RUN mkdir -p plink && \
   cd plink && \
-  wget -O plink_linux_x86_64.zip https://storage.googleapis.com/hail-common/plink_linux_x86_64_20181202.zip && \
+  curl >plink_linux_x86_64.zip https://storage.googleapis.com/hail-common/plink_linux_x86_64_20181202.zip && \
   unzip plink_linux_x86_64.zip && \
   mv plink /usr/local/bin && \
   cd .. && \


### PR DESCRIPTION
We have configured curl to retry so we should always prefer it to wget. I also
fixed that long-standing mistake I made when I added retry-all-errors before
it was supported in our version of curl.