### PR TITLE
[QoB] protect reference download with a lock

### DIFF
--- a/hail/python/hail/builtin_references.py
+++ b/hail/python/hail/builtin_references.py
@@ -1,1 +1,9 @@
-BUILTIN_REFERENCES = ('GRCh37', 'GRCh38', 'GRCm38', 'CanFam3')
+import threading
+
+BUILTIN_REFERENCE_DOWNLOAD_LOCKS = {
+    'GRCh37': threading.Lock(),
+    'GRCh38': threading.Lock(),
+    'GRCm38': threading.Lock(),
+    'CanFam3': threading.Lock(),
+}
+BUILTIN_REFERENCES = tuple(BUILTIN_REFERENCE_DOWNLOAD_LOCKS.keys())


### PR DESCRIPTION
The tests use multiple threads which can race to download the references. This is a bit
of a blunt fix. In particular, this is not an asyncio-friendly lock (because I need
thread safety, which asyncio.Lock does not provide). In general, users should not try
to initialize hail multiple times in different coroutines in the same thread.