### PR TITLE
Fixes for envoy

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -4,9 +4,9 @@ import secrets
 import time
 from typing import Set
 
-import aiohttp
 import pytest
 
+from hailtop import httpx
 from hailtop.auth import service_auth_headers
 from hailtop.batch_client.client import BatchClient
 from hailtop.config import get_deploy_config, get_user_config
@@ -107,14 +107,14 @@ def test_invalid_resource_requests(client: BatchClient):
     bb = client.create_batch()
     resources = {'cpu': '1', 'memory': '250Gi', 'storage': '1Gi'}
     bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
+    with pytest.raises(httpx.ClientResponseError, match='resource requests.*unsatisfiable'):
         bb.submit()
 
     bb = client.create_batch()
     resources = {'cpu': '0', 'memory': '1Gi', 'storage': '1Gi'}
     bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
-        aiohttp.client.ClientResponseError,
+        httpx.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
         bb.submit()
@@ -123,7 +123,7 @@ def test_invalid_resource_requests(client: BatchClient):
     resources = {'cpu': '0.1', 'memory': '1Gi', 'storage': '1Gi'}
     bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
-        aiohttp.client.ClientResponseError,
+        httpx.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
         bb.submit()
@@ -132,7 +132,7 @@ def test_invalid_resource_requests(client: BatchClient):
     resources = {'cpu': '0.25', 'memory': 'foo', 'storage': '1Gi'}
     bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
-        aiohttp.client.ClientResponseError,
+        httpx.ClientResponseError,
         match=".*.resources.memory must match regex:.*.resources.memory must be one of:.*",
     ):
         bb.submit()
@@ -140,13 +140,13 @@ def test_invalid_resource_requests(client: BatchClient):
     bb = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '500Mi', 'storage': '10000000Gi'}
     bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
+    with pytest.raises(httpx.ClientResponseError, match='resource requests.*unsatisfiable'):
         bb.submit()
 
     bb = client.create_batch()
     resources = {'storage': '10000000Gi', 'machine_type': smallest_machine_type(CLOUD)}
     bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
+    with pytest.raises(httpx.ClientResponseError, match='resource requests.*unsatisfiable'):
         bb.submit()
 
 
@@ -403,7 +403,7 @@ def test_deleted_job_log(client: BatchClient):
 
     try:
         j.log()
-    except aiohttp.ClientResponseError as e:
+    except httpx.ClientResponseError as e:
         if e.status == 404:
             pass
         else:
@@ -419,7 +419,7 @@ def test_delete_batch(client: BatchClient):
     # verify doesn't exist
     try:
         client.get_job(*j.id)
-    except aiohttp.ClientResponseError as e:
+    except httpx.ClientResponseError as e:
         if e.status == 404:
             pass
         else:
@@ -443,7 +443,7 @@ def test_cancel_batch(client: BatchClient):
     # cancelled job has no log
     try:
         j.log()
-    except aiohttp.ClientResponseError as e:
+    except httpx.ClientResponseError as e:
         if e.status == 404:
             pass
         else:
@@ -453,7 +453,7 @@ def test_cancel_batch(client: BatchClient):
 def test_get_nonexistent_job(client: BatchClient):
     try:
         client.get_job(1, 666)
-    except aiohttp.ClientResponseError as e:
+    except httpx.ClientResponseError as e:
         if e.status == 404:
             pass
         else:
@@ -718,7 +718,7 @@ def test_duplicate_parents(client: BatchClient):
     bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head, head])
     try:
         batch = bb.submit()
-    except aiohttp.ClientResponseError as e:
+    except httpx.ClientResponseError as e:
         assert e.status == 400
     else:
         assert False, f'should receive a 400 Bad Request {batch.id}'
@@ -961,9 +961,9 @@ def test_verify_private_network_is_restricted(client: BatchClient):
     )
     try:
         bb.submit()
-    except aiohttp.ClientResponseError as err:
+    except httpx.ClientResponseError as err:
         assert err.status == 400
-        assert 'unauthorized network private' in err.message
+        assert 'unauthorized network private' in err.body
     else:
         assert False
 
@@ -1258,9 +1258,9 @@ def test_update_cancelled_batch_wout_fast_path(client: BatchClient):
         for _ in range(4):
             bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
         b = bb.submit()
-    except aiohttp.ClientResponseError as err:
+    except httpx.ClientResponseError as err:
         assert err.status == 400
-        assert 'Cannot submit new jobs to a cancelled batch' in err.message
+        assert 'Cannot submit new jobs to a cancelled batch' in err.body
     else:
         assert False
 
@@ -1274,9 +1274,9 @@ def test_submit_update_to_cancelled_batch(client: BatchClient):
     try:
         bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
         b = bb.submit()
-    except aiohttp.ClientResponseError as err:
+    except httpx.ClientResponseError as err:
         assert err.status == 400
-        assert 'Cannot submit new jobs to a cancelled batch' in err.message
+        assert 'Cannot submit new jobs to a cancelled batch' in err.body
     else:
         assert False
 
@@ -1290,7 +1290,7 @@ def test_submit_update_to_deleted_batch(client: BatchClient):
     try:
         bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
         b = bb.submit()
-    except aiohttp.ClientResponseError as err:
+    except httpx.ClientResponseError as err:
         assert err.status == 404
     else:
         assert False

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -741,7 +741,7 @@ SELECT frozen_merge_deploy FROM globals;
         kubernetes_asyncio.config.load_incluster_config()
         k8s_client = kubernetes_asyncio.client.CoreV1Api()
         app['task_manager'].ensure_future(periodically_call(10, update_envoy_configs, app['db'], k8s_client))
-        app['task_manager'].ensure_future(periodically_call(10, cleanup_expired_namespaces, app['db'], k8s_client))
+        app['task_manager'].ensure_future(periodically_call(10, cleanup_expired_namespaces, app['db']))
 
 
 async def on_cleanup(app):

--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -209,11 +209,15 @@ def clusters(
             clusters.append(browser_cluster)
             clusters.append(static_cluster)
         else:
-            clusters.append(make_cluster(service, f'{service}.default', proxy, verify_ca=True))
+            clusters.append(make_cluster(service, f'{service}.default.svc.cluster.local', proxy, verify_ca=True))
 
     for namespace, services in internal_services_per_namespace.items():
         for service in services:
-            clusters.append(make_cluster(f'{namespace}-{service}', f'{service}.{namespace}', proxy, verify_ca=False))
+            clusters.append(
+                make_cluster(
+                    f'{namespace}-{service}', f'{service}.{namespace}.svc.cluster.local', proxy, verify_ca=False
+                )
+            )
 
     return clusters
 

--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -108,7 +108,7 @@ def gateway_internal_host(services_per_namespace: Dict[str, List[str]]) -> dict:
         'domains': [f'internal.{DOMAIN}'],
         'routes': [
             {
-                'match': {'prefix': f'/{namespace}/{service}'},
+                'match': {'path_separated_prefix': f'/{namespace}/{service}'},
                 'route': route_to_cluster(f'{namespace}-{service}'),
                 'typed_per_filter_config': {
                     'envoy.filters.http.local_ratelimit': rate_limit_config(),
@@ -144,7 +144,7 @@ def internal_gateway_internal_host(services_per_namespace: Dict[str, List[str]])
         'domains': ['internal.hail'],
         'routes': [
             {
-                'match': {'prefix': f'/{namespace}/{service}'},
+                'match': {'path_separated_prefix': f'/{namespace}/{service}'},
                 'route': route_to_cluster(f'{namespace}-{service}'),
                 'typed_per_filter_config': {
                     'envoy.filters.http.local_ratelimit': rate_limit_config(),


### PR DESCRIPTION
- Using the full domain name instead of the shorthand `<service>.<namespace>` isn't strictly necessary but just made me nervous and I opted for the full unambiguous domain for in-cluster services (what if we had a namespace named `com`?? I feel like that would break some things)
- I got the configuration wrong on how to tell envoy *not* to worry about certs of internal namespaces (I'd recommend using the `split` view for the diff because otherwise it's pretty hard to read)
- For internal namespaces, using the `prefix` parameter for matching a route allowed `/foo/batch` to match a route like `/foo/batch-driver` which is obviously not great. the `path_separated_prefix` parameter actually does what we want
- Fixed the batch tests not to look at the HTTP 1.1 reason phrase and instead look at the response body to determine the error