### PR TITLE
[query] Clear the bdist build cache before building the wheel

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -204,7 +204,8 @@ copy-py-files: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES) 
 wheel: $(WHEEL)
 
 $(WHEEL): copy-py-files
-	cd build/deploy; $(HAIL_PYTHON3) setup.py -q sdist bdist_wheel
+	# Clear the bdist build cache before building the wheel
+	cd build/deploy; rm -rf build; $(HAIL_PYTHON3) setup.py -q sdist bdist_wheel
 
 .PHONY: egg
 egg: $(EGG)


### PR DESCRIPTION
Discovered because I accidentally had an old build directory in $HAIL/hail/python that was sneakily being rsync'd into the build/deploy directory and then silently picked up by bdist_wheel as a build cache.