### PR TITLE
[query] Fix accidental deletion of tabix files

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -370,7 +370,7 @@ class VCFTests(unittest.TestCase):
         tmp = new_temp_file(extension="bgz")
         hl.export_vcf(mt, tmp, tabix=True, parallel='header_per_shard')
         files = hl.current_backend().fs.ls(tmp)
-        self.assertTrue(any(f.path.endswith('.tbi')))
+        self.assertTrue(any(f.path.endswith('.tbi') for f in files))
 
     @fails_service_backend()
     @fails_local_backend()

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -365,6 +365,13 @@ class VCFTests(unittest.TestCase):
         hl.export_vcf(mt, tmp, tabix=True)
         self.import_gvcfs_sample_vcf(tmp)
 
+    def test_tabix_export_file_exists(self):
+        mt = hl.import_vcf(resource('sample.vcf.bgz'))
+        tmp = new_temp_file(extension="bgz")
+        hl.export_vcf(mt, tmp, tabix=True, parallel='header_per_shard')
+        files = hl.current_backend().fs.ls(tmp)
+        self.assertTrue(any(f.path.endswith('.tbi')))
+
     @fails_service_backend()
     @fails_local_backend()
     def test_import_gvcfs(self):


### PR DESCRIPTION
When cleaning up a text export, we delete all files that our successful
tasks didn't produce. We weren't adding tabix files to this set, and so
were deleting tabix files that were created during vcf export. Now, we
explicitly add tabix files to our 'to keep' list.