### PR TITLE
[ci] Accept multiple registries in the docker auth script

### DIFF
--- a/ci/buildkit/convert-cloud-credentials-to-docker-auth-config
+++ b/ci/buildkit/convert-cloud-credentials-to-docker-auth-config
@@ -13,4 +13,11 @@ elif [ ! -z "${AZURE_APPLICATION_CREDENTIALS}" ]; then
 fi
 
 USER_PASS=$(echo -n "$USERNAME:$PASSWORD" | base64 | tr -d \\n)
-echo '{"auths": { "'$REGISTRY'": { "auth": "'$USER_PASS'"}}}' > $HOME/.docker/config.json
+
+registry_auths='{}'
+for registry in ${REGISTRIES:=$REGISTRY}
+do
+    registry_auths=$(echo $registry_auths | jq --arg registry "$registry" --arg userpass "$USER_PASS" '. + { ($registry): { "auth": $userpass }}')
+done
+
+echo '{"auths": '$registry_auths'}' > $HOME/.docker/config.json


### PR DESCRIPTION
This adds support for authenticating with multiple docker registries inside a `BuildImage` CI step instead of just one. This will be necessary for switching to Artifact Registry as we will temporarily be pushing images to both registries during the migration.