### PR TITLE
[hailtop.batch] allow for remote-only dependencies, allow nested resources

### DIFF
--- a/hail/python/hailtop/batch/__init__.py
+++ b/hail/python/hailtop/batch/__init__.py
@@ -7,7 +7,7 @@ from .backend import LocalBackend, ServiceBackend, Backend
 from .docker import build_python_image
 from .exceptions import BatchException
 from .utils import concatenate, plink_merge
-from .resource import Resource, ResourceFile, ResourceGroup, PythonResult
+from .resource import Resource, ResourceGroup, PythonResult, remote
 
 __all__ = ['Batch',
            'LocalBackend',
@@ -20,8 +20,8 @@ __all__ = ['Batch',
            'plink_merge',
            'PythonResult',
            'Resource',
-           'ResourceFile',
-           'ResourceGroup'
+           'ResourceGroup',
+           'remote'
            ]
 
 nest_asyncio.apply()

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -186,7 +186,7 @@ class LocalBackend(Backend[None]):
         requester_pays_project_json = orjson.dumps(batch.requester_pays_project).decode('utf-8')
 
         async def generate_job_code(job):
-            main_code, resources_to_download = await job.compile()
+            main_code, user_code, resources_to_download = await job.compile()
             code = StringIO()
             for r in resources_to_download:
                 transfers_bytes = orjson.dumps([{

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -199,7 +199,7 @@ class LocalBackend(Backend[None]):
                     "to": r.local_location()}])
                 transfers = transfers_bytes.decode('utf-8')
                 code.write(
-                    f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}')
+                    f'/Users/dking/miniconda3/bin/python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}\n')
             code.write(main_code)
             return code.getvalue()
 
@@ -252,7 +252,7 @@ class LocalBackend(Backend[None]):
                 await copy_from_dict(
                     max_simultaneous_transfers=300,
                     files=[
-                        {'from': resource.remote_location(), 'to': destination}
+                        {'from': resource.local_location(), 'to': destination}
                         for resource, destinations in batch._outputs.items()
                         for destination in destinations])
         finally:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -1,5 +1,7 @@
-from typing import Optional, Dict, Any, TypeVar, Generic, List, Union
+from typing import Optional, Dict, Any, TypeVar, Generic, List, Tuple
+import asyncio
 import sys
+import tempfile
 import abc
 import orjson
 import os
@@ -7,18 +9,19 @@ import subprocess as sp
 import uuid
 import time
 import functools
-import copy
 from shlex import quote as shq
 import webbrowser
 import warnings
+from io import StringIO
 
+import hailtop
 from hailtop import pip_version
 from hailtop.config import get_deploy_config, get_user_config
-from hailtop.utils import parse_docker_image_reference, async_to_blocking, bounded_gather, tqdm, url_scheme
+from hailtop.utils import parse_docker_image_reference, async_to_blocking, bounded_gather, tqdm
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
+import hailtop.batch_client.aioclient as aiobc
 import hailtop.batch_client.client as bc
-from hailtop.batch_client.client import BatchClient
 from hailtop.aiotools import AsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
 
@@ -46,6 +49,9 @@ class Backend(abc.ABC, Generic[RunningBatchType]):
     """
 
     _closed = False
+
+    def remote_tmpdir(self) -> str:
+        raise NotImplementedError
 
     @abc.abstractmethod
     def _run(self, batch, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs) -> RunningBatchType:
@@ -117,7 +123,8 @@ class LocalBackend(Backend[None]):
                  tmp_dir: str = '/tmp/',
                  gsa_key_file: Optional[str] = None,
                  extra_docker_run_flags: Optional[str] = None):
-        self._tmp_dir = tmp_dir.rstrip('/')
+        self._tmp_dir = tmp_dir.rstrip('/')  # FIXME: what is this for?
+        self._remote_tmpdir = self._get_scratch_dir()
 
         flags = ''
 
@@ -133,6 +140,9 @@ class LocalBackend(Backend[None]):
 
         self._extra_docker_run_flags = flags
         self.__fs: AsyncFS = RouterAsyncFS(default_scheme='file')
+
+    def remote_tmpdir(self) -> str:
+        return self._remote_tmpdir
 
     @property
     def _fs(self):
@@ -162,125 +172,46 @@ class LocalBackend(Backend[None]):
         delete_scratch_on_exit:
             If `True`, delete temporary directories with intermediate files.
         """
+        async_to_blocking(self._async_run(batch, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs))
 
+    async def _async_run(self,
+                         batch: 'batch.Batch',
+                         dry_run: bool,
+                         verbose: bool,
+                         delete_scratch_on_exit: bool,
+                         **backend_kwargs) -> None:  # pylint: disable=R0915
         if backend_kwargs:
             raise ValueError(f'LocalBackend does not support any of these keywords: {backend_kwargs}')
 
-        tmpdir = self._get_scratch_dir()
-
-        def new_code_block():
-            return ['set -e' + ('x' if verbose else ''),
-                    '\n',
-                    '# change cd to tmp directory',
-                    f"cd {tmpdir}",
-                    '\n']
-
-        def run_code(code):
-            code = '\n'.join(code)
-            if dry_run:
-                print(code)
-            else:
-                try:
-                    sp.check_call(code, shell=True)
-                except sp.CalledProcessError as e:
-                    print(e)
-                    print(e.output)
-                    raise
-
-        copied_input_resource_files = set()
-        os.makedirs(tmpdir + '/inputs/', exist_ok=True)
-
         requester_pays_project_json = orjson.dumps(batch.requester_pays_project).decode('utf-8')
 
-        def copy_input(job, r):
-            if isinstance(r, resource.InputResourceFile):
-                if r not in copied_input_resource_files:
-                    copied_input_resource_files.add(r)
-
-                    input_scheme = url_scheme(r._input_path)
-                    if input_scheme != '':
-                        transfers_bytes = orjson.dumps([{"from": r._input_path, "to": r._get_path(tmpdir)}])
-                        transfers = transfers_bytes.decode('utf-8')
-                        return [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}']
-
-                    absolute_input_path = os.path.realpath(os.path.expanduser(r._input_path))
-
-                    dest = r._get_path(os.path.expanduser(tmpdir))
-                    dir = os.path.dirname(dest)
-                    os.makedirs(dir, exist_ok=True)
-
-                    if job._image is not None:  # pylint: disable-msg=W0640
-                        return [f'cp {shq(absolute_input_path)} {shq(dest)}']
-
-                    return [f'ln -sf {shq(absolute_input_path)} {shq(dest)}']
-
-                return []
-
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return []
-
-        def symlink_input_resource_group(r):
-            symlinks = []
-            if isinstance(r, resource.ResourceGroup) and r._source is None:
-                for name, irf in r._resources.items():
-                    src = irf._get_path(tmpdir)
-                    dest = f'{r._get_path(tmpdir)}.{name}'
-                    symlinks.append(f'ln -sf {shq(src)} {shq(dest)}')
-            return symlinks
-
-        def transfer_dicts_for_resource_file(res_file: Union[resource.ResourceFile, resource.PythonResult]) -> List[dict]:
-            if isinstance(res_file, resource.InputResourceFile):
-                source = res_file._input_path
-            else:
-                assert isinstance(res_file, (resource.JobResourceFile, resource.PythonResult))
-                source = res_file._get_path(tmpdir)
-
-            return [{"from": source, "to": dest} for dest in res_file._output_paths]
+        async def generate_job_code(job):
+            main_code, resources_to_download = await job.compile()
+            code = StringIO()
+            for r in resources_to_download:
+                transfers_bytes = orjson.dumps([{
+                    "from": r.remote_location(),
+                    "to": r.local_location()}])
+                transfers = transfers_bytes.decode('utf-8')
+                code.write(
+                    f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}')
+            code.write(main_code)
+            code.getvalue()
 
         try:
-            input_transfer_dicts = [
-                transfer_dict
-                for input_resource in batch._input_resources
-                for transfer_dict in transfer_dicts_for_resource_file(input_resource)]
-
-            if input_transfer_dicts:
-                input_transfers = orjson.dumps(input_transfer_dicts).decode('utf-8')
-                code = new_code_block()
-                code += ["# Write input resources to output destinations"]
-                code += [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(input_transfers)}']
-                code += ['\n']
-                run_code(code)
-
-            for job in batch._jobs:
-                async_to_blocking(job._compile(tmpdir, tmpdir))
-
-                os.makedirs(f'{tmpdir}/{job._dirname}/', exist_ok=True)
-
-                code = new_code_block()
-
-                code.append(f"# {job._job_id}: {job.name if job.name else ''}")
-
-                if job._user_code:
-                    code.append('# USER CODE')
-                    user_code = [f'# {line}' for cmd in job._user_code for line in cmd.split('\n')]
-                    code.append('\n'.join(user_code))
-
-                code += [x for r in job._inputs for x in copy_input(job, r)]
-                code += [x for r in job._mentioned for x in symlink_input_resource_group(r)]
-
-                env = {**job._env, 'BATCH_TMPDIR': tmpdir}
-                env_declarations = [f'export {k}={v}' for k, v in env.items()]
-                joined_env = '; '.join(env_declarations) + '; ' if env else ''
-
-                job_shell = job._shell if job._shell else DEFAULT_SHELL
-
-                cmd = " && ".join(f'{{\n{x}\n}}' for x in job._wrapper_code)
-
-                quoted_job_script = shq(joined_env + cmd)
-
-                if job._image:
-                    cpu = f'--cpus={job._cpu}' if job._cpu else ''
-
+            job_codes = await asyncio.gather(*[generate_job_code(job) for job in batch._jobs])
+            for code, job in zip(job_codes, batch._jobs):
+                if dry_run:
+                    print(code)
+                elif job._image is None:
+                    with tempfile.TemporaryDirectory() as workdir:
+                        sp.run(
+                            [job._shell, '-c', code],
+                            check=True,
+                            cwd=workdir,
+                            env=job._env  # FIXME: do I need BATCH_TMPDIR ?
+                        )
+                elif job._image:
                     memory = job._memory
                     if memory is not None:
                         memory_ratios = {'lowmem': 1024**3, 'standard': 4 * 1024**3, 'highmem': 7 * 1024**3}
@@ -293,35 +224,31 @@ class LocalBackend(Backend[None]):
                                     raise BatchException(f'invalid value for cpu: {job._cpu}')
                             else:
                                 raise BatchException(f'must specify cpu when using {memory} to specify the memory')
-                        memory = f'-m {memory}' if memory else ''
-                    else:
-                        memory = ''
 
-                    code.append(f"docker run "
-                                "--entrypoint=''"
-                                f"{self._extra_docker_run_flags} "
-                                f"-v {tmpdir}:{tmpdir} "
-                                f"-w {tmpdir} "
-                                f"{memory} "
-                                f"{cpu} "
-                                f"{job._image} "
-                                f"{job_shell} -c {quoted_job_script}")
-                else:
-                    code.append(f"{job_shell} -c {quoted_job_script}")
+                    command = [
+                        'docker',
+                        'run',
+                        '--entrypoint=' + job._shell,
+                        *self._extra_docker_run_flags.split(' '),
+                        '-v', batch._remote_location + ':' + batch._remote_location,
+                    ]
+                    if job._cpu is not None:
+                        command.extend(['--cpus', job._cpu])
+                    if memory is not None:
+                        command.extend(['-m', memory])
+                    command.extend(['--', '-c', code])
 
-                output_transfer_dicts = [
-                    transfer_dict
-                    for output_resource in job._external_outputs
-                    for transfer_dict in transfer_dicts_for_resource_file(output_resource)]
-                output_transfers = orjson.dumps(output_transfer_dicts).decode('utf-8')
+                    with tempfile.TemporaryDirectory() as workdir:
+                        sp.run(command, check=True, cwd=workdir, env=job._env)  # FIXME: do I need BATCH_TMPDIR ?
 
-                code += [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(output_transfers)}']
-                code += ['\n']
-
-                run_code(code)
+                hailtop.aiotools.copy.copy_from_dict(
+                    max_simultaneous_transfers=300,
+                    files=[
+                        {'from': resource.remote_location(), 'to': destination}
+                        for resource, destination in batch._outputs.items()])
         finally:
             if delete_scratch_on_exit:
-                sp.run(f'rm -rf {tmpdir}', shell=True, check=False)
+                sp.run(['rm', '-rf', batch._remote_location], check=False)
 
         print('Batch completed successfully!')
 
@@ -408,8 +335,8 @@ class ServiceBackend(Backend[bc.Batch]):
                 'the billing_project parameter of ServiceBackend must be set '
                 'or run `hailctl config set batch/billing_project '
                 'MY_BILLING_PROJECT`')
-        self._batch_client = BatchClient(billing_project, _token=token)
 
+        self.batch_client = async_to_blocking(aiobc.BatchClient.create(billing_project, _token=token))
         user_config = get_user_config()
 
         if bucket is not None:
@@ -443,18 +370,20 @@ class ServiceBackend(Backend[bc.Batch]):
                     f'remote_tmpdir must be a storage uri path like gs://bucket/folder. Possible schemes include {schemes}')
         if remote_tmpdir[-1] != '/':
             remote_tmpdir += '/'
-        self.remote_tmpdir = remote_tmpdir
+        self._remote_tmpdir = remote_tmpdir
 
         gcs_kwargs = {'project': google_project}
         self.__fs: AsyncFS = RouterAsyncFS(default_scheme='file', gcs_kwargs=gcs_kwargs)
+
+    def remote_tmpdir(self) -> str:
+        return self._remote_tmpdir
 
     @property
     def _fs(self):
         return self.__fs
 
     def _close(self):
-        if hasattr(self, '_batch_client'):
-            self._batch_client.close()
+        async_to_blocking(self.batch_client.close())
         async_to_blocking(self._fs.close())
 
     def _run(self,
@@ -516,69 +445,6 @@ class ServiceBackend(Backend[bc.Batch]):
 
         build_dag_start = time.time()
 
-        uid = uuid.uuid4().hex[:6]
-        batch_remote_tmpdir = f'{self.remote_tmpdir}{uid}'
-        local_tmpdir = f'/io/batch/{uid}'
-
-        default_image = 'ubuntu:20.04'
-
-        attributes = copy.deepcopy(batch.attributes)
-        if batch.name is not None:
-            attributes['name'] = batch.name
-
-        bc_batch = self._batch_client.create_batch(attributes=attributes, callback=callback,
-                                                   token=token, cancel_after_n_failures=batch._cancel_after_n_failures)
-
-        n_jobs_submitted = 0
-        used_remote_tmpdir = False
-
-        job_to_client_job_mapping: Dict[_job.Job, bc.Job] = {}
-        jobs_to_command = {}
-        commands = []
-
-        bash_flags = 'set -e' + ('x' if verbose else '')
-
-        def copy_input(r):
-            if isinstance(r, resource.InputResourceFile):
-                return [(r._input_path, r._get_path(local_tmpdir))]
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return [(r._get_path(batch_remote_tmpdir), r._get_path(local_tmpdir))]
-
-        def copy_internal_output(r):
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return [(r._get_path(local_tmpdir), r._get_path(batch_remote_tmpdir))]
-
-        def copy_external_output(r):
-            if isinstance(r, resource.InputResourceFile):
-                return [(r._input_path, dest) for dest in r._output_paths]
-            assert isinstance(r, (resource.JobResourceFile, resource.PythonResult))
-            return [(r._get_path(local_tmpdir), dest) for dest in r._output_paths]
-
-        def symlink_input_resource_group(r):
-            symlinks = []
-            if isinstance(r, resource.ResourceGroup) and r._source is None:
-                for name, irf in r._resources.items():
-                    src = irf._get_path(local_tmpdir)
-                    dest = f'{r._get_path(local_tmpdir)}.{name}'
-                    symlinks.append(f'ln -sf {shq(src)} {shq(dest)}')
-            return symlinks
-
-        write_external_inputs = [x for r in batch._input_resources for x in copy_external_output(r)]
-        if write_external_inputs:
-            transfers_bytes = orjson.dumps([
-                {"from": src, "to": dest}
-                for src, dest in write_external_inputs])
-            transfers = transfers_bytes.decode('utf-8')
-            write_cmd = ['python3', '-m', 'hailtop.aiotools.copy', 'null', transfers]
-            if dry_run:
-                commands.append(' '.join(shq(x) for x in write_cmd))
-            else:
-                j = bc_batch.create_job(image=HAIL_GENETICS_HAIL_IMAGE,
-                                        command=write_cmd,
-                                        attributes={'name': 'write_external_inputs'})
-                jobs_to_command[j] = ' '.join(shq(x) for x in write_cmd)
-                n_jobs_submitted += 1
-
         pyjobs = [j for j in batch._jobs if isinstance(j, _job.PythonJob)]
         for job in pyjobs:
             if job._image is None:
@@ -588,65 +454,66 @@ class ServiceBackend(Backend[bc.Batch]):
                         f"You must specify 'image' for Python jobs if you are using a Python version other than 3.6, 3.7, or 3.8 (you are using {version})")
                 job._image = f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
 
+        default_image = 'ubuntu:20.04'
+        attributes = batch.attributes
+        if batch.name is not None:
+            attributes = {'name': batch.name, **attributes}
+        job_to_client_job_mapping: Dict[_job.Job, aiobc.Job] = {}
+        batch_builder = self.batch_client.create_batch(
+            attributes=attributes,
+            callback=callback,
+            token=token,
+            cancel_after_n_failures=batch._cancel_after_n_failures
+        )
+
         with tqdm(total=len(batch._jobs), desc='upload code', disable=disable_progress_bar) as pbar:
-            async def compile_job(job):
-                used_remote_tmpdir = await job._compile(local_tmpdir, batch_remote_tmpdir, dry_run=dry_run)
+            async def compile_job(job: _job.Job) -> Tuple[_job.Job, str, str, List[resource.Resource]]:
+                # FIXME: data type for this triplet
+                code, user_code, resources_to_download = await job.compile(dry_run=dry_run)
                 pbar.update(1)
-                return used_remote_tmpdir
-            used_remote_tmpdir_results = await bounded_gather(*[functools.partial(compile_job, j) for j in batch._jobs], parallelism=150)
-            used_remote_tmpdir |= any(used_remote_tmpdir_results)
+                return job, code, user_code, resources_to_download
+            compiled_jobs = await bounded_gather(*[functools.partial(compile_job, j) for j in batch._jobs], parallelism=150)
 
-        for job in tqdm(batch._jobs, desc='create job objects', disable=disable_progress_bar):
-            inputs = [x for r in job._inputs for x in copy_input(r)]
+        used_remote_tmpdir = any(len(j._need_to_copy_out) > 0 for j in batch._jobs)
 
-            outputs = [x for r in job._internal_outputs for x in copy_internal_output(r)]
-            if outputs:
-                used_remote_tmpdir = True
-            outputs += [x for r in job._external_outputs for x in copy_external_output(r)]
+        for job, code, user_code, resources_to_download in tqdm(compiled_jobs, desc='create job objects', disable=disable_progress_bar):
+            inputs = [(r.remote_location(), r.local_location()) for r in resources_to_download]
 
-            symlinks = [x for r in job._mentioned for x in symlink_input_resource_group(r)]
+            def output_src_dest_pairs(r: resource.Resource) -> List[Tuple[str, str]]:
+                external_locations = batch._outputs[r]
+                if job.resource_defined_remotely(r):
+                    return [(r.remote_location(), dest) for dest in external_locations]
+                return [
+                    (r.local_location(), dest)
+                    for dest in [r.remote_location(), *external_locations]
+                ]
+
+            outputs = [
+                src_dest
+                for r in job._need_to_copy_out
+                for src_dest in output_src_dest_pairs(r)
+            ]
 
             if job._image is None:
                 if verbose:
                     print(f"Using image '{default_image}' since no image was specified.")
 
-            make_local_tmpdir = f'mkdir -p {local_tmpdir}/{job._dirname}'
-
-            job_command = [cmd.strip() for cmd in job._wrapper_code]
-            prepared_job_command = (f'{{\n{x}\n}}' for x in job_command)
-            cmd = f'''
-{bash_flags}
-{make_local_tmpdir}
-{"; ".join(symlinks)}
-{" && ".join(prepared_job_command)}
-'''
-
-            user_code = '\n\n'.join(job._user_code) if job._user_code else None
-
             if dry_run:
-                formatted_command = f'''
+                print('''
 ================================================================================
 # Job {job._job_id} {f": {job.name}" if job.name else ''}
-
---------------------------------------------------------------------------------
-## USER CODE
---------------------------------------------------------------------------------
-{user_code}
-
---------------------------------------------------------------------------------
-## COMMAND
---------------------------------------------------------------------------------
-{cmd}
+''')
+                print(code)
+                print('''
 ================================================================================
-'''
-                commands.append(formatted_command)
+''')
                 continue
 
             parents = [job_to_client_job_mapping[j] for j in job._dependencies]
 
-            attributes = copy.deepcopy(job.attributes) if job.attributes else {}
+            attributes = job.attributes or dict()
             if job.name:
-                attributes['name'] = job.name
+                attributes = {'name': job.name, **attributes}
 
             resources: Dict[str, Any] = {}
             if job._cpu:
@@ -663,59 +530,46 @@ class ServiceBackend(Backend[bc.Batch]):
             image = job._image if job._image else default_image
             image_ref = parse_docker_image_reference(image)
             if image_ref.hosted_in('dockerhub') and image_ref.name() not in HAIL_GENETICS_IMAGES:
-                warnings.warn(f'Using an image {image} from Docker Hub. '
+                warnings.warn(f'Using an image, {image}, from Docker Hub. '
                               f'Jobs may fail due to Docker Hub rate limits.')
 
-            env = {**job._env, 'BATCH_TMPDIR': local_tmpdir}
+            env = job._env
 
-            j = bc_batch.create_job(image=image,
-                                    command=[job._shell if job._shell else DEFAULT_SHELL, '-c', cmd],
-                                    parents=parents,
-                                    attributes=attributes,
-                                    resources=resources,
-                                    input_files=inputs if len(inputs) > 0 else None,
-                                    output_files=outputs if len(outputs) > 0 else None,
-                                    always_run=job._always_run,
-                                    timeout=job._timeout,
-                                    cloudfuse=job._cloudfuse if len(job._cloudfuse) > 0 else None,
-                                    env=env,
-                                    requester_pays_project=batch.requester_pays_project,
-                                    mount_tokens=True,
-                                    user_code=user_code)
-
-            n_jobs_submitted += 1
+            j = batch_builder.create_job(
+                image=image,
+                command=[job._shell if job._shell else DEFAULT_SHELL, '-c', code],
+                parents=parents,
+                attributes=attributes,
+                resources=resources,
+                input_files=inputs if len(inputs) > 0 else None,
+                output_files=outputs if len(outputs) > 0 else None,
+                always_run=job._always_run,
+                timeout=job._timeout,
+                cloudfuse=job._cloudfuse if len(job._cloudfuse) > 0 else None,
+                env=env,
+                requester_pays_project=batch.requester_pays_project,
+                mount_tokens=True,
+                user_code=user_code
+            )
 
             job_to_client_job_mapping[job] = j
-            jobs_to_command[j] = cmd
-
-        if dry_run:
-            print("\n\n".join(commands))
-            return None
 
         if delete_scratch_on_exit and used_remote_tmpdir:
-            parents = list(jobs_to_command.keys())
-            j = bc_batch.create_job(
+            j = batch_builder.create_job(
                 image=HAIL_GENETICS_HAIL_IMAGE,
-                command=['python3', '-m', 'hailtop.aiotools.delete', batch_remote_tmpdir],
-                parents=parents,
+                command=['python3', '-m', 'hailtop.aiotools.delete', batch._remote_location],
+                parents=batch_builder._jobs,
                 attributes={'name': 'remove_tmpdir'},
                 always_run=True)
-            jobs_to_command[j] = cmd
-            n_jobs_submitted += 1
 
         if verbose:
-            print(f'Built DAG with {n_jobs_submitted} jobs in {round(time.time() - build_dag_start, 3)} seconds.')
+            print(f'Built DAG with {batch_builder.n_jobs} jobs in {round(time.time() - build_dag_start, 3)} seconds.')
 
         submit_batch_start = time.time()
-        batch_handle = bc_batch.submit(disable_progress_bar=disable_progress_bar)
-
-        jobs_to_command = {j.id: cmd for j, cmd in jobs_to_command.items()}
+        batch_handle = await batch_builder.submit(disable_progress_bar=disable_progress_bar)
 
         if verbose:
-            print(f'Submitted batch {batch_handle.id} with {n_jobs_submitted} jobs in {round(time.time() - submit_batch_start, 3)} seconds:')
-            for jid, cmd in jobs_to_command.items():
-                print(f'{jid}: {cmd}')
-            print('')
+            print(f'Submitted batch {batch_handle.id} with {batch_builder.n_jobs} jobs in {round(time.time() - submit_batch_start, 3)} seconds.')
 
         deploy_config = get_deploy_config()
         url = deploy_config.external_url('batch', f'/batches/{batch_handle.id}')
@@ -725,6 +579,6 @@ class ServiceBackend(Backend[bc.Batch]):
             webbrowser.open(url)
         if wait:
             print(f'Waiting for batch {batch_handle.id}...')
-            status = batch_handle.wait()
+            status = await batch_handle.wait()
             print(f'batch {batch_handle.id} complete: {status["state"]}')
-        return batch_handle
+        return bc.Batch.from_async_batch(batch_handle)

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -331,6 +331,7 @@ class Batch:
 
         resource = _resource.ExternalResource(path, os.path.basename(path), self._local_location)
         self._input_resources.add(resource)
+        self._resource_by_uid[resource.uid()] = resource
         return resource
 
     def read_input_group(self, **kwargs: str) -> _resource.ResourceGroup:
@@ -394,6 +395,7 @@ class Batch:
 
         resource = _resource.ExternalResourceGroup(kwargs, f'<ExternalResourceGroup from {self}>', self._local_location)
         self._input_resources.add(resource)
+        self._resource_by_uid[resource.uid()] = resource
         return resource
 
     def write_output(self, resource: _resource.Resource, dest: str):  # pylint: disable=R0201

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -125,8 +125,9 @@ class Batch:
         self._backend = backend if backend else _backend.LocalBackend()
 
         # FIXME: iterate until a truly unique directory
-        uid = uuid.uuid4().hex[:6]
-        self._remote_location = f'{self._backend.remote_tmpdir()}{uid}'
+        uid = uuid.uuid4().hex[:6] + '/'
+        self._local_location = self._backend.local_tmpdir() + uid
+        self._remote_location = self._backend.remote_tmpdir() + uid
         self._resource_by_uid: Dict[int, _resource.Resource] = {}
 
         self.name = name
@@ -328,7 +329,7 @@ class Batch:
             File extension to use.
         """
 
-        resource = _resource.ExternalResource(path, os.path.basename(path))
+        resource = _resource.ExternalResource(path, os.path.basename(path), self._local_location)
         self._input_resources.add(resource)
         return resource
 
@@ -391,7 +392,7 @@ class Batch:
             is the file path.
         """
 
-        resource = _resource.ExternalResourceGroup(kwargs, f'<ExternalResourceGroup from {self}>')
+        resource = _resource.ExternalResourceGroup(kwargs, f'<ExternalResourceGroup from {self}>', self._local_location)
         self._input_resources.add(resource)
         return resource
 
@@ -457,7 +458,7 @@ class Batch:
             raise BatchException(
                 f"undefined resource '{resource.humane_name()}'\n"
                 f"Hint: resources must be defined within the job methods 'BashJob.command' or "
-                f"'BashJob.declare_resource_group' or PythonJob.call")
+                f"'BashJob.declare_resource_group' or PythonJob.call {source.defined_resources()}")
         self._outputs[resource].append(dest)
         source.resource_is_needed(resource)
 

--- a/hail/python/hailtop/batch/docs/api.rst
+++ b/hail/python/hailtop/batch/docs/api.rst
@@ -37,8 +37,15 @@ functions.
 Resources
 ~~~~~~~~~
 
-A :class:`.Resource` is an abstract class that represents files in a :class:`.Batch` and
-has two subtypes: :class:`.ResourceFile` and :class:`.ResourceGroup`.
+A :class:`.Resource` is an abstract class that represents files in a :class:`.Batch`. A resource may
+be external or internal. External resources are created by :meth:`.Batch.read_input` and
+:meth:`.Batch.read_input_group`. Resources may be members of groups which are created by
+:meth:`.Batch.read_input_group` or :meth:`.Job.declare_resource_group`.
+
+A *reference* to a resource may be *local* or *remote*. By default, a resource is referenced
+locally. A locally referenced resoruce is always downloaded to (respectively, uploaded from) the
+local file system of a job before (respectively, after) execution of the job. A remote reference to
+a resource is created by wrapping the resource in :func:`.resource.remote`.
 
 A single file is represented by a :class:`.ResourceFile` which has two subtypes:
 :class:`.InputResourceFile` and :class:`.JobResourceFile`. An InputResourceFile is used

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -552,13 +552,6 @@ class BashJob(Job):
         >>> j.command(f'plink --bfile {input} --make-bed --out {j.tmp1}')
         >>> b.run()  # doctest: +SKIP
 
-        Warning
-        -------
-        Be careful when specifying the expressions for each file as this is Python
-        code that is executed with `eval`!
-
-        # FIXME: !!!!! eval?
-
         Parameters
         ----------
         mappings:

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1012,11 +1012,11 @@ import sys
 class PythonResultUnpickler(dill.Unpickler):
     def __init__(self, file, **kwargs):
         super().__init__(file, **kwargs)
-        self.dispatch = {
+        self.dispatch = {{
             **dill.Pickler.dispatch,
             **{k: ResourceToStringPickler.save_resource
            for k in _resource.ALL_RESOURCE_CLASSES}
-        }
+        }}
 
     def save_resource(self, obj: _resource.Resource):
         return self.save(obj.as_py())

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -92,6 +92,9 @@ class Job(abc.ABC):
             return self.resource_is_defined(resource.defining_resource(), remote=True)
         self._defined_resource_remoteness[resource] = remote
 
+        for sub_resource in resource.members() or []:
+            self.resource_is_defined(sub_resource)
+
     def resource_is_needed(self, resource: _resource.Resource):
         if resource.is_remote():
             return self.resource_is_needed(resource.defining_resource())

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -414,7 +414,7 @@ class PythonResult(Resource):
 
     def local_location(self) -> str:
         if self._local_location is None:
-            self._local_location = self.local_prefix_from_uid()+ '/' + os.path.basename(self._remote_location)
+            self._local_location = self.local_prefix_from_uid() + '/' + os.path.basename(self._remote_location)
             if self._extension is not None:
                 self._local_location += self._extension
         return self._local_location

--- a/hail/python/hailtop/batch/utils.py
+++ b/hail/python/hailtop/batch/utils.py
@@ -47,7 +47,7 @@ def concatenate(b: Batch, files: List[Resource], image: str = None, branching_fa
         j = b.new_job(name=name)
         if image:
             j.image(image)
-        j.command(f'cat {" ".join(xs)} > {j.ofile}')
+        j.command(f'cat {" ".join(map(str, xs))} > {j.ofile}')
         return j.ofile
 
     if len(files) == 0:

--- a/hail/python/hailtop/batch/utils.py
+++ b/hail/python/hailtop/batch/utils.py
@@ -5,10 +5,10 @@ from typing import List
 from ..utils.utils import grouped, digits_needed
 from .batch import Batch
 from .exceptions import BatchException
-from .resource import ResourceGroup, ResourceFile
+from .resource import ResourceGroup, Resource
 
 
-def concatenate(b: Batch, files: List[ResourceFile], image: str = None, branching_factor: int = 100) -> ResourceFile:
+def concatenate(b: Batch, files: List[Resource], image: str = None, branching_factor: int = 100) -> Resource:
     """
     Concatenate files using tree aggregation.
 
@@ -53,7 +53,7 @@ def concatenate(b: Batch, files: List[ResourceFile], image: str = None, branchin
     if len(files) == 0:
         raise BatchException('Must have at least one file to concatenate.')
 
-    if not all(isinstance(f, ResourceFile) for f in files):
+    if not all([isinstance(f, Resource) for f in files]):
         raise BatchException('Invalid input file(s) - all inputs must be resource files.')
 
     return _combine(_concatenate, b, 'concatenate', files, branching_factor=branching_factor)

--- a/hail/python/hailtop/utils/tqdm.py
+++ b/hail/python/hailtop/utils/tqdm.py
@@ -1,3 +1,4 @@
+from typing import Optional, Union
 from enum import Enum
 
 
@@ -5,7 +6,7 @@ class TqdmDisableOption(Enum):
     default = 0
 
 
-def tqdm(*args, disable=TqdmDisableOption.default, **kwargs):
+def tqdm(*args, disable: Optional[Union[TqdmDisableOption, bool]] = TqdmDisableOption.default, **kwargs):
     from tqdm.notebook import tqdm as tqdm_notebook  # pylint: disable=import-outside-toplevel
     from tqdm.auto import tqdm as tqdm_auto  # pylint: disable=import-outside-toplevel
     # To tqdm_notebook, None means do not display. To standard tqdm, None means

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -7,6 +7,7 @@ import tempfile
 from shlex import quote as shq
 import uuid
 import re
+import pytest
 
 import hailtop.batch as hb
 from hailtop.batch import Batch, ServiceBackend, LocalBackend

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -308,13 +308,13 @@ class LocalTests(unittest.TestCase):
         j = b.new_job()
         j.command(f'echo "hello" > {j.ofile}')
         j.ofile.add_extension('.txt.bgz')
-        assert j.ofile._value.endswith('.txt.bgz')
+        assert j.ofile._local_location.endswith('.txt.bgz')
 
     def test_add_extension_input_resource_file(self):
         input_file1 = '/tmp/data/example1.txt.bgz.foo'
         b = self.batch()
         in1 = b.read_input(input_file1)
-        assert in1._value.endswith('.txt.bgz.foo')
+        assert in1._local_location.endswith('.txt.bgz.foo')
 
     def test_file_name_space(self):
         with tempfile.NamedTemporaryFile('w', prefix="some file name with (foo) spaces") as input_file, \

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -306,15 +306,15 @@ class LocalTests(unittest.TestCase):
     def test_add_extension_job_resource_file(self):
         b = self.batch()
         j = b.new_job()
+        j.ofile.set_extension('.txt.bgz')
         j.command(f'echo "hello" > {j.ofile}')
-        j.ofile.add_extension('.txt.bgz')
-        assert j.ofile._local_location.endswith('.txt.bgz')
+        assert j.ofile.local_location().endswith('.txt.bgz')
 
     def test_add_extension_input_resource_file(self):
         input_file1 = '/tmp/data/example1.txt.bgz.foo'
         b = self.batch()
         in1 = b.read_input(input_file1)
-        assert in1._local_location.endswith('.txt.bgz.foo')
+        assert in1.local_location().endswith('.txt.bgz.foo')
 
     def test_file_name_space(self):
         with tempfile.NamedTemporaryFile('w', prefix="some file name with (foo) spaces") as input_file, \


### PR DESCRIPTION
A while back, TJ raised some concerns about the expressivity of hailtop.batch.
In this PR, I basically rebuilt hailtop.batch from scratch as a learning
exercise. Once I understood how it worked, I added two valuable features:

1. `hb.remote` creates a "remote" resource which is never localized but still
   creates dependency relationships.

2. `ResourceToStringPickler` which pickles resources appropriately even if
   they are nested within other structures.