### PR TITLE
[ci] Consolidate check services steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ check-hail:
 
 .PHONY: check-services
 check-services: check-auth check-batch check-ci check-gear check-memory \
-  check-notebook check-web-common check-website
+  check-notebook check-monitoring check-web-common check-website
 
 .PHONY: check-auth
 check-auth:
@@ -39,6 +39,9 @@ check-memory:
 .PHONY: check-notebook
 check-notebook:
 	$(MAKE) -C notebook check
+
+.PHONY: check-monitoring
+	$(MAKE) -C monitoring check
 
 .PHONY: check-web-common
 check-web-common:

--- a/build.yaml
+++ b/build.yaml
@@ -1158,17 +1158,6 @@ steps:
       - render_notebook_nginx_conf
       - merge_code
   - kind: runImage
-    name: check_notebook
-    image:
-      valueFrom: notebook_image.image
-    script: |
-      set -ex
-      SITE_PACKAGES=$(pip3 show notebook | grep Location | sed 's/Location: //')
-      python3 -m flake8 $SITE_PACKAGES/notebook
-      python3 -m pylint --rcfile pylintrc notebook
-    dependsOn:
-      - notebook_image
-  - kind: runImage
     name: test_hail_python
     numSplits: 7
     image:
@@ -1599,17 +1588,6 @@ steps:
       - create_dummy_oauth2_client_secret
       - create_certs
       - create_accounts
-  - kind: runImage
-    name: check_monitoring
-    image:
-      valueFrom: monitoring_image.image
-    script: |
-      set -ex
-      SITE_PACKAGES=$(pip3 show monitoring | grep Location | sed 's/Location: //')
-      python3 -m flake8 $SITE_PACKAGES/monitoring
-      python3 -m pylint --rcfile pylintrc monitoring
-    dependsOn:
-      - monitoring_image
   - kind: runImage
     name: delete_monitoring_tables
     image:


### PR DESCRIPTION
I'm guessing that these steps are just here for historical reasons. Notebook was already getting checked in `check_services` so I just had to add `check_monitoring`.