### PR TITLE
[httpx] Replace inspection of e.message with e.body 

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -362,20 +362,20 @@ class BillingProjectResource:
 
         try:
             await self.batch_client.create_billing_project(billing_project)
-        except aiohttp.ClientResponseError as e:
-            if e.status != 403 or 'already exists' not in e.message:
+        except httpx.ClientResponseError as e:
+            if e.status != 403 or 'already exists' not in e.body:
                 raise
 
         try:
             await self.batch_client.reopen_billing_project(billing_project)
-        except aiohttp.ClientResponseError as e:
-            if e.status != 403 or 'is already open' not in e.message:
+        except httpx.ClientResponseError as e:
+            if e.status != 403 or 'is already open' not in e.body:
                 raise
 
         try:
             await self.batch_client.add_user(user, billing_project)
-        except aiohttp.ClientResponseError as e:
-            if e.status != 403 or 'already member of billing project' not in e.message:
+        except httpx.ClientResponseError as e:
+            if e.status != 403 or 'already member of billing project' not in e.body:
                 raise
 
         await self.batch_client.edit_billing_limit(billing_project, 10)
@@ -386,8 +386,8 @@ class BillingProjectResource:
     async def _delete(self, user, billing_project):
         try:
             bp = await self.batch_client.get_billing_project(billing_project)
-        except aiohttp.ClientResponseError as e:
-            if e.status == 403 and 'Unknown Hail Batch billing project' in e.message:
+        except httpx.ClientResponseError as e:
+            if e.status == 403 and 'Unknown Hail Batch billing project' in e.body:
                 return
             raise
         else:
@@ -396,8 +396,8 @@ class BillingProjectResource:
 
         try:
             await self.batch_client.remove_user(user, billing_project)
-        except aiohttp.ClientResponseError as e:
-            if e.status != 403 or 'is not in billing project' not in e.message:
+        except httpx.ClientResponseError as e:
+            if e.status != 403 or 'is not in billing project' not in e.body:
                 raise
         finally:
             await self.batch_client.close_billing_project(billing_project)

--- a/build.yaml
+++ b/build.yaml
@@ -2018,6 +2018,7 @@ steps:
       import json
       import asyncio
       import aiohttp
+      from hailtop import httpx
       from hailtop.utils import async_to_blocking
       from hailtop.batch_client.aioclient import BatchClient
       async def create(billing_project, user, limit=None):
@@ -2025,14 +2026,14 @@ steps:
           try:
               try:
                   await bc.create_billing_project(billing_project)
-              except aiohttp.ClientResponseError as e:
-                  if e.status != 403 or 'already exists' not in e.message:
+              except httpx.ClientResponseError as e:
+                  if e.status != 403 or 'already exists' not in e.body:
                        raise
 
               try:
                   await bc.add_user(user, billing_project)
               except aiohttp.ClientResponseError as e:
-                  if e.status != 403 or 'already member of billing project' not in e.message:
+                  if e.status != 403 or 'already member of billing project' not in e.body:
                        raise
 
               await bc.edit_billing_limit(billing_project, limit)


### PR DESCRIPTION
for error responses coming from our services.

I think I got all occurrences of this by searching for `e.message` across the codebase. The only instances I see left of this are error-handling withing `front_end.py` (which isn't a problem because this is an issue of the reason phrase not making it between server -> client) and exceptions from aiodocker which is not within our control.