### PR TITLE
[qob] Dont include the batch name in the worker name anymore

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -341,7 +341,7 @@ class ServiceBackend(Backend):
                     jar_spec=self.jar_spec.to_dict(),
                     argv=[
                         ServiceBackend.DRIVER,
-                        batch_attributes['name'] + name,
+                        name,
                         iodir + '/in',
                         iodir + '/out',
                     ],


### PR DESCRIPTION
Now the worker job names look like this instead of the worker jobs also having the batch name as the prefix:

![Screen Shot 2022-11-28 at 3 13 50 PM](https://user-images.githubusercontent.com/24440116/204371974-98a43c07-4b0a-489a-8bab-0ca90f01a862.png)
