### PR TITLE
[ci] Fix upload_query_jar azure credentials

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2173,9 +2173,7 @@ steps:
     script: |
       set -ex
       export GOOGLE_APPLICATION_CREDENTIALS=/batch-gsa-key/key.json
-      export HAIL_TEST_AZURE_ACCOUNT=hailtest
-      export HAIL_TEST_AZURE_CONTAINER=hail-test-4nxei
-      export AZURE_APPLICATION_CREDENTIALS=/test-azure-key/credentials.json
+      export AZURE_APPLICATION_CREDENTIALS=/batch-gsa-key/key.json
 
       {% if scope == "deploy" %}
       HAIL_QUERY_JAR_URL={{ global.query_storage_uri }}


### PR DESCRIPTION
Those env variables most have been copy-pasted from another step because they're neither correct nor necessary. I tried downloading the batch-gsa-key and running `upload-query-jar` with it as the credentials and it succeeded.