### PR TITLE
[compiler] Redesign streams to take outer region as init param.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -292,7 +292,7 @@ class BinarySearch[C](mb: EmitMethodBuilder[C],
   // for j in [i, n)
   findElt.emitWithBuilder[Int] { cb =>
     val haystack = findElt.getSCodeParam(1).asIndexable
-    val needle = findElt.getEmitParam(cb, 2, null) // no streams
+    val needle = findElt.getEmitParam(cb, 2)
 
     val f: (
       EmitCodeBuilder,

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -229,7 +229,7 @@ object CompileIterator {
         optStream.toI(cb).get(cb) // handle missing, but bound stream producer above
 
         cb.assign(producer.elementRegion, eltRegionField)
-        producer.initialize(cb)
+        producer.initialize(cb, outerRegion)
         cb.assign(didSetup, true)
         cb.assign(eosField, false)
       })

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -47,7 +47,7 @@ class EmitContext(
   val tryingToSplit: Memo[Unit]
 )
 
-case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[(EmitCodeBuilder, Value[Region]) => IEmitCode]) {
+case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[(EmitCodeBuilder) => IEmitCode]) {
   def bind(name: String, v: EmitValue): EmitEnv = copy(bindings = bindings.bind(name, v))
 
   def bind(newBindings: (String, EmitValue)*): EmitEnv = copy(bindings = bindings.bindIterable(newBindings))
@@ -839,7 +839,7 @@ class Emit[C](
 
     val result: IEmitCode = (ir: @unchecked) match {
       case In(i, expectedPType) =>
-        val ev = env.inputValues(i).apply(cb, region)
+        val ev = env.inputValues(i).apply(cb)
         ev
       case I32(x) =>
         presentPC(primitive(const(x)))
@@ -1145,7 +1145,7 @@ class Emit[C](
 
           def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]): Value[Boolean] = {
             cb.emb.ecb.getOrdering(sct.loadedSType, sct.loadedSType)
-              .ltNonnull(cb, sct.loadToSValue(cb, region, l), sct.loadToSValue(cb, region, r))
+              .ltNonnull(cb, sct.loadToSValue(cb, l), sct.loadToSValue(cb, r))
           }
 
           sorter.sort(cb, region, lessThan)
@@ -1170,9 +1170,9 @@ class Emit[C](
           val sorter = new ArraySorter(EmitRegion(mb, region), vab)
 
           def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]): Value[Boolean] = {
-            val lk = cb.memoize(sct.loadToSValue(cb, region, l).asBaseStruct.loadField(cb, 0))
+            val lk = cb.memoize(sct.loadToSValue(cb, l).asBaseStruct.loadField(cb, 0))
 
-            val rk = cb.memoize(sct.loadToSValue(cb, region, r).asBaseStruct.loadField(cb, 0))
+            val rk = cb.memoize(sct.loadToSValue(cb, r).asBaseStruct.loadField(cb, 0))
 
             cb.emb.ecb.getOrdering(lk.st, rk.st)
               .lt(cb, lk, rk, missingEqual = true)
@@ -1210,8 +1210,8 @@ class Emit[C](
           val sorter = new ArraySorter(EmitRegion(mb, region), sortedElts)
 
           def lt(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]): Value[Boolean] = {
-            val lk = cb.memoize(sct.loadToSValue(cb, region, l).asBaseStruct.loadField(cb, 0))
-            val rk = cb.memoize(sct.loadToSValue(cb, region, r).asBaseStruct.loadField(cb, 0))
+            val lk = cb.memoize(sct.loadToSValue(cb, l).asBaseStruct.loadField(cb, 0))
+            val rk = cb.memoize(sct.loadToSValue(cb, r).asBaseStruct.loadField(cb, 0))
 
             cb.emb.ecb.getOrdering(lk.st, rk.st)
               .lt(cb, lk, rk, missingEqual = true)
@@ -1334,7 +1334,7 @@ class Emit[C](
           val producer = stream.producer
           producer.length match {
             case Some(compLen) =>
-              producer.initialize(cb)
+              producer.initialize(cb, region)
               val xLen = cb.newLocal[Int]("streamlen_x", compLen(cb))
               producer.close(cb)
               primitive(xLen)
@@ -2118,7 +2118,7 @@ class Emit[C](
                 .map(cb)(pc => pc.castTo(cb, producer.elementRegion, stateEmitType.st)))
             }
 
-            producer.unmanagedConsume(cb) { cb =>
+            producer.unmanagedConsume(cb, region) { cb =>
               cb.assign(xElt, producer.element)
 
               if (producer.requiresMemoryManagementPerElement) {
@@ -2177,7 +2177,7 @@ class Emit[C](
               }
             }
 
-            producer.unmanagedConsume(cb) { cb =>
+            producer.unmanagedConsume(cb, region) { cb =>
               cb.assign(xElt, producer.element)
               if (producer.requiresMemoryManagementPerElement) {
                 (accVars, seq).zipped.foreach { (accVar, ir) =>
@@ -2666,8 +2666,8 @@ class Emit[C](
 
     sort.emitWithBuilder[Boolean] { cb =>
       val region = sort.getCodeParam[Region](1)
-      val leftEC = cb.memoize(EmitCode.present(sort, elemSCT.loadToSValue(cb, region, sort.getCodeParam(2)(elemSCT.ti))), "sort_leftEC")
-      val rightEC = cb.memoize(EmitCode.present(sort, elemSCT.loadToSValue(cb, region, sort.getCodeParam(3)(elemSCT.ti))), "sort_rightEC")
+      val leftEC = cb.memoize(EmitCode.present(sort, elemSCT.loadToSValue(cb, sort.getCodeParam(2)(elemSCT.ti))), "sort_leftEC")
+      val rightEC = cb.memoize(EmitCode.present(sort, elemSCT.loadToSValue(cb, sort.getCodeParam(3)(elemSCT.ti))), "sort_rightEC")
 
       if (leftRightComparatorNames.nonEmpty) {
         assert(leftRightComparatorNames.length == 2)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -820,7 +820,6 @@ abstract class PartitionReader {
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     context: EmitCode,
-    partitionRegion: Value[Region],
     requestedType: TStruct
   ): IEmitCode
 

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -65,7 +65,7 @@ class StagedArrayBuilder(val elt: SingleCodeType, val eltRequired: Boolean, mb: 
 
   def loadFromIndex(cb: EmitCodeBuilder, r: Value[Region], i: Code[Int]): IEmitCode = {
     val idx = cb.newLocal[Int]("loadFromIndex_idx", i)
-    IEmitCode(cb, isMissing(idx), elt.loadToSValue(cb, r, cb.memoizeAny(apply(idx), ti)))
+    IEmitCode(cb, isMissing(idx), elt.loadToSValue(cb, cb.memoizeAny(apply(idx), ti)))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -66,7 +66,6 @@ case class StringTablePartitionReader(lines: GenericLines, uidFieldName: String)
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     context: EmitCode,
-    partitionRegion: Value[Region],
     requestedType: TStruct
   ): IEmitCode = {
 
@@ -85,7 +84,7 @@ case class StringTablePartitionReader(lines: GenericLines, uidFieldName: String)
       SStreamValue(new StreamProducer {
         override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
-        override def initialize(cb: EmitCodeBuilder): Unit = {
+        override def initialize(cb: EmitCodeBuilder, partitionRegion: Value[Region]): Unit = {
           val contextAsJavaValue = coerce[Any](StringFunctions.svalueToJavaValue(cb, partitionRegion, partitionContext))
 
           cb.assign(fileName, partitionContext.loadField(cb, "file").get(cb).asString.loadString(cb))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -107,7 +107,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[Int], castKCode.emitParamType, typeInfo[Long]), typeInfo[Long]) { insertAt =>
       val node: Value[Long] = insertAt.getCodeParam[Long](1)
       val insertIdx: Value[Int] = insertAt.getCodeParam[Int](2)
-      val k: EmitValue = insertAt.getEmitParam(cb, 3, region)
+      val k: EmitValue = insertAt.getEmitParam(cb, 3)
       val child: Value[Long] = insertAt.getCodeParam[Long](4)
 
       def parent(cb: EmitCodeBuilder): Value[Long] = getParent(cb, node)
@@ -241,7 +241,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     val get = kb.genEmitMethod("btree_get", FastIndexedSeq[ParamType](typeInfo[Long], kc.emitParamType), typeInfo[Long])
     get.emitWithBuilder { cb =>
       val node = get.getCodeParam[Long](1)
-      val k = get.getEmitParam(cb, 2, region)
+      val k = get.getEmitParam(cb, 2)
 
       val cmp = cb.newLocal("btree_get_cmp", -1)
       val keyV = cb.newLocal("btree_get_keyV", 0L)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -447,7 +447,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
       mb.voidWithBuilder { cb =>
         val x = mb.getSCodeParam(1)
         val y = mb.getSCodeParam(2)
-        val l = mb.getEmitParam(cb, 3, region)
+        val l = mb.getEmitParam(cb, 3)
 
         def xx = x.asDouble.value
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -31,7 +31,7 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
       mb.emitWithBuilder { cb =>
         val off = mb.getCodeParam[Long](1)
         val ev1 = cb.memoize(loadCompKey(cb, off))
-        val ev2 = mb.getEmitParam(cb, 2, null) // don't need region
+        val ev2 = mb.getEmitParam(cb, 2) // don't need region
         comp(cb, ev1, ev2)
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
@@ -37,9 +37,9 @@ class NDArrayMultiplyAddAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAgg
     val seqOpMethod = cb.emb.genEmitMethod("ndarray_add_multiply_aggregator_seq_op",
       FastIndexedSeq(nextNDArrayACode.emitParamType, nextNDArrayBCode.emitParamType), CodeParamType(UnitInfo))
     seqOpMethod.voidWithBuilder { cb =>
-      val ndArrayAEmitCode = seqOpMethod.getEmitParam(cb, 1, null)
+      val ndArrayAEmitCode = seqOpMethod.getEmitParam(cb, 1)
       ndArrayAEmitCode.toI(cb).consume(cb, {}, { case checkA: SNDArrayValue =>
-        val ndArrayBEmitCode = seqOpMethod.getEmitParam(cb, 2, null)
+        val ndArrayBEmitCode = seqOpMethod.getEmitParam(cb, 2)
         ndArrayBEmitCode.toI(cb).consume(cb, {}, { case checkB: SNDArrayValue =>
           val tempRegionForCreation = cb.newLocal[Region]("ndarray_add_multily_agg_temp_region", Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
           val NDArrayA = LinalgCodeUtils.checkColMajorAndCopyIfNeeded(checkA, cb, tempRegionForCreation)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -36,7 +36,7 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
     val seqOpMethod = cb.emb.genEmitMethod("ndarray_sum_aggregator_seq_op", FastIndexedSeq(nextNDCode.emitParamType), CodeParamType(UnitInfo))
 
     seqOpMethod.voidWithBuilder { cb =>
-      val nextNDInput = seqOpMethod.getEmitParam(cb, 1, null) // no streams here
+      val nextNDInput = seqOpMethod.getEmitParam(cb, 1)
       nextNDInput.toI(cb).consume(cb, {}, { case nextNDPV: SNDArrayValue =>
         val statePV = state.storageType.loadCheapSCode(cb, state.off).asBaseStruct
         statePV.loadField(cb, ndarrayFieldNumber).consume(cb,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -168,7 +168,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     pushF.voidWithBuilder { cb =>
       pushImpl(cb,
         pushF.getCodeParam[Region](1),
-        pushF.getEmitParam(cb, 2, null)) // don't need region
+        pushF.getEmitParam(cb, 2))
     }
     cb.invokeVoid(pushF, region, elt)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -363,8 +363,8 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       UnitInfo)
 
     mb.voidWithBuilder { cb =>
-      val value = mb.getEmitParam(cb, 1, null) // don't need region
-      val key = mb.getEmitParam(cb, 2, null) // don't need region
+      val value = mb.getEmitParam(cb, 1)
+      val key = mb.getEmitParam(cb, 2)
 
       cb.ifx(maxSize > 0, {
         cb.ifx(ab.size < maxSize, {

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
@@ -115,8 +115,8 @@ abstract class CodeOrdering {
       FastIndexedSeq(arg1.emitParamType, arg2.emitParamType), ti) { mb =>
 
       mb.emitWithBuilder[T] { cb =>
-        val arg1 = mb.getEmitParam(cb, 1, null) // can't contain streams
-        val arg2 = mb.getEmitParam(cb, 2, null) // can't contain streams
+        val arg1 = mb.getEmitParam(cb, 1)
+        val arg2 = mb.getEmitParam(cb, 2)
         f(cb, arg1, arg2, missingEqual)
       }
     }

--- a/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
@@ -51,7 +51,6 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     context: EmitCode,
-    partitionRegion: Value[Region],
     requestedType: TStruct
   ): IEmitCode = {
     context.toI(cb).map(cb) { case ctxStruct: SBaseStructValue =>
@@ -73,7 +72,7 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
       val producer = new StreamProducer {
         val length: Option[EmitCodeBuilder => Code[Int]] = None
 
-        def initialize(cb: EmitCodeBuilder): Unit = {
+        def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
           val mb = cb.emb
           val codeSchema = cb.newLocal("schema", mb.getObject(schema))
           cb.assign(record, Code.newInstance[GenericData.Record, Schema](codeSchema))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
@@ -35,7 +35,7 @@ object SingleCodeType {
 sealed trait SingleCodeType {
   def ti: TypeInfo[_]
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue
 
   def virtualType: Type
 
@@ -49,7 +49,7 @@ case object Int32SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SInt32
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue = new SInt32Value(coerce[Int](c))
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SInt32Value(coerce[Int](c))
 
   def virtualType: Type = TInt32
 
@@ -62,7 +62,7 @@ case object Int64SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SInt64
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue = new SInt64Value(coerce[Long](c))
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SInt64Value(coerce[Long](c))
 
   def virtualType: Type = TInt64
 
@@ -75,7 +75,7 @@ case object Float32SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SFloat32
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue = new SFloat32Value(coerce[Float](c))
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SFloat32Value(coerce[Float](c))
 
   def virtualType: Type = TFloat32
 
@@ -88,7 +88,7 @@ case object Float64SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SFloat64
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue = new SFloat64Value(coerce[Double](c))
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SFloat64Value(coerce[Double](c))
 
   def virtualType: Type = TFloat64
 
@@ -101,7 +101,7 @@ case object BooleanSingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SBoolean
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue = new SBooleanValue(coerce[Boolean](c))
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SBooleanValue(coerce[Boolean](c))
 
   def virtualType: Type = TBoolean
 
@@ -118,7 +118,7 @@ case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, elt
 
   def ti: TypeInfo[_] = classInfo[StreamArgType]
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue = {
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = {
     val mb = cb.emb
     val xIter = mb.genFieldThisRef[Iterator[java.lang.Long]]("streamInIterator")
 
@@ -130,8 +130,8 @@ case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, elt
     val producer = new StreamProducer {
       override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
-      override def initialize(cb: EmitCodeBuilder): Unit = {
-        cb.assign(xIter, mkIter.invoke[Region, Region, Iterator[java.lang.Long]]("apply", r, eltRegion))
+      override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+        cb.assign(xIter, mkIter.invoke[Region, Region, Iterator[java.lang.Long]]("apply", outerRegion, eltRegion))
       }
 
       override val elementRegion: Settable[Region] = eltRegion
@@ -162,7 +162,7 @@ case class PTypeReferenceSingleCodeType(pt: PType) extends SingleCodeType {
 
   override def loadedSType: SType = pt.sType
 
-  def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue =
+  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
     cb.memoizeField(pt.loadCheapSCode(cb, coerce[Long](c)), "PTypeReferenceSingleCodeType")
 
   def virtualType: Type = pt.virtualType


### PR DESCRIPTION
This means we don't need out Emit params to take a region as arg to load, which was super messy.