### PR TITLE
[query] Don't tree aggregate unnecessarily

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1230,9 +1230,9 @@ object LowerTableIR {
           val initFromSerializedStates = Begin(aggs.aggs.zipWithIndex.map { case (agg, i) =>
             InitFromSerializedValue(i, GetTupleElement(initStateRef, i), agg.state)
           })
-          val big = aggs.shouldTreeAggregate
+          val branchFactor = HailContext.get.branchingFactor
+          val big = aggs.shouldTreeAggregate && branchFactor > lc.numPartitions
           val (partitionPrefixSumValues, transformPrefixSum): (IR, IR => IR) = if (big) {
-            val branchFactor = HailContext.get.branchingFactor
             val tmpDir = ctx.createTmpPath("aggregate_intermediates/")
 
             val codecSpec = TypedCodecSpec(PCanonicalTuple(true, aggs.aggs.map(_ => PCanonicalBinary(true)): _*), BufferSpec.wireSpec)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -594,13 +594,13 @@ object LowerTableIR {
         val initFromSerializedStates = Begin(aggs.aggs.zipWithIndex.map { case (agg, i) =>
           InitFromSerializedValue(i, GetTupleElement(initStateRef, i), agg.state )})
 
-        val useTreeAggregate = aggs.shouldTreeAggregate
+        val branchFactor = HailContext.get.branchingFactor
+        val useTreeAggregate = aggs.shouldTreeAggregate && branchFactor > lc.numPartitions
         val isCommutative = aggs.isCommutative
         log.info(s"Aggregate: useTreeAggregate=${ useTreeAggregate }")
         log.info(s"Aggregate: commutative=${ isCommutative }")
 
         if (useTreeAggregate) {
-          val branchFactor = HailContext.get.branchingFactor
           val tmpDir = ctx.createTmpPath("aggregate_intermediates/")
 
           val codecSpec = TypedCodecSpec(PCanonicalTuple(true, aggs.aggs.map(_ => PCanonicalBinary(true)): _*), BufferSpec.wireSpec)
@@ -690,7 +690,7 @@ object LowerTableIR {
               RunAgg(
                 Begin(FastIndexedSeq(
                   initFromSerializedStates,
-                  forIR(ToStream(collected)) { state =>
+                  forIR(ToStream(collected, requiresMemoryManagementPerElement = true)) { state =>
                     Begin(aggs.aggs.zipWithIndex.map { case (sig, i) => CombOpValue(i, GetTupleElement(state, i), sig) })
                   }
                 )),
@@ -1398,7 +1398,7 @@ object LowerTableIR {
                   val acc = Ref(genUID(), initStateRef.typ)
                   val value = Ref(genUID(), collected.typ.asInstanceOf[TArray].elementType)
                   StreamScan(
-                    ToStream(collected),
+                    ToStream(collected, requiresMemoryManagementPerElement = true),
                     initStateRef,
                     acc.name,
                     value.name,


### PR DESCRIPTION
Making the change we talked about last week in a fresh PR so PCA is faster on the service.