### PR TITLE
[batch] Remove lint errors from test_batch and test_accounts

### DIFF
--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,13 +1,13 @@
 import aiohttp
 
-from hailtop.httpx import client_session
+from hailtop import httpx
 from hailtop.utils import async_to_blocking
 
 
-class FailureInjectingClientSession:
+class FailureInjectingClientSession(httpx.ClientSession):
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = client_session()
+        self.real_session = httpx.client_session()
 
     def __enter__(self):
         return self

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -75,12 +75,12 @@ async def test_bad_token():
     token = session_id_encode_to_str(secrets.token_bytes(32))
     bc = await BatchClient.create('test', _token=token)
     try:
-        b = bc.create_batch()
-        j = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
-        await b.submit()
+        bb = bc.create_batch()
+        bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
+        b = await bb.submit()
         assert False, str(await b.debug_info())
     except aiohttp.ClientResponseError as e:
-        assert e.status == 401, str((e, await b.debug_info()))
+        assert e.status == 401
     finally:
         await bc.close()
 
@@ -398,11 +398,11 @@ async def test_billing_limit_zero(
 
     try:
         bb = client.create_batch()
-        batch = await bb.submit()
+        b = await bb.submit()
     except aiohttp.ClientResponseError as e:
-        assert e.status == 403 and 'has exceeded the budget' in e.message, str(await batch.debug_info())
+        assert e.status == 403 and 'has exceeded the budget' in e.message
     else:
-        assert False, str(await batch.debug_info())
+        assert False, str(await b.debug_info())
 
 
 async def test_billing_limit_tiny(
@@ -531,81 +531,81 @@ async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(
     assert r['billing_project'] == project
 
     user1_client = await make_client(project)
-    b = user1_client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    b_handle = await b.submit()
+    bb = user1_client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    b = await bb.submit()
 
     user2_client = dev_client
-    user2_batch = Batch(user2_client, b_handle.id, b_handle.attributes, b_handle.n_jobs, b_handle.token)
+    user2_batch = Batch(user2_client, b.id, b.attributes, b.n_jobs, b.token)
 
     try:
         try:
-            await user2_client.get_batch(b_handle.id)
+            await user2_client.get_batch(b.id)
         except aiohttp.ClientResponseError as e:
-            assert e.status == 404, str((e, await b_handle.debug_info()))
+            assert e.status == 404, str((e, await b.debug_info()))
         else:
-            assert False, str(await b_handle.debug_info)
+            assert False, str(await b.debug_info())
 
         try:
             await user2_client.get_job(j.batch_id, j.job_id)
         except aiohttp.ClientResponseError as e:
-            assert e.status == 404, str((e, await b_handle.debug_info()))
+            assert e.status == 404, str((e, await b.debug_info()))
         else:
-            assert False, str(await b_handle.debug_info())
+            assert False, str(await b.debug_info())
 
         try:
             await user2_client.get_job_log(j.batch_id, j.job_id)
         except aiohttp.ClientResponseError as e:
-            assert e.status == 404, str((e, await b_handle.debug_info()))
+            assert e.status == 404, str((e, await b.debug_info()))
         else:
-            assert False, str(await b_handle.debug_info())
+            assert False, str(await b.debug_info())
 
         try:
             await user2_client.get_job_attempts(j.batch_id, j.job_id)
         except aiohttp.ClientResponseError as e:
-            assert e.status == 404, str((e, await b_handle.debug_info()))
+            assert e.status == 404, str((e, await b.debug_info()))
         else:
-            assert False, str(await b_handle.debug_info())
+            assert False, str(await b.debug_info())
 
         try:
             await user2_batch.status()
         except aiohttp.ClientResponseError as e:
-            assert e.status == 404, str((e, await b_handle.debug_info()))
+            assert e.status == 404, str((e, await b.debug_info()))
         else:
-            assert False, str(await b_handle.debug_info())
+            assert False, str(await b.debug_info())
 
         try:
             await user2_batch.cancel()
         except aiohttp.ClientResponseError as e:
-            assert e.status == 404, str((e, await b_handle.debug_info()))
+            assert e.status == 404, str((e, await b.debug_info()))
         else:
-            assert False, str(await b_handle.debug_info())
+            assert False, str(await b.debug_info())
 
         try:
             await user2_batch.delete()
         except aiohttp.ClientResponseError as e:
-            assert e.status == 404, str((e, await b_handle.debug_info()))
+            assert e.status == 404, str((e, await b.debug_info()))
         else:
-            assert False, str(await b_handle.debug_info())
+            assert False, str(await b.debug_info())
 
         # list batches results for user2
-        found, batches = await search_batches(user2_client, b_handle.id, q='')
-        assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+        found, batches = await search_batches(user2_client, b.id, q='')
+        assert not found, str((b.id, batches, await b.debug_info()))
 
-        found, batches = await search_batches(user2_client, b_handle.id, q=f'billing_project:{project}')
-        assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+        found, batches = await search_batches(user2_client, b.id, q=f'billing_project:{project}')
+        assert not found, str((b.id, batches, await b.debug_info()))
 
-        found, batches = await search_batches(user2_client, b_handle.id, q='user:test')
-        assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+        found, batches = await search_batches(user2_client, b.id, q='user:test')
+        assert not found, str((b.id, batches, await b.debug_info()))
 
-        found, batches = await search_batches(user2_client, b_handle.id, q=None)
-        assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+        found, batches = await search_batches(user2_client, b.id, q=None)
+        assert not found, str((b.id, batches, await b.debug_info()))
 
-        found, batches = await search_batches(user2_client, b_handle.id, q='user:test-dev')
-        assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+        found, batches = await search_batches(user2_client, b.id, q='user:test-dev')
+        assert not found, str((b.id, batches, await b.debug_info()))
 
     finally:
-        await b_handle.delete()
+        await b.delete()
 
 
 async def test_deleted_open_batches_do_not_prevent_billing_project_closure(
@@ -613,8 +613,8 @@ async def test_deleted_open_batches_do_not_prevent_billing_project_closure(
     dev_client: BatchClient,
     random_billing_project_name: Callable[[], str],
 ):
+    project = await dev_client.create_billing_project(random_billing_project_name)
     try:
-        project = await dev_client.create_billing_project(random_billing_project_name)
         await dev_client.add_user('test', project)
         client = await make_client(project)
         open_batch = await client.create_batch()._open_batch()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -13,7 +13,7 @@ from hailtop.config import get_deploy_config, get_user_config
 from hailtop.utils import external_requests_client_session, retry_response_returning_functions, sync_sleep_and_backoff
 
 from .failure_injecting_client_session import FailureInjectingClientSession
-from .utils import fails_in_azure, legacy_batch_status, skip_in_azure, smallest_machine_type
+from .utils import legacy_batch_status, skip_in_azure, smallest_machine_type
 
 deploy_config = get_deploy_config()
 
@@ -34,9 +34,9 @@ def client():
 
 
 def test_job(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b = bb.submit()
 
     status = j.wait()
     assert 'attributes' not in status, str((status, b.debug_info()))
@@ -48,9 +48,9 @@ def test_job(client: BatchClient):
 
 
 def test_job_running_logs(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])
+    b = bb.submit()
 
     delay = 1
     while True:
@@ -67,9 +67,9 @@ def test_job_running_logs(client: BatchClient):
 
 
 def test_exit_code_duration(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'exit 7'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'exit 7'])
+    b = bb.submit()
     status = j.wait()
     assert status['exit_code'] == 7, str((status, b.debug_info()))
     assert isinstance(status['duration'], int), str((status, b.debug_info()))
@@ -78,16 +78,16 @@ def test_exit_code_duration(client: BatchClient):
 
 def test_attributes(client: BatchClient):
     a = {'name': 'test_attributes', 'foo': 'bar'}
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], attributes=a)
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], attributes=a)
+    b = bb.submit()
     assert j.attributes() == a, str(b.debug_info())
 
 
 def test_garbage_image(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job('dsafaaadsf', ['echo', 'test'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job('dsafaaadsf', ['echo', 'test'])
+    b = bb.submit()
     status = j.wait()
     assert j._get_exit_codes(status) == {'main': None}, str((status, b.debug_info()))
     assert j._get_error(status, 'main') is not None, str((status, b.debug_info()))
@@ -95,74 +95,74 @@ def test_garbage_image(client: BatchClient):
 
 
 def test_bad_command(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
 
 
 def test_invalid_resource_requests(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '1', 'memory': '250Gi', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0', 'memory': '1Gi', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         aiohttp.client.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.1', 'memory': '1Gi', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         aiohttp.client.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'foo', 'storage': '1Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         aiohttp.client.ClientResponseError,
         match=".*.resources.memory must match regex:.*.resources.memory must be one of:.*",
     ):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '500Mi', 'storage': '10000000Gi'}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
-        builder.submit()
+        bb.submit()
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'storage': '10000000Gi', 'machine_type': smallest_machine_type(CLOUD)}
-    builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
-        builder.submit()
+        bb.submit()
 
 
 def test_out_of_memory(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job('python:3.6-slim-stretch', ['python', '-c', 'x = "a" * 1000**3'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job('python:3.6-slim-stretch', ['python', '-c', 'x = "a" * 1000**3'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert j._get_out_of_memory(status, 'main'), str((status, b.debug_info()))
 
 
 def test_out_of_storage(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '5Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 100GiB /foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 100GiB /foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -170,12 +170,12 @@ def test_out_of_storage(client: BatchClient):
 
 
 def test_quota_applies_to_volume(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '5Gi'}
-    j = builder.create_job(
+    j = bb.create_job(
         os.environ['HAIL_VOLUME_IMAGE'], ['/bin/sh', '-c', 'fallocate -l 100GiB /data/foo'], resources=resources
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -183,28 +183,28 @@ def test_quota_applies_to_volume(client: BatchClient):
 
 
 def test_quota_shared_by_io_and_rootfs(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
-    j = builder.create_job(
+    j = bb.create_job(
         DOCKER_ROOT_IMAGE,
         ['/bin/sh', '-c', 'fallocate -l 7GiB /foo; fallocate -l 7GiB /io/foo'],
         resources=resources,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -212,28 +212,28 @@ def test_quota_shared_by_io_and_rootfs(client: BatchClient):
 
 
 def test_nonzero_storage(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '20Gi'}
-    j = builder.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 @skip_in_azure()
 def test_attached_disk(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '400Gi'}
-    j = builder.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'df -h; fallocate -l 390GiB /io/foo'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(UBUNTU_IMAGE, ['/bin/sh', '-c', 'df -h; fallocate -l 390GiB /io/foo'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_cwd_from_image_workdir(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_WORKDIR_IMAGE'], ['/bin/sh', '-c', 'pwd'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_WORKDIR_IMAGE'], ['/bin/sh', '-c', 'pwd'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -241,8 +241,8 @@ def test_cwd_from_image_workdir(client: BatchClient):
 
 
 def test_unsubmitted_state(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
 
     with pytest.raises(ValueError):
         j.batch_id
@@ -257,20 +257,20 @@ def test_unsubmitted_state(client: BatchClient):
     with pytest.raises(ValueError):
         j.wait()
 
-    builder.submit()
+    bb.submit()
     with pytest.raises(ValueError):
-        builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+        bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
 
 
 def test_list_batches(client: BatchClient):
     tag = secrets.token_urlsafe(64)
-    b1 = client.create_batch(attributes={'tag': tag, 'name': 'b1'})
-    b1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b1 = b1.submit()
+    bb1 = client.create_batch(attributes={'tag': tag, 'name': 'b1'})
+    bb1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b1 = bb1.submit()
 
-    b2 = client.create_batch(attributes={'tag': tag, 'name': 'b2'})
-    b2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b2 = b2.submit()
+    bb2 = client.create_batch(attributes={'tag': tag, 'name': 'b2'})
+    bb2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b2 = bb2.submit()
 
     batch_id_test_universe = {b1.id, b2.id}
 
@@ -310,13 +310,13 @@ def test_list_batches(client: BatchClient):
 
 
 def test_list_jobs(client: BatchClient):
-    b = client.create_batch()
-    j_success = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    j_failure = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    j_error = b.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
-    j_running = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
+    bb = client.create_batch()
+    j_success = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    j_failure = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    j_error = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
+    j_running = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
 
-    b = b.submit()
+    b = bb.submit()
     j_success.wait()
     j_failure.wait()
     j_error.wait()
@@ -337,26 +337,26 @@ def test_list_jobs(client: BatchClient):
 
 
 def test_include_jobs(client: BatchClient):
-    b1 = client.create_batch()
-    for i in range(2):
-        b1.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b1 = b1.submit()
+    bb1 = client.create_batch()
+    for _ in range(2):
+        bb1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b1 = bb1.submit()
     s = b1.status()
     assert 'jobs' not in s, str((s, b1.debug_info()))
 
 
 def test_fail(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    b = bb.submit()
     status = j.wait()
     assert j._get_exit_code(status, 'main') == 1, str((status, b.debug_info()))
 
 
 def test_unknown_image(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(f'{DOCKER_PREFIX}/does-not-exist', ['echo', 'test'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(f'{DOCKER_PREFIX}/does-not-exist', ['echo', 'test'])
+    b = bb.submit()
     status = j.wait()
     try:
         assert j._get_exit_code(status, 'main') is None
@@ -368,9 +368,9 @@ def test_unknown_image(client: BatchClient):
 
 
 def test_running_job_log_and_status(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '300'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '300'])
+    b = bb.submit()
 
     while True:
         if j.status()['state'] == 'Running' or j.is_complete():
@@ -382,9 +382,9 @@ def test_running_job_log_and_status(client: BatchClient):
 
 
 def test_deleted_job_log(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b = bb.submit()
     j.wait()
     b.delete()
 
@@ -398,9 +398,9 @@ def test_deleted_job_log(client: BatchClient):
 
 
 def test_delete_batch(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b = bb.submit()
     b.delete()
 
     # verify doesn't exist
@@ -414,9 +414,9 @@ def test_delete_batch(client: BatchClient):
 
 
 def test_cancel_batch(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b = bb.submit()
 
     status = j.status()
     assert status['state'] in ('Ready', 'Running'), str((status, b.debug_info()))
@@ -448,9 +448,9 @@ def test_get_nonexistent_job(client: BatchClient):
 
 
 def test_get_job(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b = bb.submit()
 
     j2 = client.get_job(*j.id)
     status2 = j2.status()
@@ -458,11 +458,11 @@ def test_get_job(client: BatchClient):
 
 
 def test_batch(client: BatchClient):
-    b = client.create_batch()
-    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1'])
-    j3 = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = b.submit()
+    bb = client.create_batch()
+    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1'])
+    bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b = bb.submit()
 
     j1.wait()
     j2.wait()
@@ -482,31 +482,31 @@ def test_batch(client: BatchClient):
 
 
 def test_batch_status(client: BatchClient):
-    b1 = client.create_batch()
-    b1.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b1 = b1.submit()
+    bb1 = client.create_batch()
+    bb1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b1 = bb1.submit()
     b1.wait()
     b1s = b1.status()
     assert b1s['complete'] and b1s['state'] == 'success', str((b1s, b1.debug_info()))
 
-    b2 = client.create_batch()
-    b2.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    b2.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b2 = b2.submit()
+    bb2 = client.create_batch()
+    bb2.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    bb2.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b2 = bb2.submit()
     b2.wait()
     b2s = b2.status()
     assert b2s['complete'] and b2s['state'] == 'failure', str((b2s, b2.debug_info()))
 
-    b3 = client.create_batch()
-    b3.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b3 = b3.submit()
+    bb3 = client.create_batch()
+    bb3.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b3 = bb3.submit()
     b3s = b3.status()
     assert not b3s['complete'] and b3s['state'] == 'running', str((b3s, b3.debug_info()))
     b3.cancel()
 
-    b4 = client.create_batch()
-    b4.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b4 = b4.submit()
+    bb4 = client.create_batch()
+    bb4.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b4 = bb4.submit()
     b4.cancel()
     b4.wait()
     b4s = b4.status()
@@ -514,9 +514,9 @@ def test_batch_status(client: BatchClient):
 
 
 def test_log_after_failing_job(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'echo test; exit 127'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'echo test; exit 127'])
+    b = bb.submit()
     status = j.wait()
     assert 'attributes' not in status, str((status, b.debug_info()))
     assert status['state'] == 'Failed', str((status, b.debug_info()))
@@ -529,9 +529,9 @@ def test_log_after_failing_job(client: BatchClient):
 
 
 def test_long_log_line(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])
-    b = b.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
@@ -569,28 +569,28 @@ def test_authorized_users_only():
 
 
 def test_cloud_image(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['echo', 'test'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['echo', 'test'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_service_account(client: BatchClient):
-    b = client.create_batch()
-    j = b.create_job(
+    bb = client.create_batch()
+    j = bb.create_job(
         os.environ['CI_UTILS_IMAGE'],
         ['/bin/sh', '-c', 'kubectl version'],
         service_account={'namespace': NAMESPACE, 'name': 'test-batch-sa'},
     )
-    b = b.submit()
+    b = bb.submit()
     status = j.wait()
     assert j._get_exit_code(status, 'main') == 0, str((status, b.debug_info()))
 
 
 def test_port(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(
+    bb = client.create_batch()
+    bb.create_job(
         DOCKER_ROOT_IMAGE,
         [
             'bash',
@@ -602,15 +602,15 @@ echo $HAIL_BATCH_WORKER_IP
         ],
         port=5000,
     )
-    b = builder.submit()
+    b = bb.submit()
     batch = b.wait()
     assert batch['state'] == 'success', str((batch, b.debug_info()))
 
 
 def test_timeout(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'], timeout=5)
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'], timeout=5)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Error', str((status, b.debug_info()))
     error_msg = j._get_error(status, 'main')
@@ -619,10 +619,10 @@ def test_timeout(client: BatchClient):
 
 
 def test_client_max_size(client: BatchClient):
-    builder = client.create_batch()
-    for i in range(4):
-        builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
-    builder.submit()
+    bb = client.create_batch()
+    for _ in range(4):
+        bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
+    bb.submit()
 
 
 def test_restartable_insert(client: BatchClient):
@@ -637,12 +637,12 @@ def test_restartable_insert(client: BatchClient):
 
     with FailureInjectingClientSession(every_third_time) as session:
         client = BatchClient('test', session=session)
-        builder = client.create_batch()
+        bb = client.create_batch()
 
         for _ in range(9):
-            builder.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a'])
+            bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a'])
 
-        b = builder.submit(max_bunch_size=1)
+        b = bb.submit(max_bunch_size=1)
         b = client.get_batch(b.id)  # get a batch untainted by the FailureInjectingClientSession
         status = b.wait()
         assert status['state'] == 'success', str((status, b.debug_info()))
@@ -652,10 +652,10 @@ def test_restartable_insert(client: BatchClient):
 
 def test_create_idempotence(client: BatchClient):
     token = secrets.token_urlsafe(32)
-    builder1 = client.create_batch(token=token)
-    builder2 = client.create_batch(token=token)
-    b1 = builder1._open_batch()
-    b2 = builder2._open_batch()
+    bb1 = client.create_batch(token=token)
+    bb2 = client.create_batch(token=token)
+    b1 = bb1._open_batch()
+    b2 = bb2._open_batch()
     assert b1.id == b2.id
 
 
@@ -700,11 +700,11 @@ def test_batch_create_validation():
 
 
 def test_duplicate_parents(client: BatchClient):
-    batch = client.create_batch()
-    head = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head, head])
+    bb = client.create_batch()
+    head = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
+    bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head, head])
     try:
-        batch = batch.submit()
+        batch = bb.submit()
     except aiohttp.ClientResponseError as e:
         assert e.status == 400
     else:
@@ -713,11 +713,9 @@ def test_duplicate_parents(client: BatchClient):
 
 @skip_in_azure()
 def test_verify_no_access_to_google_metadata_server(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(
-        os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'metadata.google.internal', '--max-time', '10']
-    )
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'metadata.google.internal', '--max-time', '10'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -725,9 +723,9 @@ def test_verify_no_access_to_google_metadata_server(client: BatchClient):
 
 
 def test_verify_no_access_to_metadata_server(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
-    builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -735,7 +733,7 @@ def test_verify_no_access_to_metadata_server(client: BatchClient):
 
 
 def test_submit_batch_in_job(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     script = f'''import hailtop.batch as hb
 backend = hb.ServiceBackend("test", remote_tmpdir="{remote_tmpdir}")
@@ -745,12 +743,12 @@ j.command("echo hi")
 b.run()
 backend.close()
 '''
-    j = builder.create_job(
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'],
         ['/bin/bash', '-c', f'''python3 -c \'{script}\''''],
         mount_tokens=True,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
@@ -766,8 +764,8 @@ b.run()
 backend.close()
 '''
 
-    builder = client.create_batch()
-    j = builder.create_job(
+    bb = client.create_batch()
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'],
         [
             '/bin/bash',
@@ -779,7 +777,7 @@ python3 -c \'{script}\'''',
         ],
         mount_tokens=True,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     if NAMESPACE == 'default':
         assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -787,8 +785,8 @@ python3 -c \'{script}\'''',
         assert status['state'] == 'Failed', str((status, b.debug_info()))
         assert "Please log in" in j.log()['main'], (str(j.log()['main']), status)
 
-    builder = client.create_batch()
-    j = builder.create_job(
+    bb = client.create_batch()
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'],
         [
             '/bin/bash',
@@ -800,7 +798,7 @@ python3 -c \'{script}\'''',
         ],
         mount_tokens=True,
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     if NAMESPACE == 'default':
         assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -812,7 +810,7 @@ python3 -c \'{script}\'''',
 
 def test_cannot_contact_other_internal_ips(client: BatchClient):
     internal_ips = [f'10.128.0.{i}' for i in (10, 11, 12)]
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = f'''
 if [ "$HAIL_BATCH_WORKER_IP" != "{internal_ips[0]}" ] && ! grep -Fq {internal_ips[0]} /etc/hosts; then
     OTHER_IP={internal_ips[0]}
@@ -824,8 +822,8 @@ fi
 
 curl -fsSL -m 5 $OTHER_IP
 '''
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['/bin/bash', '-c', script], port=5000)
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['/bin/bash', '-c', script], port=5000)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -836,7 +834,7 @@ curl -fsSL -m 5 $OTHER_IP
 def test_can_use_google_credentials(client: BatchClient):
     token = os.environ["HAIL_TOKEN"]
     remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = f'''import hail as hl
 import secrets
 attempt_token = secrets.token_urlsafe(5)
@@ -844,10 +842,10 @@ location = f"{remote_tmpdir}/{ token }/{{ attempt_token }}/test_can_use_hailctl_
 hl.utils.range_table(10).write(location)
 hl.read_table(location).show()
 '''
-    j = builder.create_job(
+    j = bb.create_job(
         os.environ['HAIL_HAIL_BASE_IMAGE'], ['/bin/bash', '-c', f'python3 -c >out 2>err \'{script}\'; cat out err']
     )
-    b = builder.submit()
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', f'{j.log(), status}'
     expected_log = '''+-------+
@@ -872,25 +870,25 @@ hl.read_table(location).show()
 
 
 def test_user_authentication_within_job(client: BatchClient):
-    batch = client.create_batch()
+    bb = client.create_batch()
     cmd = ['bash', '-c', 'hailctl auth user']
-    no_token = batch.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=False)
-    b = batch.submit()
+    no_token = bb.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=False)
+    b = bb.submit()
 
     no_token_status = no_token.wait()
     assert no_token_status['state'] == 'Failed', str((no_token_status, b.debug_info()))
 
 
 def test_verify_access_to_public_internet(client: BatchClient):
-    builder = client.create_batch()
-    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'example.com'])
-    b = builder.submit()
+    bb = client.create_batch()
+    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'example.com'])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_verify_can_tcp_to_localhost(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = '''
 set -e
 nc -l -p 5000 &
@@ -899,8 +897,8 @@ echo "hello" | nc -q 1 localhost 5000
 '''.lstrip(
         '\n'
     )
-    j = builder.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -908,7 +906,7 @@ echo "hello" | nc -q 1 localhost 5000
 
 
 def test_verify_can_tcp_to_127_0_0_1(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = '''
 set -e
 nc -l -p 5000 &
@@ -917,8 +915,8 @@ echo "hello" | nc -q 1 127.0.0.1 5000
 '''.lstrip(
         '\n'
     )
-    j = builder.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -926,7 +924,7 @@ echo "hello" | nc -q 1 127.0.0.1 5000
 
 
 def test_verify_can_tcp_to_self_ip(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     script = '''
 set -e
 nc -l -p 5000 &
@@ -935,8 +933,8 @@ echo "hello" | nc -q 1 $(hostname -i) 5000
 '''.lstrip(
         '\n'
     )
-    j = builder.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/sh', '-c', script])
-    b = builder.submit()
+    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/sh', '-c', script])
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -944,12 +942,12 @@ echo "hello" | nc -q 1 $(hostname -i) 5000
 
 
 def test_verify_private_network_is_restricted(client: BatchClient):
-    builder = client.create_batch()
-    builder.create_job(
+    bb = client.create_batch()
+    bb.create_job(
         os.environ['HAIL_CURL_IMAGE'], command=['curl', 'internal.hail', '--connect-timeout', '60'], network='private'
     )
     try:
-        builder.submit()
+        bb.submit()
     except aiohttp.ClientResponseError as err:
         assert err.status == 400
         assert 'unauthorized network private' in err.message
@@ -958,90 +956,90 @@ def test_verify_private_network_is_restricted(client: BatchClient):
 
 
 def test_pool_highmem_instance(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'highmem'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highmem_instance_cheapest(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '1', 'memory': '5Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highcpu_instance(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'lowmem'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highcpu_instance_cheapest(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '50Mi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_standard_instance(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': 'standard'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_standard_instance_cheapest(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'cpu': '1', 'memory': '2.5Gi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_preemptible(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'machine_type': smallest_machine_type(CLOUD)}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'job-private' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_nonpreemptible(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'machine_type': smallest_machine_type(CLOUD), 'preemptible': False}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'job-private' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_cancel(client: BatchClient):
-    builder = client.create_batch()
+    bb = client.create_batch()
     resources = {'machine_type': smallest_machine_type(CLOUD)}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = bb.submit()
 
     delay = 0.1
     start = time.time()


### PR DESCRIPTION
Basically all naming, rids these test files of linting errors. We do a lot of reassigning a `BatchBuilder` variable to a `Batch` and so I consolidated around `bb` and `b`. A couple instances where I remove debug_info from an assert statement is because the associated `Batch` object would not exist, since that assert is triggered by an error that's raised before the `Batch` object is created.