### PR TITLE
[datasets] add GENCODE v35

### DIFF
--- a/datasets/extract/extract_gencode_v35_annotation_gtf.sh
+++ b/datasets/extract/extract_gencode_v35_annotation_gtf.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+GTF_URL="https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_35/gencode.v35.annotation.gtf.gz"
+
+wget -c -O - $GTF_URL | \
+zcat | \
+bgzip -c | \
+gsutil -u broad-ctsa cp - gs://hail-datasets-tmp/GENCODE/gencode.v35.annotation.gtf.bgz

--- a/datasets/notebooks/GENCODE.ipynb
+++ b/datasets/notebooks/GENCODE.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# GENCODE\n",
+    "https://www.gencodegenes.org\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import hail as hl\n",
+    "hl.init(spark_conf={\"spark.hadoop.fs.gs.requester.pays.mode\": \"CUSTOM\",\n",
+    "                    \"spark.hadoop.fs.gs.requester.pays.project.id\": \"broad-ctsa\",\n",
+    "                    \"spark.hadoop.fs.gs.requester.pays.buckets\": \"hail-datasets-tmp,hail-datasets-us,hail-datasets-eu\"})"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Create GENCODE v35 annotation Hail Table:\n",
+    "**GENCODE Release 35 (GRCh38.p13):**\n",
+    "https://www.gencodegenes.org/human/release_35.html\n",
+    "\n",
+    "**Comprehensive gene annotation GTF file (on reference chromosomes only):**\n",
+    "https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_35/gencode.v35.annotation.gtf.gz\n",
+    "\n",
+    "**To download comprehensive gene annotation GTF file used to create Hail Table:**\n",
+    "Run `extract_gencode_v35_annotation_gtf.sh` to download the GTF file to the `hail-datasets-tmp` bucket."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "overwrite = False\n",
+    "ht = hl.experimental.import_gtf(\"gs://hail-datasets-tmp/GENCODE/gencode.v35.annotation.gtf.bgz\",\n",
+    "                                reference_genome=\"GRCh38\",\n",
+    "                                skip_invalid_contigs=True,\n",
+    "                                min_partitions=4)\n",
+    "\n",
+    "# Check all str fields for stray semicolons that remain after GTF import and remove them\n",
+    "# e.g. set(ht.transcript_support_level.collect()) == {'3','2','3;','2;','1'}, but should be {1,2,3}\n",
+    "fields = list(ht.row_value)\n",
+    "str_fields = [f for f in fields if f not in {\"score\", \"frame\"}]\n",
+    "ht = ht.annotate(**{f: ht[f].replace(\";\", \"\") for f in str_fields})\n",
+    "ht = ht.annotate(**{f: hl.int32(ht[f]) for f in [\"level\", \"exon_number\"]})\n",
+    "\n",
+    "# Restore original order of table fields after annotating and checkpoint\n",
+    "ht = ht.select(*fields)\n",
+    "ht = ht.checkpoint(\"gs://hail-datasets-tmp/GENCODE/v35/GRCh38/annotation.ht\",\n",
+    "                   overwrite=overwrite,\n",
+    "                   _read_if_exists=not overwrite)\n",
+    "ht.describe()\n",
+    "ht.show()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Read in checkpointed table, write out to hail-datasets GCS buckets\n",
+    "ht = hl.read_table(\"gs://hail-datasets-tmp/GENCODE/v35/GRCh38/annotation.ht\")\n",
+    "ht.write(\"gs://hail-datasets-us/GENCODE/v35/GRCh38/annotation.ht\")\n",
+    "ht.write(\"gs://hail-datasets-eu/GENCODE/v35/GRCh38/annotation.ht\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Read in checkpointed table, write out to hail-datasets S3 bucket\n",
+    "# To read/write to S3, need to set authentication properties in spark_conf\n",
+    "ht = hl.read_table(\"gs://hail-datasets-tmp/GENCODE/v35/GRCh38/annotation.ht\")\n",
+    "ht.write(\"s3a://hail-datasets-us-east-1/GENCODE/v35/GRCh38/annotation.ht\")\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/hail/python/hail/docs/datasets/schemas/gencode.rst
+++ b/hail/python/hail/docs/datasets/schemas/gencode.rst
@@ -3,11 +3,11 @@
 gencode
 =======
 
-*  **Versions:** v19, v31
+*  **Versions:** v19, v31, v35
 *  **Reference genome builds:** GRCh37, GRCh38
 *  **Type:** :class:`hail.Table`
 
-Schema (v19, GRCh37)
+Schema (v35, GRCh38)
 ~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
@@ -17,17 +17,29 @@ Schema (v19, GRCh37)
         None
     ----------------------------------------
     Row fields:
-        'interval': interval<locus<GRCh37>>
-        'ID': str
+        'interval': interval<locus<GRCh38>>
+        'source': str
+        'feature': str
+        'score': float64
+        'strand': str
+        'frame': int32
+        'tag': str
+        'level': int32
         'gene_id': str
-        'gene_name': str
         'gene_type': str
-        'level': str
-        'type': str
-        'gene_score': str
-        'gene_strand': str
-        'gene_phase': str
+        'ccdsid': str
+        'exon_id': str
+        'exon_number': int32
+        'havana_gene': str
+        'transcript_type': str
+        'protein_id': str
+        'gene_name': str
+        'transcript_name': str
+        'transcript_id': str
+        'transcript_support_level': str
+        'hgnc_id': str
+        'ont': str
+        'havana_transcript': str
     ----------------------------------------
     Key: ['interval']
     ----------------------------------------
-

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -2900,6 +2900,19 @@
           }
         },
         "version": "v31"
+      },
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GENCODE/v35/GRCh38/annotation.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GENCODE/v35/GRCh38/annotation.ht",
+            "us": "gs://hail-datasets-us/GENCODE/v35/GRCh38/annotation.ht"
+          }
+        },
+        "version": "v35"
       }
     ]
   },


### PR DESCRIPTION
Fixes #11899 .

To make [GENCODE v35](https://www.gencodegenes.org/human/release_35.html) available via the datasets API, as requested in issue https://github.com/hail-is/hail/issues/11899. 

The Hail Table was created from the [comprehensive gene annotation (on the reference chromosomes only) GTF file](https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_35/gencode.v35.annotation.gtf.gz).