### PR TITLE
[query] rework flags and fix QoB flags

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -172,6 +172,7 @@ class LocalBackend(Py4JBackend):
 
         if not quiet:
             connect_logger(self._utils_package_object, 'localhost', 12888)
+        self._initialize_flags()
 
     def jvm(self):
         return self._jvm

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -224,6 +224,7 @@ class SparkBackend(Py4JBackend):
             connect_logger(self._utils_package_object, 'localhost', 12888)
 
             self._jbackend.startProgressBar()
+        self._initialize_flags()
 
     def jvm(self):
         return self._jvm

--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -1,7 +1,28 @@
+from typing import Tuple, Dict, Optional
 import unittest
 
 import hail as hl
 from hail.utils.java import Env
+from hail.backend.backend import Backend
+from hail.backend.spark_backend import SparkBackend
+from test.hail.helpers import skip_unless_spark_backend
+
+
+def _scala_map_str_to_tuple_str_str_to_dict(scala) -> Dict[str, Tuple[Optional[str], Optional[str]]]:
+    it = scala.iterator()
+    s: Dict[str, Tuple[Optional[str], Optional[str]]] = {}
+    while it.hasNext():
+        kv = it.next()
+        k = kv._1()
+        assert isinstance(k, str)
+        v = kv._2()
+        l = v._1()
+        r = v._2()
+        assert l is None or isinstance(l, str)
+        assert r is None or isinstance(r, str)
+        assert k not in s
+        s[k] = (l, r)
+    return s
 
 
 class Tests(unittest.TestCase):
@@ -16,7 +37,7 @@ class Tests(unittest.TestCase):
 
         hl.init(idempotent=True)  # Should be no error
 
-        if isinstance(Env.backend(), hl.backend.spark_backend.SparkBackend):
+        if isinstance(Env.backend(), SparkBackend):
             hl.init(hl.spark_context(), idempotent=True)  # Should be no error
 
     def test_top_level_functions_are_do_not_error(self):
@@ -25,3 +46,15 @@ class Tests(unittest.TestCase):
 
     def test_tmpdir_runs(self):
         isinstance(hl.tmp_dir(), str)
+
+    def test_get_flags(self):
+         assert hl._get_flags() == {}
+         assert list(hl._get_flags('use_new_shuffle')) == ['use_new_shuffle']
+
+    @skip_unless_spark_backend(reason='requires JVM')
+    def test_flags_same_in_scala_and_python(self):
+        b = hl.current_backend()
+        assert isinstance(b, SparkBackend)
+
+        scala_flag_map = _scala_map_str_to_tuple_str_str_to_dict(b._hail_package.HailFeatureFlags.defaults())
+        assert scala_flag_map == Backend._flags_env_vars_and_defaults

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -6,7 +6,11 @@ import org.json4s.JsonAST.{JArray, JObject, JString}
 import scala.collection.mutable
 
 object HailFeatureFlags {
-  val defaults: Map[String, (String, String)] = Map[String, (String, String)](
+  val defaults = Map[String, (String, String)](
+    // Must match __flags_env_vars_and_defaults in hail/backend/backend.py
+    //
+    // The default values and envvars here are only used in the Scala tests. In all other
+    // conditions, Python initializes the flags, see HailContext._initialize_flags in context.py.
     ("no_whole_stage_codegen", ("HAIL_DEV_NO_WHOLE_STAGE_CODEGEN" -> null)),
     ("no_ir_logging", ("HAIL_DEV_NO_IR_LOG" -> null)),
     ("lower", ("HAIL_DEV_LOWER" -> null)),
@@ -17,11 +21,6 @@ object HailFeatureFlags {
     ("max_leader_scans", ("HAIL_DEV_MAX_LEADER_SCANS" -> "1000")),
     ("distributed_scan_comb_op", ("HAIL_DEV_DISTRIBUTED_SCAN_COMB_OP" -> null)),
     ("jvm_bytecode_dump", ("HAIL_DEV_JVM_BYTECODE_DUMP" -> null)),
-    ("use_packed_int_encoding", ("HAIL_DEV_USE_PACKED_INT_ENCODING" -> null)),
-    ("use_column_encoding", ("HAIL_DEV_USE_COLUMN_ENCODING" -> null)),
-    ("use_spicy_ptypes", ("HAIL_USE_SPICY_PTYPES" -> null)),
-    ("log_service_timing", ("HAIL_DEV_LOG_SERVICE_TIMING" -> null)),
-    ("cache_service_input", ("HAIL_DEV_CACHE_SERVICE_INPUT" -> null)),
     ("write_ir_files", ("HAIL_WRITE_IR_FILES" -> null)),
     ("method_split_ir_limit", ("HAIL_DEV_METHOD_SPLIT_LIMIT" -> "16")),
     ("use_new_shuffle", ("HAIL_USE_NEW_SHUFFLE" -> null)),
@@ -54,13 +53,14 @@ object HailFeatureFlags {
     )
 }
 
-class HailFeatureFlags(
+class HailFeatureFlags private (
   val flags: mutable.Map[String, String]
 ) extends Serializable {
   val available: java.util.ArrayList[String] =
     new java.util.ArrayList[String](java.util.Arrays.asList[String](flags.keys.toSeq: _*))
 
   def set(flag: String, value: String): Unit = {
+    assert(exists(flag))
     flags.update(flag, value)
   }
 


### PR DESCRIPTION
Flags now use the same user configuration machinery we use for Batch and QoB. I am not certain this is the right choice. Feedback very welcome. The configuration_of function lets us uniformly treat any configuration by checking, in order: explicit argument, envvar, config file, or a fallback.

I added a bit of code to allow us to support the envvars which do not conform to the new envvar scheme.

I also removed a few flags that are no longer used.

I kind of think these flags should actually be under a new section like "query_compiler" or something.

@tpoterba, thoughts?