### PR TITLE
Remove obsolete load_config_file argument

### DIFF
--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -249,8 +249,6 @@ resource "google_compute_address" "internal_gateway" {
 }
 
 provider "kubernetes" {
-  load_config_file = false
-
   host = "https://${google_container_cluster.vdc.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(


### PR DESCRIPTION
Looks like this has been removed: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/v2-upgrade-guide#changes-in-v200

#assign services