### PR TITLE
[website] Make autoscaler less eager

### DIFF
--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -117,7 +117,7 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 80
+      targetAverageUtilization: 2500
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
With the new resource changes it's very easy to run max website pods. I honestly would be surprised if we even need an autoscaler for the website.