### PR TITLE
[batch] Add billing tables partitioned by date

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -960,6 +960,7 @@ ON attempts.batch_id = attempt_resources.batch_id AND
   attempts.job_id = attempt_resources.job_id AND
   attempts.attempt_id = attempt_resources.attempt_id
 LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+WHERE GREATEST(COALESCE(end_time - start_time, 0), 0) != 0
 GROUP BY batch_id, job_id, attempt_id
 LOCK IN SHARE MODE;
 '''

--- a/batch/sql/add-agg-billing-by-date.sql
+++ b/batch/sql/add-agg-billing-by-date.sql
@@ -1,7 +1,7 @@
-ALTER TABLE attempts ADD COLUMN added_to_per_day_rollups BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
+ALTER TABLE attempts ADD COLUMN migrated BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
 
-DROP TABLE IF EXISTS `aggregated_billing_project_user_resources`;
-CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources` (
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v2` (
   `billing_project` VARCHAR(100) NOT NULL,
   `user` VARCHAR(100) NOT NULL,
   `resource_id` INT NOT NULL,
@@ -11,10 +11,10 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources` (
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
-CREATE INDEX aggregated_billing_project_user_resources ON `aggregated_billing_project_user_resources` (`user`);
+CREATE INDEX aggregated_billing_project_user_resources_v2 ON `aggregated_billing_project_user_resources_v2` (`user`);
 
-DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
-CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date` (
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v2` (
   `billing_timestamp` DATE NOT NULL,
   `billing_project` VARCHAR(100) NOT NULL,
   `user` VARCHAR(100) NOT NULL,
@@ -25,28 +25,26 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date` (
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
-CREATE INDEX aggregated_billing_project_user_resources_by_date_ts_user ON `aggregated_billing_project_user_resources_by_date` (`billing_timestamp`, `user`);
+CREATE INDEX aggregated_billing_project_user_resources_by_date_v2_user ON `aggregated_billing_project_user_resources_by_date_v2` (`billing_timestamp`, `user`);
 
-DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
-CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_by_date` (
+DROP TABLE IF EXISTS `aggregated_batch_resources_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v2` (
   `batch_id` BIGINT NOT NULL,
-  `billing_timestamp` DATE NOT NULL,
   `resource_id` INT NOT NULL,
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `billing_timestamp`, `resource_id`, `token`),
+  PRIMARY KEY (`batch_id`, `resource_id`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
-DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
-CREATE TABLE IF NOT EXISTS `aggregated_job_resources_by_date` (
+DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v2` (
   `batch_id` BIGINT NOT NULL,
   `job_id` INT NOT NULL,
-  `billing_timestamp` DATE NOT NULL,
   `resource_id` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `job_id`, `billing_timestamp`, `resource_id`),
+  PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -54,7 +52,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_job_resources_by_date` (
 
 DELIMITER $$
 
-DROP TRIGGER IF EXISTS attempts_before_update;
+DROP TRIGGER IF EXISTS attempts_before_update $$
 CREATE TRIGGER attempts_before_update BEFORE UPDATE ON attempts
 FOR EACH ROW
 BEGIN
@@ -72,7 +70,7 @@ BEGIN
     SET NEW.reason = OLD.reason;
   END IF;
 
-  SET NEW.added_to_per_day_rollups = TRUE;
+  SET NEW.migrated = TRUE;
 END $$
 
 DROP TRIGGER IF EXISTS attempts_after_update $$
@@ -82,11 +80,11 @@ BEGIN
   DECLARE job_cores_mcpu INT;
   DECLARE cur_billing_project VARCHAR(100);
   DECLARE msec_diff BIGINT;
-  DECLARE msec_diff_by_date BIGINT;
+  DECLARE msec_diff_migration BIGINT;
   DECLARE cur_n_tokens INT;
+  DECLARE cur_n_batch_jobs INT;
   DECLARE rand_token INT;
-  DECLARE rand_token_by_date INT;
-  DECLARE cur_prev_agg_by_date BOOLEAN;
+  DECLARE rand_token_migration INT;
   DECLARE cur_billing_timestamp DATE;
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
@@ -95,92 +93,86 @@ BEGIN
   SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
 
-  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+  SELECT billing_project, n_jobs INTO cur_billing_project, cur_n_batch_jobs FROM batches WHERE id = NEW.batch_id;
 
   SET msec_diff = (GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0) -
                    GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
 
-  SET cur_billing_timestamp = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
+  IF msec_diff != 0 THEN
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
-  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-  SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
-  FROM attempt_resources
-  JOIN batches ON batches.id = attempt_resources.batch_id
-  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
-  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
-  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-  SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
-  FROM attempt_resources
-  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
-  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    SELECT batch_id, job_id, resources.resource, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+  END IF;
 
-  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-  SELECT batch_id, job_id, resources.resource, msec_diff * quantity
-  FROM attempt_resources
-  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
-  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+  IF NOT OLD.migrated THEN
+    SET msec_diff_migration = GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0);
+    SET rand_token_migration = NEW.batch_id DIV 100000 + NEW.job_id DIV 100000;
+  ELSE
+    SET msec_diff_migration = msec_diff;
+    SET rand_token_migration = rand_token;
+  END IF;
 
-  IF NEW.end_time IS NOT NULL THEN
-    SELECT attempts_aggregated_by_date.batch_id IS NOT NULL INTO cur_prev_agg_by_date
-    FROM attempts
-    LEFT JOIN attempts_aggregated_by_date
-      ON attempts.batch_id = attempts_aggregated_by_date.batch_id AND
-        attempts.job_id = attempts_aggregated_by_date.job_id AND
-        attempts.attempt_id = attempts_aggregated_by_date.attempt_id
-    WHERE attempts.batch_id = NEW.batch_id AND attempts.job_id = NEW.job_id AND attempts.attempt_id = NEW.attempt_id;
-
-    IF NOT OLD.added_to_per_day_rollups THEN
-      SET msec_diff_by_date = GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0);
-      SET rand_token_by_date = 0;
-    ELSE
-      SET msec_diff_by_date = msec_diff;
-      SET rand_token_by_date = rand_token;
-    END IF;
-
-    INSERT INTO aggregated_billing_project_user_resources (billing_project, user, resource_id, token, `usage`)
+  IF msec_diff_migration != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
     SELECT billing_project, `user`,
       resource_id,
-      rand_token,
-      msec_diff_by_date * quantity
+      rand_token_migration,
+      msec_diff_migration * quantity
     FROM attempt_resources
     JOIN batches ON batches.id = attempt_resources.batch_id
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
 
-    INSERT INTO aggregated_billing_project_user_resources_by_date (billing_timestamp, billing_project, user, resource_id, token, `usage`)
-    SELECT cur_billing_timestamp,
-      billing_project,
-      `user`,
-      resource_id,
-      rand_token_by_date,
-      msec_diff_by_date * quantity
-    FROM attempt_resources
-    JOIN batches ON batches.id = attempt_resources.batch_id
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
-
-    INSERT INTO aggregated_batch_resources_by_date (batch_id, billing_timestamp, resource_id, token, `usage`)
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
-      cur_billing_timestamp,
       resource_id,
-      rand_token_by_date,
-      msec_diff_by_date * quantity
+      rand_token_migration,
+      msec_diff_migration * quantity
     FROM attempt_resources
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
 
-    INSERT INTO aggregated_job_resources_by_date (batch_id, job_id, billing_timestamp, resource_id, `usage`)
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
-      cur_billing_timestamp,
       resource_id,
-      msec_diff_by_date * quantity
+      msec_diff_migration * quantity
     FROM attempt_resources
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
+
+    IF NEW.end_time IS NOT NULL THEN
+      SET cur_billing_timestamp = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
+
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_timestamp, billing_project, user, resource_id, token, `usage`)
+      SELECT cur_billing_timestamp,
+        billing_project,
+        `user`,
+        resource_id,
+        rand_token_migration,
+        msec_diff_migration * quantity
+      FROM attempt_resources
+      JOIN batches ON batches.id = attempt_resources.batch_id
+      WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+      ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
+    END IF;
   END IF;
 END $$
 
@@ -201,10 +193,10 @@ BEGIN
   SELECT billing_project, user INTO cur_billing_project, cur_user
   FROM batches WHERE id = NEW.batch_id;
 
-  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
-
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
   SELECT start_time, end_time INTO cur_start_time, cur_end_time
   FROM attempts
@@ -215,41 +207,43 @@ BEGIN
 
   SET cur_billing_timestamp = CAST(FROM_UNIXTIME(cur_end_time / 1000) AS DATE);
 
-  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  INSERT INTO aggregated_billing_project_user_resources (billing_project, user, resource_id, token, `usage`)
-  VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  IF cur_billing_timestamp IS NOT NULL THEN
-    INSERT INTO aggregated_billing_project_user_resources_by_date (billing_timestamp, billing_project, user, resource_id, token, `usage`)
-    VALUES (cur_billing_timestamp, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+  IF msec_diff != 0 THEN
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
 
-    INSERT INTO aggregated_batch_resources_by_date (batch_id, billing_timestamp, resource_id, token, `usage`)
-    VALUES (NEW.batch_id, cur_billing_timestamp, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
 
-    INSERT INTO aggregated_job_resources_by_date (batch_id, job_id, billing_timestamp, resource_id, `usage`)
-    VALUES (NEW.batch_id, NEW.job_id, cur_billing_timestamp, NEW.resource_id, NEW.quantity * msec_diff)
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    IF cur_billing_timestamp IS NOT NULL THEN
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_timestamp, billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_timestamp, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff;
+    END IF;
   END IF;
 END $$
 

--- a/batch/sql/add-agg-billing-by-date.sql
+++ b/batch/sql/add-agg-billing-by-date.sql
@@ -1,0 +1,256 @@
+-- ALTER TABLE attempts DROP COLUMN dummy_aggregated_by_date, ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE attempts ADD COLUMN dummy_aggregated_by_date INT DEFAULT 0, ALGORITHM=INSTANT;
+
+DROP TABLE IF EXISTS `attempts_aggregated_by_date`;
+CREATE TABLE IF NOT EXISTS `attempts_aggregated_by_date` (
+  `batch_id` BIGINT NOT NULL,
+  `job_id` INT NOT NULL,
+  `attempt_id` VARCHAR(40) NOT NULL,
+  PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`),
+  FOREIGN KEY (`batch_id`, `job_id`, `attempt_id`) REFERENCES attempts(`batch_id`, `job_id`, `attempt_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources` (
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources ON `aggregated_billing_project_user_resources` (`user`);
+
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date` (
+  `billing_timestamp` DATE NOT NULL,
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_timestamp`, `billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_by_date_ts_user ON `aggregated_billing_project_user_resources_by_date` (`billing_timestamp`, `user`);
+
+DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
+CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_by_date` (
+  `batch_id` BIGINT NOT NULL,
+  `billing_timestamp` DATE NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `billing_timestamp`, `resource_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
+CREATE TABLE IF NOT EXISTS `aggregated_job_resources_by_date` (
+  `batch_id` BIGINT NOT NULL,
+  `job_id` INT NOT NULL,
+  `billing_timestamp` DATE NOT NULL,
+  `resource_id` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `job_id`, `billing_timestamp`, `resource_id`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_after_update $$
+CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  DECLARE job_cores_mcpu INT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE msec_diff_by_date BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE rand_token_by_date INT;
+  DECLARE cur_prev_agg_by_date BOOLEAN;
+  DECLARE cur_billing_timestamp DATE;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SET msec_diff = (GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0) -
+                   GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
+
+  SET cur_billing_timestamp = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
+
+  # do not want to add to the original billing tables if we are forcing an update
+  IF OLD.dummy_aggregated_by_date = NEW.dummy_aggregated_by_date THEN
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    SELECT batch_id, job_id, resources.resource, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+  END IF;
+
+  IF NEW.end_time IS NOT NULL THEN
+    SELECT attempts_aggregated_by_date.batch_id IS NOT NULL INTO cur_prev_agg_by_date
+    FROM attempts
+    LEFT JOIN attempts_aggregated_by_date
+      ON attempts.batch_id = attempts_aggregated_by_date.batch_id AND
+        attempts.job_id = attempts_aggregated_by_date.job_id AND
+        attempts.attempt_id = attempts_aggregated_by_date.attempt_id
+    WHERE attempts.batch_id = NEW.batch_id AND attempts.job_id = NEW.job_id AND attempts.attempt_id = NEW.attempt_id;
+
+    IF cur_prev_agg_by_date THEN
+      SET msec_diff_by_date = msec_diff;
+      SET rand_token_by_date = rand_token;
+    ELSE
+      SET msec_diff_by_date = GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0);
+      SET rand_token_by_date = 0;
+    END IF;
+
+    INSERT INTO aggregated_billing_project_user_resources (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resource_id,
+      rand_token,
+      msec_diff_by_date * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date (billing_timestamp, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_timestamp,
+      billing_project,
+      `user`,
+      resource_id,
+      rand_token_by_date,
+      msec_diff_by_date * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+
+    INSERT INTO aggregated_batch_resources_by_date (batch_id, billing_timestamp, resource_id, token, `usage`)
+    SELECT attempt_resources.batch_id,
+      cur_billing_timestamp,
+      resource_id,
+      rand_token_by_date,
+      msec_diff_by_date * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+
+    INSERT INTO aggregated_job_resources_by_date (batch_id, job_id, billing_timestamp, resource_id, `usage`)
+    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+      cur_billing_timestamp,
+      resource_id,
+      msec_diff_by_date * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+  END IF;
+
+  INSERT INTO attempts_aggregated_by_date (batch_id, job_id, attempt_id)
+  VALUES (NEW.batch_id, NEW.job_id, NEW.attempt_id)
+  ON DUPLICATE KEY UPDATE attempt_id = attempt_id;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE cur_user VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_resource VARCHAR(100);
+  DECLARE cur_billing_timestamp DATE;
+
+  SELECT billing_project, user INTO cur_billing_project, cur_user
+  FROM batches WHERE id = NEW.batch_id;
+
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT start_time, end_time INTO cur_start_time, cur_end_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+
+  SET cur_billing_timestamp = CAST(FROM_UNIXTIME(cur_end_time / 1000) AS DATE);
+
+  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_billing_project_user_resources (billing_project, user, resource_id, token, `usage`)
+  VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  IF cur_billing_timestamp IS NOT NULL THEN
+    INSERT INTO aggregated_billing_project_user_resources_by_date (billing_timestamp, billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_timestamp, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_batch_resources_by_date (batch_id, billing_timestamp, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, cur_billing_timestamp, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_job_resources_by_date (batch_id, job_id, billing_timestamp, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, cur_billing_timestamp, NEW.resource_id, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+  END IF;
+
+  INSERT INTO attempts_aggregated_by_date (batch_id, job_id, attempt_id)
+  VALUES (NEW.batch_id, NEW.job_id, NEW.attempt_id)
+  ON DUPLICATE KEY UPDATE attempt_id = attempt_id;
+END $$
+
+DELIMITER ;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -25,13 +25,13 @@ DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 DROP TABLE IF EXISTS `batch_updates`;
 
-DROP TABLE IF EXISTS `aggregated_billing_project_user_resources`;
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v2`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v2`;
 DROP TABLE IF EXISTS `aggregated_batch_resources`;
+DROP TABLE IF EXISTS `aggregated_batch_resources_v2`;
 DROP TABLE IF EXISTS `aggregated_job_resources`;
-DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
-DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
-DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
+DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
 DROP TABLE IF EXISTS `attempt_resources`;
 DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources`;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -23,7 +23,6 @@ DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
 DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
-DROP TABLE IF EXISTS `attempts_aggregated_by_date`;
 DROP TABLE IF EXISTS `batch_updates`;
 
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources`;
@@ -34,7 +33,6 @@ DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
 DROP TABLE IF EXISTS `attempt_resources`;
-DROP TABLE IF EXISTS `attempts_aggregated_by_date`;
 DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources`;
 DROP TABLE IF EXISTS `globals`;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -26,10 +26,15 @@ DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 DROP TABLE IF EXISTS `attempts_aggregated_by_date`;
 DROP TABLE IF EXISTS `batch_updates`;
 
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources`;
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;
 DROP TABLE IF EXISTS `aggregated_batch_resources`;
 DROP TABLE IF EXISTS `aggregated_job_resources`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
+DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
+DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
 DROP TABLE IF EXISTS `attempt_resources`;
+DROP TABLE IF EXISTS `attempts_aggregated_by_date`;
 DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources`;
 DROP TABLE IF EXISTS `globals`;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -433,7 +433,7 @@ BEGIN
   DECLARE cur_n_batch_jobs INT;
   DECLARE rand_token INT;
   DECLARE rand_token_migration INT;
-  DECLARE cur_billing_timestamp DATE;
+  DECLARE cur_billing_date DATE;
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
@@ -507,10 +507,10 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
 
     IF NEW.end_time IS NOT NULL THEN
-      SET cur_billing_timestamp = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
+      SET cur_billing_date = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
 
       INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_timestamp, billing_project, user, resource_id, token, `usage`)
-      SELECT cur_billing_timestamp,
+      SELECT cur_billing_date,
         billing_project,
         `user`,
         resource_id,
@@ -705,7 +705,7 @@ BEGIN
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
   DECLARE cur_resource VARCHAR(100);
-  DECLARE cur_billing_timestamp DATE;
+  DECLARE cur_billing_date DATE;
 
   SELECT billing_project, user INTO cur_billing_project, cur_user
   FROM batches WHERE id = NEW.batch_id;
@@ -722,7 +722,7 @@ BEGIN
 
   SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
 
-  SET cur_billing_timestamp = CAST(FROM_UNIXTIME(cur_end_time / 1000) AS DATE);
+  SET cur_billing_date = CAST(FROM_UNIXTIME(cur_end_time / 1000) AS DATE);
 
   IF msec_diff != 0 THEN
     INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
@@ -755,9 +755,9 @@ BEGIN
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
 
-    IF cur_billing_timestamp IS NOT NULL THEN
+    IF cur_billing_date IS NOT NULL THEN
       INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_timestamp, billing_project, user, resource_id, token, `usage`)
-      VALUES (cur_billing_timestamp, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+      VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff;
     END IF;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -249,7 +249,7 @@ CREATE TABLE IF NOT EXISTS `attempts` (
   `start_time` BIGINT,
   `end_time` BIGINT,
   `reason` VARCHAR(40),
-  `added_to_per_day_rollups` BOOLEAN DEFAULT FALSE,
+  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(batch_id, job_id) ON DELETE CASCADE,
@@ -295,19 +295,6 @@ CREATE TABLE IF NOT EXISTS `batch_attributes` (
 ) ENGINE = InnoDB;
 CREATE INDEX batch_attributes_key_value ON `batch_attributes` (`key`, `value`(256));
 
-DROP TABLE IF EXISTS `aggregated_billing_project_user_resources`;
-CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources` (
-  `billing_project` VARCHAR(100) NOT NULL,
-  `user` VARCHAR(100) NOT NULL,
-  `resource_id` INT NOT NULL,
-  `token` INT NOT NULL,
-  `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
-  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
-  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
-) ENGINE = InnoDB;
-CREATE INDEX aggregated_billing_project_user_resources ON `aggregated_billing_project_user_resources` (`user`);
-
 CREATE TABLE IF NOT EXISTS `aggregated_billing_project_resources` (
   `billing_project` VARCHAR(100) NOT NULL,
   `resource` VARCHAR(100) NOT NULL,
@@ -318,20 +305,6 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_resources` (
   FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
-DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
-CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date` (
-  `billing_timestamp` DATE NOT NULL,
-  `billing_project` VARCHAR(100) NOT NULL,
-  `user` VARCHAR(100) NOT NULL,
-  `resource_id` INT NOT NULL,
-  `token` INT NOT NULL,
-  `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`billing_timestamp`, `billing_project`, `user`, `resource_id`, `token`),
-  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
-  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
-) ENGINE = InnoDB;
-CREATE INDEX aggregated_billing_project_user_resources_by_date_ts_user ON `aggregated_billing_project_user_resources_by_date` (`billing_timestamp`, `user`);
-
 CREATE TABLE IF NOT EXISTS `aggregated_batch_resources` (
   `batch_id` BIGINT NOT NULL,
   `resource` VARCHAR(100) NOT NULL,
@@ -340,18 +313,6 @@ CREATE TABLE IF NOT EXISTS `aggregated_batch_resources` (
   PRIMARY KEY (`batch_id`, `resource`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
-) ENGINE = InnoDB;
-
-DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
-CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_by_date` (
-  `batch_id` BIGINT NOT NULL,
-  `billing_timestamp` DATE NOT NULL,
-  `resource_id` INT NOT NULL,
-  `token` INT NOT NULL,
-  `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `billing_timestamp`, `resource_id`, `token`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
-  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `aggregated_job_resources` (
@@ -365,14 +326,51 @@ CREATE TABLE IF NOT EXISTS `aggregated_job_resources` (
   FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
-DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
-CREATE TABLE IF NOT EXISTS `aggregated_job_resources_by_date` (
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v2` (
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_v2 ON `aggregated_billing_project_user_resources_v2` (`user`);
+
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v2` (
+  `billing_timestamp` DATE NOT NULL,
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_timestamp`, `billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_by_date_v2_user ON `aggregated_billing_project_user_resources_by_date_v2` (`billing_timestamp`, `user`);
+
+DROP TABLE IF EXISTS `aggregated_batch_resources_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v2` (
+  `batch_id` BIGINT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `resource_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
+CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v2` (
   `batch_id` BIGINT NOT NULL,
   `job_id` INT NOT NULL,
-  `billing_timestamp` DATE NOT NULL,
   `resource_id` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `job_id`, `billing_timestamp`, `resource_id`),
+  PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -402,14 +400,7 @@ BEGIN
   END IF;
 END $$
 
-DROP TRIGGER IF EXISTS attempts_before_insert $$
-CREATE TRIGGER attempts_before_update AFTER UPDATE ON attempts
-FOR EACH ROW
-BEGIN
-  SET NEW.added_to_per_day_rollups = TRUE;
-END $$
-
-DROP TRIGGER IF EXISTS attempts_before_update;
+DROP TRIGGER IF EXISTS attempts_before_update $$
 CREATE TRIGGER attempts_before_update BEFORE UPDATE ON attempts
 FOR EACH ROW
 BEGIN
@@ -427,7 +418,7 @@ BEGIN
     SET NEW.reason = OLD.reason;
   END IF;
 
-  SET NEW.added_to_per_day_rollups = TRUE;
+  SET NEW.migrated = TRUE;
 END $$
 
 DROP TRIGGER IF EXISTS attempts_after_update $$
@@ -437,11 +428,11 @@ BEGIN
   DECLARE job_cores_mcpu INT;
   DECLARE cur_billing_project VARCHAR(100);
   DECLARE msec_diff BIGINT;
-  DECLARE msec_diff_by_date BIGINT;
+  DECLARE msec_diff_migration BIGINT;
   DECLARE cur_n_tokens INT;
+  DECLARE cur_n_batch_jobs INT;
   DECLARE rand_token INT;
-  DECLARE rand_token_by_date INT;
-  DECLARE cur_prev_agg_by_date BOOLEAN;
+  DECLARE rand_token_migration INT;
   DECLARE cur_billing_timestamp DATE;
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
@@ -450,92 +441,86 @@ BEGIN
   SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
 
-  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+  SELECT billing_project, n_jobs INTO cur_billing_project, cur_n_batch_jobs FROM batches WHERE id = NEW.batch_id;
 
   SET msec_diff = (GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0) -
                    GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
 
-  SET cur_billing_timestamp = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
+  IF msec_diff != 0 THEN
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
-  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-  SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
-  FROM attempt_resources
-  JOIN batches ON batches.id = attempt_resources.batch_id
-  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
-  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
-  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-  SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
-  FROM attempt_resources
-  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
-  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    SELECT batch_id, job_id, resources.resource, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+  END IF;
 
-  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-  SELECT batch_id, job_id, resources.resource, msec_diff * quantity
-  FROM attempt_resources
-  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
-  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+  IF NOT OLD.migrated THEN
+    SET msec_diff_migration = GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0);
+    SET rand_token_migration = NEW.batch_id DIV 100000 + NEW.job_id DIV 100000;
+  ELSE
+    SET msec_diff_migration = msec_diff;
+    SET rand_token_migration = rand_token;
+  END IF;
 
-  IF NEW.end_time IS NOT NULL THEN
-    SELECT attempts_aggregated_by_date.batch_id IS NOT NULL INTO cur_prev_agg_by_date
-    FROM attempts
-    LEFT JOIN attempts_aggregated_by_date
-      ON attempts.batch_id = attempts_aggregated_by_date.batch_id AND
-        attempts.job_id = attempts_aggregated_by_date.job_id AND
-        attempts.attempt_id = attempts_aggregated_by_date.attempt_id
-    WHERE attempts.batch_id = NEW.batch_id AND attempts.job_id = NEW.job_id AND attempts.attempt_id = NEW.attempt_id;
-
-    IF NOT OLD.added_to_per_day_rollups THEN
-      SET msec_diff_by_date = GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0);
-      SET rand_token_by_date = 0;
-    ELSE
-      SET msec_diff_by_date = msec_diff;
-      SET rand_token_by_date = rand_token;
-    END IF;
-
-    INSERT INTO aggregated_billing_project_user_resources (billing_project, user, resource_id, token, `usage`)
+  IF msec_diff_migration != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
     SELECT billing_project, `user`,
       resource_id,
-      rand_token,
-      msec_diff_by_date * quantity
+      rand_token_migration,
+      msec_diff_migration * quantity
     FROM attempt_resources
     JOIN batches ON batches.id = attempt_resources.batch_id
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
 
-    INSERT INTO aggregated_billing_project_user_resources_by_date (billing_timestamp, billing_project, user, resource_id, token, `usage`)
-    SELECT cur_billing_timestamp,
-      billing_project,
-      `user`,
-      resource_id,
-      rand_token_by_date,
-      msec_diff_by_date * quantity
-    FROM attempt_resources
-    JOIN batches ON batches.id = attempt_resources.batch_id
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
-
-    INSERT INTO aggregated_batch_resources_by_date (batch_id, billing_timestamp, resource_id, token, `usage`)
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
-      cur_billing_timestamp,
       resource_id,
-      rand_token_by_date,
-      msec_diff_by_date * quantity
+      rand_token_migration,
+      msec_diff_migration * quantity
     FROM attempt_resources
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
 
-    INSERT INTO aggregated_job_resources_by_date (batch_id, job_id, billing_timestamp, resource_id, `usage`)
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
-      cur_billing_timestamp,
       resource_id,
-      msec_diff_by_date * quantity
+      msec_diff_migration * quantity
     FROM attempt_resources
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_by_date * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
+
+    IF NEW.end_time IS NOT NULL THEN
+      SET cur_billing_timestamp = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
+
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_timestamp, billing_project, user, resource_id, token, `usage`)
+      SELECT cur_billing_timestamp,
+        billing_project,
+        `user`,
+        resource_id,
+        rand_token_migration,
+        msec_diff_migration * quantity
+      FROM attempt_resources
+      JOIN batches ON batches.id = attempt_resources.batch_id
+      WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+      ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_migration * quantity;
+    END IF;
   END IF;
 END $$
 
@@ -725,10 +710,10 @@ BEGIN
   SELECT billing_project, user INTO cur_billing_project, cur_user
   FROM batches WHERE id = NEW.batch_id;
 
-  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
-
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
   SELECT start_time, end_time INTO cur_start_time, cur_end_time
   FROM attempts
@@ -739,41 +724,43 @@ BEGIN
 
   SET cur_billing_timestamp = CAST(FROM_UNIXTIME(cur_end_time / 1000) AS DATE);
 
-  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  INSERT INTO aggregated_billing_project_user_resources (billing_project, user, resource_id, token, `usage`)
-  VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
-  ON DUPLICATE KEY UPDATE
-    `usage` = `usage` + NEW.quantity * msec_diff;
-
-  IF cur_billing_timestamp IS NOT NULL THEN
-    INSERT INTO aggregated_billing_project_user_resources_by_date (billing_timestamp, billing_project, user, resource_id, token, `usage`)
-    VALUES (cur_billing_timestamp, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+  IF msec_diff != 0 THEN
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
 
-    INSERT INTO aggregated_batch_resources_by_date (batch_id, billing_timestamp, resource_id, token, `usage`)
-    VALUES (NEW.batch_id, cur_billing_timestamp, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
 
-    INSERT INTO aggregated_job_resources_by_date (batch_id, job_id, billing_timestamp, resource_id, `usage`)
-    VALUES (NEW.batch_id, NEW.job_id, cur_billing_timestamp, NEW.resource_id, NEW.quantity * msec_diff)
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    IF cur_billing_timestamp IS NOT NULL THEN
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_timestamp, billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_timestamp, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff;
+    END IF;
   END IF;
 END $$
 

--- a/batch/sql/populate_agg_billing_by_date.py
+++ b/batch/sql/populate_agg_billing_by_date.py
@@ -63,7 +63,7 @@ async def process_chunk(counter, db, start_offset, end_offset, quiet=True):
     await db.just_execute(
         f'''
 UPDATE attempts
-SET dummy_aggregated_by_date = dummy_aggregated_by_date + 1
+SET added_to_per_day_rollups = TRUE
 {where_cond}
 ''',
         query_args)

--- a/batch/sql/populate_agg_billing_by_date.py
+++ b/batch/sql/populate_agg_billing_by_date.py
@@ -1,0 +1,251 @@
+import asyncio
+import functools
+import os
+import random
+import time
+from typing import List, Optional, Tuple
+
+from gear import Database, transaction
+from hailtop.utils import bounded_gather
+
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+
+def offsets_to_where_statement(start_offset, end_offset):
+    assert start_offset != end_offset, str((start_offset, end_offset))
+
+    if start_offset is None:
+        start_batch_id, start_job_id, start_attempt_id = None, None, None
+    else:
+        start_batch_id, start_job_id, start_attempt_id = start_offset
+
+    if end_offset is None:
+        end_batch_id, end_job_id, end_attempt_id = None, None, None
+    else:
+        end_batch_id, end_job_id, end_attempt_id = end_offset
+
+    if start_batch_id is None or start_job_id is None or start_attempt_id is None:
+        assert end_batch_id
+        where_cond = 'WHERE attempts.batch_id < %s OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id < %s) OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id < %s)'
+        query_args = (end_batch_id, end_batch_id, end_job_id, end_batch_id, end_job_id, end_attempt_id)
+    elif end_batch_id is None or end_job_id is None or end_attempt_id is None:
+        assert start_batch_id
+        where_cond = 'WHERE attempts.batch_id > %s OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id > %s) OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id >= %s)'
+        query_args = (start_batch_id, start_batch_id, start_job_id, start_batch_id, start_job_id, start_attempt_id)
+    else:
+        where_cond = 'WHERE (attempts.batch_id > %s OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id > %s) OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id >= %s)) ' \
+                     'AND (attempts.batch_id < %s OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id < %s) OR ' \
+                     '(attempts.batch_id = %s AND attempts.job_id = %s AND attempts.attempt_id < %s))'
+        query_args = (start_batch_id, start_batch_id, start_job_id, start_batch_id, start_job_id, start_attempt_id,
+                      end_batch_id, end_batch_id, end_job_id, end_batch_id, end_job_id, end_attempt_id)
+
+    return (where_cond, query_args)
+
+
+async def process_chunk(counter, db, start_offset, end_offset, quiet=True):
+    start_time = time.time()
+
+    where_cond, query_args = offsets_to_where_statement(start_offset, end_offset)
+
+    await db.just_execute(
+        f'''
+UPDATE attempts
+SET dummy_aggregated_by_date = dummy_aggregated_by_date + 1
+{where_cond}
+''',
+        query_args)
+
+    if not quiet and counter.n % 100 == 0:
+        print(f'processed chunk ({start_offset}, {end_offset}) in {time.time() - start_time}s')
+
+    counter.n += 1
+    if counter.n % 500 == 0:
+        print(f'processed {counter.n} complete chunks')
+
+
+async def audit_changes(db):
+    job_audit_start = time.time()
+    print('starting auditing job records')
+
+    bad_job_records = db.select_and_fetchall(
+        '''
+SELECT old.batch_id, old.job_id, old.cost, new.cost, ABS(new.cost - old.cost) AS cost_diff
+FROM (
+  SELECT batch_id, job_id, COALESCE(SUM(`usage` * rate), 0) AS cost
+  FROM aggregated_job_resources
+  LEFT JOIN batches ON batches.id = aggregated_job_resources.batch_id
+  LEFT JOIN resources ON aggregated_job_resources.resource = resources.resource
+  WHERE format_version >= 3
+  GROUP BY batch_id, job_id
+) AS old
+LEFT JOIN (
+  SELECT batch_id, job_id, COALESCE(SUM(`usage` * rate), 0) AS cost
+  FROM aggregated_job_resources_by_date
+  LEFT JOIN resources ON aggregated_job_resources_by_date.resource_id = resources.resource_id
+  GROUP BY batch_id, job_id
+) AS new ON old.batch_id = new.batch_id AND old.job_id = new.job_id
+WHERE ABS(new.cost - old.cost) >= 0.00001
+LIMIT 100;
+''')
+
+    bad_job_records = [record async for record in bad_job_records]
+    failing_job_ids = []
+    for record in bad_job_records:
+        print(f'found bad job record {record}')
+
+        # we had a bug in billing for job private instances that failed to activate
+        # this was fixed in #10069
+        maybe_bad_record = await db.select_and_fetchone(
+            '''
+SELECT * FROM attempts
+WHERE batch_id = %s AND job_id = %s AND reason = "activation_timeout"
+LIMIT 10;
+''',
+            (record['batch_id'], record['job_id']))
+        if not maybe_bad_record:
+            failing_job_ids.append((record['batch_id'], record['job_id']))
+
+    print(f'finished auditing job records in {time.time() - job_audit_start}s')
+
+    batch_audit_start = time.time()
+    print('starting auditing batch records')
+
+    bad_batch_records = db.select_and_fetchall(
+        '''
+SELECT old.batch_id, old.cost, new.cost, ABS(new.cost - old.cost) AS cost_diff
+FROM (
+  SELECT batch_id, COALESCE(SUM(`usage` * rate), 0) AS cost
+  FROM aggregated_batch_resources
+  LEFT JOIN batches ON batches.id = aggregated_batch_resources.batch_id
+  LEFT JOIN resources ON aggregated_batch_resources.resource = resources.resource
+  WHERE format_version >= 3
+  GROUP BY batch_id
+) AS old
+LEFT JOIN (
+  SELECT batch_id, COALESCE(SUM(`usage` * rate), 0) AS cost
+  FROM aggregated_batch_resources_by_date
+  LEFT JOIN resources ON aggregated_batch_resources_by_date.resource_id = resources.resource_id
+  GROUP BY batch_id
+) AS new ON old.batch_id = new.batch_id
+WHERE ABS(new.cost - old.cost) >= 0.00001
+LIMIT 100;
+''')
+
+    bad_batch_records = [record async for record in bad_batch_records]
+    failing_batch_ids = []
+    for record in bad_batch_records:
+        print(f'found bad batch record {record}')
+
+        # we had a bug in billing for job private instances that failed to activate
+        # this was fixed in #10069
+        maybe_bad_record = await db.select_and_fetchone(
+            '''
+SELECT * FROM attempts
+WHERE batch_id = %s AND reason = "activation_timeout"
+LIMIT 10;
+''',
+            (record['batch_id'],))
+        if not maybe_bad_record:
+            failing_batch_ids.append(record['batch_id'])
+
+    print(f'finished auditing batch records in {time.time() - batch_audit_start}s')
+
+    # cannot audit billing project records because they are partially filled in from batches with format version < 3
+
+    if failing_job_ids or failing_batch_ids:
+        raise Exception(f'errors found in audit')
+
+
+async def find_chunk_offsets(db, size):
+    @transaction(db)
+    async def _find_chunks(tx) -> List[Optional[Tuple[int, int, str]]]:
+        start_time = time.time()
+
+        await tx.just_execute('SET @rank=0;')
+
+        query = f'''
+SELECT t.batch_id, t.job_id, t.attempt_id FROM (
+  SELECT batch_id, job_id, attempt_id
+  FROM attempts
+  ORDER BY batch_id, job_id, attempt_id
+) AS t
+WHERE MOD((@rank := @rank + 1), %s) = 0;
+'''
+
+        offsets = tx.execute_and_fetchall(query, (size,))
+        offsets = [(offset['batch_id'], offset['job_id'], offset['attempt_id']) async for offset in offsets]
+        offsets.append(None)
+
+        print(f'found chunk offsets in {round(time.time() - start_time, 4)}s')
+        return offsets
+
+    return await _find_chunks()
+
+
+async def main(chunk_size=100):
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    start_time = time.time()
+
+    try:
+        populate_start_time = time.time()
+
+        chunk_counter = Counter()
+        chunk_offsets = [None]
+        for offset in await find_chunk_offsets(db, chunk_size):
+            chunk_offsets.append(offset)
+
+        chunk_offsets = list(zip(chunk_offsets[:-1], chunk_offsets[1:]))
+
+        if chunk_offsets != [(None, None)]:
+            print(f'found {len(chunk_offsets)} chunks to process')
+
+            random.shuffle(chunk_offsets)
+
+            burn_in_start = time.time()
+            n_burn_in_chunks = 1000
+
+            burn_in_chunk_offsets = chunk_offsets[:n_burn_in_chunks]
+            chunk_offsets = chunk_offsets[n_burn_in_chunks:]  # processing a chunk is not idempotent
+
+            for start_offset, end_offset in burn_in_chunk_offsets:
+                await process_chunk(chunk_counter, db, start_offset, end_offset)
+
+            print(f'finished burn-in in {time.time() - burn_in_start}s')
+
+            parallel_insert_start = time.time()
+
+            # 4 core database, parallelism = 10 maxes out CPU
+            await bounded_gather(
+                *[functools.partial(process_chunk, chunk_counter, db, start_offset, end_offset, quiet=False)
+                  for start_offset, end_offset in chunk_offsets],
+                parallelism=10
+            )
+            print(f'took {time.time() - parallel_insert_start}s to insert the remaining complete records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_insert_start)}) attempts / sec')
+
+        print(f'finished populating records in {time.time() - populate_start_time}s')
+
+        audit_start_time = time.time()
+        await audit_changes(db)
+        print(f'finished auditing changes in {time.time() - audit_start_time}')
+    finally:
+        print(f'finished migration in {time.time() - start_time}s')
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/build.yaml
+++ b/build.yaml
@@ -2049,6 +2049,12 @@ steps:
       - name: revert-attempt-resources-trigger-back-compat
         script: /io/sql/revert-attempt-resources-trigger-back-compat.sql
         online: true
+      - name: add-agg-billing-by-date
+        script: /io/sql/add-agg-billing-by-date.sql
+        online: true
+      - name: populate-agg-billing-by-date
+        script: /io/sql/populate_agg_billing_by_date.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Stacked on #11995 

This PR creates all of the new `aggregated_*_resources_by_date` tables that will be used for real time billing and making our billing queries fast and also populates them! It will probably run for ~7-8 hours (online migration) and add an estimated 200 GB to the database. It will take around 5-6 hours to populate the tables and the remainder of the time is doing an audit.

I think we should whiteboard what is going on in person, but the general idea is as follows:
1. Revert any previous work and set the trigger back to the original state (idempotent)
2. Find the latest complete or open batch id. We know that a complete batch will not have updates to the attempts table. This is extremely important because the next steps can be done in parallel rather than serially.
3. Find offsets for complete batches up to the batch id from Step 1 in groups of 100 attempts
4. Randomize the offsets and have a burn in period of 5000 to avoid the birthday problem where we populate the `aggregated_*_resources_by_date` tables.
5. In 10-way parallelism (maxes out a 4 core database), randomly populate the tables for each chunk.
6. From the last offset (original first running batch id), we sequentially process attempts in groups of 100. We take note of where we are at with tracking any updates to the attempts table (`attempts_time_msecs_diff`), populate the `aggregated_*_resources_by_date` tables, and then do a final catchup step where we apply any updates from `attempts_time_msecs_diff` for any attempts that we have already processed.
7. Once we have reached the "end" of the attempts table, we lock all tables of interest especially the `attempts` table, and do one last final processing step before we add the new triggers that will auto-populate the `aggregated_*_resources_by_date` tables.
8. Then we perform an audit and make sure things look correct. (I might need to change or eliminate the billing_project audit query because there are 5 batches with ~20 jobs that aren't perfectly tracked when we did the original switch over to the new billing tables).
9. If there are any failures, we revert the triggers back to the original state.

Also to note, is the new table for billing_projects is keyed by (billing_project, user) which will make queries much faster so they don't have to scan the batches aggregated resources table.

I ran the migration successfully on a full test database and the audit was clean for jobs and batches except for the 5 batches that were running right when we started populating the original aggregated billing tables. 

I'd like to gather all feedback and then will run the migration one more time to do a final test.

Note, that most of the queries in the migration are not tested.

The key thing to double check is the triggers will continue to insert data into the old tables and we get the end points correct (start is inclusive and end is exclusive) as unlike the previous migration, this set of updates is NOT idempotent. 

