### PR TITLE
[query] Retry read from GCS channel

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -155,7 +155,9 @@ class GoogleStorageFS(val serviceAccountKey: Option[String] = None) extends FS {
         // read some bytes
         var n = 0
         while (n == 0) {
-          n = reader.read(bb)
+          n = retryTransientErrors {
+            reader.read(bb)
+          }
           if (n == -1) {
             eof = true
             return


### PR DESCRIPTION
AFAIK, the `retryTransientErrors` in `createNoCompression` would only retry any errors in creating the `ReadChannel`, but we still want to retry transient errors when calling read later down the line.