### PR TITLE
[ggplot] make tooltip work on geom_point

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -1,5 +1,5 @@
+from typing import Dict, Any
 import abc
-
 import numpy as np
 
 from .aes import aes
@@ -108,8 +108,11 @@ class GeomPoint(Geom):
         self.alpha = alpha
         self.shape = shape
 
-    def _map_to_plotly(self, mapping):
-        return {self.aes_to_plotly[k]: v for k, v in mapping.items()}
+    def _map_to_plotly(self, mapping) -> Dict[str, Any]:
+        plotly_kwargs = {self.aes_to_plotly[k]: v for k, v in mapping.items()}
+        if 'tooltip' in mapping:
+            plotly_kwargs['hoverinfo'] = 'text'
+        return plotly_kwargs
 
     def _get_aes_value(self, df, aes_name):
         return (


### PR DESCRIPTION
Buried in [the documentation for `add_scatter`](https://plotly.com/python-api-reference/generated/plotly.graph_objects.Figure.html\#plotly.graph_objects.Figure.add_scatter) is a little note that says you must set `hoverinfo` to `"text"` *in addition to* setting the hovertext. :shrug: