### PR TITLE
[query] persist is checkpoint

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -10,7 +10,7 @@ import re
 import yaml
 from pathlib import Path
 
-from hail.context import TemporaryDirectory, tmp_dir, TemporaryFilename, revision
+from hail.context import TemporaryDirectory, tmp_dir, TemporaryFilename, revision, _TemporaryFilenameManager
 from hail.utils import FatalError
 from hail.expr.types import HailType, dtype, ttuple, tvoid
 from hail.expr.table_type import ttable
@@ -279,6 +279,7 @@ class ServiceBackend(Backend):
         self.driver_cores = driver_cores
         self.driver_memory = driver_memory
         self.name_prefix = name_prefix
+        self._persisted_locations: Dict[Any, _TemporaryFilenameManager] = dict()
 
     def debug_info(self) -> Dict[str, Any]:
         return {
@@ -679,9 +680,31 @@ class ServiceBackend(Backend):
 
     def persist_expression(self, expr):
         # FIXME: should use context manager to clean up persisted resources
-        fname = TemporaryFilename().name
+        fname = TemporaryFilename(prefix='persist_expression').name
         write_expression(expr, fname)
         return read_expression(fname, _assert_type=expr.dtype)
+
+    def persist_table(self, t, storage_level):
+        tf = TemporaryFilename(prefix='persist_table')
+        self._persisted_locations[t] = tf
+        return t.checkpoint(tf.__enter__())
+
+    def unpersist_table(self, t):
+        try:
+            self._persisted_locations[t].__exit__(None, None, None)
+        except KeyError as err:
+            raise ValueError(f'{t} is not persisted') from err
+
+    def persist_matrix_table(self, mt, storage_level):
+        tf = TemporaryFilename(prefix='persist_matrix_table')
+        self._persisted_locations[mt] = tf
+        return mt.checkpoint(tf.__enter__())
+
+    def unpersist_matrix_table(self, mt):
+        try:
+            self._persisted_locations[mt].__exit__(None, None, None)
+        except KeyError as err:
+            raise ValueError(f'{mt} is not persisted') from err
 
     def set_flags(self, **flags: str):
         self.flags.update(flags)

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -215,6 +215,7 @@ class Tests(unittest.TestCase):
                       n_discordant=0),
         ]
 
+    @fails_service_backend()
     def test_concordance_no_values_doesnt_error(self):
         dataset = get_dataset().filter_rows(False)
         _, cols_conc, rows_conc = hl.concordance(dataset, dataset)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1808,6 +1808,7 @@ class Tests(unittest.TestCase):
             self.assertTrue(hl.methods.statgen._warn_if_no_intercept('', covariates))
             self.assertFalse(hl.methods.statgen._warn_if_no_intercept('', [intercept] + covariates))
 
+    @fails_service_backend()
     def test_regression_field_dependence(self):
         mt = hl.utils.range_matrix_table(10, 10)
         mt = mt.annotate_cols(c1 = hl.literal([x % 2 == 0 for x in range(10)])[mt.col_idx], c2 = hl.rand_norm(0, 1))


### PR DESCRIPTION
I am not sure what persist should mean in the service backend. For some linear
algebra work, persist appears to be used to store the results of an expensive
query. In that setting, we should clearly checkpoint the dataset.

cc: @tpoterba 