### PR TITLE
[query] union_cols can keep right row fields

### DIFF
--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -357,7 +357,15 @@ class MatrixUnionCols(MatrixIR):
     def _compute_type(self, deep_typecheck):
         self.left.compute_type(deep_typecheck)
         self.right.compute_type(deep_typecheck)
-        return self.left.typ
+        left_typ = self.left.typ
+        right_typ = self.right.typ
+        return hl.tmatrix(
+            global_type=left_typ.global_type,
+            col_type=left_typ.col_type,
+            col_key=left_typ.col_key,
+            row_type=left_typ.row_type._concat(right_typ.row_value_type),
+            row_key=left_typ.row_key,
+            entry_type=left_typ.entry_type)
 
 
 class MatrixMapEntries(MatrixIR):

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3665,8 +3665,9 @@ class MatrixTable(ExprContainer):
             return MatrixTable(ir.MatrixUnionRows(*[d._mir for d in datasets]))
 
     @typecheck_method(other=matrix_table_type,
-                      row_join_type=enumeration('inner', 'outer'))
-    def union_cols(self, other: 'MatrixTable', row_join_type='inner') -> 'MatrixTable':
+                      row_join_type=enumeration('inner', 'outer'),
+                      drop_right_row_fields=bool)
+    def union_cols(self, other: 'MatrixTable', row_join_type='inner', drop_right_row_fields=True) -> 'MatrixTable':
         """Take the union of dataset columns.
 
         Examples
@@ -3712,9 +3713,13 @@ class MatrixTable(ExprContainer):
         ----------
         other : :class:`.MatrixTable`
             Dataset to concatenate.
-        outer : bool
-            If `True`, perform an outer join on rows, otherwise perform an
-            inner join. Default `False`.
+        row_join_type : string
+            If `outer`, perform an outer join on rows; if 'inner', perform an
+            inner join. Default `inner`.
+        drop_right_row_fields : boolean
+            If true, non-key row fields of `other` are dropped. Otherwise,
+            non-key row fields in the two datasets must have distinct names,
+            and the result contains the union of the row fields.
 
         Returns
         -------
@@ -3737,6 +3742,9 @@ class MatrixTable(ExprContainer):
             raise ValueError(f'row key types differ:\n'
                              f'    left: {", ".join(self.row_key.dtype.values())}\n'
                              f'    right: {", ".join(other.row_key.dtype.values())}')
+
+        if drop_right_row_fields:
+            other = other.select_rows()
 
         return MatrixTable(ir.MatrixUnionCols(self._mir, other._mir, row_join_type))
 

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -526,7 +526,7 @@ object LowerMatrixIR {
                 handleMissingEntriesArray(entriesField, colsField),
                 handleMissingEntriesArray(Symbol(rightEntries), Symbol(rightCols)))
                 .flatMap('a ~> 'a))
-            .selectFields(ll.typ.rowType.fieldNames ++ right.typ.rowValueStruct.fieldNames: _*))
+            .dropFields(Symbol(rightEntries)))
           .mapGlobals('global
             .insertFields(colsField ->
               makeArray('global(colsField), 'global(Symbol(rightCols))).flatMap('a ~> 'a))

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -512,12 +512,10 @@ object LowerMatrixIR {
             } {
               'row(entries)
             }
+        val rr = lower(ctx, right, ab).distinct()
         TableJoin(
           ll,
-          lower(ctx, right, ab).distinct()
-            .mapRows('row
-              .insertFields(Symbol(rightEntries) -> 'row(entriesField))
-              .selectFields(right.typ.rowKey :+ rightEntries: _*))
+          rr.mapRows('row.castRename(rr.typ.rowType.rename(Map(entriesFieldName -> rightEntries))))
             .mapGlobals('global
               .insertFields(Symbol(rightCols) -> 'global(colsField))
               .selectFields(rightCols)),
@@ -528,8 +526,7 @@ object LowerMatrixIR {
                 handleMissingEntriesArray(entriesField, colsField),
                 handleMissingEntriesArray(Symbol(rightEntries), Symbol(rightCols)))
                 .flatMap('a ~> 'a))
-            // TableJoin puts keys first; drop rightEntries, but also restore left row field order
-            .selectFields(ll.typ.rowType.fieldNames: _*))
+            .selectFields(ll.typ.rowType.fieldNames ++ right.typ.rowValueStruct.fieldNames: _*))
           .mapGlobals('global
             .insertFields(colsField ->
               makeArray('global(colsField), 'global(Symbol(rightCols))).flatMap('a ~> 'a))

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -631,7 +631,7 @@ object PruneDeadFields {
         val rightRequestedType = requestedType.copy(
           globalType = TStruct.empty,
           rowKey = right.typ.rowKey,
-          rowType = selectKey(right.typ.rowType, right.typ.rowKey))
+          rowType = unify(right.typ.rowType, requestedType.rowType, selectKey(right.typ.rowType, right.typ.rowKey)))
         memoizeMatrixIR(ctx, left, leftRequestedType, memo)
         memoizeMatrixIR(ctx, right, rightRequestedType, memo)
       case MatrixMapEntries(child, newEntries) =>

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -1116,7 +1116,14 @@ class PruneSuite extends HailSuite {
       MakeStruct(Seq(("ck", getColField("ck")), ("c2", getColField("c2")), ("c3", getColField("c3")))), Some(FastIndexedSeq("ck"))
     )
 
-    val mucBothSame = MatrixUnionCols(wrappedMat, wrappedMat, "inner")
+    val wrappedMat2 = MatrixRename(
+        wrappedMat,
+        Map.empty,
+        Map.empty,
+        wrappedMat.typ.rowType.fieldNames.map(x => x -> (x + "_")).toMap,
+        Map.empty)
+
+    val mucBothSame = MatrixUnionCols(wrappedMat, wrappedMat2, "inner")
     checkRebuild(mucBothSame, mucBothSame.typ)
     checkRebuild[MatrixUnionCols](mucBothSame, mucBothSame.typ.copy(colType = TStruct(("ck", TString), ("c2", TInt32))), (old, rebuilt) =>
       (old.typ.rowType == rebuilt.typ.rowType) &&
@@ -1127,7 +1134,7 @@ class PruneSuite extends HailSuite {
 
     // Since `mat` is a MatrixLiteral, it won't be rebuilt, will keep all fields. But wrappedMat is a MatrixMapCols, so it will drop
     // unrequested fields. This test would fail without upcasting in the MatrixUnionCols rebuild rule.
-    val muc2 = MatrixUnionCols(mat, wrappedMat, "inner")
+    val muc2 = MatrixUnionCols(mat, wrappedMat2, "inner")
     checkRebuild[MatrixUnionCols](muc2, muc2.typ.copy(colType = TStruct(("ck", TString))), (old, rebuilt) =>
       childrenMatch(rebuilt)
     )


### PR DESCRIPTION
Needed for row uid propagation for randomness.