### PR TITLE
[batch/qob] retrieves stack trace for failed worker jobs

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -221,7 +221,7 @@ pytest-qob: upload-qob-jar upload-remote-test-resources install-editable
             --durations=50 \
             --self-contained-html \
             --html=../build/reports/pytest.html \
-            --timeout=120 \
+            --timeout=1200 \
             $(PYTEST_TARGET) \
             $(PYTEST_ARGS)
 

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -207,22 +207,11 @@ object Worker {
     timer.end("executeFunction")
     timer.start("writeOutputs")
 
-    retryTransientErrors {
-      write(s"$root/result.$i") { dos =>
-        result match {
-          case Right(bytes) =>
-            dos.writeBoolean(true)
-            dos.write(bytes)
-          case Left(throwableWhileExecutingUserCode) =>
-            val (shortMessage, expandedMessage, errorId) =
-              handleForPython(throwableWhileExecutingUserCode)
-            dos.writeBoolean(false)
-            writeString(dos, shortMessage)
-            writeString(dos, expandedMessage)
-            dos.writeInt(errorId)
-        }
-      }
-    }
+    /* TODO uncomment after testing retryTransientErrors { write(s"$root/result.$i") { dos => result
+     * match { case Right(bytes) => dos.writeBoolean(true) dos.write(bytes) case
+     * Left(throwableWhileExecutingUserCode) => val (shortMessage, expandedMessage, errorId) =
+     * handleForPython(throwableWhileExecutingUserCode) dos.writeBoolean(false) writeString(dos,
+     * shortMessage) writeString(dos, expandedMessage) dos.writeInt(errorId) } } } */
 
     timer.end("writeOutputs")
     timer.end(s"Job $i")

--- a/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
+++ b/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
@@ -222,6 +222,12 @@ class BatchClient(
     throw new AssertionError("unreachable")
   }
 
+  def getJob(batchId: Long, jobId: Int): (JValue, JValue) =
+    (
+      get(s"/api/v1alpha/batches/$batchId/jobs/$jobId"),
+      get(s"/api/v1alpha/batches/$batchId/jobs/$jobId/log"),
+    )
+
   private def createBunches(jobs: IndexedSeq[JObject]): BoxedArrayBuilder[Array[Array[Byte]]] = {
     val bunches = new BoxedArrayBuilder[Array[Array[Byte]]]()
     val bunchb = new BoxedArrayBuilder[Array[Byte]]()


### PR DESCRIPTION
Currently, when a QoB worker job fails in a way that prevents it from writing a result file with the error's stack trace in it, the Batch worker that started the job tries to get the result file anyway, and when it fails, raises a 404. This change retrieves the stack trace from the QoB job and raises an error with the stack trace included.