### PR TITLE
[query] allow other kwargs in export

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -951,7 +951,12 @@ class Expression(object):
                 return None, source.select_rows().select_cols()
         return self._to_relational(fallback_name)
 
-    @typecheck_method(path=str, delimiter=str, missing=str, header=bool)
+    @typecheck_method(path=str,
+                      delimiter=str,
+                      missing=str,
+                      header=bool,
+                      parallel=nullable(ir.ExportType.checker),
+                      types_file=nullable(str))
     def export(self, path, delimiter='\t', missing='NA', header=True, *, parallel=None, types_file=None):
         """Export a field to a text file.
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2835,7 +2835,7 @@ class Tests(unittest.TestCase):
         mt = hl.balding_nichols_model(1, 3, 3)
         mt = mt.key_cols_by(s = 's' + hl.str(mt.sample_idx))
         with hl.TemporaryDirectory(ensure_exists=False) as f:
-            mt.GT.export(f, parallel=True)
+            mt.GT.export(f, parallel='header_per_shard')
             actual = hl.import_matrix_table(f + '/*',
                                             row_fields={'locus': hl.tstr,
                                                         'alleles': hl.tstr},


### PR DESCRIPTION
CHANGELOG: Teach BaseExpression.export to support `parallel` and file `types_file`.