### PR TITLE
[query][qob] simplify QoB error handling and fix flaky test

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -4,7 +4,7 @@ from ..fs.fs import FS
 from ..expr import Expression
 from ..expr.types import HailType
 from ..ir import BaseIR
-from ..utils.java import FatalError, HailUserError
+from ..utils.java import FatalError
 
 
 def fatal_error_from_java_error_triplet(short_message, expanded_message, error_id):
@@ -171,19 +171,3 @@ class Backend(abc.ABC):
     @abc.abstractmethod
     def requires_lowering(self):
         pass
-
-    def _raise_error_from_driver(self, err: FatalError, ir: BaseIR):
-        if err._error_id is None:
-            raise err
-
-        error_sources = ir.base_search(lambda x: x._error_id == err._error_id)
-        if len(error_sources) == 0:
-            raise err
-
-        better_stack_trace = error_sources[0]._stack_trace
-        error_message = str(err)
-        message_and_trace = (f'{error_message}\n'
-                             '------------\n'
-                             'Hail stack trace:\n'
-                             f'{better_stack_trace}')
-        raise HailUserError(message_and_trace) from None

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -172,7 +172,7 @@ class Backend(abc.ABC):
     def requires_lowering(self):
         pass
 
-    def _handle_fatal_error_from_backend(self, err: FatalError, ir: BaseIR):
+    def _raise_error_from_driver(self, err: FatalError, ir: BaseIR):
         if err._error_id is None:
             raise err
 

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -101,7 +101,7 @@ class Py4JBackend(Backend):
 
             return (value, timings) if timed else value
         except FatalError as e:
-            self._handle_fatal_error_from_backend(e, ir)
+            self._raise_error_from_driver(e, ir)
 
     async def _async_execute(self, ir, timed=False):
         raise NotImplementedError('no async available in Py4JBackend')

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -101,7 +101,7 @@ class Py4JBackend(Backend):
 
             return (value, timings) if timed else value
         except FatalError as e:
-            self._raise_error_from_driver(e, ir)
+            raise e.maybe_user_error(ir) from None
 
     async def _async_execute(self, ir, timed=False):
         raise NotImplementedError('no async available in Py4JBackend')

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -396,10 +396,11 @@ class ServiceBackend(Backend):
                     short_message = await read_str(outfile)
                     expanded_message = await read_str(outfile)
                     error_id = await read_int(outfile)
-                    assert ir is not None
-                    self._raise_error_from_driver(
-                        fatal_error_from_java_error_triplet(short_message, expanded_message, error_id),
-                        ir)
+
+                    reconstructed_error = fatal_error_from_java_error_triplet(short_message, expanded_message, error_id)
+                    if ir is None:
+                        raise reconstructed_error
+                    raise reconstructed_error.maybe_user_error(ir)
 
     def execute(self, ir: BaseIR, timed: bool = False):
         return async_to_blocking(self._async_execute(ir, timed=timed))

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -6,8 +6,6 @@ import os
 from hail.expr.expressions.base_expression import Expression
 import orjson
 import logging
-import re
-import yaml
 from pathlib import Path
 
 from hail.context import TemporaryDirectory, tmp_dir, TemporaryFilename, revision, _TemporaryFilenameManager
@@ -346,7 +344,7 @@ class ServiceBackend(Backend):
                 if self.driver_memory is not None:
                     resources['memory'] = str(self.driver_memory)
 
-                j = bb.create_jvm_job(
+                bb.create_jvm_job(
                     jar_spec=self.jar_spec.to_dict(),
                     argv=[
                         ServiceBackend.DRIVER,
@@ -367,9 +365,9 @@ class ServiceBackend(Backend):
                         url = deploy_config.external_url('batch', f'/batches/{b.id}/jobs/1')
                         print(f'Submitted batch {b.id}, see {url}')
 
-                    status = await b.wait(description=name,
-                                          disable_progress_bar=self.disable_progress_bar,
-                                          progress=progress)
+                    await b.wait(description=name,
+                                 disable_progress_bar=self.disable_progress_bar,
+                                 progress=progress)
                 except Exception:
                     await b.cancel()
                     raise
@@ -390,7 +388,7 @@ class ServiceBackend(Backend):
                         try:
                             return token, result_bytes, timings
                         except orjson.JSONDecodeError as err:
-                            raise FatalError(f'Hail internal error. Please contact the Hail team and provide the following information.\n\n' + yamlx.dump({
+                            raise FatalError('Hail internal error. Please contact the Hail team and provide the following information.\n\n' + yamlx.dump({
                                 'service_backend_debug_info': self.debug_info(),
                                 'batch_debug_info': b.debug_info()
                             })) from err

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 import sys
 import re
 
@@ -10,16 +10,29 @@ def choose_backend(backend: Optional[str] = None) -> str:
     return configuration_of('query', 'backend', backend, 'spark')
 
 
+class HailUserError(Exception):
+    """:class:`.HailUserError` is an error thrown by Hail when the user makes an error."""
+
+
 class FatalError(Exception):
     """:class:`.FatalError` is an error thrown by Hail method failures"""
 
-    def __init__(self, msg, error_id=-1):
+    def __init__(self, msg, error_id: int = -1):
         super().__init__(msg)
         self._error_id = error_id
 
+    def maybe_user_error(self, ir) -> Union['FatalError', HailUserError]:
+        error_sources = ir.base_search(lambda x: x._error_id == self._error_id)
+        if len(error_sources) == 0:
+            return self
 
-class HailUserError(Exception):
-    """:class:`.HailUserError` is an error thrown by Hail when the user makes an error."""
+        better_stack_trace = error_sources[0]._stack_trace
+        error_message = str(self)
+        message_and_trace = (f'{error_message}\n'
+                             '------------\n'
+                             'Hail stack trace:\n'
+                             f'{better_stack_trace}')
+        return HailUserError(message_and_trace)
 
 
 class Env:

--- a/hail/python/hailtop/yamlx.py
+++ b/hail/python/hailtop/yamlx.py
@@ -1,0 +1,20 @@
+import yaml
+
+
+def yaml_dump_multiline_str_as_literal_block(dumper, data):
+    if len(data.splitlines()) > 1:
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data.lstrip().rstrip(), style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+
+class HailDumper(yaml.SafeDumper):
+    @property
+    def yaml_representers(self):
+        return {
+            **super().yaml_representers,
+            str: yaml_dump_multiline_str_as_literal_block
+        }
+
+
+def dump(data) -> str:
+    return yaml.dump(data, Dumper=HailDumper)

--- a/hail/python/test/hailtop/test_yamlx.py
+++ b/hail/python/test/hailtop/test_yamlx.py
@@ -1,0 +1,11 @@
+from hailtop import yamlx
+
+
+def test_multiline_str_is_literal_block():
+    actual = yamlx.dump({'hello': 'abc', 'multiline': 'abc\ndef'})
+    expected = '''hello: abc
+multiline: |-
+  abc
+  def
+'''
+    assert actual == expected


### PR DESCRIPTION
The root issue here was that sometimes exc.args[0] was a string and sometimes it was a dict. When it was a string the `in` condition worked fine. When it was a dict, it was looking at the keys of the dict and not finding the error message (which is buried under a few layers).

The code was unnecessarily complex. I reworked the yaml printer to be simpler and work for any multiline string. I removed the regular expression that was used to discover the worker batch when the worker jobs were in a different batch from the driver jobs. I remove all specialized debugging information in favor of the general `debug_info` methods on `Batch` and `ServiceBackend`. I also have two clear error cases: if the driver does not write its output file, then something went horribly wrong. We dump all the debug info. If we do not receive valid JSON from the driver, again, something went horribly wrong. We dump all the debug info. The only remaining exceptional case is an error purposely serialized by the QoB driver to us (with or without an error id).


In particular, note that we now completely ignore the number of failing or successful jobs. That doesn't matter. If the driver sends us an output file, we use the data found there. If the driver does not send us an output file or sends us an output file without valid JSON, we dump as much debug info as possible.

cc: @tpoterba for visibility on your end
cc: @iris-garden because you're in this space (albeit, the bug you're fixing is in the QoB *driver* whereas this is the *client* [nb: *client* is the Python code which starts a batch with a *driver*. A *driver* adds zero or more *worker* jobs to its batch. You're addressing an issue with how the *driver* handles errors from the *workers*. This PR simplifies the logic for how the *client* handles errors from the *driver*.]).