### PR TITLE
[batch] Add job_id to UI search

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -238,13 +238,15 @@ async def _query_batch_jobs(request, batch_id):
     where_conditions = ['(jobs.batch_id = %s AND batch_updates.committed)']
     where_args = [batch_id]
 
-    last_job_id = request.query.get('last_job_id')
-    if last_job_id is not None:
-        last_job_id = int(last_job_id)
-        where_conditions.append('(jobs.job_id > %s)')
-        where_args.append(last_job_id)
-
     q = request.query.get('q', '')
+    last_query = request.query.get('_last_query', '')
+    if q == last_query:
+        last_job_id = request.query.get('last_job_id')
+        if last_job_id is not None:
+            last_job_id = int(last_job_id)
+            where_conditions.append('(jobs.job_id > %s)')
+            where_args.append(last_job_id)
+
     terms = q.split()
     for t in terms:
         if t[0] == '!':
@@ -255,12 +257,16 @@ async def _query_batch_jobs(request, batch_id):
 
         if '=' in t:
             k, v = t.split('=', 1)
-            condition = '''
+            if k == 'job_id':
+                condition = '(jobs.job_id = %s)'
+                args = [v]
+            else:
+                condition = '''
 ((jobs.batch_id, jobs.job_id) IN
  (SELECT batch_id, job_id FROM job_attributes
   WHERE `key` = %s AND `value` = %s))
 '''
-            args = [k, v]
+                args = [k, v]
         elif t.startswith('has:'):
             k = t[4:]
             condition = '''
@@ -1687,7 +1693,8 @@ async def ui_batch(request, userdata, batch_id):
 
     batch['cost'] = cost_str(batch['cost'])
 
-    page_context = {'batch': batch, 'q': request.query.get('q'), 'last_job_id': last_job_id}
+    q = request.query.get('q')
+    page_context = {'batch': batch, 'q': q, '_last_query': q, 'last_job_id': last_job_id}
     return await render_template('batch', request, userdata, 'batch.html', page_context)
 
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -238,15 +238,13 @@ async def _query_batch_jobs(request, batch_id):
     where_conditions = ['(jobs.batch_id = %s AND batch_updates.committed)']
     where_args = [batch_id]
 
-    q = request.query.get('q', '')
-    last_query = request.query.get('_last_query', '')
-    if q == last_query:
-        last_job_id = request.query.get('last_job_id')
-        if last_job_id is not None:
-            last_job_id = int(last_job_id)
-            where_conditions.append('(jobs.job_id > %s)')
-            where_args.append(last_job_id)
+    last_job_id = request.query.get('last_job_id')
+    if last_job_id is not None:
+        last_job_id = int(last_job_id)
+        where_conditions.append('(jobs.job_id > %s)')
+        where_args.append(last_job_id)
 
+    q = request.query.get('q', '')
     terms = q.split()
     for t in terms:
         if t[0] == '!':
@@ -1693,8 +1691,7 @@ async def ui_batch(request, userdata, batch_id):
 
     batch['cost'] = cost_str(batch['cost'])
 
-    q = request.query.get('q')
-    page_context = {'batch': batch, 'q': q, '_last_query': q, 'last_job_id': last_job_id}
+    page_context = {'batch': batch, 'q': request.query.get('q'), 'last_job_id': last_job_id}
     return await render_template('batch', request, userdata, 'batch.html', page_context)
 
 

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -45,6 +45,7 @@
 <div class="flex-col">
   <div class="flex-col-align-right">
     <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
+      <input type="hidden" name="_last_query" value="{{ last_query }}"/>
       <input style="vertical-align:text-bottom;" id="searchBar" name="q" size=30 type="text"
         {% if q %}
         value="{{ q }}"
@@ -60,6 +61,7 @@
       <p>Search jobs with the given search terms.  Return jobs
         that match all terms.  Terms:</p>
       <ul>
+        <li>job_id=JOB_ID - jobs with an id equal to JOB_ID</li>
         <li>k=v - jobs with an attribute with key k and value v</li>
         <li>has:k - jobs that have an attribute with key k</li>
         <li>state - jobs in the given state, one of:

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -45,7 +45,6 @@
 <div class="flex-col">
   <div class="flex-col-align-right">
     <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
-      <input type="hidden" name="_last_query" value="{{ last_query }}"/>
       <input style="vertical-align:text-bottom;" id="searchBar" name="q" size=30 type="text"
         {% if q %}
         value="{{ q }}"


### PR DESCRIPTION
This is a feature Bob asked for to be able to search by job id in the UI. I added new functionality where if the "q" query string changes, we reset the last_job_id. Otherwise, something like "job_id=100" followed by "job_id=5" wouldn't work.