### PR TITLE
[letsencrypt] no secret logging and no blowing away secret

### DIFF
--- a/letsencrypt/Makefile
+++ b/letsencrypt/Makefile
@@ -9,9 +9,6 @@ LETSENCRYPT_IMAGE := $(DOCKER_PREFIX)/letsencrypt:$(TOKEN)
 build:
 	../docker-build.sh . Dockerfile $(LETSENCRYPT_IMAGE)
 
-start-service:
-	kubectl -n default apply -f service.yaml
-
 DRY_RUN ?= false
 run: build
 	echo $(DOMAIN) > domains.txt.out

--- a/letsencrypt/letsencrypt.sh
+++ b/letsencrypt/letsencrypt.sh
@@ -22,6 +22,8 @@ ssl_prefer_server_ciphers on;
 ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
 EOF
 
+set +x # do not leak the secrets into the stdout logs
+
 cat | $KUBECTL_APPLY <<EOF
 apiVersion: v1
 kind: Secret
@@ -35,3 +37,7 @@ data:
   options-ssl-nginx.conf: $(cat /options-ssl-nginx.conf | base64 | tr -d \\n)
   ssl-dhparams.pem: $(cat /opt/certbot/src/certbot/certbot/ssl-dhparams.pem | base64 | tr -d \\n)
 EOF
+
+set -x
+
+echo finished.

--- a/letsencrypt/service.yaml
+++ b/letsencrypt/service.yaml
@@ -3,11 +3,6 @@ kind: ServiceAccount
 metadata:
   name: letsencrypt
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: letsencrypt-config
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
1. Do not leak the private key for lets encrypt into the renewal container's stdout and consequently into the logs.
2. Do not revert the secret to an empty state before renewing the certificate. Doing so causes a failed renewal (e.g. 500s from lets encrypt) to destroy the extant keys.

---

Anyone using the Hail infrastructure should both regenerate their lets encrypt certificates with the changes in that PR. To do so they can execute the following from the root of the Hail repository:

    make -C letsencrypt run

To take advantage of this vulnerability, someone would need access to the k8s container logs and the ability to redirect the relevant domain name to an IP they control. We have no evidence anyone has done this with Hail’s certs.
