### PR TITLE
[query] propagate type information when we have it in BlockMatrix

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -3,17 +3,18 @@ from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.types import tarray
 from .blockmatrix_reader import BlockMatrixReader
 from .base_ir import BlockMatrixIR, IR
-from hail.typecheck import typecheck_method, sequenceof
+from hail.typecheck import typecheck_method, sequenceof, nullable
 from hail.utils.misc import escape_id
 
 from hail.utils.java import Env
 
 
 class BlockMatrixRead(BlockMatrixIR):
-    @typecheck_method(reader=BlockMatrixReader)
-    def __init__(self, reader):
+    @typecheck_method(reader=BlockMatrixReader, _assert_type=nullable(tblockmatrix))
+    def __init__(self, reader, _assert_type=None):
         super().__init__()
         self.reader = reader
+        self._type = _assert_type
 
     def head_str(self):
         return f'"{self.reader.render()}"'
@@ -22,7 +23,8 @@ class BlockMatrixRead(BlockMatrixIR):
         return self.reader == other.reader
 
     def _compute_type(self):
-        self._type = Env.backend().blockmatrix_type(self)
+        if self._type is None:
+            self._type = Env.backend().blockmatrix_type(self)
 
 
 class BlockMatrixMap(BlockMatrixIR):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -419,7 +419,8 @@ class BlockMatrix(object):
         path = new_temp_file()
         cls.write_from_entry_expr(entry_expr, path, overwrite=False, mean_impute=mean_impute,
                                   center=center, normalize=normalize, axis=axis, block_size=block_size)
-        return cls.read(path, _assert_type=self._bmir._type)
+        return cls.read(path)
+
     @classmethod
     @typecheck_method(n_rows=int,
                       n_cols=int,

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -229,7 +229,7 @@ class BlockMatrix(object):
 
     @classmethod
     @typecheck_method(path=str, _assert_type=nullable(tblockmatrix))
-    def read(cls, path, *, _assert_type):
+    def read(cls, path, *, _assert_type=None):
         """Reads a block matrix.
 
         Parameters

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1,4 +1,4 @@
-import os
+nimport os
 
 import itertools
 import math
@@ -9,6 +9,7 @@ import scipy.linalg as spla
 import hail as hl
 import hail.expr.aggregators as agg
 from hail.expr import construct_expr, construct_variable
+from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.expressions import (expr_float64, matrix_table_source, expr_ndarray,
                                    check_entry_indexed, expr_tuple, expr_array, expr_int32, expr_int64)
 from hail.ir import (BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, F64,
@@ -227,8 +228,8 @@ class BlockMatrix(object):
         self._bmir = bmir
 
     @classmethod
-    @typecheck_method(path=str)
-    def read(cls, path):
+    @typecheck_method(path=str, _assert_type=nullable(tblockmatrix))
+    def read(cls, path, *, _assert_type):
         """Reads a block matrix.
 
         Parameters
@@ -240,14 +241,15 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return cls(BlockMatrixRead(BlockMatrixNativeReader(path)))
+        return cls(BlockMatrixRead(BlockMatrixNativeReader(path), _assert_type=_assert_type))
 
     @classmethod
     @typecheck_method(uri=str,
                       n_rows=int,
                       n_cols=int,
-                      block_size=nullable(int))
-    def fromfile(cls, uri, n_rows, n_cols, block_size=None):
+                      block_size=nullable(int),
+                      _assert_type=nullable(tblockmatrix))
+    def fromfile(cls, uri, n_rows, n_cols, block_size=None, *, _assert_type=None):
         """Creates a block matrix from a binary file.
 
         Examples
@@ -301,7 +303,7 @@ class BlockMatrix(object):
         if not block_size:
             block_size = BlockMatrix.default_block_size()
 
-        return cls(BlockMatrixRead(BlockMatrixBinaryReader(uri, [n_rows, n_cols], block_size)))
+        return cls(BlockMatrixRead(BlockMatrixBinaryReader(uri, [n_rows, n_cols], block_size), _assert_type=_assert_type))
 
     @classmethod
     @typecheck_method(ndarray=np.ndarray,
@@ -417,8 +419,7 @@ class BlockMatrix(object):
         path = new_temp_file()
         cls.write_from_entry_expr(entry_expr, path, overwrite=False, mean_impute=mean_impute,
                                   center=center, normalize=normalize, axis=axis, block_size=block_size)
-        return cls.read(path)
-
+        return cls.read(path, _assert_type=self._bmir._type)
     @classmethod
     @typecheck_method(n_rows=int,
                       n_cols=int,
@@ -645,7 +646,7 @@ class BlockMatrix(object):
             before being copied to ``output``.
         """
         self.write(path, overwrite, force_row_major, stage_locally)
-        return BlockMatrix.read(path)
+        return BlockMatrix.read(path, _assert_type=self._bmir._type)
 
     @staticmethod
     @typecheck(entry_expr=expr_float64,
@@ -1330,7 +1331,7 @@ class BlockMatrix(object):
         """
         id = Env.get_uid()
         Env.backend().execute(BlockMatrixWrite(self._bmir, BlockMatrixPersistWriter(id, storage_level)))
-        return BlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id, self._bmir)))
+        return BlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id, self._bmir), _assert_type=self._bmir._type))
 
     def unpersist(self):
         """Unpersists this block matrix from memory/disk.

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1,4 +1,4 @@
-nimport os
+import os
 
 import itertools
 import math


### PR DESCRIPTION
Same principle as #11677.