### PR TITLE
[query] Fix pytest-qob and fix test_import_bed

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -80,7 +80,7 @@ endif
 else
 JAR_LOCATION = $(TEST_STORAGE_URI)/$(NAMESPACE)/jars/$(TOKEN)/$(REVISION).jar
 endif
-HAIL_TEST_RESOURCES_PREFIX = $(TEST_STORAGE_URI)/$(HAIL_TEST_GCS_TOKEN)/hail-test-resources
+HAIL_TEST_RESOURCES_PREFIX = $(TEST_STORAGE_URI)/$(shell whoami)/hail-test-resources
 HAIL_TEST_RESOURCES_DIR = $(HAIL_TEST_RESOURCES_PREFIX)/test/resources/
 HAIL_DOCTEST_DATA_DIR = $(HAIL_TEST_RESOURCES_PREFIX)/doctest/data/
 
@@ -182,12 +182,13 @@ pytest: python/README.md $(PYTHON_JAR)
 .PHONY: pytest-qob
 pytest-qob: upload-qob-jar upload-qob-test-resources install-editable
 	! [ -z $(NAMESPACE) ]  # call this like: make pytest-qob NAMESPACE=default
-	HAIL_QUERY_BACKEND=batch \
-	HAIL_QUERY_JAR_URL=$$(cat upload-qob-jar) \
+	cd python && \
+  HAIL_QUERY_BACKEND=batch \
+	HAIL_QUERY_JAR_URL=$$(cat ../upload-qob-jar) \
 	HAIL_DEFAULT_NAMESPACE=$(NAMESPACE) \
 	HAIL_TEST_RESOURCES_DIR='$(HAIL_TEST_RESOURCES_DIR)' \
 	HAIL_DOCTEST_DATA_DIR='$(HAIL_DOCTEST_DATA_DIR)' \
-	cd python && pytest \
+	pytest \
 		-v \
 		--color=no \
 		--instafail \

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1670,14 +1670,13 @@ class LocusIntervalTests(unittest.TestCase):
         t = hl.import_locus_intervals(interval_file, reference_genome=None, skip_invalid_intervals=True)
         self.assertEqual(t.count(), 22)
 
-    @fails_service_backend()
     def test_import_bed(self):
         bed_file = resource('example1.bed')
         bed = hl.import_bed(bed_file, reference_genome='GRCh37')
 
         nbed = bed.count()
         i = 0
-        with open(bed_file) as f:
+        with hl.hadoop_open(bed_file) as f:
             for line in f:
                 if len(line.strip()) != 0:
                     try:


### PR DESCRIPTION
The environment variables should be affecting `pytest`, not `cd`.

`test_import_bed` just needs to use an `open` that can speak `gs://`.