### PR TITLE
[ci] Track active namespaces in CI database

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/thibaudcolas/curlylint
-    rev: v0.12.0
+    rev: v0.13.1
     hooks:
       - id: curlylint
         types: [file] # By default only runs on .jinja files, this disables that

--- a/build.yaml
+++ b/build.yaml
@@ -1894,6 +1894,9 @@ steps:
       - name: add-frozen-mode
         script: /io/sql/add-frozen-mode.sql
         online: true
+      - name: active-namespaces
+        script: /io/sql/active-namespaces.sql
+        online: true
     inputs:
       - from: /repo/ci/sql
         to: /io/sql

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -3,7 +3,7 @@ import json
 import logging
 from collections import Counter, defaultdict
 from shlex import quote as shq
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import jinja2
 import yaml
@@ -143,12 +143,18 @@ class BuildConfiguration:
             if step.can_run_in_scope(scope):
                 step.cleanup(batch, scope, parent_jobs)
 
-    def deployed_services(self) -> Dict[str, List[str]]:
+    def deployed_services(self) -> Tuple[str, List[str]]:
         services = defaultdict(list)
         for s in self.steps:
             if isinstance(s, DeployStep):
                 services[s.namespace].extend(s.services())
-        return services
+        # build.yaml allows for multiple namespaces, but
+        # in actuality we only ever use 1 and make many assumptions
+        # around there being a 1:1 correspondence between builds and namespaces
+        namespaces = list(services.keys())
+        assert len(namespaces) == 1
+        ns = namespaces[0]
+        return ns, services[ns]
 
 
 class Step(abc.ABC):

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -143,6 +143,13 @@ class BuildConfiguration:
             if step.can_run_in_scope(scope):
                 step.cleanup(batch, scope, parent_jobs)
 
+    def deployed_services(self) -> Dict[str, List[str]]:
+        services = defaultdict(list)
+        for s in self.steps:
+            if isinstance(s, DeployStep):
+                services[s.namespace].extend(s.services())
+        return services
+
 
 class Step(abc.ABC):
     def __init__(self, params):
@@ -786,6 +793,11 @@ class DeployStep(Step):
             json.get('link'),
             json.get('wait'),
         )
+
+    def services(self):
+        if self.wait:
+            return [w['name'] for w in self.wait]
+        return []
 
     def config(self, scope):  # pylint: disable=unused-argument
         return {'token': self.token}

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -402,10 +402,11 @@ async def batch_callback_handler(request):
                         assert 'dev' not in attrs
                         namespace = json.loads(attrs['namespace'])
                         assert namespace != 'default'
-                        await db.execute_update(
-                            'DELETE FROM active_namespaces WHERE namespace = %s',
-                            (namespace,),
-                        )
+                        if DEFAULT_NAMESPACE == 'default':
+                            await db.execute_update(
+                                'DELETE FROM active_namespaces WHERE namespace = %s',
+                                (namespace,),
+                            )
 
                     await wb.notify_batch_changed(app)
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -21,11 +21,11 @@ from hailtop.batch_client.aioclient import Batch, BatchClient
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
-from hailtop.utils import collect_agen, humanize_timedelta_msecs
+from hailtop.utils import collect_agen, humanize_timedelta_msecs, periodically_call
 from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
 from .constants import AUTHORIZED_USERS, TEAMS
-from .environment import STORAGE_URI
+from .environment import DEFAULT_NAMESPACE, STORAGE_URI
 from .github import PR, WIP, FQBranch, MergeFailureBatch, Repo, UnwatchedBranch, WatchedBranch, select_random_teammate
 
 with open(os.environ.get('HAIL_CI_OAUTH_TOKEN', 'oauth-token/oauth-token'), 'r', encoding='utf-8') as f:
@@ -395,6 +395,17 @@ async def batch_callback_handler(request):
             for wb in watched_branches:
                 if wb.branch.short_str() == target_branch:
                     log.info(f'watched_branch {wb.branch.short_str()} notify batch changed')
+
+                    if 'test' in params and params['complete']:
+                        assert 'deploy' not in params
+                        db: Database = app['db']
+                        namespaces = json.loads(params['namespaces'])
+                        await db.execute_update(
+                            f'''
+DELETE FROM active_namespaces
+WHERE {" OR ".join("namespace=" + ns for ns in namespaces)}'''
+                        )
+
                     await wb.notify_batch_changed(app)
 
 
@@ -488,7 +499,7 @@ async def dev_deploy_branch(request, userdata):
     batch_client = app['batch_client']
 
     try:
-        batch_id = await unwatched_branch.deploy(batch_client, steps, excluded_steps=excluded_steps)
+        batch_id = await unwatched_branch.deploy(app['db'], batch_client, steps, excluded_steps=excluded_steps)
     except asyncio.CancelledError:
         raise
     except Exception as e:  # pylint: disable=broad-except
@@ -553,6 +564,75 @@ UPDATE globals SET frozen_merge_deploy = 0;
     return web.HTTPFound(deploy_config.external_url('ci', '/'))
 
 
+@routes.get('/namespaces')
+@web_authenticated_developers_only()
+async def get_active_namespaces(request, userdata):
+    db: Database = request.app['db']
+    namespaces = [
+        r
+        async for r in db.execute_and_fetchall(
+            '''
+SELECT active_namespaces.*, JSON_ARRAYAGG(service) as services
+FROM active_namespaces
+LEFT JOIN deployed_services
+ON active_namespaces.namespace = deployed_services.namespace
+GROUP BY active_namespaces.namespace'''
+        )
+    ]
+    for ns in namespaces:
+        ns['services'] = [s for s in json.loads(ns['services']) if s is not None]
+    context = {
+        'namespaces': namespaces,
+    }
+    return await render_template('ci', request, userdata, 'namespaces.html', context)
+
+
+@routes.post('/namespaces/{namespace}/services/add')
+@check_csrf_token
+@web_authenticated_developers_only()
+async def add_namespaced_service(request, userdata):  # pylint: disable=unused-argument
+    db: Database = request.app['db']
+    post = await request.post()
+    service = post['service']
+    namespace = request.match_info['namespace']
+
+    await db.execute_insertone(
+        'INSERT INTO deployed_services VALUES (%s, %s)',
+        (namespace, service),
+    )
+
+    return web.HTTPFound(deploy_config.external_url('ci', '/namespaces'))
+
+
+@routes.post('/namespaces/add')
+@check_csrf_token
+@web_authenticated_developers_only()
+async def add_namespace(request, userdata):  # pylint: disable=unused-argument
+    db: Database = request.app['db']
+    post = await request.post()
+    namespace = post['namespace']
+
+    await db.execute_insertone(
+        'INSERT INTO active_namespaces (`namespace`) VALUES (%s)',
+        (namespace,),
+    )
+
+    return web.HTTPFound(deploy_config.external_url('ci', '/namespaces'))
+
+
+async def cleanup_expired_namespaces(db: Database):
+    expired_namespaces = [
+        record['namespace']
+        async for record in db.execute_and_fetchall(
+            'SELECT namespace from active_namespaces WHERE expiration_time < UTC_TIMESTAMP()'
+        )
+    ]
+    for namespace in expired_namespaces:
+        assert namespace != 'default'
+        log.info(f'Cleaning up expired namespace: {namespace}')
+        await db.execute_update('DELETE FROM active_namespaces WHERE namespace = %s', (namespace,))
+
+
 async def update_loop(app):
     while True:
         try:
@@ -584,6 +664,9 @@ SELECT frozen_merge_deploy FROM globals;
 
     app['task_manager'] = aiotools.BackgroundTaskManager()
     app['task_manager'].ensure_future(update_loop(app))
+
+    if DEFAULT_NAMESPACE == 'default':
+        app['task_manager'].ensure_future(periodically_call(300, cleanup_expired_namespaces, app['db']))
 
 
 async def on_cleanup(app):

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -643,6 +643,7 @@ async def add_namespace(request, userdata):  # pylint: disable=unused-argument
 
 
 async def cleanup_expired_namespaces(db: Database):
+    assert DEFAULT_NAMESPACE == 'default'
     expired_namespaces = [
         record['namespace']
         async for record in db.execute_and_fetchall(

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -567,7 +567,7 @@ UPDATE globals SET frozen_merge_deploy = 0;
 
 
 @routes.get('/namespaces')
-@web_authenticated_developers_only()
+@auth.web_authenticated_developers_only()
 async def get_active_namespaces(request, userdata):
     db: Database = request.app['db']
     namespaces = [
@@ -591,7 +591,7 @@ GROUP BY active_namespaces.namespace'''
 
 @routes.post('/namespaces/{namespace}/services/add')
 @check_csrf_token
-@web_authenticated_developers_only()
+@auth.web_authenticated_developers_only()
 async def add_namespaced_service(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
     post = await request.post()
@@ -613,7 +613,7 @@ async def add_namespaced_service(request, userdata):  # pylint: disable=unused-a
 
 @routes.post('/namespaces/add')
 @check_csrf_token
-@web_authenticated_developers_only()
+@auth.web_authenticated_developers_only()
 async def add_namespace(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
     post = await request.post()

--- a/ci/ci/templates/namespaces.html
+++ b/ci/ci/templates/namespaces.html
@@ -1,0 +1,64 @@
+{% extends "layout.html" %}
+{% block title %}Active Namespaces{% endblock %}
+{% block content %}
+<h1>Active Namespaces</h1>
+
+<table id="namespaces-table" class="grouped-data-table">
+  <thead>
+    <tr>
+      <th colspan="1">Namespace</th>
+      <th colspan="1">Creation Time</th>
+      <th colspan="1">Expiration Time</th>
+      <th colspan="2">Services</th>
+    </tr>
+  </thead>
+  {% for ns in namespaces %}
+  <tbody>
+    <tr>
+      <td rowspan="{{ ns['services']|length + 4 }}">
+        {{ ns['namespace'] }}
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="{{ ns['services']|length + 4 }}">
+        {{ ns['creation_time'] }}
+      </td>
+    </tr>
+    <tr>
+      <td rowspan="{{ ns['services']|length + 4 }}">
+        {{ ns['expiration_time'] }}
+      </td>
+    </tr>
+    {% for service in ns['services'] %}
+    <tr>
+      <td>
+        {{ service }}
+      </td>
+    </tr>
+    {% endfor %}
+    <tr>
+      <form action="{{ base_path }}/namespaces/{{ ns['namespace'] }}/services/add" method="POST">
+        <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+        <td><input type="text" name="service"></td>
+        <td>
+          <button>Add</button>
+        </td>
+      </form>
+    </tr>
+  </tbody>
+  {% endfor %}
+  <tbody>
+    <form action="{{ base_path }}/namespaces/add" method="POST">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      <tr>
+        <td><input type="text" name="namespace"></td>
+        <td>
+          <button>Add</button>
+        </td>
+        <td></td>
+        <td></td>
+      </tr>
+    </form>
+  </tbody>
+</table>
+{% endblock %}

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -1,5 +1,9 @@
+import datetime
 import secrets
 import string
+from typing import Dict, List, Optional
+
+from gear import Database
 
 
 def generate_token(size=12):
@@ -7,3 +11,28 @@ def generate_token(size=12):
     alpha = string.ascii_lowercase
     alnum = string.ascii_lowercase + string.digits
     return secrets.choice(alpha) + ''.join([secrets.choice(alnum) for _ in range(size - 1)])
+
+
+async def add_deployed_services(
+    db: Database,
+    services_per_namespace: Dict[str, List[str]],
+    expiration_time: Optional[datetime.datetime],
+):
+    expiration = expiration_time.strftime('%Y-%m-%d %H:%M:%S') if expiration_time else None
+    for namespace, services in services_per_namespace.items():
+        await db.execute_insertone(
+            '''
+INSERT INTO active_namespaces (`namespace`, `expiration_time`)
+VALUES (%s, %s) new
+ON DUPLICATE KEY UPDATE expiration_time = new.expiration_time
+            ''',
+            (namespace, expiration),
+        )
+        await db.execute_many(
+            '''
+INSERT INTO deployed_services (`namespace`, `service`)
+VALUES (%s, %s)
+ON DUPLICATE KEY UPDATE namespace = namespace;
+''',
+            [(namespace, service) for service in services],
+        )

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -24,7 +24,7 @@ async def add_deployed_services(
             '''
 INSERT INTO active_namespaces (`namespace`, `expiration_time`)
 VALUES (%s, %s) new
-ON DUPLICATE KEY UPDATE expiration_time = new.expiration_time
+ON DUPLICATE KEY UPDATE expiration_time = NEW.expiration_time
             ''',
             (namespace, expiration),
         )

--- a/ci/sql/active-namespaces.sql
+++ b/ci/sql/active-namespaces.sql
@@ -1,21 +1,3 @@
-CREATE TABLE authorized_shas (
-  sha VARCHAR(100) NOT NULL
-) ENGINE = InnoDB;
-
-CREATE INDEX authorized_shas_sha ON authorized_shas (sha);
-
-CREATE TABLE invalidated_batches (
-  batch_id BIGINT NOT NULL
-) ENGINE = InnoDB;
-
-CREATE INDEX invalidated_batches_batch_id ON invalidated_batches (batch_id);
-
-CREATE TABLE IF NOT EXISTS `globals` (
-  `frozen_merge_deploy` BOOLEAN NOT NULL DEFAULT FALSE
-) ENGINE = InnoDB;
-
-INSERT INTO `globals` (frozen_merge_deploy) VALUES (FALSE);
-
 CREATE TABLE IF NOT EXISTS `active_namespaces` (
   `namespace` VARCHAR(100) NOT NULL,
   `creation_time` TIMESTAMP NOT NULL DEFAULT (UTC_TIMESTAMP),
@@ -30,6 +12,6 @@ CREATE TABLE IF NOT EXISTS `deployed_services` (
   FOREIGN KEY (`namespace`) REFERENCES active_namespaces(namespace) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
-INSERT INTO `active_namespaces` (`namespace`) VALUES (`default`);
+INSERT INTO `active_namespaces` (`namespace`) VALUES ('default');
 INSERT INTO `deployed_services` (`namespace`, `service`) VALUES
 ('default', 'auth'), ('default', 'batch'), ('default', 'batch-driver'), ('default', 'ci');

--- a/ci/sql/delete-ci-tables.sql
+++ b/ci/sql/delete-ci-tables.sql
@@ -6,3 +6,5 @@ DROP TABLE IF EXISTS `ci_migrations`;
 DROP TABLE IF EXISTS `authorized_shas`;
 DROP TABLE IF EXISTS `invalidated_batches`;
 DROP TABLE IF EXISTS `globals`;
+DROP TABLE IF EXISTS `active_namespaces`;
+DROP TABLE IF EXISTS `deployed_services`;

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -47,6 +47,7 @@
       <div class="header-dropdown-menu">
         <div class="ci-caret header-dropdown-menu-caret"></div>
         <a class="header-dropdown-menu-link" href="{{ ci_base_url }}/me">Me</a>
+        <a class="header-dropdown-menu-link" href="{{ ci_base_url }}/namespaces">Namespaces</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adds functionality for CI to track which namespaces in the cluster are currently active and which services they are running. See #12095 for more context on the motivation for this change.

As an added bonus, this is one step toward more flexible internal namespace management, i.e. automatic cleanup of dev namespaces or keeping PR namespaces open for X days.