### PR TITLE
[combiner] Support ServiceBackend/Async Execution

### DIFF
--- a/hail/python/hail/ir/matrix_reader.py
+++ b/hail/python/hail/ir/matrix_reader.py
@@ -88,6 +88,7 @@ class MatrixVCFReader(MatrixReader):
                       force_gz=bool,
                       filter=nullable(str),
                       find_replace=nullable(sized_tupleof(str, str)),
+                      _sample_ids=nullable(sequenceof(str)),
                       _partitions_json=nullable(str),
                       _partitions_type=nullable(HailType))
     def __init__(self,
@@ -107,6 +108,7 @@ class MatrixVCFReader(MatrixReader):
                  filter,
                  find_replace,
                  *,
+                 _sample_ids=None,
                  _partitions_json=None,
                  _partitions_type=None):
         self.path = wrap_to_list(path)
@@ -124,6 +126,7 @@ class MatrixVCFReader(MatrixReader):
         self.force_bgz = force_bgz
         self.filter = filter
         self.find_replace = find_replace
+        self._sample_ids = _sample_ids
         self._partitions_json = _partitions_json
         self._partitions_type = _partitions_type
 
@@ -143,8 +146,9 @@ class MatrixVCFReader(MatrixReader):
                   'gzAsBGZ': self.force_bgz,
                   'forceGZ': self.force_gz,
                   'filterAndReplace': make_filter_and_replace(self.filter, self.find_replace),
-                  'partitionsJSON': self._partitions_json,
-                  'partitionsTypeStr': self._partitions_type._parsable_string() if self._partitions_type is not None else None}
+                  'sampleIDs': self._sample_ids,
+                  'partitionsTypeStr': self._partitions_type._parsable_string() if self._partitions_type is not None else None,
+                  'partitionsJSON': self._partitions_json}
         return escape_str(json.dumps(reader))
 
     def __eq__(self, other):
@@ -162,7 +166,9 @@ class MatrixVCFReader(MatrixReader):
             other.force_gz == self.force_gz and \
             other.filter == self.filter and \
             other.find_replace == self.find_replace and \
-            other._partitions_json == self._partitions_json
+            other._partitions_json == self._partitions_json and \
+            other._partitions_type == self._partitions_type and \
+            other._sample_ids == self._sample_ids
 
 
 class MatrixBGENReader(MatrixReader):

--- a/hail/python/hail/ir/matrix_reader.py
+++ b/hail/python/hail/ir/matrix_reader.py
@@ -2,7 +2,7 @@ import abc
 import json
 
 from .utils import make_filter_and_replace, impute_type_of_partition_interval_array
-from ..expr.types import tfloat32, tfloat64
+from ..expr.types import HailType, tfloat32, tfloat64
 from ..genetics.reference_genome import reference_genome_type
 from ..typecheck import (typecheck_method, sequenceof, nullable, enumeration, anytype, oneof,
                          dictof, sized_tupleof)
@@ -88,7 +88,8 @@ class MatrixVCFReader(MatrixReader):
                       force_gz=bool,
                       filter=nullable(str),
                       find_replace=nullable(sized_tupleof(str, str)),
-                      _partitions_json=nullable(str))
+                      _partitions_json=nullable(str),
+                      _partitions_type=nullable(HailType))
     def __init__(self,
                  path,
                  call_fields,
@@ -105,7 +106,9 @@ class MatrixVCFReader(MatrixReader):
                  force_gz,
                  filter,
                  find_replace,
-                 _partitions_json):
+                 *,
+                 _partitions_json=None,
+                 _partitions_type=None):
         self.path = wrap_to_list(path)
         self.header_file = header_file
         self.n_partitions = n_partitions
@@ -122,6 +125,7 @@ class MatrixVCFReader(MatrixReader):
         self.filter = filter
         self.find_replace = find_replace
         self._partitions_json = _partitions_json
+        self._partitions_type = _partitions_type
 
     def render(self, r):
         reader = {'name': 'MatrixVCFReader',
@@ -139,7 +143,8 @@ class MatrixVCFReader(MatrixReader):
                   'gzAsBGZ': self.force_bgz,
                   'forceGZ': self.force_gz,
                   'filterAndReplace': make_filter_and_replace(self.filter, self.find_replace),
-                  'partitionsJSON': self._partitions_json}
+                  'partitionsJSON': self._partitions_json,
+                  'partitionsTypeStr': self._partitions_type._parsable_string() if self._partitions_type is not None else None}
         return escape_str(json.dumps(reader))
 
     def __eq__(self, other):

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2786,7 +2786,7 @@ def import_gvcfs(path,
     :func:`.import_gvcfs` only keys the resulting matrix tables by ``locus``
     rather than ``locus, alleles``.
     """
-
+    hl.utils.no_service_backend('import_gvcfs')
     rg = reference_genome.name if reference_genome else None
 
     if partitions is not None:

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2564,9 +2564,7 @@ def get_vcf_metadata(path):
            filter=nullable(str),
            find_replace=nullable(sized_tupleof(str, str)),
            n_partitions=nullable(int),
-           block_size=nullable(int),
-           # json
-           _partitions=nullable(str))
+           block_size=nullable(int))
 def import_vcf(path,
                force=False,
                force_bgz=False,
@@ -2582,8 +2580,7 @@ def import_vcf(path,
                filter=None,
                find_replace=None,
                n_partitions=None,
-               block_size=None,
-               _partitions=None) -> MatrixTable:
+               block_size=None) -> MatrixTable:
     """Import VCF file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -2732,8 +2729,7 @@ def import_vcf(path,
     reader = ir.MatrixVCFReader(path, call_fields, entry_float_type, header_file,
                                 n_partitions, block_size, min_partitions,
                                 reference_genome, contig_recoding, array_elements_required,
-                                skip_invalid_loci, force_bgz, force, filter, find_replace,
-                                _partitions)
+                                skip_invalid_loci, force_bgz, force, filter, find_replace)
     return MatrixTable(ir.MatrixRead(reader, drop_cols=drop_samples))
 
 
@@ -2789,11 +2785,8 @@ def import_gvcfs(path,
     hl.utils.no_service_backend('import_gvcfs')
     rg = reference_genome.name if reference_genome else None
 
-    if partitions is not None:
-        partitions, partitions_type = hl.utils._dumps_partitions(partitions, hl.tstruct(locus=hl.tlocus(rg),
-                                                                                        alleles=hl.tarray(hl.tstr)))
-    else:
-        partitions_type = None
+    partitions, partitions_type = hl.utils._dumps_partitions(partitions, hl.tstruct(locus=hl.tlocus(rg),
+                                                                                    alleles=hl.tarray(hl.tstr)))
 
     vector_ref_s = Env.spark_backend('import_vcfs')._jbackend.pyImportVCFs(
         wrap_to_list(path),

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -1,6 +1,5 @@
 import collections
 import hashlib
-import itertools
 import json
 import os
 import sys
@@ -13,10 +12,9 @@ import hail as hl
 
 from hail.expr import tmatrix
 from hail.utils import Interval
-from hail.utils.java import Env, info, warning
+from hail.utils.java import info, warning
 from hail.experimental.vcf_combiner.vcf_combiner import calculate_even_genome_partitioning, \
     calculate_new_intervals
-from hail.vds.variant_dataset import VariantDataset
 from .combine import combine_variant_datasets, transform_gvcf, defined_entry_fields
 
 
@@ -225,7 +223,6 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
                  gvcf_info_to_keep: Optional[Collection[str]] = None,
                  gvcf_reference_entry_fields_to_keep: Optional[Collection[str]] = None,
                  ):
-        hl.utils.no_service_backend('VariantDatasetCombiner')
         if not (vdses or gvcfs):
             raise ValueError("one of 'vdses' or 'gvcfs' must be nonempty")
         if not gvcf_import_intervals:
@@ -431,9 +428,8 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
 
         if intervals is None:
             # we use the reference data since it generally has more rows than the variant data
-            intervals, _ = calculate_new_intervals(vds.reference_data,
-                                                                 self._target_records,
-                                                                 os.path.join(temp_path, 'interval_checkpoint.ht'))
+            intervals, _ = calculate_new_intervals(vds.reference_data, self._target_records,
+                                                   os.path.join(temp_path, 'interval_checkpoint.ht'))
             self.__intervals_cache[interval_bin] = intervals
 
         paths = [f.path for f in files_to_merge]

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -709,7 +709,6 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
         return await hl.current_backend()._async_execute_many(write_ref, write_var, timed=False)
 
 
-
 def new_combiner(*,
                  output_path: str,
                  temp_path: str,
@@ -967,4 +966,4 @@ class Decoder(json.JSONDecoder):
 
 
 def chunks(sliceable, size):
-    return (sliceable[i:i+size] for i in range(0, len(sliceable), size))
+    return (sliceable[i:(i + size)] for i in range(0, len(sliceable), size))

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -627,7 +627,7 @@ def new_combiner(*,
         rmt = mt.filter_rows(hl.is_defined(mt.info.END))
         gvcf_reference_entry_fields_to_keep = defined_entry_fields(rmt, 100_000) - {'GT', 'PGT', 'PL'}
 
-        vds = transform_gvcf(mt._key_rows_by_assert_sorted(['locus']), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep)
+        vds = transform_gvcf(mt._key_rows_by_assert_sorted('locus'), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep)
         dataset_type = VDSType(reference_type=vds.reference_data._type, variant_type=vds.variant_data._type)
     elif vds_paths:
         vds = hl.vds.read_vds(vds_paths[0])
@@ -635,7 +635,7 @@ def new_combiner(*,
     else:
         mt = hl.import_vcf(gvcf_paths[0], force_bgz=True, reference_genome=reference_genome,
                            contig_recoding=contig_recoding)
-        vds = transform_gvcf(mt._key_rows_by_assert_sorted(['locus']), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep)
+        vds = transform_gvcf(mt._key_rows_by_assert_sorted('locus'), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep)
         dataset_type = VDSType(reference_type=vds.reference_data._type, variant_type=vds.variant_data._type)
 
     if save_path is None:

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -622,7 +622,8 @@ def new_combiner(*,
         gvcf_reference_entry_fields_to_keep = set(vds.reference_data.entry) - {'END'}
         dataset_type = VDSType(reference_type=vds.reference_data._type, variant_type=vds.variant_data._type)
     elif gvcf_reference_entry_fields_to_keep is None and gvcf_paths:
-        mt = hl.import_vcf(gvcf_paths[0], force_bgz=True, reference_genome=reference_genome,
+        mt = hl.import_vcf(gvcf_paths[0], header_file=gvcf_external_header, force_bgz=True,
+                           array_elements_required=False, reference_genome=reference_genome,
                            contig_recoding=contig_recoding)
         rmt = mt.filter_rows(hl.is_defined(mt.info.END))
         gvcf_reference_entry_fields_to_keep = defined_entry_fields(rmt, 100_000) - {'GT', 'PGT', 'PL'}
@@ -633,7 +634,8 @@ def new_combiner(*,
         vds = hl.vds.read_vds(vds_paths[0])
         dataset_type = VDSType(reference_type=vds.reference_data._type, variant_type=vds.variant_data._type)
     else:
-        mt = hl.import_vcf(gvcf_paths[0], force_bgz=True, reference_genome=reference_genome,
+        mt = hl.import_vcf(gvcf_paths[0], header_file=gvcf_external_header, force_bgz=True,
+                           array_elements_required=False, reference_genome=reference_genome,
                            contig_recoding=contig_recoding)
         vds = transform_gvcf(mt._key_rows_by_assert_sorted('locus'), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep)
         dataset_type = VDSType(reference_type=vds.reference_data._type, variant_type=vds.variant_data._type)

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -188,7 +188,7 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
         '_output_path',
         '_temp_path',
         '_reference_genome',
-        '_dataset_type'
+        '_dataset_type',
         '_branch_factor',
         '_target_records',
         '_gvcf_batch_size',

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -10,7 +10,7 @@ from typing import Collection, Dict, List, NamedTuple, Optional, Union
 
 import hail as hl
 
-from hail.expr import tmatrix
+from hail.expr import HailType, tmatrix
 from hail.utils import Interval
 from hail.utils.java import info, warning
 from hail.experimental.vcf_combiner.vcf_combiner import calculate_even_genome_partitioning, \
@@ -715,6 +715,8 @@ class Encoder(json.JSONEncoder):
             return o.to_dict()
         if isinstance(o, VDSType):
             return o.serializable()
+        if isinstance(o, HailType):
+            return str(o)
         return json.JSONEncoder.default(self, o)
 
 

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -428,7 +428,7 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
                               _assert_variant_type=self._dataset_type.variant_type)
 
         interval_bin = floor(log(new_n_samples, self._branch_factor))
-        intervals, intervals_dtype = self.__intervals_cache.get(interval_bin, (None, None))
+        intervals = self.__intervals_cache.get(interval_bin)
 
         if intervals is None:
             # we use the reference data since it generally has more rows than the variant data

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -7,7 +7,8 @@ from hail.utils.java import info
 from hail.genetics import ReferenceGenome
 
 
-def read_vds(path, *, intervals=None, n_partitions=None) -> 'VariantDataset':
+def read_vds(path, *, intervals=None, n_partitions=None,
+             _assert_reference_type=None, _assert_variant_type=None) -> 'VariantDataset':
     """Read in a :class:`.VariantDataset` written with :meth:`.VariantDataset.write`.
 
     Parameters

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -257,7 +257,7 @@ class MatrixIRTests(unittest.TestCase):
             matrix_read,
             matrix_range,
             ir.MatrixRead(ir.MatrixVCFReader(resource('sample.vcf'), ['GT'], hl.tfloat64, None, None, None, None, None, None,
-                                             False, True, False, True, None, None, None)),
+                                             False, True, False, True, None, None)),
             ir.MatrixRead(ir.MatrixBGENReader(resource('example.8bits.bgen'), None, {}, 10, 1, None)),
             ir.MatrixFilterRows(matrix_read, ir.FalseIR()),
             ir.MatrixFilterCols(matrix_read, ir.FalseIR()),

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -87,7 +87,6 @@ def test_vcf_vds_combiner_equivalence():
     assert smt._same(smt_from_vds)
 
 
-@fails_service_backend
 def test_combiner_plan_round_trip_serialization():
     sample_names = all_samples[:5]
     paths = [os.path.join(resource('gvcfs'), '1kg_chr22', f'{s}.hg38.g.vcf.gz') for s in sample_names]

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -1,10 +1,13 @@
 package is.hail.expr.ir
 
 import is.hail.backend.spark.SparkBackend
-import is.hail.utils._
-import is.hail.types.virtual.{TBoolean, TInt32, TInt64, TString, TStruct, Type}
 import is.hail.io.compress.BGzipInputStream
 import is.hail.io.fs.{FS, FileStatus, Positioned, PositionedInputStream, BGZipCompressionCodec}
+import is.hail.io.tabix.{TabixReader, TabixLineIterator}
+import is.hail.types.virtual.{TBoolean, TInt32, TInt64, TString, TStruct, Type}
+import is.hail.utils._
+import is.hail.variant.Locus
+
 import org.apache.commons.io.input.{CountingInputStream, ProxyInputStream}
 import org.apache.hadoop.io.compress.SplittableCompressionCodec
 import org.apache.spark.{Partition, TaskContext}
@@ -14,6 +17,14 @@ import org.apache.spark.sql.Row
 import scala.annotation.meta.param
 
 trait CloseableIterator[T] extends Iterator[T] with AutoCloseable
+
+object CloseableIterator {
+  def empty[T]: CloseableIterator[T] = new CloseableIterator[T] {
+    def close(): Unit = ()
+    def hasNext: Boolean = false
+    def next: T = throw new NoSuchElementException
+  }
+}
 
 object GenericLines {
   def read(fs: FS, contexts: IndexedSeq[Any], gzAsBGZ: Boolean, filePerPartition: Boolean): GenericLines = {
@@ -296,6 +307,90 @@ object GenericLines {
     }
 
     GenericLines.read(fs, contexts, gzAsBGZ, filePerPartition)
+  }
+
+  def readTabix(fs: FS, fileStatus: FileStatus, contigMapping: Map[String, String], partitions: IndexedSeq[Interval]): GenericLines = {
+    val reverseContigMapping: Map[String, String] =
+      contigMapping.toArray
+        .groupBy(_._2)
+        .map { case (target, mappings) =>
+          if (mappings.length > 1)
+            fatal(s"contig_recoding may not map multiple contigs to the same target contig, " +
+              s"due to ambiguity when querying the tabix index." +
+            s"\n  Duplicate mappings: ${ mappings.map(_._1).mkString(",") } all map to ${ target }")
+            (target, mappings.head._1)
+        }.toMap
+    val contexts = partitions.zipWithIndex.map { case (interval, i) =>
+      val start = interval.start.asInstanceOf[Row].getAs[Locus](0)
+      val end = interval.end.asInstanceOf[Row].getAs[Locus](0)
+      val contig = reverseContigMapping.getOrElse(start.contig, start.contig)
+      Row(i, fileStatus.getPath, contig, start.position, end.position)
+    }
+    val body: (FS, Any) => CloseableIterator[GenericLine] = { (fs: FS, context: Any) =>
+      val contextRow = context.asInstanceOf[Row]
+      val index = contextRow.getAs[Int](0)
+      val file = contextRow.getAs[String](1)
+      val chrom = contextRow.getAs[String](2)
+      val start = contextRow.getAs[Int](3)
+      val end = contextRow.getAs[Int](4)
+
+      val reg = {
+        val r = new TabixReader(file, fs)
+        val tid = r.chr2tid(chrom)
+        r.queryPairs(tid, start - 1, end)
+      }
+      if (reg.isEmpty) {
+        CloseableIterator.empty
+      } else {
+        new CloseableIterator[GenericLine] {
+          val lines = new TabixLineIterator(fs, file, reg)
+          val inner = new CloseableIterator[GenericLine] {
+            private var l = lines.next()
+            private var curIdx: Long = lines.getCurIdx()
+
+            def hasNext: Boolean = l != null
+            def next(): GenericLine = {
+              assert(l != null)
+              val n = l
+              val idx = curIdx
+              l = lines.next()
+              curIdx = lines.getCurIdx()
+              if (l == null)
+                lines.close()
+              val bytes = n.getBytes
+              new GenericLine(file, 0, idx, bytes, bytes.length)
+            }
+
+            def close(): Unit = lines.close()
+          }
+
+          val it = inner.filter { l =>
+            val s = l.toString
+            val t1 = s.indexOf('\t')
+            val t2 = s.indexOf('\t', t1 + 1)
+
+            val chr = s.substring(0, t1)
+            val pos = s.substring(t1 + 1, t2).toInt
+
+            if (chr != chrom) {
+              throw new RuntimeException(s"bad chromosome! ${chrom}, $s")
+            }
+            start <= pos && pos <= end
+          }
+
+          def hasNext: Boolean = it.hasNext
+          def next(): GenericLine = it.next()
+          def close(): Unit = inner.close()
+        }
+      }
+    }
+    val contextType = TStruct(
+      "partitionIndex" -> TInt32,
+      "file" -> TString,
+      "chrom" -> TString,
+      "start" -> TInt64,
+      "end" -> TInt64)
+    new GenericLines(contextType, contexts, body)
   }
 
   def collect(fs: FS, lines: GenericLines): IndexedSeq[String] = {

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1572,11 +1572,12 @@ object MatrixVCFReader {
     gzAsBGZ: Boolean,
     forceGZ: Boolean,
     filterAndReplace: TextInputFilterAndReplace,
-    partitionsJSON: String): MatrixVCFReader = {
+    partitionsJSON: Option[String],
+    partitionsTypeStr: Option[String]): MatrixVCFReader = {
     MatrixVCFReader(ctx, MatrixVCFReaderParameters(
       files, callFields, entryFloatTypeName, headerFile, nPartitions, blockSizeInMB, minPartitions, rg,
       contigRecoding, arrayElementsRequired, skipInvalidLoci, gzAsBGZ, forceGZ, filterAndReplace,
-      partitionsJSON))
+      partitionsJSON, partitionsTypeStr))
   }
 
   def apply(ctx: ExecuteContext, params: MatrixVCFReaderParameters): MatrixVCFReader = {
@@ -1648,9 +1649,6 @@ object MatrixVCFReader {
           bytes
         }
 
-      } else {
-        warn("Loading user-provided header file. The sample IDs, " +
-          "INFO fields, and FORMAT fields were not checked for agreement with input data.")
       }
     }
 
@@ -1684,7 +1682,10 @@ case class MatrixVCFReaderParameters(
   gzAsBGZ: Boolean,
   forceGZ: Boolean,
   filterAndReplace: TextInputFilterAndReplace,
-  partitionsJSON: String)
+  partitionsJSON: Option[String],
+  partitionsTypeStr: Option[String]) {
+  require(partitionsJSON.isEmpty == partitionsTypeStr.isEmpty, "partitions and type must either both be defined or undefined")
+}
 
 class MatrixVCFReader(
   val params: MatrixVCFReaderParameters,

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -303,7 +303,8 @@ object TestUtils {
     contigRecoding: Option[Map[String, String]] = None,
     arrayElementsRequired: Boolean = true,
     skipInvalidLoci: Boolean = false,
-    partitionsJSON: String = null): MatrixIR = {
+    partitionsJSON: Option[String] = None,
+    partitionsTypeStr: Option[String] = None): MatrixIR = {
     rg.foreach { referenceGenome =>
       ReferenceGenome.addReference(referenceGenome)
     }
@@ -324,7 +325,8 @@ object TestUtils {
       forceBGZ,
       force,
       TextInputFilterAndReplace(),
-      partitionsJSON)
+      partitionsJSON,
+      partitionsTypeStr)
     MatrixRead(reader.fullMatrixTypeWithoutUIDs, dropSamples, false, reader)
   }
 }

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -315,6 +315,7 @@ object TestUtils {
       callFields,
       entryFloatType,
       headerFile,
+      /*sampleIDs=*/None,
       nPartitions,
       blockSizeInMB,
       minPartitions,


### PR DESCRIPTION
Implement the combiner in a ServiceBackend compatible way.

query is not set up for ergonomic asynchronous programming in any way,
shape, or form. As such, this is very rough. However, blocking round
trips have been eliminated. Care has been taken to maximize amount of
work done in each job while still allowing reasonable save points. That
is, we run every gVCF combine first in one bounded_gather2 call. Then,
for every level of vds merging (that is, `floor(log(n_samples, branch_factor)) == 0, 1, 2, 3...`),
we run every combine at that level, until we have fewer than
branch_factor files to merge, and then we merge them all at once.