### PR TITLE
[website] fix change_log.md & treat pandoc warnings as errors

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1459,6 +1459,7 @@ steps:
       valueFrom: hail_base_image.image
     script: |
       set -ex
+      set -o pipefail
       export HAIL_SHORT_VERSION='0.2'
       export SPHINXOPTS='-tgenerate_notebook_outputs'
 
@@ -1471,7 +1472,7 @@ steps:
 
       sed -E "s/\(hail\#([0-9]+)\)/(\[#\1](https:\/\/github.com\/hail-is\/hail\/pull\/\1))/g" \
         < python/hail/docs/change_log.md \
-        | pandoc -o python/hail/docs/change_log.rst
+        | pandoc -o python/hail/docs/change_log.rst --fail-if-warnings --verbose
 
       make -C python/hail/docs BUILDDIR=_build clean html
       make -C python/hailtop/batch/docs BUILDDIR=_build clean html

--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -23,6 +23,7 @@ relating to file formats**: this means that it may not be possible to use
 an earlier version of Hail to read files written in a later version.
 
 ---
+
 ## Version 0.2.96
 
 Released 2022-06-21
@@ -39,6 +40,8 @@ Released 2022-06-21
 - (hail#11937) Fixed correctness bug in scan order for `Table.annotate` and `MatrixTable.annotate_rows` in certain circumstances.
 - (hail#11887) Escape VCF description strings when exporting.
 - (hail#11886) Fix an error in an example in the docs for `hl.split_multi`.
+
+---
 
 ## Version 0.2.95
 


### PR DESCRIPTION
There must be a blank line after three dashes, otherwise you get this error:
```
[WARNING] Could not parse YAML metadata at line 64 column 1: :8:0: Unexpected '-'

```