### PR TITLE
[ci] Use image and PR-specific cache tags for image builds

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -153,9 +153,9 @@ class Step(abc.ABC):
             duplicates = [name for name, count in Counter(json['dependsOn']).items() if count > 1]
             if duplicates:
                 raise BuildConfigurationError(f'found duplicate dependencies of {self.name}: {duplicates}')
-            self.deps = [params.name_step[d] for d in json['dependsOn'] if d in params.name_step]
+            self.deps: List[Step] = [params.name_step[d] for d in json['dependsOn'] if d in params.name_step]
         else:
-            self.deps = []
+            self.deps: List[Step] = []
         self.scopes = json.get('scopes')
         self.clouds = json.get('clouds')
         self.run_if_requested = json.get('runIfRequested', False)
@@ -221,7 +221,15 @@ class Step(abc.ABC):
         return hash(self.name)
 
     @abc.abstractmethod
+    def wrapped_job(self) -> list:
+        pass
+
+    @abc.abstractmethod
     def build(self, batch, code, scope):
+        pass
+
+    @abc.abstractmethod
+    def config(self, scope) -> dict:
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
Based off of discussion in #11907, this aims to avoid separate PRs from clobbering the image cache tag and sets up PR-specific cache tags per image. Note that using `ci-intermediate` was also detrimental to the image cache and I don't think different images sharing layers under the common name holds much value. I think we should ultimately get rid of `ci-intermediate` entirely and explicitly name our images so that they don't ruin each other's caches. I tested this in my namespace's CI. Here's the image build times from two consecutive dev deploys:

Before         |  After
:-------------------------:|:-------------------------:
![Screen Shot 2022-07-05 at 6 14 36 PM](https://user-images.githubusercontent.com/24440116/177426924-5d5ade8c-0cee-4a0e-b477-2156d4e01e78.png)  |  ![Screen Shot 2022-07-05 at 6 14 45 PM](https://user-images.githubusercontent.com/24440116/177426882-c0029760-42ae-471d-b48c-daa0eadea448.png)


I don't personally see the need for adding more SHAs to the cache as mentioned in #11907, a per-PR cache seems like exactly what you would want. The one drawback I can think of here is that a deploy won't make use of the cache from the PR that resulted in the commit to main. I believe the commit SHAs would be different because we squash so other than devising a way to trace the commit back to the PR I don't see how we can easily connect the two. Still, I feel like it's not a big deal since it will still use the previously deployed commit as a cache, so most deploys will still be very fast and no one's waiting on deploys in the same way as we wait on PRs and dev deploys.