### PR TITLE
Revert "[QoB] disable import_plink using tests"

### DIFF
--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -10,7 +10,7 @@ tearDownModule = stopTestHailContext
 
 
 class Tests(unittest.TestCase):
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend
     def test_ld_score(self):
 

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -731,7 +731,7 @@ class PLINKTests(unittest.TestCase):
                     i += 1
         self.assertEqual(nfam, i)
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_export_import_plink_same(self):
         mt = get_dataset()
@@ -749,7 +749,7 @@ class PLINKTests(unittest.TestCase):
         self.assertTrue(mt._same(mt_imported))
         self.assertTrue(mt.aggregate_rows(hl.agg.all(mt.cm_position == 15.0)))
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_import_plink_empty_fam(self):
         mt = get_dataset().filter_cols(False)
@@ -767,7 +767,7 @@ class PLINKTests(unittest.TestCase):
         with self.assertRaisesRegex(FatalError, "BIM file does not contain any variants"):
             hl.import_plink(bfile + '.bed', bfile + '.bim', bfile + '.fam')
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_import_plink_a1_major(self):
         mt = get_dataset()
@@ -794,7 +794,7 @@ class PLINKTests(unittest.TestCase):
                               (j.a1_vqc.homozygote_count[0] == j.a2_vqc.homozygote_count[1]) &
                               (j.a1_vqc.homozygote_count[1] == j.a2_vqc.homozygote_count[0])))
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_import_plink_same_locus(self):
         mt = hl.balding_nichols_model(n_populations=2, n_samples=10, n_variants=100)
@@ -809,7 +809,7 @@ class PLINKTests(unittest.TestCase):
         mt3 = hl.import_plink(f'{out}.bed', f'{out}.bim', f'{out}.fam', min_partitions=10).select_cols().select_rows()
         assert mt3._same(mt)
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_import_plink_partitions(self):
         mt = hl.balding_nichols_model(n_populations=2, n_samples=10, n_variants=100)
@@ -822,7 +822,7 @@ class PLINKTests(unittest.TestCase):
         assert mt2.n_partitions() == 10
         assert mt2._same(mt)
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_import_plink_contig_recoding_w_reference(self):
         vcf = hl.split_multi_hts(
@@ -918,7 +918,7 @@ class PLINKTests(unittest.TestCase):
 
         self.assertTrue(same)
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_export_plink_exprs(self):
         ds = get_dataset()
@@ -986,7 +986,7 @@ class PLINKTests(unittest.TestCase):
         with self.assertRaisesRegex(FatalError, "no white space allowed:"):
             hl.export_plink(ds, new_temp_file(), varid="hello world")
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     def test_contig_recoding_defaults(self):
         hl.import_plink(resource('sex_mt_contigs.bed'),
                         resource('sex_mt_contigs.bim'),
@@ -1006,7 +1006,7 @@ class PLINKTests(unittest.TestCase):
                         resource('sex_mt_contigs.fam'),
                         reference_genome='random')
 
-    @skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+    @fails_service_backend()
     @fails_local_backend()
     def test_export_plink_struct_locus(self):
         mt = hl.utils.range_matrix_table(10, 10)

--- a/hail/python/test/hail/methods/test_king.py
+++ b/hail/python/test/hail/methods/test_king.py
@@ -1,7 +1,7 @@
 import pytest
 
 import hail as hl
-from ..helpers import resource, startTestHailContext, stopTestHailContext, fails_local_backend, skip_when_service_backend
+from ..helpers import resource, startTestHailContext, stopTestHailContext, fails_local_backend, fails_service_backend
 
 setUpModule = startTestHailContext
 tearDownModule = stopTestHailContext
@@ -30,7 +30,7 @@ def assert_c_king_same_as_hail_king(c_king_path, hail_king_mt):
     assert expected.count() == 0, expected.collect()
 
 
-@skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+@fails_service_backend()
 @fails_local_backend()
 def test_king_small():
     plink_path = resource('balding-nichols-1024-variants-4-samples-3-populations')
@@ -43,7 +43,7 @@ def test_king_small():
         kinship)
 
 @pytest.mark.unchecked_allocator
-@skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+@fails_service_backend()
 @fails_local_backend()
 def test_king_large():
     plink_path = resource('fastlmmTest')
@@ -55,7 +55,7 @@ def test_king_large():
     assert_c_king_same_as_hail_king(resource('fastlmmTest.kin0.bgz'), kinship)
 
 
-@skip_when_service_backend(reason='import_plink triggers O(N_variants) reads')
+@fails_service_backend()
 @fails_local_backend()
 def test_king_filtered_entries_no_error():
     plink_path = resource('balding-nichols-1024-variants-4-samples-3-populations')


### PR DESCRIPTION
Reverts hail-is/hail#11987

Now that the FS seek bug is fixed these shouldn’t run up huge GCS charges