### PR TITLE
[nginx] Fully specify in-cluster domain

### DIFF
--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -40,7 +40,8 @@ server {
     location = /auth {
         internal;
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass https://auth/api/v1alpha/verify_dev_credentials;
+        set $auth auth;
+        proxy_pass https://$auth.default.svc.cluster.local/api/v1alpha/verify_dev_credentials;
         include /ssl-config/ssl-config-proxy.conf;
     }
 

--- a/grafana/nginx.conf
+++ b/grafana/nginx.conf
@@ -57,11 +57,12 @@ http {
 
     location = /auth {
         internal;
-        set $auth "auth";
+        resolver kube-dns.kube-system.svc.cluster.local;
+        set $auth auth;
 {% if deploy %}
-        proxy_pass https://$auth/api/v1alpha/verify_dev_credentials;
+        proxy_pass https://$auth.default.svc.cluster.local/api/v1alpha/verify_dev_credentials;
 {% else %}
-        proxy_pass https://$auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_credentials;
+        proxy_pass https://$auth.{{ default_ns.name }}.svc.cluster.local/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_credentials;
 {% endif %}
         include /ssl-config/ssl-config-proxy.conf;
     }

--- a/prometheus/nginx.conf
+++ b/prometheus/nginx.conf
@@ -57,11 +57,12 @@ http {
 
     location = /auth {
         internal;
-        set $auth "auth";
+        resolver kube-dns.kube-system.svc.cluster.local;
+        set $auth auth;
 {% if deploy %}
-        proxy_pass https://$auth/api/v1alpha/verify_dev_or_sa_credentials;
+        proxy_pass https://$auth.default.svc.cluster.local/api/v1alpha/verify_dev_or_sa_credentials;
 {% else %}
-        proxy_pass https://$auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_or_sa_credentials;
+        proxy_pass https://$auth.{{ default_ns.name }}.svc.cluster.local/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_or_sa_credentials;
 {% endif %}
         include /ssl-config/ssl-config-proxy.conf;
     }

--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -195,14 +195,12 @@ spec:
             name: prometheus-storage
          resources:
            requests:
-{% if scope == "deploy" %}
+{% if deploy %}
              cpu: "50m"
              memory: 4G
-{% elif scope == "test" or scope == "dev" %}
+{% else %}
              cpu: "20m"
              memory: "0.75G"
-{% else %}
-!!! unexpected scope {{ scope }} !!!
 {% endif %}
            limits:
              cpu: "1"


### PR DESCRIPTION
After the change for headless services, for some reason nginx require the full in-cluster domain name for resolving services. It could have something to do with the explicit resolver directive, but this is all imminently getting replaced with envoy anyway so this is just a fix to get internal.hail.is and grafana/prometheus working again.