### PR TITLE
Update installation commands for using homebrew

### DIFF
--- a/hail/python/hail/docs/install/macosx.rst
+++ b/hail/python/hail/docs/install/macosx.rst
@@ -8,8 +8,8 @@ Install Hail on Mac OS X
 
   .. code-block::
 
-    brew cask install adoptopenjdk8
-    brew install --cask adoptopenjdk8
+    brew tap homebrew/cask-versions
+    brew install --cask temurin8
 
 - Install Python 3.7 or later. We recommend `Miniconda <https://docs.conda.io/en/latest/miniconda.html#macosx-installers>`__.
 - Open Terminal.app and execute ``pip install hail``.


### PR DESCRIPTION
`adoptopenjdk` has been deprecated.  `temurin` is now the official successor as of 2021-08-01 (Aug 01, 2021)
https://github.com/AdoptOpenJDK/homebrew-openjdk
https://formulae.brew.sh/cask/adoptopenjdk#default