### PR TITLE
[batch] Add resource ids to the attempt resources table

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -83,7 +83,9 @@ async def add_attempt_resources(db, batch_id, job_id, attempt_id, resources):
             # This must be sorted in order to match the order of values in the actual SQL table!
             _resources = dict(sorted(_resources.items()))
 
-            resource_args = [(batch_id, job_id, attempt_id, name, quantity, name) for name, quantity in _resources.items()]
+            resource_args = [
+                (batch_id, job_id, attempt_id, name, quantity, name) for name, quantity in _resources.items()
+            ]
 
             await db.execute_many(
                 '''

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -83,12 +83,14 @@ async def add_attempt_resources(db, batch_id, job_id, attempt_id, resources):
             # This must be sorted in order to match the order of values in the actual SQL table!
             _resources = dict(sorted(_resources.items()))
 
-            resource_args = [(batch_id, job_id, attempt_id, name, quantity) for name, quantity in _resources.items()]
+            resource_args = [(batch_id, job_id, attempt_id, name, quantity, name) for name, quantity in _resources.items()]
 
             await db.execute_many(
                 '''
-INSERT INTO `attempt_resources` (batch_id, job_id, attempt_id, resource, quantity)
-VALUES (%s, %s, %s, %s, %s)
+INSERT INTO `attempt_resources` (batch_id, job_id, attempt_id, resource, resource_id, quantity)
+SELECT %s, %s, %s, %s, resource_id, %s
+FROM resources
+WHERE resource = %s
 ON DUPLICATE KEY UPDATE quantity = quantity;
 ''',
                 resource_args,

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -953,12 +953,13 @@ async def check_resource_aggregation(app, db):
         attempt_resources = tx.execute_and_fetchall(
             '''
 SELECT attempt_resources.batch_id, attempt_resources.job_id, attempt_resources.attempt_id,
-  JSON_OBJECTAGG(resource, quantity * GREATEST(COALESCE(end_time - start_time, 0), 0)) as resources
+  JSON_OBJECTAGG(resources.resource, quantity * GREATEST(COALESCE(end_time - start_time, 0), 0)) as resources
 FROM attempt_resources
 INNER JOIN attempts
 ON attempts.batch_id = attempt_resources.batch_id AND
   attempts.job_id = attempt_resources.job_id AND
   attempts.attempt_id = attempt_resources.attempt_id
+LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
 GROUP BY batch_id, job_id, attempt_id
 LOCK IN SHARE MODE;
 '''

--- a/batch/sql/add-resource-ids.sql
+++ b/batch/sql/add-resource-ids.sql
@@ -1,0 +1,19 @@
+ALTER TABLE `resources` ADD COLUMN resource_id INT AUTO_INCREMENT UNIQUE NOT NULL;
+ALTER TABLE `attempt_resources` ADD COLUMN resource_id INT, ALGORITHM=INSTANT;
+
+SET foreign_key_checks = 0;
+ALTER TABLE `attempt_resources` ADD FOREIGN KEY (resource_id) REFERENCES `resources` (resource_id) ON DELETE CASCADE, ALGORITHM=INPLACE;
+SET foreign_key_checks = 1;
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
+CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_resource_id INT;
+  SELECT resource_id INTO cur_resource_id FROM resources WHERE resource = NEW.resource;
+  SET NEW.resource_id = cur_resource_id;
+END $$
+
+DELIMITER ;

--- a/batch/sql/add_resource_ids.py
+++ b/batch/sql/add_resource_ids.py
@@ -178,6 +178,8 @@ async def update_resource_ids(db, table_name, get_offsets_f, process_chunk_f, ch
     print(f'found {len(chunk_offsets)} chunks to process for {table_name}')
 
     if len(chunk_offsets) != 0:
+        random.shuffle(chunk_offsets)
+        
         burn_in_start = time.time()
         n_burn_in_chunks = 1000
 

--- a/batch/sql/add_resource_ids.py
+++ b/batch/sql/add_resource_ids.py
@@ -1,0 +1,229 @@
+import asyncio
+import functools
+import os
+import random
+import time
+from typing import List, Optional, Tuple
+
+from gear import Database, transaction
+from hailtop.utils import bounded_gather
+
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+
+def compile_query(start_f, end_f, start_offset, end_offset):
+    # start inclusive, end exclusive
+    if start_offset is None and end_offset is None:
+        return ('', None)
+
+    assert start_offset != end_offset, str((start_offset, end_offset))
+
+    if start_offset is None:
+        assert end_offset
+        where_cond, query_args = end_f(end_offset)
+        where_cond = f'WHERE {where_cond}'
+    elif end_offset is None:
+        assert start_offset
+        where_cond, query_args = start_f(start_offset)
+        where_cond = f'WHERE {where_cond}'
+    else:
+        start_where_cond, start_query_args = start_f(start_offset)
+        end_where_cond, end_query_args = end_f(end_offset)
+
+        where_cond = f'WHERE {start_where_cond} AND {end_where_cond}'
+        query_args = (*start_query_args, *end_query_args)
+
+    return (where_cond, query_args)
+
+
+def attempt_resources_offsets_to_where_statement(start_offset, end_offset):
+    def start(offset):
+        assert offset
+        start_batch_id, start_job_id, start_attempt_id, start_resource = offset
+        start_query = '(attempt_resources.batch_id > %s OR ' \
+                      '(attempt_resources.batch_id = %s AND attempt_resources.job_id > %s) OR ' \
+                      '(attempt_resources.batch_id = %s AND attempt_resources.job_id = %s AND attempt_resources.attempt_id > %s) OR ' \
+                      '(attempt_resources.batch_id = %s AND attempt_resources.job_id = %s AND attempt_resources.attempt_id = %s AND attempt_resources.resource >= %s))'
+        start_query_args = (start_batch_id, start_batch_id, start_job_id, start_batch_id, start_job_id, start_attempt_id, start_batch_id, start_job_id, start_attempt_id, start_resource)
+        return (start_query, start_query_args)
+
+    def end(offset):
+        assert offset
+        end_batch_id, end_job_id, end_attempt_id, end_resource = offset
+        end_query = '(attempt_resources.batch_id < %s OR ' \
+                     '(attempt_resources.batch_id = %s AND attempt_resources.job_id < %s) OR ' \
+                     '(attempt_resources.batch_id = %s AND attempt_resources.job_id = %s AND attempt_resources.attempt_id < %s) OR ' \
+                     '(attempt_resources.batch_id = %s AND attempt_resources.job_id = %s AND attempt_resources.attempt_id = %s AND attempt_resources.resource < %s))'
+        end_query_args = (end_batch_id, end_batch_id, end_job_id, end_batch_id, end_job_id, end_attempt_id, end_batch_id, end_job_id, end_attempt_id, end_resource)
+        return (end_query, end_query_args)
+
+    return compile_query(start, end, start_offset, end_offset)
+
+
+async def process_chunk(counter, db, table_name, query_f, start_offset, end_offset, quiet=True):
+    start_time = time.time()
+    where_cond, query_args = query_f(start_offset, end_offset)
+
+    await db.just_execute(
+        f'''
+UPDATE {table_name}
+SET resource_id = (
+    SELECT resource_id
+    FROM resources
+    WHERE {table_name}.resource = resources.resource
+)
+{where_cond};
+''',
+        query_args)
+
+    if not quiet and counter.n % 100 == 0:
+        print(f'processed chunk ({start_offset}, {end_offset}) in {time.time() - start_time}s')
+
+    counter.n += 1
+    if counter.n % 500 == 0:
+        print(f'processed {counter.n} complete chunks')
+
+
+async def process_attempt_resources_chunk(counter, db, start_offset, end_offset, quiet=True):
+    await process_chunk(
+        counter,
+        db,
+        'attempt_resources',
+        attempt_resources_offsets_to_where_statement,
+        start_offset,
+        end_offset,
+        quiet
+    )
+
+
+async def audit_changes(db):
+    attempt_resources_audit_start = time.time()
+    print('starting auditing attempt resources records')
+
+    bad_attempt_resources_records = db.select_and_fetchall(
+        '''
+SELECT *
+FROM attempt_resources
+LEFT JOIN resources ON attempt_resources.resource = resources.resource
+WHERE attempt_resources.resource_id IS NULL OR attempt_resources.resource_id != resources.resource_id
+LIMIT 100;
+'''
+    )
+
+    bad_attempt_resources_records = [record async for record in bad_attempt_resources_records]
+    for record in bad_attempt_resources_records:
+        print(f'found bad attempt resources record {record}')
+
+    print(f'finished auditing attempt_resources records in {time.time() - attempt_resources_audit_start}s')
+
+    if bad_attempt_resources_records:
+        raise Exception(f'errors found in audit')
+
+
+async def find_offsets(db, query, query_args):
+    @transaction(db)
+    async def _find_chunks(tx) -> List[Optional[Tuple[int, int, str]]]:
+        start_time = time.time()
+
+        await tx.just_execute('SET @rank=0;')
+
+        offsets = tx.execute_and_fetchall(query, query_args)
+        offsets = [offset async for offset in offsets]
+
+        offsets.append(None)
+
+        print(f'found chunk offsets in {round(time.time() - start_time, 4)}s')
+        return offsets
+
+    return await _find_chunks()
+
+
+async def find_attempt_resources_offsets(db, size):
+    query = f'''
+SELECT t.batch_id, t.job_id, t.attempt_id, t.resource FROM (
+  SELECT batch_id, job_id, attempt_id, resource
+  FROM attempt_resources
+  ORDER BY batch_id, job_id, attempt_id, resource
+) AS t
+WHERE MOD((@rank := @rank + 1), %s) = 0;
+'''
+    query_args = (size,)
+
+    offsets = await find_offsets(db, query, query_args)
+
+    def unpack_offset(offset):
+        if offset is None:
+            return None
+        return (offset['batch_id'], offset['job_id'], offset['attempt_id'], offset['resource'])
+
+    return [unpack_offset(offset) for offset in offsets]
+
+
+async def update_resource_ids(db, table_name, get_offsets_f, process_chunk_f, chunk_size):
+    populate_start_time = time.time()
+
+    chunk_counter = Counter()
+    chunk_offsets = [None]
+    for offset in await get_offsets_f(db, chunk_size):
+        chunk_offsets.append(offset)
+
+    chunk_offsets = list(zip(chunk_offsets[:-1], chunk_offsets[1:]))
+
+    print(f'found {len(chunk_offsets)} chunks to process for {table_name}')
+
+    if len(chunk_offsets) != 0:
+        burn_in_start = time.time()
+        n_burn_in_chunks = 1000
+
+        burn_in_chunk_offsets = chunk_offsets[:n_burn_in_chunks]
+        chunk_offsets = chunk_offsets[n_burn_in_chunks:]
+
+        for start_offset, end_offset in burn_in_chunk_offsets:
+            await process_chunk_f(chunk_counter, db, start_offset, end_offset)
+
+        print(f'finished burn-in in {time.time() - burn_in_start}s for {table_name}')
+
+        parallel_insert_start = time.time()
+
+        # 4 core database, parallelism = 10 maxes out CPU
+        await bounded_gather(
+            *[functools.partial(process_chunk_f, chunk_counter, db, start_offset, end_offset, quiet=False)
+              for start_offset, end_offset in chunk_offsets],
+            parallelism=10
+        )
+        print(
+            f'took {time.time() - parallel_insert_start}s to update the remaining records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_insert_start)}) attempts / sec for {table_name}')
+
+    print(f'finished populating records in {time.time() - populate_start_time}s for {table_name}')
+
+
+async def main(chunk_size=100):
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    start_time = time.time()
+
+    try:
+        populate_start_time = time.time()
+
+        await update_resource_ids(db, 'attempt_resources', find_attempt_resources_offsets,
+                                  process_attempt_resources_chunk, chunk_size)
+
+        print(f'finished populating records in {time.time() - populate_start_time}s')
+
+        audit_start_time = time.time()
+        await audit_changes(db)
+        print(f'finished auditing changes in {time.time() - audit_start_time}')
+    finally:
+        print(f'finished migration in {time.time() - start_time}s')
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -16,6 +16,15 @@ DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
 DROP TRIGGER IF EXISTS jobs_after_update;
 DROP TRIGGER IF EXISTS attempt_resources_after_insert;
+DROP TRIGGER IF EXISTS attempt_resources_before_insert;
+
+DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
+DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
+DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
+DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
+DROP TABLE IF EXISTS `attempts_aggregated_by_date`;
+DROP TABLE IF EXISTS `batch_updates`;
 
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;
 DROP TABLE IF EXISTS `aggregated_batch_resources`;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS `globals` (
 CREATE TABLE IF NOT EXISTS `resources` (
   `resource` VARCHAR(100) NOT NULL,
   `rate` DOUBLE NOT NULL,
+  `resource_id` INT AUTO_INCREMENT UNIQUE NOT NULL,
   PRIMARY KEY (`resource`)
 ) ENGINE = InnoDB;
 
@@ -330,11 +331,13 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
   `attempt_id` VARCHAR(40) NOT NULL,
   `resource` VARCHAR(100) NOT NULL,
   `quantity` BIGINT NOT NULL,
+  `resource_id` INT NOT NULL,
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`, `attempt_id`) REFERENCES attempts(`batch_id`, `job_id`, `attempt_id`) ON DELETE CASCADE,
-  FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
+  FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
 DELIMITER $$

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -296,8 +296,9 @@ CREATE INDEX batch_attributes_key_value ON `batch_attributes` (`key`, `value`(25
 CREATE TABLE IF NOT EXISTS `aggregated_billing_project_resources` (
   `billing_project` VARCHAR(100) NOT NULL,
   `resource` VARCHAR(100) NOT NULL,
+  `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`billing_project`, `resource`),
+  PRIMARY KEY (`billing_project`, `resource`, `token`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
@@ -574,6 +575,15 @@ BEGIN
         n_creating_jobs = n_creating_jobs + 1;
     END IF;
   END IF;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
+CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_resource_id INT;
+  SELECT resource_id INTO cur_resource_id FROM resources WHERE resource = NEW.resource;
+  SET NEW.resource_id = cur_resource_id;
 END $$
 
 DROP TRIGGER IF EXISTS attempt_resources_after_insert $$

--- a/build.yaml
+++ b/build.yaml
@@ -2042,6 +2042,12 @@ steps:
       - name: minimize-deadlock-errors
         script: /io/sql/minimize-deadlock-errors.sql
         online: true
+      - name: add-resource-ids-sql
+        script: /io/sql/add-resource-ids.sql
+        online: true
+      - name: add-resource-ids-python
+        script: /io/sql/add_resource_ids.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
This PR adds a new column to the `resources` table (resource_id) as well as to the `attempt_resources` table. The `resource_id` represents the mapping from the string resource name to an integer identifier. To make this migration work, we first need to add the new columns to the corresponding tables along with a new trigger. The trigger makes sure any writes that occur after we start populating the older values will have the new resource_ids filled into the `attempt_resources` table. I decided to not convert the `attempt_{batch, job,billing_project}_resources` tables to have the resource_id because we'll drop them anyways in the future and it was adding 75% more time to the migration. My original script had the updates happening to all tables, hence why there's overkill for the way it's structured. I can try and refactor the code back to the way it was before if you'd like.

The code to insert into the `attempt_resources` table in `job.py` needs to insert both the resource and the resource_id because we do not want to rely on the new trigger for adding the resource_id to the record so we can remove the resource column later on.