### PR TITLE
[compiler] use BindingEnv in parser

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -184,14 +184,14 @@ class LocalBackend(Py4JBackend):
             {k: t._parsable_string() for k, t in ref_map.items()},
             ir_map)
 
-    def _parse_table_ir(self, code, ref_map={}, ir_map={}):
-        return self._jbackend.parse_table_ir(code, ref_map, ir_map)
+    def _parse_table_ir(self, code, ir_map={}):
+        return self._jbackend.parse_table_ir(code, ir_map)
 
-    def _parse_matrix_ir(self, code, ref_map={}, ir_map={}):
-        return self._jbackend.parse_matrix_ir(code, ref_map, ir_map)
+    def _parse_matrix_ir(self, code, ir_map={}):
+        return self._jbackend.parse_matrix_ir(code, ir_map)
 
-    def _parse_blockmatrix_ir(self, code, ref_map={}, ir_map={}):
-        return self._jbackend.parse_blockmatrix_ir(code, ref_map, ir_map)
+    def _parse_blockmatrix_ir(self, code, ir_map={}):
+        return self._jbackend.parse_blockmatrix_ir(code, ir_map)
 
     @property
     def logger(self):

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -239,14 +239,14 @@ class SparkBackend(Py4JBackend):
             {k: t._parsable_string() for k, t in ref_map.items()},
             ir_map)
 
-    def _parse_table_ir(self, code, ref_map={}, ir_map={}):
-        return self._jbackend.parse_table_ir(code, ref_map, ir_map)
+    def _parse_table_ir(self, code, ir_map={}):
+        return self._jbackend.parse_table_ir(code, ir_map)
 
-    def _parse_matrix_ir(self, code, ref_map={}, ir_map={}):
-        return self._jbackend.parse_matrix_ir(code, ref_map, ir_map)
+    def _parse_matrix_ir(self, code, ir_map={}):
+        return self._jbackend.parse_matrix_ir(code, ir_map)
 
-    def _parse_blockmatrix_ir(self, code, ref_map={}, ir_map={}):
-        return self._jbackend.parse_blockmatrix_ir(code, ref_map, ir_map)
+    def _parse_blockmatrix_ir(self, code, ir_map={}):
+        return self._jbackend.parse_blockmatrix_ir(code, ir_map)
 
     @property
     def logger(self):

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -252,33 +252,33 @@ class LocalBackend(
   def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
     ExecutionTimer.logTime("LocalBackend.parse_value_ir") { timer =>
       withExecuteContext(timer) { ctx =>
-        IRParser.parse_value_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_value_ir(s, IRParserEnvironment(ctx, BindingEnv.eval(refMap.asScala.toMap.mapValues(IRParser.parseType).toSeq: _*), irMap.asScala.toMap))
       }
     }
   }
 
-  def parse_table_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): TableIR = {
+  def parse_table_ir(s: String, irMap: java.util.Map[String, BaseIR]): TableIR = {
     ExecutionTimer.logTime("LocalBackend.parse_table_ir") { timer =>
       withExecuteContext(timer) { ctx =>
-        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
       }
     }
   }
 
-  def parse_matrix_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): MatrixIR = {
+  def parse_matrix_ir(s: String, irMap: java.util.Map[String, BaseIR]): MatrixIR = {
     ExecutionTimer.logTime("LocalBackend.parse_matrix_ir") { timer =>
       withExecuteContext(timer) { ctx =>
-        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
       }
     }
   }
 
   def parse_blockmatrix_ir(
-    s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]
+    s: String, irMap: java.util.Map[String, BaseIR]
   ): BlockMatrixIR = {
     ExecutionTimer.logTime("LocalBackend.parse_blockmatrix_ir") { timer =>
       withExecuteContext(timer) { ctx =>
-        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
       }
     }
   }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -673,33 +673,33 @@ class SparkBackend(
   def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
     ExecutionTimer.logTime("SparkBackend.parse_value_ir") { timer =>
       withExecuteContext(timer) { ctx =>
-        IRParser.parse_value_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_value_ir(s, IRParserEnvironment(ctx, BindingEnv.eval(refMap.asScala.toMap.mapValues(IRParser.parseType).toSeq: _*), irMap.asScala.toMap))
       }
     }
   }
 
-  def parse_table_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): TableIR = {
+  def parse_table_ir(s: String, irMap: java.util.Map[String, BaseIR]): TableIR = {
     ExecutionTimer.logTime("SparkBackend.parse_table_ir") { timer =>
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
       }
     }
   }
 
-  def parse_matrix_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): MatrixIR = {
+  def parse_matrix_ir(s: String, irMap: java.util.Map[String, BaseIR]): MatrixIR = {
     ExecutionTimer.logTime("SparkBackend.parse_matrix_ir") { timer =>
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
       }
     }
   }
 
   def parse_blockmatrix_ir(
-    s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]
+    s: String, irMap: java.util.Map[String, BaseIR]
   ): BlockMatrixIR = {
     ExecutionTimer.logTime("SparkBackend.parse_blockmatrix_ir") { timer =>
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
       }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -141,20 +141,69 @@ case class TypeParserEnvironment(
 
 case class IRParserEnvironment(
   ctx: ExecuteContext,
-  refMap: Map[String, Type] = Map.empty,
+  refMap: BindingEnv[Type] = BindingEnv.empty[Type],
   irMap: Map[String, BaseIR] = Map.empty,
   typEnv: TypeParserEnvironment = TypeParserEnvironment.default
 ) {
-  def update(newRefMap: Map[String, Type] = Map.empty, newIRMap: Map[String, BaseIR] = Map.empty): IRParserEnvironment =
-    copy(refMap = refMap ++ newRefMap, irMap = irMap ++ newIRMap)
+  def promoteAgg: IRParserEnvironment = copy(refMap = refMap.promoteAgg)
 
-  def withRefMap(newRefMap: Map[String, Type]): IRParserEnvironment = {
-    assert(refMap.isEmpty || newRefMap.isEmpty)
-    copy(refMap = newRefMap)
+  def promoteScan: IRParserEnvironment = copy(refMap = refMap.promoteScan)
+
+  def promoteAggScan(isScan: Boolean): IRParserEnvironment =
+    if (isScan) promoteScan else promoteAgg
+
+  def noAgg: IRParserEnvironment = copy(refMap = refMap.noAgg)
+
+  def noScan: IRParserEnvironment = copy(refMap = refMap.noScan)
+
+  def noAggScan(isScan: Boolean): IRParserEnvironment =
+    if (isScan) noScan else noAgg
+
+  def createAgg: IRParserEnvironment = copy(refMap = refMap.createAgg)
+
+  def createScan: IRParserEnvironment = copy(refMap = refMap.createScan)
+
+  def onlyRelational: IRParserEnvironment = {
+    if (refMap.eval.isEmpty && refMap.agg.isEmpty && refMap.scan.isEmpty)
+      this
+    else
+      copy(refMap = refMap.onlyRelational)
   }
 
-  def +(t: (String, Type)): IRParserEnvironment = copy(refMap = refMap + t)
-  def ++(ts: Array[(String, Type)]): IRParserEnvironment = copy(refMap = refMap ++ ts)
+  def empty: IRParserEnvironment = copy(refMap = BindingEnv.empty)
+
+  def bindEval(name: String, t: Type): IRParserEnvironment =
+    copy(refMap = refMap.bindEval(name, t))
+
+  def bindEval(bindings: (String, Type)*): IRParserEnvironment =
+    copy(refMap = refMap.bindEval(bindings: _*))
+
+  def bindEval(bindings: Env[Type]): IRParserEnvironment =
+    copy(refMap = refMap.bindEval(bindings.m.toSeq: _*))
+
+  def bindAggScan(isScan: Boolean, bindings: (String, Type)*): IRParserEnvironment =
+    copy(refMap = if (isScan) refMap.bindScan(bindings: _*) else refMap.bindAgg(bindings: _*))
+
+  def bindAgg(name: String, t: Type): IRParserEnvironment =
+    copy(refMap = refMap.bindAgg(name, t))
+
+  def bindAgg(bindings: (String, Type)*): IRParserEnvironment =
+    copy(refMap = refMap.bindAgg(bindings: _*))
+
+  def bindAgg(bindings: Env[Type]): IRParserEnvironment =
+    copy(refMap = refMap.bindAgg(bindings.m.toSeq: _*))
+
+  def bindScan(name: String, t: Type): IRParserEnvironment =
+    copy(refMap = refMap.bindScan(name, t))
+
+  def bindScan(bindings: (String, Type)*): IRParserEnvironment =
+    copy(refMap = refMap.bindScan(bindings: _*))
+
+  def bindScan(bindings: Env[Type]): IRParserEnvironment =
+    copy(refMap = refMap.bindScan(bindings.m.toSeq: _*))
+
+  def bindRelational(name: String, t: Type): IRParserEnvironment =
+    copy(refMap = refMap.bindRelational(name, t))
 }
 
 object IRParser {
@@ -687,7 +736,7 @@ object IRParser {
         val vtwr = vtwr_expr(env.typEnv)(it)
         val accumName = identifier(it)
         val otherAccumName = identifier(it)
-        val combIR = ir_value_expr(env + ((accumName, vtwr.t)) + ((otherAccumName, vtwr.t)))(it).run()
+        val combIR = ir_value_expr(env.empty.bindEval(accumName -> vtwr.t, otherAccumName -> vtwr.t))(it).run()
         FoldStateSig(vtwr.canonicalEmitType, accumName, otherAccumName, combIR)
     }
     punctuation(it, ")")
@@ -812,14 +861,14 @@ object IRParser {
         val name = identifier(it)
         for {
           value <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> value.typ))(it)
+          body <- ir_value_expr(env.bindEval(name, value.typ))(it)
         } yield Let(name, value, body)
       case "AggLet" =>
         val name = identifier(it)
         val isScan = boolean_literal(it)
         for {
-          value <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> value.typ))(it)
+          value <- ir_value_expr(env.promoteAggScan(isScan))(it)
+          body <- ir_value_expr(env.bindAggScan(isScan, name -> value.typ))(it)
         } yield AggLet(name, value, body, isScan)
       case "TailLoop" =>
         val name = identifier(it)
@@ -827,7 +876,7 @@ object IRParser {
         for {
           paramIRs <- fillArray(paramNames.length)(ir_value_expr(env)(it))
           params = paramNames.zip(paramIRs)
-          bodyEnv = env.update(params.map { case (n, v) => n -> v.typ}.toMap)
+          bodyEnv = env.bindEval(params.map { case (n, v) => n -> v.typ}: _*)
           body <- ir_value_expr(bodyEnv)(it)
         } yield TailLoop(name, params, body)
       case "Recur" =>
@@ -838,7 +887,7 @@ object IRParser {
         }
       case "Ref" =>
         val id = identifier(it)
-        done(Ref(id, env.refMap(id)))
+        done(Ref(id, env.refMap.eval(id)))
       case "RelationalRef" =>
         val id = identifier(it)
         val t = type_expr(env.typEnv)(it)
@@ -846,8 +895,8 @@ object IRParser {
       case "RelationalLet" =>
         val name = identifier(it)
         for {
-          value <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> value.typ))(it)
+          value <- ir_value_expr(env.onlyRelational)(it)
+          body <- ir_value_expr(env.noAgg.noScan.bindRelational(name, value.typ))(it)
         } yield RelationalLet(name, value, body)
       case "ApplyBinaryPrimOp" =>
         val op = BinaryOp.fromString(identifier(it))
@@ -922,7 +971,7 @@ object IRParser {
         for {
           a <- ir_value_expr(env)(it)
           elt = coerce[TStream](a.typ).elementType
-          lessThan <- ir_value_expr(env + (l -> elt) + (r -> elt))(it)
+          lessThan <- ir_value_expr(env.bindEval(l -> elt, r -> elt))(it)
         } yield ArraySort(a, l, r, lessThan)
       case "MakeNDArray" =>
         val errorID = int32_literal(it)
@@ -947,7 +996,7 @@ object IRParser {
         val name = identifier(it)
         for {
           nd <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> coerce[TNDArray](nd.typ).elementType))(it)
+          body <- ir_value_expr(env.bindEval(name, coerce[TNDArray](nd.typ).elementType))(it)
         } yield NDArrayMap(nd, name, body)
       case "NDArrayMap2" =>
         val errorID = int32_literal(it)
@@ -956,8 +1005,9 @@ object IRParser {
         for {
           l <- ir_value_expr(env)(it)
           r <- ir_value_expr(env)(it)
-          body_env = (env + (lName -> coerce[TNDArray](l.typ).elementType)
-            + (rName -> coerce[TNDArray](r.typ).elementType))
+          body_env = env.bindEval(
+            lName -> coerce[TNDArray](l.typ).elementType,
+            rName -> coerce[TNDArray](r.typ).elementType)
           body <- ir_value_expr(body_env)(it)
         } yield NDArrayMap2(l, r, lName, rName, body, errorID)
       case "NDArrayReindex" =>
@@ -1033,7 +1083,7 @@ object IRParser {
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+          body <- ir_value_expr(env.bindEval(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamMap(a, name, body)
       case "StreamTake" =>
         for {
@@ -1056,31 +1106,31 @@ object IRParser {
         val names = identifiers(it)
         for {
           as <- names.mapRecur(_ => ir_value_expr(env)(it))
-          body <- ir_value_expr(env ++ names.zip(as.map(a => coerce[TStream](a.typ).elementType)))(it)
+          body <- ir_value_expr(env.bindEval(names.zip(as.map(a => coerce[TStream](a.typ).elementType)): _*))(it)
         } yield StreamZip(as, names, body, behavior, errorID)
       case "StreamFilter" =>
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+          body <- ir_value_expr(env.bindEval(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamFilter(a, name, body)
       case "StreamTakeWhile" =>
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-            body <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+            body <- ir_value_expr(env.bindEval(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamTakeWhile(a, name, body)
       case "StreamDropWhile" =>
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-            body <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+            body <- ir_value_expr(env.bindEval(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamDropWhile(a, name, body)
       case "StreamFlatMap" =>
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+          body <- ir_value_expr(env.bindEval(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamFlatMap(a, name, body)
       case "StreamFold" =>
         val accumName = identifier(it)
@@ -1089,7 +1139,7 @@ object IRParser {
           a <- ir_value_expr(env)(it)
           zero <- ir_value_expr(env)(it)
           eltType = coerce[TStream](a.typ).elementType
-          body <- ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
+          body <- ir_value_expr(env.bindEval(accumName -> zero.typ, valueName -> eltType))(it)
         } yield StreamFold(a, zero, accumName, valueName, body)
       case "StreamFold2" =>
         val accumNames = identifiers(it)
@@ -1099,8 +1149,8 @@ object IRParser {
           accIRs <- fillArray(accumNames.length)(ir_value_expr(env)(it))
           accs = accumNames.zip(accIRs)
           eltType = coerce[TStream](a.typ).elementType
-          resultEnv = env.update(accs.map { case (name, value) => (name, value.typ) }.toMap)
-          seqEnv = resultEnv.update(Map(valueName -> eltType))
+          resultEnv = env.bindEval(accs.map { case (name, value) => (name, value.typ) }: _*)
+          seqEnv = resultEnv.bindEval(valueName, eltType)
           seqs <- fillArray(accs.length)(ir_value_expr(seqEnv)(it))
           res <- ir_value_expr(resultEnv)(it)
         } yield StreamFold2(a, accs, valueName, seqs, res)
@@ -1111,7 +1161,7 @@ object IRParser {
           a <- ir_value_expr(env)(it)
           zero <- ir_value_expr(env)(it)
           eltType = coerce[TStream](a.typ).elementType
-          body <- ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
+          body <- ir_value_expr(env.bindEval(accumName -> zero.typ, valueName -> eltType))(it)
         } yield StreamScan(a, zero, accumName, valueName, body)
       case "StreamJoinRightDistinct" =>
         val lKey = identifiers(it)
@@ -1124,25 +1174,25 @@ object IRParser {
           right <- ir_value_expr(env)(it)
           lelt = coerce[TStream](left.typ).elementType
           relt = coerce[TStream](right.typ).elementType
-          join <- ir_value_expr(env.update(Map(l -> lelt, r -> relt)))(it)
+          join <- ir_value_expr(env.bindEval(l -> lelt, r -> relt))(it)
         } yield StreamJoinRightDistinct(left, right, lKey, rKey, l, r, join, joinType)
       case "StreamFor" =>
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+          body <- ir_value_expr(env.bindEval(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamFor(a, name, body)
       case "StreamAgg" =>
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-          query <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+          query <- ir_value_expr(env.createAgg.bindAgg(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamAgg(a, name, query)
       case "StreamAggScan" =>
         val name = identifier(it)
         for {
           a <- ir_value_expr(env)(it)
-          query <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+          query <- ir_value_expr(env.createScan.bindScan(name, coerce[TStream](a.typ).elementType))(it)
         } yield StreamAggScan(a, name, query)
       case "RunAgg" =>
         val signatures = agg_state_signatures(env)(it)
@@ -1155,7 +1205,7 @@ object IRParser {
         val signatures = agg_state_signatures(env)(it)
         for {
           array <- ir_value_expr(env)(it)
-          newE = env + (name -> coerce[TStream](array.typ).elementType)
+          newE = env.bindEval(name, coerce[TStream](array.typ).elementType)
           init <- ir_value_expr(env)(it)
           seq <- ir_value_expr(newE)(it)
           result <- ir_value_expr(newE)(it)
@@ -1163,20 +1213,20 @@ object IRParser {
       case "AggFilter" =>
         val isScan = boolean_literal(it)
         for {
-          cond <- ir_value_expr(env)(it)
+          cond <- ir_value_expr(env.promoteAggScan(isScan))(it)
           aggIR <- ir_value_expr(env)(it)
         } yield AggFilter(cond, aggIR, isScan)
       case "AggExplode" =>
         val name = identifier(it)
         val isScan = boolean_literal(it)
         for {
-          a <- ir_value_expr(env)(it)
-          aggBody <- ir_value_expr(env + (name -> coerce[TStream](a.typ).elementType))(it)
+          a <- ir_value_expr(env.promoteAggScan(isScan))(it)
+          aggBody <- ir_value_expr(env.bindAggScan(isScan, name -> coerce[TStream](a.typ).elementType))(it)
         } yield AggExplode(a, name, aggBody, isScan)
       case "AggGroupBy" =>
         val isScan = boolean_literal(it)
         for {
-          key <- ir_value_expr(env)(it)
+          key <- ir_value_expr(env.promoteAggScan(isScan))(it)
           aggIR <- ir_value_expr(env)(it)
         } yield AggGroupBy(key, aggIR, isScan)
       case "AggArrayPerElement" =>
@@ -1185,24 +1235,24 @@ object IRParser {
         val isScan = boolean_literal(it)
         val hasKnownLength = boolean_literal(it)
         for {
-          a <- ir_value_expr(env)(it)
+          a <- ir_value_expr(env.promoteAggScan(isScan))(it)
           aggBody <- ir_value_expr(env
-            + (elementName -> coerce[TArray](a.typ).elementType)
-            + (indexName -> TInt32))(it)
+            .bindEval(indexName, TInt32)
+            .bindAggScan(isScan, indexName -> TInt32, elementName -> coerce[TArray](a.typ).elementType))(it)
           knownLength <- if (hasKnownLength) ir_value_expr(env)(it).map(Some(_)) else done(None)
         } yield AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan)
       case "ApplyAggOp" =>
         val aggOp = agg_op(it)
         for {
-          initOpArgs <- ir_value_exprs(env)(it)
-          seqOpArgs <- ir_value_exprs(env)(it)
+          initOpArgs <- ir_value_exprs(env.noAgg)(it)
+          seqOpArgs <- ir_value_exprs(env.promoteAgg)(it)
           aggSig = AggSignature(aggOp, initOpArgs.map(arg => arg.typ), seqOpArgs.map(arg => arg.typ))
         } yield ApplyAggOp(initOpArgs, seqOpArgs, aggSig)
       case "ApplyScanOp" =>
         val aggOp = agg_op(it)
         for {
-          initOpArgs <- ir_value_exprs(env)(it)
-          seqOpArgs <- ir_value_exprs(env)(it)
+          initOpArgs <- ir_value_exprs(env.noScan)(it)
+          seqOpArgs <- ir_value_exprs(env.promoteScan)(it)
           aggSig = AggSignature(aggOp, initOpArgs.map(arg => arg.typ), seqOpArgs.map(arg => arg.typ))
         } yield ApplyScanOp(initOpArgs, seqOpArgs, aggSig)
       case "AggFold" =>
@@ -1210,9 +1260,14 @@ object IRParser {
         val otherAccumName = identifier(it)
         val isScan = boolean_literal(it)
         for {
-          zero <- ir_value_expr(env)(it)
-          seqOp <- ir_value_expr(env + (accumName -> zero.typ))(it)
-          combOp <- ir_value_expr(env + (accumName -> zero.typ) + (otherAccumName -> zero.typ))(it)
+          zero <- ir_value_expr(env.noAggScan(isScan))(it)
+          seqOp <- ir_value_expr(env.promoteAggScan(isScan).bindEval(accumName, zero.typ))(it)
+          combEnv = (if (isScan)
+              env.copy(refMap = env.refMap.copy(eval = Env.empty, scan = None))
+            else
+              env.copy(refMap = env.refMap.copy(eval = Env.empty, agg = None))
+            ).bindEval(accumName -> zero.typ, otherAccumName -> zero.typ)
+          combOp <- ir_value_expr(combEnv)(it)
         } yield AggFold(zero, seqOp, combOp, accumName, otherAccumName, isScan)
       case "InitOp" =>
         val i = int32_literal(it)
@@ -1323,78 +1378,78 @@ object IRParser {
           invoke(function, rt, typeArgs, errorID, args: _*)
         }
       case "MatrixCount" =>
-        matrix_ir(env.withRefMap(Map.empty))(it).map(MatrixCount)
+        matrix_ir(env)(it).map(MatrixCount)
       case "TableCount" =>
-        table_ir(env.withRefMap(Map.empty))(it).map(TableCount)
+        table_ir(env)(it).map(TableCount)
       case "TableGetGlobals" =>
-        table_ir(env.withRefMap(Map.empty))(it).map(TableGetGlobals)
+        table_ir(env)(it).map(TableGetGlobals)
       case "TableCollect" =>
-        table_ir(env.withRefMap(Map.empty))(it).map(TableCollect)
+        table_ir(env)(it).map(TableCollect)
       case "TableAggregate" =>
         for {
-          child <- table_ir(env.withRefMap(Map.empty))(it)
-          query <- ir_value_expr(env.update(child.typ.refMap))(it)
+          child <- table_ir(env.onlyRelational)(it)
+          query <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.globalEnv).bindAgg(child.typ.rowEnv))(it)
         } yield TableAggregate(child, query)
       case "TableToValueApply" =>
         val config = string_literal(it)
-        table_ir(env.withRefMap(Map.empty))(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableToValueApply(child, RelationalFunctions.lookupTableToValue(env.ctx, config))
         }
       case "MatrixToValueApply" =>
         val config = string_literal(it)
-        matrix_ir(env.withRefMap(Map.empty))(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixToValueApply(child, RelationalFunctions.lookupMatrixToValue(env.ctx, config))
         }
       case "BlockMatrixToValueApply" =>
         val config = string_literal(it)
-        blockmatrix_ir(env.withRefMap(Map.empty))(it).map { child =>
+        blockmatrix_ir(env)(it).map { child =>
           BlockMatrixToValueApply(child, RelationalFunctions.lookupBlockMatrixToValue(env.ctx, config))
         }
       case "BlockMatrixCollect" =>
-        blockmatrix_ir(env.withRefMap(Map.empty))(it).map(BlockMatrixCollect)
+        blockmatrix_ir(env)(it).map(BlockMatrixCollect)
       case "TableWrite" =>
         implicit val formats = TableWriter.formats
         val writerStr = string_literal(it)
-        table_ir(env.withRefMap(Map.empty))(it).map { child =>
+        table_ir(env)(it).map { child =>
           TableWrite(child, deserialize[TableWriter](writerStr))
         }
       case "TableMultiWrite" =>
         implicit val formats = WrappedMatrixNativeMultiWriter.formats
         val writerStr = string_literal(it)
-        table_ir_children(env.withRefMap(Map.empty))(it).map { children =>
+        table_ir_children(env)(it).map { children =>
           TableMultiWrite(children, deserialize[WrappedMatrixNativeMultiWriter](writerStr))
         }
       case "MatrixAggregate" =>
         for {
-          child <- matrix_ir(env.withRefMap(Map.empty))(it)
-          query <- ir_value_expr(env.update(child.typ.refMap))(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          query <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.globalEnv).bindAgg(child.typ.entryEnv))(it)
         } yield MatrixAggregate(child, query)
       case "MatrixWrite" =>
         val writerStr = string_literal(it)
         implicit val formats: Formats = MatrixWriter.formats
         val writer = deserialize[MatrixWriter](writerStr)
-        matrix_ir(env.withRefMap(Map.empty))(it).map { child =>
+        matrix_ir(env)(it).map { child =>
           MatrixWrite(child, writer)
         }
       case "MatrixMultiWrite" =>
         val writerStr = string_literal(it)
         implicit val formats = MatrixNativeMultiWriter.formats
         val writer = deserialize[MatrixNativeMultiWriter](writerStr)
-        matrix_ir_children(env.withRefMap(Map.empty))(it).map { children =>
+        matrix_ir_children(env)(it).map { children =>
           MatrixMultiWrite(children, writer)
         }
       case "BlockMatrixWrite" =>
         val writerStr = string_literal(it)
         implicit val formats: Formats = BlockMatrixWriter.formats
         val writer = deserialize[BlockMatrixWriter](writerStr)
-        blockmatrix_ir(env.withRefMap(Map.empty))(it).map { child =>
+        blockmatrix_ir(env)(it).map { child =>
           BlockMatrixWrite(child, writer)
         }
       case "BlockMatrixMultiWrite" =>
         val writerStr = string_literal(it)
         implicit val formats: Formats = BlockMatrixWriter.formats
         val writer = deserialize[BlockMatrixMultiWriter](writerStr)
-        repUntil(it, blockmatrix_ir(env.withRefMap(Map.empty)), PunctuationToken(")")).map { blockMatrices =>
+        repUntil(it, blockmatrix_ir(env), PunctuationToken(")")).map { blockMatrices =>
           BlockMatrixMultiWrite(blockMatrices.toFastIndexedSeq, writer)
         }
       case "CollectDistributedArray" =>
@@ -1404,7 +1459,7 @@ object IRParser {
         for {
           ctxs <- ir_value_expr(env)(it)
           globals <- ir_value_expr(env)(it)
-          body <- ir_value_expr(env + (cname -> coerce[TStream](ctxs.typ).elementType) + (gname -> globals.typ))(it)
+          body <- ir_value_expr(env.onlyRelational.bindEval(cname -> coerce[TStream](ctxs.typ).elementType, gname -> globals.typ))(it)
           dynamicID <- ir_value_expr(env)(it)
         } yield CollectDistributedArray(ctxs, globals, cname, gname, body, dynamicID, staticID)
       case "JavaIR" =>
@@ -1479,14 +1534,14 @@ object IRParser {
       case "TableKeyBy" =>
         val keys = identifiers(it)
         val isSorted = boolean_literal(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableKeyBy(child, keys, isSorted)
         }
-      case "TableDistinct" => table_ir(env)(it).map(TableDistinct)
+      case "TableDistinct" => table_ir(env.onlyRelational)(it).map(TableDistinct)
       case "TableFilter" =>
         for {
-          child <- table_ir(env)(it)
-          pred <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- table_ir(env.onlyRelational)(it)
+          pred <- ir_value_expr(env.onlyRelational.bindEval(child.typ.rowEnv))(it)
         } yield TableFilter(child, pred)
       case "TableRead" =>
         val requestedTypeRaw = it.head match {
@@ -1507,130 +1562,129 @@ object IRParser {
           case Right(t) => t
         }
         done(TableRead(requestedType, dropRows, reader))
-      case "MatrixColsTable" => matrix_ir(env)(it).map(MatrixColsTable)
-      case "MatrixRowsTable" => matrix_ir(env)(it).map(MatrixRowsTable)
-      case "MatrixEntriesTable" => matrix_ir(env)(it).map(MatrixEntriesTable)
+      case "MatrixColsTable" => matrix_ir(env.onlyRelational)(it).map(MatrixColsTable)
+      case "MatrixRowsTable" => matrix_ir(env.onlyRelational)(it).map(MatrixRowsTable)
+      case "MatrixEntriesTable" => matrix_ir(env.onlyRelational)(it).map(MatrixEntriesTable)
       case "TableAggregateByKey" =>
         for {
-          child <- table_ir(env)(it)
-          expr <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- table_ir(env.onlyRelational)(it)
+          expr <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.globalEnv).bindAgg(child.typ.rowEnv))(it)
         } yield TableAggregateByKey(child, expr)
       case "TableKeyByAndAggregate" =>
         val nPartitions = opt(it, int32_literal)
         val bufferSize = int32_literal(it)
         for {
-          child <- table_ir(env)(it)
-          newEnv = env.withRefMap(child.typ.refMap)
-          expr <- ir_value_expr(newEnv)(it)
-          newKey <- ir_value_expr(newEnv)(it)
+          child <- table_ir(env.onlyRelational)(it)
+          expr <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.globalEnv).bindAgg(child.typ.rowEnv))(it)
+          newKey <- ir_value_expr(env.onlyRelational.bindEval(child.typ.rowEnv))(it)
         } yield TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize)
       case "TableRepartition" =>
         val n = int32_literal(it)
         val strategy = int32_literal(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableRepartition(child, n, strategy)
         }
       case "TableHead" =>
         val n = int64_literal(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableHead(child, n)
         }
       case "TableTail" =>
         val n = int64_literal(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableTail(child, n)
         }
       case "TableJoin" =>
         val joinType = identifier(it)
         val joinKey = int32_literal(it)
         for {
-          left <- table_ir(env)(it)
-          right <- table_ir(env)(it)
+          left <- table_ir(env.onlyRelational)(it)
+          right <- table_ir(env.onlyRelational)(it)
         } yield TableJoin(left, right, joinType, joinKey)
       case "TableLeftJoinRightDistinct" =>
         val root = identifier(it)
         for {
-          left <- table_ir(env)(it)
-          right <- table_ir(env)(it)
+          left <- table_ir(env.onlyRelational)(it)
+          right <- table_ir(env.onlyRelational)(it)
         } yield TableLeftJoinRightDistinct(left, right, root)
       case "TableIntervalJoin" =>
         val root = identifier(it)
         val product = boolean_literal(it)
         for {
-          left <- table_ir(env)(it)
-          right <- table_ir(env)(it)
+          left <- table_ir(env.onlyRelational)(it)
+          right <- table_ir(env.onlyRelational)(it)
         } yield TableIntervalJoin(left, right, root, product)
       case "TableMultiWayZipJoin" =>
         val dataName = string_literal(it)
         val globalsName = string_literal(it)
-        table_ir_children(env)(it).map { children =>
+        table_ir_children(env.onlyRelational)(it).map { children =>
           TableMultiWayZipJoin(children, dataName, globalsName)
         }
       case "TableParallelize" =>
         val nPartitions = opt(it, int32_literal)
-        ir_value_expr(env)(it).map { rowsAndGlobal =>
+        ir_value_expr(env.onlyRelational)(it).map { rowsAndGlobal =>
           TableParallelize(rowsAndGlobal, nPartitions)
         }
       case "TableMapRows" =>
         for {
-          child <- table_ir(env)(it)
-          newRow <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- table_ir(env.onlyRelational)(it)
+          newRow <- ir_value_expr(env.onlyRelational.createScan.bindEval(child.typ.rowEnv).bindScan(child.typ.rowEnv))(it)
         } yield TableMapRows(child, newRow)
       case "TableMapGlobals" =>
         for {
-          child <- table_ir(env)(it)
-          newRow <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- table_ir(env.onlyRelational)(it)
+          newRow <- ir_value_expr(env.onlyRelational.bindEval(child.typ.globalEnv))(it)
         } yield TableMapGlobals(child, newRow)
       case "TableRange" =>
         val n = int32_literal(it)
         val nPartitions = opt(it, int32_literal)
         done(TableRange(n, nPartitions.getOrElse(HailContext.backend.defaultParallelism)))
-      case "TableUnion" => table_ir_children(env)(it).map(TableUnion(_))
+      case "TableUnion" => table_ir_children(env.onlyRelational)(it).map(TableUnion(_))
       case "TableOrderBy" =>
         val sortFields = sort_fields(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableOrderBy(child, sortFields)
         }
       case "TableExplode" =>
         val path = string_literals(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableExplode(child, path)
         }
       case "CastMatrixToTable" =>
         val entriesField = string_literal(it)
         val colsField = string_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           CastMatrixToTable(child, entriesField, colsField)
         }
       case "MatrixToTableApply" =>
         val config = string_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixToTableApply(child, RelationalFunctions.lookupMatrixToTable(env.ctx, config))
         }
       case "TableToTableApply" =>
         val config = string_literal(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableToTableApply(child, RelationalFunctions.lookupTableToTable(env.ctx, config))
         }
       case "BlockMatrixToTableApply" =>
         val config = string_literal(it)
         for {
-          bm <- blockmatrix_ir(env)(it)
-          aux <- ir_value_expr(env)(it)
+          bm <- blockmatrix_ir(env.onlyRelational)(it)
+          aux <- ir_value_expr(env.onlyRelational)(it)
         } yield BlockMatrixToTableApply(bm, aux, RelationalFunctions.lookupBlockMatrixToTable(env.ctx, config))
-      case "BlockMatrixToTable" => blockmatrix_ir(env)(it).map(BlockMatrixToTable)
+      case "BlockMatrixToTable" => blockmatrix_ir(env.onlyRelational)(it).map(BlockMatrixToTable)
       case "TableRename" =>
         val rowK = string_literals(it)
         val rowV = string_literals(it)
         val globalK = string_literals(it)
         val globalV = string_literals(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableRename(child, rowK.zip(rowV).toMap, globalK.zip(globalV).toMap)
         }
       case "TableFilterIntervals" =>
         val intervals = string_literal(it)
         val keep = boolean_literal(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           TableFilterIntervals(child,
             JSONAnnotationImpex.importAnnotation(JsonMethods.parse(intervals),
               TArray(TInterval(child.typ.keyType)),
@@ -1641,14 +1695,14 @@ object IRParser {
         val globalsName = identifier(it)
         val partitionStreamName = identifier(it)
         for {
-          child <- table_ir(env)(it)
-          body <- ir_value_expr(env ++ Array((globalsName, child.typ.globalType), (partitionStreamName, TStream(child.typ.rowType))))(it)
+          child <- table_ir(env.onlyRelational)(it)
+          body <- ir_value_expr(env.onlyRelational.bindEval(globalsName -> child.typ.globalType, partitionStreamName -> TStream(child.typ.rowType)))(it)
         } yield TableMapPartitions(child, globalsName, partitionStreamName, body)
       case "RelationalLetTable" =>
         val name = identifier(it)
         for {
-          value <- ir_value_expr(env)(it)
-          body <- table_ir(env)(it)
+          value <- ir_value_expr(env.onlyRelational)(it)
+          body <- table_ir(env.onlyRelational.bindRelational(name, value.typ))(it)
         } yield RelationalLetTable(name, value, body)
       case "JavaTable" =>
         val name = identifier(it)
@@ -1671,65 +1725,69 @@ object IRParser {
     identifier(it) match {
       case "MatrixFilterCols" =>
         for {
-          child <- matrix_ir(env)(it)
-          pred <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          pred <- ir_value_expr(env.onlyRelational.bindEval(child.typ.colEnv))(it)
         } yield MatrixFilterCols(child, pred)
       case "MatrixFilterRows" =>
         for {
-          child <- matrix_ir(env)(it)
-          pred <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          pred <- ir_value_expr(env.onlyRelational.bindEval(child.typ.rowEnv))(it)
         } yield MatrixFilterRows(child, pred)
       case "MatrixFilterEntries" =>
         for {
-          child <- matrix_ir(env)(it)
-          pred <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          pred <- ir_value_expr(env.onlyRelational.bindEval(child.typ.entryEnv))(it)
         } yield MatrixFilterEntries(child, pred)
       case "MatrixMapCols" =>
         val newKey = opt(it, string_literals)
         for {
-          child <- matrix_ir(env)(it)
-          newCol <- ir_value_expr(env.withRefMap(child.typ.refMap) + ("n_rows" -> TInt64))(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          newEnv = env.onlyRelational.createAgg.createScan
+            .bindEval(child.typ.colEnv).bindEval("n_rows", TInt64)
+            .bindAgg(child.typ.entryEnv).bindScan(child.typ.colEnv)
+          newCol <- ir_value_expr(newEnv)(it)
         } yield MatrixMapCols(child, newCol, newKey.map(_.toFastIndexedSeq))
       case "MatrixKeyRowsBy" =>
         val key = identifiers(it)
         val isSorted = boolean_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixKeyRowsBy(child, key, isSorted)
         }
       case "MatrixMapRows" =>
         for {
-          child <- matrix_ir(env)(it)
-          newRow <- ir_value_expr(env.withRefMap(child.typ.refMap) + ("n_cols" -> TInt32))(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          newEnv = env.onlyRelational.createAgg.createScan
+            .bindEval(child.typ.rowEnv).bindEval("n_cols", TInt32)
+            .bindAgg(child.typ.entryEnv).bindScan(child.typ.rowEnv)
+          newRow <- ir_value_expr(newEnv)(it)
         } yield MatrixMapRows(child, newRow)
       case "MatrixMapEntries" =>
         for {
           child <- matrix_ir(env)(it)
-          newEntry <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          newEntry <- ir_value_expr(env.onlyRelational.bindEval(child.typ.entryEnv))(it)
         } yield MatrixMapEntries(child, newEntry)
       case "MatrixUnionCols" =>
         val joinType = identifier(it)
         for {
-          left <- matrix_ir(env)(it)
-          right <- matrix_ir(env)(it)
+          left <- matrix_ir(env.onlyRelational)(it)
+          right <- matrix_ir(env.onlyRelational)(it)
         } yield MatrixUnionCols(left, right, joinType)
       case "MatrixMapGlobals" =>
         for {
-          child <- matrix_ir(env)(it)
-          newGlobals <- ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          newGlobals <- ir_value_expr(env.onlyRelational.bindEval(child.typ.globalEnv))(it)
         } yield MatrixMapGlobals(child, newGlobals)
       case "MatrixAggregateColsByKey" =>
         for {
-          child <- matrix_ir(env)(it)
-          newEnv = env.withRefMap(child.typ.refMap)
-          entryExpr <- ir_value_expr(newEnv)(it)
-          colExpr <- ir_value_expr(newEnv)(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          entryExpr <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.rowEnv).bindAgg(child.typ.entryEnv))(it)
+          colExpr <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.globalEnv).bindAgg(child.typ.colEnv))(it)
         } yield MatrixAggregateColsByKey(child, entryExpr, colExpr)
       case "MatrixAggregateRowsByKey" =>
         for {
-          child <- matrix_ir(env)(it)
-          newEnv = env.withRefMap(child.typ.refMap)
-          entryExpr <- ir_value_expr(newEnv)(it)
-          rowExpr <- ir_value_expr(newEnv)(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          entryExpr <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.colEnv).bindAgg(child.typ.entryEnv))(it)
+          rowExpr <- ir_value_expr(env.onlyRelational.createAgg.bindEval(child.typ.globalEnv).bindAgg(child.typ.rowEnv))(it)
         } yield MatrixAggregateRowsByKey(child, entryExpr, rowExpr)
       case "MatrixRead" =>
         val requestedTypeRaw = it.head match {
@@ -1742,7 +1800,7 @@ object IRParser {
         val dropCols = boolean_literal(it)
         val dropRows = boolean_literal(it)
         val readerStr = string_literal(it)
-        val reader = MatrixReader.fromJson(env, JsonMethods.parse(readerStr).asInstanceOf[JObject])
+        val reader = MatrixReader.fromJson(env.onlyRelational, JsonMethods.parse(readerStr).asInstanceOf[JObject])
         val fullType = reader.fullMatrixType
         val requestedType = requestedTypeRaw match {
           case Left("None") => fullType
@@ -1760,70 +1818,70 @@ object IRParser {
         val root = string_literal(it)
         val product = boolean_literal(it)
         for {
-          child <- matrix_ir(env)(it)
-          table <- table_ir(env)(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          table <- table_ir(env.onlyRelational)(it)
         } yield MatrixAnnotateRowsTable(child, table, root, product)
       case "MatrixAnnotateColsTable" =>
         val root = string_literal(it)
         for {
-          child <- matrix_ir(env)(it)
-          table <- table_ir(env)(it)
+          child <- matrix_ir(env.onlyRelational)(it)
+          table <- table_ir(env.onlyRelational)(it)
         } yield MatrixAnnotateColsTable(child, table, root)
       case "MatrixExplodeRows" =>
         val path = identifiers(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixExplodeRows(child, path)
         }
       case "MatrixExplodeCols" =>
         val path = identifiers(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixExplodeCols(child, path)
         }
       case "MatrixChooseCols" =>
         val oldIndices = int32_literals(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixChooseCols(child, oldIndices)
         }
       case "MatrixCollectColsByKey" =>
-        matrix_ir(env)(it).map(MatrixCollectColsByKey)
+        matrix_ir(env.onlyRelational)(it).map(MatrixCollectColsByKey)
       case "MatrixRepartition" =>
         val n = int32_literal(it)
         val strategy = int32_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixRepartition(child, n, strategy)
         }
-      case "MatrixUnionRows" => matrix_ir_children(env)(it).map(MatrixUnionRows(_))
-      case "MatrixDistinctByRow" => matrix_ir(env)(it).map(MatrixDistinctByRow)
+      case "MatrixUnionRows" => matrix_ir_children(env.onlyRelational)(it).map(MatrixUnionRows(_))
+      case "MatrixDistinctByRow" => matrix_ir(env.onlyRelational)(it).map(MatrixDistinctByRow)
       case "MatrixRowsHead" =>
         val n = int64_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixRowsHead(child, n)
         }
       case "MatrixColsHead" =>
         val n = int32_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixColsHead(child, n)
         }
       case "MatrixRowsTail" =>
         val n = int64_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixRowsTail(child, n)
         }
       case "MatrixColsTail" =>
         val n = int32_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixColsTail(child, n)
         }
       case "CastTableToMatrix" =>
         val entriesField = identifier(it)
         val colsField = identifier(it)
         val colKey = identifiers(it)
-        table_ir(env)(it).map { child =>
+        table_ir(env.onlyRelational)(it).map { child =>
           CastTableToMatrix(child, entriesField, colsField, colKey)
         }
       case "MatrixToMatrixApply" =>
         val config = string_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixToMatrixApply(child, RelationalFunctions.lookupMatrixToMatrix(env.ctx, config))
         }
       case "MatrixRename" =>
@@ -1835,13 +1893,13 @@ object IRParser {
         val rowV = string_literals(it)
         val entryK = string_literals(it)
         val entryV = string_literals(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixRename(child, globalK.zip(globalV).toMap, colK.zip(colV).toMap, rowK.zip(rowV).toMap, entryK.zip(entryV).toMap)
         }
       case "MatrixFilterIntervals" =>
         val intervals = string_literal(it)
         val keep = boolean_literal(it)
-        matrix_ir(env)(it).map { child =>
+        matrix_ir(env.onlyRelational)(it).map { child =>
           MatrixFilterIntervals(child,
             JSONAnnotationImpex.importAnnotation(JsonMethods.parse(intervals),
               TArray(TInterval(child.typ.rowKeyStruct)),
@@ -1851,8 +1909,8 @@ object IRParser {
       case "RelationalLetMatrixTable" =>
         val name = identifier(it)
         for {
-          value <- ir_value_expr(env)(it)
-          body <- matrix_ir(env)(it)
+          value <- ir_value_expr(env.onlyRelational)(it)
+          body <- matrix_ir(env.onlyRelational.bindRelational(name, value.typ))(it)
         } yield RelationalLetMatrixTable(name, value, body)
       case "JavaMatrix" =>
         val name = identifier(it)
@@ -1934,56 +1992,56 @@ object IRParser {
         val name = identifier(it)
         val needs_dense = boolean_literal(it)
         for {
-          child <- blockmatrix_ir(env)(it)
-          f <- ir_value_expr(env + (name -> child.typ.elementType))(it)
+          child <- blockmatrix_ir(env.onlyRelational)(it)
+          f <- ir_value_expr(env.onlyRelational.bindEval(name, child.typ.elementType))(it)
         } yield BlockMatrixMap(child, name, f, needs_dense)
       case "BlockMatrixMap2" =>
         val lName = identifier(it)
         val rName = identifier(it)
         val sparsityStrategy = SparsityStrategy.fromString(identifier(it))
         for {
-          left <- blockmatrix_ir(env)(it)
-          right <- blockmatrix_ir(env)(it)
-          f <- ir_value_expr(env.update(Map(lName -> left.typ.elementType, rName -> right.typ.elementType)))(it)
+          left <- blockmatrix_ir(env.onlyRelational)(it)
+          right <- blockmatrix_ir(env.onlyRelational)(it)
+          f <- ir_value_expr(env.onlyRelational.bindEval(lName -> left.typ.elementType, rName -> right.typ.elementType))(it)
         } yield BlockMatrixMap2(left, right, lName, rName, f, sparsityStrategy)
       case "BlockMatrixDot" =>
         for {
-          left <- blockmatrix_ir(env)(it)
-          right <- blockmatrix_ir(env)(it)
+          left <- blockmatrix_ir(env.onlyRelational)(it)
+          right <- blockmatrix_ir(env.onlyRelational)(it)
         } yield BlockMatrixDot(left, right)
       case "BlockMatrixBroadcast" =>
         val inIndexExpr = int32_literals(it)
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
-        blockmatrix_ir(env)(it).map { child =>
+        blockmatrix_ir(env.onlyRelational)(it).map { child =>
           BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize)
         }
       case "BlockMatrixAgg" =>
         val outIndexExpr = int32_literals(it)
-        blockmatrix_ir(env)(it).map { child =>
+        blockmatrix_ir(env.onlyRelational)(it).map { child =>
           BlockMatrixAgg(child, outIndexExpr)
         }
       case "BlockMatrixFilter" =>
         val indices = literals(literals(int64_literal))(it)
-        blockmatrix_ir(env)(it).map { child =>
+        blockmatrix_ir(env.onlyRelational)(it).map { child =>
           BlockMatrixFilter(child, indices)
         }
       case "BlockMatrixDensify" =>
-        blockmatrix_ir(env)(it).map(BlockMatrixDensify)
+        blockmatrix_ir(env.onlyRelational)(it).map(BlockMatrixDensify)
       case "BlockMatrixSparsify" =>
         for {
-          sparsifier <- blockmatrix_sparsifier(env)(it)
-          child <- blockmatrix_ir(env)(it)
+          sparsifier <- blockmatrix_sparsifier(env.onlyRelational)(it)
+          child <- blockmatrix_ir(env.onlyRelational)(it)
         } yield BlockMatrixSparsify(child, sparsifier)
       case "BlockMatrixSlice" =>
         val slices = literals(literals(int64_literal))(it)
-        blockmatrix_ir(env)(it).map { child =>
+        blockmatrix_ir(env.onlyRelational)(it).map { child =>
           BlockMatrixSlice(child, slices.map(_.toFastIndexedSeq).toFastIndexedSeq)
         }
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
-        ir_value_expr(env)(it).map { child =>
+        ir_value_expr(env.onlyRelational)(it).map { child =>
           ValueToBlockMatrix(child, shape, blockSize)
         }
       case "BlockMatrixRandom" =>
@@ -1995,8 +2053,8 @@ object IRParser {
       case "RelationalLetBlockMatrix" =>
         val name = identifier(it)
         for {
-          value <- ir_value_expr(env)(it)
-          body <- blockmatrix_ir(env)(it)
+          value <- ir_value_expr(env.onlyRelational)(it)
+          body <- blockmatrix_ir(env.onlyRelational.bindRelational(name, value.typ))(it)
         } yield RelationalLetBlockMatrix(name, value, body)
       case "JavaBlockMatrix" =>
         val name = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -96,7 +96,7 @@ object IRFunctionRegistry {
 
     val typeParameters = typeParamStrs.map(IRParser.parseType).toFastIndexedSeq
     val valueParameterTypes = argTypeStrs.map(IRParser.parseType).toFastIndexedSeq
-    val refMap = argNames.zip(valueParameterTypes).toMap
+    val refMap = BindingEnv.eval(argNames.zip(valueParameterTypes): _*)
     val body = IRParser.parse_value_ir(
       bodyStr,
       IRParserEnvironment(ctx, refMap, Map())

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.{Region, RegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.types.physical.{PCanonicalTuple, PTuple, PType, stypes}
-import is.hail.expr.ir.{Compile, IR, IRParser, IRParserEnvironment, Interpret, Literal, MakeTuple, SingleCodeEmitParamType}
+import is.hail.expr.ir.{BindingEnv, Compile, IR, IRParser, IRParserEnvironment, Interpret, Literal, MakeTuple, SingleCodeEmitParamType}
 import is.hail.types.physical.stypes.PTypeReferenceSingleCodeType
 import is.hail.types.virtual._
 import org.apache.spark.sql.Row
@@ -57,7 +57,7 @@ object Graph {
       warn(s"over 400,000 edges are in the graph; maximal_independent_set may run out of memory")
 
     val wrappedNodeType = PCanonicalTuple(true, PType.canonical(nodeType))
-    val refMap = Map("l" -> wrappedNodeType.virtualType, "r" -> wrappedNodeType.virtualType)
+    val refMap = BindingEnv.eval[Type]("l" -> wrappedNodeType.virtualType, "r" -> wrappedNodeType.virtualType)
 
     ExecuteContext.scoped() { ctx =>
       val region = ctx.r

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2661,13 +2661,13 @@ class IRSuite extends HailSuite {
   }
 
   @DataProvider(name = "valueIRs")
-  def valueIRs(): Array[Array[IR]] = {
+  def valueIRs(): Array[Array[Object]] = {
     withExecuteContext() { ctx =>
       valueIRs(ctx)
     }
   }
 
-  def valueIRs(ctx: ExecuteContext): Array[Array[IR]] = {
+  def valueIRs(ctx: ExecuteContext): Array[Array[Object]] = {
     val fs = ctx.fs
 
     IndexBgen(ctx, Array("src/test/resources/example.8bits.bgen"), rg = Some("GRCh37"), contigRecoding = Map("01" -> "1"))
@@ -2724,7 +2724,15 @@ class IRSuite extends HailSuite {
       True(), ErrorIDs.NO_ERROR)
     val rngState = RNGStateLiteral(Array(1L, 2L, 3L, 4L))
 
-    val irs = Array(
+    def collect(ir: IR): IR =
+      ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq(ir), collectSig)
+
+    implicit def addEnv(ir: IR): (IR, BindingEnv[Type] => BindingEnv[Type]) =
+      (ir, env => env)
+    implicit def liftRefs(refs: Array[Ref]): BindingEnv[Type] => BindingEnv[Type] =
+      env => env.bindEval(refs.map(r => r.name -> r.typ): _*)
+
+    val irs = Array[(IR, BindingEnv[Type] => BindingEnv[Type])](
       i, I64(5), F32(3.14f), F64(3.14), str, True(), False(), Void(),
       UUID4(),
       Cast(i, TFloat64),
@@ -2733,8 +2741,8 @@ class IRSuite extends HailSuite {
       If(b, i, j),
       Coalesce(FastSeq(i, I32(1))),
       Let("v", i, v),
-      AggLet("v", i, v, false),
-      Ref("x", TInt32),
+      AggLet("v", i, collect(v), false) -> (_.createAgg),
+      Ref("x", TInt32) -> (_.bindEval("x", TInt32)),
       ApplyBinaryPrimOp(Add(), i, j),
       ApplyUnaryPrimOp(Negate(), i),
       ApplyComparisonOp(EQ(TInt32), i, j),
@@ -2753,38 +2761,38 @@ class IRSuite extends HailSuite {
       NDArraySlice(nd, MakeTuple.ordered(FastSeq(MakeTuple.ordered(FastSeq(F64(0), F64(2), F64(1))),
                                          MakeTuple.ordered(FastSeq(F64(0), F64(2), F64(1)))))),
       NDArrayFilter(nd, FastIndexedSeq(NA(TArray(TInt64)), NA(TArray(TInt64)))),
-      ArrayRef(a, i),
-      ArrayLen(a),
+      ArrayRef(a, i) -> Array(a),
+      ArrayLen(a) -> Array(a),
       RNGSplit(rngState, MakeTuple.ordered(FastSeq(I64(1), MakeTuple.ordered(FastSeq(I64(2), I64(3)))))),
-      StreamLen(st),
+      StreamLen(st) -> Array(st),
       StreamRange(I32(0), I32(5), I32(1)),
       StreamRange(I32(0), I32(5), I32(1)),
-      ArraySort(st, b),
-      ToSet(st),
-      ToDict(std),
-      ToArray(st),
+      ArraySort(st, b) -> Array(st),
+      ToSet(st) -> Array(st),
+      ToDict(std) -> Array(std),
+      ToArray(st) -> Array(st),
       CastToArray(NA(TSet(TInt32))),
-      ToStream(a),
-      LowerBoundOnOrderedCollection(a, i, onKey = true),
-      GroupByKey(da),
-      StreamTake(st, I32(10)),
-      StreamDrop(st, I32(10)),
-      StreamTakeWhile(st, "v", v < I32(5)),
-      StreamDropWhile(st, "v", v < I32(5)),
-      StreamMap(st, "v", v),
-      StreamZip(FastIndexedSeq(st, st), FastIndexedSeq("foo", "bar"), True(), ArrayZipBehavior.TakeMinLength),
-      StreamFilter(st, "v", b),
-      StreamFlatMap(sta, "v", ToStream(a)),
-      StreamFold(st, I32(0), "x", "v", v),
-      StreamFold2(StreamFold(st, I32(0), "x", "v", v)),
-      StreamScan(st, I32(0), "x", "v", v),
+      ToStream(a) -> Array(a),
+      LowerBoundOnOrderedCollection(a, i, onKey = true) -> Array(a),
+      GroupByKey(da) -> Array(da),
+      StreamTake(st, I32(10)) -> Array(st),
+      StreamDrop(st, I32(10)) -> Array(st),
+      StreamTakeWhile(st, "v", v < I32(5)) -> Array(st),
+      StreamDropWhile(st, "v", v < I32(5)) -> Array(st),
+      StreamMap(st, "v", v) -> Array(st),
+      StreamZip(FastIndexedSeq(st, st), FastIndexedSeq("foo", "bar"), True(), ArrayZipBehavior.TakeMinLength) -> Array(st),
+      StreamFilter(st, "v", b) -> Array(st),
+      StreamFlatMap(sta, "a", ToStream(a)) -> Array(sta),
+      StreamFold(st, I32(0), "x", "v", v) -> Array(st),
+      StreamFold2(StreamFold(st, I32(0), "x", "v", v)) -> Array(st),
+      StreamScan(st, I32(0), "x", "v", v) -> Array(st),
       StreamJoinRightDistinct(
         StreamMap(StreamRange(0, 2, 1), "x", MakeStruct(FastSeq("x" -> Ref("x", TInt32)))),
         StreamMap(StreamRange(0, 3, 1), "x", MakeStruct(FastSeq("x" -> Ref("x", TInt32)))),
         FastIndexedSeq("x"), FastIndexedSeq("x"), "l", "r", I32(1), "left"),
-      StreamFor(st, "v", Void()),
-      StreamAgg(st, "x", ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq(Cast(Ref("x", TInt32), TInt64)), sumSig)),
-      StreamAggScan(st, "x", ApplyScanOp(FastIndexedSeq.empty, FastIndexedSeq(Cast(Ref("x", TInt32), TInt64)), sumSig)),
+      StreamFor(st, "v", Void()) -> Array(st),
+      StreamAgg(st, "x", ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq(Cast(Ref("x", TInt32), TInt64)), sumSig)) -> Array(st),
+      StreamAggScan(st, "x", ApplyScanOp(FastIndexedSeq.empty, FastIndexedSeq(Cast(Ref("x", TInt32), TInt64)), sumSig)) -> Array(st),
       RunAgg(Begin(FastSeq(
         InitOp(0, FastIndexedSeq(Begin(FastIndexedSeq(InitOp(0, FastSeq(), pSumSig)))), groupSignature),
         SeqOp(0, FastSeq(I32(1), SeqOp(0, FastSeq(), pSumSig)), groupSignature))),
@@ -2795,13 +2803,13 @@ class IRSuite extends HailSuite {
         SeqOp(0, FastSeq(Ref("foo", TInt32), SeqOp(0, FastSeq(), pSumSig)), groupSignature),
         AggStateValue(0, groupSignature.state),
         FastIndexedSeq(groupSignature.state)),
-      AggFilter(True(), I32(0), false),
-      AggExplode(NA(TStream(TInt32)), "x", I32(0), false),
-      AggGroupBy(True(), I32(0), false),
-      ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq(I32(0)), collectSig),
-      ApplyAggOp(FastIndexedSeq(I32(2)), FastIndexedSeq(call), callStatsSig),
-      ApplyAggOp(FastIndexedSeq(I32(10)), FastIndexedSeq(F64(-2.11), I32(4)), takeBySig),
-      AggFold(I32(0), l + I32(1), l + r, l.name, r.name, false),
+      AggFilter(True(), I32(0), false) -> (_.createAgg),
+      AggExplode(NA(TStream(TInt32)), "x", I32(0), false) -> (_.createAgg),
+      AggGroupBy(True(), I32(0), false) -> (_.createAgg),
+      ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq(I32(0)), collectSig) -> (_.createAgg),
+      ApplyAggOp(FastIndexedSeq(I32(2)), FastIndexedSeq(call), callStatsSig) -> (_.createAgg.bindAgg(call.name, call.typ)),
+      ApplyAggOp(FastIndexedSeq(I32(10)), FastIndexedSeq(F64(-2.11), I32(4)), takeBySig) -> (_.createAgg),
+      AggFold(I32(0), l + I32(1), l + r, l.name, r.name, false) -> (_.createAgg),
       InitOp(0, FastIndexedSeq(I32(2)), pCallStatsSig),
       SeqOp(0, FastIndexedSeq(i), pCollectSig),
       CombOp(0, 1, pCollectSig),
@@ -2809,20 +2817,20 @@ class IRSuite extends HailSuite {
       ResultOp(0, PhysicalAggSig(Fold(), FoldStateSig(EmitType(SInt32, true), "accum", "other", Ref("accum", TInt32)))),
       SerializeAggs(0, 0, BufferSpec.default, FastSeq(pCollectSig.state)),
       DeserializeAggs(0, 0, BufferSpec.default, FastSeq(pCollectSig.state)),
-      CombOpValue(0, bin, pCollectSig),
+      CombOpValue(0, bin, pCollectSig) -> Array(bin),
       AggStateValue(0, pCollectSig.state),
-      InitFromSerializedValue(0, bin, pCollectSig.state),
+      InitFromSerializedValue(0, bin, pCollectSig.state) -> Array(bin),
       Begin(FastIndexedSeq(Void())),
       MakeStruct(FastIndexedSeq("x" -> i)),
-      SelectFields(s, FastIndexedSeq("x", "z")),
-      InsertFields(s, FastIndexedSeq("x" -> i)),
-      InsertFields(s, FastIndexedSeq("* x *" -> i)), // Won't parse as a simple identifier
-      GetField(s, "x"),
+      SelectFields(s, FastIndexedSeq("x", "z")) -> Array(s),
+      InsertFields(s, FastIndexedSeq("x" -> i)) -> Array(s),
+      InsertFields(s, FastIndexedSeq("* x *" -> i)) -> Array(s), // Won't parse as a simple identifier
+      GetField(s, "x") -> Array(s),
       MakeTuple(FastIndexedSeq(2 -> i, 4 -> b)),
-      GetTupleElement(t, 1),
+      GetTupleElement(t, 1) -> Array(t),
       Die("mumblefoo", TFloat64),
       Trap(Die("mumblefoo", TFloat64)),
-      invoke("land", TBoolean, b, c), // ApplySpecial
+      invoke("land", TBoolean, b, c) -> Array(c), // ApplySpecial
       invoke("toFloat64", TFloat64, i), // Apply
       Literal(TStruct("x" -> TInt32), Row(1)),
       TableCount(table),
@@ -2863,7 +2871,8 @@ class IRSuite extends HailSuite {
       RelationalLet("x", I32(0), I32(0)),
       TailLoop("y", IndexedSeq("x" -> I32(0)), Recur("y", FastSeq(I32(4)), TInt32))
       )
-    irs.map(x => Array(x))
+    val emptyEnv = BindingEnv.empty[Type]
+    irs.map { case (ir, bind) => Array(ir, bind(emptyEnv)) }
   }
 
   @DataProvider(name = "tableIRs")
@@ -3061,25 +3070,8 @@ class IRSuite extends HailSuite {
   }
 
   @Test(dataProvider = "valueIRs")
-  def testValueIRParser(x: IR) {
-    val env = IRParserEnvironment(ctx, refMap = Map(
-      "c" -> TBoolean,
-      "a" -> TArray(TInt32),
-      "aa" -> TArray(TArray(TInt32)),
-      "da" -> TArray(TTuple(TInt32, TString)),
-      "st" -> TStream(TInt32),
-      "sta" -> TStream(TArray(TInt32)),
-      "std" -> TStream(TTuple(TInt32, TString)),
-      "nd" -> TNDArray(TFloat64, Nat(1)),
-      "nd2" -> TNDArray(TArray(TString), Nat(1)),
-      "v" -> TInt32,
-      "l" -> TInt32,
-      "r" -> TInt32,
-      "s" -> TStruct("x" -> TInt32, "y" -> TInt64, "z" -> TFloat64),
-      "t" -> TTuple(TInt32, TInt64, TFloat64),
-      "call" -> TCall,
-      "bin" -> TBinary,
-      "x" -> TInt32))
+  def testValueIRParser(x: IR, refMap: BindingEnv[Type]) {
+    val env = IRParserEnvironment(ctx, refMap = refMap)
 
     val s = Pretty.sexprStyle(x, elideLiterals = false)
 
@@ -3124,7 +3116,7 @@ class IRSuite extends HailSuite {
     val cached = Literal(TSet(TInt32), Set(1))
     val s = s"(JavaIR __uid1)"
     val x2 = ExecuteContext.scoped() { ctx =>
-      IRParser.parse_value_ir(s, IRParserEnvironment(ctx, refMap = Map.empty, irMap = Map("__uid1" -> cached)))
+      IRParser.parse_value_ir(s, IRParserEnvironment(ctx, irMap = Map("__uid1" -> cached)))
     }
     assert(x2 eq cached)
   }
@@ -3133,7 +3125,7 @@ class IRSuite extends HailSuite {
     val cached = TableRange(1, 1)
     val s = s"(JavaTable __uid1)"
     val x2 = ExecuteContext.scoped() { ctx =>
-      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, refMap = Map.empty, irMap = Map("__uid1" -> cached)))
+      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = Map("__uid1" -> cached)))
     }
     assert(x2 eq cached)
   }
@@ -3142,7 +3134,7 @@ class IRSuite extends HailSuite {
     val cached = MatrixIR.range(3, 7, None)
     val s = s"(JavaMatrix __uid1)"
     val x2 = ExecuteContext.scoped() { ctx =>
-      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap = Map.empty, irMap = Map("__uid1" -> cached)))
+      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = Map("__uid1" -> cached)))
     }
     assert(x2 eq cached)
   }
@@ -3152,7 +3144,7 @@ class IRSuite extends HailSuite {
     val id = hc.addIrVector(Array(cached))
     val s = s"(JavaMatrixVectorRef $id 0)"
     val x2 = ExecuteContext.scoped() { ctx =>
-      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap = Map.empty, irMap = Map.empty))
+      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = Map.empty))
     }
     assert(cached eq x2)
 


### PR DESCRIPTION
This refactors the parser to use `BindingEnv`, which tracks the separate eval, agg, scan, and relational environments. This was motivated by the new randomness work, which needs to be able to rebind row and col references in both eval and agg scopes, which was breaking the parser.

I don't like duplicating the (rather complicated) binding behavior of the nodes, but I couldn't find a way to avoid it without a much larger refactoring of the IR. So I tried to make the binding logic in the parser be as direct a copy of what is encoded in `Binds.scala` as possible. For example, relational nodes always pass `env.onlyRelational` to their children, which isn't necessary if we ensure that only relational bindings exist in environments passed to relational nodes, but it matches the logic in `Binds`.