### PR TITLE
[vds combiner] reduce default batch size

### DIFF
--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -178,7 +178,7 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
         and ``PL`` will be entry fields in the resulting reference matrix in the dataset.
 
     """
-    _default_gvcf_batch_size = 100
+    _default_gvcf_batch_size = 50
     _default_branch_factor = 100
     _default_target_records = 24_000
     _gvcf_merge_task_limit = 150_000


### PR DESCRIPTION
I've found that these days, 10k gvcfs merging at one time is generally too many.