### PR TITLE
[batch] Dont transfer outputs in the local backend if there arent any

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -313,9 +313,10 @@ class LocalBackend(Backend[None]):
                     transfer_dict
                     for output_resource in job._external_outputs
                     for transfer_dict in transfer_dicts_for_resource_file(output_resource)]
-                output_transfers = orjson.dumps(output_transfer_dicts).decode('utf-8')
 
-                code += [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(output_transfers)}']
+                if output_transfer_dicts:
+                    output_transfers = orjson.dumps(output_transfer_dicts).decode('utf-8')
+                    code += [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(output_transfers)}']
                 code += ['\n']
 
                 run_code(code)


### PR DESCRIPTION
Noticed this while running a local "Hello World" batch. It prints the transfer summary (copied 0 bytes) which would be surprising to a new user that has not specified any output files. This fixes that and makes it consistent with the check that we do with the `input_transfer_dicts`