### PR TITLE
[docker] Reorder hailgenetics hail docker image layers

### DIFF
--- a/docker/hailgenetics/hail/Dockerfile
+++ b/docker/hailgenetics/hail/Dockerfile
@@ -11,18 +11,6 @@ RUN hail-apt-get-install \
     rsync \
     unzip bzip2 zip tar tabix lz4 \
     vim pv
-RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
-    tar -xf wheel-container.tar && \
-    pip3 install -U hail-*-py3-none-any.whl && \
-    rm -rf hail-*-py3-none-any.whl
-RUN hail-pip-install \
-      ipython \
-      matplotlib \
-      numpy \
-      scikit-learn \
-      dill \
-      scipy \
-    && rm -rf hail-*-py3-none-any.whl
 RUN export SPARK_HOME=$(find_spark_home.py) && \
     curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar \
          >$SPARK_HOME/jars/gcs-connector-hadoop2-2.2.7.jar && \
@@ -37,3 +25,14 @@ RUN curl https://sdk.cloud.google.com | bash && \
       /root/google-cloud-sdk/bin/ \
       -type f -executable \
     | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
+    tar -xf wheel-container.tar && \
+    pip3 install -U hail-*-py3-none-any.whl && \
+    rm -rf hail-*-py3-none-any.whl
+RUN hail-pip-install \
+      ipython \
+      matplotlib \
+      numpy \
+      scikit-learn \
+      dill \
+      scipy

--- a/docker/hailgenetics/hail/Dockerfile
+++ b/docker/hailgenetics/hail/Dockerfile
@@ -11,14 +11,6 @@ RUN hail-apt-get-install \
     rsync \
     unzip bzip2 zip tar tabix lz4 \
     vim pv
-RUN export SPARK_HOME=$(find_spark_home.py) && \
-    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar \
-         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.2.7.jar && \
-    mkdir -p $SPARK_HOME/conf && \
-    touch $SPARK_HOME/conf/spark-defaults.conf && \
-    sed -i $SPARK_HOME/conf/spark-defaults.conf \
-        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
-        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN curl https://sdk.cloud.google.com | bash && \
     find \
@@ -36,3 +28,11 @@ RUN hail-pip-install \
       scikit-learn \
       dill \
       scipy
+RUN export SPARK_HOME=$(find_spark_home.py) && \
+    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar \
+         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.2.7.jar && \
+    mkdir -p $SPARK_HOME/conf && \
+    touch $SPARK_HOME/conf/spark-defaults.conf && \
+    sed -i $SPARK_HOME/conf/spark-defaults.conf \
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'


### PR DESCRIPTION
Installing hail from the whl is going to break this cache every time so we end up installing the gcloud sdk on every build, which takes 40 seconds. It'd be nice to also move the extra pip packages further up the image but I think they're ordered this way so that pip gives us hail-compatible versions. I think the best fix would be to track these packages in a requirements.txt that is pinned and constrained on the hail package's requirements.