### PR TITLE
Revert "[batch] Dont block on all netns creation on startup"

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2494,8 +2494,7 @@ class Worker:
         await site.start()
 
         try:
-            startup_tasks = asyncio.gather(self.activate(), network_allocator.reserve())
-            await asyncio.wait_for(startup_tasks, MAX_IDLE_TIME_MSECS / 1000)
+            await asyncio.wait_for(self.activate(), MAX_IDLE_TIME_MSECS / 1000)
         except asyncio.TimeoutError:
             log.exception(f'could not activate after trying for {MAX_IDLE_TIME_MSECS} ms, exiting')
             return
@@ -2701,6 +2700,7 @@ async def async_main():
 
     port_allocator = PortAllocator()
     network_allocator = NetworkAllocator()
+    await network_allocator.reserve()
 
     worker = Worker(httpx.client_session())
     try:


### PR DESCRIPTION
Shortly after this merged, we encountered issues where some workers shut down soon after starting up, but while they were running jobs. I think the `startup_tasks` idled out even though we activated, which caused us to return without shutting down the site. That meant we shut down while we were processing jobs and those workers spewed a bunch of errors before they finally killed themselves off.

I think it's wrong here to tie in the timing out trying to activate with other startup tasks that could potentially take a longer amount of time but will certainly finish and we should let them finish. We also don't need all of the network namespaces created in order to start accepting jobs.

For context, I think it takes just about MAX_IDLE_TIMEOUT_SECONDS to create all the network namespaces.