### PR TITLE
[batch] Use AsyncExitStack for jvm.kill cleanup

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -15,7 +15,7 @@ import traceback
 import uuid
 import warnings
 from collections import defaultdict
-from contextlib import ExitStack, contextmanager
+from contextlib import AsyncExitStack, ExitStack, contextmanager
 from typing import (
     Any,
     Awaitable,
@@ -2335,7 +2335,7 @@ class Worker:
     async def shutdown(self):
         log.info('Worker.shutdown')
         try:
-            with ExitStack() as cleanup:
+            async with AsyncExitStack() as cleanup:
                 for jvm in self._jvms:
                     cleanup.callback(jvm.kill)
         finally:


### PR DESCRIPTION
Since `jvm.kill` is an async function it needs an `AsyncExitStack`. `ExitStack` doesn't `await` its callbacks.