### PR TITLE
[internal-gateway] Higher limit for internal-gateway cpu

### DIFF
--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -42,7 +42,7 @@ spec:
              cpu: "20m"
              memory: "200M"
            limits:
-             cpu: "1"
+             cpu: "4"
              memory: "1G"
          ports:
           - containerPort: 80


### PR DESCRIPTION
nginx can use more than one core and at max load + PRs we're maxing out internal-gateway cycles, which add latency, timeouts, retries, and generally degrade the experience in one namespace based on activity in others. Allowing nginx to use more cores (in this case this is up to half our node size) got our system back into its intended state with graceful throttling.

I'll admit, other than being half a node size, 4 is a bit arbitrary here. I think our k8s nodes are annoyingly underutilized enough that we shouldn't see issues in practice with letting internal-gateway use cores that are very likely idle.