### PR TITLE
[ci] Separate .git from repo to shrink input sizes

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -18,6 +18,8 @@ steps:
       {{ code.checkout_script }}
       make -C hail python-version-info
       git rev-parse HEAD > git_version
+      # Separate out the large git history from the repo code
+      mv .git ../git
     outputs:
       - from: /io/repo/
         to: /repo
@@ -27,6 +29,8 @@ steps:
         to: /hail_pip_version
       - from: /io/repo/git_version
         to: /git_version
+      - from: /io/git
+        to: /git
     dependsOn:
       - git_make_bash_image
   - kind: buildImage2
@@ -1491,6 +1495,8 @@ steps:
     inputs:
       - from: /repo
         to: /io/repo
+      - from: /git
+        to: /io/repo/.git
       - from: /www.tar.gz
         to: /io/www.tar.gz
     outputs:
@@ -2854,6 +2860,8 @@ steps:
         to: /io/hail_pip_version
       - from: /repo
         to: /io/repo
+      - from: /git
+        to: /io/repo/.git
     secrets:
       - name: test-dataproc-service-account-key
         namespace:
@@ -2896,6 +2904,8 @@ steps:
         to: /io/hail_pip_version
       - from: /repo
         to: /io/repo
+      - from: /git
+        to: /io/repo/.git
     secrets:
       - name: test-dataproc-service-account-key
         namespace:
@@ -2959,6 +2969,8 @@ steps:
         to: /io/git_version
       - from: /repo
         to: /io/repo
+      - from: /git
+        to: /io/repo/.git
       - from: /wheel-for-azure-container.tar
         to: /io/wheel-for-azure-container.tar
       - from: /www.tar.gz

--- a/build.yaml
+++ b/build.yaml
@@ -1459,11 +1459,10 @@ steps:
 
       # dev deploy elides the hail-is remote, add it and retrieve the tags
       git remote add hail-is https://github.com/hail-is/hail.git
-      git fetch hail-is
 
       export HAIL_PIP_VERSION=$(cat hail/python/hail/hail_pip_version)
 
-      if git ls-remote --exit-code --tags origin $HAIL_PIP_VERSION
+      if git ls-remote --exit-code --tags hail-is $HAIL_PIP_VERSION
       then
         # In this case, we want to get the docs from Google Storage.
         python3 -m hailtop.aiotools.copy 'null' '[


### PR DESCRIPTION
This reduces the size of the `repo` that's input to a lot of CI steps from ~186Mb to ~68Mb, which is substantial when you look at the build for this PR and see single-digit or low double-digit Mb download speeds 🙃 