### PR TITLE
[query] More utilities for relational types

### DIFF
--- a/hail/python/hail/expr/blockmatrix_type.py
+++ b/hail/python/hail/expr/blockmatrix_type.py
@@ -29,6 +29,12 @@ class tblockmatrix(object):
         self.is_row_vector = is_row_vector
         self.block_size = block_size
 
+    def to_dict(self):
+        return dict(element_type=str(self.element_type),
+                    shape=self.shape,
+                    is_row_vector=self.is_row_vector,
+                    block_size=self.block_size)
+
     def __eq__(self, other):
         return isinstance(other, tblockmatrix) and \
             self.element_type == other.element_type and \

--- a/hail/python/hail/expr/blockmatrix_type.py
+++ b/hail/python/hail/expr/blockmatrix_type.py
@@ -5,6 +5,8 @@ from hail.expr.types import dtype, hail_type
 
 
 class tblockmatrix(object):
+    __slots__ = 'element_type', 'shape', 'is_row_vector', 'block_size'
+
     @staticmethod
     def _from_java(jtbm):
         return tblockmatrix(

--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -7,6 +7,8 @@ from hail.utils.java import jiterable_to_list
 
 
 class tmatrix(object):
+    __slots__ = 'global_type', 'col_type', 'col_key', 'row_type', 'row_key', 'entry_type'
+
     @staticmethod
     def _from_java(jtt):
         return tmatrix(

--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -41,6 +41,14 @@ class tmatrix(object):
         self.row_key = row_key
         self.entry_type = entry_type
 
+    def to_dict(self):
+        return dict(global_type=str(self.global_type),
+                    col_type=str(self.col_type),
+                    col_key=self.col_key,
+                    row_type=str(self.row_type),
+                    row_key=self.row_key,
+                    entry_type=self.entry_type)
+
     def __eq__(self, other):
         return (isinstance(other, tmatrix)
                 and self.global_type == other.global_type

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -6,6 +6,8 @@ from hail.utils.java import jiterable_to_list
 
 
 class ttable(object):
+    __slots__ = 'global_type', 'row_type', 'row_key'
+
     @staticmethod
     def _from_java(jtt):
         return ttable(

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -28,6 +28,11 @@ class ttable(object):
         self.row_type = row_type
         self.row_key = row_key
 
+    def to_dict(self):
+        return dict(global_type=str(self.global_type),
+                    row_type=str(self.row_type),
+                    row_key=self.row_key)
+
     def __eq__(self, other):
         return (isinstance(other, ttable)
                 and self.global_type == other.global_type


### PR DESCRIPTION
Add `__slots__` to prevent assignment bugs and a `_to_json` method for `ttable`, `tmatrix`, and `tblockmatrix`.
