### PR TITLE
[batch] Check for case sensitive billing project names

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -524,7 +524,7 @@ async def _query_batches(request, user, q):
     db = request.app['db']
 
     where_conditions = [
-        '(billing_project_users.`user` = %s AND billing_project_users.billing_project = batches.billing_project)',
+        '(billing_project_users.`user` = BINARY %s AND billing_project_users.billing_project = batches.billing_project)',
         'NOT deleted',
     ]
     where_args = [user]
@@ -562,7 +562,7 @@ async def _query_batches(request, user, q):
         elif t.startswith('user:'):
             k = t[5:]
             condition = '''
-(batches.`user` = %s)
+(batches.`user` = BINARY %s)
 '''
             args = [k]
         elif t.startswith('billing_project:'):

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -125,7 +125,7 @@ async def query_billing_projects(db, user=None, billing_project=None):
         args.append(user)
 
     if billing_project:
-        where_conditions.append('billing_projects.name = %s')
+        where_conditions.append('billing_projects.name = BINARY %s')
         args.append(billing_project)
 
     if where_conditions:

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -629,3 +629,69 @@ async def test_deleted_open_batches_do_not_prevent_billing_project_closure(
         await open_batch.delete()
     finally:
         await dev_client.close_billing_project(project)
+
+
+async def test_billing_project_case_sensitive(dev_client: BatchClient, new_billing_project: str):
+    project = new_billing_project
+    upper_case_project = project.upper()
+
+    dev_client.billing_project = upper_case_project
+
+    # create batch
+    try:
+        bb = dev_client.create_batch()
+        j = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+        b = await bb.submit()
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        assert False
+
+    # edit billing limit
+    try:
+        limit = 5
+        await dev_client.edit_billing_limit(upper_case_project, limit)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        assert False
+
+    # get billing project
+    try:
+        bp = await dev_client.get_billing_project(upper_case_project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        assert False
+
+    # add user to project
+    try:
+        r = await dev_client.add_user('test', upper_case_project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        assert False
+
+    # remove user from project
+    try:
+        r = await dev_client.remove_user('test', upper_case_project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        assert False
+
+    # close billing project
+    try:
+        r = await dev_client.close_billing_project(upper_case_project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        assert False
+
+    # delete billing project
+    try:
+        r = await dev_client.delete_billing_project(upper_case_project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        assert False

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -635,6 +635,11 @@ async def test_billing_project_case_sensitive(dev_client: BatchClient, new_billi
     project = new_billing_project
     upper_case_project = project.upper()
 
+    # create one batch with the correct billing project
+    bb = dev_client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    b = await bb.submit()
+
     dev_client.billing_project = upper_case_project
 
     # create batch
@@ -695,3 +700,15 @@ async def test_billing_project_case_sensitive(dev_client: BatchClient, new_billi
         assert e.status == 404, e
     else:
         assert False
+
+    # list batches for a billing project
+    batches = [batch async for batch in dev_client.list_batches(f'billing_project:{upper_case_project}')]
+    assert len(batches) == 0
+
+    # list batches for a user
+    batches = [batch async for batch in dev_client.list_batches(f'user:DEV-TEST')]
+    assert len(batches) == 0
+
+    # list batches for a user that submitted the batch
+    batches = [batch async for batch in dev_client.list_batches(f'user=DEV-TEST')]
+    assert len(batches) == 0


### PR DESCRIPTION
This is a mitigation and does not solve the issue where we have existing duplicated billing project names. I'm not entirely sure adding BINARY in front of the search value is correct, but I was going off of this post. Apparently, if you use `BINARY name = %s` instead of `name = BINARY %s`, then you pay a performance hit because you cannot use the index any longer.

https://stackoverflow.com/questions/5629111/how-can-i-make-sql-case-sensitive-string-comparison-on-mysql