### PR TITLE
[query] Refactor `coerce` functions

### DIFF
--- a/hail/src/main/scala/is/hail/compatibility/LegacyEncodedTypeParser.scala
+++ b/hail/src/main/scala/is/hail/compatibility/LegacyEncodedTypeParser.scala
@@ -1,7 +1,7 @@
 package is.hail.compatibility
 
 import is.hail.expr.ir.IRParser._
-import is.hail.expr.ir.{IRParser, PunctuationToken, TokenIterator, TypeParserEnvironment, coerce}
+import is.hail.expr.ir.{IRParser, PunctuationToken, TokenIterator, TypeParserEnvironment}
 import is.hail.types.encoded._
 import is.hail.types.virtual._
 import is.hail.rvd.RVDType

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.types.tcoerce
 import is.hail.types.virtual._
 import is.hail.utils._
 
@@ -15,43 +16,43 @@ object Bindings {
     case TailLoop(name, args, body) => if (i == args.length)
       args.map { case (name, ir) => name -> ir.typ } :+
         name -> TTuple(TTuple(args.map(_._2.typ): _*), body.typ) else empty
-    case StreamMap(a, name, _) => if (i == 1) Array(name -> coerce[TStream](a.typ).elementType) else empty
-    case StreamZip(as, names, _, _, _) => if (i == as.length) names.zip(as.map(a => coerce[TStream](a.typ).elementType)) else empty
+    case StreamMap(a, name, _) => if (i == 1) Array(name -> tcoerce[TStream](a.typ).elementType) else empty
+    case StreamZip(as, names, _, _, _) => if (i == as.length) names.zip(as.map(a => tcoerce[TStream](a.typ).elementType)) else empty
     case StreamZipJoin(as, key, curKey, curVals, _) =>
-      val eltType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
+      val eltType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
       if (i == as.length)
         Array(curKey -> eltType.typeAfterSelectNames(key),
               curVals -> TArray(eltType))
       else
         empty
-    case StreamFor(a, name, _) => if (i == 1) Array(name -> coerce[TStream](a.typ).elementType) else empty
-    case StreamFlatMap(a, name, _) => if (i == 1) Array(name -> coerce[TStream](a.typ).elementType) else empty
-    case StreamFilter(a, name, _) => if (i == 1) Array(name -> coerce[TStream](a.typ).elementType) else empty
-    case StreamTakeWhile(a, name, _) => if (i == 1) Array(name -> coerce[TStream](a.typ).elementType) else empty
-    case StreamDropWhile(a, name, _) => if (i == 1) Array(name -> coerce[TStream](a.typ).elementType) else empty
-    case StreamFold(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> coerce[TStream](a.typ).elementType) else empty
+    case StreamFor(a, name, _) => if (i == 1) Array(name -> tcoerce[TStream](a.typ).elementType) else empty
+    case StreamFlatMap(a, name, _) => if (i == 1) Array(name -> tcoerce[TStream](a.typ).elementType) else empty
+    case StreamFilter(a, name, _) => if (i == 1) Array(name -> tcoerce[TStream](a.typ).elementType) else empty
+    case StreamTakeWhile(a, name, _) => if (i == 1) Array(name -> tcoerce[TStream](a.typ).elementType) else empty
+    case StreamDropWhile(a, name, _) => if (i == 1) Array(name -> tcoerce[TStream](a.typ).elementType) else empty
+    case StreamFold(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> tcoerce[TStream](a.typ).elementType) else empty
     case StreamFold2(a, accum, valueName, seq, result) =>
       if (i <= accum.length)
         empty
       else if (i < 2 * accum.length + 1)
-        Array((valueName, coerce[TStream](a.typ).elementType)) ++ accum.map { case (name, value) => (name, value.typ) }
+        Array((valueName, tcoerce[TStream](a.typ).elementType)) ++ accum.map { case (name, value) => (name, value.typ) }
       else
         accum.map { case (name, value) => (name, value.typ) }
-    case StreamBufferedAggregate(stream, _,  _, _, name, _, _) => if (i > 0) Array(name -> coerce[TStream](stream.typ).elementType) else empty
-    case RunAggScan(a, name, _, _, _, _) => if (i == 2 || i == 3) Array(name -> coerce[TStream](a.typ).elementType) else empty
-    case StreamScan(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> coerce[TStream](a.typ).elementType) else empty
+    case StreamBufferedAggregate(stream, _,  _, _, name, _, _) => if (i > 0) Array(name -> tcoerce[TStream](stream.typ).elementType) else empty
+    case RunAggScan(a, name, _, _, _, _) => if (i == 2 || i == 3) Array(name -> tcoerce[TStream](a.typ).elementType) else empty
+    case StreamScan(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> tcoerce[TStream](a.typ).elementType) else empty
     case StreamAggScan(a, name, _) => if (i == 1) FastIndexedSeq(name -> a.typ.asInstanceOf[TStream].elementType) else empty
-    case StreamJoinRightDistinct(ll, rr, _, _, l, r, _, _) => if (i == 2) Array(l -> coerce[TStream](ll.typ).elementType, r -> coerce[TStream](rr.typ).elementType) else empty
-    case ArraySort(a, left, right, _) => if (i == 1) Array(left -> coerce[TStream](a.typ).elementType, right -> coerce[TStream](a.typ).elementType) else empty
+    case StreamJoinRightDistinct(ll, rr, _, _, l, r, _, _) => if (i == 2) Array(l -> tcoerce[TStream](ll.typ).elementType, r -> tcoerce[TStream](rr.typ).elementType) else empty
+    case ArraySort(a, left, right, _) => if (i == 1) Array(left -> tcoerce[TStream](a.typ).elementType, right -> tcoerce[TStream](a.typ).elementType) else empty
     case AggArrayPerElement(a, _, indexName, _, _, _) => if (i == 1) FastIndexedSeq(indexName -> TInt32) else empty
     case AggFold(zero, seqOp, combOp, accumName, otherAccumName, _) => {
       if (i == 1) FastIndexedSeq(accumName -> zero.typ)
       else if (i == 2) FastIndexedSeq(accumName -> zero.typ, otherAccumName -> zero.typ)
       else empty
     }
-    case NDArrayMap(nd, name, _) => if (i == 1) Array(name -> coerce[TNDArray](nd.typ).elementType) else empty
-    case NDArrayMap2(l, r, lName, rName, _, _) => if (i == 2) Array(lName -> coerce[TNDArray](l.typ).elementType, rName -> coerce[TNDArray](r.typ).elementType) else empty
-    case CollectDistributedArray(contexts, globals, cname, gname, _, _, _, _) => if (i == 2) Array(cname -> coerce[TStream](contexts.typ).elementType, gname -> globals.typ) else empty
+    case NDArrayMap(nd, name, _) => if (i == 1) Array(name -> tcoerce[TNDArray](nd.typ).elementType) else empty
+    case NDArrayMap2(l, r, lName, rName, _, _) => if (i == 2) Array(lName -> tcoerce[TNDArray](l.typ).elementType, rName -> tcoerce[TNDArray](r.typ).elementType) else empty
+    case CollectDistributedArray(contexts, globals, cname, gname, _, _, _, _) => if (i == 2) Array(cname -> tcoerce[TStream](contexts.typ).elementType, gname -> globals.typ) else empty
     case TableAggregate(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case MatrixAggregate(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case TableFilter(child, _) => if (i == 1) child.typ.rowEnv.m else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -18,7 +18,7 @@ import is.hail.types.physical.stypes.concrete._
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
-import is.hail.types.{RIterable, TypeWithRequiredness, VirtualTypeWithReq}
+import is.hail.types.{RIterable, TypeWithRequiredness, VirtualTypeWithReq, tcoerce}
 import is.hail.utils._
 
 import java.io._
@@ -1605,7 +1605,7 @@ class Emit[C](
 
               answerFinisher(cb)
             }  else {
-              val numericElementType = coerce[PNumeric](PType.canonical(lSType.elementType.storageType().setRequired(true)))
+              val numericElementType = tcoerce[PNumeric](PType.canonical(lSType.elementType.storageType().setRequired(true)))
               val eVti = typeToTypeInfo(numericElementType)
 
               val emitter = new NDArrayEmitter(unifiedShape, leftPVal.st.elementType) {

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.expr.Nat
+import is.hail.types.tcoerce
 import is.hail.types.virtual._
 import is.hail.utils._
 
@@ -30,7 +31,7 @@ object InferType {
       case MakeArray(_, t) => t
       case MakeStream(_, t, _) => t
       case MakeNDArray(data, shape, _, _) =>
-        TNDArray(coerce[TIterable](data.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
+        TNDArray(tcoerce[TIterable](data.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
       case StreamBufferedAggregate(_, _, newKey, _, _, aggSignatures, _) =>
         val tupleFieldTypes = TTuple(aggSignatures.map(_ => TBinary):_*)
         TStream(newKey.typ.asInstanceOf[TStruct].insertFields(IndexedSeq(("agg", tupleFieldTypes))))
@@ -85,30 +86,30 @@ object InferType {
         a.returnType
       case ArrayRef(a, i, _) =>
         assert(i.typ == TInt32)
-        coerce[TArray](a.typ).elementType
+        tcoerce[TArray](a.typ).elementType
       case ArraySlice(a, start, stop, step, _) =>
         assert(start.typ == TInt32)
         stop.foreach(ir => assert(ir.typ == TInt32))
         assert(step.typ == TInt32)
-        coerce[TArray](a.typ)
+        tcoerce[TArray](a.typ)
       case ArraySort(a, _, _, lessThan) =>
         assert(lessThan.typ == TBoolean)
-        val et = coerce[TStream](a.typ).elementType
+        val et = tcoerce[TStream](a.typ).elementType
         TArray(et)
       case ToSet(a) =>
-        val et = coerce[TStream](a.typ).elementType
+        val et = tcoerce[TStream](a.typ).elementType
         TSet(et)
       case ToDict(a) =>
-        val elt = coerce[TBaseStruct](coerce[TStream](a.typ).elementType)
+        val elt = tcoerce[TBaseStruct](tcoerce[TStream](a.typ).elementType)
         TDict(elt.types(0), elt.types(1))
       case ta@ToArray(a) =>
-        val elt = coerce[TStream](a.typ).elementType
+        val elt = tcoerce[TStream](a.typ).elementType
         TArray(elt)
       case CastToArray(a) =>
-        val elt = coerce[TContainer](a.typ).elementType
+        val elt = tcoerce[TContainer](a.typ).elementType
         TArray(elt)
       case ToStream(a, _) =>
-        val elt = coerce[TIterable](a.typ).elementType
+        val elt = tcoerce[TIterable](a.typ).elementType
         TStream(elt)
       case RNGStateLiteral(_) =>
         TRNGState
@@ -116,7 +117,7 @@ object InferType {
         TRNGState
       case StreamLen(a) => TInt32
       case GroupByKey(collection) =>
-        val elt = coerce[TBaseStruct](coerce[TStream](collection.typ).elementType)
+        val elt = tcoerce[TBaseStruct](tcoerce[TStream](collection.typ).elementType)
         TDict(elt.types(0), TArray(elt.types(1)))
       case StreamTake(a, _) =>
         a.typ
@@ -133,7 +134,7 @@ object InferType {
       case StreamZipJoin(_, _, _, _, joinF) =>
         TStream(joinF.typ)
       case StreamMultiMerge(as, _) =>
-        TStream(coerce[TStream](as.head.typ).elementType)
+        TStream(tcoerce[TStream](as.head.typ).elementType)
       case StreamFilter(a, name, cond) =>
         a.typ
       case StreamTakeWhile(a, name, cond) =>
@@ -141,7 +142,7 @@ object InferType {
       case StreamDropWhile(a, name, cond) =>
         a.typ
       case StreamFlatMap(a, name, body) =>
-        TStream(coerce[TStream](body.typ).elementType)
+        TStream(tcoerce[TStream](body.typ).elementType)
       case StreamFold(a, zero, accumName, valueName, body) =>
         assert(body.typ == zero.typ)
         zero.typ
@@ -166,32 +167,32 @@ object InferType {
         val ndType = nd.typ.asInstanceOf[TNDArray]
         ndType.shapeType
       case NDArrayReshape(nd, shape, _) =>
-        TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
+        TNDArray(tcoerce[TNDArray](nd.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
       case NDArrayConcat(nds, _) =>
-        coerce[TArray](nds.typ).elementType
+        tcoerce[TArray](nds.typ).elementType
       case NDArrayMap(nd, _, body) =>
-        TNDArray(body.typ, coerce[TNDArray](nd.typ).nDimsBase)
+        TNDArray(body.typ, tcoerce[TNDArray](nd.typ).nDimsBase)
       case NDArrayMap2(l, _, _, _, body, _) =>
-        TNDArray(body.typ, coerce[TNDArray](l.typ).nDimsBase)
+        TNDArray(body.typ, tcoerce[TNDArray](l.typ).nDimsBase)
       case NDArrayReindex(nd, indexExpr) =>
-        TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(indexExpr.length))
+        TNDArray(tcoerce[TNDArray](nd.typ).elementType, Nat(indexExpr.length))
       case NDArrayAgg(nd, axes) =>
-        val childType = coerce[TNDArray](nd.typ)
+        val childType = tcoerce[TNDArray](nd.typ)
         TNDArray(childType.elementType, Nat(childType.nDims - axes.length))
       case NDArrayRef(nd, idxs, _) =>
         assert(idxs.forall(_.typ == TInt64))
-        coerce[TNDArray](nd.typ).elementType
+        tcoerce[TNDArray](nd.typ).elementType
       case NDArraySlice(nd, slices) =>
-        val childTyp = coerce[TNDArray](nd.typ)
-        val slicesTyp = coerce[TTuple](slices.typ)
+        val childTyp = tcoerce[TNDArray](nd.typ)
+        val slicesTyp = tcoerce[TTuple](slices.typ)
         val tuplesOnly = slicesTyp.types.collect { case x: TTuple => x}
         val remainingDims = Nat(tuplesOnly.length)
         TNDArray(childTyp.elementType, remainingDims)
       case NDArrayFilter(nd, _) =>
         nd.typ
       case NDArrayMatMul(l, r, _) =>
-        val lTyp = coerce[TNDArray](l.typ)
-        val rTyp = coerce[TNDArray](r.typ)
+        val lTyp = tcoerce[TNDArray](l.typ)
+        val rTyp = tcoerce[TNDArray](r.typ)
         TNDArray(lTyp.elementType, Nat(TNDArray.matMulNDims(lTyp.nDims, rTyp.nDims)))
       case NDArrayQR(nd, mode, _) =>
         if (Array("complete", "reduced").contains(mode)) {
@@ -230,24 +231,24 @@ object InferType {
           (name, a.typ)
         }: _*)
       case SelectFields(old, fields) =>
-        val tbs = coerce[TStruct](old.typ)
+        val tbs = tcoerce[TStruct](old.typ)
         tbs.select(fields.toFastIndexedSeq)._1
       case InsertFields(old, fields, fieldOrder) =>
-        val tbs = coerce[TStruct](old.typ)
+        val tbs = tcoerce[TStruct](old.typ)
         val s = tbs.insertFields(fields.map(f => (f._1, f._2.typ)))
         fieldOrder.map { fds =>
           assert(fds.length == s.size, s"${fds} != ${s.types.toIndexedSeq}")
           TStruct(fds.map(f => f -> s.fieldType(f)): _*)
         }.getOrElse(s)
       case GetField(o, name) =>
-        val t = coerce[TStruct](o.typ)
+        val t = tcoerce[TStruct](o.typ)
         if (t.index(name).isEmpty)
           throw new RuntimeException(s"$name not in $t")
         t.field(name).typ
       case MakeTuple(values) =>
         TTuple(values.map { case (i, value) => TupleField(i, value.typ) }.toFastIndexedSeq)
       case GetTupleElement(o, idx) =>
-        val t = coerce[TTuple](o.typ)
+        val t = tcoerce[TTuple](o.typ)
         val fd = t.fields(t.fieldIndex(idx)).typ
         fd
       case TableCount(_) => TInt64

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -12,6 +12,7 @@ import is.hail.utils._
 import is.hail.HailContext
 import is.hail.backend.ExecuteContext
 import is.hail.types.physical.stypes.{PTypeReferenceSingleCodeType, SingleCodeType}
+import is.hail.types.tcoerce
 import org.apache.spark.sql.Row
 
 import scala.collection.mutable
@@ -343,7 +344,7 @@ object Interpret {
         if (cValue == null)
           null
         else {
-          val ordering = coerce[TIterable](c.typ).elementType.ordering.toOrdering
+          val ordering = tcoerce[TIterable](c.typ).elementType.ordering.toOrdering
           cValue match {
             case s: Set[_] =>
               s.asInstanceOf[Set[Any]].toFastIndexedSeq.sorted(ordering)
@@ -424,7 +425,7 @@ object Interpret {
         if (aValue == null)
           null
         else {
-          val structType = coerce[TStruct](coerce[TStream](a.typ).elementType)
+          val structType = tcoerce[TStruct](tcoerce[TStream](a.typ).elementType)
           val seq = aValue.asInstanceOf[IndexedSeq[Row]]
           if (seq.isEmpty)
             FastIndexedSeq[IndexedSeq[Row]]()
@@ -486,7 +487,7 @@ object Interpret {
         else {
           val k = as.length
           val tournament = Array.fill[Int](k)(-1)
-          val structType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
+          val structType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
           val (kType, getKey) = structType.select(key)
           val heads = Array.fill[Int](k)(-1)
           val ordering = kType.ordering.toOrdering.on[Row](getKey)
@@ -530,7 +531,7 @@ object Interpret {
         else {
           val k = as.length
           val tournament = Array.fill[Int](k)(-1)
-          val structType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
+          val structType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
           val (kType, getKey) = structType.select(key)
           val heads = Array.fill[Int](k)(-1)
           val ordering = kType.ordering.toOrdering.on[Row](getKey)
@@ -659,8 +660,8 @@ object Interpret {
         if (lValue == null || rValue == null)
           null
         else {
-          val (lKeyTyp, lGetKey) = coerce[TStruct](coerce[TStream](left.typ).elementType).select(lKey)
-          val (rKeyTyp, rGetKey) = coerce[TStruct](coerce[TStream](right.typ).elementType).select(rKey)
+          val (lKeyTyp, lGetKey) = tcoerce[TStruct](tcoerce[TStream](left.typ).elementType).select(lKey)
+          val (rKeyTyp, rGetKey) = tcoerce[TStruct](tcoerce[TStream](right.typ).elementType).select(rKey)
           assert(lKeyTyp isIsomorphicTo rKeyTyp)
           val keyOrd = TBaseStruct.getJoinOrdering(lKeyTyp.types)
 
@@ -723,7 +724,7 @@ object Interpret {
       case MakeStruct(fields) =>
         Row.fromSeq(fields.map { case (name, fieldIR) => interpret(fieldIR, env, args) })
       case SelectFields(old, fields) =>
-        val oldt = coerce[TStruct](old.typ)
+        val oldt = tcoerce[TStruct](old.typ)
         val oldRow = interpret(old, env, args).asInstanceOf[Row]
         if (oldRow == null)
           null

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -554,8 +554,8 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, entryExpr: IR, rowExpr: IR)
   }
 
   val typ: MatrixType = child.typ.copy(
-    rowType = child.typ.rowKeyStruct ++ coerce[TStruct](rowExpr.typ),
-    entryType = coerce[TStruct](entryExpr.typ)
+    rowType = child.typ.rowKeyStruct ++ tcoerce[TStruct](rowExpr.typ),
+    entryType = tcoerce[TStruct](entryExpr.typ)
   )
 
   override def columnCount: Option[Int] = child.columnCount
@@ -574,8 +574,8 @@ case class MatrixAggregateColsByKey(child: MatrixIR, entryExpr: IR, colExpr: IR)
   }
 
   val typ = child.typ.copy(
-    entryType = coerce[TStruct](entryExpr.typ),
-    colType = child.typ.colKeyStruct ++ coerce[TStruct](colExpr.typ))
+    entryType = tcoerce[TStruct](entryExpr.typ),
+    colType = child.typ.colKeyStruct ++ tcoerce[TStruct](colExpr.typ))
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
@@ -633,7 +633,7 @@ case class MatrixMapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
   }
 
   val typ: MatrixType =
-    child.typ.copy(entryType = coerce[TStruct](newEntries.typ))
+    child.typ.copy(entryType = tcoerce[TStruct](newEntries.typ))
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
@@ -812,7 +812,7 @@ case class MatrixExplodeRows(child: MatrixIR, path: IndexedSeq[String]) extends 
 
   val newRow: InsertFields = {
     val refs = path.init.scanLeft(Ref("va", child.typ.rowType))((struct, name) =>
-      Ref(genUID(), coerce[TStruct](struct.typ).field(name).typ))
+      Ref(genUID(), tcoerce[TStruct](struct.typ).field(name).typ))
 
     path.zip(refs).zipWithIndex.foldRight[IR](idx) {
       case (((field, ref), i), arg) =>

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -106,7 +106,7 @@ case class MatrixNativeWriter(
 
     // write out partitioner key, which may be stricter than table key
     val partitioner = lowered.partitioner
-    val pKey: PStruct = coerce[PStruct](rowSpec.decodedPType(partitioner.kType))
+    val pKey: PStruct = tcoerce[PStruct](rowSpec.decodedPType(partitioner.kType))
 
     val emptyWriter = PartitionNativeWriter(emptySpec, IndexedSeq(), s"$path/globals/globals/parts/", None, None)
     val globalWriter = PartitionNativeWriter(globalSpec, IndexedSeq(), s"$path/globals/rows/parts/", None, None)
@@ -145,8 +145,8 @@ case class MatrixNativeWriter(
 
                 val matrixWriter = MatrixSpecWriter(path, tm, "rows/rows", "globals/rows", "cols/rows", "entries/rows", "references", log = true)
 
-                val rowsIndexSpec = IndexSpec.defaultAnnotation("../../index", coerce[PStruct](pKey))
-                val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", coerce[PStruct](pKey), withOffsetField = true)
+                val rowsIndexSpec = IndexSpec.defaultAnnotation("../../index", tcoerce[PStruct](pKey))
+                val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", tcoerce[PStruct](pKey), withOffsetField = true)
 
                 bindIR(writeCols) { colInfo =>
                   bindIR(parts) { partInfo =>
@@ -973,9 +973,9 @@ case class MatrixBGENWriter(
       val partFiles = ToStream(Literal(TArray(TString), Array.tabulate(ts.numPartitions)(i => s"$folder/${ partFile(d, i) }-").toFastIndexedSeq))
       val numVariants = if (writeHeader) ToStream(ts.countPerPartition(relationalLetsAbove)) else ToStream(MakeArray(Array.tabulate(ts.numPartitions)(_ => NA(TInt64)): _*))
 
-      val ctxElt = Ref(genUID(), coerce[TStream](oldCtx.typ).elementType)
-      val pf = Ref(genUID(), coerce[TStream](partFiles.typ).elementType)
-      val nv = Ref(genUID(), coerce[TStream](numVariants.typ).elementType)
+      val ctxElt = Ref(genUID(), tcoerce[TStream](oldCtx.typ).elementType)
+      val pf = Ref(genUID(), tcoerce[TStream](partFiles.typ).elementType)
+      val nv = Ref(genUID(), tcoerce[TStream](numVariants.typ).elementType)
 
       StreamZip(FastSeq(oldCtx, partFiles, numVariants), FastSeq(ctxElt.name, pf.name, nv.name),
         MakeStruct(FastSeq("oldCtx" -> ctxElt, "numVariants" -> nv, "partFile" -> pf)),

--- a/hail/src/main/scala/is/hail/expr/ir/NumericPrimitives.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NumericPrimitives.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.asm4s.Settable
+import is.hail.asm4s.{Settable, coerce}
 import is.hail.types.virtual.{Type, TInt32, TInt64, TFloat32, TFloat64}
 
 object NumericPrimitives {

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1076,23 +1076,23 @@ object PruneDeadFields {
           memoizeValueIR(ctx, a, requestedType.asInstanceOf[TStream].elementType, memo),
           memoizeValueIR(ctx, size, size.typ, memo))
       case StreamGroupByKey(a, key, _) =>
-        val reqStructT = coerce[TStruct](coerce[TStream](coerce[TStream](requestedType).elementType).elementType)
-        val origStructT = coerce[TStruct](coerce[TStream](a.typ).elementType)
+        val reqStructT = tcoerce[TStruct](tcoerce[TStream](tcoerce[TStream](requestedType).elementType).elementType)
+        val origStructT = tcoerce[TStruct](tcoerce[TStream](a.typ).elementType)
         memoizeValueIR(ctx, a, TStream(unify(origStructT, reqStructT, selectKey(origStructT, key))), memo)
       case StreamZip(as, names, body, behavior, _) =>
         val bodyEnv = memoizeValueIR(ctx, body,
           requestedType.asInstanceOf[TStream].elementType,
           memo)
         val valueTypes = (names, as).zipped.map { (name, a) =>
-          bodyEnv.eval.lookupOption(name).map(ab => unifySeq(coerce[TStream](a.typ).elementType, ab.result()))
+          bodyEnv.eval.lookupOption(name).map(ab => unifySeq(tcoerce[TStream](a.typ).elementType, ab.result()))
         }
         if (behavior == ArrayZipBehavior.AssumeSameLength && valueTypes.forall(_.isEmpty)) {
-          unifyEnvs(memoizeValueIR(ctx, as.head, TStream(minimal(coerce[TStream](as.head.typ).elementType)), memo) +:
+          unifyEnvs(memoizeValueIR(ctx, as.head, TStream(minimal(tcoerce[TStream](as.head.typ).elementType)), memo) +:
                       Array(bodyEnv.deleteEval(names)): _*)
         } else {
           unifyEnvs(
             (as, valueTypes).zipped.map { (a, vtOption) =>
-              val at = coerce[TStream](a.typ)
+              val at = tcoerce[TStream](a.typ)
               if (behavior == ArrayZipBehavior.AssumeSameLength) {
                 vtOption.map { vt =>
                   memoizeValueIR(ctx, a, TStream(vt), memo)
@@ -1102,8 +1102,8 @@ object PruneDeadFields {
             } ++ Array(bodyEnv.deleteEval(names)): _*)
         }
       case StreamZipJoin(as, key, curKey, curVals, joinF) =>
-        val eltType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
-        val requestedEltType = coerce[TStream](requestedType).elementType
+        val eltType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
+        val requestedEltType = tcoerce[TStream](requestedType).elementType
         val bodyEnv = memoizeValueIR(ctx, joinF, requestedEltType, memo)
         val childRequestedEltType = unifySeq(
           eltType,
@@ -1111,8 +1111,8 @@ object PruneDeadFields {
             selectKey(eltType, key))
         unifyEnvsSeq(as.map(memoizeValueIR(ctx, _, TStream(childRequestedEltType), memo)))
       case StreamMultiMerge(as, key) =>
-        val eltType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
-        val requestedEltType = coerce[TStream](requestedType).elementType
+        val eltType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
+        val requestedEltType = tcoerce[TStream](requestedType).elementType
         val childRequestedEltType = unify(eltType, requestedEltType, selectKey(eltType, key))
         unifyEnvsSeq(as.map(memoizeValueIR(ctx, _, TStream(childRequestedEltType), memo)))
       case StreamFilter(a, name, cond) =>
@@ -1535,7 +1535,7 @@ object PruneDeadFields {
         assert(bodyEnv.agg.isEmpty)
 
         val cDep = bodyEnv.eval.lookupOption(cname) match {
-          case Some(ts) => TStream(unify[Type](coerce[TStream](contexts.typ).elementType, ts.result(): _*))
+          case Some(ts) => TStream(unify[Type](tcoerce[TStream](contexts.typ).elementType, ts.result(): _*))
           case None => minimal(contexts.typ)
         }
 
@@ -1942,8 +1942,8 @@ object PruneDeadFields {
           memo)
         StreamZipJoin(newAs, key, curKey, curVals, newJoinF)
       case StreamMultiMerge(as, key) =>
-        val eltType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
-        val requestedEltType = coerce[TStream](requestedType).elementType
+        val eltType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
+        val requestedEltType = tcoerce[TStream](requestedType).elementType
         val reqEltWithKey = unify(eltType, requestedEltType, selectKey(eltType, key))
 
         val newAs = as.map(a => rebuildIR(ctx, a, env, memo))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -27,7 +27,7 @@ case class RequirednessAnalysis(r: Memo[BaseTypeWithRequiredness], states: Memo[
   def lookup(node: BaseIR): BaseTypeWithRequiredness = r.lookup(node)
   def lookupState(node: BaseIR): IndexedSeq[BaseTypeWithRequiredness] = states.lookup(node)
   def lookupOpt(node: BaseIR): Option[BaseTypeWithRequiredness] = r.get(node)
-  def apply(node: IR): TypeWithRequiredness = coerce[TypeWithRequiredness](lookup(node))
+  def apply(node: IR): TypeWithRequiredness = tcoerce[TypeWithRequiredness](lookup(node))
   def getState(node: IR): IndexedSeq[TypeWithRequiredness] = states(node)
 }
 
@@ -42,10 +42,10 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
 
   def result(): RequirednessAnalysis = RequirednessAnalysis(cache, states)
 
-  def lookup(node: IR): TypeWithRequiredness = coerce[TypeWithRequiredness](cache(node))
-  def lookupAs[T <: TypeWithRequiredness](node: IR): T = coerce[T](cache(node))
-  def lookup(node: TableIR): RTable = coerce[RTable](cache(node))
-  def lookup(node: BlockMatrixIR): RBlockMatrix = coerce[RBlockMatrix](cache(node))
+  def lookup(node: IR): TypeWithRequiredness = tcoerce[TypeWithRequiredness](cache(node))
+  def lookupAs[T <: TypeWithRequiredness](node: IR): T = tcoerce[T](cache(node))
+  def lookup(node: TableIR): RTable = tcoerce[RTable](cache(node))
+  def lookup(node: BlockMatrixIR): RBlockMatrix = tcoerce[RBlockMatrix](cache(node))
 
   def supportedType(node: BaseIR): Boolean = node.isInstanceOf[TableIR] || node.isInstanceOf[IR] || node.isInstanceOf[BlockMatrixIR]
 
@@ -105,7 +105,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       assert(!(makeOptional && makeRequired))
       if (refMap.contains(name)) {
         val uses = refMap(name)
-        val eltReq = coerce[RIterable](lookup(d)).elementType
+        val eltReq = tcoerce[RIterable](lookup(d)).elementType
         val req = if (makeOptional) {
           val optional = eltReq.copy(eltReq.children)
           optional.union(false)
@@ -123,7 +123,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
     def addBlockMatrixElementBinding(name: String, d: BlockMatrixIR, makeOptional: Boolean = false): Unit = {
       if (refMap.contains(name)) {
         val uses = refMap(name)
-        val eltReq = coerce[RBlockMatrix](lookup(d)).elementType
+        val eltReq = tcoerce[RBlockMatrix](lookup(d)).elementType
         val req = if (makeOptional) {
           val optional = eltReq.copy(eltReq.children)
           optional.union(false)
@@ -188,7 +188,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
           i += 1
         }
       case StreamZipJoin(as, key, curKey, curVals, _) =>
-        val aEltTypes = as.map(a => coerce[RStruct](coerce[RIterable](lookup(a)).elementType))
+        val aEltTypes = as.map(a => tcoerce[RStruct](tcoerce[RIterable](lookup(a)).elementType))
         if (refMap.contains(curKey)) {
           val uses = refMap(curKey)
           val keyTypes = aEltTypes.map(t => RStruct(key.map(k => k -> t.fieldType(k))))
@@ -327,7 +327,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
 
       case TableParallelize(rowsAndGlobal, _) =>
         val Seq(rowsReq: RIterable, globalReq: RStruct) = lookupAs[RBaseStruct](rowsAndGlobal).children
-        requiredness.unionRows(coerce[RStruct](rowsReq.elementType))
+        requiredness.unionRows(tcoerce[RStruct](rowsReq.elementType))
         requiredness.unionGlobals(globalReq)
       case TableMapRows(child, newRow) =>
         requiredness.unionRows(lookupAs[RStruct](newRow))
@@ -343,13 +343,13 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         var childFields: TypeWithRequiredness = childReq.rowType
         while (i < path.length) {
           val explode = path(i)
-          coerce[RStruct](newFields).fields.filter(f => f.name != explode)
-            .foreach(f => f.typ.unionFrom(coerce[RStruct](childFields).field(f.name)))
-          newFields = coerce[RStruct](newFields).field(explode)
-          childFields = coerce[RStruct](childFields).field(explode)
+          tcoerce[RStruct](newFields).fields.filter(f => f.name != explode)
+            .foreach(f => f.typ.unionFrom(tcoerce[RStruct](childFields).field(f.name)))
+          newFields = tcoerce[RStruct](newFields).field(explode)
+          childFields = tcoerce[RStruct](childFields).field(explode)
           i += 1
         }
-        newFields.unionFrom(coerce[RIterable](childFields).elementType)
+        newFields.unionFrom(tcoerce[RIterable](childFields).elementType)
       case TableUnion(children) =>
         requiredness.unionFrom(lookup(children.head))
         children.tail.foreach(c => requiredness.unionRows(lookup(c)))
@@ -406,8 +406,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.field(root).union(false)
         requiredness.unionGlobals(lReq)
       case TableMultiWayZipJoin(children, valueName, globalName) =>
-        val valueStruct = coerce[RStruct](coerce[RIterable](requiredness.field(valueName)).elementType)
-        val globalStruct = coerce[RStruct](coerce[RIterable](requiredness.field(globalName)).elementType)
+        val valueStruct = tcoerce[RStruct](tcoerce[RIterable](requiredness.field(valueName)).elementType)
+        val globalStruct = tcoerce[RStruct](tcoerce[RIterable](requiredness.field(globalName)).elementType)
         children.foreach { c =>
           val cReq = lookup(c)
           requiredness.unionKeys(cReq)
@@ -419,7 +419,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         val lReq = lookup(left)
         val rReq = lookup(right)
         requiredness.unionRows(lReq)
-        val joined = coerce[RStruct](requiredness.field(root))
+        val joined = tcoerce[RStruct](requiredness.field(root))
         rReq.valueFields.foreach(n => joined.field(n).unionFrom(rReq.field(n)))
         joined.union(false)
         requiredness.unionGlobals(lReq.globalType)
@@ -509,11 +509,11 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case TailLoop(name, params, body) =>
         requiredness.unionFrom(lookup(body))
       case x: BaseRef =>
-        requiredness.unionFrom(defs(node).map(coerce[TypeWithRequiredness]))
+        requiredness.unionFrom(defs(node).map(tcoerce[TypeWithRequiredness]))
       case MakeArray(args, _) =>
-        coerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
       case MakeStream(args, _, _) =>
-        coerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
       case ArrayRef(a, i, _) =>
         val aReq = lookupAs[RIterable](a)
         requiredness.unionFrom(aReq.elementType)
@@ -527,32 +527,32 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionFrom(lookup(a))
       case ToDict(a) =>
         val aReq = lookupAs[RIterable](a)
-        val Seq(keyType, valueType) = coerce[RBaseStruct](aReq.elementType).children
-        coerce[RDict](requiredness).keyType.unionFrom(keyType)
-        coerce[RDict](requiredness).valueType.unionFrom(valueType)
+        val Seq(keyType, valueType) = tcoerce[RBaseStruct](aReq.elementType).children
+        tcoerce[RDict](requiredness).keyType.unionFrom(keyType)
+        tcoerce[RDict](requiredness).valueType.unionFrom(valueType)
         requiredness.union(aReq.required)
       case LowerBoundOnOrderedCollection(collection, elem, _) =>
         requiredness.union(lookup(collection).required)
       case GroupByKey(c) =>
         val cReq = lookupAs[RIterable](c)
-        val Seq(k, v) = coerce[RBaseStruct](cReq.elementType).children
-        coerce[RDict](requiredness).keyType.unionFrom(k)
-        coerce[RIterable](coerce[RDict](requiredness).valueType).elementType.unionFrom(v)
+        val Seq(k, v) = tcoerce[RBaseStruct](cReq.elementType).children
+        tcoerce[RDict](requiredness).keyType.unionFrom(k)
+        tcoerce[RIterable](tcoerce[RDict](requiredness).valueType).elementType.unionFrom(v)
         requiredness.union(cReq.required)
       case StreamGrouped(a, size) =>
         val aReq = lookupAs[RIterable](a)
-        coerce[RIterable](coerce[RIterable](requiredness).elementType).elementType
+        tcoerce[RIterable](tcoerce[RIterable](requiredness).elementType).elementType
           .unionFrom(aReq.elementType)
         requiredness.union(aReq.required && lookup(size).required)
       case StreamGroupByKey(a, key, _) =>
         val aReq = lookupAs[RIterable](a)
-        val elt = coerce[RIterable](coerce[RIterable](requiredness).elementType).elementType
+        val elt = tcoerce[RIterable](tcoerce[RIterable](requiredness).elementType).elementType
         elt.union(true)
         elt.children.zip(aReq.elementType.children).foreach { case (r1, r2) => r1.unionFrom(r2) }
         requiredness.union(aReq.required)
       case StreamMap(a, name, body) =>
         requiredness.union(lookup(a).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
       case StreamTake(a, n) =>
         requiredness.union(lookup(n).required)
         requiredness.unionFrom(lookup(a))
@@ -561,16 +561,16 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionFrom(lookup(a))
       case StreamZip(as, names, body, behavior, _) =>
         requiredness.union(as.forall(lookup(_).required))
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
       case StreamZipJoin(as, _, curKey, curVals, joinF) =>
         requiredness.union(as.forall(lookup(_).required))
-        val eltType = coerce[RIterable](requiredness).elementType
+        val eltType = tcoerce[RIterable](requiredness).elementType
         eltType.unionFrom(lookup(joinF))
       case StreamMultiMerge(as, _) =>
         requiredness.union(as.forall(lookup(_).required))
-        val elt = coerce[RStruct](coerce[RIterable](requiredness).elementType)
+        val elt = tcoerce[RStruct](tcoerce[RIterable](requiredness).elementType)
         as.foreach { a =>
-          elt.unionFields(coerce[RStruct](coerce[RIterable](lookup(a)).elementType))
+          elt.unionFields(tcoerce[RStruct](tcoerce[RIterable](lookup(a)).elementType))
         }
       case StreamFilter(a, name, cond) =>
         requiredness.unionFrom(lookup(a))
@@ -580,37 +580,37 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionFrom(lookup(a))
       case StreamFlatMap(a, name, body) =>
         requiredness.union(lookup(a).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(lookupAs[RIterable](body).elementType)
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookupAs[RIterable](body).elementType)
       case StreamFold(a, zero, accumName, valueName, body) =>
         requiredness.union(lookup(a).required)
         requiredness.unionFrom(lookup(body))
         requiredness.unionFrom(lookup(zero)) // if a is length 0
       case StreamScan(a, zero, accumName, valueName, body) =>
         requiredness.union(lookup(a).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(zero))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(zero))
       case StreamFold2(a, accums, valueName, seq, result) =>
         requiredness.union(lookup(a).required)
         requiredness.unionFrom(lookup(result))
       case StreamJoinRightDistinct(left, right, _, _, _, _, joinf, joinType) =>
         requiredness.union(lookup(left).required && lookup(right).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(joinf))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(joinf))
       case StreamAgg(a, name, query) =>
         requiredness.union(lookup(a).required)
         requiredness.unionFrom(lookup(query))
       case StreamAggScan(a, name, query) =>
         requiredness.union(lookup(a).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(query))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(query))
       case AggFilter(cond, aggIR, isScan) =>
         requiredness.unionFrom(lookup(aggIR))
       case AggExplode(array, name, aggBody, isScan) =>
         requiredness.unionFrom(lookup(aggBody))
       case AggGroupBy(key, aggIR, isScan) =>
-        val rdict = coerce[RDict](requiredness)
+        val rdict = tcoerce[RDict](requiredness)
         rdict.keyType.unionFrom(lookup(key))
         rdict.valueType.unionFrom(lookup(aggIR))
       case AggArrayPerElement(a, _, _, body, knownLength, isScan) =>
-        val rit = coerce[RIterable](requiredness)
+        val rit = tcoerce[RIterable](requiredness)
         rit.union(lookup(a).required)
         rit.elementType.unionFrom(lookup(body))
       case ApplyAggOp(initOpArgs, seqOpArgs, aggSig) => //FIXME round-tripping through ptype
@@ -657,10 +657,10 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionFrom(lookup(nd))
       case NDArrayMap(nd, name, body) =>
         requiredness.union(lookup(nd).required)
-        coerce[RNDArray](requiredness).unionElement(lookup(body))
+        tcoerce[RNDArray](requiredness).unionElement(lookup(body))
       case NDArrayMap2(l, r, _, _, body, _) =>
         requiredness.union(lookup(l).required && lookup(r).required)
-        coerce[RNDArray](requiredness).unionElement(lookup(body))
+        tcoerce[RNDArray](requiredness).unionElement(lookup(body))
       case NDArrayMatMul(l, r, _) =>
         requiredness.unionFrom(lookup(l))
         requiredness.union(lookup(r).required)
@@ -669,28 +669,28 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case NDArrayInv(child, _) => requiredness.unionFrom(lookup(child))
       case MakeStruct(fields) =>
         fields.foreach { case (n, f) =>
-          coerce[RStruct](requiredness).field(n).unionFrom(lookup(f))
+          tcoerce[RStruct](requiredness).field(n).unionFrom(lookup(f))
         }
       case MakeTuple(fields) =>
         fields.foreach { case (i, f) =>
-          coerce[RTuple](requiredness).field(i).unionFrom(lookup(f))
+          tcoerce[RTuple](requiredness).field(i).unionFrom(lookup(f))
         }
       case SelectFields(old, fields) =>
         val oldReq = lookupAs[RStruct](old)
         requiredness.union(oldReq.required)
         fields.foreach { n =>
-          coerce[RStruct](requiredness).field(n).unionFrom(oldReq.field(n))
+          tcoerce[RStruct](requiredness).field(n).unionFrom(oldReq.field(n))
         }
       case InsertFields(old, fields, _) =>
         lookup(old) match {
           case oldReq: RStruct =>
             requiredness.union(oldReq.required)
             val fieldMap = fields.toMap.mapValues(lookup)
-            coerce[RStruct](requiredness).fields.foreach { f =>
+            tcoerce[RStruct](requiredness).fields.foreach { f =>
               f.typ.unionFrom(fieldMap.getOrElse(f.name, oldReq.field(f.name)))
             }
           case _ => fields.foreach { case (n, f) =>
-            coerce[RStruct](requiredness).field(n).unionFrom(lookup(f))
+            tcoerce[RStruct](requiredness).field(n).unionFrom(lookup(f))
           }
         }
       case GetField(o, name) =>
@@ -710,12 +710,12 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionFrom(x.implementation.computeReturnEmitType(x.returnType, argP).typeWithRequiredness.r)
       case CollectDistributedArray(ctxs, globs, _, _, body, _, _, _) =>
         requiredness.union(lookup(ctxs).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
       case ReadPartition(context, rowType, reader) =>
         requiredness.union(lookup(context).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(reader.rowRequiredness(rowType))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(reader.rowRequiredness(rowType))
       case WritePartition(value, writeCtx, writer) =>
-        val streamtype = coerce[RIterable](lookup(value))
+        val streamtype = tcoerce[RIterable](lookup(value))
         val ctxType = lookup(writeCtx)
         writer.unionTypeRequiredness(requiredness, ctxType, streamtype)
       case ReadValue(path, spec, rt) =>
@@ -747,7 +747,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
           }
       case RunAggScan(array, name, init, seqs, result, signature) =>
         requiredness.union(lookup(array).required)
-        coerce[RIterable](requiredness).elementType.unionFrom(lookup(result))
+        tcoerce[RIterable](requiredness).elementType.unionFrom(lookup(result))
       case TableAggregate(c, q) => requiredness.unionFrom(lookup(q))
       case TableGetGlobals(c) => requiredness.unionFrom(lookup(c).globalType)
       case TableCollect(c) =>
@@ -761,8 +761,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case TableGetGlobals(c) =>
         requiredness.unionFrom(lookup(c).globalType)
       case TableCollect(c) =>
-        coerce[RIterable](coerce[RStruct](requiredness).field("rows")).elementType.unionFrom(lookup(c).rowType)
-        coerce[RStruct](requiredness).field("global").unionFrom(lookup(c).globalType)
+        tcoerce[RIterable](tcoerce[RStruct](requiredness).field("rows")).elementType.unionFrom(lookup(c).rowType)
+        tcoerce[RStruct](requiredness).field("global").unionFrom(lookup(c).globalType)
       case BlockMatrixToValueApply(child, GetElement(_)) => // BlockMatrix elements are all required
       case BlockMatrixCollect(child) =>  // BlockMatrix elements are all required
       case BlockMatrixWrite(child, writer) => // write result is required

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -5,6 +5,7 @@ import is.hail.backend.ExecuteContext
 import is.hail.types.virtual._
 import is.hail.io.bgen.MatrixBGENReader
 import is.hail.rvd.{PartitionBoundOrdering, RVDPartitionInfo}
+import is.hail.types.tcoerce
 import is.hail.utils._
 
 object Simplify {
@@ -389,7 +390,7 @@ object Simplify {
       }
       ForwardLets[IR](rw)
 
-    case SelectFields(old, fields) if coerce[TStruct](old.typ).fieldNames sameElements fields =>
+    case SelectFields(old, fields) if tcoerce[TStruct](old.typ).fieldNames sameElements fields =>
       old
 
     case SelectFields(SelectFields(old, _), fields) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -17,12 +17,12 @@ import is.hail.rvd.{AbstractRVDSpec, IndexSpec, RVDPartitioner, RVDSpecMaker}
 import is.hail.types.encoded.EType
 import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SContainer, SStringValue, SVoidValue}
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.{EmitType, SCode, SValue, SSettable}
-import is.hail.types.physical.stypes.concrete.{SStackStruct, SJavaArrayString, SJavaArrayStringValue, SSubsetStruct, SSubsetStructValue}
+import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SValue}
+import is.hail.types.physical.stypes.concrete.{SJavaArrayString, SJavaArrayStringValue, SStackStruct, SSubsetStruct, SSubsetStructValue}
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SBooleanValue, SInt64Value, SInt64}
+import is.hail.types.physical.stypes.primitives.{SBooleanValue, SInt64, SInt64Value}
 import is.hail.types.virtual._
-import is.hail.types.{RIterable, RStruct, RTuple, RTable, TableType, TypeWithRequiredness}
+import is.hail.types.{RIterable, RStruct, RTable, RTuple, TableType, TypeWithRequiredness, tcoerce}
 import is.hail.utils._
 import is.hail.utils.richUtils.ByteTrackingOutputStream
 import is.hail.variant.ReferenceGenome
@@ -50,7 +50,7 @@ object TableNativeWriter {
     rowSpec: TypedCodecSpec, globalSpec: TypedCodecSpec, relationalLetsAbove: Map[String, IR]): IR = {
     // write out partitioner key, which may be stricter than table key
     val partitioner = ts.partitioner
-    val pKey: PStruct = coerce[PStruct](rowSpec.decodedPType(partitioner.kType))
+    val pKey: PStruct = tcoerce[PStruct](rowSpec.decodedPType(partitioner.kType))
     val rowWriter = PartitionNativeWriter(rowSpec, pKey.fieldNames, s"$path/rows/parts/", Some(s"$path/index/" -> pKey), if (stageLocally) Some(ctx.localTmpdir) else None)
     val globalWriter = PartitionNativeWriter(globalSpec, IndexedSeq(), s"$path/globals/parts/", None, None)
 
@@ -76,7 +76,7 @@ object TableNativeWriter {
             WriteMetadata(MakeArray(GetField(writeGlobals, "filePath")),
               RVDSpecWriter(s"$path/globals", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(1)))),
             WriteMetadata(ToArray(mapIR(ToStream(fileCountAndDistinct)) { fc => GetField(fc, "filePath") }),
-              RVDSpecWriter(s"$path/rows", RVDSpecMaker(rowSpec, partitioner, IndexSpec.emptyAnnotation("../index", coerce[PStruct](pKey))))),
+              RVDSpecWriter(s"$path/rows", RVDSpecMaker(rowSpec, partitioner, IndexSpec.emptyAnnotation("../index", tcoerce[PStruct](pKey))))),
             WriteMetadata(ToArray(mapIR(ToStream(fileCountAndDistinct)) { fc =>
               SelectFields(fc, Seq("partitionCounts", "distinctlyKeyed", "firstKey", "lastKey"))
             }),
@@ -639,7 +639,7 @@ case class TableNativeFanoutWriter(
         val targetRowType = rowType.typeAfterSelectNames(fieldAndKey)
         val targetRowRType = rowRType.select(fieldAndKey)
         val rowSpec = TypedCodecSpec(EType.fromTypeAndAnalysis(targetRowType, targetRowRType), targetRowType, bufferSpec)
-        val keyPType = coerce[PStruct](rowSpec.decodedPType(keyType))
+        val keyPType = tcoerce[PStruct](rowSpec.decodedPType(keyType))
         val tableType = TableType(targetRowType, keyFields, t.typ.globalType)
         val rowWriter = PartitionNativeWriter(
           rowSpec,
@@ -692,7 +692,7 @@ case class TableNativeFanoutWriter(
                 RVDSpecMaker(
                   target.rowSpec,
                   partitioner,
-                  IndexSpec.emptyAnnotation("../index", coerce[PStruct](target.keyPType))
+                  IndexSpec.emptyAnnotation("../index", tcoerce[PStruct](target.keyPType))
                 )
               )
             ),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.UtilFunctions
-import is.hail.expr.ir.{coerce => _, _}
+import is.hail.expr.ir._
 import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.{PType, typeToTypeInfo}

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.functions
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir._
-import is.hail.types.coerce
+import is.hail.types.tcoerce
 import is.hail.types.physical.{PCanonicalArray, PInt32, PType}
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.concrete.SIndexablePointer
@@ -31,7 +31,7 @@ object ArrayFunctions extends RegistryFunctions {
 
   def mean(args: Seq[IR]): IR = {
     val Seq(a) = args
-    val t = coerce[TArray](a.typ).elementType
+    val t = tcoerce[TArray](a.typ).elementType
     val elt = genUID()
     val n = genUID()
     val sum = genUID()
@@ -60,7 +60,7 @@ object ArrayFunctions extends RegistryFunctions {
   }
 
   def exists(a: IR, cond: IR => IR): IR = {
-    val t = coerce[TArray](a.typ).elementType
+    val t = tcoerce[TArray](a.typ).elementType
     StreamFold(
       ToStream(a),
       False(),
@@ -79,7 +79,7 @@ object ArrayFunctions extends RegistryFunctions {
   }
 
   def sum(a: IR): IR = {
-    val t = coerce[TArray](a.typ).elementType
+    val t = tcoerce[TArray](a.typ).elementType
     val sum = genUID()
     val v = genUID()
     val zero = Cast(I64(0), t)
@@ -87,7 +87,7 @@ object ArrayFunctions extends RegistryFunctions {
   }
 
   def product(a: IR): IR = {
-    val t = coerce[TArray](a.typ).elementType
+    val t = tcoerce[TArray](a.typ).elementType
     val product = genUID()
     val v = genUID()
     val one = Cast(I64(1), t)
@@ -118,9 +118,9 @@ object ArrayFunctions extends RegistryFunctions {
 
       registerIR2(stringOp, TArray(argType), TArray(argType), TArray(retType)) { (_, array1, array2, errorID) =>
         val a1id = genUID()
-        val e1 = Ref(a1id, coerce[TArray](array1.typ).elementType)
+        val e1 = Ref(a1id, tcoerce[TArray](array1.typ).elementType)
         val a2id = genUID()
-        val e2 = Ref(a2id, coerce[TArray](array2.typ).elementType)
+        val e2 = Ref(a2id, tcoerce[TArray](array2.typ).elementType)
         ToArray(StreamZip(FastIndexedSeq(ToStream(array1), ToStream(array2)), FastIndexedSeq(a1id, a2id),
                                         irOp(e1, e2, errorID), ArrayZipBehavior.AssertSameLength))
       }
@@ -132,7 +132,7 @@ object ArrayFunctions extends RegistryFunctions {
 
     def makeMinMaxOp(op: String): Seq[IR] => IR = {
       { case Seq(a) =>
-        val t = coerce[TArray](a.typ).elementType
+        val t = tcoerce[TArray](a.typ).elementType
         val value = genUID()
         val first = genUID()
         val acc = genUID()
@@ -177,7 +177,7 @@ object ArrayFunctions extends RegistryFunctions {
     }
 
     def argF(a: IR, op: (Type) => ComparisonOp[Boolean], errorID: Int): IR = {
-      val t = coerce[TArray](a.typ).elementType
+      val t = tcoerce[TArray](a.typ).elementType
       val tAccum = TStruct("m" -> t, "midx" -> TInt32)
       val accum = genUID()
       val value = genUID()
@@ -211,7 +211,7 @@ object ArrayFunctions extends RegistryFunctions {
     registerIR1("argmax", TArray(tv("T")), TInt32)((_, a, errorID) => argF(a, GT(_), errorID))
 
     def uniqueIndex(a: IR, op: (Type) => ComparisonOp[Boolean], errorID: Int): IR = {
-      val t = coerce[TArray](a.typ).elementType
+      val t = tcoerce[TArray](a.typ).elementType
       val tAccum = TStruct("m" -> t, "midx" -> TInt32, "count" -> TInt32)
       val accum = genUID()
       val value = genUID()
@@ -262,7 +262,7 @@ object ArrayFunctions extends RegistryFunctions {
     }
 
     registerIR1("flatten", TArray(TArray(tv("T"))), TArray(tv("T"))) { (_, a, _) =>
-      val elt = Ref(genUID(), coerce[TArray](a.typ).elementType)
+      val elt = Ref(genUID(), tcoerce[TArray](a.typ).elementType)
       ToArray(StreamFlatMap(ToStream(a), elt.name, ToStream(elt)))
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -46,11 +46,11 @@ object DictFunctions extends RegistryFunctions {
 
     registerIR3("get", tdict, tv("key"), tv("value"), tv("value"))((_, a, b, c, _) => get(a, b, c))
     registerIR2("get", tdict, tv("key"), tv("tvalue")) { (_, d, k, _) =>
-      get(d, k, NA(types.coerce[TDict](d.typ).valueType))
+      get(d, k, NA(types.tcoerce[TDict](d.typ).valueType))
     }
 
     registerIR2("index", tdict, tv("key"), tv("value")) { (_, d, k, errorID) =>
-      val vtype = types.coerce[TBaseStruct](types.coerce[TContainer](d.typ).elementType).types(1)
+      val vtype = types.tcoerce[TBaseStruct](types.tcoerce[TContainer](d.typ).elementType).types(1)
       val errormsg = invoke("concat", TString,
         Str("Key "),
         invoke("concat", TString,
@@ -62,7 +62,7 @@ object DictFunctions extends RegistryFunctions {
     }
 
     registerIR1("dictToArray", tdict, TArray(TStruct("key" -> tv("key"), "value" -> tv("value")))) { (_, d, _) =>
-      val elt = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
+      val elt = Ref(genUID(), types.tcoerce[TContainer](d.typ).elementType)
       ToArray(StreamMap(
         ToStream(d),
         elt.name,
@@ -70,7 +70,7 @@ object DictFunctions extends RegistryFunctions {
     }
 
     registerIR1("keySet", tdict, TSet(tv("key"))) { (_, d, _) =>
-      val pairs = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
+      val pairs = Ref(genUID(), types.tcoerce[TContainer](d.typ).elementType)
       ToSet(StreamMap(ToStream(d), pairs.name, GetField(pairs, "key")))
     }
 
@@ -79,12 +79,12 @@ object DictFunctions extends RegistryFunctions {
     registerIR1("dict", TArray(TTuple(tv("key"), tv("value"))), tdict)((_, a, _) => ToDict(ToStream(a)))
 
     registerIR1("keys", tdict, TArray(tv("key"))) { (_, d, _) =>
-      val elt = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
+      val elt = Ref(genUID(), types.tcoerce[TContainer](d.typ).elementType)
       ToArray(StreamMap(ToStream(d), elt.name, GetField(elt, "key")))
     }
 
     registerIR1("values", tdict, TArray(tv("value"))) { (_, d, _) =>
-      val elt = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
+      val elt = Ref(genUID(), types.tcoerce[TContainer](d.typ).elementType)
       ToArray(StreamMap(ToStream(d), elt.name, GetField(elt, "value")))
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -5,7 +5,7 @@ import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.{SFloat64, SInt32}
 import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.virtual.{TArray, TFloat64, TInt32, Type}
-import is.hail.types.{coerce => _}
+import is.hail.types.{tcoerce => _}
 
 object GenotypeFunctions extends RegistryFunctions {
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.{Nat, NatVariable}
 import is.hail.linalg.{LAPACK, LinalgCodeUtils}
-import is.hail.types.coerce
+import is.hail.types.tcoerce
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SNDArrayPointer}
 import is.hail.types.physical.stypes.interfaces._
@@ -30,8 +30,8 @@ object  NDArrayFunctions extends RegistryFunctions {
       registerIR2(stringOp, TNDArray(argType, nDimVar), TNDArray(argType, nDimVar), TNDArray(retType, nDimVar)) { (_, l, r, errorID) =>
         val lid = genUID()
         val rid = genUID()
-        val lElemRef = Ref(lid, coerce[TNDArray](l.typ).elementType)
-        val rElemRef = Ref(rid, coerce[TNDArray](r.typ).elementType)
+        val lElemRef = Ref(lid, tcoerce[TNDArray](l.typ).elementType)
+        val rElemRef = Ref(rid, tcoerce[TNDArray](r.typ).elementType)
 
         NDArrayMap2(l, r, lid, rid, irOp(lElemRef, rElemRef, errorID), errorID)
       }
@@ -52,7 +52,7 @@ object  NDArrayFunctions extends RegistryFunctions {
 
       val infoDTRTRSResult = cb.newLocal[Int]("dtrtrs_result")
 
-      val outputPType = coerce[PCanonicalNDArray](outputPt)
+      val outputPType = tcoerce[PCanonicalNDArray](outputPt)
       val output = outputPType.constructByActuallyCopyingData(ndDepColMajor, cb, region)
 
       cb.assign(infoDTRTRSResult, Code.invokeScalaObject9[String, String, String, Int, Int, Long, Int, Long, Int, Int](LAPACK.getClass, "dtrtrs",
@@ -95,7 +95,7 @@ object  NDArrayFunctions extends RegistryFunctions {
 
       cb.append(Region.copyFrom(aColMajorFirstElement, aCopy, aNumBytes))
 
-      val outputPType = coerce[PCanonicalNDArray](outputPt)
+      val outputPType = tcoerce[PCanonicalNDArray](outputPt)
       val outputShape = IndexedSeq(n, nrhs)
       val (outputAddress, outputFinisher) = outputPType.constructDataFunction(outputShape, outputPType.makeColumnMajorStrides(outputShape, region, cb), cb, region)
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
@@ -13,10 +13,10 @@ case class TableCalculateNewPartitions(
   def typ(childType: types.TableType): Type = TArray(TInterval(childType.keyType))
 
   def unionRequiredness(childType: types.RTable, resultType: types.TypeWithRequiredness): Unit = {
-    val rinterval = types.coerce[types.RInterval](
-      types.coerce[types.RIterable](resultType).elementType)
-    val rstart = types.coerce[types.RStruct](rinterval.startType)
-    val rend = types.coerce[types.RStruct](rinterval.endType)
+    val rinterval = types.tcoerce[types.RInterval](
+      types.tcoerce[types.RIterable](resultType).elementType)
+    val rstart = types.tcoerce[types.RStruct](rinterval.startType)
+    val rend = types.tcoerce[types.RStruct](rinterval.endType)
     childType.keyFields.foreach { k =>
       rstart.field(k).unionFrom(childType.field(k))
       rend.field(k).unionFrom(childType.field(k))

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -5,7 +5,7 @@ import is.hail.expr.Nat
 import is.hail.expr.ir._
 import is.hail.expr.ir.functions.GetElement
 import is.hail.rvd.RVDPartitioner
-import is.hail.types.{BlockMatrixSparsity, BlockMatrixType, TypeWithRequiredness}
+import is.hail.types.{BlockMatrixSparsity, BlockMatrixType, TypeWithRequiredness, tcoerce}
 import is.hail.types.virtual._
 import is.hail.utils._
 
@@ -94,8 +94,8 @@ abstract class BlockMatrixStage(val letBindings: IndexedSeq[(String, IR)], val b
             val (nRows, nCols) = typ.blockShape(i, j)
             MakeNDArray.fill(zero(typ.elementType), FastIndexedSeq(nRows, nCols), True())
           }
-        }, coerce[TArray](cda.typ)), 1)
-      }, coerce[TArray](cda.typ))
+        }, tcoerce[TArray](cda.typ)), 1)
+      }, tcoerce[TArray](cda.typ))
     } else {
       ToArray(mapIR(rangeIR(I32(typ.nRowBlocks))){ rowIdxRef =>
         val blocksInOneRow = ToArray(mapIR(rangeIR(I32(typ.nColBlocks))) { colIdxRef =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -10,9 +10,8 @@ import is.hail.methods.{ForceCountTable, NPartitionsTable, TableFilterPartitions
 import is.hail.rvd.{PartitionBoundOrdering, RVDPartitioner}
 import is.hail.types.physical.{PCanonicalBinary, PCanonicalTuple}
 import is.hail.types.virtual._
-import is.hail.types.{RField, RPrimitive, RStruct, RTable, TableType, TypeWithRequiredness}
-import is.hail.types.{coerce => _, _}
-import is.hail.utils.{partition, _}
+import is.hail.types.{RField, RPrimitive, RStruct, RTable, TableType, TypeWithRequiredness, tcoerce, _}
+import is.hail.utils._
 import org.apache.spark.sql.Row
 
 class LowererUnsupportedOperation(msg: String = null) extends Exception(msg)
@@ -707,7 +706,7 @@ object LowerTableIR {
         lower(child).getNumPartitions()
 
       case TableWrite(child, writer) =>
-        writer.lower(ctx, lower(child), child, coerce[RTable](analyses.requirednessAnalysis.lookup(child)), relationalLetsAbove)
+        writer.lower(ctx, lower(child), child, tcoerce[RTable](analyses.requirednessAnalysis.lookup(child)), relationalLetsAbove)
 
       case node if node.children.exists(_.isInstanceOf[TableIR]) =>
         throw new LowererUnsupportedOperation(s"IR nodes with TableIR children must be defined explicitly: \n${ Pretty(ctx, node) }")

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -489,7 +489,7 @@ class MatrixBGENReader(
 
     val settings = getSettings(requestedType)
 
-    val rvdType = RVDType(coerce[PStruct](settings.rowPType.subsetTo(requestedType.rowType)),
+    val rvdType = RVDType(tcoerce[PStruct](settings.rowPType.subsetTo(requestedType.rowType)),
       fullType.key.take(requestedType.key.length))
 
     val rvd = if (dropRows)

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -108,7 +108,7 @@ class IndexWriterArrayBuilder(name: String, maxSize: Int, sb: SettableBuilder, r
   private val aoff = sb.newSettable[Long](s"${name}_aoff")
   private val len = sb.newSettable[Int](s"${name}_len")
 
-  val eltType: PCanonicalStruct = types.coerce[PCanonicalStruct](arrayType.elementType.setRequired((false)))
+  val eltType: PCanonicalStruct = types.tcoerce[PCanonicalStruct](arrayType.elementType.setRequired((false)))
   private val elt = new SBaseStructPointerSettable(SBaseStructPointer(eltType), sb.newSettable[Long](s"${name}_elt_off"))
 
   def length: Code[Int] = len

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1732,7 +1732,7 @@ class MatrixVCFReader(
   val partitionCounts: Option[IndexedSeq[Long]] = None
 
   override def concreteRowRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
-    VirtualTypeWithReq(coerce[PStruct](fullRVDType.rowType.subsetTo(requestedType.rowType)))
+    VirtualTypeWithReq(tcoerce[PStruct](fullRVDType.rowType.subsetTo(requestedType.rowType)))
 
   override def uidRequiredness: VirtualTypeWithReq =
     VirtualTypeWithReq(PCanonicalTuple(true, PInt64Required, PInt64Required))

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -259,7 +259,7 @@ sealed class RIterable(val elementType: TypeWithRequiredness, eltRequired: Boole
   val children: Seq[TypeWithRequiredness] = FastSeq(elementType)
   def _unionLiteral(a: Annotation): Unit =
     a.asInstanceOf[Iterable[_]].foreach(elt => elementType.unionLiteral(elt))
-  def _matchesPType(pt: PType): Boolean = elementType.matchesPType(coerce[PIterable](pt).elementType)
+  def _matchesPType(pt: PType): Boolean = elementType.matchesPType(tcoerce[PIterable](pt).elementType)
   def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PIterable].elementType)
   def _unionEmitType(emitType: EmitType): Unit = elementType.fromEmitType(emitType.st.asInstanceOf[SIndexablePointer].elementEmitType)
   def _toString: String = s"RIterable[${ elementType.toString }]"
@@ -279,11 +279,11 @@ sealed class RIterable(val elementType: TypeWithRequiredness, eltRequired: Boole
     if (eltRequired) {
       var i = 0
       while(i < elementType.children.length) {
-        elementType.children(i).unionWithIntersection(ts.map(t => coerce[RIterable](t).elementType.children(i)))
+        elementType.children(i).unionWithIntersection(ts.map(t => tcoerce[RIterable](t).elementType.children(i)))
         i += 1
       }
     } else
-      elementType.unionWithIntersection(ts.map(t => coerce[RIterable](t).elementType))
+      elementType.unionWithIntersection(ts.map(t => tcoerce[RIterable](t).elementType))
   }
 
   def unionElement(newElement: BaseTypeWithRequiredness): Unit = {
@@ -298,7 +298,7 @@ sealed class RIterable(val elementType: TypeWithRequiredness, eltRequired: Boole
     RIterable(newElt)
   }
   def canonicalPType(t: Type): PType = {
-    val elt = elementType.canonicalPType(coerce[TIterable](t).elementType)
+    val elt = elementType.canonicalPType(tcoerce[TIterable](t).elementType)
     t match {
       case _: TArray => PCanonicalArray(elt, required = required)
       case _: TSet => PCanonicalSet(elt, required = required)
@@ -318,8 +318,8 @@ case class RDict(keyType: TypeWithRequiredness, valueType: TypeWithRequiredness)
   }
   override def canonicalPType(t: Type): PType =
     PCanonicalDict(
-      keyType.canonicalPType(coerce[TDict](t).keyType),
-      valueType.canonicalPType(coerce[TDict](t).valueType),
+      keyType.canonicalPType(tcoerce[TDict](t).keyType),
+      valueType.canonicalPType(tcoerce[TDict](t).valueType),
       required = required)
   override def _toString: String = s"RDict[${ keyType.toString }, ${ valueType.toString }]"
 }
@@ -331,7 +331,7 @@ case class RNDArray(override val elementType: TypeWithRequiredness) extends RIte
         elementType.unionLiteral(elt)
     }
   }
-  override def _matchesPType(pt: PType): Boolean = elementType.matchesPType(coerce[PNDArray](pt).elementType)
+  override def _matchesPType(pt: PType): Boolean = elementType.matchesPType(tcoerce[PNDArray](pt).elementType)
   override def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PNDArray].elementType)
   override def _unionEmitType(emitType: EmitType): Unit = elementType.fromEmitType(emitType.st.asInstanceOf[SNDArray].elementEmitType)
   override def copy(newChildren: Seq[BaseTypeWithRequiredness]): RNDArray = {
@@ -339,7 +339,7 @@ case class RNDArray(override val elementType: TypeWithRequiredness) extends RIte
     RNDArray(newElt)
   }
   override def canonicalPType(t: Type): PType = {
-    val tnd = coerce[TNDArray](t)
+    val tnd = tcoerce[TNDArray](t)
     PCanonicalNDArray(elementType.canonicalPType(tnd.elementType), tnd.nDims, required = required)
   }
   override def _toString: String = s"RNDArray[${ elementType.toString }]"
@@ -352,8 +352,8 @@ case class RInterval(startType: TypeWithRequiredness, endType: TypeWithRequiredn
     endType.unionLiteral(a.asInstanceOf[Interval].end)
   }
   def _matchesPType(pt: PType): Boolean =
-    startType.matchesPType(coerce[PInterval](pt).pointType) &&
-      endType.matchesPType(coerce[PInterval](pt).pointType)
+    startType.matchesPType(tcoerce[PInterval](pt).pointType) &&
+      endType.matchesPType(tcoerce[PInterval](pt).pointType)
   def _unionPType(pType: PType): Unit = {
     startType.fromPType(pType.asInstanceOf[PInterval].pointType)
     endType.fromPType(pType.asInstanceOf[PInterval].pointType)
@@ -386,7 +386,7 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
   def _unionLiteral(a: Annotation): Unit =
     (children, a.asInstanceOf[Row].toSeq).zipped.foreach { (r, f) => r.unionLiteral(f) }
   def _matchesPType(pt: PType): Boolean =
-    coerce[PBaseStruct](pt).fields.forall(f => children(f.index).matchesPType(f.typ))
+    tcoerce[PBaseStruct](pt).fields.forall(f => children(f.index).matchesPType(f.typ))
   def _unionPType(pType: PType): Unit = {
     pType.asInstanceOf[PBaseStruct].fields.foreach(f => children(f.index).fromPType(f.typ))
   }
@@ -421,7 +421,7 @@ case class RStruct(fields: IndexedSeq[RField]) extends RBaseStruct {
   def hasField(name: String): Boolean = fieldType.contains(name)
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RStruct = {
     assert(newChildren.length == fields.length)
-    RStruct(Array.tabulate(fields.length)(i => fields(i).name -> coerce[TypeWithRequiredness](newChildren(i))))
+    RStruct(Array.tabulate(fields.length)(i => fields(i).name -> tcoerce[TypeWithRequiredness](newChildren(i))))
   }
   def select(newFields: Array[String]): RStruct =
     RStruct(Array.tabulate(newFields.length)(i => RField(newFields(i), field(newFields(i)), i)))
@@ -438,7 +438,7 @@ case class RTuple(fields: IndexedSeq[RField]) extends RBaseStruct {
   def field(idx: Int): TypeWithRequiredness = fieldType(idx.toString)
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RTuple = {
     assert(newChildren.length == fields.length)
-    RTuple((fields, newChildren).zipped.map { (f, c) => RField(f.name, coerce[TypeWithRequiredness](c), f.index) })
+    RTuple((fields, newChildren).zipped.map { (f, c) => RField(f.name, tcoerce[TypeWithRequiredness](c), f.index) })
   }
   def _toString: String = s"RTuple[${ fields.map(f => s"${ f.index }: ${ f.typ.toString }").mkString(",") }]"
 }
@@ -451,7 +451,7 @@ case class RUnion(cases: Seq[(String, TypeWithRequiredness)]) extends TypeWithRe
   def _unionEmitType(emitType: EmitType): Unit = ???
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RUnion = {
     assert(newChildren.length == cases.length)
-    RUnion(Array.tabulate(cases.length)(i => cases(i)._1 -> coerce[TypeWithRequiredness](newChildren(i))))
+    RUnion(Array.tabulate(cases.length)(i => cases(i)._1 -> tcoerce[TypeWithRequiredness](newChildren(i))))
   }
   def canonicalPType(t: Type): PType = ???
   def _toString: String = s"RStruct[${ cases.map { case (n, t) => s"${ n }: ${ t.toString }" }.mkString(",") }]"
@@ -497,8 +497,8 @@ case class RTable(rowFields: Seq[(String, TypeWithRequiredness)], globalFields: 
 
   def asMatrixType(colField: String, entryField: String): RMatrix = {
     val row = RStruct(rowFields.filter(_._1 != entryField))
-    val entry = coerce[RStruct](coerce[RIterable](field(entryField)).elementType)
-    val col = coerce[RStruct](coerce[RIterable](field(colField)).elementType)
+    val entry = tcoerce[RStruct](tcoerce[RIterable](field(entryField)).elementType)
+    val col = tcoerce[RStruct](tcoerce[RIterable](field(colField)).elementType)
     val global = RStruct(globalFields.filter(_._1 != colField))
     RMatrix(row, entry, col, global)
   }

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -284,9 +284,9 @@ object EType {
           EField("includesStart", EBoolean(true), 2),
           EField("includesEnd", EBoolean(true), 3)),
         required = rinterval.required)
-    case t: TIterable => EArray(fromTypeAndAnalysis(t.elementType, coerce[RIterable](r).elementType), r.required)
+    case t: TIterable => EArray(fromTypeAndAnalysis(t.elementType, tcoerce[RIterable](r).elementType), r.required)
     case t: TBaseStruct =>
-      val rstruct = coerce[RBaseStruct](r)
+      val rstruct = tcoerce[RBaseStruct](r)
       assert(t.size == rstruct.size, s"different number of fields: ${t} ${r}")
       EBaseStruct(Array.tabulate(t.size) { i =>
         val f = rstruct.fields(i)

--- a/hail/src/main/scala/is/hail/types/package.scala
+++ b/hail/src/main/scala/is/hail/types/package.scala
@@ -4,9 +4,9 @@ import is.hail.types.physical.PType
 import is.hail.types.virtual.Type
 
 package object types {
-  def coerce[T <: Type](x: Type): T = x.asInstanceOf[T]
+  def tcoerce[T <: Type](x: Type): T = x.asInstanceOf[T]
 
-  def coerce[T <: PType](x: PType): T = x.asInstanceOf[T]
+  def tcoerce[T <: PType](x: PType): T = x.asInstanceOf[T]
 
-  def coerce[T <: BaseTypeWithRequiredness](x: BaseTypeWithRequiredness): T = x.asInstanceOf[T]
+  def tcoerce[T <: BaseTypeWithRequiredness](x: BaseTypeWithRequiredness): T = x.asInstanceOf[T]
 }

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -8,7 +8,7 @@ import is.hail.expr.ir._
 import is.hail.types.physical.stypes.concrete.SRNGState
 import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual._
-import is.hail.types.{Requiredness, coerce}
+import is.hail.types.{Requiredness, tcoerce}
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.sql.Row
@@ -20,7 +20,7 @@ class PTypeSerializer extends CustomSerializer[PType](format => (
   { case t: PType => JString(t.toString) }))
 
 class PStructSerializer extends CustomSerializer[PStruct](format => (
-  { case JString(s) => coerce[PStruct](IRParser.parsePType(s)) },
+  { case JString(s) => tcoerce[PStruct](IRParser.parsePType(s)) },
   { case t: PStruct => JString(t.toString) }))
 
 object PType {

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -5,7 +5,7 @@ import is.hail.TestUtils._
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.agg._
-import is.hail.types.{MatrixType, RPrimitive, TypeWithRequiredness, VirtualTypeWithReq}
+import is.hail.types.{MatrixType, RPrimitive, TypeWithRequiredness, VirtualTypeWithReq, tcoerce}
 import is.hail.types.physical.{stypes, _}
 import is.hail.types.virtual._
 import is.hail.io.BufferSpec
@@ -416,7 +416,7 @@ class Aggregators2Suite extends HailSuite {
 
   def seqOpOverArray(aggIdx: Int, a: IR, seqOps: IR => IR, alstate: ArrayLenAggSig): IR = {
     val idx = Ref(genUID(), TInt32)
-    val elt = Ref(genUID(), coerce[TArray](a.typ).elementType)
+    val elt = Ref(genUID(), tcoerce[TArray](a.typ).elementType)
 
     Begin(FastIndexedSeq(
       SeqOp(aggIdx, FastIndexedSeq(ArrayLen(a)), alstate),

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayDeforestationSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayDeforestationSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.{ExecStrategy, HailSuite}
 import is.hail.types.virtual._
 import is.hail.TestUtils._
+import is.hail.types.tcoerce
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
@@ -27,7 +28,7 @@ class ArrayDeforestationSuite extends HailSuite {
     ToArray(StreamMap(
       ToStream(array),
       "x3",
-      GetField(Ref("x3", coerce[TArray](array.typ).elementType), "f1")))
+      GetField(Ref("x3", tcoerce[TArray](array.typ).elementType), "f1")))
   }
 
   def arrayFoldWithStructWithPrimitiveValues(len: IR, max1: Int, max2: Int): IR = {
@@ -51,7 +52,7 @@ class ArrayDeforestationSuite extends HailSuite {
       MakeStruct(FastSeq[(String, IR)]("f1" -> v1, "f2" -> v2))))
     val array = arrayWithRegion(len)
     val accum = Ref(genUID(), zero.typ)
-    val value = Ref(genUID(), coerce[TArray](array.typ).elementType)
+    val value = Ref(genUID(), tcoerce[TArray](array.typ).elementType)
     StreamFold(
       ToStream(array),
       zero,

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.HailSuite
 import is.hail.expr.Nat
 import is.hail.expr.ir.agg.CallStatsState
-import is.hail.types.{BaseTypeWithRequiredness, RTable, TableType, TypeWithRequiredness, VirtualTypeWithReq}
+import is.hail.types.{BaseTypeWithRequiredness, RTable, TableType, TypeWithRequiredness, VirtualTypeWithReq, tcoerce}
 import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.io.{BufferSpec, TypedCodecSpec}
@@ -485,7 +485,7 @@ class RequirednessSuite extends HailSuite {
     val n2 = Let("foo", I32(1), MakeStruct(FastSeq("a" -> n1, "b" -> n1)))
     val node = InsertFields(n2, FastSeq("c" -> GetField(n2, "a"), "d" -> GetField(n2, "b")))
     val res = Requiredness.apply(node, ctx)
-    val actual = coerce[TypeWithRequiredness](res.r.lookup(node)).canonicalPType(node.typ)
+    val actual = tcoerce[TypeWithRequiredness](res.r.lookup(node)).canonicalPType(node.typ)
     assert(actual == PCanonicalStruct(required,
       "a" -> PInt32(required), "b" -> PInt32(required),
       "c" -> PInt32(required), "d" -> PInt32(required)))
@@ -534,7 +534,7 @@ class RequirednessSuite extends HailSuite {
       PTupleField(4, PInt32(optional)),
       PTupleField(2, PCanonicalArray(PInt32(required), optional))), required)
     val res = Requiredness.apply(node, ctx)
-    val actual = coerce[TypeWithRequiredness](res.r.lookup(node)).canonicalPType(node.typ)
+    val actual = tcoerce[TypeWithRequiredness](res.r.lookup(node)).canonicalPType(node.typ)
     assert(actual == expected)
   }
 }


### PR DESCRIPTION
These functions have the same bytecode signature, and I'm tired of having cryptic compile errors due to changing imports.

Now coerce is just for code/value/settable, and tcoerce is for types.