### PR TITLE
[query/shuffler] fast path for tables with one partition 

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -178,7 +178,14 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, keyFields: Indexe
   val keyType = spec.encodedVirtualType.asInstanceOf[TStruct].select(keyFields)._1
 
   def ctxType: Type = TString
-  def returnType: Type = TStruct("filePath" -> TString, "partitionCounts" -> TInt64, "distinctlyKeyed" -> TBoolean, "firstKey" -> keyType, "lastKey" -> keyType)
+  def returnType: Type = TStruct(
+    "filePath" -> TString,
+    "partitionCounts" -> TInt64, // FIXME: not partitionCount*s*, just *this* partition's count
+    "distinctlyKeyed" -> TBoolean,
+    "firstKey" -> keyType,
+    "lastKey" -> keyType,
+    "bytesWritten" -> TInt64
+  )
   def unionTypeRequiredness(r: TypeWithRequiredness, ctxType: TypeWithRequiredness, streamType: RIterable): Unit = {
     val rs = r.asInstanceOf[RStruct]
     val rKeyType = streamType.elementType.asInstanceOf[RStruct].select(keyFields.toArray)
@@ -206,11 +213,12 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, keyFields: Indexe
     val indexKeyType = ifIndexed { index.get._2 }
     val indexWriter = ifIndexed { StagedIndexWriter.withDefaults(indexKeyType, mb.ecb) }
 
-    context.toI(cb).map(cb) { case ctx: SStringValue =>
+    context.toI(cb).map(cb) { case filePath: SStringValue =>
       val filename = mb.newLocal[String]("filename")
       val os = mb.newLocal[ByteTrackingOutputStream]("write_os")
       val ob = mb.newLocal[OutputBuffer]("write_ob")
       val n = mb.newLocal[Long]("partition_count")
+      val bytesWritten = mb.newLocal[Long]("partition_byte_count")
       val distinctlyKeyed = mb.newLocal[Boolean]("distinctlyKeyed")
       cb.assign(distinctlyKeyed, !keyFields.isEmpty) // True until proven otherwise, if there's a key to care about at all.
 
@@ -266,9 +274,10 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, keyFields: Indexe
           .apply(cb, row, ob)
 
         cb.assign(n, n + 1L)
+        cb.assign(bytesWritten, bytesWritten + row.sizeToStoreInBytes(cb).value)
       }
 
-      cb.assign(filename, ctx.loadString(cb))
+      cb.assign(filename, filePath.loadString(cb))
       if (hasIndex) {
         val indexFile = cb.newLocal[String]("indexFile")
         cb.assign(indexFile, const(index.get._1).concat(filename).concat(".idx"))
@@ -278,6 +287,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, keyFields: Indexe
       cb.assign(os, Code.newInstance[ByteTrackingOutputStream, OutputStream](mb.create(filename)))
       cb.assign(ob, spec.buildCodeOutputBuffer(Code.checkcast[OutputStream](os)))
       cb.assign(n, 0L)
+      cb.assign(bytesWritten, 0L)
 
       stream.memoryManagedConsume(region, cb) { cb =>
         writeFile(cb, stream.element)
@@ -290,11 +300,12 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, keyFields: Indexe
       cb += os.invoke[Unit]("close")
 
       SStackStruct.constructFromArgs(cb, region, returnType.asInstanceOf[TBaseStruct],
-        EmitCode.present(mb, ctx),
+        EmitCode.present(mb, filePath),
         EmitCode.present(mb, new SInt64Value(n)),
         EmitCode.present(mb, new SBooleanValue(distinctlyKeyed)),
         firstSeenSettable,
-        lastSeenSettable
+        lastSeenSettable,
+        EmitCode.present(mb, new SInt64Value(bytesWritten))
       )
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -340,14 +340,14 @@ object LowerDistributedSort {
         }
 
         val distributeResult = CompileAndEvaluate[Annotation](ctx, distribute)
-           .asInstanceOf[IndexedSeq[Row]].map(row => (
-           row(0).asInstanceOf[Int],
-           row(1).asInstanceOf[IndexedSeq[Row]].map(innerRow => (
-             innerRow(0).asInstanceOf[Interval],
-             innerRow(1).asInstanceOf[String],
-             innerRow(2).asInstanceOf[Int],
-             innerRow(3).asInstanceOf[Long])
-           )))
+          .asInstanceOf[IndexedSeq[Row]].map(row => (
+          row(0).asInstanceOf[Int],
+          row(1).asInstanceOf[IndexedSeq[Row]].map(innerRow => (
+            innerRow(0).asInstanceOf[Interval],
+            innerRow(1).asInstanceOf[String],
+            innerRow(2).asInstanceOf[Int],
+            innerRow(3).asInstanceOf[Long])
+          )))
 
         // distributeResult is a numPartitions length array of arrays, where each inner array tells me what
         // files were written to for each partition, as well as the number of entries in that file.

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -293,7 +293,7 @@ object LowerDistributedSort {
       log.info(s"DISTRIBUTED SORT: PHASE ${i+1}: STAGE 1: SAMPLE VALUES FROM PARTITIONS")
       // Going to check now if it's fully sorted, as well as collect and sort all the samples.
       val pivotsWithEndpointsAndInfoGroupedBySegmentNumber = CompileAndEvaluate[Annotation](ctx, pivotsPerSegmentAndSortedCheck)
-         .asInstanceOf[IndexedSeq[Row]].map(x => (x(0).asInstanceOf[IndexedSeq[Row]], x(1).asInstanceOf[Boolean], x(2).asInstanceOf[Row], x(3).asInstanceOf[IndexedSeq[Row]], x(4).asInstanceOf[IndexedSeq[Row]]))
+        .asInstanceOf[IndexedSeq[Row]].map(x => (x(0).asInstanceOf[IndexedSeq[Row]], x(1).asInstanceOf[Boolean], x(2).asInstanceOf[Row], x(3).asInstanceOf[IndexedSeq[Row]], x(4).asInstanceOf[IndexedSeq[Row]]))
 
       val (sortedSegmentsTuples, unsortedPivotsWithEndpointsAndInfoGroupedBySegmentNumber) = pivotsWithEndpointsAndInfoGroupedBySegmentNumber.zipWithIndex.partition { case ((_, isSorted, _, _, _), _) => isSorted}
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -379,9 +379,9 @@ object LowerDistributedSort {
 
     val needSortingFilenames = loopState.smallSegments.map(_.chunks.map(_.filename))
 
-    val writtenPartitionMetadata = sortAndWriteEachPartitionCDA(needSortingFilenames, keyToSortBy, sortFields, spec, writer, reader)
+    val sortedWrittenPartitionMetadata = sortAndWriteEachPartitionCDA(needSortingFilenames, keyToSortBy, sortFields, spec, writer, reader)
 
-    val sortedFilenames = CompileAndEvaluate[Annotation](ctx, sortedFilenamesIR).asInstanceOf[IndexedSeq[Row]].map(_(0).asInstanceOf[String])
+    val sortedFilenames = CompileAndEvaluate[Annotation](ctx, sortedWrittenPartitionMetadata).asInstanceOf[IndexedSeq[Row]].map(_(0).asInstanceOf[String])
     val newlySortedSegments = loopState.smallSegments.zip(sortedFilenames).map { case (sr, newFilename) =>
       OutputPartition(sr.indices, sr.interval, IndexedSeq(initialTmpPath + newFilename))
     }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -128,13 +128,13 @@ object LowerDistributedSort {
     val initialStageDataRow = CompileAndEvaluate[Annotation](ctx, inputStage.mapCollectWithGlobals(relationalLetsAbove) { part =>
       WritePartition(part, UUID4(), writer)
     }{ case (part, globals) =>
-        val streamElement = Ref(genUID(), part.typ.asInstanceOf[TArray].elementType)
-        bindIR(StreamAgg(ToStream(part), streamElement.name,
-          MakeStruct(FastSeq(
-            "min" -> AggFold.min(GetField(streamElement, "firstKey"), sortFields),
-            "max" -> AggFold.max(GetField(streamElement, "lastKey"), sortFields)
-          ))
-        )) { intervalRange =>   MakeTuple.ordered(Seq(part, globals, intervalRange)) }
+      val streamElement = Ref(genUID(), part.typ.asInstanceOf[TArray].elementType)
+      bindIR(StreamAgg(ToStream(part), streamElement.name,
+        MakeStruct(FastSeq(
+          "min" -> AggFold.min(GetField(streamElement, "firstKey"), sortFields),
+          "max" -> AggFold.max(GetField(streamElement, "lastKey"), sortFields)
+        ))
+      )) { intervalRange =>   MakeTuple.ordered(Seq(part, globals, intervalRange)) }
     }).asInstanceOf[Row]
     val (initialPartInfo, initialGlobals, intervalRange) = (initialStageDataRow(0).asInstanceOf[IndexedSeq[Row]], initialStageDataRow(1).asInstanceOf[Row], initialStageDataRow(2).asInstanceOf[Row])
     val initialGlobalsLiteral = Literal(inputStage.globalType, initialGlobals)


### PR DESCRIPTION
When there is one partition and it is small, we now use a local sort.

Stacked on #11784 and #11783.