### PR TITLE
[query] Fix text partition writers to use UUIDs and avoid speculation…

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -841,6 +841,7 @@ case class MatrixGENWriter(
 
     val sampleWriter = new GenSampleWriter
 
+
     val lineWriter = GenVariantWriter(tm, entriesFieldName, precision)
     val folder = ctx.createTmpPath("export-gen")
 
@@ -869,6 +870,8 @@ case class MatrixGENWriter(
 }
 
 final case class GenVariantWriter(typ: MatrixType, entriesFieldName: String, precision: Int) extends SimplePartitionWriter {
+
+  override def extension: String = ".gen"
   def consumeElement(cb: EmitCodeBuilder, element: EmitCode, os: Value[OutputStream], region: Value[Region]): Unit = {
     def _writeC(cb: EmitCodeBuilder, code: Code[Int]) = { cb += os.invoke[Int, Unit]("write", code) }
     def _writeB(cb: EmitCodeBuilder, code: Code[Array[Byte]]) = { cb += os.invoke[Array[Byte], Unit]("write", code) }
@@ -921,6 +924,8 @@ final case class GenVariantWriter(typ: MatrixType, entriesFieldName: String, pre
 }
 
 final class GenSampleWriter extends SimplePartitionWriter {
+
+  override def extension: String = ".txt"
   def consumeElement(cb: EmitCodeBuilder, element: EmitCode, os: Value[OutputStream], region: Value[Region]): Unit = {
     element.toI(cb).consume(cb, cb._fatal("stream element cannot be missing!"), { case sv: SBaseStructValue =>
       val id1 = sv.loadField(cb, 0).get(cb).asString.loadString(cb)
@@ -1252,7 +1257,7 @@ case class MatrixPLINKWriter(
       WritePartition(rows, ctx, lineWriter)
     }{ (parts, globals) =>
       val commit = PLINKExportFinalizer(tm, path, tmpBedDir + "/header")
-      val famWriter = TableTextPartitionWriter(tm.colsTableType.rowType, "\t", writeHeader = false)
+      val famWriter = TableTextPartitionWriter(tm.colsTableType.rowType, "\t", writeHeader = false, ".fam")
       val famPath = Str(path + ".fam")
       val cols = ToStream(GetField(globals, colsFieldName))
       val writeFam = WritePartition(cols, famPath, famWriter)

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -487,7 +487,7 @@ case class TableTextWriter(
       ctx.createTmpPath("write-table-concatenated")
     else
       path
-    val lineWriter = TableTextPartitionWriter(ts.rowType, delimiter, writeHeader = exportType == ExportType.PARALLEL_HEADER_IN_SHARD)
+    val lineWriter = TableTextPartitionWriter(ts.rowType, delimiter, writeHeader = exportType == ExportType.PARALLEL_HEADER_IN_SHARD, extension=ext)
 
     ts.mapContexts { oldCtx =>
       val d = digitsNeeded(ts.numPartitions)
@@ -508,7 +508,8 @@ case class TableTextWriter(
   }
 }
 
-case class TableTextPartitionWriter(rowType: TStruct, delimiter: String, writeHeader: Boolean) extends SimplePartitionWriter {
+case class TableTextPartitionWriter(rowType: TStruct, delimiter: String, writeHeader: Boolean, extension: String) extends SimplePartitionWriter {
+
   lazy val headerStr = rowType.fields.map(_.name).mkString(delimiter)
 
   override def preConsume(cb: EmitCodeBuilder, os: Value[OutputStream]): Unit = if (writeHeader) {


### PR DESCRIPTION
… overwrites

CHANGELOG: Fixed bug sometimes leading to dropped rows from exported text files with Spark speculation.