### PR TITLE
[query] use python:3.7 for pip-compile in hail

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -1,6 +1,6 @@
 .PHONY: jars clean
 
-HAIL_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+HAIL_HAIL_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include env_var.mk
 
@@ -373,12 +373,16 @@ install-deps: install-dev-deps
 
 .PHONY: generate-pip-lockfile
 generate-pip-lockfile:
+	docker run --rm -it \
+		-v $(HAIL_HAIL_DIR):/hail \
+		python:3.7-slim \
+		/bin/bash -c "pip install pip-tools && cd /hail && \
 	pip-compile --upgrade python/hailtop/requirements.txt \
-		--output-file=python/hailtop/pinned-requirements.txt
+		--output-file=python/hailtop/pinned-requirements.txt && \
 	pip-compile --upgrade python/requirements.txt \
-		--output-file=python/pinned-requirements.txt
+		--output-file=python/pinned-requirements.txt && \
 	pip-compile --upgrade python/dev/requirements.txt \
-		--output-file=python/dev/pinned-requirements.txt
+		--output-file=python/dev/pinned-requirements.txt"
 
 .PHONY: benchmark
 benchmark: $(WHEEL)
@@ -402,7 +406,7 @@ endif
 .PHONY: batch-docs
 batch-docs:
 	$(MAKE) -C python/hailtop/batch/docs \
-	      BUILDDIR=$(HAIL_DIR)/build/docs/batch \
+	      BUILDDIR=$(HAIL_HAIL_DIR)/build/docs/batch \
 	      html
 	rm -rf build/www/docs/batch
 	mkdir -p build/www/docs
@@ -418,7 +422,7 @@ HAIL_CACHE_VERSION = $(shell cat python/hail/hail_version)
 hail-docs: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs \
 	        SPHINXOPTS='-tgenerate_notebook_outputs' \
-	        BUILDDIR=$(HAIL_DIR)/build/docs/hail \
+	        BUILDDIR=$(HAIL_HAIL_DIR)/build/docs/hail \
 	        html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
@@ -432,7 +436,7 @@ hail-docs: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 .PHONY: hail-docs-no-test
 hail-docs-no-test: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs \
-	        BUILDDIR=$(HAIL_DIR)/build/docs/hail \
+	        BUILDDIR=$(HAIL_HAIL_DIR)/build/docs/hail \
 	        html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
@@ -441,7 +445,7 @@ hail-docs-no-test: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	     -iname *.html \
 	     -type f \
 	     -exec $(SED_INPLACE) -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
-	@echo Built docs: file://$(HAIL_DIR)/build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
+	@echo Built docs: file://$(HAIL_HAIL_DIR)/build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
 
 .PHONY: upload-docs
 upload-docs: hail-docs batch-docs


### PR DESCRIPTION
I renamed HAIL_DIR to HAIL_HAIL_DIR to better convey to which directory it refers.