### PR TITLE
[ci] Require publishAs to preserve per-image caching

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,7 @@
 steps:
   - kind: buildImage2
     name: git_make_bash_image
+    publishAs: git-make-bash
     dockerFile:
       inline: |
         FROM {{ global.docker_root_image }}
@@ -2353,6 +2354,7 @@ steps:
       - build_hail_jar_and_wheel_only_spark_3_2
   - kind: buildImage2
     name: netcat_ubuntu_image
+    publishAs: netcat
     dockerFile:
       inline: |
         FROM {{ hail_ubuntu_image.image }}
@@ -2361,6 +2363,7 @@ steps:
       - hail_ubuntu_image
   - kind: buildImage2
     name: volume_image
+    publishAs: volume
     dockerFile:
       inline: |
         FROM {{ hail_ubuntu_image.image }}
@@ -2369,6 +2372,7 @@ steps:
       - hail_ubuntu_image
   - kind: buildImage2
     name: workdir_image
+    publishAs: workdir
     dockerFile:
       inline: |
         FROM {{ hail_ubuntu_image.image }}
@@ -2377,6 +2381,7 @@ steps:
       - hail_ubuntu_image
   - kind: buildImage2
     name: curl_image
+    publishAs: curl
     dockerFile:
       inline: |
         FROM {{ hail_ubuntu_image.image }}

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -244,11 +244,10 @@ class BuildImage2Step(Step):
         super().__init__(params)
         self.dockerfile = dockerfile
         self.context_path = context_path
-        self.publish_as = publish_as
         self.inputs = inputs
         self.resources = resources
 
-        image_name = self.publish_as or 'ci-intermediate'
+        image_name = publish_as
         self.base_image = f'{DOCKER_PREFIX}/{image_name}'
         self.image = f'{self.base_image}:{self.token}'
         self.main_branch_cache_repository = f'{self.base_image}:cache'
@@ -282,7 +281,7 @@ class BuildImage2Step(Step):
             params,
             json['dockerFile'],
             json.get('contextPath'),
-            json.get('publishAs'),
+            json['publishAs'],
             json.get('inputs'),
             json.get('resources'),
         )
@@ -375,7 +374,7 @@ cat /home/user/trace
         )
 
     def cleanup(self, batch, scope, parents):
-        if scope == 'deploy' and self.publish_as and not is_test_deployment:
+        if scope == 'deploy' and not is_test_deployment:
             return
 
         if CLOUD == 'azure':

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -8,6 +8,7 @@ steps:
         optional: true
   - kind: buildImage2
     name: git_make_bash_image
+    publishAs: git-make-bash
     dockerFile:
       inline: |
         FROM {{ global.docker_root_image }}


### PR DESCRIPTION
I think this is what was wrong with the `git_make_bash_image` taking a minute each time. Since every image without a `publishAs` uses `ci-intermediate`, the `ci-intermediate:cache-PR-X` tag is left pointing to whichever anonymous image built last in the PR run. This is certainly never `git_make_bash_image`, so every time it gets rebuilt, the cache-from that it is using points to an an image whose layers do not include a layer that is `RUN apt-get update && apt-get install -y git make bash`. If this PR runs twice, hopefully we'll see the first step go super quick.