### PR TITLE
[batch] Fix JVM file exists error

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2192,6 +2192,8 @@ class JVM:
                 if self.container:
                     await self.container.remove()
 
+                await blocking_to_async(self.pool, shutil.rmtree, f'{self.root_dir}/container', ignore_errors=True)
+
                 container = await self.create_container_and_connect(
                     self.index, self.n_cores, self.socket_file, self.root_dir, self.client_session, self.pool
                 )


### PR DESCRIPTION
Docker jobs were cleaning up after themselves by including the entire directory for that job which removed the old container files. This PR makes it so `Container.remove()` removes the directory for the container.

Before we merge this, I want to check the logs for this PR and make sure there aren't error messages that don't show up in tests.