### PR TITLE
[query] Fix improper imports

### DIFF
--- a/hail/python/hail/backend/__init__.py
+++ b/hail/python/hail/backend/__init__.py
@@ -1,5 +1,7 @@
 from .backend import Backend
+from .spark_backend import SparkBackend
 
 __all__ = [
-    'Backend'
+    'Backend',
+    'SparkBackend',
 ]

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -1,4 +1,4 @@
-from .types import (dtype, HailType, hail_type, is_container, is_compound, is_numeric, is_primitive,
+from .types import (dtype, HailType, hail_type, is_container, is_compound, is_numeric, is_primitive, dtypes_from_pandas,
                     types_match, tint, tint32, tint64, tfloat, tfloat32, tfloat64, tstr, tbool, tarray, tstream,
                     tndarray, tset, tdict, tstruct, tunion, ttuple, tinterval, tlocus, tcall, tvoid, tvariable,
                     hts_entry_schema)
@@ -56,6 +56,7 @@ __all__ = ['HailType',
            'is_primitive',
            'types_match',
            'dtype',
+           'dtypes_from_pandas',
            'tint',
            'tint32',
            'tint64',

--- a/hail/python/hail/methods/relatedness/pc_relate.py
+++ b/hail/python/hail/methods/relatedness/pc_relate.py
@@ -3,7 +3,7 @@ from typing import Optional
 import hail as hl
 import hail.expr.aggregators as agg
 from hail import ir
-from hail.backend.spark_backend import SparkBackend
+from hail.backend import SparkBackend
 from hail.expr import (ArrayNumericExpression, BooleanExpression, CallExpression,
                        Float64Expression, analyze, expr_array, expr_call,
                        expr_float64, matrix_table_source)


### PR DESCRIPTION
I'm really not very sure what's going on here, but right now on main when I run `make -C hail install && python3 -c 'import hail'` I get the following:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/Caskroom/miniconda/base/envs/hail7/lib/python3.7/site-packages/hail/__init__.py", line 45, in <module>
    from .table import Table, GroupedTable, asc, desc  # noqa: E402
  File "/usr/local/Caskroom/miniconda/base/envs/hail7/lib/python3.7/site-packages/hail/table.py", line 14, in <module>
    from hail.expr.types import hail_type, tstruct, types_match, tarray, tset, dtypes_from_pandas
ImportError: cannot import name 'dtypes_from_pandas' from 'hail.expr.types' (/usr/local/Caskroom/miniconda/base/envs/hail7/lib/python3.7/site-packages/hail/expr/types.py)
```

The following changes fixed my import woes