### PR TITLE
[query] Fix lowering of aggs to preserve free variables in init args

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1662,6 +1662,14 @@ class Tests(unittest.TestCase):
         assert t.filter(t.locus.position >= 1).collect() == [
             hl.utils.Struct(idx=0, locus=hl.genetics.Locus(contig='2', position=1, reference_genome='GRCh37'))]
 
+    def test_lower_row_agg_init_arg(self):
+        mt = hl.balding_nichols_model(5, 200, 200)
+        mt2 = hl.variant_qc(mt)
+        mt2 = mt2.filter_rows((mt2.variant_qc.AF[0] > 0.05) & (mt2.variant_qc.AF[0] < 0.95))
+        mt2 = mt2.sample_rows(.99)
+        rows = mt2.rows()
+        mt = mt.semi_join_rows(rows)
+        hl.hwe_normalized_pca(mt.GT)
 
 def test_keys_before_scans():
     mt = hl.utils.range_matrix_table(6, 6)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1662,6 +1662,8 @@ class Tests(unittest.TestCase):
         assert t.filter(t.locus.position >= 1).collect() == [
             hl.utils.Struct(idx=0, locus=hl.genetics.Locus(contig='2', position=1, reference_genome='GRCh37'))]
 
+    @fails_service_backend()
+    @fails_local_backend()
     def test_lower_row_agg_init_arg(self):
         mt = hl.balding_nichols_model(5, 200, 200)
         mt2 = hl.variant_qc(mt)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -23,7 +23,7 @@ object Interpret {
     apply(tir, ctx, optimize = true)
 
   def apply(tir: TableIR, ctx: ExecuteContext, optimize: Boolean): TableValue = {
-    val lowered = LoweringPipeline.legacyRelationalLowerer(optimize)(ctx, tir).asInstanceOf[TableIR]
+    val lowered = LoweringPipeline.legacyRelationalLowerer(optimize)(ctx, tir).asInstanceOf[TableIR].noSharing
     lowered.analyzeAndExecute(ctx).asTableValue(ctx)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/LowerOrInterpretNonCompilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerOrInterpretNonCompilable.scala
@@ -69,6 +69,6 @@ object LowerOrInterpretNonCompilable {
       }
     }
 
-    rewrite(ir, mutable.HashMap.empty)
+    rewrite(ir.noSharing, mutable.HashMap.empty)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -400,7 +400,7 @@ object Extract {
 
     val bindingNodesReferenced = Memo.empty[Unit]
     val rewriteMap = Memo.empty[IR]
-    val postAgg = extract(ir, Env.empty, bindingNodesReferenced, rewriteMap, ab, seq, let, memo, ref, r, isScan)
+    extract(ir, Env.empty, bindingNodesReferenced, rewriteMap, ab, seq, let, memo, ref, r, isScan)
     val (initOps, pAggSigs) = ab.result().unzip
     val rt = TTuple(initOps.map(_.aggSig.resultType): _*)
     ref._typ = rt

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -127,9 +127,37 @@ case class AggElementsAggSig(nested: Seq[PhysicalAggSig]) extends
 case class ArrayLenAggSig(knownLength: Boolean, nested: Seq[PhysicalAggSig]) extends
   PhysicalAggSig(AggElementsLengthCheck(), ArrayAggStateSig(nested.map(_.state)), nested.flatMap(sig => sig.allOps).toArray)
 
-case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggSig]) {
+class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit], val init: IR, val seqPerElt: IR, val aggs: Array[PhysicalAggSig]) {
   val states: Array[AggStateSig] = aggs.map(_.state)
   val nAggs: Int = aggs.length
+
+
+  lazy val postAggIR: IR = {
+    rewriteMap.lookup(original)
+  }
+
+  def rewriteFromInitBindingRoot(f: IR => IR): IR = {
+    val irNumberMemo = Memo.empty[Int]
+    var i = 0
+    // depth first search -- either DFS or BFS should work here given IR assumptions
+    VisitIR(original) { x =>
+      irNumberMemo.bind(x, i)
+      i += 1
+    }
+
+    if (bindingNodesReferenced.m.isEmpty) {
+      f(rewriteMap.lookup(original))
+      // find deepest binding node referenced
+    } else {
+      val rewriteRoot = bindingNodesReferenced.m.keys.maxBy(irNumberMemo.lookup)
+      // only support let nodes here -- other binders like stream operators are undefined behavior
+      RewriteTopDown.rewriteTopDown(original, {
+        case ir if RefEquality(ir) == rewriteRoot =>
+          val Let(name, value, body) = ir
+          Let(name, value, f(rewriteMap.lookup(body)))
+      }).asInstanceOf[IR]
+    }
+  }
 
   def isCommutative: Boolean = {
     def aggCommutes(agg: PhysicalAggSig): Boolean = agg.allOps.forall(AggIsCommutative(_))
@@ -369,27 +397,40 @@ object Extract {
     val let = new BoxedArrayBuilder[AggLet]()
     val ref = Ref(resultName, null)
     val memo = mutable.Map.empty[IR, Int]
-    val postAgg = extract(ir, ab, seq, let, memo, ref, r, isScan)
+
+    val bindingNodesReferenced = Memo.empty[Unit]
+    val rewriteMap = Memo.empty[IR]
+    val postAgg = extract(ir, Env.empty, bindingNodesReferenced, rewriteMap, ab, seq, let, memo, ref, r, isScan)
     val (initOps, pAggSigs) = ab.result().unzip
     val rt = TTuple(initOps.map(_.aggSig.resultType): _*)
     ref._typ = rt
 
-    Aggs(postAgg, Begin(initOps), addLets(Begin(seq.result()), let.result()), pAggSigs)
+    new Aggs(ir, rewriteMap, bindingNodesReferenced, Begin(initOps), addLets(Begin(seq.result()), let.result()), pAggSigs)
   }
 
-  private def extract(ir: IR, ab: BoxedArrayBuilder[(InitOp, PhysicalAggSig)], seqBuilder: BoxedArrayBuilder[IR], letBuilder: BoxedArrayBuilder[AggLet], memo: mutable.Map[IR, Int], result: IR, r: RequirednessAnalysis, isScan: Boolean): IR = {
-    def extract(node: IR): IR = this.extract(node, ab, seqBuilder, letBuilder, memo, result, r, isScan)
+  private def extract(ir: IR, env: Env[RefEquality[IR]], bindingNodesReferenced: Memo[Unit], rewriteMap: Memo[IR], ab: BoxedArrayBuilder[(InitOp, PhysicalAggSig)], seqBuilder: BoxedArrayBuilder[IR], letBuilder: BoxedArrayBuilder[AggLet], memo: mutable.Map[IR, Int], result: IR, r: RequirednessAnalysis, isScan: Boolean): IR = {
+    // the env argument here tracks variable bindings that are accessible to init op arguments
 
     def newMemo: mutable.Map[IR, Int] = mutable.Map.empty[IR, Int]
 
-    ir match {
+    def bindInitArgRefs(initArgs: IndexedSeq[IR]): Unit = {
+      initArgs.foreach { arg =>
+        val fv = FreeVariables(arg, false, false).eval
+        fv.m.keys
+          .flatMap { k => env.lookupOption(k) }
+          .foreach(bindingNodesReferenced.bind(_, ()))
+      }
+    }
+
+    val newNode = ir match {
       case x@AggLet(name, value, body, _) =>
         letBuilder += x
-        extract(body)
+        this.extract(body, env, bindingNodesReferenced, rewriteMap, ab, seqBuilder, letBuilder, memo, result, r, isScan)
       case x: ApplyAggOp if !isScan =>
         val idx = memo.getOrElseUpdate(x, {
           val i = ab.length
           val op = x.aggSig.op
+          bindInitArgRefs(x.initOpArgs)
           val state = PhysicalAggSig(op, AggStateSig(op, x.initOpArgs, x.seqOpArgs, r))
           ab += InitOp(i, x.initOpArgs, state) -> state
           seqBuilder += SeqOp(i, x.seqOpArgs, state)
@@ -400,6 +441,7 @@ object Extract {
         val idx = memo.getOrElseUpdate(x, {
           val i = ab.length
           val op = x.aggSig.op
+          bindInitArgRefs(x.initOpArgs)
           val state = PhysicalAggSig(op, AggStateSig(op, x.initOpArgs, x.seqOpArgs, r))
           ab += InitOp(i, x.initOpArgs, state) -> state
           seqBuilder += SeqOp(i, x.seqOpArgs, state)
@@ -410,6 +452,7 @@ object Extract {
         val idx = memo.getOrElseUpdate(x, {
           val i = ab.length
           val initOpArgs = IndexedSeq(zero)
+          bindInitArgRefs(initOpArgs)
           val seqOpArgs = IndexedSeq(seqOp)
           val op = Fold()
           val resultEmitType = r(x).canonicalEmitType(x.typ)
@@ -425,7 +468,7 @@ object Extract {
       case AggFilter(cond, aggIR, _) =>
         val newSeq = new BoxedArrayBuilder[IR]()
         val newLet = new BoxedArrayBuilder[AggLet]()
-        val transformed = this.extract(aggIR, ab, newSeq, newLet, newMemo, result, r, isScan)
+        val transformed = this.extract(aggIR, env, bindingNodesReferenced, rewriteMap, ab, newSeq, newLet, newMemo, result, r, isScan)
 
         seqBuilder += If(cond, addLets(Begin(newSeq.result()), newLet.result()), Begin(FastIndexedSeq[IR]()))
         transformed
@@ -433,7 +476,7 @@ object Extract {
       case AggExplode(array, name, aggBody, _) =>
         val newSeq = new BoxedArrayBuilder[IR]()
         val newLet = new BoxedArrayBuilder[AggLet]()
-        val transformed = this.extract(aggBody, ab, newSeq, newLet, newMemo, result, r, isScan)
+        val transformed = this.extract(aggBody, env, bindingNodesReferenced, rewriteMap, ab, newSeq, newLet, newMemo, result, r, isScan)
 
         val (dependent, independent) = partitionDependentLets(newLet.result(), name)
         letBuilder ++= independent
@@ -444,7 +487,7 @@ object Extract {
         val newAggs = new BoxedArrayBuilder[(InitOp, PhysicalAggSig)]()
         val newSeq = new BoxedArrayBuilder[IR]()
         val newRef = Ref(genUID(), null)
-        val transformed = this.extract(aggIR, newAggs, newSeq, letBuilder, newMemo, GetField(newRef, "value"), r, isScan)
+        val transformed = this.extract(aggIR, env, bindingNodesReferenced, rewriteMap, newAggs, newSeq, letBuilder, newMemo, GetField(newRef, "value"), r, isScan)
 
         val i = ab.length
         val (initOps, pAggSigs) = newAggs.result().unzip
@@ -464,7 +507,7 @@ object Extract {
         val newSeq = new BoxedArrayBuilder[IR]()
         val newLet = new BoxedArrayBuilder[AggLet]()
         val newRef = Ref(genUID(), null)
-        val transformed = this.extract(aggBody, newAggs, newSeq, newLet, newMemo, newRef, r, isScan)
+        val transformed = this.extract(aggBody, env, bindingNodesReferenced, rewriteMap, newAggs, newSeq, newLet, newMemo, newRef, r, isScan)
 
         val (dependent, independent) = partitionDependentLets(newLet.result(), elementName)
         letBuilder ++= independent
@@ -514,7 +557,20 @@ object Extract {
       case x: StreamAggScan =>
         assert(!ContainsAgg(x))
         x
-      case _ => MapIR(extract)(ir)
+      case x =>
+        val newChildren = ir.children.zipWithIndex.map { case (child: IR, i) =>
+          val nb = Bindings(x, i)
+          val newEnv = if (nb.nonEmpty) {
+            val re = RefEquality(x)
+            env.bindIterable(nb.map { case (name, _) => (name, re)})
+          } else env
+
+          this.extract(child, newEnv, bindingNodesReferenced, rewriteMap, ab, seqBuilder, letBuilder, memo, result, r, isScan)
+        }
+        Copy(x, newChildren)
     }
+
+    rewriteMap.bind(ir, newNode)
+    newNode
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -814,7 +814,11 @@ object LowerTableIR {
         val newKeyType = newKey.typ.asInstanceOf[TStruct]
         val resultUID = genUID()
 
-        val aggs@Aggs(postAggIR, init, seq, aggSigs) = Extract(expr, resultUID, analyses.requirednessAnalysis)
+        val aggs = Extract(expr, resultUID, analyses.requirednessAnalysis)
+        val postAggIR = aggs.postAggIR
+        val init = aggs.init
+        val seq = aggs.seqPerElt
+        val aggSigs = aggs.aggs
 
         val partiallyAggregated = loweredChild.mapPartition(Some(FastIndexedSeq())) { partition =>
           Let("global", loweredChild.globals,

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -95,7 +95,7 @@ case object LowerArrayAggsToRunAggsPass extends LoweringPass {
 
   def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = {
     val r = Requiredness(ir, ctx)
-    RewriteBottomUp(ir, {
+    RewriteBottomUp(ir.noSharing, {
       case x@StreamAgg(a, name, query) =>
         val res = genUID()
         val aggs = Extract(query, res, r)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -94,8 +94,9 @@ case object LowerArrayAggsToRunAggsPass extends LoweringPass {
   val context: String = "LowerArrayAggsToRunAggs"
 
   def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = {
-    val r = Requiredness(ir, ctx)
-    RewriteBottomUp(ir.noSharing, {
+    val x = ir.noSharing
+    val r = Requiredness(x, ctx)
+    RewriteBottomUp(x, {
       case x@StreamAgg(a, name, query) =>
         val res = genUID()
         val aggs = Extract(query, res, r)


### PR DESCRIPTION
This is a bad change to a worse problem. The right solution is to redesign the IR
so that implicit init eval scopes don't exist -- but the right solution is hard to justify
going off to do right now.

This change patches the Extract.scala lowering logic to track the variables bound inside a
lowered IR and find the highest node that provides all necessary free variables. This change
still makes assumptions about the structure of the IR -- namely, it is still invalid to write
an IR like:

```
MakeTuple
  Let
    initBinding1
    <something>
    ApplyAggOp with ref to initBinding1
  Let
    initBinding2
    <something2>
    ApplyAggOp with ref to initbinding2
```

However, this fix resolves the case where init args reference a high single binding chain, as
in the test added.