### PR TITLE
[query/ggplot] re-enables interactivity for plots that use dummy traces

### DIFF
--- a/hail/python/hail/ggplot/ggplot.py
+++ b/hail/python/hail/ggplot/ggplot.py
@@ -27,8 +27,6 @@ class GGPlot:
     """
 
     def __init__(self, ht, aes, geoms=[], labels=Labels(), coord_cartesian=None, scales=None, facet=None):
-        self.is_static = False
-
         if scales is None:
             scales = {}
 
@@ -242,8 +240,7 @@ class GGPlot:
 
                 facet_row = facet_idx // n_facet_cols + 1
                 facet_col = facet_idx % n_facet_cols + 1
-                requires_static = geom.apply_to_fig(scaled_grouped_dfs, fig, precomputed[geom_label], facet_row, facet_col, legend_cache, is_faceted)
-                self.is_static |= requires_static
+                geom.apply_to_fig(scaled_grouped_dfs, fig, precomputed[geom_label], facet_row, facet_col, legend_cache, is_faceted)
 
         # Important to update axes after labels, axes names take precedence.
         self.labels.apply_to_fig(fig)
@@ -275,7 +272,7 @@ class GGPlot:
     def show(self):
         """Render and show the plot, either in a browser or notebook.
         """
-        self.to_plotly().show(config={"staticPlot": self.is_static})
+        self.to_plotly().show()
 
     def write_image(self, path):
         """Write out this plot as an image.


### PR DESCRIPTION
CHANGELOG: `hail.ggplot`s that have more than one legend group or facet are now interactive. If such a plot has enough legend entries that the legend would be taller than the plot, the legend will now be scrollable. Legend entries for such plots can be clicked to show/hide traces on the plot, but this does not work and is a known issue that will only be addressed if `hail.ggplot` is migrated off of plotly.

Currently, scatter plots with more than one legend group and plots with multiple facets are static. This is because both these types of plot leverage empty traces in order to produce legends that match R's ggplot2's legends more closely than the ones plotly generates by default. As a result, the interactive elements of the legends for these types of plot, specifically the ability to click on traces in the legend to show/hide them in the plot, do not work.

However, it appears that if there are enough legend entries that the legend would be taller than the plot, plotly makes the legend scrollable. When the plot is static, however, the scroll for the legend is disabled, and there is no other way to show the legend entries that get truncated by the height of the graph.

This change re-enables the interactivity for plots that use dummy traces to generate their legends in order to preserve the legends' scrolling functionality. The show/hide functionality still does not work, and is now a known issue that may be fixed later by the introduction of a different plotting backend (other than plotly).

An example static plot with too many legend entries:
<img width="991" alt="Screenshot 2023-01-09 at 15 29 34" src="https://user-images.githubusercontent.com/84595986/211402235-3e1db2d5-ea7f-4970-a711-ca9abbd93472.png">

The same plot after this change:
<img width="972" alt="Screenshot 2023-01-09 at 15 11 37" src="https://user-images.githubusercontent.com/84595986/211402187-4a122127-cd72-4eb2-8d2f-434b650c94cf.png">