### PR TITLE
[batch] Add pool_recycle parameter to database creation to avoid stale connections

### DIFF
--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -121,6 +121,8 @@ async def create_database_pool(config_file: str = None, autocommit: bool = True,
         ssl=ssl_context,
         cursorclass=aiomysql.cursors.DictCursor,
         autocommit=autocommit,
+        # Discard stale connections, see https://stackoverflow.com/questions/69373128/db-connection-issue-with-encode-databases-library.
+        pool_recycle=3600,
     )
 
 


### PR DESCRIPTION
To avoid `pymysql` packet sequence errors on long-running pods. See https://hail.zulipchat.com/#narrow/stream/300487-Hail-Batch-Dev/topic/PyMysql.20packet.20sequence.20errors/near/289668489 for context.

#assign services