### PR TITLE
[query] Fix limitation to 2^32 rows for new shuffle algorithm.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -235,13 +235,24 @@ package object ir {
     CollectDistributedArray(contexts, globals, contextRef.name, globalRef.name, body(contextRef, globalRef), dynamicID, staticID, None)
   }
 
-  def strConcat(irs: IR*): IR = {
+  def strConcat(irs: AnyRef*): IR = {
     assert(irs.nonEmpty)
     var s: IR = null
-    irs.foreach { x =>
+    irs.foreach { xAny =>
+      val x = xAny match {
+        case x: IR => x
+        case x: String => Str(x)
+      }
+
       if (s == null)
         s = x
-      s = invoke("concat", TString, s, x)
+      else {
+        val xstr = if (x.typ == TString)
+          x
+        else
+          invoke("str", TString, x)
+        s = invoke("concat", TString, s, xstr)
+      }
     }
     s
   }

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -93,6 +93,12 @@ package object utils extends Logging
     }
   }
 
+  def coerceToInt(l: Long): Int = {
+    if (l > Int.MaxValue || l < Int.MinValue)
+      fatal(s"int overflow: $l")
+    l.toInt
+  }
+
   def checkGzippedFile(fs: FS,
     input: String,
     forceGZ: Boolean,


### PR DESCRIPTION
Number of rows per partition still limited at MAXINT, with check.