### PR TITLE
[batch] Add attempts with format version < 3 into attempt_resources

### DIFF
--- a/batch/batch/instance_config.py
+++ b/batch/batch/instance_config.py
@@ -48,6 +48,7 @@ class InstanceConfig(abc.ABC):
         assert isinstance(extra_storage_in_gib, int), extra_storage_in_gib
         assert is_power_two(self.cores) and self.cores <= 256, self.cores
 
+        # FIXME: Only valid up to cores = 64
         worker_fraction_in_1024ths = 1024 * cpu_in_mcpu // (self.cores * 1000)
 
         _quantified_resources = []

--- a/batch/sql/add-att-resources-format-version-lt-3.sql
+++ b/batch/sql/add-att-resources-format-version-lt-3.sql
@@ -1,0 +1,49 @@
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE cur_format_version INT;
+  DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_resource VARCHAR(100);
+
+  SELECT billing_project, format_version INTO cur_billing_project, cur_format_version
+  FROM batches WHERE id = NEW.batch_id;
+
+  IF cur_format_version >= 3 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+
+    SELECT start_time, end_time INTO cur_start_time, cur_end_time
+    FROM attempts
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    LOCK IN SHARE MODE;
+
+    SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -588,39 +588,43 @@ BEGIN
   DECLARE cur_start_time BIGINT;
   DECLARE cur_end_time BIGINT;
   DECLARE cur_billing_project VARCHAR(100);
+  DECLARE cur_format_version INT;
   DECLARE msec_diff BIGINT;
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
   DECLARE cur_resource VARCHAR(100);
 
-  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+  SELECT billing_project, format_version INTO cur_billing_project, cur_format_version
+  FROM batches WHERE id = NEW.batch_id;
 
-  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+  IF cur_format_version >= 3 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
-  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+    SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
-  SELECT start_time, end_time INTO cur_start_time, cur_end_time
-  FROM attempts
-  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-  LOCK IN SHARE MODE;
+    SELECT start_time, end_time INTO cur_start_time, cur_end_time
+    FROM attempts
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    LOCK IN SHARE MODE;
 
-  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+    SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
 
-  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
 
-  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
 
-  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+  END IF;
 END $$
 
 DROP PROCEDURE IF EXISTS recompute_incremental $$

--- a/batch/sql/insert_attempt_resources_format_version_lt_3.py
+++ b/batch/sql/insert_attempt_resources_format_version_lt_3.py
@@ -1,0 +1,247 @@
+import asyncio
+import functools
+import os
+import random
+import time
+
+from gear import Database, transaction
+from hailtop.utils import bounded_gather, secret_alnum_string
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+
+async def process_chunk(counter, db, start_offset, end_offset, size=None, quiet=True):
+    # start inclusive
+    # end exclusive
+
+    @transaction(db)
+    async def _process(tx):
+        start_time = time.time()
+
+        assert start_offset != end_offset, start_offset
+
+        if start_offset is None:
+            start_batch_id, start_job_id, start_attempt_id = None, None, None
+        else:
+            start_batch_id, start_job_id, start_attempt_id = start_offset
+
+        if end_offset is None:
+            end_batch_id, end_job_id, end_attempt_id = None, None, None
+        else:
+            end_batch_id, end_job_id, end_attempt_id = end_offset
+
+        resources = [
+            ('compute/n1-preemptible/1', 'cores_mcpu'),
+            ('memory/n1-preemptible/1', '3840 * (cores_mcpu DIV 1000)'),  # standard worker has 3840 mi per core
+            ('boot-disk/pd-ssd/1', '100 * 1024 * cores_mcpu DIV (16 * 1000)'),  # worker fraction assumes there are 16 cores and 100 gi of disk
+            ('ip-fee/1024/1', '1024 * cores_mcpu DIV (16 * 1000)'),
+            ('service-fee/1', 'cores_mcpu'),
+        ]
+
+        for resource, quantity in resources:
+            if start_batch_id is None or start_job_id is None or start_attempt_id is None:
+                assert end_batch_id
+                where_cond = 'WHERE batches.`format_version` < 3 AND attempts.batch_id < %s OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id < %s) OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id < %s)'
+                query_args = (resource, end_batch_id, end_batch_id, end_job_id, end_batch_id, end_job_id, end_attempt_id)
+            elif end_batch_id is None or end_job_id is None or end_attempt_id is None:
+                assert start_batch_id
+                where_cond = 'WHERE batches.`format_version` < 3 AND ' \
+                             'attempts.batch_id > %s OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id > %s) OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id >= %s)'
+                query_args = (resource, start_batch_id, start_batch_id, start_job_id, start_batch_id, start_job_id, start_attempt_id)
+            else:
+                # adding a where check for format_version < 3 here causes a full table scan
+                where_cond = 'WHERE (attempts.batch_id > %s OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id > %s) OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id >= %s)) ' \
+                             'AND (attempts.batch_id < %s OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id < %s) OR ' \
+                             '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id < %s))'
+                query_args = (resource,
+                              start_batch_id, start_batch_id, start_job_id, start_batch_id, start_job_id, start_attempt_id,
+                              end_batch_id, end_batch_id, end_job_id, end_batch_id, end_job_id, end_attempt_id)
+
+            if size is not None:
+                limit = f'LIMIT {size}'
+            else:
+                limit = ''
+
+            query = f'''
+INSERT INTO attempt_resources (batch_id, job_id, attempt_id, resource_id, quantity)
+SELECT * FROM (
+  SELECT attempts.batch_id, attempts.job_id, attempts.attempt_id, (
+    SELECT resource_id
+    FROM resources
+    WHERE resource = %s
+  ), {quantity}
+  FROM attempts FORCE INDEX (PRIMARY)
+  LEFT JOIN jobs ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.job_id
+  LEFT JOIN batches ON attempts.batch_id = batches.id
+  {where_cond}
+  {limit}
+) AS t
+ON DUPLICATE KEY UPDATE quantity = quantity;
+'''
+
+            await tx.just_execute(query, query_args)
+
+        if not quiet:
+            print(f'processed chunk ({start_offset}, {end_offset}) in {time.time() - start_time}s')
+
+        counter.n += 1
+        if counter.n % 500 == 0:
+            print(f'processed {counter.n} chunks')
+
+    return await _process()
+
+
+async def audit_changes(db, expected_n_inserts):
+    result = await db.select_and_fetchone(
+        '''
+SELECT COUNT(*) as count
+FROM attempt_resources
+LEFT JOIN batches ON batches.id = attempt_resources.batch_id
+WHERE batches.`format_version` < 3;
+'''
+    )
+
+    if result['count'] != expected_n_inserts:
+        raise Exception(
+            f'number of attempt resources inserted ({result["count"]})does not match expected value {expected_n_inserts}')
+
+    bad_job_records = db.select_and_fetchall(
+        '''
+SELECT old.batch_id, old.job_id, old.cost, new.cost, ABS(new.cost - old.cost) AS cost_diff
+FROM (
+  SELECT batch_id, job_id, (jobs.msec_mcpu * 0.001 * 0.001) * ((0.01 + ((0.17 * 100 / 30.4375 / 24 + 0.004) / 16) + 0.01) / 3600) AS cost
+  FROM jobs
+  LEFT JOIN batches ON jobs.batch_id = batches.id
+  WHERE batches.`format_version` < 3) AS old
+LEFT JOIN (
+  SELECT attempt_resources.batch_id, attempt_resources.job_id, COALESCE(SUM(GREATEST(COALESCE(end_time - start_time, 0), 0) * quantity * rate), 0) AS cost
+  FROM attempt_resources
+  LEFT JOIN batches ON attempt_resources.batch_id = batches.id
+  LEFT JOIN attempts ON attempt_resources.batch_id = attempts.batch_id AND attempt_resources.job_id = attempts.job_id AND attempt_resources.attempt_id = attempts.attempt_id
+  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  WHERE batches.`format_version` < 3
+  GROUP BY batch_id, job_id
+) AS new ON new.batch_id = old.batch_id AND new.job_id = old.job_id
+WHERE COALESCE(ABS(new.cost - old.cost), -1) >= 0.001
+LIMIT 100;
+''')
+
+    async for record in bad_job_records:
+        raise Exception(f'found bad record {record}')
+
+
+async def find_chunk_offsets(db, size):
+    @transaction(db)
+    async def _find_chunks(tx):
+        start_time = time.time()
+
+        await tx.just_execute('SET @rank = 0;')
+
+        query = f'''
+SELECT t.batch_id, t.job_id, t.attempt_id FROM (
+  SELECT attempts.batch_id, attempts.job_id, attempts.attempt_id
+  FROM attempts
+  LEFT JOIN batches ON attempts.batch_id = batches.id
+  WHERE batches.`format_version` < 3
+  ORDER BY attempts.batch_id, attempts.job_id, attempts.attempt_id
+) AS t
+WHERE MOD((@rank := @rank + 1), %s) = 0;
+'''
+
+        offsets = tx.execute_and_fetchall(query, (size,))
+        offsets = [(offset['batch_id'], offset['job_id'], offset['attempt_id']) async for offset in offsets]
+
+        last_offset = tx.execute_and_fetchall(
+            '''
+SELECT batch_id, job_id, attempt_id
+FROM attempts
+LEFT JOIN batches ON attempts.batch_id = batches.id
+WHERE batches.format_version >= 3
+ORDER BY attempts.batch_id, attempts.job_id, attempts.attempt_id
+LIMIT 1;
+'''
+        )
+        last_offset = [(offset['batch_id'], offset['job_id'], offset['attempt_id']) async for offset in last_offset]
+        assert len(last_offset) == 1, last_offset
+        last_offset = last_offset[0]
+        offsets.append(last_offset)
+
+        print(f'found chunk offsets in {round(time.time() - start_time, 4)}s')
+        return offsets
+
+    return await _find_chunks()
+
+
+async def main(chunk_size=100):
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    start_time = time.time()
+    counter = Counter()
+
+    try:
+        count = await db.select_and_fetchone(
+            '''
+SELECT COUNT(*) as count FROM attempts
+LEFT JOIN batches ON attempts.batch_id = batches.id
+WHERE batches.`format_version` < 3;
+'''
+        )
+        n_attempts_expected = count['count']
+        print(f'expecting to process {n_attempts_expected} attempts')
+
+        if n_attempts_expected > 0:
+            chunk_offsets = [None]
+            for offset in await find_chunk_offsets(db, chunk_size):
+                chunk_offsets.append(offset)
+
+            # the endpoint of the last offset is the first record where format version >= 3
+            # thus, the start_offset should never equal the end offset
+            chunk_offsets = list(zip(chunk_offsets[:-1], chunk_offsets[1:]))
+
+            print(f'found {len(chunk_offsets)} chunks to process')
+
+            random.shuffle(chunk_offsets)
+
+            n_burn_in_chunks = 5000
+            burn_in_chunk_size = 10
+
+            start_insert = time.time()
+
+            burn_in_start = time.time()
+            burn_in_chunk_offsets = chunk_offsets[:n_burn_in_chunks]
+            for start_offset, end_offset in burn_in_chunk_offsets:
+                await process_chunk(counter, db, start_offset, end_offset, size=burn_in_chunk_size)
+
+            print(f'finished burn-in in {time.time() - burn_in_start}s')
+
+            parallel_insert_start = time.time()
+
+            # 4 core database, parallelism = 10 maxes out CPU
+            await bounded_gather(
+                *[functools.partial(process_chunk, counter, db, start_offset, end_offset, quiet=True) for start_offset, end_offset in chunk_offsets],
+                parallelism=10
+            )
+            print(f'took {time.time() - parallel_insert_start}s to insert the remaining records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_insert_start)}) attempts / sec')
+
+            print(f'took {time.time() - start_insert}s to insert all records')
+
+            await audit_changes(db, n_attempts_expected * 5)
+    finally:
+        print(f'finished migration in {time.time() - start_time}s')
+        await db.async_close()
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/build.yaml
+++ b/build.yaml
@@ -2040,6 +2040,12 @@ steps:
       - name: rm-resource-names-agg-resources-pt-2
         script: /io/sql/rm-resource-names-agg-resources-pt-2.sql
         online: true
+      - name: add-att-resources-format-version-lt-3
+        script: /io/sql/add-att-resources-format-version-lt-3.sql
+        online: true
+      - name: insert-attempt-resources-format-version-lt-3
+        script: /io/sql/insert_attempt_resources_format_version_lt_3.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
cc: @danking 

Here is the first major database migration. The goal is to add all attempt resources into the database for any attempt with batch format version less than 3. The node configuration was the same for all attempts back then with standard instances, 16 cores, and a 100GB boot disk. I figured out what the quantity for each resource should be by looking at how we compute quantities for resources in `batch/batch/resources.py`. I checked the inserted quantities are identical to the attempts that already exist in the database right after we converted the billing over to using resources.

Once we have all resources for all attempts, the next step (future PR) is to do a scan and repopulate the new aggregated billing tables **by date**. In this PR, I don't try and add the usage to the existing `aggregated_*_resources` tables. I did this to cut down on time and space since we're eventually going to deprecate those tables anyways. Because I don't touch those tables, we don't need to worry about modifying the client code and how the current billing information is calculated.

How this migration works is there are 5 phases:
1. Compute the expected number of attempts to process for format version < 3. 
2. Divide the search space into chunks of size 100 attempts (empirically determined this was the best chunk size) and randomize the order of the chunks.
3. Serially process 5000 chunks with only 10 out of the 100 records as a "burn in period" to avoid the birthday problem when trying to insert records in parallel.
4. In parallel, process all the chunks with 10 way parallelism (empirically determined to max CPU for a 4 core db instance)
5. Do an audit of the results to make sure the attempt resources now has the correct number of rows and the billing is within $0.001 per job with the old way and new way of computing the billing. The tolerance of $0.001 was empirically determined. At a threshold of $0.0001, 33/30,000,000 attempts failed. I think this is good enough as there's always going to be rounding errors.

I did not do an explicit audit in the code to make sure the other aggregated_*_resources tables did not change. I spot checked this was correct in my test database. To do the complete audit during the actual migration would take more time.

I made sure all the inserts were idempotent. Please double check this.

The inserts use a temporary table with an isolation level of read committed. The reason for this is because `INSERT INTO ... SELECT` locks the next gap lock if the isolation level is not read committed. Maybe what I did is overkill and it's no longer a problem with the new burn in period. https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html I'd be interested to hear @danking feedback on what the best query here is to allow parallelism.

There are ~30 million attempts that need to be processed for hail-vdc (~60% of the attempts). This will add ~20Gi to the existing database. I use 4 cores to get this migration to be ~3 hours, so we will want to **upgrade the database to 8 cores** while this migration is running. The inserting takes about 2 hours and the audit is 45 minutes or so.

For the Australians, I think this script should be a no-op because I believe they started their instance after the billing changes went in around May/June 2020.

The main thing to look out for is whether I got the interval queries correct! For example:

```python3
                where_cond = 'WHERE (attempts.batch_id > %s OR ' \
                             '(attempts.batch_id = %s AND attempts.job_id > %s) OR ' \
                             '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id >= %s)) ' \
                             'AND (attempts.batch_id < %s OR ' \
                             '(attempts.batch_id = %s AND attempts.job_id < %s) OR ' \
                             '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id < %s))'
```

The last thing is to do a sanity check and triple check the new database trigger won't run anything for format version < 3. Also, a sanity check that format_version < 3 is the right cutoff. I got this by looking at the `BatchFormatVersion` class where we have the cost function depending on format version.