### PR TITLE
[query] escape VCF descriptions

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -283,7 +283,7 @@ class VCFTests(unittest.TestCase):
         with TemporaryFilename(suffix='.vcf') as test_vcf:
              hl.export_vcf(ds, test_vcf, metadata=meta)
              af_lines = [
-                 line for line in hl.current_backend().fs.open(test_vcf).read().decode('utf-8').split('\n')
+                 line for line in hl.current_backend().fs.open(test_vcf).read().split('\n')
                  if line.startswith("##INFO=<ID=AF")
              ]
         assert len(af_lines) == 1, af_lines

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -276,6 +276,24 @@ class VCFTests(unittest.TestCase):
             # are py4 JavaMaps, not dicts, so can't use assertDictEqual
             self.assertEqual(vcf_metadata, metadata_imported)
 
+    def test_export_vcf_quotes_and_backslash_in_description(self):
+        ds = hl.import_vcf(resource("sample.vcf"))
+        meta = hl.get_vcf_metadata(resource("sample.vcf"))
+        meta["info"]["AF"]["Description"] = 'foo "bar" \\'
+        with TemporaryFilename(suffix='.vcf') as test_vcf:
+             hl.export_vcf(ds, test_vcf, metadata=meta)
+             af_lines = [
+                 line for line in open(test_vcf).readlines()
+                 if line.startswith("##INFO=<ID=AF")
+             ]
+        assert len(af_lines) == 1, af_lines
+        line = af_lines[0]
+        assert line.startswith("##INFO=<") and line.endswith(">\n"), line
+        line = line[8:-2]
+        fields = dict([f.split("=") for f in line.split(",")])
+        description = fields["Description"]
+        assert description == '"foo \\"bar\\" \\\\"'
+
     def test_export_vcf_empty_format(self):
         mt = hl.import_vcf(resource('sample.vcf.bgz')).select_entries()
         tmp = new_temp_file(extension="vcf")

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -289,7 +289,7 @@ class VCFTests(unittest.TestCase):
         assert len(af_lines) == 1, af_lines
         line = af_lines[0]
         assert line.startswith("##INFO=<") and line.endswith(">"), line
-        line = line[8:-2]
+        line = line[8:-1]
         fields = dict([f.split("=") for f in line.split(",")])
         description = fields["Description"]
         assert description == '"foo \\"bar\\" \\\\"'

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -283,12 +283,12 @@ class VCFTests(unittest.TestCase):
         with TemporaryFilename(suffix='.vcf') as test_vcf:
              hl.export_vcf(ds, test_vcf, metadata=meta)
              af_lines = [
-                 line for line in open(test_vcf).readlines()
+                 line for line in hl.current_backend().fs.open(test_vcf).read().decode('utf-8').split('\n')
                  if line.startswith("##INFO=<ID=AF")
              ]
         assert len(af_lines) == 1, af_lines
         line = af_lines[0]
-        assert line.startswith("##INFO=<") and line.endswith(">\n"), line
+        assert line.startswith("##INFO=<") and line.endswith(">"), line
         line = line[8:-2]
         fields = dict([f.split("=") for f in line.split(",")])
         description = fields["Description"]

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -114,7 +114,7 @@ object ExportVCF {
       sb.append(",Type=")
       sb.append(formatType(f.name, f.typ))
       sb.append(",Description=\"")
-      sb.append(attrs.getOrElse("Description", ""))
+      sb.append(attrs.getOrElse("Description", "").replace("\\", "\\\\").replace("\"", "\\\""))
       sb.append("\">\n")
     }
 
@@ -124,7 +124,7 @@ object ExportVCF {
       sb.append("##FILTER=<ID=")
       sb.append(id)
       sb.append(",Description=\"")
-      sb.append(attrs.getOrElse("Description", ""))
+      sb.append(attrs.getOrElse("Description", "").replace("\\", "\\\\").replace("\"", "\\\""))
       sb.append("\">\n")
     }
 
@@ -144,7 +144,7 @@ object ExportVCF {
       sb.append(",Type=")
       sb.append(infoType(f))
       sb.append(",Description=\"")
-      sb.append(attrs.getOrElse("Description", ""))
+      sb.append(attrs.getOrElse("Description", "").replace("\\", "\\\\").replace("\"", "\\\""))
       sb.append("\">\n")
     }
 


### PR DESCRIPTION
Fixes #9782.

We need to escape VCF descriptions when exporting.