### PR TITLE
Add support for container checkpoint/restore 

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -8,6 +8,7 @@ RUN chmod 755 /bin/retry && \
 RUN hail-apt-get-install \
     iproute2 \
     iptables \
+    wget \
     openjdk-8-jre-headless \
     liblapack3
 
@@ -48,23 +49,13 @@ RUN echo "!!! UNEXPECTED CLOUD {{global.cloud}} !!!" && exit 1
 # Install xfsprogs
 RUN hail-apt-get-install xfsprogs
 
-# Install crun runtime dependencies
-RUN hail-apt-get-install libyajl-dev
+# pycairo, libcairo2-dev and pkg-config needed for a podman dependency. Without them `pip check` fails
+RUN . /etc/os-release && \
+    sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' >/etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | apt-key add - && \
+    hail-apt-get-install libcairo2-dev pkg-config podman && \
+    hail-pip-install pycairo
 
-# Build crun in separate build step
-FROM base AS crun_builder
-RUN hail-apt-get-install make git gcc build-essential pkgconf libtool \
-   libsystemd-dev libcap-dev libseccomp-dev \
-   go-md2man libtool autoconf automake
-RUN git clone --depth 1 --branch 1.4.4 https://github.com/containers/crun.git && \
-   cd crun && \
-   ./autogen.sh && \
-   ./configure && \
-   make && \
-   make install
-
-FROM base
-COPY --from=crun_builder /usr/local/bin/crun /usr/local/bin/crun
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py

--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -9,7 +9,7 @@ RUN hail-apt-get-install \
     iproute2 \
     iptables \
     wget \
-    openjdk-8-jre-headless \
+    openjdk-11-jre-headless \
     liblapack3
 
 COPY docker/hail-ubuntu/pip.conf /root/.config/pip/pip.conf
@@ -18,7 +18,7 @@ COPY docker/requirements.txt .
 RUN chmod 755 /bin/hail-pip-install && \
     hail-pip-install -r requirements.txt pyspark==3.1.1
 
-ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
+ENV SPARK_HOME /usr/local/lib/python3.9/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 ENV PYSPARK_PYTHON python3
 
@@ -37,7 +37,7 @@ RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
 {% elif global.cloud == "azure" %}
 # https://github.com/Azure/azure-storage-fuse/issues/603
 RUN hail-apt-get-install ca-certificates pkg-config libfuse-dev cmake libcurl4-gnutls-dev libgnutls28-dev uuid-dev libgcrypt20-dev wget && \
-    wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb && \
+    wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
     apt-get update && \
     hail-apt-get-install blobfuse
@@ -51,8 +51,8 @@ RUN hail-apt-get-install xfsprogs
 
 # pycairo, libcairo2-dev and pkg-config needed for a podman dependency. Without them `pip check` fails
 RUN . /etc/os-release && \
-    sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' >/etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
-    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | apt-key add - && \
+    sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' >/etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_11/Release.key -O- | apt-key add - && \
     hail-apt-get-install libcairo2-dev pkg-config podman && \
     hail-pip-install pycairo
 

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -82,7 +82,7 @@ def create_vm_config(
                 'boot': True,
                 'autoDelete': True,
                 'initializeParams': {
-                    'sourceImage': f'projects/{project}/global/images/batch-worker-3010',
+                    'sourceImage': f'projects/{project}/global/images/batch-worker-3011',
                     'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
                     'diskSizeGb': str(boot_disk_size_gb),
                 },

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -82,7 +82,7 @@ def create_vm_config(
                 'boot': True,
                 'autoDelete': True,
                 'initializeParams': {
-                    'sourceImage': f'projects/{project}/global/images/batch-worker-3011',
+                    'sourceImage': f'projects/{project}/global/images/batch-worker-3012',
                     'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
                     'diskSizeGb': str(boot_disk_size_gb),
                 },

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -303,6 +303,8 @@ podman run \
 -v /cloudfuse:/cloudfuse:shared \
 -v /etc/netns:/etc/netns \
 -v /sys/fs/cgroup:/sys/fs/cgroup \
+-v /boot:/boot \
+-v /lib/modules:/lib/modules \
 --mount type=bind,source=/mnt/disks/$WORKER_DATA_DISK_NAME,target=/host \
 --mount type=bind,source=/dev,target=/dev,bind-propagation=rshared \
 -p 5000:5000 \

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -573,8 +573,6 @@ class Container:
 
         self.timings = Timings()
 
-        self.overlay_path = None
-
         self.container_scratch = scratch_dir
         self.container_bundle_path = f'{self.container_scratch}/rootfs_overlay'
         self.log_path = f'{self.container_scratch}/container.log'

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -787,26 +787,50 @@ class Container:
             await self.netns.expose_port(self.port, self.host_port)
 
     async def checkpoint(self):
-        await asyncio.sleep(10)
-        log.info(f'Starting crun checkpoint process for {self}')
-        checkpoint_process = await asyncio.create_subprocess_exec(
-            'crun', 'checkpoint', '--leave-running', f'--image-path={self.container_scratch}/checkpoint/', self.name
-        )
+        try:
+            await asyncio.sleep(10)
 
-        await checkpoint_process.wait()
+            pause_process = await asyncio.create_subprocess_exec('crun', 'pause', self.name)
+            await pause_process.wait()
 
-        # FIXME: make copy overwriting instead of deleting the path to the checkpoint if it exists
-        # currently if a job succeeds, there will be no checkpoint in cloud storage since checkpoint is
-        # run in a loop every 10 seconds and the container_scratch directory is deleted on job success
-        # await self.fs.rmtree(None, f'{BATCH_LOGS_STORAGE_URI}/vedant/{self.name}')
+            log.info(f'Starting crun checkpoint process for {self}')
+            # TODO: try removing --leave-running (and restoring after copying bundle over)
+            checkpoint_process = await asyncio.create_subprocess_exec(
+                'crun', 'checkpoint', '--leave-running', f'--image-path={self.container_scratch}/checkpoint/', self.name
+            )
+            await checkpoint_process.wait()
 
-        # TODO: change BATCH_LOGS_STORAGE_URI to be the proper bucket for storing checkpoints
-        await self.fs.copy(f'{self.container_scratch}/checkpoint/', self.get_remote_checkpoint_dir_url())
+            # FIXME: make copy overwriting instead of deleting the path to the checkpoint if it exists
+            # currently if a job succeeds, there will be no checkpoint in cloud storage since checkpoint is
+            # run in a loop every 10 seconds and the container_scratch directory is deleted on job success
+            # await self.fs.rmtree(None, f'{BATCH_LOGS_STORAGE_URI}/vedant/{self.name}')
 
-        log.info(f'crun checkpoint completed for {self}')
+            # log.info("crun checkpoint third copy")
+            # TODO: if this works, make a note of the bug in fs.copy method which isn't copying the config.json file or the work/ directory
+            await self.fs.copy(
+                f'{self.container_bundle_path}/config.json', f'{self.get_remote_bundle_url()}/config.json'
+            )
+
+            log.info("crun checkpoint first copy")
+            # TODO: change BATCH_LOGS_STORAGE_URI to be the proper bucket for storing checkpoints
+            await self.fs.copy(f'{self.container_scratch}/checkpoint/', self.get_remote_checkpoint_dir_url())
+
+            log.info("crun checkpoint second copy")
+            await self.fs.copy(self.container_bundle_path, self.get_remote_bundle_url())
+
+            # resume_process = await asyncio.create_subprocess_exec('crun', 'resume', self.name)
+            # await resume_process.wait()
+
+            log.info(f'crun checkpoint completed for {self}')
+        except:
+            log.exception('crun checkpointing failed')
+            raise
 
     def get_remote_checkpoint_dir_url(self):
-        return f'{BATCH_LOGS_STORAGE_URI}/vedant/{self.name}'
+        return f'{BATCH_LOGS_STORAGE_URI}/vedant/{self.name}/checkpoint'
+
+    def get_remote_bundle_url(self):
+        return f'{BATCH_LOGS_STORAGE_URI}/vedant/{self.name}/bundle'
 
     async def _run_container(self) -> bool:
         self.started_at = time_msecs()
@@ -821,13 +845,21 @@ class Container:
                     assert self.process is None
                     if self.checkpointable:
                         try:
-                            restore_dir = f'{self.container_scratch}/restore'
+                            # TODO: make sure that right layer of directory is being copied from cloud storage,
+                            # might be the same problem as copying to cloud storage when checkpointing
+                            restore_dir = f'{self.container_scratch}/restore/'
+                            # TODO: does bundle_dir need to be self.container_bundle_path
+                            bundle_dir = f'{self.container_scratch}/downloaded_bundle/'
                             await self.fs.copy(self.get_remote_checkpoint_dir_url(), restore_dir)
+
+                            # await self.fs.rmtree(None, self.container_bundle_path, None)
+                            await self.fs.copy(self.get_remote_bundle_url(), bundle_dir)
                             self.process = await asyncio.create_subprocess_exec(
                                 'crun',
                                 'restore',
                                 '--bundle',
-                                self.container_bundle_path,
+                                bundle_dir,
+                                # self.container_bundle_path,
                                 '--image-path',
                                 restore_dir,
                                 self.name,

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -829,8 +829,6 @@ class Container:
                     assert self.process is None
                     if self.checkpointable:
                         try:
-                            # TODO: make sure that right layer of directory is being copied from cloud storage,
-                            # might be the same problem as copying to cloud storage when checkpointing
                             restore_dir = f'{self.container_scratch}/restore'
                             await self.fs.copy(self.get_remote_checkpoint_dir_url(), restore_dir)
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -656,7 +656,6 @@ class Container:
         self._run_fut = asyncio.ensure_future(self._run_until_done_or_deleted(_run))
         if self.checkpointable:
             self.task_manager.ensure_future(periodically_call(10, self.checkpoint_jobs))
-            # self.task_manager.ensure_future(self.checkpoint_jobs())
 
     async def wait(self):
         assert self._run_fut
@@ -804,10 +803,12 @@ class Container:
             log.exception("CHECKPOINTING PROCESS EXECUTION FAILED")
 
         log.info(f'copying checkpoint into blob storage for {self}')
+
+        # FIXME: make copy overwriting instead of deleting the path to the checkpoint if it exists
+        await self.fs.rmtree(None, f'{BATCH_LOGS_STORAGE_URI}/vedant/{self.name}')
+
         # TODO: change BATCH_LOGS_STORAGE_URI to be the proper bucket for storing checkpoints
         await self.fs.copy(f'{self.container_scratch}/checkpoint/', f'{BATCH_LOGS_STORAGE_URI}/vedant/{self.name}')
-        # # await self.fs.copy('/root/checkpoint', 'gs://vrautela-test-data/tmp/checkpoint')
-        # log.info('done copying checkpoint')
 
         log.info(f'crun checkpoint completed for {self}')
 

--- a/batch/build-batch-worker-image-startup-gcp.sh
+++ b/batch/build-batch-worker-image-startup-gcp.sh
@@ -9,6 +9,9 @@ bash add-logging-agent-repo.sh
 # Get the latest GPG key as it might not always be up to date
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+source /etc/os-release
+sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
 apt-get update
 
 apt-get install -y \
@@ -18,37 +21,19 @@ apt-get install -y \
     google-fluentd \
     google-fluentd-catch-all-config-structured \
     jq \
-    software-properties-common
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-
-add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-
-apt-get install -y docker-ce
+    software-properties-common \
+    podman
 
 rm -rf /var/lib/apt/lists/*
-
-[ -f /etc/docker/daemon.json ] || echo "{}" > /etc/docker/daemon.json
 
 VERSION=2.0.4
 OS=linux
 ARCH=amd64
 
-curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_${OS}_${ARCH}-${VERSION}.tar.gz" \
-  | tar xz --to-stdout ./docker-credential-gcr \
-	> /usr/bin/docker-credential-gcr && chmod +x /usr/bin/docker-credential-gcr
-
 # avoid "unable to get current user home directory: os/user lookup failed"
 export HOME=/root
 
-docker-credential-gcr configure-docker --include-artifact-registry
-docker pull {{ global.docker_root_image }}
-
-# add docker daemon debug logging
-jq '.debug = true' /etc/docker/daemon.json > daemon.json.tmp
-mv daemon.json.tmp /etc/docker/daemon.json
+gcloud auth print-access-token | podman login -u oauth2accesstoken --password-stdin {{ global.docker_prefix }}
+podman pull {{ global.docker_root_image }}
 
 shutdown -h now

--- a/batch/build-batch-worker-image-startup-gcp.sh
+++ b/batch/build-batch-worker-image-startup-gcp.sh
@@ -2,26 +2,23 @@
 
 set -ex
 
-curl --silent --show-error --remote-name --fail https://dl.google.com/cloudagents/add-logging-agent-repo.sh
-bash add-logging-agent-repo.sh
-
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 
 # Get the latest GPG key as it might not always be up to date
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 source /etc/os-release
-sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
+echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_11/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_stable.gpg > /dev/null
 apt-get update
 
 apt-get install -y \
     apt-transport-https \
     ca-certificates \
-    curl \
-    google-fluentd \
-    google-fluentd-catch-all-config-structured \
     jq \
     software-properties-common \
+    xfsprogs
     podman
 
 rm -rf /var/lib/apt/lists/*

--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -7,15 +7,16 @@ source $HAIL/devbin/functions.sh
 PROJECT=$(get_global_config_field gcp_project)
 ZONE=$(get_global_config_field gcp_zone)
 DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image)
+DOCKER_PREFIX=$(get_global_config_field docker_prefix)
 
-WORKER_IMAGE_VERSION=12
+WORKER_IMAGE_VERSION=3010
 BUILDER=build-batch-worker-image
 
 create_build_image_instance() {
     gcloud -q compute --project ${PROJECT} instances delete \
         --zone=${ZONE} ${BUILDER} || true
 
-    python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"'${DOCKER_ROOT_IMAGE}'"}}' \
+    python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"'${DOCKER_ROOT_IMAGE}'","docker_prefix": "'${DOCKER_PREFIX}'"}}' \
         build-batch-worker-image-startup-gcp.sh build-batch-worker-image-startup-gcp.sh.out
 
     UBUNTU_IMAGE=$(gcloud compute images list \

--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -9,7 +9,7 @@ ZONE=$(get_global_config_field gcp_zone)
 DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image)
 DOCKER_PREFIX=$(get_global_config_field docker_prefix)
 
-WORKER_IMAGE_VERSION=3010
+WORKER_IMAGE_VERSION=3011
 BUILDER=build-batch-worker-image
 
 create_build_image_instance() {
@@ -21,7 +21,7 @@ create_build_image_instance() {
 
     UBUNTU_IMAGE=$(gcloud compute images list \
         --standard-images \
-        --filter 'family="ubuntu-minimal-2004-lts"' \
+        --filter 'family="debian-11"' \
         --format='value(name)')
 
     gcloud -q compute instances create ${BUILDER} \
@@ -35,7 +35,7 @@ create_build_image_instance() {
         --maintenance-policy=MIGRATE \
         --scopes=https://www.googleapis.com/auth/cloud-platform \
         --image=${UBUNTU_IMAGE} \
-        --image-project=ubuntu-os-cloud \
+        --image-project=debian-cloud \
         --boot-disk-size=10GB \
         --boot-disk-type=pd-ssd
 }

--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -9,7 +9,7 @@ ZONE=$(get_global_config_field gcp_zone)
 DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image)
 DOCKER_PREFIX=$(get_global_config_field docker_prefix)
 
-WORKER_IMAGE_VERSION=3011
+WORKER_IMAGE_VERSION=3012
 BUILDER=build-batch-worker-image
 
 create_build_image_instance() {

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -16,7 +16,7 @@ RUN hail-apt-get-install \
     emacs-nox \
     xsltproc pandoc \
     jq \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk-headless \
     liblapack3 \
     g++-10 \
     gcc-10 \

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM {{ global.docker_prefix }}/ubuntu:focal-20201106
+FROM debian:11-slim
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 COPY retry /bin/retry
@@ -14,14 +14,7 @@ RUN chmod 755 /bin/retry && \
     echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     mkdir -p /usr/share/keyrings/ && \
     hail-apt-get-install curl gpg && \
-    curl 'https://keyserver.ubuntu.com/pks/lookup?search=0xF23C5A6CF475977595C89F51BA6932366A755776&hash=on&exact=on&options=mr&op=get' \
-         | gpg --dearmor > /usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg && \
-    echo 'deb [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main' \
-         >> /etc/apt/sources.list && \
-    echo 'deb-src [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main' \
-         >> /etc/apt/sources.list && \
-    hail-apt-get-install python3.7-minimal python3.7-dev python3-pip python3.7-distutils && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
+    hail-apt-get-install python3-pip && \
     python3 -m pip install 'pip>=21<22' && \
     python3 -m pip check && \
     python3 -m pip --version

--- a/docker/hail-ubuntu/curlrc
+++ b/docker/hail-ubuntu/curlrc
@@ -1,5 +1,5 @@
 --connect-timeout 5
---max-time 10
+--max-time 60
 --retry 5
 --retry-connrefused
 --retry-max-time 40

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,5 +1,4 @@
 aiodns==2.0.0
-aiodocker==0.17.0
 aiohttp-jinja2==1.1.1
 aiohttp-session==2.7.0
 aiohttp==3.8.1

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -4,9 +4,8 @@ import urllib.parse
 
 from ..aiocloud import aioaws, aioazure, aiogoogle
 from .fs import (AsyncFS, MultiPartCreate, FileStatus, FileListEntry, ReadableStream,
-                 WritableStream, AsyncFSURL)
+                 WritableStream, AsyncFSURL, Copier, Transfer)
 from .local_fs import LocalAsyncFS
-
 
 class RouterAsyncFS(AsyncFS):
     def __init__(self,
@@ -145,3 +144,9 @@ class RouterAsyncFS(AsyncFS):
     def copy_part_size(self, url: str) -> int:
         fs = self._get_fs(url)
         return fs.copy_part_size(url)
+
+    async def copy(self, src: str, dest: str, max_simultaneous_transfers=75):
+        transfer = Transfer(src, dest)
+
+        sema = asyncio.Semaphore(max_simultaneous_transfers)
+        await Copier.copy(self, sema, transfer)

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -16,7 +16,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
 
 
 def configure_logging():
-    fmt = CustomJsonFormatter('(severity) (levelname) (asctime) (filename) (funcNameAndLine) (message)')
+    fmt = CustomJsonFormatter('%(severity)s %(levelname)s %(asctime)s %(filename)s %(funcNameAndLine)s %(message)s')
 
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setLevel(logging.INFO)

--- a/hail/python/test/hailtop/hailctl/dataproc/conftest.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/conftest.py
@@ -43,7 +43,7 @@ def deploy_metadata():
     return {
         "wheel": "gs://hail-common/hailctl/dataproc/test-version/hail-test-version-py3-none-any.whl",
         "init_notebook.py": "gs://hail-common/hailctl/dataproc/test-version/init_notebook.py",
-        "pip_dependencies": "aiohttp>=3.6,<3.7|aiohttp_session>=2.7,<2.8|asyncinit>=0.2.4,<0.3|bokeh>1.1,<1.3|decorator<5|humanize==1.0.0|hurry.filesize==0.9|nest_asyncio|numpy<2|pandas>0.24,<0.26|parsimonious<0.9|PyJWT|python-json-logger==0.1.11|requests>=2.21.0,<2.21.1|scipy>1.2,<1.4|tabulate==0.8.9|tqdm==4.42.1|",
+        "pip_dependencies": "aiohttp>=3.6,<3.7|aiohttp_session>=2.7,<2.8|asyncinit>=0.2.4,<0.3|bokeh>1.1,<1.3|decorator<5|humanize==1.0.0|hurry.filesize==0.9|nest_asyncio|numpy<2|pandas>0.24,<0.26|parsimonious<0.9|PyJWT|python-json-logger==2.0.2|requests>=2.21.0,<2.21.1|scipy>1.2,<1.4|tabulate==0.8.9|tqdm==4.42.1|",
         "vep-GRCh37.sh": "gs://hail-common/hailctl/dataproc/test-version/vep-GRCh37.sh",
         "vep-GRCh38.sh": "gs://hail-common/hailctl/dataproc/test-version/vep-GRCh38.sh",
     }

--- a/tls/Dockerfile
+++ b/tls/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google
     tar -xf google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
     curl -sSLO https://dl.k8s.io/release/v1.19.7/bin/linux/amd64/kubectl && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    hail-apt-get-install openssl openjdk-8-jdk-headless && \
+    hail-apt-get-install openssl openjdk-11-jdk-headless && \
     sed -i 's/^RANDFILE/#RANDFILE/' /etc/ssl/openssl.cnf && \
     hail-pip-install pyyaml
 


### PR DESCRIPTION
This PR begins the implementation of checkpointing and restoring of jobs in Batch. Currently, a container is checkpointed after 10 seconds and before running a container (using crun run) the worker container checks if it should restore a job based on a checkpoint in Google storage. Currently, the kinds of Jobs that can be checkpointed/restored are: jobs that do simple operations and only print to stdout, jobs that redirect their output to local files

Changelist:
- Add copy method to RouterAsyncFS
- Add checkpointable flag to containers (make DockerJob containers checkpointable and JVMJob containers not checkpointable)
- Create checkpoint method which pauses a container, checkpoints it, copies the checkpoint directory and upper directory of the overlay into Google storage, and then resumes the container
- Add logic in _run_container to try copying checkpoint directory and upper directory from cloud storage and then running `crun restore` if the job is checkpointable 