### PR TITLE
[ci] Fix missing api groups in pr namespace admin role

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -647,6 +647,9 @@ rules:
 - apiGroups: [""]
   resources: ["*"]
   verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["*"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Error message was this:

```
+ kubectl -n pr-12053-default-chqnmsebv8fq scale deployment batch-driver --replicas=0
Error from server (Forbidden): deployments.apps "batch-driver" is forbidden: User "system:serviceaccount:pr-12053-default-chqnmsebv8fq:admin" cannot get resource "deployments" in API group "apps" in the namespace "pr-12053-default-chqnmsebv8fq"
```