### PR TITLE
[query] Fix bug that turned off tree aggregation for scans and aggs

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -594,7 +594,7 @@ object LowerTableIR {
           InitFromSerializedValue(i, GetTupleElement(initStateRef, i), agg.state )})
 
         val branchFactor = HailContext.get.branchingFactor
-        val useTreeAggregate = aggs.shouldTreeAggregate && branchFactor > lc.numPartitions
+        val useTreeAggregate = aggs.shouldTreeAggregate && branchFactor < lc.numPartitions
         val isCommutative = aggs.isCommutative
         log.info(s"Aggregate: useTreeAggregate=${ useTreeAggregate }")
         log.info(s"Aggregate: commutative=${ isCommutative }")
@@ -1238,7 +1238,7 @@ object LowerTableIR {
             InitFromSerializedValue(i, GetTupleElement(initStateRef, i), agg.state)
           })
           val branchFactor = HailContext.get.branchingFactor
-          val big = aggs.shouldTreeAggregate && branchFactor > lc.numPartitions
+          val big = aggs.shouldTreeAggregate && branchFactor < lc.numPartitions
           val (partitionPrefixSumValues, transformPrefixSum): (IR, IR => IR) = if (big) {
             val tmpDir = ctx.createTmpPath("aggregate_intermediates/")
 


### PR DESCRIPTION
CHANGELOG: Fixed a bug that turned off tree aggregation for aggregation and scans

The alligator eats the bigger number