### PR TITLE
[hailtop] safely use chunks

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -45,7 +45,8 @@ class AzureWritableStream(WritableStream):
             n = self._chunk_size
 
         block_id = secrets.token_urlsafe(32)
-        await self.client.stage_block(block_id, self._write_buffer.chunks(n))
+        with self._write_buffer.chunks(n) as chunks:
+            await self.client.stage_block(block_id, chunks)
         self.block_ids.append(block_id)
 
         new_offset = self._write_buffer.offset() + n

--- a/hail/python/hailtop/aiotools/utils.py
+++ b/hail/python/hailtop/aiotools/utils.py
@@ -1,5 +1,6 @@
 from typing import TypeVar, AsyncIterator, Iterator
 import collections
+from contextlib import contextmanager
 import asyncio
 
 

--- a/hail/python/hailtop/aiotools/utils.py
+++ b/hail/python/hailtop/aiotools/utils.py
@@ -80,21 +80,26 @@ class WriteBuffer:
             self._size -= n
         assert self._offset == new_offset
 
-    def chunks(self, chunk_size: int) -> Iterator[bytes]:
+    @contextmanager
+    def chunks(self, chunk_size: int) -> Iterator[Iterator[bytes]]:
         """Return an iterator that yields bytes whose total size is
         `chunk_size` from the beginning of the write buffer."""
         assert not self._iterating
+
+        def _chunks_iterator() -> Iterator[bytes]:
+            remaining = chunk_size
+            i = 0
+            while remaining > 0:
+                b = self._buffers[i]
+                n = len(b)
+                if n <= remaining:
+                    yield b
+                    remaining -= n
+                    i += 1
+                else:
+                    yield b[:remaining]
+                    break
+
         self._iterating = True
-        remaining = chunk_size
-        i = 0
-        while remaining > 0:
-            b = self._buffers[i]
-            n = len(b)
-            if n <= remaining:
-                yield b
-                remaining -= n
-                i += 1
-            else:
-                yield b[:remaining]
-                break
+        yield _chunks_iterator()
         self._iterating = False


### PR DESCRIPTION
If we hit an exception and exit the iterator early, then we are no longer iterating. We need to record that fact so that we can retry transient errors.