### PR TITLE
[query] python side infrastructure for deterministic rngs

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -13,7 +13,7 @@ from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.matrix_type import tmatrix
 from hail.expr.table_type import ttable
 from hail.expr.types import dtype
-from hail.ir import Let, RNGStateLiteral, finalize_randomness
+from hail.ir import finalize_randomness
 from hail.ir.renderer import CSERenderer
 from hail.utils.java import scala_package_object, scala_object
 from .py4j_backend import Py4JBackend, handle_java_exception

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -13,6 +13,7 @@ from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.matrix_type import tmatrix
 from hail.expr.table_type import ttable
 from hail.expr.types import dtype
+from hail.ir import Let, RNGStateLiteral, finalize_randomness
 from hail.ir.renderer import CSERenderer
 from hail.utils.java import scala_package_object, scala_object
 from .py4j_backend import Py4JBackend, handle_java_exception
@@ -206,7 +207,7 @@ class LocalBackend(Py4JBackend):
         if not hasattr(ir, '_jir'):
             r = CSERenderer(stop_at_jir=True)
             # FIXME parse should be static
-            ir._jir = parse(r(ir), ir_map=r.jirs)
+            ir._jir = parse(r(finalize_randomness(ir)), ir_map=r.jirs)
         return ir._jir
 
     def _to_java_value_ir(self, ir):

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -6,7 +6,7 @@ import py4j.java_gateway
 
 import hail
 from hail.expr import construct_expr
-from hail.ir import JavaIR
+from hail.ir import JavaIR, finalize_randomness
 from hail.ir.renderer import CSERenderer
 from hail.utils.java import FatalError, Env
 from .backend import Backend, fatal_error_from_java_error_triplet

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -79,7 +79,7 @@ class Py4JBackend(Backend):
                              return_type: HailType,
                              body: Expression):
         r = CSERenderer(stop_at_jir=True)
-        code = r(body._ir)
+        code = r(finalize_randomness(body._ir))
         jbody = (self._parse_value_ir(code, ref_map=dict(zip(value_parameter_names, value_parameter_types)), ir_map=r.jirs))
 
         Env.hail().expr.ir.functions.IRFunctionRegistry.pyRegisterIR(

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -308,7 +308,7 @@ class ServiceBackend(Backend):
     def render(self, ir):
         r = CSERenderer()
         assert len(r.jirs) == 0
-        return r(ir)
+        return r(finalize_randomness(ir))
 
     async def _rpc(self,
                    name: str,

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -151,7 +151,7 @@ class IRFunction:
         self._value_parameter_names = value_parameter_names
         self._value_parameter_types = value_parameter_types
         self._return_type = return_type
-        self._rendered_body = render(body._ir)
+        self._rendered_body = render(finalize_randomness(body._ir))
 
     async def serialize(self, writer: afs.WritableStream):
         await write_str(writer, self._name)

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -17,6 +17,7 @@ from hail.expr.table_type import ttable
 from hail.expr.matrix_type import tmatrix
 from hail.expr.blockmatrix_type import tblockmatrix
 from hail.experimental import write_expression, read_expression
+from hail.ir import finalize_randomness
 from hail.ir.renderer import CSERenderer
 
 from hailtop.config import (configuration_of, get_user_local_cache_dir, get_remote_tmpdir, get_deploy_config)

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -234,7 +234,6 @@ class SparkBackend(Py4JBackend):
         uninstall_exception_handler()
 
     def _parse_value_ir(self, code, ref_map={}, ir_map={}):
-        print(code)
         return self._jbackend.parse_value_ir(
             code,
             {k: t._parsable_string() for k, t in ref_map.items()},

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -17,6 +17,7 @@ from hail.expr.table_type import ttable
 from hail.expr.matrix_type import tmatrix
 from hail.expr.blockmatrix_type import tblockmatrix
 from hail.ir.renderer import CSERenderer
+from hail.ir import finalize_randomness
 from hail.table import Table
 from hail.matrixtable import MatrixTable
 
@@ -233,6 +234,7 @@ class SparkBackend(Py4JBackend):
         uninstall_exception_handler()
 
     def _parse_value_ir(self, code, ref_map={}, ir_map={}):
+        print(code)
         return self._jbackend.parse_value_ir(
             code,
             {k: t._parsable_string() for k, t in ref_map.items()},
@@ -264,7 +266,7 @@ class SparkBackend(Py4JBackend):
         if not hasattr(ir, '_jir'):
             r = CSERenderer(stop_at_jir=True)
             # FIXME parse should be static
-            ir._jir = parse(r(ir), ir_map=r.jirs)
+            ir._jir = parse(r(finalize_randomness(ir)), ir_map=r.jirs)
         return ir._jir
 
     def _to_java_value_ir(self, ir):
@@ -361,6 +363,7 @@ class SparkBackend(Py4JBackend):
     def register_ir_function(self, name, type_parameters, argument_names, argument_types, return_type, body):
 
         r = CSERenderer(stop_at_jir=True)
+        assert not body._ir.uses_randomness
         code = r(body._ir)
         jbody = (self._parse_value_ir(code, ref_map=dict(zip(argument_names, argument_types)), ir_map=r.jirs))
 

--- a/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
@@ -265,7 +265,7 @@ def combine(ts):
     ts = Table(TableMapRows(ts._tir, Apply(merge_function._name,
                                            merge_function._ret_type,
                                            ts.row._ir,
-                                           ts.gloabls._ir)))
+                                           ts.globals._ir)))
     return ts.transmute_globals(__cols=hl.flatten(ts.g.map(lambda g: g.__cols)))
 
 

--- a/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
@@ -10,7 +10,7 @@ from hail import MatrixTable, Table
 from hail.expr import StructExpression
 from hail.expr.expressions import expr_bool, expr_str
 from hail.genetics.reference_genome import reference_genome_type
-from hail.ir import Apply, TableMapRows, MatrixKeyRowsBy, TopLevelReference
+from hail.ir import Apply, TableMapRows, MatrixKeyRowsBy
 from hail.typecheck import oneof, sequenceof, typecheck
 from hail.utils.java import info, warning, Env
 
@@ -193,7 +193,7 @@ def transform_gvcf(mt, info_to_keep=[]) -> Table:
             mt.row.dtype)
         _transform_rows_function_map[mt.row.dtype] = f
     transform_row = _transform_rows_function_map[mt.row.dtype]
-    return Table(TableMapRows(mt._tir, Apply(transform_row._name, transform_row._ret_type, TopLevelReference('row'))))
+    return Table(TableMapRows(mt._tir, Apply(transform_row._name, transform_row._ret_type, mt.row._ir)))
 
 
 def transform_one(mt, info_to_keep=[]) -> Table:
@@ -264,8 +264,8 @@ def combine(ts):
     merge_function = _merge_function_map[(ts.row.dtype, ts.globals.dtype)]
     ts = Table(TableMapRows(ts._tir, Apply(merge_function._name,
                                            merge_function._ret_type,
-                                           TopLevelReference('row'),
-                                           TopLevelReference('global'))))
+                                           ts.row._ir,
+                                           ts.gloabls._ir)))
     return ts.transmute_globals(__cols=hl.flatten(ts.g.map(lambda g: g.__cols)))
 
 

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -243,11 +243,11 @@ _agg_func = AggFunc()
 
 def _check_agg_bindings(expr, bindings):
     bound_references = {ref.name for ref in expr._ir.search(
-        lambda x: isinstance(x, ir.Ref)
-            and not isinstance(x, ir.TopLevelReference)
-            and not x.name.startswith('__uid_scan')
-            and not x.name.startswith('__uid_agg')
-            and not x.name == '__rng_state')}
+        lambda x: (isinstance(x, ir.Ref)
+                   and not isinstance(x, ir.TopLevelReference)
+                   and not x.name.startswith('__uid_scan')
+                   and not x.name.startswith('__uid_agg')
+                   and not x.name == '__rng_state'))}
     free_variables = bound_references - expr._ir.bound_variables - bindings
     if free_variables:
         raise ExpressionException("dynamic variables created by 'hl.bind' or lambda methods like 'hl.map' may not be aggregated")

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -127,7 +127,7 @@ class AggFunc(object):
         comb_op_expr = to_expr(comb_op(accum_ref, other_accum_ref))
 
         return construct_expr(ir.AggFold(initial_value_casted._ir, seq_op_expr._ir, comb_op_expr._ir, accum_name, other_accum_name, self._as_scan),
-                              initial_value.dtype,
+                              unified_type,
                               indices,
                               aggregations)
 
@@ -142,7 +142,7 @@ class AggFunc(object):
             array_agg_expr = hl.array(array_agg_expr)
         elt = array_agg_expr.dtype.element_type
         var = Env.get_uid()
-        ref = construct_expr(ir.Ref(var), elt, array_agg_expr._indices)
+        ref = construct_expr(ir.Ref(var, elt), elt, array_agg_expr._indices)
         self._agg_bindings.add(var)
         aggregated = f(ref)
         _check_agg_bindings(aggregated, self._agg_bindings)
@@ -211,7 +211,7 @@ class AggFunc(object):
 
         elt = array.dtype.element_type
         var = Env.get_uid()
-        ref = construct_expr(ir.Ref(var), elt, array._indices)
+        ref = construct_expr(ir.Ref(var, elt), elt, array._indices)
         self._agg_bindings.add(var)
         aggregated = f(ref)
         _check_agg_bindings(aggregated, self._agg_bindings)
@@ -244,9 +244,10 @@ _agg_func = AggFunc()
 def _check_agg_bindings(expr, bindings):
     bound_references = {ref.name for ref in expr._ir.search(
         lambda x: isinstance(x, ir.Ref)
-        and not isinstance(x, ir.TopLevelReference)
-        and not x.name.startswith('__uid_scan')
-        and not x.name.startswith('__uid_agg'))}
+            and not isinstance(x, ir.TopLevelReference)
+            and not x.name.startswith('__uid_scan')
+            and not x.name.startswith('__uid_agg')
+            and not x.name == '__rng_state')}
     free_variables = bound_references - expr._ir.bound_variables - bindings
     if free_variables:
         raise ExpressionException("dynamic variables created by 'hl.bind' or lambda methods like 'hl.map' may not be aggregated")

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -21,7 +21,8 @@ from hail.expr.expressions import (Expression, ArrayExpression, SetExpression,
 from hail.expr.types import (HailType, hail_type, tint32, tint64, tfloat32,
                              tfloat64, tstr, tbool, tarray, tset, tdict,
                              tstruct, tlocus, tinterval, tcall, ttuple,
-                             tndarray, is_primitive, is_numeric, is_int32, is_int64, is_float32, is_float64)
+                             tndarray, trngstate, is_primitive, is_numeric,
+                             is_int32, is_int64, is_float32, is_float64)
 from hail.genetics.reference_genome import reference_genome_type, ReferenceGenome
 import hail.ir as ir
 from hail.typecheck import (typecheck, nullable, anytype, enumeration, tupleof,
@@ -43,7 +44,8 @@ def _func(name, ret_type, *args, type_args=()):
 def _seeded_func(name, ret_type, seed, *args):
     seed = seed if seed is not None else Env.next_seed()
     indices, aggregations = unify_all(*args)
-    return construct_expr(ir.ApplySeeded(name, seed, ret_type, *(a._ir for a in args)), ret_type, indices, aggregations)
+    rng_state = ir.RNGSplit(ir.Ref('__rng_state', trngstate), ir.MakeTuple([]))
+    return construct_expr(ir.ApplySeeded(name, seed, rng_state, ret_type, *(a._ir for a in args)), ret_type, indices, aggregations)
 
 
 def ndarray_broadcasting(func):
@@ -3715,7 +3717,8 @@ def zip(*arrays, fill_missing: bool = False) -> ArrayExpression:
     """
     n_arrays = builtins.len(arrays)
     uids = [Env.get_uid() for _ in builtins.range(n_arrays)]
-    body_ir = ir.MakeTuple([ir.Ref(uid) for uid in uids])
+    types = [array._type.element_type for array in arrays]
+    body_ir = ir.MakeTuple([ir.Ref(uid, type) for uid, type in builtins.zip(uids, types)])
     indices, aggregations = unify_all(*arrays)
     behavior = 'ExtendNA' if fill_missing else 'TakeMinLength'
     return construct_expr(ir.ToArray(ir.StreamZip([ir.ToStream(a._ir) for a in arrays], uids, body_ir, behavior)),
@@ -3727,7 +3730,7 @@ def zip(*arrays, fill_missing: bool = False) -> ArrayExpression:
 def _zip_func(*arrays, fill_missing=False, f):
     n_arrays = builtins.len(arrays)
     uids = [Env.get_uid() for _ in builtins.range(n_arrays)]
-    refs = [construct_expr(ir.Ref(uid), a.dtype.element_type, a._indices, a._aggregations) for uid, a in
+    refs = [construct_expr(ir.Ref(uid, a.dtype.element_type), a.dtype.element_type, a._indices, a._aggregations) for uid, a in
             builtins.zip(uids, arrays)]
     body_result = f(*refs)
     indices, aggregations = unify_all(*arrays, body_result)
@@ -3774,9 +3777,9 @@ def enumerate(a, start=0, *, index_first=True):
     elt = Env.get_uid()
     idx = Env.get_uid()
     if index_first:
-        tuple = ir.MakeTuple([ir.Ref(idx), ir.Ref(elt)])
+        tuple = ir.MakeTuple([ir.Ref(idx, tint32), ir.Ref(elt, a.dtype.element_type)])
     else:
-        tuple = ir.MakeTuple([ir.Ref(elt), ir.Ref(idx)])
+        tuple = ir.MakeTuple([ir.Ref(elt, a.dtype.element_type), ir.Ref(idx, tint32)])
     indices, aggs = unify_all(a, start)
     return construct_expr(
         ir.ToArray(
@@ -4748,8 +4751,9 @@ def _compare(left, right):
 def _sort_by(collection, less_than):
     left_id = Env.get_uid()
     right_id = Env.get_uid()
-    left = construct_expr(ir.Ref(left_id), collection.dtype.element_type, collection._indices, collection._aggregations)
-    right = construct_expr(ir.Ref(right_id), collection.dtype.element_type, collection._indices, collection._aggregations)
+    elt_type = collection.dtype.element_type
+    left = construct_expr(ir.Ref(left_id, elt_type), elt_type, collection._indices, collection._aggregations)
+    right = construct_expr(ir.Ref(right_id, elt_type), elt_type, collection._indices, collection._aggregations)
     return construct_expr(
         ir.ArraySort(ir.ToStream(collection._ir), left_id, right_id, less_than(left, right)._ir),
         collection.dtype,

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -628,6 +628,30 @@ class _tbool(HailType):
         return byte_reader.read_bool()
 
 
+class _trngstate(HailType):
+
+    def __init__(self):
+        super(_trngstate, self).__init__()
+
+    def __str__(self):
+        return "rng_state"
+
+    def _eq(self, other):
+        return isinstance(other, _trngstate)
+
+    def _parsable_string(self):
+        return "RNGState"
+
+    def unify(self, t):
+        return t == trngstate
+
+    def subst(self):
+        return self
+
+    def clear(self):
+        pass
+
+
 class tndarray(HailType):
     """Hail type for n-dimensional arrays.
 
@@ -1976,6 +2000,8 @@ See Also
 --------
 :class:`.BooleanExpression`, :func:`.bool`
 """
+
+trngstate = _trngstate()
 
 tcall = _tcall()
 """Hail type for a diploid genotype.

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -5,7 +5,7 @@ from .ir import MatrixWrite, MatrixMultiWrite, BlockMatrixWrite, \
     BlockMatrixMultiWrite, TableToValueApply, \
     MatrixToValueApply, BlockMatrixToValueApply, BlockMatrixCollect, \
     Literal, LiftMeOut, Join, JavaIR, I32, I64, F32, F64, Str, FalseIR, TrueIR, \
-    Void, Cast, NA, IsNA, If, Coalesce, Let, AggLet, Ref, TopLevelReference, \
+    Void, Cast, NA, IsNA, If, Coalesce, Let, AggLet, Ref, TopLevelReference, ProjectedTopLevelReference, SelectedTopLevelReference, \
     TailLoop, Recur, ApplyBinaryPrimOp, ApplyUnaryPrimOp, ApplyComparisonOp, \
     MakeArray, ArrayRef, ArraySlice, ArrayLen, ArrayZeros, StreamIota, StreamRange, StreamGrouped, MakeNDArray, \
     NDArrayShape, NDArrayReshape, NDArrayMap, NDArrayMap2, NDArrayRef, NDArraySlice, NDArraySVD, \
@@ -16,9 +16,9 @@ from .ir import MatrixWrite, MatrixMultiWrite, BlockMatrixWrite, \
     StreamJoinRightDistinct, StreamFor, AggFilter, AggExplode, AggGroupBy, \
     AggArrayPerElement, BaseApplyAggOp, ApplyAggOp, ApplyScanOp, AggFold, Begin, \
     MakeStruct, SelectFields, InsertFields, GetField, MakeTuple, \
-    GetTupleElement, Die, ConsoleLog, Apply, ApplySeeded, TableCount, TableGetGlobals, \
-    TableCollect, TableAggregate, MatrixCount, MatrixAggregate, TableWrite, \
-    udf, subst, clear_session_functions
+    GetTupleElement, Die, ConsoleLog, Apply, ApplySeeded, RNGStateLiteral, RNGSplit,\
+    TableCount, TableGetGlobals, TableCollect, TableAggregate, MatrixCount,\
+    MatrixAggregate, TableWrite, udf, subst, clear_session_functions, get_static_split_uid
 from .register_functions import register_functions
 from .register_aggregators import register_aggregators
 from .table_ir import MatrixRowsTable, TableJoin, TableLeftJoinRightDistinct, \
@@ -45,7 +45,7 @@ from .blockmatrix_ir import BlockMatrixRead, BlockMatrixMap, BlockMatrixMap2, \
     RowIntervalSparsifier, RectangleSparsifier, PerBlockSparsifier, BlockMatrixSparsify, \
     BlockMatrixSlice, ValueToBlockMatrix, BlockMatrixRandom, \
     tensor_shape_to_matrix_shape
-from .utils import filter_predicate_with_keep, make_filter_and_replace
+from .utils import filter_predicate_with_keep, make_filter_and_replace, finalize_randomness
 from .matrix_reader import MatrixReader, MatrixNativeReader, MatrixRangeReader, \
     MatrixVCFReader, MatrixBGENReader, MatrixPLINKReader
 from .table_reader import AvroTableReader, TableReader, TableNativeReader, \
@@ -74,6 +74,7 @@ __all__ = [
     'register_aggregators',
     'filter_predicate_with_keep',
     'make_filter_and_replace',
+    'finalize_randomness',
     'Renderable',
     'RenderableStr',
     'ParensRenderer',
@@ -134,6 +135,8 @@ __all__ = [
     'AggLet',
     'Ref',
     'TopLevelReference',
+    'ProjectedTopLevelReference',
+    'SelectedTopLevelReference',
     'TailLoop',
     'Recur',
     'ApplyBinaryPrimOp',
@@ -197,6 +200,8 @@ __all__ = [
     'ConsoleLog',
     'Apply',
     'ApplySeeded',
+    'RNGStateLiteral',
+    'RNGSplit',
     'TableCount',
     'TableGetGlobals',
     'TableCollect',
@@ -207,6 +212,7 @@ __all__ = [
     'udf',
     'subst',
     'clear_session_functions',
+    'get_static_split_uid',
     'MatrixWrite',
     'MatrixMultiWrite',
     'BlockMatrixWrite',

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -300,7 +300,6 @@ class IR(BaseIR):
             if self._type is not None:
                 assert self._type == computed
             self._type = computed
-            # assert self._type is not None
 
     def assign_type(self, typ):
         if self._type is None:
@@ -320,6 +319,14 @@ class IR(BaseIR):
         pass
 
     def handle_randomness(self, create_uids):
+        """Elaborate rng semantics in stream typed IR.
+
+        Recursive transformation of stream typed IRs. Ensures that all
+        contained seeded randomness gets a unique rng state on every stream
+        iteration. Optionally inserts a uid in the returned stream element type.
+        The uid may be an int64, or arbitrary tuple of int64s. The only
+        requirement is that all stream elements contain distinct uid values.
+        """
         assert(isinstance(self.typ, tstream))
         if not create_uids and not self.uses_randomness:
             return self
@@ -403,6 +410,14 @@ class TableIR(BaseIR):
         pass
 
     def handle_randomness(self, uid_field_name):
+        """Elaborate rng semantics
+
+        Recursively transform IR to ensure that all contained seeded randomness
+        gets a unique rng state on every table row. Optionally inserts a uid
+        field in the returned table. The uid may be an int64, or arbitrary
+        tuple of int64s. The only requirement is that all table rows contain
+        distinct uid values.
+        """
         if uid_field_name is None and not self.uses_randomness:
             return self
         return self._handle_randomness(uid_field_name)
@@ -424,6 +439,14 @@ class MatrixIR(BaseIR):
         return self._children_use_randomness
 
     def handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        """Elaborate rng semantics
+
+        Recursively transform IR to ensure that all contained seeded randomness
+        gets a unique rng state on every evaluation. Optionally inserts a uid
+        row field and/or column field in the returned matrix table. The uids may
+        be an int64, or arbitrary tuple of int64s. The only requirement is that
+        all rows contain distinct uid values, and likewise for columns.
+        """
         if row_uid_field_name is None and col_uid_field_name and not self.uses_randomness:
             return self
         result = self._handle_randomness(row_uid_field_name, col_uid_field_name)

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -1,5 +1,6 @@
 import abc
 
+from hail.expr.types import tstream
 from hail.utils.java import Env
 from .renderer import Renderer, PlainRenderer, Renderable
 
@@ -93,6 +94,9 @@ class BaseIR(Renderable):
     def __hash__(self):
         return 31 + hash(str(self))
 
+    def copy(self, *args):
+        raise NotImplementedError("IR has no copy method defined.")
+
     def new_block(self, i: int) -> bool:
         return self.renderable_new_block(self.renderable_idx_of_child(i))
 
@@ -103,6 +107,11 @@ class BaseIR(Renderable):
     @staticmethod
     def is_effectful() -> bool:
         return False
+
+    @property
+    @abc.abstractmethod
+    def uses_randomness(self) -> bool:
+        pass
 
     def bindings(self, i: int, default_value=None):
         """Compute variables bound in child 'i'.
@@ -248,9 +257,6 @@ class IR(BaseIR):
             return others + [self]
         return others
 
-    def copy(self, *args):
-        raise NotImplementedError("IR has no copy method defined.")
-
     def map_ir(self, f):
         new_children = []
         for child in self.children:
@@ -262,22 +268,62 @@ class IR(BaseIR):
         return self.copy(*new_children)
 
     @property
+    def uses_randomness(self) -> bool:
+        return '__rng_state' in self.free_vars or '__rng_state' in self.free_agg_vars or '__rng_state' in self.free_scan_vars
+
+    @property
+    def uses_value_randomness(self):
+        return '__rng_state' in self.free_vars
+
+    def uses_agg_randomness(self, is_scan) -> bool:
+        if is_scan:
+            return '__rng_state' in self.free_scan_vars
+        else:
+            return '__rng_state' in self.free_agg_vars
+
+    @property
     def bound_variables(self):
         return {v for child in self.children if isinstance(child, IR) for v in child.bound_variables}
 
     @property
     def typ(self):
         if self._type is None:
-            self._compute_type({}, None)
-            assert self._type is not None, self
+            self.compute_type({}, None, deep_typecheck=False)
         return self._type
 
     def renderable_new_block(self, i: int) -> bool:
         return False
 
+    def compute_type(self, env, agg_env, deep_typecheck):
+        if deep_typecheck or self._type is None:
+            computed = self._compute_type(env, agg_env, deep_typecheck)
+            if self._type is not None:
+                assert self._type == computed
+            self._type = computed
+            # assert self._type is not None
+
+    def assign_type(self, typ):
+        if self._type is None:
+            computed = self._compute_type({}, None, deep_typecheck=False)
+            if computed is not None:
+                assert computed == typ, (computed, typ)
+            self._type = typ
+        else:
+            assert self._type == typ
+
     @abc.abstractmethod
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         raise NotImplementedError(self)
+
+    @abc.abstractmethod
+    def _handle_randomness(self, create_uids):
+        pass
+
+    def handle_randomness(self, create_uids):
+        assert(isinstance(self.typ, tstream))
+        if not create_uids and not self.uses_randomness:
+            return self
+        return self._handle_randomness(create_uids)
 
     @property
     def free_vars(self):
@@ -328,17 +374,38 @@ class IR(BaseIR):
 class TableIR(BaseIR):
     def __init__(self, *children):
         super().__init__(*children)
+        self._children_use_randomness = any(child.uses_randomness for child in children)
 
     @abc.abstractmethod
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
         ...
+
+    def compute_type(self, deep_typecheck):
+        if deep_typecheck or self._type is None:
+            computed = self._compute_type(deep_typecheck)
+            if self._type is not None:
+                assert self._type == computed
+            else:
+                self._type = computed
 
     @property
     def typ(self):
         if self._type is None:
-            self._compute_type()
-            assert self._type is not None, self
+            self.compute_type(deep_typecheck=False)
         return self._type
+
+    @property
+    def uses_randomness(self) -> bool:
+        return self._children_use_randomness
+
+    @abc.abstractmethod
+    def _handle_randomness(self, uid_field_name):
+        pass
+
+    def handle_randomness(self, uid_field_name):
+        if uid_field_name is None and not self.uses_randomness:
+            return self
+        return self._handle_randomness(uid_field_name)
 
     def renderable_new_block(self, i: int) -> bool:
         return True
@@ -350,16 +417,41 @@ class TableIR(BaseIR):
 class MatrixIR(BaseIR):
     def __init__(self, *children):
         super().__init__(*children)
+        self._children_use_randomness = any(child.uses_randomness for child in children)
+
+    @property
+    def uses_randomness(self) -> bool:
+        return self._children_use_randomness
+
+    def handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if row_uid_field_name is None and col_uid_field_name and not self.uses_randomness:
+            return self
+        result = self._handle_randomness(row_uid_field_name, col_uid_field_name)
+        assert result is not None
+        assert row_uid_field_name is None or row_uid_field_name in result.typ.row_type
+        assert col_uid_field_name is None or col_uid_field_name in result.typ.col_type
+        return result
 
     @abc.abstractmethod
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        pass
+
+    @abc.abstractmethod
+    def _compute_type(self, deep_typecheck):
         ...
+
+    def compute_type(self, deep_typecheck):
+        if deep_typecheck or self._type is None:
+            computed = self._compute_type(deep_typecheck)
+            if self._type is not None:
+                assert self._type == computed
+            else:
+                self._type = computed
 
     @property
     def typ(self):
         if self._type is None:
-            self._compute_type()
-            assert self._type is not None, self
+            self.compute_type(deep_typecheck=False)
         return self._type
 
     def renderable_new_block(self, i: int) -> bool:
@@ -374,16 +466,28 @@ class MatrixIR(BaseIR):
 class BlockMatrixIR(BaseIR):
     def __init__(self, *children):
         super().__init__(*children)
+        self._children_use_randomness = any(child.uses_randomness for child in children)
+
+    @property
+    def uses_randomness(self) -> bool:
+        return self._children_use_randomness
 
     @abc.abstractmethod
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
         ...
+
+    def compute_type(self, deep_typecheck):
+        if deep_typecheck or self._type is None:
+            computed = self._compute_type(deep_typecheck)
+            if self._type is not None:
+                assert self._type == computed
+            else:
+                self._type = computed
 
     @property
     def typ(self):
         if self._type is None:
-            self._compute_type()
-            assert self._type is not None, self
+            self.compute_type(deep_typecheck=False)
         return self._type
 
     def renderable_new_block(self, i: int) -> bool:

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -2,7 +2,7 @@ import hail as hl
 from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.types import tarray
 from .blockmatrix_reader import BlockMatrixReader
-from .base_ir import BlockMatrixIR, IR
+from .base_ir import BlockMatrixIR, IR, _env_bind
 from hail.typecheck import typecheck_method, sequenceof, nullable
 from hail.utils.misc import escape_id
 
@@ -22,9 +22,11 @@ class BlockMatrixRead(BlockMatrixIR):
     def _eq(self, other):
         return self.reader == other.reader
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
         if self._type is None:
-            self._type = Env.backend().blockmatrix_type(self)
+            return Env.backend().blockmatrix_type(self)
+        else:
+            return self._type
 
 
 class BlockMatrixMap(BlockMatrixIR):
@@ -36,8 +38,14 @@ class BlockMatrixMap(BlockMatrixIR):
         self.f = f
         self.needs_dense = needs_dense
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.f.compute_type(self.bindings(1), None, deep_typecheck)
+        child_type = self.child.typ
+        return tblockmatrix(self.f.typ,
+                            child_type.shape,
+                            child_type.is_row_vector,
+                            child_type.block_size)
 
     def head_str(self):
         return escape_id(self.name) + " " + str(self.needs_dense)
@@ -64,9 +72,15 @@ class BlockMatrixMap2(BlockMatrixIR):
         self.f = f
         self.sparsity_strategy = sparsity_strategy
 
-    def _compute_type(self):
-        self.right.typ  # Force
-        self._type = self.left.typ
+    def _compute_type(self, deep_typecheck):
+        self.left.compute_type(deep_typecheck)
+        self.right.compute_type(deep_typecheck)
+        self.f.compute_type(self.bindings(2), None, deep_typecheck)
+        left_type = self.left.typ
+        return tblockmatrix(self.f.typ,
+                            left_type.shape,
+                            left_type.is_row_vector,
+                            left_type.block_size)
 
     def head_str(self):
         return escape_id(self.left_name) + " " + escape_id(self.right_name) + " " + self.sparsity_strategy
@@ -93,16 +107,18 @@ class BlockMatrixDot(BlockMatrixIR):
         self.left = left
         self.right = right
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.left.compute_type(deep_typecheck)
+        self.right.compute_type(deep_typecheck)
         l_rows, l_cols = tensor_shape_to_matrix_shape(self.left)
         r_rows, r_cols = tensor_shape_to_matrix_shape(self.right)
         assert l_cols == r_rows
 
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(l_rows, r_cols)
-        self._type = tblockmatrix(self.left.typ.element_type,
-                                  tensor_shape,
-                                  is_row_vector,
-                                  self.left.typ.block_size)
+        return tblockmatrix(self.left.typ.element_type,
+                            tensor_shape,
+                            is_row_vector,
+                            self.left.typ.block_size)
 
 
 class BlockMatrixBroadcast(BlockMatrixIR):
@@ -127,13 +143,14 @@ class BlockMatrixBroadcast(BlockMatrixIR):
             self.shape == other.shape and \
             self.block_size == other.block_size
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         assert len(self.shape) == 2
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(self.shape[0], self.shape[1])
-        self._type = tblockmatrix(self.child.typ.element_type,
-                                  tensor_shape,
-                                  is_row_vector,
-                                  self.block_size)
+        return tblockmatrix(self.child.typ.element_type,
+                            tensor_shape,
+                            is_row_vector,
+                            self.block_size)
 
 
 class BlockMatrixAgg(BlockMatrixIR):
@@ -150,7 +167,8 @@ class BlockMatrixAgg(BlockMatrixIR):
     def _eq(self, other):
         return self.out_index_expr == other.out_index_expr
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_matrix_shape = tensor_shape_to_matrix_shape(self.child)
         if self.out_index_expr == [0, 1]:
             is_row_vector = False
@@ -164,10 +182,10 @@ class BlockMatrixAgg(BlockMatrixIR):
         else:
             raise ValueError("Invalid out_index_expr")
 
-        self._type = tblockmatrix(self.child.typ.element_type,
-                                  shape,
-                                  is_row_vector,
-                                  self.child.typ.block_size)
+        return tblockmatrix(self.child.typ.element_type,
+                            shape,
+                            is_row_vector,
+                            self.child.typ.block_size)
 
 
 class BlockMatrixFilter(BlockMatrixIR):
@@ -183,7 +201,8 @@ class BlockMatrixFilter(BlockMatrixIR):
     def _eq(self, other):
         return self.indices_to_keep == other.indices_to_keep
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         assert len(self.indices_to_keep) == 2
 
         child_tensor_shape = self.child.typ.shape
@@ -200,10 +219,10 @@ class BlockMatrixFilter(BlockMatrixIR):
                         enumerate(self.indices_to_keep)]
 
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(matrix_shape[0], matrix_shape[1])
-        self._type = tblockmatrix(self.child.typ.element_type,
-                                  tensor_shape,
-                                  is_row_vector,
-                                  self.child.typ.block_size)
+        return tblockmatrix(self.child.typ.element_type,
+                            tensor_shape,
+                            is_row_vector,
+                            self.child.typ.block_size)
 
 
 class BlockMatrixDensify(BlockMatrixIR):
@@ -212,8 +231,9 @@ class BlockMatrixDensify(BlockMatrixIR):
         super().__init__(child)
         self.child = child
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class BlockMatrixSparsifier(object):
@@ -290,8 +310,10 @@ class BlockMatrixSparsify(BlockMatrixIR):
     def _eq(self, other):
         return self.sparsifier == other.sparsifier
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.value.compute_type({}, None, deep_typecheck)
+        return self.child.typ
 
 
 class BlockMatrixSlice(BlockMatrixIR):
@@ -307,14 +329,15 @@ class BlockMatrixSlice(BlockMatrixIR):
     def _eq(self, other):
         return self.slices == other.slices
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         assert len(self.slices) == 2
         matrix_shape = [1 + (s.stop - s.start - 1) // s.step for s in self.slices]
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(matrix_shape[0], matrix_shape[1])
-        self._type = tblockmatrix(self.child.typ.element_type,
-                                  tensor_shape,
-                                  is_row_vector,
-                                  self.child.typ.block_size)
+        return tblockmatrix(self.child.typ.element_type,
+                            tensor_shape,
+                            is_row_vector,
+                            self.child.typ.block_size)
 
 
 class ValueToBlockMatrix(BlockMatrixIR):
@@ -335,7 +358,8 @@ class ValueToBlockMatrix(BlockMatrixIR):
         return self.shape == other.shape and \
             self.block_size == other.block_size
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck, {}, None)
         child_type = self.child.typ
         if isinstance(child_type, tarray):
             element_type = child_type._element_type
@@ -344,7 +368,7 @@ class ValueToBlockMatrix(BlockMatrixIR):
 
         assert len(self.shape) == 2
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(self.shape[0], self.shape[1])
-        self._type = tblockmatrix(element_type, tensor_shape, is_row_vector, self.block_size)
+        return tblockmatrix(element_type, tensor_shape, is_row_vector, self.block_size)
 
 
 class BlockMatrixRandom(BlockMatrixIR):
@@ -371,11 +395,26 @@ class BlockMatrixRandom(BlockMatrixIR):
             self.shape == other.shape and \
             self.block_size == other.block_size
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
         assert len(self.shape) == 2
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(self.shape[0], self.shape[1])
 
-        self._type = tblockmatrix(hl.tfloat64, tensor_shape, is_row_vector, self.block_size)
+        return tblockmatrix(hl.tfloat64, tensor_shape, is_row_vector, self.block_size)
+
+
+class JavaBlockMatrix(BlockMatrixIR):
+    def __init__(self, jir):
+        super().__init__()
+        self._jir = jir
+
+    def render_head(self, r):
+        return f'(JavaBlockMatrix {r.add_jir(self._jir)}'
+
+    def _compute_type(self, deep_typecheck):
+        if self._type is None:
+            return hl.tblockmatrix._from_java(self._jir.typ())
+        else:
+            return self._type
 
 
 def tensor_shape_to_matrix_shape(bmir):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -2,7 +2,7 @@ import hail as hl
 from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.types import tarray
 from .blockmatrix_reader import BlockMatrixReader
-from .base_ir import BlockMatrixIR, IR, _env_bind
+from .base_ir import BlockMatrixIR, IR
 from hail.typecheck import typecheck_method, sequenceof, nullable
 from hail.utils.misc import escape_id
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -988,7 +988,7 @@ class NDArrayAgg(IR):
         return f'({" ".join([str(i) for i in self.axes])})'
 
     def _compute_type(self, env, agg_env, deep_typecheck):
-        self.nd.compute_type(env, agg_env), deep_typecheck
+        self.nd.compute_type(env, agg_env, deep_typecheck)
         assert len(set(self.axes)) == len(self.axes)
         assert all([axis < self.nd.typ.ndim for axis in self.axes])
 
@@ -1014,8 +1014,8 @@ class NDArrayMatMul(IR):
         return str(self._error_id)
 
     def _compute_type(self, env, agg_env, deep_typecheck):
-        self.left.compute_type(env, agg_env), deep_typecheck
-        self.right.compute_type(env, agg_env), deep_typecheck
+        self.left.compute_type(env, agg_env, deep_typecheck)
+        self.right.compute_type(env, agg_env, deep_typecheck)
 
         ndim = hail.linalg.utils.misc._ndarray_matmul_ndim(self.left.typ.ndim, self.right.typ.ndim)
         from hail.expr.expressions import unify_types

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1,3 +1,4 @@
+import abc
 import copy
 from collections import defaultdict
 
@@ -6,12 +7,13 @@ import decorator
 import hail
 from hail.expr.types import dtype, HailType, hail_type, tint32, tint64, \
     tfloat32, tfloat64, tstr, tbool, tarray, tstream, tndarray, tset, tdict, \
-    tstruct, ttuple, tinterval, tvoid
+    tstruct, ttuple, tinterval, tvoid, trngstate
 from hail.ir.blockmatrix_writer import BlockMatrixWriter, BlockMatrixMultiWriter
 from hail.typecheck import typecheck, typecheck_method, sequenceof, numeric, \
     sized_tupleof, nullable, tupleof, anytype, func_spec
 from hail.utils.java import Env, HailUserError, warning
 from hail.utils.misc import escape_str, dump_json, parsable_strings, escape_id
+from .utils import default_row_uid, default_col_uid, rng_key, unpack_row_uid, unpack_col_uid
 from .base_ir import BaseIR, IR, TableIR, MatrixIR, BlockMatrixIR, _env_bind
 from .matrix_writer import MatrixWriter, MatrixNativeMultiWriter
 from .renderer import Renderer, Renderable, ParensRenderer
@@ -33,8 +35,8 @@ class I32(IR):
     def head_str(self):
         return self.x
 
-    def _compute_type(self, env, agg_env):
-        self._type = tint32
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tint32
 
 
 class I64(IR):
@@ -52,8 +54,8 @@ class I64(IR):
     def head_str(self):
         return self.x
 
-    def _compute_type(self, env, agg_env):
-        self._type = tint64
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tint64
 
 
 class F32(IR):
@@ -71,8 +73,8 @@ class F32(IR):
     def head_str(self):
         return self.x
 
-    def _compute_type(self, env, agg_env):
-        self._type = tfloat32
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tfloat32
 
 
 class F64(IR):
@@ -90,8 +92,8 @@ class F64(IR):
     def head_str(self):
         return self.x
 
-    def _compute_type(self, env, agg_env):
-        self._type = tfloat64
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tfloat64
 
 
 class Str(IR):
@@ -109,8 +111,8 @@ class Str(IR):
     def head_str(self):
         return f'"{escape_str(self.x)}"'
 
-    def _compute_type(self, env, agg_env):
-        self._type = tstr
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tstr
 
 
 class FalseIR(IR):
@@ -123,8 +125,8 @@ class FalseIR(IR):
     def _ir_name(self):
         return 'False'
 
-    def _compute_type(self, env, agg_env):
-        self._type = tbool
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tbool
 
 
 class TrueIR(IR):
@@ -137,8 +139,8 @@ class TrueIR(IR):
     def _ir_name(self):
         return 'True'
 
-    def _compute_type(self, env, agg_env):
-        self._type = tbool
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tbool
 
 
 class Void(IR):
@@ -148,8 +150,8 @@ class Void(IR):
     def copy(self):
         return Void()
 
-    def _compute_type(self, env, agg_env):
-        self._type = tvoid
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return tvoid
 
 
 class Cast(IR):
@@ -173,9 +175,9 @@ class Cast(IR):
     def head_str(self):
         return self._typ._parsable_string()
 
-    def _compute_type(self, env, agg_env):
-        self.v._compute_type(env, agg_env)
-        self._type = self._typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.v.compute_type(env, agg_env, deep_typecheck)
+        return self._typ
 
 
 class NA(IR):
@@ -183,6 +185,14 @@ class NA(IR):
     def __init__(self, typ):
         super().__init__()
         self._typ = typ
+
+    def _handle_randomness(self, create_uids):
+        if create_uids:
+            if isinstance(self.typ.element_type, tstruct):
+                new_elt_typ = self.typ.element_type._insert_field(uid_field_name, tint64)
+            else:
+                new_elt_typ = ttuple(tint64, self.typ.element_type)
+            return NA(tstream(new_elt_typ))
 
     @property
     def typ(self):
@@ -197,8 +207,8 @@ class NA(IR):
     def head_str(self):
         return self._typ._parsable_string()
 
-    def _compute_type(self, env, agg_env):
-        self._type = self._typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return self._typ
 
 
 class IsNA(IR):
@@ -211,9 +221,9 @@ class IsNA(IR):
     def copy(self, value):
         return IsNA(value)
 
-    def _compute_type(self, env, agg_env):
-        self.value._compute_type(env, agg_env)
-        self._type = tbool
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.value.compute_type(env, agg_env, deep_typecheck)
+        return tbool
 
 
 class If(IR):
@@ -224,16 +234,21 @@ class If(IR):
         self.cnsq = cnsq
         self.altr = altr
 
+    def _handle_randomness(self, create_uids):
+        return If(self.cond,
+                  self.cnsq.handle_randomness(create_uids),
+                  self.altr.handle_randomness(create_uids))
+
     @typecheck_method(cond=IR, cnsq=IR, altr=IR)
     def copy(self, cond, cnsq, altr):
         return If(cond, cnsq, altr)
 
-    def _compute_type(self, env, agg_env):
-        self.cond._compute_type(env, agg_env)
-        self.cnsq._compute_type(env, agg_env)
-        self.altr._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.cond.compute_type(env, agg_env, deep_typecheck)
+        self.cnsq.compute_type(env, agg_env, deep_typecheck)
+        self.altr.compute_type(env, agg_env, deep_typecheck)
         assert (self.cnsq.typ == self.altr.typ)
-        self._type = self.cnsq.typ
+        return self.cnsq.typ
 
     def renderable_new_block(self, i):
         return i == 1 or i == 2
@@ -249,18 +264,20 @@ class Coalesce(IR):
     def copy(self, *values):
         return Coalesce(*values)
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         first, *rest = self.values
-        first._compute_type(env, agg_env)
+        first.compute_type(env, agg_env, deep_typecheck)
         for x in rest:
-            x._compute_type(env, agg_env)
+            x.compute_type(env, agg_env, deep_typecheck)
             assert x.typ == first.typ
-        self._type = first.typ
+        return first.typ
 
 
 class Let(IR):
     @typecheck_method(name=str, value=IR, body=IR)
     def __init__(self, name, value, body):
+        if isinstance(value.typ, tstream):
+            value = value.handle_randomness(False)
         super().__init__(value, body)
         self.name = name
         self.value = value
@@ -280,10 +297,10 @@ class Let(IR):
     def _eq(self, other):
         return other.name == self.name
 
-    def _compute_type(self, env, agg_env):
-        self.value._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(1)), agg_env)
-        self._type = self.body._type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.value.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(1)), agg_env, deep_typecheck)
+        return self.body.typ
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -319,10 +336,10 @@ class AggLet(IR):
     def _eq(self, other):
         return other.name == self.name and other.is_scan == self.is_scan
 
-    def _compute_type(self, env, agg_env):
-        self.value._compute_type(agg_env, None)
-        self.body._compute_type(env, _env_bind(agg_env, {self.name: self.value._type}))
-        self._type = self.body._type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.value.compute_type(agg_env, None, deep_typecheck)
+        self.body.compute_type(env, _env_bind(agg_env, {self.name: self.value.typ}), deep_typecheck)
+        return self.body.typ
 
     def renderable_agg_bindings(self, i, default_value=None):
         if not self.is_scan and i == 1:
@@ -352,14 +369,24 @@ class AggLet(IR):
 
 
 class Ref(IR):
-    @typecheck_method(name=str)
-    def __init__(self, name):
+    @typecheck_method(name=str, type=nullable(HailType))
+    def __init__(self, name, type=None):
         super().__init__()
         self.name = name
         self._free_vars = {name}
+        self._typ = type
+
+    def _handle_randomness(self, create_uids):
+        if not create_uids:
+            return self
+        elt = Env.get_uid
+        uid = Env.get_uid
+        return StreamZip([self, StreamIota(I32(0), I32(1))],
+                         [elt, uid],
+                         pack_uid(Cast(Ref(uid, tint32), tint64), Ref(elt, tint32)))
 
     def copy(self):
-        return Ref(self.name)
+        return Ref(self.name, self._type)
 
     def head_str(self):
         return escape_id(self.name)
@@ -367,30 +394,33 @@ class Ref(IR):
     def _eq(self, other):
         return other.name == self.name
 
-    def _compute_type(self, env, agg_env):
-        self._type = env[self.name]
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        if deep_typecheck:
+            assert self.name in env, f'{self.name} not found in {env}'
+            if self._typ is not None:
+                assert self._typ == env[self.name]
+            return env[self.name]
+        else:
+            return self._typ
 
 
 class TopLevelReference(Ref):
-    @typecheck_method(name=str)
-    def __init__(self, name):
-        super().__init__(name)
+    @typecheck_method(name=str, type=nullable(HailType))
+    def __init__(self, name, type=None):
+        super().__init__(name, type)
 
     @property
     def is_nested_field(self):
         return True
 
     def copy(self):
-        return TopLevelReference(self.name)
+        return TopLevelReference(self.name, self.type)
 
     def _ir_name(self):
         return 'Ref'
 
-    def _compute_type(self, env, agg_env):
-        assert self.name in env, f'{self.name} not found in {env}'
-        self._type = env[self.name]
 
-
+# FIXME: If body uses randomness, create a new uid induction variable
 class TailLoop(IR):
     @typecheck_method(name=str, body=IR, params=sequenceof(sized_tupleof(str, IR)))
     def __init__(self, name, body, params):
@@ -415,11 +445,11 @@ class TailLoop(IR):
     def bound_variables(self):
         return {n for n, _ in self.params} | {self.name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for _, b in self.params:
-            b._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(len(self.params))), agg_env)
-        self._type = self.body.typ
+            b.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(len(self.params))), agg_env, deep_typecheck)
+        return self.body.typ
 
     def renderable_bindings(self, i, default_value=None):
         if i == len(self.params):
@@ -450,9 +480,10 @@ class Recur(IR):
     def _eq(self, other):
         return other.name == self.name
 
-    def _compute_type(self, env, agg_env):
-        assert self.name in env
-        self._type = self.return_type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        if deep_typecheck:
+            assert self.name in env
+        return self.return_type
 
 
 class ApplyBinaryPrimOp(IR):
@@ -473,19 +504,19 @@ class ApplyBinaryPrimOp(IR):
     def _eq(self, other):
         return other.op == self.op
 
-    def _compute_type(self, env, agg_env):
-        self.left._compute_type(env, agg_env)
-        self.right._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.left.compute_type(env, agg_env, deep_typecheck)
+        self.right.compute_type(env, agg_env, deep_typecheck)
         if self.op == '/':
             int_types = [tint32, tint64]
             if self.left.typ in int_types and self.right.typ in int_types:
-                self._type = tfloat64
+                return tfloat64
             elif self.left.typ == tfloat64:
-                self._type = tfloat64
+                return tfloat64
             else:
-                self._type = tfloat32
+                return tfloat32
         else:
-            self._type = self.left.typ
+            return self.left.typ
 
 
 class ApplyUnaryPrimOp(IR):
@@ -505,9 +536,9 @@ class ApplyUnaryPrimOp(IR):
     def _eq(self, other):
         return other.op == self.op
 
-    def _compute_type(self, env, agg_env):
-        self.x._compute_type(env, agg_env)
-        self._type = self.x.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.x.compute_type(env, agg_env, deep_typecheck)
+        return self.x.typ
 
 
 class ApplyComparisonOp(IR):
@@ -528,10 +559,13 @@ class ApplyComparisonOp(IR):
     def _eq(self, other):
         return other.op == self.op
 
-    def _compute_type(self, env, agg_env):
-        self.left._compute_type(env, agg_env)
-        self.right._compute_type(env, agg_env)
-        self._type = tbool
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.left.compute_type(env, agg_env, deep_typecheck)
+        self.right.compute_type(env, agg_env, deep_typecheck)
+        if self.op == 'Compare':
+            return tint32
+        else:
+            return tbool
 
 
 class MakeArray(IR):
@@ -550,11 +584,10 @@ class MakeArray(IR):
     def _eq(self, other):
         return other._type == self._type
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for a in self.args:
-            a._compute_type(env, agg_env)
-        if self._type is None:
-            self._type = tarray(self.args[0].typ)
+            a.compute_type(env, agg_env, deep_typecheck)
+        return tarray(self.args[0].typ)
 
 
 class ArrayRef(IR):
@@ -575,10 +608,10 @@ class ArrayRef(IR):
     def head_str(self):
         return str(self._error_id)
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.i._compute_type(env, agg_env)
-        self._type = self.a.typ.element_type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.i.compute_type(env, agg_env, deep_typecheck)
+        return self.a.typ.element_type
 
 
 class ArraySlice(IR):
@@ -605,13 +638,13 @@ class ArraySlice(IR):
     def head_str(self):
         return str(self._error_id)
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.start._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.start.compute_type(env, agg_env, deep_typecheck)
         if self.stop is not None:
-            self.stop._compute_type(env, agg_env)
-        self.step._compute_type(env, agg_env)
-        self._type = self.a.typ
+            self.stop.compute_type(env, agg_env, deep_typecheck)
+        self.step.compute_type(env, agg_env, deep_typecheck)
+        return self.a.typ
 
 
 class ArrayLen(IR):
@@ -624,9 +657,9 @@ class ArrayLen(IR):
     def copy(self, a):
         return ArrayLen(a)
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self._type = tint32
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        return tint32
 
 
 class ArrayZeros(IR):
@@ -639,9 +672,9 @@ class ArrayZeros(IR):
     def copy(self, length):
         return ArrayZeros(length)
 
-    def _compute_type(self, env, agg_env):
-        self.length._compute_type(env, agg_env)
-        self._type = tarray(tint32)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.length.compute_type(env, agg_env, deep_typecheck)
+        return tarray(tint32)
 
 
 class StreamIota(IR):
@@ -652,6 +685,12 @@ class StreamIota(IR):
         self.step = step
         self.requires_memory_management_per_element = requires_memory_management_per_element
 
+    def _handle_randomness(self, create_uids):
+        if not create_uids:
+            return self
+        elt = Env.get_uid
+        return StreamMap(self, elt, MakeTuple([Cast(Ref(elt, tint32), tint64), Ref(elt, tint32)]))
+
     @typecheck_method(start=IR, step=IR)
     def copy(self, start, step):
         return StreamIota(start, step,
@@ -660,10 +699,10 @@ class StreamIota(IR):
     def head_str(self):
         return f'{self.requires_memory_management_per_element}'
 
-    def _compute_type(self, env, agg_env):
-        self.start._compute_type(env, agg_env)
-        self.step._compute_type(env, agg_env)
-        self._type = tstream(tint32)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.start.compute_type(env, agg_env, deep_typecheck)
+        self.step.compute_type(env, agg_env, deep_typecheck)
+        return tstream(tint32)
 
 
 class StreamRange(IR):
@@ -681,6 +720,12 @@ class StreamRange(IR):
         if error_id is None or stack_trace is None:
             self.save_error_info()
 
+    def _handle_randomness(self, create_uids):
+        if not create_uids:
+            return self
+        elt = Env.get_uid
+        return StreamMap(self, elt, MakeTuple([Cast(Ref(elt, tint32), tint64), Ref(elt, tint32)]))
+
     @typecheck_method(start=IR, stop=IR, step=IR)
     def copy(self, start, stop, step):
         return StreamRange(start, stop, step, error_id=self._error_id, stack_trace=self._stack_trace)
@@ -688,11 +733,11 @@ class StreamRange(IR):
     def head_str(self):
         return f'{self._error_id} {self.requires_memory_management_per_element}'
 
-    def _compute_type(self, env, agg_env):
-        self.start._compute_type(env, agg_env)
-        self.stop._compute_type(env, agg_env)
-        self.step._compute_type(env, agg_env)
-        self._type = tstream(tint32)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.start.compute_type(env, agg_env, deep_typecheck)
+        self.stop.compute_type(env, agg_env, deep_typecheck)
+        self.step.compute_type(env, agg_env, deep_typecheck)
+        return tstream(tint32)
 
 
 class StreamGrouped(IR):
@@ -702,13 +747,17 @@ class StreamGrouped(IR):
         self.stream = stream
         self.group_size = group_size
 
+    def _handle_randomness(self, create_uids):
+        assert(not create_uids)
+        self.stream.handle_randomness(False)
+
     @typecheck_method(stream=IR, group_size=IR)
     def copy(self, stream=IR, group_size=IR):
         return StreamGrouped(stream, group_size)
 
-    def _compute_type(self, env, agg_env):
-        self.stream._compute_type(env, agg_env)
-        self._type = tstream(self.stream._type)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.stream.compute_type(env, agg_env, deep_typecheck)
+        return tstream(self.stream.typ)
 
 
 class MakeNDArray(IR):
@@ -728,11 +777,11 @@ class MakeNDArray(IR):
     def copy(self, data, shape, row_major):
         return MakeNDArray(data, shape, row_major, self._error_id, self._stack_trace)
 
-    def _compute_type(self, env, agg_env):
-        self.data._compute_type(env, agg_env)
-        self.shape._compute_type(env, agg_env)
-        self.row_major._compute_type(env, agg_env)
-        self._type = tndarray(self.data.typ.element_type, len(self.shape.typ))
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.data.compute_type(env, agg_env, deep_typecheck)
+        self.shape.compute_type(env, agg_env, deep_typecheck)
+        self.row_major.compute_type(env, agg_env, deep_typecheck)
+        return tndarray(self.data.typ.element_type, len(self.shape.typ))
 
     def head_str(self):
         return f'{self._error_id}'
@@ -748,9 +797,9 @@ class NDArrayShape(IR):
     def copy(self, nd):
         return NDArrayShape(nd)
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
-        self._type = ttuple(*[tint64 for _ in range(self.nd.typ.ndim)])
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
+        return ttuple(*[tint64 for _ in range(self.nd.typ.ndim)])
 
 
 class NDArrayReshape(IR):
@@ -770,10 +819,10 @@ class NDArrayReshape(IR):
     def head_str(self):
         return str(self._error_id)
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
-        self.shape._compute_type(env, agg_env)
-        self._type = tndarray(self.nd.typ.element_type, len(self.shape.typ))
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
+        self.shape.compute_type(env, agg_env, deep_typecheck)
+        return tndarray(self.nd.typ.element_type, len(self.shape.typ))
 
 
 class NDArrayMap(IR):
@@ -798,10 +847,10 @@ class NDArrayMap(IR):
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(1)), agg_env)
-        self._type = tndarray(self.body.typ, self.nd.typ.ndim)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(1)), agg_env, deep_typecheck)
+        return tndarray(self.body.typ, self.nd.typ.ndim)
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -843,11 +892,11 @@ class NDArrayMap2(IR):
     def bound_variables(self):
         return {self.lname, self.rname} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.left._compute_type(env, agg_env)
-        self.right._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(2)), agg_env)
-        self._type = tndarray(self.body.typ, self.left.typ.ndim)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.left.compute_type(env, agg_env, deep_typecheck)
+        self.right.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(2)), agg_env, deep_typecheck)
+        return tndarray(self.body.typ, self.left.typ.ndim)
 
     def renderable_bindings(self, i, default_value=None):
         if i == 2:
@@ -876,10 +925,10 @@ class NDArrayRef(IR):
     def head_str(self):
         return str(self._error_id)
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
-        [idx._compute_type(env, agg_env) for idx in self.idxs]
-        self._type = self.nd.typ.element_type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
+        [idx.compute_type(env, agg_env, deep_typecheck) for idx in self.idxs]
+        return self.nd.typ.element_type
 
 
 class NDArraySlice(IR):
@@ -892,11 +941,11 @@ class NDArraySlice(IR):
     def copy(self, nd, slices):
         return NDArraySlice(nd, slices)
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
-        self.slices._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
+        self.slices.compute_type(env, agg_env, deep_typecheck)
 
-        self._type = tndarray(self.nd.typ.element_type,
+        return tndarray(self.nd.typ.element_type,
                               len([t for t in self.slices.typ.types if isinstance(t, ttuple)]))
 
 
@@ -914,15 +963,15 @@ class NDArrayReindex(IR):
     def head_str(self):
         return f'({" ".join([str(i) for i in self.idx_expr])})'
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
         n_input_dims = self.nd.typ.ndim
         n_output_dims = len(self.idx_expr)
         assert n_input_dims <= n_output_dims
         assert all([i < n_output_dims for i in self.idx_expr])
         assert all([i in self.idx_expr for i in range(n_output_dims)])
 
-        self._type = tndarray(self.nd.typ.element_type, n_output_dims)
+        return tndarray(self.nd.typ.element_type, n_output_dims)
 
 
 class NDArrayAgg(IR):
@@ -939,12 +988,12 @@ class NDArrayAgg(IR):
     def head_str(self):
         return f'({" ".join([str(i) for i in self.axes])})'
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env), deep_typecheck
         assert len(set(self.axes)) == len(self.axes)
         assert all([axis < self.nd.typ.ndim for axis in self.axes])
 
-        self._type = tndarray(self.nd.typ.element_type, self.nd.typ.ndim - len(self.axes))
+        return tndarray(self.nd.typ.element_type, self.nd.typ.ndim - len(self.axes))
 
 
 class NDArrayMatMul(IR):
@@ -965,13 +1014,13 @@ class NDArrayMatMul(IR):
     def head_str(self):
         return str(self._error_id)
 
-    def _compute_type(self, env, agg_env):
-        self.left._compute_type(env, agg_env)
-        self.right._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.left.compute_type(env, agg_env), deep_typecheck
+        self.right.compute_type(env, agg_env), deep_typecheck
 
         ndim = hail.linalg.utils.misc._ndarray_matmul_ndim(self.left.typ.ndim, self.right.typ.ndim)
         from hail.expr.expressions import unify_types
-        self._type = tndarray(unify_types(self.left.typ.element_type,
+        return tndarray(unify_types(self.left.typ.element_type,
                                           self.right.typ.element_type), ndim)
 
 
@@ -992,15 +1041,15 @@ class NDArrayQR(IR):
     def head_str(self):
         return f'{self._error_id} "{self.mode}"'
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
 
         if self.mode in ["complete", "reduced"]:
-            self._type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2))
+            return ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2))
         elif self.mode == "raw":
-            self._type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1))
+            return ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1))
         elif self.mode == "r":
-            self._type = tndarray(tfloat64, 2)
+            return tndarray(tfloat64, 2)
         else:
             raise ValueError("Cannot compute type for mode: " + self.mode)
 
@@ -1023,12 +1072,12 @@ class NDArraySVD(IR):
     def head_str(self):
         return f'{self._error_id} {self.full_matrices} {self.compute_uv}'
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
         if self.compute_uv:
-            self._type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2))
+            return ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2))
         else:
-            self._type = tndarray(tfloat64, 1)
+            return tndarray(tfloat64, 1)
 
 
 class NDArrayInv(IR):
@@ -1047,9 +1096,9 @@ class NDArrayInv(IR):
     def head_str(self):
         return str(self._error_id)
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
-        self._type = tndarray(tfloat64, 2)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
+        return tndarray(tfloat64, 2)
 
 
 class NDArrayConcat(IR):
@@ -1069,10 +1118,10 @@ class NDArrayConcat(IR):
         return other.nds == self.nds and \
             other.axis == self.axis
 
-    def _compute_type(self, env, agg_env):
-        self.nds._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nds.compute_type(env, agg_env, deep_typecheck)
 
-        self._type = self.nds.typ.element_type
+        return self.nds.typ.element_type
 
 
 class NDArrayWrite(IR):
@@ -1086,10 +1135,10 @@ class NDArrayWrite(IR):
     def copy(self, nd, path):
         return NDArrayWrite(nd, path)
 
-    def _compute_type(self, env, agg_env):
-        self.nd._compute_type(env, agg_env)
-        self.path._compute_type(env, agg_env)
-        self._type = tvoid
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.nd.compute_type(env, agg_env, deep_typecheck)
+        self.path.compute_type(env, agg_env, deep_typecheck)
+        return tvoid
 
     @staticmethod
     def is_effectful() -> bool:
@@ -1119,9 +1168,9 @@ class ArraySort(IR):
     def _eq(self, other):
         return other.l_name == self.l_name and other.r_name == self.r_name
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self._type = tarray(self.a.typ.element_type)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        return tarray(self.a.typ.element_type)
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -1144,9 +1193,9 @@ class ToSet(IR):
     def copy(self, a):
         return ToSet(a)
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self._type = tset(self.a.typ.element_type)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        return tset(self.a.typ.element_type)
 
 
 class ToDict(IR):
@@ -1159,14 +1208,16 @@ class ToDict(IR):
     def copy(self, a):
         return ToDict(a)
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self._type = tdict(self.a.typ['key'], self.a.typ['value'])
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        return tdict(self.a.typ['key'], self.a.typ['value'])
 
 
 class ToArray(IR):
     @typecheck_method(a=IR)
     def __init__(self, a):
+        if a.uses_randomness:
+            a = a.handle_randomness(False)
         super().__init__(a)
         self.a = a
 
@@ -1174,9 +1225,9 @@ class ToArray(IR):
     def copy(self, a):
         return ToArray(a)
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self._type = tarray(self.a.typ.element_type)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        return tarray(self.a.typ.element_type)
 
 
 class CastToArray(IR):
@@ -1189,9 +1240,9 @@ class CastToArray(IR):
     def copy(self, a):
         return CastToArray(a)
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self._type = tarray(self.a.typ.element_type)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        return tarray(self.a.typ.element_type)
 
 
 class ToStream(IR):
@@ -1201,6 +1252,14 @@ class ToStream(IR):
         self.a = a
         self.requires_memory_management_per_element = requires_memory_management_per_element
 
+    def _handle_randomness(self, create_uids):
+        if not create_uids:
+            return self
+        uid = Env.get_uid()
+        elt = Env.get_uid()
+        iota = StreamIota(I32(0), I32(1))
+        return StreamZip([self, iota], [elt, uid], MakeTuple([Cast(Ref(uid, tint32), tint64), Ref(elt, self.typ.element_type)]), 'TakeMinLength')
+
     @typecheck_method(a=IR)
     def copy(self, a):
         return ToStream(a)
@@ -1208,9 +1267,9 @@ class ToStream(IR):
     def head_str(self):
         return self.requires_memory_management_per_element
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self._type = tstream(self.a.typ.element_type)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        return tstream(self.a.typ.element_type)
 
 
 class LowerBoundOnOrderedCollection(IR):
@@ -1228,10 +1287,10 @@ class LowerBoundOnOrderedCollection(IR):
     def head_str(self):
         return self.on_key
 
-    def _compute_type(self, env, agg_env):
-        self.ordered_collection._compute_type(env, agg_env)
-        self.elem._compute_type(env, agg_env)
-        self._type = tint32
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.ordered_collection.compute_type(env, agg_env, deep_typecheck)
+        self.elem.compute_type(env, agg_env, deep_typecheck)
+        return tint32
 
 
 class GroupByKey(IR):
@@ -1244,10 +1303,94 @@ class GroupByKey(IR):
     def copy(self, collection):
         return GroupByKey(collection)
 
-    def _compute_type(self, env, agg_env):
-        self.collection._compute_type(env, agg_env)
-        self._type = tdict(self.collection.typ.element_type.types[0],
-                           tarray(self.collection.typ.element_type.types[1]))
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.collection.compute_type(env, agg_env, deep_typecheck)
+        return tdict(self.collection.typ.element_type.types[0],
+                     tarray(self.collection.typ.element_type.types[1]))
+
+
+rng_key = (0, 1, 2, 3)
+static_split_ctr = 0
+uid_field_name = '__uid'
+
+def get_static_split_uid():
+    global static_split_ctr
+    result = static_split_ctr
+    assert(result <= 0xFFFF_FFFF_FFFF_FFFF)
+    static_split_ctr += 1
+    return result
+
+def uid_size(type):
+    if isinstance(type, ttuple):
+        return len(type)
+    return 1
+
+def unify_uid_types(types, tag=False):
+    size = max(uid_size(type) for type in types)
+    if tag:
+        size += 1
+    if size == 1:
+        return tint64
+    return ttuple(tint64 for _ in range(size))
+
+def pad_uid(uid, type, tag=None):
+    size = uid_size(uid.typ)
+    padded = uid_size(type)
+    padding = padded - size
+    if tag is not None:
+        padding -= 1
+    assert(padding >= 0)
+    if size == 1:
+        fields = (uid,)
+    else:
+        fields = (GetTupleElement(uid, i) for i in range(size))
+    if tag is None:
+        tuple = MakeTuple([*(I64(0) for _ in range(padding)), *fields])
+    else:
+        tuple = MakeTuple([I64(tag), *(I64(0) for _ in range(padding)), *fields])
+    return If(IsNA(uid), NA(tuple.typ), tuple)
+
+def concat_uids(uid1, uid2, handle_missing_left=False, handle_missing_right=False):
+    size1 = uid_size(uid1)
+    if size1 == 1:
+        fields1 = (uid1,)
+    else:
+        fields1 = (GetTupleElement(uid1, i) for i in range(size1))
+    if handle_missing_left:
+        fields1 = (Coalesce(field, I64(0)) for field in fields1)
+    size2 = uid_size(uid2)
+    if size2 == 1:
+        fields2 = (uid2,)
+    else:
+        fields2 = (GetTupleElement(uid2, i) for i in range(size2))
+    if handle_missing_right:
+        fields2 = (Coalesce(field, I64(0)) for field in fields2)
+    tuple = MakeTuple([*fields1, *fields2])
+    return If(Apply("lor", tbool, IsNA(uid1), IsNA(uid2)), NA(tuple.typ), tuple)
+
+def unpack_uid(stream_type):
+    tuple_type = stream_type.element_type
+    tuple = Ref(Env.get_uid(), tuple_type)
+    if isinstance(tuple_type, tstruct):
+        return tuple.name,\
+               GetField(tuple, uid_field_name),\
+               SelectFields(tuple, [field for field in tuple_type.fields if not field == uid_field_name])
+    else:
+        return tuple.name, GetTupleElement(tuple, 0), GetTupleElement(tuple, 1)
+
+def pack_uid(uid, elt):
+    if isinstance(elt.typ, tstruct):
+        return InsertFields(elt, [uid_field_name, uid])
+    else:
+        return MakeTuple([uid, elt])
+
+def with_split_rng_state(ir, split, is_scan=None) -> 'BaseIR':
+    ref = Ref('__rng_state', trngstate)
+    new_state = RNGSplit(ref, split)
+    if is_scan is None:
+        return Let('__rng_state', new_state, ir)
+    else:
+        return AggLet('__rng_state', new_state, ir, is_scan)
 
 
 class StreamMap(IR):
@@ -1257,6 +1400,29 @@ class StreamMap(IR):
         self.a = a
         self.name = name
         self.body = body
+
+    def _handle_randomness(self, create_uids):
+        if not self.body.uses_randomness and not create_uids:
+            a = self.a.handle_randomness(False)
+            return StreamMap(a, self.name, self.body)
+
+        if isinstance(self.typ.element_type, tstream):
+            assert(self.body.uses_randomness and not create_uids)
+            a = self.a.handle_randomness(False)
+            uid = Env.get_uid()
+            elt = Env.get_uid()
+            new_body = with_split_rng_state(Let(self.name, elt, self.body, uid))
+            return StreamZip([a, StreamIota(I32(0), I32(1))], [elt, uid], new_body, 'TakeMinLength')
+
+        a = self.a.handle_randomness(True)
+
+        tuple, uid, elt = unpack_uid(a.typ)
+        new_body = Let(self.name, elt, self.body)
+        if self.body.uses_randomness:
+            new_body = with_split_rng_state(new_body, uid)
+        if create_uids:
+            new_body = pack_uid(uid, new_body)
+        return StreamMap(a, tuple, new_body)
 
     @typecheck_method(a=IR, body=IR)
     def copy(self, a, body):
@@ -1272,10 +1438,10 @@ class StreamMap(IR):
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(1)), agg_env)
-        self._type = tstream(self.body.typ)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(1)), agg_env, deep_typecheck)
+        return tstream(self.body.typ)
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -1302,6 +1468,34 @@ class StreamZip(IR):
         if error_id is None or stack_trace is None:
             self.save_error_info()
 
+    def _handle_randomness(self, create_uids):
+        if not self.body.uses_randomness and not create_uids:
+            new_streams = [stream.handle_randomness(False) for stream in self.streams]
+            return StreamZip(new_streams, self.names, self.body, self.behavior, self._error_id, self._stack_trace)
+
+        if self.behavior == 'ExtendNA':
+            new_streams = [stream.handle_randomness(True) for stream in self.streams]
+            tuples, uids, elts = unzip(unpack_uid(stream.typ) for stream in new_streams)
+            uid_type = unify_uid_types(uid.typ for uid in uids)
+            uid = Coalesce(If(IsNA(uid), NA(uid_type), pad_uid(uid, uid_type, i)) for i, uid in enumerate(uids))
+            new_body = self.body
+            for elt, name in zip(elts, self.names):
+                new_body = Let(name, elt, new_body)
+            if self.body.uses_randomness:
+                new_body = with_split_rng_state(new_body, uid)
+            if create_uids:
+                pack_uid(uid, new_body)
+            return StreamZip(new_streams, tuples, new_body, self.behavior, self._error_id, self._stack_trace)
+
+        new_streams = [self.streams[0].handle_randomness(True), *(stream.handle_randomness(False) for stream in self.streams[1:])]
+        tuple, uid, elt = unpack_uid(self.streams[0].typ)
+        new_body = Let(self.names[0], elt, self.body)
+        if self.body.uses_randomness:
+            new_body = with_split_rng_state(new_body, uid)
+        if create_uids:
+            pack_uid(uid, new_body)
+        return StreamZip(new_streams, [tuple, *self.names[1:]], new_body, self.behavior, self._error_id, self._stack_trace)
+
     @typecheck_method(children=IR)
     def copy(self, *children):
         return StreamZip(children[:-1], self.names, children[-1], self.behavior, self._error_id, self._stack_trace)
@@ -1316,11 +1510,11 @@ class StreamZip(IR):
     def bound_variables(self):
         return set(self.names) | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for a in self.streams:
-            a._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(len(self.names))), agg_env)
-        self._type = tstream(self.body.typ)
+            a.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(len(self.names))), agg_env, deep_typecheck)
+        return tstream(self.body.typ)
 
     def renderable_bindings(self, i, default_value=None):
         if i == len(self.names):
@@ -1337,6 +1531,21 @@ class StreamFilter(IR):
         self.name = name
         self.body = body
 
+    def _handle_randomness(self, create_uids):
+        if not self.body.uses_randomness and not create_uids:
+            a = self.a.handle_randomness(False)
+            return StreamFilter(a, self.name, self.body)
+
+        a = self.a.handle_randomness(True)
+        tuple, uid, elt = unpack_uid(a.typ)
+        new_body = Let(self.name, elt, self.body)
+        if self.body.uses_randomness:
+            new_body = with_split_rng_state(new_body, uid)
+        result = StreamFilter(a, tuple, new_body)
+        if not create_uids:
+            result = StreamMap(result, tuple, elt)
+        return result
+
     @typecheck_method(a=IR, body=IR)
     def copy(self, a, body):
         return StreamFilter(a, self.name, body)
@@ -1351,10 +1560,10 @@ class StreamFilter(IR):
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(1)), agg_env)
-        self._type = self.a.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(1)), agg_env, deep_typecheck)
+        return self.a.typ
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -1375,6 +1584,23 @@ class StreamFlatMap(IR):
         self.name = name
         self.body = body
 
+    def _handle_randomness(self, create_uids):
+        if not self.body.uses_randomness and not create_uids:
+            a = self.a.handle_randomness(False)
+            return StreamFlatMap(a, self.name, self.body)
+
+        a = self.a.handle_randomness(True)
+        tuple, uid, elt = unpack_uid(a.typ)
+        new_body = Let(self.name, elt, self.body)
+        new_body = new_body.handle_randomness(create_uids)
+        if create_uids:
+            tuple2, uid2, elt2 = unpack_uid(new_body.typ)
+            combined_uid = MakeTuple([uid, uid2])
+            new_body = StreamMap(new_body, tuple2, pack_uid(combined_uid, elt2))
+        if self.body.uses_randomness:
+            new_body = with_split_rng_state(new_body, uid)
+        return StreamFlatMap(a, tuple, new_body)
+
     @typecheck_method(a=IR, body=IR)
     def copy(self, a, body):
         return StreamFlatMap(a, self.name, body)
@@ -1389,10 +1615,10 @@ class StreamFlatMap(IR):
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(1)), agg_env)
-        self._type = tstream(self.body.typ.element_type)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(1)), agg_env, deep_typecheck)
+        return tstream(self.body.typ.element_type)
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -1407,6 +1633,14 @@ class StreamFlatMap(IR):
 class StreamFold(IR):
     @typecheck_method(a=IR, zero=IR, accum_name=str, value_name=str, body=IR)
     def __init__(self, a, zero, accum_name, value_name, body):
+        if a.uses_randomness or body.uses_randomness:
+            a = a.handle_randomness(create_uids=body.uses_randomness)
+        if body.uses_randomness:
+            tuple, uid, elt = unpack_uid(a.typ)
+            body = Let(value_name, elt, body)
+            body = with_split_rng_state(body, uid)
+            value_name = tuple
+
         super().__init__(a, zero, body)
         self.a = a
         self.zero = zero
@@ -1429,11 +1663,11 @@ class StreamFold(IR):
     def bound_variables(self):
         return {self.accum_name, self.value_name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.zero._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(2)), agg_env)
-        self._type = self.zero.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.zero.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(2)), agg_env, deep_typecheck)
+        return self.zero.typ
 
     def renderable_bindings(self, i, default_value=None):
         if i == 2:
@@ -1455,6 +1689,20 @@ class StreamScan(IR):
         self.value_name = value_name
         self.body = body
 
+    def _handle_randomness(self, create_uids):
+        if not self.body.uses_randomness and not create_uids:
+            a = self.a.handle_randomness(False)
+            return StreamScan(a, self.zero, self.accum_name, self.value_name, self.body)
+
+        a = self.a.handle_randomness(True)
+        tuple, uid, elt = unpack_uid(a.typ)
+        new_body = Let(self.name, elt, self.body)
+        if self.body.uses_randomness:
+            new_body = with_split_rng_state(new_body, uid)
+        if create_uids:
+            new_body = pack_uid(uid, new_body)
+        return StreamScan(a, self.zero, self.accum_name, tuple, new_body)
+
     @typecheck_method(a=IR, zero=IR, body=IR)
     def copy(self, a, zero, body):
         return StreamScan(a, zero, self.accum_name, self.value_name, body)
@@ -1470,11 +1718,11 @@ class StreamScan(IR):
     def bound_variables(self):
         return {self.accum_name, self.value_name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.zero._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(2)), agg_env)
-        self._type = tstream(self.body.typ)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.zero.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(2)), agg_env, deep_typecheck)
+        return tstream(self.body.typ)
 
     def renderable_bindings(self, i, default_value=None):
         if i == 2:
@@ -1498,6 +1746,41 @@ class StreamJoinRightDistinct(IR):
         self.r_name = r_name
         self.join = join
         self.join_type = join_type
+
+    def _handle_randomness(self, create_uids):
+        if not self.join.uses_randomness and not create_uids:
+            if self.left.uses_randomness:
+                left = self.left.handle_randomness(False)
+            if self.right.uses_randomness:
+                right = self.right.handle_randomness(False)
+            return StreamJoinRightDistinct(left, right, self.l_key, self.r_key, self.l_name, self.r_name, self.join, self.join_type)
+
+        if self.join_type == 'left' or self.join_type == 'inner':
+            left = self.left.handle_randomness(True)
+            if self.right.uses_randomness:
+                right = self.right.handle_randomness(False)
+            r_name = self.r_name
+            l_name, uid, l_elt = unpack_uid(left.typ)
+            new_join = Let(self.l_name, l_elt, self.join)
+        elif self.join_type == 'right':
+            right = self.right.handle_randomness(True)
+            if self.left.uses_randomness:
+                left = self.left.handle_randomness(False)
+            l_name = self.l_name
+            r_name, uid, r_elt = unpack_uid(right.typ)
+            new_join = Let(self.r_name, r_elt, self.join)
+        else:
+            left = self.left.handle_randomness(True)
+            right = self.right.handle_randomness(True)
+            [l_name, r_name], uids, elts = unzip(unpack_uid(left.typ), unpack_uid(right.typ))
+            uid_type = unify_uid_types((uid.typ for uid in uids), tag=True)
+            uid = If(IsNA(uids[0]), pad_uid(uids[1], uid_type, 1), pad_uid(uids[0], uid_type, 0))
+            new_join = Let(self.l_name, elts[0], Let(self.r_name, elts[1], self.join))
+        if self.join.uses_randomness:
+            new_join = with_split_rng_state(new_join, uid)
+        if create_uids:
+            new_join = pack_uid(uid, new_join)
+        return StreamJoinRightDistinct(left, right, self.l_key, self.r_key, l_name, r_name, new_join, self.join_type)
 
     @typecheck_method(left=IR, right=IR, join=IR)
     def copy(self, left, right, join):
@@ -1535,6 +1818,15 @@ class StreamJoinRightDistinct(IR):
 class StreamFor(IR):
     @typecheck_method(a=IR, value_name=str, body=IR)
     def __init__(self, a, value_name, body):
+        if body.uses_randomness:
+            a = a.handle_randomness(True)
+            tuple, uid, elt = unpack_uid(a.typ)
+            body = Let(value_name, elt, body)
+            body = with_split_rng_state(body, uid)
+            value_name = tuple
+        elif a.uses_randomness:
+            a = a.handle_randomness(False)
+
         super().__init__(a, body)
         self.a = a
         self.value_name = value_name
@@ -1554,10 +1846,10 @@ class StreamFor(IR):
     def bound_variables(self):
         return {self.value_name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.a._compute_type(env, agg_env)
-        self.body._compute_type(_env_bind(env, self.bindings(1)), agg_env)
-        self._type = tvoid
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(_env_bind(env, self.bindings(1)), agg_env, deep_typecheck)
+        return tvoid
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -1588,10 +1880,10 @@ class AggFilter(IR):
     def _eq(self, other):
         return self.is_scan == other.is_scan
 
-    def _compute_type(self, env, agg_env):
-        self.cond._compute_type(agg_env, None)
-        self.agg_ir._compute_type(env, agg_env)
-        self._type = self.agg_ir.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.cond.compute_type(agg_env, None, deep_typecheck)
+        self.agg_ir.compute_type(env, agg_env, deep_typecheck)
+        return self.agg_ir.typ
 
     def renderable_uses_agg_context(self, i: int):
         return i == 0 and not self.is_scan
@@ -1613,6 +1905,14 @@ class AggFilter(IR):
 class AggExplode(IR):
     @typecheck_method(s=IR, name=str, agg_body=IR, is_scan=bool)
     def __init__(self, s, name, agg_body, is_scan):
+        if s.uses_randomness or agg_body.uses_agg_randomness(is_scan):
+            if agg_body.uses_agg_randomness(is_scan):
+                s = s.handle_randomness(True)
+                tuple, uid, elt = unpack_uid(s.typ)
+                agg_body = Let(self.name, elt, agg_body)
+                agg_body = with_split_rng_state(agg_body, uid, is_scan)
+            else:
+                s = s.handle_randomness(False)
         super().__init__(s, agg_body)
         self.name = name
         self.s = s
@@ -1633,10 +1933,10 @@ class AggExplode(IR):
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def _compute_type(self, env, agg_env):
-        self.s._compute_type(agg_env, None)
-        self.agg_body._compute_type(env, _env_bind(agg_env, self.agg_bindings(1)))
-        self._type = self.agg_body.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.s.compute_type(agg_env, None, deep_typecheck)
+        self.agg_body.compute_type(env, _env_bind(agg_env, self.agg_bindings(1)), deep_typecheck)
+        return self.agg_body.typ
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -1686,10 +1986,10 @@ class AggGroupBy(IR):
     def _eq(self, other):
         return self.is_scan == other.is_scan
 
-    def _compute_type(self, env, agg_env):
-        self.key._compute_type(agg_env, None)
-        self.agg_ir._compute_type(env, agg_env)
-        self._type = tdict(self.key.typ, self.agg_ir.typ)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.key.compute_type(agg_env, None, deep_typecheck)
+        self.agg_ir.compute_type(env, agg_env, deep_typecheck)
+        return tdict(self.key.typ, self.agg_ir.typ)
 
     def renderable_bindings(self, i, default_value=None):
         if i == 1:
@@ -1711,6 +2011,8 @@ class AggGroupBy(IR):
 class AggArrayPerElement(IR):
     @typecheck_method(array=IR, element_name=str, index_name=str, agg_ir=IR, is_scan=bool)
     def __init__(self, array, element_name, index_name, agg_ir, is_scan):
+        if agg_ir.uses_agg_randomness(is_scan):
+            agg_ir = with_split_rng_state(agg_ir, Cast(Ref(index_name, tint32), tint64), is_scan)
         super().__init__(array, agg_ir)
         self.array = array
         self.element_name = element_name
@@ -1728,11 +2030,11 @@ class AggArrayPerElement(IR):
     def _eq(self, other):
         return self.element_name == other.element_name and self.index_name == other.index_name and self.is_scan == other.is_scan
 
-    def _compute_type(self, env, agg_env):
-        self.array._compute_type(agg_env, None)
-        self.agg_ir._compute_type(_env_bind(env, self.bindings(1)),
-                                  _env_bind(agg_env, self.agg_bindings(1)))
-        self._type = tarray(self.agg_ir.typ)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.array.compute_type(agg_env, None, deep_typecheck)
+        self.agg_ir.compute_type(_env_bind(env, self.bindings(1)),
+                                  _env_bind(agg_env, self.agg_bindings(1)), deep_typecheck)
+        return tarray(self.agg_ir.typ)
 
     @property
     def bound_variables(self):
@@ -1841,13 +2143,13 @@ class BaseApplyAggOp(IR):
                            tuple(self.init_op_args),
                            tuple(self.seq_op_args)]))
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for a in self.init_op_args:
-            a._compute_type(env, agg_env)
+            a.compute_type(env, agg_env, deep_typecheck)
         for a in self.seq_op_args:
-            a._compute_type(agg_env, None)
+            a.compute_type(agg_env, None, deep_typecheck)
 
-        self._type = lookup_aggregator_return_type(
+        return lookup_aggregator_return_type(
             self.agg_op,
             [a.typ for a in self.init_op_args],
             [a.typ for a in self.seq_op_args])
@@ -1907,15 +2209,15 @@ class AggFold(IR):
     def head_str(self):
         return f"{self.accum_name} {self.other_accum_name} {self.is_scan}"
 
-    def _compute_type(self, env, agg_env):
-        self.zero._compute_type(env, agg_env)
-        self.seq_op._compute_type(_env_bind(agg_env, self.bindings(1)), None)
-        self.comb_op._compute_type(self.bindings(2), None)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.zero.compute_type(env, agg_env, deep_typecheck)
+        self.seq_op.compute_type(_env_bind(agg_env, self.bindings(1)), None, deep_typecheck)
+        self.comb_op.compute_type(self.bindings(2), None, deep_typecheck)
 
-        assert self.zero._type == self.seq_op._type
-        assert self.zero._type == self.comb_op._type
+        assert self.zero.typ == self.seq_op.typ
+        assert self.zero.typ == self.comb_op.typ
 
-        self._type = self.zero._type
+        return self.zero.typ
 
     def renderable_bindings(self, i: int, default_value=None):
         dict_so_far = {}
@@ -1946,10 +2248,10 @@ class Begin(IR):
     def copy(self, *xs):
         return Begin(xs)
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for x in self.xs:
-            x._compute_type(env, agg_env)
-        self._type = tvoid
+            x.compute_type(env, agg_env, deep_typecheck)
+        return tvoid
 
 
 class MakeStruct(IR):
@@ -1972,10 +2274,10 @@ class MakeStruct(IR):
     def __hash__(self):
         return hash(tuple(self.fields))
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for f, x in self.fields:
-            x._compute_type(env, agg_env)
-        self._type = tstruct(**{f: x.typ for f, x in self.fields})
+            x.compute_type(env, agg_env, deep_typecheck)
+        return tstruct(**{f: x.typ for f, x in self.fields})
 
 
 class SelectFields(IR):
@@ -1995,9 +2297,37 @@ class SelectFields(IR):
     def _eq(self, other):
         return self.fields == other.fields
 
-    def _compute_type(self, env, agg_env):
-        self.old._compute_type(env, agg_env)
-        self._type = self.old.typ._select_fields(self.fields)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.old.compute_type(env, agg_env, deep_typecheck)
+        return self.old.typ._select_fields(self.fields)
+
+
+class SelectedTopLevelReference(SelectFields):
+    @typecheck_method(name=str, type=tstruct)
+    def __init__(self, name, type=None):
+        ref = TopLevelReference(name)
+        super().__init__(ref, type.fields)
+        self.ref = ref
+        self._typ = type
+
+    @property
+    def is_nested_field(self):
+        return True
+
+    def copy(self, ref):
+        if isinstance(ref, TopLevelReference):
+            return SelectedTopLevelReference(ref.name, self.type)
+        else:
+            return SelectFields(ref, self.fields)
+
+    def _ir_name(self):
+        return 'SelectFields'
+
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        if deep_typecheck:
+            self.ref.compute_type(env, agg_env, deep_typecheck)
+            assert(self.ref.typ._select_fields(self._typ.fields) == self._typ)
+        return self._typ
 
 
 class InsertFields(IR):
@@ -2030,12 +2360,13 @@ class InsertFields(IR):
             if v > 1:
                 uid = Env.get_uid()
                 lets.append((uid, k))
-                replacements[k] = uid
+                replacements[k] = (uid, k.typ)
 
         insert_irs = []
         for k, v in fields:
             if isinstance(v, GetField) and v.o in replacements:
-                insert_irs.append((k, GetField(Ref(replacements[v.o]), v.name)))
+                uid, type = replacements[v.o]
+                insert_irs.append((k, GetField(Ref(uid, type), v.name)))
             else:
                 insert_irs.append((k, v))
 
@@ -2072,13 +2403,14 @@ class InsertFields(IR):
     def __hash__(self):
         return hash((self.old, tuple(self.fields), tuple(self.field_order) if self.field_order else None))
 
-    def _compute_type(self, env, agg_env):
-        self.old._compute_type(env, agg_env)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.old.compute_type(env, agg_env, deep_typecheck)
         for f, x in self.fields:
-            x._compute_type(env, agg_env)
-        self._type = self.old.typ._insert_fields(**{f: x.typ for f, x in self.fields})
+            x.compute_type(env, agg_env, deep_typecheck)
+        type = self.old.typ._insert_fields(**{f: x.typ for f, x in self.fields})
         if self.field_order:
-            self._type = tstruct(**{f: self._type[f] for f in self.field_order})
+            type = tstruct(**{f: type[f] for f in self.field_order})
+        return type
 
 
 class GetField(IR):
@@ -2102,9 +2434,38 @@ class GetField(IR):
     def is_nested_field(self):
         return self.o.is_nested_field
 
-    def _compute_type(self, env, agg_env):
-        self.o._compute_type(env, agg_env)
-        self._type = self.o.typ[self.name]
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.o.compute_type(env, agg_env, deep_typecheck)
+        return self.o.typ[self.name]
+
+
+class ProjectedTopLevelReference(GetField):
+    @typecheck_method(name=str, field=str, type=HailType)
+    def __init__(self, name, field, type=None):
+        ref = TopLevelReference(name)
+        super().__init__(ref, field)
+        self.ref = ref
+        self.field = field
+        self._typ = type
+
+    @property
+    def is_nested_field(self):
+        return True
+
+    def copy(self, ref):
+        if isinstance(ref, TopLevelReference):
+            return ProjectedTopLevelReference(ref.name, self.field, self._typ)
+        else:
+            return GetField(ref, self.field)
+
+    def _ir_name(self):
+        return 'GetField'
+
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        if deep_typecheck:
+            self.ref.compute_type(env, agg_env, deep_typecheck)
+            assert(self.ref.typ[self.field] == self._typ)
+        return self._typ
 
 
 class MakeTuple(IR):
@@ -2119,10 +2480,10 @@ class MakeTuple(IR):
     def head_str(self):
         return f'({" ".join([str(i) for i in range(len(self.elements))])})'
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for x in self.elements:
-            x._compute_type(env, agg_env)
-        self._type = ttuple(*[x.typ for x in self.elements])
+            x.compute_type(env, agg_env, deep_typecheck)
+        return ttuple(*[x.typ for x in self.elements])
 
 
 class GetTupleElement(IR):
@@ -2142,9 +2503,9 @@ class GetTupleElement(IR):
     def _eq(self, other):
         return self.idx == other.idx
 
-    def _compute_type(self, env, agg_env):
-        self.o._compute_type(env, agg_env)
-        self._type = self.o.typ.types[self.idx]
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.o.compute_type(env, agg_env, deep_typecheck)
+        return self.o.typ.types[self.idx]
 
 
 class Die(IR):
@@ -2159,10 +2520,6 @@ class Die(IR):
         if error_id is None or stack_trace is None:
             self.save_error_info()
 
-    @property
-    def typ(self):
-        return self._typ
-
     def copy(self, message):
         return Die(message, self._typ, self._error_id, self._stack_trace)
 
@@ -2172,8 +2529,8 @@ class Die(IR):
     def _eq(self, other):
         return other._typ == self._typ
 
-    def _compute_type(self, env, agg_env):
-        self._type = self._typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return self._typ
 
     @staticmethod
     def is_effectful() -> bool:
@@ -2187,10 +2544,10 @@ class ConsoleLog(IR):
         self.message = message
         self.result = result
 
-    def _compute_type(self, env, agg_env):
-        self.message._compute_type(env, agg_env)
-        self.result._compute_type(env, agg_env)
-        self._type = self.result._type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.message.compute_type(env, agg_env, deep_typecheck)
+        self.result.compute_type(env, agg_env, deep_typecheck)
+        return self.result.typ
 
     def copy(self, message, result):
         return ConsoleLog(message, result)
@@ -2274,27 +2631,28 @@ class Apply(IR):
             other.type_args == self.type_args and \
             other.return_type == self.return_type
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for arg in self.args:
-            arg._compute_type(env, agg_env)
+            arg.compute_type(env, agg_env, deep_typecheck)
 
-        self._type = self.return_type
+        return self.return_type
 
 
 class ApplySeeded(IR):
-    @typecheck_method(function=str, seed=int, return_type=hail_type, args=IR)
-    def __init__(self, function, seed, return_type, *args):
+    @typecheck_method(function=str, seed=int, rng_state=IR, return_type=hail_type, args=IR)
+    def __init__(self, function, seed, rng_state, return_type, *args):
         if hail.current_backend().requires_lowering:
             warning("Seeded randomness is currently unreliable on the service. "
                     "You may observe some unexpected behavior. Don't use for real work yet.")
-        super().__init__(*args)
+        super().__init__(rng_state, *args)
         self.function = function
         self.args = args
+        self.rng_state = rng_state
         self.seed = seed
         self.return_type = return_type
 
-    def copy(self, *args):
-        return ApplySeeded(self.function, self.seed, self.return_type, *args)
+    def copy(self, rng_state, *args):
+        return ApplySeeded(self.function, self.seed, rng_state, self.return_type, *args)
 
     def head_str(self):
         return f'{escape_id(self.function)} {self.seed} {self.return_type._parsable_string()}'
@@ -2304,20 +2662,54 @@ class ApplySeeded(IR):
             other.seed == self.seed and \
             other.return_type == self.return_type
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for arg in self.args:
-            arg._compute_type(env, agg_env)
+            arg.compute_type(env, agg_env, deep_typecheck)
 
-        self._type = self.return_type
+        return self.return_type
 
-    @staticmethod
-    def is_effectful() -> bool:
-        return True
+
+class RNGStateLiteral(IR):
+    @typecheck_method(key=sized_tupleof(int, int, int, int))
+    def __init__(self, key):
+        for k in key:
+            assert 0 <= k < 0xFFFFFFFF_FFFFFFFF
+        super().__init__()
+        self.key = key
+
+    def copy(self):
+        return RNGStateLiteral(self.key)
+
+    def head_str(self):
+        return f'({" ".join(map(str, self.key))})'
+
+    def _eq(self, other):
+        return other.key == self.key
+
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return trngstate
+
+
+class RNGSplit(IR):
+    @typecheck_method(parent_state=IR, dyn_bitstring=IR)
+    def __init__(self, parent_state, dyn_bitstring):
+        super().__init__(parent_state, dyn_bitstring)
+        self.parent_state = parent_state
+        self.dyn_bitstring = dyn_bitstring
+
+    def copy(self, parent_state, dyn_bitstring):
+        return RNGSplit(parent_state, dyn_bitstring)
+
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.parent_state.compute_type(env, agg_env, deep_typecheck)
+        self.dyn_bitstring.compute_type(env, agg_env, deep_typecheck)
+        return trngstate
 
 
 class TableCount(IR):
     @typecheck_method(child=TableIR)
     def __init__(self, child):
+        child = child.handle_randomness(None)
         super().__init__(child)
         self.child = child
 
@@ -2325,14 +2717,15 @@ class TableCount(IR):
     def copy(self, child):
         return TableCount(child)
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = tint64
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return tint64
 
 
 class TableGetGlobals(IR):
     @typecheck_method(child=TableIR)
     def __init__(self, child):
+        child = child.handle_randomness(None)
         super().__init__(child)
         self.child = child
 
@@ -2340,14 +2733,15 @@ class TableGetGlobals(IR):
     def copy(self, child):
         return TableGetGlobals(child)
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = self.child.typ.global_type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ.global_type
 
 
 class TableCollect(IR):
     @typecheck_method(child=TableIR)
     def __init__(self, child):
+        child = child.handle_randomness(None)
         super().__init__(child)
         self.child = child
 
@@ -2355,15 +2749,24 @@ class TableCollect(IR):
     def copy(self, child):
         return TableCollect(child)
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = tstruct(**{'rows': tarray(self.child.typ.row_type),
-                                'global': self.child.typ.global_type})
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return tstruct(**{'rows': tarray(self.child.typ.row_type),
+                          'global': self.child.typ.global_type})
 
 
 class TableAggregate(IR):
     @typecheck_method(child=TableIR, query=IR)
     def __init__(self, child, query):
+        if query.uses_randomness:
+            child = child.handle_randomness(uid_field_name)
+            uid = GetField(Ref('row', child.typ.row_type), uid_field_name)
+            if query.uses_value_randomness:
+                query = Let('__rng_state', RNGStateLiteral(rng_key), query)
+            if query.uses_agg_randomness(is_scan=False):
+                query = AggLet('__rng_state', RNGSplit(RNGStateLiteral(rng_key), uid), query, is_scan=False)
+        else:
+            child = child.handle_randomness(None)
         super().__init__(child, query)
         self.child = child
         self.query = query
@@ -2372,9 +2775,10 @@ class TableAggregate(IR):
     def copy(self, child, query):
         return TableAggregate(child, query)
 
-    def _compute_type(self, env, agg_env):
-        self.query._compute_type(self.child.typ.global_env(), self.child.typ.row_env())
-        self._type = self.query.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.query.compute_type(self.child.typ.global_env(), self.child.typ.row_env(), deep_typecheck)
+        return self.query.typ
 
     def renderable_new_block(self, i: int):
         return i == 1
@@ -2394,6 +2798,7 @@ class TableAggregate(IR):
 class MatrixCount(IR):
     @typecheck_method(child=MatrixIR)
     def __init__(self, child):
+        child = child.handle_randomness(None, None)
         super().__init__(child)
         self.child = child
 
@@ -2401,14 +2806,26 @@ class MatrixCount(IR):
     def copy(self, child):
         return TableCount(child)
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = ttuple(tint64, tint32)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return ttuple(tint64, tint32)
 
 
 class MatrixAggregate(IR):
     @typecheck_method(child=MatrixIR, query=IR)
     def __init__(self, child, query):
+        if query.uses_value_randomness:
+            query = Let('__rng_state', RNGStateLiteral(rng_key), query)
+
+        if query.uses_agg_randomness(is_scan=False):
+            child = child.handle_randomness(default_row_uid, default_col_uid)
+            row_uid, old_row = unpack_row_uid(child.typ.row_type, default_row_uid)
+            col_uid, old_col = unpack_col_uid(child.typ.col_type, default_col_uid)
+            entry_uid = concat_uids(row_uid, col_uid)
+            query = AggLet('__rng_state', RNGSplit(RNGStateLiteral(rng_key), entry_uid), query, is_scan=False)
+        else:
+            child = child.handle_randomness(None, None)
+
         super().__init__(child, query)
         self.child = child
         self.query = query
@@ -2417,9 +2834,10 @@ class MatrixAggregate(IR):
     def copy(self, child, query):
         return MatrixAggregate(child, query)
 
-    def _compute_type(self, env, agg_env):
-        self.query._compute_type(self.child.typ.global_env(), self.child.typ.entry_env())
-        self._type = self.query.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.query.compute_type(self.child.typ.global_env(), self.child.typ.entry_env(), deep_typecheck)
+        return self.query.typ
 
     def renderable_new_block(self, i: int):
         return i == 1
@@ -2439,6 +2857,7 @@ class MatrixAggregate(IR):
 class TableWrite(IR):
     @typecheck_method(child=TableIR, writer=TableWriter)
     def __init__(self, child, writer):
+        child = child.handle_randomness(None)
         super().__init__(child)
         self.child = child
         self.writer = writer
@@ -2453,9 +2872,9 @@ class TableWrite(IR):
     def _eq(self, other):
         return other.writer == self.writer
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = tvoid
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return tvoid
 
     @staticmethod
     def is_effectful() -> bool:
@@ -2465,6 +2884,7 @@ class TableWrite(IR):
 class MatrixWrite(IR):
     @typecheck_method(child=MatrixIR, matrix_writer=MatrixWriter)
     def __init__(self, child, matrix_writer):
+        child = child.handle_randomness(None, None)
         super().__init__(child)
         self.child = child
         self.matrix_writer = matrix_writer
@@ -2479,9 +2899,9 @@ class MatrixWrite(IR):
     def _eq(self, other):
         return other.matrix_writer == self.matrix_writer
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = tvoid
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return tvoid
 
     @staticmethod
     def is_effectful() -> bool:
@@ -2491,6 +2911,7 @@ class MatrixWrite(IR):
 class MatrixMultiWrite(IR):
     @typecheck_method(children=sequenceof(MatrixIR), writer=MatrixNativeMultiWriter)
     def __init__(self, children, writer):
+        children = (child.handle_randomness(None, None) for child in children)
         super().__init__(*children)
         self.writer = writer
 
@@ -2503,10 +2924,10 @@ class MatrixMultiWrite(IR):
     def _eq(self, other):
         return other.writer == self.writer
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for x in self.children:
-            x._compute_type()
-        self._type = tvoid
+            x.compute_type(deep_typecheck)
+        return tvoid
 
     @staticmethod
     def is_effectful() -> bool:
@@ -2525,9 +2946,9 @@ class BlockMatrixCollect(IR):
     def _eq(self, other):
         return isinstance(other, BlockMatrixCollect) and self.child == other.child
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = tndarray(tfloat64, 2)
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return tndarray(tfloat64, 2)
 
 
 class BlockMatrixWrite(IR):
@@ -2546,9 +2967,9 @@ class BlockMatrixWrite(IR):
     def _eq(self, other):
         return self.writer == other.writer
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = self.writer._type()
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.writer._type()
 
     @staticmethod
     def is_effectful() -> bool:
@@ -2571,10 +2992,10 @@ class BlockMatrixMultiWrite(IR):
     def _eq(self, other):
         return self.writer == other.writer
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         for x in self.block_matrices:
-            x._compute_type()
-        self._type = tvoid
+            x.compute_type(deep_typecheck)
+        return tvoid
 
     @staticmethod
     def is_effectful() -> bool:
@@ -2583,6 +3004,7 @@ class BlockMatrixMultiWrite(IR):
 
 class TableToValueApply(IR):
     def __init__(self, child, config):
+        child = child.handle_randomness(None)
         super().__init__(child)
         self.child = child
         self.config = config
@@ -2597,19 +3019,20 @@ class TableToValueApply(IR):
     def _eq(self, other):
         return other.config == self.config
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         name = self.config['name']
         if name == 'ForceCountTable':
-            self._type = tint64
+            return tint64
         elif name == 'TableCalculateNewPartitions':
-            self._type = tarray(tinterval(self.child.typ.key_type))
+            return tarray(tinterval(self.child.typ.key_type))
         else:
             assert name == 'NPartitionsTable', name
-            self._type = tint32
+            return tint32
 
 
 class MatrixToValueApply(IR):
     def __init__(self, child, config):
+        child = child.handle_randomness(None, None)
         super().__init__(child)
         self.child = child
         self.config = config
@@ -2624,17 +3047,17 @@ class MatrixToValueApply(IR):
     def _eq(self, other):
         return other.config == self.config
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         name = self.config['name']
         if name == 'ForceCountMatrixTable':
-            self._type = tint64
+            return tint64
         elif name == 'NPartitionsMatrixTable':
-            self._type = tint32
+            return tint32
         elif name == 'MatrixExportEntriesByCol':
-            self._type = tvoid
+            return tvoid
         else:
             assert name == 'MatrixWriteBlockMatrix', name
-            self._type = tvoid
+            return tvoid
 
 
 class BlockMatrixToValueApply(IR):
@@ -2654,9 +3077,10 @@ class BlockMatrixToValueApply(IR):
     def _eq(self, other):
         return other.config == self.config
 
-    def _compute_type(self, env, agg_env):
+    def _compute_type(self, env, agg_env, deep_typecheck):
         assert self.config['name'] == 'GetElement'
-        self._type = tfloat64
+        self.child.compute_type(deep_typecheck)
+        return tfloat64
 
 
 class Literal(IR):
@@ -2677,8 +3101,8 @@ class Literal(IR):
         return other._typ == self._typ and \
             other.value == self.value
 
-    def _compute_type(self, env, agg_env):
-        self._type = self._typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return self._typ
 
 
 class LiftMeOut(IR):
@@ -2690,9 +3114,9 @@ class LiftMeOut(IR):
     def copy(self, child):
         return LiftMeOut(child)
 
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type(env, agg_env)
-        self._type = self.child.typ
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.child.compute_type(env, agg_env, deep_typecheck)
+        return self.child.typ
 
 
 class Join(IR):
@@ -2737,9 +3161,9 @@ class Join(IR):
     def render_children(self, r):
         return self.virtual_ir.render_children(r)
 
-    def _compute_type(self, env, agg_env):
-        self.virtual_ir._compute_type(env, agg_env)
-        self._type = self.virtual_ir._type
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.virtual_ir.compute_type(env, agg_env, deep_typecheck)
+        return self.virtual_ir.typ
 
 
 class JavaIR(IR):
@@ -2757,8 +3181,8 @@ class JavaIR(IR):
     def _eq(self, other):
         return self._jir == other._jir
 
-    def _compute_type(self, env, agg_env):
-        self._type = dtype(self._jir.typ().toString())
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        return dtype(self._jir.typ().toString())
 
 
 def subst(ir, env, agg_env):

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -1,7 +1,9 @@
 from typing import Optional
 import hail as hl
-from hail.expr.types import HailType
+from hail.expr.types import HailType, tint64
 from hail.ir.base_ir import BaseIR, MatrixIR
+from hail.ir.utils import modify_deep_field, zip_with_index, zip_with_index_field, default_row_uid, default_col_uid, rng_key, unpack_row_uid, unpack_col_uid
+import hail.ir.ir as ir
 from hail.utils.misc import escape_str, parsable_strings, dump_json, escape_id
 from hail.utils.java import Env
 
@@ -13,11 +15,64 @@ class MatrixAggregateRowsByKey(MatrixIR):
         self.entry_expr = entry_expr
         self.row_expr = row_expr
 
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        drop_row_uid = False
+        drop_col_uid = False
+        if self.entry_expr.uses_randomness:
+            drop_row_uid = row_uid_field_name is None
+            if row_uid_field_name is None:
+                row_uid_field_name = default_row_uid
+        if self.entry_expr.uses_randomness or self.row_expr.uses_randomness:
+            drop_col_uid = col_uid_field_name is None
+            if col_uid_field_name is None:
+                col_uid_field_name = default_col_uid
+
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        entry_expr = self.entry_expr
+        row_expr = self.row_expr
+        if row_uid_field_name is not None:
+            row_uid, old_row = unpack_row_uid(child.typ.row_type, row_uid_field_name)
+            first_row_uid = ir.ApplyAggOp('Take', [1], [row_uid])
+            entry_expr = ir.Let('va', old_row, entry_expr)
+            entry_expr = ir.AggLet('va', old_row, entry_expr, is_scan=False)
+        if col_uid_field_name is not None:
+            col_uid, old_col = unpack_col_uid(child.typ.col_type, col_uid_field_name)
+            entry_expr = ir.AggLet('sa', old_col, entry_expr, is_scan=False)
+            row_expr = ir.AggLet('sa', old_col, row_expr, is_scan=False)
+        if self.entry_expr.uses_value_randomness:
+            entry_expr = ir.Let('__rng_state',
+                                ir.RNGSplit(ir.RNGStateLiteral(rng_key), ir.concat_uids(first_row_uid, col_uid)),
+                                entry_expr)
+        if self.entry_expr.uses_agg_randomness(is_scan=False):
+            entry_expr = ir.AggLet('__rng_state',
+                                   ir.RNGSplit(ir.RNGStateLiteral(rng_key), ir.concat_uids(row_uid, col_uid)),
+                                   entry_expr,
+                                   is_scan=False)
+        if self.row_expr.uses_value_randomness:
+            row_expr = ir.Let('__rng_state',
+                              ir.RNGSplit(ir.RNGStateLiteral(rng_key), first_row_uid),
+                              row_expr)
+        if self.row_expr.uses_agg_randomness(is_scan=False):
+            row_expr = ir.AggLet('__rng_state',
+                                 ir.RNGSplit(ir.RNGStateLiteral(rng_key), row_uid),
+                                 row_expr,
+                                 is_scan=False)
+
+        result = MatrixAggregateColsByKey(child, entry_expr, row_expr)
+        if drop_row_uid:
+            _, old_row = unpack_row_uid(result.typ.row_type, row_uid_field_name)
+            result = MatrixMapRows(result, old_row)
+        if drop_col_uid:
+            _, old_col = unpack_col_uid(result.typ.col_type, col_uid_field_name)
+            result = MatrixMapCols(result, old_col, None)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self.entry_expr._compute_type(child_typ.col_env(), child_typ.entry_env())
-        self.row_expr._compute_type(child_typ.global_env(), child_typ.row_env())
-        self._type = hl.tmatrix(
+        self.entry_expr.compute_type(child_typ.col_env(), child_typ.entry_env(), deep_typecheck)
+        self.row_expr.compute_type(child_typ.global_env(), child_typ.row_env(), deep_typecheck)
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
@@ -59,15 +114,28 @@ class MatrixRead(MatrixIR):
         self.drop_rows = drop_rows
         self._type: Optional[HailType] = _assert_type
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        # FIXME
+        result = self
+        if row_uid_field_name is not None:
+            new_row = ir.InsertFields(ir.Ref('va', result.typ.row_type), [(row_uid_field_name, ir.NA(tint64))], None)
+            result = MatrixMapRows(result, new_row)
+        if col_uid_field_name is not None:
+            new_col = ir.InsertFields(ir.Ref('sa', result.typ.col_type), [(col_uid_field_name, ir.NA(tint64))], None)
+            result = MatrixMapCols(result, new_col, None)
+        return result
+
     def render_head(self, r):
         return f'(MatrixRead None {self.drop_cols} {self.drop_rows} "{self.reader.render(r)}"'
 
     def _eq(self, other):
         return self.reader == other.reader and self.drop_cols == other.drop_cols and self.drop_rows == other.drop_rows
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
         if self._type is None:
-            self._type = Env.backend().matrix_type(self)
+            return Env.backend().matrix_type(self)
+        else:
+            return self._type
 
 
 class MatrixFilterRows(MatrixIR):
@@ -76,9 +144,28 @@ class MatrixFilterRows(MatrixIR):
         self.child = child
         self.pred = pred
 
-    def _compute_type(self):
-        self.pred._compute_type(self.child.typ.row_env(), None)
-        self._type = self.child.typ
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if not self.pred.uses_randomness and row_uid_field_name is None:
+            child = self.child.handle_randomness(None, col_uid_field_name)
+            return MatrixFilterRows(child, self.pred)
+
+        drop_row_uid = row_uid_field_name is None
+        if row_uid_field_name is None:
+            row_uid_field_name = default_row_uid
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        uid, old_row = unpack_row_uid(child.typ.row_type, row_uid_field_name)
+        pred = ir.Let('va', old_row, self.pred)
+        if self.pred.uses_randomness:
+            pred = ir.Let('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), uid), pred)
+        result = MatrixFilterRows(child, pred)
+        if drop_row_uid:
+            result = MatrixMapRows(result, old_row)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.pred.compute_type(self.child.typ.row_env(), None, deep_typecheck)
+        return self.child.typ
 
     def renderable_bindings(self, i, default_value=None):
         return self.child.typ.row_env(default_value) if i == 1 else {}
@@ -90,14 +177,19 @@ class MatrixChooseCols(MatrixIR):
         self.child = child
         self.old_indices = old_indices
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        return MatrixChooseCols(child, self.old_indices)
+
     def head_str(self):
         return f'({" ".join([str(i) for i in self.old_indices])})'
 
     def _eq(self, other):
         return self.old_indices == other.old_indices
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class MatrixMapCols(MatrixIR):
@@ -107,16 +199,47 @@ class MatrixMapCols(MatrixIR):
         self.new_col = new_col
         self.new_key = new_key
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if not self.new_col.uses_randomness and col_uid_field_name is None:
+            child = self.child.handle_randomness(row_uid_field_name, None)
+            return MatrixMapCols(child, self.new_col, self.new_key)
+
+        drop_row_uid = row_uid_field_name is None
+        if self.new_col.uses_agg_randomness(is_scan=False) and row_uid_field_name is None:
+            row_uid_field_name = default_row_uid
+        keep_col_uid = col_uid_field_name is not None
+        if col_uid_field_name is None:
+            col_uid_field_name = default_col_uid
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        col_uid, old_col = unpack_col_uid(child.typ.col_type, col_uid_field_name)
+        new_col = ir.Let('sa', old_col, self.new_col)
+        if row_uid_field_name is not None:
+            row_uid, old_row = unpack_row_uid(child.typ.row_type, row_uid_field_name)
+        if self.new_col.uses_value_randomness:
+            new_col = ir.Let('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), col_uid), new_col)
+        if self.new_col.uses_agg_randomness(is_scan=True):
+            new_col = ir.AggLet('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), col_uid), new_col, is_scan=True)
+        if self.new_col.uses_agg_randomness(is_scan=False):
+            entry_uid = ir.concat_uids(row_uid, col_uid)
+            new_col = ir.AggLet('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), entry_uid), new_col, is_scan=False)
+        if keep_col_uid:
+            new_col = ir.InsertFields(new_col, [(col_uid_field_name, col_uid)], None)
+        result = MatrixMapCols(child, new_col, self.new_key)
+        if drop_row_uid:
+            result = MatrixMapRows(result, old_row)
+        return result
+
     def head_str(self):
         return '(' + ' '.join(f'"{escape_str(f)}"' for f in self.new_key) + ')' if self.new_key is not None else 'None'
 
     def _eq(self, other):
         return self.new_key == other.new_key
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self.new_col._compute_type({**child_typ.col_env(), 'n_rows': hl.tint64}, child_typ.entry_env())
-        self._type = hl.tmatrix(
+        self.new_col.compute_type({**child_typ.col_env(), 'n_rows': hl.tint64}, child_typ.entry_env(), deep_typecheck)
+        return hl.tmatrix(
             child_typ.global_type,
             self.new_col.typ,
             self.new_key if self.new_key is not None else child_typ.col_key,
@@ -147,15 +270,47 @@ class MatrixUnionCols(MatrixIR):
         self.right = right
         self.join_type = join_type
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if self.join_type == 'outer':
+            # FIXME: Need to make MatrixUnionCols preserve row fields from the right
+            # to handle the outer join case
+            row_uid_field_name = None
+        left = self.left.handle_randomness(row_uid_field_name, col_uid_field_name)
+        right = self.right.handle_randomness(None, col_uid_field_name)
+
+        if col_uid_field_name is not None:
+            left_uid = unpack_col_uid(left.typ.col_type, col_uid_field_name)
+            right_uid = unpack_col_uid(right.typ.col_type, col_uid_field_name)
+            uid_type = ir.unify_uid_types(left_uid.typ, right_uid.typ)
+            left = MatrixMapCols(left,
+                                 ir.InsertFields(ir.Ref('sa', left.typ.col_type),
+                                                 [(col_uid_field_name, ir.pad_uid(left_uid, uid_type, 0))], None),
+                                 new_key=None)
+            right = MatrixMapCols(right,
+                                  ir.InsertFields(ir.Ref('sa', right.typ.col_type),
+                                                  [(col_uid_field_name, ir.pad_uid(right_uid, uid_type, 1))], None),
+                                  new_key=None)
+
+        result = MatrixUnionCols(left, right, self.join_type)
+        # FIXME: Need to make MatrixUnionCols preserve row fields from the right
+        # to handle the outer join case
+        if row_uid_field_name is not None and self.join_type == 'outer':
+            result = MatrixMapRows(result,
+                                   ir.InsertFields(ir.Ref('va', result.typ.row_type),
+                                                   [(row_uid_field_name, ir.NA(tint64))],
+                                                   None))
+        return result
+
     def head_str(self):
         return f'{escape_id(self.join_type)}'
 
     def _eq(self, other):
         return self.join_type == other.join_type
 
-    def _compute_type(self):
-        self.right.typ  # force
-        self._type = self.left.typ
+    def _compute_type(self, deep_typecheck):
+        self.left.compute_type(deep_typecheck)
+        self.right.compute_type(deep_typecheck)
+        return self.left.typ
 
 
 class MatrixMapEntries(MatrixIR):
@@ -164,10 +319,41 @@ class MatrixMapEntries(MatrixIR):
         self.child = child
         self.new_entry = new_entry
 
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        drop_row_uid = False
+        drop_col_uid = False
+        if self.new_entry.uses_randomness:
+            drop_row_uid = row_uid_field_name is None
+            drop_col_uid = col_uid_field_name is None
+            if row_uid_field_name is None:
+                row_uid_field_name = default_row_uid
+            if col_uid_field_name is None:
+                col_uid_field_name = default_col_uid
+
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        new_entry = self.new_entry
+        if row_uid_field_name is not None:
+            row_uid, old_row = unpack_row_uid(child.typ.row_type, row_uid_field_name)
+            new_entry = ir.Let('va', old_row, new_entry)
+        if col_uid_field_name is not None:
+            col_uid, old_col = unpack_col_uid(child.typ.col_type, col_uid_field_name)
+            new_entry = ir.Let('sa', old_col, new_entry)
+        if self.new_entry.uses_value_randomness:
+            new_entry = ir.Let('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), ir.concat_uids(row_uid, col_uid)), new_entry)
+        result = MatrixMapEntries(child, new_entry)
+        if drop_row_uid:
+            _, old_row = unpack_row_uid(result.typ.row_type, row_uid_field_name)
+            result = MatrixMapRows(result, old_row)
+        if drop_col_uid:
+            _, old_col = unpack_col_uid(result.typ.col_type, col_uid_field_name)
+            result = MatrixMapCols(result, old_col, None)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self.new_entry._compute_type(child_typ.entry_env(), None)
-        self._type = hl.tmatrix(
+        self.new_entry.compute_type(child_typ.entry_env(), None, deep_typecheck)
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
@@ -185,9 +371,40 @@ class MatrixFilterEntries(MatrixIR):
         self.child = child
         self.pred = pred
 
-    def _compute_type(self):
-        self.pred._compute_type(self.child.typ.entry_env(), None)
-        self._type = self.child.typ
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        drop_row_uid = False
+        drop_col_uid = False
+        if self.pred.uses_randomness:
+            drop_row_uid = row_uid_field_name is None
+            drop_col_uid = col_uid_field_name is None
+            if row_uid_field_name is None:
+                row_uid_field_name = default_row_uid
+            if col_uid_field_name is None:
+                col_uid_field_name = default_col_uid
+
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        pred = self.pred
+        if row_uid_field_name is not None:
+            row_uid, old_row = unpack_row_uid(child.typ.row_type, row_uid_field_name)
+            pred = ir.Let('va', old_row, pred)
+        if col_uid_field_name is not None:
+            col_uid, old_col = unpack_col_uid(child.typ.col_type, col_uid_field_name)
+            pred = ir.Let('sa', old_col, pred)
+        if self.pred.uses_value_randomness:
+            pred = ir.Let('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), ir.concat_uids(row_uid, col_uid)), pred)
+        result = MatrixFilterEntries(child, pred)
+        if drop_row_uid:
+            _, old_row = unpack_row_uid(result.typ.row_type, row_uid_field_name)
+            result = MatrixMapRows(result, old_row)
+        if drop_col_uid:
+            _, old_col = unpack_col_uid(result.typ.col_type, col_uid_field_name)
+            result = MatrixMapRows(result, old_col)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.pred.compute_type(self.child.typ.entry_env(), None, deep_typecheck)
+        return self.child.typ
 
     def renderable_bindings(self, i, default_value=None):
         return self.child.typ.entry_env(default_value) if i == 1 else {}
@@ -200,6 +417,10 @@ class MatrixKeyRowsBy(MatrixIR):
         self.keys = keys
         self.is_sorted = is_sorted
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        return MatrixKeyRowsBy(child, self.keys, self.is_sorted)
+
     def head_str(self):
         return '({}) {}'.format(
             ' '.join([escape_id(x) for x in self.keys]),
@@ -208,9 +429,10 @@ class MatrixKeyRowsBy(MatrixIR):
     def _eq(self, other):
         return self.keys == other.keys and self.is_sorted == other.is_sorted
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self._type = hl.tmatrix(
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
@@ -225,10 +447,42 @@ class MatrixMapRows(MatrixIR):
         self.child = child
         self.new_row = new_row
 
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if not self.new_row.uses_randomness and row_uid_field_name is None:
+            child = self.child.handle_randomness(None, col_uid_field_name)
+            return MatrixMapRows(child, self.new_row)
+
+        drop_col_uid = False
+        if self.new_row.uses_agg_randomness(is_scan=False) and col_uid_field_name is None:
+            col_uid_field_name = default_col_uid
+            drop_col_uid = True
+        keep_row_uid = row_uid_field_name is not None
+        if row_uid_field_name is None:
+            row_uid_field_name = default_row_uid
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        row_uid, old_row = unpack_row_uid(child.typ.row_type, row_uid_field_name)
+        new_row = ir.Let('va', old_row, self.new_row)
+        if col_uid_field_name is not None:
+            col_uid, old_col = unpack_col_uid(child.typ.col_type, col_uid_field_name)
+        if self.new_row.uses_value_randomness:
+            new_row = ir.Let('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), row_uid), new_row)
+        if self.new_row.uses_agg_randomness(is_scan=True):
+            new_row = ir.AggLet('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), row_uid), new_row, is_scan=True)
+        if self.new_row.uses_agg_randomness(is_scan=False):
+            entry_uid = ir.concat_uids(row_uid, col_uid)
+            new_row = ir.AggLet('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), entry_uid), new_row, is_scan=False)
+        if keep_row_uid:
+            new_row = ir.InsertFields(new_row, [(row_uid_field_name, row_uid)], None)
+        result = MatrixMapRows(child, new_row)
+        if drop_col_uid:
+            result = MatrixMapRows(result, old_col)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self.new_row._compute_type({**child_typ.row_env(), 'n_cols': hl.tint32}, child_typ.entry_env())
-        self._type = hl.tmatrix(
+        self.new_row.compute_type({**child_typ.row_env(), 'n_cols': hl.tint32}, child_typ.entry_env(), deep_typecheck)
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
@@ -258,10 +512,18 @@ class MatrixMapGlobals(MatrixIR):
         self.child = child
         self.new_global = new_global
 
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        new_global = self.new_global
+        if new_global.uses_randomness:
+            new_global = ir.Let('__rng_state', ir.RNGStateLiteral(rng_key), new_global)
+        return MatrixMapGlobals(child, new_global)
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self.new_global._compute_type(child_typ.global_env(), None)
-        self._type = hl.tmatrix(
+        self.new_global.compute_type(child_typ.global_env(), None, deep_typecheck)
+        return hl.tmatrix(
             self.new_global.typ,
             child_typ.col_type,
             child_typ.col_key,
@@ -279,9 +541,28 @@ class MatrixFilterCols(MatrixIR):
         self.child = child
         self.pred = pred
 
-    def _compute_type(self):
-        self.pred._compute_type(self.child.typ.col_env(), None)
-        self._type = self.child.typ
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if not self.pred.uses_randomness and col_uid_field_name is None:
+            child = self.child.handle_randomness(row_uid_field_name, None)
+            return MatrixFilterCols(child, self.pred)
+
+        drop_col_uid = col_uid_field_name is None
+        if col_uid_field_name is None:
+            col_uid_field_name = default_col_uid
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        col_uid, old_col = unpack_col_uid(child.typ.col_type, col_uid_field_name)
+        pred = ir.Let('sa', old_col, self.pred)
+        if self.pred.uses_randomness:
+            pred = ir.Let('__rng_state', ir.RNGSplit(ir.RNGStateLiteral(rng_key), col_uid))
+        result = MatrixFilterCols(child, pred)
+        if drop_col_uid:
+            result = MatrixMapCols(result, old_col, new_key=None)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.pred.compute_type(self.child.typ.col_env(), None, deep_typecheck)
+        return self.child.typ
 
     def renderable_bindings(self, i, default_value=None):
         return self.child.typ.col_env(default_value) if i == 1 else {}
@@ -292,9 +573,21 @@ class MatrixCollectColsByKey(MatrixIR):
         super().__init__(child)
         self.child = child
 
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        child = self.child(row_uid_field_name, col_uid_field_name)
+        result = MatrixCollectColsByKey(child)
+        if col_uid_field_name is not None:
+            col = ir.Ref('sa', result.typ.col_type)
+            uids = ir.GetField(col, col_uid_field_name)
+            # FIXME: might cause issues being dependent on col order
+            uid = ir.ArrayRef(uids, ir.I32(0))
+            result = MatrixMapCols(result, ir.InsertFields(col, [(col_uid_field_name, uid)], None), None)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self._type = hl.tmatrix(
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_key_type._concat(
                 hl.tstruct(**{f: hl.tarray(t) for f, t in child_typ.col_value_type.items()})),
@@ -311,11 +604,64 @@ class MatrixAggregateColsByKey(MatrixIR):
         self.entry_expr = entry_expr
         self.col_expr = col_expr
 
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        drop_row_uid = False
+        drop_col_uid = False
+        if self.entry_expr.uses_randomness:
+            drop_row_uid = row_uid_field_name is None
+            if row_uid_field_name is None:
+                row_uid_field_name = default_row_uid
+        if self.entry_expr.uses_randomness or self.col_expr.uses_randomness:
+            drop_col_uid = col_uid_field_name is None
+            if col_uid_field_name is None:
+                col_uid_field_name = default_col_uid
+
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        entry_expr = self.entry_expr
+        col_expr = self.col_expr
+        if row_uid_field_name is not None:
+            row_uid, old_row = unpack_row_uid(child.typ.row_type, row_uid_field_name)
+            entry_expr = ir.Let('va', old_row, entry_expr)
+            entry_expr = ir.AggLet('va', old_row, entry_expr, is_scan=False)
+        if col_uid_field_name is not None:
+            col_uid, old_col = unpack_col_uid(child.typ.col_type, col_uid_field_name)
+            first_col_uid = ir.ApplyAggOp('Take', [1], [col_uid])
+            entry_expr = ir.AggLet('sa', old_col, entry_expr, is_scan=False)
+            col_expr = ir.AggLet('sa', old_col, col_expr, is_scan=False)
+        if self.entry_expr.uses_value_randomness:
+            entry_expr = ir.Let('__rng_state',
+                               ir.RNGSplit(ir.RNGStateLiteral(rng_key), ir.concat_uids(row_uid, first_col_uid)),
+                               entry_expr)
+        if self.entry_expr.uses_agg_randomness(is_scan=False):
+            entry_expr = ir.AggLet('__rng_state',
+                                  ir.RNGSplit(ir.RNGStateLiteral(rng_key), ir.concat_uids(row_uid, col_uid)),
+                                  entry_expr,
+                                  is_scan=False)
+        if self.col_expr.uses_value_randomness:
+            col_expr = ir.Let('__rng_state',
+                                ir.RNGSplit(ir.RNGStateLiteral(rng_key), first_col_uid),
+                                col_expr)
+        if self.col_expr.uses_agg_randomness(is_scan=False):
+            col_expr = ir.AggLet('__rng_state',
+                                   ir.RNGSplit(ir.RNGStateLiteral(rng_key), col_uid),
+                                   col_expr,
+                                   is_scan=False)
+
+        result = MatrixAggregateColsByKey(child, entry_expr, col_expr)
+        if drop_row_uid:
+            _, old_row = unpack_row_uid(result.typ.row_type, row_uid_field_name)
+            result = MatrixMapRows(result, old_row)
+        if drop_col_uid:
+            _, old_col = unpack_col_uid(result.typ.col_type, col_uid_field_name)
+            result = MatrixMapCols(result, old_col)
+        return result
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self.entry_expr._compute_type(child_typ.row_env(), child_typ.entry_env())
-        self.col_expr._compute_type(child_typ.global_env(), child_typ.col_env())
-        self._type = hl.tmatrix(
+        self.entry_expr.compute_type(child_typ.row_env(), child_typ.entry_env(), deep_typecheck)
+        self.col_expr.compute_type(child_typ.global_env(), child_typ.col_env(), deep_typecheck)
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_key_type._concat(self.col_expr.typ),
             child_typ.col_key,
@@ -350,17 +696,38 @@ class MatrixExplodeRows(MatrixIR):
         self.child = child
         self.path = path
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if row_uid_field_name is None:
+            MatrixExplodeRows(self.child.handle_randomness(None, col_uid_field_name), self.path)
+
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+
+        if row_uid_field_name not in child.typ.row_type.fields:
+            return MatrixExplodeRows(child, self.path)
+
+        new_row = modify_deep_field(ir.Ref('va', child.typ.row_type), self.path, zip_with_index)
+        child = MatrixMapRows(child, new_row)
+
+        new_explode = MatrixExplodeRows(child, self.path)
+        new_row = modify_deep_field(
+            ir.Ref('va', new_explode.typ.row_type),
+            self.path,
+            lambda tuple: ir.GetTupleElement(tuple, 0),
+            lambda row, tuple: ir.InsertFields(row, (row_uid_field_name, ir.concat_uids(ir.GetField(row, row_uid_field_name), ir.GetTupleElement(tuple, 1))), None))
+        return MatrixMapRows(new_explode, new_row)
+
     def head_str(self):
         return f"({' '.join([escape_id(id) for id in self.path])})"
 
     def _eq(self, other):
         return self.path == other.path
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
         a = child_typ.row_type._index_path(self.path)
         new_row_type = child_typ.row_type._insert(self.path, a.element_type)
-        self._type = hl.tmatrix(
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
@@ -376,14 +743,18 @@ class MatrixRepartition(MatrixIR):
         self.n = n
         self.strategy = strategy
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixRepartition(self.child.handle_randomness(row_uid_field_name, col_uid_field_name), self.n, self.strategy)
+
     def head_str(self):
         return f'{self.n} {self.strategy}'
 
     def _eq(self, other):
         return self.n == other.n and self.strategy == other.strategy
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class MatrixUnionRows(MatrixIR):
@@ -391,10 +762,25 @@ class MatrixUnionRows(MatrixIR):
         super().__init__(*children)
         self.children = children
 
-    def _compute_type(self):
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        children = [self.children[0].handle_randomness(row_uid_field_name, col_uid_field_name),
+                    *[child.handle_randomness(row_uid_field_name, None) for child in self.children[1:]]]
+
+        if row_uid_field_name is not None:
+            uids, _ = unzip(unpack_row_uid(child.typ.row_type, row_uid_field_name) for child in children)
+            uid_type = ir.unify_uid_types(uid.typ for uid in uids)
+            children = [MatrixMapRows(child,
+                                      ir.InsertFields(ir.Ref('va', child.typ.row_type),
+                                                      [(row_uid_field_name, ir.pad_uid(uid, uid_type, i))],
+                                                      None))
+                        for i, (child, uid) in enumerate(zip(children, uids))]
+
+        return MatrixUnionRows(*children)
+
+    def _compute_type(self, deep_typecheck):
         for c in self.children:
-            c.typ  # force
-        self._type = self.children[0].typ
+            c.compute_type(deep_typecheck)
+        return self.children[0].typ
 
 
 class MatrixDistinctByRow(MatrixIR):
@@ -402,8 +788,12 @@ class MatrixDistinctByRow(MatrixIR):
         super().__init__(child)
         self.child = child
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixDistinctByRow(self.child.handle_randomness(row_uid_field_name, col_uid_field_name))
+
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class MatrixRowsHead(MatrixIR):
@@ -412,14 +802,18 @@ class MatrixRowsHead(MatrixIR):
         self.child = child
         self.n = n
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixRowsHead(self.child.handle_randomness(row_uid_field_name, col_uid_field_name), self.n)
+
     def head_str(self):
         return self.n
 
     def _eq(self, other):
         return self.n == other.n
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class MatrixColsHead(MatrixIR):
@@ -428,14 +822,18 @@ class MatrixColsHead(MatrixIR):
         self.child = child
         self.n = n
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixColsHead(self.child.handle_randomness(row_uid_field_name, col_uid_field_name), self.n)
+
     def head_str(self):
         return self.n
 
     def _eq(self, other):
         return self.n == other.n
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class MatrixRowsTail(MatrixIR):
@@ -444,14 +842,18 @@ class MatrixRowsTail(MatrixIR):
         self.child = child
         self.n = n
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixRowsTail(self.child.handle_randomness(row_uid_field_name, col_uid_field_name), self.n)
+
     def head_str(self):
         return self.n
 
     def _eq(self, other):
         return self.n == other.n
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class MatrixColsTail(MatrixIR):
@@ -460,14 +862,18 @@ class MatrixColsTail(MatrixIR):
         self.child = child
         self.n = n
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixColsTail(self.child.handle_randomness(row_uid_field_name, col_uid_field_name), self.n)
+
     def head_str(self):
         return self.n
 
     def _eq(self, other):
         return self.n == other.n
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class MatrixExplodeCols(MatrixIR):
@@ -476,17 +882,38 @@ class MatrixExplodeCols(MatrixIR):
         self.child = child
         self.path = path
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        if col_uid_field_name is None:
+            MatrixExplodeCols(self.child.handle_randomness(row_uid_field_name, None), self.path)
+
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+
+        if col_uid_field_name not in child.typ.col_type.fields:
+            return MatrixExplodeCols(child, self.path)
+
+        new_col = modify_deep_field(ir.Ref('sa', child.typ.col_type), self.path, zip_with_index)
+        child = MatrixMapCols(child, new_col)
+
+        new_explode = MatrixExplodeCols(child, self.path)
+        new_col = modify_deep_field(
+            ir.Ref('sa', new_explode.typ.col_type),
+            self.path,
+            lambda tuple: ir.GetTupleElement(tuple, 0),
+            lambda col, tuple: ir.InsertFields(col, (col_uid_field_name, ir.concat_uids(ir.GetField(col, col_uid_field_name), ir.GetTupleElement(tuple, 1))), None))
+        return MatrixMapCols(new_explode, new_col)
+
     def head_str(self):
         return f"({' '.join([escape_id(id) for id in self.path])})"
 
     def _eq(self, other):
         return self.path == other.path
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
         a = child_typ.col_type._index_path(self.path)
         new_col_type = child_typ.col_type._insert(self.path, a.element_type)
-        self._type = hl.tmatrix(
+        return hl.tmatrix(
             child_typ.global_type,
             new_col_type,
             child_typ.col_key,
@@ -503,6 +930,20 @@ class CastTableToMatrix(MatrixIR):
         self.cols_field_name = cols_field_name
         self.col_key = col_key
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        child = self.child
+        if col_uid_field_name is not None:
+            new_globals = modify_deep_field(
+                ir.Ref('global', child.typ.global_type),
+                [self.cols_field_name],
+                lambda g: zip_with_index_field(g, col_uid_field_name))
+            child = TableMapGlobals(child, new_globals)
+
+        return CastTableToMatrix(self.child.handle_randomness(row_uid_field_name),
+                                 self.entries_field_name,
+                                 self.cols_field_name,
+                                 self.col_key)
+
     def head_str(self):
         return '{} {} ({})'.format(
             escape_str(self.entries_field_name),
@@ -514,9 +955,10 @@ class CastTableToMatrix(MatrixIR):
             self.cols_field_name == other.cols_field_name and \
             self.col_key == other.col_key
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self._type = hl.tmatrix(
+        return hl.tmatrix(
             child_typ.global_type._drop_fields([self.cols_field_name]),
             child_typ.global_type[self.cols_field_name].element_type,
             self.col_key,
@@ -533,19 +975,28 @@ class MatrixAnnotateRowsTable(MatrixIR):
         self.root = root
         self.product = product
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixAnnotateRowsTable(
+            self.child.handle_randomness(row_uid_field_name, col_uid_field_name),
+            self.table.handle_randomness(None),
+            self.root,
+            self.product)
+
     def head_str(self):
         return f'"{escape_str(self.root)}" {self.product}'
 
     def _eq(self, other):
         return self.root == other.root and self.product == other.product
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.table.compute_type(deep_typecheck)
         child_typ = self.child.typ
         if self.product:
             value_type = hl.tarray(self.table.typ.value_type)
         else:
             value_type = self.table.typ.value_type
-        self._type = hl.tmatrix(
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
@@ -561,15 +1012,23 @@ class MatrixAnnotateColsTable(MatrixIR):
         self.table = table
         self.root = root
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        return MatrixAnnotateColsTable(
+            self.child.handle_randomness(row_uid_field_name, col_uid_field_name),
+            self.table.handle_randomness(None),
+            self.root)
+
     def head_str(self):
         return f'"{escape_str(self.root)}"'
 
     def _eq(self, other):
         return self.root == other.root
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        self.table.compute_type(deep_typecheck)
         child_typ = self.child.typ
-        self._type = hl.tmatrix(
+        return hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type._insert_field(self.root, self.table.typ.value_type),
             child_typ.col_key,
@@ -584,17 +1043,29 @@ class MatrixToMatrixApply(MatrixIR):
         self.child = child
         self.config = config
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        child = self.child.handle_randomness(None, None)
+        result = MatrixToMatrixApply(child, self.config)
+        if row_uid_field_name is not None:
+            new_row = ir.InsertFields(ir.Ref('va', result.typ.row_type), [(row_uid_field_name, ir.NA(tint64))], None)
+            result = MatrixMapRows(result, new_row)
+        if col_uid_field_name is not None:
+            new_col = ir.InsertFields(ir.Ref('sa', result.typ.col_type), [(col_uid_field_name, ir.NA(tint64))], None)
+            result = MatrixMapCols(result, new_col, None)
+        return result
+
     def head_str(self):
         return dump_json(self.config)
 
     def _eq(self, other):
         return self.config == other.config
 
-    def _compute_type(self):
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
         name = self.config['name']
         child_typ = self.child.typ
-        if name == 'MatrixFilterPartitions':
-            self._type = child_typ
+        assert name == 'MatrixFilterPartitions'
+        return child_typ
 
 
 class MatrixRename(MatrixIR):
@@ -622,8 +1093,9 @@ class MatrixRename(MatrixIR):
             self.row_map == other.row_map and \
             self.entry_map == other.entry_map
 
-    def _compute_type(self):
-        self._type = self.child.typ._rename(self.global_map, self.col_map, self.row_map, self.entry_map)
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ._rename(self.global_map, self.col_map, self.row_map, self.entry_map)
 
 
 class MatrixFilterIntervals(MatrixIR):
@@ -640,8 +1112,9 @@ class MatrixFilterIntervals(MatrixIR):
     def _eq(self, other):
         return self.intervals == other.intervals and self.point_type == other.point_type and self.keep == other.keep
 
-    def _compute_type(self):
-        self._type = self.child.typ
+    def _compute_type(self, deep_typecheck):
+        self.child.compute_type(deep_typecheck)
+        return self.child.typ
 
 
 class JavaMatrix(MatrixIR):
@@ -649,11 +1122,24 @@ class JavaMatrix(MatrixIR):
         super().__init__()
         self._jir = jir
 
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        result = self
+        if row_uid_field_name is not None:
+            new_row = ir.InsertFields(ir.Ref('va', result.typ.row_type), [(row_uid_field_name, ir.NA(tint64))], None)
+            result = MatrixMapRows(result, new_row)
+        if col_uid_field_name is not None:
+            new_col = ir.InsertFields(ir.Ref('sa', result.typ.col_type), [(col_uid_field_name, ir.NA(tint64))], None)
+            result = MatrixMapCols(result, new_col, None)
+        return result
+
     def render_head(self, r):
         return f'(JavaMatrix {r.add_jir(self._jir)}'
 
-    def _compute_type(self):
-        self._type = hl.tmatrix._from_java(self._jir.typ())
+    def _compute_type(self, deep_typecheck):
+        if self._type is None:
+            return hl.tmatrix._from_java(self._jir.typ())
+        else:
+            return self._type
 
 
 class JavaMatrixVectorRef(MatrixIR):
@@ -665,5 +1151,5 @@ class JavaMatrixVectorRef(MatrixIR):
     def head_str(self):
         return f'{self.vec_ref.jid} {self.idx}'
 
-    def _compute_type(self):
-        self._type = self.vec_ref.item_type
+    def _compute_type(self, deep_typecheck):
+        return self.vec_ref.item_type

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -204,8 +204,9 @@ class MatrixMapCols(MatrixIR):
             child = self.child.handle_randomness(row_uid_field_name, None)
             return MatrixMapCols(child, self.new_col, self.new_key)
 
-        drop_row_uid = row_uid_field_name is None
+        drop_row_uid = False
         if self.new_col.uses_agg_randomness(is_scan=False) and row_uid_field_name is None:
+            drop_row_uid = True
             row_uid_field_name = default_row_uid
         keep_col_uid = col_uid_field_name is not None
         if col_uid_field_name is None:

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -58,7 +58,7 @@ class MatrixAggregateRowsByKey(MatrixIR):
                                  row_expr,
                                  is_scan=False)
 
-        result = MatrixAggregateColsByKey(child, entry_expr, row_expr)
+        result = MatrixAggregateRowsByKey(child, entry_expr, row_expr)
         if drop_row_uid:
             _, old_row = unpack_row_uid(result.typ.row_type, row_uid_field_name)
             result = MatrixMapRows(result, old_row)
@@ -1121,6 +1121,10 @@ class MatrixFilterIntervals(MatrixIR):
         self.intervals = intervals
         self.point_type = point_type
         self.keep = keep
+
+    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
+        return MatrixFilterIntervals(child, self.intervals, self.point_type, self.keep)
 
     def head_str(self):
         return f'{dump_json(hl.tarray(hl.tinterval(self.point_type))._convert_to_json(self.intervals))} {self.keep}'

--- a/hail/python/hail/ir/renderer.py
+++ b/hail/python/hail/ir/renderer.py
@@ -120,6 +120,8 @@ class PlainRenderer(Renderer):
                         builder.append(f'(JavaMatrix {jir_id})')
                     elif isinstance(x, ir.TableIR):
                         builder.append(f'(JavaTable {jir_id})')
+                    elif isinstance(x, ir.BlockMatrixIR):
+                        builder.append(f'(JavaBlockMatrix {jir_id})')
                     else:
                         assert isinstance(x, ir.IR)
                         builder.append(f'(JavaIR {jir_id})')
@@ -178,6 +180,8 @@ class CSERenderer(Renderer):
         self.memo[id(node)] = jref
 
     def __call__(self, root: 'ir.BaseIR') -> str:
+        print("starting CSERenderer")
+        print(PlainRenderer(stop_at_jir=self.stop_at_jir)(root))
         binding_sites = CSEAnalysisPass(self)(root)
         return CSEPrintPass(self)(root, binding_sites)
 

--- a/hail/python/hail/ir/renderer.py
+++ b/hail/python/hail/ir/renderer.py
@@ -180,8 +180,6 @@ class CSERenderer(Renderer):
         self.memo[id(node)] = jref
 
     def __call__(self, root: 'ir.BaseIR') -> str:
-        print("starting CSERenderer")
-        print(PlainRenderer(stop_at_jir=self.stop_at_jir)(root))
         binding_sites = CSEAnalysisPass(self)(root)
         return CSEPrintPass(self)(root, binding_sites)
 

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -876,8 +876,12 @@ class TableToTableApply(TableIR):
         self.config = config
 
     def _handle_randomness(self, uid_field_name):
-        # FIXME: finish
-        return TableToTableApply(self.child.handle_randomness(None), self.config)
+        child = self.child.handle_randomness(None)
+        result = TableToTableApply(child, self.config)
+        if uid_field_name is not None:
+            new_row = ir.InsertFields(ir.Ref('row', result.typ.row_type), [(uid_field_name, ir.NA(tint64))], None)
+            result = TableMapRows(result, new_row)
+        return result
 
     def head_str(self):
         return dump_json(self.config)
@@ -919,8 +923,12 @@ class MatrixToTableApply(TableIR):
         self.config = config
 
     def _handle_randomness(self, uid_field_name):
-        # FIXME: finish
-        return self
+        child = self.child.handle_randomness(None, None)
+        result = MatrixToTableApply(child, self.config)
+        if uid_field_name is not None:
+            new_row = ir.InsertFields(ir.Ref('row', result.typ.row_type), [(uid_field_name, ir.NA(tint64))], None)
+            result = TableMapRows(result, new_row)
+        return result
 
     def head_str(self):
         return dump_json(self.config)
@@ -1012,8 +1020,11 @@ class BlockMatrixToTableApply(TableIR):
         self.config = config
 
     def _handle_randomness(self, uid_field_name):
-        # FIXME: finish
-        return self
+        result = self
+        if uid_field_name is not None:
+            new_row = ir.InsertFields(ir.Ref('row', result.typ.row_type), [(uid_field_name, ir.NA(tint64))], None)
+            result = TableMapRows(result, new_row)
+        return result
 
     def head_str(self):
         return dump_json(self.config)
@@ -1042,10 +1053,11 @@ class BlockMatrixToTable(TableIR):
         self.child = child
 
     def _handle_randomness(self, uid_field_name):
+        result = self
         if uid_field_name is not None:
-            row = ir.Ref('row', self.typ.row_type)
-            new_row = ir.InsertFields(row, [(uid_field_name, ir.MakeTuple(ir.GetField(row, 'i'), ir.GetField(row, 'j')))], None)
-        return TableMapRows(self, new_row)
+            new_row = ir.InsertFields(ir.Ref('row', result.typ.row_type), [(uid_field_name, ir.NA(tint64))], None)
+            result = TableMapRows(result, new_row)
+        return result
 
     def _compute_type(self, deep_typecheck):
         self.child.compute_type(deep_typecheck)
@@ -1058,8 +1070,11 @@ class JavaTable(TableIR):
         self._jir = jir
 
     def _handle_randomness(self, uid_field_name):
-        # FIXME: what to do here?
-        return self
+        result = self
+        if uid_field_name is not None:
+            new_row = ir.InsertFields(ir.Ref('row', result.typ.row_type), [(uid_field_name, ir.NA(tint64))], None)
+            result = TableMapRows(result, new_row)
+        return result
 
     def render_head(self, r):
         return f'(JavaTable {r.add_jir(self._jir)}'

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -205,8 +205,12 @@ class TableMapGlobals(TableIR):
         self.new_globals = new_globals
 
     def _handle_randomness(self, uid_field_name):
+        new_globals = self.new_globals
+        if new_globals.uses_randomness:
+            new_globals = ir.Let('__rng_state', ir.RNGStateLiteral(rng_key), new_globals)
+
         return TableMapGlobals(self.child.handle_randomness(uid_field_name),
-                               self.new_globals)
+                               new_globals)
 
     def _compute_type(self, deep_typecheck):
         self.new_globals.compute_type(self.child.typ.global_env(), None, deep_typecheck)

--- a/hail/python/hail/ir/utils.py
+++ b/hail/python/hail/ir/utils.py
@@ -1,6 +1,84 @@
 from typing import Optional, List, Any, Tuple
-from .ir import Coalesce, ApplyUnaryPrimOp, FalseIR
 import hail as hl
+from hail.utils.java import Env
+from hail.expr.types import tint32, tint64
+
+
+def finalize_randomness(x, key=(0, 0, 0, 0)):
+    import hail.ir.ir as ir
+    if isinstance(x, ir.IR):
+        x = ir.Let('__rng_state', ir.RNGStateLiteral(key), x)
+    elif isinstance(x, ir.TableIR):
+        x = x.handle_randomness(None)
+    elif isinstance(x, ir.MatrixIR):
+        x = x.handle_randomness(None, None)
+    return x
+
+
+default_row_uid = '__row_uid'
+default_col_uid = '__col_uid'
+rng_key = (0, 1, 2, 3)
+
+
+def unpack_row_uid(new_row_type, uid_field_name):
+    import hail.ir.ir as ir
+    new_row = ir.Ref('va', new_row_type)
+    if uid_field_name in new_row_type.fields:
+        uid = ir.GetField(new_row, uid_field_name)
+    else:
+        uid = ir.NA(tint64)
+    return uid, \
+           ir.SelectFields(new_row, [field for field in new_row_type.fields if not field == uid_field_name])
+
+
+def unpack_col_uid(new_col_type, uid_field_name):
+    import hail.ir.ir as ir
+    new_row = ir.Ref('sa', new_col_type)
+    if uid_field_name in new_col_type.fields:
+        uid = ir.GetField(new_row, uid_field_name)
+    else:
+        uid = ir.NA(tint64)
+    return uid, \
+           ir.SelectFields(new_row, [field for field in new_col_type.fields if not field == uid_field_name])
+
+
+def modify_deep_field(struct, path, new_deep_field, new_struct=None):
+    import hail.ir.ir as ir
+    refs = [struct]
+    for i in range(len(path)):
+        refs[i+1] = ir.Ref(Env.gen_uid(), refs[i].typ[path[i]])
+
+    acc = new_deep_field(refs[-1])
+    for parent_struct, field_name in reversed(zip(refs[:-1], path)):
+        acc = ir.InsertFields(parent_struct, [(field_name, acc)], None)
+    acc = new_struct(acc, refs[-1])
+    for struct_ref, field_ref, field_name in reversed(zip(refs[:-1], refs[1:], path)):
+        acc = ir.Let(field_ref.name, ir.GetField(struct_ref, field_name))
+    return acc
+
+
+def zip_with_index(array):
+    import hail.ir.ir as ir
+    elt = Env.gen_uid()
+    inner_row_uid = Env.gen_uid()
+    iota = ir.StreamIota(ir.I32(0), ir.I32(1))
+    return ir.StreamZip(
+        [ir.ToStream(array), iota],
+        [elt, inner_row_uid],
+        ir.MakeTuple(ir.Ref(elt, array.typ.element_type), ir.Ref(inner_row_uid, tint32)),
+        'TakeMinLength')
+
+
+def zip_with_index_field(array, idx_field_name):
+    import hail.ir.ir as ir
+    elt = Env.gen_uid()
+    inner_row_uid = Env.gen_uid()
+    iota = ir.StreamIota(ir.I32(0), ir.I32(1))
+    return ir.StreamZip(
+        [ir.ToStream(array), iota],
+        [elt, inner_row_uid],
+        ir.InsertFields(ir.Ref(elt, array.typ.element_type), [(idx_field_name, ir.Ref(inner_row_uid, tint32))], None),
+        'TakeMinLength')
 
 
 def impute_type_of_partition_interval_array(
@@ -31,7 +109,8 @@ def impute_type_of_partition_interval_array(
 
 
 def filter_predicate_with_keep(ir_pred, keep):
-    return Coalesce(ir_pred if keep else ApplyUnaryPrimOp('!', ir_pred), FalseIR())
+    import hail.ir.ir as ir
+    return ir.Coalesce(ir_pred if keep else ir.ApplyUnaryPrimOp('!', ir_pred), ir.FalseIR())
 
 
 def make_filter_and_replace(filter, find_replace):

--- a/hail/python/hail/ir/utils.py
+++ b/hail/python/hail/ir/utils.py
@@ -28,7 +28,7 @@ def unpack_row_uid(new_row_type, uid_field_name):
     else:
         uid = ir.NA(tint64)
     return uid, \
-           ir.SelectFields(new_row, [field for field in new_row_type.fields if not field == uid_field_name])
+        ir.SelectFields(new_row, [field for field in new_row_type.fields if not field == uid_field_name])
 
 
 def unpack_col_uid(new_col_type, uid_field_name):
@@ -39,14 +39,14 @@ def unpack_col_uid(new_col_type, uid_field_name):
     else:
         uid = ir.NA(tint64)
     return uid, \
-           ir.SelectFields(new_row, [field for field in new_col_type.fields if not field == uid_field_name])
+        ir.SelectFields(new_row, [field for field in new_col_type.fields if not field == uid_field_name])
 
 
 def modify_deep_field(struct, path, new_deep_field, new_struct=None):
     import hail.ir.ir as ir
     refs = [struct]
     for i in range(len(path)):
-        refs[i+1] = ir.Ref(Env.gen_uid(), refs[i].typ[path[i]])
+        refs[i + 1] = ir.Ref(Env.gen_uid(), refs[i].typ[path[i]])
 
     acc = new_deep_field(refs[-1])
     for parent_struct, field_name in reversed(zip(refs[:-1], path)):

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -122,7 +122,7 @@ def sample_qc(mt, name='sample_qc') -> MatrixTable:
     bound_exprs['n_called'] = hl.agg.count_where(hl.is_defined(mt['GT']))
     bound_exprs['n_not_called'] = hl.agg.count_where(hl.is_missing(mt['GT']))
 
-    n_rows_ref = hl.expr.construct_expr(hl.ir.Ref('n_rows'), hl.tint64, mt._col_indices,
+    n_rows_ref = hl.expr.construct_expr(hl.ir.Ref('n_rows', hl.tint64), hl.tint64, mt._col_indices,
                                         hl.utils.LinkedList(hl.expr.expressions.Aggregation))
     bound_exprs['n_filtered'] = n_rows_ref - hl.agg.count()
     bound_exprs['n_hom_ref'] = hl.agg.count_where(mt['GT'].is_hom_ref())
@@ -269,7 +269,7 @@ def variant_qc(mt, name='variant_qc') -> MatrixTable:
 
     bound_exprs['n_called'] = hl.agg.count_where(hl.is_defined(mt['GT']))
     bound_exprs['n_not_called'] = hl.agg.count_where(hl.is_missing(mt['GT']))
-    n_cols_ref = hl.expr.construct_expr(hl.ir.Ref('n_cols'), hl.tint32,
+    n_cols_ref = hl.expr.construct_expr(hl.ir.Ref('n_cols', hl.tint32), hl.tint32,
                                         mt._row_indices, hl.utils.LinkedList(hl.expr.expressions.Aggregation))
     bound_exprs['n_filtered'] = hl.int64(n_cols_ref) - hl.agg.count()
     bound_exprs['call_stats'] = hl.agg.call_stats(mt.GT, mt.alleles)

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1764,7 +1764,7 @@ class Table(ExprContainer):
                 return rekey_f(left)
 
             all_uids.append(uid)
-            join_ir = ir.Join(ir.GetField(ir.TopLevelReference('row'), uid),
+            join_ir = ir.Join(ir.ProjectedTopLevelReference('row', uid, new_schema),
                               all_uids,
                               exprs,
                               joiner)
@@ -1800,19 +1800,20 @@ class Table(ExprContainer):
                                                             join_table[value_uid]])))})
 
                     def joiner(left: MatrixTable):
+                        mart = ir.MatrixAnnotateRowsTable(left._mir, join_table._tir, uid)
                         return MatrixTable(
                             ir.MatrixMapRows(
-                                ir.MatrixAnnotateRowsTable(left._mir, join_table._tir, uid),
+                                mart,
                                 ir.InsertFields(
-                                    ir.Ref('va'),
+                                    ir.Ref('va', mart.typ.row_type),
                                     [(uid, ir.Apply('get', join_table._row_type[uid].value_type,
-                                                    ir.GetField(ir.GetField(ir.Ref('va'), uid), uid),
+                                                    ir.GetField(ir.GetField(ir.Ref('va', mart.typ.row_type), uid), uid),
                                                     ir.MakeTuple([e._ir for e in exprs])))],
                                     None)))
                 else:
                     def joiner(left: MatrixTable):
                         return MatrixTable(ir.MatrixAnnotateRowsTable(left._mir, right._tir, uid, all_matches))
-                ast = ir.Join(ir.GetField(ir.TopLevelReference('va'), uid),
+                ast = ir.Join(ir.ProjectedTopLevelReference('va', uid, new_schema),
                               [uid],
                               exprs,
                               joiner)
@@ -1849,7 +1850,7 @@ class Table(ExprContainer):
                             joined._tir,
                             uid)).key_cols_by(*prev_key)
                         return result
-                join_ir = ir.Join(ir.GetField(ir.TopLevelReference('sa'), uid),
+                join_ir = ir.Join(ir.ProjectedTopLevelReference('sa', uid, new_schema),
                                   all_uids,
                                   exprs,
                                   joiner)
@@ -3641,13 +3642,13 @@ class Table(ExprContainer):
     def _map_partitions(self, f):
         rows_uid = 'tmp_rows_' + Env.get_uid()
         globals_uid = 'tmp_globals_' + Env.get_uid()
-        expr = construct_expr(ir.ToArray(ir.Ref(rows_uid)), hl.tarray(self.row.dtype), self._row_indices)
+        expr = construct_expr(ir.ToArray(ir.Ref(rows_uid, hl.tstream(self.row.dtype))), hl.tarray(self.row.dtype), self._row_indices)
         body = f(expr)
         result_t = body.dtype
         if any(k not in result_t.element_type for k in self.key):
             raise ValueError('Table._map_partitions must preserve key fields')
 
-        body_ir = ir.Let('global', ir.Ref(globals_uid), ir.ToStream(body._ir))
+        body_ir = ir.Let('global', ir.Ref(globals_uid, self._global_type), ir.ToStream(body._ir))
         return Table(ir.TableMapPartitions(self._tir, globals_uid, rows_uid, body_ir))
 
     def _calculate_new_partitions(self, n_partitions):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -451,16 +451,17 @@ class CSETests(unittest.TestCase):
         assert expected == CSERenderer()(cond)
 
     def test_shadowing(self):
-        x = ir.GetField(ir.Ref('row', tint32), 'idx')
+        x = ir.ApplyBinaryPrimOp('*', ir.Ref('row', tint32), ir.I32(2))
         sum = ir.ApplyBinaryPrimOp('+', x, x)
         inner = ir.Let('row', sum, sum)
         outer = ir.Let('row', ir.I32(5), inner)
         expected = (
-            '(Let row (I32 5)'
-            ' (Let __cse_1 (GetField idx (Ref row))'
+            '(Let __cse_2 (I32 2)'
+            ' (Let row (I32 5)'
+            ' (Let __cse_1 (ApplyBinaryPrimOp `*` (Ref row) (Ref __cse_2))'
             ' (Let row (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
-            ' (Let __cse_2 (GetField idx (Ref row))'
-            ' (ApplyBinaryPrimOp `+` (Ref __cse_2) (Ref __cse_2))))))')
+            ' (Let __cse_3 (ApplyBinaryPrimOp `*` (Ref row) (Ref __cse_2))'
+            ' (ApplyBinaryPrimOp `+` (Ref __cse_3) (Ref __cse_3)))))))')
         assert expected == CSERenderer()(outer)
 
     def test_agg_cse(self):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -13,21 +13,38 @@ tearDownModule = stopTestHailContext
 
 
 class ValueIRTests(unittest.TestCase):
+    def value_irs_env(self):
+        return {
+            'c': hl.tbool,
+            'a': hl.tarray(hl.tint32),
+            'st': hl.tstream(hl.tint32),
+            'aa': hl.tarray(hl.tarray(hl.tint32)),
+            'sta': hl.tstream(hl.tarray(hl.tint32)),
+            'da': hl.tarray(hl.ttuple(hl.tint32, hl.tstr)),
+            'nd': hl.tndarray(hl.tfloat64, 1),
+            'v': hl.tint32,
+            's': hl.tstruct(x=hl.tint32, y=hl.tint64, z=hl.tfloat64),
+            't': hl.ttuple(hl.tint32, hl.tint64, hl.tfloat64),
+            'call': hl.tcall,
+            'x': hl.tint32}
+
     def value_irs(self):
+        env = self.value_irs_env()
         b = ir.TrueIR()
-        c = ir.Ref('c')
+        c = ir.Ref('c', env['c'])
         i = ir.I32(5)
         j = ir.I32(7)
-        a = ir.Ref('a')
-        st = ir.Ref('st')
-        aa = ir.Ref('aa')
-        sta = ir.Ref('sta')
-        da = ir.Ref('da')
-        nd = ir.Ref('nd')
-        v = ir.Ref('v')
-        s = ir.Ref('s')
-        t = ir.Ref('t')
-        call = ir.Ref('call')
+        a = ir.Ref('a', env['a'])
+        st = ir.Ref('st', env['st'])
+        aa = ir.Ref('aa', env['aa'])
+        sta = ir.Ref('sta', env['sta'])
+        da = ir.Ref('da', env['da'])
+        nd = ir.Ref('nd', env['nd'])
+        v = ir.Ref('v', env['v'])
+        s = ir.Ref('s', env['s'])
+        t = ir.Ref('t', env['t'])
+        call = ir.Ref('call', env['call'])
+        rngState = ir.RNGStateLiteral((1, 2, 3, 4))
 
         table = ir.TableRange(5, 3)
 
@@ -45,14 +62,14 @@ class ValueIRTests(unittest.TestCase):
             ir.If(b, i, j),
             ir.Coalesce(i, j),
             ir.Let('v', i, v),
-            ir.Ref('x'),
+            ir.Ref('x', env['x']),
             ir.ApplyBinaryPrimOp('+', i, j),
             ir.ApplyUnaryPrimOp('-', i),
             ir.ApplyComparisonOp('EQ', i, j),
             ir.MakeArray([i, ir.NA(hl.tint32), ir.I32(-3)], hl.tarray(hl.tint32)),
             ir.ArrayRef(a, i),
             ir.ArrayLen(a),
-            ir.ArraySort(ir.ToStream(a), 'l', 'r', ir.ApplyComparisonOp("LT", ir.Ref('l'), ir.Ref('r'))),
+            ir.ArraySort(ir.ToStream(a), 'l', 'r', ir.ApplyComparisonOp("LT", ir.Ref('l', hl.tint32), ir.Ref('r', hl.tint32))),
             ir.ToSet(a),
             ir.ToDict(da),
             ir.ToArray(a),
@@ -67,6 +84,7 @@ class ValueIRTests(unittest.TestCase):
             ir.NDArrayMatMul(nd, nd),
             ir.LowerBoundOnOrderedCollection(a, i, True),
             ir.GroupByKey(da),
+            ir.RNGSplit(rngState, ir.MakeTuple([ir.I64(1), ir.MakeTuple([ir.I64(2), ir.I64(3)])])),
             ir.StreamMap(st, 'v', v),
             ir.StreamZip([st, st], ['a', 'b'], ir.TrueIR(), 'ExtendNA'),
             ir.StreamFilter(st, 'v', v),
@@ -122,18 +140,7 @@ class ValueIRTests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     def test_parses(self):
-        env = {'c': hl.tbool,
-               'a': hl.tarray(hl.tint32),
-               'st': hl.tstream(hl.tint32),
-               'aa': hl.tarray(hl.tarray(hl.tint32)),
-               'sta': hl.tstream(hl.tarray(hl.tint32)),
-               'da': hl.tarray(hl.ttuple(hl.tint32, hl.tstr)),
-               'nd': hl.tndarray(hl.tfloat64, 1),
-               'v': hl.tint32,
-               's': hl.tstruct(x=hl.tint32, y=hl.tint64, z=hl.tfloat64),
-               't': hl.ttuple(hl.tint32, hl.tint64, hl.tfloat64),
-               'call': hl.tcall,
-               'x': hl.tint32}
+        env = self.value_irs_env()
         for x in self.value_irs():
             Env.spark_backend('ValueIRTests.test_parses')._parse_value_ir(str(x), env)
 
@@ -184,7 +191,7 @@ class TableIRTests(unittest.TestCase):
             ir.TableMapRows(
                 ir.TableKeyBy(table_read, []),
                 ir.MakeStruct([
-                    ('a', ir.GetField(ir.Ref('row'), 'f32')),
+                    ('a', ir.GetField(ir.Ref('row', table_read_row_type), 'f32')),
                     ('b', ir.F64(-2.11))])),
             ir.TableMapGlobals(
                 table_read,
@@ -205,7 +212,7 @@ class TableIRTests(unittest.TestCase):
             ir.TableToTableApply(table_read, {'name': 'TableFilterPartitions', 'parts': [0], 'keep': True}),
             ir.BlockMatrixToTableApply(block_matrix_read, aa, {'name': 'PCRelate', 'maf': 0.01, 'blockSize': 4096}),
             ir.TableFilterIntervals(table_read, [hl.utils.Interval(hl.utils.Struct(row_idx=0), hl.utils.Struct(row_idx=10))], hl.tstruct(row_idx=hl.tint32), keep=False),
-            ir.TableMapPartitions(table_read, 'glob', 'rows', ir.Ref('rows'))
+            ir.TableMapPartitions(table_read, 'glob', 'rows', ir.Ref('rows', hl.tstream(table_read_row_type)))
         ]
 
         return table_irs
@@ -297,9 +304,9 @@ class BlockMatrixIRTests(unittest.TestCase):
         vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64))
 
         read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader(resource('blockmatrix_example/0')))
-        add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')), "Union")
-        negate_bm = ir.BlockMatrixMap(read, 'element', ir.ApplyUnaryPrimOp('-', ir.Ref('element')), False)
-        sqrt_bm = ir.BlockMatrixMap(read, 'element', hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir, False)
+        add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l', hl.tfloat64), ir.Ref('r', hl.tfloat64)), "Union")
+        negate_bm = ir.BlockMatrixMap(read, 'element', ir.ApplyUnaryPrimOp('-', ir.Ref('element', hl.tfloat64)), False)
+        sqrt_bm = ir.BlockMatrixMap(read, 'element', hl.sqrt(construct_expr(ir.Ref('element', hl.tfloat64), hl.tfloat64))._ir, False)
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1)
         col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1)
@@ -320,7 +327,7 @@ class BlockMatrixIRTests(unittest.TestCase):
 
         densify = ir.BlockMatrixDensify(read)
 
-        pow_ir = (construct_expr(ir.Ref('l'), hl.tfloat64) ** construct_expr(ir.Ref('r'), hl.tfloat64))._ir
+        pow_ir = (construct_expr(ir.Ref('l', hl.tfloat64), hl.tfloat64) ** construct_expr(ir.Ref('r', hl.tfloat64), hl.tfloat64))._ir
         squared_bm = ir.BlockMatrixMap2(scalar_to_bm, scalar_to_bm, 'l', 'r', pow_ir, "NeedsDense")
         slice_bm = ir.BlockMatrixSlice(matmul, [slice(0, 2, 1), slice(0, 1, 1)])
 
@@ -384,10 +391,11 @@ class ValueTests(unittest.TestCase):
         expecteds = []
         for t, v in self.values():
             row_v = ir.Literal(t, v)
+            range = ir.TableRange(1, 1)
             map_globals_ir = ir.TableMapGlobals(
-                ir.TableRange(1, 1),
+                range,
                 ir.InsertFields(
-                    ir.Ref("global"),
+                    ir.Ref("global", range.typ.global_type),
                     [("foo", row_v)],
                     None))
 
@@ -443,7 +451,7 @@ class CSETests(unittest.TestCase):
         assert expected == CSERenderer()(cond)
 
     def test_shadowing(self):
-        x = ir.GetField(ir.Ref('row'), 'idx')
+        x = ir.GetField(ir.Ref('row', tint32), 'idx')
         sum = ir.ApplyBinaryPrimOp('+', x, x)
         inner = ir.Let('row', sum, sum)
         outer = ir.Let('row', ir.I32(5), inner)
@@ -456,12 +464,13 @@ class CSETests(unittest.TestCase):
         assert expected == CSERenderer()(outer)
 
     def test_agg_cse(self):
-        x = ir.GetField(ir.Ref('row'), 'idx')
+        table = ir.TableRange(5, 1)
+        x = ir.GetField(ir.Ref('row', table.typ.row_type), 'idx')
         inner_sum = ir.ApplyBinaryPrimOp('+', x, x)
         agg = ir.ApplyAggOp('AggOp', [], [inner_sum])
         outer_sum = ir.ApplyBinaryPrimOp('+', agg, agg)
         filter = ir.AggFilter(ir.TrueIR(), outer_sum, False)
-        table_agg = ir.TableAggregate(ir.TableRange(5, 1), ir.MakeTuple([outer_sum, filter]))
+        table_agg = ir.TableAggregate(table, ir.MakeTuple([outer_sum, filter]))
         expected = (
             '(TableAggregate (TableRange 5 1)'
                 ' (AggLet __cse_1 False (GetField idx (Ref row))'
@@ -491,7 +500,7 @@ class CSETests(unittest.TestCase):
         assert expected == CSERenderer()(top)
 
     def test_agg_let(self):
-        agg = ir.ApplyAggOp('AggOp', [], [ir.Ref('foo')])
+        agg = ir.ApplyAggOp('AggOp', [], [ir.Ref('foo', tint32)])
         sum = ir.ApplyBinaryPrimOp('+', agg, agg)
         agglet = ir.AggLet('foo', ir.I32(2), sum, False)
         expected = (
@@ -502,8 +511,9 @@ class CSETests(unittest.TestCase):
         assert expected == CSERenderer()(agglet)
 
     def test_refs(self):
-        ref = ir.Ref('row')
-        x = ir.TableMapRows(ir.TableRange(10, 1),
+        table = ir.TableRange(10, 1)
+        ref = ir.Ref('row', table.typ.row_type)
+        x = ir.TableMapRows(table,
                             ir.MakeStruct([('foo', ir.GetField(ref, 'idx')),
                                            ('bar', ir.GetField(ref, 'idx'))]))
         expected = (

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2048,18 +2048,18 @@ class Emit[C](
         val impl = x.implementation
         val unified = impl.unify(Array.empty[Type], x.argTypes, rt)
         assert(unified)
-        if (fn == "rand_unif") {
-          val pureImpl = x.pureImplementation
-          assert(pureImpl.unify(Array.empty[Type], rngState.typ +: x.argTypes, rt))
-          val codeArgsMem = codeArgs.map(_.memoize(cb, "ApplySeeded_arg"))
-          emitI(rngState).consumeI(cb, {
-            impl.applySeededI(seed, cb, region, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, codeArgsMem.map(_.load): _*)
-          }, { state =>
-            pureImpl.applyI(EmitRegion(cb.emb, region), cb, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, Seq[Type](), const(0), EmitCode.present(mb, state) +: codeArgsMem.map(_.load): _*)
-          })
-        } else {
+//        if (fn == "rand_unif") {
+//          val pureImpl = x.pureImplementation
+//          assert(pureImpl.unify(Array.empty[Type], rngState.typ +: x.argTypes, rt))
+//          val codeArgsMem = codeArgs.map(_.memoize(cb, "ApplySeeded_arg"))
+//          emitI(rngState).consumeI(cb, {
+//            impl.applySeededI(seed, cb, region, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, codeArgsMem.map(_.load): _*)
+//          }, { state =>
+//            pureImpl.applyI(EmitRegion(cb.emb, region), cb, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, Seq[Type](), const(0), EmitCode.present(mb, state) +: codeArgsMem.map(_.load): _*)
+//          })
+//        } else {
           impl.applySeededI(seed, cb, region, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, codeArgs: _*)
-        }
+//        }
 
       case AggStateValue(i, _) =>
         val AggContainer(_, sc, _) = container.get

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2048,18 +2048,19 @@ class Emit[C](
         val impl = x.implementation
         val unified = impl.unify(Array.empty[Type], x.argTypes, rt)
         assert(unified)
-//        if (fn == "rand_unif") {
-//          val pureImpl = x.pureImplementation
-//          assert(pureImpl.unify(Array.empty[Type], rngState.typ +: x.argTypes, rt))
-//          val codeArgsMem = codeArgs.map(_.memoize(cb, "ApplySeeded_arg"))
-//          emitI(rngState).consumeI(cb, {
-//            impl.applySeededI(seed, cb, region, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, codeArgsMem.map(_.load): _*)
-//          }, { state =>
-//            pureImpl.applyI(EmitRegion(cb.emb, region), cb, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, Seq[Type](), const(0), EmitCode.present(mb, state) +: codeArgsMem.map(_.load): _*)
-//          })
-//        } else {
+        val newRNGEnabled = Array[String]()
+        if (newRNGEnabled.contains(fn)) {
+          val pureImpl = x.pureImplementation
+          assert(pureImpl.unify(Array.empty[Type], rngState.typ +: x.argTypes, rt))
+          val codeArgsMem = codeArgs.map(_.memoize(cb, "ApplySeeded_arg"))
+          emitI(rngState).consumeI(cb, {
+            impl.applySeededI(seed, cb, region, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, codeArgsMem.map(_.load): _*)
+          }, { state =>
+            pureImpl.applyI(EmitRegion(cb.emb, region), cb, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, Seq[Type](), const(0), EmitCode.present(mb, state) +: codeArgsMem.map(_.load): _*)
+          })
+        } else {
           impl.applySeededI(seed, cb, region, impl.computeReturnEmitType(x.typ, codeArgs.map(_.emitType)).st, codeArgs: _*)
-//        }
+        }
 
       case AggStateValue(i, _) =>
         val AggContainer(_, sc, _) = container.get

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -40,7 +40,8 @@ object Interpretable {
         _: WriteMetadata |
         _: ReadValue |
         _: WriteValue |
-        _: NDArrayWrite  => false
+        _: NDArrayWrite |
+        _: RNGStateLiteral => false
       case x: ApplyIR =>
         !Exists(x.body, {
           case n: IR => !Interpretable(n)

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -19,10 +19,12 @@ object Optimize {
     }
 
     ctx.timer.time("Optimize") {
+      val normalizeNames = new NormalizeNames(_.toString, allowFreeVariables = true)
       while (iter < maxIter && ir != last) {
         last = ir
         runOpt(FoldConstants(ctx, _), iter, "FoldConstants")
         runOpt(ExtractIntervalFilters(ctx, _), iter, "ExtractIntervalFilters")
+        runOpt(normalizeNames(_), iter, "NormalizeNames")
         runOpt(Simplify(ctx, _), iter, "Simplify")
         runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(ForwardRelationalLets(_), iter, "ForwardRelationalLets")

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1311,9 +1311,9 @@ object IRParser {
         val seed = int64_literal(it)
         val rt = type_expr(env.typEnv)(it)
         for {
-//          rngState <- ir_value_expr(env)(it)
+          rngState <- ir_value_expr(env)(it)
           args <- ir_value_children(env)(it)
-        } yield ApplySeeded(function, args, NA(TRNGState), seed, rt)
+        } yield ApplySeeded(function, args, rngState, seed, rt)
       case "ApplyIR" | "ApplySpecial" | "Apply" =>
         val errorID = int32_literal(it)
         val function = identifier(it)

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -694,7 +694,9 @@ class RVD(
     ac.result()
   }
 
-  def count(): Long =
+  def count(): Long = {
+    println(s"num partitions: $getNumPartitions")
+    println(crdd.rdd.partitions.length)
     crdd.boundary.cmapPartitions { (ctx, it) =>
       var count = 0L
       it.foreach { _ =>
@@ -702,6 +704,7 @@ class RVD(
       }
       Iterator.single(count)
     }.run.fold(0L)(_ + _)
+  }
 
   def countPerPartition(): Array[Long] =
     crdd.boundary.cmapPartitions { (ctx, it) =>


### PR DESCRIPTION
High level design:
* `ApplySeeded` takes a child of type `trngstate`. It is always constructed as a free reference `__rng_state`, which must be defined by a parent, who has the responsibility to ensure the seeded function is given a distinct rng state on each invocation.
* Any node with a child which may be executed more than once (e.g. `TailLoop`, stream nodes, table nodes) must use `Let('__rng_state', RNGSplit(Ref('__rng_state'), uid), child)`, where `uid` is a long or tuple of longs which is guaranteed to be distinct on every execution of `child`.
* Uids are typically created at the leaves of pipelines (`TableRead`, `StreamRange`, etc.), and propagated upwards.

There was a phase-ordering conflict that had to be worked around:
* IRs must be given explict rng state and uid semantics as early as possible, to ensure determinism.
* The transformation to explicitly pass rng states and uids must happen during IR construction. If it happened later, it would create new IR objects, which would defeat the python CSE pass (which only recognizes equivalent subexpressions when they are represented by the same python object).
* The rng explication requires some type information.
* Types on the python IR are assigned after the IR is fully constructed.

To fix this:
* `Ref`'s must be given a type at construction
  * `TopLevelReference`s are the only case that needs to be constructed before a type is known. But they are always constructed wrapped in a `SelectFields` or `GetField`, whose type is known at construction. I added new IR classes `SelectedTopLevelReference` and `ProjectedTopLevelReference` for these two cases, which are thin wrappers which don't appear in the rendered IR.
* `construct_expr` always assigns a type to the ir. Bottom-up type construction will later assert equality with the assigned type. This caught some existing bugs, where expression type and ir type didn't agree.
* At construction of the root node of a stream/table/matrixtable pipeline (i.e. a non-stream value ir with at least one stream/table/matrixtable child), recursively rewrite the contained pipeline(s) to make rng states and uids explicit. This is safe, since stream/table/matrixtable IRs won't be CSE'd, because they may only be evaluated once. Contained value IRs are not rewritten, only wrapped with bindings which define the rng state.

These are currently non-functional changes, as `ApplySeeded` still uses the old rng, and will ignore the rng state.