### PR TITLE
[query] fix bug that prevents exploding a random field

### DIFF
--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -229,7 +229,7 @@ class TableExplode(TableIR):
 
     def _handle_randomness(self, uid_field_name):
         if uid_field_name is None:
-            TableExplode(self.child.handle_randomness(None), self.path)
+            return TableExplode(self.child.handle_randomness(None), self.path)
 
         child = self.child.handle_randomness(uid_field_name)
 

--- a/hail/python/test/hail/test_randomness.py
+++ b/hail/python/test/hail/test_randomness.py
@@ -59,16 +59,6 @@ def test_table_annotate():
     assert expected == actual
 
 
-def test_table_map_partitions():
-    hl.reset_global_randomness()
-    ht = hl.utils.range_table(5)
-    ht = ht.annotate(x = hl.rand_int32(5))
-    ht = ht._map_partitions(lambda part: hl.array([hl.struct(y=hl.sum(part.map(lambda row: row.x).to_array()))])._to_stream())
-    expected = []
-    actual = ht.collect()
-    assert expected == actual
-
-
 def test_matrix_table_entries():
     hl.reset_global_randomness()
     mt = hl.utils.range_matrix_table(5, 2)

--- a/hail/python/test/hail/test_randomness.py
+++ b/hail/python/test/hail/test_randomness.py
@@ -1,0 +1,109 @@
+import hail as hl
+
+
+def test_table_explode():
+    hl.reset_global_randomness()
+    ht = hl.utils.range_table(5)
+    ht = ht.annotate(x = hl.range(hl.rand_int32(5)))
+    ht = ht.explode('x')
+    expected = [
+        hl.Struct(idx=0, x=0),
+        hl.Struct(idx=0, x=1),
+        hl.Struct(idx=0, x=2),
+        hl.Struct(idx=0, x=3),
+        hl.Struct(idx=1, x=0),
+        hl.Struct(idx=1, x=1),
+        hl.Struct(idx=1, x=2),
+        hl.Struct(idx=2, x=0),
+        hl.Struct(idx=2, x=1),
+        hl.Struct(idx=3, x=0),
+        hl.Struct(idx=3, x=1),
+        hl.Struct(idx=3, x=2),
+        hl.Struct(idx=4, x=0),
+        hl.Struct(idx=4, x=1),
+        hl.Struct(idx=4, x=2)
+    ]
+    actual = ht.collect()
+    assert expected == actual
+
+
+def test_table_key_by():
+    hl.reset_global_randomness()
+    ht = hl.utils.range_table(5)
+    ht = ht.annotate(x = hl.rand_int32(5))
+    ht = ht.key_by('x')
+    expected = [
+        hl.Struct(idx=2, x=2),
+        hl.Struct(idx=1, x=3),
+        hl.Struct(idx=3, x=3),
+        hl.Struct(idx=4, x=3),
+        hl.Struct(idx=0, x=4)
+    ]
+    actual = ht.collect()
+    assert expected == actual
+
+
+def test_table_annotate():
+    hl.reset_global_randomness()
+    ht = hl.utils.range_table(5)
+    ht = ht.annotate(x = hl.rand_int32(5))
+    ht = ht.annotate(y = ht.x * 10)
+    expected = [
+        hl.Struct(idx=0, x=4, y=40),
+        hl.Struct(idx=1, x=3, y=30),
+        hl.Struct(idx=2, x=2, y=20),
+        hl.Struct(idx=3, x=3, y=30),
+        hl.Struct(idx=4, x=3, y=30),
+    ]
+    actual = ht.collect()
+    assert expected == actual
+
+
+def test_table_map_partitions():
+    hl.reset_global_randomness()
+    ht = hl.utils.range_table(5)
+    ht = ht.annotate(x = hl.rand_int32(5))
+    ht = ht._map_partitions(lambda part: hl.array([hl.struct(y=hl.sum(part.map(lambda row: row.x).to_array()))])._to_stream())
+    expected = []
+    actual = ht.collect()
+    assert expected == actual
+
+
+def test_matrix_table_entries():
+    hl.reset_global_randomness()
+    mt = hl.utils.range_matrix_table(5, 2)
+    mt = mt.annotate_entries(x = hl.rand_int32(5))
+    expected = [
+        hl.Struct(row_idx=0, col_idx=0, x=0),
+        hl.Struct(row_idx=0, col_idx=1, x=3),
+        hl.Struct(row_idx=1, col_idx=0, x=2),
+        hl.Struct(row_idx=1, col_idx=1, x=4),
+        hl.Struct(row_idx=2, col_idx=0, x=1),
+        hl.Struct(row_idx=2, col_idx=1, x=4),
+        hl.Struct(row_idx=3, col_idx=0, x=4),
+        hl.Struct(row_idx=3, col_idx=1, x=2),
+        hl.Struct(row_idx=4, col_idx=0, x=4),
+        hl.Struct(row_idx=4, col_idx=1, x=4),
+    ]
+    actual = mt.entries().collect()
+    assert expected == actual
+
+
+def test_table_filter():
+    hl.reset_global_randomness()
+    ht = hl.utils.range_table(5)
+    ht = ht.annotate(x = hl.rand_int32(5))
+    ht = ht.filter(ht.x % 3 == 0)
+    expected = [hl.Struct(idx=1, x=3), hl.Struct(idx=3, x=3), hl.Struct(idx=4, x=3)]
+    actual = ht.collect()
+    assert expected == actual
+
+
+def test_table_key_by_aggregate():
+    hl.reset_global_randomness()
+    ht = hl.utils.range_table(5)
+    ht = ht.annotate(x = hl.rand_int32(5))
+    ht = ht.group_by(ht.x).aggregate(y=hl.agg.count())
+    expected = [hl.Struct(x=2, y=1), hl.Struct(x=3, y=3), hl.Struct(x=4, y=1)]
+    actual = ht.collect()
+    assert expected == actual


### PR DESCRIPTION
CHANGELOG: Fix a bug that prevented exploding on a field of a Table whose value is a random value.