### PR TITLE
[gateway] use Mozilla recommended TLS intermediate settings

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -2,7 +2,8 @@ FROM {{ hail_ubuntu_image.image }}
 
 RUN hail-apt-get-install nginx
 
-RUN rm -f /etc/nginx/sites-enabled/default
+RUN rm -f /etc/nginx/sites-enabled/default && \
+    curl https://ssl-config.mozilla.org/ffdhe2048.txt > /opt/ffdhe2048.txt
 ADD nginx.conf /etc/nginx/
 ADD gateway.nginx.conf.out /etc/nginx/conf.d/gateway.conf
 ADD gzip.conf /etc/nginx/conf.d/gzip.conf

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -34,6 +34,24 @@ http {
   access_log /var/log/nginx/access.log json-log;
   error_log /var/log/nginx/error.log;
 
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+  ssl_session_tickets off;
+
+  ssl_dhparam /opt/ffdhe2048.txt;
+
+  # intermediate configuration
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+  ssl_prefer_server_ciphers off;
+
+  # HSTS (ngx_http_headers_module is required) (63072000 seconds)
+  add_header Strict-Transport-Security "max-age=63072000" always;
+
+  # OCSP stapling
+  ssl_stapling on;
+  ssl_stapling_verify on;
+
   include /ssl-config/ssl-config-http.conf;
 
   gzip on;


### PR DESCRIPTION
I think we should do this with the Envoy gateway as well. If Envoy is gonna land this week, then we can just close this and fold in over there instead.