### PR TITLE
[query] add rand_int32 and rand_int64

### DIFF
--- a/hail/python/hail/docs/functions/index.rst
+++ b/hail/python/hail/docs/functions/index.rst
@@ -182,6 +182,8 @@ These functions are exposed at the top level of the module, e.g. ``hl.case``.
     rand_norm
     rand_pois
     rand_unif
+    rand_int32
+    rand_int64
     shuffle
 
 .. rubric:: Genetics functions

--- a/hail/python/hail/docs/functions/random.rst
+++ b/hail/python/hail/docs/functions/random.rst
@@ -125,6 +125,8 @@ guaranteed to have the same results if the global seed is set right beforehand:
     rand_norm
     rand_pois
     rand_unif
+    rand_int32
+    rand_int64
     shuffle
 
 
@@ -136,4 +138,6 @@ guaranteed to have the same results if the global seed is set right beforehand:
 .. autofunction:: rand_norm
 .. autofunction:: rand_pois
 .. autofunction:: rand_unif
+.. autofunction:: rand_int32
+.. autofunction:: rand_int64
 .. autofunction:: shuffle

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -5,48 +5,37 @@ from .types import (dtype, HailType, hail_type, is_container, is_compound, is_nu
 from .table_type import ttable
 from .matrix_type import tmatrix
 from .blockmatrix_type import tblockmatrix
-from .expressions import analyze, eval, eval_typed, eval_timed, \
-    extract_refs_by_indices, get_refs, matrix_table_source, table_source, \
-    check_entry_indexed, check_row_indexed, \
-    Indices, Aggregation, apply_expr, construct_expr, construct_variable, \
-    construct_reference, impute_type, to_expr, cast_expr, unify_all, \
-    unify_types_limited, unify_types, unify_exprs, \
-    Expression, ExpressionException, ArrayExpression, ArrayNumericExpression, \
-    BooleanExpression, CallExpression, CollectionExpression, DictExpression, \
-    IntervalExpression, LocusExpression, NumericExpression, Int32Expression, \
-    Int64Expression, Float32Expression, Float64Expression, SetExpression, \
-    StringExpression, StructExpression, TupleExpression, NDArrayExpression, \
-    NDArrayNumericExpression, \
-    expr_any, expr_int32, expr_int64, \
-    expr_float32, expr_float64, expr_call, expr_bool, expr_str, expr_locus, \
-    expr_interval, expr_array, expr_ndarray, expr_set, expr_dict, expr_tuple, \
-    expr_struct, expr_oneof, expr_numeric, coercer_from_dtype, \
-    _eval_many, _async_eval, _async_eval_typed, _async_eval_timed, _async_eval_many
-from .functions import literal, chi_squared_test, if_else, cond, switch, case, \
-    bind, rbind, contingency_table_test, dbeta, dict, dpois, exp, entropy, \
-    fisher_exact_test, gp_dosage, hardy_weinberg_test, parse_locus, \
-    parse_variant, variant_str, locus, locus_from_global_position, interval, \
-    locus_interval, parse_locus_interval, call, is_defined, is_missing, \
-    is_nan, is_finite, is_infinite, json, parse_json, log, log10, null, missing, \
-    or_else, coalesce, or_missing, binom_test, pchisqtail, pl_dosage, \
-    pl_to_gp, pnorm, pT, pF, ppois, qchisqtail, qnorm, qpois, range, zeros, \
-    rand_bool, rand_norm, rand_norm2d, rand_pois, rand_unif, rand_beta, \
-    rand_gamma, rand_cat, rand_dirichlet, sqrt, corr, str, is_snp, is_mnp, \
-    is_transition, is_transversion, is_insertion, is_deletion, is_indel, \
-    is_star, is_complex, is_strand_ambiguous, allele_type, hamming, \
-    mendel_error_code, triangle, downcode, gq_from_pl, parse_call, \
-    unphased_diploid_gt_index_call, argmax, argmin, zip, _zip_func, enumerate, zip_with_index, map, \
-    flatmap, starmap, flatten, any, all, filter, sorted, find, group_by, fold, \
-    array_scan, len, min, nanmin, max, nanmax, mean, median, product, sum, \
-    cumulative_sum, struct, tuple, set, empty_set, array, empty_array, \
-    empty_dict, delimit, abs, sign, floor, ceil, float, float32, float64, \
-    parse_float, parse_float32, parse_float64, int, int32, int64, parse_int, \
-    parse_int32, parse_int64, bool, get_sequence, reverse_complement, \
-    is_valid_contig, is_valid_locus, contig_length, liftover, min_rep, \
-    uniroot, format, approx_equal, reversed, bit_and, bit_or, bit_xor, \
-    bit_lshift, bit_rshift, bit_not, binary_search, logit, expit, \
-    _values_similar, _showstr, _sort_by, _compare, _locus_windows_per_contig, \
-    shuffle, _console_log, dnorm, dchisq
+from .expressions import (analyze, eval, eval_typed, eval_timed, extract_refs_by_indices, get_refs,
+                          matrix_table_source, table_source, check_entry_indexed, check_row_indexed, Indices, Aggregation,
+                          apply_expr, construct_expr, construct_variable, construct_reference, impute_type, to_expr,
+                          cast_expr, unify_all, unify_types_limited, unify_types, unify_exprs, Expression,
+                          ExpressionException, ArrayExpression, ArrayNumericExpression, BooleanExpression, CallExpression,
+                          CollectionExpression, DictExpression, IntervalExpression, LocusExpression, NumericExpression,
+                          Int32Expression, Int64Expression, Float32Expression, Float64Expression, SetExpression,
+                          StringExpression, StructExpression, TupleExpression, NDArrayExpression,
+                          NDArrayNumericExpression, expr_any, expr_int32, expr_int64, expr_float32, expr_float64,
+                          expr_call, expr_bool, expr_str, expr_locus, expr_interval, expr_array, expr_ndarray, expr_set,
+                          expr_dict, expr_tuple, expr_struct, expr_oneof, expr_numeric, coercer_from_dtype, _eval_many,
+                          _async_eval, _async_eval_typed, _async_eval_timed, _async_eval_many)
+from .functions import (literal, chi_squared_test, if_else, cond, switch, case, bind, rbind,
+                        contingency_table_test, dbeta, dict, dpois, exp, entropy, fisher_exact_test, gp_dosage,
+                        hardy_weinberg_test, parse_locus, parse_variant, variant_str, locus, locus_from_global_position,
+                        interval, locus_interval, parse_locus_interval, call, is_defined, is_missing, is_nan, is_finite,
+                        is_infinite, json, parse_json, log, log10, null, missing, or_else, coalesce, or_missing,
+                        binom_test, pchisqtail, pl_dosage, pl_to_gp, pnorm, pT, pF, ppois, qchisqtail, qnorm, qpois,
+                        range, zeros, rand_bool, rand_norm, rand_norm2d, rand_pois, rand_unif, rand_int32, rand_int64,
+                        rand_beta, rand_gamma, rand_cat, rand_dirichlet, sqrt, corr, str, is_snp, is_mnp, is_transition,
+                        is_transversion, is_insertion, is_deletion, is_indel, is_star, is_complex, is_strand_ambiguous,
+                        allele_type, hamming, mendel_error_code, triangle, downcode, gq_from_pl, parse_call,
+                        unphased_diploid_gt_index_call, argmax, argmin, zip, _zip_func, enumerate, zip_with_index, map,
+                        flatmap, starmap, flatten, any, all, filter, sorted, find, group_by, fold, array_scan, len, min,
+                        nanmin, max, nanmax, mean, median, product, sum, cumulative_sum, struct, tuple, set, empty_set,
+                        array, empty_array, empty_dict, delimit, abs, sign, floor, ceil, float, float32, float64,
+                        parse_float, parse_float32, parse_float64, int, int32, int64, parse_int, parse_int32,
+                        parse_int64, bool, get_sequence, reverse_complement, is_valid_contig, is_valid_locus,
+                        contig_length, liftover, min_rep, uniroot, format, approx_equal, reversed, bit_and, bit_or,
+                        bit_xor, bit_lshift, bit_rshift, bit_not, binary_search, logit, expit, _values_similar,
+                        _showstr, _sort_by, _compare, _locus_windows_per_contig, shuffle, _console_log, dnorm, dchisq)
 
 __all__ = ['HailType',
            'hail_type',
@@ -156,6 +145,8 @@ __all__ = ['HailType',
            'rand_norm2d',
            'rand_pois',
            'rand_unif',
+           'rand_int32',
+           'rand_int64',
            'rand_beta',
            'rand_gamma',
            'rand_cat',

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -2608,6 +2608,83 @@ def rand_unif(lower=0.0, upper=1.0, seed=None) -> Float64Expression:
     return _seeded_func("rand_unif", tfloat64, seed, lower, upper)
 
 
+@typecheck(a=expr_int32, b=nullable(expr_int32), seed=nullable(int))
+def rand_int32(a, b=None, *, seed=None) -> Int32Expression:
+    """Samples from a uniform distribution of 32-bit integers.
+
+    If b is `None`, samples from the uniform distribution over [0, a). Otherwise, sample from the
+    uniform distribution over [a, b).
+
+    Examples
+    --------
+
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_int32(10))
+    0
+
+    >>> hl.eval(hl.rand_int32(10, 15))
+    10
+
+    >>> hl.eval(hl.rand_int32(10, 15))
+    12
+
+    Parameters
+    ----------
+    a : :obj:`int` or :class:`.Int32Expression`
+        If b is `None`, the right boundary of the range; otherwise, the left boundary of range.
+    b : :obj:`int` or :class:`.Int32Expression`
+        If specified, the right boundary of the range.
+    seed : :obj:`int`, optional
+        Random seed.
+
+    Returns
+    -------
+    :class:`.Int32Expression`
+
+    """
+    if b is None:
+        return _seeded_func("rand_int32", tint32, seed, a)
+    return _seeded_func("rand_int32", tint32, seed, b - a) + a
+
+
+@typecheck(a=expr_int64, b=nullable(expr_int64), seed=nullable(int))
+def rand_int64(a, b=None, *, seed=None) -> Int64Expression:
+    """Samples from a uniform distribution of 64-bit integers.
+
+    If b is `None`, samples from the uniform distribution over [0, a). Otherwise, sample from the
+    uniform distribution over [a, b).
+
+    Examples
+    --------
+
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_int64(10))
+    6
+
+    >>> hl.eval(hl.rand_int64(1 << 33, 1 << 35))
+    23592867963
+
+    >>> hl.eval(hl.rand_int64(1 << 33, 1 << 35))
+    30607113212
+
+    Parameters
+    ----------
+    a : :obj:`int` or :class:`.Int64Expression`
+        If b is `None`, the right boundary of the range; otherwise, the left boundary of range.
+    b : :obj:`int` or :class:`.Int64xpression`
+        If specified, the right boundary of the range.
+    seed : :obj:`int`, optional
+        Random seed.
+
+    Returns
+    -------
+    :class:`.Int64Expression`
+    """
+    if b is None:
+        return _seeded_func("rand_int64", tint64, seed, a)
+    return _seeded_func("rand_int64", tint64, seed, b - a) + a
+
+
 @typecheck(a=expr_float64,
            b=expr_float64,
            lower=nullable(expr_float64),

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -2662,10 +2662,10 @@ def rand_int64(a, b=None, *, seed=None) -> Int64Expression:
     2
 
     >>> hl.eval(hl.rand_int64(1 << 33, 1 << 35))
-    23592867963
+    13313179445
 
     >>> hl.eval(hl.rand_int64(1 << 33, 1 << 35))
-    30607113212
+    18981019040
 
     Parameters
     ----------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -2623,7 +2623,7 @@ def rand_int32(a, b=None, *, seed=None) -> Int32Expression:
     0
 
     >>> hl.eval(hl.rand_int32(10, 15))
-    10
+    11
 
     >>> hl.eval(hl.rand_int32(10, 15))
     12
@@ -2659,7 +2659,7 @@ def rand_int64(a, b=None, *, seed=None) -> Int64Expression:
 
     >>> hl.set_global_seed(0)
     >>> hl.eval(hl.rand_int64(10))
-    6
+    2
 
     >>> hl.eval(hl.rand_int64(1 << 33, 1 << 35))
     23592867963
@@ -2671,7 +2671,7 @@ def rand_int64(a, b=None, *, seed=None) -> Int64Expression:
     ----------
     a : :obj:`int` or :class:`.Int64Expression`
         If b is `None`, the right boundary of the range; otherwise, the left boundary of range.
-    b : :obj:`int` or :class:`.Int64xpression`
+    b : :obj:`int` or :class:`.Int64Expression`
         If specified, the right boundary of the range.
     seed : :obj:`int`, optional
         Random seed.

--- a/hail/python/hail/ir/register_functions.py
+++ b/hail/python/hail/ir/register_functions.py
@@ -156,6 +156,8 @@ def register_functions():
     register_function("includesEnd", (dtype("interval<?T>"),), dtype("bool"))
     register_function("position", (dtype("?T:locus"),), dtype("int32"))
     register_seeded_function("rand_unif", (dtype("float64"), dtype("float64"),), dtype("float64"))
+    register_seeded_function("rand_int32", (dtype("int32")), dtype("int32"))
+    register_seeded_function("rand_int64", (dtype("int64"),), dtype("int64"))
     register_function("showStr", (dtype("?T"), dtype("int32")), dtype("str"))
     register_function("str", (dtype("?T"),), dtype("str"))
     register_function("valuesSimilar", (dtype("?T"), dtype("?T"), dtype('float64'), dtype('bool'),), dtype("bool"))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -55,6 +55,11 @@ class Tests(unittest.TestCase):
             self.assertTrue(ht.aggregate(hl.agg.all((ht.x == ht.y)) & ~hl.agg.all((ht.x == ht.z))))
 
         test_random_function(lambda: hl.rand_unif(0, 1))
+        test_random_function(lambda: hl.rand_int32(10))
+        test_random_function(lambda: hl.rand_int32(5, 15))
+        test_random_function(lambda: hl.rand_int64(23))
+        test_random_function(lambda: hl.rand_int64(5, 15))
+        test_random_function(lambda: hl.rand_int64(1 << 33, 1 << 35))
         test_random_function(lambda: hl.rand_bool(0.5))
         test_random_function(lambda: hl.rand_norm(0, 1))
         test_random_function(lambda: hl.rand_pois(1))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -28,6 +28,10 @@ class IRRandomness(seed: Long) {
 
   def runif(min: Double, max: Double): Double = min + (max - min) * random.nextDouble()
 
+  def rint32(n: Int): Int = random.nextInt(n)
+
+  def rint64(n: Long): Long = random.nextLong(n)
+
   def rcoin(p: Double): Boolean = random.nextDouble() < p
 
   def rpois(lambda: Double): Double = Poisson.random(lambda, random, poisState)
@@ -97,6 +101,18 @@ object RandomSeededFunctions extends RegistryFunctions {
       case (_: Type, _: SType, _: SType, _: SType) => SFloat64
     }) { case (_, cb, rt, rngState: SRNGStateStaticSizeValue, min: SFloat64Value, max: SFloat64Value, errorID) =>
       primitive(cb.memoize(rand_unif(cb, rngState.rand(cb)) * (max.value - min.value) + min.value))
+    }
+
+    registerSeeded1("rand_int32", TInt32, TInt32, {
+      case (_: Type, _: SType) => SInt32
+    }) { case (cb, r, rt, seed, n) =>
+      primitive(cb.memoize(cb.emb.newRNG(seed).invoke[Int, Int]("rint32", n.asInt.value)))
+    }
+
+    registerSeeded1("rand_int64", TInt64, TInt64, {
+      case (_: Type, _: SType) => SInt64
+    }) { case (cb, r, rt, seed, n) =>
+      primitive(cb.memoize(cb.emb.newRNG(seed).invoke[Long, Long]("rint64", n.asLong.value)))
     }
 
     registerSeeded2("rand_norm", TFloat64, TFloat64, TFloat64, {


### PR DESCRIPTION
CHANGELOG: Add `rand_int32` and `rand_int64` for generating random 32-bit and 64-bit integers, respectively.