### PR TITLE
[query] don't send timing info if not requested

### DIFF
--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -95,7 +95,7 @@ class Py4JBackend(Backend):
         stream_codec = '{"name":"StreamBufferSpec"}'
         # print(self._hail_package.expr.ir.Pretty.apply(jir, True, -1))
         try:
-            result_tuple = self._jbackend.executeEncode(jir, stream_codec)
+            result_tuple = self._jbackend.executeEncode(jir, stream_codec, timed)
             (result, timings) = (result_tuple._1(), result_tuple._2())
             value = ir.typ._from_encoding(result)
 

--- a/hail/python/hail/experimental/codec.py
+++ b/hail/python/hail/experimental/codec.py
@@ -5,7 +5,7 @@ stream_codec = '{"name":"StreamBufferSpec"}'
 
 def encode(expression, codec=stream_codec):
     jir = Env.backend()._to_java_value_ir(expression._ir)
-    return Env.backend()._jhc.backend().executeEncode(jir, codec)._1()
+    return Env.backend()._jhc.backend().executeEncode(jir, codec, False)._1()
 
 
 def decode(typ, bytes):

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -184,14 +184,14 @@ class LocalBackend(
     }
   }
 
-  def executeEncode(ir: IR, bufferSpecString: String): (Array[Byte], String) = {
+  def executeEncode(ir: IR, bufferSpecString: String, timed: Boolean): (Array[Byte], String) = {
     val (bytes, timer) = ExecutionTimer.time("LocalBackend.encodeToBytes") { timer =>
       val bs = BufferSpec.parseOrDefault(bufferSpecString)
       withExecuteContext(timer) { ctx =>
         executeToEncoded(timer, ir, bs)
       }
     }
-    (bytes, Serialization.write(Map("timings" -> timer.toMap))(new DefaultFormats {}))
+    (bytes, if (timed) Serialization.write(Map("timings" -> timer.toMap))(new DefaultFormats {}) else "")
   }
 
   def decodeToJSON(ptypeString: String, b: Array[Byte], bufferSpecString: String): String = {


### PR DESCRIPTION
Reduces the size of the payload sent back to the client with each query