### PR TITLE
[batch] Send batch-driver push notification out of task of commit update

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1588,11 +1588,13 @@ async def _commit_update(app: web.Application, batch_id: int, update_id: int, us
             raise web.HTTPBadRequest(reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
-    await request_retry_transient_errors(
-        client_session,
-        'PATCH',
-        deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/update'),
-        headers=app['batch_headers'],
+    app['task_manager'].ensure_future(
+        request_retry_transient_errors(
+            client_session,
+            'PATCH',
+            deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/update'),
+            headers=app['batch_headers'],
+        )
     )
 
 


### PR DESCRIPTION
Should help a bit to speed up the the create-fast and update-fast endpoints if the user doesn't have to wait on this request to the driver.