### PR TITLE
[query] fix a possible bug in read_table and read_matrix_table

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2479,7 +2479,13 @@ def read_matrix_table(path, *, _intervals=None, _filter_intervals=False, _drop_c
                                    _assert_type=_assert_type))
     if _n_partitions:
         intervals = mt._calculate_new_partitions(_n_partitions)
-        return read_matrix_table(path, _drop_rows=_drop_rows, _drop_cols=_drop_cols, _intervals=intervals)
+        return read_matrix_table(
+            path,
+            _drop_rows=_drop_rows,
+            _drop_cols=_drop_cols,
+            _intervals=intervals,
+            _filter_intervals=_filter_intervals
+        )
     return mt
 
 
@@ -2933,7 +2939,7 @@ def read_table(path,
 
     if _n_partitions:
         intervals = ht._calculate_new_partitions(_n_partitions)
-        return read_table(path, _intervals=intervals)
+        return read_table(path, _intervals=intervals, _filter_intervals=_filter_intervals)
     return ht
 
 


### PR DESCRIPTION
It seems like we should pass the interval filters into the newly
partitioned table, right?