### PR TITLE
[query] fix show when col keys are not unique & escape table headers

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2669,12 +2669,15 @@ class MatrixTable(ExprContainer):
         if len(t.key) > 0:
             t = t.order_by(*t.key)
         col_key_type = self.col_key.dtype
+
+        col_headers = [f'<col {i}>' for i in range(0, displayed_n_cols)]
         if len(col_key_type) == 1 and col_key_type[0] in (hl.tstr, hl.tint32, hl.tint64):
             cols = self.col_key[0].take(displayed_n_cols)
-            entries = {repr(cols[i]): t.entries[i]
-                       for i in range(0, displayed_n_cols)}
-        else:
-            entries = {f'<col {i}>': t.entries[i] for i in range(0, displayed_n_cols)}
+            if len(set(cols)) == len(cols):
+                col_headers = [repr(c) for c in cols]
+
+        entries = {col_headers[i]: t.entries[i]
+                   for i in range(0, displayed_n_cols)}
         t = t.select(
             **{f: t[f] for f in self.row_key},
             **{f: t[f] for f in self.row_value if include_row_fields},

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1616,7 +1616,7 @@ class Table(ExprContainer):
                     s += f'<td style="{default_td_style}" colspan="{width}">'
                     if text is not None:
                         s += f'<div style="{div_style}{non_empty_div_style}">'
-                        s += text
+                        s += html.escape(text)
                         s += '</div>'
                     else:
                         s += f'<div style="{div_style}"></div>'

--- a/hail/python/test/hail/expr/test_show.py
+++ b/hail/python/test/hail/expr/test_show.py
@@ -1,24 +1,43 @@
-import unittest
-
 import hail as hl
 
+def test_show():
+    mt = hl.balding_nichols_model(3, 10, 10)
+    t = mt.rows()
+    mt.GT.show()
+    mt.locus.show()
+    mt.af.show()
+    mt.pop.show()
+    mt.sample_idx.show()
+    mt.bn.show()
+    mt.bn.fst.show()
+    mt.GT.n_alt_alleles().show()
+    (mt.GT.n_alt_alleles() * mt.GT.n_alt_alleles()).show()
+    (mt.af * mt.GT.n_alt_alleles()).show()
+    t.af.show()
+    (t.af * 3).show()
 
-class Tests(unittest.TestCase):
-    def test(self):
-        mt = hl.balding_nichols_model(3, 10, 10)
-        t = mt.rows()
-        mt.GT.show()
-        mt.locus.show()
-        mt.af.show()
-        mt.pop.show()
-        mt.sample_idx.show()
-        mt.bn.show()
-        mt.bn.fst.show()
-        mt.GT.n_alt_alleles().show()
-        (mt.GT.n_alt_alleles() * mt.GT.n_alt_alleles()).show()
-        (mt.af * mt.GT.n_alt_alleles()).show()
-        t.af.show()
-        (t.af * 3).show()
 
-    def test_show_negative(self):
-        hl.utils.range_table(5).show(-1)
+def test_show_negative():
+    hl.utils.range_table(5).show(-1)
+
+
+def test_show_mt_duplicate_col_key():
+    shown_cols = 2
+
+    mt = hl.utils.range_matrix_table(5, 5)
+    mt = mt.key_cols_by(c = 0)
+    showobj = mt.show(n_cols=shown_cols, handler=lambda x: x)
+
+    assert len(showobj.table_show.table.row) == len(mt.row) + shown_cols
+
+
+def test_show_mt_fewer_cols():
+    shown_cols = 7
+
+    mt = hl.utils.range_matrix_table(5, 5)
+    mt = mt.key_cols_by(c = 0)
+    showobj = mt.show(n_cols=shown_cols, handler=lambda x: x)
+
+    assert len(showobj.table_show.table.row) == len(mt.row) + mt.count_cols()
+
+


### PR DESCRIPTION
CHANGELOG: Fix bug where matrix tables with duplicate col keys do not show properly. Also fix bug where tables and matrix tables with HTML unsafe column headers are rendered wrong in Jupyter.