### PR TITLE
[batch] Reduce redundant SQL queries for mark_healthy

### DIFF
--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -274,6 +274,7 @@ SET last_updated = %s,
 WHERE name = %s;
 ''',
             (now, self.name),
+            'mark_healthy',
         )
 
     async def incr_failed_request_count(self):

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -261,6 +261,11 @@ VALUES (%s, %s);
         if not changed:
             return
 
+        self.inst_coll.adjust_for_remove_instance(self)
+        self._failed_request_count = 0
+        self._last_updated = now
+        self.inst_coll.adjust_for_add_instance(self)
+
         await self.db.execute_update(
             '''
 UPDATE instances
@@ -270,11 +275,6 @@ WHERE name = %s;
 ''',
             (now, self.name),
         )
-
-        self.inst_coll.adjust_for_remove_instance(self)
-        self._failed_request_count = 0
-        self._last_updated = now
-        self.inst_coll.adjust_for_add_instance(self)
 
     async def incr_failed_request_count(self):
         await self.db.execute_update(


### PR DESCRIPTION
`Instance.mark_healthy` avoids a database call if the instance was marked healthy within the last five seconds. However, since `self._last_updated = now` is set *after* the database query, multiple invocations of `mark_healthy` can still race and execute the query. Since this is run every time we receive an MJC, we end up executing this query very often, instead of just once every five seconds per worker. Bringing the state checking / setting together into 1 synchronous block instead of split across an await fixed the issue.