### PR TITLE
[query] add a small & incomplete test suite for good index errors

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -4422,10 +4422,10 @@ class NDArrayNumericExpression(NDArrayExpression):
         -------
         :class:`.NDArrayNumericExpression` or :class:`.NumericExpression`
         """
-        indices, aggregations = unify_all(self, other)
-
         if not isinstance(other, NDArrayNumericExpression):
             other = hl.nd.array(other)
+
+        indices, aggregations = unify_all(self, other)
 
         if self.ndim == 0 or other.ndim == 0:
             raise ValueError('MatMul must be between objects of 1 dimension or more. Try * instead')

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -4048,7 +4048,6 @@ class NDArrayExpression(Expression):
             list_types = [type(e) for e in list_item]
             ellipsis_location = list_types.index(type(...))
             num_slices_to_add = self.ndim - (len(item) - num_nones) + 1
-
             no_ellipses = list_item[:ellipsis_location] + [slice(None)] * num_slices_to_add + list_item[ellipsis_location + 1:]
         else:
             no_ellipses = list_item
@@ -4162,7 +4161,6 @@ class NDArrayExpression(Expression):
         """
 
         # varargs with many ints works, but can't be a mix of ints and tuples.
-
         if len(shape) > 1:
             for i, arg in enumerate(shape):
                 if not isinstance(arg, Int64Expression):

--- a/hail/python/test/hail/test_indices_aggregations.py
+++ b/hail/python/test/hail/test_indices_aggregations.py
@@ -2,11 +2,11 @@ import hail as hl
 
 
 ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE = '''scope violation: 'MatrixTable.annotate_rows: field 'c'' expects an expression indexed by ['row']
-    Found indices ['column'], with unexpected indices ['column']. Invalid fields:
+    Found indices ['column', 'row], with unexpected indices ['column']. Invalid fields:
         'col_idx' (indices ['column'])
     'MatrixTable.annotate_rows: field 'c'' supports aggregation over axes ['column'], so these fields may appear inside an aggregator function.'''
 ROW_FIELD_C_REFERENCES_COL_FIELD_A_ERROR_MESSAGE = '''scope violation: 'MatrixTable.annotate_rows: field 'c'' expects an expression indexed by ['row']
-    Found indices ['column'], with unexpected indices ['column']. Invalid fields:
+    Found indices ['column', 'row'], with unexpected indices ['column']. Invalid fields:
         'a' (indices ['column'])
     'MatrixTable.annotate_rows: field 'c'' supports aggregation over axes ['column'], so these fields may appear inside an aggregator function.'''
 
@@ -112,7 +112,7 @@ def test_ndarray_reshape_1():
     ht = hl.utils.range_matrix_table(1, 1)
     ht = ht.annotate_rows(b = hl.nd.array([[0]]))
     try:
-        ht = ht.annotate_rows(c = ht.b.reshape((ht.col_idx, None)))
+        ht = ht.annotate_rows(c = ht.b.reshape((ht.col_idx, 1)))
     except hl.ExpressionException as exc:
         assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
     else:
@@ -123,7 +123,7 @@ def test_ndarray_reshape_2():
     ht = hl.utils.range_matrix_table(1, 1)
     ht = ht.annotate_rows(b = hl.nd.array([[0]]))
     try:
-        ht = ht.annotate_rows(c = ht.b.reshape((None, ht.col_idx)))
+        ht = ht.annotate_rows(c = ht.b.reshape((1, ht.col_idx)))
     except hl.ExpressionException as exc:
         assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
     else:

--- a/hail/python/test/hail/test_indices_aggregations.py
+++ b/hail/python/test/hail/test_indices_aggregations.py
@@ -1,22 +1,13 @@
 import hail as hl
 
 
-ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE = '''scope violation: 'MatrixTable.annotate_rows: field 'c'' expects an expression indexed by ['row']
-    Found indices ['column', 'row], with unexpected indices ['column']. Invalid fields:
-        'col_idx' (indices ['column'])
-    'MatrixTable.annotate_rows: field 'c'' supports aggregation over axes ['column'], so these fields may appear inside an aggregator function.'''
-ROW_FIELD_C_REFERENCES_COL_FIELD_A_ERROR_MESSAGE = '''scope violation: 'MatrixTable.annotate_rows: field 'c'' expects an expression indexed by ['row']
-    Found indices ['column', 'row'], with unexpected indices ['column']. Invalid fields:
-        'a' (indices ['column'])
-    'MatrixTable.annotate_rows: field 'c'' supports aggregation over axes ['column'], so these fields may appear inside an aggregator function.'''
-
-
 def test_array_slice_end():
     ht = hl.utils.range_matrix_table(1, 1)
     try:
         ht = ht.annotate_rows(c = hl.array([1,2,3])[:ht.col_idx])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -26,7 +17,8 @@ def test_array_slice_start():
     try:
         ht = ht.annotate_rows(c = hl.array([1,2,3])[ht.col_idx:])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -36,7 +28,7 @@ def test_array_slice_step():
     try:
         ht = ht.annotate_rows(c = hl.array([1,2,3])[::ht.col_idx])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE == exc.args[0]
     else:
         assert False
 
@@ -48,7 +40,8 @@ def test_matmul():
     try:
         ht = ht.annotate_rows(c = ht.b @ ht.a)
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_A_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'a' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -59,7 +52,8 @@ def test_ndarray_index():
     try:
         ht = ht.annotate_rows(c = ht.b[ht.col_idx])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -70,7 +64,8 @@ def test_ndarray_index_with_slice_1():
     try:
         ht = ht.annotate_rows(c = ht.b[ht.col_idx, :])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -81,7 +76,8 @@ def test_ndarray_index_with_slice_2():
     try:
         ht = ht.annotate_rows(c = ht.b[:, ht.col_idx])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -92,7 +88,8 @@ def test_ndarray_index_with_None_1():
     try:
         ht = ht.annotate_rows(c = ht.b[ht.col_idx, None])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -103,7 +100,8 @@ def test_ndarray_index_with_None_2():
     try:
         ht = ht.annotate_rows(c = ht.b[None, ht.col_idx])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -114,7 +112,8 @@ def test_ndarray_reshape_1():
     try:
         ht = ht.annotate_rows(c = ht.b.reshape((ht.col_idx, 1)))
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -125,7 +124,8 @@ def test_ndarray_reshape_2():
     try:
         ht = ht.annotate_rows(c = ht.b.reshape((1, ht.col_idx)))
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 
@@ -137,6 +137,7 @@ def test_ndarray_reshape_tuple():
     try:
         ht = ht.annotate_rows(c = ht.b.reshape(ht.a))
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_A_ERROR_MESSAGE in exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'a' (indices ['column'])" in exc.args[0]
     else:
         assert False

--- a/hail/python/test/hail/test_indices_aggregations.py
+++ b/hail/python/test/hail/test_indices_aggregations.py
@@ -28,7 +28,8 @@ def test_array_slice_step():
     try:
         ht = ht.annotate_rows(c = hl.array([1,2,3])[::ht.col_idx])
     except hl.ExpressionException as exc:
-        assert ROW_FIELD_C_REFERENCES_COL_FIELD_COL_IDX_ERROR_MESSAGE == exc.args[0]
+        assert 'scope violation' in exc.args[0]
+        assert "'col_idx' (indices ['column'])" in exc.args[0]
     else:
         assert False
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -427,8 +427,8 @@ class CSETests(unittest.TestCase):
             ' (Let __cse_2 (I32 10)'
             ' (Let __cse_3 (I32 1)'
             ' (MakeTuple (0 1)'
-                ' (ToArray (StreamRange 1 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
-                ' (ToArray (StreamRange 1 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
+                ' (ToArray (StreamRange 27 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
+                ' (ToArray (StreamRange 27 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
         )
         assert expected == CSERenderer()(t)
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -431,6 +431,7 @@ class CSETests(unittest.TestCase):
                 ' (ToArray (StreamRange [0-9]+ False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
                 ' (ToArray (StreamRange [0-9]+ False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
         )
+        expected_re = expected_re.replace('(', '\\(').replace(')', '\\)')
         assert re.match(expected_re, CSERenderer()(t))
 
     def test_cse2(self):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -427,8 +427,8 @@ class CSETests(unittest.TestCase):
             ' (Let __cse_2 (I32 10)'
             ' (Let __cse_3 (I32 1)'
             ' (MakeTuple (0 1)'
-                ' (ToArray (StreamRange 27 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
-                ' (ToArray (StreamRange 27 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
+                ' (ToArray (StreamRange 7 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
+                ' (ToArray (StreamRange 7 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
         )
         assert expected == CSERenderer()(t)
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 import hail as hl
 import hail.ir as ir
@@ -422,15 +423,15 @@ class CSETests(unittest.TestCase):
         a1 = ir.ToArray(x)
         a2 = ir.ToArray(x)
         t = ir.MakeTuple([a1, a2])
-        expected = (
+        expected_re = (
             '(Let __cse_1 (I32 0)'
             ' (Let __cse_2 (I32 10)'
             ' (Let __cse_3 (I32 1)'
             ' (MakeTuple (0 1)'
-                ' (ToArray (StreamRange 7 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
-                ' (ToArray (StreamRange 7 False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
+                ' (ToArray (StreamRange [0-9]+ False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
+                ' (ToArray (StreamRange [0-9]+ False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
         )
-        assert expected == CSERenderer()(t)
+        assert re.match(expected_re, CSERenderer()(t))
 
     def test_cse2(self):
         x = ir.I32(5)


### PR DESCRIPTION
CHANGELOG: Improve error message when combining incompatibly indexed fields in certain operations including array indexing.

See test cases for straightforward examples. In main, none of the test code triggers errors. You have to execute the table to actually trigger an error in IR serialization which will reference `"sa"` which is totally meaningless to the user (let alone many Hail engineers).