### PR TITLE
[batch] All public images must be under DOCKER_PREFIX/hailgenetics

### DIFF
--- a/batch/batch/publicly_available_images.py
+++ b/batch/batch/publicly_available_images.py
@@ -2,9 +2,4 @@ from typing import List
 
 
 def publicly_available_images(docker_prefix: str) -> List[str]:
-    # the worker cannot import batch_configuration because it does not have all the environment
-    # variables
-    return [
-        f'{docker_prefix}/{name}'
-        for name in ('hailgenetics/hail', 'hailgenetics/genetics', 'python-dill', 'batch-worker')
-    ]
+    return [f'{docker_prefix}/hailgenetics/{name}' for name in ('hail', 'genetics', 'python-dill')]

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -795,7 +795,7 @@ class PythonJob(Job):
 
         # Create a batch object with a default Python image
 
-        b = Batch(default_python_image='gcr.io/hail-vdc/python-dill:3.7-slim')
+        b = Batch(default_python_image='hailgenetics/python-dill:3.7-slim')
 
         def multiply(x, y):
             return x * y
@@ -853,11 +853,11 @@ class PythonJob(Job):
         Examples
         --------
 
-        Set the job's docker image to `gcr.io/hail-vdc/python-dill:3.7-slim`:
+        Set the job's docker image to `hailgenetics/python-dill:3.7-slim`:
 
         >>> b = Batch()
         >>> j = b.new_python_job()
-        >>> (j.image('gcr.io/hail-vdc/python-dill:3.7-slim')
+        >>> (j.image('hailgenetics/python-dill:3.7-slim')
         ...   .call(print, 'hello'))
         >>> b.run()  # doctest: +SKIP
 


### PR DESCRIPTION
We should just treat `python-dill` like other images in the `hailgenetics` DockerHub repo and not hard-code our own registry into the docs