### PR TITLE
[batch] Remove unneeded foreign key constraints

### DIFF
--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -249,7 +249,6 @@ CREATE TABLE IF NOT EXISTS `attempts` (
   `end_time` BIGINT,
   `reason` VARCHAR(40),
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(batch_id, job_id) ON DELETE CASCADE,
   FOREIGN KEY (`instance_name`) REFERENCES instances(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;
@@ -268,7 +267,6 @@ CREATE TABLE IF NOT EXISTS `job_parents` (
   `job_id` INT NOT NULL,
   `parent_id` INT NOT NULL,
   PRIMARY KEY (`batch_id`, `job_id`, `parent_id`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(batch_id, job_id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX job_parents_parent_id ON `job_parents` (batch_id, parent_id);
@@ -279,7 +277,6 @@ CREATE TABLE IF NOT EXISTS `job_attributes` (
   `key` VARCHAR(100) NOT NULL,
   `value` TEXT,
   PRIMARY KEY (`batch_id`, `job_id`, `key`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(batch_id, job_id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX job_attributes_key_value ON `job_attributes` (`key`, `value`(256));
@@ -318,7 +315,6 @@ CREATE TABLE IF NOT EXISTS `aggregated_job_resources` (
   `resource` VARCHAR(100) NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (`batch_id`, `job_id`, `resource`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
@@ -330,8 +326,6 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
   `resource` VARCHAR(100) NOT NULL,
   `quantity` BIGINT NOT NULL,
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
-  FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`, `attempt_id`) REFERENCES attempts(`batch_id`, `job_id`, `attempt_id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
 ) ENGINE = InnoDB;

--- a/batch/sql/remove_bad_foreign_key_constraints.py
+++ b/batch/sql/remove_bad_foreign_key_constraints.py
@@ -1,0 +1,53 @@
+import asyncio
+from gear import Database
+from gear.database import get_sql_config
+
+
+async def delete_foreign_key_constraint(db, db_name, table_name, referenced_table_name, referenced_column_names):
+    # https://dev.mysql.com/doc/refman/8.0/en/information-schema-key-column-usage-table.html
+
+    assert referenced_column_names
+    referenced_column_str = '(' + " OR ".join(['REFERENCED_COLUMN_NAME = %s' for _ in referenced_column_names]) + ')'
+
+    query = f'''
+SELECT CONSTRAINT_NAME as constraint_name
+FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+WHERE REFERENCED_TABLE_SCHEMA = %s AND
+  TABLE_NAME = %s AND
+  REFERENCED_TABLE_NAME = %s AND
+  {referenced_column_str};
+'''
+
+    query_args = [db_name, table_name, referenced_table_name] + referenced_column_names
+
+    records = [record async for record in db.select_and_fetchall(query, query_args)]
+    assert len(records) == len(referenced_column_names)
+
+    constraint_names = {record['constraint_name'] for record in records}
+    assert len(constraint_names) == 1
+    constraint_name = list(constraint_names)[0]
+
+    await db.just_execute(f'ALTER TABLE {table_name} DROP FOREIGN KEY `{constraint_name}`;')
+
+
+async def main():
+    db = Database()
+    await db.async_init()
+
+    try:
+        sql_config = get_sql_config()
+        db_name = sql_config.db
+        assert db_name is not None
+
+        await delete_foreign_key_constraint(db, db_name, 'attempts', 'batches', ['id'])
+        await delete_foreign_key_constraint(db, db_name, 'job_parents', 'batches', ['id'])
+        await delete_foreign_key_constraint(db, db_name, 'job_attributes', 'batches', ['id'])
+        await delete_foreign_key_constraint(db, db_name, 'aggregated_job_resources', 'batches', ['id'])
+        await delete_foreign_key_constraint(db, db_name, 'attempt_resources', 'batches', ['id'])
+        await delete_foreign_key_constraint(db, db_name, 'attempt_resources', 'jobs', ['batch_id', 'job_id'])
+    finally:
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/build.yaml
+++ b/build.yaml
@@ -2038,6 +2038,9 @@ steps:
       - name: set-test-and-dev-jpim-to-max-5
         script: /io/sql/set-test-and-dev-jpim-to-max-5.py
         online: true
+      - name: remove-bad-foreign-key-constraints
+        script: /io/sql/remove_bad_foreign_key_constraints.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Too many foreign key constraints are bad because they add compute time for every insert into a referenced table. Foreign key constraints also cause any insert on a referenced table to take out exclusive write locks on the referenced row. For example, every time we insert a new row into `attempt_resources` we're locking both `batches` and `jobs` unnecessarily which makes inserts effectively serial.