### PR TITLE
[query] various nd array fixes

### DIFF
--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -473,14 +473,16 @@ def concatenate(nds, axis=0):
         The concatenated array
     """
     head_nd = nds[0]
-    head_ndim = head_nd.ndim
-    hl.case().when(hl.all(lambda a: a.ndim == head_ndim, nds), True).or_error("Mismatched ndim")
 
     makearr = aarray(nds)
     concat_ir = NDArrayConcat(makearr._ir, axis)
-    indices, aggregations = unify_all(*nds)
+    if isinstance(nds, list):
+        indices, aggregations = unify_all(*nds)
+    else:
+        indices = nds._indices
+        aggregations = nds._aggregations
 
-    return construct_expr(concat_ir, tndarray(head_nd._type.element_type, head_ndim), indices, aggregations)
+    return construct_expr(concat_ir, tndarray(head_nd._type.element_type, head_nd.ndim), indices, aggregations)
 
 
 @typecheck(N=expr_numeric, M=nullable(expr_numeric), dtype=HailType)

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -7,7 +7,8 @@ from hail.expr.types import HailType, tfloat64, tfloat32, ttuple, tndarray
 from hail.typecheck import typecheck, nullable, oneof, tupleof, sequenceof
 from hail.expr.expressions import (
     expr_int32, expr_int64, expr_tuple, expr_any, expr_array, expr_ndarray,
-    expr_numeric, Int64Expression, cast_expr, construct_expr, expr_bool)
+    expr_numeric, Int64Expression, cast_expr, construct_expr, expr_bool,
+    unify_all)
 from hail.expr.expressions.typed_expressions import NDArrayNumericExpression
 from hail.ir import NDArrayQR, NDArrayInv, NDArrayConcat, NDArraySVD, Apply
 
@@ -40,6 +41,7 @@ def array(input_array, dtype=None):
     Parameters
     ----------
     input_array : :class:`.ArrayExpression`, numpy ndarray, or nested python lists/tuples
+        The array to convert to a Hail ndarray.
     dtype : :class:`.HailType`
         Desired hail type.  Default: `float64`.
 
@@ -214,8 +216,15 @@ def diagonal(nd):
     >>> hl.eval(hl.nd.diagonal(hl.nd.array([[1, 2], [3, 4]])))
     array([1, 4], dtype=int32)
 
-    :param nd: A 2 dimensional NDArray, shape(M, N).
-    :return: A 1 dimension NDArray of length min (M, N), containing the diagonal of `nd`.
+    Parameters
+    ----------
+    nd : :class:`.NDArrayNumericExpression`
+        A 2 dimensional NDArray, shape(M, N).
+
+    Returns
+    -------
+    :class:`.NDArrayExpression`
+        A 1 dimension NDArray of length min(M, N), containing the diagonal of `nd`.
     """
     assert nd.ndim == 2, "diagonal requires 2 dimensional ndarray"
     shape_min = hl.min(nd.shape[0], nd.shape[1])
@@ -248,8 +257,9 @@ def solve(a, b, no_crash=False):
         name = "linear_solve"
         return_type = hl.tndarray(hl.tfloat64, 2)
 
+    indices, aggregations = unify_all(a, b)
     ir = Apply(name, return_type, a._ir, b._ir)
-    result = construct_expr(ir, return_type, a._indices, a._aggregations)
+    result = construct_expr(ir, return_type, indices, aggregations)
 
     if b_ndim_orig == 1:
         if no_crash:
@@ -282,8 +292,11 @@ def solve_triangular(nd_coef, nd_dep, lower=False):
     nd_dep_ndim_orig = nd_dep.ndim
     nd_coef, nd_dep = solve_helper(nd_coef, nd_dep, nd_dep_ndim_orig)
     return_type = hl.tndarray(hl.tfloat64, 2)
+
+    indices, aggregations = unify_all(nd_coef, nd_dep)
+
     ir = Apply("linear_triangular_solve", return_type, nd_coef._ir, nd_dep._ir, lower._ir)
-    result = construct_expr(ir, return_type, nd_coef._indices, nd_coef._aggregations)
+    result = construct_expr(ir, return_type, indices, aggregations)
     if nd_dep_ndim_orig == 1:
         result = result.reshape((-1))
     return result
@@ -305,17 +318,47 @@ def solve_helper(nd_coef, nd_dep, nd_dep_ndim_orig):
 
 @typecheck(nd=expr_ndarray(), mode=str)
 def qr(nd, mode="reduced"):
-    """Performs a QR decomposition.
+    r"""Performs a QR decomposition.
 
-    :param nd: A 2 dimensional ndarray, shape(M, N)
-    :param mode: One of "reduced", "complete", "r", or "raw".
+    If K = min(M, N), then:
 
-        If K = min(M, N), then:
+    - `reduced`: returns q and r with dimensions (M, K), (K, N)
+    - `complete`: returns q and r with dimensions (M, M), (M, N)
+    - `r`: returns only r with dimensions (K, N)
+    - `raw`: returns h, tau with dimensions (N, M), (K,)
 
-        - `reduced`: returns q and r with dimensions (M, K), (K, N)
-        - `complete`: returns q and r with dimensions (M, M), (M, N)
-        - `r`: returns only r with dimensions (K, N)
-        - `raw`: returns h, tau with dimensions (N, M), (K,)
+    Notes
+    -----
+
+    The reduced QR, the default output of this function, has the following properties:
+
+    .. math::
+
+        m \gte n \\
+        nd : \mathbb{R}^{m \times n} \\
+        Q : \mathbb{R}^{m \times n} \\
+        R : \mathbb{R}^{n \times n} \\
+        \\
+        Q^T Q = \mathbb{1}
+
+    The complete QR, has the following properties:
+
+    .. math::
+
+        m \gte n \\
+        nd : \mathbb{R}^{m \times n} \\
+        Q : \mathbb{R}^{m \times m} \\
+        R : \mathbb{R}^{m \times n} \\
+        \\
+        Q^T Q = \mathbb{1}
+        Q Q^T = \mathbb{1}
+
+    Parameters
+    ----------
+    nd : :class:`.NDArrayExpressoin`
+        A 2 dimensional ndarray, shape(M, N)
+    mode : :class:`.str`
+        One of "reduced", "complete", "r", or "raw". Defaults to "reduced".
 
     Returns
     -------
@@ -349,47 +392,53 @@ def qr(nd, mode="reduced"):
 def svd(nd, full_matrices=True, compute_uv=True):
     """Performs a singular value decomposition.
 
-    :param nd: :class:`.NDArrayExpression`
+    Parameters
+    ----------
+    nd : :class:`.NDArrayNumericExpression`
         A 2 dimensional ndarray, shape(M, N).
-    :param full_matrices: `bool`
+    full_matrices: :class:`.bool`
         If True (default), u and vt have dimensions (M, M) and (N, N) respectively. Otherwise, they have dimensions
         (M, K) and (K, N), where K = min(M, N)
-    :param compute_uv: `bool`
+    compute_uv : :class:`.bool`
         If True (default), compute the singular vectors u and v. Otherwise, only return a single ndarray, s.
 
     Returns
     -------
-    - u: :class:`.NDArrayExpression`
+    - u: :class:`.NDArrayNumericExpression`
         The left singular vectors.
-    - s: :class:`.NDArrayExpression`
+    - s: :class:`.NDArrayNumericExpression`
         The singular values.
-    - vt: :class:`.NDArrayExpression`
+    - vt: :class:`.NDArrayNumericExpression`
         The right singular vectors.
     """
     float_nd = nd.map(lambda x: hl.float64(x))
     ir = NDArraySVD(float_nd._ir, full_matrices, compute_uv)
 
     return_type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)) if compute_uv else tndarray(tfloat64, 1)
-    return construct_expr(ir, return_type)
+    return construct_expr(ir, return_type, nd._indices, nd._aggregations)
 
 
 @typecheck(nd=expr_ndarray())
 def inv(nd):
     """Performs a matrix inversion.
 
-    :param nd: A 2 dimensional ndarray, shape(M, N)
+    Parameters
+    ----------
+
+    nd : :class:`.NDArrayNumericExpression`
+        A 2 dimensional ndarray.
 
     Returns
     -------
-    - a: ndarray of float64
-        The inverted matrix
+    :class:`.NDArrayNumericExpression`
+        The inverted matrix.
     """
 
     assert nd.ndim == 2, "Matrix inversion requires 2 dimensional ndarray"
 
     float_nd = nd.map(lambda x: hl.float64(x))
     ir = NDArrayInv(float_nd._ir)
-    return construct_expr(ir, tndarray(tfloat64, 2))
+    return construct_expr(ir, tndarray(tfloat64, 2), nd._indices, nd._aggregations)
 
 
 @typecheck(nds=tsequenceof_nd, axis=int)
@@ -411,16 +460,16 @@ def concatenate(nds, axis=0):
 
     Parameters
     ----------
-    :param nds: a1, a2, …sequence of array_like
+    nds : a sequence of :class:`.NDArrayNumericExpression`
         The arrays must have the same shape, except in the dimension corresponding to axis (the first, by default).
         Note: unlike Numpy, the numerical element type of each array_like must match.
-    :param axis: int, optional
+    axis : int, optional
         The axis along which the arrays will be joined. Default is 0.
         Note: unlike Numpy, if provided, axis cannot be None.
 
     Returns
     -------
-    - res: ndarray
+    :class:`.NDArrayExpression`
         The concatenated array
     """
     head_nd = nds[0]
@@ -429,8 +478,9 @@ def concatenate(nds, axis=0):
 
     makearr = aarray(nds)
     concat_ir = NDArrayConcat(makearr._ir, axis)
+    indices, aggregations = unify_all(*nds)
 
-    return construct_expr(concat_ir, tndarray(head_nd._type.element_type, head_ndim))
+    return construct_expr(concat_ir, tndarray(head_nd._type.element_type, head_ndim), indices, aggregations)
 
 
 @typecheck(N=expr_numeric, M=nullable(expr_numeric), dtype=HailType)
@@ -438,6 +488,16 @@ def eye(N, M=None, dtype=hl.tfloat64):
     """
     Construct a 2-D :class:`.NDArrayExpression` with ones on the *main* diagonal
     and zeros elsewhere.
+
+    Examples
+    --------
+    >>> hl.eval(hl.nd.eye(3))
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
+    >>> hl.eval(hl.nd.eye(2, 5, dtype=hl.tint32))
+    array([[1, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0]], dtype=int32)
 
     Parameters
     ----------
@@ -450,23 +510,14 @@ def eye(N, M=None, dtype=hl.tfloat64):
 
     Returns
     -------
-    I : :class:`.NDArrayExpression` representing a Hail ndarray of shape (N,M)
-      An ndarray whose elements are equal to one on the main diagonal, zeroes elsewhere.
+    :class:`.NDArrayExpression`
+        An (N, M) matrix with ones on the main diagonal, zeros elsewhere.
 
     See Also
     --------
     :func:`.identity`
     :func:`.diagonal`
 
-    Examples
-    --------
-    >>> hl.eval(hl.nd.eye(3))
-    array([[1., 0., 0.],
-           [0., 1., 0.],
-           [0., 0., 1.]])
-    >>> hl.eval(hl.nd.eye(2, 5, dtype=hl.tint32))
-    array([[1, 0, 0, 0, 0],
-           [0, 1, 0, 0, 0]], dtype=int32)
     """
 
     n_row = hl.int32(N)
@@ -488,6 +539,13 @@ def identity(N, dtype=hl.tfloat64):
     Constructs a 2-D :class:`.NDArrayExpression` representing the identity array.
     The identity array is a square array with ones on the main diagonal.
 
+    Examples
+    --------
+    >>> hl.eval(hl.nd.identity(3))
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
+
     Parameters
     ----------
     n : :class:`.NumericExpression` or Python number
@@ -497,19 +555,13 @@ def identity(N, dtype=hl.tfloat64):
 
     Returns
     -------
-    out : :class:`.NDArrayExpression`
-        `n` x `n` ndarray with its main diagonal set to one, and all other elements 0.
+    :class:`.NDArrayExpression`
+        An (N, N) matrix with its main diagonal set to one, and all other elements 0.
 
     See Also
     --------
     :func:`.eye`
 
-    Examples
-    --------
-    >>> hl.eval(hl.nd.identity(3))
-    array([[1., 0., 0.],
-           [0., 1., 0.],
-           [0., 0., 1.]])
     """
     return eye(N, dtype=dtype)
 
@@ -520,21 +572,6 @@ def vstack(arrs):
     Stack arrays in sequence vertically (row wise).
     1-D arrays of shape `(N,)`, will reshaped to `(1,N)` before concatenation.
     For all other arrays, equivalent to  :func:`.concatenate` with axis=0.
-
-    Parameters
-    ----------
-    arrs : sequence of :class:`.NDArrayExpression`
-        The arrays must have the same shape along all but the first axis.
-        1-D arrays must have the same length.
-
-    Returns
-    -------
-    stacked : :class:`.NDArrayExpression`
-        The array formed by stacking the given arrays, will be at least 2-D.
-
-    See Also
-    --------
-    :func:`.concatenate` : Join a sequence of arrays along an existing axis.
 
     Examples
     --------
@@ -552,6 +589,22 @@ def vstack(arrs):
            [2],
            [3],
            [4]], dtype=int32)
+
+    Parameters
+    ----------
+    arrs : sequence of :class:`.NDArrayExpression`
+        The arrays must have the same shape along all but the first axis.
+        1-D arrays must have the same length.
+
+    Returns
+    -------
+    :class:`.NDArrayExpression`
+        The array formed by stacking the given arrays, will be at least 2-D.
+
+    See Also
+    --------
+    :func:`.concatenate` : Join a sequence of arrays along an existing axis.
+
     """
     head_ndim = arrs[0].ndim
 
@@ -579,7 +632,7 @@ def hstack(arrs):
 
     Returns
     -------
-    stacked : :class:`.NDArrayExpression`
+    :class:`.NDArrayExpression`
         The array formed by stacking the given arrays.
 
     See Also
@@ -612,26 +665,12 @@ def hstack(arrs):
 
 @typecheck(nd1=expr_ndarray(), nd2=oneof(expr_ndarray(), list))
 def maximum(nd1, nd2):
-    """
-    Compares elements at corresponding indexes in  arrays
+    """Compares elements at corresponding indexes in  arrays
     and returns an array of the maximum element found
     at each compared index.
 
     If an array element being compared has the value NaN,
     the maximum for that index will be NaN.
-
-    Parameters
-    ----------
-    nd1 : :class:`.NDArrayExpression`
-    nd2 : class:`.NDArrayExpression`, `.ArrayExpression`, numpy ndarray, or nested python lists/tuples.
-        Nd1 and nd2 must be the same shape or broadcastable into common shape. Nd1 and nd2 must
-        have elements of comparable types
-
-    Returns
-    -------
-    max_array : :class:`.NDArrayExpression` Element-wise maximums of nd1 and nd2. If nd1 has the
-        same shape as nd2, the resulting array will be of that shape. If nd1 and nd2 were broadcasted
-        into a common shape, the resulting array will be of that shape
 
     Examples
     --------
@@ -643,6 +682,21 @@ def maximum(nd1, nd2):
     >>> b = hl.nd.array([2.0, 3.0, hl.float64(float("NaN"))])
     >>> hl.eval(hl.nd.maximum(a, b))
     array([nan, 5., nan])
+
+    Parameters
+    ----------
+    nd1 : :class:`.NDArrayExpression`
+    nd2 : class:`.NDArrayExpression`, `.ArrayExpression`, numpy ndarray, or nested python lists/tuples.
+        Nd1 and nd2 must be the same shape or broadcastable into common shape. Nd1 and nd2 must
+        have elements of comparable types
+
+    Returns
+    -------
+    :class:`.NDArrayExpression`
+        Element-wise maximums of nd1 and nd2. If nd1 has the same shape as nd2, the resulting array
+        will be of that shape. If nd1 and nd2 were broadcasted into a common shape, the resulting
+        array will be of that shape
+
     """
 
     if (nd1.dtype.element_type or nd2.dtype.element_type) == (tfloat64 or tfloat32):
@@ -653,26 +707,12 @@ def maximum(nd1, nd2):
 
 @typecheck(nd1=expr_ndarray(), nd2=oneof(expr_ndarray(), list))
 def minimum(nd1, nd2):
-    """
-    Compares elements at corresponding indexes in arrays
+    """Compares elements at corresponding indexes in arrays
     and returns an array of the minimum element found
     at each compared index.
 
     If an array element being compared has the value NaN,
     the minimum for that index will be NaN.
-
-    Parameters
-    ----------
-    nd1 : :class:`.NDArrayExpression`
-    nd2 : class:`.NDArrayExpression`, `.ArrayExpression`, numpy ndarray, or nested python lists/tuples.
-        nd1 and nd2 must be the same shape or broadcastable into common shape. Nd1 and nd2 must
-        have elements of comparable types
-
-    Returns
-    -------
-    min_array : :class:`.NDArrayExpression` Element-wise minimums of nd1 and nd2. If nd1 has the
-        same shape as nd2, the resulting array will be of that shape. If nd1 and nd2 were broadcasted
-        into a common shape, resulting array will be of that shape
 
     Examples
     --------
@@ -684,6 +724,21 @@ def minimum(nd1, nd2):
     >>> b = hl.nd.array([2.0, 3.0, hl.float64(float("NaN"))])
     >>> hl.eval(hl.nd.minimum(a, b))
     array([nan, 3., nan])
+
+    Parameters
+    ----------
+    nd1 : :class:`.NDArrayExpression`
+    nd2 : class:`.NDArrayExpression`, `.ArrayExpression`, numpy ndarray, or nested python lists/tuples.
+        nd1 and nd2 must be the same shape or broadcastable into common shape. Nd1 and nd2 must
+        have elements of comparable types
+
+    Returns
+    -------
+    min_array : :class:`.NDArrayExpression`
+        Element-wise minimums of nd1 and nd2. If nd1 has the same shape as nd2, the resulting array
+        will be of that shape. If nd1 and nd2 were broadcasted into a common shape, resulting array
+        will be of that shape
+
     """
 
     if (nd1.dtype.element_type or nd2.dtype.element_type) == (tfloat64 or tfloat32):

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -355,7 +355,7 @@ def qr(nd, mode="reduced"):
 
     Parameters
     ----------
-    nd : :class:`.NDArrayExpressoin`
+    nd : :class:`.NDArrayExpression`
         A 2 dimensional ndarray, shape(M, N)
     mode : :class:`.str`
         One of "reduced", "complete", "r", or "raw". Defaults to "reduced".

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1208,5 +1208,5 @@ def test_ndarray_indices_aggregations():
     ht = ht.annotate(d = hl.nd.solve_triangular(hl.nd.eye(2), 2 * ht.g))
     ht = ht.annotate(e = hl.nd.svd(ht.x))
     ht = ht.annotate(f = hl.nd.inv(ht.x))
-    ht = ht.annotate(g = hl.nd.concatenate((ht.x, ht.g)))
-    ht = ht.annotate(g = hl.nd.concatenate((ht.g, ht.x)))
+    ht = ht.annotate(h = hl.nd.concatenate((ht.x, ht.g)))
+    ht = ht.annotate(i = hl.nd.concatenate((ht.g, ht.x)))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1091,6 +1091,11 @@ def test_hstack():
     assert_table(a, b)
 
 
+def test_hstack_broadcast():
+    assert hl.eval(hl.nd.hstack((hl.nd.ones((10,)),
+                                 hl.nd.ones((10, 1))))).shape == (10, 2)
+
+
 def test_eye():
     for i in range(13):
         assert_ndarrays_eq(*[(hl.nd.eye(i, y), np.eye(i, y)) for y in range(13)])
@@ -1175,6 +1180,7 @@ def test_maximum_minimuim():
     assert(nan_max.size == max_matches)
     assert(nan_min.size == min_matches)
 
+
 def test_ndarray_broadcasting_with_decorator():
     nd = hl.nd.array([[1, 4, 9], [16, 25, 36]])
     nd_sqrt = hl.eval(hl.nd.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
@@ -1190,3 +1196,17 @@ def test_ndarray_broadcasting_with_decorator():
     nd_floor = hl.eval(hl.nd.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
     nd = hl.eval(hl.floor(nd))
     assert(np.array_equal(nd, nd_floor))
+
+
+def test_ndarray_indices_aggregations():
+    ht = hl.utils.range_table(1)
+    ht = ht.annotate_globals(g = hl.nd.ones((2, 2)))
+    ht = ht.annotate(x = hl.nd.ones((2, 2)))
+    ht = ht.annotate(a = hl.nd.solve(ht.x, 2 * ht.g))
+    ht = ht.annotate(b = hl.nd.solve(2 * ht.g, ht.x))
+    ht = ht.annotate(c = hl.nd.solve_triangular(2 * ht.g, hl.nd.eye(2)))
+    ht = ht.annotate(d = hl.nd.solve_triangular(hl.nd.eye(2), 2 * ht.g))
+    ht = ht.annotate(e = hl.nd.svd(ht.x))
+    ht = ht.annotate(f = hl.nd.inv(ht.x))
+    ht = ht.annotate(g = hl.nd.concatenate((ht.x, ht.g)))
+    ht = ht.annotate(g = hl.nd.concatenate((ht.g, ht.x)))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1091,11 +1091,6 @@ def test_hstack():
     assert_table(a, b)
 
 
-def test_hstack_broadcast():
-    assert hl.eval(hl.nd.hstack((hl.nd.ones((10,)),
-                                 hl.nd.ones((10, 1))))).shape == (10, 2)
-
-
 def test_eye():
     for i in range(13):
         assert_ndarrays_eq(*[(hl.nd.eye(i, y), np.eye(i, y)) for y in range(13)])


### PR DESCRIPTION
1. ndarray methods now properly propagate indices or aggregations.
2. `hl.nd.qr` has some extra documentation about the properties of those matrices.
3. Examples are always first, parameters use our standard style, return values are only named when there are more than one of them.