### PR TITLE
[docker] Dont store the wheel tar in hailgenetics image

### DIFF
--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -11,8 +11,8 @@ RUN hail-apt-get-install \
     rsync \
     unzip bzip2 zip tar tabix lz4 \
     vim pv
-COPY wheel-container.tar ./
-RUN tar -xf wheel-container.tar && \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+    tar -xf wheel-container.tar && \
     pip3 install -U hail-*-py3-none-any.whl && \
     rm -rf hail-*-py3-none-any.whl
 RUN hail-pip-install \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -11,7 +11,7 @@ RUN hail-apt-get-install \
     rsync \
     unzip bzip2 zip tar tabix lz4 \
     vim pv
-RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
     pip3 install -U hail-*-py3-none-any.whl && \
     rm -rf hail-*-py3-none-any.whl

--- a/hail/Dockerfile.hail-pip-installed
+++ b/hail/Dockerfile.hail-pip-installed
@@ -6,7 +6,7 @@ RUN hail-apt-get-install liblz4-dev
 COPY python/dev/requirements.txt dev-requirements.txt
 RUN hail-pip-install -r dev-requirements.txt
 
-COPY wheel-container.tar ./
-RUN tar -xf wheel-container.tar && \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+    tar -xf wheel-container.tar && \
     pip3 install -U hail-*-py3-none-any.whl && \
     rm -rf hail-*-py3-none-any.whl

--- a/hail/Dockerfile.hail-pip-installed
+++ b/hail/Dockerfile.hail-pip-installed
@@ -6,7 +6,7 @@ RUN hail-apt-get-install liblz4-dev
 COPY python/dev/requirements.txt dev-requirements.txt
 RUN hail-pip-install -r dev-requirements.txt
 
-RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
     pip3 install -U hail-*-py3-none-any.whl && \
     rm -rf hail-*-py3-none-any.whl

--- a/hail/Dockerfile.hail-pip-installed-python37
+++ b/hail/Dockerfile.hail-pip-installed-python37
@@ -10,8 +10,8 @@ RUN file=$(mktemp) && \
     cat requirements.txt dev-requirements.txt > $file && \
     hail-pip-install -r $file
 
-COPY wheel-container.tar wheel-container.tar
-RUN tar -xf wheel-container.tar && \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+    tar -xf wheel-container.tar && \
     hail-pip-install hail-*-py3-none-any.whl
 
 COPY pylintrc setup.cfg /

--- a/hail/Dockerfile.hail-pip-installed-python37
+++ b/hail/Dockerfile.hail-pip-installed-python37
@@ -10,7 +10,7 @@ RUN file=$(mktemp) && \
     cat requirements.txt dev-requirements.txt > $file && \
     hail-pip-install -r $file
 
-RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
     hail-pip-install hail-*-py3-none-any.whl
 

--- a/hail/Dockerfile.hail-pip-installed-python38
+++ b/hail/Dockerfile.hail-pip-installed-python38
@@ -12,8 +12,8 @@ RUN file=$(mktemp) && \
     cat requirements.txt dev-requirements.txt > $file && \
     hail-pip-install -r $file
 
-COPY wheel-container.tar wheel-container.tar
-RUN tar -xf wheel-container.tar && \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+    tar -xf wheel-container.tar && \
     hail-pip-install hail-*-py3-none-any.whl
 
 COPY pylintrc setup.cfg /

--- a/hail/Dockerfile.hail-pip-installed-python38
+++ b/hail/Dockerfile.hail-pip-installed-python38
@@ -12,7 +12,7 @@ RUN file=$(mktemp) && \
     cat requirements.txt dev-requirements.txt > $file && \
     hail-pip-install -r $file
 
-RUN --mount=src=wheel-container.tar,target=/wheel-container.tar,ro=true \
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
     hail-pip-install hail-*-py3-none-any.whl
 


### PR DESCRIPTION
Putting the tar in its own `COPY` layer means we drag around the tar in the resultant image. This uses a read-only mount for the subsequent `RUN` command to extract the tar without adding it to the image. This should save close to 100MB on the image size.

Also realized that this happens in our pip-installed images.