### PR TITLE
[hailtop][batch] unify & simplify docker transient error handling

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -61,6 +61,7 @@ from hailtop.utils import (
     periodically_call,
     request_retry_transient_errors,
     retry_transient_errors,
+    retry_transient_errors_with_debug_string,
     sleep_and_backoff,
     time_msecs,
     time_msecs_str,
@@ -354,37 +355,12 @@ class NetworkAllocator:
             self.public_networks.put_nowait(netns)
 
 
-def docker_call_retry(timeout, name):
-    async def wrapper(f, *args, **kwargs):
-        delay = 0.1
-        while True:
-            try:
-                return await asyncio.wait_for(f(*args, **kwargs), timeout)
-            except DockerError as e:
-                # 408 request timeout, 503 service unavailable
-                if e.status in (408, 503):
-                    log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
-                # DockerError(500, 'Head https://registry-1.docker.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)'
-                # DockerError(500, 'error creating overlay mount to /var/lib/docker/overlay2/545a1337742e0292d9ed197b06fe900146c85ab06e468843cd0461c3f34df50d/merged: device or resource busy'
-                # DockerError(500, 'Get https://gcr.io/v2/: dial tcp: lookup gcr.io: Temporary failure in name resolution')
-                # DockerError(500, 'Get \"https://mcr.microsoft.com/v2/azure-cli/manifests/sha256:068eaecb7abab2d5195a05a6c144c71e9ba1c532efc2912b3ea290d98fbeadb2\": dial tcp 131.253.33.219:443: i/o timeout')
-                # DockerError(500, 'received unexpected HTTP status: 503 Service Unavailable')
-                elif e.status == 500 and (
-                    "Client.Timeout exceeded while awaiting headers" in e.message
-                    or re.match("error creating overlay mount.*device or resource busy", e.message)
-                    or "Temporary failure in name resolution" in e.message
-                    or 'i/o timeout' in e.message
-                    or 'received unexpected HTTP status: 503 Service Unavailable' in e.message
-                ):
-                    log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
-                else:
-                    raise
-            except (aiohttp.client_exceptions.ServerDisconnectedError, asyncio.TimeoutError):
-                log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
-                delay = await sleep_and_backoff(delay)
+def docker_call_retry(timeout, name, *args, **kwargs):
+    debug_string = f'In docker call to {f.__name__} for {name}'
 
-    return wrapper
-
+    async def timed_out_f(f, *args, **kwargs):
+        return await asyncio.wait_for(f(*args, **kwargs), timeout)
+    return retry_transient_errors_with_debug_string(debug_string, timed_out_f, *args, *kwargs)
 
 class ImageCannotBePulled(Exception):
     pass
@@ -443,7 +419,7 @@ class Image:
     async def _pull_image(self):
         assert docker
 
-        async def do_pull():
+        try:
             if not self.is_cloud_image:
                 await self._ensure_image_is_pulled()
             elif self.is_public_image:
@@ -457,18 +433,13 @@ class Image:
                 # FIXME improve the performance of this with a
                 # per-user image cache.
                 auth = self._current_user_access_token()
-                await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
-                    docker.images.pull, self.image_ref_str, auth=auth
+                await docker_call_retry(
+                    MAX_DOCKER_IMAGE_PULL_SECS,
+                    str(self),
+                    docker.images.pull,
+                    self.image_ref_str,
+                    auth=auth
                 )
-
-        try:
-            try:
-                await do_pull()
-            except DockerError as e:
-                if is_retry_once_error(e):
-                    await do_pull()
-                else:
-                    raise
         except DockerError as e:
             if e.status == 404 and 'pull access denied' in e.message:
                 raise ImageCannotBePulled from e
@@ -483,11 +454,20 @@ class Image:
         assert docker
 
         try:
-            await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(docker.images.get, self.image_ref_str)
+            await docker_call_retry(
+                MAX_DOCKER_OTHER_OPERATION_SECS,
+                str(self),
+                docker.images.get,
+                self.image_ref_str
+            )
         except DockerError as e:
             if e.status == 404:
-                await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
-                    docker.images.pull, self.image_ref_str, auth=auth
+                await docker_call_retry(
+                    MAX_DOCKER_IMAGE_PULL_SECS,
+                    str(self),
+                    docker.images.pull,
+                    self.image_ref_str,
+                    auth=auth
                 )
             else:
                 raise

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -358,7 +358,8 @@ def docker_call_retry(timeout, name, f, *args, **kwargs):
 
     async def timed_out_f(*args, **kwargs):
         return await asyncio.wait_for(f(*args, **kwargs), timeout)
-    return retry_transient_errors_with_debug_string(debug_string, timed_out_f, *args, *kwargs)
+    return retry_transient_errors_with_debug_string(debug_string, timed_out_f, *args, **kwargs)
+
 
 class ImageCannotBePulled(Exception):
     pass

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -56,13 +56,11 @@ from hailtop.utils import (
     check_shell_output,
     dump_all_stacktraces,
     find_spark_home,
-    is_retry_once_error,
     parse_docker_image_reference,
     periodically_call,
     request_retry_transient_errors,
     retry_transient_errors,
     retry_transient_errors_with_debug_string,
-    sleep_and_backoff,
     time_msecs,
     time_msecs_str,
 )
@@ -355,10 +353,10 @@ class NetworkAllocator:
             self.public_networks.put_nowait(netns)
 
 
-def docker_call_retry(timeout, name, *args, **kwargs):
+def docker_call_retry(timeout, name, f, *args, **kwargs):
     debug_string = f'In docker call to {f.__name__} for {name}'
 
-    async def timed_out_f(f, *args, **kwargs):
+    async def timed_out_f(*args, **kwargs):
         return await asyncio.wait_for(f(*args, **kwargs), timeout)
     return retry_transient_errors_with_debug_string(debug_string, timed_out_f, *args, *kwargs)
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,17 +1,18 @@
 from .time import time_msecs, time_msecs_str, humanize_timedelta_msecs, parse_timestamp_msecs
-from .utils import (
-    unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
-    bounded_gather, grouped, sync_sleep_and_backoff, sleep_and_backoff, is_transient_error,
-    request_retry_transient_errors, request_raise_transient_errors,
-    collect_agen, retry_all_errors, retry_transient_errors,
-    retry_long_running, run_if_changed, run_if_changed_idempotent, LoggingTimer,
-    WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
-    retry_response_returning_functions, first_extant_file, secret_alnum_string,
-    flatten, filter_none, partition, cost_str, external_requests_client_session, url_basename,
-    url_join, parse_docker_image_reference, url_and_params,
-    url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home, TransientError,
-    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, unpack_key_value_inputs,
-    retry_all_errors_n_times, Timings, is_retry_once_error)
+from .utils import (unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, bounded_gather,
+                    grouped, sync_sleep_and_backoff, sleep_and_backoff, is_transient_error,
+                    request_retry_transient_errors, request_raise_transient_errors, collect_agen,
+                    retry_all_errors, retry_transient_errors,
+                    retry_transient_errors_with_debug_string, retry_long_running, run_if_changed,
+                    run_if_changed_idempotent, LoggingTimer, WaitableSharedPool,
+                    RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
+                    retry_response_returning_functions, first_extant_file, secret_alnum_string,
+                    flatten, filter_none, partition, cost_str, external_requests_client_session,
+                    url_basename, url_join, parse_docker_image_reference, url_and_params,
+                    url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home,
+                    TransientError, bounded_gather2, OnlineBoundedGather2,
+                    unpack_comma_delimited_inputs, unpack_key_value_inputs,
+                    retry_all_errors_n_times, Timings, is_retry_once_error)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output, sync_check_exec)
@@ -47,6 +48,7 @@ __all__ = [
     'sleep_and_backoff',
     'retry_all_errors',
     'retry_transient_errors',
+    'retry_transient_errors_with_debug_string',
     'retry_long_running',
     'run_if_changed',
     'run_if_changed_idempotent',

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -678,8 +678,7 @@ def is_transient_error(e):
     if isinstance(e, botocore.exceptions.ConnectionClosedError):
         return True
     if aiodocker is not None and isinstance(e, aiodocker.exceptions.DockerError):
-        # aiodocker.exceptions.DockerError: DockerError(500, 'Get https://gcr.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)')
-        return e.status == 500 and 'Client.Timeout exceeded while awaiting headers' in e.message
+        return e.status in RETRYABLE_HTTP_STATUS_CODES
     if isinstance(e, TransientError):
         return True
     return False
@@ -736,6 +735,9 @@ def retry_all_errors_n_times(max_errors=10, msg=None, error_logging_interval=10)
 
 
 async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs) -> T:
+    return await retry_transient_errors_with_debug_string('', f, *args, **kwargs)
+
+async def retry_transient_errors_with_debug_string(debug_string: str, f: Callable[..., Awaitable[T]], *args, **kwargs) -> T:
     delay = 0.1
     errors = 0
     while True:
@@ -750,12 +752,12 @@ async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs
             if errors == 2:
                 log.warning(f'A transient error occured. We will automatically retry. Do not be alarmed. '
                             f'We have thus far seen {errors} transient errors (current delay: '
-                            f'{delay}). The most recent error was {type(e)} {e}')
+                            f'{delay}). The most recent error was {type(e)} {e}. {debug_string}')
             elif errors % 10 == 0:
                 st = ''.join(traceback.format_stack())
                 log.warning(f'A transient error occured. We will automatically retry. '
                             f'We have thus far seen {errors} transient errors (current delay: '
-                            f'{delay}). The stack trace for this call is {st}. The most recent error was {type(e)} {e}', exc_info=True)
+                            f'{delay}). The stack trace for this call is {st}. The most recent error was {type(e)} {e}. {debug_string}', exc_info=True)
         delay = await sleep_and_backoff(delay)
 
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -737,6 +737,7 @@ def retry_all_errors_n_times(max_errors=10, msg=None, error_logging_interval=10)
 async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs) -> T:
     return await retry_transient_errors_with_debug_string('', f, *args, **kwargs)
 
+
 async def retry_transient_errors_with_debug_string(debug_string: str, f: Callable[..., Awaitable[T]], *args, **kwargs) -> T:
     delay = 0.1
     errors = 0


### PR DESCRIPTION
1. Treat any 500 from Docker as a retryable error.
2. Move DockerError transiency to is_transient_errors and use retry_transient_errors instead of a hand rolled transient wrapper.

The first change also makes us robust to changes in error messages on the GCR side. In particular, we started seeing this error message:

```
Head https://gcr.io/v2/hail-vdc/ubuntu/manifests/18.04: Get https://gcr.io/v2/token?account=_json_key&scope=repository%3Ahail-vdc%2Fubuntu%3Apull&service=gcr.io: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

which is slightly different from the extant messages we check for.