### PR TITLE
[datasets] update pan-UKB datasets and make available via GCS

### DIFF
--- a/hail/python/hail/docs/datasets/schemas/panukb_meta_analysis_all_ancestries.rst
+++ b/hail/python/hail/docs/datasets/schemas/panukb_meta_analysis_all_ancestries.rst
@@ -1,0 +1,290 @@
+.. _panukb_meta_analysis_all_ancestries:
+
+panukb_meta_analysis_all_ancestries
+===================================
+
+*  **Versions:** 0.3
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (0.3, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Column fields:
+        'trait_type': str
+        'phenocode': str
+        'pheno_sex': str
+        'coding': str
+        'modifier': str
+        'pheno_data': array<struct {
+            n_cases: int32, 
+            n_controls: int32, 
+            heritability: struct {
+                estimates: struct {
+                    ldsc: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        intercept: float64, 
+                        intercept_se: float64, 
+                        ratio: float64, 
+                        ratio_se: float64
+                    }, 
+                    sldsc_25bin: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        intercept: float64, 
+                        intercept_se: float64, 
+                        ratio: float64, 
+                        ratio_se: float64
+                    }, 
+                    rhemc_25bin: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64
+                    }, 
+                    rhemc_8bin: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        h2_z: float64
+                    }, 
+                    rhemc_25bin_50rv: struct {
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64
+                    }, 
+                    final: struct {
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64
+                    }
+                }, 
+                qcflags: struct {
+                    GWAS_run: bool, 
+                    ancestry_reasonable_n: bool, 
+                    defined_h2: bool, 
+                    significant_z: bool, 
+                    in_bounds_h2: bool, 
+                    normal_lambda: bool, 
+                    normal_ratio: bool, 
+                    EUR_plus_1: bool, 
+                    pass_all: bool
+                }, 
+                N_ancestry_QC_pass: int32
+            }, 
+            saige_version: str, 
+            inv_normalized: bool, 
+            pop: str, 
+            lambda_gc: float64, 
+            n_variants: int64, 
+            n_sig_variants: int64, 
+            saige_heritability: float64
+        }>
+        'description': str
+        'description_more': str
+        'coding_description': str
+        'category': str
+        'n_cases_full_cohort_both_sexes': int64
+        'n_cases_full_cohort_females': int64
+        'n_cases_full_cohort_males': int64
+        'meta_analysis_data': array<struct {
+            n_cases: int32, 
+            n_controls: int32, 
+            pop: array<str>
+        }>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'rsid': str
+        'varid': str
+        'vep': struct {
+            assembly_name: str, 
+            allele_string: str, 
+            ancestral: str, 
+            colocated_variants: array<struct {
+                aa_allele: str, 
+                aa_maf: float64, 
+                afr_allele: str, 
+                afr_maf: float64, 
+                allele_string: str, 
+                amr_allele: str, 
+                amr_maf: float64, 
+                clin_sig: array<str>, 
+                end: int32, 
+                eas_allele: str, 
+                eas_maf: float64, 
+                ea_allele: str, 
+                ea_maf: float64, 
+                eur_allele: str, 
+                eur_maf: float64, 
+                exac_adj_allele: str, 
+                exac_adj_maf: float64, 
+                exac_allele: str, 
+                exac_afr_allele: str, 
+                exac_afr_maf: float64, 
+                exac_amr_allele: str, 
+                exac_amr_maf: float64, 
+                exac_eas_allele: str, 
+                exac_eas_maf: float64, 
+                exac_fin_allele: str, 
+                exac_fin_maf: float64, 
+                exac_maf: float64, 
+                exac_nfe_allele: str, 
+                exac_nfe_maf: float64, 
+                exac_oth_allele: str, 
+                exac_oth_maf: float64, 
+                exac_sas_allele: str, 
+                exac_sas_maf: float64, 
+                id: str, 
+                minor_allele: str, 
+                minor_allele_freq: float64, 
+                phenotype_or_disease: int32, 
+                pubmed: array<int32>, 
+                sas_allele: str, 
+                sas_maf: float64, 
+                somatic: int32, 
+                start: int32, 
+                strand: int32
+            }>, 
+            context: str, 
+            end: int32, 
+            id: str, 
+            input: str, 
+            intergenic_consequences: array<struct {
+                allele_num: int32, 
+                consequence_terms: array<str>, 
+                impact: str, 
+                minimised: int32, 
+                variant_allele: str
+            }>, 
+            most_severe_consequence: str, 
+            motif_feature_consequences: array<struct {
+                allele_num: int32, 
+                consequence_terms: array<str>, 
+                high_inf_pos: str, 
+                impact: str, 
+                minimised: int32, 
+                motif_feature_id: str, 
+                motif_name: str, 
+                motif_pos: int32, 
+                motif_score_change: float64, 
+                strand: int32, 
+                variant_allele: str
+            }>, 
+            regulatory_feature_consequences: array<struct {
+                allele_num: int32, 
+                biotype: str, 
+                consequence_terms: array<str>, 
+                impact: str, 
+                minimised: int32, 
+                regulatory_feature_id: str, 
+                variant_allele: str
+            }>, 
+            seq_region_name: str, 
+            start: int32, 
+            strand: int32, 
+            transcript_consequences: array<struct {
+                allele_num: int32, 
+                amino_acids: str, 
+                biotype: str, 
+                canonical: int32, 
+                ccds: str, 
+                cdna_start: int32, 
+                cdna_end: int32, 
+                cds_end: int32, 
+                cds_start: int32, 
+                codons: str, 
+                consequence_terms: array<str>, 
+                distance: int32, 
+                domains: array<struct {
+                    db: str, 
+                    name: str
+                }>, 
+                exon: str, 
+                gene_id: str, 
+                gene_pheno: int32, 
+                gene_symbol: str, 
+                gene_symbol_source: str, 
+                hgnc_id: str, 
+                hgvsc: str, 
+                hgvsp: str, 
+                hgvs_offset: int32, 
+                impact: str, 
+                intron: str, 
+                lof: str, 
+                lof_flags: str, 
+                lof_filter: str, 
+                lof_info: str, 
+                minimised: int32, 
+                polyphen_prediction: str, 
+                polyphen_score: float64, 
+                protein_end: int32, 
+                protein_start: int32, 
+                protein_id: str, 
+                sift_prediction: str, 
+                sift_score: float64, 
+                strand: int32, 
+                swissprot: str, 
+                transcript_id: str, 
+                trembl: str, 
+                uniparc: str, 
+                variant_allele: str
+            }>, 
+            variant_class: str
+        }
+        'freq': array<struct {
+            pop: str, 
+            ac: float64, 
+            af: float64, 
+            an: int64, 
+            gnomad_exomes_ac: int32, 
+            gnomad_exomes_af: float64, 
+            gnomad_exomes_an: int32, 
+            gnomad_genomes_ac: int32, 
+            gnomad_genomes_af: float64, 
+            gnomad_genomes_an: int32
+        }>
+        'pass_gnomad_exomes': bool
+        'pass_gnomad_genomes': bool
+        'n_passing_populations': int32
+        'high_quality': bool
+        'nearest_genes': str
+        'info': float64
+    ----------------------------------------
+    Entry fields:
+        'meta_analysis': array<struct {
+            BETA: float64, 
+            SE: float64, 
+            Pvalue: float64, 
+            Q: float64, 
+            Pvalue_het: float64, 
+            N: int32, 
+            N_pops: int32, 
+            AF_Allele2: float64, 
+            AF_Cases: float64, 
+            AF_Controls: float64
+        }>
+    ----------------------------------------
+    Column key: ['trait_type', 'phenocode', 'pheno_sex', 'coding', 'modifier']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/panukb_meta_analysis_high_quality.rst
+++ b/hail/python/hail/docs/datasets/schemas/panukb_meta_analysis_high_quality.rst
@@ -1,0 +1,290 @@
+.. _panukb_meta_analysis_high_quality:
+
+panukb_meta_analysis_high_quality
+=================================
+
+*  **Versions:** 0.3
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (0.3, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Column fields:
+        'trait_type': str
+        'phenocode': str
+        'pheno_sex': str
+        'coding': str
+        'modifier': str
+        'pheno_data': array<struct {
+            n_cases: int32, 
+            n_controls: int32, 
+            heritability: struct {
+                estimates: struct {
+                    ldsc: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        intercept: float64, 
+                        intercept_se: float64, 
+                        ratio: float64, 
+                        ratio_se: float64
+                    }, 
+                    sldsc_25bin: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        intercept: float64, 
+                        intercept_se: float64, 
+                        ratio: float64, 
+                        ratio_se: float64
+                    }, 
+                    rhemc_25bin: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64
+                    }, 
+                    rhemc_8bin: struct {
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        h2_z: float64
+                    }, 
+                    rhemc_25bin_50rv: struct {
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64
+                    }, 
+                    final: struct {
+                        h2_observed: float64, 
+                        h2_observed_se: float64, 
+                        h2_liability: float64, 
+                        h2_liability_se: float64, 
+                        h2_z: float64
+                    }
+                }, 
+                qcflags: struct {
+                    GWAS_run: bool, 
+                    ancestry_reasonable_n: bool, 
+                    defined_h2: bool, 
+                    significant_z: bool, 
+                    in_bounds_h2: bool, 
+                    normal_lambda: bool, 
+                    normal_ratio: bool, 
+                    EUR_plus_1: bool, 
+                    pass_all: bool
+                }, 
+                N_ancestry_QC_pass: int32
+            }, 
+            saige_version: str, 
+            inv_normalized: bool, 
+            pop: str, 
+            lambda_gc: float64, 
+            n_variants: int64, 
+            n_sig_variants: int64, 
+            saige_heritability: float64
+        }>
+        'description': str
+        'description_more': str
+        'coding_description': str
+        'category': str
+        'n_cases_full_cohort_both_sexes': int64
+        'n_cases_full_cohort_females': int64
+        'n_cases_full_cohort_males': int64
+        'meta_analysis_data': array<struct {
+            n_cases: int32, 
+            n_controls: int32, 
+            pop: array<str>
+        }>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'rsid': str
+        'varid': str
+        'vep': struct {
+            assembly_name: str, 
+            allele_string: str, 
+            ancestral: str, 
+            colocated_variants: array<struct {
+                aa_allele: str, 
+                aa_maf: float64, 
+                afr_allele: str, 
+                afr_maf: float64, 
+                allele_string: str, 
+                amr_allele: str, 
+                amr_maf: float64, 
+                clin_sig: array<str>, 
+                end: int32, 
+                eas_allele: str, 
+                eas_maf: float64, 
+                ea_allele: str, 
+                ea_maf: float64, 
+                eur_allele: str, 
+                eur_maf: float64, 
+                exac_adj_allele: str, 
+                exac_adj_maf: float64, 
+                exac_allele: str, 
+                exac_afr_allele: str, 
+                exac_afr_maf: float64, 
+                exac_amr_allele: str, 
+                exac_amr_maf: float64, 
+                exac_eas_allele: str, 
+                exac_eas_maf: float64, 
+                exac_fin_allele: str, 
+                exac_fin_maf: float64, 
+                exac_maf: float64, 
+                exac_nfe_allele: str, 
+                exac_nfe_maf: float64, 
+                exac_oth_allele: str, 
+                exac_oth_maf: float64, 
+                exac_sas_allele: str, 
+                exac_sas_maf: float64, 
+                id: str, 
+                minor_allele: str, 
+                minor_allele_freq: float64, 
+                phenotype_or_disease: int32, 
+                pubmed: array<int32>, 
+                sas_allele: str, 
+                sas_maf: float64, 
+                somatic: int32, 
+                start: int32, 
+                strand: int32
+            }>, 
+            context: str, 
+            end: int32, 
+            id: str, 
+            input: str, 
+            intergenic_consequences: array<struct {
+                allele_num: int32, 
+                consequence_terms: array<str>, 
+                impact: str, 
+                minimised: int32, 
+                variant_allele: str
+            }>, 
+            most_severe_consequence: str, 
+            motif_feature_consequences: array<struct {
+                allele_num: int32, 
+                consequence_terms: array<str>, 
+                high_inf_pos: str, 
+                impact: str, 
+                minimised: int32, 
+                motif_feature_id: str, 
+                motif_name: str, 
+                motif_pos: int32, 
+                motif_score_change: float64, 
+                strand: int32, 
+                variant_allele: str
+            }>, 
+            regulatory_feature_consequences: array<struct {
+                allele_num: int32, 
+                biotype: str, 
+                consequence_terms: array<str>, 
+                impact: str, 
+                minimised: int32, 
+                regulatory_feature_id: str, 
+                variant_allele: str
+            }>, 
+            seq_region_name: str, 
+            start: int32, 
+            strand: int32, 
+            transcript_consequences: array<struct {
+                allele_num: int32, 
+                amino_acids: str, 
+                biotype: str, 
+                canonical: int32, 
+                ccds: str, 
+                cdna_start: int32, 
+                cdna_end: int32, 
+                cds_end: int32, 
+                cds_start: int32, 
+                codons: str, 
+                consequence_terms: array<str>, 
+                distance: int32, 
+                domains: array<struct {
+                    db: str, 
+                    name: str
+                }>, 
+                exon: str, 
+                gene_id: str, 
+                gene_pheno: int32, 
+                gene_symbol: str, 
+                gene_symbol_source: str, 
+                hgnc_id: str, 
+                hgvsc: str, 
+                hgvsp: str, 
+                hgvs_offset: int32, 
+                impact: str, 
+                intron: str, 
+                lof: str, 
+                lof_flags: str, 
+                lof_filter: str, 
+                lof_info: str, 
+                minimised: int32, 
+                polyphen_prediction: str, 
+                polyphen_score: float64, 
+                protein_end: int32, 
+                protein_start: int32, 
+                protein_id: str, 
+                sift_prediction: str, 
+                sift_score: float64, 
+                strand: int32, 
+                swissprot: str, 
+                transcript_id: str, 
+                trembl: str, 
+                uniparc: str, 
+                variant_allele: str
+            }>, 
+            variant_class: str
+        }
+        'freq': array<struct {
+            pop: str, 
+            ac: float64, 
+            af: float64, 
+            an: int64, 
+            gnomad_exomes_ac: int32, 
+            gnomad_exomes_af: float64, 
+            gnomad_exomes_an: int32, 
+            gnomad_genomes_ac: int32, 
+            gnomad_genomes_af: float64, 
+            gnomad_genomes_an: int32
+        }>
+        'pass_gnomad_exomes': bool
+        'pass_gnomad_genomes': bool
+        'n_passing_populations': int32
+        'high_quality': bool
+        'nearest_genes': str
+        'info': float64
+    ----------------------------------------
+    Entry fields:
+        'meta_analysis': array<struct {
+            BETA: float64, 
+            SE: float64, 
+            Pvalue: float64, 
+            Q: float64, 
+            Pvalue_het: float64, 
+            N: int32, 
+            N_pops: int32, 
+            AF_Allele2: float64, 
+            AF_Cases: float64, 
+            AF_Controls: float64
+        }>
+    ----------------------------------------
+    Column key: ['trait_type', 'phenocode', 'pheno_sex', 'coding', 'modifier']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/panukb_summary_stats.rst
+++ b/hail/python/hail/docs/datasets/schemas/panukb_summary_stats.rst
@@ -1,0 +1,62 @@
+.. _panukb_summary_stats:
+
+panukb_summary_stats
+====================
+
+*  **Versions:** 0.3
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (0.3, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Column fields:
+        'trait_type': str
+        'phenocode': str
+        'pheno_sex': str
+        'coding': str
+        'modifier': str
+        'pheno_data': array<struct {
+            n_cases: int32, 
+            n_controls: int32, 
+            heritability: float64, 
+            saige_version: str, 
+            inv_normalized: bool, 
+            pop: str
+        }>
+        'description': str
+        'description_more': str
+        'coding_description': str
+        'category': str
+        'n_cases_full_cohort_both_sexes': int64
+        'n_cases_full_cohort_females': int64
+        'n_cases_full_cohort_males': int64
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'gene': str
+        'annotation': str
+    ----------------------------------------
+    Entry fields:
+        'summary_stats': array<struct {
+            AF_Allele2: float64, 
+            imputationInfo: float64, 
+            BETA: float64, 
+            SE: float64, 
+            `p.value.NA`: float64, 
+            `AF.Cases`: float64, 
+            `AF.Controls`: float64, 
+            Pvalue: float64, 
+            low_confidence: bool
+        }>
+    ----------------------------------------
+    Column key: ['trait_type', 'phenocode', 'pheno_sex', 'coding', 'modifier']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -4880,6 +4880,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.AFR.ldadj.bm"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/AFR/UKBB.AFR.ldadj.bm"
           }
         },
         "version": "0.2"
@@ -4895,6 +4898,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.AMR.ldadj.bm"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/AMR/UKBB.AMR.ldadj.bm"
           }
         },
         "version": "0.2"
@@ -4910,6 +4916,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.CSA.ldadj.bm"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/CSA/UKBB.CSA.ldadj.bm"
           }
         },
         "version": "0.2"
@@ -4925,6 +4934,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.EAS.ldadj.bm"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/EAS/UKBB.EAS.ldadj.bm"
           }
         },
         "version": "0.2"
@@ -4940,6 +4952,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.EUR.ldadj.bm"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/EUR/UKBB.EUR.ldadj.bm"
           }
         },
         "version": "0.2"
@@ -4955,6 +4970,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.MID.ldadj.bm"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/MID/UKBB.MID.ldadj.bm"
           }
         },
         "version": "0.2"
@@ -4975,6 +4993,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.AFR.ldscore.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld_release/UKBB.AFR.ldscore.ht"
           }
         },
         "version": "0.2"
@@ -4995,6 +5016,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.AMR.ldscore.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld_release/UKBB.AMR.ldscore.ht"
           }
         },
         "version": "0.2"
@@ -5015,6 +5039,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.CSA.ldscore.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld_release/UKBB.CSA.ldscore.ht"
           }
         },
         "version": "0.2"
@@ -5035,6 +5062,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.EAS.ldscore.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld_release/UKBB.EAS.ldscore.ht"
           }
         },
         "version": "0.2"
@@ -5055,6 +5085,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.EUR.ldscore.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld_release/UKBB.EUR.ldscore.ht"
           }
         },
         "version": "0.2"
@@ -5075,6 +5108,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.MID.ldscore.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld_release/UKBB.MID.ldscore.ht"
           }
         },
         "version": "0.2"
@@ -5095,6 +5131,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.AFR.ldadj.variant.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/AFR/UKBB.AFR.ldadj.variant.ht"
           }
         },
         "version": "0.2"
@@ -5115,6 +5154,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.AMR.ldadj.variant.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/AMR/UKBB.AMR.ldadj.variant.ht"
           }
         },
         "version": "0.2"
@@ -5135,6 +5177,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.CSA.ldadj.variant.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/CSA/UKBB.CSA.ldadj.variant.ht"
           }
         },
         "version": "0.2"
@@ -5155,6 +5200,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.EAS.ldadj.variant.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/EAS/UKBB.EAS.ldadj.variant.ht"
           }
         },
         "version": "0.2"
@@ -5175,6 +5223,9 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.EUR.ldadj.variant.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/EUR/UKBB.EUR.ldadj.variant.ht"
           }
         },
         "version": "0.2"
@@ -5195,27 +5246,48 @@
         "url": {
           "aws": {
             "us": "s3://pan-ukb-us-east-1/ld_release/UKBB.MID.ldadj.variant.ht"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/ld/MID/UKBB.MID.ldadj.variant.ht"
           }
         },
         "version": "0.2"
       }
     ]
   },
-  "panukb_meta_analysis": {
-    "description": "Pan-UKB: pan-ancestry GWAS of UK Biobank, full meta-analysis Hail MatrixTable.",
+  "panukb_meta_analysis_high_quality": {
+    "description": "Pan-UKB: pan-ancestry GWAS of UK Biobank, full \"high-quality\" meta-analysis Hail MatrixTable (meta-analyses of only ancestry groups passing all QC filters).",
     "url": "https://pan.ukbb.broadinstitute.org/docs/technical-overview/index.html",
     "versions": [
       {
         "reference_genome": "GRCh37",
         "url": {
           "aws": {
-            "us": "s3://pan-ukb-us-east-1/sumstats_release/meta_analysis.mt"
+            "us": "s3://pan-ukb-us-east-1/sumstats_release/meta_analysis.h2_qc.mt"
           },
           "gcp": {
-            "us": "gs://ukb-diverse-pops-public/sumstats_release/meta_analysis.mt"
+            "us": "gs://ukb-diverse-pops-public/sumstats_release/meta_analysis.h2_qc.mt"
           }
         },
-        "version": "0.1"
+        "version": "0.3"
+      }
+    ]
+  },
+  "panukb_meta_analysis_all_ancestries": {
+    "description": "Pan-UKB: pan-ancestry GWAS of UK Biobank, full \"raw\" meta-analysis Hail MatrixTable (meta-analyses for all ancestries (no QC)).",
+    "url": "https://pan.ukbb.broadinstitute.org/docs/technical-overview/index.html",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://pan-ukb-us-east-1/sumstats_release/meta_analysis.raw.mt"
+          },
+          "gcp": {
+            "us": "gs://ukb-diverse-pops-public/sumstats_release/meta_analysis.raw.mt"
+          }
+        },
+        "version": "0.3"
       }
     ]
   },
@@ -5233,7 +5305,7 @@
             "us": "gs://ukb-diverse-pops-public/sumstats_release/results_full.mt"
           }
         },
-        "version": "0.1"
+        "version": "0.3"
       }
     ]
   }


### PR DESCRIPTION
Currently, the Hail datasets API only has the pan-UKB datasets available via the Amazon S3 bucket. This PR makes the pan-UKB datasets available via GCS as well (from the `gs://ukb-diverse-pops-public` bucket), and updates the summary statistics and meta-analysis MatrixTables to reflect the most up-to-date release.