### PR TITLE
[batch] Allow finer granularity for JVM memory settings

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -805,8 +805,8 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
 
         if spec['process']['type'] == 'jvm':
             jvm_requested_cpu = parse_cpu_in_mcpu(resources.get('cpu', BATCH_JOB_DEFAULT_CPU))
-            if 'cpu' in resources and jvm_requested_cpu not in (1000, 8000):
-                raise web.HTTPBadRequest(reason='invalid cpu for jvm jobs. must be 1 or 8')
+            if 'cpu' in resources and jvm_requested_cpu not in (1000, 2000, 4000, 8000):
+                raise web.HTTPBadRequest(reason='invalid cpu for jvm jobs. must be 1, 2, 4, or 8')
             if 'memory' in resources and resources['memory'] == 'lowmem':
                 raise web.HTTPBadRequest(reason='jvm jobs cannot be on lowmem machines')
             if 'storage' in resources:

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2308,11 +2308,11 @@ class Worker:
 
     async def _initialize_jvms(self):
         if instance_config.worker_type() in ('standard', 'D', 'highmem', 'E'):
-            jvms = await asyncio.gather(
-                *[JVM.create(i, 1, self) for i in range(CORES)],
-                *[JVM.create(CORES + i, 8, self) for i in range(CORES // 8)],
-            )
-            self._jvms.update(jvms)
+            jvms = []
+            for jvm_cores in (1, 2, 4, 8):
+                for _ in range(CORES // jvm_cores):
+                    jvms.append(JVM.create(len(jvms), jvm_cores, self))
+            self._jvms.update(await asyncio.gather(*jvms))
         log.info(f'JVMs initialized {self._jvms}')
 
     async def borrow_jvm(self, n_cores: int) -> JVM:

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -274,13 +274,13 @@ def init(sc=None, app_name=None, master=None, local='local[*]',
         Local temporary directory.  Used on driver and executor nodes.
         Must use the file scheme.  Defaults to TMPDIR, or /tmp.
     driver_cores : :class:`str` or :class:`int`, optional
-        Batch backend only. Number of cores to use for the driver process. May be 1 or 8. Default is
+        Batch backend only. Number of cores to use for the driver process. May be 1, 2, 4, or 8. Default is
         1.
     driver_memory : :class:`str`, optional
         Batch backend only. Memory tier to use for the driver process. May be standard or
         highmem. Default is standard.
     worker_cores : :class:`str` or :class:`int`, optional
-        Batch backend only. Number of cores to use for the worker processes. May be 1 or 8. Default is
+        Batch backend only. Number of cores to use for the worker processes. May be 1, 2, 4, or 8. Default is
         1.
     worker_memory : :class:`str`, optional
         Batch backend only. Memory tier to use for the worker processes. May be standard or


### PR DESCRIPTION
This is useful for tuning resource consumption of large QoB jobs.

#assign services