### PR TITLE
[compiler] fix tree aggregation on empty table

### DIFF
--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -215,7 +215,6 @@ class Tests(unittest.TestCase):
                       n_discordant=0),
         ]
 
-    @fails_service_backend()
     def test_concordance_no_values_doesnt_error(self):
         dataset = get_dataset().filter_rows(False)
         _, cols_conc, rows_conc = hl.concordance(dataset, dataset)


### PR DESCRIPTION
Fix TableAggregate tree aggregation on a table with 0 partitions, by making the last layer of aggregation initialize the agg states using the initializers, rather than the head of the results array, just as we do in non-tree aggregate.