### PR TITLE
[batch] Fix /batches in the UI another time with straight join

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -608,7 +608,7 @@ LEFT JOIN aggregated_batch_resources
   ON batches.id = aggregated_batch_resources.batch_id
 LEFT JOIN resources
   ON aggregated_batch_resources.resource = resources.resource
-LEFT JOIN billing_project_users ON batches.billing_project = billing_project_users.billing_project
+STRAIGHT_JOIN billing_project_users ON batches.billing_project = billing_project_users.billing_project
 WHERE {' AND '.join(where_conditions)}
 GROUP BY batches.id
 ORDER BY batches.id DESC


### PR DESCRIPTION
This should always force the temporary table to never be materialized for `billing_project_users`.

> STRAIGHT_JOIN is similar to JOIN, except that the left table is always read before the right table. This can be used for those (few) cases for which the join optimizer processes the tables in a suboptimal order.