### PR TITLE
[ci] Dont require a deploy step for a dev deploy

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -3,7 +3,7 @@ import json
 import logging
 from collections import Counter, defaultdict
 from shlex import quote as shq
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import jinja2
 import yaml
@@ -158,18 +158,20 @@ class BuildConfiguration:
             if step.can_run_in_scope(scope):
                 step.cleanup(batch, scope, parent_jobs)
 
-    def deployed_services(self) -> Tuple[str, List[str]]:
-        services = defaultdict(list)
-        for s in self.steps:
-            if isinstance(s, DeployStep):
-                services[s.namespace].extend(s.services())
+    def namespace(self) -> Optional[str]:
         # build.yaml allows for multiple namespaces, but
         # in actuality we only ever use 1 and make many assumptions
         # around there being a 1:1 correspondence between builds and namespaces
-        namespaces = list(services.keys())
-        assert len(namespaces) == 1
-        ns = namespaces[0]
-        return ns, services[ns]
+        namespaces = {s.namespace for s in self.steps if isinstance(s, DeployStep)}
+        assert len(namespaces) <= 1
+        return namespaces.pop() if len(namespaces) == 1 else None
+
+    def deployed_services(self) -> List[str]:
+        services = []
+        for s in self.steps:
+            if isinstance(s, DeployStep):
+                services.extend(s.services())
+        return services
 
 
 class Step(abc.ABC):

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -483,12 +483,14 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 config = BuildConfiguration(self, f.read(), scope='test')
-                namespace, services = config.deployed_services()
+                namespace = config.namespace()
+                services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                _, test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+                test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
 
             services.extend(test_services)
             tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+            assert namespace is not None
             await add_deployed_services(db, namespace, services, tomorrow)
 
             log.info(f'creating test batch for {self.number}')
@@ -896,11 +898,13 @@ mkdir -p {shq(repo_dir)}
             )
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS, scope='deploy')
-                namespace, services = config.deployed_services()
+                namespace = config.namespace()
+                services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                _, test_services = BuildConfiguration(self, f.read(), scope='deploy').deployed_services()
+                test_services = BuildConfiguration(self, f.read(), scope='deploy').deployed_services()
 
             services.extend(test_services)
+            assert namespace is not None
             await add_deployed_services(db, namespace, services, None)
 
             log.info(f'creating deploy batch for {self.branch.short_str()}')
@@ -996,12 +1000,13 @@ mkdir -p {shq(repo_dir)}
                 config = BuildConfiguration(
                     self, f.read(), scope='dev', requested_step_names=steps, excluded_step_names=excluded_steps
                 )
-                namespace, services = config.deployed_services()
+                namespace = config.namespace()
+                services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                _, test_services = BuildConfiguration(self, f.read(), scope='dev').deployed_services()
-
-            services.extend(test_services)
-            await add_deployed_services(db, namespace, services, None)
+                test_services = BuildConfiguration(self, f.read(), scope='dev').deployed_services()
+            if namespace is not None:
+                services.extend(test_services)
+                await add_deployed_services(db, namespace, services, None)
 
             log.info(f'creating dev deploy batch for {self.branch.short_str()} and user {self.user}')
 


### PR DESCRIPTION
Currently you can't do a dev deploy that only builds an image, because the `deployed_services` method breaks if there are no `deploy_*` steps in the config. This change allows a dev deploy to work with just steps that don't transitively depend on the create namespace step.