### PR TITLE
[hailtop] Use python3.8-compatible format string for json logger

### DIFF
--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -16,7 +16,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
 
 
 def configure_logging():
-    fmt = CustomJsonFormatter('(severity) (levelname) (asctime) (filename) (funcNameAndLine) (message)')
+    fmt = CustomJsonFormatter('%(severity)s %(levelname)s %(asctime)s %(filename)s %(funcNameAndLine)s %(message)s')
 
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setLevel(logging.INFO)


### PR DESCRIPTION
Python 3.8 [added a validate parameter](https://docs.python.org/3/library/logging.html#logging.Formatter) to the stdlib Formatter which is on by default and doesn't like our format strings, which I guess python 3.7 is just too lenient about? Anyway I updated the format string to match the docs' recommendation.