### PR TITLE
[batch] remove unnecessary comment

### DIFF
--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -741,16 +741,9 @@ class BashJob(Job):
         if len(self._command) == 0:
             return False
 
-        job_shell = self._shell if self._shell else DEFAULT_SHELL
-
         job_command = [cmd.strip() for cmd in self._command]
         job_command = [f'{{\n{x}\n}}' for x in job_command]
         job_command = '\n'.join(job_command)
-
-        job_command = f'''
-#! {job_shell}
-{job_command}
-'''
 
         job_command_bytes = job_command.encode()
 


### PR DESCRIPTION
This comment is neither necessary nor has any effect. We specify the shell explicitly when we call `BatchClient.create_job`, so this comment is ignored. Moreover, this comment is never the first line because we always add `set -e` before it.

Compare the code we invoke on main:

```
'/bin/bash' '-c' '
set -e
mkdir -p /io/batch/3eb5d0/T9uk0

{
#! /bin/bash
{
git checkout https://github.com/hail-is/hail.git
}
}
'
```

to the code this branch invokes:
```
'/bin/bash' '-c' '
set -e
mkdir -p /io/batch/3eb5d0/T9uk0

{
{
git checkout https://github.com/hail-is/hail.git
}
}
'

```