### PR TITLE
[fs] not FileNotFoundError for glob patterns

### DIFF
--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -167,6 +167,7 @@ class Tests(unittest.TestCase):
         ls3 = hl.hadoop_ls(path3)
         assert len(ls3) == 2, ls3
 
+    def test_hadoop_ls_file_that_does_not_exist(self):
         try:
             hl.hadoop_ls('a_file_that_does_not_exist')
         except FileNotFoundError:
@@ -175,6 +176,31 @@ class Tests(unittest.TestCase):
             assert 'FileNotFoundException: a_file_that_does_not_exist' in err.args[0]
         else:
             assert False
+
+    def test_hadoop_glob_heterogenous_structure(self):
+        with hl.TemporaryDirectory() as dirname:
+            dirname = normalize_path(dirname)
+            touch(dirname + '/abc/cat')
+            touch(dirname + '/abc/dog')
+            touch(dirname + '/def/cat')
+            touch(dirname + '/def/dog')
+            touch(dirname + '/ghi/cat')
+            touch(dirname + '/ghi/cat')
+
+            actual = [x['path'] for x in hl.hadoop_ls(dirname + '/*/cat')]
+            expected = [
+                dirname + '/abc/cat',
+                dirname + '/def/cat',
+                dirname + '/ghi/cat',
+            ]
+            assert actual == expected
+
+            actual = [x['path'] for x in hl.hadoop_ls(dirname + '/*/dog')]
+            expected = [
+                dirname + '/abc/dog',
+                dirname + '/def/dog',
+            ]
+            assert actual == expected
 
     @fails_local_backend()
     def test_hadoop_ls_glob_no_slash_in_group(self):

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -179,13 +179,13 @@ class Tests(unittest.TestCase):
 
     def test_hadoop_glob_heterogenous_structure(self):
         with hl.TemporaryDirectory() as dirname:
-            dirname = normalize_path(dirname)
             touch(dirname + '/abc/cat')
             touch(dirname + '/abc/dog')
             touch(dirname + '/def/cat')
             touch(dirname + '/def/dog')
             touch(dirname + '/ghi/cat')
             touch(dirname + '/ghi/cat')
+            dirname = normalize_path(dirname)
 
             actual = [x['path'] for x in hl.hadoop_ls(dirname + '/*/cat')]
             expected = [


### PR DESCRIPTION
Currently, if we have a file structure like:

    a/
        b/
    aa/
        bb/

A glob pattern like `*/b` will raise FileNotFoundError beacuse
we try to list the file or folder named "b" inside `aa`. We should
not error. We should return `['a/b']`.

It is insufficient to avoid FileNotFoundError altogether because
the Hadoop API treats paths without globs differently. In particular,
listing the path `aa/b` should raise an error.

This change fixes behavior in the first case and treats the second
case explicitly.