### PR TITLE
[hailtop.batch] Add ability to update a batch

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -772,7 +772,7 @@ class ServiceBackend(Backend[bc.Batch]):
             batch._batch_handle = batch_handle
         else:
             new_batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
-            assert batch_handle.id == new_batch_handle.id
+            assert batch._batch_handle.id == new_batch_handle.id
             batch_handle = batch._batch_handle
 
         for job in batch._unsubmitted_jobs:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -332,7 +332,6 @@ class LocalBackend(Backend[None]):
                 job._submitted = True
         finally:
             batch._python_function_defs.clear()
-            batch._python_function_files.clear()
             if delete_scratch_on_exit:
                 sp.run(f'rm -rf {tmpdir}', shell=True, check=False)
 
@@ -795,7 +794,6 @@ class ServiceBackend(Backend[bc.Batch]):
             print(f'batch {batch_handle.id} complete: {status["state"]}')
 
         batch._python_function_defs.clear()
-        batch._python_function_files.clear()
         return batch_handle
 
     def validate_file_scheme(self, uri: str) -> None:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -577,7 +577,7 @@ class ServiceBackend(Backend[bc.Batch]):
                 attributes=attributes, callback=callback, token=token, cancel_after_n_failures=batch._cancel_after_n_failures
             )
         else:
-            bc_batch_builder = self._batch_client.update_batch(batch._batch_handle.id)
+            bc_batch_builder = self._batch_client.update_batch(batch._batch_handle)
 
         n_jobs_submitted = 0
         used_remote_tmpdir = False
@@ -767,13 +767,12 @@ class ServiceBackend(Backend[bc.Batch]):
             print(f'Built DAG with {n_jobs_submitted} jobs in {round(time.time() - build_dag_start, 3)} seconds.')
 
         submit_batch_start = time.time()
+        batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
+
         if batch._batch_handle is None:
-            batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
             batch._batch_handle = batch_handle
         else:
-            new_batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
-            assert batch._batch_handle.id == new_batch_handle.id
-            batch_handle = batch._batch_handle
+            assert batch._batch_handle == batch_handle
 
         for job in batch._unsubmitted_jobs:
             job._submitted = True

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -572,13 +572,12 @@ class ServiceBackend(Backend[bc.Batch]):
         if batch.name is not None:
             attributes['name'] = batch.name
 
-        if batch._batch_id is None:
+        if batch._batch_handle is None:
             bc_batch_builder = self._batch_client.create_batch(
                 attributes=attributes, callback=callback, token=token, cancel_after_n_failures=batch._cancel_after_n_failures
             )
         else:
-            assert batch._batch_id
-            bc_batch_builder = self._batch_client.update_batch(batch._batch_id)
+            bc_batch_builder = self._batch_client.update_batch(batch._batch_handle.id)
 
         n_jobs_submitted = 0
         used_remote_tmpdir = False
@@ -771,10 +770,9 @@ class ServiceBackend(Backend[bc.Batch]):
         if batch._batch_handle is None:
             batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
             batch._batch_handle = batch_handle
-            batch._batch_id = batch_handle.id
         else:
-            assert batch._batch_id == batch._batch_handle.id
-            bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
+            new_batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
+            assert batch_handle.id == new_batch_handle.id
             batch_handle = batch._batch_handle
 
         for job in batch._unsubmitted_jobs:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -572,13 +572,13 @@ class ServiceBackend(Backend[bc.Batch]):
         if batch.name is not None:
             attributes['name'] = batch.name
 
-        if batch._client_batch is None:
+        if batch._batch_id is None:
             bc_batch_builder = self._batch_client.create_batch(
                 attributes=attributes, callback=callback, token=token, cancel_after_n_failures=batch._cancel_after_n_failures
             )
         else:
-            assert batch._client_batch
-            bc_batch_builder = self._batch_client.update_batch(batch._client_batch.id)
+            assert batch._batch_id
+            bc_batch_builder = self._batch_client.update_batch(batch._batch_id)
 
         n_jobs_submitted = 0
         used_remote_tmpdir = False
@@ -767,7 +767,7 @@ class ServiceBackend(Backend[bc.Batch]):
 
         submit_batch_start = time.time()
         batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
-        batch._client_batch = batch_handle
+        batch._batch_id = batch_handle.id
 
         for job in batch._unsubmitted_jobs:
             job._submitted = True

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -743,6 +743,7 @@ class ServiceBackend(Backend[bc.Batch]):
 
             n_jobs_submitted += 1
 
+            job._client_job = j
             job_to_client_job_mapping[job] = j
             jobs_to_command[j] = cmd
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -768,8 +768,14 @@ class ServiceBackend(Backend[bc.Batch]):
             print(f'Built DAG with {n_jobs_submitted} jobs in {round(time.time() - build_dag_start, 3)} seconds.')
 
         submit_batch_start = time.time()
-        batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
-        batch._batch_id = batch_handle.id
+        if batch._batch_handle is None:
+            batch_handle = bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
+            batch._batch_handle = batch_handle
+            batch._batch_id = batch_handle.id
+        else:
+            assert batch._batch_id == batch._batch_handle.id
+            bc_batch_builder.submit(disable_progress_bar=disable_progress_bar)
+            batch_handle = batch._batch_handle
 
         for job in batch._unsubmitted_jobs:
             job._submitted = True

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -331,6 +331,8 @@ class LocalBackend(Backend[None]):
                 run_code(code)
                 job._submitted = True
         finally:
+            batch._python_function_defs.clear()
+            batch._python_function_files.clear()
             if delete_scratch_on_exit:
                 sp.run(f'rm -rf {tmpdir}', shell=True, check=False)
 
@@ -791,6 +793,9 @@ class ServiceBackend(Backend[bc.Batch]):
             starting_job_id = min(j._client_job.job_id for j in unsubmitted_jobs)
             status = batch_handle.wait(disable_progress_bar=disable_progress_bar, starting_job=starting_job_id)
             print(f'batch {batch_handle.id} complete: {status["state"]}')
+
+        batch._python_function_defs.clear()
+        batch._python_function_files.clear()
         return batch_handle
 
     def validate_file_scheme(self, uri: str) -> None:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -332,6 +332,7 @@ class LocalBackend(Backend[None]):
                 job._submitted = True
         finally:
             batch._python_function_defs.clear()
+            batch._python_function_files.clear()
             if delete_scratch_on_exit:
                 sp.run(f'rm -rf {tmpdir}', shell=True, check=False)
 
@@ -794,6 +795,7 @@ class ServiceBackend(Backend[bc.Batch]):
             print(f'batch {batch_handle.id} complete: {status["state"]}')
 
         batch._python_function_defs.clear()
+        batch._python_function_files.clear()
         return batch_handle
 
     def validate_file_scheme(self, uri: str) -> None:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -572,8 +572,12 @@ class ServiceBackend(Backend[bc.Batch]):
         if batch.name is not None:
             attributes['name'] = batch.name
 
-        bc_batch = self._batch_client.create_batch(attributes=attributes, callback=callback,
-                                                   token=token, cancel_after_n_failures=batch._cancel_after_n_failures)
+        if batch._client_batch is None:
+            batch._client_batch = self._batch_client.create_batch(
+                attributes=attributes, callback=callback, token=token, cancel_after_n_failures=batch._cancel_after_n_failures
+            )
+
+        bc_batch = batch._client_batch
 
         n_jobs_submitted = 0
         used_remote_tmpdir = False

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -8,7 +8,6 @@ import dill
 from hailtop.utils import secret_alnum_string, url_scheme, async_to_blocking
 from hailtop.aiotools import AsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
-import hailtop.batch_client as _bc
 from hailtop.config import configuration_of
 
 from . import backend as _backend, job, resource as _resource  # pylint: disable=cyclic-import
@@ -169,7 +168,7 @@ class Batch:
         self._python_function_defs: Dict[int, Callable] = {}
         self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
 
-        self._client_batch: Optional[_bc.client.Batch] = None
+        self._batch_id: Optional[int] = None
 
     @property
     def _unsubmitted_jobs(self):

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -209,7 +209,6 @@ class Batch:
                     path, "functions", function_id, function, dry_run
                 )
                 self._python_function_files[function_id] = file
-        self._python_function_defs.clear()
 
     def _unique_job_token(self, n=5):
         token = secret_alnum_string(n)

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -8,6 +8,7 @@ import dill
 from hailtop.utils import secret_alnum_string, url_scheme, async_to_blocking
 from hailtop.aiotools import AsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
+import hailtop.batch_client.client as _bc
 from hailtop.config import configuration_of
 
 from . import backend as _backend, job, resource as _resource  # pylint: disable=cyclic-import
@@ -169,6 +170,7 @@ class Batch:
         self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
 
         self._batch_id: Optional[int] = None
+        self._batch_handle: Optional[_bc.Batch] = None
 
     @property
     def _unsubmitted_jobs(self):
@@ -204,11 +206,10 @@ class Batch:
         self, path: str, dry_run: bool = False
     ) -> None:
         for function_id, function in self._python_function_defs.items():
-            if function_id not in self._python_function_files:
-                file = await self._serialize_python_to_input_file(
-                    path, "functions", function_id, function, dry_run
-                )
-                self._python_function_files[function_id] = file
+            file = await self._serialize_python_to_input_file(
+                path, "functions", function_id, function, dry_run
+            )
+            self._python_function_files[function_id] = file
 
     def _unique_job_token(self, n=5):
         token = secret_alnum_string(n)

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -168,6 +168,14 @@ class Batch:
         self._python_function_defs: Dict[int, Callable] = {}
         self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
 
+    @property
+    def _unsubmitted_jobs(self):
+        return [j for j in self._jobs if not j._submitted]
+
+    @property
+    def _submitted_jobs(self):
+        return [j for j in self._jobs if j._submitted]
+
     def _register_python_function(self, function: Callable) -> int:
         function_id = id(function)
         self._python_function_defs[function_id] = function
@@ -343,6 +351,7 @@ class Batch:
             j.timeout(self._default_timeout)
 
         self._jobs.append(j)
+        self._unsubmitted_jobs.append(j)
         return j
 
     def _new_job_resource_file(self, source, value=None):

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -14,16 +14,6 @@ from . import backend as _backend, job, resource as _resource  # pylint: disable
 from .exceptions import BatchException
 
 
-class PythonFunctionDefinition:
-    def __init__(self, id: int, function: Callable):
-        self.id = id
-        self.function = function
-        self.references: List['job.PythonJob'] = []
-
-    def add_reference(self, j: 'job.PythonJob'):
-        self.references.append(j)
-
-
 class Batch:
     """
     Object representing the distributed acyclic graph (DAG) of jobs to run.
@@ -175,7 +165,7 @@ class Batch:
 
         self._cancel_after_n_failures = cancel_after_n_failures
 
-        self._python_function_defs: Dict[int, PythonFunctionDefinition] = {}
+        self._python_function_defs: Dict[int, Callable] = {}
         self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
 
         self._batch_id: Optional[int] = None
@@ -188,16 +178,9 @@ class Batch:
     def _submitted_jobs(self):
         return [j for j in self._jobs if j._submitted]
 
-    def _register_python_function(self, j: 'job.PythonJob', function: Callable) -> int:
+    def _register_python_function(self, function: Callable) -> int:
         function_id = id(function)
-
-        func_def = self._python_function_defs.get(function_id)
-        if func_def is None:
-            func_def = PythonFunctionDefinition(function_id, function)
-            self._python_function_defs[function_id] = func_def
-
-        func_def.add_reference(j)
-
+        self._python_function_defs[function_id] = function
         return function_id
 
     async def _serialize_python_to_input_file(
@@ -220,13 +203,13 @@ class Batch:
     async def _serialize_python_functions_to_input_files(
         self, path: str, dry_run: bool = False
     ) -> None:
-        for function_id, func_def in self._python_function_defs.items():
-            transfer_required = any(not j._submitted for j in func_def.references)
-            if transfer_required:
+        for function_id, function in self._python_function_defs.items():
+            if function_id not in self._python_function_files:
                 file = await self._serialize_python_to_input_file(
-                    path, "functions", function_id, func_def.function, dry_run
+                    path, "functions", function_id, function, dry_run
                 )
                 self._python_function_files[function_id] = file
+        self._python_function_defs.clear()
 
     def _unique_job_token(self, n=5):
         token = secret_alnum_string(n)

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -110,6 +110,29 @@ class Batch:
 
     @staticmethod
     def from_batch_id(batch_id: int, *args, **kwargs):
+        """
+        Create a Batch from an existing batch id.
+
+        Notes
+        -----
+        Can only be used with the :class:`.ServiceBackend`.
+
+        Examples
+        --------
+
+        Create a batch object from an existing batch id:
+
+        >>> b = Batch.from_batch_id(1)  # doctest: +SKIP
+
+        Parameters
+        ----------
+        batch_id:
+            ID of an existing Batch
+
+        Returns
+        -------
+        A Batch object that can append jobs to an existing batch.
+        """
         b = Batch(*args, **kwargs)
         assert isinstance(b._backend, _backend.ServiceBackend)
         b._batch_handle = b._backend._batch_client.get_batch(batch_id)

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -8,6 +8,7 @@ import dill
 from hailtop.utils import secret_alnum_string, url_scheme, async_to_blocking
 from hailtop.aiotools import AsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
+import hailtop.batch_client as _bc
 from hailtop.config import configuration_of
 
 from . import backend as _backend, job, resource as _resource  # pylint: disable=cyclic-import
@@ -167,6 +168,8 @@ class Batch:
 
         self._python_function_defs: Dict[int, Callable] = {}
         self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
+
+        self._client_batch: Optional[_bc.client.Batch] = None
 
     @property
     def _unsubmitted_jobs(self):

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -108,6 +108,13 @@ class Batch:
         cls._counter += 1
         return uid
 
+    @staticmethod
+    def from_batch_id(batch_id: int, *args, **kwargs):
+        b = Batch(*args, **kwargs)
+        assert isinstance(b._backend, _backend.ServiceBackend)
+        b._batch_handle = b._backend._batch_client.get_batch(batch_id)
+        return b
+
     def __init__(self,
                  name: Optional[str] = None,
                  backend: Optional[_backend.Backend] = None,
@@ -169,7 +176,6 @@ class Batch:
         self._python_function_defs: Dict[int, Callable] = {}
         self._python_function_files: Dict[int, _resource.InputResourceFile] = {}
 
-        self._batch_id: Optional[int] = None
         self._batch_handle: Optional[_bc.Batch] = None
 
     @property

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -7,6 +7,8 @@ import warnings
 from shlex import quote as shq
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 
+import hailtop.batch_client.client as bc
+
 from . import backend, batch  # pylint: disable=cyclic-import
 from . import resource as _resource  # pylint: disable=cyclic-import
 from .exceptions import BatchException
@@ -96,6 +98,8 @@ class Job:
         self._mentioned: Set[_resource.Resource] = set()  # resources used in the command
         self._valid: Set[_resource.Resource] = set()  # resources declared in the appropriate place
         self._dependencies: Set[Job] = set()
+        self._submitted: bool = False
+        self._client_job: Optional[bc.Job] = None
 
         def safe_str(s):
             new_s = []

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1110,7 +1110,7 @@ class PythonJob(Job):
         result = self._get_resource(f'result{self.n_results}')
         handle_arg(result)
 
-        unapplied_id = self._batch._register_python_function(unapplied)
+        unapplied_id = self._batch._register_python_function(self, unapplied)
 
         self._function_calls.append((result, unapplied_id, args, kwargs))
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1185,7 +1185,7 @@ with open('{result}', 'wb') as dill_out:
             wrapper_code = self._interpolate_command(wrapper_code, allow_python_results=True)
             self._wrapper_code.append(wrapper_code)
 
-            unapplied = self._batch._python_function_defs[unapplied_id]
+            unapplied = self._batch._python_function_defs[unapplied_id].function
             self._user_code.append(textwrap.dedent(inspect.getsource(unapplied)))
             args_str = ', '.join([f'{arg!r}' for _, arg in prepared_args])
             kwargs_str = ', '.join([f'{k}={v!r}' for k, (_, v) in kwargs.items()])

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1110,7 +1110,7 @@ class PythonJob(Job):
         result = self._get_resource(f'result{self.n_results}')
         handle_arg(result)
 
-        unapplied_id = self._batch._register_python_function(self, unapplied)
+        unapplied_id = self._batch._register_python_function(unapplied)
 
         self._function_calls.append((result, unapplied_id, args, kwargs))
 
@@ -1185,7 +1185,7 @@ with open('{result}', 'wb') as dill_out:
             wrapper_code = self._interpolate_command(wrapper_code, allow_python_results=True)
             self._wrapper_code.append(wrapper_code)
 
-            unapplied = self._batch._python_function_defs[unapplied_id].function
+            unapplied = self._batch._python_function_defs[unapplied_id]
             self._user_code.append(textwrap.dedent(inspect.getsource(unapplied)))
             args_str = ', '.join([f'{arg!r}' for _, arg in prepared_args])
             kwargs_str = ', '.join([f'{k}={v!r}' for k, (_, v) in kwargs.items()])

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -535,7 +535,7 @@ class BatchBuilder:
                     in_update_parent_ids.append(job._job_id)
             else:
                 assert isinstance(job, SubmittedJob)
-                if self._batch is None or job._batch != self._batch:
+                if self._batch is None or (job._batch != self._batch and job._batch.id != self._batch.id):
                     foreign_batches.append(job)
                 else:
                     absolute_parent_ids.append(job.job_id)

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -535,7 +535,7 @@ class BatchBuilder:
                     in_update_parent_ids.append(job._job_id)
             else:
                 assert isinstance(job, SubmittedJob)
-                if self._batch is None or (job._batch != self._batch and job._batch.id != self._batch.id):
+                if self._batch is None or job._batch.id != self._batch.id:
                     foreign_batches.append(job)
                 else:
                     absolute_parent_ids.append(job.job_id)

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -535,7 +535,7 @@ class BatchBuilder:
                     in_update_parent_ids.append(job._job_id)
             else:
                 assert isinstance(job, SubmittedJob)
-                if self._batch is None or job._batch.id != self._batch.id:
+                if self._batch is None or job._batch != self._batch:
                     foreign_batches.append(job)
                 else:
                     absolute_parent_ids.append(job.job_id)

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -321,7 +321,7 @@ class BatchClient:
 
     def update_batch(self, batch: Union[int, Batch]) -> 'BatchBuilder':
         _batch = batch._async_batch if isinstance(batch, Batch) else batch
-        batch_builder = self._async_client.update_batch(_batch)
+        batch_builder = async_to_blocking(self._async_client.update_batch(_batch))
         if isinstance(batch, Batch):
             return BatchBuilder.from_async_builder(batch_builder, batch=batch)
         return BatchBuilder.from_async_builder(batch_builder, batch=None)

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -315,7 +315,7 @@ class BatchClient:
         return BatchBuilder.from_async_builder(builder)
 
     def update_batch(self, batch: Union[int, Batch]) -> 'BatchBuilder':
-        builder = async_to_blocking(self._async_client.update_batch(batch))
+        builder = async_to_blocking(self._async_client.update_batch(batch._async_batch))
         return BatchBuilder.from_async_builder(builder)
 
     def get_billing_project(self, billing_project):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 import asyncio
 
 from ..config import DeployConfig
@@ -314,8 +314,8 @@ class BatchClient:
                                                   cancel_after_n_failures=cancel_after_n_failures)
         return BatchBuilder.from_async_builder(builder)
 
-    def update_batch(self, batch_id: int) -> 'BatchBuilder':
-        builder = async_to_blocking(self._async_client.update_batch(batch_id))
+    def update_batch(self, batch: Union[int, Batch]) -> 'BatchBuilder':
+        builder = async_to_blocking(self._async_client.update_batch(batch))
         return BatchBuilder.from_async_builder(builder)
 
     def get_billing_project(self, billing_project):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -315,7 +315,9 @@ class BatchClient:
         return BatchBuilder.from_async_builder(builder)
 
     def update_batch(self, batch: Union[int, Batch]) -> 'BatchBuilder':
-        builder = async_to_blocking(self._async_client.update_batch(batch._async_batch))
+        if isinstance(batch, Batch):
+            batch = batch._async_batch
+        builder = async_to_blocking(self._async_client.update_batch(batch))
         return BatchBuilder.from_async_builder(builder)
 
     def get_billing_project(self, billing_project):

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1114,3 +1114,19 @@ class ServiceTests(unittest.TestCase):
         batch = b.run()
         batch_status = batch.status()
         assert batch_status['state'] == 'success', str((batch_status, batch.debug_info()))
+
+    def test_update_batch_from_batch_id(self):
+        b = self.batch()
+        j = b.new_job()
+        j.command('true')
+        res = b.run()
+
+        res_status = res.status()
+        assert res_status['state'] == 'success', str((res_status, res.debug_info()))
+
+        b2 = Batch.from_batch_id(b._batch_handle.id)
+        j2 = b2.new_job()
+        j2.command('true')
+        res = b2.run()
+        res_status = res.status()
+        assert res_status['state'] == 'success', str((res_status, res.debug_info()))

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1124,7 +1124,7 @@ class ServiceTests(unittest.TestCase):
         res_status = res.status()
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
 
-        b2 = Batch.from_batch_id(b._batch_handle.id)
+        b2 = Batch.from_batch_id(b._batch_handle.id, backend=b._backend)
         j2 = b2.new_job()
         j2.command('true')
         res = b2.run()

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1044,3 +1044,18 @@ class ServiceTests(unittest.TestCase):
         res = b2.run()
         res_status = res.status()
         assert res_status['state'] == 'failure', str((res_status, res.debug_info()))
+
+    def test_update_batch(self):
+        b = self.batch()
+        j = b.new_job()
+        j.command('true')
+        res = b.run()
+
+        res_status = res.status()
+        assert res_status['state'] == 'success', str((res_status, res.debug_info()))
+
+        j2 = b.new_job()
+        j2.command('true')
+        res = b.run()
+        res_status = res.status()
+        assert res_status['state'] == 'success', str((res_status, res.debug_info()))


### PR DESCRIPTION
CHANGELOG: Added the ability to update an existing batch with additional jobs by calling `Batch.run()` more than once.

I wrote this quite awhile ago, so I don't remember if there were any issues as to why I didn't make a PR sooner or if I'm missing some complexity here.