### PR TITLE
[query] Make caching in PartitionNativeIntervalReader more aggressive

### DIFF
--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -3,6 +3,26 @@ package is.hail.backend
 import is.hail.annotations.RegionPool
 import is.hail.utils._
 
+import java.io.Closeable
+
+class TaskFinalizer {
+  val closeables = new BoxedArrayBuilder[Closeable]()
+
+  def clear(): Unit = {
+    closeables.clear()
+  }
+  
+  def addCloseable(c: Closeable): Unit = {
+    closeables += c
+  }
+
+  def closeAll(): Unit = {
+    (0 until closeables.size).foreach { i =>
+      closeables(i).close()
+    }
+  }
+}
+
 abstract class HailTaskContext extends AutoCloseable {
   def stageId(): Int
 
@@ -20,10 +40,21 @@ abstract class HailTaskContext extends AutoCloseable {
     s"${ stageId() }-${ partitionId() }-${ attemptNumber() }-$fileUUID"
   }
 
+  val finalizers = new BoxedArrayBuilder[TaskFinalizer]()
+
+  def newFinalizer(): TaskFinalizer = {
+    val f = new TaskFinalizer
+    finalizers += f
+    f
+  }
+
   def close(): Unit = {
     log.info(s"TaskReport: stage=${ stageId() }, partition=${ partitionId() }, attempt=${ attemptNumber() }, " +
       s"peakBytes=${ thePool.getHighestTotalUsage }, peakBytesReadable=${ formatSpace(thePool.getHighestTotalUsage) }, "+
       s"chunks requested=${thePool.getUsage._1}, cache hits=${thePool.getUsage._2}")
+    (0 until finalizers.size).foreach { i =>
+      finalizers(i).closeAll()
+    }
     thePool.close()
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -814,7 +814,7 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
           cb.assign(currPartitionIdx, startPartitionIndex)
 
 
-          cb.assign(streamFirst, true) // basically "!first"
+          cb.assign(streamFirst, true)
           cb.assign(currIdxInPartition, 0L)
           cb.assign(stopIdxInPartition, 0L)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -786,8 +786,6 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
       val indexCachedIndex = mb.genFieldThisRef[Int]("index_last_idx")
       val streamFirst = mb.genFieldThisRef[Boolean]("stream_first")
 
-      val nOpens = mb.genFieldThisRef[Int]("n_opens")
-
       val region = mb.genFieldThisRef[Region]("pnr_region")
 
       val decodedRow = cb.emb.newPField("rowsValue", eltSType)
@@ -838,12 +836,6 @@ case class PartitionNativeIntervalReader(tablePath: String, tableSpec: AbstractT
               // if first, reuse open index from previous time the stream was run if possible
               // this is a common case if looking up nearby keys
               cb.assign(requiresIndexInit, !(indexInitialized && (indexCachedIndex ceq currPartitionIdx)))
-              cb.ifx(indexInitialized, {
-                cb.assign(nOpens, nOpens + 1)
-                cb.logInfo("query_table: nOpens=", nOpens.toS)
-              }, {
-                cb.assign(nOpens, 0)
-              })
             }, {
               // if not first, then the index must be open to the previous partition and needs to be reinitialized
               cb.assign(streamFirst, false)

--- a/hail/src/main/scala/is/hail/utils/Cache.scala
+++ b/hail/src/main/scala/is/hail/utils/Cache.scala
@@ -2,6 +2,7 @@ package is.hail.utils
 
 import is.hail.annotations.{Region, RegionMemory}
 
+import java.io.Closeable
 import java.util
 import java.util.Map.Entry
 
@@ -17,7 +18,7 @@ class Cache[K, V](capacity: Int) {
   def size: Int = synchronized { m.size() }
 }
 
-class LongToRegionValueCache(capacity: Int) {
+class LongToRegionValueCache(capacity: Int) extends Closeable {
   private[this] val m = new util.LinkedHashMap[Long, (RegionMemory, Long)](capacity, 0.75f, true) {
     override def removeEldestEntry(eldest: Entry[Long, (RegionMemory, Long)]): Boolean = {
       val b = (size() > capacity)
@@ -50,4 +51,6 @@ class LongToRegionValueCache(capacity: Int) {
     m.forEach((k, v) => v._1.release())
     m.clear()
   }
+
+  def close(): Unit = free()
 }


### PR DESCRIPTION
Add finalizers to HailTaskContext to clean up open indices.