### PR TITLE
[batch] Implement job run conditions

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1072,6 +1072,8 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
         spec_writer.add(json.dumps(spec))
         db_spec = batch_format_version.db_spec(spec)
 
+        run_condition = spec.get('run_condition', 'all')
+
         jobs_args.append(
             (
                 batch_id,
@@ -1085,6 +1087,7 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
                 inst_coll_name,
                 n_regions,
                 regions_bits_rep,
+                run_condition == 'any' and len(parent_ids) > 0,
             )
         )
 
@@ -1106,8 +1109,8 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
             try:
                 await tx.execute_many(
                     '''
-INSERT INTO jobs (batch_id, job_id, update_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll, n_regions, regions_bits_rep)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+INSERT INTO jobs (batch_id, job_id, update_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll, n_regions, regions_bits_rep, cancelled)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
 ''',
                     jobs_args,
                     query_name='insert_jobs',

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1072,8 +1072,6 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
         spec_writer.add(json.dumps(spec))
         db_spec = batch_format_version.db_spec(spec)
 
-        run_condition = spec.get('run_condition', 'all')
-
         jobs_args.append(
             (
                 batch_id,
@@ -1087,7 +1085,8 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
                 inst_coll_name,
                 n_regions,
                 regions_bits_rep,
-                run_condition == 'any' and len(parent_ids) > 0,
+                spec['run_condition'],
+                0,
             )
         )
 
@@ -1109,8 +1108,8 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
             try:
                 await tx.execute_many(
                     '''
-INSERT INTO jobs (batch_id, job_id, update_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll, n_regions, regions_bits_rep, cancelled)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+INSERT INTO jobs (batch_id, job_id, update_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll, n_regions, regions_bits_rep, run_condition, n_succeeded_parents)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
 ''',
                     jobs_args,
                     query_name='insert_jobs',

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -201,7 +201,10 @@ def handle_job_backwards_compatibility(job):
     if 'always_copy_output' not in job:
         job['always_copy_output'] = True
     if 'run_condition' not in job:
-        job['run_condition'] = 'all_succeeded'
+        if job['always_run']:
+            job['run_condition'] = 'always'
+        else:
+            job['run_condition'] = 'all_succeeded'
 
 
 def validate_batch(batch):

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -93,7 +93,7 @@ job_validator = keyed(
                 'preemptible': bool_type,
             }
         ),
-        'run_condition': oneof('any', 'all', 'always'),
+        'run_condition': nullable(oneof('any', 'all', 'always')),
         'secrets': listof(
             keyed({required('namespace'): k8s_str, required('name'): k8s_str, required('mount_path'): str_type})
         ),

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -93,7 +93,7 @@ job_validator = keyed(
                 'preemptible': bool_type,
             }
         ),
-        'run_condition': nullable(oneof('any', 'all', 'always')),
+        'run_condition': nullable(oneof('any_succeeded', 'all_succeeded', 'always')),
         'secrets': listof(
             keyed({required('namespace'): k8s_str, required('name'): k8s_str, required('mount_path'): str_type})
         ),
@@ -200,6 +200,8 @@ def handle_job_backwards_compatibility(job):
         job['absolute_parent_ids'] = job.pop('parent_ids')
     if 'always_copy_output' not in job:
         job['always_copy_output'] = True
+    if 'run_condition' not in job:
+        job['run_condition'] = 'all_succeeded'
 
 
 def validate_batch(batch):

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -93,6 +93,7 @@ job_validator = keyed(
                 'preemptible': bool_type,
             }
         ),
+        'run_condition': oneof('any', 'all', 'always'),
         'secrets': listof(
             keyed({required('namespace'): k8s_str, required('name'): k8s_str, required('mount_path'): str_type})
         ),

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -1,7 +1,191 @@
 ALTER TABLE jobs ADD COLUMN run_condition VARCHAR(40) DEFAULT NULL, ALGORITHM=INSTANT;
 ALTER TABLE jobs ADD COLUMN n_succeeded_parents INT DEFAULT NULL, ALGORITHM=INSTANT;
+ALTER TABLE jobs ADD COLUMN migrated_n_succeeded_parents BOOLEAN DEFAULT 0, ALGORITHM=INSTANT;
+ALTER TABLE batches ADD COLUMN migrated_n_succeeded_parents BOOLEAN DEFAULT 0, ALGORITHM=INSTANT;
 
 DELIMITER $$
+
+DROP TRIGGER IF EXISTS jobs_after_update $$
+CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
+FOR EACH ROW
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_cancelled BOOLEAN;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE batch_migrated_n_succeeded_parents BOOLEAN;
+
+  SELECT user, migrated_n_succeeded_parents INTO cur_user, batch_migrated_n_succeeded_parents
+  FROM batches WHERE id = NEW.batch_id;
+
+  SET cur_batch_cancelled = EXISTS (SELECT TRUE
+                                    FROM batches_cancelled
+                                    WHERE id = NEW.batch_id
+                                    LOCK IN SHARE MODE);
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  IF NOT OLD.migrated_n_succeeded_parents AND NOT batch_migrated_n_succeeded_parents THEN
+    SET NEW.n_succeeded_parents = (
+      SELECT COALESCE(SUM(jobs.state = 'Success'), 0)
+      FROM `job_parents`
+      LEFT JOIN `jobs` ON jobs.batch_id = job_parents.batch_id AND jobs.job_id = job_parents.parent_id
+      WHERE job_parents.batch_id = NEW.batch_id AND job_parents.job_id = NEW.job_id
+      GROUP BY `job_parents`.batch_id, `job_parents`.job_id
+      FOR UPDATE
+    );
+  END IF;
+
+  IF OLD.state = 'Ready' THEN
+    IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
+    ELSE
+      # runnable
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs - 1,
+        ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Running' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
+    ELSE
+      # running
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs - 1,
+        running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Creating' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs - 1;
+    END IF;
+
+    # state = 'Creating' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_creating_jobs = n_cancelled_creating_jobs - 1;
+    ELSE
+      # creating
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
+      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_jobs = n_creating_jobs - 1;
+    END IF;
+
+  END IF;
+
+  IF NEW.state = 'Ready' THEN
+    IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
+    ELSE
+      # runnable
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + 1,
+        ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Running' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
+    ELSE
+      # running
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs + 1,
+        running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Creating' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
+      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_cancellable_jobs = n_creating_cancellable_jobs + 1;
+    END IF;
+
+    # state = 'Creating' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_creating_jobs = n_cancelled_creating_jobs + 1;
+    ELSE
+      # creating
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
+      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_creating_jobs = n_creating_jobs + 1;
+    END IF;
+  END IF;
+END $$
 
 DROP PROCEDURE IF EXISTS commit_batch_update $$
 CREATE PROCEDURE commit_batch_update(
@@ -76,14 +260,12 @@ BEGIN
           SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
               jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
-              jobs.cancelled = (CASE run_condition
-                WHEN 'always' THEN jobs.cancelled
-                WHEN 'all_succeeded' THEN IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
-                WHEN 'any_succeeded' THEN IF(COALESCE(t.n_pending_parents, 0) = 0,
-                                             IF(COALESCE(t.n_parents, 0) = 0 OR COALESCE(t.n_succeeded_parents, 0) > 0, jobs.cancelled, 1),
-                                             jobs.cancelled)
-                ELSE IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)  # backwards compatibility
-                END)
+              jobs.cancelled = CASE jobs.run_condition
+                                 WHEN 'always' THEN jobs.cancelled
+                                 WHEN 'all_succeeded' THEN new_state != 'Success' OR jobs.cancelled
+                                 WHEN 'any_succeeded' THEN (COALESCE(jobs.n_pending_parents - 1, 0) = 0 AND COALESCE(jobs.n_succeeded_parents, 0) = 0 AND new_state != 'Success') OR jobs.cancelled
+                                 ELSE new_state != 'Success' or jobs.cancelled  # backwards compatibility
+                               END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;
       END IF;
@@ -180,20 +362,22 @@ BEGIN
     END IF;
 
     UPDATE jobs
+    SET migrated_n_succeeded_parents = 1
+    WHERE jobs.batch_id = in_batch_id AND jobs.job_id = in_job_id;
+
+    UPDATE jobs
       INNER JOIN `job_parents`
         ON jobs.batch_id = `job_parents`.batch_id AND
            jobs.job_id = `job_parents`.job_id
       SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
           jobs.n_pending_parents = jobs.n_pending_parents - 1,
           jobs.n_succeeded_parents = jobs.n_succeeded_parents + (new_state = 'Success'),
-          jobs.cancelled = (CASE jobs.run_condition
-                WHEN 'always' THEN jobs.cancelled
-                WHEN 'all_succeeded' THEN IF(new_state = 'Success', jobs.cancelled, 1)
-                WHEN 'any_succeeded' THEN IF(COALESCE(jobs.n_pending_parents - 1, 0) = 0,
-                                             IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1),
-                                             jobs.cancelled)
-                ELSE IF(new_state = 'Success', jobs.cancelled, 1)  # backwards compatibility
-                END)
+          jobs.cancelled = CASE jobs.run_condition
+                             WHEN 'always' THEN jobs.cancelled
+                             WHEN 'all_succeeded' THEN new_state != 'Success' OR jobs.cancelled
+                             WHEN 'any_succeeded' THEN (COALESCE(jobs.n_pending_parents - 1, 0) = 0 AND COALESCE(jobs.n_succeeded_parents, 0) = 0 AND new_state != 'Success') OR jobs.cancelled
+                             ELSE new_state != 'Success' or jobs.cancelled  # backwards compatibility
+                           END
       WHERE jobs.batch_id = in_batch_id AND
             `job_parents`.batch_id = in_batch_id AND
             `job_parents`.parent_id = in_job_id;
@@ -215,6 +399,20 @@ BEGIN
       delta_cores_mcpu,
       'job state not Ready, Creating, Running or complete' as message;
   END IF;
+END $$
+
+DROP TRIGGER IF EXISTS batches_before_insert $$
+CREATE TRIGGER batches_before_insert BEFORE INSERT ON batches
+FOR EACH ROW
+BEGIN
+  SET migrated_n_succeeded_parents = 1;
+END $$
+
+DROP TRIGGER IF EXISTS jobs_before_update $$
+CREATE TRIGGER jobs_before_update BEFORE UPDATE ON jobs
+FOR EACH ROW
+BEGIN
+  SET migrated_n_succeeded_parents = 1;
 END $$
 
 DELIMITER ;

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -77,7 +77,7 @@ BEGIN
               jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
               jobs.cancelled = (CASE run_condition
-                WHEN 'always' THEN 0
+                WHEN 'always' THEN jobs.cancelled
                 WHEN 'all_succeeded' THEN IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(t.n_pending_parents, 0) = 0,
                                              IF(COALESCE(t.n_parents, 0) = 0 OR COALESCE(t.n_succeeded_parents, 0) > 0, jobs.cancelled, 1),
@@ -187,7 +187,7 @@ BEGIN
           jobs.n_pending_parents = jobs.n_pending_parents - 1,
           jobs.n_succeeded_parents = jobs.n_succeeded_parents + (new_state = 'Success'),
           jobs.cancelled = (CASE jobs.run_condition
-                WHEN 'always' THEN 0
+                WHEN 'always' THEN jobs.cancelled
                 WHEN 'all_succeeded' THEN IF(new_state = 'Success', jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(jobs.n_pending_parents - 1, 0) = 0,
                                              IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1),

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -225,14 +225,14 @@ BEGIN
   SET NEW.migrated_n_succeeded_parents = 1;
 
   IF NOT OLD.migrated_n_succeeded_parents THEN
-    SET NEW.n_succeeded_parents = (
+    SET NEW.n_succeeded_parents = COALESCE((
       SELECT COALESCE(SUM(jobs.state = 'Success'), 0)
       FROM `job_parents`
       LEFT JOIN `jobs` ON jobs.batch_id = job_parents.batch_id AND jobs.job_id = job_parents.parent_id
       WHERE job_parents.batch_id = NEW.batch_id AND job_parents.job_id = NEW.job_id
       GROUP BY `job_parents`.batch_id, `job_parents`.job_id
-      FOR UPDATE
-    );
+      LOCK IN SHARE MODE
+    ), 0);
   END IF;
 END $$
 

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -79,9 +79,9 @@ BEGIN
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
               jobs.cancelled = CASE jobs.run_condition
                                  WHEN 'always' THEN jobs.cancelled
-                                 WHEN 'all_succeeded' THEN new_state != 'Success' OR jobs.cancelled
-                                 WHEN 'any_succeeded' THEN (COALESCE(jobs.n_pending_parents - 1, 0) = 0 AND COALESCE(jobs.n_succeeded_parents, 0) = 0 AND new_state != 'Success') OR jobs.cancelled
-                                 ELSE new_state != 'Success' or jobs.cancelled  # backwards compatibility
+                                 WHEN 'all_succeeded' THEN t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled
+                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded = 0) OR jobs.cancelled
+                                 ELSE t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled  # backwards compatibility
                                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -192,7 +192,7 @@ BEGIN
           jobs.cancelled = CASE jobs.run_condition
                              WHEN 'always' THEN jobs.cancelled
                              WHEN 'all_succeeded' THEN new_state != 'Success' OR jobs.cancelled
-                             WHEN 'any_succeeded' THEN (COALESCE(jobs.n_pending_parents - 1, 0) = 0 AND COALESCE(jobs.n_succeeded_parents, 0) = 0 AND new_state != 'Success') OR jobs.cancelled
+                             WHEN 'any_succeeded' THEN COALESCE(jobs.n_pending_parents = 1 AND jobs.n_succeeded_parents = 0 AND new_state != 'Success', 0) OR jobs.cancelled
                              ELSE new_state != 'Success' or jobs.cancelled  # backwards compatibility
                            END
       WHERE jobs.batch_id = in_batch_id AND

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -1,0 +1,210 @@
+ALTER TABLE jobs ADD COLUMN run_condition VARCHAR(40) NOT NULL DEFAULT "all", ALGORITHM=INSTANT;
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS commit_batch_update $$
+CREATE PROCEDURE commit_batch_update(
+  IN in_batch_id BIGINT,
+  IN in_update_id INT,
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_update_committed BOOLEAN;
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE cur_update_start_job_id INT;
+
+  START TRANSACTION;
+
+  SELECT committed, n_jobs INTO cur_update_committed, expected_n_jobs
+  FROM batch_updates
+  WHERE batch_id = in_batch_id AND update_id = in_update_id
+  FOR UPDATE;
+
+  IF cur_update_committed THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT COALESCE(SUM(n_jobs), 0) INTO staging_n_jobs
+    FROM batches_inst_coll_staging
+    WHERE batch_id = in_batch_id AND update_id = in_update_id
+    FOR UPDATE;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      UPDATE batch_updates
+      SET committed = 1, time_committed = in_timestamp
+      WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+      UPDATE batches SET
+        `state` = 'running',
+        time_completed = NULL,
+        n_jobs = n_jobs + expected_n_jobs
+      WHERE id = in_batch_id;
+
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
+      FROM batches_inst_coll_staging
+      JOIN batches ON batches.id = batches_inst_coll_staging.batch_id
+      WHERE batch_id = in_batch_id AND update_id = in_update_id
+      GROUP BY `user`, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
+
+      DELETE FROM batches_inst_coll_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+      IF in_update_id != 1 THEN
+        SELECT start_job_id INTO cur_update_start_job_id FROM batch_updates WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+        UPDATE jobs
+          LEFT JOIN (
+            SELECT `job_parents`.batch_id, `job_parents`.job_id,
+              COALESCE(SUM(1), 0) AS n_parents,
+              COALESCE(SUM(state IN ('Pending', 'Ready', 'Creating', 'Running')), 0) AS n_pending_parents,
+              COALESCE(SUM(state = 'Success'), 0) AS n_succeeded
+            FROM `job_parents`
+            LEFT JOIN `jobs` ON jobs.batch_id = `job_parents`.batch_id AND jobs.job_id = `job_parents`.parent_id
+            WHERE job_parents.batch_id = in_batch_id AND
+              `job_parents`.job_id >= cur_update_start_job_id AND
+              `job_parents`.job_id < cur_update_start_job_id + staging_n_jobs
+            GROUP BY `job_parents`.batch_id, `job_parents`.job_id
+            FOR UPDATE
+          ) AS t
+            ON jobs.batch_id = t.batch_id AND
+               jobs.job_id = t.job_id
+          SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
+              jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
+              jobs.cancelled = IF(jobs.run_condition = 'all',
+                                  IF(COALESCE(t.n_succeeded, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1),
+                                  IF(jobs.run_condition = 'always', 0,
+                                     (COALESCE(t.n_parents, 0) = 0) | COALESCE(t.n_succeeded, 0) > 0)  # run_condition = 'any'
+          WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
+              jobs.job_id < cur_update_start_job_id + staging_n_jobs;
+      END IF;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 1 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS mark_job_complete $$
+CREATE PROCEDURE mark_job_complete(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_state VARCHAR(40),
+  IN new_status TEXT,
+  IN new_start_time BIGINT,
+  IN new_end_time BIGINT,
+  IN new_reason VARCHAR(40),
+  IN new_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE delta_cores_mcpu INT DEFAULT 0;
+  DECLARE total_jobs_in_batch INT;
+  DECLARE expected_attempt_id VARCHAR(40);
+
+  START TRANSACTION;
+
+  SELECT n_jobs INTO total_jobs_in_batch FROM batches WHERE id = in_batch_id;
+
+  SELECT state, cores_mcpu
+  INTO cur_job_state, cur_cores_mcpu
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  SELECT end_time INTO cur_end_time FROM attempts
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id
+  FOR UPDATE;
+
+  UPDATE attempts
+  SET start_time = new_start_time, rollup_time = new_end_time, end_time = new_end_time, reason = new_reason
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+  IF cur_instance_state = 'active' AND cur_end_time IS NULL THEN
+    UPDATE instances_free_cores_mcpu
+    SET free_cores_mcpu = free_cores_mcpu + cur_cores_mcpu
+    WHERE instances_free_cores_mcpu.name = in_instance_name;
+
+    SET delta_cores_mcpu = delta_cores_mcpu + cur_cores_mcpu;
+  END IF;
+
+  SELECT attempt_id INTO expected_attempt_id FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  IF expected_attempt_id IS NOT NULL AND expected_attempt_id != in_attempt_id THEN
+    COMMIT;
+    SELECT 2 as rc,
+      expected_attempt_id,
+      delta_cores_mcpu,
+      'input attempt id does not match expected attempt id' as message;
+  ELSEIF cur_job_state = 'Ready' OR cur_job_state = 'Creating' OR cur_job_state = 'Running' THEN
+    UPDATE jobs
+    SET state = new_state, status = new_status, attempt_id = in_attempt_id
+    WHERE batch_id = in_batch_id AND job_id = in_job_id;
+
+    UPDATE batches_n_jobs_in_complete_states
+      SET n_completed = (@new_n_completed := n_completed + 1),
+          n_cancelled = n_cancelled + (new_state = 'Cancelled'),
+          n_failed    = n_failed + (new_state = 'Error' OR new_state = 'Failed'),
+          n_succeeded = n_succeeded + (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed')
+      WHERE id = in_batch_id;
+
+    # Grabbing an exclusive lock on batches here could deadlock,
+    # but this IF should only execute for the last job
+    IF @new_n_completed = total_jobs_in_batch THEN
+      UPDATE batches
+      SET time_completed = new_timestamp,
+          `state` = 'complete'
+      WHERE id = in_batch_id;
+    END IF;
+
+    UPDATE jobs
+      INNER JOIN `job_parents`
+        ON jobs.batch_id = `job_parents`.batch_id AND
+           jobs.job_id = `job_parents`.job_id
+      SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
+          jobs.n_pending_parents = jobs.n_pending_parents - 1,
+          jobs.cancelled = IF(jobs.run_condition = 'any', IF(jobs.cancelled & new_state = 'Success', 0, 1),
+                              IF(jobs.run_condition = 'always', 0,
+                                IF(new_state = 'Success', jobs.cancelled, 1)  # jobs.run_condition = 'all'
+                              )
+                            )
+      WHERE jobs.batch_id = in_batch_id AND
+            `job_parents`.batch_id = in_batch_id AND
+            `job_parents`.parent_id = in_job_id;
+
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSEIF cur_job_state = 'Cancelled' OR cur_job_state = 'Error' OR
+         cur_job_state = 'Failed' OR cur_job_state = 'Success' THEN
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc,
+      cur_job_state,
+      delta_cores_mcpu,
+      'job state not Ready, Creating, Running or complete' as message;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -83,7 +83,7 @@ BEGIN
                                              IF(COALESCE(t.n_parents, 0) = 0 OR COALESCE(t.n_succeeded_parents, 0) > 0, jobs.cancelled, 1),
                                              jobs.cancelled)
                 ELSE IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)  # backwards compatibility
-                END CASE
+                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;
       END IF;
@@ -193,7 +193,7 @@ BEGIN
                                              IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1)
                                              jobs.cancelled)
                 ELSE IF(new_state = 'Success', jobs.cancelled, 1)  # backwards compatibility
-                END CASE
+                END
       WHERE jobs.batch_id = in_batch_id AND
             `job_parents`.batch_id = in_batch_id AND
             `job_parents`.parent_id = in_job_id;

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -79,9 +79,9 @@ BEGIN
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
               jobs.cancelled = CASE jobs.run_condition
                                  WHEN 'always' THEN jobs.cancelled
-                                 WHEN 'all_succeeded' THEN t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled
-                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded_parents = 0) OR jobs.cancelled
-                                 ELSE t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled  # backwards compatibility
+                                 WHEN 'all_succeeded' THEN COALESCE(t.n_succeeded_parents != t.n_parents - t.n_pending_parents, 0) OR jobs.cancelled
+                                 WHEN 'any_succeeded' THEN COALESCE(t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded_parents = 0, 0) OR jobs.cancelled
+                                 ELSE COALESCE(t.n_succeeded_parents != t.n_parents - t.n_pending_parents, 0) OR jobs.cancelled  # backwards compatibility
                                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -80,7 +80,7 @@ BEGIN
               jobs.cancelled = CASE jobs.run_condition
                                  WHEN 'always' THEN jobs.cancelled
                                  WHEN 'all_succeeded' THEN t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled
-                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded = 0) OR jobs.cancelled
+                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded_parents = 0) OR jobs.cancelled
                                  ELSE t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled  # backwards compatibility
                                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -190,7 +190,7 @@ BEGIN
                 WHEN 'always' THEN 0
                 WHEN 'all_succeeded' THEN IF(new_state = 'Success', jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(jobs.n_pending_parents - 1, 0) = 0,
-                                             IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1)
+                                             IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1),
                                              jobs.cancelled)
                 ELSE IF(new_state = 'Success', jobs.cancelled, 1)  # backwards compatibility
                 END)

--- a/batch/sql/add-run-conditions.sql
+++ b/batch/sql/add-run-conditions.sql
@@ -4,186 +4,6 @@ ALTER TABLE jobs ADD COLUMN migrated_n_succeeded_parents BOOLEAN DEFAULT 0, ALGO
 
 DELIMITER $$
 
-DROP TRIGGER IF EXISTS jobs_after_update $$
-CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
-FOR EACH ROW
-BEGIN
-  DECLARE cur_user VARCHAR(100);
-  DECLARE cur_batch_cancelled BOOLEAN;
-  DECLARE cur_n_tokens INT;
-  DECLARE rand_token INT;
-
-  SELECT user INTO cur_user FROM batches WHERE id = NEW.batch_id;
-
-  SET cur_batch_cancelled = EXISTS (SELECT TRUE
-                                    FROM batches_cancelled
-                                    WHERE id = NEW.batch_id
-                                    LOCK IN SHARE MODE);
-
-  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-  SET rand_token = FLOOR(RAND() * cur_n_tokens);
-
-  IF NOT OLD.migrated_n_succeeded_parents THEN
-    SET NEW.n_succeeded_parents = (
-      SELECT COALESCE(SUM(jobs.state = 'Success'), 0)
-      FROM `job_parents`
-      LEFT JOIN `jobs` ON jobs.batch_id = job_parents.batch_id AND jobs.job_id = job_parents.parent_id
-      WHERE job_parents.batch_id = NEW.batch_id AND job_parents.job_id = NEW.job_id
-      GROUP BY `job_parents`.batch_id, `job_parents`.job_id
-      FOR UPDATE
-    );
-  END IF;
-
-  IF OLD.state = 'Ready' THEN
-    IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
-      # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
-        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
-    END IF;
-
-    IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
-      # cancelled
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
-      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
-      ON DUPLICATE KEY UPDATE
-        n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
-    ELSE
-      # runnable
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
-      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_ready_jobs = n_ready_jobs - 1,
-        ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
-    END IF;
-  ELSEIF OLD.state = 'Running' THEN
-    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
-      # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
-        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
-    END IF;
-
-    # state = 'Running' jobs cannot be cancelled at the job level
-    IF NOT OLD.always_run AND cur_batch_cancelled THEN
-      # cancelled
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
-      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
-      ON DUPLICATE KEY UPDATE
-        n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
-    ELSE
-      # running
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
-      VALUES (cur_user, OLD.inst_coll, rand_token, -1, -OLD.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_running_jobs = n_running_jobs - 1,
-        running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
-    END IF;
-  ELSEIF OLD.state = 'Creating' THEN
-    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
-      # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (OLD.batch_id, NEW.update_id, OLD.inst_coll, rand_token, -1)
-      ON DUPLICATE KEY UPDATE
-        n_creating_cancellable_jobs = n_creating_cancellable_jobs - 1;
-    END IF;
-
-    # state = 'Creating' jobs cannot be cancelled at the job level
-    IF NOT OLD.always_run AND cur_batch_cancelled THEN
-      # cancelled
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
-      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
-      ON DUPLICATE KEY UPDATE
-        n_cancelled_creating_jobs = n_cancelled_creating_jobs - 1;
-    ELSE
-      # creating
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
-      VALUES (cur_user, OLD.inst_coll, rand_token, -1)
-      ON DUPLICATE KEY UPDATE
-        n_creating_jobs = n_creating_jobs - 1;
-    END IF;
-
-  END IF;
-
-  IF NEW.state = 'Ready' THEN
-    IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
-      # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
-        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
-    END IF;
-
-    IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
-      # cancelled
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_ready_jobs)
-      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
-      ON DUPLICATE KEY UPDATE
-        n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
-    ELSE
-      # runnable
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
-      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_ready_jobs = n_ready_jobs + 1,
-        ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
-    END IF;
-  ELSEIF NEW.state = 'Running' THEN
-    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
-      # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
-      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
-        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
-    END IF;
-
-    # state = 'Running' jobs cannot be cancelled at the job level
-    IF NOT NEW.always_run AND cur_batch_cancelled THEN
-      # cancelled
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_running_jobs)
-      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
-      ON DUPLICATE KEY UPDATE
-        n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
-    ELSE
-      # running
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_running_jobs, running_cores_mcpu)
-      VALUES (cur_user, NEW.inst_coll, rand_token, 1, NEW.cores_mcpu)
-      ON DUPLICATE KEY UPDATE
-        n_running_jobs = n_running_jobs + 1,
-        running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
-    END IF;
-  ELSEIF NEW.state = 'Creating' THEN
-    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
-      # cancellable
-      INSERT INTO batch_inst_coll_cancellable_resources (batch_id, update_id, inst_coll, token, n_creating_cancellable_jobs)
-      VALUES (NEW.batch_id, NEW.update_id, NEW.inst_coll, rand_token, 1)
-      ON DUPLICATE KEY UPDATE
-        n_creating_cancellable_jobs = n_creating_cancellable_jobs + 1;
-    END IF;
-
-    # state = 'Creating' jobs cannot be cancelled at the job level
-    IF NOT NEW.always_run AND cur_batch_cancelled THEN
-      # cancelled
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_cancelled_creating_jobs)
-      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
-      ON DUPLICATE KEY UPDATE
-        n_cancelled_creating_jobs = n_cancelled_creating_jobs + 1;
-    ELSE
-      # creating
-      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_creating_jobs)
-      VALUES (cur_user, NEW.inst_coll, rand_token, 1)
-      ON DUPLICATE KEY UPDATE
-        n_creating_jobs = n_creating_jobs + 1;
-    END IF;
-  END IF;
-END $$
-
 DROP PROCEDURE IF EXISTS commit_batch_update $$
 CREATE PROCEDURE commit_batch_update(
   IN in_batch_id BIGINT,
@@ -402,7 +222,18 @@ DROP TRIGGER IF EXISTS jobs_before_update $$
 CREATE TRIGGER jobs_before_update BEFORE UPDATE ON jobs
 FOR EACH ROW
 BEGIN
-  SET migrated_n_succeeded_parents = 1;
+  SET NEW.migrated_n_succeeded_parents = 1;
+
+  IF NOT OLD.migrated_n_succeeded_parents THEN
+    SET NEW.n_succeeded_parents = (
+      SELECT COALESCE(SUM(jobs.state = 'Success'), 0)
+      FROM `job_parents`
+      LEFT JOIN `jobs` ON jobs.batch_id = job_parents.batch_id AND jobs.job_id = job_parents.parent_id
+      WHERE job_parents.batch_id = NEW.batch_id AND job_parents.job_id = NEW.job_id
+      GROUP BY `job_parents`.batch_id, `job_parents`.job_id
+      FOR UPDATE
+    );
+  END IF;
 END $$
 
 DELIMITER ;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -19,6 +19,7 @@ DROP TRIGGER IF EXISTS batches_after_update;
 DROP TRIGGER IF EXISTS instances_before_update;
 DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
+DROP TRIGGER IF EXISTS jobs_before_update;
 DROP TRIGGER IF EXISTS jobs_after_update;
 DROP TRIGGER IF EXISTS attempt_resources_after_insert;
 DROP TRIGGER IF EXISTS attempt_resources_before_insert;  # deprecated

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1080,9 +1080,9 @@ BEGIN
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
               jobs.cancelled = CASE jobs.run_condition
                                  WHEN 'always' THEN jobs.cancelled
-                                 WHEN 'all_succeeded' THEN new_state != 'Success' OR jobs.cancelled
-                                 WHEN 'any_succeeded' THEN (COALESCE(jobs.n_pending_parents - 1, 0) = 0 AND COALESCE(jobs.n_succeeded_parents, 0) = 0 AND new_state != 'Success') OR jobs.cancelled
-                                 ELSE new_state != 'Success' or jobs.cancelled  # backwards compatibility
+                                 WHEN 'all_succeeded' THEN t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled
+                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded = 0) OR jobs.cancelled
+                                 ELSE t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled  # backwards compatibility
                                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -249,13 +249,14 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   `cores_mcpu` INT NOT NULL,
   `status` TEXT,
   `n_pending_parents` INT NOT NULL,
+  `n_succeeded_parents` INT DEFAULT NULL,
   `cancelled` BOOLEAN NOT NULL DEFAULT FALSE,
   `msec_mcpu` BIGINT NOT NULL DEFAULT 0,
   `attempt_id` VARCHAR(40),
   `inst_coll` VARCHAR(255),
   `n_regions` INT DEFAULT NULL,
   `regions_bits_rep` BIGINT DEFAULT NULL,
-  `run_condition` ENUM('any', 'all', 'always') NOT NULL DEFAULT 'all',
+  `run_condition` ENUM('any_succeeded', 'all_succeeded', 'always') DEFAULT NULL,
   PRIMARY KEY (`batch_id`, `job_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `update_id`) REFERENCES batch_updates(batch_id, update_id) ON DELETE CASCADE,
@@ -1044,7 +1045,7 @@ BEGIN
             SELECT `job_parents`.batch_id, `job_parents`.job_id,
               COALESCE(SUM(1), 0) AS n_parents,
               COALESCE(SUM(state IN ('Pending', 'Ready', 'Creating', 'Running')), 0) AS n_pending_parents,
-              COALESCE(SUM(state = 'Success'), 0) AS n_succeeded
+              COALESCE(SUM(state = 'Success'), 0) AS n_succeeded_parents
             FROM `job_parents`
             LEFT JOIN `jobs` ON jobs.batch_id = `job_parents`.batch_id AND jobs.job_id = `job_parents`.parent_id
             WHERE job_parents.batch_id = in_batch_id AND
@@ -1057,10 +1058,15 @@ BEGIN
                jobs.job_id = t.job_id
           SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
               jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
-              jobs.cancelled = IF(jobs.run_condition = 'all',
-                                  IF(COALESCE(t.n_succeeded, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1),
-                                  IF(jobs.run_condition = 'always', 0,
-                                     (COALESCE(t.n_parents, 0) = 0) | COALESCE(t.n_succeeded, 0) > 0)  # run_condition = 'any'
+              jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
+              jobs.cancelled = CASE run_condition
+                WHEN 'always' THEN 0
+                WHEN 'all_succeeded' THEN IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
+                WHEN 'any_succeeded' THEN IF(COALESCE(t.n_pending_parents, 0) = 0,
+                                             IF(COALESCE(t.n_parents, 0) = 0 OR COALESCE(t.n_succeeded_parents, 0) > 0, jobs.cancelled, 1),
+                                             jobs.cancelled)
+                ELSE IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)  # backwards compatibility
+                END CASE
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;
       END IF;
@@ -1540,11 +1546,15 @@ BEGIN
            jobs.job_id = `job_parents`.job_id
       SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
           jobs.n_pending_parents = jobs.n_pending_parents - 1,
-          jobs.cancelled = IF(jobs.run_condition = 'any', IF(jobs.cancelled & new_state = 'Success', 0, 1),
-                              IF(jobs.run_condition = 'always', 0,
-                                IF(new_state = 'Success', jobs.cancelled, 1)  # jobs.run_condition = 'all'
-                              )
-                            )
+          jobs.n_succeeded_parents = jobs.n_succeeded_parents + (new_state = 'Success'),
+          jobs.cancelled = CASE jobs.run_condition
+                WHEN 'always' THEN 0
+                WHEN 'all_succeeded' THEN IF(new_state = 'Success', jobs.cancelled, 1)
+                WHEN 'any_succeeded' THEN IF(COALESCE(jobs.n_pending_parents - 1, 0) = 0,
+                                             IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1)
+                                             jobs.cancelled)
+                ELSE IF(new_state = 'Success', jobs.cancelled, 1)  # backwards compatibility
+                END CASE
       WHERE jobs.batch_id = in_batch_id AND
             `job_parents`.batch_id = in_batch_id AND
             `job_parents`.parent_id = in_job_id;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1571,7 +1571,7 @@ BEGIN
           jobs.cancelled = CASE jobs.run_condition
                              WHEN 'always' THEN jobs.cancelled
                              WHEN 'all_succeeded' THEN new_state != 'Success' OR jobs.cancelled
-                             WHEN 'any_succeeded' THEN (COALESCE(jobs.n_pending_parents - 1, 0) = 0 AND COALESCE(jobs.n_succeeded_parents, 0) = 0 AND new_state != 'Success') OR jobs.cancelled
+                             WHEN 'any_succeeded' THEN COALESCE(jobs.n_pending_parents = 1 AND jobs.n_succeeded_parents = 0 AND new_state != 'Success', 0) OR jobs.cancelled
                              ELSE new_state != 'Success' or jobs.cancelled  # backwards compatibility
                            END
       WHERE jobs.batch_id = in_batch_id AND

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1060,7 +1060,7 @@ BEGIN
               jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
               jobs.cancelled = (CASE run_condition
-                WHEN 'always' THEN 0
+                WHEN 'always' THEN jobs.cancelled
                 WHEN 'all_succeeded' THEN IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(t.n_pending_parents, 0) = 0,
                                              IF(COALESCE(t.n_parents, 0) = 0 OR COALESCE(t.n_succeeded_parents, 0) > 0, jobs.cancelled, 1),
@@ -1548,7 +1548,7 @@ BEGIN
           jobs.n_pending_parents = jobs.n_pending_parents - 1,
           jobs.n_succeeded_parents = jobs.n_succeeded_parents + (new_state = 'Success'),
           jobs.cancelled = (CASE jobs.run_condition
-                WHEN 'always' THEN 0
+                WHEN 'always' THEN jobs.cancelled
                 WHEN 'all_succeeded' THEN IF(new_state = 'Success', jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(jobs.n_pending_parents - 1, 0) = 0,
                                              IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1),

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1066,7 +1066,7 @@ BEGIN
                                              IF(COALESCE(t.n_parents, 0) = 0 OR COALESCE(t.n_succeeded_parents, 0) > 0, jobs.cancelled, 1),
                                              jobs.cancelled)
                 ELSE IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)  # backwards compatibility
-                END CASE
+                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;
       END IF;
@@ -1554,7 +1554,7 @@ BEGIN
                                              IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1)
                                              jobs.cancelled)
                 ELSE IF(new_state = 'Success', jobs.cancelled, 1)  # backwards compatibility
-                END CASE
+                END
       WHERE jobs.batch_id = in_batch_id AND
             `job_parents`.batch_id = in_batch_id AND
             `job_parents`.parent_id = in_job_id;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1081,7 +1081,7 @@ BEGIN
               jobs.cancelled = CASE jobs.run_condition
                                  WHEN 'always' THEN jobs.cancelled
                                  WHEN 'all_succeeded' THEN t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled
-                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded = 0) OR jobs.cancelled
+                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded_parents = 0) OR jobs.cancelled
                                  ELSE t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled  # backwards compatibility
                                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1059,14 +1059,14 @@ BEGIN
           SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
               jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
-              jobs.cancelled = CASE run_condition
+              jobs.cancelled = (CASE run_condition
                 WHEN 'always' THEN 0
                 WHEN 'all_succeeded' THEN IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(t.n_pending_parents, 0) = 0,
                                              IF(COALESCE(t.n_parents, 0) = 0 OR COALESCE(t.n_succeeded_parents, 0) > 0, jobs.cancelled, 1),
                                              jobs.cancelled)
                 ELSE IF(COALESCE(t.n_succeeded_parents, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1)  # backwards compatibility
-                END
+                END)
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;
       END IF;
@@ -1547,14 +1547,14 @@ BEGIN
       SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
           jobs.n_pending_parents = jobs.n_pending_parents - 1,
           jobs.n_succeeded_parents = jobs.n_succeeded_parents + (new_state = 'Success'),
-          jobs.cancelled = CASE jobs.run_condition
+          jobs.cancelled = (CASE jobs.run_condition
                 WHEN 'always' THEN 0
                 WHEN 'all_succeeded' THEN IF(new_state = 'Success', jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(jobs.n_pending_parents - 1, 0) = 0,
                                              IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1)
                                              jobs.cancelled)
                 ELSE IF(new_state = 'Success', jobs.cancelled, 1)  # backwards compatibility
-                END
+                END)
       WHERE jobs.batch_id = in_batch_id AND
             `job_parents`.batch_id = in_batch_id AND
             `job_parents`.parent_id = in_job_id;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1080,9 +1080,9 @@ BEGIN
               jobs.n_succeeded_parents = COALESCE(t.n_succeeded_parents, 0),
               jobs.cancelled = CASE jobs.run_condition
                                  WHEN 'always' THEN jobs.cancelled
-                                 WHEN 'all_succeeded' THEN t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled
-                                 WHEN 'any_succeeded' THEN (t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded_parents = 0) OR jobs.cancelled
-                                 ELSE t.n_succeeded_parents != t.n_parents - t.n_pending_parents OR jobs.cancelled  # backwards compatibility
+                                 WHEN 'all_succeeded' THEN COALESCE(t.n_succeeded_parents != t.n_parents - t.n_pending_parents, 0) OR jobs.cancelled
+                                 WHEN 'any_succeeded' THEN COALESCE(t.n_parents > 0 AND t.n_pending_parents = 0 AND t.n_succeeded_parents = 0, 0) OR jobs.cancelled
+                                 ELSE COALESCE(t.n_succeeded_parents != t.n_parents - t.n_pending_parents, 0) OR jobs.cancelled  # backwards compatibility
                                END
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1551,7 +1551,7 @@ BEGIN
                 WHEN 'always' THEN 0
                 WHEN 'all_succeeded' THEN IF(new_state = 'Success', jobs.cancelled, 1)
                 WHEN 'any_succeeded' THEN IF(COALESCE(jobs.n_pending_parents - 1, 0) = 0,
-                                             IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1)
+                                             IF(COALESCE(jobs.n_succeeded_parents, 0) + (new_state = 'Success') > 0, jobs.cancelled, 1),
                                              jobs.cancelled)
                 ELSE IF(new_state = 'Success', jobs.cancelled, 1)  # backwards compatibility
                 END)

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -576,7 +576,18 @@ DROP TRIGGER IF EXISTS jobs_before_update $$
 CREATE TRIGGER jobs_before_update BEFORE UPDATE ON jobs
 FOR EACH ROW
 BEGIN
-  SET migrated_n_succeeded_parents = 1;
+  SET NEW.migrated_n_succeeded_parents = 1;
+
+  IF NOT OLD.migrated_n_succeeded_parents THEN
+    SET NEW.n_succeeded_parents = (
+      SELECT COALESCE(SUM(jobs.state = 'Success'), 0)
+      FROM `job_parents`
+      LEFT JOIN `jobs` ON jobs.batch_id = job_parents.batch_id AND jobs.job_id = job_parents.parent_id
+      WHERE job_parents.batch_id = NEW.batch_id AND job_parents.job_id = NEW.job_id
+      GROUP BY `job_parents`.batch_id, `job_parents`.job_id
+      FOR UPDATE
+    );
+  END IF;
 END $$
 
 DROP TRIGGER IF EXISTS jobs_after_update $$
@@ -597,17 +608,6 @@ BEGIN
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
-
-  IF NOT OLD.migrated_n_succeeded_parents THEN
-    SET NEW.n_succeeded_parents = (
-      SELECT COALESCE(SUM(jobs.state = 'Success'), 0)
-      FROM `job_parents`
-      LEFT JOIN `jobs` ON jobs.batch_id = job_parents.batch_id AND jobs.job_id = job_parents.parent_id
-      WHERE job_parents.batch_id = NEW.batch_id AND job_parents.job_id = NEW.job_id
-      GROUP BY `job_parents`.batch_id, `job_parents`.job_id
-      FOR UPDATE
-    );
-  END IF;
 
   IF OLD.state = 'Ready' THEN
     IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN

--- a/batch/sql/populate_n_succeeded_parents.py
+++ b/batch/sql/populate_n_succeeded_parents.py
@@ -1,0 +1,146 @@
+import asyncio
+import functools
+import os
+import random
+import time
+from typing import List, Optional, Tuple
+
+from gear import Database, transaction
+from hailtop.utils import bounded_gather
+
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+
+def offsets_to_where_statement(start_id, end_id):
+    if start_id is None and end_id is None:
+        where_cond = ''
+        query_args = None
+        return (where_cond, query_args)
+
+    assert start_id != end_id, start_id
+    if start_id is None:
+        assert end_id
+        end_batch_id, end_job_id = end_id
+        where_cond = 'WHERE jobs.batch_id < %s OR ' \
+                     '(jobs.batch_id = %s AND jobs.job_id < %s)'
+        query_args = (end_batch_id, end_batch_id, end_job_id)
+    elif end_id is None:
+        assert start_id
+        start_batch_id, start_job_id = start_id
+        where_cond = 'WHERE jobs.batch_id > %s OR ' \
+                     '(jobs.batch_id = %s AND jobs.job_id >= %s)'
+        query_args = (start_batch_id, start_batch_id, start_job_id)
+    else:
+        assert start_id
+        assert end_id
+        start_batch_id, start_job_id = start_id
+        end_batch_id, end_job_id = end_id
+        where_cond = 'WHERE (jobs.batch_id > %s OR (jobs.batch_id = %s AND jobs.job_id >= %s)) ' \
+                     'AND (jobs.batch_id < %s OR (jobs.batch_id = %s AND jobs.job_id < %s))'
+        query_args = (start_batch_id, start_batch_id, start_job_id, end_batch_id, end_batch_id, end_job_id)
+
+    return (where_cond, query_args)
+
+
+async def process_chunk(counter, db, start_offset, end_offset, quiet=True):
+    start_time = time.time()
+
+    where_cond, query_args = offsets_to_where_statement(start_offset, end_offset)
+
+    await db.just_execute(
+        f'''
+UPDATE jobs
+SET migrated_n_succeeded_parents = TRUE
+{where_cond}
+''',
+        query_args)
+
+    if not quiet and counter.n % 100 == 0:
+        print(f'processed chunk ({start_offset}, {end_offset}) in {time.time() - start_time}s')
+
+    counter.n += 1
+    if counter.n % 500 == 0:
+        print(f'processed {counter.n} complete chunks')
+
+
+async def find_chunk_offsets(db, size):
+    @transaction(db)
+    async def _find_chunks(tx) -> List[Optional[Tuple[int, int]]]:
+        start_time = time.time()
+
+        await tx.just_execute('SET @rank=0;')
+
+        query = f'''
+SELECT t.batch_id, t.job_id FROM (
+  SELECT batch_id, job_id
+  FROM jobs
+  ORDER BY batch_id, job_id
+) AS t
+WHERE MOD((@rank := @rank + 1), %s) = 0;
+'''
+
+        offsets = tx.execute_and_fetchall(query, (size,))
+        offsets = [(offset['batch_id'], offset['job_id']) async for offset in offsets]
+        offsets.append(None)
+
+        print(f'found chunk offsets in {round(time.time() - start_time, 4)}s')
+        return offsets
+
+    return await _find_chunks()
+
+
+async def main(chunk_size=100):
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    start_time = time.time()
+
+    try:
+        populate_start_time = time.time()
+
+        chunk_counter = Counter()
+        chunk_offsets = [None]
+        for offset in await find_chunk_offsets(db, chunk_size):
+            chunk_offsets.append(offset)
+
+        chunk_offsets = list(zip(chunk_offsets[:-1], chunk_offsets[1:]))
+
+        if chunk_offsets:
+            print(f'found {len(chunk_offsets)} chunks to process')
+
+            random.shuffle(chunk_offsets)
+
+            burn_in_start = time.time()
+            n_burn_in_chunks = 1000
+
+            burn_in_chunk_offsets = chunk_offsets[:n_burn_in_chunks]
+            chunk_offsets = chunk_offsets[n_burn_in_chunks:]
+
+            for start_offset, end_offset in burn_in_chunk_offsets:
+                await process_chunk(chunk_counter, db, start_offset, end_offset, quiet=False)
+
+            print(f'finished burn-in in {time.time() - burn_in_start}s')
+
+            parallel_update_start = time.time()
+
+            await bounded_gather(
+                *[functools.partial(process_chunk, chunk_counter, db, start_offset, end_offset, quiet=False)
+                  for start_offset, end_offset in chunk_offsets],
+                parallelism=6
+            )
+            print(f'took {time.time() - parallel_update_start}s to update the remaining records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_update_start)}) attempts / sec')
+
+        print(f'finished populating records in {time.time() - populate_start_time}s')
+    finally:
+        print(f'finished migration in {time.time() - start_time}s')
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1320,19 +1320,31 @@ def test_run_condition_always_job(client: BatchClient):
     j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1], run_condition='always')
     b = bb.submit()
     j2.wait()
-
     assert j2.status()['state'] == 'Success', str((j2.status(), b.debug_info()))
+
+    # test no parents
+    bb = client.create_batch()
+    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], run_condition='always')
+    b = bb.submit()
+    j1.wait()
+    assert j1.status()['state'] == 'Success', str((j1.status(), b.debug_info()))
 
 
 def test_run_condition_any_job(client: BatchClient):
     bb = client.create_batch()
     j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
     j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    j3 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1, j2], run_condition='any')
+    j3 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1, j2], run_condition='any_succeeded')
     b = bb.submit()
     j3.wait()
-
     assert j3.status()['state'] == 'Success', str((j3.status(), b.debug_info()))
+
+    # test no parents
+    bb = client.create_batch()
+    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], run_condition='any_succeeded')
+    b = bb.submit()
+    j1.wait()
+    assert j1.status()['state'] == 'Success', str((j1.status(), b.debug_info()))
 
 
 def test_run_condition_always_job_with_update(client: BatchClient):
@@ -1342,10 +1354,12 @@ def test_run_condition_always_job_with_update(client: BatchClient):
     j1.wait()
 
     j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1], run_condition='always')
+    j3 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], run_condition='always')  # test no parents
     b = bb.submit()
-    j2.wait()
+    b.wait()
 
     assert j2.status()['state'] == 'Success', str((j2.status(), b.debug_info()))
+    assert j3.status()['state'] == 'Success', str((j3.status(), b.debug_info()))
 
 
 def test_run_condition_any_job_with_update(client: BatchClient):
@@ -1355,8 +1369,10 @@ def test_run_condition_any_job_with_update(client: BatchClient):
     b = bb.submit()
     b.wait()
 
-    j3 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1, j2], run_condition='any')
+    j3 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1, j2], run_condition='any_succeeded')
+    j4 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], run_condition='any_succeeded')  # test no parents
     b = bb.submit()
-    j3.wait()
+    b.wait()
 
     assert j3.status()['state'] == 'Success', str((j3.status(), b.debug_info()))
+    assert j4.status()['state'] == 'Success', str((j4.status(), b.debug_info()))

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -259,7 +259,7 @@ def test_always_run_cancel(client):
         DOCKER_ROOT_IMAGE, command=['/bin/sh', '-c', 'while true; do sleep 86000; done'], parents=[head]
     )
     right = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'right'], parents=[head])
-    tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[left, right], always_run=True)
+    tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[left, right], always_run=True, run_condition='always')
     batch = batch.submit()
     right.wait()
     batch.cancel()
@@ -277,7 +277,7 @@ def test_always_run_cancel(client):
 def test_always_run_error(client):
     batch = client.create_batch()
     head = batch.create_job(DOCKER_ROOT_IMAGE, command=['/bin/sh', '-c', 'exit 1'])
-    tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head], always_run=True)
+    tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head], always_run=True, run_condition='always')
     batch = batch.submit()
     batch.wait()
     status = legacy_batch_status(batch)

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -259,7 +259,9 @@ def test_always_run_cancel(client):
         DOCKER_ROOT_IMAGE, command=['/bin/sh', '-c', 'while true; do sleep 86000; done'], parents=[head]
     )
     right = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'right'], parents=[head])
-    tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[left, right], always_run=True, run_condition='always')
+    tail = batch.create_job(
+        DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[left, right], always_run=True, run_condition='always'
+    )
     batch = batch.submit()
     right.wait()
     batch.cancel()
@@ -277,7 +279,9 @@ def test_always_run_cancel(client):
 def test_always_run_error(client):
     batch = client.create_batch()
     head = batch.create_job(DOCKER_ROOT_IMAGE, command=['/bin/sh', '-c', 'exit 1'])
-    tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head], always_run=True, run_condition='always')
+    tail = batch.create_job(
+        DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head], always_run=True, run_condition='always'
+    )
     batch = batch.submit()
     batch.wait()
     status = legacy_batch_status(batch)

--- a/build.yaml
+++ b/build.yaml
@@ -2075,6 +2075,9 @@ steps:
       - name: add-run-conditions
         script: /io/sql/add-run-conditions.sql
         online: true
+      - name: populate-n-succeeded-parents
+        script: /io/sql/populate_n_succeeded_parents.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/build.yaml
+++ b/build.yaml
@@ -2072,6 +2072,9 @@ steps:
       - name: case-sensitive-billing-project
         script: /io/sql/case-sensitive-billing-project.sql
         online: true
+      - name: add-run-conditions
+        script: /io/sql/add-run-conditions.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -466,6 +466,7 @@ true
             ],
             parents=parents,
             always_run=True,
+            run_condition='always',
             network='private',
             timeout=5 * 60,
             regions=[REGION],
@@ -590,6 +591,7 @@ class RunImageStep(Step):
             service_account=self.service_account,
             parents=self.deps_parents(),
             always_run=self.always_run,
+            run_condition='always' if self.always_run else 'all_succeeded',
             timeout=self.timeout,
             network='private',
             env=env,
@@ -793,6 +795,7 @@ true
             service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
             parents=parents,
             always_run=True,
+            run_condition='always',
             network='private',
             regions=[REGION],
         )
@@ -951,6 +954,7 @@ date
                 service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
                 parents=parents,
                 always_run=True,
+                run_condition='always',
                 network='private',
                 regions=[REGION],
             )
@@ -1147,6 +1151,7 @@ done
             service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
             parents=parents,
             always_run=True,
+            run_condition='always',
             network='private',
             regions=[REGION],
         )

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -724,7 +724,7 @@ class ServiceBackend(Backend[bc.Batch]):
                                     resources=resources,
                                     input_files=inputs if len(inputs) > 0 else None,
                                     output_files=outputs if len(outputs) > 0 else None,
-                                    always_run=job._always_run,
+                                    always_run=(not job._cancellable),
                                     timeout=job._timeout,
                                     cloudfuse=job._cloudfuse if len(job._cloudfuse) > 0 else None,
                                     env=env,
@@ -732,8 +732,8 @@ class ServiceBackend(Backend[bc.Batch]):
                                     mount_tokens=True,
                                     user_code=user_code,
                                     regions=job._regions,
-                                    always_copy_output=job._always_copy_output)
-
+                                    always_copy_output=job._always_copy_output,
+                                    run_condition=job._run_condition)
             n_jobs_submitted += 1
 
             job_to_client_job_mapping[job] = j

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -320,13 +320,13 @@ class Job:
 
         >>> b = Batch(backend=backend.ServiceBackend('test'))
         >>> j = b.new_job()
-        >>> (j.always_run()
+        >>> (j.run_when('any', True)
         ...   .command(f'echo "hello"'))
 
         Parameters
         ----------
         condition:
-            One of 'any', 'all', or 'always'. 'any' is to run the job if at least one parent dependency succeeds.
+            One of 'any', 'all', and 'always'. 'any' is to run the job if at least one parent dependency succeeds.
             'all' is to run the job if all parent dependencies succeed. 'always' is to run the job regardless of whether
             the parent dependencies succeed.
         cancellable:
@@ -339,7 +339,7 @@ class Job:
         """
 
         if not isinstance(self._batch._backend, backend.ServiceBackend):
-            raise NotImplementedError("A ServiceBackend is required to use the 'always_run' option")
+            raise NotImplementedError("A ServiceBackend is required to use the 'run_when' option")
 
         self._run_condition = condition
         self._cancellable = cancellable
@@ -375,7 +375,8 @@ class Job:
         Same job object set to always run.
         """
 
-        return self.run_when('always', cancellable=False)
+        cancellable = not always_run
+        return self.run_when('always', cancellable=cancellable)
 
     def regions(self, regions: Optional[List[str]]) -> 'Job':
         """

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -75,7 +75,7 @@ class Job:
         self._storage: Optional[str] = None
         self._image: Optional[str] = None
         self._cancellable: bool = True
-        self._run_condition: str = 'all'
+        self._run_condition: str = 'all_succeeded'
         self._preemptible: Optional[bool] = None
         self._machine_type: Optional[str] = None
         self._timeout: Optional[Union[int, float]] = None
@@ -306,7 +306,7 @@ class Job:
         self._cpu = opt_str(cores)
         return self
 
-    def run_when(self, condition: str = 'all', cancellable: bool = True) -> 'Job':
+    def run_when(self, condition: str = 'all_succeeded', cancellable: bool = True) -> 'Job':
         """
         Set when a job should run based on the success status of parent jobs and whether the
         job is cancellable.
@@ -326,8 +326,8 @@ class Job:
         Parameters
         ----------
         condition:
-            One of 'any', 'all', and 'always'. 'any' is to run the job if at least one parent dependency succeeds.
-            'all' is to run the job if all parent dependencies succeed. 'always' is to run the job regardless of whether
+            One of 'any_succeeded', 'all_succeeded', and 'always'. 'any_succeeded' is to run the job if at least one parent dependency succeeds.
+            'all_succeeded' is to run the job if all parent dependencies succeed. 'always' is to run the job regardless of whether
             the parent dependencies succeed.
         cancellable:
             Whether the job can be cancelled. If a job is not cancellable, it will always run regardless of

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -513,7 +513,8 @@ class BatchBuilder:
                     network: Optional[str] = None,
                     unconfined: bool = False,
                     user_code: Optional[str] = None,
-                    regions: Optional[List[str]] = None):
+                    regions: Optional[List[str]] = None,
+                    run_condition: Optional[str] = None):
         self._job_idx += 1
 
         if parents is None:
@@ -558,6 +559,7 @@ class BatchBuilder:
         job_spec = {
             'always_run': always_run,
             'always_copy_output': always_copy_output,
+            'run_condition': run_condition,
             'job_id': self._job_idx,
             'absolute_parent_ids': absolute_parent_ids,
             'in_update_parent_ids': in_update_parent_ids,

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -556,7 +556,7 @@ class BatchBuilder:
         if error_msg:
             raise ValueError("\n".join(error_msg))
 
-        job_spec = {
+        job_spec: Dict[Any, Any] = {
             'always_run': always_run,
             'always_copy_output': always_copy_output,
             'run_condition': run_condition,

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -226,7 +226,8 @@ class BatchBuilder:
                    mount_tokens=False, network: Optional[str] = None,
                    unconfined: bool = False, user_code: Optional[str] = None,
                    regions: Optional[List[str]] = None,
-                   always_copy_output: bool = False) -> Job:
+                   always_copy_output: bool = False,
+                   run_condition: Optional[str] = None) -> Job:
         if parents:
             parents = [parent._async_job for parent in parents]
 
@@ -239,7 +240,7 @@ class BatchBuilder:
             always_copy_output=always_copy_output, timeout=timeout, cloudfuse=cloudfuse,
             requester_pays_project=requester_pays_project, mount_tokens=mount_tokens,
             network=network, unconfined=unconfined, user_code=user_code,
-            regions=regions)
+            regions=regions, run_condition=run_condition)
 
         return Job.from_async_job(async_job)
 


### PR DESCRIPTION
CHANGELOG: Added `Job.run_when()` which allows you to specify under what conditions a job should run based on the state of its parent dependencies and whether the job is cancellable.

The gist of this PR is that we now have an extra variable `run_condition` which specifies under what conditions a job should run (any, all, always). The default is to maintain the current behavior that a job runs when all its parent dependencies succeeded. The semantics of `always_run` should stay the same.

Can you check over the jobs_after_update trigger and make sure I'm not crazy and nothing needs to be modified there since the job state where the cancelled state matters is a Ready or Running job and the run_condition / cancelled interaction applies to Pending jobs with parent dependencies.

Also, I did this crazily fast, so maybe I'm missing something and it shouldn't be this easy????