### PR TITLE
[query] fix global seed initialization and enable doctests

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -53,7 +53,7 @@ class HailContext(object):
                            tmpdir: str,
                            local_tmpdir: str,
                            default_reference: str,
-                           global_seed: Optional[str],
+                           global_seed: Optional[int],
                            backend: Backend):
         hc = HailContext(log=log,
                          quiet=quiet,
@@ -73,7 +73,7 @@ class HailContext(object):
                tmpdir: str,
                local_tmpdir: str,
                default_reference: str,
-               global_seed: Optional[str],
+               global_seed: Optional[int],
                backend: Backend):
         hc = HailContext(log=log,
                          quiet=quiet,
@@ -124,8 +124,13 @@ class HailContext(object):
             sys.stderr.write(f'LOGGING: writing to {log}\n')
 
         if global_seed is None:
-            global_seed = 6348563392232659379
-        Env.set_seed(global_seed)
+            if Env._seed_generator is None:
+                Env.set_seed(6348563392232659379)
+        else:  # global_seed is not None
+            if Env._seed_generator is not None:
+                raise ValueError(
+                    'Do not call hl.init with a non-None global seed *after* calling hl.set_global_seed')
+            Env.set_seed(global_seed)
         Env._hc = self
 
     def initialize_references(self, references, default_reference):
@@ -178,7 +183,7 @@ def init(sc=None, app_name=None, master=None, local='local[*]',
          log=None, quiet=False, append=False,
          min_block_size=0, branching_factor=50, tmp_dir=None,
          default_reference='GRCh37', idempotent=False,
-         global_seed=6348563392232659379,
+         global_seed=None,
          spark_conf=None,
          skip_logging_configuration=False,
          local_tmpdir=None,
@@ -380,7 +385,7 @@ def init_spark(sc=None,
                tmp_dir=None,
                default_reference='GRCh37',
                idempotent=False,
-               global_seed=6348563392232659379,
+               global_seed=None,
                spark_conf=None,
                skip_logging_configuration=False,
                local_tmpdir=None,
@@ -435,7 +440,7 @@ async def init_batch(
         tmpdir: Optional[str] = None,
         local_tmpdir: Optional[str] = None,
         default_reference: str = 'GRCh37',
-        global_seed: int = 6348563392232659379,
+        global_seed: Optional[int] = None,
         disable_progress_bar: bool = True,
         driver_cores: Optional[Union[str, int]] = None,
         driver_memory: Optional[str] = None,
@@ -484,7 +489,7 @@ def init_local(
         branching_factor=50,
         tmpdir=None,
         default_reference='GRCh37',
-        global_seed=6348563392232659379,
+        global_seed=None,
         skip_logging_configuration=False,
         _optimizer_iterations=None):
     from hail.backend.local_backend import LocalBackend

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4474,8 +4474,8 @@ def set(collection) -> SetExpression:
     --------
 
     >>> s = hl.set(['Bob', 'Charlie', 'Alice', 'Bob', 'Bob'])
-    >>> hl.eval(s)
-    frozenset({'Alice', 'Charlie', 'Bob'})
+    >>> hl.eval(s) # doctest: +SKIP
+    frozenset({'Alice', 'Bob', 'Charlie'})
 
     Returns
     -------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -659,8 +659,8 @@ def dict(collection) -> DictExpression:
     Examples
     --------
 
-    >>> hl.eval(hl.dict([('foo', 1), ('bar', 2), ('baz', 3)]))  # doctest: +SKIP_OUTPUT_CHECK
-    {u'bar': 2, u'baz': 3, u'foo': 1}
+    >>> hl.eval(hl.dict([('foo', 1), ('bar', 2), ('baz', 3)]))
+    frozendict({'bar': 2, 'baz': 3, 'foo': 1})
 
     Notes
     -----
@@ -1698,8 +1698,8 @@ def json(x) -> StringExpression:
     >>> hl.eval(hl.json([1,2,3,4,5]))
     '[1,2,3,4,5]'
 
-    >>> hl.eval(hl.json(hl.struct(a='Hello', b=0.12345, c=[1,2], d={'hi', 'bye'})))  # doctest: +SKIP_OUTPUT_CHECK
-    '{"a":"Hello","c":[1,2],"b":0.12345,"d":["bye","hi"]}'
+    >>> hl.eval(hl.json(hl.struct(a='Hello', b=0.12345, c=[1,2], d={'hi', 'bye'})))
+    '{"a":"Hello","b":0.12345,"c":[1,2],"d":["bye","hi"]}'
 
     Parameters
     ----------
@@ -2432,11 +2432,12 @@ def rand_bool(p, seed=None) -> BooleanExpression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_bool(0.5))  # doctest: +SKIP_OUTPUT_CHECK
-    True
-
-    >>> hl.eval(hl.rand_bool(0.5))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_bool(0.5))
     False
+
+    >>> hl.eval(hl.rand_bool(0.5))
+    True
 
     Parameters
     ----------
@@ -2460,11 +2461,12 @@ def rand_norm(mean=0, sd=1, seed=None) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_norm())  # doctest: +SKIP_OUTPUT_CHECK
-    1.5388475315213386
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_norm())
+    0.30971254606692267
 
-    >>> hl.eval(hl.rand_norm())  # doctest: +SKIP_OUTPUT_CHECK
-    -0.3006188509144124
+    >>> hl.eval(hl.rand_norm())
+    -1.6120679347033475
 
     Parameters
     ----------
@@ -2489,11 +2491,12 @@ def rand_norm2d(mean=None, cov=None, seed=None) -> ArrayNumericExpression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_norm2d())  # doctest: +SKIP_OUTPUT_CHECK
-    [0.5515477294463427, -1.1782691532205807]
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_norm2d())
+    [0.30971254606692267, -1.266553783097155]
 
-    >>> hl.eval(hl.rand_norm2d())  # doctest: +SKIP_OUTPUT_CHECK
-    [-1.127240906867922, 1.4495317887283203]
+    >>> hl.eval(hl.rand_norm2d())
+    [-1.6120679347033475, 1.6121791827078364]
 
     Notes
     -----
@@ -2550,11 +2553,12 @@ def rand_pois(lamb, seed=None) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_pois(1))  # doctest: +SKIP_OUTPUT_CHECK
-    2.0
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_pois(1))
+    1.0
 
-    >>> hl.eval(hl.rand_pois(1))  # doctest: +SKIP_OUTPUT_CHECK
-    3.0
+    >>> hl.eval(hl.rand_pois(1))
+    1.0
 
     Parameters
     ----------
@@ -2578,14 +2582,15 @@ def rand_unif(lower=0.0, upper=1.0, seed=None) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_unif())  # doctest: +SKIP_OUTPUT_CHECK
-    0.4748146494885547
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_unif())
+    0.6830630912401323
 
-    >>> hl.eval(hl.rand_unif(0, 1))  # doctest: +SKIP_OUTPUT_CHECK
-    0.7983073825816226
+    >>> hl.eval(hl.rand_unif(0, 1))
+    0.4035978197966855
 
-    >>> hl.eval(hl.rand_unif(0, 1))  # doctest: +SKIP_OUTPUT_CHECK
-    0.5161799497741769
+    >>> hl.eval(hl.rand_unif(0, 1))
+    0.26020045338162423
 
     Parameters
     ----------
@@ -2624,11 +2629,12 @@ def rand_beta(a, b, lower=None, upper=None, seed=None) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_beta(0, 1))  # doctest: +SKIP_OUTPUT_CHECK
-    0.6696807666871818
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_beta(0.5, 0.5))
+    0.3483677318466065
 
-    >>> hl.eval(hl.rand_beta(0, 1))  # doctest: +SKIP_OUTPUT_CHECK
-    0.8512985039011525
+    >>> hl.eval(hl.rand_beta(2, 5))
+    0.23894608018057753
 
     Parameters
     ----------
@@ -2666,11 +2672,12 @@ def rand_gamma(shape, scale, seed=None) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_gamma(1, 1))  # doctest: +SKIP_OUTPUT_CHECK
-    2.3915947710237537
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_gamma(1, 1))
+    0.8934929450909811
 
-    >>> hl.eval(hl.rand_gamma(1, 1))  # doctest: +SKIP_OUTPUT_CHECK
-    0.1339939936379711
+    >>> hl.eval(hl.rand_gamma(1, 1))
+    0.3423233699402248
 
     Parameters
     ----------
@@ -2705,10 +2712,11 @@ def rand_cat(prob, seed=None) -> Int32Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_cat([0, 1.7, 2]))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_cat([0, 1.7, 2]))
     2
 
-    >>> hl.eval(hl.rand_cat([0, 1.7, 2]))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.rand_cat([0, 1.7, 2]))
     1
 
     Parameters
@@ -2733,11 +2741,12 @@ def rand_dirichlet(a, seed=None) -> ArrayExpression:
     Examples
     --------
 
-    >>> hl.eval(hl.rand_dirichlet([1, 1, 1]))  # doctest: +SKIP_OUTPUT_CHECK
-    [0.4630197581640282,0.18207753442497876,0.3549027074109931]
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.rand_dirichlet([1, 1, 1]))
+    [0.31600799564679466, 0.22921566396520351, 0.45477634038800185]
 
-    >>> hl.eval(hl.rand_dirichlet([1, 1, 1]))  # doctest: +SKIP_OUTPUT_CHECK
-    [0.20851948405364765,0.7873859423649898,0.004094573581362475]
+    >>> hl.eval(hl.rand_dirichlet([1, 1, 1]))
+    [0.28935842257116556, 0.40020478428981887, 0.31043679313901557]
 
     Parameters
     ----------
@@ -2792,7 +2801,7 @@ def corr(x, y) -> Float64Expression:
 
     Examples
     --------
-    >>> hl.eval(hl.corr([1, 2, 4], [2, 3, 1]))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.corr([1, 2, 4], [2, 3, 1]))
     -0.6546536707079772
 
     Notes
@@ -3600,9 +3609,8 @@ def group_by(f: Callable, collection) -> DictExpression:
     --------
 
     >>> a = ['The', 'quick', 'brown', 'fox']
-
-    >>> hl.eval(hl.group_by(lambda x: hl.len(x), a))  # doctest: +SKIP_OUTPUT_CHECK
-    {5: ['quick', 'brown'], 3: ['The', 'fox']}
+    >>> hl.eval(hl.group_by(lambda x: hl.len(x), a))
+    frozendict({3: ['The', 'fox'], 5: ['quick', 'brown']})
 
     Parameters
     ----------
@@ -4236,7 +4244,7 @@ def sign(x):
     >>> hl.eval(hl.sign([0.0, 3.14]))
     [0.0, 1.0]
 
-    >>> hl.eval(hl.sign(float('nan')))  # doctest: +SKIP
+    >>> hl.eval(hl.sign(float('nan')))
     nan
 
     Notes
@@ -4466,8 +4474,8 @@ def set(collection) -> SetExpression:
     --------
 
     >>> s = hl.set(['Bob', 'Charlie', 'Alice', 'Bob', 'Bob'])
-    >>> hl.eval(s)  # doctest: +SKIP_OUTPUT_CHECK
-    {'Alice', 'Bob', 'Charlie'}
+    >>> hl.eval(s)
+    frozenset({'Alice', 'Bob', 'Charlie'})
 
     Returns
     -------
@@ -4916,13 +4924,13 @@ def float64(x) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.float64('1.1'))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.float64('1.1'))
     1.1
 
-    >>> hl.eval(hl.float64(1))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.float64(1))
     1.0
 
-    >>> hl.eval(hl.float64(True))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.float64(True))
     1.0
 
     Parameters
@@ -4946,7 +4954,7 @@ def parse_float64(x) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.parse_float64('1.1'))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.parse_float64('1.1'))
     1.1
 
     >>> hl.eval(hl.parse_float64('asdf'))
@@ -4975,13 +4983,13 @@ def float32(x) -> Float32Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.float32('1.1'))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.float32('1.1'))
     1.1
 
-    >>> hl.eval(hl.float32(1))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.float32(1))
     1.0
 
-    >>> hl.eval(hl.float32(True))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.float32(True))
     1.0
 
     Parameters
@@ -5005,7 +5013,7 @@ def parse_float32(x) -> Float32Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.parse_float32('1.1'))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.parse_float32('1.1'))
     1.1
 
     >>> hl.eval(hl.parse_float32('asdf'))
@@ -5252,7 +5260,7 @@ def parse_float(x) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.parse_float('1.1'))  # doctest: +SKIP_OUTPUT_CHECK
+    >>> hl.eval(hl.parse_float('1.1'))
     1.1
 
     >>> hl.eval(hl.parse_float('asdf'))
@@ -6183,8 +6191,9 @@ def shuffle(a, seed: builtins.int = None) -> ArrayExpression:
     Example
     -------
 
-    >>> hl.eval(hl.shuffle(hl.range(5)))  # doctest: +SKIP_OUTPUT_CHECK
-    [4, 2, 0, 3, 1]
+    >>> hl.set_global_seed(0)
+    >>> hl.eval(hl.shuffle(hl.range(5)))
+    [3, 2, 0, 4, 1]
 
     Parameters
     ----------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4475,7 +4475,7 @@ def set(collection) -> SetExpression:
 
     >>> s = hl.set(['Bob', 'Charlie', 'Alice', 'Bob', 'Bob'])
     >>> hl.eval(s)
-    frozenset({'Alice', 'Bob', 'Charlie'})
+    frozenset({'Alice', 'Charlie', 'Bob'})
 
     Returns
     -------
@@ -4984,7 +4984,7 @@ def float32(x) -> Float32Expression:
     --------
 
     >>> hl.eval(hl.float32('1.1'))
-    1.1
+    1.100000023841858
 
     >>> hl.eval(hl.float32(1))
     1.0
@@ -5014,7 +5014,7 @@ def parse_float32(x) -> Float32Expression:
     --------
 
     >>> hl.eval(hl.parse_float32('1.1'))
-    1.1
+    1.100000023841858
 
     >>> hl.eval(hl.parse_float32('asdf'))
     None


### PR DESCRIPTION
CHANGELOG: Fix bug where hl.init could silently overwrite the global random seed.