### PR TITLE
[batch-driver] reduce requests

### DIFF
--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -38,8 +38,8 @@ spec:
         image: {{ batch_driver_nginx_image.image }}
         resources:
           requests:
-            cpu: "2"
-            memory: "1G"
+            cpu: "300m"
+            memory: "100M"
           limits:
             cpu: "2.5"
             memory: "2G"
@@ -65,8 +65,8 @@ spec:
          - batch.driver
         resources:
           requests:
-            cpu: "1"
-            memory: "2G"
+            cpu: "350m"
+            memory: "200M"
           limits:
             cpu: "1.5"
             memory: "2.5G"


### PR DESCRIPTION
Again, [looking at utilization](https://console.cloud.google.com/monitoring/dashboards/builder/982ec67a-4b20-4901-a0aa-af418813a9c4?project=hail-vdc&dashboardBuilderState=%257B%2522editModeEnabled%2522:false%257D&timeDomain=1m&f.rlabel.namespace_name=default&f.umlabel.app=batch-driver), the driver is generally not using its full request. The Python spikes are maybe 35% of utilization and the nginx spikes are maybe 15%. I set the requests to around the top of these spikes. That should ensure that normal daily load is handled without scale up, but during low periods we can pack much better.

cc: @jigold 