### PR TITLE
[ci] Fix bug where we pushed test images to the main image cache

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -249,8 +249,10 @@ class BuildImage2Step(Step):
         self.image = f'{self.base_image}:{self.token}'
         if publish_as and not is_test_deployment:
             self.cache_repository = f'{DOCKER_PREFIX}/{self.publish_as}:cache'
-        else:
+        elif publish_as and is_test_deployment:
             self.cache_repository = f'{DOCKER_PREFIX}/ci-intermediate/{self.publish_as}:cache'
+        else:
+            self.cache_repository = f'{DOCKER_PREFIX}/ci-intermediate:cache'
         self.job = None
 
     def wrapped_job(self):

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -247,10 +247,10 @@ class BuildImage2Step(Step):
         else:
             self.base_image = f'{DOCKER_PREFIX}/ci-intermediate'
         self.image = f'{self.base_image}:{self.token}'
-        if publish_as:
+        if publish_as and not is_test_deployment:
             self.cache_repository = f'{DOCKER_PREFIX}/{self.publish_as}:cache'
         else:
-            self.cache_repository = f'{DOCKER_PREFIX}/ci-intermediate:cache'
+            self.cache_repository = f'{DOCKER_PREFIX}/ci-intermediate/{self.publish_as}:cache'
         self.job = None
 
     def wrapped_job(self):


### PR DESCRIPTION
We don't want this in PR namespaces when running `test_ci`

```
retry buildctl-daemonless.sh      build      --frontend dockerfile.v0      --local context=/io/repo/      --local dockerfile=/home/user      --output 'type=image,"name=gcr.io/hail-vdc/ci-intermediate:kbqu6modc66u,gcr.io/hail-vdc/service-base:cache",push=true'      --export-cache type=inline      --import-cache type=registry,ref=gcr.io/hail-vdc/service-base:cache      --trace=/home/user/trace
cat /home/user/trace
```