### PR TITLE
[batch] Modify attempt resources trigger to prepare for future migrations

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -83,14 +83,12 @@ async def add_attempt_resources(db, batch_id, job_id, attempt_id, resources):
             # This must be sorted in order to match the order of values in the actual SQL table!
             _resources = dict(sorted(_resources.items()))
 
-            resource_args = [
-                (batch_id, job_id, attempt_id, name, quantity, name) for name, quantity in _resources.items()
-            ]
+            resource_args = [(batch_id, job_id, attempt_id, quantity, name) for name, quantity in _resources.items()]
 
             await db.execute_many(
                 '''
-INSERT INTO `attempt_resources` (batch_id, job_id, attempt_id, resource, resource_id, quantity)
-SELECT %s, %s, %s, %s, resource_id, %s
+INSERT INTO `attempt_resources` (batch_id, job_id, attempt_id, resource_id, quantity)
+SELECT %s, %s, %s, resource_id, %s
 FROM resources
 WHERE resource = %s
 ON DUPLICATE KEY UPDATE quantity = quantity;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -584,9 +584,9 @@ DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
 CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
 FOR EACH ROW
 BEGIN
-  DECLARE cur_resource_id INT;
-  SELECT resource_id INTO cur_resource_id FROM resources WHERE resource = NEW.resource;
-  SET NEW.resource_id = cur_resource_id;
+  DECLARE cur_resource VARCHAR(100);
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+  SET NEW.resource = cur_resource;
 END $$
 
 DROP TRIGGER IF EXISTS attempt_resources_after_insert $$

--- a/batch/sql/modify-resource-id-trigger.sql
+++ b/batch/sql/modify-resource-id-trigger.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
+CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_resource VARCHAR(100);
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+  SET NEW.resource = cur_resource;
+END $$
+
+DELIMITER ;

--- a/build.yaml
+++ b/build.yaml
@@ -2028,6 +2028,9 @@ steps:
       - name: add-resource-ids-python
         script: /io/sql/add_resource_ids.py
         online: true
+      - name: modify-resource-id-trigger
+        script: /io/sql/modify-resource-id-trigger.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Stacked on #12028

This PR just does some reconfiguring to enable us to remove the `resource` column in the `attempt_resources` table in the next PR with an online migration.