### PR TITLE
[query/service] use authority, not host

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -44,8 +44,8 @@ object GoogleStorageFS {
     val scheme = uri.getScheme
     assert(scheme != null && scheme == "gs", (uri.getScheme, filename))
 
-    val bucket = uri.getHost
-    assert(bucket != null)
+    val bucket = uri.getAuthority
+    assert(bucket != null, (filename, uri.toString(), uri.getScheme))
 
     var path = uri.getPath
     if (path.nonEmpty && path.head == '/')

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -45,7 +45,7 @@ object GoogleStorageFS {
     assert(scheme != null && scheme == "gs", (uri.getScheme, filename))
 
     val bucket = uri.getAuthority
-    assert(bucket != null, (filename, uri.toString(), uri.getScheme))
+    assert(bucket != null, (filename, uri.toString(), uri.getScheme, uri.getAuthority, uri.getRawAuthority(), uri.getUserInfo()))
 
     var path = uri.getPath
     if (path.nonEmpty && path.head == '/')


### PR DESCRIPTION
This feels like a bug in `java.net.URI`, but who am I to upend decades of software:

```
scala> import java.net.URI
import java.net.URI

scala> new URI("gs://nd_qc/preimp_qc/GWASpy/Preimp_QC/wave1_pilot_qced.mt").getAuthority
res0: String = nd_qc

scala> new URI("gs://nd_qc/preimp_qc/GWASpy/Preimp_QC/wave1_pilot_qced.mt").getHost
res1: String = null

scala> new URI("gs://nd_qc/preimp_qc/GWASpy/Preimp_QC/wave1_pilot_qced.mt").getPort
res2: Int = -1

scala> new URI("gs://nd_qc/preimp_qc/GWASpy/Preimp_QC/wave1_pilot_qced.mt").getUserInfo()
res3: String = null

```