### PR TITLE
[batch] Don't double log exceptions in job scheduling

### DIFF
--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -475,7 +475,8 @@ LIMIT %s;
                         try:
                             await schedule_job(app, record, instance)
                         except Exception:
-                            log.info(f'scheduling job {id} on {instance} for {self.pool}', exc_info=True)
+                            if instance.state == 'active':
+                                instance.adjust_free_cores_in_memory(record['cores_mcpu'])
 
                     await waitable_pool.call(schedule_with_error_handling, self.app, record, id, instance)
 

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -452,9 +452,6 @@ LIMIT %s;
 
             remaining = Box(share)
             async for record in user_runnable_jobs(user, remaining):
-                batch_id = record['batch_id']
-                job_id = record['job_id']
-                id = (batch_id, job_id)
                 attempt_id = secret_alnum_string(6)
                 record['attempt_id'] = attempt_id
 

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -471,14 +471,14 @@ LIMIT %s;
                     scheduled_cores_mcpu += record['cores_mcpu']
                     n_scheduled += 1
 
-                    async def schedule_with_error_handling(app, record, id, instance):
+                    async def schedule_with_error_handling(app, record, instance):
                         try:
                             await schedule_job(app, record, instance)
                         except Exception:
                             if instance.state == 'active':
                                 instance.adjust_free_cores_in_memory(record['cores_mcpu'])
 
-                    await waitable_pool.call(schedule_with_error_handling, self.app, record, id, instance)
+                    await waitable_pool.call(schedule_with_error_handling, self.app, record, instance)
 
                 remaining.value -= 1
                 if remaining.value <= 0:

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -416,70 +416,65 @@ async def schedule_job(app, record, instance):
     id = (batch_id, job_id)
 
     try:
-        try:
-            body = await job_config(app, record, attempt_id)
-        except Exception:
-            log.exception('while making job config')
-            status = {
-                'version': STATUS_FORMAT_VERSION,
-                'worker': None,
-                'batch_id': batch_id,
-                'job_id': job_id,
-                'attempt_id': attempt_id,
-                'user': record['user'],
-                'state': 'error',
-                'error': traceback.format_exc(),
-                'container_statuses': {k: None for k in tasks},
-            }
+        body = await job_config(app, record, attempt_id)
+    except Exception:
+        log.exception('while making job config')
+        status = {
+            'version': STATUS_FORMAT_VERSION,
+            'worker': None,
+            'batch_id': batch_id,
+            'job_id': job_id,
+            'attempt_id': attempt_id,
+            'user': record['user'],
+            'state': 'error',
+            'error': traceback.format_exc(),
+            'container_statuses': {k: None for k in tasks},
+        }
 
-            if format_version.has_full_status_in_gcs():
-                await file_store.write_status_file(batch_id, job_id, attempt_id, json.dumps(status))
+        if format_version.has_full_status_in_gcs():
+            await file_store.write_status_file(batch_id, job_id, attempt_id, json.dumps(status))
 
-            db_status = format_version.db_status(status)
-            resources = []
+        db_status = format_version.db_status(status)
+        resources = []
 
-            await mark_job_complete(
-                app, batch_id, job_id, attempt_id, instance.name, 'Error', db_status, None, None, 'error', resources
-            )
-            raise
+        await mark_job_complete(
+            app, batch_id, job_id, attempt_id, instance.name, 'Error', db_status, None, None, 'error', resources
+        )
+        raise
 
-        log.info(f'schedule job {id} on {instance}: made job config')
+    log.info(f'schedule job {id} on {instance}: made job config')
 
-        try:
-            await client_session.post(
-                f'http://{instance.ip_address}:5000/api/v1alpha/batches/jobs/create',
-                json=body,
-                timeout=aiohttp.ClientTimeout(total=2),
-            )
-            await instance.mark_healthy()
-        except aiohttp.ClientResponseError as e:
-            await instance.mark_healthy()
-            if e.status == 403:
-                log.info(f'attempt already exists for job {id} on {instance}, aborting')
-            if e.status == 503:
-                log.info(f'job {id} cannot be scheduled because {instance} is shutting down, aborting')
-            raise e
-        except Exception:
-            await instance.incr_failed_request_count()
-            raise
+    try:
+        await client_session.post(
+            f'http://{instance.ip_address}:5000/api/v1alpha/batches/jobs/create',
+            json=body,
+            timeout=aiohttp.ClientTimeout(total=2),
+        )
+        await instance.mark_healthy()
+    except aiohttp.ClientResponseError as e:
+        await instance.mark_healthy()
+        if e.status == 403:
+            log.info(f'attempt already exists for job {id} on {instance}, aborting')
+        if e.status == 503:
+            log.info(f'job {id} cannot be scheduled because {instance} is shutting down, aborting')
+        raise e
+    except Exception:
+        await instance.incr_failed_request_count()
+        raise
 
-        log.info(f'schedule job {id} on {instance}: called create job')
+    log.info(f'schedule job {id} on {instance}: called create job')
 
-        try:
-            rv = await db.execute_and_fetchone(
-                '''
+    try:
+        rv = await db.execute_and_fetchone(
+            '''
     CALL schedule_job(%s, %s, %s, %s);
     ''',
-                (batch_id, job_id, attempt_id, instance.name),
-                'schedule_job',
-            )
-        except Exception:
-            log.exception(f'error while scheduling job {id} on {instance}')
-            raise
+            (batch_id, job_id, attempt_id, instance.name),
+            'schedule_job',
+        )
     except Exception:
-        if instance.state == 'active':
-            instance.adjust_free_cores_in_memory(record['cores_mcpu'])
-        return
+        log.exception(f'Error while running schedule_job procedure for job {id}')
+        raise
 
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
         instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])


### PR DESCRIPTION
The `log.exception` in the wrapping try/except means we log anything that raises as an error, even things like 503's and 403's from the workers which we explicitly log as info. I think we're abusing exception handling here to catch a potentially non-exceptional failure mode which is "we couldn't schedule, we need to add back those cores". Didn't rework things though, just pushed the exception logging in to the only chunk of code that wasn't already in a nested try/except.