### PR TITLE
[infra] Move GCP preemptible pool to spot

### DIFF
--- a/infra/gcp/gsa_k8s_secret/main.tf
+++ b/infra/gcp/gsa_k8s_secret/main.tf
@@ -23,6 +23,7 @@ resource "kubernetes_secret" "k8s_key" {
 resource "google_project_iam_member" "iam_member" {
   for_each = toset(var.iam_roles)
 
+  project = var.project
   role = "roles/${each.key}"
   member = "serviceAccount:${google_service_account.service_account.email}"
 }

--- a/infra/gcp/gsa_k8s_secret/variables.tf
+++ b/infra/gcp/gsa_k8s_secret/variables.tf
@@ -2,6 +2,10 @@ variable "name" {
   type = string
 }
 
+variable project {
+  type = string
+}
+
 variable "iam_roles" {
   type = list(string)
   default = []

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "3.48.0"
+      version = "4.32.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -149,7 +149,7 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
   }
 
   node_config {
-    preemptible = true
+    spot = true
     machine_type = "n1-standard-4"
 
     labels = {
@@ -374,6 +374,7 @@ resource "google_service_account_key" "gcr_push_key" {
 
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_batch_agent_viewer" {
   provider = google-beta
+  project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.gcp_location
   role = "roles/artifactregistry.reader"
@@ -382,6 +383,7 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_bat
 
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_viewer" {
   provider = google-beta
+  project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.gcp_location
   role = "roles/artifactregistry.reader"
@@ -396,6 +398,7 @@ resource "google_storage_bucket_iam_member" "gcr_push_admin" {
 
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_push_admin" {
   provider = google-beta
+  project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.gcp_location
   role = "roles/artifactregistry.admin"
@@ -423,6 +426,7 @@ module "ukbb" {
 module "auth_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "auth"
+  project = var.gcp_project
   iam_roles = [
     "iam.serviceAccountAdmin",
     "iam.serviceAccountKeyAdmin",
@@ -432,6 +436,7 @@ module "auth_gsa_secret" {
 module "batch_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "batch"
+  project = var.gcp_project
   iam_roles = [
     "compute.instanceAdmin.v1",
     "iam.serviceAccountUser",
@@ -449,15 +454,18 @@ resource "google_storage_bucket_iam_member" "batch_hail_query_bucket_storage_vie
 module "benchmark_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "benchmark"
+  project = var.gcp_project
 }
 
 module "ci_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "ci"
+  project = var.gcp_project
 }
 
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_viewer" {
   provider = google-beta
+  project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.gcp_location
   role = "roles/artifactregistry.reader"
@@ -467,16 +475,19 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_vie
 module "monitoring_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "monitoring"
+  project = var.gcp_project
 }
 
 module "grafana_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "grafana"
+  project = var.gcp_project
 }
 
 module "test_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "test"
+  project = var.gcp_project
   iam_roles = [
     "compute.instanceAdmin.v1",
     "iam.serviceAccountUser",
@@ -500,6 +511,7 @@ resource "google_storage_bucket_iam_member" "test_gcr_viewer" {
 module "test_dev_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "test-dev"
+  project = var.gcp_project
 }
 
 resource "google_service_account" "batch_agent" {
@@ -515,6 +527,7 @@ resource "google_project_iam_member" "batch_agent_iam_member" {
     "storage.objectViewer",
   ])
 
+  project = var.gcp_project
   role = "roles/${each.key}"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
 }


### PR DESCRIPTION
The real change here is changing the preemptible pool config from `preemptible = true` to `spot = true`, but the `spot` config was only available in the new provider which involved a major version upgrade. The only incompatibility was the addition of an explicit `project` input to `google_project_iam_member`, as opposed to picking it up from the provider configuration.

Tested just now in my own project.

If one wants to apply this change without incurring downtime for preemptible deployments, they should follow the instructions outlined in the [migrating node pools dev-docs](https://github.com/hail-is/hail/blob/main/dev-docs/kubernetes-operations.md#when-using-terraform).