### PR TITLE
[ci] Add RunImage type to support cleanup only jobs

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -456,6 +456,8 @@ class RunImageStep(Step):
         self.always_run = always_run
         self.timeout = timeout
         self.job_type = job_type
+        if self.job_type not in ('main', 'cleanup'):
+            raise BuildConfigurationError(f"{self.job_type} is not a valid type when running an image: choose from main or cleanup")
         self.job = None
 
     def wrapped_job(self):

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -280,3 +280,18 @@ steps:
       - service_base_image
       - default_ns
       - deploy_hello
+  - kind: runImage
+    name: test_cleanup_only_job
+    type: cleanup
+    image:
+      valueFrom: base_image.image
+    script: |
+      set -ex
+      kubectl get namespace | grep -v "{{ default_ns.name }}"
+      exit $?
+    serviceAccount:
+      name: admin
+      namespace:
+        valueFrom: default_ns.name
+    dependsOn:
+      - default_ns


### PR DESCRIPTION
This is intended to solve the issue with `delete_batch_instances` running before the batch deployment has been deleted. I added a "cleanup" job type to RunImage jobs. The default is the current behavior.