### PR TITLE
[QOB] reduce default parallelism

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -71,7 +71,7 @@ class ServiceBackend(
   private[this] val MAX_AVAILABLE_GCS_CONNECTIONS = 100
   private[this] val availableGCSConnections = new Semaphore(MAX_AVAILABLE_GCS_CONNECTIONS, true)
 
-  def defaultParallelism: Int = 10
+  def defaultParallelism: Int = 4
 
   def broadcast[T: ClassTag](_value: T): BroadcastValue[T] = {
     using(new ObjectOutputStream(new ByteArrayOutputStream())) { os =>


### PR DESCRIPTION
This should be configurable, but that was harder than I expected.

This should cut down on the number of class A operations we do a bit. It is quite high right now.