### PR TITLE
[copy] fix the TimeoutError and ServerDisconnected issues in copy

### DIFF
--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -299,6 +299,9 @@ class GetObjectStream(ReadableStream):
 
 class GoogleStorageClient(GoogleBaseClient):
     def __init__(self, **kwargs):
+        if 'timeout' not in kwargs and 'http_session' not in kwargs:
+            # Around May 2022, GCS started timing out a lot with our default 5s timeout
+            kwargs['timeout'] = aiohttp.ClientTimeout(total=20)
         super().__init__('https://storage.googleapis.com/storage/v1', **kwargs)
 
     # docs:

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -265,8 +265,8 @@ class ResumableInsertObjectStream(WritableStream):
 class GetObjectStream(ReadableStream):
     def __init__(self, resp: aiohttp.ClientResponse):
         super().__init__()
-        self._resp = resp
-        self._content = resp.content
+        self._resp: Optional[aiohttp.ClientResponse] = resp
+        self._content: Optional[aiohttp.StreamReader] = resp.content
 
     # https://docs.aiohttp.org/en/stable/streams.html#aiohttp.StreamReader.read
     # Read up to n bytes. If n is not provided, or set to -1, read until EOF

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -1,6 +1,6 @@
 import os
 from typing import (Tuple, Any, Set, Optional, MutableMapping, Dict, AsyncIterator, cast, Type,
-                    List)
+                    List, Awaitable, Coroutine)
 from types import TracebackType
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import
 import sys
@@ -55,7 +55,9 @@ class PageIterator:
 
 
 class InsertObjectStream(WritableStream):
-    def __init__(self, it, request_task):
+    def __init__(self,
+                 it: FeedableAsyncIterable[bytes],
+                 request_task: asyncio.Future):  # in Python 3.9: asyncio.Future[aiohttp.ClientResponse]
         super().__init__()
         self._it = it
         self._request_task = request_task
@@ -63,24 +65,31 @@ class InsertObjectStream(WritableStream):
 
     async def write(self, b):
         assert not self.closed
-        await self._it.feed(b)
-        return len(b)
+
+        fut = asyncio.ensure_future(self._it.feed(b))
+        try:
+            await asyncio.wait([fut, self._request_task], return_when=asyncio.FIRST_COMPLETED)
+            if fut.done():
+                return len(b)
+            raise ValueError(f'request task finished early')
+        finally:
+            fut.cancel()
 
     async def _wait_closed(self):
+        fut = asyncio.ensure_future(self._it.stop())
         try:
-            await self._it.stop()
-        except:
-            await self._request_task  # retrieve exceptions
-            raise
-        else:
+            await asyncio.wait([fut, self._request_task], return_when=asyncio.FIRST_COMPLETED)
             async with await self._request_task as resp:
                 self._value = await resp.json()
+        finally:
+            fut.cancel()
 
 
 class _TaskManager:
-    def __init__(self, coro):
+    def __init__(self, coro: Coroutine[Any, Any, Any], closable: bool = False):
         self._coro = coro
-        self._task = None
+        self._task: Optional[asyncio.Task[Any]] = None
+        self._closable = closable
 
     async def __aenter__(self) -> asyncio.Task:
         self._task = asyncio.create_task(self._coro)
@@ -90,17 +99,27 @@ class _TaskManager:
                         exc_type: Optional[Type[BaseException]],
                         exc_val: Optional[BaseException],
                         exc_tb: Optional[TracebackType]) -> None:
+        assert self._task is not None
+
         if not self._task.done():
             if exc_val:
                 self._task.cancel()
                 try:
-                    await self._task
+                    value = await self._task
+                    if self._closable:
+                        value.close()
                 except:
                     _, exc, _ = sys.exc_info()
                     if exc is not exc_val:
                         log.warning('dropping preempted task exception', exc_info=True)
             else:
-                await self._task
+                value = await self._task
+                if self._closable:
+                    value.close()
+        else:
+            value = await self._task
+            if self._closable:
+                value.close()
 
 
 class ResumableInsertObjectStream(WritableStream):
@@ -138,31 +157,31 @@ class ResumableInsertObjectStream(WritableStream):
             # https://cloud.google.com/storage/docs/performing-resumable-uploads#status-check
 
             # note: this retries
-            resp = await self._session.put(self._session_url,
-                                           headers={
-                                               'Content-Length': '0',
-                                               'Content-Range': f'bytes */{total_size_str}'
-                                           },
-                                           raise_for_status=False)
-            if resp.status >= 200 and resp.status < 300:
-                assert self._closed
-                assert total_size is not None
-                self._write_buffer.advance_offset(total_size)
-                assert self._write_buffer.size() == 0
-                self._done = True
-                return
-            if resp.status == 308:
-                range = resp.headers.get('Range')
-                if range is not None:
-                    new_offset = self._range_upper(range) + 1
+            async with await self._session.put(self._session_url,
+                                               headers={
+                                                   'Content-Length': '0',
+                                                   'Content-Range': f'bytes */{total_size_str}'
+                                               },
+                                               raise_for_status=False) as resp:
+                if resp.status >= 200 and resp.status < 300:
+                    assert self._closed
+                    assert total_size is not None
+                    self._write_buffer.advance_offset(total_size)
+                    assert self._write_buffer.size() == 0
+                    self._done = True
+                    return
+                if resp.status == 308:
+                    range = resp.headers.get('Range')
+                    if range is not None:
+                        new_offset = self._range_upper(range) + 1
+                    else:
+                        new_offset = 0
+                    self._write_buffer.advance_offset(new_offset)
+                    self._broken = False
                 else:
-                    new_offset = 0
-                self._write_buffer.advance_offset(new_offset)
-                self._broken = False
-            else:
-                assert resp.status >= 400
-                resp.raise_for_status()
-                assert False
+                    assert resp.status >= 400
+                    resp.raise_for_status()
+                    assert False
 
         assert not self._broken
         self._broken = True
@@ -192,7 +211,8 @@ class ResumableInsertObjectStream(WritableStream):
                                       'Content-Range': range
                                   },
                                   raise_for_status=False,
-                                  retry=False)) as put_task:
+                                  retry=False),
+                closable=True) as put_task:
             for chunk in self._write_buffer.chunks(n):
                 async with _TaskManager(it.feed(chunk)) as feed_task:
                     done, _ = await asyncio.wait([put_task, feed_task], return_when=asyncio.FIRST_COMPLETED)
@@ -243,7 +263,7 @@ class ResumableInsertObjectStream(WritableStream):
 
 
 class GetObjectStream(ReadableStream):
-    def __init__(self, resp):
+    def __init__(self, resp: aiohttp.ClientResponse):
         super().__init__()
         self._resp = resp
         self._content = resp.content
@@ -252,22 +272,28 @@ class GetObjectStream(ReadableStream):
     # Read up to n bytes. If n is not provided, or set to -1, read until EOF
     # and return all read bytes.
     async def read(self, n: int = -1) -> bytes:
-        assert not self._closed
+        assert not self._closed and self._content is not None
         return await self._content.read(n)
 
     async def readexactly(self, n: int) -> bytes:
-        assert not self._closed and n >= 0
+        assert not self._closed and n >= 0 and self._content is not None
         try:
             return await self._content.readexactly(n)
         except asyncio.IncompleteReadError as e:
             raise UnexpectedEOFError() from e
 
     def headers(self) -> 'CIMultiDictProxy[str]':
+        assert self._resp is not None
+
         return self._resp.headers
 
     async def _wait_closed(self) -> None:
+        assert self._resp is not None
+        assert self._content is not None
+
         self._content = None
         self._resp.release()
+        self._resp.close()
         self._resp = None
 
 
@@ -290,10 +316,7 @@ class GoogleStorageClient(GoogleBaseClient):
         assert 'name' not in params
         params['name'] = name
 
-        if 'data' in params:
-            return await self._session.post(
-                f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o',
-                **kwargs)
+        assert 'data' not in params
 
         upload_type = params.get('uploadType')
         if not upload_type:
@@ -303,7 +326,7 @@ class GoogleStorageClient(GoogleBaseClient):
         if upload_type == 'media':
             it: FeedableAsyncIterable[bytes] = FeedableAsyncIterable()
             kwargs['data'] = aiohttp.AsyncIterablePayload(it)
-            request_task = asyncio.ensure_future(self._session.post(
+            request_task: asyncio.Future = asyncio.ensure_future(self._session.post(
                 f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o',
                 retry=False,
                 **kwargs))
@@ -314,10 +337,11 @@ class GoogleStorageClient(GoogleBaseClient):
         assert upload_type == 'resumable'
         chunk_size = kwargs.get('bufsize', 256 * 1024)
 
-        resp = await self._session.post(
+        async with await self._session.post(
             f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o',
-            **kwargs)
-        session_url = resp.headers['Location']
+            **kwargs
+        ) as resp:
+            session_url = resp.headers['Location']
         return ResumableInsertObjectStream(self._session, session_url, chunk_size)
 
     async def get_object(self, bucket: str, name: str, **kwargs) -> GetObjectStream:

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -1,6 +1,6 @@
 import os
 from typing import (Tuple, Any, Set, Optional, MutableMapping, Dict, AsyncIterator, cast, Type,
-                    List, Awaitable, Coroutine)
+                    List, Coroutine)
 from types import TracebackType
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import
 import sys
@@ -71,7 +71,7 @@ class InsertObjectStream(WritableStream):
             await asyncio.wait([fut, self._request_task], return_when=asyncio.FIRST_COMPLETED)
             if fut.done():
                 return len(b)
-            raise ValueError(f'request task finished early')
+            raise ValueError('request task finished early')
         finally:
             fut.cancel()
 

--- a/hail/python/hailtop/aiocloud/common/session.py
+++ b/hail/python/hailtop/aiocloud/common/session.py
@@ -1,5 +1,6 @@
 from types import TracebackType
 from typing import Optional, Type, TypeVar, Mapping
+import aiohttp
 import abc
 from hailtop import httpx
 from hailtop.utils import request_retry_transient_errors, RateLimit, RateLimiter
@@ -10,22 +11,22 @@ SessionType = TypeVar('SessionType', bound='BaseSession')
 
 class BaseSession(abc.ABC):
     @abc.abstractmethod
-    async def request(self, method: str, url: str, **kwargs):
+    async def request(self, method: str, url: str, **kwargs) -> aiohttp.ClientResponse:
         pass
 
-    async def get(self, url: str, **kwargs):
+    async def get(self, url: str, **kwargs) -> aiohttp.ClientResponse:
         return await self.request('GET', url, **kwargs)
 
-    async def post(self, url: str, **kwargs):
+    async def post(self, url: str, **kwargs) -> aiohttp.ClientResponse:
         return await self.request('POST', url, **kwargs)
 
-    async def put(self, url: str, **kwargs):
+    async def put(self, url: str, **kwargs) -> aiohttp.ClientResponse:
         return await self.request('PUT', url, **kwargs)
 
-    async def delete(self, url: str, **kwargs):
+    async def delete(self, url: str, **kwargs) -> aiohttp.ClientResponse:
         return await self.request('DELETE', url, **kwargs)
 
-    async def head(self, url: str, **kwargs):
+    async def head(self, url: str, **kwargs) -> aiohttp.ClientResponse:
         return await self.request('HEAD', url, **kwargs)
 
     async def close(self) -> None:
@@ -78,7 +79,7 @@ class Session(BaseSession):
             self._http_session = httpx.ClientSession(**kwargs)
         self._credentials = credentials
 
-    async def request(self, method: str, url: str, **kwargs):
+    async def request(self, method: str, url: str, **kwargs) -> aiohttp.ClientResponse:
         auth_headers = await self._credentials.auth_headers()
         if auth_headers:
             if 'headers' in kwargs:

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -91,12 +91,12 @@ async def async_copy_paste_login(copy_paste_token: str, namespace: Optional[str]
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=5),
             headers=headers) as session:
-        resp = await request_retry_transient_errors(
-            session, 'POST', deploy_config.url('auth', '/api/v1alpha/copy-paste-login'),
-            params={'copy_paste_token': copy_paste_token})
-        resp = await resp.json()
-    token = resp['token']
-    username = resp['username']
+        async with await request_retry_transient_errors(
+                session, 'POST', deploy_config.url('auth', '/api/v1alpha/copy-paste-login'),
+                params={'copy_paste_token': copy_paste_token}) as resp:
+            data = await resp.json()
+    token = data['token']
+    username = data['username']
 
     tokens = get_tokens()
     tokens[namespace] = token
@@ -119,10 +119,9 @@ async def async_get_user(username: str, namespace: Optional[str] = None) -> dict
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=30),
             headers=headers) as session:
-        resp = await request_retry_transient_errors(
-            session, 'GET', deploy_config.url('auth', f'/api/v1alpha/users/{username}')
-        )
-        return await resp.json()
+        async with await request_retry_transient_errors(
+                session, 'GET', deploy_config.url('auth', f'/api/v1alpha/users/{username}')) as resp:
+            return await resp.json()
 
 
 def create_user(username: str, login_id: str, is_developer: bool, is_service_account: bool, namespace: Optional[str] = None):

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -101,7 +101,7 @@ class ClientSession:
         assert 'connector' not in kwargs
 
         if timeout is None:
-            timeout = aiohttp.ClientTimeout(total=5)
+            timeout = aiohttp.ClientTimeout(total=20)
 
         self.raise_for_status = raise_for_status
         self.client_session = aiohttp.ClientSession(

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -101,7 +101,7 @@ class ClientSession:
         assert 'connector' not in kwargs
 
         if timeout is None:
-            timeout = aiohttp.ClientTimeout(total=20)
+            timeout = aiohttp.ClientTimeout(total=5)
 
         self.raise_for_status = raise_for_status
         self.client_session = aiohttp.ClientSession(

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -762,7 +762,7 @@ def sync_retry_transient_errors(f, *args, **kwargs):
 
 
 async def request_retry_transient_errors(
-        session, # : Union[httpx.ClientSession, aiohttp.ClientSession]
+        session,  # : Union[httpx.ClientSession, aiohttp.ClientSession]
         method: str,
         url,
         **kwargs
@@ -771,7 +771,7 @@ async def request_retry_transient_errors(
 
 
 async def request_raise_transient_errors(
-        session, # : Union[httpx.ClientSession, aiohttp.ClientSession]
+        session,  # : Union[httpx.ClientSession, aiohttp.ClientSession]
         method: str,
         url,
         **kwargs

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -734,12 +734,12 @@ async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs
             if errors == 2:
                 log.warning(f'A transient error occured. We will automatically retry. Do not be alarmed. '
                             f'We have thus far seen {errors} transient errors (current delay: '
-                            f'{delay}). The most recent error was {e}')
+                            f'{delay}). The most recent error was {type(e)} {e}')
             elif errors % 10 == 0:
                 st = ''.join(traceback.format_stack())
                 log.warning(f'A transient error occured. We will automatically retry. '
                             f'We have thus far seen {errors} transient errors (current delay: '
-                            f'{delay}). The stack trace for this call is {st}. The most recent error was {e}', exc_info=True)
+                            f'{delay}). The stack trace for this call is {st}. The most recent error was {type(e)} {e}', exc_info=True)
         delay = await sleep_and_backoff(delay)
 
 
@@ -761,11 +761,21 @@ def sync_retry_transient_errors(f, *args, **kwargs):
         delay = sync_sleep_and_backoff(delay)
 
 
-async def request_retry_transient_errors(session, method, url, **kwargs):
+async def request_retry_transient_errors(
+        session, # : Union[httpx.ClientSession, aiohttp.ClientSession]
+        method: str,
+        url,
+        **kwargs
+) -> aiohttp.ClientResponse:
     return await retry_transient_errors(session.request, method, url, **kwargs)
 
 
-async def request_raise_transient_errors(session, method, url, **kwargs):
+async def request_raise_transient_errors(
+        session, # : Union[httpx.ClientSession, aiohttp.ClientSession]
+        method: str,
+        url,
+        **kwargs
+) -> aiohttp.ClientResponse:
     try:
         return await session.request(method, url, **kwargs)
     except Exception as e:


### PR DESCRIPTION
cc: @daniel-goldstein, this is a tricky asyncio situation which you should also keep in mind

OK, there were two problems:

1. A timeout of 5s appears to be now too short for Google Cloud Storage. I am not sure why but we
   timeout substantially more frequently. I have observed this myself on my laptop. Just this
   morning I saw it happen to Daniel.

2. When using an `aiohttp.AsyncIterablePayload`, it is *critical* to always check if the coroutine
   which actually writes to GCS (which is stashed in the variable `request_task`) is still
   alive. In the current `main`, we do not do this which causes hangs (in particular the timeout
   exceptions are never thrown ergo we never retry).

To understand the second problem, you must first recall how writing works in aiogoogle. There are
two Tasks and an `asyncio.Queue`. The terms "writer" and "reader" are somewhat confusing, so let's
use left and right. The left Task has the owning reference to both the source "file" and the
destination "file". In particular, it is the *left* Task which closes both "files". Moreover, the
left Task reads chunks from the source file and places those chunks on the `asyncio.Queue`. The
right Task takes chunks off the queue and writes those chunks to the destination file.

This situation can go awry in two ways.

First, if the right Task encounters any kind of failure, it will stop taking chunks off of the
queue. When the queue (which has a size limit of one) is full, the left Task will hang. The system
is stuck. The left Task will wait forever for the right Task to empty the queue.

The second scenario is exactly the same except that the left Task is trying to add the "stop"
message to the queue rather than a chunk.

In either case, it is critical that the left Task waits simultaneously on the queue operation *and*
on the right Task completing. If the right Task has died, no further writes can occur and the left
Task must raise an exception. In the first scenario, we do not observe the right Task's exception
because that will be done when we close the `InsertObjectStream` (which represents the destination
"file").

---

I also added several types, assertions, and a few missing `async with ... as resp:` blocks.