### PR TITLE
[query] Fix key pruning bug with respect to table/matrix row scans.

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1663,6 +1663,17 @@ class Tests(unittest.TestCase):
             hl.utils.Struct(idx=0, locus=hl.genetics.Locus(contig='2', position=1, reference_genome='GRCh37'))]
 
 
+def test_keys_before_scans():
+    mt = hl.utils.range_matrix_table(6, 6)
+    mt = mt.annotate_rows(rev_idx = -mt.row_idx)
+    mt = mt.key_rows_by(mt.rev_idx)
+
+    mt = mt.annotate_rows(idx_scan = hl.scan.collect(mt.row_idx))
+
+    mt = mt.key_rows_by(mt.row_idx)
+    assert mt.rows().idx_scan.collect() == [[5, 4, 3, 2, 1], [5, 4, 3, 2], [5, 4, 3], [5, 4], [5], []]
+
+
 def test_read_write_all_types():
     mt = create_all_values_matrix_table()
     tmp_file = new_temp_file()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1679,6 +1679,15 @@ def test_map_partitions_indexed():
     ht = ht.key_by()._map_partitions(lambda partition: [hl.struct(foo=partition)])
     assert [inner.idx for outer in ht.foo.collect() for inner in outer] == list(range(11, 55))
 
+def test_keys_before_scans():
+    ht = hl.utils.range_table(6)
+    ht = ht.annotate(rev_idx = -ht.idx)
+    ht = ht.key_by(ht.rev_idx)
+
+    ht = ht.annotate(idx_scan = hl.scan.collect(ht.idx))
+
+    ht = ht.key_by(ht.idx)
+    assert ht.idx_scan.collect() == [[5, 4, 3, 2, 1], [5, 4, 3, 2], [5, 4, 3], [5, 4], [5], []]
 
 
 @lower_only()

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1605,8 +1605,8 @@ object PruneDeadFields {
         val newRowType = newRow2.typ.asInstanceOf[TStruct]
         val child2Keyed = if (child2.typ.key.exists(k => !newRowType.hasField(k))) {
           val upcastKey = child2.typ.key.takeWhile(newRowType.hasField)
-          assert(requestedType.key.startsWith(upcastKey))
-          TableKeyBy(child2, child2.typ.key.takeWhile(newRowType.hasField))
+          assert(upcastKey.startsWith(requestedType.key))
+          TableKeyBy(child2, upcastKey)
         } else
           child2
         TableMapRows(child2Keyed, newRow2)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -500,10 +500,15 @@ object PruneDeadFields {
           globalType = depGlobalType.asInstanceOf[TStruct])
         memoizeTableIR(ctx, child, dep, memo)
       case TableMapRows(child, newRow) =>
-        val rowDep = memoizeAndGetDep(ctx, newRow, requestedType.rowType, child.typ, memo)
+        val (reqKey, reqRowType) = if (ContainsScan(newRow))
+          (child.typ.key, unify(newRow.typ, requestedType.rowType, selectKey(newRow.typ.asInstanceOf[TStruct], child.typ.key)))
+        else
+          (requestedType.key, requestedType.rowType)
+        val rowDep = memoizeAndGetDep(ctx, newRow, reqRowType, child.typ, memo)
+
         val dep = TableType(
-          key = requestedType.key,
-          rowType = unify(child.typ.rowType, selectKey(requestedType.rowType, requestedType.key), rowDep.rowType),
+          key = reqKey,
+          rowType = unify(child.typ.rowType, selectKey(child.typ.rowType, reqKey), rowDep.rowType),
           globalType = unify(child.typ.globalType, requestedType.globalType, rowDep.globalType)
         )
         memoizeTableIR(ctx, child, dep, memo)
@@ -641,8 +646,13 @@ object PruneDeadFields {
           rowType = unify(child.typ.rowType, requestedType.rowType, selectKey(child.typ.rowType, childReqKey))),
           memo)
       case MatrixMapRows(child, newRow) =>
-        val irDep = memoizeAndGetDep(ctx, newRow, requestedType.rowType, child.typ, memo)
-        val depMod = requestedType.copy(rowType = selectKey(child.typ.rowType, child.typ.rowKey))
+        val (reqKey, reqRowType) = if (ContainsScan(newRow))
+          (child.typ.rowKey, unify(newRow.typ, requestedType.rowType, selectKey(newRow.typ.asInstanceOf[TStruct], child.typ.rowKey)))
+        else
+          (requestedType.rowKey, requestedType.rowType)
+
+        val irDep = memoizeAndGetDep(ctx, newRow, reqRowType, child.typ, memo)
+        val depMod = requestedType.copy(rowType = selectKey(child.typ.rowType, reqKey), rowKey = reqKey)
         memoizeMatrixIR(ctx, child, unify(child.typ, depMod, irDep), memo)
       case MatrixMapCols(child, newCol, newKey) =>
         val irDep = memoizeAndGetDep(ctx, newCol, requestedType.colType, child.typ, memo)
@@ -1593,9 +1603,11 @@ object PruneDeadFields {
         val child2 = rebuild(ctx, child, memo)
         val newRow2 = rebuildIR(ctx, newRow, BindingEnv(child2.typ.rowEnv, scan = Some(child2.typ.rowEnv)), memo)
         val newRowType = newRow2.typ.asInstanceOf[TStruct]
-        val child2Keyed = if (child2.typ.key.exists(k => !newRowType.hasField(k)))
+        val child2Keyed = if (child2.typ.key.exists(k => !newRowType.hasField(k))) {
+          val upcastKey = child2.typ.key.takeWhile(newRowType.hasField)
+          assert(requestedType.key.startsWith(upcastKey))
           TableKeyBy(child2, child2.typ.key.takeWhile(newRowType.hasField))
-        else
+        } else
           child2
         TableMapRows(child2Keyed, newRow2)
       case TableMapGlobals(child, newGlobals) =>
@@ -1609,8 +1621,12 @@ object PruneDeadFields {
           child2 = upcastTable(ctx, child2, memo.requestedType.lookup(child).asInstanceOf[TableType], upcastGlobals = false)
         TableKeyBy(child2, keys2, isSorted)
       case TableOrderBy(child, sortFields) =>
-        // fully upcast before shuffle
-        val child2 = upcastTable(ctx, rebuild(ctx, child, memo), memo.requestedType.lookup(child).asInstanceOf[TableType], upcastGlobals = false)
+        val child2 = if (sortFields.forall(_.sortOrder == Ascending) && child.typ.key.startsWith(sortFields.map(_.field)))
+          rebuild(ctx, child, memo)
+        else {
+          // fully upcast before shuffle
+          upcastTable(ctx, rebuild(ctx, child, memo), memo.requestedType.lookup(child).asInstanceOf[TableType], upcastGlobals = false)
+        }
         TableOrderBy(child2, sortFields)
       case TableLeftJoinRightDistinct(left, right, root) =>
         if (requestedType.rowType.hasField(root))


### PR DESCRIPTION
Can lead to keys being pruned upstream, producing invalid scans.

CHANGELOG: Fixed correctness bug in scan order for `Table.annotate` and `MatrixTable.annotate_rows` in certain circumstances.