### PR TITLE
[batch] Dont blow up the killing task when killing a container

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -750,6 +750,8 @@ class Container:
         try:
             if self._run_fut is not None:
                 await self._run_fut
+        except ContainerDeletedError:
+            pass
         finally:
             try:
                 if self.container_is_running():


### PR DESCRIPTION
`self._run_fut` will blow up with a `ContainerDeletedError` when the container is forcibly stopped in `Container.kill`. The task running `Container.kill` wants to block on the deletion and cleanup of the container, hence the `await self._run_fut`, but it shouldn't itself be interrupted by the container deletion error.

This fixes a bug where if a JVM job wanted to delete the JVM a job was running in for X reason, it wouldn't get passed `jvm.kill` and the user would see a Job deleted error stacktrace instead of useful diagnostic information.