### PR TITLE
[batch][azure] increase timeout for Azure

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/session.py
+++ b/hail/python/hailtop/aiocloud/aioazure/session.py
@@ -14,4 +14,6 @@ class AzureSession(Session):
                 credentials = AzureCredentials.from_file(credentials_file, scopes=scopes)
             else:
                 credentials = AzureCredentials.default_credentials(scopes=scopes)
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = aiohttp.ClientTimeout(total=30)
         super().__init__(credentials=credentials, params=params, **kwargs)

--- a/hail/python/hailtop/aiocloud/aioazure/session.py
+++ b/hail/python/hailtop/aiocloud/aioazure/session.py
@@ -1,5 +1,7 @@
 from typing import Mapping, Optional, List, Union
 
+import aiohttp
+
 from ..common import Session, AnonymousCloudCredentials
 from .credentials import AzureCredentials
 


### PR DESCRIPTION
Azure seems to have pervasively higher latency than GCP. This should reduce the amount of warning logs we receive.