### PR TITLE
[batch] Explicitly use index in get_batches query

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -599,7 +599,7 @@ async def _query_batches(request, user, q):
 
     sql = f'''
 SELECT batches.*, batches_cancelled.id IS NOT NULL AS cancelled, COALESCE(SUM(`usage` * rate), 0) AS cost, batches_n_jobs_in_complete_states.n_completed, batches_n_jobs_in_complete_states.n_succeeded, batches_n_jobs_in_complete_states.n_failed, batches_n_jobs_in_complete_states.n_cancelled
-FROM batches
+FROM batches USE INDEX (batches_deleted)
 LEFT JOIN batches_n_jobs_in_complete_states
   ON batches.id = batches_n_jobs_in_complete_states.id
 LEFT JOIN batches_cancelled


### PR DESCRIPTION
The old query plan is here:
```
+----+-------------+-----------------------------------+------------+--------+---------------------------------------------------------------------------------------------------------------+-------------------------------+---------+---------------------------------------------+------+----------+-----------------------------------------------------------+
| id | select_type | table                             | partitions | type   | possible_keys                                                                                                 | key                           | key_len | ref                                         | rows | filtered | Extra                                                     |
+----+-------------+-----------------------------------+------------+--------+---------------------------------------------------------------------------------------------------------------+-------------------------------+---------+---------------------------------------------+------+----------+-----------------------------------------------------------+
|  1 | SIMPLE      | billing_project_users             | NULL       | index  | PRIMARY                                                                                                       | PRIMARY                       | 204     | NULL                                        | 3201 |    10.00 | Using where; Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | batches                           | NULL       | ref    | PRIMARY,batches_deleted,batches_token,batches_user_state,batches_time_completed,batches_billing_project_state | batches_billing_project_state | 102     | batch.billing_project_users.billing_project |  519 |    25.00 | Using where                                               |
|  1 | SIMPLE      | batches_n_jobs_in_complete_states | NULL       | eq_ref | PRIMARY                                                                                                       | PRIMARY                       | 8       | batch.batches.id                            |    1 |   100.00 | NULL                                                      |
|  1 | SIMPLE      | batches_cancelled                 | NULL       | eq_ref | PRIMARY                                                                                                       | PRIMARY                       | 8       | batch.batches.id                            |    1 |   100.00 | Using index                                               |
|  1 | SIMPLE      | aggregated_batch_resources        | NULL       | ref    | PRIMARY                                                                                                       | PRIMARY                       | 8       | batch.batches.id                            |   44 |   100.00 | NULL                                                      |
|  1 | SIMPLE      | resources                         | NULL       | eq_ref | PRIMARY                                                                                                       | PRIMARY                       | 102     | batch.aggregated_batch_resources.resource   |    1 |   100.00 | NULL                                                      |
+----+-------------+-----------------------------------+------------+--------+---------------------------------------------------------------------------------------------------------------+-------------------------------+---------+---------------------------------------------+------+----------+-----------------------------------------------------------+
```

New plan
```
+----+-------------+-----------------------------------+------------+--------+-----------------+-----------------+---------+-------------------------------------------+--------+----------+----------------------------------+
| id | select_type | table                             | partitions | type   | possible_keys   | key             | key_len | ref                                       | rows   | filtered | Extra                            |
+----+-------------+-----------------------------------+------------+--------+-----------------+-----------------+---------+-------------------------------------------+--------+----------+----------------------------------+
|  1 | SIMPLE      | batches                           | NULL       | ref    | batches_deleted | batches_deleted | 1       | const                                     | 493389 |    33.33 | Using where; Backward index scan |
|  1 | SIMPLE      | batches_n_jobs_in_complete_states | NULL       | eq_ref | PRIMARY         | PRIMARY         | 8       | batch.batches.id                          |      1 |   100.00 | NULL                             |
|  1 | SIMPLE      | batches_cancelled                 | NULL       | eq_ref | PRIMARY         | PRIMARY         | 8       | batch.batches.id                          |      1 |   100.00 | Using index                      |
|  1 | SIMPLE      | billing_project_users             | NULL       | eq_ref | PRIMARY         | PRIMARY         | 204     | batch.batches.billing_project,const       |      1 |   100.00 | Using index                      |
|  1 | SIMPLE      | aggregated_batch_resources        | NULL       | ref    | PRIMARY         | PRIMARY         | 8       | batch.batches.id                          |     44 |   100.00 | NULL                             |
|  1 | SIMPLE      | resources                         | NULL       | eq_ref | PRIMARY         | PRIMARY         | 102     | batch.aggregated_batch_resources.resource |      1 |   100.00 | NULL                             |
+----+-------------+-----------------------------------+------------+--------+-----------------+-----------------+---------+-------------------------------------------+--------+----------+----------------------------------+
```

See Zulip discussions here:
https://hail.zulipchat.com/#narrow/stream/127527-team/topic/CI.20Deploy.20Failure/near/290764243

https://hail.zulipchat.com/#narrow/stream/219455-CLOSED-ServicesDev/topic/UI.20.2Fbatches.20slowness/near/226853300