### PR TITLE
[query/service] fixes for large pipelines

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -60,7 +60,7 @@ object Worker {
   def main(argv: Array[String]): Unit = {
     val theHailClassLoader = new HailClassLoader(getClass().getClassLoader())
 
-    if (argv.length != 6) {
+    if (argv.length != 7) {
       throw new IllegalArgumentException(s"expected seven arguments, not: ${ argv.length }")
     }
     val scratchDir = argv(0)


### PR DESCRIPTION
1. Until we scale up the memory service's throughput, avoid use on the client
   and the worker if there are more than 50 partitions.

2. On the driver, open no more than 100 concurrent connections to Google Cloud
   Storage.

3. Set a timeout of five seconds to connect or read from Google Cloud Storage.