### PR TITLE
[ggplot] avoid weird dataframe error

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -112,12 +112,13 @@ class GeomPoint(Geom):
         return {self.aes_to_plotly[k]: v for k, v in mapping.items()}
 
     def _get_aes_value(self, df, aes_name):
-        return (
-            getattr(self, aes_name, None)
-            or (aes_name in df.attrs and df.attrs[aes_name])
-            or (aes_name in df.columns and df.columns[aes_name])
-            or self.aes_defaults.get(aes_name, None)
-        )
+        if getattr(self, aes_name, None) is not None:
+            return getattr(self, aes_name)
+        if df.attrs.get(aes_name) is not None:
+            return df.attrs[aes_name]
+        if df.get(aes_name) is not None:
+            return df[aes_name]
+        return self.aes_defaults.get(aes_name, None)
 
     def _get_aes_values(self, df):
         values = {}


### PR DESCRIPTION
I do not fully understand why, but I was getting errors about df.columns not accepting string indexes:

```
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

```

I think `df.columns` is not intended to let us get the Series for a column from the DataFrame. I think we are supposed to use `df` directly for this purpose, which is what I do here.

I also noticed an unfortunate issue where `''` is false-y so it is overlooked by the `or` in favor of the default value. It would be nice to have some kind of lazy `None` coalescing operator in Python :/.