### PR TITLE
[batch] Dont allow log test to possibly run forever

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -61,6 +61,8 @@ def test_job_running_logs(client: BatchClient):
             if log is not None and log['main'] != '':
                 assert log['main'] == 'test\n', str((log, b.debug_info()))
                 break
+        elif status['state'] != 'Ready':
+            assert False, str((j.log(), b.debug_info()))
         delay = sync_sleep_and_backoff(delay)
 
     b.cancel()


### PR DESCRIPTION
This test could run forever if batch is temporarily down between starting the job and the job completing. I'm not entirely sure what to do in this scenario, failing doesn't seem too bad because we weren't actually able to verify the test, but it seems better than potentially having the job hang.