### PR TITLE
[query] use native pca on service, better default params

### DIFF
--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -302,7 +302,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(f1(1, 3)), 24) # idempotent
         self.assertEqual(hl.eval(f2(1, 3)), 24) # idempotent
 
-    @fails_service_backend()
     @fails_local_backend()
     def test_pc_project(self):
         mt = hl.balding_nichols_model(3, 100, 50)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1737,7 +1737,6 @@ class Tests(unittest.TestCase):
         assert t.filter(t.locus.position >= 1).collect() == [
             hl.utils.Struct(idx=0, locus=hl.genetics.Locus(contig='2', position=1, reference_genome='GRCh37'))]
 
-    @fails_service_backend()
     @fails_local_backend()
     def test_lower_row_agg_init_arg(self):
         mt = hl.balding_nichols_model(5, 200, 200)

--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -12,7 +12,6 @@ setUpModule = startTestHailContext
 tearDownModule = stopTestHailContext
 
 
-@fails_service_backend()
 @fails_local_backend()
 def test_hwe_normalized_pca():
     mt = hl.balding_nichols_model(3, 100, 50)
@@ -27,7 +26,6 @@ def test_hwe_normalized_pca():
     assert loadings is None
 
 
-@fails_service_backend()
 @fails_local_backend()
 def test_pca_against_numpy():
     mt = hl.import_vcf(resource('tiny_m.vcf'))


### PR DESCRIPTION
CHANGELOG: pca and hwe_normalized_pca now supported in Query-on-Batch