### PR TITLE
[native compiler] disable expensive clang-tidy check

### DIFF
--- a/query/.clang-tidy
+++ b/query/.clang-tidy
@@ -15,6 +15,7 @@ Checks: >
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   misc-*,
+  -misc-confusable-identifiers,
   -misc-unused-parameters,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,


### PR DESCRIPTION
From local timing results using `clang-tidy -enable-check-profile`, I'm pretty sure `misc-confusable-identifiers` is quadratic. It was taking about a quarter of the time on `hail-opt`