### PR TITLE
[ci] Fix retryable cloning of ci test repo

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2544,7 +2544,7 @@ steps:
       # destination on successful clone
       set +x
       clone() {
-        tmp_dir=$(mktemp -d) && git clone https://$1@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $2
+        tmp_dir=$(mktemp -d) && git clone https://$1@github.com/hail-ci-test/$2.git $tmp_dir && mv $tmp_dir $2
       }
       typeset -fx clone
       retry clone $TOKEN $REPO_NAME

--- a/build.yaml
+++ b/build.yaml
@@ -2545,6 +2545,7 @@ steps:
       clone() {
         tmp_dir=$(mktemp -d) && git clone https://$TOKEN@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $REPO_NAME
       }
+      typeset -fx clone
       retry clone
       cd $REPO_NAME
 

--- a/build.yaml
+++ b/build.yaml
@@ -2542,7 +2542,10 @@ steps:
       # checkout new ci repo
       # Repeated clones should happen in fresh directories so we mv to the final
       # destination on successful clone
-      retry tmp_dir=$(mktemp -d) && git clone https://$TOKEN@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $REPO_NAME
+      clone() {
+        tmp_dir=$(mktemp -d) && git clone https://$TOKEN@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $REPO_NAME
+      }
+      retry clone
       cd $REPO_NAME
 
       mkdir -p ./ci/test ./hail/

--- a/build.yaml
+++ b/build.yaml
@@ -2543,10 +2543,10 @@ steps:
       # Repeated clones should happen in fresh directories so we mv to the final
       # destination on successful clone
       clone() {
-        tmp_dir=$(mktemp -d) && git clone https://$TOKEN@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $REPO_NAME
+        tmp_dir=$(mktemp -d) && git clone https://$1@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $2
       }
       typeset -fx clone
-      retry clone
+      retry clone $TOKEN $REPO_NAME
       cd $REPO_NAME
 
       mkdir -p ./ci/test ./hail/

--- a/build.yaml
+++ b/build.yaml
@@ -2542,11 +2542,13 @@ steps:
       # checkout new ci repo
       # Repeated clones should happen in fresh directories so we mv to the final
       # destination on successful clone
+      set +x
       clone() {
         tmp_dir=$(mktemp -d) && git clone https://$1@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $2
       }
       typeset -fx clone
       retry clone $TOKEN $REPO_NAME
+      set -x
       cd $REPO_NAME
 
       mkdir -p ./ci/test ./hail/

--- a/build.yaml
+++ b/build.yaml
@@ -2540,11 +2540,9 @@ steps:
         -d "{ \"name\" : \"$REPO_NAME\" }"
 
       # checkout new ci repo
-      cd /io
-      for i in {1..12}; do
-          git clone https://$TOKEN@github.com/hail-ci-test/$REPO_NAME.git && break
-          sleep 5;
-      done
+      # Repeated clones should happen in fresh directories so we mv to the final
+      # destination on successful clone
+      retry tmp_dir=$(mktemp -d) && git clone https://$TOKEN@github.com/hail-ci-test/$REPO_NAME.git $tmp_dir && mv $tmp_dir $REPO_NAME
       cd $REPO_NAME
 
       mkdir -p ./ci/test ./hail/


### PR DESCRIPTION
This step uses `set -e` so a failed clone fails the whole step. I fixed this using `retry` but also use a fresh temporary directory for each clones so if a clone fails part of the way through it doesn't reuse the broken directory.