### PR TITLE
[query] Rewrite ld prune to use java objects for filtering

### DIFF
--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -4,7 +4,8 @@ import java.util
 import is.hail.annotations._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.MatrixToTableFunction
-import is.hail.expr.ir.{MatrixValue, TableValue}
+import is.hail.expr.ir.{LongArrayBuilder, MatrixValue, TableValue}
+import is.hail.sparkextras.ContextRDD
 import is.hail.types._
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -12,64 +13,100 @@ import is.hail.rvd.RVD
 import is.hail.utils._
 import is.hail.variant._
 
-object BitPackedVectorView {
-  val bpvElementSize: Long = PInt64Required.byteSize
+import org.apache.spark.rdd.RDD
 
-  def rvRowPType(locusType: PType, allelesType: PType): PStruct =
-    PCanonicalStruct(true,
-      "locus" -> locusType,
-      "alleles" -> allelesType,
-      "bpv" -> PCanonicalArray(PInt64Required),
-      "nSamples" -> PInt32Required,
-      "mean" -> PFloat64(),
-      "centered_length_rec" -> PFloat64())
+import BitPackedVector._
+
+object BitPackedVector {
+  final val GENOTYPES_PER_PACK: Int = 32
+  final val BITS_PER_PACK: Int = 2 * GENOTYPES_PER_PACK
 }
 
-class BitPackedVectorView(rvRowType: PStruct) {
-  val vView = new RegionValueVariant(rvRowType)
+private class BitPackedVectorLoader(fullRowPType: PStruct, callField: String, nSamples: Int) {
+  require(nSamples >= 0)
+  val PField(_, locusType: PLocus, locusIdx) = fullRowPType.fieldByName("locus")
+  val PField(_, allelesType: PArray, allelesIdx) = fullRowPType.fieldByName("alleles")
+  val alleleType = allelesType.elementType.asInstanceOf[PString]
+  val hcView = new HardCallView(fullRowPType, callField)
 
-  // All types are required!
-  private var bpvOffset: Long = _
-  private var bpvLength: Int = _
-  private var bpvElementOffset: Long = _
-  private var nSamplesOffset: Long = _
-  private var meanOffset: Long = _
-  private var centeredLengthRecOffset: Long = _
-  private val bpvPType = PCanonicalArray(PInt64Required)
+  def load(ptr: Long): Option[BitPackedVector] = {
+    require(nSamples >= 0)
+    hcView.set(ptr)
 
-  def set(offset: Long) {
-    bpvOffset = rvRowType.loadField(offset, rvRowType.fieldIdx("bpv"))
-    bpvLength = bpvPType.loadLength(bpvOffset)
-    bpvElementOffset = bpvPType.elementOffset(bpvOffset, bpvLength, 0)
-    nSamplesOffset = rvRowType.loadField(offset, rvRowType.fieldIdx("nSamples"))
-    meanOffset = rvRowType.loadField(offset, rvRowType.fieldIdx("mean"))
-    centeredLengthRecOffset = rvRowType.loadField(offset, rvRowType.fieldIdx("centered_length_rec"))
+    val lptr = fullRowPType.loadField(ptr, locusIdx)
+    val locus = Locus(locusType.contig(lptr), locusType.position(lptr))
 
-    vView.set(offset)
+    val aptr = fullRowPType.loadField(ptr, allelesIdx)
+    val alen = allelesType.loadLength(aptr)
+    val aiter = allelesType.elementIterator(aptr, alen)
+    val alleles = new Array[String](alen)
+    var i = 0
+    while (i < alen) {
+      alleles(i) = alleleType.loadString(allelesType.loadElement(aptr, alen, i))
+      i += 1
+    }
+
+    var nMissing = 0
+    var gtSum = 0
+    var gtSumSq = 0
+
+    val nPacks = (nSamples - 1) / GENOTYPES_PER_PACK + 1
+    val packs = new LongArrayBuilder(nPacks)
+    var pack = 0L
+    var packOffset = BITS_PER_PACK - 2
+    i = 0
+    while (i < nSamples) {
+      hcView.setGenotype(i)
+      val gt = if (hcView.hasGT) Call.nNonRefAlleles(hcView.getGT) else -1
+      pack = pack | ((gt & 3).toLong << packOffset)
+
+      if (packOffset == 0) {
+        packs.add(pack)
+        pack = 0L
+        packOffset = BITS_PER_PACK
+      }
+
+      packOffset -= 2
+
+      gt match {
+        case 1 => gtSum += 1; gtSumSq += 1
+        case 2 => gtSum += 2; gtSumSq += 4
+        case -1 => nMissing += 1
+        case _ =>
+      }
+
+      i += 1
+    }
+
+    if (packs.size < nPacks) {
+      packs.add(pack)
+    }
+
+    val nPresent = nSamples - nMissing
+    val allHomRef = gtSum == 0
+    val allHet = gtSum == nPresent && gtSumSq == nPresent
+    val allHomVar = gtSum == 2 * nPresent
+
+    if (allHomRef || allHet || allHomVar || nMissing == nSamples) {
+      None
+    } else {
+      val gtMean = gtSum.toDouble / nPresent
+      val gtSumAll = gtSum + nMissing * gtMean
+      val gtSumSqAll = gtSumSq + nMissing * gtMean * gtMean
+      val gtCenteredLengthRec = 1d / math.sqrt(gtSumSqAll - (gtSumAll * gtSumAll / nSamples))
+
+      Some(BitPackedVector(locus, alleles, packs.result(), nSamples, gtMean, gtCenteredLengthRec))
+    }
   }
+}
 
-  def getContig: String = vView.contig()
+case class BitPackedVector(locus: Locus, alleles: Array[String], bpv: Array[Long], nSamples: Int, mean: Double, centeredLengthRec: Double) {
+  def nPacks: Int = bpv.length
 
-  def getStart: Int = vView.position()
-
-  def getPack(idx: Int): Long = {
-    if (idx < 0 || idx >= bpvLength)
-      throw new ArrayIndexOutOfBoundsException(idx)
-    val packOffset = bpvElementOffset + idx * BitPackedVectorView.bpvElementSize
-    Region.loadLong(packOffset)
-  }
-
-  def getNPacks: Int = bpvLength
-
-  def getNSamples: Int = Region.loadInt(nSamplesOffset)
-
-  def getMean: Double = Region.loadDouble(meanOffset)
-
-  def getCenteredLengthRec: Double = Region.loadDouble(centeredLengthRecOffset)
+  def getPack(idx: Int): Long = bpv(idx)
 }
 
 object LocalLDPrune {
-  val genotypesPerPack = 32
 
   val lookupTable: Array[Byte] = {
     val table = Array.ofDim[Byte](256 * 4)
@@ -119,87 +156,22 @@ object LocalLDPrune {
     (xySum, XbarCount, YbarCount, XbarYbarCount)
   }
 
-  def addBitPackedVector(rvb: RegionValueBuilder, hcView: HardCallView, nSamples: Int): Boolean = {
-    require(nSamples >= 0)
-    val nBitsPerPack = 2 * genotypesPerPack
-    val nPacks = (nSamples - 1) / genotypesPerPack + 1
+  def computeR(x: BitPackedVector, y: BitPackedVector): Double = {
+    require(x.nSamples == y.nSamples && x.nPacks == y.nPacks)
 
-    rvb.startArray(nPacks)
-
-    var nMissing = 0
-    var gtSum = 0
-    var gtSumSq = 0
-
-    var pack = 0L
-    var packOffset = nBitsPerPack - 2
-    var packIndex = 0
-    var i = 0
-    while (i < nSamples) {
-      hcView.setGenotype(i)
-      val gt = if (hcView.hasGT) Call.nNonRefAlleles(hcView.getGT) else -1
-
-      pack = pack | ((gt & 3).toLong << packOffset)
-
-      if (packOffset == 0) {
-        rvb.addLong(pack)
-        packIndex += 1
-        pack = 0L
-        packOffset = nBitsPerPack
-      }
-      packOffset -= 2
-
-      gt match {
-        case 1 => gtSum += 1; gtSumSq += 1
-        case 2 => gtSum += 2; gtSumSq += 4
-        case -1 => nMissing += 1
-        case _ =>
-      }
-
-      i += 1
-    }
-
-    if (packIndex < nPacks)
-      rvb.addLong(pack)
-
-    rvb.endArray()
-
-    val nPresent = nSamples - nMissing
-    val allHomRef = gtSum == 0
-    val allHet = gtSum == nPresent && gtSumSq == nPresent
-    val allHomVar = gtSum == 2 * nPresent
-
-    if (allHomRef || allHet || allHomVar || nMissing == nSamples) {
-      rvb.clear()
-      false
-    } else {
-      val gtMean = gtSum.toDouble / nPresent
-      val gtSumAll = gtSum + nMissing * gtMean
-      val gtSumSqAll = gtSumSq + nMissing * gtMean * gtMean
-      val gtCenteredLengthRec = 1d / math.sqrt(gtSumSqAll - (gtSumAll * gtSumAll / nSamples))
-
-      rvb.addInt(nSamples)
-      rvb.addDouble(gtMean)
-      rvb.addDouble(gtCenteredLengthRec)
-      true
-    }
-  }
-
-  def computeR(x: BitPackedVectorView, y: BitPackedVectorView): Double = {
-    require(x.getNSamples == y.getNSamples && x.getNPacks == y.getNPacks)
-
-    val N = x.getNSamples
-    val meanX = x.getMean
-    val meanY = y.getMean
-    val centeredLengthRecX = x.getCenteredLengthRec
-    val centeredLengthRecY = y.getCenteredLengthRec
+    val N = x.nSamples
+    val meanX = x.mean
+    val meanY = y.mean
+    val centeredLengthRecX = x.centeredLengthRec
+    val centeredLengthRecY = y.centeredLengthRec
 
     var XbarYbarCount = 0
     var XbarCount = 0
     var YbarCount = 0
     var xySum = 0
 
-    val nPacks = x.getNPacks
-    val shiftInit = 2 * (genotypesPerPack - 2)
+    val nPacks = x.nPacks
+    val shiftInit = 2 * (GENOTYPES_PER_PACK - 2)
     var pack = 0
     while (pack < nPacks) {
       val lX = x.getPack(pack)
@@ -221,37 +193,26 @@ object LocalLDPrune {
       ((xySum + XbarCount * meanX + YbarCount * meanY + XbarYbarCount * meanX * meanY) - N * meanX * meanY)
   }
 
-  def computeR2(x: BitPackedVectorView, y: BitPackedVectorView): Double = {
+  def computeR2(x: BitPackedVector, y: BitPackedVector): Double = {
     val r = computeR(x, y)
     val r2 = r * r
     assert(D_>=(r2, 0d) && D_<=(r2, 1d), s"R2 must lie in [0,1]. Found $r2.")
     r2
   }
 
-  private def pruneLocal(inputRDD: RVD, r2Threshold: Double, windowSize: Int, queueSize: Option[Int]): RVD = {
-    val localRowType = inputRDD.typ.rowType
-
-    inputRDD.mapPartitionsWithContext(inputRDD.typ) { (ctx, prevPartition) =>
-      val queue = new util.ArrayDeque[RegionValue](queueSize.getOrElse(16))
-
-      val producerContext = ctx.freshContext()
-
-      val bpvv = new BitPackedVectorView(localRowType)
-      val bpvvPrev = new BitPackedVectorView(localRowType)
-      val rvb = new RegionValueBuilder()
-
-      prevPartition(producerContext).filter { ptr =>
-        bpvv.set(ptr)
-
+  private def pruneLocal(inputRDD: RDD[BitPackedVector], r2Threshold: Double, windowSize: Int, queueSize: Int): RDD[BitPackedVector] = {
+    inputRDD.mapPartitions({ it =>
+      val queue = new util.ArrayDeque[BitPackedVector](queueSize)
+      it.filter { bpvv =>
         var keepVariant = true
         var done = false
         val qit = queue.descendingIterator()
 
         while (!done && qit.hasNext) {
-          bpvvPrev.set(qit.next().offset)
-          if (bpvv.getContig != bpvvPrev.getContig || bpvv.getStart - bpvvPrev.getStart > windowSize)
+          val bpvvPrev = qit.next()
+          if (bpvv.locus.contig != bpvvPrev.locus.contig || bpvv.locus.position - bpvvPrev.locus.position > windowSize) {
             done = true
-          else {
+          } else {
             val r2 = computeR2(bpvv, bpvvPrev)
             if (r2 >= r2Threshold) {
               keepVariant = false
@@ -261,24 +222,15 @@ object LocalLDPrune {
         }
 
         if (keepVariant) {
-          val r = ctx.freshRegion()
-          rvb.set(r)
-          rvb.start(localRowType)
-          rvb.addRegionValue(localRowType, producerContext.region, ptr)
-          queue.addLast(RegionValue(rvb.region, rvb.end()))
-          queueSize.foreach { qs =>
-            if (queue.size() > qs) {
-              queue.pop().region.invalidate()
-            }
+          queue.addLast(bpvv)
+          if (queue.size() > queueSize) {
+            queue.pop()
           }
-          ctx.r.addReferenceTo(r)
         }
-
-        producerContext.region.clear()
 
         keepVariant
       }
-    }
+    }, preservesPartitioning = true)
   }
 
   def apply(ctx: ExecuteContext,
@@ -293,6 +245,7 @@ object LocalLDPrune {
 case class LocalLDPrune(
   callField: String, r2Threshold: Double, windowSize: Int, maxQueueSize: Int
 ) extends MatrixToTableFunction {
+  require(maxQueueSize > 0, s"Maximum queue size must be positive. Found '$maxQueueSize'.")
 
   override def typ(childType: MatrixType): TableType = {
     TableType(
@@ -303,72 +256,38 @@ case class LocalLDPrune(
   def preservesPartitionCounts: Boolean = false
 
   def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
-    if (maxQueueSize < 1)
-      fatal(s"Maximum queue size must be positive. Found '$maxQueueSize'.")
-
     val nSamples = mv.nCols
 
     val fullRowPType = mv.rvRowPType
 
-    val locusIndex = fullRowPType.fieldIdx("locus")
-    val allelesIndex = fullRowPType.fieldIdx("alleles")
-
-    val bpvType = BitPackedVectorView.rvRowPType(fullRowPType.types(locusIndex), fullRowPType.types(allelesIndex))
-
+    val bpvLoader = new BitPackedVectorLoader(fullRowPType, callField, nSamples)
     val tableType = typ(mv.typ)
 
     val standardizedRDD = mv.rvd
-      .mapPartitionsWithContext(mv.rvd.typ.copy(rowType = bpvType)){ (ctx, prevPartition) =>
+      .mapPartitions{ (ctx, prevPartition) =>
 
-        val producerContext = ctx.freshContext()
-
-        val hcView = new HardCallView(fullRowPType, callField)
-        val region = producerContext.region
-        val rvb = new RegionValueBuilder(region)
-
-        prevPartition(producerContext).flatMap { ptr =>
-          hcView.set(ptr)
-          rvb.start(bpvType)
-          rvb.startStruct()
-          rvb.addFields(fullRowPType, ctx.r, ptr, Array(locusIndex, allelesIndex))
-
-          val keep = LocalLDPrune.addBitPackedVector(rvb, hcView, nSamples)
-
-          if (keep) {
-            rvb.endStruct()
-
-            ctx.region.addReferenceTo(region)
-            region.clear()
-
-            Some(rvb.end())
-          }
-          else {
-            region.clear()
-            None
-          }
+        prevPartition.flatMap { ptr =>
+          bpvLoader.load(ptr)
         }
       }
 
-    val rvdLP = LocalLDPrune.pruneLocal(standardizedRDD, r2Threshold, windowSize, Some(maxQueueSize))
+    val rddLP = LocalLDPrune.pruneLocal(standardizedRDD, r2Threshold, windowSize, maxQueueSize)
 
-    val fieldIndicesToAdd = Array("locus", "alleles", "mean", "centered_length_rec")
-      .map(field => bpvType.fieldIdx(field))
-    val sitesOnly = rvdLP.mapPartitions(
-      tableType.canonicalRVDType
-    )({ (ctx, it) =>
+    val sitesOnly = RVD(tableType.canonicalRVDType, mv.rvd.partitioner, ContextRDD.weaken(rddLP).cmapPartitions({ (ctx, it) =>
       val rvb = new RegionValueBuilder(ctx.r)
-
-      it.map { ptr =>
+      it.map { bpvv =>
         rvb.set(ctx.r)
         rvb.start(tableType.canonicalRowPType)
         rvb.startStruct()
-        rvb.addFields(bpvType, ctx.r, ptr, fieldIndicesToAdd)
+        rvb.addLocus(bpvv.locus.contig, bpvv.locus.position)
+        rvb.addAnnotation(TArray(TString), bpvv.alleles)
+        rvb.addDouble(bpvv.mean)
+        rvb.addDouble(bpvv.centeredLengthRec)
         rvb.endStruct()
         rvb.end()
       }
-    })
+    }, true))
 
     TableValue(ctx, tableType, BroadcastRow.empty(ctx), sitesOnly)
   }
 }
-

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -100,7 +100,7 @@ private case class BitPackedVectorLoader(fullRowPType: PStruct, callField: Strin
   }
 }
 
-case class BitPackedVector(locus: Locus, alleles: Array[String], gs: Array[Long], nSamples: Int, mean: Double, centeredLengthRec: Double) {
+case class BitPackedVector(locus: Locus, alleles: IndexedSeq[String], gs: Array[Long], nSamples: Int, mean: Double, centeredLengthRec: Double) {
   def nPacks: Int = gs.length
 
   def getPack(idx: Int): Long = gs(idx)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -95,62 +95,6 @@ object TestUtils {
     m.map(g => if (g == -1) null: BoxedCall else Call2.fromUnphasedDiploidGtIndex(g): BoxedCall)
   }
 
-  // !useHWE: mean 0, norm exactly sqrt(n), variance 1
-  // useHWE: mean 0, norm approximately sqrt(m), variance approx. m / n
-  // missing gt are mean imputed, constant variants return None, only HWE uses nVariants
-  def normalizedHardCalls(view: HardCallView, nSamples: Int, useHWE: Boolean = false, nVariants: Int = -1): Option[Array[Double]] = {
-    require(!(useHWE && nVariants == -1))
-    val vals = Array.ofDim[Double](nSamples)
-    var nMissing = 0
-    var sum = 0
-    var sumSq = 0
-
-    var row = 0
-    while (row < nSamples) {
-      view.setGenotype(row)
-      if (view.hasGT) {
-        val gt = Call.unphasedDiploidGtIndex(view.getGT)
-        vals(row) = gt
-        (gt: @unchecked) match {
-          case 0 =>
-          case 1 =>
-            sum += 1
-            sumSq += 1
-          case 2 =>
-            sum += 2
-            sumSq += 4
-        }
-      } else {
-        vals(row) = -1
-        nMissing += 1
-      }
-      row += 1
-    }
-
-    val nPresent = nSamples - nMissing
-    val nonConstant = !(sum == 0 || sum == 2 * nPresent || sum == nPresent && sumSq == nPresent)
-
-    if (nonConstant) {
-      val mean = sum.toDouble / nPresent
-      val stdDev = math.sqrt(
-        if (useHWE)
-          mean * (2 - mean) * nVariants / 2
-        else {
-          val meanSq = (sumSq + nMissing * mean * mean) / nSamples
-          meanSq - mean * mean
-        })
-
-      val gtDict = Array(0, -mean / stdDev, (1 - mean) / stdDev, (2 - mean) / stdDev)
-      var i = 0
-      while (i < nSamples) {
-        vals(i) = gtDict(vals(i).toInt + 1)
-        i += 1
-      }
-
-      Some(vals)
-    } else
-      None
-  }
 
   def loweredExecute(ctx: ExecuteContext, x: IR, env: Env[(Any, Type)],
     args: IndexedSeq[(Any, Type)],

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -6,7 +6,7 @@ import is.hail.backend.HailTaskContext
 import is.hail.backend.spark.SparkTaskContext
 import is.hail.check.Prop._
 import is.hail.check.{Gen, Properties}
-import is.hail.expr.ir.{Interpret, MatrixValue, TableValue}
+import is.hail.expr.ir.{Interpret, LongArrayBuilder, MatrixValue, TableValue}
 import is.hail.types._
 import is.hail.types.physical.{PStruct, PType}
 import is.hail.types.virtual.{TArray, TString, TStruct}
@@ -16,37 +16,11 @@ import is.hail.{HailSuite, TestUtils}
 import org.apache.spark.rdd.RDD
 import org.testng.annotations.Test
 
-case class BitPackedVector(gs: Array[Long], nSamples: Int, mean: Double, stdDevRec: Double) {
-  def unpack(): Array[Int] = {
-    val gts = Array.ofDim[Int](nSamples)
-    val nPacks = gs.length
-
-    var packIndex = 0
-    var i = 0
-    val shiftInit = LocalLDPrune.genotypesPerPack * 2 - 2
-    while (packIndex < nPacks && i < nSamples) {
-      val l = gs(packIndex)
-      var shift = shiftInit
-      while (shift >= 0 && i < nSamples) {
-        val gt = (l >> shift) & 3
-        if (gt == 3)
-          gts(i) = -1
-        else
-          gts(i) = gt.toInt
-        shift -= 2
-        i += 1
-      }
-      packIndex += 1
-    }
-
-    gts
-  }
-}
+import BitPackedVector._
 
 object LocalLDPruneSuite {
   val variantByteOverhead = 50
   val fractionMemoryToUse = 0.25
-  val genotypesPerPack = LocalLDPrune.genotypesPerPack
 
   val rvRowType = TStruct(
     "locus" -> ReferenceGenome.GRCh37.locusType,
@@ -54,69 +28,67 @@ object LocalLDPruneSuite {
     MatrixType.entriesIdentifier -> TArray(Genotype.htsGenotypeType)
   )
 
-  val bitPackedVectorViewType = BitPackedVectorView.rvRowPType(PType.canonical(rvRowType.field("locus").typ),
-    PType.canonical(rvRowType.field("alleles").typ))
-
-  def makeRV(gs: Iterable[Annotation], pool: RegionPool): RegionValue = {
-    val gArr = gs.toFastIndexedSeq
-    val rvb = new RegionValueBuilder(Region(pool=pool))
-    rvb.start(PType.canonical(rvRowType))
-    rvb.startStruct()
-    rvb.addAnnotation(rvRowType.types(0), Locus("1", 1))
-    rvb.addAnnotation(rvRowType.types(1), FastIndexedSeq("A", "T"))
-    rvb.addAnnotation(TArray(Genotype.htsGenotypeType), gArr)
-    rvb.endStruct()
-    rvb.end()
-    rvb.result()
-  }
-
-  def convertCallsToGs(calls: Array[BoxedCall]): Iterable[Annotation] = calls.map(Genotype(_)).toIterable
-
-  // expecting iterable of Genotype with htsjdk schema
-  def toBitPackedVectorView(gs: Iterable[Annotation], nSamples: Int, pool: RegionPool): Option[BitPackedVectorView] = {
-    val bpvv = new BitPackedVectorView(bitPackedVectorViewType)
-    toBitPackedVectorRegionValue(gs, nSamples, pool) match {
-      case Some(rv) =>
-        bpvv.set(rv.offset)
-        Some(bpvv)
-      case None => None
-    }
-  }
-
-  // expecting iterable of Genotype with htsjdk schema
-  def toBitPackedVectorRegionValue(gs: Iterable[Annotation], nSamples: Int, pool: RegionPool): Option[RegionValue] = {
-    toBitPackedVectorRegionValue(makeRV(gs, pool), nSamples, pool)
-  }
-
-  def toBitPackedVectorRegionValue(rv: RegionValue, nSamples: Int, pool: RegionPool): Option[RegionValue] = {
-    val rvb = new RegionValueBuilder(Region(pool = pool))
-    val hcView = HardCallView(PType.canonical(rvRowType).asInstanceOf[PStruct])
-    hcView.set(rv.offset)
-
-    rvb.start(bitPackedVectorViewType)
-    rvb.startStruct()
-    rvb.addAnnotation(rvRowType.types(0), Locus("1", 1))
-    rvb.addAnnotation(rvRowType.types(1), FastIndexedSeq("A", "T"))
-    val keep = LocalLDPrune.addBitPackedVector(rvb, hcView, nSamples)
-
-    if (keep) {
-      rvb.endStruct()
-      rvb.end()
-      Some(rvb.result())
-    }
-    else
-      None
-  }
-
-  def toBitPackedVector(calls: Array[BoxedCall], pool: RegionPool): Option[BitPackedVector] = {
+  def fromCalls(calls: IndexedSeq[BoxedCall]): Option[BitPackedVector] = {
+    val locus = Locus("1", 1)
+    val alleles = Array("A", "T")
     val nSamples = calls.length
-    toBitPackedVectorView(convertCallsToGs(calls), nSamples, pool).map { bpvv =>
-      BitPackedVector((0 until bpvv.getNPacks).map(bpvv.getPack).toArray, bpvv.getNSamples, bpvv.getMean, bpvv.getCenteredLengthRec)
+
+    var nMissing = 0
+    var gtSum = 0
+    var gtSumSq = 0
+
+    val nPacks = (nSamples - 1) / GENOTYPES_PER_PACK + 1
+    val packs = new LongArrayBuilder(nPacks)
+    var pack = 0L
+    var packOffset = BITS_PER_PACK - 2
+    var i = 0
+    for (call <- calls) {
+      val gt = if (call == null) -1 else Call.nNonRefAlleles(call)
+      pack = pack | ((gt & 3).toLong << packOffset)
+
+      if (packOffset == 0) {
+        packs.add(pack)
+        pack = 0L
+        packOffset = BITS_PER_PACK
+      }
+
+      packOffset -= 2
+
+      gt match {
+        case 1 => gtSum += 1; gtSumSq += 1
+        case 2 => gtSum += 2; gtSumSq += 4
+        case -1 => nMissing += 1
+        case _ =>
+      }
+    }
+
+    if (packs.size < nPacks) {
+      packs.add(pack)
+    }
+
+    val nPresent = nSamples - nMissing
+    val allHomRef = gtSum == 0
+    val allHet = gtSum == nPresent && gtSumSq == nPresent
+    val allHomVar = gtSum == 2 * nPresent
+
+    if (allHomRef || allHet || allHomVar || nMissing == nSamples) {
+      None
+    } else {
+      val gtMean = gtSum.toDouble / nPresent
+      val gtSumAll = gtSum + nMissing * gtMean
+      val gtSumSqAll = gtSumSq + nMissing * gtMean * gtMean
+      val gtCenteredLengthRec = 1d / math.sqrt(gtSumSqAll - (gtSumAll * gtSumAll / nSamples))
+
+      Some(BitPackedVector(locus, alleles, packs.result(), nSamples, gtMean, gtCenteredLengthRec))
     }
   }
 
-  def correlationMatrix(gts: Array[Iterable[Annotation]], nSamples: Int, pool: RegionPool) = {
-    val bvi = gts.map { gs => LocalLDPruneSuite.toBitPackedVectorView(gs, nSamples, pool) }
+  def correlationMatrixGT(gts: Array[Iterable[Annotation]]) = correlationMatrix(gts.map { gts =>
+    gts.map { gt => Genotype.call(gt).map(c => c: BoxedCall).orNull }.toArray
+  })
+
+  def correlationMatrix(gts: Array[Array[BoxedCall]]) = {
+    val bvi = gts.map { gs => LocalLDPruneSuite.fromCalls(gs.toIndexedSeq) }
     val r2 = for (i <- bvi.indices; j <- bvi.indices) yield {
       (bvi(i), bvi(j)) match {
         case (Some(x), Some(y)) =>
@@ -129,7 +101,7 @@ object LocalLDPruneSuite {
   }
 
   def estimateMemoryRequirements(nVariants: Long, nSamples: Int, memoryPerCore: Long): Int = {
-    val bytesPerVariant = math.ceil(8 * nSamples.toDouble / genotypesPerPack).toLong + variantByteOverhead
+    val bytesPerVariant = math.ceil(8 * nSamples.toDouble / GENOTYPES_PER_PACK).toLong + variantByteOverhead
     val memoryAvailPerCore = memoryPerCore * fractionMemoryToUse
 
     val maxQueueSize = math.max(1, math.ceil(memoryAvailPerCore / bytesPerVariant).toInt)
@@ -174,7 +146,7 @@ class LocalLDPruneSuite extends HailSuite {
     val locallyPrunedRDD = getLocallyPrunedRDDWithGT(unprunedMatrixTable, locallyPrunedTable)
     val nSamples = unprunedMatrixTable.nCols
 
-    val r2Matrix = LocalLDPruneSuite.correlationMatrix(locallyPrunedRDD.map { case (locus, alleles, gs) => gs }.collect(), nSamples, pool)
+    val r2Matrix = LocalLDPruneSuite.correlationMatrixGT(locallyPrunedRDD.map { case (locus, alleles, gs) => gs }.collect())
     val variantMap = locallyPrunedRDD.zipWithIndex.map { case ((locus, alleles, gs), i) => (i.toInt, locus) }.collectAsMap()
 
     r2Matrix.indices.forall { case (i, j) =>
@@ -198,11 +170,11 @@ class LocalLDPruneSuite extends HailSuite {
     val locallyUncorrelated = {
       locallyPrunedRDD.mapPartitions(it => {
         // bind function for serialization
-        val computeCorrelationMatrix = (gts: Array[Iterable[Annotation]], nSamps: Int) =>
-          LocalLDPruneSuite.correlationMatrix(gts, nSamps, SparkTaskContext.get().getRegionPool())
+        val computeCorrelationMatrix = (gts: Array[Iterable[Annotation]]) =>
+          LocalLDPruneSuite.correlationMatrixGT(gts)
 
         val (it1, it2) = it.duplicate
-        val localR2Matrix = computeCorrelationMatrix(it1.map { case (locus, alleles, gs) => gs }.toArray, nSamples)
+        val localR2Matrix = computeCorrelationMatrix(it1.map { case (locus, alleles, gs) => gs }.toArray)
         val localVariantMap = it2.zipWithIndex.map { case ((locus, alleles, gs), i) => (i, locus) }.toMap
 
         val uncorrelated = localR2Matrix.indices.forall { case (i, j) =>
@@ -229,8 +201,8 @@ class LocalLDPruneSuite extends HailSuite {
     val calls3 = calls1 ++ Array.ofDim[Int](32 - calls1.length).map(toC2) ++ calls2
 
     for (calls <- Array(calls1, calls2, calls3)) {
-      assert(LocalLDPruneSuite.toBitPackedVector(calls, pool).forall { bpv =>
-        bpv.unpack().map(toC2) sameElements calls
+      assert(LocalLDPruneSuite.fromCalls(calls).forall { bpv =>
+        bpv.unpack().map(toC2(_)) sameElements calls
       })
     }
   }
@@ -250,7 +222,7 @@ class LocalLDPruneSuite extends HailSuite {
       line.trim.split("\t").map(r2 => if (r2 == "NA") None else Some(r2.toDouble))
     }.value).toArray))
 
-    val computedR2 = LocalLDPruneSuite.correlationMatrix(calls.map(LocalLDPruneSuite.convertCallsToGs), 8, pool)
+    val computedR2 = LocalLDPruneSuite.correlationMatrix(calls)
 
     val isSame = actualR2.indices.forall { case (i, j) =>
       val expected = actualR2(i, j)
@@ -272,8 +244,8 @@ class LocalLDPruneSuite extends HailSuite {
     assert(isSame)
 
     val input = Array(0, 1, 2, 2, 2, 0, -1, -1).map(toC2)
-    val bvi1 = LocalLDPruneSuite.toBitPackedVectorView(LocalLDPruneSuite.convertCallsToGs(input), input.length, pool).get
-    val bvi2 = LocalLDPruneSuite.toBitPackedVectorView(LocalLDPruneSuite.convertCallsToGs(input), input.length, pool).get
+    val bvi1 = LocalLDPruneSuite.fromCalls(input).get
+    val bvi2 = LocalLDPruneSuite.fromCalls(input).get
 
     assert(D_==(LocalLDPrune.computeR2(bvi1, bvi2), 1d))
   }
@@ -286,46 +258,47 @@ class LocalLDPruneSuite extends HailSuite {
 
     property("bitPacked pack and unpack give same as orig") =
       forAll(vectorGen) { case (nSamples: Int, v1: Array[BoxedCall], _) =>
-        val bpv = LocalLDPruneSuite.toBitPackedVector(v1, pool)
+        val bpv = LocalLDPruneSuite.fromCalls(v1)
 
         bpv match {
-          case Some(x) => LocalLDPruneSuite.toBitPackedVector(x.unpack().map(toC2), pool).get.gs sameElements x.gs
+          case Some(x) => LocalLDPruneSuite.fromCalls(x.unpack().map(toC2)).get.gs sameElements x.gs
           case None => true
         }
       }
 
-    property("R2 bitPacked same as BVector") =
-      forAll(vectorGen) { case (nSamples: Int, v1: Array[BoxedCall], v2: Array[BoxedCall]) =>
-        val v1Ann = LocalLDPruneSuite.convertCallsToGs(v1)
-        val v2Ann = LocalLDPruneSuite.convertCallsToGs(v2)
+      // FIXME fix from RV version to vector
+    //property("R2 bitPacked same as BVector") =
+    //  forAll(vectorGen) { case (nSamples: Int, v1: Array[BoxedCall], v2: Array[BoxedCall]) =>
+    //    val v1Ann = LocalLDPruneSuite.convertCallsToGs(v1)
+    //    val v2Ann = LocalLDPruneSuite.convertCallsToGs(v2)
 
-        val bv1 = LocalLDPruneSuite.toBitPackedVectorView(v1Ann, nSamples, pool)
-        val bv2 = LocalLDPruneSuite.toBitPackedVectorView(v2Ann, nSamples, pool)
+    //    val bv1 = LocalLDPruneSuite.toBitPackedVectorView(v1Ann, nSamples, pool)
+    //    val bv2 = LocalLDPruneSuite.toBitPackedVectorView(v2Ann, nSamples, pool)
 
-        val view = HardCallView(PType.canonical(LocalLDPruneSuite.rvRowType).asInstanceOf[PStruct])
+    //    val view = HardCallView(PType.canonical(LocalLDPruneSuite.rvRowType).asInstanceOf[PStruct])
 
-        val rv1 = LocalLDPruneSuite.makeRV(v1Ann, pool)
-        view.set(rv1.offset)
-        val sgs1 = TestUtils.normalizedHardCalls(view, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
+    //    val rv1 = LocalLDPruneSuite.makeRV(v1Ann, pool)
+    //    view.set(rv1.offset)
+    //    val sgs1 = TestUtils.normalizedHardCalls(view, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
 
-        val rv2 = LocalLDPruneSuite.makeRV(v2Ann, pool)
-        view.set(rv2.offset)
-        val sgs2 = TestUtils.normalizedHardCalls(view, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
+    //    val rv2 = LocalLDPruneSuite.makeRV(v2Ann, pool)
+    //    view.set(rv2.offset)
+    //    val sgs2 = TestUtils.normalizedHardCalls(view, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
 
-        (bv1, bv2, sgs1, sgs2) match {
-          case (Some(a), Some(b), Some(c: BVector[Double]), Some(d: BVector[Double])) =>
-            val rBreeze = c.dot(d): Double
-            val r2Breeze = rBreeze * rBreeze
-            val r2BitPacked = LocalLDPrune.computeR2(a, b)
+    //    (bv1, bv2, sgs1, sgs2) match {
+    //      case (Some(a), Some(b), Some(c: BVector[Double]), Some(d: BVector[Double])) =>
+    //        val rBreeze = c.dot(d): Double
+    //        val r2Breeze = rBreeze * rBreeze
+    //        val r2BitPacked = LocalLDPrune.computeR2(a, b)
 
-            val isSame = D_==(r2BitPacked, r2Breeze) && D_>=(r2BitPacked, 0d) && D_<=(r2BitPacked, 1d)
-            if (!isSame) {
-              println(s"breeze=$r2Breeze bitPacked=$r2BitPacked nSamples=$nSamples")
-            }
-            isSame
-          case _ => true
-        }
-      }
+    //        val isSame = D_==(r2BitPacked, r2Breeze) && D_>=(r2BitPacked, 0d) && D_<=(r2BitPacked, 1d)
+    //        if (!isSame) {
+    //          println(s"breeze=$r2Breeze bitPacked=$r2BitPacked nSamples=$nSamples")
+    //        }
+    //        isSame
+    //      case _ => true
+    //    }
+    //  }
   }
 
   @Test def testRandom() {


### PR DESCRIPTION
This simplifies the code and means that region bookeeping for the prune
queue is unnecessary.