### PR TITLE
[query] Support missing values in primitive columns in `Table.to_pandas`

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3476,6 +3476,16 @@ class Table(ExprContainer):
             hl_dtype = dtypes_struct[column]
             if hl_dtype == hl.tstr:
                 pd_dtype = 'string'
+            elif hl_dtype == hl.tint32:
+                pd_dtype = 'Int32'
+            elif hl_dtype == hl.tint64:
+                pd_dtype = 'Int64'
+            elif hl_dtype == hl.tfloat32:
+                pd_dtype = 'Float32'
+            elif hl_dtype == hl.tfloat64:
+                pd_dtype = 'Float64'
+            elif hl_dtype == hl.tbool:
+                pd_dtype = 'boolean'
             else:
                 pd_dtype = hl_dtype.to_numpy()
             data_dict[column] = pandas.Series(column_struct_array[column], dtype=pd_dtype)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1810,7 +1810,6 @@ def test_table_head_and_tail(test):
 
 
 def test_to_pandas():
-    import numpy as np
     ht = hl.utils.range_table(3)
     strs = ["foo", "bar", "baz"]
     ht = ht.annotate(s = hl.array(strs)[ht.idx], nested=hl.struct(foo = ht.idx, bar=hl.range(ht.idx)))
@@ -1819,7 +1818,7 @@ def test_to_pandas():
     print(df_from_hail.dtypes)
 
     python_data = {
-        "idx": pd.Series([0, 1, 2], dtype=np.int32),
+        "idx": pd.Series([0, 1, 2], dtype='Int32'),
         "s": pd.Series(["foo", "bar", "baz"], dtype='string'),
         "nested": pd.Series([hl.Struct(foo=0, bar=[]), hl.Struct(foo=1, bar=[0]),
                              hl.Struct(foo=2, bar=[0, 1])], dtype=object)
@@ -1830,16 +1829,15 @@ def test_to_pandas():
 
 
 def test_to_pandas_flatten():
-    import numpy as np
     ht = hl.utils.range_table(3)
     strs = ["foo", "bar", "baz"]
     ht = ht.annotate(s = hl.array(strs)[ht.idx], nested = hl.struct(foo = ht.idx, bar=hl.range(ht.idx)))
     df_from_hail = ht.to_pandas(flatten=True)
 
     python_data = {
-        "idx": pd.Series([0, 1, 2], dtype=np.int32),
+        "idx": pd.Series([0, 1, 2], dtype='Int32'),
         "s": pd.Series(["foo", "bar", "baz"], dtype='string'),
-        "nested.foo": pd.Series([0, 1, 2], dtype=np.int32),
+        "nested.foo": pd.Series([0, 1, 2], dtype='Int32'),
         "nested.bar": pd.Series([[], [0], [0, 1]], dtype=object)
     }
 
@@ -1878,7 +1876,7 @@ def test_to_pandas_nd_array():
     df_from_hail = ht.to_pandas()
 
     python_data = {
-        "idx": pd.Series([0, 1, 2], dtype=np.int32),
+        "idx": pd.Series([0, 1, 2], dtype='Int32'),
         "nd": pd.Series([np.arange(3), np.arange(3), np.arange(3)])
     }
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1847,6 +1847,30 @@ def test_to_pandas_flatten():
     pd.testing.assert_frame_equal(df_from_hail, df_from_python)
 
 
+def test_to_pandas_null_ints():
+    ht = hl.utils.range_table(3)
+    ht = ht.annotate(missing_int32 = hl.or_missing(ht.idx == 0, ht.idx),
+                     missing_int64 = hl.or_missing(ht.idx == 0, hl.int64(ht.idx)),
+                     missing_float32 = hl.or_missing(ht.idx == 0, hl.float32(ht.idx)),
+                     missing_float64 = hl.or_missing(ht.idx == 0, hl.float64(ht.idx)),
+                     missing_bool = hl.or_missing(ht.idx == 0, True),
+                     missing_str = hl.or_missing(ht.idx == 0, 'foo'))
+    df_from_hail = ht.to_pandas()
+
+    python_data = {
+        "idx": pd.Series([0, 1, 2], dtype='Int32'),
+        "missing_int32": pd.Series([0, None, None], dtype='Int32'),
+        "missing_int64": pd.Series([0, None, None], dtype='Int64'),
+        "missing_float32": pd.Series([0, None, None], dtype='Float32'),
+        "missing_float64": pd.Series([0, None, None], dtype='Float64'),
+        "missing_bool": pd.Series([True, None, None], dtype='boolean'),
+        "missing_str": pd.Series(['foo', None, None], dtype='string'),
+    }
+
+    df_from_python = pd.DataFrame(python_data)
+    pd.testing.assert_frame_equal(df_from_hail, df_from_python)
+
+
 def test_to_pandas_nd_array():
     import numpy as np
     ht = hl.utils.range_table(3)


### PR DESCRIPTION
CHANGELOG: Support missing values in primitive columns in `Table.to_pandas`.