### PR TITLE
allow empty partition in BlockMatrixReadRowBlockedRDD

### DIFF
--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -2122,6 +2122,9 @@ class BlockMatrixReadRowBlockedRDD(
     val pi = split.index
     val rowsForPartition = partitionRanges(pi)
 
+    if (rowsForPartition.isEmpty) {
+      return Iterator.single(ctx => Iterator.empty)
+    }
     Iterator.single { ctx =>
       val region = ctx.region
       val rvb = new RegionValueBuilder(region)


### PR DESCRIPTION
When `hl.king` is called on a mt with only 2 samples, the result has an empty partition. It probably shouldn't, but regardless I don't think we should be assuming non-empty partitions.