### PR TITLE
[query] Allow seeks more than MAX_INT bytes away

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -152,11 +152,11 @@ abstract class FSSeekableInputStream extends InputStream with Seekable {
   }
 
   def seek(newPos: Long): Unit = {
-    assert((newPos - pos) <= Int.MaxValue)
-    val distance = (newPos - pos).toInt
-    val seekPosition = bb.position() + distance
-    if (seekPosition >= 0 && seekPosition < bb.limit()) {
-      bb.position(seekPosition)
+    val distance = newPos - pos
+    val bufferSeekPosition = bb.position() + distance
+    if (bufferSeekPosition >= 0 && bufferSeekPosition < bb.limit()) {
+      assert(bufferSeekPosition <= Int.MaxValue)
+      bb.position(bufferSeekPosition.toInt)
     } else {
       bb.clear()
       bb.limit(0)

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -318,11 +318,12 @@ trait FSSuite {
   @Test def testSeekMoreThanMaxInt(): Unit = {
     val f = t()
     using (fs.create(f)) { os =>
-      val eight_mib = Array.fill(8 * 1024 * 1024){0.toByte}
+      val eight_mib = 8 * 1024 * 1024
+      val arr = Array.fill(){0.toByte}
       var i = 0
       // 256 * 8MiB = 2GiB
       while (i < 256) {
-        os.write(eight_mib, 0, Int.MaxValue)
+        os.write(arr, 0, eight_mib)
         i = i + 1
       }
       os.write(100)

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -319,7 +319,7 @@ trait FSSuite {
     val f = t()
     using (fs.create(f)) { os =>
       val eight_mib = Array.fill(8 * 1024 * 1024){0.toByte}
-      val i = 0
+      var i = 0
       // 256 * 8MiB = 2GiB
       while (i < 256) {
         os.write(eight_mib, 0, Int.MaxValue)

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -319,7 +319,7 @@ trait FSSuite {
     val f = t()
     using (fs.create(f)) { os =>
       val eight_mib = 8 * 1024 * 1024
-      val arr = Array.fill(){0.toByte}
+      val arr = Array.fill(eight_mib){0.toByte}
       var i = 0
       // 256 * 8MiB = 2GiB
       while (i < 256) {

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -4,7 +4,7 @@ import java.io.FileNotFoundException
 import is.hail.HailSuite
 import is.hail.backend.ExecuteContext
 import is.hail.io.fs.FSUtil.dropTrailingSlash
-import is.hail.io.fs.{FS, FileStatus}
+import is.hail.io.fs.{FS, FileStatus, Seekable}
 import is.hail.utils._
 import org.apache.commons.io.IOUtils
 import org.testng.annotations.Test
@@ -333,7 +333,9 @@ trait FSSuite {
     assert(fs.exists(f))
 
     using(fs.open(f)) { is =>
-      is.seek(Int.MaxValue + 1.toLong)
+      is match {
+        case base: Seekable => base.seek(Int.MaxValue + 1.toLong)
+      }
       assert(is.read() == 200)
       assert(is.read() == 300)
     }

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -323,7 +323,7 @@ trait FSSuite {
       // 256 * 8MiB = 2GiB
       while (i < 256) {
         os.write(eight_mib, 0, Int.MaxValue)
-        i += 1
+        i = i + 1
       }
       os.write(100)
       os.write(200)

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -326,19 +326,20 @@ trait FSSuite {
         os.write(arr, 0, eight_mib)
         i = i + 1
       }
-      os.write(100)
-      os.write(200)
-      os.write(300)
+      os.write(10)
+      os.write(20)
+      os.write(30)
     }
 
     assert(fs.exists(f))
 
     using(fs.open(f)) { is =>
       is match {
-        case base: Seekable => base.seek(Int.MaxValue + 1.toLong)
+        case base: Seekable => base.seek(Int.MaxValue + 2.toLong)
+        case base: org.apache.hadoop.fs.Seekable => base.seek(Int.MaxValue + 2.toLong)
       }
-      assert(is.read() == 200)
-      assert(is.read() == 300)
+      assert(is.read() == 20)
+      assert(is.read() == 30)
     }
 
     fs.delete(f, false)


### PR DESCRIPTION
This assert is here because the buffer we use in the FS is a Java array and can't be longer than MAX_INT, but clearly the position in the blob can be more than that. This currently breaks range reads into indexes on data that's more than 2GiB.