### PR TITLE
[query] Fix bug where dictionary literal couldn't have falsey key

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -203,7 +203,7 @@ def _impute_type(x, partial_type):
         vts = {_impute_type(element, partial_type.value_type) for element in x.values()}
         unified_key_type = super_unify_types(*kts)
         unified_value_type = super_unify_types(*vts)
-        if not unified_key_type:
+        if unified_key_type is None:
             raise ExpressionException("Hail does not support heterogeneous dicts: "
                                       "found dict with keys {} of types {} ".format(list(x.keys()), list(kts)))
         if not unified_value_type:

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3904,6 +3904,10 @@ Caused by: java.lang.AssertionError: assertion failed
         fd = hl.utils.frozendict({"a": 4, "b": 8})
         assert hl.eval(hl.literal(fd)) == hl.utils.frozendict({"a": 4, "b": 8})
 
+    def test_literal_with_empty_struct_key(self):
+        original = {hl.Struct(): 4}
+        assert hl.eval(hl.literal(original)) == original
+
     def test_nan_roundtrip(self):
         a = [math.nan, math.inf, -math.inf, 0, 1]
         round_trip = hl.eval(hl.literal(a))


### PR DESCRIPTION
The test for keys has to be `is not None` to make sure falsey things like `Struct()` can be keys.