### PR TITLE
[batch] Return update-id from update-fast endpoint not batch id

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1304,7 +1304,7 @@ async def update_batch_fast(request, userdata):
             return web.json_response({'id': batch_id, 'start_job_id': start_job_id})
         raise
     await _commit_update(app, batch_id, update_id, user, db)
-    return web.json_response({'id': batch_id, 'start_job_id': start_job_id})
+    return web.json_response({'update_id': update_id, 'start_job_id': start_job_id})
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/updates/create')


### PR DESCRIPTION
This isn't used / breaking anything but I noticed that `update-fast` returns the batch id not the update id. The update id makes more sense and aligns with the create-fast endpoint where it returns the id of the thing that it made.