### PR TITLE
[batch] do not require `mkdir` for bash jobs

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -622,13 +622,10 @@ class ServiceBackend(Backend[bc.Batch]):
                 if verbose:
                     print(f"Using image '{default_image}' since no image was specified.")
 
-            make_local_tmpdir = f'mkdir -p {local_tmpdir}/{job._dirname}'
-
             job_command = [cmd.strip() for cmd in job._wrapper_code]
             prepared_job_command = (f'{{\n{x}\n}}' for x in job_command)
             cmd = f'''
 {bash_flags}
-{make_local_tmpdir}
 {"; ".join(symlinks)}
 {" && ".join(prepared_job_command)}
 '''

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1062,7 +1062,8 @@ class PythonJob(Job):
                 [(result._json, "json.dumps"), (result._str, "str"), (result._repr, "repr")]
             ]
 
-            wrapper_code = f'''python3 -c "
+            wrapper_code = f'''mkdir -p "{local_tmpdir}/{self._dirname}"
+python3 -c "
 import os
 import base64
 import dill


### PR DESCRIPTION
This local temporary directory is only needed for Python jobs. In the bash job case, these directories are created by the input step. Using `mkdir` for all jobs means all images must have `mkdir` which, for example, `nixery.dev/shell/git/htop` does not.