### PR TITLE
[batch] Remove redundant env variable for internal gateway ip

### DIFF
--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -94,11 +94,6 @@ spec:
              secretKeyRef:
                name: global-config
                key: docker_prefix
-         - name: HAIL_INTERNAL_IP
-           valueFrom:
-             secretKeyRef:
-               name: global-config
-               key: internal_ip
          - name: KUBERNETES_SERVER_URL
            valueFrom:
              secretKeyRef:


### PR DESCRIPTION
This is unused and the same as `INTERNAL_GATEWAY_IP` a few variables down