### PR TITLE
[aiotools] Make Azure asyncfs support blobs with ? in the blob name

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -1,10 +1,8 @@
 from typing import Any, AsyncContextManager, AsyncIterator, Dict, List, Optional, Set, Tuple, Type
 from types import TracebackType
 
-import os
 import re
 import asyncio
-import urllib
 import secrets
 import logging
 
@@ -218,20 +216,21 @@ class AzureReadableStream(ReadableStream):
 
 
 class AzureFileListEntry(FileListEntry):
-    def __init__(self, url: str, blob_props: Optional[BlobProperties]):
-        self._url = url
+    def __init__(self, account: str, container: str, name: str, blob_props: Optional[BlobProperties]):
+        self._account = account
+        self._container = container
+        self._name = name
         self._blob_props = blob_props
         self._status: Optional[AzureFileStatus] = None
 
     def name(self) -> str:
-        parsed = urllib.parse.urlparse(self._url)
-        return os.path.basename(parsed.path)
+        return self._name
 
     async def url(self) -> str:
-        return self._url
+        return f'hail-az://{self._account}/{self._container}/{self._name}'
 
     def url_maybe_trailing_slash(self) -> str:
-        return self._url
+        return f'hail-az://{self._account}/{self._container}/{self._name}'
 
     async def is_file(self) -> bool:
         return self._blob_props is not None
@@ -242,7 +241,7 @@ class AzureFileListEntry(FileListEntry):
     async def status(self) -> FileStatus:
         if self._status is None:
             if self._blob_props is None:
-                raise IsADirectoryError(self._url)
+                raise IsADirectoryError(await self.url())
             self._status = AzureFileStatus(self._blob_props)
         return self._status
 
@@ -306,16 +305,25 @@ class AzureAsyncFS(AsyncFS):
 
     @staticmethod
     def get_account_container_and_name(url: str) -> Tuple[str, str, str]:
-        parsed = urllib.parse.urlparse(url)
+        colon_index = url.find(':')
+        if colon_index == -1:
+            raise ValueError(f'invalid URL: {url}')
 
-        if parsed.scheme != 'hail-az':
-            raise ValueError(f'invalid scheme, expected hail-az: {parsed.scheme}')
+        scheme = url[:colon_index]
+        if scheme != 'hail-az':
+            raise ValueError(f'invalid scheme, expected hail-az: {scheme}')
 
-        account = parsed.netloc
+        rest = url[(colon_index + 1):]
+        if not rest.startswith('//'):
+            raise ValueError(f'invalid path name, expected hail-az://account/container/blob_name: {url}')
 
-        match = AzureAsyncFS.PATH_REGEX.fullmatch(parsed.path)
+        end_of_account = rest.find('/', 2)
+        account = rest[2:end_of_account]
+        container_and_name = rest[end_of_account:]
+
+        match = AzureAsyncFS.PATH_REGEX.fullmatch(container_and_name)
         if match is None:
-            raise ValueError(f'invalid path name, expected hail-az://account/container/blob_name: {parsed.path}')
+            raise ValueError(f'invalid path name, expected hail-az://account/container/blob_name: {container_and_name}')
 
         container = match.groupdict()['container']
 
@@ -401,8 +409,7 @@ class AzureAsyncFS(AsyncFS):
         assert not name or name.endswith('/')
         async for blob_props in client.list_blobs(name_starts_with=name,
                                                   include=['metadata']):
-            url = f'hail-az://{client.account_name}/{client.container_name}/{blob_props.name}'
-            yield AzureFileListEntry(url, blob_props)
+            yield AzureFileListEntry(client.account_name, client.container_name, blob_props.name, blob_props)
 
     @staticmethod
     async def _listfiles_flat(client: ContainerClient, name: str) -> AsyncIterator[FileListEntry]:
@@ -411,12 +418,10 @@ class AzureAsyncFS(AsyncFS):
                                             include=['metadata'],
                                             delimiter='/'):
             if isinstance(item, BlobPrefix):
-                url = f'hail-az://{client.account_name}/{client.container_name}/{item.prefix}'
-                yield AzureFileListEntry(url, None)
+                yield AzureFileListEntry(client.account_name, client.container_name, item.prefix, None)
             else:
                 assert isinstance(item, BlobProperties)
-                url = f'hail-az://{client.account_name}/{client.container_name}/{item.name}'
-                yield AzureFileListEntry(url, item)
+                yield AzureFileListEntry(client.account_name, client.container_name, item.name, item)
 
     async def listfiles(self,
                         url: str,

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -208,18 +208,17 @@ class LocalAsyncFS(AsyncFS):
     @staticmethod
     def _get_path(url):
         parsed = urllib.parse.urlparse(url)
-        if parsed.scheme and parsed.scheme != 'file':
-            raise ValueError(f"invalid file URL: {url}, invalid scheme: expected file, got {parsed.scheme}")
-        if parsed.netloc and parsed.netloc != 'localhost':
-            raise ValueError(
-                f"invalid file URL: {url}, invalid netloc: expected localhost or empty, got {parsed.netloc}")
-        if parsed.params:
-            raise ValueError(f"invalid file URL: params not allowed: {url}")
-        if parsed.query:
-            raise ValueError(f"invalid file URL: query not allowed: {url}")
-        if parsed.fragment:
-            raise ValueError(f"invalid file URL: fragment not allowed: {url}")
-        return parsed.path
+        prefix = ''
+        if parsed.scheme:
+            if parsed.scheme != 'file':
+                raise ValueError(f"invalid file URL: {url}, invalid scheme: expected file, got {parsed.scheme}")
+            prefix += f'{parsed.scheme}://'
+        if parsed.netloc:
+            if parsed.netloc != 'localhost':
+                raise ValueError(
+                    f"invalid file URL: {url}, invalid netloc: expected localhost or empty, got {parsed.netloc}")
+            prefix += parsed.netloc
+        return url[len(prefix):]
 
     async def open(self, url: str) -> ReadableStream:
         f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'rb')

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -86,7 +86,7 @@ def file_data(request):
 
 @pytest.mark.asyncio
 async def test_write_read(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str], file_data):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -103,7 +103,7 @@ async def test_write_read(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str], fi
 
 @pytest.mark.asyncio
 async def test_open_from(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -117,7 +117,7 @@ async def test_open_from(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
 
 @pytest.mark.asyncio
 async def test_open_from_with_length(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -153,7 +153,7 @@ async def test_open_from_with_length(filesystem: Tuple[asyncio.Semaphore, AsyncF
 
 @pytest.mark.asyncio
 async def test_open_empty(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -167,7 +167,7 @@ async def test_open_empty(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
 
 @pytest.mark.asyncio
 async def test_open_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -182,7 +182,7 @@ async def test_open_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncF
 
 @pytest.mark.asyncio
 async def test_open_from_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -197,7 +197,7 @@ async def test_open_from_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, A
 
 @pytest.mark.asyncio
 async def test_read_from(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -208,7 +208,7 @@ async def test_read_from(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
 
 @pytest.mark.asyncio
 async def test_read_range(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -230,7 +230,7 @@ async def test_read_range(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
 
 @pytest.mark.asyncio
 async def test_read_range_end_exclusive_empty_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -240,7 +240,7 @@ async def test_read_range_end_exclusive_empty_file(filesystem: Tuple[asyncio.Sem
 
 @pytest.mark.asyncio
 async def test_read_range_end_inclusive_empty_file_should_error(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -256,7 +256,7 @@ async def test_read_range_end_inclusive_empty_file_should_error(filesystem: Tupl
 
 @pytest.mark.asyncio
 async def test_read_range_end_exclusive_nonempty_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -267,7 +267,7 @@ async def test_read_range_end_exclusive_nonempty_file(filesystem: Tuple[asyncio.
 
 @pytest.mark.asyncio
 async def test_write_read_range(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str], file_data):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -288,7 +288,7 @@ async def test_write_read_range(filesystem: Tuple[asyncio.Semaphore, AsyncFS, st
 
 @pytest.mark.asyncio
 async def test_isfile(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -302,7 +302,7 @@ async def test_isfile(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
 
 @pytest.mark.asyncio
 async def test_isdir(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     # mkdir with trailing slash
     dir = f'{base}dir/'
@@ -324,7 +324,7 @@ async def test_isdir(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
 
 @pytest.mark.asyncio
 async def test_isdir_subdir_only(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     dir = f'{base}dir/'
     await fs.mkdir(dir)
@@ -341,7 +341,7 @@ async def test_isdir_subdir_only(filesystem: Tuple[asyncio.Semaphore, AsyncFS, s
 
 @pytest.mark.asyncio
 async def test_remove(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     file = f'{base}foo'
 
@@ -455,7 +455,7 @@ async def test_cloud_rmtree_file_ending_in_slash(filesystem: Tuple[asyncio.Semap
 
 @pytest.mark.asyncio
 async def test_statfile_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     with pytest.raises(FileNotFoundError):
         await fs.statfile(f'{base}foo')
@@ -463,7 +463,7 @@ async def test_statfile_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, As
 
 @pytest.mark.asyncio
 async def test_statfile_directory(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     await fs.mkdir(f'{base}dir/')
     await fs.touch(f'{base}dir/foo')
@@ -475,7 +475,7 @@ async def test_statfile_directory(filesystem: Tuple[asyncio.Semaphore, AsyncFS, 
 
 @pytest.mark.asyncio
 async def test_statfile(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     n = 37
     file = f'{base}bar'
@@ -483,9 +483,24 @@ async def test_statfile(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
     status = await fs.statfile(file)
     assert await status.size() == n
 
+
+@pytest.mark.asyncio
+async def test_file_can_contain_url_query_delimiter(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
+    _, fs, base = filesystem
+
+    file = f'{base}bar?baz'
+    await fs.write(file, secrets.token_bytes(10))
+    assert await fs.exists(file)
+    async for f in fs.listfiles(base):
+        if f.name() == 'bar?baz':
+            break
+    else:
+        assert False, 'File bar?baz not found'
+
+
 @pytest.mark.asyncio
 async def test_listfiles(filesystem: Tuple[asyncio.Semaphore, AsyncFS, str]):
-    sema, fs, base = filesystem
+    _, fs, base = filesystem
 
     with pytest.raises(FileNotFoundError):
         await fs.listfiles(f'{base}does/not/exist')

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -491,7 +491,7 @@ async def test_file_can_contain_url_query_delimiter(filesystem: Tuple[asyncio.Se
     file = f'{base}bar?baz'
     await fs.write(file, secrets.token_bytes(10))
     assert await fs.exists(file)
-    async for f in fs.listfiles(base):
+    async for f in await fs.listfiles(base):
         if f.name() == 'bar?baz':
             break
     else:

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -492,7 +492,7 @@ async def test_file_can_contain_url_query_delimiter(filesystem: Tuple[asyncio.Se
     await fs.write(file, secrets.token_bytes(10))
     assert await fs.exists(file)
     async for f in await fs.listfiles(base):
-        if f.name() == '/bar?baz':
+        if 'bar?baz' in f.name():
             break
     else:
         assert False, 'File bar?baz not found'

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -492,7 +492,7 @@ async def test_file_can_contain_url_query_delimiter(filesystem: Tuple[asyncio.Se
     await fs.write(file, secrets.token_bytes(10))
     assert await fs.exists(file)
     async for f in await fs.listfiles(base):
-        if f.name() == 'bar?baz':
+        if f.name() == '/bar?baz':
             break
     else:
         assert False, 'File bar?baz not found'


### PR DESCRIPTION
urlparse isn't really what we want for breaking down a blob storage URL. There are special characters that delimit different parts of a typical URL that don't translate to a blob. Specifically, if a blob name contains a `?` (which is totally valid if albeit horrendous), `parsed.path` will terminate before the `?` and drop the rest because it views those as query params. We really just want everything after the container to be the blob name, so we do a bit more manual work in the name of simplicity. Dan already handled this in the Google async fs but this was never changed in the azure implementation. They now resemble each other more closely.