### PR TITLE
[ci] Use 4 cores for db migration jobs in deploys

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1023,6 +1023,8 @@ EOF
                 parents=self.deps_parents(),
             )
 
+        n_cores = 1 if is_test_deployment else 4
+
         self.create_database_job = batch.create_job(
             CI_UTILS_IMAGE,
             command=['bash', '-c', create_database_script],
@@ -1038,7 +1040,7 @@ EOF
             input_files=input_files,
             parents=[self.create_passwords_job] if self.create_passwords_job else self.deps_parents(),
             network='private',
-            resources={'preemptible': False},
+            resources={'preemptible': False, 'cpu': n_cores},
         )
 
     def cleanup(self, batch, scope, parents):

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1023,7 +1023,7 @@ EOF
                 parents=self.deps_parents(),
             )
 
-        n_cores = 1 if is_test_deployment else 4
+        n_cores = 4 if scope == 'deploy' and not is_test_deployment else 1
 
         self.create_database_job = batch.create_job(
             CI_UTILS_IMAGE,

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1040,7 +1040,7 @@ EOF
             input_files=input_files,
             parents=[self.create_passwords_job] if self.create_passwords_job else self.deps_parents(),
             network='private',
-            resources={'preemptible': False, 'cpu': n_cores},
+            resources={'preemptible': False, 'cpu': str(n_cores)},
         )
 
     def cleanup(self, batch, scope, parents):


### PR DESCRIPTION
This is to ensure when we're getting the offsets of the chunks that we don't run out of memory on the client.