### PR TITLE
[batch] Create pool scheduling loops after loading existing instances

### DIFF
--- a/batch/batch/cloud/azure/driver/driver.py
+++ b/batch/batch/cloud/azure/driver/driver.py
@@ -64,7 +64,7 @@ class AzureDriver(CloudDriver):
                 app['async_worker_pool'],
                 task_manager,
             )
-            for pool_name, config in inst_coll_configs.name_pool_config.items()
+            for config in inst_coll_configs.name_pool_config.values()
         ]
 
         jpim, *_ = await asyncio.gather(

--- a/batch/batch/cloud/gcp/driver/driver.py
+++ b/batch/batch/cloud/gcp/driver/driver.py
@@ -62,7 +62,7 @@ class GCPDriver(CloudDriver):
                 app['async_worker_pool'],
                 task_manager,
             )
-            for pool_name, config in inst_coll_configs.name_pool_config.items()
+            for config in inst_coll_configs.name_pool_config.values()
         ]
 
         jpim, *_ = await asyncio.gather(

--- a/batch/batch/driver/instance_collection/base.py
+++ b/batch/batch/driver/instance_collection/base.py
@@ -199,7 +199,7 @@ class InstanceCollection:
             self.live_free_cores_mcpu_by_location[instance.location] += max(0, instance.free_cores_mcpu)
 
     def add_instance(self, instance: Instance):
-        assert instance.name not in self.name_instance
+        assert instance.name not in self.name_instance, instance.name
 
         self.name_instance[instance.name] = instance
         self.adjust_for_add_instance(instance)

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -65,6 +65,7 @@ WHERE removed = 0 AND inst_coll = %s;
         ):
             pool.add_instance(Instance.from_record(app, pool, record))
 
+        task_manager.ensure_future(pool.control_loop())
         return pool
 
     def __init__(
@@ -108,8 +109,6 @@ WHERE removed = 0 AND inst_coll = %s;
         self.data_disk_size_gb = config.data_disk_size_gb
         self.data_disk_size_standing_gb = config.data_disk_size_standing_gb
         self.preemptible = config.preemptible
-
-        task_manager.ensure_future(self.control_loop())
 
     @property
     def local_ssd_data_disk(self) -> bool:

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1147,31 +1147,18 @@ async def on_startup(app):
 SELECT instance_id, internal_token, frozen FROM globals;
 '''
     )
-
     instance_id = row['instance_id']
     log.info(f'instance_id {instance_id}')
     app['instance_id'] = instance_id
-
     app['internal_token'] = row['internal_token']
-
     app['batch_headers'] = {'Authorization': f'Bearer {row["internal_token"]}'}
-
     app['frozen'] = row['frozen']
 
-    scheduler_state_changed = Notice()
-    app['scheduler_state_changed'] = scheduler_state_changed
-
-    cancel_ready_state_changed = asyncio.Event()
-    app['cancel_ready_state_changed'] = cancel_ready_state_changed
-
-    cancel_creating_state_changed = asyncio.Event()
-    app['cancel_creating_state_changed'] = cancel_creating_state_changed
-
-    cancel_running_state_changed = asyncio.Event()
-    app['cancel_running_state_changed'] = cancel_running_state_changed
-
-    async_worker_pool = AsyncWorkerPool(100, queue_size=100)
-    app['async_worker_pool'] = async_worker_pool
+    app['scheduler_state_changed'] = Notice()
+    app['cancel_ready_state_changed'] = asyncio.Event()
+    app['cancel_creating_state_changed'] = asyncio.Event()
+    app['cancel_running_state_changed'] = asyncio.Event()
+    app['async_worker_pool'] = AsyncWorkerPool(100, queue_size=100)
 
     credentials_file = '/gsa-key/key.json'
     fs = get_cloud_async_fs(credentials_file=credentials_file)
@@ -1183,8 +1170,7 @@ SELECT instance_id, internal_token, frozen FROM globals;
         app, db, MACHINE_NAME_PREFIX, DEFAULT_NAMESPACE, inst_coll_configs, credentials_file, task_manager
     )
 
-    canceller = await Canceller.create(app)
-    app['canceller'] = canceller
+    app['canceller'] = await Canceller.create(app)
 
     app['check_incremental_error'] = None
     app['check_resource_aggregation_error'] = None


### PR DESCRIPTION
Currently, tasks to schedule new instances are put on the event loop inside the `Pool` and `JobPrivateInstanceManager` constructors. `Pool.create` and `JobPrivateInstanceManager.create` first instantiate an object of their respective type and then load existing instances from the database into the in-memory instance collection. This could potentially cause the create instances loop to trigger while we're drawing "existing" instances, which causes the assertion error in https://github.com/hail-is/hail-tasks/issues/24 when the create instances loop and load instances query race to add the instance to the in-memory data structure.

This change moves the task creation from the constructor to the `create` method, so we don't start creating instances until all existing instances are accounted for. I think I would have liked to simply pass the constructor a list of instances, but we can't create an `Instance` without an `InstanceCollection`.

Resolves hail-is/hail-tasks#24