### PR TITLE
[batch] Remove disk usage monitoring that was added for debugging pur…

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -36,7 +36,6 @@ import aiohttp
 import aiohttp.client_exceptions
 import aiorwlock
 import async_timeout
-import humanize
 import orjson
 from aiodocker.exceptions import DockerError  # type: ignore
 from aiohttp import web


### PR DESCRIPTION
…poses only

This was added to debug if the resource usage monitoring triggered out of disk space errors again. Since, there's been no issues, let's take this out since it's O(n_jobs)