### PR TITLE
[batch] Add dill support for 3.9 and 3.10

### DIFF
--- a/docker/python-dill/push.sh
+++ b/docker/python-dill/push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for version in 3.6 3.6-slim 3.7 3.7-slim 3.8 3.8-slim
+for version in 3.6 3.6-slim 3.7 3.7-slim 3.8 3.8-slim 3.9 3.9-slim 3.10 3.10-slim
 do
     sed "s/@PYTHON_VERSION@/$version/g" Dockerfile > Dockerfile.out
 

--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -50,9 +50,9 @@ def build_python_image(fullname: str,
         major_version = int(version[0])
         minor_version = int(version[1])
 
-    if major_version != 3 or minor_version not in (6, 7, 8):
+    if major_version != 3 or minor_version < 6:
         raise ValueError(
-            f'Python versions other than 3.6, 3.7, or 3.8 (you are using {major_version}.{minor_version}) are not supported')
+            f'Python versions older than 3.6 (you are using {major_version}.{minor_version}) are not supported')
 
     base_image = f'hailgenetics/python-dill:{major_version}.{minor_version}-slim'
 

--- a/hail/python/hailtop/batch/docs/cookbook/random_forest.rst
+++ b/hail/python/hailtop/batch/docs/cookbook/random_forest.rst
@@ -120,7 +120,7 @@ Build Python Image
 In order to run a :class:`.PythonJob`, Batch needs an image that has the
 same version of Python as the version of Python running on your computer
 and the Python package `dill` installed. Batch will automatically
-choose a suitable image for you if your Python version is 3.7 or 3.8.
+choose a suitable image for you if your Python version is 3.7 or newer.
 You can supply your own image that meets the requirements listed above to the
 method :meth:`.PythonJob.image` or as the argument `default_python_image` when
 constructing a Batch . We also provide a convenience function :func:`.docker.build_python_image`


### PR DESCRIPTION
Python 3.6 has been EOL for over three months, and around that time we dropped support in the docs but silently kept support in the code. I'd like to drop support for 3.6 but our stance seems inconsistent on how long we support something after EOL (I would like to not ever) so I wanted to double check.

Regardless we should support new versions of python.

I pushed these into our internal registry but I don't believe I have access to dockerhub's hailgenetics, so haven't been able to push them there yet.