### PR TITLE
[ggplot] make identity color scale continuous

### DIFF
--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -101,7 +101,9 @@ class GGPlot:
         return GGPlot(self.ht, self.aes, self.geoms[:], self.labels, self.coord_cartesian, self.scales, self.facet)
 
     def verify_scales(self):
-        for geom_idx, geom in enumerate(self.geoms):
+        for aes_key in self.aes.keys():
+            check_scale_continuity(self.scales[aes_key], self.aes[aes_key].dtype, aes_key)
+        for geom in self.geoms:
             aesthetic_dict = geom.aes.properties
             for aes_key in aesthetic_dict.keys():
                 check_scale_continuity(self.scales[aes_key], aesthetic_dict[aes_key].dtype, aes_key)
@@ -162,7 +164,7 @@ class GGPlot:
                 if use_faceting:
                     agg = hl.agg.group_by(selected.facet, stat.make_agg(combined_mapping, precomputed[geom_label]))
                 else:
-                    agg = stat.make_agg(combined_mapping, precomputed[geom_label])
+                    agg = stat.make_agg(combined_mapping, precomputed[geom_label], self.scales)
                 aggregators[geom_label] = agg
                 labels_to_stats[geom_label] = stat
 

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -162,7 +162,7 @@ class GGPlot:
                 stat = self.geoms[geom_idx].get_stat()
                 geom_label = make_geom_label(geom_idx)
                 if use_faceting:
-                    agg = hl.agg.group_by(selected.facet, stat.make_agg(combined_mapping, precomputed[geom_label]))
+                    agg = hl.agg.group_by(selected.facet, stat.make_agg(combined_mapping, precomputed[geom_label], self.scales))
                 else:
                     agg = stat.make_agg(combined_mapping, precomputed[geom_label], self.scales)
                 aggregators[geom_label] = agg

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -5,12 +5,12 @@ import numpy as np
 
 import hail as hl
 from hail.utils.java import warning
-from .utils import should_use_for_grouping
+from .utils import should_use_for_grouping, should_use_scale_for_grouping
 
 
 class Stat:
     @abc.abstractmethod
-    def make_agg(self, mapping, precomputed):
+    def make_agg(self, mapping, precomputed, scales):
         return
 
     @abc.abstractmethod
@@ -23,9 +23,9 @@ class Stat:
 
 
 class StatIdentity(Stat):
-    def make_agg(self, mapping, precomputed):
+    def make_agg(self, mapping, precomputed, scales):
         grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys()
-                              if should_use_for_grouping(aes_key, mapping[aes_key].dtype)}
+                              if should_use_scale_for_grouping(scales[aes_key])}
         non_grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys() if aes_key not in grouping_variables}
         return hl.agg.group_by(hl.struct(**grouping_variables), hl.agg.collect(hl.struct(**non_grouping_variables)))
 
@@ -49,13 +49,13 @@ class StatFunction(StatIdentity):
     def __init__(self, fun):
         self.fun = fun
 
-    def make_agg(self, mapping, precomputed):
+    def make_agg(self, mapping, precomputed, scales):
         with_y_value = mapping.annotate(y=self.fun(mapping.x))
-        return super().make_agg(with_y_value, precomputed)
+        return super().make_agg(with_y_value, precomputed, scales)
 
 
 class StatNone(Stat):
-    def make_agg(self, mapping, precomputed):
+    def make_agg(self, mapping, precomputed, scales):
         return hl.agg.take(hl.struct(), 0)
 
     def listify(self, agg_result):
@@ -63,9 +63,9 @@ class StatNone(Stat):
 
 
 class StatCount(Stat):
-    def make_agg(self, mapping, precomputed):
+    def make_agg(self, mapping, precomputed, scales):
         grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys()
-                              if should_use_for_grouping(aes_key, mapping[aes_key].dtype)}
+                              if should_use_scale_for_grouping(scales[aes_key])}
         if "weight" in mapping:
             return hl.agg.group_by(hl.struct(**grouping_variables), hl.agg.counter(mapping["x"], weight=mapping["weight"]))
         return hl.agg.group_by(hl.struct(**grouping_variables), hl.agg.group_by(mapping["x"], hl.agg.count()))
@@ -102,9 +102,9 @@ class StatBin(Stat):
             precomputes["max_val"] = hl.agg.max(mapping.x)
         return hl.struct(**precomputes)
 
-    def make_agg(self, mapping, precomputed):
+    def make_agg(self, mapping, precomputed, scales):
         grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys()
-                              if should_use_for_grouping(aes_key, mapping[aes_key].dtype)}
+                              if should_use_scale_for_grouping(scales[aes_key])}
 
         start = self.min_val if self.min_val is not None else precomputed.min_val
         end = self.max_val if self.max_val is not None else precomputed.max_val
@@ -137,9 +137,9 @@ class StatCDF(Stat):
     def __init__(self, k):
         self.k = k
 
-    def make_agg(self, mapping, precomputed):
+    def make_agg(self, mapping, precomputed, scales):
         grouping_variables = {aes_key: mapping[aes_key] for aes_key in mapping.keys()
-                              if should_use_for_grouping(aes_key, mapping[aes_key].dtype)}
+                              if should_use_scale_for_grouping(scales[aes_key])}
         return hl.agg.group_by(hl.struct(**grouping_variables), hl.agg.approx_cdf(mapping["x"], self.k))
 
     def listify(self, agg_result):

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import hail as hl
 from hail.utils.java import warning
-from .utils import should_use_for_grouping, should_use_scale_for_grouping
+from .utils import should_use_scale_for_grouping
 
 
 class Stat:

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -3,11 +3,8 @@ import hail as hl
 
 
 def check_scale_continuity(scale, dtype, aes_key):
-
-    if scale.is_discrete() and not is_discrete_type(dtype):
-        raise ValueError(f"Aesthetic {aes_key} has discrete scale but not a discrete type.")
-    if scale.is_continuous() and not is_continuous_type(dtype):
-        raise ValueError(f"Aesthetic {aes_key} has continuous scale but not a continuous type.")
+    if not scale.valid_dtype(dtype):
+        raise ValueError(f"Invalid scale for aesthetic {aes_key} of type {dtype}")
 
 
 def is_genomic_type(dtype):
@@ -25,7 +22,7 @@ def is_discrete_type(dtype):
 excluded_from_grouping = {"x", "tooltip", "label"}
 
 
-def should_use_for_grouping(name, type):
+def should_use_for_grouping(name, type, scale):
     return (name not in excluded_from_grouping) and is_discrete_type(type)
 
 


### PR DESCRIPTION
The identity color scale (which treats the values of the "color" aesthetic mapping as literal hex color codes) was grouping by the color values, because their type "tstr" is normally a discrete type. This had the effect of reordering data unnecessarily, and creating a pointless noisy legend for the trivial color scale.

This changes the identity color scale to be continuous. It also modifies the grouping logic to group by aesthetics with discrete scales, not with "discrete types". Now the identity color scale doesn't group or create a legend.