### PR TITLE
[docker] add new python third-party images

### DIFF
--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -5,13 +5,15 @@ google/cloud-sdk:305.0.0-slim
 jupyter/scipy-notebook
 jupyter/scipy-notebook:c094bb7219f9
 moby/buildkit:v0.8.3-rootless
-python:3.6
-python:3.6-slim
 python:3.7
 python:3.7-slim
 python:3.7-slim-stretch
 python:3.8
 python:3.8-slim
+python:3.9
+python:3.9-slim
+python:3.10
+python:3.10-slim
 redis:6.0.6-alpine
 ubuntu:18.04
 ubuntu:19.04


### PR DESCRIPTION
I figure we should keep this up to date with our supported python images. AFAIK, we currently only use the mirror of python:3.7. We don't expose any of them as publicly available images, but perhaps we should due to dockerhub rate limits? I suppose that's a question for another day.

We probably want to base our python-dill images on these so that docker hub can't just force push a new version of a tag and break our builds.