### PR TITLE
[copy] finally eliminate all stalls from the copy tool

### DIFF
--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -307,10 +307,11 @@ class S3AsyncFS(AsyncFS):
         except self._s3.exceptions.NoSuchKey as e:
             raise FileNotFoundError(url) from e
 
-    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+    async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         bucket, name = self.get_bucket_and_name(url)
         range_str = f'bytes={start}-'
         if length is not None:
+            assert length >= 1
             range_str += str(start + length - 1)
         try:
             resp = await blocking_to_async(self._thread_pool, self._s3.get_object,

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -311,7 +311,7 @@ class S3AsyncFS(AsyncFS):
         bucket, name = self.get_bucket_and_name(url)
         range_str = f'bytes={start}-'
         if length is not None:
-            range_str += str(start + length)
+            range_str += str(start + length - 1)
         try:
             resp = await blocking_to_async(self._thread_pool, self._s3.get_object,
                                            Bucket=bucket,

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -343,6 +343,8 @@ class AzureAsyncFS(AsyncFS):
         return stream
 
     async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+        if length == 0:
+            raise ValueError(f'Azure Blob Storage does not suport length=0.')
         client = self.get_blob_client(url)
         stream = AzureReadableStream(client, url, offset=start, length=length)
         return stream

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -142,7 +142,7 @@ class AzureCreateManager(AsyncContextManager[WritableStream]):
 
 
 class AzureReadableStream(ReadableStream):
-    def __init__(self, client: BlobClient, url: str, offset: Optional[int] = None):
+    def __init__(self, client: BlobClient, url: str, offset: Optional[int] = None, length: Optional[int] = None):
         super().__init__()
         self._client = client
         self._buffer = bytearray()
@@ -151,6 +151,7 @@ class AzureReadableStream(ReadableStream):
         # cannot set the default to 0 because this will fail on an empty file
         # offset means to start at the first byte
         self._offset = offset
+        self._length = length
 
         self._eof = False
         self._downloader: Optional[StorageStreamDownloader] = None
@@ -162,7 +163,7 @@ class AzureReadableStream(ReadableStream):
 
         if n == -1:
             try:
-                downloader = await self._client.download_blob(offset=self._offset)
+                downloader = await self._client.download_blob(offset=self._offset, length=self._length)
             except azure.core.exceptions.ResourceNotFoundError as e:
                 raise FileNotFoundError(self._url) from e
             data = await downloader.readall()
@@ -341,9 +342,9 @@ class AzureAsyncFS(AsyncFS):
         stream = AzureReadableStream(client, url)
         return stream
 
-    async def open_from(self, url: str, start: int) -> ReadableStream:
+    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         client = self.get_blob_client(url)
-        stream = AzureReadableStream(client, url, offset=start)
+        stream = AzureReadableStream(client, url, offset=start, length=length)
         return stream
 
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:  # pylint: disable=unused-argument

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -16,8 +16,9 @@ import azure.core.exceptions
 from hailtop.utils import retry_transient_errors, flatten
 from hailtop.aiotools import WriteBuffer
 from hailtop.aiotools.fs import (AsyncFS, AsyncFSURL, AsyncFSFactory, ReadableStream,
-                                 WritableStream, MultiPartCreate, FileListEntry, FileStatus,
-                                 FileAndDirectoryError, UnexpectedEOFError)
+                                 EmptyReadableStream, WritableStream, MultiPartCreate,
+                                 FileListEntry, FileStatus, FileAndDirectoryError,
+                                 UnexpectedEOFError)
 
 from .credentials import AzureCredentials
 
@@ -344,7 +345,7 @@ class AzureAsyncFS(AsyncFS):
 
     async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         if length == 0:
-            raise ValueError(f'Azure Blob Storage does not suport length=0.')
+            return EmptyReadableStream()
         client = self.get_blob_client(url)
         stream = AzureReadableStream(client, url, offset=start, length=length)
         return stream

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -175,6 +175,10 @@ class AzureReadableStream(ReadableStream):
                 self._downloader = await self._client.download_blob(offset=self._offset)
             except azure.core.exceptions.ResourceNotFoundError as e:
                 raise FileNotFoundError(self._url) from e
+            except azure.core.exceptions.HttpResponseError as e:
+                if e.status_code == 416:
+                    raise UnexpectedEOFError from e
+                raise
 
         if self._chunk_it is None:
             self._chunk_it = self._downloader.chunks()

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -16,9 +16,8 @@ import azure.core.exceptions
 from hailtop.utils import retry_transient_errors, flatten
 from hailtop.aiotools import WriteBuffer
 from hailtop.aiotools.fs import (AsyncFS, AsyncFSURL, AsyncFSFactory, ReadableStream,
-                                 EmptyReadableStream, WritableStream, MultiPartCreate,
-                                 FileListEntry, FileStatus, FileAndDirectoryError,
-                                 UnexpectedEOFError)
+                                 WritableStream, MultiPartCreate, FileListEntry, FileStatus,
+                                 FileAndDirectoryError, UnexpectedEOFError)
 
 from .credentials import AzureCredentials
 
@@ -343,9 +342,8 @@ class AzureAsyncFS(AsyncFS):
         stream = AzureReadableStream(client, url)
         return stream
 
-    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
-        if length == 0:
-            return EmptyReadableStream()
+    async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+        assert length is None or length >= 1
         client = self.get_blob_client(url)
         stream = AzureReadableStream(client, url, offset=start, length=length)
         return stream

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -363,6 +363,8 @@ class GoogleStorageClient(GoogleBaseClient):
         except aiohttp.ClientResponseError as e:
             if e.status == 404:
                 raise FileNotFoundError from e
+            if e.status == 416:
+                raise UnexpectedEOFError from e
             raise
 
     async def get_object_metadata(self, bucket: str, name: str, **kwargs) -> Dict[str, str]:

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -594,6 +594,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         bucket, name = self.get_bucket_and_name(url)
         range_str = f'bytes={start}-'
         if length is not None:
+            assert length >= 1
             range_str += str(start + length - 1)
         return await self._storage_client.get_object(
             bucket, name, headers={'Range': range_str})

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -590,7 +590,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         bucket, name = self.get_bucket_and_name(url)
         return await self._storage_client.get_object(bucket, name)
 
-    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+    async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         bucket, name = self.get_bucket_and_name(url)
         range_str = f'bytes={start}-'
         if length is not None:

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -292,7 +292,6 @@ class GetObjectStream(ReadableStream):
         assert self._content is not None
 
         self._content = None
-        self._resp.release()
         self._resp.close()
         self._resp = None
 
@@ -591,10 +590,13 @@ class GoogleStorageAsyncFS(AsyncFS):
         bucket, name = self.get_bucket_and_name(url)
         return await self._storage_client.get_object(bucket, name)
 
-    async def open_from(self, url: str, start: int) -> ReadableStream:
+    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         bucket, name = self.get_bucket_and_name(url)
+        range_str = f'bytes={start}-'
+        if length is not None:
+            range_str += str(start + length)
         return await self._storage_client.get_object(
-            bucket, name, headers={'Range': f'bytes={start}-'})
+            bucket, name, headers={'Range': range_str})
 
     async def create(self, url: str, *, retry_writes: bool = True) -> WritableStream:
         bucket, name = self.get_bucket_and_name(url)

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -594,7 +594,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         bucket, name = self.get_bucket_and_name(url)
         range_str = f'bytes={start}-'
         if length is not None:
-            range_str += str(start + length)
+            range_str += str(start + length - 1)
         return await self._storage_client.get_object(
             bucket, name, headers={'Range': range_str})
 

--- a/hail/python/hailtop/aiotools/fs/__init__.py
+++ b/hail/python/hailtop/aiotools/fs/__init__.py
@@ -1,7 +1,8 @@
 from .fs import AsyncFS, AsyncFSURL, AsyncFSFactory, MultiPartCreate, FileListEntry, FileStatus
 from .copier import Copier, CopyReport, SourceCopier, SourceReport, Transfer, TransferReport
 from .exceptions import UnexpectedEOFError, FileAndDirectoryError
-from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
+from .stream import (ReadableStream, EmptyReadableStream, WritableStream,
+                     blocking_readable_stream_to_async, blocking_writable_stream_to_async)
 
 __all__ = [
     'AsyncFS',
@@ -13,6 +14,7 @@ __all__ = [
     'SourceReport',
     'Transfer',
     'TransferReport',
+    'EmptyReadableStream',
     'ReadableStream',
     'WritableStream',
     'blocking_readable_stream_to_async',

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -224,7 +224,7 @@ class SourceCopier:
                          return_exceptions: bool) -> None:
         try:
             async with self.xfer_sema.acquire_manager(min(Copier.BUFFER_SIZE, this_part_size)):
-                async with await self.router_fs.open_from(srcfile, part_number * part_size) as srcf:
+                async with await self.router_fs.open_from(srcfile, part_number * part_size, length=this_part_size) as srcf:
                     async with await part_creator.create_part(part_number, part_number * part_size, size_hint=this_part_size) as destf:
                         n = this_part_size
                         while n > 0:

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -228,8 +228,6 @@ class AsyncFS(abc.ABC):
             return await f.read()
 
     async def read_range(self, url: str, start: int, end: int, *, end_inclusive=True) -> bytes:
-        if start == end:
-            return b''
         n = (end - start) + bool(end_inclusive)
         async with await self.open_from(url, start, length=n) as f:
             return await f.readexactly(n)

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -108,8 +108,13 @@ class AsyncFS(abc.ABC):
 
     async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         if length == 0:
-            assert not url.endswith('/')
-            isfile, isdir = await asyncio.gather(self.isfile(url), self.isdir(url + '/'))
+            if url.endswith('/'):
+                file_url = url.rstrip('/')
+                dir_url = url
+            else:
+                file_url = url
+                dir_url = '/'
+            isfile, isdir = await asyncio.gather(self.isfile(file_url), self.isdir(dir_url))
             if isfile:
                 if isdir:
                     raise FileAndDirectoryError

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -108,7 +108,8 @@ class AsyncFS(abc.ABC):
 
     async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         if length == 0:
-            isfile, isdir = await asyncio.gather(self.isfile(url), self.isdir(url))
+            assert not url.endswith('/')
+            isfile, isdir = await asyncio.gather(self.isfile(url), self.isdir(url + '/'))
             if isfile:
                 if isdir:
                     raise FileAndDirectoryError

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -4,7 +4,7 @@ from types import TracebackType
 import abc
 import asyncio
 from hailtop.utils import retry_transient_errors, OnlineBoundedGather2
-from .stream import ReadableStream, WritableStream
+from .stream import EmptyReadableStream, ReadableStream, WritableStream
 from .exceptions import FileAndDirectoryError
 
 
@@ -106,8 +106,20 @@ class AsyncFS(abc.ABC):
     async def open(self, url: str) -> ReadableStream:
         pass
 
-    @abc.abstractmethod
     async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+        if length == 0:
+            isfile, isdir = await asyncio.gather(self.isfile(url), self.isdir(url))
+            if isfile:
+                if isdir:
+                    raise FileAndDirectoryError
+                return EmptyReadableStream()
+            if isdir:
+                raise IsADirectoryError
+            raise FileNotFoundError
+        return await self._open_from(url, start, length=length)
+
+    @abc.abstractmethod
+    async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         pass
 
     @abc.abstractmethod

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -227,8 +227,10 @@ class AsyncFS(abc.ABC):
         async with await self.open_from(url, start) as f:
             return await f.read()
 
-    async def read_range(self, url: str, start: int, end: int) -> bytes:
-        n = (end - start) + 1
+    async def read_range(self, url: str, start: int, end: int, *, end_inclusive=True) -> bytes:
+        if start == end:
+            return b''
+        n = (end - start) + bool(end_inclusive)
         async with await self.open_from(url, start, length=n) as f:
             return await f.readexactly(n)
 

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -113,7 +113,7 @@ class AsyncFS(abc.ABC):
                 dir_url = url
             else:
                 file_url = url
-                dir_url = '/'
+                dir_url = url + '/'
             isfile, isdir = await asyncio.gather(self.isfile(file_url), self.isdir(dir_url))
             if isfile:
                 if isdir:

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -107,7 +107,7 @@ class AsyncFS(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def open_from(self, url: str, start: int) -> ReadableStream:
+    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         pass
 
     @abc.abstractmethod
@@ -229,7 +229,7 @@ class AsyncFS(abc.ABC):
 
     async def read_range(self, url: str, start: int, end: int) -> bytes:
         n = (end - start) + 1
-        async with await self.open_from(url, start) as f:
+        async with await self.open_from(url, start, length=n) as f:
             return await f.readexactly(n)
 
     async def write(self, url: str, data: bytes) -> None:

--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -66,6 +66,9 @@ class EmptyReadableStream(ReadableStream):
             return b''
         raise UnexpectedEOFError
 
+    async def _wait_closed(self) -> None:
+        return
+
 
 class WritableStream(abc.ABC):
     def __init__(self):

--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -56,7 +56,7 @@ class ReadableStream(abc.ABC):
 
 class EmptyReadableStream(ReadableStream):
     def __init__(self):
-        pass
+        super().__init__()
 
     async def read(self, n: int = -1) -> bytes:
         return b''

--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -55,9 +55,6 @@ class ReadableStream(abc.ABC):
 
 
 class EmptyReadableStream(ReadableStream):
-    def __init__(self):
-        super().__init__()
-
     async def read(self, n: int = -1) -> bytes:
         return b''
 

--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -18,6 +18,8 @@ class EmptyReadableStream(abc.ABC):
         return b''
 
     async def readexactly(self, n: int) -> bytes:
+        if n == 0:
+            return b''
         raise UnexpectedEOFError
 
 

--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -10,6 +10,17 @@ from hailtop.utils import blocking_to_async
 from .exceptions import UnexpectedEOFError
 
 
+class EmptyReadableStream(abc.ABC):
+    def __init__(self):
+        pass
+
+    async def read(self, n: int = -1) -> bytes:
+        return b''
+
+    async def readexactly(self, n: int) -> bytes:
+        raise UnexpectedEOFError
+
+
 class ReadableStream(abc.ABC):
     def __init__(self):
         self._closed = False

--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -10,7 +10,7 @@ from hailtop.utils import blocking_to_async
 from .exceptions import UnexpectedEOFError
 
 
-class EmptyReadableStream(abc.ABC):
+class EmptyReadableStream(ReadableStream):
     def __init__(self):
         pass
 

--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -10,19 +10,6 @@ from hailtop.utils import blocking_to_async
 from .exceptions import UnexpectedEOFError
 
 
-class EmptyReadableStream(ReadableStream):
-    def __init__(self):
-        pass
-
-    async def read(self, n: int = -1) -> bytes:
-        return b''
-
-    async def readexactly(self, n: int) -> bytes:
-        if n == 0:
-            return b''
-        raise UnexpectedEOFError
-
-
 class ReadableStream(abc.ABC):
     def __init__(self):
         self._closed = False
@@ -65,6 +52,19 @@ class ReadableStream(abc.ABC):
             exc_value: Optional[BaseException] = None,
             exc_traceback: Optional[TracebackType] = None) -> None:
         await self.wait_closed()
+
+
+class EmptyReadableStream(ReadableStream):
+    def __init__(self):
+        pass
+
+    async def read(self, n: int = -1) -> bytes:
+        return b''
+
+    async def readexactly(self, n: int) -> bytes:
+        if n == 0:
+            return b''
+        raise UnexpectedEOFError
 
 
 class WritableStream(abc.ABC):

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -141,7 +141,9 @@ class LocalAsyncFS(AsyncFS):
         f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'rb')
         return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, f))
 
-    async def open_from(self, url: str, start: int) -> ReadableStream:
+    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+        if length is not None:
+            raise ValueError(f'LocalFS does not support the length argument')
         f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'rb')
         f.seek(start, io.SEEK_SET)
         return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, f))

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -156,7 +156,7 @@ class TruncatedReadableBinaryIO(BinaryIO):
             n = self.limit - self.offset
         else:
             n = min(self.limit - self.offset, n)
-        b = self.bio.read(self.limit - self.offset)
+        b = self.bio.read(n)
         self.offset += len(b)
         return b
 

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -187,6 +187,12 @@ class TruncatedReadableBinaryIO(BinaryIO):
     def writelines(self, lines) -> None:  # pylint: disable=unused-argument
         raise NotImplementedError
 
+    def __iter__(self) -> None:
+        raise NotImplementedError
+
+    def __next__(self) -> None:
+        raise NotImplementedError
+
 
 class LocalAsyncFS(AsyncFS):
     schemes: Set[str] = {'file'}

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -187,10 +187,10 @@ class TruncatedReadableBinaryIO(BinaryIO):
     def writelines(self, lines) -> None:  # pylint: disable=unused-argument
         raise NotImplementedError
 
-    def __iter__(self) -> None:
+    def __iter__(self):
         raise NotImplementedError
 
-    def __next__(self) -> None:
+    def __next__(self):
         raise NotImplementedError
 
 

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -110,6 +110,82 @@ class LocalAsyncFSURL(AsyncFSURL):
         return 'file:' + self._path
 
 
+class TruncatedReadableBinaryIO(BinaryIO):
+    def __init__(self, bio: BinaryIO, limit: int):
+        self.bio = bio
+        self.n = 0
+        self.limit = limit
+
+    def write(self, s) -> int:  # pylint: disable=unused-argument
+        raise NotImplementedError
+
+    def __enter__(self) -> 'BinaryIO':
+        return self
+
+    def __exit__(self):
+        self.close()
+
+    def mode(self) -> str:
+        return self.bio.mode
+
+    def name(self) -> str:
+        return self.bio.name
+
+    def close(self) -> None:
+        return self.bio.close()
+
+    def closed(self) -> bool:
+        return self.bio.closed
+
+    def fileno(self) -> int:
+        return self.bio.fileno()
+
+    def flush(self) -> None:
+        raise NotImplementedError
+
+    def isatty(self) -> bool:
+        return self.bio.isatty()
+
+    def read(self, n: int = -1):
+        if n == -1:
+            n = self.limit - self.n
+        else:
+            n = min(self.limit - self.n, n)
+        b = self.bio.read(self.limit - self.n)
+        self.n += len(b)
+        return b
+
+    def readable(self) -> bool:
+        return True
+
+    def readline(self, limit: int = -1):  # pylint: disable=unused-argument
+        raise NotImplementedError
+
+    def readlines(self, hint: int = -1):  # pylint: disable=unused-argument
+        raise NotImplementedError
+
+    def seek(self, offset: int, whence: int = 0) -> int:  # pylint: disable=unused-argument
+        raise NotImplementedError
+
+    def seekable(self) -> bool:
+        return False
+
+    def tell(self) -> int:
+        return self.bio.tell()
+
+    def truncate(self, size: int = None):
+        raise NotImplementedError
+
+    def writable(self) -> bool:
+        return False
+
+    def write(self, s) -> int:  # pylint: disable=unused-argument
+        raise NotImplementedError
+
+    def writelines(self, lines) -> None:  # pylint: disable=unused-argument
+        raise NotImplementedError
+
+
 class LocalAsyncFS(AsyncFS):
     schemes: Set[str] = {'file'}
 
@@ -142,11 +218,12 @@ class LocalAsyncFS(AsyncFS):
         return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, f))
 
     async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
-        if length is not None:
-            raise ValueError(f'LocalFS does not support the length argument')
         f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'rb')
         f.seek(start, io.SEEK_SET)
-        return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, f))
+        bio = cast(BinaryIO, f)
+        if length is not None:
+            bio = TruncatedReadableBinaryIO(bio, length)
+        return blocking_readable_stream_to_async(self._thread_pool, bio)
 
     async def create(self, url: str, *, retry_writes: bool = True) -> WritableStream:  # pylint: disable=unused-argument
         f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'wb')

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -122,18 +122,21 @@ class TruncatedReadableBinaryIO(BinaryIO):
     def __enter__(self) -> 'BinaryIO':
         return self
 
-    def __exit__(self):
+    def __exit__(self, type, value, traceback):
         self.close()
 
+    @property
     def mode(self) -> str:
         return self.bio.mode
 
+    @property
     def name(self) -> str:
         return self.bio.name
 
     def close(self) -> None:
         return self.bio.close()
 
+    @property
     def closed(self) -> bool:
         return self.bio.closed
 
@@ -147,6 +150,8 @@ class TruncatedReadableBinaryIO(BinaryIO):
         return self.bio.isatty()
 
     def read(self, n: int = -1):
+        assert self.n <= self.limit
+
         if n == -1:
             n = self.limit - self.n
         else:

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -179,9 +179,6 @@ class TruncatedReadableBinaryIO(BinaryIO):
     def writable(self) -> bool:
         return False
 
-    def write(self, s) -> int:  # pylint: disable=unused-argument
-        raise NotImplementedError
-
     def writelines(self, lines) -> None:  # pylint: disable=unused-argument
         raise NotImplementedError
 
@@ -217,11 +214,12 @@ class LocalAsyncFS(AsyncFS):
         f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'rb')
         return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, f))
 
-    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+    async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'rb')
         f.seek(start, io.SEEK_SET)
         bio = cast(BinaryIO, f)
         if length is not None:
+            assert length >= 1
             bio = TruncatedReadableBinaryIO(bio, length)
         return blocking_readable_stream_to_async(self._thread_pool, bio)
 

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -113,7 +113,7 @@ class LocalAsyncFSURL(AsyncFSURL):
 class TruncatedReadableBinaryIO(BinaryIO):
     def __init__(self, bio: BinaryIO, limit: int):
         self.bio = bio
-        self.n = 0
+        self.offset = 0
         self.limit = limit
 
     def write(self, s) -> int:  # pylint: disable=unused-argument
@@ -150,14 +150,14 @@ class TruncatedReadableBinaryIO(BinaryIO):
         return self.bio.isatty()
 
     def read(self, n: int = -1):
-        assert self.n <= self.limit
+        assert self.offset <= self.limit
 
         if n == -1:
-            n = self.limit - self.n
+            n = self.limit - self.offset
         else:
-            n = min(self.limit - self.n, n)
-        b = self.bio.read(self.limit - self.n)
-        self.n += len(b)
+            n = min(self.limit - self.offset, n)
+        b = self.bio.read(self.limit - self.offset)
+        self.offset += len(b)
         return b
 
     def readable(self) -> bool:

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -79,9 +79,9 @@ class RouterAsyncFS(AsyncFS):
         fs = self._get_fs(url)
         return await fs.open(url)
 
-    async def open_from(self, url: str, start: int) -> ReadableStream:
+    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         fs = self._get_fs(url)
-        return await fs.open_from(url, start)
+        return await fs.open_from(url, start, length=length)
 
     async def create(self, url: str, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         fs = self._get_fs(url)

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -79,7 +79,7 @@ class RouterAsyncFS(AsyncFS):
         fs = self._get_fs(url)
         return await fs.open(url)
 
-    async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
+    async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         fs = self._get_fs(url)
         return await fs.open_from(url, start, length=length)
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -38,8 +38,8 @@ class ClientResponse:
     def __init__(self, client_response: aiohttp.ClientResponse):
         self.client_response = client_response
 
-    def release(self) -> None:
-        return self.client_response.release()
+    async def release(self) -> None:
+        return await self.client_response.release()
 
     @property
     def closed(self) -> bool:
@@ -79,7 +79,7 @@ class ClientResponse:
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> None:
-        self.release()
+        await self.release()
 
 
 class ClientSession:
@@ -137,7 +137,7 @@ class ClientSession:
                     # reason should always be not None for a started response
                     assert resp.reason is not None
                     body = (await resp.read()).decode()
-                    resp.release()
+                    await resp.release()
                     raise ClientResponseError(
                         resp.request_info,
                         resp.history,

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -130,6 +130,20 @@ async def test_open_from_with_length(filesystem: Tuple[asyncio.Semaphore, AsyncF
 
 
 @pytest.mark.asyncio
+async def test_open_empty(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    async with await fs.create(file) as f:
+        await f.write(b'')
+
+    async with await fs.open_from(file, 0, 0) as f:
+        r = await f.read()
+        assert r == b''
+
+
+@pytest.mark.asyncio
 async def test_open_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
     sema, fs, base = filesystem
 

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -238,6 +238,21 @@ async def test_read_range_end_exclusive_empty_file(filesystem: Tuple[asyncio.Sem
 
     assert await fs.read_range(file, 0, 0, end_inclusive=False) == b''
 
+@pytest.mark.asyncio
+async def test_read_range_end_inclusive_empty_file_should_error(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    await fs.write(file, b'')
+
+    try:
+        assert await fs.read_range(file, 0, 0, end_inclusive=True) == b''
+    except UnexpectedEOFError:
+        pass
+    else:
+        assert False
+
 
 @pytest.mark.asyncio
 async def test_read_range_end_exclusive_nonempty_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -124,7 +124,7 @@ async def test_open_from_with_length(filesystem: Tuple[asyncio.Semaphore, AsyncF
     async with await fs.create(file) as f:
         await f.write(b'abcde')
 
-    async with await fs.open_from(file, 2, 2) as f:
+    async with await fs.open_from(file, 2, length=2) as f:
         r = await f.read()
         assert r == b'cd'
 
@@ -138,7 +138,7 @@ async def test_open_empty(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
     async with await fs.create(file) as f:
         await f.write(b'')
 
-    async with await fs.open_from(file, 0, 0) as f:
+    async with await fs.open_from(file, 0, length=0) as f:
         r = await f.read()
         assert r == b''
 
@@ -203,7 +203,29 @@ async def test_read_range(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
     except UnexpectedEOFError:
         pass
     else:
-        assert False
+       assert False
+
+
+@pytest.mark.asyncio
+async def test_read_range_end_exclusive_empty_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    await fs.write(file, b'')
+
+    assert await fs.read_range(file, 0, 0, end_inclusive=False) == b''
+
+
+@pytest.mark.asyncio
+async def test_read_range_end_exclusive_nonempty_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    await fs.write(file, b'abcde')
+
+    assert await fs.read_range(file, 2, 4, end_inclusive=False) == b'cd'
 
 
 @pytest.mark.asyncio

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -136,6 +136,20 @@ async def test_open_from_with_length(filesystem: Tuple[asyncio.Semaphore, AsyncF
         r = await f.read()
         assert r == b''
 
+    try:
+        await fs.open_from(f'{file}doesnotexist', 2, length=0)
+    except FileNotFoundError:
+        pass
+    else:
+        assert False
+
+    try:
+        await fs.open_from(base, 2, length=0)
+    except IsADirectoryError:
+        pass
+    else:
+        assert False
+
 
 @pytest.mark.asyncio
 async def test_open_empty(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -128,6 +128,14 @@ async def test_open_from_with_length(filesystem: Tuple[asyncio.Semaphore, AsyncF
         r = await f.read()
         assert r == b'cd'
 
+    async with await fs.open_from(file, 2, length=1) as f:
+        r = await f.read()
+        assert r == b'c'
+
+    async with await fs.open_from(file, 2, length=0) as f:
+        r = await f.read()
+        assert r == b''
+
 
 @pytest.mark.asyncio
 async def test_open_empty(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -116,6 +116,20 @@ async def test_open_from(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
 
 
 @pytest.mark.asyncio
+async def test_open_from_with_length(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    async with await fs.create(file) as f:
+        await f.write(b'abcde')
+
+    async with await fs.open_from(file, 2, 2) as f:
+        r = await f.read()
+        assert r == b'cd'
+
+
+@pytest.mark.asyncio
 async def test_open_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
     sema, fs, base = filesystem
 


### PR DESCRIPTION
No changelog because the copy tool is not properly public, though
maybe it can be public now.

The main problem was that we were saturating our network bandwidth
with data we did not need. Why? As far as I can tell, `release` on
an `aiohttp.ClientResponse` is insufficient to stop the receipt of
more bytes.

I realized one proper fix was to simply tell the cloud storage vendors
how much data we wanted to receive. That is the change to `open_from`
which I have made pervasively to all clouds.

I also changed `release` to `close` because that seems more correct.
I do not understand why we only `release`d it before.