### PR TITLE
[ci] Permit deployment of batch and auth at the same time

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2096,7 +2096,6 @@ steps:
       - batch_worker_image
       - batch_driver_nginx_image
       - batch_database
-      - deploy_auth
       - create_certs
   - kind: runImage
     name: create_billing_projects
@@ -2157,6 +2156,7 @@ steps:
       - service_base_image
       - create_deploy_config
       - create_accounts
+      - deploy_auth
       - deploy_batch
   - kind: runImage
     name: upload_query_jar
@@ -2190,7 +2190,6 @@ steps:
         to: /io/git_version
     dependsOn:
       - default_ns
-      - deploy_batch
       - hail_pip_installed_image
       - build_hail_jar_and_wheel_only_spark_3_2
       - merge_code
@@ -2271,6 +2270,7 @@ steps:
     dependsOn:
       - default_ns
       - merge_code
+      - deploy_auth
       - deploy_batch
       - deploy_memory
       - create_deploy_config
@@ -2431,6 +2431,7 @@ steps:
       - hail_base_image
       - batch_image
       - ci_utils_image
+      - deploy_auth
       - deploy_batch
       - netcat_ubuntu_image
       - volume_image
@@ -2474,6 +2475,7 @@ steps:
       - default_ns
       - merge_code
       - batch_image
+      - deploy_auth
       - deploy_batch
       - test_batch
   - kind: runImage
@@ -2701,6 +2703,7 @@ steps:
       - default_ns
       - merge_code
       - service_base_image
+      - deploy_auth
       - deploy_batch
   - kind: runImage
     name: test_batch_docs
@@ -2736,6 +2739,7 @@ steps:
       - default_ns
       - service_base_image
       - merge_code
+      - deploy_auth
       - deploy_batch
     timeout: 1200
     inputs:
@@ -3176,6 +3180,7 @@ steps:
       - create_accounts
       - hail_run_tests_image
       - build_hail
+      - deploy_auth
       - deploy_batch
   - kind: runImage
     name: cancel_all_running_test_batches
@@ -3217,6 +3222,7 @@ steps:
       - create_accounts
       - default_ns
       - service_base_image
+      - deploy_auth
       - deploy_batch
       - test_batch
       - test_ci
@@ -3256,6 +3262,7 @@ steps:
       - default_ns
       - merge_code
       - batch_image
+      - deploy_auth
       - deploy_batch
       - test_batch
       - test_ci

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -118,7 +118,7 @@ Finally, run the following to deploy Hail in the cluster.
 download-secret global-config && sudo cp -r contents /global-config
 download-secret database-server-config && sudo cp -r contents /sql-config
 cd ~/hail/infra/azure
-./bootstrap.sh bootstrap <REPO>/hail:<BRANCH> deploy_batch
+./bootstrap.sh bootstrap <REPO>/hail:<BRANCH> deploy_auth,deploy_batch
 ```
 
 Create the initial (developer) user. The OBJECT_ID is the Azure Active

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -67,8 +67,8 @@ Instructions:
    # The storage class for the batch logs bucket.  It should span the
    # batch regions and be compatible with the bucket location.
    batch_logs_bucket_storage_class = "MULTI_REGIONAL"
-   
-   # Similarly, bucket locations and storage classes are specified 
+
+   # Similarly, bucket locations and storage classes are specified
    # for other services:
    hail_query_bucket_location = "<bucket-location>"
    hail_query_bucket_storage_class = "MULTI_REGIONAL"
@@ -164,7 +164,7 @@ Instructions:
   ```
 
 - Install terraform.
-  
+
 - Run `terraform init`.
 
 - Run `terraform apply -var-file=$GITHUB_ORGANIZATION/global.tfvars`.  At the
@@ -236,7 +236,7 @@ You can now install Hail:
 - Bootstrap the cluster.
 
   ```
-  ./bootstrap.sh bootstrap $GITHUB_ORGANIZATION/hail:<BRANCH> deploy_batch
+  ./bootstrap.sh bootstrap $GITHUB_ORGANIZATION/hail:<BRANCH> deploy_auth,deploy_batch
   ```
 
 - Deploy the gateway. First, edit `$HAIL/letsencrypt/subdomains.txt` to include


### PR DESCRIPTION
The serial deployment of auth and batch can lengthen the critical path of CI pipelines by a few minutes if k8s needs to spin up new nodes. While auth is necessary for batch to function correctly, it's not necessary to deploy batch, so I think it's more appropriate to not have `deploy_batch` depend on `deploy_auth` but have anything that depends on `deploy_batch` also depend on `deploy_auth`. There's already a precedent for this in that the service backend tests depend on `deploy_batch` and `deploy_memory` as opposed to `deploy_batch` being dependent on `deploy_memory`.


I also removed the dependency of `upload_query_jar` on `deploy_batch`, no idea why that was there, but maybe it should be the other way around?