### PR TITLE
[query][qob][hailtop/fs] Expose modification and creation time.

### DIFF
--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -8,7 +8,7 @@ import functools
 import glob
 import fnmatch
 
-from hailtop.aiotools.fs import Copier, Transfer, FileListEntry, ReadableStream, WritableStream, FileStatus
+from hailtop.aiotools.fs import Copier, Transfer, FileListEntry, ReadableStream, WritableStream
 from hailtop.aiotools.local_fs import LocalAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.utils import bounded_gather, async_to_blocking

--- a/hail/python/hail/fs/router_fs.py
+++ b/hail/python/hail/fs/router_fs.py
@@ -1,4 +1,4 @@
-from typing import List, AsyncContextManager, BinaryIO, Optional
+from typing import List, AsyncContextManager, BinaryIO, Optional, Tuple
 import asyncio
 import io
 from hailtop.aiotools.local_fs import LocalAsyncFSURL
@@ -8,7 +8,7 @@ import functools
 import glob
 import fnmatch
 
-from hailtop.aiotools.fs import Copier, Transfer, FileListEntry, ReadableStream, WritableStream
+from hailtop.aiotools.fs import Copier, Transfer, FileListEntry, ReadableStream, WritableStream, FileStatus
 from hailtop.aiotools.local_fs import LocalAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.utils import bounded_gather, async_to_blocking
@@ -101,7 +101,7 @@ class SyncWritableStream(io.RawIOBase, BinaryIO):  # type: ignore # https://gith
 
     def close(self):
         self.aws.close()
-        async_to_blocking(self.cm.__aexit__())
+        async_to_blocking(self.cm.__aexit__(None, None, None))
 
     @property
     def closed(self) -> bool:
@@ -153,13 +153,18 @@ class SyncWritableStream(io.RawIOBase, BinaryIO):  # type: ignore # https://gith
         return async_to_blocking(self.aws.write(b))
 
 
-def _stat_result(is_dir: bool, size_bytes: int, path: str) -> StatResult:
+def _stat_result(is_dir: bool, size_bytes_and_time_modified: Optional[Tuple[int, float]], path: str) -> StatResult:
+    if size_bytes_and_time_modified:
+        size_bytes, time_modified = size_bytes_and_time_modified
+    else:
+        size_bytes = 0
+        time_modified = None
     return StatResult(
         path=path.rstrip('/'),
         size=size_bytes,
         typ=FileType.DIRECTORY if is_dir else FileType.FILE,
         owner=None,
-        modification_time=None)
+        modification_time=time_modified)
 
 
 class RouterFS(FS):
@@ -214,28 +219,31 @@ class RouterFS(FS):
         return async_to_blocking(self._async_is_dir(path))
 
     def stat(self, path: str) -> StatResult:
-        size_bytes, is_dir = async_to_blocking(asyncio.gather(
-            self._size_bytes_or_none(path), self._async_is_dir(path)))
-        if size_bytes is None:
+        maybe_sb_and_t, is_dir = async_to_blocking(asyncio.gather(
+            self._size_bytes_and_time_modified_or_none(path), self._async_is_dir(path)))
+        if maybe_sb_and_t is None:
             if not is_dir:
                 raise FileNotFoundError(path)
-            return _stat_result(True, 0, path)
-        return _stat_result(is_dir, size_bytes, path)
+            return _stat_result(True, None, path)
+        return _stat_result(is_dir, maybe_sb_and_t, path)
 
-    async def _size_bytes_or_none(self, path: str):
+    async def _size_bytes_and_time_modified_or_none(self, path: str) -> Optional[Tuple[int, float]]:
         try:
-            return await (await self.afs.statfile(path)).size()
+            # Hadoop semantics: creation time is used if the object has no notion of last modification time.
+            file_status = await self.afs.statfile(path)
+            return (await file_status.size(), file_status.time_modified().timestamp())
         except FileNotFoundError:
             return None
 
     async def _fle_to_dict(self, fle: FileListEntry) -> StatResult:
-        async def size():
+        async def maybe_status() -> Optional[Tuple[int, float]]:
             try:
-                return await (await fle.status()).size()
+                file_status = await fle.status()
+                return (await file_status.size(), file_status.time_modified().timestamp())
             except IsADirectoryError:
-                return 0
+                return None
         return _stat_result(
-            *await asyncio.gather(fle.is_dir(), size(), fle.url()))
+            *await asyncio.gather(fle.is_dir(), maybe_status(), fle.url()))
 
     def ls(self,
            path: str,
@@ -323,11 +331,11 @@ class RouterFS(FS):
                     parallelism=_max_simultaneous_files)
             except (FileNotFoundError, NotADirectoryError):
                 return None
-        maybe_size, maybe_contents = await asyncio.gather(
-            self._size_bytes_or_none(path), ls_as_dir())
+        maybe_sb_and_t, maybe_contents = await asyncio.gather(
+            self._size_bytes_and_time_modified_or_none(path), ls_as_dir())
 
-        if maybe_size is not None:
-            file_stat = _stat_result(False, maybe_size, path)
+        if maybe_sb_and_t is not None:
+            file_stat = _stat_result(False, maybe_sb_and_t, path)
             if maybe_contents is not None:
                 if error_when_file_and_directory:
                     raise ValueError(f'{path} is both a file and a directory')

--- a/hail/python/hail/fs/stat_result.py
+++ b/hail/python/hail/fs/stat_result.py
@@ -19,7 +19,7 @@ class StatResult(NamedTuple):
     size: int
     typ: FileType
     # common point between unix, google, and hadoop filesystems, represented as a unix timestamp
-    modification_time: Optional[float] = None
+    modification_time: Optional[float]
 
     def is_dir(self) -> bool:
         return self.typ is FileType.DIRECTORY

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -7,10 +7,12 @@ import os.path
 import threading
 import asyncio
 import logging
+import datetime
 
 import botocore.config
 import botocore.exceptions
 import boto3
+from hailtop import timex
 from hailtop.utils import blocking_to_async
 from hailtop.aiotools.fs import (FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
                                  AsyncFSURL, MultiPartCreate, FileAndDirectoryError)
@@ -65,6 +67,16 @@ class S3HeadObjectFileStatus(FileStatus):
     async def size(self) -> int:
         return self.head_object_resp['ContentLength']
 
+    def time_created(self) -> datetime.datetime:
+        # https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax
+        # Misleading name: LastModified is creation time.
+        # S3 Python library strips dashes from header names
+        return self.head_object_resp['LastModified']
+
+    def time_modified(self) -> datetime.datetime:
+        # S3 objects are immutable, so creation == modified
+        return self.head_object_resp['LastModified']
+
     async def __getitem__(self, key: str) -> Any:
         return self.head_object_resp[key]
 
@@ -75,6 +87,17 @@ class S3ListFilesFileStatus(FileStatus):
 
     async def size(self) -> int:
         return self._item['Size']
+
+    def time_created(self) -> datetime.datetime:
+        # https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_ResponseSyntax
+        # Misleading name: LastModified is creation time.
+        # S3 Python library strips dashes from header names
+        return self._item['LastModified']
+
+    def time_modified(self) -> datetime.datetime:
+        # S3 objects are immutable, so creation == modified
+        print(repr(self._item))
+        return self._item['LastModified']
 
     async def __getitem__(self, key: str) -> Any:
         return self._item[key]

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -12,7 +12,6 @@ import datetime
 import botocore.config
 import botocore.exceptions
 import boto3
-from hailtop import timex
 from hailtop.utils import blocking_to_async
 from hailtop.aiotools.fs import (FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
                                  AsyncFSURL, MultiPartCreate, FileAndDirectoryError)

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -258,10 +258,14 @@ class AzureFileStatus(FileStatus):
         return size
 
     def time_created(self) -> datetime.datetime:
-        return self.blob_props.creation_time
+        ct = self.blob_props.creation_time
+        assert isinstance(ct, datetime.datetime)
+        return ct
 
     def time_modified(self) -> datetime.datetime:
-        return self.blob_props.last_modified
+        lm = self.blob_props.last_modified
+        assert isinstance(lm, datetime.datetime)
+        return lm
 
     async def __getitem__(self, key: str) -> Any:
         return self.blob_props.__dict__[key]

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -5,6 +5,7 @@ import re
 import asyncio
 import secrets
 import logging
+import datetime
 
 from azure.storage.blob import BlobProperties
 from azure.storage.blob.aio import BlobClient, ContainerClient, BlobServiceClient, StorageStreamDownloader
@@ -255,6 +256,12 @@ class AzureFileStatus(FileStatus):
         size = self.blob_props.size
         assert isinstance(size, int)
         return size
+
+    def time_created(self) -> datetime.datetime:
+        return self.blob_props.creation_time
+
+    def time_modified(self) -> datetime.datetime:
+        return self.blob_props.last_modified
 
     async def __getitem__(self, key: str) -> Any:
         return self.blob_props.__dict__[key]

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -8,6 +8,8 @@ import logging
 import asyncio
 import urllib.parse
 import aiohttp
+import datetime
+from hailtop import timex
 from hailtop.utils import (
     secret_alnum_string, OnlineBoundedGather2,
     TransientError, retry_transient_errors)
@@ -402,6 +404,12 @@ class GetObjectFileStatus(FileStatus):
 
     async def size(self) -> int:
         return int(self._items['size'])
+
+    def time_created(self) -> datetime.datetime:
+        return timex.parse_rfc3339(self._items['timeCreated'])
+
+    def time_modified(self) -> datetime.datetime:
+        return timex.parse_rfc3339(self._items['updated'])
 
     async def __getitem__(self, key: str) -> str:
         return self._items[key]

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -17,7 +17,6 @@ class FileStatus(abc.ABC):
     @abc.abstractmethod
     def time_created(self) -> datetime.datetime:
         '''The time the object was created in seconds since the epcoh, UTC.'''
-        pass
 
     @abc.abstractmethod
     def time_modified(self) -> datetime.datetime:
@@ -26,7 +25,6 @@ class FileStatus(abc.ABC):
         Not all clouds expose a modification time.
 
         '''
-        pass
 
     @abc.abstractmethod
     async def __getitem__(self, key: str) -> Any:

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -3,6 +3,7 @@ from typing import (Any, AsyncContextManager, Optional, Type, Set, AsyncIterator
 from types import TracebackType
 import abc
 import asyncio
+import datetime
 from hailtop.utils import retry_transient_errors, OnlineBoundedGather2
 from .stream import EmptyReadableStream, ReadableStream, WritableStream
 from .exceptions import FileAndDirectoryError
@@ -11,6 +12,20 @@ from .exceptions import FileAndDirectoryError
 class FileStatus(abc.ABC):
     @abc.abstractmethod
     async def size(self) -> int:
+        pass
+
+    @abc.abstractmethod
+    def time_created(self) -> datetime.datetime:
+        '''The time the object was created in seconds since the epcoh, UTC.'''
+        pass
+
+    @abc.abstractmethod
+    def time_modified(self) -> datetime.datetime:
+        '''The time the object was last modified in seconds since the epoch, UTC.
+
+        Not all clouds expose a modification time.
+
+        '''
         pass
 
     @abc.abstractmethod

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -16,13 +16,19 @@ class FileStatus(abc.ABC):
 
     @abc.abstractmethod
     def time_created(self) -> datetime.datetime:
-        '''The time the object was created in seconds since the epcoh, UTC.'''
+        '''The time the object was created in seconds since the epcoh, UTC.
+
+        Some filesystems do not support creation time. In that case, an error is raised.
+
+        '''
 
     @abc.abstractmethod
     def time_modified(self) -> datetime.datetime:
         '''The time the object was last modified in seconds since the epoch, UTC.
 
-        Not all clouds expose a modification time.
+        The meaning of modification time is cloud-defined. In some clouds, it is the creation
+        time. In some clouds, it is the more recent of the creation time or the time of the most
+        recent metadata modification.
 
         '''
 

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -5,6 +5,7 @@ import os.path
 import io
 import stat
 import asyncio
+import datetime
 from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
 
@@ -15,12 +16,19 @@ from .fs import (FileStatus, FileListEntry, MultiPartCreate, AsyncFS, AsyncFSURL
 
 
 class LocalStatFileStatus(FileStatus):
-    def __init__(self, stat_result):
+    def __init__(self, stat_result: os.stat_result):
         self._stat_result = stat_result
         self._items = None
 
     async def size(self) -> int:
         return self._stat_result.st_size
+
+    def time_created(self) -> datetime.datetime:
+        raise ValueError('LocalFS does not support time created.')
+
+    def time_modified(self) -> datetime.datetime:
+        return datetime.datetime.fromtimestamp(self._stat_result.st_mtime,
+                                               tz=datetime.timezone.utc)
 
     async def __getitem__(self, key: str) -> Any:
         raise KeyError(key)

--- a/hail/python/hailtop/timex.py
+++ b/hail/python/hailtop/timex.py
@@ -19,12 +19,10 @@ rfc3339_re = re.compile(
     '(.[0-9][0-9]*)?'                   # optional fractional seconds
     '([Zz]|[+-][0-9][0-9]:[0-9][0-9])'  # offset / timezone
 )
-_timezone_cache: Dict[str, datetime.timezone] = dict()
+_timezone_cache: Dict[str, datetime.timezone] = {}
 
 
 def parse_rfc3339(s: str) -> datetime.datetime:
-    global _timezone_cache
-
     parts = rfc3339_re.fullmatch(s)
     if parts is None:
         raise ValueError(f'Datetime string is not RFC3339 compliant: {s}.')

--- a/hail/python/hailtop/timex.py
+++ b/hail/python/hailtop/timex.py
@@ -1,0 +1,75 @@
+from typing import Dict
+
+import re
+import datetime
+
+rfc3339_re = re.compile(
+    # https://www.rfc-editor.org/rfc/rfc3339#section-5.6
+    '([0-9][0-9][0-9][0-9])'            # YYYY
+    '-'
+    '([0-9][0-9])'                      # MM
+    '-'
+    '([0-9][0-9])'                      # DD
+    '[Tt ]'                             # see NOTE in link
+    '([0-9][0-9])'                      # HH
+    ':'
+    '([0-9][0-9])'                      # MM
+    ':'
+    '([0-9][0-9])'                      # SS
+    '(.[0-9][0-9]*)?'                   # optional fractional seconds
+    '([Zz]|[+-][0-9][0-9]:[0-9][0-9])'  # offset / timezone
+)
+_timezone_cache: Dict[str, datetime.timezone] = dict()
+
+
+def parse_rfc3339(s: str) -> datetime.datetime:
+    global _timezone_cache
+
+    parts = rfc3339_re.fullmatch(s)
+    if parts is None:
+        raise ValueError(f'Datetime string is not RFC3339 compliant: {s}.')
+    year, month, day, hour, minute, second, fractional_second, offset = parts.groups()
+
+    if offset in ('z', 'Z'):
+        tz = datetime.timezone.utc
+    else:
+        tz = _timezone_cache.get(offset)
+        if tz is None:
+            if offset[0] not in ('+', '-') or offset[3] != ':':
+                raise ValueError(f'Datetime string is not RFC3339 compliant: {s}.')
+            is_neg = offset[0] == '-'
+            offset_h = int(offset[1:3])
+            offset_m = int(offset[4:6])
+            if is_neg:
+                offset_h = offset_h * -1
+                offset_m = offset_m * -1
+            tz_delta = datetime.timedelta(hours=offset_h, minutes=offset_m)
+            tz = datetime.timezone(tz_delta)
+            _timezone_cache[offset] = tz
+
+    if fractional_second is None:
+        microsecond = 0
+    else:
+        fractional_second = fractional_second[1:]  # skip the '.'
+        n_digits = len(fractional_second)
+        if n_digits > 6:
+            # python only supports integral microseconds
+            rounding_digit = fractional_second[6]
+            fractional_second = int(fractional_second[:6])
+            if rounding_digit in ('5', '6', '7', '8', '9'):
+                fractional_second += 1
+        else:
+            fractional_second = int(fractional_second)
+            magnitude_relative_to_micro = (10 ** (6 - n_digits))
+            microsecond = int(fractional_second) * magnitude_relative_to_micro
+
+    return datetime.datetime(
+        year=int(year),
+        month=int(month),
+        day=int(day),
+        hour=int(hour),
+        minute=int(minute),
+        second=int(second),
+        microsecond=microsecond,
+        tzinfo=tz
+    )

--- a/hail/python/hailtop/timex.py
+++ b/hail/python/hailtop/timex.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 import re
 import datetime
@@ -28,6 +28,7 @@ def parse_rfc3339(s: str) -> datetime.datetime:
         raise ValueError(f'Datetime string is not RFC3339 compliant: {s}.')
     year, month, day, hour, minute, second, fractional_second, offset = parts.groups()
 
+    tz: Optional[datetime.timezone]
     if offset in ('z', 'Z'):
         tz = datetime.timezone.utc
     else:

--- a/hail/python/hailtop/timex.py
+++ b/hail/python/hailtop/timex.py
@@ -55,9 +55,9 @@ def parse_rfc3339(s: str) -> datetime.datetime:
         if n_digits > 6:
             # python only supports integral microseconds
             rounding_digit = fractional_second[6]
-            fractional_second = int(fractional_second[:6])
+            microsecond = int(fractional_second[:6])
             if rounding_digit in ('5', '6', '7', '8', '9'):
-                fractional_second += 1
+                microsecond += 1
         else:
             fractional_second = int(fractional_second)
             magnitude_relative_to_micro = (10 ** (6 - n_digits))

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -482,7 +482,12 @@ async def test_statfile_creation_and_modified_time(filesystem: Tuple[asyncio.Sem
     await fs.write(file, b'abc123')
     status = await fs.statfile(file)
 
-    if isinstance(fs, LocalAsyncFS):
+    if isinstance(fs, RouterAsyncFS):
+        is_local = isinstance(fs._get_fs(file), LocalAsyncFS)
+    else:
+        is_local = isinstance(fs, LocalAsyncFS)
+
+    if is_local:
         try:
             status.time_created()
         except ValueError as err:

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -497,7 +497,7 @@ async def test_statfile_creation_and_modified_time(filesystem: Tuple[asyncio.Sem
             assert False
 
         modified_time = status.time_modified()
-        assert modified_time == pytest.approx(now.timestamp(), abs=60)
+        assert modified_time.timestamp() == pytest.approx(now.timestamp(), abs=60)
     else:
         create_time = status.time_created()
         assert create_time.timestamp() == pytest.approx(now.timestamp(), abs=60)

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -487,6 +487,7 @@ async def test_statfile_creation_and_modified_time(filesystem: Tuple[asyncio.Sem
     else:
         is_local = isinstance(fs, LocalAsyncFS)
 
+
     if is_local:
         try:
             status.time_created()
@@ -494,6 +495,9 @@ async def test_statfile_creation_and_modified_time(filesystem: Tuple[asyncio.Sem
             assert err.args[0] == 'LocalFS does not support time created.'
         else:
             assert False
+
+        modified_time = status.time_modified()
+        assert modified_time == pytest.approx(now.timestamp(), abs=60)
     else:
         create_time = status.time_created()
         assert create_time.timestamp() == pytest.approx(now.timestamp(), abs=60)

--- a/hail/python/test/hailtop/test_timex.py
+++ b/hail/python/test/hailtop/test_timex.py
@@ -1,0 +1,132 @@
+from hailtop import timex
+import datetime
+
+
+def test_google_cloud_storage_example():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.404Z')
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo=datetime.timezone.utc)
+    assert actual == expected
+
+
+def test_timezone_positive():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.404+04:00')
+
+    tzinfo = datetime.timezone(datetime.timedelta(hours=4))
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+def test_timezone_negative():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.404-04:00')
+
+    tzinfo = datetime.timezone(datetime.timedelta(hours=-4))
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+def test_timezone_positive_with_minutes():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.404+04:35')
+
+    tzinfo = datetime.timezone(datetime.timedelta(hours=4, minutes=35))
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+def test_timezone_negative_with_minutes():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.404-04:35')
+
+    tzinfo = datetime.timezone(datetime.timedelta(hours=-4, minutes=-35))
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+def test_space_instead_of_T():
+    actual = timex.parse_rfc3339('2022-12-27 16:48:06Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+    actual = timex.parse_rfc3339('2022-12-27 16:48:06.404Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+    actual = timex.parse_rfc3339('2022-12-27 16:48:06.404-04:35')
+
+    tzinfo = datetime.timezone(datetime.timedelta(hours=-4, minutes=-35))
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+def test_lowercase_T():
+    actual = timex.parse_rfc3339('2022-12-27t16:48:06Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+    actual = timex.parse_rfc3339('2022-12-27t16:48:06.404Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+    actual = timex.parse_rfc3339('2022-12-27t16:48:06.404-04:35')
+
+    tzinfo = datetime.timezone(datetime.timedelta(hours=-4, minutes=-35))
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+def test_lowercase_z():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.404z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    assert actual == expected
+
+
+
+def test_one_fractional_second_digit():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.1Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 100000, tzinfo)
+    assert actual == expected
+
+
+def test_six_fractional_second_digits():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.123456Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 123456, tzinfo)
+    assert actual == expected
+
+
+def test_ten_fractional_second_digits_should_round_correctly_1():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.1234567890Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 123457, tzinfo)
+    assert actual == expected
+
+
+def test_ten_fractional_second_digits_should_round_correctly_2():
+    actual = timex.parse_rfc3339('2022-12-27T16:48:06.1234564890Z')
+
+    tzinfo = datetime.timezone.utc
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 123456, tzinfo)
+    assert actual == expected

--- a/hail/python/test/hailtop/test_timex.py
+++ b/hail/python/test/hailtop/test_timex.py
@@ -44,9 +44,8 @@ def test_space_instead_of_T():
     actual = timex.parse_rfc3339('2022-12-27 16:48:06Z')
 
     tzinfo = datetime.timezone.utc
-    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 0, tzinfo)
     assert actual == expected
-
 
     actual = timex.parse_rfc3339('2022-12-27 16:48:06.404Z')
 
@@ -66,7 +65,7 @@ def test_lowercase_T():
     actual = timex.parse_rfc3339('2022-12-27t16:48:06Z')
 
     tzinfo = datetime.timezone.utc
-    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 0, tzinfo)
     assert actual == expected
 
 
@@ -88,7 +87,7 @@ def test_lowercase_z():
     actual = timex.parse_rfc3339('2022-12-27T16:48:06z')
 
     tzinfo = datetime.timezone.utc
-    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 404000, tzinfo)
+    expected = datetime.datetime(2022, 12, 27, 16, 48, 6, 0, tzinfo)
     assert actual == expected
 
 


### PR DESCRIPTION
Fixes #12540.

CHANGELOG: When using Query-on-Batch, hl.hadoop* methods now properly support creation and modification time.

Creation time is supported by modern Linuxes but only through a new statx API which is not exposed by the Python standard library. There is a 0.1 version library from 2021 which exposes statx including the "birth time". I chose to raise an exception for now.

Each cloud does support a "modification time" but it generally refers to changes to metadata or is just the creation time:
- https://cloud.google.com/storage/docs/json_api/v1/objects#resource (see updated)
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_ResponseSyntax ("Last-Modified", is always creation time)
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax same as above
- https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob (see Last-Modified and x-ms-creation-time)