### PR TITLE
[compiler] Redesign streams to take outer region as init param.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -66,7 +66,7 @@ object Emit {
     val region = mb.getCodeParam[Region](1)
     val returnTypeOption: Option[SingleCodeType] = if (ir.typ == TVoid) {
       fb.apply_method.voidWithBuilder { cb =>
-        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.getEmitParam(cb, i + 2))) // this, region, ...
+        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.storeEmitParamAsField(cb, i + 2))) // this, region, ...
         emitter.emitVoid(cb, ir, region, env, container, None)
       }
       None
@@ -74,7 +74,7 @@ object Emit {
       var sct: SingleCodeType = null
       fb.emitWithBuilder { cb =>
 
-        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.getEmitParam(cb, i + 2))) // this, region, ...
+        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.storeEmitParamAsField(cb, i + 2)))  // this, region, ...
         val sc = emitter.emitI(ir, cb, region, env, container, None).handle(cb, {
           cb._throw[RuntimeException](
             Code.newInstance[RuntimeException, String]("cannot return empty"))
@@ -585,6 +585,7 @@ class Emit[C](
     val mb = cb.emb.genEmitMethod(context, FastIndexedSeq[ParamType](), UnitInfo)
     val r = cb.newField[Region]("emitInSeparate_region", region)
 
+    println(s"emitting in separate method - $context:\n${Pretty(ctx.executeContext, ir)}")
     var ev: EmitSettable = null
     mb.voidWithBuilder { cb =>
       ctx.tryingToSplit.bind(ir, ())

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -47,7 +47,7 @@ class EmitContext(
   val tryingToSplit: Memo[Unit]
 )
 
-case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[(EmitCodeBuilder) => IEmitCode]) {
+case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[EmitValue]) {
   def bind(name: String, v: EmitValue): EmitEnv = copy(bindings = bindings.bind(name, v))
 
   def bind(newBindings: (String, EmitValue)*): EmitEnv = copy(bindings = bindings.bindIterable(newBindings))
@@ -66,7 +66,7 @@ object Emit {
     val region = mb.getCodeParam[Region](1)
     val returnTypeOption: Option[SingleCodeType] = if (ir.typ == TVoid) {
       fb.apply_method.voidWithBuilder { cb =>
-        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.storeEmitParam(i + 2, cb))) // this, region, ...
+        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.getEmitParam(cb, i + 2))) // this, region, ...
         emitter.emitVoid(cb, ir, region, env, container, None)
       }
       None
@@ -74,7 +74,7 @@ object Emit {
       var sct: SingleCodeType = null
       fb.emitWithBuilder { cb =>
 
-        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.storeEmitParam(i + 2, cb))) // this, region, ...
+        val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.getEmitParam(cb, i + 2))) // this, region, ...
         val sc = emitter.emitI(ir, cb, region, env, container, None).handle(cb, {
           cb._throw[RuntimeException](
             Code.newInstance[RuntimeException, String]("cannot return empty"))
@@ -663,7 +663,7 @@ class Emit[C](
         emitStream(a, region).toI(cb).consume(cb,
           {},
           { case stream: SStreamValue =>
-            val producer = stream.producer
+            val producer = stream.getProducer(mb)
             producer.memoryManagedConsume(region, cb) { cb =>
               cb.withScopedMaybeStreamValue(producer.element, s"streamfor_$valueName") { ev =>
                 emitVoid(body, region = producer.elementRegion, env = env.bind(valueName -> ev))
@@ -839,8 +839,8 @@ class Emit[C](
 
     val result: IEmitCode = (ir: @unchecked) match {
       case In(i, expectedPType) =>
-        val ev = env.inputValues(i).apply(cb)
-        ev
+        val ev = env.inputValues(i)
+        ev.toI(cb)
       case I32(x) =>
         presentPC(primitive(const(x)))
       case I64(x) =>
@@ -1122,12 +1122,12 @@ class Emit[C](
 
       case x@ArraySort(a, left, right, lessThan) =>
         emitStream(a, cb, region).map(cb) { case stream: SStreamValue =>
-          val producer = stream.producer
+          val producer = stream.getProducer(mb)
 
           val sct = SingleCodeType.fromSType(producer.element.st)
 
           val vab = new StagedArrayBuilder(sct, producer.element.required, mb, 0)
-          StreamUtils.writeToArrayBuilder(cb, stream.producer, vab, region)
+          StreamUtils.writeToArrayBuilder(cb, producer, vab, region)
           val sorter = new ArraySorter(EmitRegion(mb, region), vab)
           sorter.sort(cb, region, makeDependentSortingFunction(cb, sct, lessThan, env, emitSelf, Array(left, right)))
           sorter.toRegion(cb, x.typ)
@@ -1135,12 +1135,12 @@ class Emit[C](
 
       case x@ToSet(a) =>
         emitStream(a, cb, region).map(cb) { case stream: SStreamValue =>
-          val producer = stream.producer
+          val producer = stream.getProducer(mb)
 
           val sct = SingleCodeType.fromSType(producer.element.st)
 
           val vab = new StagedArrayBuilder(sct, producer.element.required, mb, 0)
-          StreamUtils.writeToArrayBuilder(cb, stream.producer, vab, region)
+          StreamUtils.writeToArrayBuilder(cb, producer, vab, region)
           val sorter = new ArraySorter(EmitRegion(mb, region), vab)
 
           def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]): Value[Boolean] = {
@@ -1161,12 +1161,12 @@ class Emit[C](
 
       case x@ToDict(a) =>
         emitStream(a, cb, region).map(cb) { case stream: SStreamValue =>
-          val producer = stream.producer
+          val producer = stream.getProducer(mb)
 
           val sct = SingleCodeType.fromSType(producer.element.st)
 
           val vab = new StagedArrayBuilder(sct, producer.element.required, mb, 0)
-          StreamUtils.writeToArrayBuilder(cb, stream.producer, vab, region)
+          StreamUtils.writeToArrayBuilder(cb, producer, vab, region)
           val sorter = new ArraySorter(EmitRegion(mb, region), vab)
 
           def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]): Value[Boolean] = {
@@ -1204,9 +1204,10 @@ class Emit[C](
       case GroupByKey(collection) =>
         emitStream(collection, cb, region).map(cb) { case stream: SStreamValue =>
 
-          val sct = SingleCodeType.fromSType(stream.producer.element.st)
-          val sortedElts = new StagedArrayBuilder(sct, stream.producer.element.required, mb, 16)
-          StreamUtils.writeToArrayBuilder(cb, stream.producer, sortedElts, region)
+          val producer = stream.getProducer(mb)
+          val sct = SingleCodeType.fromSType(producer.element.st)
+          val sortedElts = new StagedArrayBuilder(sct, producer.element.required, mb, 16)
+          StreamUtils.writeToArrayBuilder(cb, producer, sortedElts, region)
           val sorter = new ArraySorter(EmitRegion(mb, region), sortedElts)
 
           def lt(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]): Value[Boolean] = {
@@ -1331,7 +1332,7 @@ class Emit[C](
 
       case x@StreamLen(a) =>
         emitStream(a, cb, region).map(cb) { case stream: SStreamValue =>
-          val producer = stream.producer
+          val producer = stream.getProducer(mb)
           producer.length match {
             case Some(compLen) =>
               producer.initialize(cb, region)
@@ -1345,7 +1346,7 @@ class Emit[C](
                 cb.assign(count, count + 1)
               }
               producer.element.pv match {
-                case SStreamValue(_, nested) => StreamProducer.defineUnusedLabels(nested, mb)
+                case ss: SStreamValue => ss.defineUnusedLabels(mb)
                 case _ =>
               }
               primitive(count)
@@ -1435,7 +1436,7 @@ class Emit[C](
                       })
 
                       val (firstElementAddress, finisher) = xP.constructDataFunction(shapeValues, stridesSettables, cb, region)
-                      StreamUtils.storeNDArrayElementsAtAddress(cb, stream.producer, region, firstElementAddress, errorId)
+                      StreamUtils.storeNDArrayElementsAtAddress(cb, stream.getProducer(mb), region, firstElementAddress, errorId)
                       finisher(cb)
                   }
             }
@@ -2090,12 +2091,12 @@ class Emit[C](
 
       case ToArray(a) =>
         EmitStream.produce(this, a, cb, region, env, container)
-          .map(cb) { case stream: SStreamValue => StreamUtils.toArray(cb, stream.producer, region) }
+          .map(cb) { case stream: SStreamValue => StreamUtils.toArray(cb, stream.getProducer(mb), region) }
 
       case x@StreamFold(a, zero, accumName, valueName, body) =>
         EmitStream.produce(this, a, cb, region, env, container)
           .flatMap(cb) { case stream: SStreamValue =>
-            val producer = stream.producer
+            val producer = stream.getProducer(mb)
 
             val stateEmitType = VirtualTypeWithReq(zero.typ, ctx.req.lookupState(x).head.asInstanceOf[TypeWithRequiredness]).canonicalEmitType
 
@@ -2145,7 +2146,7 @@ class Emit[C](
       case x@StreamFold2(a, acc, valueName, seq, res) =>
         emitStream(a, cb, region)
           .flatMap(cb) { case stream: SStreamValue =>
-            val producer = stream.producer
+            val producer = stream.getProducer(mb)
 
             var tmpRegion: Settable[Region] = null
 
@@ -2445,7 +2446,7 @@ class Emit[C](
           cb.assign(baos, Code.newInstance[ByteArrayOutputStream]())
           cb.assign(buf, contextSpec.buildCodeOutputBuffer(baos)) // TODO: take a closer look at whether we need two codec buffers?
           cb.assign(ctxab, Code.newInstance[ByteArrayArrayBuilder, Int](16))
-          addContexts(cb, ctxStream.producer)
+          addContexts(cb, ctxStream.getProducer(mb))
           cb += baos.invoke[Unit]("reset")
           addGlobals(cb)
 
@@ -2625,7 +2626,7 @@ class Emit[C](
         val streamCode = emitStream(stream, region)
         EmitCode.fromI(mb) { cb =>
           streamCode.toI(cb).flatMap(cb) { case stream: SStreamValue =>
-            writer.consumeStream(ctx.executeContext, cb, stream.producer, ctxCode, region)
+            writer.consumeStream(ctx.executeContext, cb, stream.getProducer(mb), ctxCode, region)
           }
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -946,7 +946,13 @@ class EmitMethodBuilder[C](
     })
   }
 
-  // needs region to support stream arguments
+  def storeEmitParamAsField(cb: EmitCodeBuilder, emitIndex: Int): EmitValue = {
+    val param = getEmitParam(cb, emitIndex)
+    val fd = newEmitField(s"${mb.methodName}_param_${emitIndex}", param.emitType)
+    cb.assign(fd, param)
+    fd
+  }
+
   def getEmitParam(cb: EmitCodeBuilder, emitIndex: Int): EmitValue = {
     assert(mb.isStatic || emitIndex != 0)
     val static = (!mb.isStatic).toInt
@@ -973,7 +979,6 @@ class EmitMethodBuilder[C](
         EmitValue(m, v)
     }
   }
-
 
   def invokeCode[T](cb: CodeBuilderLike, args: Param*): Value[T] = {
     assert(emitReturnType.isInstanceOf[CodeParamType])

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -191,7 +191,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
       }
       val res = f(ev)
       ec.pv match {
-        case SStreamValue(_, producer) => StreamProducer.defineUnusedLabels(producer, emb)
+        case ss: SStreamValue => ss.defineUnusedLabels(emb)
       }
       res
     }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -180,10 +180,11 @@ object EmitStreamDistribute {
     // in splitters list. Since We don't want many empty files, we need to make an array mapping output buckets to files.
 
     val encoder = spec.encodedType.buildEncoder(childStream.st.elementType, cb.emb.ecb)
-    childStream.producer.memoryManagedConsume(region, cb) { cb =>
+    val producer = childStream.getProducer(mb)
+    producer.memoryManagedConsume(region, cb) { cb =>
       val b = cb.newLocal[Int]("stream_dist_b_i", 1)
       val current = mb.newEmitField("stream_dist_current", childStream.st.elementEmitType)
-      cb.assign(current, childStream.producer.element)
+      cb.assign(current, producer.element)
 
       val r = cb.newLocal[Int]("stream_dist_r")
       cb.forLoop(cb.assign(r, 0), r < treeHeight, cb.assign(r, r + 1), {

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -70,6 +70,7 @@ class PartitionIteratorLongReader(
       val rv = mb.genFieldThisRef[Long]("pilr_rv")
 
       val producer = new StreamProducer {
+        override def method: EmitMethodBuilder[_] = cb.emb
         override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
         override def initialize(cb: EmitCodeBuilder, partitionRegion: Value[Region]): Unit = {
@@ -104,7 +105,7 @@ class PartitionIteratorLongReader(
         override def close(cb: EmitCodeBuilder): Unit = {}
       }
 
-      SStreamValue(SStream(producer.element.emitType), producer)
+      SStreamValue(producer)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -723,8 +723,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.fromPType(spec.encodedType.decodedPType(rt))
       case In(_, t) => t match {
         case SCodeEmitParamType(et) => requiredness.unionFrom(et.typeWithRequiredness.r)
-        case SingleCodeEmitParamType(required, StreamSingleCodeType(_, eltType)) =>
-          requiredness.asInstanceOf[RIterable].elementType.fromPType(eltType)
+        case SingleCodeEmitParamType(required, StreamSingleCodeType(_, eltType, eltRequired)) =>
+          requiredness.asInstanceOf[RIterable].elementType.fromPType(eltType.setRequired(eltRequired))
           requiredness.union(required)
         case SingleCodeEmitParamType(required, PTypeReferenceSingleCodeType(pt)) =>
           requiredness.fromPType(pt.setRequired(required))

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -82,6 +82,7 @@ case class StringTablePartitionReader(lines: GenericLines, uidFieldName: String)
       val rowIdx = cb.emb.genFieldThisRef[Long]("rowIdx")
 
       SStreamValue(new StreamProducer {
+        override def method: EmitMethodBuilder[_] = cb.emb
         override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
         override def initialize(cb: EmitCodeBuilder, partitionRegion: Value[Region]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -2163,15 +2163,17 @@ case class TableMapPartitions(child: TableIR,
     val fsBc = tv.ctx.fsBc
     val itF = { (idx: Int, consumerCtx: RVDContext, partition: (RVDContext) => Iterator[Long]) =>
       val boxedPartition = new NoBoxLongIterator {
+        var eos: Boolean = false
         var iter: Iterator[Long] = _
         override def init(partitionRegion: Region, elementRegion: Region): Unit = {
           iter = partition(new RVDContext(partitionRegion, elementRegion))
         }
 
         override def next(): Long = {
-          if (!iter.hasNext)
-            -1L
-          else
+          if (!iter.hasNext) {
+            eos = true
+            0L
+          } else
             iter.next()
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -8,7 +8,7 @@ import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.expr.ir
 import is.hail.expr.ir.functions.{BlockMatrixToTableFunction, MatrixToTableFunction, StringFunctions, TableToTableFunction}
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage, TableStageDependency}
-import is.hail.expr.ir.streams.{StreamArgType, StreamProducer}
+import is.hail.expr.ir.streams.StreamProducer
 import is.hail.io._
 import is.hail.io.avro.AvroTableReader
 import is.hail.io.fs.FS
@@ -19,7 +19,7 @@ import is.hail.sparkextras.ContextRDD
 import is.hail.types._
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.concrete._
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructValue, SStreamValue, primitive}
+import is.hail.types.physical.stypes.interfaces.{NoBoxLongIterator, SBaseStruct, SBaseStructValue, SStreamValue, primitive}
 import is.hail.types.physical.stypes.primitives.{SInt64, SInt64Value}
 import is.hail.types.physical.stypes._
 import is.hail.types.virtual._
@@ -576,6 +576,7 @@ case class PartitionRVDReader(rvd: RVD, uidFieldName: String) extends PartitionR
       val broadcastRVD = mb.getObject[BroadcastRVD](new BroadcastRVD(ctx.backend.asSpark("RVDReader"), rvd))
 
       val producer = new StreamProducer {
+        override def method: EmitMethodBuilder[_] = cb.emb
         override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
         override def initialize(cb: EmitCodeBuilder, partitionRegion: Value[Region]): Unit = {
@@ -674,6 +675,7 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec, uidFieldName: Str
       val region = mb.genFieldThisRef[Region]("pnr_region")
 
       val producer = new StreamProducer {
+        override def method: EmitMethodBuilder[_] = cb.emb
         override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
         override def initialize(cb: EmitCodeBuilder, partitionRegion: Value[Region]): Unit = {
@@ -757,6 +759,7 @@ case class PartitionNativeReaderIndexed(
       val decodedRow = cb.emb.newPField("rowsValue", eltSType)
 
       val producer = new StreamProducer {
+        override def method: EmitMethodBuilder[_] = cb.emb
         override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => (endIdx - curIdx).toI)
 
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -884,12 +887,13 @@ case class PartitionZippedNativeReader(left: PartitionReader, right: PartitionRe
       left.emitStream(ctx, cb, ctx1, lRequested).flatMap(cb) { sstream1 =>
         right.emitStream(ctx, cb, ctx2, rRequested).map(cb) { sstream2 =>
 
-          val stream1 = sstream1.asStream.producer
-          val stream2 = sstream2.asStream.producer
+          val stream1 = sstream1.asStream.getProducer(cb.emb)
+          val stream2 = sstream2.asStream.getProducer(cb.emb)
 
           val region = cb.emb.genFieldThisRef[Region]("partition_zipped_reader_region")
 
           SStreamValue(new StreamProducer {
+            override def method: EmitMethodBuilder[_] = cb.emb
             override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1018,6 +1022,7 @@ case class PartitionZippedIndexedNativeReader(specLeft: AbstractTypedCodecSpec, 
       val rightValue = mb.newPField("rightValue", specRight.encodedType.decodedSType(rightRType))
 
       val producer = new StreamProducer {
+        override def method: EmitMethodBuilder[_] = cb.emb
         override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => (endIdx - curIdx).toI)
 
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -2151,17 +2156,28 @@ case class TableMapPartitions(child: TableIR,
       globalPType, rowPType,
       Subst(body, BindingEnv(Env(
         globalName -> In(0, SingleCodeEmitParamType(true, PTypeReferenceSingleCodeType(globalPType))),
-        partitionStreamName -> In(1, SingleCodeEmitParamType(true, StreamSingleCodeType(requiresMemoryManagementPerElement = true, rowPType)))))))
+        partitionStreamName -> In(1, SingleCodeEmitParamType(true, StreamSingleCodeType(requiresMemoryManagementPerElement = true, rowPType, true)))))))
 
     val globalsBc = tv.globals.broadcast(ctx.theHailClassLoader)
 
     val fsBc = tv.ctx.fsBc
     val itF = { (idx: Int, consumerCtx: RVDContext, partition: (RVDContext) => Iterator[Long]) =>
-      val boxedPartition = new StreamArgType {
-        def apply(outerRegion: Region, eltRegion: Region): Iterator[java.lang.Long] =
-          partition(new RVDContext(outerRegion, eltRegion)).map(box)
+      val boxedPartition = new NoBoxLongIterator {
+        var iter: Iterator[Long] = _
+        override def init(partitionRegion: Region, elementRegion: Region): Unit = {
+          iter = partition(new RVDContext(partitionRegion, elementRegion))
+        }
+
+        override def next(): Long = {
+          if (!iter.hasNext)
+            -1L
+          else
+            iter.next()
+        }
+
+        override def close(): Unit = ()
       }
-      makeIterator(theHailClassLoaderForSparkWorkers, fsBc.value, idx, consumerCtx,
+    makeIterator(theHailClassLoaderForSparkWorkers, fsBc.value, idx, consumerCtx,
         globalsBc.value.readRegionValue(consumerCtx.partitionRegion, theHailClassLoaderForSparkWorkers),
         boxedPartition
       ).map(l => l.longValue())

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -399,7 +399,7 @@ object EmitStream {
         val emittedArgs = args.map(a => EmitCode.fromI(mb)(cb => emit(a, cb, region))).toFastIndexedSeq
 
         // FIXME use SType.chooseCompatibleType
-        val unifiedType = typeWithReq.canonicalEmitType
+        val unifiedType = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream].elementEmitType
         val eltField = mb.newEmitField("makestream_elt", unifiedType)
 
         val staticLen = args.size

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -16,28 +16,11 @@ import is.hail.types.{TypeWithRequiredness, VirtualTypeWithReq}
 import is.hail.utils._
 
 
-object StreamProducer {
-  def defineUnusedLabels(producer: StreamProducer, mb: EmitMethodBuilder[_]): Unit = {
-    (producer.LendOfStream.isImplemented, producer.LproduceElementDone.isImplemented) match {
-      case (true, true) =>
-      case (false, false) =>
-
-        EmitCodeBuilder.scopedVoid(mb) { cb =>
-          cb.define(producer.LendOfStream)
-          cb.define(producer.LproduceElementDone)
-          cb._fatal("unreachable")
-        }
-
-      case (eos, ped) => throw new RuntimeException(s"unrealizable value unused asymmetrically: eos=$eos, ped=$ped")
-    }
-    producer.element.pv match {
-      case SStreamValue(_, nested) => defineUnusedLabels(nested, mb)
-      case _ =>
-    }
-  }
-}
-
 abstract class StreamProducer {
+
+  // method builder where this stream is valid
+  def method: EmitMethodBuilder[_]
+
   /**
     * Stream length, which is present if it can be computed (somewhat) cheaply without
     * consuming the stream.
@@ -173,6 +156,7 @@ object EmitStream {
         val st = SStream(EmitType(SUnreachable.fromVirtualType(_typ.elementType), true))
         val region = mb.genFieldThisRef[Region]("na_region")
         val producer = new StreamProducer {
+          override def method: EmitMethodBuilder[_] = mb
           override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {}
 
           override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => Code._fatal[Int]("tried to get NA stream length"))
@@ -191,8 +175,9 @@ object EmitStream {
         assert(_typ.isInstanceOf[TStream])
         env.bindings.lookup(name).toI(cb)
           .map(cb) { case stream: SStreamValue =>
-            val childProducer = stream.producer
+            val childProducer = stream.getProducer(mb)
             val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = childProducer.initialize(cb, outerRegion)
 
               override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
@@ -210,7 +195,7 @@ object EmitStream {
             mb.implementLabel(childProducer.LendOfStream) { cb =>
               cb.goto(producer.LendOfStream)
             }
-            stream.copy(producer = producer)
+            SStreamValue(producer)
           }
 
       case Let(name, value, body) =>
@@ -220,7 +205,7 @@ object EmitStream {
 
       case In(n, _) =>
         // this, Code[Region], ...
-        val param = env.inputValues(n).apply(cb)
+        val param = env.inputValues(n).toI(cb)
         if (!param.st.isInstanceOf[SStream])
           throw new RuntimeException(s"parameter ${ 2 + n } is not a stream! t=${ param.st } }, params=${ mb.emitParamTypes }")
         param
@@ -235,6 +220,7 @@ object EmitStream {
 
           SStreamValue(
             new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
                 cb.assign(containerField, ind)
                 cb.assign(idx, -1)
@@ -265,7 +251,7 @@ object EmitStream {
         val region = mb.genFieldThisRef[Region]("stream_buff_agg_region")
         produce(streamChild, cb)
           .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.producer
+            val childProducer = childStream.getProducer(mb)
             val eltField = mb.newEmitField("stream_buff_agg_elt", childProducer.element.emitType)
             val newKeyVType = typeWithReqx(newKey)
             val kb = mb.ecb
@@ -287,6 +273,7 @@ object EmitStream {
             val childStreamEnded = mb.genFieldThisRef[Boolean]("stream_buff_agg_child_stream_ended")
             val produceElementMode = mb.genFieldThisRef[Boolean]("stream_buff_agg_child_produce_elt_mode")
             val producer: StreamProducer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -412,16 +399,15 @@ object EmitStream {
         val emittedArgs = args.map(a => EmitCode.fromI(mb)(cb => emit(a, cb, region))).toFastIndexedSeq
 
         // FIXME use SType.chooseCompatibleType
-        val st = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream]
-        val unifiedType = st.elementEmitType
+        val unifiedType = typeWithReq.canonicalEmitType
         val eltField = mb.newEmitField("makestream_elt", unifiedType)
 
         val staticLen = args.size
         val current = mb.genFieldThisRef[Int]("makestream_current")
 
         IEmitCode.present(cb, SStreamValue(
-          st,
           new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
               cb.assign(current, 0) // switches on 1..N
             }
@@ -466,8 +452,8 @@ object EmitStream {
           val leftEC = EmitCode.fromI(mb)(cb => produce(cnsq, cb))
           val rightEC = EmitCode.fromI(mb)(cb => produce(altr, cb))
 
-          val leftProducer = leftEC.pv.asStream.producer
-          val rightProducer = rightEC.pv.asStream.producer
+          val leftProducer = leftEC.pv.asStream.getProducer(mb)
+          val rightProducer = rightEC.pv.asStream.getProducer(mb)
 
           val unifiedStreamSType = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream]
           val unifiedElementType = unifiedStreamSType.elementEmitType
@@ -480,6 +466,7 @@ object EmitStream {
             rightEC.toI(cb).consume(cb, cb.goto(Lmissing), _ => cb.goto(Lpresent)))
 
           val producer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] = leftProducer.length
               .liftedZip(rightProducer.length).map { case (computeL1, computeL2) =>
               cb: EmitCodeBuilder => {
@@ -538,6 +525,7 @@ object EmitStream {
             val stepVar = mb.genFieldThisRef[Int]("streamrange_stop")
             val regionVar = mb.genFieldThisRef[Region]("sr_region")
             val producer: StreamProducer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -571,6 +559,7 @@ object EmitStream {
             val stopVar = mb.genFieldThisRef[Int]("streamrange_stop")
             val regionVar = mb.genFieldThisRef[Region]("sr_region")
             val producer: StreamProducer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = Some({ cb =>
                 val len = cb.newLocal[Int]("streamrange_len")
                 if (step > 0)
@@ -635,6 +624,7 @@ object EmitStream {
               val idx = mb.genFieldThisRef[Int]("streamrange_idx")
 
               val producer: StreamProducer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
                 override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => len)
 
                 override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -701,6 +691,7 @@ object EmitStream {
             val elementToReturn = cb.newField[Int]("seq_sample_element_to_return", -1) // -1 should never be returned.
 
             val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => len)
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -741,13 +732,14 @@ object EmitStream {
       case StreamFilter(a, name, cond) =>
         produce(a, cb)
           .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.producer
+            val childProducer = childStream.getProducer(mb)
 
             val filterEltRegion = mb.genFieldThisRef[Region]("streamfilter_filter_region")
 
             val elementField = cb.emb.newEmitField("streamfilter_cond", childProducer.element.emitType)
 
             val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -806,11 +798,12 @@ object EmitStream {
         produce(a, cb)
           .flatMap(cb) { case childStream: SStreamValue =>
             emit(num, cb).map(cb) { case num: SInt32Value =>
-              val childProducer = childStream.producer
+              val childProducer = childStream.getProducer(mb)
               val n = mb.genFieldThisRef[Int]("stream_take_n")
               val idx = mb.genFieldThisRef[Int]("stream_take_idx")
 
               val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
                 override val length: Option[EmitCodeBuilder => Code[Int]] =
                   childProducer.length.map(compLen => (cb: EmitCodeBuilder) => compLen(cb).min(n))
 
@@ -849,11 +842,12 @@ object EmitStream {
         produce(a, cb)
           .flatMap(cb) { case (childStream: SStreamValue) =>
             emit(num, cb).map(cb) { case num: SInt32Value =>
-              val childProducer = childStream.producer
+              val childProducer = childStream.getProducer(mb)
               val n = mb.genFieldThisRef[Int]("stream_drop_n")
               val idx = mb.genFieldThisRef[Int]("stream_drop_idx")
 
               val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
                 override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length.map { computeL =>
                   (cb: EmitCodeBuilder) => (computeL(cb) - n).max(0)
                 }
@@ -895,11 +889,12 @@ object EmitStream {
       case StreamTakeWhile(a, elt, condIR) =>
         produce(a, cb)
           .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.producer
+            val childProducer = childStream.getProducer(mb)
 
             val eltSettable = mb.newEmitField("stream_take_while_elt", childProducer.element.emitType)
 
             val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -937,11 +932,12 @@ object EmitStream {
       case StreamDropWhile(a, elt, condIR) =>
         produce(a, cb)
           .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.producer
+            val childProducer = childStream.getProducer(mb)
             val eltSettable = mb.newEmitField("stream_drop_while_elt", childProducer.element.emitType)
             val doneComparisons = mb.genFieldThisRef[Boolean]("stream_drop_while_donecomparisons")
 
             val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -993,7 +989,7 @@ object EmitStream {
       case StreamMap(a, name, body) =>
         produce(a, cb)
           .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.producer
+            val childProducer = childStream.getProducer(mb)
 
             val bodyResult = EmitCode.fromI(mb) { cb =>
               cb.withScopedMaybeStreamValue(childProducer.element, "streammap_element") { childProducerElement =>
@@ -1005,6 +1001,7 @@ object EmitStream {
             }
 
             val producer: StreamProducer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1035,7 +1032,7 @@ object EmitStream {
 
       case x@StreamScan(childIR, zeroIR, accName, eltName, bodyIR) =>
         produce(childIR, cb).map(cb) { case childStream: SStreamValue =>
-          val childProducer = childStream.producer
+          val childProducer = childStream.getProducer(mb)
 
           val accEmitType = VirtualTypeWithReq(zeroIR.typ, emitter.ctx.req.lookupState(x).head.asInstanceOf[TypeWithRequiredness]).canonicalEmitType
 
@@ -1047,6 +1044,7 @@ object EmitStream {
           val first = mb.genFieldThisRef[Boolean]("streamscan_first")
 
           val producer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] =
               childProducer.length.map(compL => (cb: EmitCodeBuilder) => compL(cb) + const(1))
 
@@ -1121,7 +1119,7 @@ object EmitStream {
         val (newContainer, aggSetup, aggCleanup) = AggContainer.fromMethodBuilder(states.toArray, mb, "run_agg_scan")
 
         produce(child, cb).map(cb) { case childStream: SStreamValue =>
-          val childProducer = childStream.producer
+          val childProducer = childStream.getProducer(mb)
 
           val childEltField = mb.newEmitField("runaggscan_child_elt", childProducer.element.emitType)
           val bodyEnv = env.bind(name -> childEltField)
@@ -1130,6 +1128,7 @@ object EmitStream {
           val bodyResultField = mb.newEmitField("runaggscan_result_elt", bodyResult.emitType)
 
           val producer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
 
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1165,7 +1164,7 @@ object EmitStream {
 
       case StreamFlatMap(a, name, body) =>
         produce(a, cb).map(cb) { case outerStream: SStreamValue =>
-          val outerProducer = outerStream.producer
+          val outerProducer = outerStream.getProducer(mb)
 
           // variables used in control flow
           val first = mb.genFieldThisRef[Boolean]("flatmap_first")
@@ -1182,9 +1181,10 @@ object EmitStream {
 
           val resultElementRegion = mb.genFieldThisRef[Region]("flatmap_result_region")
           // grabbing emitcode.pv weird pattern but should be safe
-          val SStreamValue(_, innerProducer) = innerStreamEmitCode.pv
+          val innerProducer = innerStreamEmitCode.pv.asStream.getProducer(mb)
 
           val producer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1290,8 +1290,8 @@ object EmitStream {
         produce(leftIR, cb).flatMap(cb) { case leftStream: SStreamValue =>
           produce(rightIR, cb).map(cb) { case rightStream: SStreamValue =>
 
-            val leftProducer = leftStream.producer
-            val rightProducer = rightStream.producer
+            val leftProducer = leftStream.getProducer(mb)
+            val rightProducer = rightStream.getProducer(mb)
 
             val lEltType = leftProducer.element.emitType
             val rEltType = rightProducer.element.emitType
@@ -1380,6 +1380,7 @@ object EmitStream {
                 val pulledRight = mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
 
                 val producer = new StreamProducer {
+                  override def method: EmitMethodBuilder[_] = mb
                   override val length: Option[EmitCodeBuilder => Code[Int]] = leftProducer.length
 
                   override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1469,6 +1470,7 @@ object EmitStream {
                 val c = mb.genFieldThisRef[Int]("join_right_distinct_compResult")
 
                 val producer = new StreamProducer {
+                  override def method: EmitMethodBuilder[_] = mb
                   override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
                   override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1571,6 +1573,7 @@ object EmitStream {
                 val pulledRight = mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
 
                 val producer = new StreamProducer {
+                  override def method: EmitMethodBuilder[_] = mb
                   override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
                   override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1641,6 +1644,7 @@ object EmitStream {
                 val c = mb.genFieldThisRef[Int]("join_right_distinct_compResult")
 
                 val producer = new StreamProducer {
+                  override def method: EmitMethodBuilder[_] = mb
                   override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
                   override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1808,7 +1812,7 @@ object EmitStream {
       case StreamGroupByKey(a, key, missingEqual) =>
         produce(a, cb).map(cb) { case childStream: SStreamValue =>
 
-          val childProducer = childStream.producer
+          val childProducer = childStream.getProducer(mb)
 
           val xCurElt = mb.newPField("st_grpby_curelt", childProducer.element.st)
 
@@ -1839,6 +1843,7 @@ object EmitStream {
           val LchildProduceDoneInner = CodeLabel()
           val LchildProduceDoneOuter = CodeLabel()
           val innerProducer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {}
@@ -1885,6 +1890,7 @@ object EmitStream {
           }
 
           val outerProducer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -1983,7 +1989,7 @@ object EmitStream {
 
             val n = mb.genFieldThisRef[Int]("streamgrouped_n")
 
-            val childProducer = childStream.producer
+            val childProducer = childStream.getProducer(mb)
 
             val xCounter = mb.genFieldThisRef[Int]("streamgrouped_ctr")
             val inOuter = mb.genFieldThisRef[Boolean]("streamgrouped_io")
@@ -2000,6 +2006,7 @@ object EmitStream {
             val LchildProduceDoneInner = CodeLabel()
             val LchildProduceDoneOuter = CodeLabel()
             val innerProducer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {}
@@ -2034,6 +2041,7 @@ object EmitStream {
             val innerStreamCode = EmitCode.present(mb, SStreamValue(innerProducer))
 
             val outerProducer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
               override val length: Option[EmitCodeBuilder => Code[Int]] =
                 childProducer.length.map(compL => (cb: EmitCodeBuilder) => ((compL(cb).toL + n.toL - 1L) / n.toL).toI)
 
@@ -2101,7 +2109,7 @@ object EmitStream {
       case StreamZip(as, names, body, behavior, errorID) =>
         IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(mb)(cb => produce(a, cb)))) { childStreams =>
 
-          val producers = childStreams.map(_.asInstanceOf[SStreamValue].producer)
+          val producers = childStreams.map(_.asStream.getProducer(mb))
 
           assert(names.length == producers.length)
 
@@ -2113,6 +2121,7 @@ object EmitStream {
               val bodyCode = EmitCode.fromI(mb)(cb => emit(body, cb, region = eltRegion, env = env.bind(names.zip(vars): _*)))
 
               new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
                 override val length: Option[EmitCodeBuilder => Code[Int]] = {
                   behavior match {
                     case ArrayZipBehavior.AssumeSameLength =>
@@ -2181,6 +2190,7 @@ object EmitStream {
 
 
               new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
                 override val length: Option[EmitCodeBuilder => Code[Int]] = producers.flatMap(_.length) match {
                   case Seq() => None
                   case ls =>
@@ -2259,6 +2269,7 @@ object EmitStream {
               val nEOS = mb.genFieldThisRef[Int]("zip_n_eos")
 
               new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
                 override val length: Option[EmitCodeBuilder => Code[Int]] =
                   anyFailAllFail(producers.map(_.length))
                     .map  { compLens =>
@@ -2332,7 +2343,7 @@ object EmitStream {
 
       case x@StreamZipJoin(as, key, keyRef, valsRef, joinIR) =>
         IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(mb)(cb => emit(a, cb)))) { children =>
-          val producers = children.map(_.asStream.producer)
+          val producers = children.map(_.asStream.getProducer(mb))
 
           val eltType = VirtualTypeWithReq.union(as.map(a => typeWithReqx(a))).canonicalEmitType
             .st
@@ -2403,6 +2414,7 @@ object EmitStream {
           }
 
           val producer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
@@ -2568,7 +2580,7 @@ object EmitStream {
 
       case x@StreamMultiMerge(as, key) =>
         IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(mb)(cb => emit(a, cb)))) { children =>
-          val producers = children.map(_.asStream.producer)
+          val producers = children.map(_.asStream.getProducer(mb))
 
           val unifiedType = VirtualTypeWithReq.union(as.map(a => typeWithReqx(a))).canonicalEmitType
             .st
@@ -2648,6 +2660,7 @@ object EmitStream {
           }
 
           val producer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
             override val length: Option[EmitCodeBuilder => Code[Int]] =
               anyFailAllFail(producers.map(_.length))
                 .map { compLens =>

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -8,10 +8,6 @@ import is.hail.types.physical.stypes.SingleCodeType
 import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.utils.HailException
 
-trait StreamArgType {
-  def apply(outerRegion: Region, eltRegion: Region): Iterator[java.lang.Long]
-}
-
 object StreamUtils {
 
   def storeNDArrayElementsAtAddress(

--- a/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.streams.StreamProducer
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitValue, IEmitCode, PartitionReader}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitValue, IEmitCode, PartitionReader}
 import is.hail.types.physical.{PCanonicalTuple, PInt64Required}
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.concrete._
@@ -70,6 +70,7 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
       val rowIdx = mb.genFieldThisRef[Long]("rowIdx")
 
       val producer = new StreamProducer {
+        override def method: EmitMethodBuilder[_] = cb.emb
         val length: Option[EmitCodeBuilder => Code[Int]] = None
 
         def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/package.scala
@@ -1,8 +1,6 @@
 package is.hail.types
 
 import is.hail.asm4s._
-import is.hail.expr.ir.streams.StreamArgType
-import is.hail.types.physical.stypes.{SCode, SValue}
 
 import scala.language.implicitConversions
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
@@ -3,9 +3,8 @@ package is.hail.types.physical.stypes
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir._
-import is.hail.expr.ir.streams.{StreamArgType, StreamProducer}
 import is.hail.types.physical.PType
-import is.hail.types.physical.stypes.interfaces.{SStream, SStreamValue}
+import is.hail.types.physical.stypes.interfaces.{NoBoxLongIterator, SStream, SStreamConcrete, SStreamIteratorLong, SStreamValue}
 import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -109,48 +108,20 @@ case object BooleanSingleCodeType extends SingleCodeType {
     SingleCodeSCode(this, pc.asBoolean.value)
 }
 
-case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, eltType: PType) extends SingleCodeType {
+case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, eltType: PType, eltRequired: Boolean) extends SingleCodeType {
   self =>
 
   override def loadedSType: SType = SStream(EmitType(eltType.sType, true))
 
   def virtualType: Type = TStream(eltType.virtualType)
 
-  def ti: TypeInfo[_] = classInfo[StreamArgType]
+  def ti: TypeInfo[_] = classInfo[NoBoxLongIterator]
 
   def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = {
-    val mb = cb.emb
-    val xIter = mb.genFieldThisRef[Iterator[java.lang.Long]]("streamInIterator")
-
-    // this, Region, ...
-    val mkIter = coerce[StreamArgType](c)
-    val eltRegion = mb.genFieldThisRef[Region]("stream_input_element_region")
-    val rvAddr = mb.genFieldThisRef[Long]("stream_input_addr")
-
-    val producer = new StreamProducer {
-      override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-      override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-        cb.assign(xIter, mkIter.invoke[Region, Region, Iterator[java.lang.Long]]("apply", outerRegion, eltRegion))
-      }
-
-      override val elementRegion: Settable[Region] = eltRegion
-      override val requiresMemoryManagementPerElement: Boolean = self.requiresMemoryManagementPerElement
-      override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-        // NB: locals should not be used in this implementation. The way In() nodes are
-        // stored in fields at the beginning of code generation leads to the method builder
-        // here being different from the method the stream will eventually be consumed in
-        cb.ifx(!xIter.load().hasNext, cb.goto(LendOfStream))
-        cb.assign(rvAddr, xIter.load().next().invoke[Long]("longValue"))
-        cb.goto(LproduceElementDone)
-      }
-
-      override val element: EmitCode =
-        EmitCode.fromI(mb)(cb => IEmitCode.present(cb, cb.memoizeField(eltType.loadCheapSCode(cb, rvAddr), "stream_input_element")))
-
-      override def close(cb: EmitCodeBuilder): Unit = {}
-    }
-    SStreamValue(SStream(EmitType(eltType.sType, true)), producer)
+    new SStreamConcrete(
+      SStreamIteratorLong(eltRequired, eltType, requiresMemoryManagementPerElement),
+      coerce[NoBoxLongIterator](c)
+    )
   }
 
   def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean): SingleCodeSCode =

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -17,7 +17,7 @@ trait NoBoxLongIterator {
   // (and value returned by next() is garbage)
   def eos: Boolean
 
-  def next(): Long // -1L if EOS, 0 if missing
+  def next(): Long  // 0L represents missing value
 
   def close(): Unit
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -1,15 +1,47 @@
 package is.hail.types.physical.stypes.interfaces
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Settable, TypeInfo, Value}
-import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.asm4s._
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.types.physical.PType
 import is.hail.types.physical.stypes._
 import is.hail.types.virtual.{TStream, Type}
 import is.hail.types.{RIterable, TypeWithRequiredness}
+import is.hail.utils.FastIndexedSeq
 
-final case class SStream(elementEmitType: EmitType) extends SType {
+trait NoBoxLongIterator {
+  def init(partitionRegion: Region, elementRegion: Region)
+
+  def next(): Long // -1L if EOS, 0 if missing
+
+  def close(): Unit
+}
+
+object SStream {
+  def apply(elementEmitType: EmitType): SimpleSStream = SimpleSStream(elementEmitType)
+}
+
+final case class SimpleSStream(elementEmitType: EmitType) extends SStream {
+  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = throw new NotImplementedError()
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new NotImplementedError()
+
+  override def fromValues(values: IndexedSeq[Value[_]]): SValue = throw new NotImplementedError()
+}
+
+final case class SStreamIteratorLong(elementRequired: Boolean, elementPType: PType, requiresMemoryManagement: Boolean) extends SStream {
+  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = IndexedSeq(classInfo[NoBoxLongIterator])
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = new SStreamConcreteSettable(this, coerce[NoBoxLongIterator](settables(0)))
+
+  override def fromValues(values: IndexedSeq[Value[_]]): SValue = new SStreamConcrete(this, coerce[NoBoxLongIterator](values(0)))
+
+  override val elementEmitType: EmitType = EmitType(elementPType.sType, elementRequired)
+}
+
+sealed trait SStream extends SType {
+
+  def elementEmitType: EmitType
+
   def elementType: SType = elementEmitType.st
 
   override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): SValue = {
@@ -18,12 +50,6 @@ final case class SStream(elementEmitType: EmitType) extends SType {
     assert(value.st == this)
     value
   }
-
-  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = throw new NotImplementedError()
-
-  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new NotImplementedError()
-
-  override def fromValues(values: IndexedSeq[Value[_]]): SValue = throw new NotImplementedError()
 
   override def storageType(): PType = throw new NotImplementedError()
 
@@ -38,10 +64,93 @@ final case class SStream(elementEmitType: EmitType) extends SType {
   override def _typeWithRequiredness: TypeWithRequiredness = RIterable(elementEmitType.typeWithRequiredness.r)
 }
 
-object SStreamValue{
-  def apply(producer: StreamProducer): SStreamValue = SStreamValue(SStream(producer.element.emitType), producer)
+object SStreamValue {
+  def apply(producer: StreamProducer): SStreamValue = SStreamControlFlow(SStream(producer.element.emitType), producer)
 }
 
-final case class SStreamValue(st: SStream, producer: StreamProducer) extends SUnrealizableValue {
+
+trait SStreamValue extends SUnrealizableValue {
+  def st: SStream
+
+  def getProducer(mb: EmitMethodBuilder[_]): StreamProducer
+
+  def defineUnusedLabels(mb: EmitMethodBuilder[_]): Unit
+}
+
+class SStreamConcrete(val st: SStreamIteratorLong, val it: Value[NoBoxLongIterator]) extends SStreamValue {
+
+  lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(it)
+
+  override def getProducer(mb: EmitMethodBuilder[_]): StreamProducer = {
+
+    new StreamProducer {
+      override def method: EmitMethodBuilder[_] = mb
+      val elRegion = mb.genFieldThisRef[Region]("stream_iter_elregion")
+      val next = mb.genFieldThisRef[Long]("stream_iter_next")
+      override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+      override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+        cb += it.invoke[Region, Region, Unit]("init", outerRegion, elementRegion)
+      }
+
+      override val elementRegion: Settable[Region] = elRegion
+      override val requiresMemoryManagementPerElement: Boolean = st.requiresMemoryManagement
+      override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+        cb.assign(next, it.invoke[Long]("next"))
+        cb.ifx(next ceq -1L, cb.goto(LendOfStream))
+        cb.goto(LproduceElementDone)
+      }
+      override val element: EmitCode = {
+
+        EmitCode.fromI(mb) { cb =>
+          IEmitCode(cb, if (st.elementRequired) const(false) else (next cne 0L), st.elementPType.loadCheapSCode(cb, next))
+        }
+      }
+
+      override def close(cb: EmitCodeBuilder): Unit = it.invoke[Unit]("close")
+    }
+  }
+
+  override def defineUnusedLabels(mb: EmitMethodBuilder[_]): Unit = () // nothing to do
+}
+
+class SStreamConcreteSettable(st: SStreamIteratorLong, val itSettable: Settable[NoBoxLongIterator])
+  extends SStreamConcrete(st, itSettable) with SSettable {
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {
+    assert(v.st == st)
+    cb.assign(itSettable, v.asInstanceOf[SStreamConcrete].it)
+  }
+
+  override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(itSettable)
+}
+
+case class SStreamControlFlow(st: SimpleSStream, producer: StreamProducer) extends SStreamValue {
+  override def getProducer(mb: EmitMethodBuilder[_]): StreamProducer = {
+    if (mb != producer.method)
+      throw new RuntimeException("stream used in method different from where it was generated -- " +
+        s"generated in ${ producer.method.mb.methodName }, used in ${ mb.mb.methodName }")
+    producer
+  }
+
   def valueTuple: IndexedSeq[Value[_]] = throw new NotImplementedError()
+
+  override def defineUnusedLabels(mb: EmitMethodBuilder[_]): Unit = {
+    (producer.LendOfStream.isImplemented, producer.LproduceElementDone.isImplemented) match {
+      case (true, true) =>
+      case (false, false) =>
+
+        EmitCodeBuilder.scopedVoid(mb) { cb =>
+          cb.define(producer.LendOfStream)
+          cb.define(producer.LproduceElementDone)
+          cb._fatal("unreachable")
+        }
+
+      case (eos, ped) => throw new RuntimeException(s"unrealizable value unused asymmetrically: eos=$eos, ped=$ped")
+    }
+    producer.element.pv match {
+      case ss: SStreamValue => ss.defineUnusedLabels(mb)
+      case _ =>
+    }
+  }
+
 }

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -67,7 +67,7 @@ class EmitStreamSuite extends HailSuite {
         case s => s
       }
       TypeCheck(ctx, s)
-      EmitStream.produce(new Emit(emitContext, fb.ecb), s, cb, region, EmitEnv(Env.empty, inputTypes.indices.map(i => mb.getEmitParam(cb, i + 2))), None)
+      EmitStream.produce(new Emit(emitContext, fb.ecb), s, cb, region, EmitEnv(Env.empty, inputTypes.indices.map(i => mb.storeEmitParamAsField(cb, i + 2))), None)
         .consumeCode[Long](cb, 0L, { s =>
           val arr = StreamUtils.toArray(cb, s.asStream.getProducer(mb), region)
           val scp = SingleCodeSCode.fromSCode(cb, arr, region, false)

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -6,10 +6,10 @@ import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.agg.{CollectStateSig, PhysicalAggSig, TypedStateSig}
 import is.hail.expr.ir.lowering.LoweringPipeline
-import is.hail.expr.ir.streams.{EmitStream, StreamArgType, StreamUtils}
+import is.hail.expr.ir.streams.{EmitStream, StreamUtils}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.interfaces.SStreamValue
+import is.hail.types.physical.stypes.interfaces.{NoBoxLongIterator, SStreamValue}
 import is.hail.types.physical.stypes.{PTypeReferenceSingleCodeType, SingleCodeSCode, StreamSingleCodeType}
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -67,9 +67,9 @@ class EmitStreamSuite extends HailSuite {
         case s => s
       }
       TypeCheck(ctx, s)
-      EmitStream.produce(new Emit(emitContext, fb.ecb), s, cb, region, EmitEnv(Env.empty, inputTypes.indices.map(i => mb.storeEmitParam(i + 2, cb))), None)
+      EmitStream.produce(new Emit(emitContext, fb.ecb), s, cb, region, EmitEnv(Env.empty, inputTypes.indices.map(i => mb.getEmitParam(cb, i + 2))), None)
         .consumeCode[Long](cb, 0L, { s =>
-          val arr = StreamUtils.toArray(cb, s.asStream.producer, region)
+          val arr = StreamUtils.toArray(cb, s.asStream.getProducer(mb), region)
           val scp = SingleCodeSCode.fromSCode(cb, arr, region, false)
           arrayType = scp.typ.asInstanceOf[PTypeReferenceSingleCodeType].pt
 
@@ -99,19 +99,16 @@ class EmitStreamSuite extends HailSuite {
 
   private def compileStreamWithIter(ir: IR, requiresMemoryManagementPerElement: Boolean, elementType: PType): Iterator[Any] => IndexedSeq[Any] = {
     trait F {
-      def apply(o: Region, a: StreamArgType): Long
+      def apply(o: Region, a: NoBoxLongIterator): Long
     }
     compileStream[F, Iterator[Any]](ir,
-      IndexedSeq(SingleCodeEmitParamType(true, StreamSingleCodeType(requiresMemoryManagementPerElement, elementType)))) { (f: F, r: Region, it: Iterator[Any]) =>
-      val rvi = new StreamArgType {
-        def apply(outerRegion: Region, eltRegion: Region): Iterator[java.lang.Long] =
-          new Iterator[java.lang.Long] {
-            def hasNext: Boolean = it.hasNext
+      IndexedSeq(SingleCodeEmitParamType(true, StreamSingleCodeType(requiresMemoryManagementPerElement, elementType, true)))) { (f: F, r: Region, it: Iterator[Any]) =>
+      val rvi = new NoBoxLongIterator  {
+        var _eltRegion: Region = _
+        def init(outerRegion: Region, eltRegion: Region): Unit = _eltRegion = eltRegion
 
-            def next(): java.lang.Long = {
-              ScalaToRegionValue(eltRegion, elementType, it.next())
-            }
-          }
+        override def next(): Long = ScalaToRegionValue(_eltRegion, elementType, it.next())
+        override def close(): Unit = ()
       }
       assert(it != null, "null iterators not supported")
       f(r, rvi)
@@ -138,7 +135,8 @@ class EmitStreamSuite extends HailSuite {
         .consume(cb,
           {},
           { case stream: SStreamValue =>
-            stream.producer.memoryManagedConsume(region, cb, { cb => stream.producer.length.foreach(computeLen => cb.assign(len2, computeLen(cb))) }) { cb =>
+            val producer = stream.getProducer(cb.emb)
+            producer.memoryManagedConsume(region, cb, { cb => producer.length.foreach(computeLen => cb.assign(len2, computeLen(cb))) }) { cb =>
               cb.assign(len, len + 1)
             }
           })
@@ -677,7 +675,7 @@ class EmitStreamSuite extends HailSuite {
     val intsPType = PInt32(true)
 
     val f1 = compileStreamWithIter(
-      StreamScan(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(true, PInt32(true)))),
+      StreamScan(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(true, PInt32(true), true))),
         zero = 0,
         "a", "x", Ref("a", TInt32) + Ref("x", TInt32) * Ref("x", TInt32)
       ), false, intsPType)
@@ -686,13 +684,13 @@ class EmitStreamSuite extends HailSuite {
 
     val f2 = compileStreamWithIter(
       StreamFlatMap(
-        In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32(true)))),
+        In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32(true), true))),
         "n", StreamRange(0, Ref("n", TInt32), 1)
       ), false, intsPType)
     assert(f2(Seq(1, 5, 2, 9).iterator) == IndexedSeq(1, 5, 2, 9).flatMap(0 until _))
 
     val f3 = compileStreamWithIter(
-      StreamRange(0, StreamLen(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32(true))))), 1), false, intsPType)
+      StreamRange(0, StreamLen(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32(true), true)))), 1), false, intsPType)
     assert(f3(Seq(1, 5, 2, 9).iterator) == IndexedSeq(0, 1, 2, 3))
     assert(f3(Seq().iterator) == IndexedSeq())
   }


### PR DESCRIPTION
This change makes it possible for us to have real stream settables
using iterators. I want to use this to pass streams as params to
generated functions.