### PR TITLE
[query] Change indexed reads with filter_intervals=True to repartitio…

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1623,6 +1623,7 @@ class Tests(unittest.TestCase):
         mt.write(tmp, _partitions=parts)
 
         mt2 = hl.read_matrix_table(tmp)
+        assert mt2.aggregate_rows(hl.agg.all(hl.literal(hl.Interval(hl.Locus('20', 10277621), hl.Locus('20', 11898992))).contains(mt2.locus)))
         assert mt2.n_partitions() == len(parts)
         assert hl.filter_intervals(mt, parts)._same(mt2)
 

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -878,6 +878,34 @@ class Tests(unittest.TestCase):
         q = (vcf.locus >= l3) & (vcf.locus < l4)
         self.assertTrue(vcf.filter_rows(p | q)._same(mt))
 
+    def test_interval_filter_partitions(self):
+        mt = hl.utils.range_matrix_table(100, 3, 3)
+        path = new_temp_file()
+        mt.write(path)
+        intervals = [
+            hl.Interval(hl.Struct(idx=5), hl.Struct(idx=10)),
+            hl.Interval(hl.Struct(idx=12), hl.Struct(idx=13)),
+            hl.Interval(hl.Struct(idx=15), hl.Struct(idx=17)),
+            hl.Interval(hl.Struct(idx=19), hl.Struct(idx=20))
+        ]
+        assert hl.read_matrix_table(path, _intervals=intervals, _filter_intervals = True).n_partitions() == 1
+
+        intervals = [
+            hl.Interval(hl.Struct(idx=5), hl.Struct(idx=10)),
+            hl.Interval(hl.Struct(idx=12), hl.Struct(idx=13)),
+            hl.Interval(hl.Struct(idx=15), hl.Struct(idx=17)),
+
+            hl.Interval(hl.Struct(idx=45), hl.Struct(idx=50)),
+            hl.Interval(hl.Struct(idx=52), hl.Struct(idx=53)),
+            hl.Interval(hl.Struct(idx=55), hl.Struct(idx=57)),
+
+            hl.Interval(hl.Struct(idx=75), hl.Struct(idx=80)),
+            hl.Interval(hl.Struct(idx=82), hl.Struct(idx=83)),
+            hl.Interval(hl.Struct(idx=85), hl.Struct(idx=87)),
+        ]
+
+        assert hl.read_matrix_table(path, _intervals=intervals, _filter_intervals = True).n_partitions() == 3
+
     @fails_service_backend()
     def test_codecs_matrix(self):
         from hail.utils.java import scala_object

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1769,6 +1769,36 @@ def test_read_partitions_with_missing_key():
     assert hl.read_table(path, _n_partitions=10).n_partitions() == 1  # one key => one partition
 
 
+def test_interval_filter_partitions():
+    ht = hl.utils.range_table(100, 3)
+    path = new_temp_file()
+    ht.write(path)
+    intervals = [
+        hl.Interval(hl.Struct(idx=5), hl.Struct(idx=10)),
+        hl.Interval(hl.Struct(idx=12), hl.Struct(idx=13)),
+        hl.Interval(hl.Struct(idx=15), hl.Struct(idx=17)),
+        hl.Interval(hl.Struct(idx=19), hl.Struct(idx=20))
+    ]
+    assert hl.read_table(path, _intervals=intervals, _filter_intervals = True).n_partitions() == 1
+
+    intervals = [
+        hl.Interval(hl.Struct(idx=5), hl.Struct(idx=10)),
+        hl.Interval(hl.Struct(idx=12), hl.Struct(idx=13)),
+        hl.Interval(hl.Struct(idx=15), hl.Struct(idx=17)),
+
+        hl.Interval(hl.Struct(idx=45), hl.Struct(idx=50)),
+        hl.Interval(hl.Struct(idx=52), hl.Struct(idx=53)),
+        hl.Interval(hl.Struct(idx=55), hl.Struct(idx=57)),
+
+        hl.Interval(hl.Struct(idx=75), hl.Struct(idx=80)),
+        hl.Interval(hl.Struct(idx=82), hl.Struct(idx=83)),
+        hl.Interval(hl.Struct(idx=85), hl.Struct(idx=87)),
+    ]
+
+    assert hl.read_table(path, _intervals=intervals, _filter_intervals = True).n_partitions() == 3
+
+
+
 def test_grouped_flatmap_streams():
     ht = hl.import_vcf(resource('sample.vcf')).rows()
     ht = ht.annotate(x=hl.str(ht.locus))  # add a map node

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -241,7 +241,7 @@ class TableStage(
       repartitionNoShuffle(partitioner.strictify)
   }
 
-  def repartitionNoShuffle(newPartitioner: RVDPartitioner, allowDuplication: Boolean = false): TableStage = {
+  def repartitionNoShuffle(newPartitioner: RVDPartitioner, allowDuplication: Boolean = false, allowPartitionFilter: Boolean = false): TableStage = {
     if (newPartitioner == this.partitioner) {
       return this
     }
@@ -250,6 +250,30 @@ class TableStage(
       require(newPartitioner.satisfiesAllowedOverlap(newPartitioner.kType.size - 1))
     }
     require(newPartitioner.kType.isPrefixOf(kType))
+
+    val startAndEnd = partitioner.rangeBounds.map(newPartitioner.intervalRange)
+    if (startAndEnd.forall { case (start, end) => start + 1 == end }) {
+      val newToOld = startAndEnd.zipWithIndex
+        .groupBy(_._1._1)
+        .map { case (newIdx, values) => (newIdx, values.map(_._2).sorted.toFastIndexedSeq) }
+
+
+      val (oldPartIndices, newPartitionerFilt) = if (allowPartitionFilter) {
+        val indices = (0 until newPartitioner.numPartitions).filter(newToOld.contains)
+        (indices.map(i => newToOld(i)), newPartitioner.copy(rangeBounds = indices.toArray.map(i => newPartitioner.rangeBounds(i))))
+      } else
+        ((0 until newPartitioner.numPartitions).map(i => newToOld.getOrElse(i, FastIndexedSeq())), newPartitioner)
+      log.info(s"repartitionNoShuffle - fast path, generated ${oldPartIndices.length} partitions from ${partitioner.numPartitions}" +
+        s" (dropped ${newPartitioner.numPartitions - oldPartIndices.length} empty output parts)")
+
+      val newContexts = bindIR(ToArray(contexts)) { oldCtxs =>
+        mapIR(ToStream(Literal(TArray(TArray(TInt32)), oldPartIndices))) { inds =>
+          ToArray(mapIR(ToStream(inds)) { i => ArrayRef(oldCtxs, i) })
+        }
+      }
+      return TableStage(letBindings, broadcastVals, globals, newPartitionerFilt, dependency, newContexts,
+        (ctx: Ref) => flatMapIR(ToStream(ctx, true)) { oldCtx => partition(oldCtx) })
+    }
 
     val boundType = RVDPartitioner.intervalIRRepresentation(newPartitioner.kType)
     val partitionMapping: IndexedSeq[Row] = newPartitioner.rangeBounds.map { i =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -241,7 +241,7 @@ class TableStage(
       repartitionNoShuffle(partitioner.strictify)
   }
 
-  def repartitionNoShuffle(newPartitioner: RVDPartitioner, allowDuplication: Boolean = false, allowPartitionFilter: Boolean = false): TableStage = {
+  def repartitionNoShuffle(newPartitioner: RVDPartitioner, allowDuplication: Boolean = false, dropEmptyPartitions: Boolean = false): TableStage = {
     if (newPartitioner == this.partitioner) {
       return this
     }
@@ -261,7 +261,7 @@ class TableStage(
         .map { case (newIdx, values) => (newIdx, values.map(_._2).sorted.toFastIndexedSeq) }
 
 
-      val (oldPartIndices, newPartitionerFilt) = if (allowPartitionFilter) {
+      val (oldPartIndices, newPartitionerFilt) = if (dropEmptyPartitions) {
         val indices = (0 until newPartitioner.numPartitions).filter(newToOld.contains)
         (indices.map(i => newToOld(i)), newPartitioner.copy(rangeBounds = indices.toArray.map(i => newPartitioner.rangeBounds(i))))
       } else

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -252,8 +252,11 @@ class TableStage(
     require(newPartitioner.kType.isPrefixOf(kType))
 
     val startAndEnd = partitioner.rangeBounds.map(newPartitioner.intervalRange)
-    if (startAndEnd.forall { case (start, end) => start + 1 == end }) {
-      val newToOld = startAndEnd.zipWithIndex
+      .zipWithIndex
+    val ord = PartitionBoundOrdering.apply(newPartitioner.kType)
+    if (startAndEnd.forall { case ((start, end), index) =>
+      start + 1 == end && newPartitioner.rangeBounds(start).includes(ord, partitioner.rangeBounds(index)) }) {
+      val newToOld = startAndEnd
         .groupBy(_._1._1)
         .map { case (newIdx, values) => (newIdx, values.map(_._2).sorted.toFastIndexedSeq) }
 

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -183,7 +183,7 @@ object AbstractRVDSpec {
             contexts,
             body)
           if (filterIntervals)
-            ts.repartitionNoShuffle(partitioner, allowPartitionFilter = true)
+            ts.repartitionNoShuffle(partitioner, dropEmptyPartitions = true)
           else
             ts.repartitionNoShuffle(extendedNewPartitioner.coarsen(requestedKey.length))
         }
@@ -467,7 +467,7 @@ case class IndexedRVDSpec2(
           TableStageDependency.none,
           contexts,
           body)
-        if (filterIntervals) ts.repartitionNoShuffle(partitioner, allowPartitionFilter = true) else ts.repartitionNoShuffle(extendedNP)
+        if (filterIntervals) ts.repartitionNoShuffle(partitioner, dropEmptyPartitions = true) else ts.repartitionNoShuffle(extendedNP)
       }
 
     case None =>

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -183,7 +183,7 @@ object AbstractRVDSpec {
             contexts,
             body)
           if (filterIntervals)
-            ts
+            ts.repartitionNoShuffle(partitioner, allowPartitionFilter = true)
           else
             ts.repartitionNoShuffle(extendedNewPartitioner.coarsen(requestedKey.length))
         }
@@ -467,7 +467,7 @@ case class IndexedRVDSpec2(
           TableStageDependency.none,
           contexts,
           body)
-        if (filterIntervals) ts else ts.repartitionNoShuffle(extendedNP)
+        if (filterIntervals) ts.repartitionNoShuffle(partitioner, allowPartitionFilter = true) else ts.repartitionNoShuffle(extendedNP)
       }
 
     case None =>


### PR DESCRIPTION
…n back to the original partitioning

This means reading a 10-partition table with 100K intervals doesn't give you a 100k-partition table with tiny intervals.

Improved repartitionNoShuffle to have a fast path that drops partitions and produces no key comparisons.