### PR TITLE
[batch] Kill any remaining jobs on worker shutdown

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1296,7 +1296,6 @@ class Job:
         self.worker = worker
 
         self.deleted_event = asyncio.Event()
-        self.killed = False
 
         self.token = uuid.uuid4().hex
         self.scratch = f'/batch/{self.token}'
@@ -1369,7 +1368,6 @@ class Job:
         self.project_id = Job.get_next_xfsquota_project_id()
 
         self.mjs_fut: Optional[asyncio.Future] = None
-        self.run_job_fut: Optional[asyncio.Future] = None
 
     def write_batch_config(self):
         os.makedirs(f'{self.scratch}/batch-config')
@@ -1402,22 +1400,10 @@ class Job:
         log.info(f'deleting {self}')
         self.deleted_event.set()
 
-    async def kill(self):
-        log.info(f'killing {self}')
-        self.killed = True
-        if self.run_job_fut is not None:
-            self.run_job_fut.cancel()
-            await asyncio.wait([self.run_job_fut])
-            assert self.run_job_fut.done()
-            self.run_job_fut = None
-
     def mark_started(self):
         self.mjs_fut = self.task_manager.ensure_future(self.worker.post_job_started(self))
 
     async def mark_complete(self):
-        if self.killed:
-            return
-
         self.end_time = time_msecs()
 
         full_status = self.status()
@@ -1619,6 +1605,7 @@ class DockerJob(Job):
     async def run(self):
         async with self.worker.cpu_sem(self.cpu_in_mcpu):
             self.start_time = time_msecs()
+
             try:
                 self.mark_started()
 
@@ -2361,36 +2348,31 @@ class Worker:
     async def shutdown(self):
         log.info('Worker.shutdown')
         try:
-            await asyncio.gather(*[job.kill() for job in self.jobs.values()])
-            log.info('killed any remaining jobs')
+            async with AsyncExitStack() as cleanup:
+                for jvm in self._jvms:
+                    cleanup.callback(jvm.kill)
         finally:
             try:
-                async with AsyncExitStack() as cleanup:
-                    for jvm in self._jvms:
-                        cleanup.callback(jvm.kill)
-                log.info('shut down jvms')
+                await self.task_manager.shutdown_and_wait()
+                log.info('shutdown task manager')
             finally:
                 try:
-                    self.task_manager.shutdown()
-                    log.info('shutdown task manager')
+                    if self.file_store:
+                        await self.file_store.close()
+                        log.info('closed file store')
                 finally:
                     try:
-                        if self.file_store:
-                            await self.file_store.close()
-                            log.info('closed file store')
+                        if self.compute_client:
+                            await self.compute_client.close()
+                            log.info('closed compute client')
                     finally:
                         try:
-                            if self.compute_client:
-                                await self.compute_client.close()
-                                log.info('closed compute client')
+                            if self.fs:
+                                await self.fs.close()
+                                log.info('closed worker file system')
                         finally:
-                            try:
-                                if self.fs:
-                                    await self.fs.close()
-                                    log.info('closed worker file system')
-                            finally:
-                                await self.client_session.close()
-                                log.info('closed client session')
+                            await self.client_session.close()
+                            log.info('closed client session')
 
     async def run_job(self, job):
         try:
@@ -2458,7 +2440,7 @@ class Worker:
 
         self.jobs[job.id] = job
 
-        job.run_job_fut = self.task_manager.ensure_future(self.run_job(job))
+        self.task_manager.ensure_future(self.run_job(job))
 
         return web.Response()
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1701,7 +1701,9 @@ class DockerJob(Job):
                     try:
                         await self.cleanup()
                     finally:
-                        await self.mark_complete()
+                        _, exc, _ = sys.exc_info()
+                        if not isinstance(exc, asyncio.CancelledError):
+                            await self.mark_complete()
 
     async def cleanup(self):
         if self.disk:
@@ -1893,7 +1895,9 @@ class JVMJob(Job):
             else:
                 await self.cleanup()
             finally:
-                await self.mark_complete()
+                _, exc, _ = sys.exc_info()
+                if not isinstance(exc, asyncio.CancelledError):
+                    await self.mark_complete()
 
     async def cleanup(self):
         if self.jvm is not None:

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -3,7 +3,7 @@ from .fs import (FileStatus, FileListEntry, AsyncFS, Transfer, MultiPartCreate,
                  WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async)
 from .local_fs import LocalAsyncFS
 from .utils import FeedableAsyncIterable, WriteBuffer
-from .tasks import BackgroundTaskManager
+from .tasks import BackgroundTaskManager, TaskManagerClosedError
 from .weighted_semaphore import WeightedSemaphore
 
 __all__ = [
@@ -17,6 +17,7 @@ __all__ = [
     'LocalAsyncFS',
     'FeedableAsyncIterable',
     'BackgroundTaskManager',
+    'TaskManagerClosedError',
     'Transfer',
     'FileAndDirectoryError',
     'MultiPartCreate',

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -7,6 +7,10 @@ import weakref
 log = logging.getLogger('aiotools.tasks')
 
 
+class TaskManagerClosedError(Exception):
+    pass
+
+
 class BackgroundTaskManager:
     def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None):
         if loop is None:
@@ -15,15 +19,22 @@ class BackgroundTaskManager:
         self.tasks: weakref.WeakSet = weakref.WeakSet()
         self.loop = loop
 
+        self._closed = False
+
     def ensure_future(self, coroutine) -> asyncio.Future:
+        if self._closed:
+            raise TaskManagerClosedError
         t = asyncio.ensure_future(coroutine)
         self.tasks.add(t)
         return t
 
     def ensure_future_threadsafe(self, coroutine):
+        if self._closed:
+            raise TaskManagerClosedError
         self.tasks.add(asyncio.run_coroutine_threadsafe(coroutine, self.loop))
 
     def shutdown(self):
+        self._closed = True
         for task in self.tasks:
             try:
                 task.cancel()

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -29,3 +29,7 @@ class BackgroundTaskManager:
                 task.cancel()
             except Exception:
                 log.warning(f'encountered an exception while cancelling background task: {task}', exc_info=True)
+
+    async def shutdown_and_wait(self):
+        self.shutdown()
+        await asyncio.wait(self.tasks, return_when=asyncio.ALL_COMPLETED)


### PR DESCRIPTION
This should fix the issue where we were trying to use a nonexistent GoogleAsyncFS when a worker is killed in the UI. I tested this in my namespace.