### PR TITLE
[many] update gcs connector to recent version

### DIFF
--- a/batch/download-gcs-connector.py
+++ b/batch/download-gcs-connector.py
@@ -2,6 +2,6 @@ import os
 import shutil
 import urllib.request
 
-with urllib.request.urlopen("https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar") as input:
-    with open(os.environ['SPARK_HOME'] + "/jars/gcs-connector-hadoop2-2.7.1.jar", 'wb') as output:
+with urllib.request.urlopen("https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar") as input:
+    with open(os.environ['SPARK_HOME'] + "/jars/gcs-connector-hadoop2-2.2.7.jar", 'wb') as output:
         shutil.copyfileobj(input, output)

--- a/batch/download-gcs-connector.py
+++ b/batch/download-gcs-connector.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import urllib.request
 
-# Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
-with urllib.request.urlopen("https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar") as input:
-    with open(os.environ['SPARK_HOME'] + "/jars/gcs-connector-hadoop2-2.0.1.jar", 'wb') as output:
+with urllib.request.urlopen("https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar") as input:
+    with open(os.environ['SPARK_HOME'] + "/jars/gcs-connector-hadoop2-2.7.1.jar", 'wb') as output:
         shutil.copyfileobj(input, output)

--- a/docker/Dockerfile.base-with-spark-3-2
+++ b/docker/Dockerfile.base-with-spark-3-2
@@ -5,6 +5,5 @@ ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 ENV PYSPARK_PYTHON python3
 
-# Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
-RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar
+RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml

--- a/docker/Dockerfile.base-with-spark-3-2
+++ b/docker/Dockerfile.base-with-spark-3-2
@@ -5,5 +5,5 @@ ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 ENV PYSPARK_PYTHON python3
 
-RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar
+RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.2.7.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml

--- a/docker/Dockerfile.service-java-run-base
+++ b/docker/Dockerfile.service-java-run-base
@@ -13,9 +13,8 @@ RUN hail-pip-install -r requirements.txt pyspark==3.1.1
 ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PYSPARK_PYTHON python3
 
-# Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
-RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-         > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar
+RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar \
+         > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
 
 COPY docker/service-base-requirements.txt .

--- a/docker/Dockerfile.service-java-run-base
+++ b/docker/Dockerfile.service-java-run-base
@@ -13,8 +13,8 @@ RUN hail-pip-install -r requirements.txt pyspark==3.1.1
 ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PYSPARK_PYTHON python3
 
-RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar \
-         > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar
+RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar \
+         > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.2.7.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
 
 COPY docker/service-base-requirements.txt .

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -24,8 +24,8 @@ RUN hail-pip-install \
       scipy \
     && rm -rf hail-*-py3-none-any.whl
 RUN export SPARK_HOME=$(find_spark_home.py) && \
-    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.0.1.jar && \
+    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar \
+         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.7.1.jar && \
     mkdir -p $SPARK_HOME/conf && \
     touch $SPARK_HOME/conf/spark-defaults.conf && \
     sed -i $SPARK_HOME/conf/spark-defaults.conf \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -24,8 +24,8 @@ RUN hail-pip-install \
       scipy \
     && rm -rf hail-*-py3-none-any.whl
 RUN export SPARK_HOME=$(find_spark_home.py) && \
-    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar \
-         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.7.1.jar && \
+    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar \
+         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.2.7.jar && \
     mkdir -p $SPARK_HOME/conf && \
     touch $SPARK_HOME/conf/spark-defaults.conf && \
     sed -i $SPARK_HOME/conf/spark-defaults.conf \

--- a/hail/Dockerfile.hail-run
+++ b/hail/Dockerfile.hail-run
@@ -9,8 +9,7 @@ ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 ENV PYSPARK_PYTHON python3
 
-# Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
-RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar
+RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
 
 RUN hail-apt-get-install liblz4-dev

--- a/hail/Dockerfile.hail-run
+++ b/hail/Dockerfile.hail-run
@@ -9,7 +9,7 @@ ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 ENV PYSPARK_PYTHON python3
 
-RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar
+RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.2.7.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
 
 RUN hail-apt-get-install liblz4-dev

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -132,7 +132,7 @@ class Tests(unittest.TestCase):
         except ValueError as err:
             assert f'glob pattern only allowed in path (e.g. not in bucket): {glob_in_bucket_url}' in err.args[0]
         except FatalError as err:
-            assert f"Invalid bucket name 'glob*{bucket}': bucket name must contain only 'a-z0-9_.-' characters." in err.args[0]
+            assert f"Invalid GCS bucket name 'glob*{bucket}': bucket name must contain only 'a-z0-9_.-' characters." in err.args[0]
         else:
             assert False
 

--- a/hail/scripts/install-gcs-connector.sh
+++ b/hail/scripts/install-gcs-connector.sh
@@ -42,7 +42,7 @@ echo "${SVC_ACCT_ENABLE} true" >> ${CONF_FILE}
 echo "${SVC_ACCT_KEY_FILE} ${KEY_FILE}" >> ${CONF_FILE}
 
 curl -v \
-     https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-     > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar
+     https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar \
+     > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar
 
 echo "success"

--- a/hail/scripts/install-gcs-connector.sh
+++ b/hail/scripts/install-gcs-connector.sh
@@ -42,7 +42,7 @@ echo "${SVC_ACCT_ENABLE} true" >> ${CONF_FILE}
 echo "${SVC_ACCT_KEY_FILE} ${KEY_FILE}" >> ${CONF_FILE}
 
 curl -v \
-     https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.7.1.jar \
-     > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.7.1.jar
+     https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar \
+     > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.2.7.jar
 
 echo "success"


### PR DESCRIPTION
Modern Spark versions including 3.1.2 [include up-to-date hadoop versions](https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12/3.1.2).