### PR TITLE
[envoy] Set higher rate limits for most services and add test_ci services

### DIFF
--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -93,7 +93,7 @@ def gateway_default_host(service: str) -> dict:
                 'match': {'prefix': '/'},
                 'route': route_to_cluster(service),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, 'default'),
                     'envoy.filters.http.ext_authz': auth_check_exemption(),
                 },
             }
@@ -111,7 +111,7 @@ def gateway_internal_host(services_per_namespace: Dict[str, List[str]]) -> dict:
                 'match': {'path_separated_prefix': f'/{namespace}/{service}'},
                 'route': route_to_cluster(f'{namespace}-{service}'),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, namespace),
                 },
             }
             for namespace, services in services_per_namespace.items()
@@ -130,7 +130,7 @@ def internal_gateway_default_host(service: str) -> dict:
                 'match': {'prefix': '/'},
                 'route': route_to_cluster(service),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, 'default'),
                 },
             }
         ],
@@ -147,7 +147,7 @@ def internal_gateway_internal_host(services_per_namespace: Dict[str, List[str]])
                 'match': {'path_separated_prefix': f'/{namespace}/{service}'},
                 'route': route_to_cluster(f'{namespace}-{service}'),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, namespace),
                 },
             }
             for namespace, services in services_per_namespace.items()
@@ -172,13 +172,17 @@ def auth_check_exemption() -> dict:
     }
 
 
-def rate_limit_config() -> dict:
+def rate_limit_config(service: str, namespace: str) -> dict:
+    # FIXME We didn't set a rate limit before with nginx so I'm making this
+    # sort of unreasonably high. This should be tuned per service
+    max_rps = 60 if service == 'batch-driver' and namespace == 'default' else 200
+
     return {
         '@type': 'type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit',
         'stat_prefix': 'http_local_rate_limiter',
         'token_bucket': {
-            'max_tokens': 60,
-            'tokens_per_fill': 60,
+            'max_tokens': max_rps,
+            'tokens_per_fill': max_rps,
             'fill_interval': '1s',
         },
         'filter_enabled': {

--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -93,7 +93,7 @@ def gateway_default_host(service: str) -> dict:
                 'match': {'prefix': '/'},
                 'route': route_to_cluster(service),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, 'default'),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                     'envoy.filters.http.ext_authz': auth_check_exemption(),
                 },
             }
@@ -111,7 +111,7 @@ def gateway_internal_host(services_per_namespace: Dict[str, List[str]]) -> dict:
                 'match': {'path_separated_prefix': f'/{namespace}/{service}'},
                 'route': route_to_cluster(f'{namespace}-{service}'),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, namespace),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                 },
             }
             for namespace, services in services_per_namespace.items()
@@ -130,7 +130,7 @@ def internal_gateway_default_host(service: str) -> dict:
                 'match': {'prefix': '/'},
                 'route': route_to_cluster(service),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, 'default'),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                 },
             }
         ],
@@ -147,7 +147,7 @@ def internal_gateway_internal_host(services_per_namespace: Dict[str, List[str]])
                 'match': {'path_separated_prefix': f'/{namespace}/{service}'},
                 'route': route_to_cluster(f'{namespace}-{service}'),
                 'typed_per_filter_config': {
-                    'envoy.filters.http.local_ratelimit': rate_limit_config(service, namespace),
+                    'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                 },
             }
             for namespace, services in services_per_namespace.items()
@@ -172,8 +172,8 @@ def auth_check_exemption() -> dict:
     }
 
 
-def rate_limit_config(service: str, namespace: str) -> dict:
-    max_rps = 60 if service == 'batch-driver' and namespace == 'default' else 200
+def rate_limit_config(service: str) -> dict:
+    max_rps = 60 if service == 'batch-driver' else 200
 
     return {
         '@type': 'type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit',

--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -173,8 +173,6 @@ def auth_check_exemption() -> dict:
 
 
 def rate_limit_config(service: str, namespace: str) -> dict:
-    # FIXME We didn't set a rate limit before with nginx so I'm making this
-    # sort of unreasonably high. This should be tuned per service
     max_rps = 60 if service == 'batch-driver' and namespace == 'default' else 200
 
     return {

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -897,7 +897,7 @@ mkdir -p {shq(repo_dir)}
                 config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS, scope='deploy')
                 namespace, services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                _, test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+                _, test_services = BuildConfiguration(self, f.read(), scope='deploy').deployed_services()
 
             services.extend(test_services)
             await add_deployed_services(db, namespace, services, None)
@@ -996,7 +996,7 @@ mkdir -p {shq(repo_dir)}
                 )
                 namespace, services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                _, test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+                _, test_services = BuildConfiguration(self, f.read(), scope='dev').deployed_services()
 
             services.extend(test_services)
             await add_deployed_services(db, namespace, services, None)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -483,8 +483,12 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 config = BuildConfiguration(self, f.read(), scope='test')
+                namespace, services = config.deployed_services()
+            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
+                _, test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+
+            services.extend(test_services)
             tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-            namespace, services = config.deployed_services()
             await add_deployed_services(db, namespace, services, tomorrow)
 
             log.info(f'creating test batch for {self.number}')
@@ -891,7 +895,11 @@ mkdir -p {shq(repo_dir)}
             )
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS, scope='deploy')
-            namespace, services = config.deployed_services()
+                namespace, services = config.deployed_services()
+            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
+                _, test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+
+            services.extend(test_services)
             await add_deployed_services(db, namespace, services, None)
 
             log.info(f'creating deploy batch for {self.branch.short_str()}')
@@ -986,7 +994,11 @@ mkdir -p {shq(repo_dir)}
                 config = BuildConfiguration(
                     self, f.read(), scope='dev', requested_step_names=steps, excluded_step_names=excluded_steps
                 )
-            namespace, services = config.deployed_services()
+                namespace, services = config.deployed_services()
+            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
+                _, test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+
+            services.extend(test_services)
             await add_deployed_services(db, namespace, services, None)
 
             log.info(f'creating dev deploy batch for {self.branch.short_str()} and user {self.user}')


### PR DESCRIPTION
- CI needs to account not only for the services that it is deploying but the services that the test-ci might later deploy into that same namespace
- I had earlier applied batch-driver's rate limit to everything and soon found that it is a bit too restrictive w.r.t. many simultaneous client submissions to the batch front end. With nginx we just didn't have rate limits on anything else, which seems less good than setting high rate limits. I'll admit that 200 was incredibly arbitrary (let's call it optimistic) and I'm happy to take more precise suggestions.