### PR TITLE
[query] quiet makefile

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -67,7 +67,7 @@ GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION)
 
 QUERY_STORAGE_URI = $(shell kubectl get secret global-config --template={{.data.query_storage_uri}} | base64 --decode)
 TEST_STORAGE_URI = $(shell kubectl get secret global-config --template={{.data.test_storage_uri}} | base64 --decode)
-TOKEN := $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
+TOKEN := $(shell cat /dev/urandom 2> /dev/null | LC_ALL=C tr -dc 'a-z0-9' 2> /dev/null | head -c 12)
 
 ifeq ($(NAMESPACE),default)
 ifeq ($(UPLOAD_RELEASE_JAR),true)


### PR DESCRIPTION
depending on implementation, cat and tr will report broken pipes adding noise to the output of make.