### PR TITLE
[query] Specialize GoogleStorageFS.copy

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -152,6 +152,17 @@ class GoogleStorageFS(val serviceAccountKey: Option[String] = None) extends FS {
     new WrappedPositionedDataOutputStream(os)
   }
 
+  override def copy(src: String, dst: String, deleteSource: Boolean = false): Unit = {
+    val (srcBucket, srcPath) = getBucketPath(src)
+    val (dstBucket, dstPath) = getBucketPath(dst)
+    val srcId = BlobId.of(srcBucket, srcPath)
+    val dstId = BlobId.of(dstBucket, dstPath)
+    val copyReq = Storage.CopyRequest.of(srcId, dstId)
+    storage.copy(copyReq).getResult() // getResult is necessary to cause this to go to completion
+    if (deleteSource)
+      storage.delete(srcId)
+  }
+
   def delete(filename: String, recursive: Boolean): Unit = retryTransientErrors {
     val (bucket, path) = getBucketPath(filename)
     if (recursive) {


### PR DESCRIPTION
Issue the [rewrite] request. To save on reading and writing entire
blobs, as well as transferring data to the machine running the copy
rather than letting google storage move the data.

This operation should be effectively free when copying from one location
in a bucket to a different location in the same bucket, as the linked
docs say, when source and destination have the same location and storage
class, the blob is copied in a single request and returns immediately.

[rewrite]: https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite