### PR TITLE
[aiotools] Make Azure fs.open raise a FileNotFoundError if blob does not exist

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -342,15 +342,17 @@ class AzureAsyncFS(AsyncFS):
         return blob_service_client.get_container_client(container)
 
     async def open(self, url: str) -> ReadableStream:
+        if not await self.exists(url):
+            raise FileNotFoundError
         client = self.get_blob_client(url)
-        stream = AzureReadableStream(client, url)
-        return stream
+        return AzureReadableStream(client, url)
 
     async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         assert length is None or length >= 1
+        if not await self.exists(url):
+            raise FileNotFoundError
         client = self.get_blob_client(url)
-        stream = AzureReadableStream(client, url, offset=start, length=length)
-        return stream
+        return AzureReadableStream(client, url, offset=start, length=length)
 
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:  # pylint: disable=unused-argument
         client = self.get_blob_client(url)

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -170,14 +170,8 @@ async def test_open_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncF
     sema, fs, base = filesystem
 
     file = f'{base}foo'
-
-    try:
-        async with await fs.open(file) as f:
-            await f.read()
-    except FileNotFoundError:
-        pass
-    else:
-        assert False
+    with pytest.raises(FileNotFoundError):
+        await fs.open(file)
 
 
 @pytest.mark.asyncio
@@ -185,14 +179,8 @@ async def test_open_from_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, A
     sema, fs, base = filesystem
 
     file = f'{base}foo'
-
-    try:
-        async with await fs.open_from(file, 2) as f:
-            await f.read()
-    except FileNotFoundError:
-        pass
-    else:
-        assert False
+    with pytest.raises(FileNotFoundError):
+        await fs.open_from(file, 2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
[This test](https://github.com/hail-is/hail/blob/9ad2e64bd7570199ebdb64304b6ca6599749b260/hail/python/test/hail/utils/test_utils.py#L88) suggests that `fs.open` should fail immediately if the desired blob does not already exist. This is true of the hadoop and the aiogoogle FS implementations. The azure implementation varies slightly in that `open` will succeed if the blob does not exist but *read* will throw an exception. The current async fs test for a nonexistent file does both open and read so the subtle distinction is flying under the radar. The azure sdk intentionally allows you to create a blob client for a blob that doesn't exist, so we have to do an existence check ourselves.