### PR TITLE
[query] avoid rare test collection bug

### DIFF
--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 
 import hail as hl
 from hail.utils.java import Env, scala_object
@@ -47,13 +48,24 @@ def all_values_table_fixture():
     return create_all_values_table()
 
 
-resource_dir = resource('backward_compatability')
-fs = hl.current_backend().fs
+# pytest sometimes uses background threads, named "Dummy-1", to collect tests. asyncio will only
+# create an event loop when `asyncio.get_event_loop()` is called if the current thread is the main
+# thread. We therefore manually create an event loop which is used only for collecting the files.
+old_loop = asyncio.get_event_loop()
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
 try:
-    ht_paths = [x.path for x in fs.ls(resource_dir + '/*/table/')]
-    mt_paths = [x.path for x in fs.ls(resource_dir + '/*/matrix_table/')]
+    resource_dir = resource('backward_compatability')
+    fs = hl.current_backend().fs
+    try:
+        ht_paths = [x.path for x in fs.ls(resource_dir + '/*/table/')]
+        mt_paths = [x.path for x in fs.ls(resource_dir + '/*/matrix_table/')]
+    finally:
+        hl.stop()
 finally:
-    hl.stop()
+    loop.stop()
+    loop.close()
+    asyncio.set_event_loop(old_loop)
 
 
 @pytest.mark.parametrize("path", mt_paths)

--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -51,7 +51,11 @@ def all_values_table_fixture():
 # pytest sometimes uses background threads, named "Dummy-1", to collect tests. asyncio will only
 # create an event loop when `asyncio.get_event_loop()` is called if the current thread is the main
 # thread. We therefore manually create an event loop which is used only for collecting the files.
-old_loop = asyncio.get_event_loop()
+try:
+    old_loop = asyncio.get_event_loop()
+except RuntimeError as err:
+    assert 'There is no current event loop in thread' in err
+    old_loop = None
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 try:


### PR DESCRIPTION
Pytest sometimes uses a background thread to collect tests. That interacts badly
with asyncio. We avoid this by explicitly managing the event loop.