### PR TITLE
[query] Fix high memory usage VDS converters after splitting multiallelics

### DIFF
--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -44,7 +44,7 @@ def to_dense_mt(vds: 'VariantDataset') -> 'MatrixTable':
     refl = ref.localize_entries('_ref_entries')
     varl = var.localize_entries('_var_entries', '_var_cols')
     varl = varl.annotate(_variant_defined=True)
-    joined = refl.join(varl.key_by('locus'), how='outer')
+    joined = varl.key_by('locus').join(refl, how='outer')
     dr = joined.annotate(
         dense_ref=hl.or_missing(
             joined._variant_defined,
@@ -110,7 +110,7 @@ def to_merged_sparse_mt(vds: 'VariantDataset') -> 'MatrixTable':
         else:
             merged_schema[e] = vds.reference_data[e].dtype
 
-    ht = rht.join(vht, how='outer').drop('_ref_cols')
+    ht = vht.join(rht, how='outer').drop('_ref_cols')
 
     def merge_arrays(r_array, v_array):
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -369,6 +369,7 @@ object StreamJoin {
     l: String, r: String,
     joinF: IR,
     joinType: String,
+    requiresMemoryManagement: Boolean,
     rightKeyIsDistinct: Boolean = false
   ): IR = {
     val lType = coerce[TStream](left.typ)
@@ -401,8 +402,8 @@ object StreamJoin {
         flatMapIR(joined) { x =>
           Let(l, GetField(x, "left"), bindIR(GetField(GetField(x, "rightGroup"), groupField)) { rightElts =>
             joinType match {
-              case "left" | "outer" => StreamMap(ToStream(If(IsNA(rightElts), missingSingleton, rightElts)), r, joinF)
-              case "right" | "inner" => StreamMap(ToStream(rightElts), r, joinF)
+              case "left" | "outer" => StreamMap(ToStream(If(IsNA(rightElts), missingSingleton, rightElts), requiresMemoryManagement), r, joinF)
+              case "right" | "inner" => StreamMap(ToStream(rightElts, requiresMemoryManagement), r, joinF)
             }
           })
         }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -464,7 +464,7 @@ object LowerDistributedSort {
 
     val joined = StreamJoin(dataWithIdx, structSampleIndices, IndexedSeq("idx"), IndexedSeq(samplingIndexName), leftName, rightName,
       MakeStruct(Seq(("elt", GetField(leftRef, "elt")), ("shouldKeep", ApplyUnaryPrimOp(Bang(), IsNA(rightRef))))),
-      "left")
+      "left", requiresMemoryManagement = true)
 
     // Step 2: Aggregate over joined, figure out how to collect only the rows that are marked "shouldKeep"
     val streamElementType = joined.typ.asInstanceOf[TStream].elementType.asInstanceOf[TStruct]

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -357,7 +357,8 @@ class TableStage(
       val lEltRef = Ref(genUID(), lEltType)
       val rEltRef = Ref(genUID(), rEltType)
 
-      StreamJoin(lPart, rPart, lKey, rKey, lEltRef.name, rEltRef.name, joiner(lEltRef, rEltRef), joinType, rightKeyIsDistinct)
+      StreamJoin(lPart, rPart, lKey, rKey, lEltRef.name, rEltRef.name, joiner(lEltRef, rEltRef), joinType,
+        requiresMemoryManagement = true, rightKeyIsDistinct = rightKeyIsDistinct)
     }
 
     val newKey = kType.fieldNames ++ right.kType.fieldNames.drop(joinKey)
@@ -1569,7 +1570,7 @@ object LowerTableIR {
               i += 1
             }
             refs.tail.zip(roots).foldRight(
-              mapIR(ToStream(refs.last)) { elt =>
+              mapIR(ToStream(refs.last, true)) { elt =>
                 path.zip(refs.init).foldRight[IR](elt) { case ((p, ref), inserted) =>
                   InsertFields(ref, FastSeq(p -> inserted))
                 }

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -167,10 +167,10 @@ package object ir {
     ArraySlice(arrayIR, startIR, Some(stopIR))
   }
 
-  def joinIR(left: IR, right: IR, lkey: IndexedSeq[String], rkey: IndexedSeq[String], joinType: String)(f: (Ref, Ref) => IR): IR = {
+  def joinIR(left: IR, right: IR, lkey: IndexedSeq[String], rkey: IndexedSeq[String], joinType: String, requiresMemoryManagement: Boolean)(f: (Ref, Ref) => IR): IR = {
     val lRef = Ref(genUID(), left.typ.asInstanceOf[TStream].elementType)
     val rRef = Ref(genUID(), right.typ.asInstanceOf[TStream].elementType)
-    StreamJoin(left, right, lkey, rkey, lRef.name, rRef.name, f(lRef, rRef), joinType)
+    StreamJoin(left, right, lkey, rkey, lRef.name, rRef.name, f(lRef, rRef), joinType, requiresMemoryManagement)
   }
 
   def streamSumIR(stream: IR): IR = {

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -914,16 +914,16 @@ class EmitStreamSuite extends HailSuite {
   @Test def testStreamJoinMemory(): Unit = {
 
     assertMemoryDoesNotScaleWithStreamSize() { size =>
-      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "inner") { case (l, r) => I32(1) })
+      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "inner", false) { case (l, r) => I32(1) })
     }
     assertMemoryDoesNotScaleWithStreamSize() { size =>
-      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "left") { case (l, r) => I32(1) })
+      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "left", false) { case (l, r) => I32(1) })
     }
     assertMemoryDoesNotScaleWithStreamSize() { size =>
-      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "right") { case (l, r) => I32(1) })
+      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "right", false) { case (l, r) => I32(1) })
     }
     assertMemoryDoesNotScaleWithStreamSize() { size =>
-      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "outer") { case (l, r) => I32(1) })
+      sumIR(joinIR(rangeStructs(size), filteredRangeStructs(size), IndexedSeq("idx"), IndexedSeq("idx"), "outer", false) { case (l, r) => I32(1) })
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2002,7 +2002,7 @@ class IRSuite extends HailSuite {
     }
     ToArray(StreamJoin.apply(left, right, lKeys, rKeys, "_l", "_r",
                      joinF(Ref("_l", coerce[TStream](left.typ).elementType), Ref("_r", coerce[TStream](right.typ).elementType)),
-                     joinType, rightDistinct))
+                     joinType, requiresMemoryManagement = false, rightKeyIsDistinct = rightDistinct))
   }
 
   @Test def testStreamZipJoin() {


### PR DESCRIPTION
The `to_dense_mt` and `to_merged_sparse_representation` methods required
localizing into an array all of the split rows at each locus when the
variant data is on the right side of the join. We flip the order so that
the variant data are on the left and the reference data, known to be
locus-distinct, are on the right.

I also fix a few stream mis-parameterizations that led to a slightly
higher (but similarly scaling) memory usage.