### PR TITLE
[httpx] use timeouts and remove footgun

### DIFF
--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -83,9 +83,34 @@ class ClientResponse:
 
 
 class ClientSession:
-    def __init__(self, *args, **kwargs):
-        self.raise_for_status = kwargs.pop('raise_for_status', False)
-        self.client_session = aiohttp.ClientSession(*args, raise_for_status=False, **kwargs)
+    def __init__(self,
+                 *args,
+                 raise_for_status: bool = True,
+                 timeout: Union[aiohttp.ClientTimeout, float] = None,
+                 **kwargs):
+        location = get_deploy_config().location()
+        if location == 'external':
+            tls = external_client_ssl_context()
+        elif location == 'k8s':
+            tls = internal_client_ssl_context()
+        else:
+            assert location in ('gce', 'azure')
+            # no encryption on the internal gateway
+            tls = external_client_ssl_context()
+
+        assert 'connector' not in kwargs
+        kwargs['connector'] = aiohttp.TCPConnector(ssl=tls)
+
+        if timeout is None:
+            timeout = aiohttp.ClientTimeout(total=5)
+
+        self.raise_for_status = raise_for_status
+        self.client_session = aiohttp.ClientSession(
+            *args,
+            timeout=timeout,
+            raise_for_status=False,
+            **kwargs
+        )
 
     def request(
         self, method: str, url: aiohttp.client.StrOrURL, **kwargs: Any
@@ -191,29 +216,7 @@ class ClientSession:
         await self.client_session.__aexit__(exc_type, exc_val, exc_tb)
 
 
-def client_session(*args,
-                   raise_for_status: bool = True,
-                   timeout: Union[aiohttp.ClientTimeout, float] = None,
-                   **kwargs) -> ClientSession:
-    location = get_deploy_config().location()
-    if location == 'external':
-        tls = external_client_ssl_context()
-    elif location == 'k8s':
-        tls = internal_client_ssl_context()
-    else:
-        assert location in ('gce', 'azure')
-        # no encryption on the internal gateway
-        tls = external_client_ssl_context()
-
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=tls)
-
-    kwargs['raise_for_status'] = raise_for_status
-
-    if timeout is None:
-        timeout = aiohttp.ClientTimeout(total=5)
-    kwargs['timeout'] = timeout
-
+def client_session(*args, **kwargs) -> ClientSession:
     return ClientSession(*args, **kwargs)
 
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -151,7 +151,7 @@ class ClientSession:
 
     def ws_connect(
         self, *args, **kwargs
-    ) -> aiohttp.client._WSRequestContextManager
+    ) -> aiohttp.client._WSRequestContextManager:
         return self.client_session.ws_connect(*args, **kwargs)
 
     def get(

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -99,7 +99,6 @@ class ClientSession:
             tls = external_client_ssl_context()
 
         assert 'connector' not in kwargs
-        kwargs['connector'] = aiohttp.TCPConnector(ssl=tls)
 
         if timeout is None:
             timeout = aiohttp.ClientTimeout(total=5)
@@ -109,6 +108,7 @@ class ClientSession:
             *args,
             timeout=timeout,
             raise_for_status=False,
+            connector=aiohttp.TCPConnector(ssl=tls),
             **kwargs
         )
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -151,7 +151,7 @@ class ClientSession:
 
     def ws_connect(
         self, *args, **kwargs
-    ) -> aiohttp.client_ws.ClientWebSocketResponse:
+    ) -> aiohttp.client._WSRequestContextManager
         return self.client_session.ws_connect(*args, **kwargs)
 
     def get(


### PR DESCRIPTION
`httpx.ClientSession` did not include the logic to set up the timeout. I do
not recall why I had a factory function distinct from the class itself. That
was a mistake. I leave the factory function because it is used prevasively.
However, now, allocating the class itself is also OK.