### PR TITLE
[query/ggplot] Replaces cross-product legends with grouped ones

### DIFF
--- a/hail/python/hail/ggplot/__init__.py
+++ b/hail/python/hail/ggplot/__init__.py
@@ -4,7 +4,7 @@ from .aes import aes, Aesthetic # noqa F401
 from .geoms import FigureAttribute, geom_line, geom_point, geom_text, geom_bar,\
     geom_histogram, geom_density, geom_func, geom_hline, geom_vline, geom_tile,\
     geom_col, geom_area, geom_ribbon # noqa F401
-from .labels import ggtitle, xlab, ylab
+from .labels import ggtitle, xlab, ylab, labs
 from .scale import scale_x_continuous, scale_y_continuous, scale_x_discrete, scale_y_discrete, scale_x_genomic, \
     scale_x_log10, scale_y_log10, scale_x_reverse, scale_y_reverse, scale_color_discrete, scale_color_hue, scale_color_identity,\
     scale_color_manual, scale_color_continuous, scale_fill_discrete, scale_fill_hue, scale_fill_identity, scale_fill_continuous,\
@@ -30,6 +30,7 @@ __all__ = [
     "ggtitle",
     "xlab",
     "ylab",
+    "labs",
     "coord_cartesian",
     "scale_x_continuous",
     "scale_y_continuous",

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -27,6 +27,8 @@ class GGPlot:
     """
 
     def __init__(self, ht, aes, geoms=[], labels=Labels(), coord_cartesian=None, scales=None, facet=None):
+        self.is_static = False
+
         if scales is None:
             scales = {}
 
@@ -263,7 +265,7 @@ class GGPlot:
     def show(self):
         """Render and show the plot, either in a browser or notebook.
         """
-        self.to_plotly().show()
+        self.to_plotly().show(config={"staticPlot": self.is_static})
 
     def write_image(self, path):
         """Write out this plot as an image.

--- a/hail/python/hail/ggplot/labels.py
+++ b/hail/python/hail/ggplot/labels.py
@@ -2,10 +2,11 @@ from .geoms import FigureAttribute
 
 
 class Labels(FigureAttribute):
-    def __init__(self, title=None, xlabel=None, ylabel=None, **kwargs):
+    def __init__(self, title=None, xlabel=None, ylabel=None, group_labels={}, **kwargs):
         self.title = title
         self.xlabel = xlabel
         self.ylabel = ylabel
+        self.group_labels = group_labels
 
     def apply_to_fig(self, fig_so_far):
         layout_updates = {}
@@ -18,12 +19,16 @@ class Labels(FigureAttribute):
 
         fig_so_far.update_layout(**layout_updates)
 
+        for legend_group, label in self.group_labels.items():
+            fig_so_far.update_traces({"legendgrouptitle_text": label}, {"legendgroup": legend_group})
+
     def merge(self, other):
         new_title = other.title if other.title is not None else self.title
         new_xlabel = other.xlabel if other.xlabel is not None else self.xlabel
         new_ylabel = other.ylabel if other.ylabel is not None else self.ylabel
+        new_group_labels = {**self.group_labels, **other.group_labels}
 
-        return Labels(title=new_title, xlabel=new_xlabel, ylabel=new_ylabel)
+        return Labels(title=new_title, xlabel=new_xlabel, ylabel=new_ylabel, group_labels=new_group_labels)
 
 
 def ggtitle(label):
@@ -72,3 +77,34 @@ def ylab(label):
         Label object to change the y-axis label.
     """
     return Labels(ylabel=label)
+
+
+def labs(**group_labels):
+    """Sets the labels for the legend groups of a plot.
+
+    Examples
+    --------
+
+    Create a scatterplot and label the legend groups according to their field names:
+
+    >>> ht = hl.utils.range_table(10)
+    >>> ht = ht.annotate(squared=ht.idx ** 2)
+    >>> ht = ht.annotate(even=hl.if_else(ht.idx % 2 == 0, "yes", "no"))
+    >>> ht = ht.annotate(threeven=hl.if_else(ht.idx % 3 == 0, "good", "bad"))
+    >>> fig = (
+    ...     hl.ggplot.ggplot(ht, hl.ggplot.aes(x=ht.idx, y=ht.squared))
+    ...     + hl.ggplot.geom_point(hl.ggplot.aes(color=ht.even, shape=ht.threeven))
+    ...     + hl.ggplot.labs(color="Even", shape="Threeven")
+    ... )
+
+    Parameters
+    ----------
+    group_labels:
+        Map names of plotly ``legendgroup``s to the desired replacement labels.
+
+    Returns
+    -------
+    :class:`.FigureAttribute`
+        Label object to change the legend group labels.
+    """
+    return Labels(group_labels=group_labels)


### PR DESCRIPTION
Currently, `hail.ggplot.geom_point` generates cross-product-style legends when the `shape` and `color` aesthetics each have multiple groups. This change makes that behavior consistent with `ggplot2`'s implementation, producing legends where the groups are factored out. Because the strategy used to accomplish this does not preserve the interactive features of the legends, such as toggling groups' visibility, this change also makes all plots generated via `hail.ggplot.geom_point` [static](https://plotly.com/python/configuration-options/#making-a-static-chart).

For example, before this change, this code:

```python
import hail as hl
from hail.ggplot import ggplot, aes, geom_point
ht = hl.utils.range_table(10)
ht = ht.annotate(squared=ht.idx ** 2)
ht = ht.annotate(even=hl.if_else(ht.idx % 2 == 0, "yes", "no"))
ht = ht.annotate(threeven=hl.if_else(ht.idx % 3 == 0, "good", "bad"))
fig = (
    ggplot(ht, aes(x=ht.idx, y=ht.squared))
    + geom_point(aes(color=ht.even, shape=ht.threeven))
)
fig.show()
```

Generates this legend:

<img width="107" alt="Screen Shot 2022-09-29 at 12 22 57" src="https://user-images.githubusercontent.com/84595986/193085964-e4545e78-473f-46a3-8c8c-7d6189eb7adc.png">

After the change, this legend is generated:

<img width="102" alt="Screen Shot 2022-10-03 at 13 56 01" src="https://user-images.githubusercontent.com/84595986/193645748-b02ec35c-37c0-400e-b4d6-5c11a5d8df8c.png">

Custom labels can be used by updating the code like so:
```python
...
from hail.ggplot import ggplot, aes, geom_point, labs
...
fig = (
    ggplot(ht, aes(x=ht.idx, y=ht.squared))
    + geom_point(aes(color=ht.even, shape=ht.threeven))
    + labs(color="Even", shape="Threeven")
)
...
```

Generating this legend:

<img width="106" alt="Screen Shot 2022-10-03 at 13 58 34" src="https://user-images.githubusercontent.com/84595986/193646267-f935b880-94fe-4a1e-a8a8-b0f850b54a86.png">

For more information on the current behavior, see #12244 and #12207.