### PR TITLE
[batch] Fix deadlock errors when inserting attempts and attempt resources

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -80,6 +80,9 @@ async def add_attempt_resources(db, batch_id, job_id, attempt_id, resources):
             for resource in resources:
                 _resources[resource['name']] += resource['quantity']
 
+            # This must be sorted in order to match the order of values in the actual SQL table!
+            _resources = dict(sorted(_resources.items()))
+
             resource_args = [(batch_id, job_id, attempt_id, name, quantity) for name, quantity in _resources.items()]
 
             await db.execute_many(

--- a/batch/sql/minimize-deadlock-errors.sql
+++ b/batch/sql/minimize-deadlock-errors.sql
@@ -1,0 +1,83 @@
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SELECT start_time, end_time INTO cur_start_time, cur_end_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+
+  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+  VALUES (cur_billing_project, NEW.resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  VALUES (NEW.batch_id, NEW.resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  VALUES (NEW.batch_id, NEW.job_id, NEW.resource, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+END $$
+
+DROP PROCEDURE IF EXISTS add_attempt $$
+CREATE PROCEDURE add_attempt(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN in_cores_mcpu INT,
+  OUT delta_cores_mcpu INT
+)
+BEGIN
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE dummy_lock INT;
+
+  SET delta_cores_mcpu = IFNULL(delta_cores_mcpu, 0);
+
+  IF in_attempt_id IS NOT NULL THEN
+    SELECT 1 INTO dummy_lock FROM instances_free_cores_mcpu
+    WHERE instances_free_cores_mcpu.name = in_instance_name
+    FOR UPDATE;
+
+    INSERT INTO attempts (batch_id, job_id, attempt_id, instance_name)
+    VALUES (in_batch_id, in_job_id, in_attempt_id, in_instance_name)
+    ON DUPLICATE KEY UPDATE batch_id = batch_id;
+
+    IF ROW_COUNT() = 1 THEN
+      SELECT state INTO cur_instance_state
+      FROM instances
+      WHERE name = in_instance_name
+      LOCK IN SHARE MODE;
+
+      IF cur_instance_state = 'pending' OR cur_instance_state = 'active' THEN
+        UPDATE instances_free_cores_mcpu
+        SET free_cores_mcpu = free_cores_mcpu - in_cores_mcpu
+        WHERE instances_free_cores_mcpu.name = in_instance_name;
+      END IF;
+
+      SET delta_cores_mcpu = -1 * in_cores_mcpu;
+    END IF;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/build.yaml
+++ b/build.yaml
@@ -2038,6 +2038,9 @@ steps:
       - name: set-test-and-dev-jpim-to-max-5
         script: /io/sql/set-test-and-dev-jpim-to-max-5.py
         online: true
+      - name: minimize-deadlock-errors
+        script: /io/sql/minimize-deadlock-errors.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
There were two sources of deadlocks:

1. The attempt resources were not inserted in the same order in the aggregated_*_resources tabes between the two triggers `attempt_resources_after_insert` and `attempts_after_update`. One had jobs -> batches -> billing projects and the other had billing_projects -> batches -> jobs. We also were inserting the resources in a different order in the two triggers. I solved the ordering issue by making sure we `INSERT MANY` the resources in alphabetical order.

2. Once I fixed (1), then the next set of errors were in `add_attempt`. We were locking the `instances_free_cores_mcpu` table only if the attempt didn't already exist. This was causing cryptic deadlock errors like this:

```
------------------------
LATEST DETECTED DEADLOCK
------------------------
2022-06-23 18:08:12 0x7f1807665700
*** (1) TRANSACTION:
TRANSACTION 1215034153, ACTIVE 0 sec starting index read
mysql tables in use 1, locked 1
LOCK WAIT 21 lock struct(s), heap size 1136, 12 row lock(s), undo log entries 5
MySQL thread id 962402, OS thread handle 139741222766336, query id 6809292838 10.32.5.50 jigold updating
UPDATE instances_free_cores_mcpu
    SET free_cores_mcpu = free_cores_mcpu + cur_cores_mcpu
    WHERE instances_free_cores_mcpu.name = in_instance_name
*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 1578686 page no 3 n bits 72 index PRIMARY of table `jigold`.`instances_free_cores_mcpu` trx id 1215034153 lock_mode X locks rec but not gap waiting
Record lock, heap no 3 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 30; hex 62617463682d776f726b65722d6a69676f6c642d7374616e646172642d62; asc batch-worker-jigold-standard-b; (total 34 bytes);
 1: len 6; hex 0000486bf32c; asc   Hk ,;;
 2: len 7; hex 600001287513cb; asc `  (u  ;;
 3: len 4; hex 80002de6; asc   - ;;

*** (2) TRANSACTION:
TRANSACTION 1215034156, ACTIVE 0 sec inserting
mysql tables in use 6, locked 6
22 lock struct(s), heap size 1136, 13 row lock(s), undo log entries 7
MySQL thread id 962349, OS thread handle 139741180090112, query id 6809294284 10.32.5.50 jigold update
INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
      VALUES (OLD.batch_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
      ON DUPLICATE KEY UPDATE
        n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu
*** (2) HOLDS THE LOCK(S):
RECORD LOCKS space id 1578686 page no 3 n bits 72 index PRIMARY of table `jigold`.`instances_free_cores_mcpu` trx id 1215034156 lock_mode X locks rec but not gap
Record lock, heap no 3 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 30; hex 62617463682d776f726b65722d6a69676f6c642d7374616e646172642d62; asc batch-worker-jigold-standard-b; (total 34 bytes);
 1: len 6; hex 0000486bf32c; asc   Hk ,;;
 2: len 7; hex 600001287513cb; asc `  (u  ;;
 3: len 4; hex 80002de6; asc   - ;;

*** (2) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 1578672 page no 3 n bits 272 index PRIMARY of table `jigold`.`batch_inst_coll_cancellable_resources` trx id 1215034156 lock_mode X locks rec but not gap waiting
Record lock, heap no 162 PHYSICAL RECORD: n_fields 10; compact format; info bits 0
 0: len 8; hex 8000000000000001; asc         ;;
 1: len 8; hex 7374616e64617264; asc standard;;
 2: len 4; hex 80000020; asc     ;;
 3: len 6; hex 0000486bf329; asc   Hk );;
 4: len 7; hex 5d0000e7531a42; asc ]   S B;;
 5: len 4; hex 7ffffff6; asc     ;;
 6: len 8; hex 7ffffffffffff63c; asc        <;;
 7: len 4; hex 7fffffff; asc     ;;
 8: len 8; hex 7fffffffffffff06; asc         ;;
 9: len 4; hex 80000000; asc     ;;

*** WE ROLL BACK TRANSACTION (1)
```

We cannot separate these two changes out as the number of deadlock errors will actually increase.