### PR TITLE
[batch] Do not retry pulling images from invalid repositories

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -370,8 +370,8 @@ def test_unknown_image(client: BatchClient):
 @skip_in_azure
 def test_invalid_gcr(client: BatchClient):
     b = client.create_batch()
-    token = secrets.token_urlsafe(32)
-    j = b.create_job(f'gcr.io/invalid-repository-{token}/does-not-exist', ['echo', 'test'])
+    # GCP projects can't be strictly numeric
+    j = b.create_job(f'gcr.io/1/does-not-exist', ['echo', 'test'])
     b = b.submit()
     status = j.wait()
     try:

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -367,6 +367,22 @@ def test_unknown_image(client: BatchClient):
         raise AssertionError(str((status, b.debug_info())), e)
 
 
+@skip_in_azure
+def test_invalid_gcr(client: BatchClient):
+    b = client.create_batch()
+    token = secrets.token_urlsafe(32)
+    j = b.create_job(f'gcr.io/invalid-repository-{token}/does-not-exist', ['echo', 'test'])
+    b = b.submit()
+    status = j.wait()
+    try:
+        assert j._get_exit_code(status, 'main') is None
+        assert status['status']['container_statuses']['main']['short_error'] == 'image repository is invalid', str(
+            (status, b.debug_info())
+        )
+    except Exception as e:
+        raise AssertionError(str((status, b.debug_info())), e)
+
+
 def test_running_job_log_and_status(client: BatchClient):
     b = client.create_batch()
     j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '300'])

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -679,6 +679,8 @@ def is_transient_error(e):
     if isinstance(e, botocore.exceptions.ConnectionClosedError):
         return True
     if aiodocker is not None and isinstance(e, aiodocker.exceptions.DockerError):
+        if e.status == 500 and 'Invalid repository name' in e.message:
+            return False
         return e.status in RETRYABLE_HTTP_STATUS_CODES
     if isinstance(e, TransientError):
         return True


### PR DESCRIPTION
Weirdly, GCR returns a 500 for an invalid repository name instead of a 404, so we retry it endlessly. We need to special-case our transient errors to treat 500s with "Invalid repository name" messages as *not* transient errors, and then give the user the error message that their image repository is invalid. This follows the same pattern that we use for invalid image names.