### PR TITLE
[grafana] Update to 9.1.4

### DIFF
--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -2,6 +2,7 @@ alpine:3.8
 debian:9.5
 ghost:3.0-alpine
 google/cloud-sdk:305.0.0-slim
+grafana/grafana:9.1.4
 jupyter/scipy-notebook
 jupyter/scipy-notebook:c094bb7219f9
 moby/buildkit:v0.8.3-rootless

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -16,5 +16,5 @@ build:
 
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"global": {"cloud": "$(CLOUD)", "domain": "$(DOMAIN)"},"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}, "base_image":{"image":"'$$(cat ../docker/base-image-ref)'"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"global": {"cloud": "$(CLOUD)", "domain": "$(DOMAIN)", "docker_prefix": "$(DOCKER_PREFIX)"},"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}, "base_image":{"image":"'$$(cat ../docker/base-image-ref)'"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -49,7 +49,7 @@ spec:
              name: grafana-shared
       containers:
        - name: grafana
-         image: grafana/grafana:8.0.2
+         image: {{ global.docker_prefix }}/grafana/grafana:9.1.4
          env:
 {% if deploy %}
           - name: GF_SERVER_DOMAIN


### PR DESCRIPTION
Also added it to third-party images so we're not pulling from DockerHub. Turns out the \ufeff bug we were seeing is hitting a lot of people and is addressed in this release. I put this up in my namespace to see that I can load it without error (though didn't try copying over dashboards and such).