### PR TITLE
[qob] Invalidate batch cache on error

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -363,6 +363,7 @@ class ServiceBackend(Backend):
                     raise
                 except Exception:
                     await self._batch.cancel()
+                    self._batch = None
                     raise
 
             with timings.step("read output"):


### PR DESCRIPTION
Not sure this is the right fix, but I believe we can't update a batch once it's been cancelled still.