### PR TITLE
[query/ggplot] Updates faceting to respect legend grouping

### DIFF
--- a/hail/python/hail/ggplot/facets.py
+++ b/hail/python/hail/ggplot/facets.py
@@ -1,12 +1,16 @@
 import abc
 import math
 
+from typing import Dict, Tuple
+
 from .geoms import FigureAttribute
+from .utils import n_partitions
 
 import hail as hl
+from hail import Expression, StructExpression
 
 
-def vars(*args):
+def vars(*args: Expression) -> StructExpression:
     """
 
     Parameters
@@ -23,13 +27,19 @@ def vars(*args):
     return hl.struct(**{f"var_{i}": arg for i, arg in enumerate(args)})
 
 
-def facet_wrap(facets):
+def facet_wrap(facets: StructExpression, *, nrow: int = None, ncol: int = None, scales: str = "fixed") -> "FacetWrap":
     """Introduce a one dimensional faceting on specified fields.
 
     Parameters
     ----------
     facets: :class:`StructExpression` created by `hl.ggplot.vars` function.
         The fields to facet on.
+    nrow: :class:`int`
+        The number of rows into which the facets will be spread. Will be ignored if `ncol` is set.
+    ncol: :class:`int`
+        The number of columns into which the facets will be spread.
+    scales: :class:`str`
+        Whether the scales are the same across facets. For more information and a list of supported options, see `the ggplot documentation <https://ggplot2-book.org/facet.html#controlling-scales>`__.
 
     Returns
     -------
@@ -37,26 +47,65 @@ def facet_wrap(facets):
         The faceter.
 
     """
-    return FacetWrap(facets)
+    return FacetWrap(facets, nrow, ncol, scales)
 
 
 class Faceter(FigureAttribute):
 
     @abc.abstractmethod
-    def get_expr_to_group_by(self):
+    def get_expr_to_group_by(self) -> StructExpression:
         pass
 
 
 class FacetWrap(Faceter):
+    _base_scale_mappings = {
+        "shared_xaxes": "all",
+        "shared_yaxes": "all",
+    }
 
-    def __init__(self, facets):
+    _scale_mappings = {
+        "fixed": _base_scale_mappings,
+        "free_x": {
+            **_base_scale_mappings,
+            "shared_xaxes": False,
+        },
+        "free_y": {
+            **_base_scale_mappings,
+            "shared_yaxes": False,
+        },
+        "free": {
+            "shared_xaxes": False,
+            "shared_yaxes": False,
+        }
+    }
+
+    def __init__(self, facets: StructExpression, nrow: int = None, ncol: int = None, scales: str = "fixed"):
+        if nrow is not None and ncol is not None:
+            raise ValueError(
+                "Both `nrow` and `ncol` were specified. "
+                "Please specify only one of these values."
+            )
+        if scales not in self._scale_mappings:
+            raise ValueError(
+                f"An unsupported value ({scales}) was provided for `scales`. "
+                f"Supported values are: {[k for k in self._scale_mappings.keys()]}."
+            )
+        self.nrow = nrow
+        self.ncol = ncol
         self.facets = facets
+        self.scales = scales
 
-    def get_expr_to_group_by(self):
+    def get_expr_to_group_by(self) -> StructExpression:
         return self.facets
 
-    def get_facet_nrows_and_ncols(self, num_facet_values):
-        ncol = int(math.ceil(math.sqrt(num_facet_values)))
-        nrow = int(math.ceil(num_facet_values / ncol))
+    def get_facet_nrows_and_ncols(self, num_facet_values: int) -> Tuple[int, int]:
+        if self.ncol is not None:
+            return (n_partitions(num_facet_values, self.ncol), self.ncol)
+        elif self.nrow is not None:
+            return (self.nrow, n_partitions(num_facet_values, self.nrow))
+        else:
+            ncol = int(math.ceil(math.sqrt(num_facet_values)))
+            return (n_partitions(num_facet_values, ncol), ncol)
 
-        return (nrow, ncol)
+    def get_shared_axis_kwargs(self) -> Dict[str, str]:
+        return self._scale_mappings[self.scales]

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -2,6 +2,10 @@ import plotly
 import hail as hl
 
 
+def n_partitions(items: int, n_splits: int) -> int:
+    return (items + n_splits - 1) // n_splits
+
+
 def check_scale_continuity(scale, dtype, aes_key):
     if not scale.valid_dtype(dtype):
         raise ValueError(f"Invalid scale for aesthetic {aes_key} of type {dtype}")


### PR DESCRIPTION
This change brings the `facet_wrap` interface more in line with [the `ggplot2` implementation](https://ggplot2-book.org/facet.html#facet-wrap) by defaulting to show axes (with tick marks) for all facets, as well as providing `scales`, `nrow` and `ncol` arguments that the user can use to specify whether the scales should be the same across facets and how many rows or columns to use.

It also updates the faceting code to avoid duplicating legend entries when [grouped legends](https://github.com/hail-is/hail/pull/12254) are used, and to disable interactivity accordingly.

With this update, running this code:

```python
import hail as hl
from hail.ggplot import aes, facet_wrap, geom_point, ggplot, vars
ht = hl.utils.range_table(10)
ht = ht.annotate(squared=ht.idx ** 2)
ht = ht.annotate(even=hl.if_else(ht.idx % 2 == 0, "yes", "no"))
ht = ht.annotate(threeven=hl.if_else(ht.idx % 3 == 0, "good", "bad"))
ht = ht.annotate(fourven=hl.if_else(ht.idx % 4 == 0, "minor", "major"))
fig = (
    ggplot(ht, aes(x=ht.idx, y=ht.squared))
    + geom_point(aes(shape=ht.even, color=ht.threeven))
    + facet_wrap(vars(ht.threeven, ht.fourven), nrow=1)
)
fig.show()
```

Produces the following plot:

<img width="1283" alt="Screen Shot 2022-11-23 at 12 23 21" src="https://user-images.githubusercontent.com/84595986/203611376-682b98e7-2915-4e2c-8f1e-ef8c74b12907.png">
