### PR TITLE
[batch] Undo trigger change to ignore updates for format_version < 3

### DIFF
--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -588,43 +588,40 @@ BEGIN
   DECLARE cur_start_time BIGINT;
   DECLARE cur_end_time BIGINT;
   DECLARE cur_billing_project VARCHAR(100);
-  DECLARE cur_format_version INT;
   DECLARE msec_diff BIGINT;
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
   DECLARE cur_resource VARCHAR(100);
 
-  SELECT billing_project, format_version INTO cur_billing_project, cur_format_version
+  SELECT billing_project INTO cur_billing_project
   FROM batches WHERE id = NEW.batch_id;
 
-  IF cur_format_version >= 3 THEN
-    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
-    SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
-    SELECT start_time, end_time INTO cur_start_time, cur_end_time
-    FROM attempts
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    LOCK IN SHARE MODE;
+  SELECT start_time, end_time INTO cur_start_time, cur_end_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
 
-    SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
 
-    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-    VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
-    ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.quantity * msec_diff;
+  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
 
-    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-    VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
-    ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.quantity * msec_diff;
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
 
-    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-    VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
-    ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.quantity * msec_diff;
-  END IF;
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
 END $$
 
 DROP PROCEDURE IF EXISTS recompute_incremental $$

--- a/batch/sql/revert-attempt-resources-trigger-back-compat.sql
+++ b/batch/sql/revert-attempt-resources-trigger-back-compat.sql
@@ -1,0 +1,46 @@
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_resource VARCHAR(100);
+
+  SELECT billing_project INTO cur_billing_project
+  FROM batches WHERE id = NEW.batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+
+  SELECT start_time, end_time INTO cur_start_time, cur_end_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+
+  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+END $$
+
+DELIMITER ;

--- a/build.yaml
+++ b/build.yaml
@@ -2046,6 +2046,9 @@ steps:
       - name: insert-attempt-resources-format-version-lt-3
         script: /io/sql/insert_attempt_resources_format_version_lt_3.py
         online: true
+      - name: revert-attempt-resources-trigger-back-compat
+        script: /io/sql/revert-attempt-resources-trigger-back-compat.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
To make future modifications to the `attempt_resources_after_insert` trigger easier to follow, I have this PR which reverts the change to ignore any updates for batch format_version < 3.

Stacked on #11990