### PR TITLE
[query] deduplicate identical LiftMeOut nodes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/LiftRelationalValues.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LiftRelationalValues.scala
@@ -3,21 +3,30 @@ package is.hail.expr.ir
 import is.hail.types.virtual.TVoid
 import is.hail.utils.BoxedArrayBuilder
 
+import scala.collection.mutable
+
 object LiftRelationalValues {
 
   def apply(ir0: IR): IR = {
 
-    def rewrite(ir: BaseIR, ab: BoxedArrayBuilder[(String, IR)]): BaseIR = ir match {
+    def rewrite(ir: BaseIR, ab: BoxedArrayBuilder[(String, IR)], memo: mutable.Map[IR, String]): BaseIR = ir match {
       case RelationalLet(name, value, body) =>
-        val value2 = rewrite(value, ab).asInstanceOf[IR]
+        val value2 = rewrite(value, ab, memo).asInstanceOf[IR]
         val ab2 = new BoxedArrayBuilder[(String, IR)]
-        val body2 = rewrite(body, ab2).asInstanceOf[IR]
+        val memo2 = mutable.Map.empty[IR, String]
+        val body2 = rewrite(body, ab2, memo2).asInstanceOf[IR]
         RelationalLet(name, value2, ab2.result().foldRight[IR](body2) { case ((name, value), acc) => RelationalLet(name, value, acc) })
       case LiftMeOut(child) =>
-        val ref = RelationalRef(genUID(), child.typ)
-        val newChild = rewrite(child, ab).asInstanceOf[IR]
-        ab += ((ref.name, newChild))
-        ref
+        val name = memo.get(child) match {
+          case Some(name) => name
+          case None =>
+            val name = genUID()
+            val newChild = rewrite(child, ab, memo).asInstanceOf[IR]
+            ab += ((name, newChild))
+            memo(child) = name
+            name
+        }
+        RelationalRef(name, child.typ)
       case (_: TableAggregate
            | _: TableCount
            | _: TableToValueApply
@@ -26,7 +35,7 @@ object LiftRelationalValues {
            | _: BlockMatrixCollect
            | _: TableGetGlobals) if ir.typ != TVoid =>
         val ref = RelationalRef(genUID(), ir.asInstanceOf[IR].typ)
-        val rwChildren = ir.children.map(rewrite(_, ab))
+        val rwChildren = ir.children.map(rewrite(_, ab, memo))
         val newChild = if ((rwChildren, ir.children).zipped.forall(_ eq _))
           ir
         else
@@ -34,7 +43,7 @@ object LiftRelationalValues {
         ab += ((ref.name, newChild.asInstanceOf[IR]))
         ref
       case x =>
-        val rwChildren = x.children.map(rewrite(_, ab))
+        val rwChildren = x.children.map(rewrite(_, ab, memo))
         if ((rwChildren, ir.children).zipped.forall(_ eq _))
           ir
         else
@@ -42,7 +51,8 @@ object LiftRelationalValues {
     }
 
     val ab = new BoxedArrayBuilder[(String, IR)]
-    val rw = rewrite(ir0, ab).asInstanceOf[IR]
+    val memo = mutable.Map.empty[IR, String]
+    val rw = rewrite(ir0, ab, memo).asInstanceOf[IR]
     ab.result().foldRight[IR](rw) { case ((name, value), acc) => RelationalLet(name, value, acc)
     }
   }


### PR DESCRIPTION
Not a long-term solution, but we do hacky dedups like this elsewhere in the compiler and it can clean up simple duplicated IRs. Not chained duplicated IRs, as you've noticed.