### PR TITLE
[query] Add good error messages for semi/anti join, fix semantics

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1483,7 +1483,7 @@ class MatrixTable(ExprContainer):
                              f'\n  MatrixTable col key: {", ".join(str(x.dtype) for x in self.col_key.values())}'
                              f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
 
-        return self.filter_cols(hl.is_defined(*(self.col_key[i] for i in range(len(other.key)))))
+        return self.filter_cols(hl.is_defined(other.index(*(self.col_key[i] for i in range(len(other.key))))))
 
     @typecheck_method(other=Table)
     def anti_join_cols(self, other: 'Table') -> 'MatrixTable':

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1392,7 +1392,7 @@ class MatrixTable(ExprContainer):
             raise ValueError('semi_join_rows: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
                              f'\n  MatrixTable row key: {", ".join(str(x.dtype) for x in self.row_key.values())}'
                              f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
-        return self.filter_rows(hl.is_defined(other.index(self.row_key[:len(other.key)])))
+        return self.filter_rows(hl.is_defined(other.index(*(self.row_key[i] for i in range(len(other.key))))))
 
     @typecheck_method(other=Table)
     def anti_join_rows(self, other: 'Table') -> 'MatrixTable':
@@ -1437,7 +1437,7 @@ class MatrixTable(ExprContainer):
             raise ValueError('anti_join_rows: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
                              f'\n  MatrixTable row key: {", ".join(str(x.dtype) for x in self.row_key.values())}'
                              f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
-        return self.filter_rows(hl.is_missing(other.index(self.row_key[:len(other.key)])))
+        return self.filter_rows(hl.is_missing(other.index(*(self.row_key[i] for i in range(len(other.key))))))
 
     @typecheck_method(other=Table)
     def semi_join_cols(self, other: 'Table') -> 'MatrixTable':
@@ -1483,7 +1483,7 @@ class MatrixTable(ExprContainer):
                              f'\n  MatrixTable col key: {", ".join(str(x.dtype) for x in self.col_key.values())}'
                              f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
 
-        return self.filter_cols(hl.is_defined(other.index(self.col_key[:len(other.key)])))
+        return self.filter_cols(hl.is_defined(*(self.col_key[i] for i in range(len(other.key)))))
 
     @typecheck_method(other=Table)
     def anti_join_cols(self, other: 'Table') -> 'MatrixTable':
@@ -1529,7 +1529,7 @@ class MatrixTable(ExprContainer):
                              f'\n  MatrixTable col key: {", ".join(str(x.dtype) for x in self.col_key.values())}'
                              f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
 
-        return self.filter_cols(hl.is_missing(other.index(self.col_key[:len(other.key)])))
+        return self.filter_cols(hl.is_missing(other.index(*(self.col_key[i] for i in range(len(other.key))))))
 
     @typecheck_method(expr=expr_bool, keep=bool)
     def filter_rows(self, expr, keep: bool = True) -> 'MatrixTable':

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1386,7 +1386,13 @@ class MatrixTable(ExprContainer):
         --------
         :meth:`.anti_join_rows`, :meth:`.filter_rows`, :meth:`.semi_join_cols`
         """
-        return self.filter_rows(hl.is_defined(other.index(self.row_key)))
+        if len(other.key) == 0:
+            raise ValueError('semi_join_rows: cannot join with a table with no key')
+        if len(other.key) > len(self.row_key) or any(t[0].dtype != t[1].dtype for t in zip(self.row_key.values(), other.key.values())):
+            raise ValueError('semi_join_rows: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
+                             f'\n  MatrixTable row key: {", ".join(str(x.dtype) for x in self.row_key.values())}'
+                             f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
+        return self.filter_rows(hl.is_defined(other.index(self.row_key[:len(other.key)])))
 
     @typecheck_method(other=Table)
     def anti_join_rows(self, other: 'Table') -> 'MatrixTable':
@@ -1425,7 +1431,13 @@ class MatrixTable(ExprContainer):
         --------
         :meth:`.anti_join_rows`, :meth:`.filter_rows`, :meth:`.anti_join_cols`
         """
-        return self.filter_rows(hl.is_missing(other.index(self.row_key)))
+        if len(other.key) == 0:
+            raise ValueError('anti_join_rows: cannot join with a table with no key')
+        if len(other.key) > len(self.row_key) or any(t[0].dtype != t[1].dtype for t in zip(self.row_key.values(), other.key.values())):
+            raise ValueError('anti_join_rows: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
+                             f'\n  MatrixTable row key: {", ".join(str(x.dtype) for x in self.row_key.values())}'
+                             f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
+        return self.filter_rows(hl.is_missing(other.index(self.row_key[:len(other.key)])))
 
     @typecheck_method(other=Table)
     def semi_join_cols(self, other: 'Table') -> 'MatrixTable':
@@ -1464,7 +1476,14 @@ class MatrixTable(ExprContainer):
         --------
         :meth:`.anti_join_cols`, :meth:`.filter_cols`, :meth:`.semi_join_rows`
         """
-        return self.filter_cols(hl.is_defined(other.index(self.col_key)))
+        if len(other.key) == 0:
+            raise ValueError('semi_join_cols: cannot join with a table with no key')
+        if len(other.key) > len(self.col_key) or any(t[0].dtype != t[1].dtype for t in zip(self.col_key.values(), other.key.values())):
+            raise ValueError('semi_join_cols: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
+                             f'\n  MatrixTable col key: {", ".join(str(x.dtype) for x in self.col_key.values())}'
+                             f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
+
+        return self.filter_cols(hl.is_defined(other.index(self.col_key[:len(other.key)])))
 
     @typecheck_method(other=Table)
     def anti_join_cols(self, other: 'Table') -> 'MatrixTable':
@@ -1503,7 +1522,14 @@ class MatrixTable(ExprContainer):
         --------
         :meth:`.semi_join_cols`, :meth:`.filter_cols`, :meth:`.anti_join_rows`
         """
-        return self.filter_cols(hl.is_missing(other.index(self.col_key)))
+        if len(other.key) == 0:
+            raise ValueError('anti_join_cols: cannot join with a table with no key')
+        if len(other.key) > len(self.col_key) or any(t[0].dtype != t[1].dtype for t in zip(self.col_key.values(), other.key.values())):
+            raise ValueError('anti_join_cols: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
+                             f'\n  MatrixTable col key: {", ".join(str(x.dtype) for x in self.col_key.values())}'
+                             f'\n            Table key: {", ".join(str(x.dtype) for x in other.key.values())}')
+
+        return self.filter_cols(hl.is_missing(other.index(self.col_key[:len(other.key)])))
 
     @typecheck_method(expr=expr_bool, keep=bool)
     def filter_rows(self, expr, keep: bool = True) -> 'MatrixTable':

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2549,7 +2549,14 @@ class Table(ExprContainer):
         --------
         :meth:`.anti_join`
         """
-        return self.filter(hl.is_defined(other.index(self.key)))
+        if len(other.key) == 0:
+            raise ValueError('semi_join: cannot join with a table with no key')
+        if len(other.key) > len(self.key) or any(t[0].dtype != t[1].dtype for t in zip(self.key.values(), other.key.values())):
+            raise ValueError('semi_join: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
+                             f'\n   Left key: {", ".join(str(x.dtype) for x in self.key.values())}'
+                             f'\n  Right key: {", ".join(str(x.dtype) for x in other.key.values())}')
+
+        return self.filter(hl.is_defined(other.index(self.key[:len(other.key)])))
 
     @typecheck_method(other=table_type)
     def anti_join(self, other: 'Table') -> 'Table':
@@ -2587,7 +2594,14 @@ class Table(ExprContainer):
         --------
         :meth:`.semi_join`, :meth:`.filter`
         """
-        return self.filter(hl.is_missing(other.index(self.key)))
+        if len(other.key) == 0:
+            raise ValueError('anti_join: cannot join with a table with no key')
+        if len(other.key) > len(self.key) or any(t[0].dtype != t[1].dtype for t in zip(self.key.values(), other.key.values())):
+            raise ValueError('anti_join: cannot join: table must have a key of the same type(s) and be the same length or shorter:'
+                             f'\n   Left key: {", ".join(str(x.dtype) for x in self.key.values())}'
+                             f'\n  Right key: {", ".join(str(x.dtype) for x in other.key.values())}')
+
+        return self.filter(hl.is_missing(other.index(self.key[:len(other.key)])))
 
     @typecheck_method(right=table_type,
                       how=enumeration('inner', 'outer', 'left', 'right'),

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2556,7 +2556,7 @@ class Table(ExprContainer):
                              f'\n   Left key: {", ".join(str(x.dtype) for x in self.key.values())}'
                              f'\n  Right key: {", ".join(str(x.dtype) for x in other.key.values())}')
 
-        return self.filter(hl.is_defined(other.index(self.key[:len(other.key)])))
+        return self.filter(hl.is_defined(other.index(*(self.key[i] for i in range(len(other.key))))))
 
     @typecheck_method(other=table_type)
     def anti_join(self, other: 'Table') -> 'Table':
@@ -2601,7 +2601,7 @@ class Table(ExprContainer):
                              f'\n   Left key: {", ".join(str(x.dtype) for x in self.key.values())}'
                              f'\n  Right key: {", ".join(str(x.dtype) for x in other.key.values())}')
 
-        return self.filter(hl.is_missing(other.index(self.key[:len(other.key)])))
+        return self.filter(hl.is_missing(*(self.key[i] for i in range(len(other.key)))))
 
     @typecheck_method(right=table_type,
                       how=enumeration('inner', 'outer', 'left', 'right'),

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2601,7 +2601,7 @@ class Table(ExprContainer):
                              f'\n   Left key: {", ".join(str(x.dtype) for x in self.key.values())}'
                              f'\n  Right key: {", ".join(str(x.dtype) for x in other.key.values())}')
 
-        return self.filter(hl.is_missing(*(self.key[i] for i in range(len(other.key)))))
+        return self.filter(hl.is_missing(other.index(*(self.key[i] for i in range(len(other.key))))))
 
     @typecheck_method(right=table_type,
                       how=enumeration('inner', 'outer', 'left', 'right'),

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -422,16 +422,48 @@ class Tests(unittest.TestCase):
     def test_semi_anti_join_rows(self):
         mt = hl.utils.range_matrix_table(10, 3)
         ht = hl.utils.range_table(3)
+        mt2 = mt.key_rows_by(k1 = mt.row_idx, k2 = hl.str(mt.row_idx * 2))
+        ht2 = ht.key_by(k1 = ht.idx, k2 = hl.str(ht.idx * 2))
 
         assert mt.semi_join_rows(ht).count() == (3, 3)
         assert mt.anti_join_rows(ht).count() == (7, 3)
+        assert mt2.semi_join_rows(ht).count() == (3, 3)
+        assert mt2.anti_join_rows(ht).count() == (7, 3)
+        assert mt2.semi_join_rows(ht2).count() == (3, 3)
+        assert mt2.anti_join_rows(ht2).count() == (7, 3)
+
+        with pytest.raises(ValueError, match='semi_join_rows: cannot join'):
+            mt.semi_join_rows(ht2)
+        with pytest.raises(ValueError, match='semi_join_rows: cannot join'):
+            mt.semi_join_rows(ht.key_by())
+
+        with pytest.raises(ValueError, match='anti_join_rows: cannot join'):
+            mt.anti_join_rows(ht2)
+        with pytest.raises(ValueError, match='anti_join_rows: cannot join'):
+            mt.anti_join_rows(ht.key_by())
 
     def test_semi_anti_join_cols(self):
         mt = hl.utils.range_matrix_table(3, 10)
         ht = hl.utils.range_table(3)
+        mt2 = mt.key_cols_by(k1 = mt.col_idx, k2 = hl.str(mt.col_idx * 2))
+        ht2 = ht.key_by(k1 = ht.idx, k2 = hl.str(ht.idx * 2))
 
         assert mt.semi_join_cols(ht).count() == (3, 3)
         assert mt.anti_join_cols(ht).count() == (3, 7)
+        assert mt2.semi_join_cols(ht).count() == (3, 3)
+        assert mt2.anti_join_cols(ht).count() == (3, 7)
+        assert mt2.semi_join_cols(ht2).count() == (3, 3)
+        assert mt2.anti_join_cols(ht2).count() == (3, 7)
+
+        with pytest.raises(ValueError, match='semi_join_cols: cannot join'):
+            mt.semi_join_cols(ht2)
+        with pytest.raises(ValueError, match='semi_join_cols: cannot join'):
+            mt.semi_join_cols(ht.key_by())
+
+        with pytest.raises(ValueError, match='anti_join_cols: cannot join'):
+            mt.anti_join_cols(ht2)
+        with pytest.raises(ValueError, match='anti_join_cols: cannot join'):
+            mt.anti_join_cols(ht.key_by())
 
     def test_joins(self):
         mt = self.get_mt().select_rows(x1=1, y1=1)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -384,9 +384,25 @@ class Tests(unittest.TestCase):
     def test_semi_anti_join(self):
         ht = hl.utils.range_table(10)
         ht2 = ht.filter(ht.idx < 3)
+        ht_2k = ht.key_by(k1 = ht.idx, k2 = hl.str(ht.idx * 2))
+        ht2_2k = ht2.key_by(k1 = ht2.idx, k2 = hl.str(ht2.idx * 2))
 
         assert ht.semi_join(ht2).count() == 3
         assert ht.anti_join(ht2).count() == 7
+        assert ht_2k.semi_join(ht2).count() == 3
+        assert ht_2k.anti_join(ht2).count() == 7
+        assert ht_2k.semi_join(ht2_2k).count() == 3
+        assert ht_2k.anti_join(ht2_2k).count() == 7
+
+        with pytest.raises(ValueError, match='semi_join: cannot join'):
+            ht.semi_join(ht2_2k)
+        with pytest.raises(ValueError, match='semi_join: cannot join'):
+            ht.semi_join(ht2.key_by())
+
+        with pytest.raises(ValueError, match='anti_join: cannot join'):
+            ht.anti_join(ht2_2k)
+        with pytest.raises(ValueError, match='anti_join: cannot join'):
+            ht.anti_join(ht2.key_by())
 
     def test_indirected_joins(self):
         kt = hl.utils.range_table(1)


### PR DESCRIPTION
CHANGELOG: semi/anti join methods will now properly accept tables with a shorter but compatible key.