### PR TITLE
[batch] Avoid calling add_attempt_resources in MJC if MJS succeeded

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -314,6 +314,7 @@ async def kill_instance(request, userdata):  # pylint: disable=unused-argument
 async def job_complete_1(request, instance):
     body = await request.json()
     job_status = body['status']
+    marked_job_started = body.get('marked_job_started', False)
 
     batch_id = job_status['batch_id']
     job_id = job_status['job_id']
@@ -345,6 +346,7 @@ async def job_complete_1(request, instance):
         end_time,
         'completed',
         resources,
+        marked_job_started=marked_job_started,
     )
 
     await instance.mark_healthy()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2582,7 +2582,9 @@ class Worker:
             raise web.HTTPServiceUnavailable
         return await asyncio.shield(self.kill_1(request))
 
-    async def post_job_complete_1(self, job, full_status):
+    async def post_job_complete_1(self, job: Job, full_status):
+        assert job.end_time
+        assert job.start_time
         run_duration = job.end_time - job.start_time
         db_status = job.format_version.db_status(full_status)
 
@@ -2598,7 +2600,10 @@ class Worker:
             'status': db_status,
         }
 
-        body = {'status': status}
+        body = {
+            'status': status,
+            'marked_job_started': job.marked_job_started,
+        }
 
         start_time = time_msecs()
         delay_secs = 0.1


### PR DESCRIPTION
Tested in a dev deploy'd load test that # of add_attempt_resources queries == # of jobs instead of double as you can currently observe in default.