### PR TITLE
[batch] Mount job secrets as read-only

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1364,8 +1364,7 @@ class Job:
                     }
                 )
 
-        secrets = job_spec.get('secrets')
-        self.secrets = secrets
+        self.secrets = job_spec.get('secrets')
         self.env = job_spec.get('env', [])
 
         self.project_id = Job.get_next_xfsquota_project_id()
@@ -1494,7 +1493,7 @@ class DockerJob(Job):
                     'source': self.secret_host_path(secret),
                     'destination': secret["mount_path"],
                     'type': 'none',
-                    'options': ['rbind', 'rw'],
+                    'options': ['rbind', 'ro'],
                 }
                 self.main_volume_mounts.append(volume_mount)
                 # this will be the user credentials

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1808,9 +1808,6 @@ class JVMJob(Job):
         except StepInterruptedError as e:
             raise JobDeletedError from e
 
-    def secret_host_path(self, secret):
-        return f'{self.scratch}/secrets/{secret["mount_path"]}'
-
     async def download_jar(self):
         async with self.worker.jar_download_locks[self.jar_url]:
             unique_key = self.jar_url.replace('_', '__').replace('/', '_')

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -801,28 +801,6 @@ python3 -c \'{script}\'''',
         assert status['state'] == 'Failed', str((status, b.debug_info()))
         assert "Please log in" in j.log()['main'], (str(j.log()['main']), status)
 
-    bb = client.create_batch()
-    j = bb.create_job(
-        os.environ['HAIL_HAIL_BASE_IMAGE'],
-        [
-            '/bin/bash',
-            '-c',
-            f'''
-jq '.default_namespace = "default"' /deploy-config/deploy-config.json > tmp.json
-mv tmp.json /deploy-config/deploy-config.json
-python3 -c \'{script}\'''',
-        ],
-        mount_tokens=True,
-    )
-    b = bb.submit()
-    status = j.wait()
-    if NAMESPACE == 'default':
-        assert status['state'] == 'Success', str((status, b.debug_info()))
-    else:
-        assert status['state'] == 'Failed', str((status, b.debug_info()))
-        job_log = j.log()
-        assert "Please log in" in job_log['main'], str((job_log, b.debug_info()))
-
 
 def test_cannot_contact_other_internal_ips(client: BatchClient):
     internal_ips = [f'10.128.0.{i}' for i in (10, 11, 12)]

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -787,7 +787,8 @@ backend.close()
             '-c',
             f'''
 hailctl config set domain {DOMAIN}
-rm /deploy-config/deploy-config.json
+cat /deploy-config/deploy-config.json | jq '.default_namespace= "default"' > /default-deploy-config.json
+export HAIL_DEPLOY_CONFIG_FILE=/default-deploy-config.json
 python3 -c \'{script}\'''',
         ],
         mount_tokens=True,

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -884,6 +884,19 @@ hl.read_table(location).show()
     assert expected_log in log['main'], str((log, b.debug_info()))
 
 
+def test_credentials_are_readonly(client: BatchClient):
+    builder = client.create_batch()
+    script = '''
+set -e
+touch foo
+mv foo /gsa-key/key.json
+'''
+    j = builder.create_job(DOCKER_ROOT_IMAGE, command=['/bin/bash', '-c', script])
+    b = builder.submit()
+    status = j.wait()
+    assert status['state'] == 'Failed', str((status, b.debug_info()))
+
+
 def test_user_authentication_within_job(client: BatchClient):
     bb = client.create_batch()
     cmd = ['bash', '-c', 'hailctl auth user']

--- a/build.yaml
+++ b/build.yaml
@@ -1126,9 +1126,8 @@ steps:
       tar xvf debug-wheel-container.tar
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
 
-      # pyspark/conf/core-site.xml already points at /gsa-key/key.json
-      # mv /test-gsa-key/key.json /gsa-key/key.json
-      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      # The test should use the test credentials, not CI's credentials
+      sed -i 's/gsa-key/test-gsa-key/g' ${SPARK_HOME}/conf/core-site.xml
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}

--- a/build.yaml
+++ b/build.yaml
@@ -1127,8 +1127,8 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
 
       # pyspark/conf/core-site.xml already points at /gsa-key/key.json
-      mv /test-gsa-key/key.json /gsa-key/key.json
-
+      # mv /test-gsa-key/key.json /gsa-key/key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}

--- a/build.yaml
+++ b/build.yaml
@@ -1128,6 +1128,7 @@ steps:
 
       # The test should use the test credentials, not CI's credentials
       sed -i 's/gsa-key/test-gsa-key/g' ${SPARK_HOME}/conf/core-site.xml
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
@@ -1233,9 +1234,9 @@ steps:
       tar xvf wheel-container.tar
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
 
-      # pyspark/conf/core-site.xml already points at /gsa-key/key.json
-      mv /test-gsa-key/key.json /gsa-key/key.json
-
+      # The test should use the test credentials, not CI's credentials
+      sed -i 's/gsa-key/test-gsa-key/g' ${SPARK_HOME}/conf/core-site.xml
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}


### PR DESCRIPTION
These should never have been read-write. Caught this because a CI job I was modifying overwrote `/gsa-key/key.json` with `/test-gsa-key/key.json` which caused the Output step to use the test credentials instead of CI credentials.

I also removed an overriding definition of `secret_host_path` in `JVMJob`. I don't see why it should be different than what's defined in `Job` and using `host_path` seems quite dangerous.

Added a test that we can't `mv` a secret path and updated some existing tests that assumed we can overwrite secrets.

TODO: Update `build.yaml` to not `mv` any secrets or PRs will fail when this joins the mainline.