### PR TITLE
[batch] Add special-casing for Artifact Registry access denied message

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -444,6 +444,11 @@ class Image:
         except DockerError as e:
             if e.status == 404 and 'pull access denied' in e.message:
                 raise ImageCannotBePulled from e
+            if (
+                e.status == 500
+                and 'Permission "artifactregistry.repositories.downloadArtifacts" denied on resource' in e.message
+            ):
+                raise ImageCannotBePulled from e
             if 'not found: manifest unknown' in e.message:
                 raise ImageNotFound from e
             if 'Invalid repository name' in e.message:

--- a/build.yaml
+++ b/build.yaml
@@ -2728,7 +2728,6 @@ steps:
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
-      export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_GENETICS_HAIL_IMAGE="{{ hailgenetics_hail_image.image }}"
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -686,6 +686,8 @@ def is_transient_error(e):
     if aiodocker is not None and isinstance(e, aiodocker.exceptions.DockerError):
         if e.status == 500 and 'Invalid repository name' in e.message:
             return False
+        if e.status == 500 and 'Permission "artifactregistry.repositories.downloadArtifacts" denied on resource' in e.message:
+            return False
         return e.status in RETRYABLE_HTTP_STATUS_CODES
     if isinstance(e, TransientError):
         return True

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -21,7 +21,7 @@ from ..utils import skip_in_azure
 
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
-PYTHON_DILL_IMAGE = os.environ['PYTHON_DILL_IMAGE']
+PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.7'
 HAIL_GENETICS_HAIL_IMAGE = os.environ['HAIL_GENETICS_HAIL_IMAGE']
 
 class LocalTests(unittest.TestCase):
@@ -960,4 +960,3 @@ class ServiceTests(unittest.TestCase):
         assert batch_status['state'] == 'success', str((batch_status, batch.debug_info()))
         job_log_2 = batch.get_job_log(2)
         assert job_log_2['main'] == "6\n", str((job_log_2, batch.debug_info()))
-

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -21,7 +21,7 @@ from ..utils import skip_in_azure
 
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
-PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.7'
+PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.7-slim'
 HAIL_GENETICS_HAIL_IMAGE = os.environ['HAIL_GENETICS_HAIL_IMAGE']
 
 class LocalTests(unittest.TestCase):

--- a/hail/python/test/hailtop/batch/test_batch_pool_executor.py
+++ b/hail/python/test/hailtop/batch/test_batch_pool_executor.py
@@ -11,7 +11,7 @@ from hailtop.config import get_user_config
 from hailtop.utils import sync_sleep_and_backoff
 from hailtop.batch_client.client import BatchClient
 
-PYTHON_DILL_IMAGE = os.environ['PYTHON_DILL_IMAGE']
+PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.7'
 
 
 submitted_batch_ids = []


### PR DESCRIPTION
For some reason either artifact registry or aiodocker returns a 500 instead of a 403 when a service account does not have access to pull an image. Had to add another special case for handling this error.


https://console.cloud.google.com/logs/query;query=%22ys6od%22;pinnedLogId=2022-10-03T13:09:09.430766581Z%2Fyw46w2divo5eqk0vv;cursorTimestamp=2022-10-03T13:09:09.430766581Z?project=hail-vdc