### PR TITLE
[batch] Add index on batches.state

### DIFF
--- a/batch/sql/add-batch-state-index.sql
+++ b/batch/sql/add-batch-state-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `batches_state` ON `batches` (`state`);

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -162,6 +162,7 @@ CREATE TABLE IF NOT EXISTS `batches` (
   PRIMARY KEY (`id`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name)
 ) ENGINE = InnoDB;
+CREATE INDEX `batches_state` ON `batches` (`state`);
 CREATE INDEX `batches_user_state` ON `batches` (`user`, `state`);
 CREATE INDEX `batches_deleted` ON `batches` (`deleted`);
 CREATE INDEX `batches_token` ON `batches` (`token`);

--- a/build.yaml
+++ b/build.yaml
@@ -2061,6 +2061,9 @@ steps:
       - name: faster-regions-pool-scheduler
         script: /io/sql/faster-regions-pool-scheduler.sql
         online: true
+      - name: add-batch-state-index
+        script: /io/sql/add-batch-state-index.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
Should improve queries like [this one](https://console.cloud.google.com/sql/instances/db-jcaq4/insights;database=batch;duration=PT1H;trace=2a8c32c1dc3084ef49937289a31cffb5;span=16a6210f0941d4dd;norm_query_id=SELECT%20%60jobs%60%20.%20*%20,%20%60batches%60%20.%20%60format_version%60%20,%20%60batches%60%20.%20%60userdata%60%20,%20%60batches%60%20.%20%60user%60%20,%20%60attempts%60%20.%20%60instance_name%60%20FROM%20%60batches%60%20INNER%20JOIN%20%60jobs%60%20ON%20%60batches%60%20.%20%60id%60%20%3D%20%60jobs%60%20.%20%60batch_id%60%20LEFT%20JOIN%20%60attempts%60%20ON%20%60jobs%60%20.%20%60batch_id%60%20%3D%20%60attempts%60%20.%20%60batch_id%60%20AND%20%60jobs%60%20.%20%60job_id%60%20%3D%20%60attempts%60%20.%20%60job_id%60%20LEFT%20JOIN%20%60instances%60%20ON%20%60attempts%60%20.%20%60instance_name%60%20%3D%20%60instances%60%20.%20%60name%60%20WHERE%20%60batches%60%20.%20%60state%60%20%3D%20%3F%20AND%20%60jobs%60%20.%20%60state%60%20%3D%20%3F%20AND%20%28%20%60jobs%60%20.%20%60always_run%60%20OR%20NOT%20%60jobs%60%20.%20%60cancelled%60%20%29%20AND%20%60jobs%60%20.%20%60inst_coll%60%20%3D%20%3F%20AND%20%60instances%60%20.%20%60state%60%20%3D%20%3F%20ORDER%20BY%20%60instances%60%20.%20%60time_activated%60%20ASC%20LIMIT%20%3F;sort_by=TOTAL_EXEC_TIME?project=hail-vdc) that need to look at only running batches and currently do a full table scan. Not a big priority I just didn't want to forget this.