### PR TITLE
Replace issue template with form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,23 @@
+name: Bug Report
+description: Report a bug
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also, what did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of Hail are you using?
+    validations:
+      required: true
+  - type: textarea
+    id: log
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussion forum
+    url: https://discuss.hail.is/
+    about: Please post support and feature requests here.
+  - name: Zulip chatroom
+    url: https://hail.zulipchat.com/
+    about: Chat with us about Hail development.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,0 @@
-To report a bug, fill in the information below. 
-For support and feature requests, please use the discussion forum: 
-https://discuss.hail.is/
-
-Please include the full Hail version and as much detail as possible.
-
------------------------------------------------------------------------------


### PR DESCRIPTION
I discovered [issue forms](https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/) the other day and thought it might be helpful for directing users to the discussion forum / Zulip chatroom.

With this configuration, when someone opens an issue, they'll be presented with some options:
![Screen Shot 2023-01-13 at 8 01 11 AM](https://user-images.githubusercontent.com/1156625/212326189-214fb8b2-e210-4c96-8b52-7000d5025148.png)

If they choose to report a bug, they'll be presented with a form prompting for Hail version and log output.
![Screen Shot 2023-01-13 at 8 01 46 AM](https://user-images.githubusercontent.com/1156625/212326274-affeaa80-adec-45c9-b436-73059c6fc841.png)
