### PR TITLE
[batch] Add resource_limits to enable new autoscaling_policy

### DIFF
--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -122,6 +122,16 @@ resource "google_container_cluster" "vdc" {
   cluster_autoscaling {
     enabled = true
     autoscaling_profile = "OPTIMIZE_UTILIZATION"
+    resource_limits {
+      resource_type = "cpu"
+      minimum       = 4
+      maximum       = 100
+    }
+    resource_limits {
+      resource_type = "memory"
+      minimum       = 8
+      maximum       = 500
+    }
   }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/hail-is/hail/pull/12025. Without this setting, the Terraform cluster upgrade will fail eventually.

These are cluster-wide limits. I picked rather generous limits, but I'm not sure how many dev deployments you have or whether you generally need a lot of nodes (the current node pool max is 200 nodes).

#assign services