### PR TITLE
[query/ggplot/docs] fix the tutorials TOC by adding a page title

### DIFF
--- a/hail/python/hail/docs/tutorials/09-ggplot.ipynb
+++ b/hail/python/hail/docs/tutorials/09-ggplot.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GGPlot Tutorial\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "popular-budapest",


### PR DESCRIPTION
### Before
<img width="299" alt="Screen Shot 2022-10-06 at 13 32 52" src="https://user-images.githubusercontent.com/84595986/194380378-d99890b4-e7ec-4144-84fe-9b8db28aeec9.png">

### After
<img width="301" alt="Screen Shot 2022-10-06 at 13 32 31" src="https://user-images.githubusercontent.com/84595986/194380470-4d839129-b0d1-4422-b8d3-d350ed3b10f4.png">

Ignore the missing `[-]` icon; this is a local build of the docs, and I suspect I'm missing a font that it expects me to have installed.