### PR TITLE
[query] Lower BlockMatrix to Table

### DIFF
--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -227,8 +227,6 @@ Caused by: is.hail.utils.HailException: bad shuffle close
         bm = BlockMatrix._create(n_rows, n_cols, data.tolist(), block_size=4)
         self._assert_eq(bm.to_numpy(_force_blocking=True), a)
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_to_table(self):
         schema = hl.tstruct(row_idx=hl.tint64, entries=hl.tarray(hl.tfloat64))
         rows = [{'row_idx': 0, 'entries': [0.0, 1.0]},
@@ -258,8 +256,6 @@ Caused by: is.hail.utils.HailException: bad shuffle close
         bm = BlockMatrix._create(5, 2, [float(i) for i in range(10)], 2)
         bm.to_table_row_major(2, maximum_cache_memory_in_bytes=16)._force_count()
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_to_matrix_table(self):
         n_partitions = 2
         rows, cols = 2, 5

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1237,7 +1237,7 @@ case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeRe
     val numSlicesInNormalBlock = slicePointsForNormalBlock.length
 
     val lastBlockRow = metadata.nRows / metadata.blockSize + (if (metadata.nRows % metadata.blockSize > 0) 1 else 0)
-    val rowsInLastBlock = metadata.nRows % metadata.blockSize
+    val rowsInLastBlock = (metadata.nRows % metadata.blockSize).toInt
     val slicePointsForLastBlock = ((0 until rowsInLastBlock by sliceSize) :+ rowsInLastBlock).sliding(2).map(is => (is(0), is(1))).toIndexedSeq
     val slicePointsForLastBlockIR = Literal(TArray(TTuple(TInt32, TInt32)), slicePointsForLastBlock)
 
@@ -1253,7 +1253,7 @@ case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeRe
               bindIR(NDArrayShape(block)) { shapeTuple =>
                 bindIR(GetTupleElement(shapeTuple, 0)) { numRowsInBlock =>
                   // Do slicing into vertical chunks of right size.
-                  mapIR(zipWithIndex(ToStream(If(blockRow != lastBlockRow,
+                  mapIR(zipWithIndex(ToStream(If(blockRow cne lastBlockRow,
                     slicePointsForNormalBlockIR,
                     slicePointsForLastBlockIR
                   )))) { sliceIdxAndSliceStartStop =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -13,7 +13,6 @@ import is.hail.io._
 import is.hail.io.avro.AvroTableReader
 import is.hail.io.fs.FS
 import is.hail.io.index.{IndexReadIterator, IndexReader, IndexReaderBuilder, LeafChild}
-import is.hail.linalg.BlockMatrixReadRowBlockedRDD.DEFAULT_MAXIMUM_CACHE_MEMORY_IN_BYTES
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, BlockMatrixReadRowBlockedRDD}
 import is.hail.rvd._
 import is.hail.sparkextras.ContextRDD

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1233,7 +1233,19 @@ case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeRe
     val tableOfBlocks = LowerBlockMatrixIR.lowerToTableStage(BlockMatrixRead(BlockMatrixNativeReader(ctx.fs, params.path)), ???, ctx, ???, ???)
     val branchFactor = 4
 
-    tableOfBlocks
+    tableOfBlocks.mapPartition(None)(part => flatMapIR(part){ element =>
+      // Part ought to be a blockRow, blockCol, block struct.
+      bindIR(GetField(element, "blockRow")) { blockRow =>
+        bindIR(GetField(element, "blockCol")) { blockCol =>
+          bindIR(GetField(element, "block")) { block =>
+            bindIR(NDArraySlice(block, ???)) { slice =>
+              /// Take the slices, renumber them. 
+              ???
+            }
+          }
+        }
+      }
+    })
 
     // Step 1: Split all blocks vertically into chunks we can fit in memory.
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1231,16 +1231,19 @@ case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeRe
   override def lower(ctx: ExecuteContext, requestedType: TableType): TableStage =  {
 
     val tableOfBlocks = LowerBlockMatrixIR.lowerToTableStage(BlockMatrixRead(BlockMatrixNativeReader(ctx.fs, params.path)), ???, ctx, ???, ???)
-    val branchFactor = 4
+    val sliceSize = 4
 
+    val rowReq = ???
+    val tableOfBlocksByRow = ctx.backend.lowerDistributedSort(ctx, tableOfBlocks, sortFields = IndexedSeq(SortField("blockRow", Ascending)), Map(), rowReq)
     tableOfBlocks.mapPartition(None)(part => flatMapIR(part){ element =>
       // Part ought to be a blockRow, blockCol, block struct.
       bindIR(GetField(element, "blockRow")) { blockRow =>
         bindIR(GetField(element, "blockCol")) { blockCol =>
           bindIR(GetField(element, "block")) { block =>
-            bindIR(NDArraySlice(block, ???)) { slice =>
-              /// Take the slices, renumber them. 
-              ???
+            bindIR(NDArrayShape(block)) { shapeTuple =>
+              bindIR(GetTupleElement(shapeTuple, 0)) { numRowsInBlock =>
+                
+              }
             }
           }
         }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1220,6 +1220,14 @@ case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeRe
   }
 
   def renderShort(): String = defaultRender()
+
+  override def lowerGlobals(ctx: ExecuteContext, requestedGlobalsType: TStruct): IR = {
+    MakeStruct(Seq())
+  }
+
+  override def lower(ctx: ExecuteContext, requestedType: TableType): TableStage =  {
+    ???
+  }
 }
 
 object TableRead {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -146,10 +146,11 @@ object  NDArrayFunctions extends RegistryFunctions {
         resPCode
     }
 
-    registerSCode1("ndarray_rows", TNDArray(TFloat64, Nat(2)), TArray(TFloat64), (_, s) => SIndexablePointer(PCanonicalArray(PCanonicalArray(s.asInstanceOf[SNDArray].elementPType)))) { (er, cb, ret, nd, errorId) =>
+    registerSCode1("ndarray_rows", TNDArray(TFloat64, Nat(2)), TArray(TArray(TFloat64)), (_, s) => SIndexablePointer(PCanonicalArray(PCanonicalArray(s.asInstanceOf[SNDArray].elementPType)))) { (er, cb, ret, nd, errorId) =>
       val ndRowMajor = LinalgCodeUtils.checkRowMajorAndCopyIfNeeded(nd.asNDArray, cb, er.region)
       val retPType = ret.asInstanceOf[SIndexablePointer].pType.asInstanceOf[PCanonicalArray]
-      retPType.constructFromElements(cb, er.region, ???, true) { (cb, rowIdx) =>
+      val rowLengthInt = cb.memoize(ndRowMajor.shapes(0).get.toI)
+      retPType.constructFromElements(cb, er.region, rowLengthInt, true) { (cb, rowIdx) =>
         val rowStart = ndRowMajor.firstDataAddress + ndRowMajor.strides(0) * rowIdx.toL
         val innerArrayPType = retPType.elementType.asInstanceOf[PCanonicalArray]
         val nCols = cb.memoize(ndRowMajor.shapes(1).get.toI)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -2125,7 +2125,6 @@ class BlockMatrixReadRowBlockedRDD(
     Iterator.single { ctx =>
       val region = ctx.region
       val rvb = new RegionValueBuilder(region)
-      val rv = RegionValue(region)
       val firstRow = rowsForPartition(0)
       var blockRow = (firstRow / blockSize).toInt
       val fs = fsBc.value

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -2098,22 +2098,17 @@ class WriteBlocksRDD(
   }
 }
 
-object BlockMatrixReadRowBlockedRDD {
-  val DEFAULT_MAXIMUM_CACHE_MEMORY_IN_BYTES = 32 * 1024 * 1024
-}
-
 class BlockMatrixReadRowBlockedRDD(
   fsBc: BroadcastValue[FS],
   path: String,
   partitionRanges: IndexedSeq[NumericRange.Exclusive[Long]],
   metadata: BlockMatrixMetadata,
-  maybeMaximumCacheMemoryInBytes: Option[Int]
+  maximumCacheMemoryInBytes: Int
 ) extends RDD[RVDContext => Iterator[Long]](SparkBackend.sparkContext("BlockMatrixReadRowBlockedRDD"), Nil) {
   import BlockMatrixReadRowBlockedRDD._
 
   private[this] val BlockMatrixMetadata(blockSize, nRows, nCols, maybeFiltered, partFiles) = metadata
   private[this] val gp = GridPartitioner(blockSize, nRows, nCols)
-  private[this] val maximumCacheMemoryInBytes = maybeMaximumCacheMemoryInBytes.getOrElse(DEFAULT_MAXIMUM_CACHE_MEMORY_IN_BYTES)
   private[this] val doublesPerFile = maximumCacheMemoryInBytes / (gp.nBlockCols * 8)
   assert(doublesPerFile >= blockSize,
     "BlockMatrixCachedPartFile must be able to hold at least one row of every block in memory")

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -2105,7 +2105,6 @@ class BlockMatrixReadRowBlockedRDD(
   metadata: BlockMatrixMetadata,
   maximumCacheMemoryInBytes: Int
 ) extends RDD[RVDContext => Iterator[Long]](SparkBackend.sparkContext("BlockMatrixReadRowBlockedRDD"), Nil) {
-  import BlockMatrixReadRowBlockedRDD._
 
   private[this] val BlockMatrixMetadata(blockSize, nRows, nCols, maybeFiltered, partFiles) = metadata
   private[this] val gp = GridPartitioner(blockSize, nRows, nCols)


### PR DESCRIPTION
This isn't working yet, but I think it's pretty close. It transforms a BlockMatrix into a row major table of entries. 

Things to note:

1. I'm not respecting `partitionRanges` right now, need to do that for same behavior as unlowered. 
2. `sliceSize` 4 is arbitrary, it should be computed based on the known width of the BlockMatrix. 