### PR TITLE
[batch] Update docker client timeout transient error message

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -364,13 +364,13 @@ def docker_call_retry(timeout, name):
                 # 408 request timeout, 503 service unavailable
                 if e.status in (408, 503):
                     log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
-                # DockerError(500, 'Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+                # DockerError(500, 'Head https://registry-1.docker.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)'
                 # DockerError(500, 'error creating overlay mount to /var/lib/docker/overlay2/545a1337742e0292d9ed197b06fe900146c85ab06e468843cd0461c3f34df50d/merged: device or resource busy'
                 # DockerError(500, 'Get https://gcr.io/v2/: dial tcp: lookup gcr.io: Temporary failure in name resolution')
                 # DockerError(500, 'Get \"https://mcr.microsoft.com/v2/azure-cli/manifests/sha256:068eaecb7abab2d5195a05a6c144c71e9ba1c532efc2912b3ea290d98fbeadb2\": dial tcp 131.253.33.219:443: i/o timeout')
                 # DockerError(500, 'received unexpected HTTP status: 503 Service Unavailable')
                 elif e.status == 500 and (
-                    "request canceled while waiting for connection" in e.message
+                    "Client.Timeout exceeded while awaiting headers" in e.message
                     or re.match("error creating overlay mount.*device or resource busy", e.message)
                     or "Temporary failure in name resolution" in e.message
                     or 'i/o timeout' in e.message


### PR DESCRIPTION
Looks like they changed their error message. See [here](https://ci.hail.is/batches/3181369/jobs/80) for an example.