### PR TITLE
[query] Finally get tabix vcf reading working

### DIFF
--- a/hail/python/hail/ir/matrix_reader.py
+++ b/hail/python/hail/ir/matrix_reader.py
@@ -88,6 +88,7 @@ class MatrixVCFReader(MatrixReader):
                       force_gz=bool,
                       filter=nullable(str),
                       find_replace=nullable(sized_tupleof(str, str)),
+                      _sample_ids=nullable(sequenceof(str)),
                       _partitions_json=nullable(str),
                       _partitions_type=nullable(HailType))
     def __init__(self,
@@ -107,6 +108,7 @@ class MatrixVCFReader(MatrixReader):
                  filter,
                  find_replace,
                  *,
+                 _sample_ids=None,
                  _partitions_json=None,
                  _partitions_type=None):
         self.path = wrap_to_list(path)
@@ -124,6 +126,7 @@ class MatrixVCFReader(MatrixReader):
         self.force_bgz = force_bgz
         self.filter = filter
         self.find_replace = find_replace
+        self._sample_ids = _sample_ids
         self._partitions_json = _partitions_json
         self._partitions_type = _partitions_type
 
@@ -143,8 +146,9 @@ class MatrixVCFReader(MatrixReader):
                   'gzAsBGZ': self.force_bgz,
                   'forceGZ': self.force_gz,
                   'filterAndReplace': make_filter_and_replace(self.filter, self.find_replace),
-                  'partitionsJSON': self._partitions_json,
-                  'partitionsTypeStr': self._partitions_type._parsable_string() if self._partitions_type is not None else None}
+                  'sampleIDs': self._sample_ids,
+                  'partitionsTypeStr': self._partitions_type._parsable_string() if self._partitions_type is not None else None,
+                  'partitionsJSON': self._partitions_json}
         return escape_str(json.dumps(reader))
 
     def __eq__(self, other):
@@ -162,7 +166,9 @@ class MatrixVCFReader(MatrixReader):
             other.force_gz == self.force_gz and \
             other.filter == self.filter and \
             other.find_replace == self.find_replace and \
-            other._partitions_json == self._partitions_json
+            other._partitions_json == self._partitions_json and \
+            other._partitions_type == self._partitions_type and \
+            other._sample_ids == self._sample_ids
 
 
 class MatrixBGENReader(MatrixReader):

--- a/hail/python/hail/ir/matrix_reader.py
+++ b/hail/python/hail/ir/matrix_reader.py
@@ -2,7 +2,7 @@ import abc
 import json
 
 from .utils import make_filter_and_replace, impute_type_of_partition_interval_array
-from ..expr.types import tfloat32, tfloat64
+from ..expr.types import HailType, tfloat32, tfloat64
 from ..genetics.reference_genome import reference_genome_type
 from ..typecheck import (typecheck_method, sequenceof, nullable, enumeration, anytype, oneof,
                          dictof, sized_tupleof)
@@ -88,7 +88,8 @@ class MatrixVCFReader(MatrixReader):
                       force_gz=bool,
                       filter=nullable(str),
                       find_replace=nullable(sized_tupleof(str, str)),
-                      _partitions_json=nullable(str))
+                      _partitions_json=nullable(str),
+                      _partitions_type=nullable(HailType))
     def __init__(self,
                  path,
                  call_fields,
@@ -105,7 +106,9 @@ class MatrixVCFReader(MatrixReader):
                  force_gz,
                  filter,
                  find_replace,
-                 _partitions_json):
+                 *,
+                 _partitions_json=None,
+                 _partitions_type=None):
         self.path = wrap_to_list(path)
         self.header_file = header_file
         self.n_partitions = n_partitions
@@ -122,6 +125,7 @@ class MatrixVCFReader(MatrixReader):
         self.filter = filter
         self.find_replace = find_replace
         self._partitions_json = _partitions_json
+        self._partitions_type = _partitions_type
 
     def render(self, r):
         reader = {'name': 'MatrixVCFReader',
@@ -139,7 +143,8 @@ class MatrixVCFReader(MatrixReader):
                   'gzAsBGZ': self.force_bgz,
                   'forceGZ': self.force_gz,
                   'filterAndReplace': make_filter_and_replace(self.filter, self.find_replace),
-                  'partitionsJSON': self._partitions_json}
+                  'partitionsJSON': self._partitions_json,
+                  'partitionsTypeStr': self._partitions_type._parsable_string() if self._partitions_type is not None else None}
         return escape_str(json.dumps(reader))
 
     def __eq__(self, other):

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2564,9 +2564,7 @@ def get_vcf_metadata(path):
            filter=nullable(str),
            find_replace=nullable(sized_tupleof(str, str)),
            n_partitions=nullable(int),
-           block_size=nullable(int),
-           # json
-           _partitions=nullable(str))
+           block_size=nullable(int))
 def import_vcf(path,
                force=False,
                force_bgz=False,
@@ -2582,8 +2580,7 @@ def import_vcf(path,
                filter=None,
                find_replace=None,
                n_partitions=None,
-               block_size=None,
-               _partitions=None) -> MatrixTable:
+               block_size=None) -> MatrixTable:
     """Import VCF file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -2732,8 +2729,7 @@ def import_vcf(path,
     reader = ir.MatrixVCFReader(path, call_fields, entry_float_type, header_file,
                                 n_partitions, block_size, min_partitions,
                                 reference_genome, contig_recoding, array_elements_required,
-                                skip_invalid_loci, force_bgz, force, filter, find_replace,
-                                _partitions)
+                                skip_invalid_loci, force_bgz, force, filter, find_replace)
     return MatrixTable(ir.MatrixRead(reader, drop_cols=drop_samples))
 
 
@@ -2789,11 +2785,8 @@ def import_gvcfs(path,
 
     rg = reference_genome.name if reference_genome else None
 
-    if partitions is not None:
-        partitions, partitions_type = hl.utils._dumps_partitions(partitions, hl.tstruct(locus=hl.tlocus(rg),
-                                                                                        alleles=hl.tarray(hl.tstr)))
-    else:
-        partitions_type = None
+    partitions, partitions_type = hl.utils._dumps_partitions(partitions, hl.tstruct(locus=hl.tlocus(rg),
+                                                                                    alleles=hl.tarray(hl.tstr)))
 
     vector_ref_s = Env.spark_backend('import_vcfs')._jbackend.pyImportVCFs(
         wrap_to_list(path),

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -368,8 +368,6 @@ class VCFTests(unittest.TestCase):
         self.assertEqual(hl.filter_intervals(vcf2, interval_b).n_partitions(), 2)
         self.assertEqual(hl.filter_intervals(vcf2, interval_c).n_partitions(), 3)
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_tabix_export(self):
         mt = hl.import_vcf(resource('sample.vcf.bgz'))
         tmp = new_temp_file(extension="bgz")
@@ -383,8 +381,6 @@ class VCFTests(unittest.TestCase):
         files = hl.current_backend().fs.ls(tmp)
         self.assertTrue(any(f.path.endswith('.tbi') for f in files))
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_import_gvcfs(self):
         path = resource('sample.vcf.bgz')
         self.import_gvcfs_sample_vcf(path)

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -349,7 +349,7 @@ class VCFTests(unittest.TestCase):
                                  n_partitions=None, _partitions_json=parts_str,
                                  _partitions_type=parts_type)
 
-        vcf1 = hl.import_vcf(path).key_rows_by('locus')
+        vcf1 = hl.import_vcf(path)
         vcf2 = hl.MatrixTable(ir.MatrixRead(vir))
         self.assertEqual(len(parts), vcf2.n_partitions())
         self.assertTrue(vcf1._same(vcf2))

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -340,7 +340,7 @@ class VCFTests(unittest.TestCase):
                         end=hl.Struct(locus=hl.Locus('20', 20000000)),
                         includes_end=True)
         ]
-        parts_str = parts_type._convert_to_json(parts)
+        parts_str = json.dumps(parts_type._convert_to_json(parts))
         vir = ir.MatrixVCFReader(path=path, call_fields=['PGT'], entry_float_type=hl.tfloat64,
                                  header_file=None, block_size=None, min_partitions=None,
                                  reference_genome='default', contig_recoding=None,

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -12,6 +12,7 @@ from hail.context import TemporaryFilename
 import pytest
 import hail as hl
 from ..helpers import *
+from hail import ir
 from hail.utils import new_temp_file, FatalError, run_command, uri_path, HailUserError
 
 setUpModule = startTestHailContext
@@ -327,6 +328,7 @@ class VCFTests(unittest.TestCase):
         assert hl.import_vcf(tmp)._same(mt)
 
     def import_gvcfs_sample_vcf(self, path):
+        parts_type = hl.tarray(hl.tinterval(hl.tstruct(locus=hl.tlocus('GRCh37'))))
         parts = [
             hl.Interval(start=hl.Struct(locus=hl.Locus('20', 1)),
                         end=hl.Struct(locus=hl.Locus('20', 13509135)),
@@ -338,8 +340,17 @@ class VCFTests(unittest.TestCase):
                         end=hl.Struct(locus=hl.Locus('20', 20000000)),
                         includes_end=True)
         ]
+        parts_str = parts_type._convert_to_json(parts)
+        vir = ir.MatrixVCFReader(path=path, call_fields=['PGT'], entry_float_type=hl.tfloat64,
+                                 header_file=None, block_size=None, min_partitions=None,
+                                 reference_genome='default', contig_recoding=None,
+                                 array_elements_required=True, skip_invalid_loci=False,
+                                 force_bgz=False, force_gz=False, filter=None, find_replace=None,
+                                 n_partitions=None, _partitions_json=parts_str,
+                                 _partitions_type=parts_type)
+
         vcf1 = hl.import_vcf(path).key_rows_by('locus')
-        vcf2 = hl.import_gvcfs([path], parts)[0]
+        vcf2 = hl.MatrixTable(ir.MatrixRead(vir))
         self.assertEqual(len(parts), vcf2.n_partitions())
         self.assertTrue(vcf1._same(vcf2))
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -257,7 +257,7 @@ class MatrixIRTests(unittest.TestCase):
             matrix_read,
             matrix_range,
             ir.MatrixRead(ir.MatrixVCFReader(resource('sample.vcf'), ['GT'], hl.tfloat64, None, None, None, None, None, None,
-                                             False, True, False, True, None, None, None)),
+                                             False, True, False, True, None, None)),
             ir.MatrixRead(ir.MatrixBGENReader(resource('example.8bits.bgen'), None, {}, 10, 1, None)),
             ir.MatrixFilterRows(matrix_read, ir.FalseIR()),
             ir.MatrixFilterCols(matrix_read, ir.FalseIR()),

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -383,8 +383,8 @@ object GenericLines {
       "partitionIndex" -> TInt32,
       "file" -> TString,
       "chrom" -> TString,
-      "start" -> TInt64,
-      "end" -> TInt64)
+      "start" -> TInt32,
+      "end" -> TInt32)
     new GenericLines(contextType, contexts, body)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -343,10 +343,10 @@ object GenericLines {
         CloseableIterator.empty
       } else {
         new CloseableIterator[GenericLine] {
-          val lines = new TabixLineIterator(fs, file, reg)
-          private var l = lines.next()
-          private var curIdx: Long = lines.getCurIdx()
-          val inner = new Iterator[GenericLine] {
+          private[this] val lines = new TabixLineIterator(fs, file, reg)
+          private[this] var l = lines.next()
+          private[this] var curIdx: Long = lines.getCurIdx()
+          private[this] val inner = new Iterator[GenericLine] {
             def hasNext: Boolean = l != null
             def next(): GenericLine = {
               assert(l != null)

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -344,10 +344,9 @@ object GenericLines {
       } else {
         new CloseableIterator[GenericLine] {
           val lines = new TabixLineIterator(fs, file, reg)
-          val inner = new CloseableIterator[GenericLine] {
-            private var l = lines.next()
-            private var curIdx: Long = lines.getCurIdx()
-
+          private var l = lines.next()
+          private var curIdx: Long = lines.getCurIdx()
+          val inner = new Iterator[GenericLine] {
             def hasNext: Boolean = l != null
             def next(): GenericLine = {
               assert(l != null)
@@ -360,12 +359,8 @@ object GenericLines {
               val bytes = n.getBytes
               new GenericLine(file, 0, idx, bytes, bytes.length)
             }
-
-            def close(): Unit = lines.close()
-          }
-
-          val it = inner.filter { l =>
-            val s = l.toString
+          }.filter { gl =>
+            val s = gl.toString
             val t1 = s.indexOf('\t')
             val t2 = s.indexOf('\t', t1 + 1)
 
@@ -378,9 +373,9 @@ object GenericLines {
             start <= pos && pos <= end
           }
 
-          def hasNext: Boolean = it.hasNext
-          def next(): GenericLine = it.next()
-          def close(): Unit = inner.close()
+          def hasNext: Boolean = inner.hasNext
+          def next(): GenericLine = inner.next()
+          def close(): Unit = lines.close()
         }
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -1,10 +1,13 @@
 package is.hail.expr.ir
 
 import is.hail.backend.spark.SparkBackend
-import is.hail.utils._
-import is.hail.types.virtual.{TBoolean, TInt32, TInt64, TString, TStruct, Type}
 import is.hail.io.compress.BGzipInputStream
 import is.hail.io.fs.{FS, FileStatus, Positioned, PositionedInputStream, BGZipCompressionCodec}
+import is.hail.io.tabix.{TabixReader, TabixLineIterator}
+import is.hail.types.virtual.{TBoolean, TInt32, TInt64, TString, TStruct, Type}
+import is.hail.utils._
+import is.hail.variant.Locus
+
 import org.apache.commons.io.input.{CountingInputStream, ProxyInputStream}
 import org.apache.hadoop.io.compress.SplittableCompressionCodec
 import org.apache.spark.{Partition, TaskContext}
@@ -14,6 +17,14 @@ import org.apache.spark.sql.Row
 import scala.annotation.meta.param
 
 trait CloseableIterator[T] extends Iterator[T] with AutoCloseable
+
+object CloseableIterator {
+  def empty[T]: CloseableIterator[T] = new CloseableIterator[T] {
+    def close(): Unit = ()
+    def hasNext: Boolean = false
+    def next: T = throw new NoSuchElementException
+  }
+}
 
 object GenericLines {
   def read(fs: FS, contexts: IndexedSeq[Any], gzAsBGZ: Boolean, filePerPartition: Boolean): GenericLines = {
@@ -296,6 +307,90 @@ object GenericLines {
     }
 
     GenericLines.read(fs, contexts, gzAsBGZ, filePerPartition)
+  }
+
+  def readTabix(fs: FS, fileStatus: FileStatus, contigMapping: Map[String, String], partitions: IndexedSeq[Interval]): GenericLines = {
+    val reverseContigMapping: Map[String, String] =
+      contigMapping.toArray
+        .groupBy(_._2)
+        .map { case (target, mappings) =>
+          if (mappings.length > 1)
+            fatal(s"contig_recoding may not map multiple contigs to the same target contig, " +
+              s"due to ambiguity when querying the tabix index." +
+            s"\n  Duplicate mappings: ${ mappings.map(_._1).mkString(",") } all map to ${ target }")
+            (target, mappings.head._1)
+        }.toMap
+    val contexts = partitions.zipWithIndex.map { case (interval, i) =>
+      val start = interval.start.asInstanceOf[Row].getAs[Locus](0)
+      val end = interval.end.asInstanceOf[Row].getAs[Locus](0)
+      val contig = reverseContigMapping.getOrElse(start.contig, start.contig)
+      Row(i, fileStatus.getPath, contig, start.position, end.position)
+    }
+    val body: (FS, Any) => CloseableIterator[GenericLine] = { (fs: FS, context: Any) =>
+      val contextRow = context.asInstanceOf[Row]
+      val index = contextRow.getAs[Int](0)
+      val file = contextRow.getAs[String](1)
+      val chrom = contextRow.getAs[String](2)
+      val start = contextRow.getAs[Int](3)
+      val end = contextRow.getAs[Int](4)
+
+      val reg = {
+        val r = new TabixReader(file, fs)
+        val tid = r.chr2tid(chrom)
+        r.queryPairs(tid, start - 1, end)
+      }
+      if (reg.isEmpty) {
+        CloseableIterator.empty
+      } else {
+        new CloseableIterator[GenericLine] {
+          val lines = new TabixLineIterator(fs, file, reg)
+          val inner = new CloseableIterator[GenericLine] {
+            private var l = lines.next()
+            private var curIdx: Long = lines.getCurIdx()
+
+            def hasNext: Boolean = l != null
+            def next(): GenericLine = {
+              assert(l != null)
+              val n = l
+              val idx = curIdx
+              l = lines.next()
+              curIdx = lines.getCurIdx()
+              if (l == null)
+                lines.close()
+              val bytes = n.getBytes
+              new GenericLine(file, 0, idx, bytes, bytes.length)
+            }
+
+            def close(): Unit = lines.close()
+          }
+
+          val it = inner.filter { l =>
+            val s = l.toString
+            val t1 = s.indexOf('\t')
+            val t2 = s.indexOf('\t', t1 + 1)
+
+            val chr = s.substring(0, t1)
+            val pos = s.substring(t1 + 1, t2).toInt
+
+            if (chr != chrom) {
+              throw new RuntimeException(s"bad chromosome! ${chrom}, $s")
+            }
+            start <= pos && pos <= end
+          }
+
+          def hasNext: Boolean = it.hasNext
+          def next(): GenericLine = it.next()
+          def close(): Unit = inner.close()
+        }
+      }
+    }
+    val contextType = TStruct(
+      "partitionIndex" -> TInt32,
+      "file" -> TString,
+      "chrom" -> TString,
+      "start" -> TInt64,
+      "end" -> TInt64)
+    new GenericLines(contextType, contexts, body)
   }
 
   def collect(fs: FS, lines: GenericLines): IndexedSeq[String] = {

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1572,11 +1572,12 @@ object MatrixVCFReader {
     gzAsBGZ: Boolean,
     forceGZ: Boolean,
     filterAndReplace: TextInputFilterAndReplace,
-    partitionsJSON: String): MatrixVCFReader = {
+    partitionsJSON: Option[String],
+    partitionsTypeStr: Option[String]): MatrixVCFReader = {
     MatrixVCFReader(ctx, MatrixVCFReaderParameters(
       files, callFields, entryFloatTypeName, headerFile, nPartitions, blockSizeInMB, minPartitions, rg,
       contigRecoding, arrayElementsRequired, skipInvalidLoci, gzAsBGZ, forceGZ, filterAndReplace,
-      partitionsJSON))
+      partitionsJSON, partitionsTypeStr))
   }
 
   def apply(ctx: ExecuteContext, params: MatrixVCFReaderParameters): MatrixVCFReader = {
@@ -1648,9 +1649,6 @@ object MatrixVCFReader {
           bytes
         }
 
-      } else {
-        warn("Loading user-provided header file. The sample IDs, " +
-          "INFO fields, and FORMAT fields were not checked for agreement with input data.")
       }
     }
 
@@ -1684,7 +1682,10 @@ case class MatrixVCFReaderParameters(
   gzAsBGZ: Boolean,
   forceGZ: Boolean,
   filterAndReplace: TextInputFilterAndReplace,
-  partitionsJSON: String)
+  partitionsJSON: Option[String],
+  partitionsTypeStr: Option[String]) {
+  require(partitionsJSON.isEmpty == partitionsTypeStr.isEmpty, "partitions and type must either both be defined or undefined")
+}
 
 class MatrixVCFReader(
   val params: MatrixVCFReaderParameters,

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -303,7 +303,8 @@ object TestUtils {
     contigRecoding: Option[Map[String, String]] = None,
     arrayElementsRequired: Boolean = true,
     skipInvalidLoci: Boolean = false,
-    partitionsJSON: String = null): MatrixIR = {
+    partitionsJSON: Option[String] = None,
+    partitionsTypeStr: Option[String] = None): MatrixIR = {
     rg.foreach { referenceGenome =>
       ReferenceGenome.addReference(referenceGenome)
     }
@@ -324,7 +325,8 @@ object TestUtils {
       forceBGZ,
       force,
       TextInputFilterAndReplace(),
-      partitionsJSON)
+      partitionsJSON,
+      partitionsTypeStr)
     MatrixRead(reader.fullMatrixTypeWithoutUIDs, dropSamples, false, reader)
   }
 }

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -315,6 +315,7 @@ object TestUtils {
       callFields,
       entryFloatType,
       headerFile,
+      /*sampleIDs=*/None,
       nPartitions,
       blockSizeInMB,
       minPartitions,


### PR DESCRIPTION
This does, what I believe to be the minimum necessary to get Tabix reading working in a standard VCF reader.
 
* Add GenericLines readTabix
* Harmonize import_gvcfs arguments and MatrixVCFReader parameters, as such, it is now possible to directly override the sample ids.
* Remove the undocumented (and until this change, dead) _partitions argument to import_vcf