### PR TITLE
Print external URL in batch submission log

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -718,7 +718,7 @@ class ServiceBackend(Backend[bc.Batch]):
             print('')
 
         deploy_config = get_deploy_config()
-        url = deploy_config.url('batch', f'/batches/{batch_handle.id}')
+        url = deploy_config.external_url('batch', f'/batches/{batch_handle.id}')
         print(f'Submitted batch {batch_handle.id}, see {url}')
 
         if open:


### PR DESCRIPTION
Otherwise, "batch-in-batch" will print the internal (`batch.hail`) domain.

#assign services