### PR TITLE
[hailgenetics] Use fully-pinned requirements in hailgenetics/hail

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -904,7 +904,7 @@ steps:
       - from: /just-wheel/wheel-container.tar
         to: /io/hail/wheel-container.tar
     dependsOn:
-      - hail_ubuntu_image
+      - service_base_image
       - build_hail_jar_and_wheel_only
       - merge_code
     resources:

--- a/build.yaml
+++ b/build.yaml
@@ -2564,14 +2564,16 @@ steps:
       - create_ci_test_repo
   - kind: buildImage2
     name: hailgenetics_hail_image
-    dockerFile: /io/docker/hailgenetics/hail/Dockerfile
-    contextPath: /io/docker/hailgenetics/hail
+    dockerFile: /io/repo/docker/hailgenetics/hail/Dockerfile
+    contextPath: /io/repo
     publishAs: hailgenetics/hail
     inputs:
       - from: /repo/docker/hailgenetics/hail
-        to: /io/docker/hailgenetics/hail
+        to: /io/repo/docker/hailgenetics/hail
+      - from: /repo/hail/python/pinned-requirements.txt
+        to: /io/repo/hail/python/pinned-requirements.txt
       - from: /just-wheel/wheel-container.tar
-        to: /io/docker/hailgenetics/hail/wheel-container.tar
+        to: /io/repo/wheel-container.tar
     dependsOn:
       - merge_code
       - build_hail_jar_and_wheel_only

--- a/build.yaml
+++ b/build.yaml
@@ -904,7 +904,7 @@ steps:
       - from: /just-wheel/wheel-container.tar
         to: /io/hail/wheel-container.tar
     dependsOn:
-      - service_base_image
+      - hail_ubuntu_image
       - build_hail_jar_and_wheel_only
       - merge_code
     resources:

--- a/docker/hailgenetics/hail/Dockerfile
+++ b/docker/hailgenetics/hail/Dockerfile
@@ -38,5 +38,5 @@ RUN export SPARK_HOME=$(find_spark_home.py) && \
 
 RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
-    pip3 install --no-deps hail-*-py3-none-any.whl && \
+    hail-pip-install --no-deps hail-*-py3-none-any.whl && \
     rm -rf hail-*-py3-none-any.whl

--- a/docker/hailgenetics/hail/Dockerfile
+++ b/docker/hailgenetics/hail/Dockerfile
@@ -7,27 +7,26 @@ RUN hail-apt-get-install \
     git \
     liblapack3 \
     openjdk-8-jre-headless \
-    python3 python3-pip \
     rsync \
     unzip bzip2 zip tar tabix lz4 \
     vim pv
+
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN curl https://sdk.cloud.google.com | bash && \
     find \
       /root/google-cloud-sdk/bin/ \
       -type f -executable \
     | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'
-RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
-    tar -xf wheel-container.tar && \
-    pip3 install -U hail-*-py3-none-any.whl && \
-    rm -rf hail-*-py3-none-any.whl
-RUN hail-pip-install \
+
+COPY hail/python/pinned-requirements.txt requirements.txt
+RUN hail-pip-install -r requirements.txt \
       ipython \
       matplotlib \
       numpy \
       scikit-learn \
       dill \
       scipy
+
 RUN export SPARK_HOME=$(find_spark_home.py) && \
     curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar \
          >$SPARK_HOME/jars/gcs-connector-hadoop2-2.2.7.jar && \
@@ -36,3 +35,8 @@ RUN export SPARK_HOME=$(find_spark_home.py) && \
     sed -i $SPARK_HOME/conf/spark-defaults.conf \
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
+
+RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
+    tar -xf wheel-container.tar && \
+    pip3 install --no-deps hail-*-py3-none-any.whl && \
+    rm -rf hail-*-py3-none-any.whl

--- a/hail/Dockerfile.hail-pip-installed
+++ b/hail/Dockerfile.hail-pip-installed
@@ -1,4 +1,4 @@
-FROM {{ hail_ubuntu_image.image }}
+FROM {{ service_base_image.image }}
 
 ENV PYTHONPATH ""
 RUN hail-apt-get-install openjdk-8-jdk-headless liblz4-dev

--- a/hail/Dockerfile.hail-pip-installed
+++ b/hail/Dockerfile.hail-pip-installed
@@ -8,5 +8,5 @@ RUN hail-pip-install -r dev-requirements.txt
 
 RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
-    pip3 install -U hail-*-py3-none-any.whl && \
+    hail-pip-install --no-deps hail-*-py3-none-any.whl && \
     rm -rf hail-*-py3-none-any.whl

--- a/hail/Dockerfile.hail-pip-installed
+++ b/hail/Dockerfile.hail-pip-installed
@@ -1,10 +1,13 @@
-FROM {{ service_base_image.image }}
+FROM {{ hail_ubuntu_image.image }}
 
 ENV PYTHONPATH ""
-RUN hail-apt-get-install liblz4-dev
+RUN hail-apt-get-install openjdk-8-jdk-headless liblz4-dev
 
+COPY python/pinned-requirements.txt requirements.txt
 COPY python/dev/pinned-requirements.txt dev-requirements.txt
-RUN hail-pip-install -r dev-requirements.txt
+RUN file=$(mktemp) && \
+    cat requirements.txt dev-requirements.txt > $file && \
+    hail-pip-install -r $file
 
 RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \

--- a/hail/Dockerfile.hail-pip-installed
+++ b/hail/Dockerfile.hail-pip-installed
@@ -1,7 +1,7 @@
 FROM {{ service_base_image.image }}
 
 ENV PYTHONPATH ""
-RUN hail-apt-get-install openjdk-8-jdk-headless liblz4-dev
+RUN hail-apt-get-install liblz4-dev
 
 COPY python/pinned-requirements.txt requirements.txt
 COPY python/dev/pinned-requirements.txt dev-requirements.txt

--- a/hail/Dockerfile.hail-pip-installed-python37
+++ b/hail/Dockerfile.hail-pip-installed-python37
@@ -4,14 +4,14 @@ ENV LANG C.UTF-8
 
 RUN hail-apt-get-install openjdk-8-jdk-headless
 
-COPY hail/python/requirements.txt requirements.txt
-COPY hail/python/dev/requirements.txt dev-requirements.txt
+COPY hail/python/pinned-requirements.txt requirements.txt
+COPY hail/python/dev/pinned-requirements.txt dev-requirements.txt
 RUN file=$(mktemp) && \
     cat requirements.txt dev-requirements.txt > $file && \
     hail-pip-install -r $file
 
 RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
-    hail-pip-install hail-*-py3-none-any.whl
+    hail-pip-install --no-deps hail-*-py3-none-any.whl
 
 COPY pylintrc setup.cfg /

--- a/hail/Dockerfile.hail-pip-installed-python38
+++ b/hail/Dockerfile.hail-pip-installed-python38
@@ -6,14 +6,14 @@ RUN hail-apt-get-install \
     python3.8 python3-pip \
   && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
-COPY hail/python/requirements.txt requirements.txt
-COPY hail/python/dev/requirements.txt dev-requirements.txt
+COPY hail/python/pinned-requirements.txt requirements.txt
+COPY hail/python/dev/pinned-requirements.txt dev-requirements.txt
 RUN file=$(mktemp) && \
     cat requirements.txt dev-requirements.txt > $file && \
     hail-pip-install -r $file
 
 RUN --mount=src=wheel-container.tar,target=/wheel-container.tar \
     tar -xf wheel-container.tar && \
-    hail-pip-install hail-*-py3-none-any.whl
+    hail-pip-install --no-deps hail-*-py3-none-any.whl
 
 COPY pylintrc setup.cfg /


### PR DESCRIPTION
This installs our fully-pinned requirements deep in the docker image and then installs the hail wheel without dependencies on top. This will be a lot more consistent (and docker cache friendly) than the current approach, which will install all dependencies with the wheel and possibly upgrade some of them.

Also did the same to the hail-pip-installed images used for testing.