### PR TITLE
[docs] preserve iframe_figure directory during build

### DIFF
--- a/hail/python/hail/docs/Makefile
+++ b/hail/python/hail/docs/Makefile
@@ -48,7 +48,7 @@ clean:
 	rm -rf $(BUILDDIR)
 
 .PHONY: html
-html: tutorials-tar
+html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	rsync -avz tutorials/iframe_figures/ $(BUILDDIR)/html/tutorials/iframe_figures/ # https://github.com/plotly/plotly.py/blob/master/packages/python/plotly/plotly/io/_base_renderers.py#L522-L529
 	tar cvf $(BUILDDIR)/html/tutorials.tar.gz $(BUILDDIR)/html/tutorials

--- a/hail/python/hail/docs/Makefile
+++ b/hail/python/hail/docs/Makefile
@@ -47,16 +47,11 @@ help:
 clean:
 	rm -rf $(BUILDDIR)
 
-.PHONY: tutorials-tar
-tutorials-tar: $(BUILDDIR)/html/tutorials.tar.gz
-
-$(BUILDDIR)/html/tutorials.tar.gz: $(wildcard tutorials/*.ipynb)
-	mkdir -p $(BUILDDIR)/html
-	tar cvf $(BUILDDIR)/html/tutorials.tar.gz $^
-
 .PHONY: html
 html: tutorials-tar
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	rsync -avz tutorials/iframe_figures/ $(BUILDDIR)/html/tutorials/iframe_figures/ # https://github.com/plotly/plotly.py/blob/master/packages/python/plotly/plotly/io/_base_renderers.py#L522-L529
+	tar cvf $(BUILDDIR)/html/tutorials.tar.gz $(BUILDDIR)/html/tutorials
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
Currently none of the figures are copied with the notebook into the docs.