### PR TITLE
[query] remove incompatibilities with java 11

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -104,7 +104,7 @@ services-jvm-test: $(SCALA_BUILD_INFO) $(JAR_SOURCES) $(JAR_TEST_SOURCES)
 # javac args from compileJava in build.gradle
 $(BUILD_DEBUG_PREFIX)/%.class: src/debug/scala/%.java
 	@mkdir -p $(BUILD_DEBUG_PREFIX)
-	$(JAVAC) -d $(BUILD_DEBUG_PREFIX) -Xlint:all -Werror -XDenableSunApiLintControl -Xlint:-sunapi $<
+	$(JAVAC) -d $(BUILD_DEBUG_PREFIX) -Xlint:all -Werror -XDenableSunApiLintControl -XDignore.symbol.file $<
 
 src/main/resources/build-info.properties: env/REVISION env/SHORT_REVISION env/BRANCH
 src/main/resources/build-info.properties: env/SPARK_VERSION env/HAIL_PIP_VERSION

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -33,7 +33,7 @@ sourceSets {
 }
 
 compileJava {
-    options.compilerArgs << "-Xlint:all" << "-Werror" << "-XDenableSunApiLintControl" << "-Xlint:-sunapi"
+    options.compilerArgs << "-Xlint:all" << "-Werror" << "-XDenableSunApiLintControl" << "-XDignore.symbol.file"
 }
 tasks.withType(JavaCompile) {
     options.fork = true // necessary to make -XDenableSunApiLintControl work
@@ -57,7 +57,7 @@ compileScala {
         "-Xlint:all" <<
         "-Werror" <<
         "-XDenableSunApiLintControl" <<
-        "-Xlint:-sunapi" <<
+        "-XDignore.symbol.file" <<
         "-Xlint:-path" // Apparently we try to find some libraries that aren't always installed
 
     scalaCompileOptions.additionalParameters = [

--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -377,7 +377,7 @@ class ClassBuilder[C](
           }
         }
 
-        theClass.newInstance().asInstanceOf[C]
+        theClass.getDeclaredConstructor().newInstance().asInstanceOf[C]
       }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -719,7 +719,7 @@ class EmitClassBuilder[C](
             }
           }
         }
-        val f = theClass.newInstance().asInstanceOf[C]
+        val f = theClass.getDeclaredConstructor().newInstance().asInstanceOf[C]
         f.asInstanceOf[FunctionWithHailClassLoader].addHailClassLoader(hcl)
         f.asInstanceOf[FunctionWithFS].addFS(fs)
         f.asInstanceOf[FunctionWithPartitionRegion].addPartitionRegion(region)


### PR DESCRIPTION
Between Java 8 and Java 11, the `.newInstance()` method and the `-Xlint:-sunapi` compiler flag were deprecated, which prevents hail from being built with the Java 11 JDK, despite [the docs](https://hail.is/docs/0.2/getting_started_developing.html) suggesting otherwise. This change replaces usages of `.newInstance()` with [`.getDeclaredConstructor().newinstance()`](https://stackoverflow.com/questions/56079042/fix-to-java-newinstance-deprecated) and of `-Xlint:-sunapi` with [`-XDignore.symbol.file`](https://stackoverflow.com/questions/13855700/suppress-javac-warning-is-internal-proprietary-api-and-may-be-removed-in-a-f).