### PR TITLE
[ggplot] avoid circularity in types

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -19,7 +19,7 @@ class Geom(FigureAttribute):
 
     @abc.abstractmethod
     def apply_to_fig(self, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
-        """Add this geometry to the figure and indicate if this geometry demand a static figure."""
+        """Add this geometry to the figure and indicate if this geometry demands a static figure."""
         pass
 
     @abc.abstractmethod

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -18,7 +18,8 @@ class Geom(FigureAttribute):
         self.aes = aes
 
     @abc.abstractmethod
-    def apply_to_fig(self, parent, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
+        """Add this geometry to the figure and indicate if this geometry demand a static figure."""
         pass
 
     @abc.abstractmethod
@@ -58,7 +59,7 @@ class GeomLineBasic(Geom):
         super().__init__(aes)
         self.color = color
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
 
         def plot_group(df):
             trace_args = {
@@ -76,6 +77,8 @@ class GeomLineBasic(Geom):
 
         for group_df in grouped_data:
             plot_group(group_df)
+
+        return False
 
     @abc.abstractmethod
     def get_stat(self):
@@ -163,14 +166,7 @@ class GeomPoint(Geom):
             }
         )
 
-    def _add_legends(self, fig_so_far: go.Figure, legends):
-        for aes_name, legend_group in legends.items():
-            if len(legend_group) > 1:
-                for category, value in legend_group.items():
-                    self._add_legend(fig_so_far, aes_name, category, value)
-
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
-        parent.is_static = True
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         legends = {}
         for df in grouped_data:
             values = self._get_aes_values(df)
@@ -180,7 +176,14 @@ class GeomPoint(Geom):
                     **legends.get(aes_name, {}),
                     self._get_aes_value(df, f"{aes_name}_legend"): values[aes_name]
                 })
-        self._add_legends(fig_so_far, legends)
+
+        number_of_displayed_legends = 0
+        for aes_name, legend_group in legends.items():
+            if len(legend_group) > 1:
+                number_of_displayed_legends += 1
+                for category, value in legend_group.items():
+                    self._add_legend(fig_so_far, aes_name, category, value)
+        return number_of_displayed_legends > 1
 
     def get_stat(self):
         return StatIdentity()
@@ -205,8 +208,8 @@ class GeomLine(GeomLineBasic):
         super().__init__(aes, color)
         self.color = color
 
-    def apply_to_fig(self, parent, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
-        super().apply_to_fig(parent, agg_result, fig_so_far, precomputed, facet_row, facet_col, legend_cache)
+    def apply_to_fig(self, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
+        return super().apply_to_fig(agg_result, fig_so_far, precomputed, facet_row, facet_col, legend_cache)
 
     def get_stat(self):
         return StatIdentity()
@@ -240,7 +243,7 @@ class GeomText(Geom):
         self.size = size
         self.alpha = alpha
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         def plot_group(df):
             trace_args = {
                 "x": df.x,
@@ -258,6 +261,8 @@ class GeomText(Geom):
 
         for group_df in grouped_data:
             plot_group(group_df)
+
+        return False
 
     def get_stat(self):
         return StatIdentity()
@@ -298,7 +303,7 @@ class GeomBar(Geom):
             stat = StatCount()
         self.stat = stat
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         def plot_group(df):
             trace_args = {
                 "x": df.x,
@@ -316,6 +321,8 @@ class GeomBar(Geom):
             plot_group(group_df)
 
         fig_so_far.update_layout(barmode=bar_position_plotly_to_gg(self.position))
+
+        return False
 
     def get_stat(self):
         return self.stat
@@ -368,7 +375,7 @@ class GeomHistogram(Geom):
         self.position = position
         self.size = size
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         min_val = self.min_val if self.min_val is not None else precomputed.min_val
         max_val = self.max_val if self.max_val is not None else precomputed.max_val
         # This assumes it doesn't really make sense to use another stat for geom_histogram
@@ -414,6 +421,8 @@ class GeomHistogram(Geom):
             plot_group(group_df, idx)
 
         fig_so_far.update_layout(barmode=bar_position_plotly_to_gg(self.position))
+
+        return False
 
     def get_stat(self):
         return StatBin(self.min_val, self.max_val, self.bins)
@@ -471,7 +480,7 @@ class GeomDensity(Geom):
         self.color = color
         self.alpha = alpha
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         def plot_group(df, idx):
             slope = 1.0 / (df.attrs['max'] - df.attrs['min'])
             n = df.attrs['n']
@@ -506,6 +515,8 @@ class GeomDensity(Geom):
 
         for idx, group_df in enumerate(grouped_data):
             plot_group(group_df, idx)
+
+        return False
 
     def get_stat(self):
         return StatCDF(self.k)
@@ -555,7 +566,7 @@ class GeomHLine(Geom):
         self.linetype = linetype
         self.color = color
 
-    def apply_to_fig(self, parent, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         line_attributes = {
             "y": self.yintercept,
             "line_dash": linetype_plotly_to_gg(self.linetype)
@@ -564,6 +575,8 @@ class GeomHLine(Geom):
             line_attributes["line_color"] = self.color
 
         fig_so_far.add_hline(**line_attributes)
+
+        return False
 
     def get_stat(self):
         return StatNone()
@@ -598,7 +611,7 @@ class GeomVLine(Geom):
         self.linetype = linetype
         self.color = color
 
-    def apply_to_fig(self, parent, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         line_attributes = {
             "x": self.xintercept,
             "line_dash": linetype_plotly_to_gg(self.linetype)
@@ -607,6 +620,8 @@ class GeomVLine(Geom):
             line_attributes["line_color"] = self.color
 
         fig_so_far.add_vline(**line_attributes)
+
+        return False
 
     def get_stat(self):
         return StatNone()
@@ -638,7 +653,7 @@ class GeomTile(Geom):
     def __init__(self, aes):
         self.aes = aes
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         def plot_group(df):
 
             for idx, row in df.iterrows():
@@ -667,6 +682,8 @@ class GeomTile(Geom):
         for group_df in grouped_data:
             plot_group(group_df)
 
+        return False
+
     def get_stat(self):
         return StatIdentity()
 
@@ -680,8 +697,8 @@ class GeomFunction(GeomLineBasic):
         super().__init__(aes, color)
         self.fun = fun
 
-    def apply_to_fig(self, parent, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
-        super().apply_to_fig(parent, agg_result, fig_so_far, precomputed, facet_row, facet_col, legend_cache)
+    def apply_to_fig(self, agg_result, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
+        return super().apply_to_fig(agg_result, fig_so_far, precomputed, facet_row, facet_col, legend_cache)
 
     def get_stat(self):
         return StatFunction(self.fun)
@@ -704,7 +721,7 @@ class GeomArea(Geom):
         self.fill = fill
         self.color = color
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         def plot_group(df):
             trace_args = {
                 "x": df.x,
@@ -721,6 +738,8 @@ class GeomArea(Geom):
 
         for group_df in grouped_data:
             plot_group(group_df)
+
+        return False
 
     def get_stat(self):
         return StatIdentity()
@@ -761,7 +780,7 @@ class GeomRibbon(Geom):
         self.fill = fill
         self.color = color
 
-    def apply_to_fig(self, parent, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache):
+    def apply_to_fig(self, grouped_data, fig_so_far: go.Figure, precomputed, facet_row, facet_col, legend_cache) -> bool:
         def plot_group(df):
 
             trace_args_bottom = {
@@ -791,6 +810,8 @@ class GeomRibbon(Geom):
 
         for group_df in grouped_data:
             plot_group(group_df)
+
+        return False
 
     def get_stat(self):
         return StatIdentity()

--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -239,7 +239,8 @@ class GGPlot:
 
                 facet_row = facet_idx // n_facet_cols + 1
                 facet_col = facet_idx % n_facet_cols + 1
-                geom.apply_to_fig(self, scaled_grouped_dfs, fig, precomputed[geom_label], facet_row, facet_col, legend_cache)
+                requires_static = geom.apply_to_fig(scaled_grouped_dfs, fig, precomputed[geom_label], facet_row, facet_col, legend_cache)
+                self.is_static |= requires_static
 
         # Important to update axes after labels, axes names take precedence.
         self.labels.apply_to_fig(fig)


### PR DESCRIPTION
I love simpler solutions that leverage mutation, but in this case, `ggplot.py` and `geom.py` are circularly dependent if we want to use `GGPlot` in `geom.py`. I return a Boolean indicating if this geom makes the plot static. I do not love it because there is little indication of what that return value means, but I do not see another simple solution.