### PR TITLE
[query] Fix handle_randomness for `collect_cols_by_key`

### DIFF
--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -575,7 +575,7 @@ class MatrixCollectColsByKey(MatrixIR):
         self.child = child
 
     def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
-        child = self.child(row_uid_field_name, col_uid_field_name)
+        child = self.child.handle_randomness(row_uid_field_name, col_uid_field_name)
         result = MatrixCollectColsByKey(child)
         if col_uid_field_name is not None:
             col = ir.Ref('sa', result.typ.col_type)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -385,6 +385,13 @@ class Tests(unittest.TestCase):
              hl.Struct(row_idx=2, col_idx=1, bar=[4, 6]),
              hl.Struct(row_idx=2, col_idx=2, bar=[8, 10, 12])])
 
+    def test_collect_cols_by_key_with_rand(self):
+        mt = hl.utils.range_matrix_table(3, 3)
+        mt = mt.annotate_cols(x = hl.rand_norm())
+        mt = mt.collect_cols_by_key()
+        mt = mt.annotate_cols(x = hl.rand_norm())
+        mt.cols().collect()
+
     def test_weird_names(self):
         ds = self.get_mt()
         exprs = {'a': 5, '   a    ': 5, r'\%!^!@#&#&$%#$%': [5], '$': 5, 'ß': 5}


### PR DESCRIPTION
CHANGELOG: Fixed crash in `collect_cols_by_key` with preceding random functions