### PR TITLE
[infra] Disable GKE node auto-provisioning

### DIFF
--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -116,18 +116,9 @@ resource "google_container_cluster" "vdc" {
   }
 
   cluster_autoscaling {
-    enabled = true
+    # Don't use node auto-provisioning since we manage node pools ourselves
+    enabled = false
     autoscaling_profile = "OPTIMIZE_UTILIZATION"
-    resource_limits {
-      resource_type = "cpu"
-      minimum       = 4
-      maximum       = 100
-    }
-    resource_limits {
-      resource_type = "memory"
-      minimum       = 8
-      maximum       = 500
-    }
   }
 }
 


### PR DESCRIPTION
Node auto-provisioning (turned on by the `enabled` flag) doesn't mix well with manually-provisioned pools like we do here with terraform. TL;DR, the auto-provisioning autoscaler will not direct manually-provisioned node pools to autoscale. This does not impact the scheduler, so applying this terraform to a cluster that already has the nodes that it needs can silently work, but without this fix a new cluster will fail to scale up from 0 nodes.