### PR TITLE
[query] Fix leaked Array[Byte] for serialized aggregator states

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -40,7 +40,7 @@ trait AggregatorState {
     cb += lazyBuffer.invoke[Array[Byte], Unit]("set", bytes.loadBytes(cb))
     val ib = cb.memoize(lazyBuffer.invoke[InputBuffer]("buffer"))
     deserialize(BufferSpec.defaultUncompressed)(cb, ib)
-    cb += lazyBuffer.invoke[Unit]("clear")
+    cb += lazyBuffer.invoke[Unit]("invalidate")
   }
 
   def serializeToRegion(cb: EmitCodeBuilder, t: PBinary, r: Value[Region]): SValue = {

--- a/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
+++ b/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
@@ -11,6 +11,10 @@ final class MemoryBuffer extends Serializable {
 
   def capacity: Int = mem.length
 
+  def invalidate(): Unit = {
+    mem = null
+  }
+
   def clear() {
     pos = 0
     end = 0

--- a/hail/src/main/scala/is/hail/utils/MemoryBufferWrapper.scala
+++ b/hail/src/main/scala/is/hail/utils/MemoryBufferWrapper.scala
@@ -10,7 +10,7 @@ final class MemoryBufferWrapper {
 
   def set(bytes: Array[Byte]): Unit = mb.set(bytes)
 
-  def clear(): Unit = mb.clear()
+  def invalidate(): Unit = mb.invalidate()
 }
 
 final class MemoryWriterWrapper {


### PR DESCRIPTION
I suspect this is why the `sum_table_of_ndarrays` OOMs. Will retest.