### PR TITLE
[monitoring] disable grafana-specific login screen 

### DIFF
--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -131,10 +131,8 @@ data:
     root_url = %(protocol)s://%(domain)/{{ default_ns.name }}/grafana/
     serve_from_sub_path = true
 {% endif %}
-    [auth.anonymous]
-    enabled = true
-    org_name = Hail
-    org_role = Admin
+    [auth]
+    disable_login_form
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -131,8 +131,10 @@ data:
     root_url = %(protocol)s://%(domain)/{{ default_ns.name }}/grafana/
     serve_from_sub_path = true
 {% endif %}
-    [auth]
-    oauth_automatic_login = true
+    [auth.anonymous]
+    enabled = true
+    org_name = Hail
+    org_role = Admin
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -132,7 +132,8 @@ data:
     serve_from_sub_path = true
 {% endif %}
     [auth]
-    disable_login_form
+    disable_login_form = true
+    disable_signout_menu = true
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -131,6 +131,8 @@ data:
     root_url = %(protocol)s://%(domain)/{{ default_ns.name }}/grafana/
     serve_from_sub_path = true
 {% endif %}
+    [auth]
+    oauth_automatic_login = true
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -131,6 +131,10 @@ data:
     root_url = %(protocol)s://%(domain)/{{ default_ns.name }}/grafana/
     serve_from_sub_path = true
 {% endif %}
+    [auth.anonymous]
+    enabled = true
+    org_name = Hail
+    org_role = Admin
     [auth]
     disable_login_form = true
     disable_signout_menu = true


### PR DESCRIPTION
Currently, the Grafana service deployed with the Hail environment is behind two layers of authentication, since the Grafana NGINX configuration proxies requests to it through the `/auth` route, and the login screen built into Grafana also displays. This change removes the second login screen.