### PR TITLE
[batch] Dont use tls for Azure pricing API

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/client/pricing_client.py
+++ b/hail/python/hailtop/aiocloud/aioazure/client/pricing_client.py
@@ -10,7 +10,7 @@ from .base_client import AzureBaseClient
 class AzurePricingClient(AzureBaseClient):
     def __init__(self):
         session = AzureSession(credentials=AnonymousCloudCredentials())
-        super().__init__('https://prices.azure.com/api/retail', session=session)
+        super().__init__('http://prices.azure.com/api/retail', session=session)
 
     async def _paged_get(self, path, **kwargs) -> AsyncGenerator[Any, None]:
         page = await self.get(path, **kwargs)


### PR DESCRIPTION
pricing.azure.com just changed their certificates to use an internal certificate authority that is not widely trusted. This caused the batch-driver to fail to start. They might fix this, but since we're just getting public information and we're not sending any data, we just use http instead.