### PR TITLE
[batch] Switch attempt resources primary keys and triggers to use resource ids

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -953,7 +953,7 @@ async def check_resource_aggregation(app, db):
         attempt_resources = tx.execute_and_fetchall(
             '''
 SELECT attempt_resources.batch_id, attempt_resources.job_id, attempt_resources.attempt_id,
-  JSON_OBJECTAGG(resources.resource, quantity * GREATEST(COALESCE(end_time - start_time, 0), 0)) as resources
+  JSON_OBJECTAGG(resource, quantity * GREATEST(COALESCE(end_time - start_time, 0), 0)) as resources
 FROM attempt_resources
 INNER JOIN attempts
 ON attempts.batch_id = attempt_resources.batch_id AND

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -953,7 +953,7 @@ async def check_resource_aggregation(app, db):
         attempt_resources = tx.execute_and_fetchall(
             '''
 SELECT attempt_resources.batch_id, attempt_resources.job_id, attempt_resources.attempt_id,
-  JSON_OBJECTAGG(resource, quantity * GREATEST(COALESCE(end_time - start_time, 0), 0)) as resources
+  JSON_OBJECTAGG(resources.resource, quantity * GREATEST(COALESCE(end_time - start_time, 0), 0)) as resources
 FROM attempt_resources
 INNER JOIN attempts
 ON attempts.batch_id = attempt_resources.batch_id AND

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -393,7 +393,7 @@ BEGIN
   INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
   SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
   FROM attempt_resources
-  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
   JOIN batches ON batches.id = attempt_resources.batch_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
@@ -401,14 +401,14 @@ BEGIN
   INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
   SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
   FROM attempt_resources
-  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
   INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
   SELECT batch_id, job_id, resources.resource, msec_diff * quantity
   FROM attempt_resources
-  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 END $$

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -329,14 +329,13 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
   `batch_id` BIGINT NOT NULL,
   `job_id` INT NOT NULL,
   `attempt_id` VARCHAR(40) NOT NULL,
-  `resource` VARCHAR(100) NOT NULL,
+  `resource` VARCHAR(100),
   `quantity` BIGINT NOT NULL,
   `resource_id` INT NOT NULL,
-  PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource`),
+  PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`, `attempt_id`) REFERENCES attempts(`batch_id`, `job_id`, `attempt_id`) ON DELETE CASCADE,
-  FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
@@ -392,21 +391,24 @@ BEGIN
                    GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
 
   INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-  SELECT billing_project, resource, rand_token, msec_diff * quantity
+  SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
   FROM attempt_resources
+  JOIN resources ON attempt_resources.resource_id = resources.resource_id
   JOIN batches ON batches.id = attempt_resources.batch_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
   INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-  SELECT batch_id, resource, rand_token, msec_diff * quantity
+  SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
   FROM attempt_resources
+  JOIN resources ON attempt_resources.resource_id = resources.resource_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
   INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-  SELECT batch_id, job_id, resource, msec_diff * quantity
+  SELECT batch_id, job_id, resources.resource, msec_diff * quantity
   FROM attempt_resources
+  JOIN resources ON attempt_resources.resource_id = resources.resource_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 END $$
@@ -599,11 +601,14 @@ BEGIN
   DECLARE msec_diff BIGINT;
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
+  DECLARE cur_resource VARCHAR(100);
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
   SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
   SELECT start_time, end_time INTO cur_start_time, cur_end_time
   FROM attempts
@@ -613,17 +618,17 @@ BEGIN
   SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
 
   INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
-  VALUES (cur_billing_project, NEW.resource, rand_token, NEW.quantity * msec_diff)
+  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
   ON DUPLICATE KEY UPDATE
     `usage` = `usage` + NEW.quantity * msec_diff;
 
   INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
-  VALUES (NEW.batch_id, NEW.resource, rand_token, NEW.quantity * msec_diff)
+  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
   ON DUPLICATE KEY UPDATE
     `usage` = `usage` + NEW.quantity * msec_diff;
 
   INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
-  VALUES (NEW.batch_id, NEW.job_id, NEW.resource, NEW.quantity * msec_diff)
+  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
   ON DUPLICATE KEY UPDATE
     `usage` = `usage` + NEW.quantity * msec_diff;
 END $$

--- a/batch/sql/rm-resource-foreign-keys.py
+++ b/batch/sql/rm-resource-foreign-keys.py
@@ -1,0 +1,52 @@
+import asyncio
+import os
+from gear import Database
+from gear.database import get_sql_config
+
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+async def delete_foreign_key_constraint(db, db_name, table_name, referenced_table_name, referenced_column_names):
+    # https://dev.mysql.com/doc/refman/8.0/en/information-schema-key-column-usage-table.html
+
+    assert referenced_column_names
+    referenced_column_str = '(' + " OR ".join(['REFERENCED_COLUMN_NAME = %s' for _ in referenced_column_names]) + ')'
+
+    query = f'''
+SELECT CONSTRAINT_NAME as constraint_name
+FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+WHERE REFERENCED_TABLE_SCHEMA = %s AND
+  TABLE_NAME = %s AND
+  REFERENCED_TABLE_NAME = %s AND
+  {referenced_column_str};
+'''
+
+    query_args = [db_name, table_name, referenced_table_name] + referenced_column_names
+
+    records = [record async for record in db.select_and_fetchall(query, query_args)]
+    assert len(records) == len(referenced_column_names)
+
+    constraint_names = {record['constraint_name'] for record in records}
+    assert len(constraint_names) == 1
+    constraint_name = list(constraint_names)[0]
+
+    await db.just_execute(f'ALTER TABLE {table_name} DROP FOREIGN KEY `{constraint_name}`;')
+
+
+async def main():
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    try:
+        sql_config = get_sql_config(maybe_config_file=MYSQL_CONFIG_FILE)
+        db_name = sql_config.db
+        assert db_name is not None
+
+        await delete_foreign_key_constraint(db, db_name, 'attempt_resources', 'resources', ['resource'])
+    finally:
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/sql/rm-resource-names-agg-resources.sql
+++ b/batch/sql/rm-resource-names-agg-resources.sql
@@ -1,0 +1,92 @@
+ALTER TABLE attempt_resources DROP PRIMARY KEY, ADD PRIMARY KEY (batch_id, job_id, attempt_id, resource_id), ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE attempt_resources MODIFY resource VARCHAR(100), ALGORITHM=INPLACE, LOCK=NONE;
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_after_update $$
+CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  DECLARE job_cores_mcpu INT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SET msec_diff = (GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0) -
+                   GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
+
+  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+  SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
+  FROM attempt_resources
+  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  JOIN batches ON batches.id = attempt_resources.batch_id
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
+  FROM attempt_resources
+  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  SELECT batch_id, job_id, resources.resource, msec_diff * quantity
+  FROM attempt_resources
+  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_resource VARCHAR(100);
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+
+  SELECT start_time, end_time INTO cur_start_time, cur_end_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+
+  INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
+  VALUES (cur_billing_project, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+END $$
+
+DELIMITER ;

--- a/batch/sql/rm-resource-names-agg-resources.sql
+++ b/batch/sql/rm-resource-names-agg-resources.sql
@@ -27,7 +27,7 @@ BEGIN
   INSERT INTO aggregated_billing_project_resources (billing_project, resource, token, `usage`)
   SELECT billing_project, resources.resource, rand_token, msec_diff * quantity
   FROM attempt_resources
-  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
   JOIN batches ON batches.id = attempt_resources.batch_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
@@ -35,14 +35,14 @@ BEGIN
   INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
   SELECT batch_id, resources.resource, rand_token, msec_diff * quantity
   FROM attempt_resources
-  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
   INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
   SELECT batch_id, job_id, resources.resource, msec_diff * quantity
   FROM attempt_resources
-  JOIN resources ON attempt_resources.resource_id = resources.resource_id
+  LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
   ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 END $$

--- a/build.yaml
+++ b/build.yaml
@@ -2031,6 +2031,12 @@ steps:
       - name: modify-resource-id-trigger
         script: /io/sql/modify-resource-id-trigger.sql
         online: true
+      - name: rm-resource-names-agg-resources
+        script: /io/sql/rm-resource-names-agg-resources.sql
+        online: true
+      - name: rm-resource-foreign-keys
+        script: /io/sql/rm-resource-foreign-keys.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Stacked on #12029. This is basically the same as #12030, but I separated dropping the final trigger and the resource column of the table from this PR so we can double check everything looks good and do that last dangerous step separately.

I think this will take about an hour, but I haven't looked timed it recently.

@danking Can you double check none of the SQL operations are blocking. If they are, I think we just have to live with it.