### PR TITLE
[batch] Remove python 3.6 support for python jobs

### DIFF
--- a/docker/python-dill/push.sh
+++ b/docker/python-dill/push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for version in 3.6 3.6-slim 3.7 3.7-slim 3.8 3.8-slim 3.9 3.9-slim 3.10 3.10-slim
+for version in 3.7 3.7-slim 3.8 3.8-slim 3.9 3.9-slim 3.10 3.10-slim
 do
     sed "s/@PYTHON_VERSION@/$version/g" Dockerfile > Dockerfile.out
 

--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -50,9 +50,9 @@ def build_python_image(fullname: str,
         major_version = int(version[0])
         minor_version = int(version[1])
 
-    if major_version != 3 or minor_version < 6:
+    if major_version != 3 or minor_version < 7:
         raise ValueError(
-            f'Python versions older than 3.6 (you are using {major_version}.{minor_version}) are not supported')
+            f'Python versions older than 3.7 (you are using {major_version}.{minor_version}) are not supported')
 
     base_image = f'hailgenetics/python-dill:{major_version}.{minor_version}-slim'
 


### PR DESCRIPTION
Follow up to previous PR that added 3.9 and 3.10 support.