### PR TITLE
[batch] Specify web server port through env variable

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import json
 import logging
+import os
 import re
 import signal
 from collections import defaultdict
@@ -1409,6 +1410,6 @@ def run():
     web.run_app(
         deploy_config.prefix_application(app, 'batch-driver', client_max_size=HTTP_CLIENT_MAX_SIZE),
         host='0.0.0.0',
-        port=5000,
+        port=int(os.environ['PORT']),
         access_log_class=BatchDriverAccessLogger,
     )

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2860,7 +2860,7 @@ def run():
     web.run_app(
         deploy_config.prefix_application(app, 'batch', client_max_size=HTTP_CLIENT_MAX_SIZE),
         host='0.0.0.0',
-        port=443,
+        port=int(os.environ['PORT']),
         access_log_class=BatchFrontEndAccessLogger,
         ssl_context=internal_server_ssl_context(),
     )

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -171,6 +171,8 @@ spec:
             cpu: "1.5"
             memory: "2.5G"
         env:
+         - name: PORT
+           value: "5000"
          - name: HAIL_DOMAIN
            valueFrom:
              secretKeyRef:
@@ -368,6 +370,8 @@ spec:
          - -m
          - batch.front_end
         env:
+         - name: PORT
+           value: "443"
          - name: HAIL_DOMAIN
            valueFrom:
              secretKeyRef:


### PR DESCRIPTION
For terra I currently have the front-end and driver running in the same pod, so I can't have the front-end listening on port 443 since it's in use by something else in the pod. Seemed like a reasonable enough change on its own. There will be an entirely separate `deployment.yaml` for terra so better to expose small options like these there than in the python code.