### PR TITLE
[internal-gateway] disable access log

### DIFF
--- a/internal-gateway/nginx.conf
+++ b/internal-gateway/nginx.conf
@@ -34,7 +34,7 @@ http {
    '"http_user_agent":"$http_user_agent"'
  '}';
 
-  access_log /var/log/nginx/access.log json-log;
+  # access_log /var/log/nginx/access.log json-log;
   error_log /var/log/nginx/error.log;
 
   include /ssl-config/ssl-config-http.conf;


### PR DESCRIPTION
We still have the error log. This produces a lot of logs and I have never used it for debugging purposes.