### PR TITLE
[docker] Include distutils in hail ubuntu image

### DIFF
--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod 755 /bin/retry && \
          >> /etc/apt/sources.list && \
     echo 'deb-src [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main' \
          >> /etc/apt/sources.list && \
-    hail-apt-get-install python3.7-minimal python3.7-dev python3-pip && \
+    hail-apt-get-install python3.7-minimal python3.7-dev python3-pip python3.7-distutils && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
     python3 -m pip install 'pip>=21<22' && \
     python3 -m pip check && \


### PR DESCRIPTION
Apparently distutils isn't a core python package anymore. Here's an example where I tried to build the hail ubuntu image on main https://ci.hail.is/batches/2214931

```
#13 59.80 update-alternatives: using /usr/bin/python3.7 to provide /usr/bin/python3 (python3) in auto mode
#13 59.87 Traceback (most recent call last):
#13 59.87   File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
#13 59.87     "__main__", mod_spec)
#13 59.87   File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
#13 59.87     exec(code, run_globals)
#13 59.87   File "/usr/lib/python3/dist-packages/pip/__main__.py", line 16, in <module>
#13 59.87     from pip._internal.cli.main import main as _main  # isort:skip # noqa
#13 59.87   File "/usr/lib/python3/dist-packages/pip/_internal/cli/main.py", line 10, in <module>
#13 59.87     from pip._internal.cli.autocompletion import autocomplete
#13 59.87   File "/usr/lib/python3/dist-packages/pip/_internal/cli/autocompletion.py", line 9, in <module>
#13 59.87     from pip._internal.cli.main_parser import create_main_parser
#13 59.87   File "/usr/lib/python3/dist-packages/pip/_internal/cli/main_parser.py", line 7, in <module>
#13 59.87     from pip._internal.cli import cmdoptions
#13 59.87   File "/usr/lib/python3/dist-packages/pip/_internal/cli/cmdoptions.py", line 19, in <module>
#13 59.87     from distutils.util import strtobool
#13 59.87 ModuleNotFoundError: No module named 'distutils.util'
```

My guess is that we haven't actually built this layer in a while and we've been riding the cache, but my recent experiments with our docker images might have invalidated it? Seems like it hasn't been a core module for a while so I'm surprised we haven't hit this issue sooner.