### PR TITLE
[k8s] Move to headless services and make pods listen on 443

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -716,7 +716,7 @@ async def get_session_id(request):
     return session.get('session_id')
 
 
-@routes.get('/api/v1alpha/verify_dev_credentials')
+@routes.route('*', '/api/v1alpha/verify_dev_credentials')
 async def verify_dev_credentials(request):
     session_id = await get_session_id(request)
     if not session_id:
@@ -728,7 +728,7 @@ async def verify_dev_credentials(request):
     return web.Response(status=200)
 
 
-@routes.get('/api/v1alpha/verify_dev_or_sa_credentials')
+@routes.route('*', '/api/v1alpha/verify_dev_or_sa_credentials')
 async def verify_dev_or_sa_credentials(request):
     session_id = await get_session_id(request)
     if not session_id:
@@ -789,7 +789,7 @@ def run():
     web.run_app(
         deploy_config.prefix_application(app, 'auth'),
         host='0.0.0.0',
-        port=5000,
+        port=443,
         access_log_class=AuthAccessLogger,
         ssl_context=internal_server_ssl_context(),
     )

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -276,9 +276,5 @@ metadata:
     app: auth
 spec:
   clusterIP: None
-  ports:
-   - port: 443
-     protocol: TCP
-     targetPort: 443
   selector:
     app: auth

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             mountPath: /ssl-config
             readOnly: true
          ports:
-          - containerPort: 5000
+          - containerPort: 443
       volumes:
        - name: deploy-config
          secret:
@@ -202,10 +202,10 @@ spec:
             mountPath: /ssl-config
             readOnly: true
          ports:
-          - containerPort: 5000
+          - containerPort: 443
          readinessProbe:
            tcpSocket:
-             port: 5000
+             port: 443
            initialDelaySeconds: 5
            periodSeconds: 5
       volumes:
@@ -275,9 +275,10 @@ metadata:
   labels:
     app: auth
 spec:
+  clusterIP: None
   ports:
    - port: 443
      protocol: TCP
-     targetPort: 5000
+     targetPort: 443
   selector:
     app: auth

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2656,7 +2656,7 @@ def run():
     web.run_app(
         deploy_config.prefix_application(app, 'batch', client_max_size=HTTP_CLIENT_MAX_SIZE),
         host='0.0.0.0',
-        port=5000,
+        port=443,
         access_log_class=BatchFrontEndAccessLogger,
         ssl_context=internal_server_ssl_context(),
     )

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -338,7 +338,7 @@ spec:
            value: "/{{ default_ns.name }}/jars"
 {% endif %}
         ports:
-         - containerPort: 5000
+         - containerPort: 443
         resources:
           requests:
             cpu: "20m"
@@ -367,7 +367,7 @@ spec:
            readOnly: true
         readinessProbe:
           tcpSocket:
-            port: 5000
+            port: 443
           initialDelaySeconds: 5
           periodSeconds: 5
       volumes:
@@ -434,10 +434,11 @@ metadata:
   labels:
     app: batch
 spec:
+  clusterIP: None
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 5000
+    targetPort: 443
   selector:
     app: batch
 ---
@@ -448,6 +449,7 @@ metadata:
   labels:
     app: batch-driver
 spec:
+  clusterIP: None
   ports:
   - port: 443
     protocol: TCP

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -435,10 +435,6 @@ metadata:
     app: batch
 spec:
   clusterIP: None
-  ports:
-  - port: 443
-    protocol: TCP
-    targetPort: 443
   selector:
     app: batch
 ---
@@ -450,9 +446,5 @@ metadata:
     app: batch-driver
 spec:
   clusterIP: None
-  ports:
-  - port: 443
-    protocol: TCP
-    targetPort: 443
   selector:
     app: batch-driver

--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -124,7 +124,8 @@ server {
 
     location / {
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass https://{{ service }}.default.svc.cluster.local;
+        set $service "{{ service }}";
+        proxy_pass https://$service.default.svc.cluster.local;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/grafana/nginx.conf
+++ b/grafana/nginx.conf
@@ -57,10 +57,11 @@ http {
 
     location = /auth {
         internal;
+        set $auth "auth";
 {% if deploy %}
-        proxy_pass https://auth/api/v1alpha/verify_dev_credentials;
+        proxy_pass https://$auth/api/v1alpha/verify_dev_credentials;
 {% else %}
-        proxy_pass https://auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_credentials;
+        proxy_pass https://$auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_credentials;
 {% endif %}
         include /ssl-config/ssl-config-proxy.conf;
     }

--- a/prometheus/nginx.conf
+++ b/prometheus/nginx.conf
@@ -57,10 +57,11 @@ http {
 
     location = /auth {
         internal;
+        set $auth "auth";
 {% if deploy %}
-        proxy_pass https://auth/api/v1alpha/verify_dev_or_sa_credentials;
+        proxy_pass https://$auth/api/v1alpha/verify_dev_or_sa_credentials;
 {% else %}
-        proxy_pass https://auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_or_sa_credentials;
+        proxy_pass https://$auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_or_sa_credentials;
 {% endif %}
         include /ssl-config/ssl-config-proxy.conf;
     }


### PR DESCRIPTION
Moves multi-pod deployments over to using Headless Services, which enables client-side load-balancing to the underlying pods. See #12095 for more context.

The reason I put this in its own PR is that Kubernetes won't let me apply the `clusterIP: None` changes to existing `Services`, and I must delete the `Service` resources first. I can manually delete and apply new headless services in a way that is compatible with what is currently on main and with just a few seconds of downtime, but I should do this manually just before this PR merges.