### PR TITLE
[gke] optimize utilization autoscaling and shrink nodes

### DIFF
--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -23,7 +23,7 @@ variable k8s_default_node_pool_machine_type {
 
 variable k8s_user_pool_machine_type {
   type    = string
-  default = "Standard_D4_v2"  # 4 vCPU
+  default = "Standard_D3_v2"  # 4 vCPU
 }
 
 variable k8s_preemptible_node_pool_name {

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -23,7 +23,7 @@ variable k8s_default_node_pool_machine_type {
 
 variable k8s_user_pool_machine_type {
   type    = string
-  default = "Standard_D4_v2"  # 8 vCPU
+  default = "Standard_D4_v2"  # 4 vCPU
 }
 
 variable k8s_preemptible_node_pool_name {

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -129,11 +129,12 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
   autoscaling {
     min_node_count = 0
     max_node_count = 200
+    autoscaling_profile = "OPTIMIZE_UTILIZATION"
   }
 
   node_config {
     preemptible = true
-    machine_type = "n1-standard-8"
+    machine_type = "n1-standard-4"
 
     labels = {
       "preemptible" = "true"
@@ -166,11 +167,12 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
   autoscaling {
     min_node_count = 0
     max_node_count = 200
+    autoscaling_profile = "OPTIMIZE_UTILIZATION"
   }
 
   node_config {
     preemptible = false
-    machine_type = "n1-standard-8"
+    machine_type = "n1-standard-4"
 
     labels = {
       preemptible = "false"


### PR DESCRIPTION
I need to get GKE costs down further. The driver is now 3 CPU anyway.

@daniel-goldstein, I am not sure how to modify the Azure terraform. It appears this
is controlled by a variable which is already set to a 4 core machine?