### PR TITLE
[vds] Add option to VDS impute sex to use only the variant data

### DIFF
--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -358,14 +358,16 @@ def filter_samples(vds: 'VariantDataset', samples_table: 'Table', *,
 
 @typecheck(vds=VariantDataset,
            calling_intervals=oneof(Table, expr_array(expr_interval(expr_locus()))),
-           normalization_contig=str
+           normalization_contig=str,
+           use_variant_dataset=bool
            )
 def impute_sex_chromosome_ploidy(
         vds: VariantDataset,
         calling_intervals,
-        normalization_contig: str
+        normalization_contig: str,
+        use_variant_dataset: bool = False
 ) -> hl.Table:
-    """Impute sex chromosome ploidy from depth of reference data within calling intervals.
+    """Impute sex chromosome ploidy from depth of reference or variant data within calling intervals.
 
     Returns a :class:`.Table` with sample ID keys, with the following fields:
 
@@ -383,6 +385,8 @@ def impute_sex_chromosome_ploidy(
         Calling intervals with consistent read coverage (for exomes, trim the capture intervals).
     normalization_contig : str
         Autosomal contig for depth comparison.
+    use_variant_dataset : bool
+        Whether to use depth of variant data within calling intervals instead of reference data. Default will use reference data.
 
     Returns
     -------
@@ -437,16 +441,25 @@ def impute_sex_chromosome_ploidy(
     vds = VariantDataset(hl.filter_intervals(vds.reference_data, kept_contig_filter),
                          hl.filter_intervals(vds.variant_data, kept_contig_filter))
 
-    coverage = interval_coverage(vds, calling_intervals, gq_thresholds=()).drop('gq_thresholds')
+    if use_variant_dataset:
+        mt = vds.variant_data
+        mt = mt.filter_rows(hl.is_defined(calling_intervals[mt.locus]))
+        coverage = mt.select_cols(
+            __mean_dp=hl.agg.group_by(mt.locus.contig,
+                                      hl.agg.sum(mt.DP)
+                                      / hl.agg.filter(mt["LGT" if "LGT" in mt.entry else "GT"].is_non_ref(),
+                                                      hl.agg.count())))
+    else:
+        coverage = interval_coverage(vds, calling_intervals, gq_thresholds=()).drop('gq_thresholds')
 
-    coverage = coverage.annotate_rows(contig=coverage.interval.start.contig)
-    coverage = coverage.annotate_cols(
-        __mean_dp=hl.agg.group_by(coverage.contig, hl.agg.sum(coverage.sum_dp) / hl.agg.sum(coverage.interval_size)))
+        coverage = coverage.annotate_rows(contig=coverage.interval.start.contig)
+        coverage = coverage.annotate_cols(
+            __mean_dp=hl.agg.group_by(coverage.contig, hl.agg.sum(coverage.sum_dp) / hl.agg.sum(coverage.interval_size)))
 
     mean_dp_dict = coverage.__mean_dp
-    auto_dp = mean_dp_dict.get(normalization_contig)
-    x_dp = mean_dp_dict.get(chr_x)
-    y_dp = mean_dp_dict.get(chr_y)
+    auto_dp = mean_dp_dict.get(normalization_contig, 0.0)
+    x_dp = mean_dp_dict.get(chr_x, 0.0)
+    y_dp = mean_dp_dict.get(chr_y, 0.0)
     per_sample = coverage.transmute_cols(autosomal_mean_dp=auto_dp,
                                          x_mean_dp=x_dp,
                                          x_ploidy=2 * x_dp / auto_dp,

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -261,22 +261,52 @@ def test_impute_sex_chromosome_ploidy():
         hl.Struct(s='sample_xy', ref_allele='A', locus=hl.Locus('X', x_par_end-10, rg), END=x_par_end+9, GQ=9, DP=3),
         hl.Struct(s='sample_xy', ref_allele='A', locus=hl.Locus('X', x_par_end+10, rg), END=x_par_end+29, GQ=6, DP=2),
         hl.Struct(s='sample_xy', ref_allele='A', locus=hl.Locus('Y', y_par_end-10, rg), END=y_par_end+9, GQ=12, DP=4),
-        hl.Struct(s='sample_xy', ref_allele='A', locus=hl.Locus('Y', y_par_end + 10, rg), END=y_par_end + 29, GQ=9, DP=3),
+        hl.Struct(s='sample_xy', ref_allele='A', locus=hl.Locus('Y', y_par_end+10, rg), END=y_par_end+29, GQ=9, DP=3),
+    ]
+    var = [
+        hl.Struct(locus=hl.Locus('22', 2000021, rg), alleles=hl.array(["A", "C"]), s="sample_xx", LA=hl.array([0, 1]),
+                  LGT=hl.call(0, 1, phased=False), GQ=15, DP=5),
+        hl.Struct(locus=hl.Locus('X', x_par_end-11, rg), alleles=hl.array(["A", "C"]), s="sample_xx", LA=hl.array([0, 1]),
+                  LGT=hl.call(0, 1, phased=False), GQ=18, DP=6),
+        hl.Struct(locus=hl.Locus('X', x_par_end+30, rg), alleles=hl.array(["A", "C"]), s="sample_xx",
+                  LA=hl.array([0, 1]),
+                  LGT=hl.call(0, 1, phased=False), GQ=18, DP=6),
+        hl.Struct(locus=hl.Locus('X', x_par_end + 33, rg), alleles=hl.array(["A", "C", "G"]), s="sample_xx",
+                  LA=hl.array([0, 1, 2]),
+                  LGT=hl.call(0, 2, phased=False), GQ=15, DP=5),
+        hl.Struct(locus=hl.Locus('22', 2000021, rg), alleles=hl.array(["A", "C"]), s="sample_xy", LA=hl.array([0, 1]),
+                  LGT=hl.call(0, 1, phased=False), GQ=15, DP=5),
+        hl.Struct(locus=hl.Locus('X', x_par_end - 11, rg), alleles=hl.array(["A", "C"]), s="sample_xy",
+                  LA=hl.array([0, 1]),
+                  LGT=hl.call(1, 1, phased=False), GQ=5, DP=2),
+        hl.Struct(locus=hl.Locus('X', x_par_end + 30, rg), alleles=hl.array(["A", "C"]), s="sample_xy",
+                  LA=hl.array([0, 1]),
+                  LGT=hl.call(1, 1, phased=False), GQ=7, DP=4),
+        hl.Struct(locus=hl.Locus('X', x_par_end + 33, rg), alleles=hl.array(["A", "C", "G"]), s="sample_xy",
+                  LA=hl.array([0, 1, 2]),
+                  LGT=hl.call(2, 2, phased=False), GQ=5, DP=3),
+        hl.Struct(locus=hl.Locus('Y', y_par_end-11, rg), alleles=hl.array(["A", "C"]), s="sample_xy", LA=hl.array([0, 1]),
+                  LGT=hl.call(1, 1, phased=False), GQ=9, DP=2),
+        hl.Struct(locus=hl.Locus('Y', y_par_end+30, rg), alleles=hl.array(["A", "C"]), s="sample_xy", LA=hl.array([0, 1]),
+                  LGT=hl.call(1, 1, phased=False), GQ=12, DP=4),
+        hl.Struct(locus=hl.Locus('Y', y_par_end+33, rg), alleles=hl.array(["A", "C"]), s="sample_xy",
+                  LA=hl.array([0, 1]),
+                  LGT=hl.call(1, 1, phased=False), GQ=6, DP=2),
     ]
 
     ref_mt = hl.Table.parallelize(ref_blocks,
                                   schema=hl.dtype('struct{s:str,locus:locus<GRCh37>,ref_allele:str,END:int32,GQ:int32,DP:int32}')) \
         .to_matrix_table(row_key=['locus'], row_fields=['ref_allele'], col_key=['s'])
     var_mt = hl.Table.parallelize([],
-                                  schema=hl.dtype('struct{locus:locus<GRCh37>,alleles:array<str>,s:str,LA:array<int32>,LGT:call,GQ:int32}'))\
-    .to_matrix_table(row_key=['locus', 'alleles'], col_key=['s'])
+                                  schema=hl.dtype('struct{locus:locus<GRCh37>,alleles:array<str>,s:str,LA:array<int32>,LGT:call,GQ:int32,DP:int32}'))\
+        .to_matrix_table(row_key=['locus', 'alleles'], col_key=['s'])
 
     vds = hl.vds.VariantDataset(ref_mt, var_mt)
 
     calling_intervals = [
         hl.parse_locus_interval('22:1000010-1000020', reference_genome='GRCh37'),
-        hl.parse_locus_interval(f'X:{x_par_end}-{x_par_end+20}', reference_genome='GRCh37'),
-        hl.parse_locus_interval(f'Y:{y_par_end}-{y_par_end+20}', reference_genome='GRCh37'),
+        hl.parse_locus_interval(f'X:{x_par_end}-{x_par_end + 20}', reference_genome='GRCh37'),
+        hl.parse_locus_interval(f'Y:{y_par_end}-{y_par_end + 20}', reference_genome='GRCh37'),
     ]
 
     r = hl.vds.impute_sex_chromosome_ploidy(vds, calling_intervals, normalization_contig='22')
@@ -294,6 +324,37 @@ def test_impute_sex_chromosome_ploidy():
                   x_ploidy=1.0,
                   y_mean_dp=3.5,
                   y_ploidy=1.4)
+    ]
+
+    var_mt = hl.Table.parallelize(var,
+                                  schema=hl.dtype('struct{locus:locus<GRCh37>,alleles:array<str>,s:str,LA:array<int32>,LGT:call,GQ:int32,DP:int32}'))\
+        .to_matrix_table(row_key=['locus', 'alleles'], col_key=['s'])
+
+    vds = hl.vds.VariantDataset(ref_mt, var_mt)
+
+    calling_intervals = [
+        hl.parse_locus_interval('22:1000010-1000020', reference_genome='GRCh37'),
+        hl.parse_locus_interval('22:2000020-2000030', reference_genome='GRCh37'),
+        hl.parse_locus_interval(f'X:{x_par_end}-{x_par_end + 20}', reference_genome='GRCh37'),
+        hl.parse_locus_interval(f'X:{x_par_end + 32}-{x_par_end + 40}', reference_genome='GRCh37'),
+        hl.parse_locus_interval(f'Y:{y_par_end}-{y_par_end + 20}', reference_genome='GRCh37'),
+        hl.parse_locus_interval(f'Y:{y_par_end + 32}-{y_par_end + 40}', reference_genome='GRCh37'),
+    ]
+    r = hl.vds.impute_sex_chromosome_ploidy(vds, calling_intervals, normalization_contig='22', use_variant_dataset=True)
+
+    assert r.collect() == [
+        hl.Struct(s='sample_xx',
+                  autosomal_mean_dp=5.0,
+                  x_mean_dp=5.0,
+                  x_ploidy=2.0,
+                  y_mean_dp=0.0,
+                  y_ploidy=0.0),
+        hl.Struct(s='sample_xy',
+                  autosomal_mean_dp=5.0,
+                  x_mean_dp=3.0,
+                  x_ploidy=1.2,
+                  y_mean_dp=2.0,
+                  y_ploidy=0.8)
     ]
 
 


### PR DESCRIPTION
During testing of our gnomAD v4 exome dataset we determined that there was better separation of x-ploidy values by using only the variant dataset to determine the mean DP of chromosome X rather than the reference blocks.

This PR is my attempt to add an option to the the VDS `impute_sex_chromosome_ploidy` method that will only compute the ploidy estimates using the variant dataset instead of the default option of using the reference blocks.

The code should still filter to variants that fall within the `calling_intervals`.