### PR TITLE
[batch] Turn off logging syslog on workers for GCP

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -207,17 +207,6 @@ touch /run.log
 
 sudo rm /etc/google-fluentd/config.d/*  # remove unused config files
 
-sudo tee /etc/google-fluentd/config.d/syslog.conf <<EOF
-<source>
-@type tail
-format syslog
-path /var/log/syslog
-pos_file /var/lib/google-fluentd/pos/syslog.pos
-read_from_head true
-tag syslog
-</source>
-EOF
-
 sudo tee /etc/google-fluentd/config.d/worker-log.conf <<EOF
 <source>
 @type tail


### PR DESCRIPTION
I don't think we need this anymore for GCP only. I'll need to figure out the equivalent in Azure with the OMS agent.

cc: @daniel-goldstein 