### PR TITLE
[dependabot] also monitor hail/build.gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+  - package-ecosystem: "gradle"
+    directory: "/hail"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Curious to hear your reaction to this, Daniel, as you've effectively become the dependency czar. For this, we might need to pull in @chrisvittal or @tpoterba to resolve dependency issues.