### PR TITLE
[batch] Add real time billing!

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -387,23 +387,24 @@ async def billing_update_1(request, instance):
     update_timestamp = body['timestamp']
     running_attempts = body['attempts']
 
-    where_attempt_query = []
-    where_attempt_args = []
-    for attempt in running_attempts:
-        where_attempt_query.append('(batch_id = %s AND job_id = %s AND attempt_id = %s)')
-        where_attempt_args.append([attempt['batch_id'], attempt['job_id'], attempt['attempt_id']])
+    if running_attempts:
+        where_attempt_query = []
+        where_attempt_args = []
+        for attempt in running_attempts:
+            where_attempt_query.append('(batch_id = %s AND job_id = %s AND attempt_id = %s)')
+            where_attempt_args.append([attempt['batch_id'], attempt['job_id'], attempt['attempt_id']])
 
-    where_query = f'WHERE {" OR ".join(where_attempt_query)}'
-    where_args = [update_timestamp] + flatten(where_attempt_args)
+        where_query = f'WHERE {" OR ".join(where_attempt_query)}'
+        where_args = [update_timestamp] + flatten(where_attempt_args)
 
-    await db.execute_many(
-        f'''
+        await db.execute_many(
+            f'''
 UPDATE attempts
 SET rollup_time = %s
 {where_query};
 ''',
-        where_args,
-    )
+            where_args,
+        )
 
     await instance.mark_healthy()
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2718,14 +2718,15 @@ class Worker:
                     }
                 )
 
-            billing_update_data = {'timestamp': update_timestamp, 'attempts': running_attempts}
+            if running_attempts:
+                billing_update_data = {'timestamp': update_timestamp, 'attempts': running_attempts}
 
-            await self.client_session.post(
-                deploy_config.url('batch-driver', '/api/v1alpha/billing_update'),
-                json=billing_update_data,
-                headers=self.headers,
-            )
-            log.info(f'sent billing update for {time_msecs_str(update_timestamp)}')
+                await self.client_session.post(
+                    deploy_config.url('batch-driver', '/api/v1alpha/billing_update'),
+                    json=billing_update_data,
+                    headers=self.headers,
+                )
+                log.info(f'sent billing update for {time_msecs_str(update_timestamp)}')
 
         await retry_transient_errors(update)
 

--- a/batch/sql/add-real-time-billing.sql
+++ b/batch/sql/add-real-time-billing.sql
@@ -1,0 +1,510 @@
+ALTER TABLE attempts ADD COLUMN rollup_time BIGINT, ALGORITHM=INSTANT;
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_before_update;
+CREATE TRIGGER attempts_before_update BEFORE UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  IF OLD.start_time IS NOT NULL AND (NEW.start_time IS NULL OR OLD.start_time < NEW.start_time) THEN
+    SET NEW.start_time = OLD.start_time;
+  END IF;
+
+  # for job private instances that do not finish creating
+  IF NEW.reason = 'activation_timeout' THEN
+    SET NEW.start_time = NULL;
+  END IF;
+
+  IF OLD.reason IS NOT NULL AND (OLD.end_time IS NULL OR NEW.end_time IS NULL OR NEW.end_time >= OLD.end_time) THEN
+    SET NEW.end_time = OLD.end_time;
+    SET NEW.reason = OLD.reason;
+  END IF;
+
+  # rollup_time should not go backward in time
+  # this could happen if MJS happens after the billing update is received
+  IF NEW.rollup_time IS NOT NULL AND OLD.rollup_time IS NOT NULL AND NEW.rollup_time < OLD.rollup_time THEN
+    SET NEW.rollup_time = OLD.rollup_time;
+  END IF;
+
+  # rollup_time should never be less than the start time
+  IF NEW.rollup_time IS NOT NULL AND NEW.start_time IS NOT NULL AND NEW.rollup_time < NEW.start_time THEN
+    SET NEW.rollup_time = OLD.rollup_time;
+  END IF;
+
+  # rollup_time should never be greater than the end time
+  IF NEW.rollup_time IS NOT NULL AND NEW.end_time IS NOT NULL AND NEW.rollup_time > NEW.end_time THEN
+    SET NEW.rollup_time = NEW.end_time;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS attempts_after_update $$
+CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  DECLARE job_cores_mcpu INT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_billing_date DATE;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SET msec_diff = (GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0) -
+                   GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
+
+  SET msec_diff_rollup = (GREATEST(COALESCE(NEW.rollup_time - NEW.start_time, 0), 0) -
+                          GREATEST(COALESCE(OLD.rollup_time - OLD.start_time, 0), 0));
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff != 0 THEN
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    SELECT batch_id, job_id, resources.resource, msec_diff * quantity
+    FROM attempt_resources
+    LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+  END IF;
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    SELECT attempt_resources.batch_id,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+      resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      billing_project,
+      `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_rollup_time BIGINT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE cur_user VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_resource VARCHAR(100);
+  DECLARE cur_billing_date DATE;
+
+  SELECT billing_project, user INTO cur_billing_project, cur_user
+  FROM batches WHERE id = NEW.batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+
+  SELECT start_time, end_time, rollup_time INTO cur_start_time, cur_end_time, cur_rollup_time
+
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+  SET msec_diff_rollup = GREATEST(COALESCE(cur_rollup_time - cur_start_time, 0), 0);
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff != 0 THEN
+    INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+    VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+    VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+
+    INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff;
+  END IF;
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    IF cur_billing_date IS NOT NULL THEN
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS deactivate_instance $$
+CREATE PROCEDURE deactivate_instance(
+  IN in_instance_name VARCHAR(100),
+  IN in_reason VARCHAR(40),
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_state VARCHAR(40);
+
+  START TRANSACTION;
+
+  SELECT state INTO cur_state FROM instances WHERE name = in_instance_name FOR UPDATE;
+
+  UPDATE instances
+  SET time_deactivated = in_timestamp
+  WHERE name = in_instance_name;
+
+  UPDATE attempts
+  SET rollup_time = in_timestamp, end_time = in_timestamp, reason = in_reason
+  WHERE instance_name = in_instance_name;
+
+  IF cur_state = 'pending' or cur_state = 'active' THEN
+    UPDATE jobs
+    INNER JOIN attempts ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id AND jobs.attempt_id = attempts.attempt_id
+    SET state = 'Ready',
+        jobs.attempt_id = NULL
+    WHERE instance_name = in_instance_name AND (state = 'Running' OR state = 'Creating');
+
+    UPDATE instances, instances_free_cores_mcpu
+    SET state = 'inactive',
+        free_cores_mcpu = cores_mcpu
+    WHERE instances.name = in_instance_name
+      AND instances.name = instances_free_cores_mcpu.name;
+
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    ROLLBACK;
+    SELECT 1 as rc, cur_state, 'state not live (active or pending)' as message;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS unschedule_job $$
+CREATE PROCEDURE unschedule_job(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_end_time BIGINT,
+  IN new_reason VARCHAR(40)
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_attempt_id VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE delta_cores_mcpu INT DEFAULT 0;
+
+  START TRANSACTION;
+
+  SELECT state, cores_mcpu, attempt_id
+  INTO cur_job_state, cur_cores_mcpu, cur_attempt_id
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  SELECT end_time INTO cur_end_time
+  FROM attempts
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id
+  FOR UPDATE;
+
+  UPDATE attempts
+  SET rollup_time = new_end_time, end_time = new_end_time, reason = new_reason
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+
+  IF cur_instance_state = 'active' AND cur_end_time IS NULL THEN
+    UPDATE instances_free_cores_mcpu
+    SET free_cores_mcpu = free_cores_mcpu + cur_cores_mcpu
+    WHERE instances_free_cores_mcpu.name = in_instance_name;
+
+    SET delta_cores_mcpu = cur_cores_mcpu;
+  END IF;
+
+  IF (cur_job_state = 'Creating' OR cur_job_state = 'Running') AND cur_attempt_id = in_attempt_id THEN
+    UPDATE jobs SET state = 'Ready', attempt_id = NULL WHERE batch_id = in_batch_id AND job_id = in_job_id;
+    COMMIT;
+    SELECT 0 as rc, delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc, cur_job_state, delta_cores_mcpu,
+      'job state not Running or Creating or wrong attempt id' as message;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS mark_job_creating $$
+CREATE PROCEDURE mark_job_creating(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_start_time BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_job_cancel BOOLEAN;
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE delta_cores_mcpu INT;
+
+  START TRANSACTION;
+
+  SELECT state, cores_mcpu
+  INTO cur_job_state, cur_cores_mcpu
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  SELECT (jobs.cancelled OR batches_cancelled.id IS NOT NULL) AND NOT jobs.always_run
+  INTO cur_job_cancel
+  FROM jobs
+  LEFT JOIN batches_cancelled ON batches_cancelled.id = jobs.batch_id
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  LOCK IN SHARE MODE;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  UPDATE attempts SET start_time = new_start_time, rollup_time = new_start_time
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+
+  IF cur_job_state = 'Ready' AND NOT cur_job_cancel AND cur_instance_state = 'pending' THEN
+    UPDATE jobs SET state = 'Creating', attempt_id = in_attempt_id WHERE batch_id = in_batch_id AND job_id = in_job_id;
+  END IF;
+
+  COMMIT;
+  SELECT 0 as rc, delta_cores_mcpu;
+END $$
+
+DROP PROCEDURE IF EXISTS mark_job_started $$
+CREATE PROCEDURE mark_job_started(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_start_time BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_job_cancel BOOLEAN;
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE delta_cores_mcpu INT;
+
+  START TRANSACTION;
+
+  SELECT state, cores_mcpu
+  INTO cur_job_state, cur_cores_mcpu
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  SELECT (jobs.cancelled OR batches_cancelled.id IS NOT NULL) AND NOT jobs.always_run
+  INTO cur_job_cancel
+  FROM jobs
+  LEFT JOIN batches_cancelled ON batches_cancelled.id = jobs.batch_id
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  LOCK IN SHARE MODE;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  UPDATE attempts SET start_time = new_start_time, rollup_time = new_start_time
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+
+  IF cur_job_state = 'Ready' AND NOT cur_job_cancel AND cur_instance_state = 'active' THEN
+    UPDATE jobs SET state = 'Running', attempt_id = in_attempt_id WHERE batch_id = in_batch_id AND job_id = in_job_id;
+  END IF;
+
+  COMMIT;
+  SELECT 0 as rc, delta_cores_mcpu;
+END $$
+
+DROP PROCEDURE IF EXISTS mark_job_complete $$
+CREATE PROCEDURE mark_job_complete(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_state VARCHAR(40),
+  IN new_status TEXT,
+  IN new_start_time BIGINT,
+  IN new_end_time BIGINT,
+  IN new_reason VARCHAR(40),
+  IN new_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE delta_cores_mcpu INT DEFAULT 0;
+  DECLARE total_jobs_in_batch INT;
+  DECLARE expected_attempt_id VARCHAR(40);
+
+  START TRANSACTION;
+
+  SELECT n_jobs INTO total_jobs_in_batch FROM batches WHERE id = in_batch_id;
+
+  SELECT state, cores_mcpu
+  INTO cur_job_state, cur_cores_mcpu
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  SELECT end_time INTO cur_end_time FROM attempts
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id
+  FOR UPDATE;
+
+  UPDATE attempts
+  SET start_time = new_start_time, rollup_time = new_end_time, end_time = new_end_time, reason = new_reason
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+  IF cur_instance_state = 'active' AND cur_end_time IS NULL THEN
+    UPDATE instances_free_cores_mcpu
+    SET free_cores_mcpu = free_cores_mcpu + cur_cores_mcpu
+    WHERE instances_free_cores_mcpu.name = in_instance_name;
+
+    SET delta_cores_mcpu = delta_cores_mcpu + cur_cores_mcpu;
+  END IF;
+
+  SELECT attempt_id INTO expected_attempt_id FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  IF expected_attempt_id IS NOT NULL AND expected_attempt_id != in_attempt_id THEN
+    COMMIT;
+    SELECT 2 as rc,
+      expected_attempt_id,
+      delta_cores_mcpu,
+      'input attempt id does not match expected attempt id' as message;
+  ELSEIF cur_job_state = 'Ready' OR cur_job_state = 'Creating' OR cur_job_state = 'Running' THEN
+    UPDATE jobs
+    SET state = new_state, status = new_status, attempt_id = in_attempt_id
+    WHERE batch_id = in_batch_id AND job_id = in_job_id;
+
+    UPDATE batches_n_jobs_in_complete_states
+      SET n_completed = (@new_n_completed := n_completed + 1),
+          n_cancelled = n_cancelled + (new_state = 'Cancelled'),
+          n_failed    = n_failed + (new_state = 'Error' OR new_state = 'Failed'),
+          n_succeeded = n_succeeded + (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed')
+      WHERE id = in_batch_id;
+
+    # Grabbing an exclusive lock on batches here could deadlock,
+    # but this IF should only execute for the last job
+    IF @new_n_completed = total_jobs_in_batch THEN
+      UPDATE batches
+      SET time_completed = new_timestamp,
+          `state` = 'complete'
+      WHERE id = in_batch_id;
+    END IF;
+
+    UPDATE jobs
+      INNER JOIN `job_parents`
+        ON jobs.batch_id = `job_parents`.batch_id AND
+           jobs.job_id = `job_parents`.job_id
+      SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
+          jobs.n_pending_parents = jobs.n_pending_parents - 1,
+          jobs.cancelled = IF(new_state = 'Success', jobs.cancelled, 1)
+      WHERE jobs.batch_id = in_batch_id AND
+            `job_parents`.batch_id = in_batch_id AND
+            `job_parents`.parent_id = in_job_id;
+
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSEIF cur_job_state = 'Cancelled' OR cur_job_state = 'Error' OR
+         cur_job_state = 'Failed' OR cur_job_state = 'Success' THEN
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc,
+      cur_job_state,
+      delta_cores_mcpu,
+      'job state not Ready, Creating, Running or complete' as message;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/batch/sql/add-real-time-billing.sql
+++ b/batch/sql/add-real-time-billing.sql
@@ -156,7 +156,6 @@ BEGIN
   SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
   SELECT start_time, end_time, rollup_time INTO cur_start_time, cur_end_time, cur_rollup_time
-
   FROM attempts
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   LOCK IN SHARE MODE;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -247,6 +247,7 @@ CREATE TABLE IF NOT EXISTS `attempts` (
   `attempt_id` VARCHAR(40) NOT NULL,
   `instance_name` VARCHAR(100),
   `start_time` BIGINT,
+  `rollup_time` BIGINT,
   `end_time` BIGINT,
   `reason` VARCHAR(40),
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`),
@@ -416,6 +417,22 @@ BEGIN
     SET NEW.end_time = OLD.end_time;
     SET NEW.reason = OLD.reason;
   END IF;
+
+  # rollup_time should not go backward in time
+  # this could happen if MJS happens after the billing update is received
+  IF NEW.rollup_time IS NOT NULL AND OLD.rollup_time IS NOT NULL AND NEW.rollup_time < OLD.rollup_time THEN
+    SET NEW.rollup_time = OLD.rollup_time;
+  END IF;
+
+  # rollup_time should never be less than the start time
+  IF NEW.rollup_time IS NOT NULL AND NEW.start_time IS NOT NULL AND NEW.rollup_time < NEW.start_time THEN
+    SET NEW.rollup_time = OLD.rollup_time;
+  END IF;
+
+  # rollup_time should never be greater than the end time
+  IF NEW.rollup_time IS NOT NULL AND NEW.end_time IS NOT NULL AND NEW.rollup_time > NEW.end_time THEN
+    SET NEW.rollup_time = NEW.end_time;
+  END IF;
 END $$
 
 DROP TRIGGER IF EXISTS attempts_after_update $$
@@ -425,6 +442,7 @@ BEGIN
   DECLARE job_cores_mcpu INT;
   DECLARE cur_billing_project VARCHAR(100);
   DECLARE msec_diff BIGINT;
+  DECLARE msec_diff_rollup BIGINT;
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
   DECLARE cur_billing_date DATE;
@@ -439,6 +457,11 @@ BEGIN
 
   SET msec_diff = (GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0) -
                    GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
+
+  SET msec_diff_rollup = (GREATEST(COALESCE(NEW.rollup_time - NEW.start_time, 0), 0) -
+                          GREATEST(COALESCE(OLD.rollup_time - OLD.start_time, 0), 0));
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
 
   IF msec_diff != 0 THEN
     INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
@@ -462,49 +485,47 @@ BEGIN
     LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+  END IF;
 
+  IF msec_diff_rollup != 0 THEN
     INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
     SELECT billing_project, `user`,
       resource_id,
       rand_token,
-      msec_diff * quantity
+      msec_diff_rollup * quantity
     FROM attempt_resources
     JOIN batches ON batches.id = attempt_resources.batch_id
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
       resource_id,
       rand_token,
-      msec_diff * quantity
+      msec_diff_rollup * quantity
     FROM attempt_resources
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
       resource_id,
-      msec_diff * quantity
+      msec_diff_rollup * quantity
     FROM attempt_resources
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
-    IF NEW.end_time IS NOT NULL THEN
-      SET cur_billing_date = CAST(FROM_UNIXTIME(NEW.end_time / 1000) AS DATE);
-
-      INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
-      SELECT cur_billing_date,
-        billing_project,
-        `user`,
-        resource_id,
-        rand_token,
-        msec_diff * quantity
-      FROM attempt_resources
-      JOIN batches ON batches.id = attempt_resources.batch_id
-      WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
-      ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
-    END IF;
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      billing_project,
+      `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
   END IF;
 END $$
 
@@ -682,10 +703,12 @@ CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
 FOR EACH ROW
 BEGIN
   DECLARE cur_start_time BIGINT;
+  DECLARE cur_rollup_time BIGINT;
   DECLARE cur_end_time BIGINT;
   DECLARE cur_billing_project VARCHAR(100);
   DECLARE cur_user VARCHAR(100);
   DECLARE msec_diff BIGINT;
+  DECLARE msec_diff_rollup BIGINT;
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
   DECLARE cur_resource VARCHAR(100);
@@ -699,14 +722,16 @@ BEGIN
 
   SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
-  SELECT start_time, end_time INTO cur_start_time, cur_end_time
+  SELECT start_time, end_time, rollup_time INTO cur_start_time, cur_end_time, cur_rollup_time
+
   FROM attempts
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   LOCK IN SHARE MODE;
 
   SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+  SET msec_diff_rollup = GREATEST(COALESCE(cur_rollup_time - cur_start_time, 0), 0);
 
-  SET cur_billing_date = CAST(FROM_UNIXTIME(cur_end_time / 1000) AS DATE);
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
 
   IF msec_diff != 0 THEN
     INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
@@ -723,27 +748,29 @@ BEGIN
     VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff;
+  END IF;
 
+  IF msec_diff_rollup != 0 THEN
     INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
-    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.quantity * msec_diff;
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
-    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.quantity * msec_diff;
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
-    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.quantity * msec_diff;
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
     IF cur_billing_date IS NOT NULL THEN
       INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
-      VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff)
+      VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
-        `usage` = `usage` + NEW.quantity * msec_diff;
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
     END IF;
   END IF;
 END $$
@@ -874,7 +901,7 @@ BEGIN
   WHERE name = in_instance_name;
 
   UPDATE attempts
-  SET end_time = in_timestamp, reason = in_reason
+  SET rollup_time = in_timestamp, end_time = in_timestamp, reason = in_reason
   WHERE instance_name = in_instance_name;
 
   IF cur_state = 'pending' or cur_state = 'active' THEN
@@ -1180,7 +1207,7 @@ BEGIN
   FOR UPDATE;
 
   UPDATE attempts
-  SET end_time = new_end_time, reason = new_reason
+  SET rollup_time = new_end_time, end_time = new_end_time, reason = new_reason
   WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
 
   SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
@@ -1236,7 +1263,7 @@ BEGIN
 
   CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
 
-  UPDATE attempts SET start_time = new_start_time
+  UPDATE attempts SET start_time = new_start_time, rollup_time = new_start_time
   WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
 
   SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
@@ -1281,7 +1308,7 @@ BEGIN
 
   CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
 
-  UPDATE attempts SET start_time = new_start_time
+  UPDATE attempts SET start_time = new_start_time, rollup_time = new_start_time
   WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
 
   SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
@@ -1333,7 +1360,7 @@ BEGIN
   FOR UPDATE;
 
   UPDATE attempts
-  SET start_time = new_start_time, end_time = new_end_time, reason = new_reason
+  SET start_time = new_start_time, rollup_time = new_end_time, end_time = new_end_time, reason = new_reason
   WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
 
   SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -723,7 +723,6 @@ BEGIN
   SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
   SELECT start_time, end_time, rollup_time INTO cur_start_time, cur_end_time, cur_rollup_time
-
   FROM attempts
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   LOCK IN SHARE MODE;

--- a/build.yaml
+++ b/build.yaml
@@ -2061,6 +2061,9 @@ steps:
       - name: rename-timestamp-to-date
         script: /io/sql/rename-timestamp-to-date.sql
         online: true
+      - name: add-real-time-billing
+        script: /io/sql/add-real-time-billing.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Stacked on #11997

This PR enables real-time billing. It should be relatively straightforward. It uses the MySQL v8 instant add of a column. Therefore, we need to switch the Azure infrastructure to use V8.0 before this PR merges. I'm not sure how long this update will lock the attempts table, but hopefully it's not too long. I can test it out on my test database next week. This is an online migration.

The key thing to double check is I got the trigger updates to use the new `rollup_time` correctly and am not missing any updates to the attempts where the rollup time needs to be updated as well.

