### PR TITLE
[batch] Use Spot VMs on GCP

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -96,7 +96,13 @@ def create_vm_config(
                 'accessConfigs': [{'type': 'ONE_TO_ONE_NAT', 'name': 'external-nat'}],
             }
         ],
-        'scheduling': {'automaticRestart': False, 'onHostMaintenance': "TERMINATE", 'preemptible': preemptible},
+        'scheduling': {
+            'automaticRestart': False,
+            'instanceTerminationAction': 'DELETE',
+            'onHostMaintenance': 'TERMINATE',
+            'preemptible': preemptible,
+            'provisioningModel': 'SPOT' if preemptible else 'STANDARD',
+        },
         'serviceAccounts': [
             {
                 'email': f'batch2-agent@{project}.iam.gserviceaccount.com',


### PR DESCRIPTION
This will allow preemptible VMs to run longer than 24h.

See https://cloud.google.com/compute/docs/instances/create-use-spot#create.

#assign services