### PR TITLE
[query] Update JSON serialized relational type names

### DIFF
--- a/hail/python/hail/expr/blockmatrix_type.py
+++ b/hail/python/hail/expr/blockmatrix_type.py
@@ -15,10 +15,10 @@ class tblockmatrix(object):
 
     @staticmethod
     def _from_json(json):
-        return tblockmatrix(dtype(json['element_type']),
-                            json['shape'],
-                            json['is_row_vector'],
-                            json['block_size'])
+        return tblockmatrix(element_type=dtype(json['element_type']),
+                            shape=json['shape'],
+                            is_row_vector=json['is_row_vector'],
+                            block_size=json['block_size'])
 
     @typecheck_method(element_type=hail_type, shape=sequenceof(int), is_row_vector=bool, block_size=int)
     def __init__(self, element_type, shape, is_row_vector, block_size):

--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -20,12 +20,12 @@ class tmatrix(object):
     @staticmethod
     def _from_json(json):
         return tmatrix(
-            dtype(json['global']),
-            dtype(json['col']),
-            json['col_key'],
-            dtype(json['row']),
-            json['row_key'],
-            dtype(json['entry']))
+            global_type=dtype(json['global_type']),
+            col_type=dtype(json['col_type']),
+            col_key=json['col_key'],
+            row_type=dtype(json['row_type']),
+            row_key=json['row_key'],
+            entry_type=dtype(json['entry_type']))
 
     @typecheck_method(global_type=tstruct,
                       col_type=tstruct, col_key=sequenceof(str),

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -16,9 +16,9 @@ class ttable(object):
     @staticmethod
     def _from_json(json):
         return ttable(
-            dtype(json['global']),
-            dtype(json['row']),
-            json['row_key'])
+            global_type=dtype(json['global_type']),
+            row_type=dtype(json['row_type']),
+            row_key=json['row_key'])
 
     @typecheck_method(global_type=tstruct, row_type=tstruct, row_key=sequenceof(str))
     def __init__(self, global_type, row_type, row_key):

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -271,8 +271,8 @@ class ServiceBackend(
   ): String =  {
     val x = IRParser.parse_table_ir(ctx, s)
     val t = x.typ
-    val jv = JObject("global" -> JString(t.globalType.toString),
-      "row" -> JString(t.rowType.toString),
+    val jv = JObject("global_type" -> JString(t.globalType.toString),
+      "row_type" -> JString(t.rowType.toString),
       "row_key" -> JArray(t.key.map(f => JString(f)).toList))
     JsonMethods.compact(jv)
   }
@@ -282,14 +282,7 @@ class ServiceBackend(
     s: String
   ): String = {
     val x = IRParser.parse_matrix_ir(ctx, s)
-    val t = x.typ
-    val jv = JObject("global" -> JString(t.globalType.toString),
-      "col" -> JString(t.colType.toString),
-      "col_key" -> JArray(t.colKey.map(f => JString(f)).toList),
-      "row" -> JString(t.rowType.toString),
-      "row_key" -> JArray(t.rowKey.map(f => JString(f)).toList),
-      "entry" -> JString(t.entryType.toString))
-    JsonMethods.compact(jv)
+    JsonMethods.compact(x.typ.pyJson)
   }
 
   def blockMatrixType(

--- a/hail/src/main/scala/is/hail/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/MatrixType.scala
@@ -207,12 +207,12 @@ case class MatrixType(
 
   def pyJson: JObject = {
     JObject(
-      "row" -> JString(rowType.toString),
+      "row_type" -> JString(rowType.toString),
       "row_key" -> JArray(rowKey.toList.map(JString(_))),
-      "col" -> JString(colType.toString),
+      "col_type" -> JString(colType.toString),
       "col_key" -> JArray(colKey.toList.map(JString(_))),
-      "entry" -> JString(entryType.toString),
-      "global" -> JString(globalType.toString)
+      "entry_type" -> JString(entryType.toString),
+      "global_type" -> JString(globalType.toString)
     )
   }
 }


### PR DESCRIPTION
This makes the keys we produce in serialized representation the same as the field names in the python objects.