### PR TITLE
[batch] Add always_copy_output option

### DIFF
--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -43,6 +43,7 @@ image_str = str_type
 
 job_validator = keyed(
     {
+        'always_copy_output': bool_type,
         'always_run': bool_type,
         'attributes': dictof(str_type),
         'env': listof(keyed({'name': str_type, 'value': str_type})),

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -197,6 +197,8 @@ def handle_job_backwards_compatibility(job):
         job['gcsfuse'] = job.pop('cloudfuse')
     if 'parent_ids' in job:
         job['absolute_parent_ids'] = job.pop('parent_ids')
+    if 'always_copy_output' not in job:
+        job['always_copy_output'] = True
 
 
 def validate_batch(batch):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1675,12 +1675,16 @@ class DockerJob(Job):
                     await self.run_container(main, 'main')
 
                     output = self.containers.get('output')
-                    if output:
+
+                    always_copy_output = self.job_spec.get('always_copy_output', False)
+                    copy_output = output and (main.state == 'succeeded' or always_copy_output)
+
+                    if copy_output:
                         await self.run_container(output, 'output')
 
                     if main.state != 'succeeded':
                         self.state = main.state
-                    elif output:
+                    elif copy_output:
                         self.state = output.state
                     else:
                         self.state = 'succeeded'

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1676,7 +1676,7 @@ class DockerJob(Job):
 
                     output = self.containers.get('output')
 
-                    always_copy_output = self.job_spec.get('always_copy_output', False)
+                    always_copy_output = self.job_spec.get('always_copy_output', True)
                     copy_output = output and (main.state == 'succeeded' or always_copy_output)
 
                     if copy_output:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -731,7 +731,8 @@ class ServiceBackend(Backend[bc.Batch]):
                                     requester_pays_project=batch.requester_pays_project,
                                     mount_tokens=True,
                                     user_code=user_code,
-                                    regions=job._regions)
+                                    regions=job._regions,
+                                    always_copy_output=job._always_copy_output)
 
             n_jobs_submitted += 1
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -585,7 +585,7 @@ class Job:
 
                     if self._always_run:
                         warnings.warn('A job marked as always run has a resource file dependency on another job. If the dependent job fails, '
-                                      f'the always run job with the following command will not run:\n{command}')
+                                      f'the always run job with the following command may not succeed:\n{command}')
 
                     self._dependencies.add(r._source)
                     r._source._add_internal_outputs(r)

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -582,6 +582,11 @@ class Job:
                         raise BatchException(f"undefined resource '{name}'\n"
                                              f"Hint: resources must be defined within "
                                              f"the job methods 'command' or 'declare_resource_group'")
+
+                    if self._always_run:
+                        warnings.warn('A job marked as always run has a resource file dependency on another job. If the dependent job fails, '
+                                      f'the always run job with the following command will not run:\n{command}')
+
                     self._dependencies.add(r._source)
                     r._source._add_internal_outputs(r)
             else:

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -78,6 +78,7 @@ class Job:
         self._machine_type: Optional[str] = None
         self._timeout: Optional[Union[int, float]] = None
         self._cloudfuse: List[Tuple[str, str, bool]] = []
+        self._always_copy_output: bool = False
         self._env: Dict[str, str] = {}
         self._wrapper_code: List[str] = []
         self._user_code: List[str] = []
@@ -516,6 +517,39 @@ class Job:
             raise BatchException('mount_point cannot be the empty string')
 
         self._cloudfuse.append((bucket, mount_point, read_only))
+        return self
+
+    def always_copy_output(self, always_copy_output: bool = True) -> 'Job':
+        """
+        Set the job to always copy output to cloud storage, even if the job failed.
+
+        Notes
+        -----
+        Can only be used with the :class:`.backend.ServiceBackend`.
+
+        Examples
+        --------
+
+        >>> b = Batch(backend=backend.ServiceBackend('test'))
+        >>> j = b.new_job()
+        >>> (j.always_copy_output()
+        ...   .command(f'echo "hello" > {j.ofile} && false'))
+
+        Parameters
+        ----------
+        always_copy_output:
+            If True, set job to always copy output to cloud storage regardless
+            of whether the job succeeded.
+
+        Returns
+        -------
+        Same job object set to always copy output.
+        """
+
+        if not isinstance(self._batch._backend, backend.ServiceBackend):
+            raise NotImplementedError("A ServiceBackend is required to use the 'always_copy_output' option")
+
+        self._always_copy_output = always_copy_output
         return self
 
     async def _compile(self, local_tmpdir, remote_tmpdir, *, dry_run=False):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -552,14 +552,13 @@ class BatchBuilder:
 
         job_spec = {
             'always_run': always_run,
+            'always_copy_output': always_copy_output,
             'job_id': self._job_idx,
             'absolute_parent_ids': absolute_parent_ids,
             'in_update_parent_ids': in_update_parent_ids,
             'process': process,
         }
 
-        if always_copy_output:
-            job_spec['always_copy_output'] = always_copy_output
         if env:
             job_spec['env'] = [{'name': k, 'value': v} for (k, v) in env.items()]
         if port is not None:

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -483,6 +483,8 @@ class BatchBuilder:
         )
 
     def create_jvm_job(self, jar_spec: Dict[str, str], argv: List[str], **kwargs):
+        if 'always_copy_output' in kwargs:
+            raise ValueError("the 'always_copy_output' option is not allowed for JVM jobs")
         return self._create_job({'type': 'jvm', 'jar_spec': jar_spec, 'command': argv}, **kwargs)
 
     def _create_job(self,
@@ -498,6 +500,7 @@ class BatchBuilder:
                     input_files: Optional[List[Tuple[str, str]]] = None,
                     output_files: Optional[List[Tuple[str, str]]] = None,
                     always_run: bool = False,
+                    always_copy_output: bool = False,
                     timeout: Optional[Union[int, float]] = None,
                     cloudfuse: Optional[List[Tuple[str, str, bool]]] = None,
                     requester_pays_project: Optional[str] = None,
@@ -555,6 +558,8 @@ class BatchBuilder:
             'process': process,
         }
 
+        if always_copy_output:
+            job_spec['always_copy_output'] = always_copy_output
         if env:
             job_spec['env'] = [{'name': k, 'value': v} for (k, v) in env.items()]
         if port is not None:

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -225,7 +225,8 @@ class BatchBuilder:
                    timeout=None, cloudfuse=None, requester_pays_project=None,
                    mount_tokens=False, network: Optional[str] = None,
                    unconfined: bool = False, user_code: Optional[str] = None,
-                   regions: Optional[List[str]] = None) -> Job:
+                   regions: Optional[List[str]] = None,
+                   always_copy_output: bool = False) -> Job:
         if parents:
             parents = [parent._async_job for parent in parents]
 
@@ -235,7 +236,7 @@ class BatchBuilder:
             service_account=service_account,
             attributes=attributes, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,
-            timeout=timeout, cloudfuse=cloudfuse,
+            always_copy_output=always_copy_output, timeout=timeout, cloudfuse=cloudfuse,
             requester_pays_project=requester_pays_project, mount_tokens=mount_tokens,
             network=network, unconfined=unconfined, user_code=user_code,
             regions=regions)

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -971,3 +971,47 @@ class ServiceTests(unittest.TestCase):
         res = b.run()
         res_status = res.status()
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
+
+    def test_always_copy_output(self):
+        output_path = f'{self.cloud_output_dir}/test_always_copy_output.txt'
+
+        b = self.batch()
+        j = b.new_job()
+        j.always_copy_output()
+        j.command(f'echo "hello" > {j.ofile} && false')
+
+        b.write_output(j.ofile, output_path)
+        res = b.run()
+        res_status = res.status()
+        assert res_status['state'] == 'failure', str((res_status, res.debug_info()))
+
+        b2 = self.batch()
+        input = b2.read_input(output_path)
+        file_exists_j = b.new_job()
+        file_exists_j.command(f'cat {input}')
+
+        res = b2.run()
+        res_status = res.status()
+        assert res_status['state'] == 'success', str((res_status, res.debug_info()))
+        assert res.get_job_log(1)['main'] == "hello\n", str(res.debug_info())
+
+    def test_no_copy_output_on_failure(self):
+        output_path = f'{self.cloud_output_dir}/test_no_copy_output.txt'
+
+        b = self.batch()
+        j = b.new_job()
+        j.command(f'echo "hello" > {j.ofile} && false')
+
+        b.write_output(j.ofile, output_path)
+        res = b.run()
+        res_status = res.status()
+        assert res_status['state'] == 'failure', str((res_status, res.debug_info()))
+
+        b2 = self.batch()
+        input = b2.read_input(output_path)
+        file_exists_j = b.new_job()
+        file_exists_j.command(f'cat {input}')
+
+        res = b2.run()
+        res_status = res.status()
+        assert res_status['state'] == 'failure', str((res_status, res.debug_info()))

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -987,7 +987,7 @@ class ServiceTests(unittest.TestCase):
 
         b2 = self.batch()
         input = b2.read_input(output_path)
-        file_exists_j = b.new_job()
+        file_exists_j = b2.new_job()
         file_exists_j.command(f'cat {input}')
 
         res = b2.run()
@@ -1009,7 +1009,7 @@ class ServiceTests(unittest.TestCase):
 
         b2 = self.batch()
         input = b2.read_input(output_path)
-        file_exists_j = b.new_job()
+        file_exists_j = b2.new_job()
         file_exists_j.command(f'cat {input}')
 
         res = b2.run()


### PR DESCRIPTION
CHANGE_LOG: 
- Added ``Job.always_copy_output`` when using the ``ServiceBackend``. The default behavior is `False` which
  is a breaking change from the previous behavior to always copy output files irregardless of the job's
  completion state.

Thoughts on introducing this "breaking" change? I think it's okay and we will announce the change on Zulip. I think the benefits of getting rid of this not so intuitive behavior where we copy files despite the main container's completion state outweighs possibly breaking someone's pipeline that relied on files being there when the copy step could have failed as well.