### PR TITLE
[qob] fix use of nest_asycnio

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,9 +1,9 @@
 import nest_asyncio
 nest_asyncio.apply()
 
-from typing import Optional
-import pkg_resources
-import sys
+from typing import Optional  # noqa: E402
+import pkg_resources  # noqa: E402
+import sys  # noqa: E402
 
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6 or later, found {}.{}'.format(

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,22 +1,13 @@
+import nest_asyncio
+nest_asyncio.apply()
+
 from typing import Optional
 import pkg_resources
 import sys
-import asyncio
-import nest_asyncio
 
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6 or later, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
-
-if sys.version_info[:2] == (3, 6):
-    if asyncio._get_running_loop() is not None:
-        nest_asyncio.apply()
-else:
-    try:
-        asyncio.get_running_loop()
-        nest_asyncio.apply()
-    except RuntimeError as err:
-        assert 'no running event loop' in err.args[0]
 
 
 __pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()


### PR DESCRIPTION
As of [nest_asyncio 1.5.2](https://github.com/erdewit/nest_asyncio/commit/1856573ac86954d15b0f617c97c02844bcbc7ea4), we can initialize nest_asyncio inside running loops (e.g. Jupyter). If nest_asyncio is initialized after even one task is created, [users receive inscrutable errors](https://github.com/erdewit/nest_asyncio/issues/22\#issuecomment-874710264). This error happened during the QoB workshop I ran. This change takes advantage of nest_asyncio 1.5.2 to initialize nest_asyncio before *everything*, thus ensuring it can completely patch the event loop.

You can reproduce the error yourself by running `python3 -c "import hail as hl; hl.init(billing_project=\"not-a-real-billing-project\")"` repeatedly in a terminal. I encounter the error ~50% of the time. With this change, I did not see the error after 5 invocations of that command.