### PR TITLE
[notebook] Delete unused Dockerfile

### DIFF
--- a/notebook/Dockerfile.create-tables
+++ b/notebook/Dockerfile.create-tables
@@ -1,3 +1,0 @@
-FROM {{ base_image.image }}
-
-COPY create-notebook-tables.sql .


### PR DESCRIPTION
Couldn't find any use of this Dockerfile anywhere nor could I find `create-notebook-tables.sql` so I'm assuming it's dead.