### PR TITLE
[batch] Dont use worker_processes auto in nginx sidecar

### DIFF
--- a/batch/driver-nginx.conf
+++ b/batch/driver-nginx.conf
@@ -1,9 +1,9 @@
-worker_processes auto;
+worker_processes 2;
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
-  worker_connections 768;
+  worker_connections 1024;
 }
 
 http {


### PR DESCRIPTION
The improvement here was really remarkable. Went from a shaky ~80 jobs per second to ~120 and NGINX max CPU use from 100% to 73%.