### PR TITLE
[batch] Add support for open batches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/thibaudcolas/curlylint
-    rev: v0.12.0
+    rev: v0.13.1
     hooks:
       - id: curlylint
         types: [file] # By default only runs on .jinja files, this disables that

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/thibaudcolas/curlylint
-    rev: v0.13.1
+    rev: v0.12.0
     hooks:
       - id: curlylint
         types: [file] # By default only runs on .jinja files, this disables that

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -12,8 +12,6 @@ log = logging.getLogger('batch')
 
 
 def batch_record_to_dict(record):
-    n_jobs = record['n_committed_jobs']
-
     if record['state'] == 'open':
         state = 'open'
     elif record['n_failed'] > 0:
@@ -21,7 +19,7 @@ def batch_record_to_dict(record):
     elif record['cancelled'] or record['n_cancelled'] > 0:
         state = 'cancelled'
     elif record['state'] == 'complete':
-        assert record['n_succeeded'] == n_jobs, record
+        assert record['n_succeeded'] == record['n_jobs']
         state = 'success'
     else:
         state = 'running'
@@ -33,7 +31,7 @@ def batch_record_to_dict(record):
 
     time_created = _time_msecs_str(record['time_created'])
     time_closed = _time_msecs_str(record['time_closed'])
-    time_updated_str = _time_msecs_str(record['time_updated'])
+    time_updated = _time_msecs_str(record['time_updated'] or record['time_created'])
     time_completed = _time_msecs_str(record['time_completed'])
 
     if record['time_created'] and record['time_completed']:
@@ -49,15 +47,15 @@ def batch_record_to_dict(record):
         'state': state,
         'complete': record['state'] == 'complete',
         'closed': record['state'] != 'open',  # deprecated
-        'n_updates_in_progress': record['n_updates_in_progress'],
-        'n_jobs': n_jobs,
+        'n_updates_in_progress': record['n_updates_in_progress'] or 0,
+        'n_jobs': record['n_jobs'],
         'n_completed': record['n_completed'],
         'n_succeeded': record['n_succeeded'],
         'n_failed': record['n_failed'],
         'n_cancelled': record['n_cancelled'],
         'time_created': time_created,
         'time_closed': time_closed,  # deprecated
-        'time_updated': time_updated_str,
+        'time_updated': time_updated,
         'time_completed': time_completed,
         'duration': duration,
         'msec_mcpu': record['msec_mcpu'],

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -12,11 +12,7 @@ log = logging.getLogger('batch')
 
 
 def batch_record_to_dict(record):
-    # backwards compatibility
-    if record['n_updates'] != 0:
-        n_jobs = record['n_committed_jobs']
-    else:
-        n_jobs = record['n_jobs']
+    n_jobs = record['n_committed_jobs']
 
     if record['state'] == 'open':
         state = 'open'
@@ -35,16 +31,9 @@ def batch_record_to_dict(record):
             return time_msecs_str(t)
         return None
 
-    if record['time_completed']:
-        time_updated = record['time_completed']
-    elif record['time_updated']:
-        time_updated = record['time_updated']
-    else:
-        time_updated = record['time_created']
-
     time_created = _time_msecs_str(record['time_created'])
     time_closed = _time_msecs_str(record['time_closed'])
-    time_updated_str = _time_msecs_str(time_updated)
+    time_updated_str = _time_msecs_str(record['time_updated'])
     time_completed = _time_msecs_str(record['time_completed'])
 
     if record['time_created'] and record['time_completed']:

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -68,7 +68,7 @@ LEFT JOIN (
   FROM base_t
   LEFT JOIN batch_updates ON batches.id = batch_updates.batch_id
   GROUP BY batch_updates.batch_id
-) AS updates_t ON base_t.id = updates_t.id;
+) AS updates_t ON base_t.id = updates_t.batch_id;
 ''',
         (batch_id,),
         'notify_batch_job_complete',

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -38,7 +38,7 @@ SELECT batches.*,
   batches_n_jobs_in_complete_states.n_completed,
   batches_n_jobs_in_complete_states.n_succeeded,
   batches_n_jobs_in_complete_states.n_failed,
-  batches_n_jobs_in_complete_states.n_cancelled,
+  batches_n_jobs_in_complete_states.n_cancelled
 FROM batches
 LEFT JOIN batches_n_jobs_in_complete_states
   ON batches.id = batches_n_jobs_in_complete_states.id
@@ -60,13 +60,14 @@ LEFT JOIN (
   GROUP BY batch_id
 ) AS cost_t ON base_t.id = cost_t.batch_id
 LEFT JOIN (
-  SELECT batch_updates.id,
+  SELECT batch_updates.batch_id,
     CAST(COALESCE(SUM(1), 0) AS SIGNED) AS n_updates,
     CAST(COALESCE(SUM(IF(batch_updates.committed, batch_updates.n_jobs, 0)), 0) AS SIGNED) AS n_committed_jobs,
-    CAST(COALESCE(SUM(NOT batch_updates.committed), 0) AS SIGNED) AS n_updates_in_progress
+    CAST(COALESCE(SUM(NOT batch_updates.committed), 0) AS SIGNED) AS n_updates_in_progress,
+    MAX(batch_updates.time_committed) AS time_updated
   FROM base_t
-  LEFT JOIN batch_updates ON batches.id = batch_updates.id
-  GROUP BY batch_updates.id
+  LEFT JOIN batch_updates ON batches.id = batch_updates.batch_id
+  GROUP BY batch_updates.batch_id
 ) AS updates_t ON base_t.id = updates_t.id;
 ''',
         (batch_id,),

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -184,9 +184,9 @@ async def get_check_invariants(request, userdata):  # pylint: disable=unused-arg
     return web.json_response(data=data)
 
 
-@routes.patch('/api/v1alpha/batches/{user}/{batch_id}/close')
+@routes.patch('/api/v1alpha/batches/{user}/{batch_id}/update')
 @batch_only
-async def close_batch(request):
+async def update_batch(request):
     db = request.app['db']
 
     user = request.match_info['user']

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1333,7 +1333,7 @@ FROM batch_updates
 LEFT JOIN batches ON batch_updates.batch_id = batches.id
 LEFT JOIN batches_cancelled
   ON batch_updates.batch_id = batches_cancelled.id
-WHERE user = %s AND batch_updates.batch_id = %s AND batch_updates.update_id = %s AND NOT batches.deleted;            
+WHERE user = %s AND batch_updates.batch_id = %s AND batch_updates.update_id = %s AND NOT batches.deleted;
 ''',
             (batch_id, batch_id, update_id, user, batch_id, update_id),
         )

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1368,17 +1368,13 @@ async def _create_batch_update(batch_id: int, update_token: str, n_update_jobs: 
         assert n_update_jobs > 0
         record = await tx.execute_and_fetchone(
             '''
-SELECT update_id, committed, start_job_id FROM batch_updates
+SELECT update_id, start_job_id FROM batch_updates
 WHERE batch_id = %s AND token = %s;
 ''',
             (batch_id, update_token),
         )
 
         if record:
-            if record['committed']:
-                raise web.HTTPBadRequest(
-                    reason=f'update {record["update_id"]} for batch {batch_id} has already been committed'
-                )
             return record['update_id'], record['start_job_id']
 
         now = time_msecs()

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1233,15 +1233,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             ),
         )
 
-        update_id = await tx.execute_and_fetchone(
-            '''
-SELECT update_id FROM batch_updates WHERE batch_id = %s;
-''',
-            (id,),
-        )
-
-        if update_id is None:
-            update_id = secret_alnum_string(8)
+        update_id = secret_alnum_string(8)
 
         await tx.execute_insertone(
             '''

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1713,7 +1713,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
     update_id = record['update_id']
 
-    next_url = request.app.router['commit-batch-update'].url_for(batch_id=batch_id, update_id=update_id)
+    next_url = request.app.router['commit-batch-update'].url_for(batch_id=str(batch_id), update_id=update_id)
     raise web.HTTPFound(location=next_url)
 
 

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -12,7 +12,6 @@
   <li>User: {{ batch['user'] }}</li>
   <li>Billing Project: {{ batch['billing_project'] }}</li>
   <li>Time Created: {% if 'time_created' in batch and batch['time_created'] is not none %}{{ batch['time_created'] }}{% endif %}</li>
-  <li>Time Updated: {% if 'time_updated' in batch and batch['time_updated'] is not none %}{{ batch['time_updated'] }}{% endif %}</li>
   <li>Time Completed: {% if 'time_completed' in batch and batch['time_completed'] is not none %}{{ batch['time_completed'] }}{% endif %}</li>
   <li>Total Jobs: {{ batch['n_jobs'] }}</li>
   <ul>
@@ -41,34 +40,6 @@
 <p>{{ name }}: {{ value }}</p>
 {% endfor %}
 {% endif %}
-
-<h2>Updates</h2>
-  <div class='flex-col' style="overflow: auto;">
-    <table class="data-table" id="updates" style="width: 100%">
-      <thead>
-        <tr>
-          <th>ID</th>
-          <th>Number of Jobs</th>
-          <th>Start Job ID</th>
-          <th>End Job ID</th>
-          <th>Time Created</th>
-          <th>Committed</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for update in updates %}
-        <tr>
-          <td>{{ update['update_id'] }}</td>
-          <td>{{ update['n_jobs'] }}</td>
-          <td>{{ update['start_job_id'] }}</td>
-          <td>{{ update['end_job_id'] }}</td>
-          <td>{{ update['time_created'] }}</td>
-          <td>{{ update['committed'] }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
 
 <h2>Jobs</h2>
 <div class="flex-col">

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -12,7 +12,7 @@
   <li>User: {{ batch['user'] }}</li>
   <li>Billing Project: {{ batch['billing_project'] }}</li>
   <li>Time Created: {% if 'time_created' in batch and batch['time_created'] is not none %}{{ batch['time_created'] }}{% endif %}</li>
-  <li>Time Closed: {% if 'time_closed' in batch and batch['time_closed'] is not none %}{{ batch['time_closed'] }}{% endif %}</li>
+  <li>Time Updated: {% if 'time_updated' in batch and batch['time_updated'] is not none %}{{ batch['time_updated'] }}{% endif %}</li>
   <li>Time Completed: {% if 'time_completed' in batch and batch['time_completed'] is not none %}{{ batch['time_completed'] }}{% endif %}</li>
   <li>Total Jobs: {{ batch['n_jobs'] }}</li>
   <ul>
@@ -41,6 +41,34 @@
 <p>{{ name }}: {{ value }}</p>
 {% endfor %}
 {% endif %}
+
+<h2>Updates</h2>
+  <div class='flex-col' style="overflow: auto;">
+    <table class="data-table" id="updates" style="width: 100%">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Number of Jobs</th>
+          <th>Start Job ID</th>
+          <th>End Job ID</th>
+          <th>Time Created</th>
+          <th>Committed</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for update in updates %}
+        <tr>
+          <td>{{ update['update_id'] }}</td>
+          <td>{{ update['n_jobs'] }}</td>
+          <td>{{ update['start_job_id'] }}</td>
+          <td>{{ update['end_job_id'] }}</td>
+          <td>{{ update['time_created'] }}</td>
+          <td>{{ update['committed'] }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
 <h2>Jobs</h2>
 <div class="flex-col">

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -56,8 +56,7 @@
 	    <th>Billing Project</th>
 	    <th>Name</th>
 	    <th>Created</th>
-	    <th>Updated</th>
-            <th>Completed</th>
+			<th>Completed</th>
 	    <th>State</th>
 	    <th>Jobs</th>
 	    <th>Pending</th>
@@ -84,11 +83,6 @@
 	    <td>
 	      {% if 'time_created' in batch and batch['time_created'] is not none %}
 	      {{ batch['time_created'] }}
-	      {% endif %}
-	    </td>
-	    <td>
-	      {% if 'time_updated' in batch and batch['time_updated'] is not none %}
-	      {{ batch['time_updated'] }}
 	      {% endif %}
 	    </td>
 	    <td>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -55,8 +55,9 @@
 	    <th>User</th>
 	    <th>Billing Project</th>
 	    <th>Name</th>
-	    <th>Submitted</th>
-	    <th>Completed</th>
+	    <th>Created</th>
+	    <th>Updated</th>
+            <th>Completed</th>
 	    <th>State</th>
 	    <th>Jobs</th>
 	    <th>Pending</th>
@@ -81,8 +82,13 @@
 	      {% endif %}
 	    </td>
 	    <td>
-	      {% if 'time_closed' in batch and batch['time_closed'] is not none %}
-	      {{ batch['time_closed'] }}
+	      {% if 'time_created' in batch and batch['time_created'] is not none %}
+	      {{ batch['time_created'] }}
+	      {% endif %}
+	    </td>
+	    <td>
+	      {% if 'time_updated' in batch and batch['time_updated'] is not none %}
+	      {{ batch['time_updated'] }}
 	      {% endif %}
 	    </td>
 	    <td>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -56,7 +56,7 @@
 	    <th>Billing Project</th>
 	    <th>Name</th>
 	    <th>Created</th>
-			<th>Completed</th>
+	    <th>Completed</th>
 	    <th>State</th>
 	    <th>Jobs</th>
 	    <th>Pending</th>

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -56,7 +56,8 @@ job_validator = keyed(
             )
         ),
         'input_files': listof(keyed({required('from'): str_type, required('to'): str_type})),
-        required('job_id'): int_type,
+        'job_id': int_type,
+        'relative_job_id': int_type,
         'mount_tokens': bool_type,
         'network': oneof('public', 'private'),
         'unconfined': bool_type,
@@ -188,6 +189,18 @@ def handle_deprecated_job_keys(i, job):
 
     if 'gcsfuse' in job:
         job['cloudfuse'] = job.pop('gcsfuse')
+
+    if 'job_id' in job and 'relative_job_id' in job:
+        raise ValidationError(
+            f"jobs[{i}] has both the job_id and relative_job_id defined. Only one can be given."
+        )
+    if 'job_id' not in job and 'relative_job_id' not in job:
+        raise ValidationError(
+            f"jobs[{i}] does not have either a job_id or relative_job_id defined."
+        )
+
+    if 'job_id' in job:
+        job['relative_job_id'] = job.pop('job_id')
 
 
 def handle_job_backwards_compatibility(job):

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -191,13 +191,9 @@ def handle_deprecated_job_keys(i, job):
         job['cloudfuse'] = job.pop('gcsfuse')
 
     if 'job_id' in job and 'relative_job_id' in job:
-        raise ValidationError(
-            f"jobs[{i}] has both the job_id and relative_job_id defined. Only one can be given."
-        )
+        raise ValidationError(f"jobs[{i}] has both the job_id and relative_job_id defined. Only one can be given.")
     if 'job_id' not in job and 'relative_job_id' not in job:
-        raise ValidationError(
-            f"jobs[{i}] does not have either a job_id or relative_job_id defined."
-        )
+        raise ValidationError(f"jobs[{i}] does not have either a job_id or relative_job_id defined.")
 
     if 'job_id' in job:
         job['relative_job_id'] = job.pop('job_id')

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -61,7 +61,9 @@ job_validator = keyed(
         'network': oneof('public', 'private'),
         'unconfined': bool_type,
         'output_files': listof(keyed({required('from'): str_type, required('to'): str_type})),
-        required('parent_ids'): listof(int_type),
+        'parent_ids': listof(int_type),
+        'absolute_parent_ids': listof(int_type),
+        'relative_parent_ids': listof(int_type),
         'port': int_type,
         required('process'): switch(
             'type',
@@ -191,6 +193,8 @@ def handle_deprecated_job_keys(i, job):
 def handle_job_backwards_compatibility(job):
     if 'cloudfuse' in job:
         job['gcsfuse'] = job.pop('cloudfuse')
+    if 'parent_ids' in job:
+        job['absolute_parent_ids'] = job.pop('parent_ids')
 
 
 def validate_batch(batch):

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -105,7 +105,14 @@ batch_validator = keyed(
         'callback': nullable(str_type),
         required('n_jobs'): int_type,
         required('token'): str_type,
+        'update_id': str_type,
         'cancel_after_n_failures': nullable(numeric(**{"x > 0": lambda x: isinstance(x, int) and x > 0})),
+    }
+)
+
+batch_update_validator = keyed(
+    {
+        required('n_jobs'): int_type,
     }
 )
 
@@ -188,3 +195,7 @@ def handle_job_backwards_compatibility(job):
 
 def validate_batch(batch):
     batch_validator.validate('batch', batch)
+
+
+def validate_batch_update(update):
+    batch_update_validator.validate('batch_update', update)

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -108,14 +108,14 @@ batch_validator = keyed(
         'callback': nullable(str_type),
         required('n_jobs'): int_type,
         required('token'): str_type,
-        'update_id': str_type,
         'cancel_after_n_failures': nullable(numeric(**{"x > 0": lambda x: isinstance(x, int) and x > 0})),
     }
 )
 
 batch_update_validator = keyed(
     {
-        required('n_jobs'): int_type,
+        required('token'): str_type,
+        required('n_jobs'): numeric(**{"x > 0": lambda x: isinstance(x, int) and x > 0}),
     }
 )
 

--- a/batch/batch/globals.py
+++ b/batch/batch/globals.py
@@ -19,7 +19,7 @@ memory_types = ('lowmem', 'standard', 'highmem')
 
 HTTP_CLIENT_MAX_SIZE = 8 * 1024 * 1024
 
-BATCH_FORMAT_VERSION = 6
+BATCH_FORMAT_VERSION = 7
 STATUS_FORMAT_VERSION = 5
 INSTANCE_VERSION = 22
 

--- a/batch/batch/spec_writer.py
+++ b/batch/batch/spec_writer.py
@@ -46,32 +46,32 @@ class SpecWriter:
             if job_id in range(start, end):
                 return (token, start)
 
-        token, start_job_id, next_start_job_id = await SpecWriter._get_token_start_id_and_next_start_id(
-            db, batch_id, job_id
-        )
+        token, start_job_id, end_job_id = await SpecWriter._get_token_start_id_and_end_id(db, batch_id, job_id)
 
-        if next_start_job_id is not None:
-            # It is least likely that old batches or early bunches in a given
-            # batch will be needed again
-            if len(JOB_TOKEN_CACHE) == JOB_TOKEN_CACHE_MAX_BATCHES:
-                JOB_TOKEN_CACHE.pop(min(JOB_TOKEN_CACHE.keys()))
-            elif len(JOB_TOKEN_CACHE[batch_id]) == JOB_TOKEN_CACHE_MAX_BUNCHES_PER_BATCH:
-                JOB_TOKEN_CACHE[batch_id].pop(0)
-            JOB_TOKEN_CACHE[batch_id].add((token, start_job_id, next_start_job_id))
+        # It is least likely that old batches or early bunches in a given
+        # batch will be needed again
+        if len(JOB_TOKEN_CACHE) == JOB_TOKEN_CACHE_MAX_BATCHES:
+            JOB_TOKEN_CACHE.pop(min(JOB_TOKEN_CACHE.keys()))
+        elif len(JOB_TOKEN_CACHE[batch_id]) == JOB_TOKEN_CACHE_MAX_BUNCHES_PER_BATCH:
+            JOB_TOKEN_CACHE[batch_id].pop(0)
+
+        JOB_TOKEN_CACHE[batch_id].add((token, start_job_id, end_job_id))
 
         return (token, start_job_id)
 
     @staticmethod
-    async def _get_token_start_id_and_next_start_id(db, batch_id, job_id) -> Tuple[str, int, Optional[int]]:
+    async def _get_token_start_id_and_end_id(db, batch_id, job_id) -> Tuple[str, int, int]:
         bunch_record = await db.select_and_fetchone(
             '''
 SELECT
-start_job_id,
-token,
-(SELECT start_job_id FROM batch_bunches WHERE batch_id = %s AND start_job_id > %s ORDER BY start_job_id LIMIT 1) AS next_start_job_id
+batch_bunches.start_job_id,
+batch_bunches.token,
+(SELECT start_job_id FROM batch_bunches WHERE batch_id = %s AND start_job_id > %s ORDER BY start_job_id LIMIT 1) AS next_start_job_id,
+batches.n_jobs
 FROM batch_bunches
-WHERE batch_id = %s AND start_job_id <= %s
-ORDER BY start_job_id DESC
+JOIN batches ON batches.id = batch_bunches.batch_id
+WHERE batch_bunches.batch_id = %s AND batch_bunches.start_job_id <= %s
+ORDER BY batch_bunches.start_job_id DESC
 LIMIT 1;
 ''',
             (batch_id, job_id, batch_id, job_id),
@@ -79,8 +79,8 @@ LIMIT 1;
         )
         token = bunch_record['token']
         start_job_id = bunch_record['start_job_id']
-        next_start_job_id = bunch_record['next_start_job_id']
-        return (token, start_job_id, next_start_job_id)
+        end_job_id = bunch_record['next_start_job_id'] or bunch_record['n_jobs']
+        return (token, start_job_id, end_job_id)
 
     def __init__(self, file_store, batch_id):
         self.file_store = file_store

--- a/batch/batch/spec_writer.py
+++ b/batch/batch/spec_writer.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-from typing import Dict, Tuple, Optional
+from typing import Dict, Tuple
 
 import sortedcontainers
 

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -13,6 +13,13 @@ from hailtop.utils import secret_alnum_string
 log = logging.getLogger('utils')
 
 
+@web.middleware
+async def unavailable_if_frozen(request: web.Request, handler):
+    if request.method in ("POST", "PATCH") and request.app['frozen']:
+        raise web.HTTPServiceUnavailable()
+    return await handler(request)
+
+
 def authorization_token(request):
     auth_header = request.headers.get('Authorization')
     if not auth_header:

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -153,7 +153,7 @@ LEFT JOIN (
   GROUP BY base_t.billing_project, resource_id
 ) AS usage_t ON usage_t.billing_project = base_t.billing_project
 LEFT JOIN resources ON resources.resource_id = usage_t.resource_id
-GROUP BY base_t.billing_project;
+GROUP BY base_t.billing_project, base_t.status, base_t.users, base_t.`limit`;
 '''
 
     def record_to_dict(record):

--- a/batch/sql/add-batch-updates.sql
+++ b/batch/sql/add-batch-updates.sql
@@ -1,0 +1,446 @@
+START TRANSACTION;
+
+# Foreign key constraint for batch_id needs to be added in a subsequent PR in order for the migration to work
+CREATE TABLE IF NOT EXISTS `batch_updates` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `start_job_id` INT,
+  `n_jobs` INT NOT NULL,
+  `committed` BOOLEAN NOT NULL DEFAULT FALSE,
+  `time_created` BIGINT,
+  `time_committed` BIGINT,
+  PRIMARY KEY (`batch_id`, `update_id`)
+) ENGINE = InnoDB;
+CREATE INDEX `batch_updates_committed` ON `batch_updates` (`batch_id`, `committed`);
+CREATE INDEX `batch_updates_start_job_id` ON `batch_updates` (`batch_id`, `start_job_id`);
+
+ALTER TABLE batches ADD COLUMN update_added BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
+ALTER TABLE batches_inst_coll_staging ADD COLUMN update_id VARCHAR(40), ALGORITHM=INSTANT;
+ALTER TABLE batch_inst_coll_cancellable_resources ADD COLUMN update_id VARCHAR(40), ALGORITHM=INSTANT;
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS batches_before_insert $$
+CREATE TRIGGER batches_before_insert BEFORE INSERT ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+  DECLARE new_update_id VARCHAR(40);
+
+  SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.id;
+
+  IF cur_update_id IS NULL THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+  END IF;
+
+  SET NEW.update_added = TRUE;
+END $$
+
+DROP TRIGGER IF EXISTS batches_before_update $$
+CREATE TRIGGER batches_before_update BEFORE UPDATE ON batches
+FOR EACH ROW
+BEGIN
+  SET NEW.update_added = TRUE;
+END $$
+
+DROP TRIGGER IF EXISTS batches_after_update $$
+CREATE TRIGGER batches_after_update AFTER UPDATE ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE new_update_id VARCHAR(40);
+
+  IF NOT OLD.update_added THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+
+    UPDATE batches_inst_coll_staging
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+
+    UPDATE batch_inst_coll_cancellable_resources
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert $$
+CREATE TRIGGER batches_inst_coll_staging_before_insert BEFORE INSERT ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update $$
+CREATE TRIGGER batches_inst_coll_staging_before_update BEFORE UPDATE ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_insert BEFORE INSERT ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_update BEFORE UPDATE ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS close_batch $$
+CREATE PROCEDURE close_batch(
+  IN in_batch_id BIGINT,
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_batch_state VARCHAR(40);
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE staging_n_ready_jobs INT;
+  DECLARE staging_ready_cores_mcpu BIGINT;
+  DECLARE cur_user VARCHAR(100);
+
+  START TRANSACTION;
+
+  SELECT `state`, n_jobs INTO cur_batch_state, expected_n_jobs FROM batches
+  WHERE id = in_batch_id AND NOT deleted
+  FOR UPDATE;
+
+  IF cur_batch_state != 'open' THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
+    INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
+    FROM batches_inst_coll_staging
+    WHERE batch_id = in_batch_id
+    FOR UPDATE;
+
+    SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      IF expected_n_jobs = 0 THEN
+        UPDATE batches SET `state` = 'complete', time_completed = in_timestamp, time_closed = in_timestamp
+          WHERE id = in_batch_id;
+      ELSE
+        UPDATE batches SET `state` = 'running', time_closed = in_timestamp
+          WHERE id = in_batch_id;
+      END IF;
+
+      UPDATE batch_updates SET `committed` = TRUE, time_committed = in_timestamp
+      WHERE batch_id = in_batch_id;
+
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
+      FROM batches_inst_coll_staging
+      JOIN batches ON batches.id = batches_inst_coll_staging.batch_id
+      WHERE batch_id = in_batch_id
+      GROUP BY `user`, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
+
+      DELETE FROM batches_inst_coll_staging WHERE batch_id = in_batch_id;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 2 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS jobs_after_update $$
+CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
+FOR EACH ROW
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_cancelled BOOLEAN;
+  DECLARE cur_n_tokens INT;
+  DECLARE cur_update_id VARCHAR(40);
+  DECLARE rand_token INT;
+
+  SELECT user INTO cur_user FROM batches WHERE id = NEW.batch_id;
+
+  SELECT update_id INTO cur_update_id
+  FROM batch_updates
+  WHERE batch_id = NEW.batch_id AND NEW.job_id >= start_job_id AND NEW.job_id < start_job_id + n_jobs;
+
+  SET cur_batch_cancelled = EXISTS (SELECT TRUE
+                                    FROM batches_cancelled
+                                    WHERE id = NEW.batch_id
+                                    LOCK IN SHARE MODE);
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  IF OLD.state = 'Ready' THEN
+    IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
+    ELSE
+      # runnable
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs - 1,
+        ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Running' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
+    ELSE
+      # running
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs - 1,
+        running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Creating' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs - 1;
+    END IF;
+
+    # state = 'Creating' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_creating_jobs = n_cancelled_creating_jobs - 1;
+    ELSE
+      # creating
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_jobs = n_creating_jobs - 1;
+    END IF;
+
+  END IF;
+
+  IF NEW.state = 'Ready' THEN
+    IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
+    ELSE
+      # runnable
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + 1,
+        ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Running' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
+    ELSE
+      # running
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs + 1,
+        running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Creating' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs + 1;
+    END IF;
+
+    # state = 'Creating' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_creating_jobs = n_cancelled_creating_jobs + 1;
+    ELSE
+      # creating
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_jobs = n_creating_jobs + 1;
+    END IF;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS recompute_incremental $$
+CREATE PROCEDURE recompute_incremental(
+) BEGIN
+
+  DELETE FROM batches_inst_coll_staging;
+  DELETE FROM batch_inst_coll_cancellable_resources;
+  DELETE FROM user_inst_coll_resources;
+
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
+
+  CREATE TEMPORARY TABLE `tmp_batch_inst_coll_resources` AS (
+    SELECT batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll,
+      COALESCE(SUM(1), 0) as n_jobs,
+      COALESCE(SUM(job_state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Running' AND cancellable), 0) as n_running_cancellable_jobs,
+      COALESCE(SUM(IF(job_state = 'Running' AND cancellable, cores_mcpu, 0)), 0) as running_cancellable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Creating' AND cancellable), 0) as n_creating_cancellable_jobs,
+      COALESCE(SUM(job_state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
+      COALESCE(SUM(IF(job_state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
+      COALESCE(SUM(job_state = 'Ready' AND runnable), 0) as n_ready_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu,
+      COALESCE(SUM(job_state = 'Creating' AND NOT cancelled), 0) as n_creating_jobs,
+      COALESCE(SUM(job_state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(job_state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs,
+      COALESCE(SUM(job_state = 'Creating' AND cancelled), 0) as n_cancelled_creating_jobs
+    FROM (
+      SELECT batches.user,
+        batches.id as batch_id,
+        batch_updates.update_id,
+        batches.state as batch_state,
+        batches.cancelled as batch_cancelled,
+        jobs.inst_coll as job_inst_coll,
+        jobs.state as job_state,
+        jobs.cores_mcpu,
+        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable,
+        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
+        (NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled
+      FROM jobs
+      INNER JOIN batches
+        ON batches.id = jobs.batch_id
+      LEFT JOIN batch_updates ON jobs.batch_id = batch_updates.batch_id AND jobs.job_id >= batch_updates.start_job_id
+        AND jobs.job_id < batch_updates.start_job_id + batch_updates.n_jobs
+      LOCK IN SHARE MODE) as t
+    GROUP BY batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll
+  );
+
+  INSERT INTO batches_inst_coll_staging (batch_id, update_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT batch_id, update_id, job_inst_coll, 0, n_jobs, n_ready_jobs, ready_cores_mcpu
+  FROM tmp_batch_inst_coll_resources
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT `committed`;
+
+  INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs,
+    ready_cancellable_cores_mcpu, n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs)
+  SELECT batch_id, update_id, job_inst_coll, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
+    n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs
+  FROM tmp_batch_inst_coll_resources
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT batch_cancelled AND `committed`;
+
+  INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu,
+    n_running_jobs, running_cores_mcpu, n_creating_jobs,
+    n_cancelled_ready_jobs, n_cancelled_running_jobs, n_cancelled_creating_jobs)
+  SELECT t.user, t.job_inst_coll, 0, t.n_ready_jobs, t.ready_cores_mcpu,
+    t.n_running_jobs, t.running_cores_mcpu, t.n_creating_jobs,
+    t.n_cancelled_ready_jobs, t.n_cancelled_running_jobs, t.n_cancelled_creating_jobs
+  FROM (SELECT user, job_inst_coll,
+      COALESCE(SUM(n_running_jobs), 0) as n_running_jobs,
+      COALESCE(SUM(running_cores_mcpu), 0) as running_cores_mcpu,
+      COALESCE(SUM(n_ready_jobs), 0) as n_ready_jobs,
+      COALESCE(SUM(ready_cores_mcpu), 0) as ready_cores_mcpu,
+      COALESCE(SUM(n_creating_jobs), 0) as n_creating_jobs,
+      COALESCE(SUM(n_cancelled_ready_jobs), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(n_cancelled_running_jobs), 0) as n_cancelled_running_jobs,
+      COALESCE(SUM(n_cancelled_creating_jobs), 0) as n_cancelled_creating_jobs
+    FROM tmp_batch_inst_coll_resources
+    LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+    WHERE batch_state != 'open' AND `committed`
+    GROUP by user, job_inst_coll) as t;
+
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
+
+END $$
+
+DELIMITER ;
+
+COMMIT;

--- a/batch/sql/add-open-batches.sql
+++ b/batch/sql/add-open-batches.sql
@@ -1,0 +1,168 @@
+ALTER TABLE batches ADD COLUMN time_updated BIGINT, ALGORITHM=INSTANT;
+
+CREATE TABLE IF NOT EXISTS `batch_updates` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `update_id` VARCHAR(40) NOT NULL,
+  `start_job_id` INT,
+  `end_job_id` INT,
+  `n_jobs` INT NOT NULL,
+  `committed` BOOLEAN NOT NULL DEFAULT FALSE,
+  `time_created` BIGINT,
+  `time_committed` BIGINT,
+  PRIMARY KEY (`id`, `update_id`),
+  FOREIGN KEY (`id`) REFERENCES batches(id) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX `batch_updates_committed` ON `batch_updates` (`id`, `committed`);
+CREATE INDEX `batch_updates_start_end_job_id` ON `batch_updates` (`id`, start_job_id, end_job_id);
+
+CREATE TABLE IF NOT EXISTS `batch_updates_inst_coll_staging` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `inst_coll` VARCHAR(255),
+  `token` INT NOT NULL,
+  `n_jobs` INT NOT NULL DEFAULT 0,
+  `n_ready_jobs` INT NOT NULL DEFAULT 0,
+  `ready_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`),
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(`id`, `update_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX `batch_updates_inst_coll_staging_inst_coll` ON `batch_updates_inst_coll_staging` (`inst_coll`);
+
+CREATE TABLE `batch_inst_coll_cancellable_resources_staging` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `inst_coll` VARCHAR(255),
+  `token` INT NOT NULL,
+  # neither run_always nor cancelled
+  `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `ready_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  `n_creating_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `n_running_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `running_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `inst_coll`, `token`),
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(`id`, `update_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS commit_batch_update $$
+CREATE PROCEDURE commit_batch_update(
+  IN in_batch_id BIGINT,
+  IN in_update_id VARCHAR(40),
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_update_committed BOOLEAN;
+  DECLARE cur_update_start_job_id INT;
+  DECLARE cur_update_end_job_id INT;
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE staging_n_ready_jobs INT;
+  DECLARE staging_ready_cores_mcpu BIGINT;
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_other_updates_in_progress INT;
+
+  START TRANSACTION;
+
+  SELECT committed, n_jobs, start_job_id, end_job_id INTO
+    cur_update_committed, expected_n_jobs, cur_update_start_job_id, cur_update_end_job_id
+  FROM batch_updates
+  WHERE id = in_batch_id AND update_id = in_update_id
+  FOR UPDATE;
+
+  IF cur_update_committed THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT SUM(NOT committed) INTO cur_other_updates_in_progress
+    FROM batch_updates
+    WHERE id = in_batch_id AND update_id != in_update_id
+    GROUP BY id
+    FOR UPDATE;
+
+    SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
+    INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
+    FROM batch_updates_inst_coll_staging
+    WHERE batch_id = in_batch_id AND update_id = in_update_id
+    FOR UPDATE;
+
+    SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      UPDATE batches SET `state` = IF(expected_n_jobs != 0, 'running', state),
+        time_updated = in_timestamp,
+        time_completed = IF(expected_n_jobs != 0, NULL, time_completed)
+      WHERE id = in_batch_id;
+
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
+      FROM batch_updates_inst_coll_staging
+      JOIN batches ON batches.id = batch_updates_inst_coll_staging.batch_id
+      WHERE batch_id = in_batch_id AND update_id = in_update_id
+      GROUP BY `user`, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
+
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs,
+        ready_cancellable_cores_mcpu, n_creating_cancellable_jobs, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      SELECT batch_id, inst_coll, 0,
+        @n_ready_cancellable_jobs := COALESCE(SUM(n_ready_cancellable_jobs), 0),
+        @ready_cancellable_cores_mcpu := COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
+        @n_creating_cancellable_jobs := COALESCE(SUM(n_creating_cancellable_jobs), 0),
+        @n_running_cancellable_jobs := COALESCE(SUM(n_running_cancellable_jobs), 0),
+        @running_cancellable_cores_mcpu := COALESCE(SUM(running_cancellable_cores_mcpu), 0)
+      FROM batch_inst_coll_cancellable_resources_staging
+      WHERE batch_id = in_batch_id AND update_id = in_update_id
+      GROUP BY batch_id, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs + @n_ready_cancellable_jobs,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + @ready_cancellable_cores_mcpu,
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs + @n_creating_cancellable_jobs,
+        n_running_cancellable_jobs = n_running_cancellable_jobs + @n_running_cancellable_jobs,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + @running_cancellable_cores_mcpu;
+
+      DELETE FROM batch_updates_inst_coll_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
+      DELETE FROM batch_inst_coll_cancellable_resources_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+      IF cur_update_start_job_id != 1 THEN
+        # FIXME see if an exists query is faster
+        UPDATE jobs
+          LEFT JOIN (
+            SELECT `job_parents`.batch_id, `job_parents`.job_id,
+              COALESCE(SUM(1), 0) AS n_parents,
+              COALESCE(SUM(state IN ('Pending', 'Ready', 'Creating', 'Running')), 0) AS n_pending_parents,
+              COALESCE(SUM(state = 'Success'), 0) AS n_succeeded
+            FROM `job_parents`
+            LEFT JOIN `jobs` ON jobs.batch_id = `job_parents`.batch_id AND jobs.job_id = `job_parents`.parent_id
+            WHERE `job_parents`.batch_id = in_batch_id AND
+              `job_parents`.job_id >= cur_update_start_job_id AND
+              `job_parents`.job_id <= cur_update_end_job_id
+            GROUP BY `job_parents`.batch_id, `job_parents`.job_id
+            FOR UPDATE
+          ) AS t
+            ON jobs.batch_id = t.batch_id AND
+               jobs.job_id = t.job_id
+          SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
+              jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
+              jobs.cancelled = IF(COALESCE(t.n_succeeded, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
+          WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
+              jobs.job_id <= cur_update_end_job_id;
+      END IF;
+
+      UPDATE batch_updates
+      SET committed = 1, time_committed = in_timestamp
+      WHERE id = in_batch_id AND update_id = in_update_id;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 1 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/batch/sql/cleanup-add-batch-updates.sql
+++ b/batch/sql/cleanup-add-batch-updates.sql
@@ -1,0 +1,26 @@
+START TRANSACTION;
+
+ALTER TABLE batches_inst_coll_staging MODIFY COLUMN `update_id` VARCHAR(40) NOT NULL;
+ALTER TABLE batch_inst_coll_cancellable_resources MODIFY COLUMN `update_id` VARCHAR(40) NOT NULL;
+
+ALTER TABLE batches_inst_coll_staging ADD FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates (`batch_id`, `update_id`) ON DELETE CASCADE;
+ALTER TABLE batch_inst_coll_cancellable_resources ADD FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates (`batch_id`, `update_id`) ON DELETE CASCADE;
+
+SET foreign_key_checks = 0;
+ALTER TABLE batches_inst_coll_staging DROP PRIMARY KEY, ADD PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`), ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE batch_inst_coll_cancellable_resources DROP PRIMARY KEY, ADD PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`), ALGORITH=INPLACE, LOCK=NONE;
+SET foreign_key_checks = 1;
+
+DROP TRIGGER IF EXISTS batches_before_insert;
+DROP TRIGGER IF EXISTS batches_before_update;
+DROP TRIGGER IF EXISTS batches_after_update;
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert;
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update;
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert;
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update;
+
+ALTER TABLE batch_updates ADD FOREIGN KEY (`batch_id`) REFERENCES batches (`id`) ON DELETE CASCADE;
+
+ALTER TABLE batches DROP COLUMN update_added, ALGORITHM=INPLACE, LOCK=NONE;
+
+COMMIT;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -11,6 +11,13 @@ DROP PROCEDURE IF EXISTS mark_job_started;
 DROP PROCEDURE IF EXISTS mark_job_complete;
 DROP PROCEDURE IF EXISTS add_attempt;
 
+DROP TRIGGER IF EXISTS batches_before_insert;
+DROP TRIGGER IF EXISTS batches_before_update;
+DROP TRIGGER IF EXISTS batches_after_update;
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert;
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update;
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert;
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update;
 DROP TRIGGER IF EXISTS instances_before_update;
 DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
@@ -21,8 +28,6 @@ DROP TRIGGER IF EXISTS attempt_resources_before_insert;  # deprecated
 DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
-DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
-DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 DROP TABLE IF EXISTS `batch_updates`;
 
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -4,6 +4,7 @@ DROP PROCEDURE IF EXISTS activate_instance;
 DROP PROCEDURE IF EXISTS deactivate_instance;
 DROP PROCEDURE IF EXISTS mark_instance_deleted;
 DROP PROCEDURE IF EXISTS close_batch;
+DROP PROCEDURE IF EXISTS commit_batch_update;
 DROP PROCEDURE IF EXISTS schedule_job;
 DROP PROCEDURE IF EXISTS unschedule_job;
 DROP PROCEDURE IF EXISTS mark_job_creating;
@@ -38,6 +39,7 @@ DROP TABLE IF EXISTS `aggregated_batch_resources_v2`;
 DROP TABLE IF EXISTS `aggregated_job_resources`;
 DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
 DROP TABLE IF EXISTS `attempt_resources`;
+DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources`;
 DROP TABLE IF EXISTS `globals`;
@@ -53,7 +55,9 @@ DROP TABLE IF EXISTS `jobs`;
 DROP TABLE IF EXISTS `batches_cancelled`;
 DROP TABLE IF EXISTS `batches_staging`;  # deprecated
 DROP TABLE IF EXISTS `batches_inst_coll_staging`;
+DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
 DROP TABLE IF EXISTS `batches_n_jobs_in_complete_states`;
+DROP TABLE IF EXISTS `batch_updates`;
 DROP TABLE IF EXISTS `batches`;
 DROP TABLE IF EXISTS `user_resources`;  # deprecated
 DROP TABLE IF EXISTS `user_inst_coll_resources`;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -39,7 +39,6 @@ DROP TABLE IF EXISTS `aggregated_batch_resources_v2`;
 DROP TABLE IF EXISTS `aggregated_job_resources`;
 DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
 DROP TABLE IF EXISTS `attempt_resources`;
-DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources`;
 DROP TABLE IF EXISTS `globals`;
@@ -55,9 +54,7 @@ DROP TABLE IF EXISTS `jobs`;
 DROP TABLE IF EXISTS `batches_cancelled`;
 DROP TABLE IF EXISTS `batches_staging`;  # deprecated
 DROP TABLE IF EXISTS `batches_inst_coll_staging`;
-DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
 DROP TABLE IF EXISTS `batches_n_jobs_in_complete_states`;
-DROP TABLE IF EXISTS `batch_updates`;
 DROP TABLE IF EXISTS `batches`;
 DROP TABLE IF EXISTS `user_resources`;  # deprecated
 DROP TABLE IF EXISTS `user_inst_coll_resources`;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -159,6 +159,7 @@ CREATE TABLE IF NOT EXISTS `batches` (
   `token` VARCHAR(100) DEFAULT NULL,
   `format_version` INT NOT NULL,
   `cancel_after_n_failures` INT DEFAULT NULL,
+  `update_added` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`id`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name)
 ) ENGINE = InnoDB;
@@ -167,6 +168,19 @@ CREATE INDEX `batches_deleted` ON `batches` (`deleted`);
 CREATE INDEX `batches_token` ON `batches` (`token`);
 CREATE INDEX `batches_time_completed` ON `batches` (`time_completed`);
 CREATE INDEX `batches_billing_project_state` ON `batches` (`billing_project`, `state`);
+
+CREATE TABLE IF NOT EXISTS `batch_updates` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `start_job_id` INT,
+  `n_jobs` INT NOT NULL,
+  `committed` BOOLEAN NOT NULL DEFAULT FALSE,
+  `time_created` BIGINT,
+  `time_committed` BIGINT,
+  PRIMARY KEY (`batch_id`, `update_id`)
+) ENGINE = InnoDB;
+CREATE INDEX `batch_updates_committed` ON `batch_updates` (`batch_id`, `committed`);
+CREATE INDEX `batch_updates_start_job_id` ON `batch_updates` (`batch_id`, `start_job_id`);
 
 CREATE TABLE IF NOT EXISTS `batches_n_jobs_in_complete_states` (
   `id` BIGINT NOT NULL,
@@ -186,19 +200,22 @@ CREATE TABLE IF NOT EXISTS `batches_cancelled` (
 
 CREATE TABLE IF NOT EXISTS `batches_inst_coll_staging` (
   `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
   `inst_coll` VARCHAR(255),
   `token` INT NOT NULL,
   `n_jobs` INT NOT NULL DEFAULT 0,
   `n_ready_jobs` INT NOT NULL DEFAULT 0,
   `ready_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `inst_coll`, `token`),
+  PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(batch_id, update_id) ON DELETE CASCADE,
   FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX `batches_inst_coll_staging_inst_coll` ON `batches_inst_coll_staging` (`inst_coll`);
 
 CREATE TABLE `batch_inst_coll_cancellable_resources` (
   `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
   `inst_coll` VARCHAR(255),
   `token` INT NOT NULL,
   # neither run_always nor cancelled
@@ -207,8 +224,9 @@ CREATE TABLE `batch_inst_coll_cancellable_resources` (
   `n_creating_cancellable_jobs` INT NOT NULL DEFAULT 0,
   `n_running_cancellable_jobs` INT NOT NULL DEFAULT 0,
   `running_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `inst_coll`, `token`),
+  PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(batch_id, update_id) ON DELETE CASCADE,
   FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX `batch_inst_coll_cancellable_resources_inst_coll` ON `batch_inst_coll_cancellable_resources` (`inst_coll`);
@@ -391,6 +409,97 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
 
 DELIMITER $$
 
+DROP TRIGGER IF EXISTS batches_before_insert $$
+CREATE TRIGGER batches_before_insert BEFORE INSERT ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+  DECLARE new_update_id VARCHAR(40);
+
+  SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.id;
+
+  IF cur_update_id IS NULL THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+  END IF;
+
+  SET NEW.update_added = TRUE;
+END $$
+
+DROP TRIGGER IF EXISTS batches_after_update $$
+CREATE TRIGGER batches_after_update AFTER UPDATE ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE new_update_id VARCHAR(40);
+
+  IF NOT OLD.update_added THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+
+    UPDATE batches_inst_coll_staging
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+
+    UPDATE batch_inst_coll_cancellable_resources
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert $$
+CREATE TRIGGER batches_inst_coll_staging_before_insert BEFORE INSERT ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update $$
+CREATE TRIGGER batches_inst_coll_staging_before_update BEFORE UPDATE ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_insert BEFORE INSERT ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_update BEFORE UPDATE ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
 DROP TRIGGER IF EXISTS instances_before_update $$
 CREATE TRIGGER instances_before_update BEFORE UPDATE on instances
 FOR EACH ROW
@@ -536,9 +645,14 @@ BEGIN
   DECLARE cur_user VARCHAR(100);
   DECLARE cur_batch_cancelled BOOLEAN;
   DECLARE cur_n_tokens INT;
+  DECLARE cur_update_id VARCHAR(40);
   DECLARE rand_token INT;
 
   SELECT user INTO cur_user FROM batches WHERE id = NEW.batch_id;
+
+  SELECT update_id INTO cur_update_id
+  FROM batch_updates
+  WHERE batch_id = NEW.batch_id AND NEW.job_id >= start_job_id AND NEW.job_id < start_job_id + n_jobs;
 
   SET cur_batch_cancelled = EXISTS (SELECT TRUE
                                     FROM batches_cancelled
@@ -551,8 +665,8 @@ BEGIN
   IF OLD.state = 'Ready' THEN
     IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
         ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
@@ -575,8 +689,8 @@ BEGIN
   ELSEIF OLD.state = 'Running' THEN
     IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
         running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
@@ -600,8 +714,8 @@ BEGIN
   ELSEIF OLD.state = 'Creating' THEN
     IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (OLD.batch_id, OLD.inst_coll, rand_token, -1)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1)
       ON DUPLICATE KEY UPDATE
         n_creating_cancellable_jobs = n_creating_cancellable_jobs - 1;
     END IF;
@@ -626,8 +740,8 @@ BEGIN
   IF NEW.state = 'Ready' THEN
     IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
         ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
@@ -650,8 +764,8 @@ BEGIN
   ELSEIF NEW.state = 'Running' THEN
     IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
         running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
@@ -675,8 +789,8 @@ BEGIN
   ELSEIF NEW.state = 'Creating' THEN
     IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (NEW.batch_id, NEW.inst_coll, rand_token, 1)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1)
       ON DUPLICATE KEY UPDATE
         n_creating_cancellable_jobs = n_creating_cancellable_jobs + 1;
     END IF;
@@ -785,7 +899,7 @@ CREATE PROCEDURE recompute_incremental(
   DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
 
   CREATE TEMPORARY TABLE `tmp_batch_inst_coll_resources` AS (
-    SELECT batch_id, batch_state, batch_cancelled, user, job_inst_coll,
+    SELECT batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll,
       COALESCE(SUM(1), 0) as n_jobs,
       COALESCE(SUM(job_state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
       COALESCE(SUM(IF(job_state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
@@ -803,6 +917,7 @@ CREATE PROCEDURE recompute_incremental(
     FROM (
       SELECT batches.user,
         batches.id as batch_id,
+        batch_updates.update_id,
         batches.state as batch_state,
         batches.cancelled as batch_cancelled,
         jobs.inst_coll as job_inst_coll,
@@ -814,21 +929,25 @@ CREATE PROCEDURE recompute_incremental(
       FROM jobs
       INNER JOIN batches
         ON batches.id = jobs.batch_id
+      LEFT JOIN batch_updates ON jobs.batch_id = batch_updates.batch_id AND jobs.job_id >= batch_updates.start_job_id
+        AND jobs.job_id < batch_updates.start_job_id + batch_updates.n_jobs
       LOCK IN SHARE MODE) as t
-    GROUP BY batch_id, batch_state, batch_cancelled, user, job_inst_coll
+    GROUP BY batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll
   );
 
-  INSERT INTO batches_inst_coll_staging (batch_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
-  SELECT batch_id, job_inst_coll, 0, n_jobs, n_ready_jobs, ready_cores_mcpu
+  INSERT INTO batches_inst_coll_staging (batch_id, update_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT batch_id, update_id, job_inst_coll, 0, n_jobs, n_ready_jobs, ready_cores_mcpu
   FROM tmp_batch_inst_coll_resources
-  WHERE batch_state = 'open';
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT `committed`;
 
-  INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs,
+  INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs,
     ready_cancellable_cores_mcpu, n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs)
-  SELECT batch_id, job_inst_coll, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
+  SELECT batch_id, update_id, job_inst_coll, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
     n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs
   FROM tmp_batch_inst_coll_resources
-  WHERE NOT batch_cancelled;
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT batch_cancelled AND `committed`;
 
   INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu,
     n_running_jobs, running_cores_mcpu, n_creating_jobs,
@@ -846,7 +965,8 @@ CREATE PROCEDURE recompute_incremental(
       COALESCE(SUM(n_cancelled_running_jobs), 0) as n_cancelled_running_jobs,
       COALESCE(SUM(n_cancelled_creating_jobs), 0) as n_cancelled_creating_jobs
     FROM tmp_batch_inst_coll_resources
-    WHERE batch_state != 'open'
+    LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+    WHERE batch_state != 'open' AND `committed`
     GROUP by user, job_inst_coll) as t;
 
   DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
@@ -983,6 +1103,9 @@ BEGIN
         UPDATE batches SET `state` = 'running', time_closed = in_timestamp
           WHERE id = in_batch_id;
       END IF;
+
+      UPDATE batch_updates SET `committed` = TRUE, time_committed = in_timestamp
+      WHERE batch_id = in_batch_id;
 
       INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
       SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -154,7 +154,6 @@ CREATE TABLE IF NOT EXISTS `batches` (
   `n_jobs` INT NOT NULL,
   `time_created` BIGINT NOT NULL,
   `time_closed` BIGINT,  # deprecated
-  `time_updated` BIGINT,
   `time_completed` BIGINT,
   `msec_mcpu` BIGINT NOT NULL DEFAULT 0,
   `token` VARCHAR(100) DEFAULT NULL,
@@ -214,20 +213,6 @@ CREATE TABLE IF NOT EXISTS `batches_inst_coll_staging` (
 ) ENGINE = InnoDB;
 CREATE INDEX `batches_inst_coll_staging_inst_coll` ON `batches_inst_coll_staging` (`inst_coll`);
 
-CREATE TABLE IF NOT EXISTS `batch_updates_inst_coll_staging` (
-  `batch_id` BIGINT NOT NULL,
-  `update_id` VARCHAR(40) NOT NULL,
-  `inst_coll` VARCHAR(255),
-  `token` INT NOT NULL,
-  `n_jobs` INT NOT NULL DEFAULT 0,
-  `n_ready_jobs` INT NOT NULL DEFAULT 0,
-  `ready_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`),
-  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(`id`, `update_id`) ON DELETE CASCADE,
-  FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
-) ENGINE = InnoDB;
-CREATE INDEX `batch_updates_inst_coll_staging_inst_coll` ON `batch_updates_inst_coll_staging` (`inst_coll`);
-
 CREATE TABLE `batch_inst_coll_cancellable_resources` (
   `batch_id` BIGINT NOT NULL,
   `update_id` VARCHAR(40) NOT NULL,
@@ -245,22 +230,6 @@ CREATE TABLE `batch_inst_coll_cancellable_resources` (
   FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX `batch_inst_coll_cancellable_resources_inst_coll` ON `batch_inst_coll_cancellable_resources` (`inst_coll`);
-
-CREATE TABLE `batch_inst_coll_cancellable_resources_staging` (
-  `batch_id` BIGINT NOT NULL,
-  `update_id` VARCHAR(40) NOT NULL,
-  `inst_coll` VARCHAR(255),
-  `token` INT NOT NULL,
-  # neither run_always nor cancelled
-  `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,
-  `ready_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  `n_creating_cancellable_jobs` INT NOT NULL DEFAULT 0,
-  `n_running_cancellable_jobs` INT NOT NULL DEFAULT 0,
-  `running_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `inst_coll`, `token`),
-  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(`id`, `update_id`) ON DELETE CASCADE,
-  FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
-) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `jobs` (
   `batch_id` BIGINT NOT NULL,
@@ -1007,13 +976,12 @@ END $$
 DROP PROCEDURE IF EXISTS commit_batch_update $$
 CREATE PROCEDURE commit_batch_update(
   IN in_batch_id BIGINT,
-  IN in_update_id VARCHAR(100),
+  IN in_update_id VARCHAR(40),
   IN in_timestamp BIGINT
 )
 BEGIN
   DECLARE cur_update_committed BOOLEAN;
   DECLARE cur_update_start_job_id INT;
-  DECLARE cur_update_end_job_id INT;
   DECLARE expected_n_jobs INT;
   DECLARE staging_n_jobs INT;
   DECLARE staging_n_ready_jobs INT;
@@ -1023,10 +991,10 @@ BEGIN
 
   START TRANSACTION;
 
-  SELECT committed, n_jobs, start_job_id, end_job_id INTO
-    cur_update_committed, expected_n_jobs, cur_update_start_job_id, cur_update_end_job_id
+  SELECT committed, n_jobs, start_job_id INTO
+    cur_update_committed, expected_n_jobs, cur_update_start_job_id
   FROM batch_updates
-  WHERE id = in_batch_id AND update_id = in_update_id
+  WHERE batch_id = in_batch_id AND update_id = in_update_id
   FOR UPDATE;
 
   IF cur_update_committed THEN
@@ -1035,54 +1003,38 @@ BEGIN
   ELSE
     SELECT SUM(NOT committed) INTO cur_other_updates_in_progress
     FROM batch_updates
-    WHERE id = in_batch_id AND update_id != in_update_id
-    GROUP BY id
+    WHERE batch_id = in_batch_id AND update_id != in_update_id
+    GROUP BY batch_id
     FOR UPDATE;
 
     SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
     INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
-    FROM batch_updates_inst_coll_staging
+    FROM batches_inst_coll_staging
     WHERE batch_id = in_batch_id AND update_id = in_update_id
     FOR UPDATE;
 
     SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
 
+    UPDATE batch_updates
+    SET committed = 1, time_committed = in_timestamp
+    WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
     IF staging_n_jobs = expected_n_jobs THEN
       UPDATE batches SET `state` = IF(expected_n_jobs != 0, 'running', state),
-        time_updated = in_timestamp,
         time_completed = IF(expected_n_jobs != 0, NULL, time_completed)
       WHERE id = in_batch_id;
 
       INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
       SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
-      FROM batch_updates_inst_coll_staging
-      JOIN batches ON batches.id = batch_updates_inst_coll_staging.batch_id
+      FROM batches_inst_coll_staging
+      JOIN batches ON batches.id = batches_inst_coll_staging.batch_id
       WHERE batch_id = in_batch_id AND update_id = in_update_id
       GROUP BY `user`, inst_coll
       ON DUPLICATE KEY UPDATE
         n_ready_jobs = n_ready_jobs + @n_ready_jobs,
         ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
 
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs,
-        ready_cancellable_cores_mcpu, n_creating_cancellable_jobs, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      SELECT batch_id, inst_coll, 0,
-        @n_ready_cancellable_jobs := COALESCE(SUM(n_ready_cancellable_jobs), 0),
-        @ready_cancellable_cores_mcpu := COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
-        @n_creating_cancellable_jobs := COALESCE(SUM(n_creating_cancellable_jobs), 0),
-        @n_running_cancellable_jobs := COALESCE(SUM(n_running_cancellable_jobs), 0),
-        @running_cancellable_cores_mcpu := COALESCE(SUM(running_cancellable_cores_mcpu), 0)
-      FROM batch_inst_coll_cancellable_resources_staging
-      WHERE batch_id = in_batch_id AND update_id = in_update_id
-      GROUP BY batch_id, inst_coll
-      ON DUPLICATE KEY UPDATE
-        n_ready_cancellable_jobs = n_ready_cancellable_jobs + @n_ready_cancellable_jobs,
-        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + @ready_cancellable_cores_mcpu,
-        n_creating_cancellable_jobs = n_creating_cancellable_jobs + @n_creating_cancellable_jobs,
-        n_running_cancellable_jobs = n_running_cancellable_jobs + @n_running_cancellable_jobs,
-        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + @running_cancellable_cores_mcpu;
-
-      DELETE FROM batch_updates_inst_coll_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
-      DELETE FROM batch_inst_coll_cancellable_resources_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
+      DELETE FROM batches_inst_coll_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
 
       IF cur_update_start_job_id != 1 THEN
         # FIXME see if an exists query is faster
@@ -1096,7 +1048,7 @@ BEGIN
             LEFT JOIN `jobs` ON jobs.batch_id = `job_parents`.batch_id AND jobs.job_id = `job_parents`.parent_id
             WHERE `job_parents`.batch_id = in_batch_id AND
               `job_parents`.job_id >= cur_update_start_job_id AND
-              `job_parents`.job_id <= cur_update_end_job_id
+              `job_parents`.job_id < cur_update_start_job_id + staging_n_jobs
             GROUP BY `job_parents`.batch_id, `job_parents`.job_id
             FOR UPDATE
           ) AS t
@@ -1106,12 +1058,8 @@ BEGIN
               jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
               jobs.cancelled = IF(COALESCE(t.n_succeeded, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
-              jobs.job_id <= cur_update_end_job_id;
+              jobs.job_id < cur_update_start_job_id + staging_n_jobs;
       END IF;
-
-      UPDATE batch_updates
-      SET committed = 1, time_committed = in_timestamp
-      WHERE id = in_batch_id AND update_id = in_update_id;
 
       COMMIT;
       SELECT 0 as rc;
@@ -1228,7 +1176,9 @@ BEGIN
       COALESCE(SUM(n_creating_cancellable_jobs), 0)
     FROM batch_inst_coll_cancellable_resources
     JOIN batches ON batches.id = batch_inst_coll_cancellable_resources.batch_id
-    WHERE batch_id = in_batch_id
+    LEFT JOIN batch_updates ON batch_inst_coll_cancellable_resources.batch_id = batch_updates.batch_id AND
+      batch_inst_coll_cancellable_resources.update_id = batch_updates.update_id
+    WHERE batch_updates.batch_id = in_batch_id AND `committed`
     GROUP BY user, inst_coll
     ON DUPLICATE KEY UPDATE
       n_ready_jobs = n_ready_jobs - @n_ready_cancellable_jobs,

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -153,7 +153,8 @@ CREATE TABLE IF NOT EXISTS `batches` (
   `deleted` BOOLEAN NOT NULL DEFAULT FALSE,
   `n_jobs` INT NOT NULL,
   `time_created` BIGINT NOT NULL,
-  `time_closed` BIGINT,
+  `time_closed` BIGINT,  # deprecated
+  `time_updated` BIGINT,
   `time_completed` BIGINT,
   `msec_mcpu` BIGINT NOT NULL DEFAULT 0,
   `token` VARCHAR(100) DEFAULT NULL,
@@ -213,6 +214,20 @@ CREATE TABLE IF NOT EXISTS `batches_inst_coll_staging` (
 ) ENGINE = InnoDB;
 CREATE INDEX `batches_inst_coll_staging_inst_coll` ON `batches_inst_coll_staging` (`inst_coll`);
 
+CREATE TABLE IF NOT EXISTS `batch_updates_inst_coll_staging` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `inst_coll` VARCHAR(255),
+  `token` INT NOT NULL,
+  `n_jobs` INT NOT NULL DEFAULT 0,
+  `n_ready_jobs` INT NOT NULL DEFAULT 0,
+  `ready_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`),
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(`id`, `update_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX `batch_updates_inst_coll_staging_inst_coll` ON `batch_updates_inst_coll_staging` (`inst_coll`);
+
 CREATE TABLE `batch_inst_coll_cancellable_resources` (
   `batch_id` BIGINT NOT NULL,
   `update_id` VARCHAR(40) NOT NULL,
@@ -230,6 +245,22 @@ CREATE TABLE `batch_inst_coll_cancellable_resources` (
   FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX `batch_inst_coll_cancellable_resources_inst_coll` ON `batch_inst_coll_cancellable_resources` (`inst_coll`);
+
+CREATE TABLE `batch_inst_coll_cancellable_resources_staging` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `inst_coll` VARCHAR(255),
+  `token` INT NOT NULL,
+  # neither run_always nor cancelled
+  `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `ready_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  `n_creating_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `n_running_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `running_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `inst_coll`, `token`),
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(`id`, `update_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
+) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `jobs` (
   `batch_id` BIGINT NOT NULL,
@@ -970,6 +1001,124 @@ BEGIN
   ELSE
     ROLLBACK;
     SELECT 1 as rc, cur_state, 'state not inactive' as message;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS commit_batch_update $$
+CREATE PROCEDURE commit_batch_update(
+  IN in_batch_id BIGINT,
+  IN in_update_id VARCHAR(100),
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_update_committed BOOLEAN;
+  DECLARE cur_update_start_job_id INT;
+  DECLARE cur_update_end_job_id INT;
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE staging_n_ready_jobs INT;
+  DECLARE staging_ready_cores_mcpu BIGINT;
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_other_updates_in_progress INT;
+
+  START TRANSACTION;
+
+  SELECT committed, n_jobs, start_job_id, end_job_id INTO
+    cur_update_committed, expected_n_jobs, cur_update_start_job_id, cur_update_end_job_id
+  FROM batch_updates
+  WHERE id = in_batch_id AND update_id = in_update_id
+  FOR UPDATE;
+
+  IF cur_update_committed THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT SUM(NOT committed) INTO cur_other_updates_in_progress
+    FROM batch_updates
+    WHERE id = in_batch_id AND update_id != in_update_id
+    GROUP BY id
+    FOR UPDATE;
+
+    SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
+    INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
+    FROM batch_updates_inst_coll_staging
+    WHERE batch_id = in_batch_id AND update_id = in_update_id
+    FOR UPDATE;
+
+    SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      UPDATE batches SET `state` = IF(expected_n_jobs != 0, 'running', state),
+        time_updated = in_timestamp,
+        time_completed = IF(expected_n_jobs != 0, NULL, time_completed)
+      WHERE id = in_batch_id;
+
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
+      FROM batch_updates_inst_coll_staging
+      JOIN batches ON batches.id = batch_updates_inst_coll_staging.batch_id
+      WHERE batch_id = in_batch_id AND update_id = in_update_id
+      GROUP BY `user`, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
+
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs,
+        ready_cancellable_cores_mcpu, n_creating_cancellable_jobs, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      SELECT batch_id, inst_coll, 0,
+        @n_ready_cancellable_jobs := COALESCE(SUM(n_ready_cancellable_jobs), 0),
+        @ready_cancellable_cores_mcpu := COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
+        @n_creating_cancellable_jobs := COALESCE(SUM(n_creating_cancellable_jobs), 0),
+        @n_running_cancellable_jobs := COALESCE(SUM(n_running_cancellable_jobs), 0),
+        @running_cancellable_cores_mcpu := COALESCE(SUM(running_cancellable_cores_mcpu), 0)
+      FROM batch_inst_coll_cancellable_resources_staging
+      WHERE batch_id = in_batch_id AND update_id = in_update_id
+      GROUP BY batch_id, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs + @n_ready_cancellable_jobs,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + @ready_cancellable_cores_mcpu,
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs + @n_creating_cancellable_jobs,
+        n_running_cancellable_jobs = n_running_cancellable_jobs + @n_running_cancellable_jobs,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + @running_cancellable_cores_mcpu;
+
+      DELETE FROM batch_updates_inst_coll_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
+      DELETE FROM batch_inst_coll_cancellable_resources_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+      IF cur_update_start_job_id != 1 THEN
+        # FIXME see if an exists query is faster
+        UPDATE jobs
+          LEFT JOIN (
+            SELECT `job_parents`.batch_id, `job_parents`.job_id,
+              COALESCE(SUM(1), 0) AS n_parents,
+              COALESCE(SUM(state IN ('Pending', 'Ready', 'Creating', 'Running')), 0) AS n_pending_parents,
+              COALESCE(SUM(state = 'Success'), 0) AS n_succeeded
+            FROM `job_parents`
+            LEFT JOIN `jobs` ON jobs.batch_id = `job_parents`.batch_id AND jobs.job_id = `job_parents`.parent_id
+            WHERE `job_parents`.batch_id = in_batch_id AND
+              `job_parents`.job_id >= cur_update_start_job_id AND
+              `job_parents`.job_id <= cur_update_end_job_id
+            GROUP BY `job_parents`.batch_id, `job_parents`.job_id
+            FOR UPDATE
+          ) AS t
+            ON jobs.batch_id = t.batch_id AND
+               jobs.job_id = t.job_id
+          SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
+              jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
+              jobs.cancelled = IF(COALESCE(t.n_succeeded, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
+          WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
+              jobs.job_id <= cur_update_end_job_id;
+      END IF;
+
+      UPDATE batch_updates
+      SET committed = 1, time_committed = in_timestamp
+      WHERE id = in_batch_id AND update_id = in_update_id;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 1 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
   END IF;
 END $$
 

--- a/batch/sql/populate_batch_updates.py
+++ b/batch/sql/populate_batch_updates.py
@@ -1,0 +1,137 @@
+import asyncio
+import functools
+import os
+import random
+import time
+from typing import List, Optional, Tuple
+
+from gear import Database, transaction
+from hailtop.utils import bounded_gather
+
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+
+def offsets_to_where_statement(start_batch_id, end_batch_id):
+    if start_batch_id is None and end_batch_id is None:
+        where_cond = ''
+        query_args = None
+        return (where_cond, query_args)
+
+    assert start_batch_id != end_batch_id, start_batch_id
+    if start_batch_id is None:
+        assert end_batch_id
+        where_cond = 'WHERE batches.id < %s'
+        query_args = (end_batch_id,)
+    elif end_batch_id is None:
+        assert start_batch_id
+        where_cond = 'WHERE batches.id >= %s'
+        query_args = (start_batch_id,)
+    else:
+        where_cond = 'WHERE batches.id >= %s AND batches.id < %s'
+        query_args = (start_batch_id, end_batch_id)
+
+    return (where_cond, query_args)
+
+
+async def process_chunk(counter, db, start_offset, end_offset, quiet=True):
+    start_time = time.time()
+
+    where_cond, query_args = offsets_to_where_statement(start_offset, end_offset)
+
+    await db.just_execute(
+        f'''
+UPDATE batches
+SET update_added = TRUE
+{where_cond}
+''',
+        query_args)
+
+    if not quiet and counter.n % 100 == 0:
+        print(f'processed chunk ({start_offset}, {end_offset}) in {time.time() - start_time}s')
+
+    counter.n += 1
+    if counter.n % 500 == 0:
+        print(f'processed {counter.n} complete chunks')
+
+
+async def find_chunk_offsets(db, size):
+    @transaction(db)
+    async def _find_chunks(tx) -> List[Optional[int]]:
+        start_time = time.time()
+
+        await tx.just_execute('SET @rank=0;')
+
+        query = f'''
+SELECT t.id FROM (
+  SELECT id
+  FROM batches
+  ORDER BY id
+) AS t
+WHERE MOD((@rank := @rank + 1), %s) = 0;
+'''
+
+        offsets = tx.execute_and_fetchall(query, (size,))
+        offsets = [offset['id'] async for offset in offsets]
+        offsets.append(None)
+
+        print(f'found chunk offsets in {round(time.time() - start_time, 4)}s')
+        return offsets
+
+    return await _find_chunks()
+
+
+async def main(chunk_size=100):
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    start_time = time.time()
+
+    try:
+        populate_start_time = time.time()
+
+        chunk_counter = Counter()
+        chunk_offsets = [None]
+        for offset in await find_chunk_offsets(db, chunk_size):
+            chunk_offsets.append(offset)
+
+        chunk_offsets = list(zip(chunk_offsets[:-1], chunk_offsets[1:]))
+
+        if chunk_offsets:
+            print(f'found {len(chunk_offsets)} chunks to process')
+
+            random.shuffle(chunk_offsets)
+
+            burn_in_start = time.time()
+            n_burn_in_chunks = 1000
+
+            burn_in_chunk_offsets = chunk_offsets[:n_burn_in_chunks]
+            chunk_offsets = chunk_offsets[n_burn_in_chunks:]
+
+            for start_offset, end_offset in burn_in_chunk_offsets:
+                await process_chunk(chunk_counter, db, start_offset, end_offset, quiet=False)
+
+            print(f'finished burn-in in {time.time() - burn_in_start}s')
+
+            parallel_update_start = time.time()
+
+            await bounded_gather(
+                *[functools.partial(process_chunk, chunk_counter, db, start_offset, end_offset, quiet=False)
+                  for start_offset, end_offset in chunk_offsets],
+                parallelism=10
+            )
+            print(f'took {time.time() - parallel_update_start}s to update the remaining records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_update_start)}) attempts / sec')
+
+        print(f'finished populating records in {time.time() - populate_start_time}s')
+    finally:
+        print(f'finished migration in {time.time() - start_time}s')
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,13 +1,13 @@
 import aiohttp
 
-from hailtop.httpx import client_session
+from hailtop import httpx
 from hailtop.utils import async_to_blocking
 
 
-class FailureInjectingClientSession:
+class FailureInjectingClientSession(httpx.ClientSession):
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = client_session()
+        self.real_session = httpx.client_session()
 
     def __enter__(self):
         return self

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,13 +1,13 @@
 import aiohttp
 
-from hailtop import httpx
+from hailtop.httpx import client_session
 from hailtop.utils import async_to_blocking
 
 
-class FailureInjectingClientSession(httpx.ClientSession):
+class FailureInjectingClientSession:
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = httpx.client_session()
+        self.real_session = client_session()
 
     def __enter__(self):
         return self

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -178,7 +178,7 @@ async def test_close_billing_project_with_open_batch_errors(
     project = new_billing_project
     await dev_client.add_user("test", project)
     client = await make_client(project)
-    b = await client.create_batch()._open_batch()
+    b = await client.create_batch()._create_batch()
 
     try:
         await dev_client.close_billing_project(project)
@@ -617,7 +617,7 @@ async def test_deleted_open_batches_do_not_prevent_billing_project_closure(
         project = await dev_client.create_billing_project(random_billing_project_name)
         await dev_client.add_user('test', project)
         client = await make_client(project)
-        open_batch = await client.create_batch()._open_batch()
+        open_batch = await client.create_batch()._create_batch()
         await open_batch.delete()
     finally:
         await dev_client.close_billing_project(project)

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -519,7 +519,7 @@ async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(
     b_handle = await b.submit()
 
     user2_client = dev_client
-    user2_batch = Batch(user2_client, b_handle.id, b_handle.attributes, b_handle.n_jobs, b_handle.token)
+    user2_batch = Batch(user2_client, b_handle.id, b_handle.attributes, b_handle.token)
 
     try:
         try:

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -34,9 +34,9 @@ def client():
 
 
 def test_job(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b = bb.submit()
 
     status = j.wait()
     assert 'attributes' not in status, str((status, b.debug_info()))
@@ -48,9 +48,9 @@ def test_job(client: BatchClient):
 
 
 def test_job_running_logs(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])
+    b = bb.submit()
 
     delay = 1
     while True:
@@ -67,9 +67,9 @@ def test_job_running_logs(client: BatchClient):
 
 
 def test_exit_code_duration(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'exit 7'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'exit 7'])
+    b = bb.submit()
     status = j.wait()
     assert status['exit_code'] == 7, str((status, b.debug_info()))
     assert isinstance(status['duration'], int), str((status, b.debug_info()))
@@ -78,16 +78,16 @@ def test_exit_code_duration(client: BatchClient):
 
 def test_attributes(client: BatchClient):
     a = {'name': 'test_attributes', 'foo': 'bar'}
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], attributes=a)
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], attributes=a)
+    b = bb.submit()
     assert j.attributes() == a, str(b.debug_info())
 
 
 def test_garbage_image(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job('dsafaaadsf', ['echo', 'test'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job('dsafaaadsf', ['echo', 'test'])
+    b = bb.submit()
     status = j.wait()
     assert j._get_exit_codes(status) == {'main': None}, str((status, b.debug_info()))
     assert j._get_error(status, 'main') is not None, str((status, b.debug_info()))
@@ -95,74 +95,74 @@ def test_garbage_image(client: BatchClient):
 
 
 def test_bad_command(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
 
 
 def test_invalid_resource_requests(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '1', 'memory': '250Gi', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0', 'memory': '1Gi', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         aiohttp.client.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.1', 'memory': '1Gi', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         aiohttp.client.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'foo', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         aiohttp.client.ClientResponseError,
         match=".*.resources.memory must match regex:.*.resources.memory must be one of:.*",
     ):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '500Mi', 'storage': '10000000Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'storage': '10000000Gi', 'machine_type': smallest_machine_type(CLOUD)}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
-        builder.submit()
+        bb.submit()
 
 
 def test_out_of_memory(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job('python:3.6-slim-stretch', ['python', '-c', 'x = "a" * 1000**3'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job('python:3.6-slim-stretch', ['python', '-c', 'x = "a" * 1000**3'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert j._get_out_of_memory(status, 'main'), str((status, b.debug_info()))
 
 
 def test_out_of_storage(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '5Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 100GiB /foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 100GiB /foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -170,12 +170,12 @@ def test_out_of_storage(client: BatchClient):
 
 
 def test_quota_applies_to_volume(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '5Gi'}
-    j = builder.create_job(
+    j = bb.create_job(
         os.environ['HAIL_VOLUME_IMAGE'], ['/bin/sh', '-c', 'fallocate -l 100GiB /data/foo'], resources=resources
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -183,28 +183,28 @@ def test_quota_applies_to_volume(client: BatchClient):
 
 
 def test_quota_shared_by_io_and_rootfs(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job(
+    j = bb.create_job(
         DOCKER_ROOT_IMAGE,
         ['/bin/sh', '-c', 'fallocate -l 7GiB /foo; fallocate -l 7GiB /io/foo'],
         resources=resources,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -212,37 +212,37 @@ def test_quota_shared_by_io_and_rootfs(client: BatchClient):
 
 
 def test_nonzero_storage(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '20Gi'}
-    j = builder.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 @skip_in_azure()
 def test_attached_disk(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '400Gi'}
-    j = builder.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'df -h; fallocate -l 390GiB /io/foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'df -h; fallocate -l 390GiB /io/foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_cwd_from_image_workdir(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_WORKDIR_IMAGE'], ['/bin/sh', '-c', 'pwd'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_WORKDIR_IMAGE'], ['/bin/sh', '-c', 'pwd'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
     assert "/work" in job_log['main'], str((job_log, b.debug_info()))
 
 
-def test_unsubmitted_state(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+def test_unsubmitted_jobs_dont_have_data(client: BatchClient):
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
 
     with pytest.raises(ValueError):
         j.batch_id
@@ -257,20 +257,16 @@ def test_unsubmitted_state(client: BatchClient):
     with pytest.raises(ValueError):
         j.wait()
 
-    builder.submit()
-    builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    assert j.id == 1
-
 
 def test_list_batches(client: BatchClient):
     tag = secrets.token_urlsafe(64)
-    builder1 = client.create_batch(attributes={'tag': tag, 'name': 'b1'})
-    builder1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b1 = builder1.submit()
+    bb1 = client.create_batch(attributes={'tag': tag, 'name': 'b1'})
+    bb1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b1 = bb1.submit()
 
-    builder2 = client.create_batch(attributes={'tag': tag, 'name': 'b2'})
-    builder2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b2 = builder2.submit()
+    bb2 = client.create_batch(attributes={'tag': tag, 'name': 'b2'})
+    bb2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b2 = bb2.submit()
 
     batch_id_test_universe = {b1.id, b2.id}
 
@@ -310,13 +306,13 @@ def test_list_batches(client: BatchClient):
 
 
 def test_list_jobs(client: BatchClient):
-    builder = client.create_batch()
-    j_success = builder.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    j_failure = builder.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    j_error = builder.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
-    j_running = builder.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
+    bb = client.create_batch()
+    j_success = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    j_failure = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    j_error = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
+    j_running = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
 
-    b = builder.submit()
+    b = bb.submit()
     j_success.wait()
     j_failure.wait()
     j_error.wait()
@@ -337,26 +333,26 @@ def test_list_jobs(client: BatchClient):
 
 
 def test_include_jobs(client: BatchClient):
-    builder = client.create_batch()
+    bb1 = client.create_batch()
     for _ in range(2):
-        builder.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = builder.submit()
-    s = b.status()
-    assert 'jobs' not in s, str((s, b.debug_info()))
+        bb1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b1 = bb1.submit()
+    s = b1.status()
+    assert 'jobs' not in s, str((s, b1.debug_info()))
 
 
 def test_fail(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    b = bb.submit()
     status = j.wait()
     assert j._get_exit_code(status, 'main') == 1, str((status, b.debug_info()))
 
 
 def test_unknown_image(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(f'{DOCKER_PREFIX}/does-not-exist', ['echo', 'test'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(f'{DOCKER_PREFIX}/does-not-exist', ['echo', 'test'])
+    b = bb.submit()
     status = j.wait()
     try:
         assert j._get_exit_code(status, 'main') is None
@@ -368,9 +364,9 @@ def test_unknown_image(client: BatchClient):
 
 
 def test_running_job_log_and_status(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '300'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '300'])
+    b = bb.submit()
 
     while True:
         if j.status()['state'] == 'Running' or j.is_complete():
@@ -382,9 +378,9 @@ def test_running_job_log_and_status(client: BatchClient):
 
 
 def test_deleted_job_log(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b = bb.submit()
     j.wait()
     b.delete()
 
@@ -398,9 +394,9 @@ def test_deleted_job_log(client: BatchClient):
 
 
 def test_delete_batch(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b = bb.submit()
     b.delete()
 
     # verify doesn't exist
@@ -414,9 +410,9 @@ def test_delete_batch(client: BatchClient):
 
 
 def test_cancel_batch(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b = bb.submit()
 
     status = j.status()
     assert status['state'] in ('Ready', 'Running'), str((status, b.debug_info()))
@@ -448,9 +444,9 @@ def test_get_nonexistent_job(client: BatchClient):
 
 
 def test_get_job(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b = bb.submit()
 
     j2 = client.get_job(*j.id)
     status2 = j2.status()
@@ -458,11 +454,11 @@ def test_get_job(client: BatchClient):
 
 
 def test_batch(client: BatchClient):
-    b = client.create_batch()
-    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1'])
-    b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = b.submit()
+    bb = client.create_batch()
+    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1'])
+    bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b = bb.submit()
 
     j1.wait()
     j2.wait()
@@ -482,31 +478,31 @@ def test_batch(client: BatchClient):
 
 
 def test_batch_status(client: BatchClient):
-    b1 = client.create_batch()
-    b1.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b1 = b1.submit()
+    bb1 = client.create_batch()
+    bb1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b1 = bb1.submit()
     b1.wait()
     b1s = b1.status()
     assert b1s['complete'] and b1s['state'] == 'success', str((b1s, b1.debug_info()))
 
-    b2 = client.create_batch()
-    b2.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    b2.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b2 = b2.submit()
+    bb2 = client.create_batch()
+    bb2.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    bb2.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b2 = bb2.submit()
     b2.wait()
     b2s = b2.status()
     assert b2s['complete'] and b2s['state'] == 'failure', str((b2s, b2.debug_info()))
 
-    b3 = client.create_batch()
-    b3.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b3 = b3.submit()
+    bb3 = client.create_batch()
+    bb3.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b3 = bb3.submit()
     b3s = b3.status()
     assert not b3s['complete'] and b3s['state'] == 'running', str((b3s, b3.debug_info()))
     b3.cancel()
 
-    b4 = client.create_batch()
-    b4.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b4 = b4.submit()
+    bb4 = client.create_batch()
+    bb4.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b4 = bb4.submit()
     b4.cancel()
     b4.wait()
     b4s = b4.status()
@@ -514,9 +510,9 @@ def test_batch_status(client: BatchClient):
 
 
 def test_log_after_failing_job(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'echo test; exit 127'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'echo test; exit 127'])
+    b = bb.submit()
     status = j.wait()
     assert 'attributes' not in status, str((status, b.debug_info()))
     assert status['state'] == 'Failed', str((status, b.debug_info()))
@@ -529,9 +525,9 @@ def test_log_after_failing_job(client: BatchClient):
 
 
 def test_long_log_line(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
@@ -569,28 +565,28 @@ def test_authorized_users_only():
 
 
 def test_cloud_image(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['echo', 'test'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['echo', 'test'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_service_account(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(
+    bb = client.create_batch()
+    j = bb.create_job(
         os.environ['CI_UTILS_IMAGE'],
         ['/bin/sh', '-c', 'kubectl version'],
         service_account={'namespace': NAMESPACE, 'name': 'test-batch-sa'},
     )
-    b = b.submit()
+    b = bb.submit()
     status = j.wait()
     assert j._get_exit_code(status, 'main') == 0, str((status, b.debug_info()))
 
 
 def test_port(client: BatchClient):
-    builder = client.create_batch()
-    builder.create_job(
+    bb = client.create_batch()
+    bb.create_job(
         DOCKER_ROOT_IMAGE,
         [
             'bash',
@@ -602,15 +598,15 @@ echo $HAIL_BATCH_WORKER_IP
         ],
         port=5000,
     )
-    b = builder.submit()
+    b = bb.submit()
     batch = b.wait()
     assert batch['state'] == 'success', str((batch, b.debug_info()))
 
 
 def test_timeout(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'], timeout=5)
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'], timeout=5)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Error', str((status, b.debug_info()))
     error_msg = j._get_error(status, 'main')
@@ -619,10 +615,10 @@ def test_timeout(client: BatchClient):
 
 
 def test_client_max_size(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     for _ in range(4):
-        builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
-    builder.submit()
+        bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
+    bb.submit()
 
 
 def test_restartable_insert(client: BatchClient):
@@ -637,12 +633,12 @@ def test_restartable_insert(client: BatchClient):
 
     with FailureInjectingClientSession(every_third_time) as session:
         client = BatchClient('test', session=session)
-        builder = client.create_batch()
+        bb = client.create_batch()
 
         for _ in range(9):
-            builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a'])
+            bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a'])
 
-        b = builder.submit(max_bunch_size=1)
+        b = bb.submit(max_bunch_size=1)
         b = client.get_batch(b.id)  # get a batch untainted by the FailureInjectingClientSession
         status = b.wait()
         assert status['state'] == 'success', str((status, b.debug_info()))
@@ -652,10 +648,10 @@ def test_restartable_insert(client: BatchClient):
 
 def test_create_idempotence(client: BatchClient):
     token = secrets.token_urlsafe(32)
-    builder1 = client.create_batch(token=token)
-    builder2 = client.create_batch(token=token)
-    b1 = builder1._create_batch()
-    b2 = builder2._create_batch()
+    bb1 = client.create_batch(token=token)
+    bb2 = client.create_batch(token=token)
+    b1 = bb1._create_batch()
+    b2 = bb2._create_batch()
     assert b1.id == b2.id
 
 
@@ -700,11 +696,11 @@ def test_batch_create_validation():
 
 
 def test_duplicate_parents(client: BatchClient):
-    batch = client.create_batch()
-    head = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head, head])
+    bb = client.create_batch()
+    head = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
+    bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head, head])
     try:
-        batch = batch.submit()
+        batch = bb.submit()
     except aiohttp.ClientResponseError as e:
         assert e.status == 400
     else:
@@ -713,11 +709,9 @@ def test_duplicate_parents(client: BatchClient):
 
 @skip_in_azure()
 def test_verify_no_access_to_google_metadata_server(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(
-        os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'metadata.google.internal', '--max-time', '10']
-    )
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'metadata.google.internal', '--max-time', '10'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -725,9 +719,9 @@ def test_verify_no_access_to_google_metadata_server(client: BatchClient):
 
 
 def test_verify_no_access_to_metadata_server(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -735,7 +729,7 @@ def test_verify_no_access_to_metadata_server(client: BatchClient):
 
 
 def test_submit_batch_in_job(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     script = f'''import hailtop.batch as hb
 backend = hb.ServiceBackend("test", remote_tmpdir="{remote_tmpdir}")
@@ -745,12 +739,12 @@ j.command("echo hi")
 b.run()
 backend.close()
 '''
-    j = builder.create_job(
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'],
         ['/bin/bash', '-c', f'''python3 -c \'{script}\''''],
         mount_tokens=True,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
@@ -766,8 +760,8 @@ b.run()
 backend.close()
 '''
 
-    builder = client.create_batch()
-    j = builder.create_job(
+    bb = client.create_batch()
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'],
         [
             '/bin/bash',
@@ -779,7 +773,7 @@ python3 -c \'{script}\'''',
         ],
         mount_tokens=True,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     if NAMESPACE == 'default':
         assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -787,8 +781,8 @@ python3 -c \'{script}\'''',
         assert status['state'] == 'Failed', str((status, b.debug_info()))
         assert "Please log in" in j.log()['main'], (str(j.log()['main']), status)
 
-    builder = client.create_batch()
-    j = builder.create_job(
+    bb = client.create_batch()
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'],
         [
             '/bin/bash',
@@ -800,7 +794,7 @@ python3 -c \'{script}\'''',
         ],
         mount_tokens=True,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     if NAMESPACE == 'default':
         assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -812,7 +806,7 @@ python3 -c \'{script}\'''',
 
 def test_cannot_contact_other_internal_ips(client: BatchClient):
     internal_ips = [f'10.128.0.{i}' for i in (10, 11, 12)]
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = f'''
 if [ "$HAIL_BATCH_WORKER_IP" != "{internal_ips[0]}" ] && ! grep -Fq {internal_ips[0]} /etc/hosts; then
     OTHER_IP={internal_ips[0]}
@@ -824,8 +818,8 @@ fi
 
 curl -fsSL -m 5 $OTHER_IP
 '''
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['/bin/bash', '-c', script], port=5000)
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['/bin/bash', '-c', script], port=5000)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -836,7 +830,7 @@ curl -fsSL -m 5 $OTHER_IP
 def test_can_use_google_credentials(client: BatchClient):
     token = os.environ["HAIL_TOKEN"]
     remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = f'''import hail as hl
 import secrets
 attempt_token = secrets.token_urlsafe(5)
@@ -844,10 +838,10 @@ location = f"{remote_tmpdir}/{ token }/{{ attempt_token }}/test_can_use_hailctl_
 hl.utils.range_table(10).write(location)
 hl.read_table(location).show()
 '''
-    j = builder.create_job(
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'], ['/bin/bash', '-c', f'python3 -c >out 2>err \'{script}\'; cat out err']
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', f'{j.log(), status}'
     expected_log = '''+-------+
@@ -872,25 +866,25 @@ hl.read_table(location).show()
 
 
 def test_user_authentication_within_job(client: BatchClient):
-    batch = client.create_batch()
+    bb = client.create_batch()
     cmd = ['bash', '-c', 'hailctl auth user']
-    no_token = batch.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=False)
-    b = batch.submit()
+    no_token = bb.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=False)
+    b = bb.submit()
 
     no_token_status = no_token.wait()
     assert no_token_status['state'] == 'Failed', str((no_token_status, b.debug_info()))
 
 
 def test_verify_access_to_public_internet(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'example.com'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'example.com'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_verify_can_tcp_to_localhost(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = '''
 set -e
 nc -l -p 5000 &
@@ -899,8 +893,8 @@ echo "hello" | nc -q 1 localhost 5000
 '''.lstrip(
         '\n'
     )
-    j = builder.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -908,7 +902,7 @@ echo "hello" | nc -q 1 localhost 5000
 
 
 def test_verify_can_tcp_to_127_0_0_1(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = '''
 set -e
 nc -l -p 5000 &
@@ -917,8 +911,8 @@ echo "hello" | nc -q 1 127.0.0.1 5000
 '''.lstrip(
         '\n'
     )
-    j = builder.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -926,7 +920,7 @@ echo "hello" | nc -q 1 127.0.0.1 5000
 
 
 def test_verify_can_tcp_to_self_ip(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = '''
 set -e
 nc -l -p 5000 &
@@ -935,8 +929,8 @@ echo "hello" | nc -q 1 $(hostname -i) 5000
 '''.lstrip(
         '\n'
     )
-    j = builder.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/sh', '-c', script])
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/sh', '-c', script])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -944,12 +938,12 @@ echo "hello" | nc -q 1 $(hostname -i) 5000
 
 
 def test_verify_private_network_is_restricted(client: BatchClient):
-    builder = client.create_batch()
-    builder.create_job(
+    bb = client.create_batch()
+    bb.create_job(
         os.environ['HAIL_CURL_IMAGE'], command=['curl', 'internal.hail', '--connect-timeout', '60'], network='private'
     )
     try:
-        builder.submit()
+        bb.submit()
     except aiohttp.ClientResponseError as err:
         assert err.status == 400
         assert 'unauthorized network private' in err.message
@@ -958,90 +952,90 @@ def test_verify_private_network_is_restricted(client: BatchClient):
 
 
 def test_pool_highmem_instance(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'highmem'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highmem_instance_cheapest(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '1', 'memory': '5Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highcpu_instance(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'lowmem'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highcpu_instance_cheapest(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '50Mi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_standard_instance(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'standard'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_standard_instance_cheapest(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '1', 'memory': '2.5Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_preemptible(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'machine_type': smallest_machine_type(CLOUD)}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'job-private' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_nonpreemptible(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'machine_type': smallest_machine_type(CLOUD), 'preemptible': False}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'job-private' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_cancel(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'machine_type': smallest_machine_type(CLOUD)}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
 
     delay = 0.1
     start = time.time()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -258,8 +258,8 @@ def test_unsubmitted_state(client: BatchClient):
         j.wait()
 
     builder.submit()
-    with pytest.raises(ValueError):
-        builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    assert j.id == 1
 
 
 def test_list_batches(client: BatchClient):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1062,10 +1062,8 @@ def test_update_batch_no_deps(client: BatchClient):
     b = client.create_batch()
     b.create_job(DOCKER_ROOT_IMAGE, ['false'])
     b = b.submit()
-
-    u = client.update_batch(b.id)
-    j = u.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = u.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b = b.submit()
     status = j.wait()
 
     assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -1075,9 +1073,7 @@ def test_empty_update(client: BatchClient):
     b = client.create_batch()
     b.create_job(DOCKER_ROOT_IMAGE, ['false'])
     b = b.submit()
-
-    u = client.update_batch(b.id)
-    b = u.submit()
+    b = b.submit()
     status = b.wait()
 
     assert status['state'] == 'success', str((status, b.debug_info()))
@@ -1088,10 +1084,8 @@ def test_update_batch_w_submitted_job_deps(client: BatchClient):
     j1 = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
     b = b.submit()
     j1.wait()
-
-    u = client.update_batch(b.id)
-    j2 = u.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
-    b = u.submit()
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
+    b = b.submit()
     status = j2.wait()
 
     assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -1102,9 +1096,8 @@ def test_update_batch_w_failing_submitted_job_deps(client: BatchClient):
     j1 = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
     b = b.submit()
 
-    u = client.update_batch(b.id)
-    j2 = u.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
-    b = u.submit()
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
+    b = b.submit()
     status = j2.wait()
 
     assert status['state'] == 'Cancelled', str((status, b.debug_info()))
@@ -1115,10 +1108,9 @@ def test_update_batch_w_deps_in_update(client: BatchClient):
     j = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
     b = b.submit()
 
-    u = client.update_batch(b.id)
-    j1 = u.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    j2 = u.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j, j1])
-    b = u.submit()
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j, j1])
+    b = b.submit()
     status = j2.wait()
 
     assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -1148,7 +1140,8 @@ def test_update_batch_w_multiple_empty_updates(client: BatchClient):
 
     u = client.update_batch(b.id)
     j1 = u.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    status = u.submit()
+    b = u.submit()
+    status = b.wait()
 
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert j1.job_id == 1, str(b.debug_info())

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -37,7 +37,7 @@ def test_simple(client):
 def test_missing_parent_is_400(client):
     try:
         batch = client.create_batch()
-        fake_job = aioclient.Job.unsubmitted_job(batch._async_builder, aioclient.JobSpec(1000, {}))
+        fake_job = aioclient.Job.unsubmitted_job(batch._async_builder, aioclient.JobSpec(10000, {}))
         fake_job = Job.from_async_job(fake_job)
         batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'], parents=[fake_job])
         batch = batch.submit()

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -26,7 +26,7 @@ def client():
 def test_simple(client):
     batch = client.create_batch()
     head = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head])
+    tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head])
     batch = batch.submit()
     batch.wait()
     status = legacy_batch_status(batch)
@@ -128,7 +128,6 @@ def test_callback(client):
         callback_body.append(body)
         return Response(status=200)
 
-    server = None
     try:
         server = ServerThread(app)
         server.start()

--- a/build.yaml
+++ b/build.yaml
@@ -2064,6 +2064,12 @@ steps:
       - name: add-real-time-billing
         script: /io/sql/add-real-time-billing.sql
         online: true
+      - name: add-batch-updates
+        script: /io/sql/add-batch-updates.sql
+        online: true
+      - name: populate-batch-updates
+        script: /io/sql/populate_batch_updates.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/build.yaml
+++ b/build.yaml
@@ -2070,6 +2070,9 @@ steps:
       - name: populate-batch-updates
         script: /io/sql/populate_batch_updates.py
         online: true
+      - name: add-open-batches
+        script: /io/sql/add-open-batches.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -435,8 +435,9 @@ class JobSpec:
 
 
 class BatchSubmissionInfo:
-    def __init__(self, used_fast_create):
+    def __init__(self, used_fast_create: Optional[bool] = None, used_fast_update: Optional[bool] = None):
         self.used_fast_create = used_fast_create
+        self.used_fast_update = used_fast_update
 
 
 class Batch:
@@ -709,7 +710,7 @@ class BatchBuilder:
                       self.attributes,
                       n_jobs,
                       self.token,
-                      submission_info=BatchSubmissionInfo(True))
+                      submission_info=BatchSubmissionInfo(used_fast_create=True))
         start_job_id = batch_json['start_job_id']
         return (batch, start_job_id)
 
@@ -746,7 +747,8 @@ class BatchBuilder:
                           self._batch_id,
                           self.attributes,
                           update_json['n_jobs'],
-                          self.token)
+                          self.token,
+                          submission_info=BatchSubmissionInfo(used_fast_update=True))
 
         start_job_id = update_json['start_job_id']
         if start_job_id is None:
@@ -777,7 +779,7 @@ class BatchBuilder:
                      self.attributes,
                      batch_spec['n_jobs'],
                      self.token,
-                     submission_info=BatchSubmissionInfo(False))
+                     submission_info=BatchSubmissionInfo(used_fast_create=False))
 
     async def _create_update(self):
         assert self._batch_id and self._update_id
@@ -794,7 +796,8 @@ class BatchBuilder:
         if self._batch:
             self._batch.n_jobs = new_n_jobs
         else:
-            self._batch = Batch(self._client, self._batch_id, commit_json['attributes'], new_n_jobs, commit_json['token'])
+            self._batch = Batch(self._client, self._batch_id, commit_json['attributes'], new_n_jobs, commit_json['token'],
+                                submission_info=BatchSubmissionInfo(used_fast_update=False))
         return (self._batch, commit_json['start_job_id'])
 
     MAX_BUNCH_BYTESIZE = 1024 * 1024

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -190,6 +190,9 @@ class Batch:
                    timeout=None, cloudfuse=None, requester_pays_project=None,
                    mount_tokens=False, network: Optional[str] = None,
                    unconfined: bool = False, user_code: Optional[str] = None) -> Job:
+        if parents:
+            parents = [parent._async_job for parent in parents]
+
         async_job = self._async_batch.create_job(
             image, command, env=env, mount_docker_socket=mount_docker_socket,
             port=port, resources=resources, secrets=secrets,
@@ -197,6 +200,7 @@ class Batch:
             input_files=input_files, output_files=output_files, always_run=always_run,
             timeout=timeout, cloudfuse=cloudfuse, requester_pays_project=requester_pays_project,
             mount_tokens=mount_tokens, network=network, unconfined=unconfined, user_code=user_code)
+
         return Job.from_async_job(async_job)
 
     def create_jvm_job(self, command, *, parents=None, **kwargs) -> Job:


### PR DESCRIPTION
Stacked on #12120 

This PR implements open batches. Future PRs will expose the functionality to users in the Query Service and hailtop.batch. There's a [design document](https://docs.google.com/document/d/168Mq5nNATmSrwzL4h1oYGBIFmcNlgFyHr_Vwjx59Zss/edit#heading=h.ghe60pdzl3mv) that specified all of the changes.

To briefly summarize, there are now the concept of batch updates. Each job belongs inside an "update". The BatchClient has two types of builders now: UpdateBatchBuilder and CreateBatchBuilder. I play some tricks with the job ids being allowed to be negative numbers denoting relative to an offset to make things more efficient when updating a batch because you don't have to make multiple API calls to get the current job offset in the batch.

There are only two batch states in the database: `running` and `complete`. A batch starts out as `complete` until an update is committed at which point if the n_jobs > 0, it will change to `running`.

The main thing to look at implementation-wise is the new stored procedure `commit_batch_update` with a nasty update that will block progress on the batch while the update is in progress.

I added the updates to the UI. We can get rid of it if it's too confusing. There's also a `Time Updated` column now in the UI instead of `Time Closed`.
<img width="1573" alt="Screen Shot 2022-07-07 at 5 33 50 PM" src="https://user-images.githubusercontent.com/1693348/177875516-5f48e9a7-7fc2-4344-b3d2-c9560a846abe.png">

<img width="786" alt="Screen Shot 2022-07-07 at 5 34 07 PM" src="https://user-images.githubusercontent.com/1693348/177875535-e9b3a99f-bdc9-4a3b-8a53-5d20df05f161.png">

