### PR TITLE
[ci] allow core AUS devs to see CI pages

### DIFF
--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -32,4 +32,7 @@ AUTHORIZED_USERS = [
     User('patrick-schultz', 'pschultz', [COMPILER_TEAM]),
     User('pwc2', 'pcumming'),
     User('tpoterba', 'tpoterba', [COMPILER_TEAM]),
+    User('lgruen', 'lgruensc', []),
+    User('vladsaveliev', 'vsavelye', []),
+    User('illusional', 'mfrankli', []),
 ]


### PR DESCRIPTION
They all have broad emails now, which is what I used for their Batch usernames.