### PR TITLE
[query] Add assertion that methods have fewer than 255 parameters

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -488,6 +488,10 @@ class MethodBuilder[C](
   val returnTypeInfo: TypeInfo[_],
   val isStatic: Boolean = false
 ) extends WrappedClassBuilder[C] {
+  require(parameterTypeInfo.length + isStatic.toInt <= 255,
+    s"""Invalid method, methods may have at most 255 arguments, found ${parameterTypeInfo.length + isStatic.toInt}
+       |Return Type Info: $returnTypeInfo
+       |Parameter Type Info: ${parameterTypeInfo.mkString}""".stripMargin)
   // very long method names, repeated hundreds of thousands of times can cause memory issues.
   // If necessary to find the name of a method precisely, this can be set to around the constant
   // limit of 65535 characters, but usually, this can be much smaller.


### PR DESCRIPTION
According to the JVM specification, methods may only have 255 parameters
(including this).