### PR TITLE
[query] fix docs for split_multi

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -1811,7 +1811,7 @@ def split_multi(ds, keep_star=False, left_aligned=False, *, permit_shuffle=False
     non-split variants.
 
     >>> bi = mt.filter_rows(hl.len(mt.alleles) == 2)
-    >>> bi = bi.annotate_rows(was_split=False)
+    >>> bi = bi.annotate_rows(a_index=1, was_split=False)
     >>> multi = mt.filter_rows(hl.len(mt.alleles) > 2)
     >>> split = hl.split_multi_hts(multi)
     >>> mt = split.union_rows(bi)


### PR DESCRIPTION
Fixes #11229.

The `a_index` field is added by split_multi and should be present
on the non-split table as well.