### PR TITLE
[grafana] allow grafana to be evicted by autoscaler

### DIFF
--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: grafana
   labels:
     app: grafana
+  annotations:
+    "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The emptyDir is only used to communicate from the initcontainer to the
main container. The autoscaler can safely evict and reschedule Grafana
and the initcontainer will run again and generate the token as necessary.