### PR TITLE
[qob] Upload function and contexts in parallel

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -149,8 +149,8 @@ class ServiceBackend(
       }
     }
 
-    scalaConcurrent.Await.result(uploadFunction, scalaConcurrent.duration.Duration.Inf)
-    scalaConcurrent.Await.result(uploadContexts, scalaConcurrent.duration.Duration.Inf)
+    val uploadFunctionAndContexts = scalaConcurrent.Future.sequence(uploadFunction, uploadContexts)
+    scalaConcurrent.Await.result(uploadFunctionAndContexts, scalaConcurrent.duration.Duration.Inf)
 
     val batchClient = BatchClient.fromSessionID(backendContext.sessionID)
     val jobs = new Array[JObject](n)


### PR DESCRIPTION
This might have just gotten lost in the Big QoB PR, but I'm assuming that the reason to make these futures in the first place was to await them together, instead of in sequence.