### PR TITLE
[batch] Treat any 500 from pulling with unknown in the message as a 404

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -455,10 +455,10 @@ class Image:
                 and 'Permission "artifactregistry.repositories.downloadArtifacts" denied on resource' in e.message
             ):
                 raise ImageCannotBePulled from e
-            if 'not found: manifest unknown' in e.message:
-                raise ImageNotFound from e
             if 'Invalid repository name' in e.message:
                 raise InvalidImageRepository from e
+            if 'unknown' in e.message:
+                raise ImageNotFound from e
             raise
 
         image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)


### PR DESCRIPTION
Docker just always returns 500s for images that don't exist and has a slightly different error message for each thing that could go wrong (project / repository / image / tag don't exist) and that message varies across registries.