### PR TITLE
[auth] Cache user sessions in memory

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -682,6 +682,7 @@ INNER JOIN sessions ON users.id = sessions.user_id
 WHERE users.state = 'active' AND (sessions.session_id = %s) AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
 ''',
             session_id,
+            'get_userinfo',
         )
     ]
 

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -125,6 +125,7 @@ spec:
       labels:
         app: auth
         hail.is/sha: "{{ code.sha }}"
+        grafanak8sapp: "true"
     spec:
 {% if deploy %}
       priorityClassName: production


### PR DESCRIPTION
This prevents decorators like `@rest_authenticated_users_only` from making an additional request to `auth` (which includes a database query for the `userinfo` endpoint on every API request. I also realized that auth wasn't getting scraped by prometheus so I added the `grafanak8sapp` label to fix that.