### PR TITLE
[hailtop.utils] Add new transient error to the list

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -668,6 +668,8 @@ def is_transient_error(e):
         return e.status == 500 and 'Client.Timeout exceeded while awaiting headers' in e.message
     if isinstance(e, TransientError):
         return True
+    if isinstance(e, concurrent.futures._base.TimeoutError):
+        return True
     return False
 
 


### PR DESCRIPTION
A user reported this error `concurrent.futures._base.TimeoutError` with no stack trace while copying files in a batch job. There's a comment in `is_transient_error` that we should catch this error, but I did not see it caught in the existing function.