### PR TITLE
[batch] Return the start_job_id from _create_job_update when the update exists

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1338,14 +1338,14 @@ async def _create_batch_update(
         assert n_jobs > 0
         record = await tx.execute_and_fetchone(
             '''
-SELECT update_id FROM batch_updates
+SELECT update_id, start_job_id FROM batch_updates
 WHERE batch_id = %s AND token = %s;
 ''',
             (batch_id, update_token),
         )
 
         if record:
-            return record['update_id']
+            return record['update_id'], record['start_job_id']
 
         # We use FOR UPDATE so that we serialize batch update insertions
         # This is necessary to reserve job id ranges.


### PR DESCRIPTION
This will stuck any clients try to use the token-based idempotency, e.g. QoB