### PR TITLE
Better windows support

### DIFF
--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -19,7 +19,7 @@ except ImportError as e:
     if not sys.platform.startswith('win32'):
         raise e
 
-    def uvloop_install(*args, **kwargs):
+    def uvloop_install():
         pass
 
 

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -4,13 +4,23 @@ import asyncio
 import json
 import logging
 import sys
-import uvloop
+
 from concurrent.futures import ThreadPoolExecutor
 
 from ..utils import tqdm
 from . import Transfer, Copier
 from .router_fs import RouterAsyncFS
 from .utils import make_tqdm_listener
+
+try:
+    import uvloop
+    uvloop_install = uvloop.install
+except ImportError as e:
+    if not sys.platform.startswith('win32'):
+        raise e
+
+    def uvloop_install(*args, **kwargs):
+        pass
 
 
 async def copy(*,
@@ -109,5 +119,5 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    uvloop.install()
+    uvloop_install()
     asyncio.run(main())

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -30,4 +30,4 @@ scipy>1.2,<1.8
 sortedcontainers==2.4.0
 tabulate==0.8.9
 tqdm==4.*
-uvloop==0.16.0
+uvloop==0.16.0; sys_platform != 'win32'


### PR DESCRIPTION
For the `hail` python package, even if some things don't work great/at all, I think it would be nice if it at least installed on windows. `uvloop` is unsupported on windows, so I add a little logic to ensure that it's not requried on windows and the copy tool doesn't fail if it's not found.