### PR TITLE
[batch] serialize user-defined python functions once per batch

### DIFF
--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -1,7 +1,9 @@
 import os
 import warnings
 import re
-from typing import Optional, Dict, Union, List, Any, Set
+from typing import Callable, Optional, Dict, Union, List, Any, Set
+from io import BytesIO
+import dill
 
 from hailtop.utils import secret_alnum_string, url_scheme, async_to_blocking
 from hailtop.aiotools import AsyncFS
@@ -148,6 +150,40 @@ class Batch:
         self._DEPRECATED_fs: Optional[RouterAsyncFS] = None
 
         self._cancel_after_n_failures = cancel_after_n_failures
+
+        self._python_function_defs: Dict[int, Callable] = {}
+        self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
+
+    def _register_python_function(self, function: Callable) -> int:
+        function_id = id(function)
+        self._python_function_defs[function_id] = function
+        return function_id
+
+    async def _serialize_python_to_input_file(
+        self, path: str, subdir: str, file_id: int, code: Any, dry_run: bool = False
+    ) -> _resource.InputResourceFile:
+        pipe = BytesIO()
+        dill.dump(code, pipe, recurse=True)
+        pipe.seek(0)
+
+        code_path = f"{path}/{subdir}/code{file_id}.p"
+
+        if not dry_run:
+            await self._fs.makedirs(os.path.dirname(code_path), exist_ok=True)
+            await self._fs.write(code_path, pipe.getvalue())
+
+        code_input_file = self.read_input(code_path)
+
+        return code_input_file
+
+    async def _serialize_python_functions_to_input_files(
+        self, path: str, dry_run: bool = False
+    ) -> None:
+        for function_id, function in self._python_function_defs.items():
+            file = await self._serialize_python_to_input_file(
+                path, "functions", function_id, function, dry_run
+            )
+            self._python_function_files[function_id] = file
 
     def _unique_job_token(self, n=5):
         token = secret_alnum_string(n)

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1,15 +1,11 @@
 import asyncio
-import functools
 import inspect
 import os
 import re
 import textwrap
 import warnings
-from io import BytesIO
 from shlex import quote as shq
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
-
-import dill
 
 from . import backend, batch  # pylint: disable=cyclic-import
 from . import resource as _resource  # pylint: disable=cyclic-import
@@ -828,7 +824,7 @@ class PythonJob(Job):
         super().__init__(batch, token, name=name, attributes=attributes, shell=None)
         self._resources: Dict[str, _resource.Resource] = {}
         self._resources_inverse: Dict[_resource.Resource, str] = {}
-        self._functions: List[Tuple[_resource.PythonResult, Callable, Tuple[Any, ...], Dict[str, Any]]] = []
+        self._function_calls: List[Tuple[_resource.PythonResult, int, Tuple[Any, ...], Dict[str, Any]]] = []
         self.n_results = 0
 
     def _get_resource(self, item: str) -> '_resource.PythonResult':
@@ -1030,7 +1026,9 @@ class PythonJob(Job):
         result = self._get_resource(f'result{self.n_results}')
         handle_arg(result)
 
-        self._functions.append((result, unapplied, args, kwargs))
+        unapplied_id = self._batch._register_python_function(unapplied)
+
+        self._function_calls.append((result, unapplied_id, args, kwargs))
 
         return result
 
@@ -1045,60 +1043,24 @@ class PythonJob(Job):
                                       for name, resource in arg._resources.items()})
             return ('value', arg)
 
-        def deserialize_argument(arg):
-            typ, val = arg
-            if typ == 'py_path':
-                return dill.load(open(val, 'rb'))
-            if typ in ('path', 'dict_path'):
-                return val
-            assert typ == 'value'
-            return val
+        for i, (result, unapplied_id, args, kwargs) in enumerate(self._function_calls):
+            func_file = self._batch._python_function_files[unapplied_id]
 
-        def wrap(f):
-            @functools.wraps(f)
-            def wrapped(*args, **kwargs):
-                args = [deserialize_argument(arg) for arg in args]
-                kwargs = {kw: deserialize_argument(arg) for kw, arg in kwargs.items()}
-                return f(*args, **kwargs)
-            return wrapped
-
-        for i, (result, unapplied, args, kwargs) in enumerate(self._functions):
             args = [prepare_argument_for_serialization(arg) for arg in args]
             kwargs = {kw: prepare_argument_for_serialization(arg) for kw, arg in kwargs.items()}
 
-            pipe = BytesIO()
-            dill.dump(functools.partial(wrap(unapplied), *args, **kwargs), pipe, recurse=True)
-            pipe.seek(0)
+            args_file = await self._batch._serialize_python_to_input_file(
+                os.path.dirname(result._get_path(remote_tmpdir)), "args", i, (args, kwargs), dry_run
+            )
 
-            job_path = os.path.dirname(result._get_path(remote_tmpdir))
-            code_path = f'{job_path}/code{i}.p'
-
-            if not dry_run:
-                await self._batch._fs.makedirs(os.path.dirname(code_path), exist_ok=True)
-                await self._batch._fs.write(code_path, pipe.getvalue())
-
-            code = self._batch.read_input(code_path)
-
-            json_write = ''
-            if result._json:
-                json_write = f'''
-            with open(\\"{result._json}\\", \\"w\\") as out:
-                out.write(json.dumps(result) + \\"\\n\\")
+            json_write, str_write, repr_write = [
+                '' if not output else f'''
+        with open('{output}', 'w') as out:
+            out.write({formatter}(result) + '\\n')
 '''
-
-            str_write = ''
-            if result._str:
-                str_write = f'''
-            with open(\\"{result._str}\\", \\"w\\") as out:
-                out.write(str(result) + \\"\\n\\")
-'''
-
-            repr_write = ''
-            if result._repr:
-                repr_write = f'''
-            with open(\\"{result._repr}\\", \\"w\\") as out:
-                out.write(repr(result) + \\"\\n\\")
-'''
+                for output, formatter in
+                [(result._json, "json.dumps"), (result._str, "str"), (result._repr, "repr")]
+            ]
 
             wrapper_code = f'''python3 -c "
 import os
@@ -1108,14 +1070,28 @@ import traceback
 import json
 import sys
 
-with open(\\"{result}\\", \\"wb\\") as dill_out:
+def deserialize_argument(arg):
+    typ, val = arg
+    if typ == 'py_path':
+        return dill.load(open(val, 'rb'))
+    if typ in ('path', 'dict_path'):
+        return val
+    assert typ == 'value'
+    return val
+
+with open('{result}', 'wb') as dill_out:
     try:
-        with open(\\"{code}\\", \\"rb\\") as f:
-            result = dill.load(f)()
-            dill.dump(result, dill_out, recurse=True)
-            {json_write}
-            {str_write}
-            {repr_write}
+        with open('{func_file}', 'rb') as func_file:
+            func = dill.load(func_file)
+        with open('{args_file}', 'rb') as arg_file:
+            args, kwargs = dill.load(arg_file)
+            args = [deserialize_argument(arg) for arg in args]
+            kwargs = {{kw: deserialize_argument(arg) for kw, arg in kwargs.items()}}
+        result = func(*args, **kwargs)
+        dill.dump(result, dill_out, recurse=True)
+        {json_write}
+        {str_write}
+        {repr_write}
     except Exception as e:
         traceback.print_exc()
         dill.dump((e, traceback.format_exception(type(e), e, e.__traceback__)), dill_out, recurse=True)
@@ -1125,6 +1101,7 @@ with open(\\"{result}\\", \\"wb\\") as dill_out:
             wrapper_code = self._interpolate_command(wrapper_code, allow_python_results=True)
             self._wrapper_code.append(wrapper_code)
 
+            unapplied = self._batch._python_function_defs[unapplied_id]
             self._user_code.append(textwrap.dedent(inspect.getsource(unapplied)))
             args = ', '.join([f'{arg!r}' for _, arg in args])
             kwargs = ', '.join([f'{k}={v!r}' for k, (_, v) in kwargs.items()])


### PR DESCRIPTION
Currently, for each function call that a Python job has, it serializes the entire function definition to a file, to be deserialized and called when the job is run. This change moves the serialization to the batch level, so if the same job calls the same function multiple times, or if multiple jobs within a single batch all call the same function, it will only have its definition serialized once.