### PR TITLE
[query] Fix latent bug in ArrayElementAggregator copy

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -147,18 +147,13 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
   }
 
   def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
-    // FIXME: does this really need to be a field?
-    val srcOff = cb.newField("aelca_copyfromaddr_srcoff", src)
-    val initOffset = cb.memoize(typ.loadField(srcOff, 0))
-    val eltOffset = cb.memoize(arrayType.loadElement(typ.loadField(srcOff, 1), idx))
-
-    init(cb, cb => initContainer.copyFrom(cb, initOffset), initLen = false)
-    cb.ifx(typ.isFieldMissing(cb, srcOff, 1), {
+    init(cb, cb => initContainer.copyFrom(cb, cb.memoize(typ.loadField(src, 0))), initLen = false)
+    cb.ifx(typ.isFieldMissing(cb, src, 1), {
       typ.setFieldMissing(cb, off, 1)
       cb.assign(lenRef, -1)
     }, {
-      cb.assign(lenRef, arrayType.loadLength(typ.loadField(srcOff, 1)))
-      seq(cb, container.copyFrom(cb, eltOffset))
+      cb.assign(lenRef, arrayType.loadLength(typ.loadField(src, 1)))
+      seq(cb, container.copyFrom(cb, cb.memoize(arrayType.loadElement(typ.loadField(src, 1), idx))))
     })
   }
 }


### PR DESCRIPTION
I spruced up the entire method, but the bug was in the original
L153. One of the Code=>Value changes in the last couple of months
added the memoize to eltOffset. This was a ticking time bomb --
the usage of eltOffset inside `seq` must be evaluated inline, since
the value of `idx` changes between iterations of the loop where the
code argument to `seq` is located.

I suspect this has worked until now because `idx` is 0 every time
this method is called in typical runtimes. It exploded for the
buffered aggregator PR, where we are calling the copy with a stale
value of `idx` presumably equal to the length of the array, so we're
reading memory off the end of the array allocation.