### PR TITLE
[batch] Remove resource names from the attempt resources table

### DIFF
--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -16,7 +16,7 @@ DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
 DROP TRIGGER IF EXISTS jobs_after_update;
 DROP TRIGGER IF EXISTS attempt_resources_after_insert;
-DROP TRIGGER IF EXISTS attempt_resources_before_insert;
+DROP TRIGGER IF EXISTS attempt_resources_before_insert;  # deprecated
 
 DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -329,7 +329,6 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
   `batch_id` BIGINT NOT NULL,
   `job_id` INT NOT NULL,
   `attempt_id` VARCHAR(40) NOT NULL,
-  `resource` VARCHAR(100),
   `quantity` BIGINT NOT NULL,
   `resource_id` INT NOT NULL,
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource_id`),
@@ -580,15 +579,6 @@ BEGIN
         n_creating_jobs = n_creating_jobs + 1;
     END IF;
   END IF;
-END $$
-
-DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
-CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
-FOR EACH ROW
-BEGIN
-  DECLARE cur_resource VARCHAR(100);
-  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
-  SET NEW.resource = cur_resource;
 END $$
 
 DROP TRIGGER IF EXISTS attempt_resources_after_insert $$

--- a/batch/sql/rm-resource-names-agg-resources-pt-2.sql
+++ b/batch/sql/rm-resource-names-agg-resources-pt-2.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS attempt_resources_before_insert;
+ALTER TABLE attempt_resources DROP COLUMN resource, ALGORITHM=INSTANT;

--- a/batch/sql/rm-resource-names-agg-resources-pt-2.sql
+++ b/batch/sql/rm-resource-names-agg-resources-pt-2.sql
@@ -1,2 +1,2 @@
 DROP TRIGGER IF EXISTS attempt_resources_before_insert;
-ALTER TABLE attempt_resources DROP COLUMN resource, ALGORITHM=INSTANT;
+ALTER TABLE attempt_resources DROP COLUMN resource, ALGORITHM=INPLACE, LOCK=NONE;

--- a/build.yaml
+++ b/build.yaml
@@ -2037,6 +2037,9 @@ steps:
       - name: rm-resource-foreign-keys
         script: /io/sql/rm-resource-foreign-keys.py
         online: true
+      - name: rm-resource-names-agg-resources-pt-2
+        script: /io/sql/rm-resource-names-agg-resources-pt-2.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Stacked on #12029 

This PR rips out the `resource` column from the `attempt_resources` table and used the `resource_id` instead. Notice that the triggers need to use the `resource` and not the `resource_id` because we didn't convert the column in the `aggregated_{batch, jobs,billing_project}_resources` tables.