### PR TITLE
[query] handle retry once errors in the correct order

### DIFF
--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -41,11 +41,11 @@ package object services {
     // true error.
     val e = reactor.core.Exceptions.unwrap(_e)
     e match {
+      case e: HttpResponseException =>
+        e.getStatusCode() == 400 && e.getMessage.contains("Invalid grant: account not found")
       case e @ (_: SSLException | _: StorageException | _: IOException) =>
         val cause = e.getCause
         cause != null && isRetryOnceError(cause)
-      case e: HttpResponseException =>
-        e.getStatusCode() == 400 && e.getMessage.contains("Invalid grant: account not found")
       case _ =>
         false
     }


### PR DESCRIPTION
Because HttpResponseException is a subclass of IOException, the match clause for HttpResponseException in isRetryOnceError is unreachable. As a result, account-not-found errors for Google Cloud Storage are not handled correctly. This change reorders the match clauses accordingly.