### PR TITLE
[compiler] Move serialized object array to module, instead of class

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -191,8 +191,6 @@ class ModuleBuilder() {
     _objects += obj
     Code.checkcast[T](toCodeArray(_objectsField).apply(i))
   }
-
-  def objectArray: Array[AnyRef] = if (_objects == null) null else _objects.result()
 }
 
 trait WrappedClassBuilder[C] extends WrappedModuleBuilder {

--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -154,6 +154,44 @@ class ModuleBuilder() {
     }
     classesBytes
   }
+
+  private var staticFieldWrapperIdx: Int = 0
+  private val maxFieldsOrMethodsOnClass: Int = 512
+  private var nStaticFieldsOnThisClass: Int = maxFieldsOrMethodsOnClass
+  private var staticCls: ClassBuilder[_] = null
+
+  private def incrStaticClassSize(n: Int = 1): Unit = {
+    if (nStaticFieldsOnThisClass + n >= maxFieldsOrMethodsOnClass) {
+      nStaticFieldsOnThisClass = n
+      staticFieldWrapperIdx += 1
+      staticCls = genClass[Unit](s"staticWrapperClass_$staticFieldWrapperIdx")
+    }
+  }
+
+  def genStaticField[T: TypeInfo](name: String = null): StaticFieldRef[T] = {
+    incrStaticClassSize()
+    val fd = staticCls.newStaticField[T](genName("f", name))
+    new StaticFieldRef[T](fd)
+  }
+
+  var _objectsField: Settable[Array[AnyRef]] = _
+  var _objects: BoxedArrayBuilder[AnyRef] = _
+
+  def setObjects(cb: EmitCodeBuilder, objects: Code[Array[AnyRef]]): Unit = {
+    cb.assign(_objectsField, objects)
+  }
+
+  def getObject[T <: AnyRef : TypeInfo](obj: T): Code[T] = {
+    if (_objectsField == null) {
+      _objectsField = genStaticField[Array[AnyRef]]()
+      _objects = new BoxedArrayBuilder[AnyRef]()
+    }
+
+    val i = _objects.size
+    _objects += obj
+    Code.checkcast[T](toCodeArray(_objectsField).apply(i))
+  }
+
 }
 
 trait WrappedClassBuilder[C] extends WrappedModuleBuilder {

--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -192,6 +192,7 @@ class ModuleBuilder() {
     Code.checkcast[T](toCodeArray(_objectsField).apply(i))
   }
 
+  def objectArray: Array[AnyRef] = if (_objects == null) null else _objects.result()
 }
 
 trait WrappedClassBuilder[C] extends WrappedModuleBuilder {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -65,8 +65,6 @@ class EmitModuleBuilder(val ctx: ExecuteContext, val modb: ModuleBuilder) {
   def setObjects(cb: EmitCodeBuilder, objects: Code[Array[AnyRef]]): Unit = modb.setObjects(cb, objects)
 
   def getObject[T <: AnyRef : TypeInfo](obj: T): Code[T] = modb.getObject(obj)
-
-  def objectArray: Array[AnyRef] = modb.objectArray
 }
 
 trait WrappedEmitModuleBuilder {
@@ -700,8 +698,6 @@ class EmitClassBuilder[C](
 
     val useBackend = _backendField != null
     val backend = if (useBackend) new BackendUtils(_mods.result()) else null
-
-    val objects = emodb.objectArray
 
     assert(TaskContext.get() == null,
       "FunctionBuilder emission should happen on master, but happened on worker")


### PR DESCRIPTION
No multithreading issues here -- these are intended to be used in a read-only way.