### PR TITLE
Requirements.txt has spaces that causes errors

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -30,4 +30,4 @@ scipy>1.2,<1.8
 sortedcontainers==2.4.0
 tabulate==0.8.9
 tqdm==4.*
-uvloop==0.16.0; sys_platform != 'win32'
+uvloop==0.16.0; sys_platform!='win32'


### PR DESCRIPTION
I removed the spaces after sys_platform which allowed my installation from source to work.