### PR TITLE
[black] Upgrade to 22.3.0

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -14,6 +14,7 @@ black==22.3.0
 boto3==1.21.13
 botocore==1.24.13
 curlylint==0.12.0
+click==8.0.4
 decorator==4.4.0
 dictdiffer==0.8.1
 dill>=0.3.1.1,<0.4

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -10,7 +10,7 @@ async-timeout==4.0.2
 asyncinit==0.2.4
 azure-identity==1.8.0
 azure-storage-blob==12.8.1
-black==22.1.0
+black==22.3.0
 boto3==1.21.13
 botocore==1.24.13
 curlylint==0.12.0

--- a/hail/python/dev/requirements.txt
+++ b/hail/python/dev/requirements.txt
@@ -2,7 +2,7 @@ flake8==4.0.1
 mypy==0.780
 pylint==2.12.2
 pre-commit==2.17.0
-black==22.1.0
+black==22.3.0
 curlylint==0.12.0
 isort==5.10.1
 pytest==7.1.1

--- a/hail/python/dev/requirements.txt
+++ b/hail/python/dev/requirements.txt
@@ -4,6 +4,7 @@ pylint==2.12.2
 pre-commit==2.17.0
 black==22.3.0
 curlylint==0.12.0
+click==8.0.4
 isort==5.10.1
 pytest==7.1.1
 pytest-html==1.20.0


### PR DESCRIPTION
Fixes a transitive dependency breaking issue. See [here](https://github.com/psf/black/issues/2964).