### PR TITLE
[query] Don't write/read for naive_coalesce in service backend

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3397,10 +3397,6 @@ class MatrixTable(ExprContainer):
         :class:`.MatrixTable`
             Matrix table with at most `max_partitions` partitions.
         """
-
-        if hl.current_backend().requires_lowering:
-            return self.repartition(max_partitions)
-
         return MatrixTable(ir.MatrixRepartition(
             self._mir, max_partitions, ir.RepartitionStrategy.NAIVE_COALESCE))
 


### PR DESCRIPTION
Horrifying! Lowering supports naive_coalesce, has for some time...