### PR TITLE
[vcf combiner] Fix error in determining intermidiate file names

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
@@ -713,7 +713,7 @@ def run_combiner(sample_paths: List[str],
 
             tmp = f'{tmp_path}_phase{phase_i}_job{job_i}/'
             hl.experimental.write_matrix_tables(merge_mts, tmp, overwrite=True)
-            pad = len(str(len(merge_mts)))
+            pad = len(str(len(merge_mts) - 1))
             new_files_to_merge.extend(tmp + str(n).zfill(pad) + '.mt' for n in range(len(merge_mts)))
             total_work_done += job.input_total_size
             info(


### PR DESCRIPTION
We were not properly handling cases where there were exactly 10 or 100
files to write. We would handle all other cases correctly.

Closes #11891