### PR TITLE
[vds] Fix behavior of to_dense_mt and off-by-one END comparison

### DIFF
--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -69,7 +69,7 @@ def to_dense_mt(vds: 'VariantDataset') -> 'MatrixTable':
 
     dr = dr.annotate(
         _dense=hl.zip(dr._var_entries, dr.dense_ref).map(
-            lambda tuple: coalesce_join(hl.or_missing(tuple[1].END > dr.locus.position, tuple[1]), tuple[0])
+            lambda tuple: coalesce_join(hl.or_missing(tuple[1].END >= dr.locus.position, tuple[1]), tuple[0])
         ),
     )
 

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -468,14 +468,17 @@ def test_to_dense_mt():
     assert as_dict.get(('chr22:10514784', 'NA12891')) == None
     assert as_dict.get(('chr22:10514784', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=23, DP=4)
 
-    assert as_dict.get(('chr22:10516102', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=21, DP=9)
-    assert as_dict.get(('chr22:10516102', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=21, DP=7)
+    assert as_dict.get(('chr22:10516102', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=12, DP=7)
+    assert as_dict.get(('chr22:10516102', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=26, DP=3)
 
     assert as_dict.get(('chr22:10516150', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=64, DP=4)
     assert as_dict.get(('chr22:10516150', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=99, DP=10)
 
     assert as_dict.get(('chr22:10519088', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=99, DP=21)
     assert as_dict.get(('chr22:10519088', 'NA12878')) == None
+
+    assert as_dict.get(('chr22:10557694', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=28, DP=19)
+    assert as_dict.get(('chr22:10557694', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=13, DP=16)
 
     assert as_dict.get(('chr22:10562435', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=99, DP=15)
     assert as_dict.get(('chr22:10562435', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=21, DP=9)

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -468,6 +468,9 @@ def test_to_dense_mt():
     assert as_dict.get(('chr22:10514784', 'NA12891')) == None
     assert as_dict.get(('chr22:10514784', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=23, DP=4)
 
+    assert as_dict.get(('chr22:10516102', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=21, DP=9)
+    assert as_dict.get(('chr22:10516102', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=21, DP=7)
+
     assert as_dict.get(('chr22:10516150', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=64, DP=4)
     assert as_dict.get(('chr22:10516150', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=99, DP=10)
 


### PR DESCRIPTION
CHANGELOG: Fix incorrectly missing entries in to_dense_mt at the position of ref block END.