### PR TITLE
[compiler] Fix RNGSplit tuple requiredness

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -276,9 +276,8 @@ object TypeCheck {
       case RNGSplit(state, dynBitstring) =>
         assert(state.typ == TRNGState)
         def isValid: Type => Boolean = {
-          case tuple: TTuple => tuple.types.forall(isValid)
-          case TInt64 => true
-          case _ => false
+          case tuple: TTuple => tuple.types.forall(_ == TInt64)
+          case t => t == TInt64
         }
         assert(isValid(dynBitstring.typ))
       case StreamLen(a) =>


### PR DESCRIPTION
The RNGSplit emitter assumed the components of `dynBitstring` were always inferred to be required, but it seems to be impossible to construct the bitstrings in a way that the requiredness inference can always see that.

This first makes the type of `dynBitstring` more constrained to simplify the emitter. Before it was allowed to be a single long, or an arbitrarily nested tuple all of whose leaves are longs. But I believe only flat tuples are actually being generated, so this makes that the enforced type.

Then the emitter asserts all fields are present at runtime.