### PR TITLE
[query/service] retry entire partition when we encounter transient errors in compiled code

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -138,7 +138,9 @@ object Worker {
     var result: Array[Byte] = null
     var userError: HailException = null
     try {
-      result = f(context, htc, theHailClassLoader, fs)
+      retryTransientErrors {
+        result = f(context, htc, theHailClassLoader, fs)
+      }
     } catch {
       case err: HailException => userError = err
     }


### PR DESCRIPTION
Ideally, a stream would be able to recover from a transient error by
seeking, but until we have that functionality, this avoids having
one failure out of 5000 (which I have now seen twice).

Example:  https://batch.hail.is/batches/1531518/jobs/2094.