### PR TITLE
[query] Remove indeed lsmtree

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -198,8 +198,6 @@ dependencies {
 
     bundled 'commons-io:commons-io:2.5'
 
-    bundled 'com.indeed:util-serialization:1.0.36'
-    bundled 'com.indeed:util-mmap:1.0.36'
     bundled group: 'org.freemarker', name: 'freemarker', version: '2.3.14'
 
     bundled 'com.kohlschutter.junixsocket:junixsocket-core:2.3.2'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -196,7 +196,8 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core'
     }
 
-    bundled 'com.indeed:lsmtree-core:1.0.7'
+    bundled 'commons-io:commons-io:2.5'
+
     bundled 'com.indeed:util-serialization:1.0.36'
     bundled 'com.indeed:util-mmap:1.0.36'
     bundled group: 'org.freemarker', name: 'freemarker', version: '2.3.14'
@@ -320,8 +321,6 @@ tasks.withType(ShadowJar) {
     relocate 'org.codehaus.jackson', 'is.hail.relocated.org.codehaus.jackson'
     relocate 'org.apache.commons.lang3', 'is.hail.relocated.org.apache.commons.lang3'
     relocate 'org.apache.commons.io', 'is.hail.relocated.org.apache.commons.io'
-    // we should really shade indeed, but it has native libraries
-    // relocate 'com.indeed', 'is.hail.relocated.com.indeed'
     relocate 'com.google.cloud', 'is.hail.relocated.com.google.cloud'
     relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'
     relocate 'org.lz4', 'is.hail.relocated.org.lz4'


### PR DESCRIPTION
Needed to sub in commons-io, which we were getting transitively from lsmtree. I picked the version that hadoop/spark depend on at runtime. lsmtree depends on an older one but currently in `main` gradle upgrades it for the one requested by the runtime dependencies.