### PR TITLE
[query] Add milliseconds to log output

### DIFF
--- a/hail/src/main/resources/log4j.properties
+++ b/hail/src/main/resources/log4j.properties
@@ -5,4 +5,4 @@ log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %m%n

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -33,7 +33,7 @@ case class FilePartition(index: Int, file: String) extends Partition
 object HailContext {
   val tera: Long = 1024L * 1024L * 1024L * 1024L
 
-  val logFormat: String = "%d{yyyy-MM-dd HH:mm:ss} %c{1}: %p: %m%n"
+  val logFormat: String = "%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1}: %p: %m%n"
 
   private var theContext: HailContext = _
 

--- a/hail/src/main/scala/is/hail/services/JSONLogLayout.scala
+++ b/hail/src/main/scala/is/hail/services/JSONLogLayout.scala
@@ -12,7 +12,7 @@ import org.json4s.jackson.JsonMethods
 import scala.collection.mutable.ArrayBuffer
 
 class DateFormatter {
-  private[this] val fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS")
+  private[this] val fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
   private[this] val buffer = new StringBuffer()
   private[this] val fp = new FieldPosition(0)
 


### PR DESCRIPTION
It was the change to `HailContext.scala` that finally affected the output for QoB jobs, but I tried to stay consistent.