### PR TITLE
[query] Redesign staged index reading to compute index then query by index

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1986,3 +1986,17 @@ def test_write_many():
             hl.Struct(idx=3, c='3'),
             hl.Struct(idx=4, c='4')
         ]
+
+@pytest.mark.parametrize('branching_factor', [2, 3, 5, 7, 121])
+def test_indexed_read_boundaries(branching_factor):
+    with hl._with_flags(index_branching_factor=str(branching_factor)):
+        t = hl.utils.range_table(1000, 4)
+        t = t.filter(t.idx % 5 != 0)
+        f = new_temp_file(extension='ht')
+        t.write(f)
+        t1 = hl.read_table(f, _intervals=[
+            hl.Interval(start=140, end=145, includes_start=True, includes_end=True),
+            hl.Interval(start=151, end=153, includes_start=False, includes_end=False),
+        ])
+
+        assert t1.idx.collect() == [141, 142, 143, 144, 152]

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -28,7 +28,8 @@ object HailFeatureFlags {
     ("grouped_aggregate_buffer_size", ("HAIL_GROUPED_AGGREGATE_BUFFER_SIZE" -> "50")),
     ("use_ssa_logs", "HAIL_USE_SSA_LOGS" -> null),
     ("gcs_requester_pays_project", "HAIL_GCS_REQUESTER_PAYS_PROJECT" -> null),
-    ("gcs_requester_pays_buckets", "HAIL_GCS_REQUESTER_PAYS_BUCKETS" -> null)
+    ("gcs_requester_pays_buckets", "HAIL_GCS_REQUESTER_PAYS_BUCKETS" -> null),
+    ("index_branching_factor", "HAIL_INDEX_BRANCHING_FACTOR" -> null)
   )
 
   def fromEnv(): HailFeatureFlags =

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -222,7 +222,8 @@ case class SplitPartitionNativeWriter(
     val iAnnotationType = PCanonicalStruct(required = true, "entries_offset" -> PInt64())
     val mb = cb.emb
 
-    val indexWriter = ifIndexed { StagedIndexWriter.withDefaults(index.get._2, mb.ecb, annotationType = iAnnotationType) }
+    val indexWriter = ifIndexed { StagedIndexWriter.withDefaults(index.get._2, mb.ecb, annotationType = iAnnotationType,
+      branchingFactor = Option(mb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)) }
 
     context.toI(cb).map(cb) { pctx =>
       val filename1 = mb.newLocal[String]("filename1")

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -222,7 +222,8 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, keyFields: Indexe
     private[this] val ctx = _ctx.asString
     private[this] val mb = cb.emb
     private[this] val indexKeyType = ifIndexed { index.get._2 }
-    private[this] val indexWriter = ifIndexed { StagedIndexWriter.withDefaults(indexKeyType, mb.ecb) }
+    private[this] val indexWriter = ifIndexed { StagedIndexWriter.withDefaults(indexKeyType, mb.ecb,
+      branchingFactor = Option(mb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)) }
     private[this] val filename = mb.newLocal[String]("filename")
     private[this] val os = mb.newLocal[ByteTrackingOutputStream]("write_os")
     private[this] val ob = mb.newLocal[OutputBuffer]("write_ob")

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -329,7 +329,7 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
     val m = cb.genEmitMethod[Unit]("writeLeafNode")
 
     val parentBuilder = new StagedInternalNodeBuilder(branchingFactor, keyType, annotationType, m.localBuilder)
-    m.emitWithBuilder { cb =>
+    m.voidWithBuilder { cb =>
       val idxOff = cb.newLocal[Long]("indexOff")
       cb.assign(idxOff, utils.bytesWritten)
       cb += ob.writeByte(0.toByte)
@@ -344,7 +344,6 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
       parentBuilder.add(cb, idxOff, leafBuilder.firstIdx(cb).asLong.value, leafBuilder.getLoadedChild)
       parentBuilder.store(cb, utils, 0)
       leafBuilder.reset(cb, elementIdx)
-      Code._empty
     }
     m
   }

--- a/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
@@ -37,8 +37,6 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
   private[this]val internalDec = spec.internalNodeCodec.encodedType.buildDecoder(spec.internalNodeCodec.encodedVirtualType, emb.ecb)
 
   private[this] val leafChildType = leafPType.asInstanceOf[PCanonicalBaseStruct].types(1).asInstanceOf[PCanonicalArray].elementType.sType
-  val leafChildEmitType = EmitType(leafChildType, false)
-  private[this] val queryType = SStackStruct(TTuple(TInt64, leafChildType.virtualType), FastIndexedSeq(EmitType(SInt64, true), leafChildEmitType))
 
   def initialize(cb: EmitCodeBuilder,
     indexPath: Value[String]
@@ -65,7 +63,7 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
   /**
    * returns tuple of (start index, end index, starting leaf)
    * memory of starting leaf is not owned by `region`, consumers should deep copy if necessary
-   * starting leaf may be missing if the index is empty
+   * starting leaf IS MISSING if (end_idx - start_idx == 0)
    */
   def queryInterval(cb: EmitCodeBuilder,
     region: Value[Region],
@@ -76,19 +74,17 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
     val includesStart = interval.includesStart()
     val includesEnd = interval.includesEnd()
 
-    val startQuerySettable = queryBound(cb, region, start, primitive(cb.memoize(!includesStart)))
-
-    val endQuerySettable = queryBound(cb, region, end, primitive(includesEnd))
-
-    val startIdx = cb.memoize(startQuerySettable.asBaseStruct.loadField(cb, 0).get(cb).asInt64.value)
-    val endIdx = cb.memoize(endQuerySettable.asBaseStruct.loadField(cb, 0).get(cb).asInt64.value)
+    val startIdx = queryBound(cb, region, start, primitive(cb.memoize(!includesStart)))
+    val endIdx = queryBound(cb, region, end, primitive(includesEnd))
     val n = cb.memoize(endIdx - startIdx)
-    val startLeaf = cb.memoize(startQuerySettable.asBaseStruct.loadField(cb, 1))
+    val nKeys = cb.memoize(metadata.invoke[Long]("nKeys"))
+    cb.ifx(n < 0L, cb._fatal("n less than 0: ", n.toS, ", startIdx=", startIdx.toS, ", endIdx=", endIdx.toS, ", query=", cb.strValue(interval)))
+    cb.ifx(n > 0L && startIdx >= nKeys, cb._fatal("bad start idx: ", startIdx.toS, ", nKeys=", nKeys.toS))
 
-    cb.ifx(n < 0L, cb._fatal("n less than 0: ", n.toS, ", startQuery=", cb.strValue(startQuerySettable), ", endQuery=", cb.strValue(endQuerySettable)))
-
-
-    SStackStruct.constructFromArgs(cb, region, TTuple(TInt64, TInt64, startLeaf.st.virtualType), EmitCode.present(cb.emb, primitive(startIdx)), EmitCode.present(cb.emb, primitive(endIdx)), startLeaf)
+    SStackStruct.constructFromArgs(cb, region, TTuple(TInt64, TInt64, leafChildType.virtualType),
+      EmitCode.present(cb.emb, primitive(startIdx)),
+      EmitCode.present(cb.emb, primitive(endIdx)),
+      EmitCode.fromI(cb.emb)(cb => IEmitCode(cb, n ceq 0L, queryIndex(cb, region, startIdx))))
   }
 
   // internal node is an array of children
@@ -147,31 +143,69 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
   }
 
   // returns queryType
-  def queryBound(cb: EmitCodeBuilder, region: Value[Region], partitionBoundLeftEndpoint: SBaseStructValue, leansRight: SBooleanValue): SBaseStructValue = {
-    cb.invokeSCode(
+  def queryBound(cb: EmitCodeBuilder, region: Value[Region], partitionBoundLeftEndpoint: SBaseStructValue, leansRight: SBooleanValue): Value[Long] = {
+    cb.invokeCode[Long](
       cb.emb.ecb.getOrGenEmitMethod("lowerBound",
         ("lowerBound", this),
         FastIndexedSeq(typeInfo[Region], partitionBoundLeftEndpoint.st.paramType, leansRight.st.paramType),
-      queryType.paramType) { emb =>
-      emb.emitSCode { cb =>
+        LongInfo) { emb =>
+      emb.emitWithBuilder { cb =>
         val region = emb.getCodeParam[Region](1)
         val endpoint = emb.getSCodeParam(2).asBaseStruct
         val leansRight = emb.getSCodeParam(3).asBoolean
-        queryType.coerceOrCopy(cb, region, queryBound(cb, region, endpoint, leansRight, cb.memoize(metadata.invoke[Int]("height") - 1), cb.memoize(metadata.invoke[Long]("rootOffset"))), false) }
-    }, region, partitionBoundLeftEndpoint, leansRight).asBaseStruct
+        queryBound(cb, region, endpoint, leansRight, cb.memoize(metadata.invoke[Int]("height") - 1), cb.memoize(metadata.invoke[Long]("rootOffset"))) }
+    }, region, partitionBoundLeftEndpoint, leansRight)
+  }
+
+  private def queryIndex(cb: EmitCodeBuilder, region: Value[Region], absIndex: Value[Long]): SBaseStructValue = {
+    cb.invokeSCode(
+      cb.emb.ecb.getOrGenEmitMethod("queryIndex",
+        ("queryIndex", this),
+        FastIndexedSeq(classInfo[Region], typeInfo[Long]),
+        leafChildType.paramType) { emb =>
+        emb.emitSCode { cb =>
+
+          val region = emb.getCodeParam[Region](1)
+          val absIndex = emb.getCodeParam[Long](2)
+          val level = cb.newLocal[Int]("lowerBound_level", metadata.invoke[Int]("height") - 1)
+          val offset = cb.newLocal[Long]("lowerBound_offset", metadata.invoke[Long]("rootOffset"))
+          val branchingFactor = cb.memoize(metadata.invoke[Int]("branchingFactor"))
+          val result = cb.emb.newPLocal(leafChildType)
+
+          val Lstart = CodeLabel()
+          cb.define(Lstart)
+          cb.ifx(level ceq 0, {
+            val leafNode = readLeafNode(cb, offset)
+            val localIdx = cb.memoize((absIndex - leafNode.loadField(cb, "first_idx").get(cb).asInt64.value.toL).toI)
+            cb.assign(result, leafNode.loadField(cb, "keys").get(cb).asIndexable.loadElement(cb, localIdx).get(cb))
+          }, {
+            val internalNode = readInternalNode(cb, offset)
+            val children = internalNode.loadField(cb, "children").get(cb).asIndexable
+            val firstIdx = children.loadElement(cb, 0).get(cb).asBaseStruct.loadField(cb, "first_idx").get(cb).asInt64.value
+            val nKeysPerChild = cb.memoize(Code.invokeStatic2[java.lang.Math, Double, Double, Double]("pow",
+              branchingFactor.toD,
+              level.toD).toL)
+            val localIdx = cb.memoize((absIndex - firstIdx) / nKeysPerChild)
+            cb.assign(level, level - 1)
+            cb.assign(offset, children.loadElement(cb, localIdx.toI).get(cb).asBaseStruct.loadField(cb, "index_file_offset").get(cb).asInt64.value)
+            cb.goto(Lstart)
+          })
+
+          leafChildType.coerceOrCopy(cb, region, result, false)
+        }
+      }, region, absIndex).asBaseStruct
   }
 
   // partitionBoundEndpoint is a tuple(partitionBoundEndpoint, bool)
-  // returns a tuple of (index, LeafChild)
+  // returns leaf index
   private def queryBound(cb: EmitCodeBuilder,
     region: Value[Region],
     endpoint: SBaseStructValue,
     leansRight: SBooleanValue,
     level: Value[Int],
-    offset: Value[Long]): SBaseStructValue = {
+    offset: Value[Long]): Value[Long] = {
 
     val rInd: Settable[Long] = cb.newLocal[Long]("lowerBoundIndex")
-    val rLeafChild: EmitSettable = cb.emb.newEmitLocal(leafChildEmitType)
 
     val levelSettable = cb.newLocal[Int]("lowerBound_level")
     val offsetSettable = cb.newLocal[Long]("lowerBound_offset")
@@ -222,15 +256,11 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
       val firstIndex = node.asBaseStruct.loadField(cb, "first_idx").get(cb).asInt64.value.get
       val updatedIndex = firstIndex + idx.toL
       cb.assign(rInd, updatedIndex)
-      cb.assign(rLeafChild, IEmitCode(cb,
-        idx >= children.loadLength(),
-        children.loadElement(cb, idx).get(cb).asBaseStruct))
     }, {
       val children = readInternalNode(cb, offsetSettable).loadField(cb, "children").get(cb).asIndexable
       cb.ifx(children.loadLength() ceq 0, {
-        // empty interal node occurs if the indexed file contains no keys
+        // empty internal node occurs if the indexed file contains no keys
         cb.assign(rInd, 0L)
-        cb.assign(rLeafChild, EmitCode.missing(cb.emb, leafChildType))
       }, {
         val idx = new BinarySearch(cb.emb,
           children.st,
@@ -253,8 +283,6 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
       })
     })
 
-    SStackStruct.constructFromArgs(cb, region, queryType.virtualType,
-      EmitCode.present(cb.emb, primitive(rInd)),
-      rLeafChild)
+    rInd
   }
 }

--- a/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
@@ -142,7 +142,6 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
     ret.asBaseStruct
   }
 
-  // returns queryType
   def queryBound(cb: EmitCodeBuilder, region: Value[Region], partitionBoundLeftEndpoint: SBaseStructValue, leansRight: SBooleanValue): Value[Long] = {
     cb.invokeCode[Long](
       cb.emb.ecb.getOrGenEmitMethod("lowerBound",


### PR DESCRIPTION
CHANGELOG: Fixes a rare crash reading tables/matrixtables with _intervals