### PR TITLE
[website] Clean up use of scope instead of deploy

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2187,13 +2187,10 @@ steps:
       export GOOGLE_APPLICATION_CREDENTIALS=/batch-gsa-key/key.json
       export AZURE_APPLICATION_CREDENTIALS=/batch-gsa-key/key.json
 
-      {% if scope == "deploy" %}
+      {% if deploy %}
       HAIL_QUERY_JAR_URL={{ global.query_storage_uri }}
-      {% elif scope == "test" or scope == "dev" %}
-      HAIL_QUERY_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
       {% else %}
-      echo "!!! unexpected scope {{ scope }} !!!"
-      exit 1
+      HAIL_QUERY_JAR_URL={{ global.test_storage_uri }}/{{ default_ns.name }}
       {% endif %}
       HAIL_QUERY_JAR_URL=${HAIL_QUERY_JAR_URL}/jars/$(cat /io/git_version).jar
 

--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -9,12 +9,10 @@ spec:
   selector:
     matchLabels:
       app: www
-{% if scope == "deploy" %}
+{% if deploy %}
   replicas: 3
-{% elif scope == "test" or scope == "dev" %}
-  replicas: 1
 {% else %}
-!!! unexpected scope {{ scope }} !!!
+  replicas: 1
 {% endif %}
   template:
     metadata:
@@ -110,14 +108,12 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: www
-{% if scope == "deploy" %}
+{% if deploy %}
   minReplicas: 3
   maxReplicas: 10
-{% elif scope == "test" or scope == "dev" %}
+{% else %}
   minReplicas: 1
   maxReplicas: 3
-{% else %}
-!!! unexpected scope {{ scope }} !!!
 {% endif %}
   metrics:
   - type: Resource
@@ -130,12 +126,10 @@ kind: PodDisruptionBudget
 metadata:
   name: www
 spec:
-{% if scope == "deploy" %}
+{% if deploy %}
   minAvailable: 2
-{% elif scope == "test" or scope == "dev" %}
-  minAvailable: 0
 {% else %}
-!!! unexpected scope {{ scope }} !!!
+  minAvailable: 0
 {% endif %}
   selector:
     matchLabels:


### PR DESCRIPTION
I noticed in #12526 that you added `scope` to the website Makefile but I don't think it's needed as using `deploy` is a little cleaner.