### PR TITLE
[query] fix install-on-cluster to handle lines with spaces

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -256,7 +256,7 @@ install: $(WHEEL)
 
 .PHONY: install-on-cluster
 install-on-cluster: $(WHEEL)
-	sed '/^pyspark/d' python/requirements.txt | grep -v '^#' | xargs $(PIP) install -U
+	sed '/^pyspark/d' python/requirements.txt | grep -v '^#' | tr '\n' '\0' | xargs -0 $(PIP) install -U
 	-$(PIP) uninstall -y hail
 	$(PIP) install $(WHEEL) --no-deps
 


### PR DESCRIPTION
CHANGELOG: Fix bug that caused make install-on-cluster to fail with a message about sys_platform.

Co-authored-by: ryerobinson <39314627+ryerobinson@users.noreply.github.com>