### PR TITLE
[aiogoogle] Increase chunk size when copying files to GCS

### DIFF
--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -337,7 +337,7 @@ class GoogleStorageClient(GoogleBaseClient):
         # Write using resumable uploads.  See:
         # https://cloud.google.com/storage/docs/performing-resumable-uploads
         assert upload_type == 'resumable'
-        chunk_size = kwargs.get('bufsize', 256 * 1024)
+        chunk_size = kwargs.get('bufsize', 8 * 1024 * 1024)
 
         async with await self._session.post(
             f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o',


### PR DESCRIPTION
The docs say we should use at a minimum 8 MB chunks. With 50 way parallelism that's 400 MB in memory which should be fine.