### PR TITLE
[hailtop/aiogoogle] Fix import

### DIFF
--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -259,7 +259,7 @@ class GetObjectStream(ReadableStream):
         assert not self._closed and n >= 0
         try:
             return await self._content.readexactly(n)
-        except asyncio.streams.IncompleteReadError as e:
+        except asyncio.IncompleteReadError as e:
             raise UnexpectedEOFError() from e
 
     def headers(self) -> 'CIMultiDictProxy[str]':


### PR DESCRIPTION
IncompleteReadError is exported from asyncio and has been since python
3.6 (as far back as I checked). At some point (checked with python 3.10)
it stopped being accessible from asyncio.streams