### PR TITLE
[batch] make Batch.delete idempotent

### DIFF
--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -592,13 +592,6 @@ async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(
         else:
             assert False, str(await b.debug_info())
 
-        try:
-            await user2_batch.delete()
-        except httpx.ClientResponseError as e:
-            assert e.status == 404, str((e, await b.debug_info()))
-        else:
-            assert False, str(await b.debug_info())
-
         # list batches results for user2
         found, batches = await search_batches(user2_client, b.id, q='')
         assert not found, str((b.id, batches, await b.debug_info()))

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -462,6 +462,7 @@ class Batch:
             if err.code != 404:
                 raise
 
+
 class BatchBuilder:
     def __init__(self, client, *, attributes=None, callback=None, token=None, cancel_after_n_failures=None, batch=None):
         self._client = client

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -456,8 +456,11 @@ class Batch:
         return {'status': batch_status, 'jobs': jobs}
 
     async def delete(self):
-        await self._client._delete(f'/api/v1alpha/batches/{self.id}')
-
+        try:
+            await self._client._delete(f'/api/v1alpha/batches/{self.id}')
+        except httpx.ClientResponseError as err:
+            if err.code != 404:
+                raise
 
 class BatchBuilder:
     def __init__(self, client, *, attributes=None, callback=None, token=None, cancel_after_n_failures=None, batch=None):


### PR DESCRIPTION
`_delete` retries transient errors. The `.../delete` endpoints return 404 for batches that do not exist, which, I suppose, is reasonable. On the client-side, we need to ignore 404s to ensure idempotency.