### PR TITLE
[batch][UI] update billing end field label

### DIFF
--- a/batch/batch/front_end/templates/billing.html
+++ b/batch/batch/front_end/templates/billing.html
@@ -13,7 +13,7 @@
                    placeholder="MM/DD/YYYY"
                    {% endif %}
             ><br>
-            <label for="end">End:</label>
+            <label for="end">End (inclusive):</label>
             <input style="vertical-align:text-bottom;" name="end" size=30 type="text"
                    {% if end is not none %}
                    value = "{{ end }}"


### PR DESCRIPTION
Currently, the label for the end field on the billing page is `End:`.
<img width="352" alt="Screen Shot 2022-09-20 at 11 43 38" src="https://user-images.githubusercontent.com/84595986/191303649-13833871-ecec-4571-9664-6817134c0a58.png">
This change clarifies how the field is used by updating that label to `End (inclusive):`.
<img width="402" alt="Screen Shot 2022-09-20 at 11 55 38" src="https://user-images.githubusercontent.com/84595986/191306496-cd533146-b98d-405d-b48d-f3b40bae1bec.png">
