### PR TITLE
[qob] Add capability for worker jobs to go in the same batch as the driver job

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -366,6 +366,7 @@ class ServiceBackend(Backend):
                     ],
                     mount_tokens=True,
                     resources=resources,
+                    attributes={'name': 'driver'},
                 )
                 b = await bb.submit(disable_progress_bar=True)
 
@@ -382,7 +383,7 @@ class ServiceBackend(Backend):
                     raise
 
             with timings.step("parse status"):
-                if status['n_succeeded'] != 1:
+                if status['n_succeeded'] != status['n_jobs']:
                     job_status = await j.status()
                     if 'status' in job_status:
                         if 'error' in job_status['status']:

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -133,11 +133,11 @@ object Worker {
     timer.start("executeFunction")
 
     if (HailContext.isInitialized) {
-      HailContext.get.backend = new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()))
+      HailContext.get.backend = new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()), null, None)
     } else {
       HailContext(
         // FIXME: workers should not have backends, but some things do need hail contexts
-        new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader())), skipLoggingConfiguration = true, quiet = true)
+        new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()), null, None), skipLoggingConfiguration = true, quiet = true)
     }
     val htc = new ServiceTaskContext(i)
     var result: Array[Byte] = null

--- a/hail/src/main/scala/is/hail/services/BatchConfig.scala
+++ b/hail/src/main/scala/is/hail/services/BatchConfig.scala
@@ -1,0 +1,29 @@
+package is.hail.services
+
+import java.io.{File, FileInputStream}
+
+import is.hail.utils._
+import org.json4s._
+import org.json4s.jackson.JsonMethods
+import org.apache.log4j.Logger
+
+object BatchConfig {
+  private[this] val log = Logger.getLogger("BatchConfig")
+
+  def fromConfigFile(file: String): Option[BatchConfig] = {
+    if (new File(file).exists()) {
+      using(new FileInputStream(file)) { in =>
+        Some(fromConfig(JsonMethods.parse(in)))
+      }
+    } else {
+      None
+    }
+  }
+
+  def fromConfig(config: JValue): BatchConfig = {
+    implicit val formats: Formats = DefaultFormats
+    new BatchConfig((config \ "batch_id").extract[Int])
+  }
+}
+
+class BatchConfig(val batchId: Long)

--- a/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
+++ b/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
@@ -13,7 +13,7 @@ import org.apache.http.entity.{ByteArrayEntity, ContentType, StringEntity}
 import org.apache.http.impl.client.{CloseableHttpClient, HttpClients}
 import org.apache.http.util.EntityUtils
 import org.apache.log4j.{LogManager, Logger}
-import org.json4s.{DefaultFormats, Formats, JObject, JValue}
+import org.json4s.{DefaultFormats, Formats, JInt, JObject, JString, JValue}
 import org.json4s.jackson.JsonMethods
 
 import scala.util.Random
@@ -74,9 +74,131 @@ class BatchClient(
   def delete(path: String, token: String): JValue =
     request(new HttpDelete(s"$baseUrl$path"))
 
+  def update(batchID: Long, token: String, jobs: IndexedSeq[JObject]) = {
+    implicit val formats: Formats = DefaultFormats
+
+    val updateJson = JObject("n_jobs" -> JInt(jobs.length), "token" -> JString(token))
+    val bunches = createBunches(jobs)
+    val updateID = if (bunches.length == 1) {
+      val b = new ByteArrayBuilder()
+      b ++= "{\"bunch\":".getBytes(StandardCharsets.UTF_8)
+      addBunchBytes(b, bunches(0))
+      b ++= ",\"update\":".getBytes(StandardCharsets.UTF_8)
+      b ++= JsonMethods.compact(updateJson).getBytes(StandardCharsets.UTF_8)
+      b += '}'
+      val data = b.result()
+      val resp = retryTransientErrors{
+        post(s"/api/v1alpha/batches/$batchID/update-fast",
+          new ByteArrayEntity(data, ContentType.create("application/json")))
+      }
+      b.clear()
+      (resp \ "update_id").extract[Long]
+    } else {
+      val resp = retryTransientErrors { post(s"/api/v1alpha/batches/$batchID/updates/create", json = updateJson) }
+      val updateID = (resp \ "update_id").extract[Long]
+
+      val b = new ByteArrayBuilder()
+      var i = 0
+      while (i < bunches.length) {
+        addBunchBytes(b, bunches(i))
+        val data = b.result()
+        retryTransientErrors {
+          post(
+            s"/api/v1alpha/batches/$batchID/updates/$updateID/jobs/create",
+            new ByteArrayEntity(
+              data,
+              ContentType.create("application/json")))
+        }
+        b.clear()
+        i += 1
+      }
+
+      retryTransientErrors { patch(s"/api/v1alpha/batches/$batchID/updates/$updateID/commit") }
+      updateID
+    }
+    log.info(s"run: created update $updateID for batch $batchID")
+  }
+
   def create(batchJson: JObject, jobs: IndexedSeq[JObject]): Long = {
     implicit val formats: Formats = DefaultFormats
 
+    val bunches = createBunches(jobs)
+    val batchID = if (bunches.length == 1) {
+      val bunch = bunches(0)
+      val b = new ByteArrayBuilder()
+      b ++= "{\"bunch\":".getBytes(StandardCharsets.UTF_8)
+      addBunchBytes(b, bunch)
+      b ++= ",\"batch\":".getBytes(StandardCharsets.UTF_8)
+      b ++= JsonMethods.compact(batchJson).getBytes(StandardCharsets.UTF_8)
+      b += '}'
+      val data = b.result()
+      val resp = retryTransientErrors{
+        post("/api/v1alpha/batches/create-fast",
+          new ByteArrayEntity(data, ContentType.create("application/json")))
+      }
+      b.clear()
+      (resp \ "id").extract[Long]
+    } else {
+      val resp = retryTransientErrors { post("/api/v1alpha/batches/create", json = batchJson) }
+      val batchID = (resp \ "id").extract[Long]
+
+      val b = new ByteArrayBuilder()
+
+      var i = 0
+      while (i < bunches.length) {
+        addBunchBytes(b, bunches(i))
+        val data = b.result()
+        retryTransientErrors {
+          post(
+            s"/api/v1alpha/batches/$batchID/jobs/create",
+            new ByteArrayEntity(
+              data,
+              ContentType.create("application/json")))
+        }
+        b.clear()
+        i += 1
+      }
+
+      retryTransientErrors { patch(s"/api/v1alpha/batches/$batchID/close") }
+      batchID
+    }
+    log.info(s"run: created batch $batchID")
+    batchID
+  }
+
+  def run(batchJson: JObject, jobs: IndexedSeq[JObject]): JValue = {
+    val batchID = create(batchJson, jobs)
+    waitForBatch(batchID, jobs.length)
+  }
+
+  def waitForBatch(batchID: Long, nJobsToComplete: Int): JValue = {
+    implicit val formats: Formats = DefaultFormats
+
+    val start = System.nanoTime()
+
+    while (true) {
+      val batch = retryTransientErrors { get(s"/api/v1alpha/batches/$batchID") }
+      val n_completed = (batch \ "n_completed").extract[Int]
+      if (n_completed == nJobsToComplete)
+        return batch
+
+      // wait 10% of duration so far
+      // at least, 50ms
+      // at most, 5s
+      val now = System.nanoTime()
+      val elapsed = now - start
+      var d = math.max(
+        math.min(
+          (0.1 * (0.8 + Random.nextFloat() * 0.4) * (elapsed / 1000.0 / 1000)).toInt,
+          5000),
+        50)
+      Thread.sleep(d)
+    }
+
+    throw new AssertionError("unreachable")
+  }
+
+  private def createBunches(jobs: IndexedSeq[JObject]): BoxedArrayBuilder[Array[Array[Byte]]] = {
     val bunches = new BoxedArrayBuilder[Array[Array[Byte]]]()
     val bunchb = new BoxedArrayBuilder[Array[Byte]]()
 
@@ -97,96 +219,18 @@ class BatchClient(
 
     bunches += bunchb.result()
     bunchb.clear()
-    size = 0
-
-    val batchID = if (bunches.length == 1) {
-      val bunch = bunches(0)
-      val b = new ByteArrayBuilder()
-      b ++= "{\"bunch\":".getBytes(StandardCharsets.UTF_8)
-      b += '['
-      var j = 0
-      while (j < bunch.length) {
-        if (j > 0)
-          b += ','
-        b ++= bunch(j)
-        j += 1
-      }
-      b += ']'
-      b ++= ",\"batch\":".getBytes(StandardCharsets.UTF_8)
-      b ++= JsonMethods.compact(batchJson).getBytes(StandardCharsets.UTF_8)
-      b += '}'
-      val data = b.result()
-      val resp = retryTransientErrors{
-        post("/api/v1alpha/batches/create-fast",
-          new ByteArrayEntity(data, ContentType.create("application/json")))
-      }
-      b.clear()
-      (resp \ "id").extract[Long]
-    } else {
-      val resp = retryTransientErrors { post("/api/v1alpha/batches/create", json = batchJson) }
-      val batchID = (resp \ "id").extract[Long]
-
-      val b = new ByteArrayBuilder()
-
-      i = 0 // reuse
-      while (i < bunches.length) {
-        val bunch = bunches(i)
-        b += '['
-        var j = 0
-        while (j < bunch.length) {
-          if (j > 0)
-            b += ','
-          b ++= bunch(j)
-          j += 1
-        }
-        b += ']'
-        val data = b.result()
-        retryTransientErrors {
-          post(
-            s"/api/v1alpha/batches/$batchID/jobs/create",
-            new ByteArrayEntity(
-              data,
-              ContentType.create("application/json")))
-        }
-        b.clear()
-        i += 1
-      }
-
-      retryTransientErrors { patch(s"/api/v1alpha/batches/$batchID/close") }
-      batchID
-    }
-    log.info(s"run: created batch $batchID")
-    batchID
+    bunches
   }
 
-  def waitForBatch(batchID: Long): JValue = {
-    implicit val formats: Formats = DefaultFormats
-
-    val start = System.nanoTime()
-
-    while (true) {
-      val batch = retryTransientErrors { get(s"/api/v1alpha/batches/$batchID") }
-      if ((batch \ "complete").extract[Boolean])
-        return batch
-
-      // wait 10% of duration so far
-      // at least, 50ms
-      // at most, 5s
-      val now = System.nanoTime()
-      val elapsed = now - start
-      var d = math.max(
-        math.min(
-          (0.1 * (0.8 + Random.nextFloat() * 0.4) * (elapsed / 1000.0 / 1000)).toInt,
-          5000),
-        50)
-      Thread.sleep(d)
+  private def addBunchBytes(b: ByteArrayBuilder, bunch: Array[Array[Byte]]) {
+    var j = 0
+    b += '['
+    while (j < bunch.length) {
+      if (j > 0)
+        b += ','
+      b ++= bunch(j)
+      j += 1
     }
-
-    throw new AssertionError("unreachable")
-  }
-
-  def run(batchJson: JObject, jobs: IndexedSeq[JObject]): JValue = {
-    val batchID = create(batchJson, jobs)
-    waitForBatch(batchID)
+    b += ']'
   }
 }


### PR DESCRIPTION
This leverages open batches to submit all QoB stages as updates to the same batch the Query Driver is running in. Most of this implementation feels uncontroversial, but there is a backwards-incompatible change to the JVMJob that I don't love. I needed to let the Query Driver know which batch it's running in and did so by adding that as another argument to main. I initially wanted this as an environment variable, but considering that these containers are long-lived I wasn't quite sure how to do that.
I didn't stack this on open batches so this won't work until that goes in but the changes are entirely disjoint