### PR TITLE
[qob] Add 429 to retryable status codes

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -542,7 +542,7 @@ async def bounded_gather2(
     return await bounded_gather2_raise_exceptions(sema, *pfs, cancel_on_error=cancel_on_error)
 
 
-RETRYABLE_HTTP_STATUS_CODES = {408, 500, 502, 503, 504, 429}
+RETRYABLE_HTTP_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 if os.environ.get('HAIL_DONT_RETRY_500') == '1':
     RETRYABLE_HTTP_STATUS_CODES.remove(500)
 

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -22,7 +22,7 @@ package object services {
   lazy val log: Logger = LogManager.getLogger("is.hail.services")
 
   val RETRYABLE_HTTP_STATUS_CODES: Set[Int] = {
-    val s = Set(408, 500, 502, 503, 504)
+    val s = Set(408, 429, 500, 502, 503, 504)
     if (System.getenv("HAIL_DONT_RETRY_500") == "1")
       s - 500
     else


### PR DESCRIPTION
Envoy uses [429](https://http.cat/429) for rate-limiting whereas nginx uses [503](https://http.cat/503). Looks like I'd only added it to Python and not Scala