### PR TITLE
[query] nCombines calculation in tree aggregate

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1245,7 +1245,7 @@ object LowerTableIR {
                   bindIR(ArrayRef(aggStack, (ArrayLen(aggStack) - 1))) { states =>
                     bindIR(ArrayLen(states)) { statesLen =>
                       If(statesLen > branchFactor,
-                        bindIR((statesLen + branchFactor) floorDiv branchFactor) { nCombines =>
+                        bindIR((statesLen + branchFactor - 1) floorDiv branchFactor) { nCombines =>
                           val contexts = mapIR(rangeIR(nCombines)) { outerIdxRef =>
                             sliceArrayIR(states, outerIdxRef * branchFactor, (outerIdxRef + 1) * branchFactor)
                           }


### PR DESCRIPTION
Consider the case where there are 100 states. We will attempt
three combines because (100 + 50) / 50 is 3. In that case the
third context will be an empty slice. This will trigger the
errror reported by Wenhan [here](https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query-0.2E2-support/topic/HailException.3A.20array.20index.20out.20of.20bounds/near/286347013).