### PR TITLE
[query/service] fast path for checkpoint and persist

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -127,6 +127,7 @@ class Backend(abc.ABC):
         pass
 
     def persist_table(self, t, storage_level):
+        # FIXME: this can't possibly be right.
         return t
 
     def unpersist_table(self, t):

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -600,7 +600,7 @@ class ServiceBackend(Backend):
         # FIXME: should use context manager to clean up persisted resources
         fname = TemporaryFilename().name
         write_expression(expr, fname)
-        return read_expression(fname)
+        return read_expression(fname, _assert_type=expr.dtype)
 
     def set_flags(self, **flags: Mapping[str, str]):
         self.flags.update(flags)

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -1,4 +1,6 @@
+from typing import Optional
 import hail as hl
+from hail.expr.types import HailType
 from hail.ir.base_ir import BaseIR, MatrixIR
 from hail.utils.misc import escape_str, parsable_strings, dump_json, escape_id
 from hail.utils.java import Env
@@ -45,11 +47,17 @@ class MatrixAggregateRowsByKey(MatrixIR):
 
 
 class MatrixRead(MatrixIR):
-    def __init__(self, reader, drop_cols=False, drop_rows=False):
+    def __init__(self,
+                 reader,
+                 drop_cols: bool = False,
+                 drop_rows: bool = False,
+                 *,
+                 _assert_type: Optional[HailType] = None):
         super().__init__()
         self.reader = reader
         self.drop_cols = drop_cols
         self.drop_rows = drop_rows
+        self._type: Optional[HailType] = _assert_type
 
     def render_head(self, r):
         return f'(MatrixRead None {self.drop_cols} {self.drop_rows} "{self.reader.render(r)}"'
@@ -58,7 +66,8 @@ class MatrixRead(MatrixIR):
         return self.reader == other.reader and self.drop_cols == other.drop_cols and self.drop_rows == other.drop_rows
 
     def _compute_type(self):
-        self._type = Env.backend().matrix_type(self)
+        if self._type is None:
+            self._type = Env.backend().matrix_type(self)
 
 
 class MatrixFilterRows(MatrixIR):

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -1,5 +1,6 @@
+from typing import Optional
 import hail as hl
-from hail.expr.types import dtype
+from hail.expr.types import dtype, HailType
 from hail.ir.base_ir import BaseIR, TableIR
 from hail.utils.java import Env
 from hail.utils.misc import escape_str, parsable_strings, dump_json, escape_id
@@ -233,10 +234,15 @@ class TableMapPartitions(TableIR):
 
 
 class TableRead(TableIR):
-    def __init__(self, reader, drop_rows=False):
+    def __init__(self,
+                 reader,
+                 drop_rows: bool = False,
+                 *,
+                 _assert_type: Optional[HailType] = None):
         super().__init__()
         self.reader = reader
         self.drop_rows = drop_rows
+        self._type = _assert_type
 
     def head_str(self):
         return f'None {self.drop_rows} "{self.reader.render()}"'
@@ -245,7 +251,8 @@ class TableRead(TableIR):
         return self.reader == other.reader and self.drop_rows == other.drop_rows
 
     def _compute_type(self):
-        self._type = Env.backend().table_type(self)
+        if self._type is None:
+            self._type = Env.backend().table_type(self)
 
 
 class MatrixEntriesTable(TableIR):

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2500,8 +2500,20 @@ class MatrixTable(ExprContainer):
 }"""
         if not _read_if_exists or not hl.hadoop_exists(f'{output}/_SUCCESS'):
             self.write(output=output, overwrite=overwrite, stage_locally=stage_locally, _codec_spec=_codec_spec)
-        return hl.read_matrix_table(output, _intervals=_intervals, _filter_intervals=_filter_intervals,
-                                    _drop_cols=_drop_cols, _drop_rows=_drop_rows)
+            _assert_type = self._type
+            _load_refs = False
+        else:
+            _assert_type = None
+            _load_refs = True
+        return hl.read_matrix_table(
+            output,
+            _intervals=_intervals,
+            _filter_intervals=_filter_intervals,
+            _drop_cols=_drop_cols,
+            _drop_rows=_drop_rows,
+            _assert_type=_assert_type,
+            _load_refs=_load_refs
+        )
 
     @typecheck_method(output=str,
                       overwrite=bool,

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1289,7 +1289,18 @@ class Table(ExprContainer):
 
         if not _read_if_exists or not hl.hadoop_exists(f'{output}/_SUCCESS'):
             self.write(output=output, overwrite=overwrite, stage_locally=stage_locally, _codec_spec=_codec_spec)
-        return hl.read_table(output, _intervals=_intervals, _filter_intervals=_filter_intervals)
+            _assert_type = self._type
+            _load_refs = False
+        else:
+            _assert_type = None
+            _load_refs = True
+        return hl.read_table(
+            output,
+            _intervals=_intervals,
+            _filter_intervals=_filter_intervals,
+            _assert_type=_assert_type,
+            _load_refs=_load_refs
+        )
 
     @typecheck_method(output=str,
                       overwrite=bool,

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -67,7 +67,17 @@ def range_matrix_table(n_rows, n_cols, n_partitions=None) -> 'hail.MatrixTable':
     check_nonnegative_and_in_range('range_matrix_table', 'n_cols', n_cols)
     if n_partitions is not None:
         check_positive_and_in_range('range_matrix_table', 'n_partitions', n_partitions)
-    return hail.MatrixTable(hail.ir.MatrixRead(hail.ir.MatrixRangeReader(n_rows, n_cols, n_partitions)))
+    return hail.MatrixTable(hail.ir.MatrixRead(
+        hail.ir.MatrixRangeReader(n_rows, n_cols, n_partitions),
+        _assert_type=hl.tmatrix(
+            hl.tstruct(),
+            hl.tstruct(col_idx=hl.tint32),
+            ['col_idx'],
+            hl.tstruct(row_idx=hl.tint32),
+            ['row_idx'],
+            hl.tstruct()
+        )
+    ))
 
 
 @typecheck(n=int, n_partitions=nullable(int))


### PR DESCRIPTION
As much as possible, avoid network requests. In particular, we know the type of tables that are read in checkpoint and Expression.persist.