### PR TITLE
[batch] Enable use of requester-pays buckets with gcsfuse

### DIFF
--- a/batch/batch/cloud/gcp/worker/worker_api.py
+++ b/batch/batch/cloud/gcp/worker/worker_api.py
@@ -74,9 +74,9 @@ class GCPWorkerAPI(CloudWorkerAPI):
         if config['read_only']:
             options.append('ro')
 
-        if config['requester_pays_project']:
+        try:
             billing_project_flag = f'--billing-project "{config["requester_pays_project"]}"'
-        else:
+        except KeyError:
             billing_project_flag = ''
 
         return f'''

--- a/batch/batch/cloud/gcp/worker/worker_api.py
+++ b/batch/batch/cloud/gcp/worker/worker_api.py
@@ -74,6 +74,11 @@ class GCPWorkerAPI(CloudWorkerAPI):
         if config['read_only']:
             options.append('ro')
 
+        if config['requester_pays_project']:
+            billing_project_flag = f'--billing-project "{config["requester_pays_project"]}"'
+        else:
+            billing_project_flag = ''
+
         return f'''
 /usr/bin/gcsfuse \
     -o {",".join(options)} \
@@ -81,6 +86,7 @@ class GCPWorkerAPI(CloudWorkerAPI):
     --dir-mode 770 \
     --implicit-dirs \
     --key-file {fuse_credentials_path} \
+    {billing_project_flag} \
     {bucket} {mount_base_path_data}
 '''
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1345,10 +1345,13 @@ class Job:
         self.main_volume_mounts.append(io_volume_mount)
         self.output_volume_mounts.append(io_volume_mount)
 
+        requester_pays_project = job_spec.get('requester_pays_project')
         cloudfuse = job_spec.get('cloudfuse') or job_spec.get('gcsfuse')
         self.cloudfuse = cloudfuse
         if cloudfuse:
             for config in cloudfuse:
+                if requester_pays_project:
+                    config['requester_pays_project'] = requester_pays_project
                 config['mounted'] = False
                 bucket = config['bucket']
                 assert bucket


### PR DESCRIPTION
CHANGELOG: `Job.cloudfuse` now supports requester-pays buckets in GCP. The billing project specified in `hb.Batch(requester_pays_project=…)` is used to bill against.