### PR TITLE
[docker] Cleanup mirror script

### DIFF
--- a/docker/hailgenetics/mirror_images.sh
+++ b/docker/hailgenetics/mirror_images.sh
@@ -16,7 +16,7 @@ then
     exit 1
 fi
 
-python_dill_images=(
+images=(
     "python-dill:3.7"
     "python-dill:3.7-slim"
     "python-dill:3.8"
@@ -25,18 +25,10 @@ python_dill_images=(
     "python-dill:3.9-slim"
     "python-dill:3.10"
     "python-dill:3.10-slim"
-)
-
-for image in "${python_dill_images[@]}"
-do
-    copy_image "hailgenetics/${image}" "${DOCKER_PREFIX}/hailgenetics/${image}"
-done
-
-pip_release_images=(
     "hail:${HAIL_PIP_VERSION}"
     "genetics:${HAIL_PIP_VERSION}"
 )
-for image in "${pip_release_images[@]}"
+for image in "${images[@]}"
 do
     copy_image "hailgenetics/${image}" "${DOCKER_PREFIX}/hailgenetics/${image}"
 done


### PR DESCRIPTION
A very uninteresting PR but just to show you more bits of the codebase that are relevant to our earlier `python-dill` bug. We publish a small collection of images in DockerHub that users can use, like `python-dill` and a `hail` image that includes the whole hail pip package. You can use these like `j.image('hailgenetics/hail')`. However, DockerHub sets severe rate limits that would throttle a large batch from pulling those images on N workers for sufficiently large N. So, we mirror these images in our private image registry in GCP / Azure. If a user submits a job with one of these images, we instead pull from our own registry instead. This script does the mirroring from DockerHub -> internal registry.