### PR TITLE
[batch] Use the end-time in the UI atttempt-ordering if start_time is None

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1741,7 +1741,7 @@ WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
     if len(attempts) == 1 and attempts[0]['attempt_id'] is None:
         return None
 
-    attempts.sort(key=lambda x: x['start_time'])
+    attempts.sort(key=lambda x: x['start_time'] or x['end_time'])
 
     for attempt in attempts:
         start_time = attempt['start_time']


### PR DESCRIPTION
This can happen when a job-private instance fails to activate. We want to retain that attempt so we have a record of the instances that we tried to create for the job.