### PR TITLE
[batch] Omit setup progress bars on small batch submission

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1071,6 +1071,14 @@ def test_job_private_instance_cancel(client: BatchClient):
     assert status['state'] == 'Cancelled', str((status, b.debug_info()))
 
 
+def test_create_fast_path_more_than_one_job(client: BatchClient):
+    bb = client.create_batch()
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b = bb.submit()
+    assert b.submission_info.used_fast_create, b.submission_info
+
+
 def test_update_batch_no_deps(client: BatchClient):
     bb = client.create_batch()
     j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -6,6 +6,7 @@ import json
 import functools
 import asyncio
 import aiohttp
+import orjson
 import secrets
 
 from hailtop.config import get_deploy_config, DeployConfig
@@ -711,13 +712,12 @@ class BatchBuilder:
     MAX_BUNCH_SIZE = 1024
 
     async def _submit_bunches(self,
-                              byte_job_specs: List[bytes],
                               byte_job_specs_bunches: List[List[bytes]],
                               bunch_sizes: List[int],
                               progress: BatchProgressBar,
                               disable_progress_bar: bool):
         with progress.with_task('submit bunches', total=len(self._job_specs), disable=disable_progress_bar) as progress_task:
-            n_bunches = len(byte_job_specs)
+            n_bunches = len(byte_job_specs_bunches)
             if self._batch is None:
                 if n_bunches == 0:
                     self._batch = await self._open_batch()
@@ -767,7 +767,7 @@ class BatchBuilder:
                      ) -> Batch:
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0
-        byte_job_specs = [json.dumps(job_spec).encode('utf-8')
+        byte_job_specs = [orjson.dumps(job_spec)
                           for job_spec in self._job_specs]
         byte_job_specs_bunches: List[List[bytes]] = []
         bunch_sizes = []
@@ -794,15 +794,14 @@ class BatchBuilder:
             bunch_sizes.append(bunch_n_jobs)
 
         if progress is not None:
-            start_job_id = await self._submit_bunches(byte_job_specs,
-                                                      byte_job_specs_bunches,
+            start_job_id = await self._submit_bunches(byte_job_specs_bunches,
                                                       bunch_sizes,
                                                       progress,
                                                       disable_progress_bar)
         else:
-            with BatchProgressBar(disable=disable_progress_bar) as progress2:
-                start_job_id = await self._submit_bunches(byte_job_specs,
-                                                          byte_job_specs_bunches,
+            n_bunches = len(byte_job_specs_bunches)
+            with BatchProgressBar(disable=disable_progress_bar or n_bunches < 100) as progress2:
+                start_job_id = await self._submit_bunches(byte_job_specs_bunches,
                                                           bunch_sizes,
                                                           progress2,
                                                           disable_progress_bar)


### PR DESCRIPTION
I also noticed a bug in the process where the python client uses create-fast only if there is one *job* not one *bunch*. I fixed that and threw in a test.