### PR TITLE
[batch] Remove existing JVM container before recreating

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2184,6 +2184,9 @@ class JVM:
                 return await asyncio.open_unix_connection(self.socket_file)
             except ConnectionRefusedError:
                 os.remove(self.socket_file)
+                if self.container:
+                    await self.container.remove()
+
                 container = await self.create_container_and_connect(
                     self.index, self.n_cores, self.socket_file, self.root_dir, self.client_session, self.pool
                 )


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 2148, in new_connection
    return await asyncio.open_unix_connection(self.socket_file)
  File "/usr/lib/python3.7/asyncio/streams.py", line 128, in open_unix_connection
    lambda: protocol, path, **kwds)
  File "/usr/lib/python3.7/asyncio/unix_events.py", line 232, in create_unix_connection
    await self.sock_connect(sock, path)
  File "/usr/lib/python3.7/asyncio/selector_events.py", line 473, in sock_connect
    return await fut
  File "/usr/lib/python3.7/asyncio/futures.py", line 266, in __await__
    return self.result()  # May raise too.
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/lib/python3.7/asyncio/selector_events.py", line 478, in _sock_connect
    sock.connect(address)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 519, in run_until_done_or_deleted
    return step.result()
  File "/usr/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
  File "/usr/local/lib/python3.7/dist-packages/batch/worker/worker.py", line 824, in _setup_overlay
    os.makedirs(d)
  File "/usr/lib/python3.7/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/host/jvm-8a647848eab142e181a79f12216337ef/container/rootfs_overlay/upper'
```