### PR TITLE
[hailtop.batch] Add ability to update a batch

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -260,7 +260,7 @@ class LocalBackend(Backend[None]):
                 batch._serialize_python_functions_to_input_files(tmpdir, dry_run=dry_run)
             )
 
-            for job in batch._jobs:
+            for job in batch._unsubmitted_jobs:
                 async_to_blocking(job._compile(tmpdir, tmpdir, dry_run=dry_run))
 
                 os.makedirs(f'{tmpdir}/{job._dirname}/', exist_ok=True)
@@ -329,6 +329,9 @@ class LocalBackend(Backend[None]):
                 code += ['\n']
 
                 run_code(code)
+
+                for job in batch._unsubmitted_jobs:
+                    job._submitted = True
         finally:
             if delete_scratch_on_exit:
                 sp.run(f'rm -rf {tmpdir}', shell=True, check=False)
@@ -645,7 +648,10 @@ class ServiceBackend(Backend[bc.Batch]):
             used_remote_tmpdir_results = await bounded_gather(*[functools.partial(compile_job, j) for j in batch._jobs], parallelism=150)
             used_remote_tmpdir |= any(used_remote_tmpdir_results)
 
-        for job in track(batch._jobs, description='create job objects', disable=disable_progress_bar):
+        for job in batch._submitted_jobs:
+            job_to_client_job_mapping[job] = job._client_job
+
+        for job in track(batch._unsubmitted_jobs, description='create job objects', disable=disable_progress_bar):
             inputs = [x for r in job._inputs for x in copy_input(r)]
 
             outputs = [x for r in job._internal_outputs for x in copy_internal_output(r)]
@@ -758,6 +764,9 @@ class ServiceBackend(Backend[bc.Batch]):
 
         submit_batch_start = time.time()
         batch_handle = bc_batch.submit(disable_progress_bar=disable_progress_bar)
+
+        for job in batch._unsubmitted_jobs:
+            job._submitted = True
 
         jobs_to_command = {j.id: cmd for j, cmd in jobs_to_command.items()}
 

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -153,6 +153,14 @@ class Batch:
         self._python_function_defs: Dict[int, Callable] = {}
         self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
 
+    @property
+    def _unsubmitted_jobs(self):
+        return [j for j in self._jobs if not j._submitted]
+
+    @property
+    def _submitted_jobs(self):
+        return [j for j in self._jobs if j._submitted]
+
     def _register_python_function(self, function: Callable) -> int:
         function_id = id(function)
         self._python_function_defs[function_id] = function
@@ -328,6 +336,7 @@ class Batch:
             j.timeout(self._default_timeout)
 
         self._jobs.append(j)
+        self._unsubmitted_jobs.append(j)
         return j
 
     def _new_job_resource_file(self, source, value=None):

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -7,6 +7,8 @@ import warnings
 from shlex import quote as shq
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 
+import hailtop.batch_client.client as bc
+
 from . import backend, batch  # pylint: disable=cyclic-import
 from . import resource as _resource  # pylint: disable=cyclic-import
 from .exceptions import BatchException
@@ -94,6 +96,8 @@ class Job:
         self._mentioned: Set[_resource.Resource] = set()  # resources used in the command
         self._valid: Set[_resource.Resource] = set()  # resources declared in the appropriate place
         self._dependencies: Set[Job] = set()
+        self._submitted: bool = False
+        self._client_job: Optional[bc.Job] = None
 
         def safe_str(s):
             new_s = []

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -971,3 +971,18 @@ class ServiceTests(unittest.TestCase):
         res = b.run()
         res_status = res.status()
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
+
+    def test_update_batch(self):
+        b = self.batch()
+        j = b.new_job()
+        j.command('true')
+        res = b.run()
+
+        res_status = res.status()
+        assert res_status['state'] == 'success', str((res_status, res.debug_info()))
+
+        j2 = b.new_job()
+        j2.command('true')
+        res = b.run()
+        res_status = res.status()
+        assert res_status['state'] == 'success', str((res_status, res.debug_info()))


### PR DESCRIPTION
I feel like I must be missing some complexity here. I think in the past, the complexity was if we allowed submitting to the same batch from a different process and trying to have dependencies on previously submitted jobs.