### PR TITLE
[ci] Dont try to json.loads the namespace string

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -411,7 +411,7 @@ async def batch_callback_handler(request):
                     if 'test' in attrs and params['complete']:
                         assert 'deploy' not in attrs
                         assert 'dev' not in attrs
-                        namespace = json.loads(attrs['namespace'])
+                        namespace = attrs['namespace']
                         if DEFAULT_NAMESPACE == 'default':
                             await remove_namespace_from_db(db, namespace)
 


### PR DESCRIPTION
It's just a string so `json.loads` fails on it. Not sure why I did that anyway.

This has been broken on CI for a bit now. CI still manages fine because it checks everything on an interval but the callback helps it respond immediately to when batches finish for a PR test or deploy.