### PR TITLE
[auth] avoid redirect loop on failed login

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -311,7 +311,7 @@ async def callback(request):
     if user is None:
         if caller == 'login':
             set_message(session, f'Account does not exist for login id {login_id}', 'error')
-            return aiohttp.web.HTTPFound(next_url)
+            return aiohttp.web.HTTPFound(deploy_config.external_url('auth', ''))
 
         assert caller == 'signup'
 


### PR DESCRIPTION
If we cannot authenticate the user, we should send them to a publicly accessible page where the error message can be presented.