### PR TITLE
[query] Add flush to lowered text exporters

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -839,6 +839,7 @@ abstract class SimplePartitionWriter extends PartitionWriter {
       }
       postConsume(cb, os)
 
+      cb += os.invoke[Unit]("flush")
       cb += os.invoke[Unit]("close")
 
       SJavaString.construct(cb, filename)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -526,6 +526,7 @@ case class VCFPartitionWriter(typ: MatrixType, entriesFieldName: String, writeHe
         consumeElement(cb, stream.element, os, stream.elementRegion)
       }
 
+      cb += os.invoke[Unit]("flush")
       cb += os.invoke[Unit]("close")
 
       if (tabix) {
@@ -858,7 +859,6 @@ final case class GenVariantWriter(typ: MatrixType, entriesFieldName: String, pre
     def _writeB(cb: EmitCodeBuilder, code: Code[Array[Byte]]) = { cb += os.invoke[Array[Byte], Unit]("write", code) }
     def _writeS(cb: EmitCodeBuilder, code: Code[String]) = { _writeB(cb, code.invoke[Array[Byte]]("getBytes")) }
     def writeC(code: Code[Int]) = _writeC(cb, code)
-    def writeB(code: Code[Array[Byte]]) = _writeB(cb, code)
     def writeS(code: Code[String]) = _writeS(cb, code)
 
     val hasGPField = typ.entryType.hasField("GP")


### PR DESCRIPTION
Just to be sure that we're committing all the data, in case there's
a poorly behaved output stream somewhere.