### PR TITLE
[hailtop] eagerly give transient error info and include delay

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -724,9 +724,9 @@ async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs
             if not is_transient_error(e):
                 raise
             errors += 1
-            if errors % 10 == 0:
+            if errors == 2 or errors % 10 == 0:
                 st = ''.join(traceback.format_stack())
-                log.warning(f'Encountered {errors} errors. My stack trace is {st}. Most recent error was {e}', exc_info=True)
+                log.warning(f'Encountered {errors} errors (current delay: {delay}). My stack trace is {st}. Most recent error was {e}', exc_info=True)
         delay = await sleep_and_backoff(delay)
 
 


### PR DESCRIPTION
Two rare events is notable and probably indicates an error anyway. Let us prefer
to get information as soon as possible.