### PR TITLE
[query] improved index search algorithm

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -743,8 +743,9 @@ class EmitClassBuilder[C](
   def getOrGenEmitMethod(
     baseName: String, key: Any, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType
   )(body: EmitMethodBuilder[C] => Unit): EmitMethodBuilder[C] = {
-    methodMemo.getOrElseUpdate(key, {
+    methodMemo.getOrElse(key, {
       val mb = genEmitMethod(baseName, argsInfo, returnInfo)
+      methodMemo(key) = mb
       body(mb)
       mb
     })

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -836,7 +836,7 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
             cb.ifx(currPartitionIdx ceq lastIncludedPartitionIdx, {
               cb.ifx(currPartitionIdx ceq startPartitionIndex, {
                 // query the full interval
-                val indexResult = index.queryInterval(cb, region, ctx)
+                val indexResult = index.queryInterval(cb, ctx)
                 val startIdx = indexResult.loadField(cb, 0)
                   .get(cb)
                   .asInt64
@@ -861,26 +861,24 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
               }, {
                 // read from start of partition to the end interval
 
-                val idx = index.queryBound(cb, region, ctx.loadEnd(cb).get(cb).asBaseStruct, primitive(ctx.includesEnd()))
+                val indexResult = index.queryBound(cb, ctx.loadEnd(cb).get(cb).asBaseStruct, ctx.includesEnd())
+                val startIdx = indexResult.loadField(cb, 0).get(cb).asInt64.value
                 cb.assign(currIdxInPartition, 0L)
-                cb.assign(stopIdxInPartition, idx)
+                cb.assign(stopIdxInPartition, startIdx)
                 // no need to seek, starting at beginning of partition
               })
             }, {
               cb.ifx(currPartitionIdx ceq startPartitionIndex,
                 {
                   // read from left endpoint until end of partition
-                  val idx = index.queryBound(cb, region, ctx.loadStart(cb).get(cb).asBaseStruct, primitive(cb.memoize(!ctx.includesStart())))
-                  val queryResult = index.queryIndex(cb, elementRegion, idx)
+                  val indexResult = index.queryBound(cb, ctx.loadStart(cb).get(cb).asBaseStruct, cb.memoize(!ctx.includesStart()))
+                  val startIdx = indexResult.loadField(cb, 0).get(cb).asInt64.value
 
-                  cb.assign(currIdxInPartition, idx)
+                  cb.assign(currIdxInPartition, startIdx)
                   cb.assign(stopIdxInPartition, index.nKeys(cb))
                   cb.ifx(currIdxInPartition < stopIdxInPartition, {
-                    val firstOffset = queryResult.asBaseStruct
-                      .loadField(cb, "offset")
-                      .get(cb)
-                      .asInt64
-                      .value
+                    val firstOffset = indexResult.loadField(cb, 1).get(cb).asBaseStruct
+                      .loadField(cb, "offset").get(cb).asInt64.value
 
                     cb += ib.seek(firstOffset)
                   })
@@ -992,7 +990,7 @@ case class PartitionNativeReaderIndexed(
             .asInterval
           index.initialize(cb, indexPath)
 
-          val indexResult = index.queryInterval(cb, outerRegion, interval)
+          val indexResult = index.queryInterval(cb, interval)
           val startIndex = indexResult.loadField(cb, 0)
             .get(cb)
             .asInt64
@@ -1250,7 +1248,7 @@ case class PartitionZippedIndexedNativeReader(specLeft: AbstractTypedCodecSpec, 
             .asInterval
           index.initialize(cb, indexPath)
 
-          val indexResult = index.queryInterval(cb, outerRegion, interval)
+          val indexResult = index.queryInterval(cb, interval)
           val startIndex = indexResult.loadField(cb, 0)
             .get(cb)
             .asInt64

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -788,9 +788,9 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
 
           val startBound = ctx.loadStart(cb).get(cb)
-          val includesStart = ctx.includesStart()
+          val includesStart = ctx.includesStart
           val endBound = ctx.loadEnd(cb).get(cb)
-          val includesEnd = ctx.includesEnd()
+          val includesEnd = ctx.includesEnd
 
           val (startPart, endPart) = IntervalFunctions.partitionerFindIntervalRange(cb,
             partitionerRuntime,
@@ -861,7 +861,7 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
               }, {
                 // read from start of partition to the end interval
 
-                val indexResult = index.queryBound(cb, ctx.loadEnd(cb).get(cb).asBaseStruct, ctx.includesEnd())
+                val indexResult = index.queryBound(cb, ctx.loadEnd(cb).get(cb).asBaseStruct, ctx.includesEnd)
                 val startIdx = indexResult.loadField(cb, 0).get(cb).asInt64.value
                 cb.assign(currIdxInPartition, 0L)
                 cb.assign(stopIdxInPartition, startIdx)
@@ -871,7 +871,7 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
               cb.ifx(currPartitionIdx ceq startPartitionIndex,
                 {
                   // read from left endpoint until end of partition
-                  val indexResult = index.queryBound(cb, ctx.loadStart(cb).get(cb).asBaseStruct, cb.memoize(!ctx.includesStart()))
+                  val indexResult = index.queryBound(cb, ctx.loadStart(cb).get(cb).asBaseStruct, cb.memoize(!ctx.includesStart))
                   val startIdx = indexResult.loadField(cb, 0).get(cb).asInt64.value
 
                   cb.assign(currIdxInPartition, startIdx)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -44,11 +44,11 @@ object IntervalFunctions extends RegistryFunctions {
 
   def pointIntervalCompare(cb: EmitCodeBuilder, point: SValue, interval: SIntervalValue): IEmitCode = {
     interval.loadStart(cb).flatMap(cb) { start =>
-      cb.ifx(pointLTIntervalEndpoint(cb, point, start, !interval.includesStart()), {
+      cb.ifx(pointLTIntervalEndpoint(cb, point, start, !interval.includesStart), {
         IEmitCode.present(cb, primitive(const(-1)))
       }, {
         interval.loadEnd(cb).map(cb) { end =>
-          cb.ifx(pointLTIntervalEndpoint(cb, point, end, interval.includesEnd()), {
+          cb.ifx(pointLTIntervalEndpoint(cb, point, end, interval.includesEnd), {
             primitive(const(0))
           }, {
             primitive(const(1))
@@ -60,11 +60,11 @@ object IntervalFunctions extends RegistryFunctions {
 
   def intervalPointCompare(cb: EmitCodeBuilder, interval: SIntervalValue, point: SValue): IEmitCode = {
     interval.loadStart(cb).flatMap(cb) { start =>
-      cb.ifx(pointLTIntervalEndpoint(cb, point, start, !interval.includesStart()), {
+      cb.ifx(pointLTIntervalEndpoint(cb, point, start, !interval.includesStart), {
         IEmitCode.present(cb, primitive(const(1)))
       }, {
         interval.loadEnd(cb).map(cb) { end =>
-          cb.ifx(pointLTIntervalEndpoint(cb, point, end, interval.includesEnd()), {
+          cb.ifx(pointLTIntervalEndpoint(cb, point, end, interval.includesEnd), {
             primitive(const(0))
           }, {
             primitive(const(-1))
@@ -76,9 +76,9 @@ object IntervalFunctions extends RegistryFunctions {
 
   def intervalContains(cb: EmitCodeBuilder, interval: SIntervalValue, point: SValue): IEmitCode = {
     interval.loadStart(cb).flatMap(cb) { start =>
-      cb.ifx(pointGTIntervalEndpoint(cb, point, start, !interval.includesStart()),
+      cb.ifx(pointGTIntervalEndpoint(cb, point, start, !interval.includesStart),
         interval.loadEnd(cb).map(cb) { end =>
-          primitive(cb.memoize(pointLTIntervalEndpoint(cb, point, end, interval.includesEnd())))
+          primitive(cb.memoize(pointLTIntervalEndpoint(cb, point, end, interval.includesEnd)))
         },
         IEmitCode.present(cb, primitive(false)))
     }
@@ -88,11 +88,11 @@ object IntervalFunctions extends RegistryFunctions {
     IEmitCode.multiFlatMap(cb,
       FastIndexedSeq(lhs.loadEnd, rhs.loadStart)
     ) { case Seq(lEnd, rStart) =>
-      cb.ifx(intervalEndpointCompare(cb, lEnd, lhs.includesEnd(), rStart, !rhs.includesStart()) > 0, {
+      cb.ifx(intervalEndpointCompare(cb, lEnd, lhs.includesEnd, rStart, !rhs.includesStart) > 0, {
         IEmitCode.multiMap(cb,
           FastIndexedSeq(lhs.loadStart, rhs.loadEnd)
         ) { case Seq(lStart, rEnd) =>
-          primitive(cb.memoize(intervalEndpointCompare(cb, rEnd, rhs.includesEnd(), lStart, !lhs.includesStart()) > 0))
+          primitive(cb.memoize(intervalEndpointCompare(cb, rEnd, rhs.includesEnd, lStart, !lhs.includesStart) > 0))
         }
       }, {
         IEmitCode.present(cb, primitive(const(false)))
@@ -163,13 +163,13 @@ object IntervalFunctions extends RegistryFunctions {
     val start = interval.loadStart(cb)
       .get(cb, "partition intervals cannot have missing endpoints")
       .asBaseStruct
-    cb.ifx(compareStructWithPartitionIntervalEndpoint(cb, point, start, !interval.includesStart()) < 0, {
+    cb.ifx(compareStructWithPartitionIntervalEndpoint(cb, point, start, !interval.includesStart) < 0, {
       primitive(const(-1))
     }, {
       val end = interval.loadEnd(cb)
         .get(cb, "partition intervals cannot have missing endpoints")
         .asBaseStruct
-      cb.ifx(compareStructWithPartitionIntervalEndpoint(cb, point, end, interval.includesEnd()) < 0, {
+      cb.ifx(compareStructWithPartitionIntervalEndpoint(cb, point, end, interval.includesEnd) < 0, {
         primitive(const(0))
       }, {
         primitive(const(1))
@@ -193,8 +193,8 @@ object IntervalFunctions extends RegistryFunctions {
         .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
         .asBaseStruct
       val c = partitionIntervalEndpointCompare(cb,
-        intervalEnd, cb.memoize((intervalVal.includesEnd().toI << 1) - 1),
-        needleStart, cb.memoize(const(1) - (query.includesStart().toI << 1)))
+        intervalEnd, cb.memoize((intervalVal.includesEnd.toI << 1) - 1),
+        needleStart, cb.memoize(const(1) - (query.includesStart.toI << 1)))
       c <= 0
     }
 
@@ -206,8 +206,8 @@ object IntervalFunctions extends RegistryFunctions {
         .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
         .asBaseStruct
       val c = partitionIntervalEndpointCompare(cb,
-        intervalStart, cb.memoize(const(1) - (intervalVal.includesStart().toI << 1)),
-        needleEnd, cb.memoize((query.includesEnd().toI << 1) - 1))
+        intervalStart, cb.memoize(const(1) - (intervalVal.includesStart.toI << 1)),
+        needleEnd, cb.memoize((query.includesEnd.toI << 1) - 1))
       c >= 0
     }
 
@@ -278,13 +278,13 @@ object IntervalFunctions extends RegistryFunctions {
     registerSCode1("includesStart", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
       SBoolean
     ) {
-      case (r, cb, rt, interval: SIntervalValue, _) => primitive(interval.includesStart())
+      case (r, cb, rt, interval: SIntervalValue, _) => primitive(interval.includesStart)
     }
 
     registerSCode1("includesEnd", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
       SBoolean
     ) {
-      case (r, cb, rt, interval: SIntervalValue, _) => primitive(interval.includesEnd())
+      case (r, cb, rt, interval: SIntervalValue, _) => primitive(interval.includesEnd)
     }
 
     registerIEmitCode2("contains", TInterval(tv("T")), tv("T"), TBoolean, {
@@ -348,7 +348,7 @@ object IntervalFunctions extends RegistryFunctions {
           .asBaseStruct
         val c = compareStructWithPartitionIntervalEndpoint(cb,
           point,
-          intervalEnd, intervalVal.includesEnd())
+          intervalEnd, intervalVal.includesEnd)
         c > 0
       }
       def gtNeedle(interval: IEmitCode): Code[Boolean] = {
@@ -360,7 +360,7 @@ object IntervalFunctions extends RegistryFunctions {
           .asBaseStruct
         val c = compareStructWithPartitionIntervalEndpoint(cb,
           point,
-          intervalStart, !intervalVal.includesStart())
+          intervalStart, !intervalVal.includesStart)
         c < 0
       }
       primitive(BinarySearch.containsOrdered(cb, intervals, ltNeedle, gtNeedle))
@@ -400,7 +400,7 @@ object IntervalFunctions extends RegistryFunctions {
       case (_, cb, _, interval: SIntervalValue, point: SBaseStructValue, _) =>
         val leftTuple = interval.loadStart(cb).get(cb).asBaseStruct
 
-        val includesLeft = interval.includesStart()
+        val includesLeft = interval.includesStart
         val pointGTLeft = compareStructWithPartitionIntervalEndpoint(cb, point, leftTuple, !includesLeft) > 0
 
         val isContained = cb.newLocal[Boolean]("partitionInterval_b", pointGTLeft)
@@ -409,7 +409,7 @@ object IntervalFunctions extends RegistryFunctions {
           // check right endpoint
           val rightTuple = interval.loadEnd(cb).get(cb).asBaseStruct
 
-          val includesRight = interval.includesEnd()
+          val includesRight = interval.includesEnd
           val pointLTRight = compareStructWithPartitionIntervalEndpoint(cb, point, rightTuple, includesRight) < 0
           cb.assign(isContained, pointLTRight)
         })

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/IntervalOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/IntervalOrdering.scala
@@ -22,15 +22,15 @@ object IntervalOrdering {
       val rstart = cb.memoize(rhs.loadStart(cb))
       cb.assign(cmp, pointCompare(cb, lstart, rstart))
       cb.ifx(cmp.ceq(0), {
-        cb.ifx(lhs.includesStart().cne(rhs.includesStart()), {
-          cb.assign(cmp, lhs.includesStart().mux(-1, 1))
+        cb.ifx(lhs.includesStart.cne(rhs.includesStart), {
+          cb.assign(cmp, lhs.includesStart.mux(-1, 1))
         }, {
           val lend = cb.memoize(lhs.loadEnd(cb))
           val rend = cb.memoize(rhs.loadEnd(cb))
           cb.assign(cmp, pointCompare(cb, lend, rend))
           cb.ifx(cmp.ceq(0), {
-            cb.ifx(lhs.includesEnd().cne(rhs.includesEnd()), {
-              cb.assign(cmp, lhs.includesEnd().mux(1, -1))
+            cb.ifx(lhs.includesEnd.cne(rhs.includesEnd), {
+              cb.assign(cmp, lhs.includesEnd.mux(1, -1))
             })
           })
         })
@@ -52,8 +52,8 @@ object IntervalOrdering {
       val lhs = x.asInterval
       val rhs = y.asInterval
 
-      cb.ifx(lhs.includesStart().cne(rhs.includesStart()) ||
-        lhs.includesEnd().cne(rhs.includesEnd()), {
+      cb.ifx(lhs.includesStart.cne(rhs.includesStart) ||
+        lhs.includesEnd.cne(rhs.includesEnd), {
         exitWith(false)
       })
 
@@ -87,14 +87,14 @@ object IntervalOrdering {
 
       cb.ifx(pointLt(cb, lstart, rstart), exitWith(true))
       cb.ifx(!pointEq(cb, lstart, rstart), exitWith(false))
-      cb.ifx(lhs.includesStart() && !rhs.includesStart(), exitWith(true))
-      cb.ifx(lhs.includesStart().cne(rhs.includesStart()), exitWith(false))
+      cb.ifx(lhs.includesStart && !rhs.includesStart, exitWith(true))
+      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
 
       cb.ifx(pointLt(cb, lend, rend), exitWith(true))
-      cb.assign(ret, pointEq(cb, lend, rend) && !lhs.includesEnd() && rhs.includesEnd())
+      cb.assign(ret, pointEq(cb, lend, rend) && !lhs.includesEnd && rhs.includesEnd)
 
       cb.define(Lout)
       ret
@@ -118,13 +118,13 @@ object IntervalOrdering {
 
       cb.ifx(!pointLtEq(cb, lstart, rstart), exitWith(false))
       cb.ifx(!pointEq(cb, lstart, rstart), exitWith(true))
-      cb.ifx(lhs.includesStart() && !rhs.includesStart(), exitWith(true))
-      cb.ifx(lhs.includesStart().cne(rhs.includesStart()), exitWith(false))
+      cb.ifx(lhs.includesStart && !rhs.includesStart, exitWith(true))
+      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
       cb.ifx(!pointLtEq(cb, lend, rend), exitWith(false))
-      cb.assign(ret, !pointEq(cb, lend, rend) || !lhs.includesEnd() || rhs.includesEnd())
+      cb.assign(ret, !pointEq(cb, lend, rend) || !lhs.includesEnd || rhs.includesEnd)
 
       cb.define(Lout)
       ret
@@ -148,14 +148,14 @@ object IntervalOrdering {
 
       cb.ifx(pointGt(cb, lstart, rstart), exitWith(true))
       cb.ifx(!pointEq(cb, lstart, rstart), exitWith(false))
-      cb.ifx(!lhs.includesStart() && rhs.includesStart(), exitWith(true))
-      cb.ifx(lhs.includesStart().cne(rhs.includesStart()), exitWith(false))
+      cb.ifx(!lhs.includesStart && rhs.includesStart, exitWith(true))
+      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
 
       cb.ifx(pointGt(cb, lend, rend), exitWith(true))
-      cb.assign(ret, pointEq(cb, lend, rend) && lhs.includesEnd() && !rhs.includesEnd())
+      cb.assign(ret, pointEq(cb, lend, rend) && lhs.includesEnd && !rhs.includesEnd)
 
       cb.define(Lout)
       ret
@@ -179,13 +179,13 @@ object IntervalOrdering {
 
       cb.ifx(!pointGtEq(cb, lstart, rstart), exitWith(false))
       cb.ifx(!pointEq(cb, lstart, rstart), exitWith(true))
-      cb.ifx(!lhs.includesStart() && rhs.includesStart(), exitWith(true))
-      cb.ifx(lhs.includesStart().cne(rhs.includesStart()), exitWith(false))
+      cb.ifx(!lhs.includesStart && rhs.includesStart, exitWith(true))
+      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
       cb.ifx(!pointGtEq(cb, lend, rend), exitWith(false))
-      cb.assign(ret, !pointEq(cb, lend, rend) || lhs.includesEnd() || !rhs.includesEnd())
+      cb.assign(ret, !pointEq(cb, lend, rend) || lhs.includesEnd || !rhs.includesEnd)
 
       cb.define(Lout)
       ret

--- a/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
@@ -2,13 +2,13 @@ package is.hail.io.index
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.functions.IntervalFunctions.compareStructWithPartitionIntervalEndpoint
-import is.hail.expr.ir.{BinarySearch, EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitSettable, IEmitCode}
+import is.hail.expr.ir.functions.IntervalFunctions.{arrayOfStructFindIntervalRange, compareStructWithPartitionIntervalEndpoint, partitionIntervalEndpointCompare}
+import is.hail.expr.ir.{BinarySearch, EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitSettable, EmitValue, IEmitCode}
 import is.hail.io.fs.FS
 import is.hail.rvd.AbstractIndexSpec
-import is.hail.types.physical.stypes.EmitType
-import is.hail.types.physical.stypes.concrete.SStackStruct
-import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SIntervalValue, primitive}
+import is.hail.types.physical.stypes.{EmitType, SSettable, SValue}
+import is.hail.types.physical.stypes.concrete.{SStackStruct, SStackStructSettable, SStackStructValue}
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructSettable, SBaseStructValue, SIndexableValue, SIntervalValue, primitive}
 import is.hail.types.physical.stypes.primitives.{SBooleanValue, SInt64}
 import is.hail.types.physical.{PCanonicalArray, PCanonicalBaseStruct}
 import is.hail.types.virtual.{TBoolean, TInt64, TTuple}
@@ -26,17 +26,22 @@ case class VariableMetadata(
 
 
 class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
+  private[this] val leafPType = spec.leafCodec.encodedType.decodedPType(spec.leafCodec.encodedVirtualType)
+  private[this] val leafChildType = leafPType.asInstanceOf[PCanonicalBaseStruct].types(1).asInstanceOf[PCanonicalArray].elementType.sType.asInstanceOf[SBaseStruct]
+  private[this] val leafChildLocalType = SStackStruct(leafChildType.virtualType, leafChildType.fieldEmitTypes)
+  private[this] val internalPType = spec.internalNodeCodec.encodedType.decodedPType(spec.internalNodeCodec.encodedVirtualType)
+  private[this] val leafDec = spec.leafCodec.encodedType.buildDecoder(spec.leafCodec.encodedVirtualType, emb.ecb)
+  private[this] val internalDec = spec.internalNodeCodec.encodedType.buildDecoder(spec.internalNodeCodec.encodedVirtualType, emb.ecb)
+
   private[this] val cache: Settable[LongToRegionValueCache] = emb.genFieldThisRef[LongToRegionValueCache]("index_cache")
   private[this] val metadata: Settable[VariableMetadata] = emb.genFieldThisRef[VariableMetadata]("index_file_metadata")
 
   private[this] val is: Settable[ByteTrackingInputStream] = emb.genFieldThisRef[ByteTrackingInputStream]("index_is")
 
-  private[this] val leafPType = spec.leafCodec.encodedType.decodedPType(spec.leafCodec.encodedVirtualType)
-  private[this] val internalPType = spec.internalNodeCodec.encodedType.decodedPType(spec.internalNodeCodec.encodedVirtualType)
-  private[this] val leafDec = spec.leafCodec.encodedType.buildDecoder(spec.leafCodec.encodedVirtualType, emb.ecb)
-  private[this]val internalDec = spec.internalNodeCodec.encodedType.buildDecoder(spec.internalNodeCodec.encodedVirtualType, emb.ecb)
+  private[this] val queryResultStartIndex: Settable[Long] = emb.genFieldThisRef[Long]("index_resultIndex")
+  private[this] val queryResultStartLeaf: SSettable = emb.newPField("index_resultOffset", leafChildLocalType)
 
-  private[this] val leafChildType = leafPType.asInstanceOf[PCanonicalBaseStruct].types(1).asInstanceOf[PCanonicalArray].elementType.sType
+  def nKeys(cb: EmitCodeBuilder): Value[Long] = cb.memoize(metadata.invoke[Long]("nKeys"))
 
   def initialize(cb: EmitCodeBuilder,
     indexPath: Value[String]
@@ -60,33 +65,279 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
     cb.assign(metadata, Code._null)
   }
 
-  def nKeys(cb: EmitCodeBuilder): Value[Long] = cb.memoize(metadata.invoke[Long]("nKeys"))
+  def queryBound(cb: EmitCodeBuilder,
+    endpoint: SBaseStructValue,
+    leansRight: Value[Boolean]
+  ): SBaseStructValue = {
+    val rootLevel = cb.memoize(metadata.invoke[Int]("height") - 1)
+    val rootOffset = cb.memoize(metadata.invoke[Long]("rootOffset"))
+    val nKeys = this.nKeys(cb)
+
+    val index = cb.newLocal[Long]("queryInterval_startIdx")
+    val leaf = cb.newSLocal(leafChildLocalType, "queryInterval_startOffset")
+
+    val LReturn = CodeLabel()
+
+    // handle the cases where the query is less than all keys (including the
+    // empty index case), to establish the precondition of runQuery, and as a
+    // fast path for a common case
+    cb.ifx(nKeys.ceq(0), {
+      cb.assign(index, 0L)
+      cb.goto(LReturn)
+    })
+
+    val rootChildren = readInternalNode(cb, rootOffset).loadField(cb, "children").get(cb).asIndexable
+    val firstChild = rootChildren.loadElement(cb, 0).get(cb).asBaseStruct
+    val firstKey = firstChild.loadField(cb, "first_key").get(cb).asBaseStruct
+    val compEndpointWithFirstKey =
+      compareStructWithPartitionIntervalEndpoint(cb, firstKey, endpoint, leansRight)
+    cb.ifx(compEndpointWithFirstKey > 0, {
+      cb.assign(index, firstChild.loadField(cb, "first_idx").get(cb).asLong.value)
+      cb.assign(leaf, getFirstLeaf(cb, firstChild))
+      cb.goto(LReturn)
+    })
+
+    queryBound(cb, endpoint, leansRight, rootLevel, rootOffset, nKeys, leaf)
+    cb.assign(index, queryResultStartIndex)
+    cb.assign(leaf, queryResultStartLeaf)
+
+    cb.define(LReturn)
+
+    SStackStruct.constructFromArgs(cb, null, TTuple(TInt64, leafChildType.virtualType),
+      EmitCode.present(cb.emb, primitive(index)),
+      EmitCode.fromI(cb.emb)(cb => IEmitCode(cb, index ceq nKeys, leaf)))
+  }
 
   /**
    * returns tuple of (start index, end index, starting leaf)
    * memory of starting leaf is not owned by `region`, consumers should deep copy if necessary
    * starting leaf IS MISSING if (end_idx - start_idx == 0)
    */
-  def queryInterval(cb: EmitCodeBuilder,
-    region: Value[Region],
-    interval: SIntervalValue): SBaseStructValue = {
-
-    val start = interval.loadStart(cb).get(cb).asBaseStruct
-    val end = interval.loadEnd(cb).get(cb).asBaseStruct
-    val includesStart = interval.includesStart()
-    val includesEnd = interval.includesEnd()
-
-    val startIdx = queryBound(cb, region, start, primitive(cb.memoize(!includesStart)))
-    val endIdx = queryBound(cb, region, end, primitive(includesEnd))
-    val n = cb.memoize(endIdx - startIdx)
+  def queryInterval(cb: EmitCodeBuilder, interval: SIntervalValue): SBaseStructValue = {
+    val rootLevel = cb.memoize(metadata.invoke[Int]("height") - 1)
+    val rootOffset = cb.memoize(metadata.invoke[Long]("rootOffset"))
     val nKeys = this.nKeys(cb)
+
+    val startIdx = cb.newLocal[Long]("queryInterval_startIdx")
+    val startLeaf = cb.newSLocal(leafChildLocalType, "queryInterval_startOffset")
+    val endIdx = cb.newLocal[Long]("queryInterval_endIdx")
+
+    val startKey = interval.loadStart(cb).get(cb).asBaseStruct
+    val startLeansRight = cb.memoize(!interval.includesStart())
+    val endKey = interval.loadEnd(cb).get(cb).asBaseStruct
+    val endLeansRight = interval.includesEnd()
+
+    val LReturn = CodeLabel()
+
+    // handle the cases where the query is less than all keys (including the
+    // empty index case), to establish the precondition of runQuery, and as a
+    // fast path for a common case
+    cb.ifx(nKeys.ceq(0), {
+      cb.assign(startIdx, 0L)
+      cb.assign(endIdx, 0L)
+      cb.goto(LReturn)
+    })
+
+    val rootChildren = readInternalNode(cb, rootOffset).loadField(cb, "children").get(cb).asIndexable
+    val firstChild = rootChildren.loadElement(cb, 0).get(cb).asBaseStruct
+    val firstKey = firstChild.loadField(cb, "first_key").get(cb).asBaseStruct
+    val compStartWithFirstKey =
+      compareStructWithPartitionIntervalEndpoint(cb, firstKey, startKey, startLeansRight)
+    cb.ifx(compStartWithFirstKey > 0, {
+      cb.assign(startIdx, firstChild.loadField(cb, "first_idx").get(cb).asLong.value)
+      cb.assign(startLeaf, getFirstLeaf(cb, firstChild))
+
+      val compEndWithFirstKey =
+        compareStructWithPartitionIntervalEndpoint(cb, firstKey, endKey, endLeansRight)
+      cb.ifx(compEndWithFirstKey > 0, {
+        cb.assign(endIdx, startIdx)
+      }, {
+        queryBound(cb, endKey, endLeansRight, rootLevel, rootOffset, nKeys, startLeaf)
+        cb.assign(endIdx, queryResultStartIndex)
+      })
+      cb.goto(LReturn)
+    })
+
+    val (_startIdx, _startLeaf, _endIdx) = runQuery(cb,
+      startKey, startLeansRight, endKey, endLeansRight,
+      rootLevel, rootOffset, nKeys, startLeaf, isPointQuery = false)
+    cb.assign(startIdx, _startIdx)
+    cb.assign(startLeaf, _startLeaf)
+    cb.assign(endIdx, _endIdx)
+
+    cb.define(LReturn)
+
+    val n = cb.memoize(endIdx - startIdx)
     cb.ifx(n < 0L, cb._fatal("n less than 0: ", n.toS, ", startIdx=", startIdx.toS, ", endIdx=", endIdx.toS, ", query=", cb.strValue(interval)))
     cb.ifx(n > 0L && startIdx >= nKeys, cb._fatal("bad start idx: ", startIdx.toS, ", nKeys=", nKeys.toS))
 
-    SStackStruct.constructFromArgs(cb, region, TTuple(TInt64, TInt64, leafChildType.virtualType),
+    SStackStruct.constructFromArgs(cb, null, TTuple(TInt64, TInt64, leafChildType.virtualType),
       EmitCode.present(cb.emb, primitive(startIdx)),
       EmitCode.present(cb.emb, primitive(endIdx)),
-      EmitCode.fromI(cb.emb)(cb => IEmitCode(cb, n ceq 0L, queryIndex(cb, region, startIdx))))
+      EmitCode.fromI(cb.emb)(cb => IEmitCode(cb, n ceq 0L, startLeaf)))
+  }
+
+  private[this] def queryBound(cb: EmitCodeBuilder,
+    endpoint: SBaseStructValue,
+    leansRight: Value[Boolean],
+    rootLevel: Value[Int],
+    rootOffset: Value[Long],
+    rootSuccessorIndex: Value[Long],
+    rootSuccessorLeaf: SValue
+  ): Unit = {
+    cb.invokeVoid(
+      cb.emb.ecb.getOrGenEmitMethod("queryBound",
+        ("queryBound", this),
+        FastIndexedSeq(endpoint.st.paramType, typeInfo[Boolean], typeInfo[Int], typeInfo[Long], typeInfo[Long], leafChildLocalType.paramType),
+        UnitInfo) { emb =>
+        emb.emitWithBuilder { cb =>
+          val endpoint = emb.getSCodeParam(1).asBaseStruct
+          val leansRight = emb.getCodeParam[Boolean](2)
+          val rootLevel = emb.getCodeParam[Int](3)
+          val rootOffset = emb.getCodeParam[Long](4)
+          val rootSuccessorIndex = emb.getCodeParam[Long](5)
+          val rootSuccessorLeaf = emb.getSCodeParam(6)
+          val (startIndex, startLeaf, _) = runQuery(cb, endpoint, leansRight, endpoint, leansRight, rootLevel, rootOffset, rootSuccessorIndex, rootSuccessorLeaf, isPointQuery = true)
+          cb.assign(queryResultStartIndex, startIndex)
+          cb.assign(queryResultStartLeaf, startLeaf)
+          Code._empty
+        }
+      }, endpoint, leansRight, rootLevel, rootOffset, rootSuccessorIndex, rootSuccessorLeaf)
+  }
+
+  // Supports both point and interval queries. If `isPointQuery`, end key
+  // is ignored.
+  // `rootSuccessorIndex` and `rootSuccessorLeaf` must contain the data of the
+  // first record following the subtree rooted at `rootOffset`.
+  // If this is the root of the index, so there is no following record,
+  // `rootSuccessorIndex` must be `nKeys`, and `rootSuccessorLeaf` can be anything,
+  // as it will never be accessed.
+  private[this] def runQuery(cb: EmitCodeBuilder,
+    startKey: SBaseStructValue,
+    startLeansRight: Value[Boolean],
+    endKey: SBaseStructValue,
+    endLeansRight: Value[Boolean],
+    rootLevel: Value[Int],
+    rootOffset: Value[Long],
+    rootSuccessorIndex: Value[Long],
+    rootSuccessorLeaf: SValue,
+    isPointQuery: Boolean
+  ): (Value[Long], SStackStructValue, Value[Long]) = {
+
+    def searchChildren(children: SIndexableValue, isInternalNode: Boolean): (Value[Int], Value[Int]) = {
+      val keyFieldName = if (isInternalNode) "first_key" else "key"
+      if (isPointQuery) {
+        def ltNeedle(child: IEmitCode): Code[Boolean] = {
+          val key = child.get(cb).asBaseStruct.loadField(cb, keyFieldName).get(cb).asBaseStruct
+          val c = compareStructWithPartitionIntervalEndpoint(cb, key, startKey, startLeansRight)
+          c < 0
+        }
+        val idx = BinarySearch.lowerBound(cb, children, ltNeedle)
+        (idx, idx)
+      } else {
+        arrayOfStructFindIntervalRange(cb, children, startKey, startLeansRight, endKey, endLeansRight,
+          _.get(cb).asBaseStruct.loadField(cb, keyFieldName))
+      }
+    }
+
+    val startIndex: Settable[Long] = cb.newLocal[Long]("startIndex")
+    val startLeaf: SStackStructSettable = cb.newSLocal(leafChildLocalType, "startOffset").asInstanceOf[SStackStructSettable]
+    val endIndex: Settable[Long] = cb.newLocal[Long]("endIndex")
+
+    val successorIndex: Settable[Long] = cb.newLocal[Long]("queryInterval_successorIndex", rootSuccessorIndex)
+    val successorLeaf: SStackStructSettable = cb.newSLocal(leafChildLocalType, "successorLeaf").asInstanceOf[SStackStructSettable]
+    cb.assign(successorLeaf, rootSuccessorLeaf)
+
+    val level = cb.newLocal[Int]("queryInterval_level", rootLevel)
+    val nodeOffset = cb.newLocal[Long]("queryInterval_nodeOffset", rootOffset)
+
+    // loop invariants:
+    // * `successorIndex` and `successorOffset` always point to the first record
+    // to the right of the current subtree.
+    // * `startKey` is always greater than the first key of the current subtree
+    val Lstart = CodeLabel()
+    cb.define(Lstart)
+
+    def updateSuccessor(children: SIndexableValue, idx: Value[Int]): Unit = {
+      cb.ifx(idx < children.loadLength(), {
+        val successorChild = children.loadElement(cb, idx).get(cb).asBaseStruct
+        cb.assign(successorIndex, successorChild.loadField(cb, "first_idx").get(cb).asLong.value)
+        cb.assign(successorLeaf, getFirstLeaf(cb, successorChild))
+      })
+    }
+
+    cb.ifx(level > 0, {
+      /*
+      InternalNode(
+        children: IndexedSeq[InternalChild])
+      InternalChild(
+        index_file_offset: Long,
+        first_idx: Long,
+        first_key: Annotation,
+        first_record_offset: Long,
+        first_annotation: Annotation)
+       */
+      val children = readInternalNode(cb, nodeOffset).loadField(cb, "children").get(cb).asIndexable
+
+      val (start, end) = searchChildren(children, isInternalNode = true)
+
+      cb.assign(level, level-1)
+      cb.ifx(start.ceq(0) || end.ceq(0), cb._fatal("queryInterval broken invariant"))
+
+      cb.ifx(if (isPointQuery) const(true).get else start.ceq(end), {
+        updateSuccessor(children, start)
+        cb.assign(nodeOffset, children.loadElement(cb, start-1).get(cb).asBaseStruct.loadField(cb, "index_file_offset").get(cb).asLong.value)
+        cb.goto(Lstart)
+      })
+
+      cb.ifx(!(start < children.loadLength()), cb._fatal("unreachable"))
+
+      // continue with separate point queries for each endpoint
+      updateSuccessor(children, end)
+      cb.assign(nodeOffset, children.loadElement(cb, end-1).get(cb).asBaseStruct.loadField(cb, "index_file_offset").get(cb).asLong.value)
+      queryBound(cb, endKey, endLeansRight, level, nodeOffset, successorIndex, successorLeaf)
+      cb.assign(endIndex, queryResultStartIndex)
+
+      updateSuccessor(children, start)
+      cb.assign(nodeOffset, children.loadElement(cb, start-1).get(cb).asBaseStruct.loadField(cb, "index_file_offset").get(cb).asLong.value)
+      queryBound(cb, startKey, startLeansRight, level, nodeOffset, successorIndex, successorLeaf)
+      cb.assign(startIndex, queryResultStartIndex)
+      cb.assign(startLeaf, queryResultStartLeaf)
+    }, {
+      /*
+      LeafNode(
+        first_idx: Long,
+        keys: IndexedSeq[LeafChild])
+      LeafChild(
+        key: Annotation,
+        offset: Long,
+        annotation: Annotation)
+       */
+      val node = readLeafNode(cb, nodeOffset).asBaseStruct
+      val children = node.asBaseStruct.loadField(cb, "keys").get(cb).asIndexable
+
+      val (start, end) = searchChildren(children, isInternalNode = false)
+
+      val firstIndex = cb.memoize(node.asBaseStruct.loadField(cb, "first_idx")).get(cb).asInt64.value
+      cb.ifx(start < children.loadLength(), {
+        cb.assign(startIndex, firstIndex + start.toL)
+        cb.assign(startLeaf, children.loadElement(cb, start).get(cb).asBaseStruct.toStackStruct(cb))
+      }, {
+        cb.ifx(successorIndex.cne(firstIndex + start.toL), cb._fatal("queryInterval broken invariant"))
+        cb.assign(startIndex, successorIndex)
+        cb.assign(startLeaf, successorLeaf)
+      })
+      cb.assign(endIndex, firstIndex + end.toL)
+    })
+
+    (startIndex, startLeaf, endIndex)
+  }
+
+  private[this] def getFirstLeaf(cb: EmitCodeBuilder, internalChild: SBaseStructValue): SValue = {
+    new SStackStructValue(leafChildLocalType, Array(
+      EmitValue.present(internalChild.loadField(cb, "first_key").get(cb)),
+      EmitValue.present(internalChild.loadField(cb, "first_record_offset").get(cb)),
+      EmitValue.present(internalChild.loadField(cb, "first_annotation").get(cb))))
   }
 
   // internal node is an array of children
@@ -144,21 +395,7 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
     ret.asBaseStruct
   }
 
-  def queryBound(cb: EmitCodeBuilder, region: Value[Region], partitionBoundLeftEndpoint: SBaseStructValue, leansRight: SBooleanValue): Value[Long] = {
-    cb.invokeCode[Long](
-      cb.emb.ecb.getOrGenEmitMethod("lowerBound",
-        ("lowerBound", this),
-        FastIndexedSeq(typeInfo[Region], partitionBoundLeftEndpoint.st.paramType, leansRight.st.paramType),
-        LongInfo) { emb =>
-      emb.emitWithBuilder { cb =>
-        val region = emb.getCodeParam[Region](1)
-        val endpoint = emb.getSCodeParam(2).asBaseStruct
-        val leansRight = emb.getSCodeParam(3).asBoolean
-        queryBound(cb, region, endpoint, leansRight, cb.memoize(metadata.invoke[Int]("height") - 1), cb.memoize(metadata.invoke[Long]("rootOffset"))) }
-    }, region, partitionBoundLeftEndpoint, leansRight)
-  }
-
-  def queryIndex(cb: EmitCodeBuilder, region: Value[Region], absIndex: Value[Long]): SBaseStructValue = {
+  private def queryIndex(cb: EmitCodeBuilder, region: Value[Region], absIndex: Value[Long]): SBaseStructValue = {
     cb.invokeSCode(
       cb.emb.ecb.getOrGenEmitMethod("queryIndex",
         ("queryIndex", this),
@@ -195,95 +432,5 @@ class StagedIndexReader(emb: EmitMethodBuilder[_], spec: AbstractIndexSpec) {
           leafChildType.coerceOrCopy(cb, region, result, false)
         }
       }, region, absIndex).asBaseStruct
-  }
-
-  // partitionBoundEndpoint is a tuple(partitionBoundEndpoint, bool)
-  // returns leaf index
-  private def queryBound(cb: EmitCodeBuilder,
-    region: Value[Region],
-    endpoint: SBaseStructValue,
-    leansRight: SBooleanValue,
-    level: Value[Int],
-    offset: Value[Long]): Value[Long] = {
-
-    val rInd: Settable[Long] = cb.newLocal[Long]("lowerBoundIndex")
-
-    val levelSettable = cb.newLocal[Int]("lowerBound_level")
-    val offsetSettable = cb.newLocal[Long]("lowerBound_offset")
-
-    cb.assign(levelSettable,level)
-    cb.assign(offsetSettable,offset)
-
-    val boundAndSignTuple = SStackStruct.constructFromArgs(cb,
-      region,
-      TTuple(endpoint.st.virtualType, TBoolean),
-      EmitCode.present(cb.emb, endpoint),
-      EmitCode.present(cb.emb, leansRight)
-    )
-
-    val Lstart = CodeLabel()
-    cb.define(Lstart)
-
-    cb.ifx(levelSettable ceq 0, {
-      val node = readLeafNode(cb, offsetSettable).asBaseStruct
-
-      /*
-      LeafNode(
-        firstIndex: Long,
-        children: IndexedSeq[LeafChild]
-      LeafChild(
-        key: Annotation,
-        recordOffset: Long,
-        annotation: Annotation)
-       */
-      val children = node.asBaseStruct.loadField(cb, "keys").get(cb).asIndexable
-
-      val idx = new BinarySearch(cb.emb,
-        children.st,
-        EmitType(boundAndSignTuple.st, true),
-        ((cb, elt) => cb.memoize(elt.get(cb).asBaseStruct.loadField(cb, "key"))),
-        bound="lower",
-        ltF = { (cb, containerEltEV, partBoundEV) =>
-          val containerElt = containerEltEV.get(cb).asBaseStruct
-          val partBound = partBoundEV.get(cb).asBaseStruct
-          val endpoint = partBound.loadField(cb, 0).get(cb).asBaseStruct
-          val leansRight = partBound.loadField(cb, 1).get(cb).asBoolean.value
-          val comp = compareStructWithPartitionIntervalEndpoint(cb, containerElt, endpoint, leansRight)
-          cb.memoize(comp < 0)
-        }
-      )
-        .search(cb, children, EmitCode.present(cb.emb, boundAndSignTuple))
-
-      val firstIndex = node.asBaseStruct.loadField(cb, "first_idx").get(cb).asInt64.value.get
-      val updatedIndex = firstIndex + idx.toL
-      cb.assign(rInd, updatedIndex)
-    }, {
-      val children = readInternalNode(cb, offsetSettable).loadField(cb, "children").get(cb).asIndexable
-      cb.ifx(children.loadLength() ceq 0, {
-        // empty internal node occurs if the indexed file contains no keys
-        cb.assign(rInd, 0L)
-      }, {
-        val idx = new BinarySearch(cb.emb,
-          children.st,
-          EmitType(boundAndSignTuple.st, true),
-          ((cb, elt) => cb.memoize(elt.get(cb).asBaseStruct.loadField(cb, "first_key"))),
-          bound="lower",
-          ltF = { (cb, containerEltEV, partBoundEV) =>
-            val containerElt = containerEltEV.get(cb).asBaseStruct
-            val partBound = partBoundEV.get(cb).asBaseStruct
-            val endpoint = partBound.loadField(cb, 0).get(cb).asBaseStruct
-            val leansRight = partBound.loadField(cb, 1).get(cb).asBoolean.value
-            val comp = compareStructWithPartitionIntervalEndpoint(cb, containerElt, endpoint, leansRight)
-            cb.memoize(comp < 0)
-          }
-        )
-          .search(cb, children, EmitCode.present(cb.emb, boundAndSignTuple))
-        cb.assign(levelSettable, levelSettable-1)
-        cb.assign(offsetSettable, children.loadElement(cb, (idx-1).max(0)).get(cb).asBaseStruct.loadField(cb, "index_file_offset").get(cb).asLong.value)
-        cb.goto(Lstart)
-      })
-    })
-
-    rInd
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -90,8 +90,8 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
         val interval = value.asInterval
         val start = EmitCode.fromI(cb.emb)(cb => interval.loadStart(cb))
         val stop = EmitCode.fromI(cb.emb)(cb => interval.loadEnd(cb))
-        val includesStart = EmitCode.present(cb.emb, new SBooleanValue(interval.includesStart()))
-        val includesStop = EmitCode.present(cb.emb, new SBooleanValue(interval.includesEnd()))
+        val includesStart = EmitCode.present(cb.emb, new SBooleanValue(interval.includesStart))
+        val includesStop = EmitCode.present(cb.emb, new SBooleanValue(interval.includesEnd))
         representation.store(cb, region,
           SStackStruct.constructFromArgs(cb, region, representation.virtualType,
             start, stop, includesStart, includesStop), deepCopy)
@@ -106,8 +106,8 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
         val interval = value.asInterval
         val start = EmitCode.fromI(cb.emb)(cb => interval.loadStart(cb))
         val stop = EmitCode.fromI(cb.emb)(cb => interval.loadEnd(cb))
-        val includesStart = EmitCode.present(cb.emb, new SBooleanValue(interval.includesStart()))
-        val includesStop = EmitCode.present(cb.emb, new SBooleanValue(interval.includesEnd()))
+        val includesStart = EmitCode.present(cb.emb, new SBooleanValue(interval.includesStart))
+        val includesStop = EmitCode.present(cb.emb, new SBooleanValue(interval.includesEnd))
         representation.storeAtAddress(cb, addr, region,
           SStackStruct.constructFromArgs(cb, region, representation.virtualType,
             start, stop, includesStart, includesStop),

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -17,7 +17,7 @@ final case class SIntervalPointer(pType: PInterval) extends SInterval {
   override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): SValue =
     value match {
       case value: SIntervalValue =>
-        new SIntervalPointerValue(this, pType.store(cb, region, value, deepCopy), value.includesStart(), value.includesEnd())
+        new SIntervalPointerValue(this, pType.store(cb, region, value, deepCopy), value.includesStart, value.includesEnd)
     }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackInterval.scala
@@ -30,8 +30,8 @@ final case class SStackInterval(pointEmitType: EmitType) extends SInterval {
         new SStackIntervalValue(this,
           pointEmitType.coerceOrCopy(cb, region, cb.memoize(value.loadStart(cb)), deepCopy),
           pointEmitType.coerceOrCopy(cb, region, cb.memoize(value.loadEnd(cb)), deepCopy),
-          value.includesStart(),
-          value.includesEnd()
+          value.includesStart,
+          value.includesEnd
         ) 
     }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
@@ -16,7 +16,7 @@ object SStackStruct {
   def constructFromArgs(cb: EmitCodeBuilder, region: Value[Region], t: TBaseStruct, args: EmitCode*): SBaseStructValue = {
     val as = args.toArray
     assert(t.size == args.size)
-    if (as.length > MAX_FIELDS_FOR_CONSTRUCT) {
+    if (region != null && as.length > MAX_FIELDS_FOR_CONSTRUCT) {
       val structType: PCanonicalBaseStruct = t match {
         case ts: TStruct =>
           PCanonicalStruct(false, ts.fieldNames.zip(as.map(_.emitType)).map { case (f, et) => (f, et.storageType) }: _*)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -178,9 +178,9 @@ case class SUnreachableInterval(virtualType: TInterval) extends SUnreachable wit
 }
 
 class SUnreachableIntervalValue(override val st: SUnreachableInterval) extends SUnreachableValue with SIntervalValue {
-  override def includesStart(): Value[Boolean] = const(false)
+  override def includesStart: Value[Boolean] = const(false)
 
-  override def includesEnd(): Value[Boolean] = const(false)
+  override def includesEnd: Value[Boolean] = const(false)
 
   override def loadStart(cb: EmitCodeBuilder): IEmitCode = IEmitCode.present(cb, SUnreachable.fromVirtualType(st.virtualType.pointType).defaultValue)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -95,6 +95,12 @@ trait SBaseStructValue extends SValue {
     new SInt64Value(sizeSoFar)
   }
 
+  def toStackStruct(cb: EmitCodeBuilder): SStackStructValue = {
+    new SStackStructValue(
+      SStackStruct(st.virtualType, st.fieldEmitTypes),
+      Array.tabulate(st.size)( i => cb.memoize(loadField(cb, i))))
+  }
+
   def _insert(newType: TStruct, fields: (String, EmitValue)*): SBaseStructValue = {
     new SInsertFieldsStructValue(
       SInsertFieldsStruct(newType, st, fields.map { case (name, ec) => (name, ec.emitType) }.toFastIndexedSeq),

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -20,9 +20,9 @@ trait SInterval extends SType {
 trait SIntervalValue extends SValue {
   def st: SInterval
 
-  def includesStart(): Value[Boolean]
+  def includesStart: Value[Boolean]
 
-  def includesEnd(): Value[Boolean]
+  def includesEnd: Value[Boolean]
 
   def loadStart(cb: EmitCodeBuilder): IEmitCode
 


### PR DESCRIPTION
~Stacked on #12376~

Reworks the staged index reader query algorithm. Before, `queryInterval` did three traversals from root to leaf: one each for the start and end of the interval, and one to find the first record. Now it always does a single traversal, visiting one or two nodes at each level (two if the paths for the start and end keys diverge), and doing a single binary search at each visited node.

This is probably not a significant performance improvement when doing a single query per partition, but could be beneficial when using the new `query_table` per row.