### PR TITLE
[ci] Use correct hailgenetics_hailtop image step in deploy

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2904,7 +2904,7 @@ steps:
                              /io/repo/hail/build/deploy/dist/hail-*-py3-none-any.whl \
                              /io/github-oauth \
                              docker://{{ hailgenetics_hail_image.image }} \
-                             docker://{{ hailgenetics_hailtop_slim_image.image }} \
+                             docker://{{ hailgenetics_hailtop_image.image }} \
                              /io/wheel-for-azure/hail-*-py3-none-any.whl \
                              /io/www.tar.gz
     inputs:


### PR DESCRIPTION
This didn't fail the PR because this step does not have the test scope.