### PR TITLE
[gear] Dont redirect to auth flow if authenticated but not authorized

### DIFF
--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -70,7 +70,7 @@ def rest_authenticated_users_only(fun):
     return wrapped
 
 
-def _web_unauthorized(request, redirect):
+def _web_unauthenticated(request, redirect):
     if not redirect:
         return web.HTTPUnauthorized()
 
@@ -97,7 +97,7 @@ def web_authenticated_users_only(redirect=True):
                 rest_userdata = await userdata_from_rest_request(request)
                 if rest_userdata:
                     return web.HTTPUnauthorized(reason="provided REST auth to web endpoint")
-                raise _web_unauthorized(request, redirect)
+                raise _web_unauthenticated(request, redirect)
             return await fun(request, userdata, *args, **kwargs)
 
         return wrapped
@@ -120,7 +120,7 @@ def web_authenticated_developers_only(redirect=True):
         async def wrapped(request, userdata, *args, **kwargs):
             if userdata['is_developer'] == 1:
                 return await fun(request, userdata, *args, **kwargs)
-            raise _web_unauthorized(request, redirect)
+            raise web.HTTPUnauthorized()
 
         return wrapped
 


### PR DESCRIPTION
`_web_unauthorized` should really be `_web_unauthenticated`, since it only makes sense to send someone through an auth flow if they are not logged in. If they are logged in but don't have the right credentials, e.g. in `web_authenticated_developers_only`, this will result in an infinite loop of auth redirects. As such, this also jumps straight to the point in `web_authenticated_developers_only` and raises Unauthorized if the session belongs to a user that is not a dev.