### PR TITLE
[batch] Fix errors on the worker

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2142,8 +2142,6 @@ class JVM:
                         break
                     finally:
                         writer.close()
-                except ConnectionRefusedError:
-                    raise
                 except FileNotFoundError as err:
                     attempts += 1
                     if attempts == 240:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 525, in run_until_done_or_deleted
    return step.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 695, in _run
    raise ContainerTimeoutError(f'timed out after {self.timeout}s')
ContainerTimeoutError: timed out after 5s
```

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2378, in run_job
    await job.run()
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1695, in run
    await self.mark_complete()
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1392, in mark_complete
    json.dumps(full_status),
  File "/usr/local/lib/python3.7/dist-packages/hailtop/utils/utils.py", line 722, in retry_transient_errors
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/batch/file_store.py", line 76, in write_status_file
    await self.fs.write(url, status.encode('utf-8'))
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/fs.py", line 208, in write
    await retry_transient_errors(_write)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/utils/utils.py", line 722, in retry_transient_errors
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiotools/fs/fs.py", line 205, in _write
    async with await self.create(url, retry_writes=False) as f:
  File "/usr/local/lib/python3.7/dist-packages/hailtop/aiocloud/aiogoogle/client/storage_client.py", line 543, in create
    return await self._storage_client.insert_object(bucket, name, params=params)
AttributeError: 'GoogleStorageAsyncFS' object has no attribute '_storage_client'
```

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2134, in create_container_and_connect
    reader, writer = await asyncio.open_unix_connection(socket_file)
  File "/usr/lib/python3.7/asyncio/streams.py", line 128, in open_unix_connection
    lambda: protocol, path, **kwds)
  File "/usr/lib/python3.7/asyncio/unix_events.py", line 232, in create_unix_connection
    await self.sock_connect(sock, path)
  File "/usr/lib/python3.7/asyncio/selector_events.py", line 473, in sock_connect
    return await fut
  File "/usr/lib/python3.7/asyncio/futures.py", line 266, in __await__
    return self.result()  # May raise too.
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/lib/python3.7/asyncio/selector_events.py", line 478, in _sock_connect
    sock.connect(address)
ConnectionRefusedError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1840, in run
    self.jvm = await self.worker.borrow_jvm(self.cpu_in_mcpu // 1000)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2337, in borrow_jvm
    await self._jvm_initializer_task
  File "/usr/lib/python3.7/asyncio/futures.py", line 263, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1840, in run
    self.jvm = await self.worker.borrow_jvm(self.cpu_in_mcpu // 1000)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2337, in borrow_jvm
    await self._jvm_initializer_task
  File "/usr/lib/python3.7/asyncio/futures.py", line 263, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1840, in run
    self.jvm = await self.worker.borrow_jvm(self.cpu_in_mcpu // 1000)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2337, in borrow_jvm
    await self._jvm_initializer_task
  File "/usr/lib/python3.7/asyncio/futures.py", line 263, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1840, in run
    self.jvm = await self.worker.borrow_jvm(self.cpu_in_mcpu // 1000)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2337, in borrow_jvm
    await self._jvm_initializer_task
  File "/usr/lib/python3.7/asyncio/futures.py", line 263, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1840, in run
    self.jvm = await self.worker.borrow_jvm(self.cpu_in_mcpu // 1000)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2337, in borrow_jvm
    await self._jvm_initializer_task
  File "/usr/lib/python3.7/asyncio/futures.py", line 263, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 1840, in run
    self.jvm = await self.worker.borrow_jvm(self.cpu_in_mcpu // 1000)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2337, in borrow_jvm
    await self._jvm_initializer_task
  File "/usr/lib/python3.7/asyncio/futures.py", line 263, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/lib/python3.7/asyncio/tasks.py", line 251, in __step
    result = coro.throw(exc)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2329, in _initialize_jvms
    *[JVM.create(CORES + i, 8, self) for i in range(CORES // 8)],
  File "/usr/lib/python3.7/asyncio/tasks.py", line 318, in __wakeup
    future.result()
  File "/usr/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2167, in create
    index, n_cores, socket_file, root_dir, worker.client_session, worker.pool
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2154, in create_container_and_connect
    raise JVMCreationError from e
JVMCreationError
```