### PR TITLE
[infra] Provide namespace variable to bootstrap uses of make deploy

### DIFF
--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -54,6 +54,7 @@ deploy_unmanaged() {
     copy_images
     generate_ssl_certs
 
+    export NAMESPACE=default
     kubectl -n default apply -f $HAIL/ci/bootstrap.yaml
     make -C $HAIL/ci build-ci-utils build-hail-buildkit
     make -C $HAIL/batch build-worker


### PR DESCRIPTION
Hadn't tested bootstrapping since a recent PR made `NAMESPACE` required for any make steps that push images.