### PR TITLE
[batch] Tone down healthcheck exception

### DIFF
--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -248,7 +248,8 @@ VALUES (%s, %s);
                 await self.mark_healthy()
                 return True
             except Exception:
-                log.exception(f'while requesting {self} /healthcheck')
+                if (time_msecs() - self.last_updated) / 1000 > 300:
+                    log.exception(f'while requesting {self} /healthcheck')
                 await self.incr_failed_request_count()
         return False
 


### PR DESCRIPTION
We were getting lots of exceptions when an instance was no longer reachable because it had either been preempted or idled out. The driver could have been offline or the monitor instances / health check loop ran before the activity log monitor was able to process the delete instance events. This PR attempts to tone down the exceptions such that we only get errors for instances that are likely to be zombies (no contact for 5 minutes) rather than normally disappearing instances. However, I do think we should have a separate Grafana alert for when we have lots of instances being deactivated because they couldn't contact the driver as that's a sign of a bigger problem.