### PR TITLE
[query/ggplot] add support for MatrixTables

### DIFF
--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -137,7 +137,8 @@ class GGPlot:
                 geom_label = make_geom_label(geom_idx)
                 fields_to_select[geom_label] = hl.struct(**geom.aes.properties)
 
-            return self.ht.select(**fields_to_select)
+            name, ht = hl.struct(**fields_to_select)._to_table('__fallback')
+            return ht.select(**{field: ht[name][field] for field in fields_to_select})
 
         def collect_mappings_and_precomputed(selected):
             mapping_per_geom = []

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -107,3 +107,19 @@ def test_faceting():
     pfig = (ggplot(ht) + geom_point(aes(x=ht.idx, y=ht.idx)) + facet_wrap(vars(ht.x))).to_plotly()
 
     assert(len(pfig.layout.annotations) == 2)
+
+
+def test_matrix_tables():
+    mt = hl.utils.range_matrix_table(3, 3)
+    mt = mt.annotate_rows(row_doubled=mt.row_idx * 2)
+    mt = mt.annotate_entries(entry_idx=mt.row_idx + mt.col_idx)
+    for field, expected in [
+            (mt.row_doubled, [(0, 0), (1, 2), (2, 4)]),
+            (mt.entry_idx, [(0, 0), (0, 1), (0, 2), (1, 1), (1, 2), (1, 3), (2, 2), (2, 3), (2, 4)])
+    ]:
+        data = (ggplot(mt, aes(x=mt.row_idx, y=field)) + geom_point()).to_plotly().data[0]
+        assert len(data.x) == len(expected)
+        assert len(data.y) == len(expected)
+        for idx, (x, y) in enumerate(zip(data.x, data.y)):
+            assert(x == expected[idx][0])
+            assert(y == expected[idx][1])


### PR DESCRIPTION
Currently, `ggplot` expects a `Table` to be passed in as its data, and errors if passed a `MatrixTable`. With this change, the following code:

```python
import hail as hl
mt = hl.utils.range_matrix_table(10, 10)
mt = mt.annotate_entries(entry_idx = mt.row_idx + mt.col_idx)
mt.show()
```

Which produces a `MatrixTable` that looks like this:

```
+---------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
| row_idx | 0.entry_idx | 1.entry_idx | 2.entry_idx | 3.entry_idx | 4.entry_idx | 5.entry_idx | 6.entry_idx | 7.entry_idx |
+---------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
|   int32 |       int32 |       int32 |       int32 |       int32 |       int32 |       int32 |       int32 |       int32 |
+---------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
|       0 |           0 |           1 |           2 |           3 |           4 |           5 |           6 |           7 |
|       1 |           1 |           2 |           3 |           4 |           5 |           6 |           7 |           8 |
|       2 |           2 |           3 |           4 |           5 |           6 |           7 |           8 |           9 |
|       3 |           3 |           4 |           5 |           6 |           7 |           8 |           9 |          10 |
|       4 |           4 |           5 |           6 |           7 |           8 |           9 |          10 |          11 |
|       5 |           5 |           6 |           7 |           8 |           9 |          10 |          11 |          12 |
|       6 |           6 |           7 |           8 |           9 |          10 |          11 |          12 |          13 |
|       7 |           7 |           8 |           9 |          10 |          11 |          12 |          13 |          14 |
|       8 |           8 |           9 |          10 |          11 |          12 |          13 |          14 |          15 |
|       9 |           9 |          10 |          11 |          12 |          13 |          14 |          15 |          16 |
+---------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
showing the first 8 of 10 columns
```

Can be plugged into `ggplot` like so:

```python
from hail.ggplot import *
fig = ggplot(mt, aes(x=mt.row_idx, y=mt.entry_idx)) + geom_point()
fig.show()
```

To produce this plot:

<img width="1512" alt="Screen Shot 2022-10-07 at 15 30 50" src="https://user-images.githubusercontent.com/84595986/194639655-e88de8fa-2992-4e57-ad06-5f6164dc4d84.png">

This is accomplished using `Expr._to_table` to transform the `MatrixTable` such that the fields used to generate the plot can be straightforwardly selected from it.