### PR TITLE
[query] enable fs tests

### DIFF
--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -400,11 +400,14 @@ pyrsistent==0.19.2
 pytest==7.2.0
     # via
     #   -r python/dev/requirements.txt
+    #   pytest-asyncio
     #   pytest-forked
     #   pytest-html
     #   pytest-instafail
     #   pytest-metadata
     #   pytest-xdist
+pytest-asyncio==0.20.2
+    # via -r python/dev/requirements.txt
 pytest-forked==1.4.0
     # via pytest-xdist
 pytest-html==1.22.1
@@ -586,6 +589,7 @@ typing-extensions==4.4.0
     #   jsonschema
     #   mypy
     #   pylint
+    #   pytest-asyncio
     #   rich
     #   yarl
 urllib3==1.26.13

--- a/hail/python/dev/requirements.txt
+++ b/hail/python/dev/requirements.txt
@@ -11,6 +11,7 @@ pytest>=7.1.3,<8
 pytest-html>=1.20.0,<2
 pytest-xdist>=2.2.1,<3
 pytest-instafail>=0.4.2,<1
+pytest-asyncio>=0.14.0,<1
 sphinx>=3.5.4,<4
 sphinx-autodoc-typehints==1.11.1
 nbsphinx>=0.8.8,<1

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -110,7 +110,7 @@ orjson==3.8.2
     # via -r python/hailtop/requirements.txt
 portalocker==2.6.0
     # via msal-extensions
-protobuf==4.21.9
+protobuf==4.21.10
     # via
     #   google-api-core
     #   googleapis-common-protos


### PR DESCRIPTION
The FS tests were accidentally disabled because pytest-asyncio was never included in dev/requirements.txt (as it should have been). As a result, all the `async def` tests were (silently) ignored by pytest.