### PR TITLE
[batch] Add infrastructure for updates

### DIFF
--- a/batch/sql/add-batch-updates.sql
+++ b/batch/sql/add-batch-updates.sql
@@ -1,0 +1,446 @@
+START TRANSACTION;
+
+# Foreign key constraint for batch_id needs to be added in a subsequent PR in order for the migration to work
+CREATE TABLE IF NOT EXISTS `batch_updates` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `start_job_id` INT,
+  `n_jobs` INT NOT NULL,
+  `committed` BOOLEAN NOT NULL DEFAULT FALSE,
+  `time_created` BIGINT,
+  `time_committed` BIGINT,
+  PRIMARY KEY (`batch_id`, `update_id`)
+) ENGINE = InnoDB;
+CREATE INDEX `batch_updates_committed` ON `batch_updates` (`batch_id`, `committed`);
+CREATE INDEX `batch_updates_start_job_id` ON `batch_updates` (`batch_id`, `start_job_id`);
+
+ALTER TABLE batches ADD COLUMN update_added BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
+ALTER TABLE batches_inst_coll_staging ADD COLUMN update_id VARCHAR(40), ALGORITHM=INSTANT;
+ALTER TABLE batch_inst_coll_cancellable_resources ADD COLUMN update_id VARCHAR(40), ALGORITHM=INSTANT;
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS batches_before_insert $$
+CREATE TRIGGER batches_before_insert BEFORE INSERT ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+  DECLARE new_update_id VARCHAR(40);
+
+  SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.id;
+
+  IF cur_update_id IS NULL THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+  END IF;
+
+  SET NEW.update_added = TRUE;
+END $$
+
+DROP TRIGGER IF EXISTS batches_before_update $$
+CREATE TRIGGER batches_before_update BEFORE UPDATE ON batches
+FOR EACH ROW
+BEGIN
+  SET NEW.update_added = TRUE;
+END $$
+
+DROP TRIGGER IF EXISTS batches_after_update $$
+CREATE TRIGGER batches_after_update AFTER UPDATE ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE new_update_id VARCHAR(40);
+
+  IF NOT OLD.update_added THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+
+    UPDATE batches_inst_coll_staging
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+
+    UPDATE batch_inst_coll_cancellable_resources
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert $$
+CREATE TRIGGER batches_inst_coll_staging_before_insert BEFORE INSERT ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update $$
+CREATE TRIGGER batches_inst_coll_staging_before_update BEFORE UPDATE ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_insert BEFORE INSERT ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_update BEFORE UPDATE ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS close_batch $$
+CREATE PROCEDURE close_batch(
+  IN in_batch_id BIGINT,
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_batch_state VARCHAR(40);
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE staging_n_ready_jobs INT;
+  DECLARE staging_ready_cores_mcpu BIGINT;
+  DECLARE cur_user VARCHAR(100);
+
+  START TRANSACTION;
+
+  SELECT `state`, n_jobs INTO cur_batch_state, expected_n_jobs FROM batches
+  WHERE id = in_batch_id AND NOT deleted
+  FOR UPDATE;
+
+  IF cur_batch_state != 'open' THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
+    INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
+    FROM batches_inst_coll_staging
+    WHERE batch_id = in_batch_id
+    FOR UPDATE;
+
+    SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      IF expected_n_jobs = 0 THEN
+        UPDATE batches SET `state` = 'complete', time_completed = in_timestamp, time_closed = in_timestamp
+          WHERE id = in_batch_id;
+      ELSE
+        UPDATE batches SET `state` = 'running', time_closed = in_timestamp
+          WHERE id = in_batch_id;
+      END IF;
+
+      UPDATE batch_updates SET `committed` = TRUE, time_committed = in_timestamp
+      WHERE batch_id = in_batch_id;
+
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
+      FROM batches_inst_coll_staging
+      JOIN batches ON batches.id = batches_inst_coll_staging.batch_id
+      WHERE batch_id = in_batch_id
+      GROUP BY `user`, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
+
+      DELETE FROM batches_inst_coll_staging WHERE batch_id = in_batch_id;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 2 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS jobs_after_update $$
+CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
+FOR EACH ROW
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_cancelled BOOLEAN;
+  DECLARE cur_n_tokens INT;
+  DECLARE cur_update_id VARCHAR(40);
+  DECLARE rand_token INT;
+
+  SELECT user INTO cur_user FROM batches WHERE id = NEW.batch_id;
+
+  SELECT update_id INTO cur_update_id
+  FROM batch_updates
+  WHERE batch_id = NEW.batch_id AND NEW.job_id >= start_job_id AND NEW.job_id < start_job_id + n_jobs;
+
+  SET cur_batch_cancelled = EXISTS (SELECT TRUE
+                                    FROM batches_cancelled
+                                    WHERE id = NEW.batch_id
+                                    LOCK IN SHARE MODE);
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  IF OLD.state = 'Ready' THEN
+    IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
+    ELSE
+      # runnable
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs - 1,
+        ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Running' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
+    ELSE
+      # running
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs - 1,
+        running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Creating' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs - 1;
+    END IF;
+
+    # state = 'Creating' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_creating_jobs = n_cancelled_creating_jobs - 1;
+    ELSE
+      # creating
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_jobs = n_creating_jobs - 1;
+    END IF;
+
+  END IF;
+
+  IF NEW.state = 'Ready' THEN
+    IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
+    ELSE
+      # runnable
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + 1,
+        ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Running' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
+    ELSE
+      # running
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs + 1,
+        running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Creating' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs + 1;
+    END IF;
+
+    # state = 'Creating' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_creating_jobs = n_cancelled_creating_jobs + 1;
+    ELSE
+      # creating
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_jobs = n_creating_jobs + 1;
+    END IF;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS recompute_incremental $$
+CREATE PROCEDURE recompute_incremental(
+) BEGIN
+
+  DELETE FROM batches_inst_coll_staging;
+  DELETE FROM batch_inst_coll_cancellable_resources;
+  DELETE FROM user_inst_coll_resources;
+
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
+
+  CREATE TEMPORARY TABLE `tmp_batch_inst_coll_resources` AS (
+    SELECT batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll,
+      COALESCE(SUM(1), 0) as n_jobs,
+      COALESCE(SUM(job_state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Running' AND cancellable), 0) as n_running_cancellable_jobs,
+      COALESCE(SUM(IF(job_state = 'Running' AND cancellable, cores_mcpu, 0)), 0) as running_cancellable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Creating' AND cancellable), 0) as n_creating_cancellable_jobs,
+      COALESCE(SUM(job_state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
+      COALESCE(SUM(IF(job_state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
+      COALESCE(SUM(job_state = 'Ready' AND runnable), 0) as n_ready_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu,
+      COALESCE(SUM(job_state = 'Creating' AND NOT cancelled), 0) as n_creating_jobs,
+      COALESCE(SUM(job_state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(job_state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs,
+      COALESCE(SUM(job_state = 'Creating' AND cancelled), 0) as n_cancelled_creating_jobs
+    FROM (
+      SELECT batches.user,
+        batches.id as batch_id,
+        batch_updates.update_id,
+        batches.state as batch_state,
+        batches.cancelled as batch_cancelled,
+        jobs.inst_coll as job_inst_coll,
+        jobs.state as job_state,
+        jobs.cores_mcpu,
+        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable,
+        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
+        (NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled
+      FROM jobs
+      INNER JOIN batches
+        ON batches.id = jobs.batch_id
+      LEFT JOIN batch_updates ON jobs.batch_id = batch_updates.batch_id AND jobs.job_id >= batch_updates.start_job_id
+        AND jobs.job_id < batch_updates.start_job_id + batch_updates.n_jobs
+      LOCK IN SHARE MODE) as t
+    GROUP BY batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll
+  );
+
+  INSERT INTO batches_inst_coll_staging (batch_id, update_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT batch_id, update_id, job_inst_coll, 0, n_jobs, n_ready_jobs, ready_cores_mcpu
+  FROM tmp_batch_inst_coll_resources
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT `committed`;
+
+  INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs,
+    ready_cancellable_cores_mcpu, n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs)
+  SELECT batch_id, update_id, job_inst_coll, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
+    n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs
+  FROM tmp_batch_inst_coll_resources
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT batch_cancelled AND `committed`;
+
+  INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu,
+    n_running_jobs, running_cores_mcpu, n_creating_jobs,
+    n_cancelled_ready_jobs, n_cancelled_running_jobs, n_cancelled_creating_jobs)
+  SELECT t.user, t.job_inst_coll, 0, t.n_ready_jobs, t.ready_cores_mcpu,
+    t.n_running_jobs, t.running_cores_mcpu, t.n_creating_jobs,
+    t.n_cancelled_ready_jobs, t.n_cancelled_running_jobs, t.n_cancelled_creating_jobs
+  FROM (SELECT user, job_inst_coll,
+      COALESCE(SUM(n_running_jobs), 0) as n_running_jobs,
+      COALESCE(SUM(running_cores_mcpu), 0) as running_cores_mcpu,
+      COALESCE(SUM(n_ready_jobs), 0) as n_ready_jobs,
+      COALESCE(SUM(ready_cores_mcpu), 0) as ready_cores_mcpu,
+      COALESCE(SUM(n_creating_jobs), 0) as n_creating_jobs,
+      COALESCE(SUM(n_cancelled_ready_jobs), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(n_cancelled_running_jobs), 0) as n_cancelled_running_jobs,
+      COALESCE(SUM(n_cancelled_creating_jobs), 0) as n_cancelled_creating_jobs
+    FROM tmp_batch_inst_coll_resources
+    LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+    WHERE batch_state != 'open' AND `committed`
+    GROUP by user, job_inst_coll) as t;
+
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
+
+END $$
+
+DELIMITER ;
+
+COMMIT;

--- a/batch/sql/add-batch-updates.sql
+++ b/batch/sql/add-batch-updates.sql
@@ -1,22 +1,25 @@
 START TRANSACTION;
 
-# Foreign key constraint for batch_id needs to be added in a subsequent PR in order for the migration to work
 CREATE TABLE IF NOT EXISTS `batch_updates` (
   `batch_id` BIGINT NOT NULL,
-  `update_id` VARCHAR(40) NOT NULL,
-  `start_job_id` INT,
+  `update_id` INT NOT NULL,
+  `token` VARCHAR(100) DEFAULT NULL,
+  `start_job_id` INT NOT NULL,
   `n_jobs` INT NOT NULL,
   `committed` BOOLEAN NOT NULL DEFAULT FALSE,
   `time_created` BIGINT,
   `time_committed` BIGINT,
-  PRIMARY KEY (`batch_id`, `update_id`)
+  PRIMARY KEY (`batch_id`, `update_id`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`),
+  UNIQUE KEY (`batch_id`, `start_job_id`)
 ) ENGINE = InnoDB;
 CREATE INDEX `batch_updates_committed` ON `batch_updates` (`batch_id`, `committed`);
 CREATE INDEX `batch_updates_start_job_id` ON `batch_updates` (`batch_id`, `start_job_id`);
 
 ALTER TABLE batches ADD COLUMN update_added BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
-ALTER TABLE batches_inst_coll_staging ADD COLUMN update_id VARCHAR(40), ALGORITHM=INSTANT;
-ALTER TABLE batch_inst_coll_cancellable_resources ADD COLUMN update_id VARCHAR(40), ALGORITHM=INSTANT;
+ALTER TABLE jobs ADD COLUMN update_id INT DEFAULT 1, ALGORITHM=INSTANT;
+ALTER TABLE batches_inst_coll_staging ADD COLUMN update_id INT DEFAULT 1, ALGORITHM=INSTANT;
+ALTER TABLE batch_inst_coll_cancellable_resources ADD COLUMN update_id INT DEFAULT 1, ALGORITHM=INSTANT;
 
 DELIMITER $$
 
@@ -24,20 +27,17 @@ DROP TRIGGER IF EXISTS batches_before_insert $$
 CREATE TRIGGER batches_before_insert BEFORE INSERT ON batches
 FOR EACH ROW
 BEGIN
-  DECLARE cur_update_id VARCHAR(40);
-  DECLARE new_update_id VARCHAR(40);
-
-  SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.id;
-
-  IF cur_update_id IS NULL THEN
-    SET new_update_id = LEFT(MD5(RAND()), 8);
-
-    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
-      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
-    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
-  END IF;
-
   SET NEW.update_added = TRUE;
+END $$
+
+DROP TRIGGER IF EXISTS batches_after_insert $$
+CREATE TRIGGER batches_after_insert AFTER INSERT ON batches
+FOR EACH ROW
+BEGIN
+  IF NEW.n_jobs > 0 THEN
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, `token`, start_job_id, n_jobs, `committed`, time_created)
+    VALUES (NEW.id, 1, NEW.token, 1, NEW.n_jobs, FALSE, NEW.time_created);
+  END IF;
 END $$
 
 DROP TRIGGER IF EXISTS batches_before_update $$
@@ -51,134 +51,11 @@ DROP TRIGGER IF EXISTS batches_after_update $$
 CREATE TRIGGER batches_after_update AFTER UPDATE ON batches
 FOR EACH ROW
 BEGIN
-  DECLARE new_update_id VARCHAR(40);
-
-  IF NOT OLD.update_added THEN
-    SET new_update_id = LEFT(MD5(RAND()), 8);
-
-    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
-      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
-    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
-
-    UPDATE batches_inst_coll_staging
-    SET update_id = new_update_id
-    WHERE batch_id = NEW.id;
-
-    UPDATE batch_inst_coll_cancellable_resources
-    SET update_id = new_update_id
-    WHERE batch_id = NEW.id;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert $$
-CREATE TRIGGER batches_inst_coll_staging_before_insert BEFORE INSERT ON batches_inst_coll_staging
-FOR EACH ROW
-BEGIN
-  DECLARE cur_update_id VARCHAR(40);
-
-  IF NEW.update_id IS NULL THEN
-    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
-    SET NEW.update_id = cur_update_id;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update $$
-CREATE TRIGGER batches_inst_coll_staging_before_update BEFORE UPDATE ON batches_inst_coll_staging
-FOR EACH ROW
-BEGIN
-  DECLARE cur_update_id VARCHAR(40);
-
-  IF OLD.update_id IS NULL THEN
-    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
-    SET NEW.update_id = cur_update_id;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert $$
-CREATE TRIGGER batch_inst_coll_cancellable_resources_before_insert BEFORE INSERT ON batch_inst_coll_cancellable_resources
-FOR EACH ROW
-BEGIN
-  DECLARE cur_update_id VARCHAR(40);
-
-  IF NEW.update_id IS NULL THEN
-    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
-    SET NEW.update_id = cur_update_id;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update $$
-CREATE TRIGGER batch_inst_coll_cancellable_resources_before_update BEFORE UPDATE ON batch_inst_coll_cancellable_resources
-FOR EACH ROW
-BEGIN
-  DECLARE cur_update_id VARCHAR(40);
-
-  IF OLD.update_id IS NULL THEN
-    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
-    SET NEW.update_id = cur_update_id;
-  END IF;
-END $$
-
-DROP PROCEDURE IF EXISTS close_batch $$
-CREATE PROCEDURE close_batch(
-  IN in_batch_id BIGINT,
-  IN in_timestamp BIGINT
-)
-BEGIN
-  DECLARE cur_batch_state VARCHAR(40);
-  DECLARE expected_n_jobs INT;
-  DECLARE staging_n_jobs INT;
-  DECLARE staging_n_ready_jobs INT;
-  DECLARE staging_ready_cores_mcpu BIGINT;
-  DECLARE cur_user VARCHAR(100);
-
-  START TRANSACTION;
-
-  SELECT `state`, n_jobs INTO cur_batch_state, expected_n_jobs FROM batches
-  WHERE id = in_batch_id AND NOT deleted
-  FOR UPDATE;
-
-  IF cur_batch_state != 'open' THEN
-    COMMIT;
-    SELECT 0 as rc;
-  ELSE
-    SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
-    INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
-    FROM batches_inst_coll_staging
-    WHERE batch_id = in_batch_id
-    FOR UPDATE;
-
-    SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
-
-    IF staging_n_jobs = expected_n_jobs THEN
-      IF expected_n_jobs = 0 THEN
-        UPDATE batches SET `state` = 'complete', time_completed = in_timestamp, time_closed = in_timestamp
-          WHERE id = in_batch_id;
-      ELSE
-        UPDATE batches SET `state` = 'running', time_closed = in_timestamp
-          WHERE id = in_batch_id;
-      END IF;
-
-      UPDATE batch_updates SET `committed` = TRUE, time_committed = in_timestamp
-      WHERE batch_id = in_batch_id;
-
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
-      SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
-      FROM batches_inst_coll_staging
-      JOIN batches ON batches.id = batches_inst_coll_staging.batch_id
-      WHERE batch_id = in_batch_id
-      GROUP BY `user`, inst_coll
-      ON DUPLICATE KEY UPDATE
-        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
-        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
-
-      DELETE FROM batches_inst_coll_staging WHERE batch_id = in_batch_id;
-
-      COMMIT;
-      SELECT 0 as rc;
-    ELSE
-      ROLLBACK;
-      SELECT 2 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
-    END IF;
+  # We want to change the update to committed when the batch is closed
+  IF NEW.n_jobs > 0 THEN
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, `token`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+    VALUES (NEW.id, 1, NEW.token, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE committed = NEW.state != 'open';
   END IF;
 END $$
 
@@ -189,14 +66,9 @@ BEGIN
   DECLARE cur_user VARCHAR(100);
   DECLARE cur_batch_cancelled BOOLEAN;
   DECLARE cur_n_tokens INT;
-  DECLARE cur_update_id VARCHAR(40);
   DECLARE rand_token INT;
 
   SELECT user INTO cur_user FROM batches WHERE id = NEW.batch_id;
-
-  SELECT update_id INTO cur_update_id
-  FROM batch_updates
-  WHERE batch_id = NEW.batch_id AND NEW.job_id >= start_job_id AND NEW.job_id < start_job_id + n_jobs;
 
   SET cur_batch_cancelled = EXISTS (SELECT TRUE
                                     FROM batches_cancelled
@@ -210,7 +82,7 @@ BEGIN
     IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
       # cancellable
       INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
         ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
@@ -234,7 +106,7 @@ BEGIN
     IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
       # cancellable
       INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
         running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
@@ -259,7 +131,7 @@ BEGIN
     IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
       # cancellable
       INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1)
+      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1)
       ON DUPLICATE KEY UPDATE
         n_creating_cancellable_jobs = n_creating_cancellable_jobs - 1;
     END IF;
@@ -285,7 +157,7 @@ BEGIN
     IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
       # cancellable
       INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
         ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
@@ -309,7 +181,7 @@ BEGIN
     IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
       # cancellable
       INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
         running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
@@ -334,7 +206,7 @@ BEGIN
     IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
       # cancellable
       INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1)
+      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1)
       ON DUPLICATE KEY UPDATE
         n_creating_cancellable_jobs = n_creating_cancellable_jobs + 1;
     END IF;
@@ -354,91 +226,6 @@ BEGIN
         n_creating_jobs = n_creating_jobs + 1;
     END IF;
   END IF;
-END $$
-
-DROP PROCEDURE IF EXISTS recompute_incremental $$
-CREATE PROCEDURE recompute_incremental(
-) BEGIN
-
-  DELETE FROM batches_inst_coll_staging;
-  DELETE FROM batch_inst_coll_cancellable_resources;
-  DELETE FROM user_inst_coll_resources;
-
-  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
-
-  CREATE TEMPORARY TABLE `tmp_batch_inst_coll_resources` AS (
-    SELECT batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll,
-      COALESCE(SUM(1), 0) as n_jobs,
-      COALESCE(SUM(job_state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
-      COALESCE(SUM(IF(job_state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
-      COALESCE(SUM(job_state = 'Running' AND cancellable), 0) as n_running_cancellable_jobs,
-      COALESCE(SUM(IF(job_state = 'Running' AND cancellable, cores_mcpu, 0)), 0) as running_cancellable_cores_mcpu,
-      COALESCE(SUM(job_state = 'Creating' AND cancellable), 0) as n_creating_cancellable_jobs,
-      COALESCE(SUM(job_state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
-      COALESCE(SUM(IF(job_state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
-      COALESCE(SUM(job_state = 'Ready' AND runnable), 0) as n_ready_jobs,
-      COALESCE(SUM(IF(job_state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu,
-      COALESCE(SUM(job_state = 'Creating' AND NOT cancelled), 0) as n_creating_jobs,
-      COALESCE(SUM(job_state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
-      COALESCE(SUM(job_state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs,
-      COALESCE(SUM(job_state = 'Creating' AND cancelled), 0) as n_cancelled_creating_jobs
-    FROM (
-      SELECT batches.user,
-        batches.id as batch_id,
-        batch_updates.update_id,
-        batches.state as batch_state,
-        batches.cancelled as batch_cancelled,
-        jobs.inst_coll as job_inst_coll,
-        jobs.state as job_state,
-        jobs.cores_mcpu,
-        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable,
-        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
-        (NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled
-      FROM jobs
-      INNER JOIN batches
-        ON batches.id = jobs.batch_id
-      LEFT JOIN batch_updates ON jobs.batch_id = batch_updates.batch_id AND jobs.job_id >= batch_updates.start_job_id
-        AND jobs.job_id < batch_updates.start_job_id + batch_updates.n_jobs
-      LOCK IN SHARE MODE) as t
-    GROUP BY batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll
-  );
-
-  INSERT INTO batches_inst_coll_staging (batch_id, update_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
-  SELECT batch_id, update_id, job_inst_coll, 0, n_jobs, n_ready_jobs, ready_cores_mcpu
-  FROM tmp_batch_inst_coll_resources
-  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
-  WHERE NOT `committed`;
-
-  INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs,
-    ready_cancellable_cores_mcpu, n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs)
-  SELECT batch_id, update_id, job_inst_coll, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
-    n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs
-  FROM tmp_batch_inst_coll_resources
-  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
-  WHERE NOT batch_cancelled AND `committed`;
-
-  INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu,
-    n_running_jobs, running_cores_mcpu, n_creating_jobs,
-    n_cancelled_ready_jobs, n_cancelled_running_jobs, n_cancelled_creating_jobs)
-  SELECT t.user, t.job_inst_coll, 0, t.n_ready_jobs, t.ready_cores_mcpu,
-    t.n_running_jobs, t.running_cores_mcpu, t.n_creating_jobs,
-    t.n_cancelled_ready_jobs, t.n_cancelled_running_jobs, t.n_cancelled_creating_jobs
-  FROM (SELECT user, job_inst_coll,
-      COALESCE(SUM(n_running_jobs), 0) as n_running_jobs,
-      COALESCE(SUM(running_cores_mcpu), 0) as running_cores_mcpu,
-      COALESCE(SUM(n_ready_jobs), 0) as n_ready_jobs,
-      COALESCE(SUM(ready_cores_mcpu), 0) as ready_cores_mcpu,
-      COALESCE(SUM(n_creating_jobs), 0) as n_creating_jobs,
-      COALESCE(SUM(n_cancelled_ready_jobs), 0) as n_cancelled_ready_jobs,
-      COALESCE(SUM(n_cancelled_running_jobs), 0) as n_cancelled_running_jobs,
-      COALESCE(SUM(n_cancelled_creating_jobs), 0) as n_cancelled_creating_jobs
-    FROM tmp_batch_inst_coll_resources
-    LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
-    WHERE batch_state != 'open' AND `committed`
-    GROUP by user, job_inst_coll) as t;
-
-  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
-
 END $$
 
 DELIMITER ;

--- a/batch/sql/add-batch-updates.sql
+++ b/batch/sql/add-batch-updates.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `batch_updates` (
   `start_job_id` INT NOT NULL,
   `n_jobs` INT NOT NULL,
   `committed` BOOLEAN NOT NULL DEFAULT FALSE,
-  `time_created` BIGINT,
+  `time_created` BIGINT NOT NULL,
   `time_committed` BIGINT,
   PRIMARY KEY (`batch_id`, `update_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`),

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -11,6 +11,13 @@ DROP PROCEDURE IF EXISTS mark_job_started;
 DROP PROCEDURE IF EXISTS mark_job_complete;
 DROP PROCEDURE IF EXISTS add_attempt;
 
+DROP TRIGGER IF EXISTS batches_before_insert;
+DROP TRIGGER IF EXISTS batches_before_update;
+DROP TRIGGER IF EXISTS batches_after_update;
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert;
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update;
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert;
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update;
 DROP TRIGGER IF EXISTS instances_before_update;
 DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
@@ -21,8 +28,6 @@ DROP TRIGGER IF EXISTS attempt_resources_before_insert;  # deprecated
 DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
-DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
-DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 DROP TABLE IF EXISTS `batch_updates`;
 
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -12,12 +12,9 @@ DROP PROCEDURE IF EXISTS mark_job_complete;
 DROP PROCEDURE IF EXISTS add_attempt;
 
 DROP TRIGGER IF EXISTS batches_before_insert;
+DROP TRIGGER IF EXISTS batches_after_insert;
 DROP TRIGGER IF EXISTS batches_before_update;
 DROP TRIGGER IF EXISTS batches_after_update;
-DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert;
-DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update;
-DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert;
-DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update;
 DROP TRIGGER IF EXISTS instances_before_update;
 DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
@@ -28,7 +25,8 @@ DROP TRIGGER IF EXISTS attempt_resources_before_insert;  # deprecated
 DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date`;
-DROP TABLE IF EXISTS `batch_updates`;
+DROP TABLE IF EXISTS `batch_updates_inst_coll_staging`;
+DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v2`;
@@ -53,6 +51,7 @@ DROP TABLE IF EXISTS `jobs`;
 DROP TABLE IF EXISTS `batches_cancelled`;
 DROP TABLE IF EXISTS `batches_staging`;  # deprecated
 DROP TABLE IF EXISTS `batches_inst_coll_staging`;
+DROP TABLE IF EXISTS `batch_updates`;
 DROP TABLE IF EXISTS `batches_n_jobs_in_complete_states`;
 DROP TABLE IF EXISTS `batches`;
 DROP TABLE IF EXISTS `user_resources`;  # deprecated

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -159,6 +159,7 @@ CREATE TABLE IF NOT EXISTS `batches` (
   `token` VARCHAR(100) DEFAULT NULL,
   `format_version` INT NOT NULL,
   `cancel_after_n_failures` INT DEFAULT NULL,
+  `update_added` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`id`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name)
 ) ENGINE = InnoDB;
@@ -167,6 +168,19 @@ CREATE INDEX `batches_deleted` ON `batches` (`deleted`);
 CREATE INDEX `batches_token` ON `batches` (`token`);
 CREATE INDEX `batches_time_completed` ON `batches` (`time_completed`);
 CREATE INDEX `batches_billing_project_state` ON `batches` (`billing_project`, `state`);
+
+CREATE TABLE IF NOT EXISTS `batch_updates` (
+  `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
+  `start_job_id` INT,
+  `n_jobs` INT NOT NULL,
+  `committed` BOOLEAN NOT NULL DEFAULT FALSE,
+  `time_created` BIGINT,
+  `time_committed` BIGINT,
+  PRIMARY KEY (`batch_id`, `update_id`)
+) ENGINE = InnoDB;
+CREATE INDEX `batch_updates_committed` ON `batch_updates` (`batch_id`, `committed`);
+CREATE INDEX `batch_updates_start_job_id` ON `batch_updates` (`batch_id`, `start_job_id`);
 
 CREATE TABLE IF NOT EXISTS `batches_n_jobs_in_complete_states` (
   `id` BIGINT NOT NULL,
@@ -186,19 +200,22 @@ CREATE TABLE IF NOT EXISTS `batches_cancelled` (
 
 CREATE TABLE IF NOT EXISTS `batches_inst_coll_staging` (
   `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
   `inst_coll` VARCHAR(255),
   `token` INT NOT NULL,
   `n_jobs` INT NOT NULL DEFAULT 0,
   `n_ready_jobs` INT NOT NULL DEFAULT 0,
   `ready_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `inst_coll`, `token`),
+  PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(batch_id, update_id) ON DELETE CASCADE,
   FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX `batches_inst_coll_staging_inst_coll` ON `batches_inst_coll_staging` (`inst_coll`);
 
 CREATE TABLE `batch_inst_coll_cancellable_resources` (
   `batch_id` BIGINT NOT NULL,
+  `update_id` VARCHAR(40) NOT NULL,
   `inst_coll` VARCHAR(255),
   `token` INT NOT NULL,
   # neither run_always nor cancelled
@@ -207,8 +224,9 @@ CREATE TABLE `batch_inst_coll_cancellable_resources` (
   `n_creating_cancellable_jobs` INT NOT NULL DEFAULT 0,
   `n_running_cancellable_jobs` INT NOT NULL DEFAULT 0,
   `running_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `inst_coll`, `token`),
+  PRIMARY KEY (`batch_id`, `update_id`, `inst_coll`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(batch_id, update_id) ON DELETE CASCADE,
   FOREIGN KEY (`inst_coll`) REFERENCES inst_colls(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 CREATE INDEX `batch_inst_coll_cancellable_resources_inst_coll` ON `batch_inst_coll_cancellable_resources` (`inst_coll`);
@@ -391,6 +409,97 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
 
 DELIMITER $$
 
+DROP TRIGGER IF EXISTS batches_before_insert $$
+CREATE TRIGGER batches_before_insert BEFORE INSERT ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+  DECLARE new_update_id VARCHAR(40);
+
+  SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.id;
+
+  IF cur_update_id IS NULL THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+  END IF;
+
+  SET NEW.update_added = TRUE;
+END $$
+
+DROP TRIGGER IF EXISTS batches_after_update $$
+CREATE TRIGGER batches_after_update AFTER UPDATE ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE new_update_id VARCHAR(40);
+
+  IF NOT OLD.update_added THEN
+    SET new_update_id = LEFT(MD5(RAND()), 8);
+
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+      VALUES (NEW.id, new_update_id, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
+    ON DUPLICATE KEY UPDATE n_jobs = n_jobs;
+
+    UPDATE batches_inst_coll_staging
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+
+    UPDATE batch_inst_coll_cancellable_resources
+    SET update_id = new_update_id
+    WHERE batch_id = NEW.id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_insert $$
+CREATE TRIGGER batches_inst_coll_staging_before_insert BEFORE INSERT ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_inst_coll_staging_before_update $$
+CREATE TRIGGER batches_inst_coll_staging_before_update BEFORE UPDATE ON batches_inst_coll_staging
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_insert $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_insert BEFORE INSERT ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF NEW.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batch_inst_coll_cancellable_resources_before_update $$
+CREATE TRIGGER batch_inst_coll_cancellable_resources_before_update BEFORE UPDATE ON batch_inst_coll_cancellable_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_update_id VARCHAR(40);
+
+  IF OLD.update_id IS NULL THEN
+    SELECT update_id INTO cur_update_id FROM batch_updates WHERE batch_id = NEW.batch_id;
+    SET NEW.update_id = cur_update_id;
+  END IF;
+END $$
+
 DROP TRIGGER IF EXISTS instances_before_update $$
 CREATE TRIGGER instances_before_update BEFORE UPDATE on instances
 FOR EACH ROW
@@ -536,9 +645,14 @@ BEGIN
   DECLARE cur_user VARCHAR(100);
   DECLARE cur_batch_cancelled BOOLEAN;
   DECLARE cur_n_tokens INT;
+  DECLARE cur_update_id VARCHAR(40);
   DECLARE rand_token INT;
 
   SELECT user INTO cur_user FROM batches WHERE id = NEW.batch_id;
+
+  SELECT update_id INTO cur_update_id
+  FROM batch_updates
+  WHERE batch_id = NEW.batch_id AND NEW.job_id >= start_job_id AND NEW.job_id < start_job_id + n_jobs;
 
   SET cur_batch_cancelled = EXISTS (SELECT TRUE
                                     FROM batches_cancelled
@@ -551,8 +665,8 @@ BEGIN
   IF OLD.state = 'Ready' THEN
     IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
         ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
@@ -575,8 +689,8 @@ BEGIN
   ELSEIF OLD.state = 'Running' THEN
     IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
         running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
@@ -600,8 +714,8 @@ BEGIN
   ELSEIF OLD.state = 'Creating' THEN
     IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (OLD.batch_id, OLD.inst_coll, rand_token, -1)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (OLD.batch_id, cur_update_id, OLD.inst_coll, rand_token, -1)
       ON DUPLICATE KEY UPDATE
         n_creating_cancellable_jobs = n_creating_cancellable_jobs - 1;
     END IF;
@@ -626,8 +740,8 @@ BEGIN
   IF NEW.state = 'Ready' THEN
     IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
         ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
@@ -650,8 +764,8 @@ BEGIN
   ELSEIF NEW.state = 'Running' THEN
     IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
         running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
@@ -675,8 +789,8 @@ BEGIN
   ELSEIF NEW.state = 'Creating' THEN
     IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
       # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (NEW.batch_id, NEW.inst_coll, rand_token, 1)
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (NEW.batch_id, cur_update_id, NEW.inst_coll, rand_token, 1)
       ON DUPLICATE KEY UPDATE
         n_creating_cancellable_jobs = n_creating_cancellable_jobs + 1;
     END IF;
@@ -785,7 +899,7 @@ CREATE PROCEDURE recompute_incremental(
   DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
 
   CREATE TEMPORARY TABLE `tmp_batch_inst_coll_resources` AS (
-    SELECT batch_id, batch_state, batch_cancelled, user, job_inst_coll,
+    SELECT batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll,
       COALESCE(SUM(1), 0) as n_jobs,
       COALESCE(SUM(job_state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
       COALESCE(SUM(IF(job_state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
@@ -803,6 +917,7 @@ CREATE PROCEDURE recompute_incremental(
     FROM (
       SELECT batches.user,
         batches.id as batch_id,
+        batch_updates.update_id,
         batches.state as batch_state,
         batches.cancelled as batch_cancelled,
         jobs.inst_coll as job_inst_coll,
@@ -814,21 +929,25 @@ CREATE PROCEDURE recompute_incremental(
       FROM jobs
       INNER JOIN batches
         ON batches.id = jobs.batch_id
+      LEFT JOIN batch_updates ON jobs.batch_id = batch_updates.batch_id AND jobs.job_id >= batch_updates.start_job_id
+        AND jobs.job_id < batch_updates.start_job_id + batch_updates.n_jobs
       LOCK IN SHARE MODE) as t
-    GROUP BY batch_id, batch_state, batch_cancelled, user, job_inst_coll
+    GROUP BY batch_id, update_id, batch_state, batch_cancelled, user, job_inst_coll
   );
 
-  INSERT INTO batches_inst_coll_staging (batch_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
-  SELECT batch_id, job_inst_coll, 0, n_jobs, n_ready_jobs, ready_cores_mcpu
+  INSERT INTO batches_inst_coll_staging (batch_id, update_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT batch_id, update_id, job_inst_coll, 0, n_jobs, n_ready_jobs, ready_cores_mcpu
   FROM tmp_batch_inst_coll_resources
-  WHERE batch_state = 'open';
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT `committed`;
 
-  INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs,
+  INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs,
     ready_cancellable_cores_mcpu, n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs)
-  SELECT batch_id, job_inst_coll, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
+  SELECT batch_id, update_id, job_inst_coll, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
     n_running_cancellable_jobs, running_cancellable_cores_mcpu, n_creating_cancellable_jobs
   FROM tmp_batch_inst_coll_resources
-  WHERE NOT batch_cancelled;
+  LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+  WHERE NOT batch_cancelled AND `committed`;
 
   INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu,
     n_running_jobs, running_cores_mcpu, n_creating_jobs,
@@ -846,7 +965,8 @@ CREATE PROCEDURE recompute_incremental(
       COALESCE(SUM(n_cancelled_running_jobs), 0) as n_cancelled_running_jobs,
       COALESCE(SUM(n_cancelled_creating_jobs), 0) as n_cancelled_creating_jobs
     FROM tmp_batch_inst_coll_resources
-    WHERE batch_state != 'open'
+    LEFT JOIN batch_updates ON tmp_batch_inst_coll_resources.batch_id = batch_updates.batch_id AND tmp_batch_inst_coll_resources.update_id = batch_updates.update_id
+    WHERE batch_state != 'open' AND `committed`
     GROUP by user, job_inst_coll) as t;
 
   DROP TEMPORARY TABLE IF EXISTS `tmp_batch_inst_coll_resources`;
@@ -983,6 +1103,9 @@ BEGIN
         UPDATE batches SET `state` = 'running', time_closed = in_timestamp
           WHERE id = in_batch_id;
       END IF;
+
+      UPDATE batch_updates SET `committed` = TRUE, time_committed = in_timestamp
+      WHERE batch_id = in_batch_id;
 
       INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
       SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -171,12 +171,12 @@ CREATE INDEX `batches_billing_project_state` ON `batches` (`billing_project`, `s
 
 CREATE TABLE IF NOT EXISTS `batch_updates` (
   `batch_id` BIGINT NOT NULL,
-  `update_id` INT NOT NULL DEFAULT 1,
+  `update_id` INT NOT NULL,
   `token` VARCHAR(100) DEFAULT NULL,
   `start_job_id` INT NOT NULL,
   `n_jobs` INT NOT NULL,
   `committed` BOOLEAN NOT NULL DEFAULT FALSE,
-  `time_created` BIGINT,
+  `time_created` BIGINT NOT NULL,
   `time_committed` BIGINT,
   PRIMARY KEY (`batch_id`, `update_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`),

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -423,8 +423,8 @@ CREATE TRIGGER batches_after_insert AFTER INSERT ON batches
 FOR EACH ROW
 BEGIN
   IF NEW.n_jobs > 0 THEN
-    INSERT INTO `batch_updates` (`batch_id`, `update_id`, `token`, start_job_id, n_jobs, `committed`, time_created)
-    VALUES (NEW.id, 1, NEW.token, 1, NEW.n_jobs, FALSE, NEW.time_created);
+    INSERT INTO `batch_updates` (`batch_id`, `update_id`, `token`, start_job_id, n_jobs, `committed`, time_created, time_committed)
+    VALUES (NEW.id, 1, NEW.token, 1, NEW.n_jobs, FALSE, NEW.time_created, NEW.time_closed);
   END IF;
 END $$
 
@@ -443,7 +443,7 @@ BEGIN
   IF NEW.n_jobs > 0 THEN
     INSERT INTO `batch_updates` (`batch_id`, `update_id`, `token`, start_job_id, n_jobs, `committed`, time_created, time_committed)
     VALUES (NEW.id, 1, NEW.token, 1, NEW.n_jobs, NEW.state != 'open', NEW.time_created, NEW.time_closed)
-    ON DUPLICATE KEY UPDATE committed = NEW.state != 'open';
+    ON DUPLICATE KEY UPDATE committed = NEW.state != 'open', time_committed = NEW.time_closed;
   END IF;
 END $$
 

--- a/batch/sql/populate_batch_updates.py
+++ b/batch/sql/populate_batch_updates.py
@@ -1,0 +1,137 @@
+import asyncio
+import functools
+import os
+import random
+import time
+from typing import List, Optional, Tuple
+
+from gear import Database, transaction
+from hailtop.utils import bounded_gather
+
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+
+def offsets_to_where_statement(start_batch_id, end_batch_id):
+    if start_batch_id is None and end_batch_id is None:
+        where_cond = ''
+        query_args = None
+        return (where_cond, query_args)
+
+    assert start_batch_id != end_batch_id, start_batch_id
+    if start_batch_id is None:
+        assert end_batch_id
+        where_cond = 'WHERE batches.id < %s'
+        query_args = (end_batch_id,)
+    elif end_batch_id is None:
+        assert start_batch_id
+        where_cond = 'WHERE batches.id >= %s'
+        query_args = (start_batch_id,)
+    else:
+        where_cond = 'WHERE batches.id >= %s AND batches.id < %s'
+        query_args = (start_batch_id, end_batch_id)
+
+    return (where_cond, query_args)
+
+
+async def process_chunk(counter, db, start_offset, end_offset, quiet=True):
+    start_time = time.time()
+
+    where_cond, query_args = offsets_to_where_statement(start_offset, end_offset)
+
+    await db.just_execute(
+        f'''
+UPDATE batches
+SET update_added = TRUE
+{where_cond}
+''',
+        query_args)
+
+    if not quiet and counter.n % 100 == 0:
+        print(f'processed chunk ({start_offset}, {end_offset}) in {time.time() - start_time}s')
+
+    counter.n += 1
+    if counter.n % 500 == 0:
+        print(f'processed {counter.n} complete chunks')
+
+
+async def find_chunk_offsets(db, size):
+    @transaction(db)
+    async def _find_chunks(tx) -> List[Optional[int]]:
+        start_time = time.time()
+
+        await tx.just_execute('SET @rank=0;')
+
+        query = f'''
+SELECT t.id FROM (
+  SELECT id
+  FROM batches
+  ORDER BY id
+) AS t
+WHERE MOD((@rank := @rank + 1), %s) = 0;
+'''
+
+        offsets = tx.execute_and_fetchall(query, (size,))
+        offsets = [offset['id'] async for offset in offsets]
+        offsets.append(None)
+
+        print(f'found chunk offsets in {round(time.time() - start_time, 4)}s')
+        return offsets
+
+    return await _find_chunks()
+
+
+async def main(chunk_size=100):
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    start_time = time.time()
+
+    try:
+        populate_start_time = time.time()
+
+        chunk_counter = Counter()
+        chunk_offsets = [None]
+        for offset in await find_chunk_offsets(db, chunk_size):
+            chunk_offsets.append(offset)
+
+        chunk_offsets = list(zip(chunk_offsets[:-1], chunk_offsets[1:]))
+
+        if chunk_offsets:
+            print(f'found {len(chunk_offsets)} chunks to process')
+
+            random.shuffle(chunk_offsets)
+
+            burn_in_start = time.time()
+            n_burn_in_chunks = 1000
+
+            burn_in_chunk_offsets = chunk_offsets[:n_burn_in_chunks]
+            chunk_offsets = chunk_offsets[n_burn_in_chunks:]
+
+            for start_offset, end_offset in burn_in_chunk_offsets:
+                await process_chunk(chunk_counter, db, start_offset, end_offset, quiet=False)
+
+            print(f'finished burn-in in {time.time() - burn_in_start}s')
+
+            parallel_update_start = time.time()
+
+            await bounded_gather(
+                *[functools.partial(process_chunk, chunk_counter, db, start_offset, end_offset, quiet=False)
+                  for start_offset, end_offset in chunk_offsets],
+                parallelism=10
+            )
+            print(f'took {time.time() - parallel_update_start}s to update the remaining records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_update_start)}) attempts / sec')
+
+        print(f'finished populating records in {time.time() - populate_start_time}s')
+    finally:
+        print(f'finished migration in {time.time() - start_time}s')
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/sql/populate_batch_updates.py
+++ b/batch/sql/populate_batch_updates.py
@@ -123,7 +123,7 @@ async def main(chunk_size=100):
             await bounded_gather(
                 *[functools.partial(process_chunk, chunk_counter, db, start_offset, end_offset, quiet=False)
                   for start_offset, end_offset in chunk_offsets],
-                parallelism=10
+                parallelism=6
             )
             print(f'took {time.time() - parallel_update_start}s to update the remaining records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_update_start)}) attempts / sec')
 

--- a/build.yaml
+++ b/build.yaml
@@ -2064,6 +2064,12 @@ steps:
       - name: add-real-time-billing
         script: /io/sql/add-real-time-billing.sql
         online: true
+      - name: add-batch-updates
+        script: /io/sql/add-batch-updates.sql
+        online: true
+      - name: populate-batch-updates
+        script: /io/sql/populate_batch_updates.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Stacked on #11998. This PR adds a new `batch_updates` table as well as propagates update_ids to the batch_inst_coll_staging and batches_cancellable_resources tables. The tricky part is making sure that old/currently running batches are migrated properly while new batches are created properly between when the migration has occurred but before batch is redeployed.