### PR TITLE
[test] hail-run image should depend on base not service base

### DIFF
--- a/batch/test/test_time_limited_max_size_cache.py
+++ b/batch/test/test_time_limited_max_size_cache.py
@@ -1,8 +1,8 @@
-import pytest
 import asyncio
 
-from gear.time_limited_max_size_cache import TimeLimitedMaxSizeCache
+import pytest
 
+from gear.time_limited_max_size_cache import TimeLimitedMaxSizeCache
 
 pytestmark = pytest.mark.asyncio
 

--- a/batch/test/test_time_limited_max_size_cache.py
+++ b/batch/test/test_time_limited_max_size_cache.py
@@ -13,7 +13,7 @@ one_day_ns = 24 * 60 * 60 * one_second_ns
 
 async def test_simple():
     async def load_secret(k: int):
-        return k ** 2
+        return k**2
 
     c = TimeLimitedMaxSizeCache(load_secret, one_day_ns, 2, 'test_cache')
     assert await c.lookup(3) == 9
@@ -26,12 +26,13 @@ async def test_simple():
 
 async def test_num_slots():
     load_counts = 0
+
     async def load_secret_only_twice(k: int):
         nonlocal load_counts
         if load_counts == 2:
             raise ValueError("already loaded secret twice")
         load_counts += 1
-        return k ** 2
+        return k**2
 
     c = TimeLimitedMaxSizeCache(load_secret_only_twice, one_day_ns, 2, 'test_cache')
     assert await c.lookup(3) == 9
@@ -50,10 +51,11 @@ async def test_num_slots():
 
 async def test_lifetime():
     load_counts = 0
+
     async def load_secret(k: int):
         nonlocal load_counts
         load_counts += 1
-        return k ** 2
+        return k**2
 
     c = TimeLimitedMaxSizeCache(load_secret, one_second_ns, 3, 'test_cache')
     assert await c.lookup(3) == 9
@@ -82,12 +84,14 @@ async def test_lifetime():
     assert await c.lookup(10) == 100
     assert load_counts == 5
 
+
 async def test_num_slots_deletes_oldest():
     load_counts = 0
+
     async def load_secret(k: int):
         nonlocal load_counts
         load_counts += 1
-        return k ** 2
+        return k**2
 
     c = TimeLimitedMaxSizeCache(load_secret, one_day_ns, 3, 'test_cache')
     assert await c.lookup(0) == 0
@@ -116,6 +120,7 @@ async def test_num_slots_deletes_oldest():
 
     assert await c.lookup(0) == 0
     assert load_counts == 5
+
 
 async def test_exception_propagates_everywhere():
     async def boom(_: int):

--- a/build.yaml
+++ b/build.yaml
@@ -526,23 +526,8 @@ steps:
       - from: /repo
         to: /io/repo
     dependsOn:
-      - service_base_image
+      - base_image
       - merge_code
-  - kind: buildImage2
-    name: hail_run_tests_image
-    dockerFile: /io/hail/Dockerfile.hail-run-tests
-    contextPath: /io/hail
-    publishAs: hail-run-tests
-    inputs:
-      - from: /repo/hail
-        to: /io/hail
-    dependsOn:
-      - hail_run_image
-      - merge_code
-    resources:
-      storage: 10Gi
-      cpu: "2"
-      memory: standard
   - kind: buildImage2
     name: monitoring_image
     dockerFile: /io/repo/monitoring/Dockerfile
@@ -942,7 +927,7 @@ steps:
     name: test_hail_java
     numSplits: 5
     image:
-      valueFrom: hail_run_tests_image.image
+      valueFrom: hail_run_image.image
     resources:
       memory: standard
       cpu: '2'
@@ -971,7 +956,7 @@ steps:
         mountPath: /test-gsa-key
     dependsOn:
       - default_ns
-      - hail_run_tests_image
+      - hail_run_image
       - build_hail
   - kind: buildImage2
     name: hail_base_image
@@ -1111,7 +1096,7 @@ steps:
     name: test_hail_python
     numSplits: 7
     image:
-      valueFrom: hail_run_tests_image.image
+      valueFrom: hail_run_image.image
     resources:
       memory: standard
       cpu: '2'
@@ -1156,7 +1141,7 @@ steps:
         mountPath: /test-gsa-key
     dependsOn:
       - default_ns
-      - hail_run_tests_image
+      - hail_run_image
       - build_hail
     clouds:
       - gcp
@@ -1219,7 +1204,7 @@ steps:
   - kind: runImage
     name: test_hail_python_unchecked_allocator
     image:
-      valueFrom: hail_run_tests_image.image
+      valueFrom: hail_run_image.image
     resources:
       memory: standard
       cpu: '2'
@@ -1265,7 +1250,7 @@ steps:
         mountPath: /test-gsa-key
     dependsOn:
       - default_ns
-      - hail_run_tests_image
+      - hail_run_image
       - build_hail
     clouds:
       - gcp
@@ -1273,7 +1258,7 @@ steps:
     name: test_hail_python_local_backend
     numSplits: 7
     image:
-      valueFrom: hail_run_tests_image.image
+      valueFrom: hail_run_image.image
     resources:
       memory: standard
       cpu: '2'
@@ -1322,7 +1307,7 @@ steps:
         mountPath: /test-gsa-key
     dependsOn:
       - default_ns
-      - hail_run_tests_image
+      - hail_run_image
       - build_hail
   - kind: runImage
     name: test_python_docs
@@ -2149,7 +2134,7 @@ steps:
     name: test_hail_python_service_backend
     numSplits: 5
     image:
-      valueFrom: hail_run_tests_image.image
+      valueFrom: hail_run_image.image
     resources:
       cpu: '1'
     script: |
@@ -2211,7 +2196,7 @@ steps:
       - deploy_memory
       - create_deploy_config
       - create_accounts
-      - hail_run_tests_image
+      - hail_run_image
       - upload_query_jar
       - upload_test_resources_to_blob_storage
       - build_hail_jar_and_wheel_only_spark_3_2
@@ -3071,7 +3056,7 @@ steps:
   - kind: runImage
     name: test_hail_services_java
     image:
-      valueFrom: hail_run_tests_image.image
+      valueFrom: hail_run_image.image
     resources:
       memory: standard
       cpu: '2'
@@ -3110,7 +3095,7 @@ steps:
       - default_ns
       - create_certs
       - create_accounts
-      - hail_run_tests_image
+      - hail_run_image
       - build_hail
       - deploy_batch
   - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -525,6 +525,8 @@ steps:
     inputs:
       - from: /repo
         to: /io/repo
+      - from: /hail_version
+        to: /io/repo/hail_version
     dependsOn:
       - base_image
       - merge_code

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -18,6 +18,7 @@ RUN hail-apt-get-install \
     jq \
     openjdk-8-jdk-headless \
     liblapack3 \
+    liblz4-dev \
     g++-10 \
     gcc-10 \
     cmake \

--- a/docker/Dockerfile.service-base
+++ b/docker/Dockerfile.service-base
@@ -13,6 +13,6 @@ RUN hail-pip-install /web_common && rm -rf /web_common
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py
 COPY hail/python/hailtop /hailtop/hailtop/
-COPY /hail_version /hailtop/hailtop/hail_version
 COPY hail/python/MANIFEST.in /hailtop/MANIFEST.in
+COPY /hail_version /hailtop/hailtop/hail_version
 RUN hail-pip-install /hailtop && rm -rf /hailtop

--- a/docker/Dockerfile.service-base
+++ b/docker/Dockerfile.service-base
@@ -13,6 +13,6 @@ RUN hail-pip-install /web_common && rm -rf /web_common
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py
 COPY hail/python/hailtop /hailtop/hailtop/
-COPY hail/python/MANIFEST.in /hailtop/MANIFEST.in
 COPY /hail_version /hailtop/hailtop/hail_version
+COPY hail/python/MANIFEST.in /hailtop/MANIFEST.in
 RUN hail-pip-install /hailtop && rm -rf /hailtop

--- a/hail/Dockerfile.hail-build
+++ b/hail/Dockerfile.hail-build
@@ -1,3 +1,3 @@
 FROM {{ base_image.image }}
 
-RUN hail-apt-get-install liblz4-dev maven
+RUN hail-apt-get-install maven

--- a/hail/Dockerfile.hail-run
+++ b/hail/Dockerfile.hail-run
@@ -17,4 +17,11 @@ ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 ENV PYSPARK_PYTHON python3
 
 RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.2.7.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar
+
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
+
+COPY hail/python/setup-hailtop.py /hailtop/setup.py
+COPY hail/python/hailtop /hailtop/hailtop/
+COPY hail/python/MANIFEST.in /hailtop/MANIFEST.in
+COPY /hail_version /hailtop/hailtop/hail_version
+RUN hail-pip-install /hailtop && rm -rf /hailtop

--- a/hail/Dockerfile.hail-run
+++ b/hail/Dockerfile.hail-run
@@ -1,4 +1,12 @@
-FROM {{ service_base_image.image }}
+FROM {{ base_image.image }}
+
+RUN mkdir -p plink && \
+  cd plink && \
+  curl >plink_linux_x86_64.zip https://storage.googleapis.com/hail-common/plink_linux_x86_64_20181202.zip && \
+  unzip plink_linux_x86_64.zip && \
+  mv plink /usr/local/bin && \
+  cd .. && \
+  rm -rf plink
 
 COPY hail/python/pinned-requirements.txt requirements.txt
 COPY hail/python/dev/pinned-requirements.txt dev-requirements.txt
@@ -10,5 +18,3 @@ ENV PYSPARK_PYTHON python3
 
 RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.2.7.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar
 COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
-
-RUN hail-apt-get-install liblz4-dev

--- a/hail/Dockerfile.hail-run-tests
+++ b/hail/Dockerfile.hail-run-tests
@@ -1,9 +1,0 @@
-FROM {{ hail_run_image.image }}
-
-RUN mkdir -p plink && \
-  cd plink && \
-  curl >plink_linux_x86_64.zip https://storage.googleapis.com/hail-common/plink_linux_x86_64_20181202.zip && \
-  unzip plink_linux_x86_64.zip && \
-  mv plink /usr/local/bin && \
-  cd .. && \
-  rm -rf plink


### PR DESCRIPTION
Wonder what your thoughts are on this. I think that we have too deep an image hierarchy and that it's only stalling our time-to-test in CI. I propose here getting rid of the run-tests image and just putting plink in the hail-run image. I also remove the dependency on service-base and just install hailtop in the hail-run image -- I don't think anything hail/hail should depend on services code. This change actually revealed an accidental dependency where there was a gear (services) test in the hail/python tests. I moved that over to the batch suite as batch is the primary user of that class and we don't have a gear suite atm.

Ultimately, I think we should have a pretty flat docker image hierarchy. Each of our Dockerfiles does a decent job of following the docker mantra of dependencies first, code later. But if you consider the fact that we stack images on top of each other then you can see that in reality that doesn't translate to our images! We instead get an interleaving of hail code and dependencies such that it's very easy to break the cache for images like this one.