### PR TITLE
[ci] Dont depend on Skopeo

### DIFF
--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -4,9 +4,3 @@ RUN hail-pip-install twine
 COPY jinja2_render.py .
 COPY wait-for.py .
 COPY create_database.py .
-
-RUN . /etc/os-release && \
-    echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
-    curl https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | apt-key add - && \
-    apt-get update && \
-    apt-get -y install skopeo

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -29,7 +29,7 @@ HAIL_GENETICS_HAIL_IMAGE=$7
 WHEEL_FOR_AZURE=$8
 WEBSITE_TAR=$9
 
-retry skopeo inspect $HAIL_GENETICS_HAIL_IMAGE || (echo "could not pull $HAIL_GENETICS_HAIL_IMAGE" ; exit 1)
+# retry skopeo inspect $HAIL_GENETICS_HAIL_IMAGE || (echo "could not pull $HAIL_GENETICS_HAIL_IMAGE" ; exit 1)
 
 if git ls-remote --exit-code --tags $REMOTE $HAIL_PIP_VERSION
 then
@@ -78,8 +78,8 @@ curl -XPOST -H @$GITHUB_OAUTH_HEADER_FILE https://api.github.com/repos/hail-is/h
   "prerelease": false
 }'
 
-retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://docker.io/hailgenetics/hail:$HAIL_PIP_VERSION
-retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://gcr.io/hail-vdc/hailgenetics/hail:$HAIL_PIP_VERSION
+# retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://docker.io/hailgenetics/hail:$HAIL_PIP_VERSION
+# retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://gcr.io/hail-vdc/hailgenetics/hail:$HAIL_PIP_VERSION
 
 # deploy to PyPI
 twine upload $WHEEL


### PR DESCRIPTION
Skopeo was yanked from the Kubic repository and there's not an obvious place to retrieve it for 20.04 yet. Removing it as a dependency to unblock current PRs until the issue is resolved.