### PR TITLE
[query] fix AzureStorageFS openNoCompression 

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -137,8 +137,9 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
           bb.put(i.toByte)
         }
 
+        val pos = getPosition
         val numBytesRemainingInBlob = blobSize - pos
-        val count = Math.min(numBytesRemainingInBlob, bb.remaining())
+        val count = Math.min(numBytesRemainingInBlob, bb.capacity())
         if (count <= 0) {
           return -1
         }
@@ -146,18 +147,13 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
         client.downloadStreamWithResponse(
           outputStreamToBuffer, new BlobRange(pos, count),
           null, null, false, timeout, null)
-        pos += count
         bb.flip()
 
         assert(bb.position() == 0 && bb.remaining() > 0)
         return count.toInt
       }
 
-      override def seek(newPos: Long): Unit = {
-        bb.clear()
-        bb.limit(0)
-        pos = newPos
-      }
+      override def adjustSeekInternalState(newPos: Long): Unit = {}
     }
 
     new WrappedSeekableDataInputStream(is)

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -152,8 +152,6 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
         assert(bb.position() == 0 && bb.remaining() > 0)
         return count.toInt
       }
-
-      override def adjustSeekInternalState(newPos: Long): Unit = {}
     }
 
     new WrappedSeekableDataInputStream(is)

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -155,10 +155,7 @@ abstract class FSSeekableInputStream extends InputStream with Seekable {
     bb.clear()
     bb.limit(0)
     pos = newPos
-    adjustSeekInternalState(newPos)
   }
-
-  def adjustSeekInternalState(newPos: Long): Unit
 
   def getPosition: Long = pos
 }

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -109,7 +109,7 @@ object FSUtil {
 
 abstract class FSSeekableInputStream extends InputStream with Seekable {
   protected[this] var closed: Boolean = false
-  protected[this] var pos: Long = 0
+  private[this] var pos: Long = 0
   private[this] var eof: Boolean = false
 
   protected[this] val bb: ByteBuffer = ByteBuffer.allocate(64 * 1024)
@@ -150,6 +150,15 @@ abstract class FSSeekableInputStream extends InputStream with Seekable {
     pos += toTransfer
     toTransfer
   }
+
+  def seek(newPos: Long): Unit = {
+    bb.clear()
+    bb.limit(0)
+    pos = newPos
+    adjustSeekInternalState(newPos)
+  }
+
+  def adjustSeekInternalState(newPos: Long): Unit
 
   def getPosition: Long = pos
 }

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -110,11 +110,8 @@ class GoogleStorageFS(val serviceAccountKey: Option[String] = None) extends FS {
         return n
       }
 
-      def seek(newPos: Long): Unit = {
-        bb.clear()
-        bb.limit(0)
+      override def adjustSeekInternalState(newPos: Long): Unit = {
         reader.seek(newPos)
-        pos = newPos
       }
     }
 

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -110,7 +110,8 @@ class GoogleStorageFS(val serviceAccountKey: Option[String] = None) extends FS {
         return n
       }
 
-      override def adjustSeekInternalState(newPos: Long): Unit = {
+      override def seek(newPos: Long): Unit = {
+        super.seek(newPos)
         reader.seek(newPos)
       }
     }

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -275,13 +275,13 @@ trait FSSuite {
     val f = t()
 
     using(fs.create(f)) { os =>
-      Array.tabulate(1000000)(i => os.write(i))
+      Array.tabulate(1000000)(i => os.write(i % 1000))
     }
 
     assert(fs.exists(f))
 
     using(fs.open(f)) { is =>
-      Array.tabulate(1000000)(i => assert(i.toByte == is.read()))
+      Array.tabulate(1000000)(i => assert((i % 1000) == is.read()))
     }
 
     fs.delete(f, false)
@@ -301,7 +301,7 @@ trait FSSuite {
 
       var i = 0
       while (i < byteBufferSize + 10) {
-        os.write(i)
+        os.write(i % 1000)
         i = i + 1
       }
     }
@@ -315,7 +315,7 @@ trait FSSuite {
 
       var i = 0
       while (i < byteBufferSize + 10) {
-        assert(is.read() == i.toByte)
+        assert(is.read() == (i % 1000))
         i = i + 1
       }
     }

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -281,7 +281,7 @@ trait FSSuite {
     assert(fs.exists(f))
 
     using(fs.open(f)) { is =>
-      Array.tabulate(1000000)(i => assert(i == is.read()))
+      Array.tabulate(1000000)(i => assert(i.toByte == is.read()))
     }
 
     fs.delete(f, false)
@@ -315,7 +315,7 @@ trait FSSuite {
 
       var i = 0
       while (i < byteBufferSize + 10) {
-        assert(is.read() == i)
+        assert(is.read() == i.toByte)
         i = i + 1
       }
     }


### PR DESCRIPTION
- fix double-counting error in openNoCompression method 
- add tests to read/write more bytes than can be held in the ByteBuffer
- abstract out seek method into FS