### PR TITLE
[query] Add worker_cores and worker_memory options to hl.init when using batch

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -199,9 +199,9 @@ class ServiceBackend(Backend):
                      flags: Optional[Dict[str, str]] = None,
                      jar_url: Optional[str] = None,
                      driver_cores: Optional[Union[int, str]] = None,
-                     driver_memory: Optional[Union[int, str]] = None,
+                     driver_memory: Optional[str] = None,
                      worker_cores: Optional[Union[int, str]] = None,
-                     worker_memory: Optional[Union[int, str]] = None,
+                     worker_memory: Optional[str] = None,
                      name_prefix: Optional[str] = None,
                      token: Optional[str] = None):
         billing_project = configuration_of('batch', 'billing_project', billing_project, None)
@@ -264,9 +264,9 @@ class ServiceBackend(Backend):
                  flags: Dict[str, str],
                  jar_spec: JarSpec,
                  driver_cores: Optional[Union[int, str]],
-                 driver_memory: Optional[Union[int, str]],
+                 driver_memory: Optional[str],
                  worker_cores: Optional[Union[int, str]],
-                 worker_memory: Optional[Union[int, str]],
+                 worker_memory: Optional[str],
                  name_prefix: str):
         self.billing_project = billing_project
         self._sync_fs = sync_fs

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -200,6 +200,8 @@ class ServiceBackend(Backend):
                      jar_url: Optional[str] = None,
                      driver_cores: Optional[Union[int, str]] = None,
                      driver_memory: Optional[Union[int, str]] = None,
+                     worker_cores: Optional[Union[int, str]] = None,
+                     worker_memory: Optional[Union[int, str]] = None,
                      name_prefix: Optional[str] = None,
                      token: Optional[str] = None):
         billing_project = configuration_of('batch', 'billing_project', billing_project, None)
@@ -225,6 +227,8 @@ class ServiceBackend(Backend):
 
         driver_cores = configuration_of('query', 'batch_driver_cores', driver_cores, None)
         driver_memory = configuration_of('query', 'batch_driver_memory', driver_memory, None)
+        worker_cores = configuration_of('query', 'batch_worker_cores', worker_cores, None)
+        worker_memory = configuration_of('query', 'batch_worker_memory', worker_memory, None)
         name_prefix = configuration_of('query', 'name_prefix', name_prefix, '')
 
         flags = {"use_new_shuffle": "1", **(flags or {})}
@@ -242,7 +246,9 @@ class ServiceBackend(Backend):
             jar_spec=jar_spec,
             driver_cores=driver_cores,
             driver_memory=driver_memory,
-            name_prefix=name_prefix
+            worker_cores=worker_cores,
+            worker_memory=worker_memory,
+            name_prefix=name_prefix or '',
         )
 
     def __init__(self,
@@ -259,6 +265,8 @@ class ServiceBackend(Backend):
                  jar_spec: JarSpec,
                  driver_cores: Optional[Union[int, str]],
                  driver_memory: Optional[Union[int, str]],
+                 worker_cores: Optional[Union[int, str]],
+                 worker_memory: Optional[Union[int, str]],
                  name_prefix: str):
         self.billing_project = billing_project
         self._sync_fs = sync_fs
@@ -274,6 +282,8 @@ class ServiceBackend(Backend):
         self.functions: List[IRFunction] = []
         self.driver_cores = driver_cores
         self.driver_memory = driver_memory
+        self.worker_cores = worker_cores
+        self.worker_memory = worker_memory
         self.name_prefix = name_prefix
 
     def debug_info(self) -> Dict[str, Any]:
@@ -285,7 +295,9 @@ class ServiceBackend(Backend):
             'remote_tmpdir': self.remote_tmpdir,
             'flags': self.flags,
             'driver_cores': self.driver_cores,
-            'driver_memory': self.driver_memory
+            'driver_memory': self.driver_memory,
+            'worker_cores': self.worker_cores,
+            'worker_memory': self.worker_memory,
         }
 
     @property
@@ -323,6 +335,8 @@ class ServiceBackend(Backend):
                         if v is not None:
                             await write_str(infile, k)
                             await write_str(infile, v)
+                    await write_str(infile, str(self.worker_cores))
+                    await write_str(infile, str(self.worker_memory))
                     await inputs(infile, token)
 
             with timings.step("submit batch"):
@@ -343,10 +357,10 @@ class ServiceBackend(Backend):
                         ServiceBackend.DRIVER,
                         batch_attributes['name'],
                         iodir + '/in',
-                        iodir + '/out'
+                        iodir + '/out',
                     ],
                     mount_tokens=True,
-                    resources=resources
+                    resources=resources,
                 )
                 b = await bb.submit(disable_progress_bar=self.disable_progress_bar)
 

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -272,15 +272,14 @@ def init(sc=None, app_name=None, master=None, local='local[*]',
         Batch backend only. Number of cores to use for the driver process. May be 1 or 8. Default is
         1.
     driver_memory : :class:`str`, optional
-        Batch backend only. Number of cores to use for the driver process. May be standard or
+        Batch backend only. Memory tier to use for the driver process. May be standard or
         highmem. Default is standard.
     worker_cores : :class:`str` or :class:`int`, optional
         Batch backend only. Number of cores to use for the worker processes. May be 1 or 8. Default is
         1.
     worker_memory : :class:`str`, optional
-        Batch backend only. Number of cores to use for the worker processes. May be standard or
+        Batch backend only. Memory tier to use for the worker processes. May be standard or
         highmem. Default is standard.
-
     """
     if Env._hc:
         if idempotent:

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -171,7 +171,9 @@ class HailContext(object):
            _optimizer_iterations=nullable(int),
            backend=nullable(str),
            driver_cores=nullable(oneof(str, int)),
-           driver_memory=nullable(str))
+           driver_memory=nullable(str),
+           worker_cores=nullable(oneof(str, int)),
+           worker_memory=nullable(str))
 def init(sc=None, app_name=None, master=None, local='local[*]',
          log=None, quiet=False, append=False,
          min_block_size=0, branching_factor=50, tmp_dir=None,
@@ -184,7 +186,9 @@ def init(sc=None, app_name=None, master=None, local='local[*]',
          *,
          backend=None,
          driver_cores=None,
-         driver_memory=None):
+         driver_memory=None,
+         worker_cores=None,
+         worker_memory=None):
     """Initialize and configure Hail.
 
     This function will be called with default arguments if any Hail functionality is used. If you
@@ -270,6 +274,12 @@ def init(sc=None, app_name=None, master=None, local='local[*]',
     driver_memory : :class:`str`, optional
         Batch backend only. Number of cores to use for the driver process. May be standard or
         highmem. Default is standard.
+    worker_cores : :class:`str` or :class:`int`, optional
+        Batch backend only. Number of cores to use for the worker processes. May be 1 or 8. Default is
+        1.
+    worker_memory : :class:`str`, optional
+        Batch backend only. Number of cores to use for the worker processes. May be standard or
+        highmem. Default is standard.
 
     """
     if Env._hc:
@@ -306,6 +316,8 @@ def init(sc=None, app_name=None, master=None, local='local[*]',
                 global_seed=global_seed,
                 driver_cores=driver_cores,
                 driver_memory=driver_memory,
+                worker_cores=worker_cores,
+                worker_memory=worker_memory,
                 name_prefix=app_name
             ))
     if backend == 'spark':
@@ -406,6 +418,8 @@ def init_spark(sc=None,
     disable_progress_bar=bool,
     driver_cores=nullable(oneof(str, int)),
     driver_memory=nullable(str),
+    worker_cores=nullable(oneof(str, int)),
+    worker_memory=nullable(str),
     name_prefix=nullable(str),
     token=nullable(str)
 )
@@ -423,6 +437,8 @@ async def init_batch(
         disable_progress_bar: bool = True,
         driver_cores: Optional[Union[str, int]] = None,
         driver_memory: Optional[str] = None,
+        worker_cores: Optional[Union[str, int]] = None,
+        worker_memory: Optional[str] = None,
         name_prefix: Optional[str] = None,
         token: Optional[str] = None,
 ):
@@ -433,6 +449,8 @@ async def init_batch(
                                           disable_progress_bar=disable_progress_bar,
                                           driver_cores=driver_cores,
                                           driver_memory=driver_memory,
+                                          worker_cores=worker_cores,
+                                          worker_memory=worker_memory,
                                           name_prefix=name_prefix,
                                           token=token)
 

--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -98,7 +98,7 @@ def get_remote_tmpdir(caller_name: str,
         found_scheme = any(remote_tmpdir.startswith(f'{scheme}://') for scheme in schemes)
         if not found_scheme:
             raise ValueError(
-                f'remote_tmpdir must be a storage uri path like gs://bucket/folder. Possible schemes include {schemes}')
+                f'remote_tmpdir must be a storage uri path like gs://bucket/folder. Received: {remote_tmpdir}. Possible schemes include {schemes}')
     if remote_tmpdir[-1] != '/':
         remote_tmpdir += '/'
     return remote_tmpdir

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -33,7 +33,7 @@ def test_big_driver_has_big_memory():
 @skip_unless_service_backend()
 def test_tiny_worker_has_tiny_memory():
     try:
-        t = hl.utils.range_table(1).annotate(nd=hl.nd.ones((30_000, 30_000)))
+        t = hl.utils.range_table(1, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
         t = t.annotate(nd_sum=t.nd.sum())
         t.aggregate(hl.agg.sum(t.nd_sum))
     except Exception as exc:

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -50,7 +50,7 @@ def test_big_worker_has_big_memory():
     try:
         backend.worker_cores = 8
         backend.worker_memory = 'highmem'
-        t = hl.utils.range_table(1).annotate(nd=hl.nd.ones((30_000, 30_000)))
+        t = hl.utils.range_table(1, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
         t = t.annotate(nd_sum=t.nd.sum())
         # We only eval the small thing so that we trigger an OOM on the worker
         # but not the driver or client

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -54,7 +54,7 @@ def test_big_worker_has_big_memory():
         t = t.annotate(nd_sum=t.nd.sum())
         # We only eval the small thing so that we trigger an OOM on the worker
         # but not the driver or client
-        hl.eval(t.aggregate(hl.agg.sum(t.nd_sum)))
+        t.aggregate(hl.agg.sum(t.nd_sum))
     finally:
         backend.driver_cores = old_driver_cores
         backend.driver_memory = old_driver_memory

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -33,7 +33,7 @@ def test_big_driver_has_big_memory():
 @skip_unless_service_backend()
 def test_tiny_worker_has_tiny_memory():
     try:
-        t = hl.utils.range_table(1).annotate(nd=hl.nd.ones(30_000, 30_000))
+        t = hl.utils.range_table(1).annotate(nd=hl.nd.ones((30_000, 30_000)))
         t = t.annotate(nd_sum=t.nd.sum())
         hl.eval(t.aggregate(hl.agg.sum(t.nd_sum)))
     except Exception as exc:
@@ -50,7 +50,7 @@ def test_big_worker_has_big_memory():
     try:
         backend.worker_cores = 8
         backend.worker_memory = 'highmem'
-        t = hl.utils.range_table(1).annotate(nd=hl.nd.ones(30_000, 30_000))
+        t = hl.utils.range_table(1).annotate(nd=hl.nd.ones((30_000, 30_000)))
         t = t.annotate(nd_sum=t.nd.sum())
         # We only eval the small thing so that we trigger an OOM on the worker
         # but not the driver or client

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -35,7 +35,7 @@ def test_tiny_worker_has_tiny_memory():
     try:
         t = hl.utils.range_table(1).annotate(nd=hl.nd.ones((30_000, 30_000)))
         t = t.annotate(nd_sum=t.nd.sum())
-        hl.eval(t.aggregate(hl.agg.sum(t.nd_sum)))
+        t.aggregate(hl.agg.sum(t.nd_sum))
     except Exception as exc:
         assert 'HailException: Hail off-heap memory exceeded maximum threshold' in exc.args[0]
     else:

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -33,7 +33,7 @@ def test_big_driver_has_big_memory():
 @skip_unless_service_backend()
 def test_tiny_worker_has_tiny_memory():
     try:
-        t = hl.utils.range_table(1, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
+        t = hl.utils.range_table(2, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
         t = t.annotate(nd_sum=t.nd.sum())
         t.aggregate(hl.agg.sum(t.nd_sum))
     except Exception as exc:
@@ -50,7 +50,7 @@ def test_big_worker_has_big_memory():
     try:
         backend.worker_cores = 8
         backend.worker_memory = 'highmem'
-        t = hl.utils.range_table(1, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
+        t = hl.utils.range_table(2, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
         t = t.annotate(nd_sum=t.nd.sum())
         # We only eval the small thing so that we trigger an OOM on the worker
         # but not the driver or client

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -47,7 +47,9 @@ import scala.collection.mutable
 class ServiceBackendContext(
   @transient val sessionID: String,
   val billingProject: String,
-  val remoteTmpDir: String
+  val remoteTmpDir: String,
+  val workerCores: String,
+  val workerMemory: String,
 ) extends BackendContext with Serializable {
   def tokens(): Tokens =
     new Tokens(Map((DeployConfig.get.defaultNamespace, sessionID)))
@@ -152,6 +154,13 @@ class ServiceBackend(
     val jobs = new Array[JObject](n)
     var i = 0
     while (i < n) {
+      var resources = JObject("preemptible" -> JBool(true))
+      if (backendContext.workerCores != "None") {
+        resources = resources.merge(JObject(("cpu" -> JString(backendContext.workerCores))))
+      }
+      if (backendContext.workerMemory != "None") {
+        resources = resources.merge(JObject(("memory" -> JString(backendContext.workerMemory))))
+      }
       jobs(i) = JObject(
         "always_run" -> JBool(false),
         "job_id" -> JInt(i + 1),
@@ -168,7 +177,7 @@ class ServiceBackend(
             JString(s"$n"))),
           "type" -> JString("jvm")),
         "mount_tokens" -> JBool(true),
-        "resources" -> JObject("preemptible" -> JBool(true))
+        "resources" -> resources,
       )
       i += 1
     }
@@ -525,6 +534,8 @@ class ServiceBackendSocketAPI2(
       flags.update(flagName, flagValue)
       nFlagsRemaining -= 1
     }
+    val workerCores = readString()
+    val workerMemory = readString()
 
     val cmd = readInt()
 
@@ -548,7 +559,7 @@ class ServiceBackendSocketAPI2(
         backend.theHailClassLoader,
         HailFeatureFlags.fromMap(flags)
       ) { ctx =>
-        ctx.backendContext = new ServiceBackendContext(sessionId, billingProject, remoteTmpDir)
+        ctx.backendContext = new ServiceBackendContext(sessionId, billingProject, remoteTmpDir, workerCores, workerMemory)
         method(ctx)
       }
     }

--- a/query/.gitignore
+++ b/query/.gitignore
@@ -1,0 +1,1 @@
+last_uploaded_jar

--- a/query/.gitignore
+++ b/query/.gitignore
@@ -1,1 +1,2 @@
 last_uploaded_jar
+upload-resources-dir


### PR DESCRIPTION
CHANGELOG: `hl.init` now supports `worker_cores` and `worker_memory` options when using Hail Batch backend.