### PR TITLE
[ci] Bring max number of concurrent PRs down to three

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -38,7 +38,7 @@ if os.path.exists("/zulip-config/.zuliprc"):
 
 TRACKED_PRS = pc.Gauge('ci_tracked_prs', 'PRs currently being monitored by CI', ['build_state', 'review_state'])
 
-MAX_CONCURRENT_PR_BATCHES = 5
+MAX_CONCURRENT_PR_BATCHES = 3
 
 
 class GithubStatus(Enum):


### PR DESCRIPTION
Given our rate limit increases and turning on additional service tests, 5 concurrent PR batches is too much for the 4-core database to handle. This is a mitigation while we figure out the right way to maintain that load.