### PR TITLE
[compiler] Refactor compiled functions to take a HailTaskContext inst…

### DIFF
--- a/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
@@ -3,6 +3,7 @@ package is.hail.backend
 import is.hail.asm4s.HailClassLoader
 import is.hail.{HailContext, HailFeatureFlags}
 import is.hail.annotations.{Region, RegionPool}
+import is.hail.backend.local.LocalTaskContext
 import is.hail.expr.ir.Threefry
 import is.hail.io.fs.FS
 import is.hail.utils.{ExecutionTimer, using}
@@ -126,6 +127,11 @@ class ExecuteContext(
 
   val memo: mutable.Map[Any, Any] = new mutable.HashMap[Any, Any]()
 
+  val taskContext: HailTaskContext = new LocalTaskContext(0, 0)
+  def scopedExecution[T](f: (HailClassLoader, FS, HailTaskContext, Region) => T): T = {
+    using(new LocalTaskContext(0, 0))(f(theHailClassLoader, fs, _, r))
+  }
+
   def createTmpPath(prefix: String, extension: String = null): String = {
     val path = ExecuteContext.createTmpPathNoCleanup(tmpdir, prefix, extension)
     tempFileManager.own(path)
@@ -152,6 +158,7 @@ class ExecuteContext(
 
   def close(): Unit = {
     tempFileManager.cleanup()
+    taskContext.close()
 
     var exception: Exception = null
     for (cleanupFunction <- cleanupFunctions) {

--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -3,7 +3,7 @@ package is.hail.backend
 import is.hail.annotations.RegionPool
 import is.hail.utils._
 
-abstract class HailTaskContext {
+abstract class HailTaskContext extends AutoCloseable {
   def stageId(): Int
 
   def partitionId(): Int
@@ -20,7 +20,7 @@ abstract class HailTaskContext {
     s"${ stageId() }-${ partitionId() }-${ attemptNumber() }-$fileUUID"
   }
 
-  def finish(): Unit = {
+  def close(): Unit = {
     log.info(s"TaskReport: stage=${ stageId() }, partition=${ partitionId() }, attempt=${ attemptNumber() }, " +
       s"peakBytes=${ thePool.getHighestTotalUsage }, peakBytesReadable=${ formatSpace(thePool.getHighestTotalUsage) }, "+
       s"chunks requested=${thePool.getUsage._1}, cache hits=${thePool.getUsage._2}")

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -125,7 +125,7 @@ class LocalBackend(
     collection.zipWithIndex.map { case (c, i) =>
       val htc = new LocalTaskContext(i, stageId)
       val bytes = f(c, htc, theHailClassLoader, fs)
-      htc.finish()
+      htc.close()
       bytes
     }
   }
@@ -150,7 +150,7 @@ class LocalBackend(
       }
 
       ctx.timer.time("Run") {
-        f(ctx.theHailClassLoader, fs, 0, ctx.r).apply(ctx.r)
+        ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))
         (pt, 0)
       }
     } else {
@@ -163,7 +163,7 @@ class LocalBackend(
       }
 
       ctx.timer.time("Run") {
-        (pt, f(ctx.theHailClassLoader, fs, 0, ctx.r).apply(ctx.r))
+        (pt, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r)))
       }
     }
   }

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -306,7 +306,7 @@ class ServiceBackend(
         x,
         optimize = true)
 
-      f(ctx.theHailClassLoader, ctx.fs, 0, ctx.r)(ctx.r)
+      ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))
       Array()
     } else {
       val (Some(PTypeReferenceSingleCodeType(pt)), f) = Compile[AsmFunction1RegionLong](ctx,
@@ -315,7 +315,7 @@ class ServiceBackend(
         MakeTuple.ordered(FastIndexedSeq(x)),
         optimize = true)
       val retPType = pt.asInstanceOf[PBaseStruct]
-      val off = f(ctx.theHailClassLoader, ctx.fs, 0, ctx.r)(ctx.r)
+      val off = ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))
       val codec = TypedCodecSpec(
         EType.fromTypeAllOptional(retPType.virtualType),
         retPType.virtualType,

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -140,7 +140,7 @@ object Worker {
     } catch {
       case err: HailException => userError = err
     }
-    htc.finish()
+    htc.close()
 
     timer.end("executeFunction")
     timer.start("writeOutputs")

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -64,14 +64,14 @@ object SparkTaskContext {
   }
 
   def finish(): Unit = {
-    taskContext.get().finish()
+    taskContext.get().close()
     taskContext.remove()
   }
 }
 
 
 class SparkTaskContext private[spark](ctx: TaskContext) extends HailTaskContext {
-  self=>
+  self =>
   override def stageId(): Int = ctx.stageId()
   override def partitionId(): Int = ctx.partitionId()
   override def attemptNumber(): Int = ctx.attemptNumber()
@@ -414,7 +414,7 @@ class SparkBackend(
             ir,
             print = print)
         }
-        ctx.timer.time("Run")(Left(f(ctx.theHailClassLoader, ctx.fs, 0, ctx.r)(ctx.r)))
+        ctx.timer.time("Run")(Left(ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))))
 
       case _ =>
         val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) = ctx.timer.time("Compile") {
@@ -424,7 +424,7 @@ class SparkBackend(
             MakeTuple.ordered(FastSeq(ir)),
             print = print)
         }
-        ctx.timer.time("Run")(Right((pt, f(ctx.theHailClassLoader, ctx.fs, 0, ctx.r).apply(ctx.r))))
+        ctx.timer.time("Run")(Right((pt, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r)))))
     }
 
     res

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -19,7 +19,7 @@ import java.io.PrintWriter
 case class CodeCacheKey(aggSigs: IndexedSeq[AggStateSig], args: Seq[(String, EmitParamType)], body: IR)
 
 case class CompiledFunction[T](typ: Option[SingleCodeType], f: (HailClassLoader, FS, HailTaskContext, Region) => T) {
-  def tuple: (Option[SingleCodeType], (HailClassLoader, FS, Int, Region) => T) = (typ, f)
+  def tuple: (Option[SingleCodeType], (HailClassLoader, FS, HailTaskContext, Region) => T) = (typ, f)
 }
 
 object Compile {

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.backend.ExecuteContext
+import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.expr.ir.agg.AggStateSig
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.expr.ir.streams.EmitStream
@@ -18,7 +18,7 @@ import java.io.PrintWriter
 
 case class CodeCacheKey(aggSigs: IndexedSeq[AggStateSig], args: Seq[(String, EmitParamType)], body: IR)
 
-case class CompiledFunction[T](typ: Option[SingleCodeType], f: (HailClassLoader, FS, Int, Region) => T) {
+case class CompiledFunction[T](typ: Option[SingleCodeType], f: (HailClassLoader, FS, HailTaskContext, Region) => T) {
   def tuple: (Option[SingleCodeType], (HailClassLoader, FS, Int, Region) => T) = (typ, f)
 }
 
@@ -31,7 +31,7 @@ object Compile {
     optimize: Boolean = true,
     writeIRs: Boolean = false,
     print: Option[PrintWriter] = None
-  ): (Option[SingleCodeType], (HailClassLoader, FS, Int, Region) => F) = {
+  ): (Option[SingleCodeType], (HailClassLoader, FS, HailTaskContext, Region) => F) = {
 
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
@@ -85,7 +85,7 @@ object CompileWithAggregators {
     expectedCodeParamTypes: IndexedSeq[TypeInfo[_]], expectedCodeReturnType: TypeInfo[_],
     body: IR,
     optimize: Boolean = true
-  ): (Option[SingleCodeType], (HailClassLoader, FS, Int, Region) => (F with FunctionWithAggRegion)) = {
+  ): (Option[SingleCodeType], (HailClassLoader, FS, HailTaskContext, Region) => (F with FunctionWithAggRegion)) = {
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
       Env(params.map { case (n, _) => n -> n }: _*))
@@ -121,7 +121,7 @@ object CompileWithAggregators {
       val rt = Emit(emitContext, ir, fb, expectedCodeReturnType, params.length, Some(aggSigs))
 
       val f = fb.resultWithIndex()
-      CompiledFunction(rt, f.asInstanceOf[(HailClassLoader, FS, Int, Region) => (F with FunctionWithAggRegion)])
+      CompiledFunction(rt, f.asInstanceOf[(HailClassLoader, FS, HailTaskContext, Region) => (F with FunctionWithAggRegion)])
     }).tuple
   }
 }
@@ -173,7 +173,7 @@ object CompileIterator {
     argTypeInfo: Array[ParamType],
     writeIRs: Boolean,
     printWriter: Option[PrintWriter]
-  ): (PType, (HailClassLoader, FS, Int, Region) => F) = {
+  ): (PType, (HailClassLoader, FS, HailTaskContext, Region) => F) = {
 
     val fb = EmitFunctionBuilder.apply[F](ctx, "stream", argTypeInfo.toFastIndexedSeq, CodeParamType(BooleanInfo))
     val outerRegionField = fb.genFieldThisRef[Region]("outerRegion")
@@ -257,7 +257,7 @@ object CompileIterator {
     ctx: ExecuteContext,
     typ0: PStruct, streamElementType: PType,
     ir: IR
-  ): (PType, (HailClassLoader, FS, Int, RVDContext, Long, NoBoxLongIterator) => Iterator[java.lang.Long]) = {
+  ): (PType, (HailClassLoader, FS, HailTaskContext, RVDContext, Long, NoBoxLongIterator) => Iterator[java.lang.Long]) = {
     assert(typ0.required)
     assert(streamElementType.required)
     val (eltPType, makeStepper) = compileStepper[TMPStepFunction](
@@ -268,8 +268,8 @@ object CompileIterator {
         SingleCodeEmitParamType(true, StreamSingleCodeType(true, streamElementType, true))),
       false,
       None)
-    (eltPType, (theHailClassLoader, fs, idx, consumerCtx, v0, part) => {
-      val stepper = makeStepper(theHailClassLoader, fs, idx, consumerCtx.partitionRegion)
+    (eltPType, (theHailClassLoader, fs, htc, consumerCtx, v0, part) => {
+      val stepper = makeStepper(theHailClassLoader, fs, htc, consumerCtx.partitionRegion)
       stepper.setRegions(consumerCtx.partitionRegion, consumerCtx.region)
       new LongIteratorWrapper {
         val stepFunction: TMPStepFunction = stepper
@@ -283,7 +283,7 @@ object CompileIterator {
     ctx: ExecuteContext,
     ctxType: PStruct, bcValsType: PType,
     ir: IR
-  ): (PType, (HailClassLoader, FS, Int, RVDContext, Long, Long) => Iterator[java.lang.Long]) = {
+  ): (PType, (HailClassLoader, FS, HailTaskContext, RVDContext, Long, Long) => Iterator[java.lang.Long]) = {
     assert(ctxType.required)
     assert(bcValsType.required)
     val (eltPType, makeStepper) = compileStepper[TableStageToRVDStepFunction](
@@ -294,8 +294,8 @@ object CompileIterator {
         SingleCodeEmitParamType(true, PTypeReferenceSingleCodeType(bcValsType))),
       false,
       None)
-    (eltPType, (theHailClassLoader, fs, idx, consumerCtx, v0, v1) => {
-      val stepper = makeStepper(theHailClassLoader, fs, idx, consumerCtx.partitionRegion)
+    (eltPType, (theHailClassLoader, fs, htc, consumerCtx, v0, v1) => {
+      val stepper = makeStepper(theHailClassLoader, fs, htc, consumerCtx.partitionRegion)
       stepper.setRegions(consumerCtx.partitionRegion, consumerCtx.region)
       new LongIteratorWrapper {
         val stepFunction: TableStageToRVDStepFunction = stepper

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -53,8 +53,10 @@ object CompileAndEvaluate {
         ir,
         print = None, optimize = optimize))
 
-      val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(ctx.theHailClassLoader, ctx.fs, 0, ctx.r))
-      ctx.timer.time("RunCompiledVoidFunction")(fRunnable(ctx.r))
+      ctx.scopedExecution { (hcl, fs, htc, r) =>
+        val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(hcl, fs, htc, r))
+        ctx.timer.time("RunCompiledVoidFunction")(fRunnable(r))
+      }
       return Left(())
     }
 
@@ -64,7 +66,8 @@ object CompileAndEvaluate {
       MakeTuple.ordered(FastSeq(ir)),
       print = None, optimize = optimize))
 
-    val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(ctx.theHailClassLoader, ctx.fs, 0, ctx.r))
+
+    val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r))
     val resultAddress = ctx.timer.time("RunCompiledFunction")(fRunnable(ctx.r))
 
     Right((resType, resultAddress))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -995,7 +995,7 @@ object Interpret {
           assert(rTyp.types(0).virtualType == query.typ)
 
           ctx.r.pool.scopedRegion { r =>
-            val resF = f(ctx.theHailClassLoader, fsBc.value, SparkTaskContext.get(), r)
+            val resF = f(ctx.theHailClassLoader, fsBc.value, ctx.taskContext, r)
             resF.setAggState(rv.region, rv.offset)
             val resAddr = resF(r, globalsOffset)
             val res = SafeRow(rTyp, resAddr)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -10,7 +10,7 @@ import is.hail.linalg.BlockMatrix
 import is.hail.rvd.RVDContext
 import is.hail.utils._
 import is.hail.HailContext
-import is.hail.backend.ExecuteContext
+import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.SparkTaskContext
 import is.hail.types.physical.stypes.{PTypeReferenceSingleCodeType, SingleCodeType}
 import is.hail.types.tcoerce
@@ -975,9 +975,9 @@ object Interpret {
 
           // creates a new region holding the zero value, giving ownership to
           // the caller
-          val mkZero = (theHailClassLoader: HailClassLoader, pool: RegionPool) => {
-            val region = Region(Region.SMALL, pool)
-            val initF = initOp(theHailClassLoader, fsBc.value, SparkTaskContext.get(), region)
+          val mkZero = (theHailClassLoader: HailClassLoader, tc: HailTaskContext) => {
+            val region = Region(Region.SMALL, tc.getRegionPool())
+            val initF = initOp(theHailClassLoader, fsBc.value, tc, region)
             initF.newAggState(region)
             initF(region, globalsBc.value.readRegionValue(region, theHailClassLoader))
             RegionValue(region, initF.getAggOffset())

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -3006,7 +3006,7 @@ case class TableKeyByAndAggregate(
     val combOp = extracted.combOpFSerializedWorkersOnly(ctx, spec)
 
     val hcl = theHailClassLoaderForSparkWorkers
-    val tc = SparkTaskContext.get()
+    val tc = ctx.taskContext
     val initF = makeInit(hcl, fsBc.value, tc, ctx.r)
     val globalsOffset = prev.globals.value.offset
     val initAggs = ctx.r.pool.scopedRegion { aggRegion =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -2580,7 +2580,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
             val b1 = using(new DataInputStream(fsBc.value.open(file1)))(readToBytes)
             val b2 = using(new DataInputStream(fsBc.value.open(file2)))(readToBytes)
             using(new DataOutputStream(fsBc.value.create(path))) { os =>
-              val bytes = combOpFNeedsPool(() => ctx.r.pool)(b1, b2)
+              val bytes = combOpFNeedsPool(() => (ctx.r.pool, theHailClassLoaderForSparkWorkers, SparkTaskContext.get()))(b1, b2)
               os.writeInt(bytes.length)
               os.write(bytes)
             }
@@ -2619,7 +2619,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
               b
             }
 
-            b = combOpFNeedsPool(() => ctx.r.pool)(b, using(new DataInputStream(fsBc.value.open(path)))(readToBytes))
+            b = combOpFNeedsPool(() => (ctx.r.pool, theHailClassLoaderForSparkWorkers, SparkTaskContext.get()))(b, using(new DataInputStream(fsBc.value.open(path)))(readToBytes))
           }
           b
         }
@@ -2668,7 +2668,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     }, ctx.getFlag("max_leader_scans").toInt)
 
     // 3. load in partition aggregations, comb op as necessary, write back out.
-    val partAggs = scanPartitionAggs.scanLeft(initAgg)(combOpFNeedsPool(() => ctx.r.pool))
+    val partAggs = scanPartitionAggs.scanLeft(initAgg)(combOpFNeedsPool(() => (ctx.r.pool, ctx.theHailClassLoader, ctx.taskContext)))
     val scanAggCount = tv.rvd.getNumPartitions
     val partitionIndices = new Array[Long](scanAggCount)
     val scanAggsPerPartitionFile = ctx.createTmpPath("table-map-rows-scan-aggs-part")

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -593,7 +593,7 @@ case class PartitionRVDReader(rvd: RVD, uidFieldName: String) extends PartitionR
           cb.assign(iterator, broadcastRVD.invoke[Int, Region, Region, Iterator[Long]](
             "computePartition", partIdx.asInt.value, region, partitionRegion))
           cb.assign(upcastF, Code.checkcast[AsmFunction2RegionLongLong](upcastCode.invoke[AnyRef, AnyRef, AnyRef, AnyRef, AnyRef](
-            "apply", cb.emb.ecb.emodb.getHailClassLoader, cb.emb.ecb.emodb.getFS, Code.boxInt(0), partitionRegion)))
+            "apply", cb.emb.ecb.emodb.getHailClassLoader, cb.emb.ecb.emodb.getFS, cb.emb.ecb.getTaskContext, partitionRegion)))
         }
 
         override val elementRegion: Settable[Region] = region

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -3,7 +3,8 @@ package is.hail.expr.ir
 import is.hail.asm4s.{HailClassLoader, theHailClassLoaderForSparkWorkers}
 import is.hail.HailContext
 import is.hail.annotations._
-import is.hail.backend.{BroadcastValue, ExecuteContext}
+import is.hail.backend.spark.SparkTaskContext
+import is.hail.backend.{BroadcastValue, ExecuteContext, HailTaskContext}
 import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.ir.lowering.{RVDToTableStage, TableStage, TableStageToRVD}
 import is.hail.io.fs.FS
@@ -97,13 +98,13 @@ case class TableValue(ctx: ExecuteContext, typ: TableType, globals: BroadcastRow
   def persist(ctx: ExecuteContext, level: StorageLevel) =
     TableValue(ctx, typ, globals, rvd.persist(ctx, level))
 
-  def filterWithPartitionOp[P](theHailClassLoader: HailClassLoader, fs: BroadcastValue[FS], partitionOp: (HailClassLoader, FS, Int, Region) => P)(pred: (P, RVDContext, Long, Long) => Boolean): TableValue = {
+  def filterWithPartitionOp[P](theHailClassLoader: HailClassLoader, fs: BroadcastValue[FS], partitionOp: (HailClassLoader, FS, HailTaskContext, Region) => P)(pred: (P, RVDContext, Long, Long) => Boolean): TableValue = {
     val localGlobals = globals.broadcast(theHailClassLoader)
     copy(rvd = rvd.filterWithContext[(P, Long)](
       { (partitionIdx, ctx) =>
         val globalRegion = ctx.partitionRegion
         (
-          partitionOp(theHailClassLoaderForSparkWorkers, fs.value, partitionIdx, globalRegion),
+          partitionOp(theHailClassLoaderForSparkWorkers, fs.value, SparkTaskContext.get(), globalRegion),
           localGlobals.value.readRegionValue(globalRegion, theHailClassLoaderForSparkWorkers)
         )
       }, { case ((p, glob), ctx, ptr) => pred(p, ctx, ptr, glob) }))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -1,8 +1,8 @@
 package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, RegionPool, RegionValue}
-import is.hail.asm4s._
-import is.hail.backend.ExecuteContext
+import is.hail.asm4s.{HailClassLoader, _}
+import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.SparkTaskContext
 import is.hail.expr.ir
 import is.hail.expr.ir._
@@ -184,7 +184,7 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
 
   def eltOp(ctx: ExecuteContext): IR = seqPerElt
 
-  def deserialize(ctx: ExecuteContext, spec: BufferSpec): ((Region, Array[Byte]) => Long) = {
+  def deserialize(ctx: ExecuteContext, spec: BufferSpec): ((HailClassLoader, HailTaskContext, Region, Array[Byte]) => Long) = {
     val (_, f) = ir.CompileWithAggregators[AsmFunction1RegionUnit](ctx,
       states,
       FastIndexedSeq(),
@@ -192,8 +192,8 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
       ir.DeserializeAggs(0, 0, spec, states))
 
     val fsBc = ctx.fsBc;
-    { (aggRegion: Region, bytes: Array[Byte]) =>
-      val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), aggRegion)
+    { (hcl: HailClassLoader, htc: HailTaskContext, aggRegion: Region, bytes: Array[Byte]) =>
+      val f2 = f(hcl, fsBc.value, htc, aggRegion)
       f2.newAggState(aggRegion)
       f2.setSerializedAgg(0, bytes)
       f2(aggRegion)
@@ -201,7 +201,7 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
     }
   }
 
-  def serialize(ctx: ExecuteContext, spec: BufferSpec): (Region, Long) => Array[Byte] = {
+  def serialize(ctx: ExecuteContext, spec: BufferSpec): (HailClassLoader, HailTaskContext, Region, Long) => Array[Byte] = {
     val (_, f) = ir.CompileWithAggregators[AsmFunction1RegionUnit](ctx,
       states,
       FastIndexedSeq(),
@@ -209,8 +209,8 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
       ir.SerializeAggs(0, 0, spec, states))
 
     val fsBc = ctx.fsBc;
-    { (aggRegion: Region, off: Long) =>
-      val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), aggRegion)
+    { (hcl: HailClassLoader, htc: HailTaskContext, aggRegion: Region, off: Long) =>
+      val f2 = f(hcl, fsBc.value, htc, aggRegion)
       f2.setAggState(aggRegion, off)
       f2(aggRegion)
       f2.storeAggsToRegion()
@@ -256,7 +256,7 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
 
   // Takes ownership of both input regions, and returns ownership of region in
   // resulting RegionValue.
-  def combOpF(ctx: ExecuteContext, spec: BufferSpec): (RegionValue, RegionValue) => RegionValue = {
+  def combOpF(ctx: ExecuteContext, spec: BufferSpec): (HailClassLoader, HailTaskContext, RegionValue, RegionValue) => RegionValue = {
     val fb = ir.EmitFunctionBuilder[AsmFunction4RegionLongRegionLongLong](
       ctx,
       "combOpF3",
@@ -298,9 +298,8 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
     val f = fb.resultWithIndex()
     val fsBc = ctx.fsBc
 
-    { (l: RegionValue, r: RegionValue) =>
-      // FIXME: this seems wrong? we cannot use broadcasted FSes in the service backend
-      val comb = f(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), l.region)
+    { (hcl: HailClassLoader, htc: HailTaskContext, l: RegionValue, r: RegionValue) =>
+      val comb = f(hcl, fsBc.value, htc, l.region)
       l.setOffset(comb(l.region, l.offset, r.region, r.offset))
       r.region.invalidate()
       l

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -193,7 +193,7 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
 
     val fsBc = ctx.fsBc;
     { (aggRegion: Region, bytes: Array[Byte]) =>
-      val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, 0, aggRegion)
+      val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), aggRegion)
       f2.newAggState(aggRegion)
       f2.setSerializedAgg(0, bytes)
       f2(aggRegion)
@@ -210,7 +210,7 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
 
     val fsBc = ctx.fsBc;
     { (aggRegion: Region, off: Long) =>
-      val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, 0, aggRegion)
+      val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), aggRegion)
       f2.setAggState(aggRegion, off)
       f2(aggRegion)
       f2.storeAggsToRegion()
@@ -243,7 +243,7 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
     val fsBc = ctx.fsBc
     poolGetter: (() => RegionPool) => { (bytes1: Array[Byte], bytes2: Array[Byte]) =>
       poolGetter().scopedSmallRegion { r =>
-        val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, 0, r)
+        val f2 = f(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), r)
         f2.newAggState(r)
         f2.setSerializedAgg(0, bytes1)
         f2.setSerializedAgg(1, bytes2)
@@ -300,7 +300,7 @@ class Aggs(original: IR, rewriteMap: Memo[IR], bindingNodesReferenced: Memo[Unit
 
     { (l: RegionValue, r: RegionValue) =>
       // FIXME: this seems wrong? we cannot use broadcasted FSes in the service backend
-      val comb = f(theHailClassLoaderForSparkWorkers, fsBc.value, 0, l.region)
+      val comb = f(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), l.region)
       l.setOffset(comb(l.region, l.offset, r.region, r.offset))
       r.region.invalidate()
       l

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
@@ -48,12 +48,15 @@ object LowerToCDA {
           print = None)
       }
 
-      val addr = ctx.timer.time("Run")(f(ctx.theHailClassLoader, ctx.fs, 0, ctx.r).apply(ctx.r))
+      val lit = ctx.scopedExecution { (hcl, fs, htc, r) =>
 
-      val lit = if (pt.isFieldMissing(addr, 0))
-        NA(pt.types(0).virtualType)
-      else
-        EncodedLiteral.fromPTypeAndAddress(pt.types(0), pt.loadField(addr, 0), ctx)
+        val addr = ctx.timer.time("Run")(f(hcl, fs, htc, r).apply(r))
+
+        if (pt.isFieldMissing(addr, 0))
+          NA(pt.types(0).virtualType)
+        else
+          EncodedLiteral.fromPTypeAndAddress(pt.types(0), pt.loadField(addr, 0), ctx)
+      }
 
       lower(body, typesToLower, ctx, analyses, relationalLetsAbove + ((name, lit)))
 

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -4,6 +4,7 @@ import java.io._
 import is.hail.asm4s.{HailClassLoader, theHailClassLoaderForSparkWorkers}
 import is.hail.annotations._
 import is.hail.backend.ExecuteContext
+import is.hail.backend.spark.SparkTaskContext
 import is.hail.types.physical._
 import is.hail.io.fs.FS
 import is.hail.io.index.IndexWriter
@@ -226,7 +227,10 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
       path,
       idxRelPath,
       stageLocally,
-      IndexWriter.builder(ctx, t.kType, +PCanonicalStruct()),
+      {
+        val f1= IndexWriter.builder(ctx, t.kType, +PCanonicalStruct())
+        f1(_, theHailClassLoaderForSparkWorkers, SparkTaskContext.get(), _)
+      },
       RichContextRDDRegionValue.writeRowsPartition(
         encoding.buildEncoder(ctx, t.rowType),
         t.kFieldIdx,

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -2,7 +2,7 @@ package is.hail.io.bgen
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.backend.{BroadcastValue, ExecuteContext}
+import is.hail.backend.{BroadcastValue, ExecuteContext, HailTaskContext}
 import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, IEmitCode, ParamType, TableReader}
 import is.hail.io.fs.FS
 import is.hail.io.index.IndexReaderBuilder
@@ -178,7 +178,7 @@ object CompileDecoder {
   def apply(
     ctx: ExecuteContext,
     settings: BgenSettings
-  ): (HailClassLoader, FS, Int, Region) => AsmFunction4[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long] = {
+  ): (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction4[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long] = {
     val fb = EmitFunctionBuilder[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long](ctx, "bgen_rdd_decoder")
     val mb = fb.apply_method
     val rowType = settings.rowPType

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -10,6 +10,7 @@ import is.hail.types.TableType
 import is.hail.types.physical.{PCanonicalStruct, PStruct}
 import is.hail.types.virtual._
 import is.hail.utils._
+import is.hail.asm4s.theHailClassLoaderForSparkWorkers
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.sql.Row
 import org.apache.spark.{Partition, TaskContext}
@@ -119,7 +120,7 @@ object IndexBgen {
         val htc = SparkTaskContext.get()
 
         htc.getRegionPool().scopedRegion { r =>
-          using(makeIW(idxPath, r.pool)) { iw =>
+          using(makeIW(idxPath, theHailClassLoaderForSparkWorkers, htc, r.pool)) { iw =>
             it.foreach { r =>
               assert(r.getInt(fileIdxIdx) == partIdx)
               iw.appendRow(Row(r(locusIdx), r(allelesIdx)), r.getLong(offsetIdx), Row())

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -3,7 +3,7 @@ package is.hail.io.index
 import java.io.OutputStream
 import is.hail.annotations.{Annotation, Region, RegionPool, RegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.backend.ExecuteContext
+import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.SparkTaskContext
 import is.hail.expr.ir.{CodeParam, EmitClassBuilder, EmitCodeBuilder, EmitFunctionBuilder, EmitMethodBuilder, IEmitCode, IntArrayBuilder, LongArrayBuilder, ParamType}
 import is.hail.io._
@@ -80,10 +80,10 @@ object IndexWriter {
     annotationType: PType,
     branchingFactor: Int = 4096,
     attributes: Map[String, Any] = Map.empty[String, Any]
-  ): (String, RegionPool) => IndexWriter = {
+  ): (String, HailClassLoader, HailTaskContext, RegionPool) => IndexWriter = {
     val f = StagedIndexWriter.build(ctx, keyType, annotationType, branchingFactor, attributes);
-    { (path: String, pool: RegionPool) =>
-      new IndexWriter(keyType, annotationType, f(path, pool), pool)
+    { (path: String, hcl: HailClassLoader, htc: HailTaskContext, pool: RegionPool) =>
+      new IndexWriter(keyType, annotationType, f(path, hcl, htc, pool), pool)
     }
   }
 }
@@ -239,7 +239,7 @@ object StagedIndexWriter {
     annotationType: PType,
     branchingFactor: Int = 4096,
     attributes: Map[String, Any] = Map.empty[String, Any]
-  ): (String, RegionPool) => CompiledIndexWriter = {
+  ): (String, HailClassLoader, HailTaskContext, RegionPool) => CompiledIndexWriter = {
     val fb = EmitFunctionBuilder[CompiledIndexWriter](ctx, "indexwriter",
       FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[Long], typeInfo[Long]),
       typeInfo[Unit])
@@ -264,10 +264,10 @@ object StagedIndexWriter {
 
     val fsBc = ctx.fsBc
 
-    { (path: String, pool: RegionPool) =>
+    { (path: String, hcl: HailClassLoader, htc: HailTaskContext, pool: RegionPool) =>
       pool.scopedRegion { r =>
         // FIXME: This seems wrong? But also, anywhere we use broadcasting for the FS is wrong.
-        val f = makeFB(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), r)
+        val f = makeFB(hcl, fsBc.value, htc, r)
         f.init(path)
         f
       }

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -4,6 +4,7 @@ import java.io.OutputStream
 import is.hail.annotations.{Annotation, Region, RegionPool, RegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
+import is.hail.backend.spark.SparkTaskContext
 import is.hail.expr.ir.{CodeParam, EmitClassBuilder, EmitCodeBuilder, EmitFunctionBuilder, EmitMethodBuilder, IEmitCode, IntArrayBuilder, LongArrayBuilder, ParamType}
 import is.hail.io._
 import is.hail.io.fs.FS
@@ -266,7 +267,7 @@ object StagedIndexWriter {
     { (path: String, pool: RegionPool) =>
       pool.scopedRegion { r =>
         // FIXME: This seems wrong? But also, anywhere we use broadcasting for the FS is wrong.
-        val f = makeFB(theHailClassLoaderForSparkWorkers, fsBc.value, 0, r)
+        val f = makeFB(theHailClassLoaderForSparkWorkers, fsBc.value, SparkTaskContext.get(), r)
         f.init(path)
         f
       }

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -56,10 +56,11 @@ class Classx[C](val name: String, val superName: String, var sourceFile: Option[
     sourceFile = Some(path)
   }
 
-  def asBytes(writeIRs: Boolean, print: Option[PrintWriter]): Array[(String, Array[Byte])] = {
+  def asBytes(_writeIRs: Boolean, print: Option[PrintWriter]): Array[(String, Array[Byte])] = {
     val classes = new mutable.ArrayBuffer[Classx[_]]()
     classes += this
 
+    val writeIRs = true
     for (m <- methods) {
       m.verify()
       SimplifyControl(m)

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -56,11 +56,10 @@ class Classx[C](val name: String, val superName: String, var sourceFile: Option[
     sourceFile = Some(path)
   }
 
-  def asBytes(_writeIRs: Boolean, print: Option[PrintWriter]): Array[(String, Array[Byte])] = {
+  def asBytes(writeIRs: Boolean, print: Option[PrintWriter]): Array[(String, Array[Byte])] = {
     val classes = new mutable.ArrayBuffer[Classx[_]]()
     classes += this
 
-    val writeIRs = true
     for (m <- methods) {
       m.verify()
       SimplifyControl(m)

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -812,7 +812,8 @@ class RVD(
     val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", typ.kType, withOffsetField = true)
     val makeRowsEnc = rowsCodecSpec.buildEncoder(execCtx, fullRowType)
     val makeEntriesEnc = entriesCodecSpec.buildEncoder(execCtx, fullRowType)
-    val makeIndexWriter = IndexWriter.builder(execCtx, typ.kType, +PCanonicalStruct("entries_offset" -> PInt64()))
+    val _makeIndexWriter = IndexWriter.builder(execCtx, typ.kType, +PCanonicalStruct("entries_offset" -> PInt64()))
+    val makeIndexWriter: (String, RegionPool) => IndexWriter = _makeIndexWriter(_, theHailClassLoaderForSparkWorkers, SparkTaskContext.get(), _)
 
     val localTyp = typ
 
@@ -1498,7 +1499,8 @@ object RVD {
     val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", localTyp.kType, withOffsetField = true)
     val makeRowsEnc = rowsCodecSpec.buildEncoder(execCtx, fullRowType)
     val makeEntriesEnc = entriesCodecSpec.buildEncoder(execCtx, fullRowType)
-    val makeIndexWriter = IndexWriter.builder(execCtx, localTyp.kType, +PCanonicalStruct("entries_offset" -> PInt64()))
+    val _makeIndexWriter = IndexWriter.builder(execCtx, localTyp.kType, +PCanonicalStruct("entries_offset" -> PInt64()))
+    val makeIndexWriter: (String, RegionPool) => IndexWriter = _makeIndexWriter(_, theHailClassLoaderForSparkWorkers, SparkTaskContext.get(), _)
 
     val partDigits = digitsNeeded(nPartitions)
     val fileDigits = digitsNeeded(rvds.length)

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -88,7 +88,7 @@ object Graph {
           rvb.endTuple()
           val rOffset = rvb.end()
 
-          val resultOffset = f(ctx.theHailClassLoader, ctx.fs, 0, region)(region, lOffset, rOffset)
+          val resultOffset = f(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, region)(region, lOffset, rOffset)
           if (resultType.isFieldMissing(resultOffset, 0)) {
             throw new RuntimeException(
               s"a comparison returned a missing value when " +

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -196,7 +196,7 @@ object TestUtils {
             rvb.endArray()
             val aggOff = rvb.end()
 
-            val resultOff = f(theHailClassLoader, ctx.fs, 0, region)(region, argsOff, aggOff)
+            val resultOff = f(theHailClassLoader, ctx.fs, ctx.taskContext, region)(region, argsOff, aggOff)
             SafeRow(resultType2.asInstanceOf[PBaseStruct], resultOff).get(0)
           }
 
@@ -221,7 +221,7 @@ object TestUtils {
             rvb.endTuple()
             val argsOff = rvb.end()
 
-            val resultOff = f(theHailClassLoader, ctx.fs, 0, region)(region, argsOff)
+            val resultOff = f(theHailClassLoader, ctx.fs, ctx.taskContext, region)(region, argsOff)
             SafeRow(resultType2.asInstanceOf[PBaseStruct], resultOff).get(0)
           }
       }

--- a/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
@@ -444,7 +444,7 @@ class StagedConstructorSuite extends HailSuite {
             fb.apply_method.getCodeParam[Region](1),
             t.loadCheapSCode(cb, fb.apply_method.getCodeParam[Long](2)),
               deepCopy = true))
-          val copyF = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, region)
+          val copyF = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, region)
           val newOff = copyF(region, src)
 
 
@@ -513,7 +513,7 @@ class StagedConstructorSuite extends HailSuite {
         val region = f1.partitionRegion
         t2.constructFromFields(cb, region, FastIndexedSeq(EmitCode.present(cb.emb, t2.types(0).loadCheapSCode(cb, v1))), deepCopy = false).a
       }
-      val cp1 = f1.resultWithIndex()(theHailClassLoader, ctx.fs, 0, r)()
+      val cp1 = f1.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, r)()
       assert(SafeRow.read(t2, cp1) == Row(value))
 
       val f2 = EmitFunctionBuilder[Long](ctx, "stagedCopy2")
@@ -521,7 +521,7 @@ class StagedConstructorSuite extends HailSuite {
         val region = f2.partitionRegion
         t1.constructFromFields(cb, region, FastIndexedSeq(EmitCode.present(cb.emb, t2.types(0).loadCheapSCode(cb, v1))), deepCopy = false).a
       }
-      val cp2 = f2.resultWithIndex()(theHailClassLoader, ctx.fs, 0, r)()
+      val cp2 = f2.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, r)()
       assert(SafeRow.read(t1, cp2) == Row(value))
     }
   }

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -24,7 +24,7 @@ class CodeSuite extends HailSuite {
       sum.load()
     )
     fb.emit(code)
-    val result = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, ctx.r)()
+    val result = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r)()
     assert(result == 10)
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -85,8 +85,8 @@ class Aggregators2Suite extends HailSuite {
           FastIndexedSeq(classInfo[Region]), LongInfo,
           ResultOp.makeTuple(Array(aggSig)))
 
-        val init = initF(theHailClassLoader, ctx.fs, 0, region)
-        val res = resOneF(theHailClassLoader, ctx.fs, 0, region)
+        val init = initF(theHailClassLoader, ctx.fs, ctx.taskContext, region)
+        val res = resOneF(theHailClassLoader, ctx.fs, ctx.taskContext, region)
 
         pool.scopedSmallRegion { aggRegion =>
           init.newAggState(aggRegion)
@@ -98,9 +98,9 @@ class Aggregators2Suite extends HailSuite {
       }
 
       val serializedParts = seqOps.grouped(math.ceil(seqOps.length / nPartitions.toDouble).toInt).map { seqs =>
-        val init = initF(theHailClassLoader, ctx.fs, 0, region)
-        val seq = withArgs(Begin(seqs))(theHailClassLoader, ctx.fs, 0, region)
-        val write = writeF(theHailClassLoader, ctx.fs, 0, region)
+        val init = initF(theHailClassLoader, ctx.fs, ctx.taskContext, region)
+        val seq = withArgs(Begin(seqs))(theHailClassLoader, ctx.fs, ctx.taskContext, region)
+        val write = writeF(theHailClassLoader, ctx.fs, ctx.taskContext, region)
         pool.scopedSmallRegion { aggRegion =>
           init.newAggState(aggRegion)
           init(region, argOff)
@@ -115,13 +115,13 @@ class Aggregators2Suite extends HailSuite {
       }.toArray
 
       pool.scopedSmallRegion { aggRegion =>
-        val combOp = combAndDuplicate(theHailClassLoader, ctx.fs, 0, region)
+        val combOp = combAndDuplicate(theHailClassLoader, ctx.fs, ctx.taskContext, region)
         combOp.newAggState(aggRegion)
         serializedParts.zipWithIndex.foreach { case (s, i) =>
           combOp.setSerializedAgg(i, s)
         }
         combOp(region)
-        val res = resF(theHailClassLoader, ctx.fs, 0, region)
+        val res = resF(theHailClassLoader, ctx.fs, ctx.taskContext, region)
         res.setAggState(aggRegion, combOp.getAggOffset())
         val double = SafeRow(rt, res(region))
         transformResult match {

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -62,7 +62,7 @@ class ETypeSuite extends HailSuite {
     val buffer = new MemoryBuffer
     val ob = new MemoryOutputBuffer(buffer)
 
-    fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, ctx.r).apply(x, ob)
+    fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r).apply(x, ob)
     ob.flush()
     buffer.clearPos()
 
@@ -75,7 +75,7 @@ class ETypeSuite extends HailSuite {
       outPType.store(cb, regArg, decoded, deepCopy = false)
     }
 
-    val result = fb2.resultWithIndex()(theHailClassLoader, ctx.fs, 0, ctx.r).apply(ctx.r, new MemoryInputBuffer(buffer))
+    val result = fb2.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r).apply(ctx.r, new MemoryInputBuffer(buffer))
     SafeRow.read(outPType, result)
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -79,7 +79,7 @@ class EmitStreamSuite extends HailSuite {
     val f = fb.resultWithIndex()
     (arg: T) =>
       pool.scopedRegion { r =>
-        val off = call(f(theHailClassLoader, ctx.fs, 0, r), r, arg)
+        val off = call(f(theHailClassLoader, ctx.fs, ctx.taskContext, r), r, arg)
         if (off == 0L)
           null
         else
@@ -155,7 +155,7 @@ class EmitStreamSuite extends HailSuite {
     }
     val f = fb.resultWithIndex()
     pool.scopedRegion { r =>
-      val len = f(theHailClassLoader, ctx.fs, 0, r)(r)
+      val len = f(theHailClassLoader, ctx.fs, ctx.taskContext, r)(r)
       if (len < 0) None else Some(len)
     }
   }
@@ -758,7 +758,7 @@ class EmitStreamSuite extends HailSuite {
     pool.scopedSmallRegion { r =>
       val input = t.unstagedStoreJavaObject(Row(null, IndexedSeq(1d, 2d), IndexedSeq(3d, 4d)), r)
 
-      assert(SafeRow.read(pt, f(theHailClassLoader, ctx.fs, 0, r)(r, input)) == Row(null))
+      assert(SafeRow.read(pt, f(theHailClassLoader, ctx.fs, ctx.taskContext, r)(r, input)) == Row(null))
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -114,7 +114,7 @@ class FunctionSuite extends HailSuite {
     })
     pool.scopedRegion { r =>
 
-      assert(fb.resultWithIndex().apply(theHailClassLoader, ctx.fs, 0, r)() == 2)
+      assert(fb.resultWithIndex().apply(theHailClassLoader, ctx.fs, ctx.taskContext, r)() == 2)
     }
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -45,7 +45,7 @@ class OrderingSuite extends HailSuite {
       fb.ecb.getOrderingFunction(cv1.st, cv2.st, op)
           .apply(cb, EmitValue.present(cv1), EmitValue.present(cv2))
     }
-    fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, r)
+    fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, r)
   }
 
   @Test def testMissingNonequalComparisons() {
@@ -67,7 +67,7 @@ class OrderingSuite extends HailSuite {
         fb.ecb.getOrderingFunction(ev1.st, ev2.st, op)
           .apply(cb, ev1, ev2)
       }
-      fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, r)
+      fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, r)
     }
 
     val compareGen = for {
@@ -468,7 +468,7 @@ class OrderingSuite extends HailSuite {
 
         val asArray = SafeIndexedSeq(pArray, soff)
 
-        val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, region)
+        val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, region)
         val closestI = f(region, soff, eoff)
         val maybeEqual = asArray(closestI)
 
@@ -509,7 +509,7 @@ class OrderingSuite extends HailSuite {
 
         val asArray = SafeIndexedSeq(PCanonicalArray(pDict.elementType), soff)
 
-        val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, region)
+        val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, region)
         val closestI = f(region, soff, eoff)
 
         if (closestI == asArray.length) {

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -76,7 +76,7 @@ object BTreeBackedSet {
 
     val inputBuffer = new StreamBufferSpec().buildInputBuffer(new ByteArrayInputStream(serialized))
     val set = new BTreeBackedSet(ctx, region, n)
-    set.root = fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, 0, region)(region, inputBuffer)
+    set.root = fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)(region, inputBuffer)
     set
   }
 }
@@ -99,7 +99,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       root
     }
 
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, 0, region)
+    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   private val getF = {
@@ -124,7 +124,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       })
       root
     }
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, 0, region)
+    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   private val getResultsF = {
@@ -161,7 +161,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       )
       returnArray
     }
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, 0, region)
+    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   private val bulkStoreF = {
@@ -190,7 +190,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       ob2.flush()
     }
 
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, 0, region)
+    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   def clear(): Unit = {

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -37,7 +37,7 @@ class TakeByAggregatorSuite extends HailSuite {
           tba.result(cb, argR, rt).a
         }
 
-        val o = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, r)(r)
+        val o = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, r)(r)
         val result = SafeRow.read(rt, o)
         assert(result == ((n - 1) to 0 by -1)
           .iterator
@@ -71,7 +71,7 @@ class TakeByAggregatorSuite extends HailSuite {
         tba.result(cb, argR, rt).a
       }
 
-      val o = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, r)(r)
+      val o = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, r)(r)
       val result = SafeRow.read(rt, o)
       assert(result == FastIndexedSeq(0, 1, 2, 3, null, null, null))
     }
@@ -114,7 +114,7 @@ class TakeByAggregatorSuite extends HailSuite {
           resultOff
         }
 
-        val o = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, r)(r)
+        val o = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, r)(r)
         val pqOffset = Region.loadAddress(o)
         val pq = SafeRow.read(rt, pqOffset)
         val collOffset = Region.loadAddress(o + 8)

--- a/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
@@ -51,7 +51,7 @@ class DownsampleSuite extends HailSuite {
     }
 
     pool.scopedSmallRegion { r =>
-      fb.resultWithIndex().apply(theHailClassLoader, ctx.fs, 0, r).apply(pool)
+      fb.resultWithIndex().apply(theHailClassLoader, ctx.fs, ctx.taskContext, r).apply(pool)
     }
   }
 }

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -42,7 +42,7 @@ class IndexSuite extends HailSuite {
     attributes: Map[String, Any]) {
     val bufferSpec = BufferSpec.default
 
-    val iw = IndexWriter.builder(ctx, keyType, annotationType, branchingFactor, attributes)(file, pool)
+    val iw = IndexWriter.builder(ctx, keyType, annotationType, branchingFactor, attributes)(file, theHailClassLoader, ctx.taskContext, pool)
     data.zip(annotations).zipWithIndex.foreach { case ((s, a), offset) =>
       iw.appendRow(s, offset, a)
     }

--- a/hail/src/test/scala/is/hail/lir/LIRSplitSuite.scala
+++ b/hail/src/test/scala/is/hail/lir/LIRSplitSuite.scala
@@ -22,6 +22,6 @@ class LIRSplitSuite extends HailSuite {
       cb.invokeVoid(mb, const(1L))
       Code._empty
     }
-    f.resultWithIndex()(theHailClassLoader, ctx.fs, 0, ctx.r)()
+    f.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r)()
   }
 }

--- a/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -164,7 +164,7 @@ class ReferenceGenomeSuite extends HailSuite {
       val rgfield = fb.getReferenceGenome(grch38)
       fb.emit(rgfield.invoke[String, Boolean]("isValidContig", fb.getCodeParam[String](1)))
 
-      val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, ctx.r)
+      val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r)
       assert(f("X") == grch38.isValidContig("X"))
     }
   }
@@ -183,7 +183,7 @@ class ReferenceGenomeSuite extends HailSuite {
       val rgfield = fb.getReferenceGenome(rg)
       fb.emit(rgfield.invoke[String, Int, Int, Int, String]("getSequence", fb.getCodeParam[String](1), fb.getCodeParam[Int](2), fb.getCodeParam[Int](3), fb.getCodeParam[Int](4)))
 
-      val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, ctx.r)
+      val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r)
       assert(f("a", 25, 0, 5) == rg.getSequence("a", 25, 0, 5))
     }
   }
@@ -200,7 +200,7 @@ class ReferenceGenomeSuite extends HailSuite {
       val rgfield = fb.getReferenceGenome(grch37)
       fb.emit(rgfield.invoke[String, Locus, Double, (Locus, Boolean)]("liftoverLocus", fb.getCodeParam[String](1), fb.getCodeParam[Locus](2), fb.getCodeParam[Double](3)))
 
-      val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, 0, ctx.r)
+      val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r)
       assert(f("GRCh38", Locus("20", 60001), 0.95) == grch37.liftoverLocus("GRCh38", Locus("20", 60001), 0.95))
       grch37.removeLiftover("GRCh38")
     }


### PR DESCRIPTION
…ead of partitionIndex

Partition index is now unnecessary due to the completion of the randomness redesign.

HailTaskContext will be used in a subsequent PR to add task-level cleanup to permit aggressive caching in generated code.