### PR TITLE
[build.py] Add missing sa privilege for deployments/scale

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -648,7 +648,7 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["apps"]
-  resources: ["deployments"]
+  resources: ["*"]
   verbs: ["*"]
 ---
 apiVersion: v1


### PR DESCRIPTION
We were missing permissions for "deployments/scale" to be able to set the number of replicas of the batch driver to 0 in the cleanup instances step.