### PR TITLE
[batch] Add indices for faster pool scheduling

### DIFF
--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -591,9 +591,9 @@ WHERE user = %s AND `state` = 'running';
                     '''
 SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep
 FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_inst_coll_cancelled)
-WHERE jobs.batch_id = %s AND jobs.state = 'Ready' AND always_run = 1 AND inst_coll = %s
-ORDER BY jobs.batch_id, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id
-LIMIT 1000;
+WHERE jobs.batch_id = %s AND inst_coll = %s AND jobs.state = 'Ready' AND always_run = 1
+ORDER BY jobs.batch_id, inst_coll, state, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id
+LIMIT 300;
 ''',
                     (batch['id'], self.pool.name),
                     "user_runnable_jobs__select_ready_always_run_jobs",
@@ -608,9 +608,9 @@ LIMIT 1000;
                         '''
 SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep
 FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
-WHERE jobs.batch_id = %s AND jobs.state = 'Ready' AND always_run = 0 AND inst_coll = %s AND cancelled = 0
-ORDER BY jobs.batch_id, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id
-LIMIT 1000;
+WHERE jobs.batch_id = %s AND inst_coll = %s AND jobs.state = 'Ready' AND always_run = 0 AND cancelled = 0
+ORDER BY jobs.batch_id, inst_coll, state, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id
+LIMIT 300;
 ''',
                         (batch['id'], self.pool.name),
                         "user_runnable_jobs__select_ready_jobs_batch_not_cancelled",

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -257,7 +257,7 @@ CREATE TABLE IF NOT EXISTS `jobs` (
 CREATE INDEX `jobs_batch_id_state_always_run_inst_coll_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `inst_coll`, `cancelled`);
 CREATE INDEX `jobs_batch_id_state_always_run_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `cancelled`);
 CREATE INDEX `jobs_batch_id_update_id` ON `jobs` (`batch_id`, `update_id`);
-CREATE INDEX `jobs_batch_id_always_run_n_regions_regions_bits_rep_job_id` ON `jobs` (`batch_id`, `always_run`, `n_regions`, `regions_bits_rep`, `job_id`);
+CREATE INDEX `jobs_batch_id_ic_state_ar_n_regions_bits_rep_job_id` ON `jobs` (`batch_id`, `inst_coll`, `state`, `always_run`, `n_regions`, `regions_bits_rep`, `job_id`);
 
 CREATE TABLE IF NOT EXISTS `batch_bunches` (
   `batch_id` BIGINT NOT NULL,

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -257,6 +257,7 @@ CREATE TABLE IF NOT EXISTS `jobs` (
 CREATE INDEX `jobs_batch_id_state_always_run_inst_coll_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `inst_coll`, `cancelled`);
 CREATE INDEX `jobs_batch_id_state_always_run_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `cancelled`);
 CREATE INDEX `jobs_batch_id_update_id` ON `jobs` (`batch_id`, `update_id`);
+CREATE INDEX `jobs_batch_id_always_run_n_regions_regions_bits_rep_job_id` ON `jobs` (`batch_id`, `always_run`, `n_regions`, `regions_bits_rep`, `job_id`);
 CREATE INDEX `jobs_batch_id_ic_state_ar_n_regions_bits_rep_job_id` ON `jobs` (`batch_id`, `inst_coll`, `state`, `always_run`, `n_regions`, `regions_bits_rep`, `job_id`);
 
 CREATE TABLE IF NOT EXISTS `batch_bunches` (

--- a/batch/sql/faster-regions-pool-scheduler.sql
+++ b/batch/sql/faster-regions-pool-scheduler.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `jobs_batch_id_ic_state_ar_n_regions_bits_rep_job_id` ON `jobs` (`batch_id`, `inst_coll`, `state`, `always_run`, `n_regions`, `regions_bits_rep`, `job_id`);

--- a/batch/sql/faster-regions-pool-scheduler.sql
+++ b/batch/sql/faster-regions-pool-scheduler.sql
@@ -1,2 +1,1 @@
 CREATE INDEX `jobs_batch_id_ic_state_ar_n_regions_bits_rep_job_id` ON `jobs` (`batch_id`, `inst_coll`, `state`, `always_run`, `n_regions`, `regions_bits_rep`, `job_id`);
-DROP INDEX `jobs_batch_id_always_run_n_regions_regions_bits_rep_job_id`;

--- a/batch/sql/faster-regions-pool-scheduler.sql
+++ b/batch/sql/faster-regions-pool-scheduler.sql
@@ -1,1 +1,2 @@
 CREATE INDEX `jobs_batch_id_ic_state_ar_n_regions_bits_rep_job_id` ON `jobs` (`batch_id`, `inst_coll`, `state`, `always_run`, `n_regions`, `regions_bits_rep`, `job_id`);
+DROP INDEX `jobs_batch_id_always_run_n_regions_regions_bits_rep_job_id`;

--- a/build.yaml
+++ b/build.yaml
@@ -2055,6 +2055,9 @@ steps:
       - name: add-job-regions
         script: /io/sql/add-job-regions.sql
         online: true
+      - name: faster-regions-pool-scheduler
+        script: /io/sql/faster-regions-pool-scheduler.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
I tried benchmarking this change and didn't see much of a difference in timings in my contrived high throughput example. However, I do think this index is better because I believe MySQL does the order by first and then filters records.

@danking Can you take a look at this and make sure the index is actually an improvement.

The speed of the query is linearly related to the number of records in the limit. So I think if we need to get the query speed back to under 10ms then we revert back to pulling a smaller number of records rather than 1000. I think 300 is fine and gets us to 10ms. I just didn't want to pull 10 jobs and then none of them are schedulable but the 100th one is. We can revisit this if the scheduler becomes the bottleneck after your changes to the gateway.