### PR TITLE
[batch] Fix bad bug with billing multiple pd-ssd resources

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -80,9 +80,7 @@ async def add_attempt_resources(db, batch_id, job_id, attempt_id, resources):
             for resource in resources:
                 _resources[resource['name']] += resource['quantity']
 
-            resource_args = [
-                (batch_id, job_id, attempt_id, name, quantity) for name, quantity in _resources.items()
-            ]
+            resource_args = [(batch_id, job_id, attempt_id, name, quantity) for name, quantity in _resources.items()]
 
             await db.execute_many(
                 '''


### PR DESCRIPTION
cc: @danking 

The issue with not billing for the external SSD was because we'd have duplicate keys when inserting into the `attempt_resources` table which would clobber each other. The two identical keys were one for the boot disk and the second for the external pd-ssd. I decided the best way to fix this was to make sure we "roll up" the quantities for duplicate keys inside the `add_attempt_resources` function rather than doing it elsewhere in the code base. Note, we cannot use `ON DUPLICATE KEY quantity = quantity + VALUES(quantity)` because this function can be called multiple times with MJS and MJC, so we need to make sure it is idempotent. Here's an example output from the database for a job with 100GiB external disk and using 1/16 of a machine (0.25 core job) with 4 cores and a 20GiB boot disk.

```
mysql> select * from attempt_resources where batch_id = 106 and job_id = 1;
+----------+--------+------------+--------------------------+----------+
| batch_id | job_id | attempt_id | resource                 | quantity |
+----------+--------+------------+--------------------------+----------+
|      106 |      1 | 7NMdWr     | compute/n1-preemptible/1 |      250 |
|      106 |      1 | 7NMdWr     | disk/local-ssd/1         |    24000 |
|      106 |      1 | 7NMdWr     | disk/pd-ssd/1            |   103680 |
|      106 |      1 | 7NMdWr     | ip-fee/1024/1            |       64 |
|      106 |      1 | 7NMdWr     | memory/n1-preemptible/1  |      960 |
|      106 |      1 | 7NMdWr     | service-fee/1            |      250 |
+----------+--------+------------+--------------------------+----------+
6 rows in set (0.01 sec)
```

I double checked the rate for pd-ssd seemed fine, but that would be the other place where we got the billing wrong.