### PR TITLE
[query] better error messages for hstack and vstack

### DIFF
--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -556,9 +556,16 @@ def vstack(arrs):
     head_ndim = arrs[0].ndim
 
     if head_ndim == 1:
-        return concatenate(hl.map(lambda a: a._broadcast(2), arrs), 0)
+        arrs = arrs.map(lambda a: a._broadcast(2))
 
-    return concatenate(arrs, 0)
+    return hl.case().when(
+        hl.len(arrs) > 0,
+        hl.case().when(
+            hl.all(arrs.map(lambda x: x.ndim == head_ndim)),
+            concatenate(arrs, 0)
+        ).or_error(hl.format('hl.nd.vstack: all matrices must have same number of dimensions, found: %s',
+                             arrs.map(lambda x: x.ndim)))
+    ).or_error('hl.nd.vstack: must provide at least one matrix')
 
 
 @typecheck(arrs=tsequenceof_nd)
@@ -607,7 +614,14 @@ def hstack(arrs):
     else:
         axis = 1
 
-    return concatenate(arrs, axis)
+    return hl.case().when(
+        hl.len(arrs) > 0,
+        hl.case().when(
+            hl.all(arrs.map(lambda x: x.ndim == head_ndim)),
+            concatenate(arrs, axis)
+        ).or_error(hl.format('hl.nd.hstack: all matrices must have same number of dimensions, found: %s',
+                             arrs.map(lambda x: x.ndim)))
+    ).or_error('hl.nd.hstack: must provide at least one matrix')
 
 
 @typecheck(nd1=expr_ndarray(), nd2=oneof(expr_ndarray(), list))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -557,7 +557,7 @@ def vstack(arrs):
 
     if isinstance(arrs, list):
         if len(arrs) == 0:
-            raise ValueError(f'hl.nd.vstack: must provide at least one matrix')
+            raise ValueError('hl.nd.vstack: must provide at least one matrix')
         if any(head_ndim != x.ndim for x in arrs):
             ndims = [x.ndim for x in arrs]
             raise ValueError(f'hl.nd.vstack: all matrices must have same number of dimensions, found: {ndims}')
@@ -614,7 +614,7 @@ def hstack(arrs):
 
     if isinstance(arrs, list):
         if len(arrs) == 0:
-            raise ValueError(f'hl.nd.hstack: must provide at least one matrix')
+            raise ValueError('hl.nd.hstack: must provide at least one matrix')
         if any(head_ndim != x.ndim for x in arrs):
             ndims = [x.ndim for x in arrs]
             raise ValueError(f'hl.nd.hstack: all matrices must have same number of dimensions, found: {ndims}')

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -555,16 +555,19 @@ def vstack(arrs):
     """
     head_ndim = arrs[0].ndim
 
+    if isinstance(arrs, list):
+        if len(arrs) == 0:
+            raise ValueError(f'hl.nd.vstack: must provide at least one matrix')
+        if any(head_ndim != x.ndim for x in arrs):
+            ndims = [x.ndim for x in arrs]
+            raise ValueError(f'hl.nd.vstack: all matrices must have same number of dimensions, found: {ndims}')
+
     if head_ndim == 1:
         arrs = arrs.map(lambda a: a._broadcast(2))
 
     return hl.case().when(
         hl.len(arrs) > 0,
-        hl.case().when(
-            hl.all(arrs.map(lambda x: x.ndim == head_ndim)),
-            concatenate(arrs, 0)
-        ).or_error(hl.format('hl.nd.vstack: all matrices must have same number of dimensions, found: %s',
-                             arrs.map(lambda x: x.ndim)))
+        concatenate(arrs, 0)
     ).or_error('hl.nd.vstack: must provide at least one matrix')
 
 
@@ -609,6 +612,13 @@ def hstack(arrs):
     """
     head_ndim = arrs[0].ndim
 
+    if isinstance(arrs, list):
+        if len(arrs) == 0:
+            raise ValueError(f'hl.nd.hstack: must provide at least one matrix')
+        if any(head_ndim != x.ndim for x in arrs):
+            ndims = [x.ndim for x in arrs]
+            raise ValueError(f'hl.nd.hstack: all matrices must have same number of dimensions, found: {ndims}')
+
     if head_ndim == 1:
         axis = 0
     else:
@@ -616,11 +626,7 @@ def hstack(arrs):
 
     return hl.case().when(
         hl.len(arrs) > 0,
-        hl.case().when(
-            hl.all(arrs.map(lambda x: x.ndim == head_ndim)),
-            concatenate(arrs, axis)
-        ).or_error(hl.format('hl.nd.hstack: all matrices must have same number of dimensions, found: %s',
-                             arrs.map(lambda x: x.ndim)))
+        concatenate(arrs, axis)
     ).or_error('hl.nd.hstack: must provide at least one matrix')
 
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1190,3 +1190,65 @@ def test_ndarray_broadcasting_with_decorator():
     nd_floor = hl.eval(hl.nd.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
     nd = hl.eval(hl.floor(nd))
     assert(np.array_equal(nd, nd_floor))
+
+
+def test_hstack_no_broadcasting_1_2():
+    try:
+        hl.eval(hl.nd.hstack((hl.nd.ones((10,)),
+                              hl.nd.ones((1, 10)))))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.hstack: all matrices must have same number of dimensions, found: [1, 2]'
+
+
+def test_hstack_no_broadcasting_2_1():
+    try:
+        hl.eval(hl.nd.hstack((hl.nd.ones((1, 10)),
+                              hl.nd.ones((10)))))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.hstack: all matrices must have same number of dimensions, found: [2, 1]'
+
+
+def test_hstack_no_broadcasting_2_3():
+    try:
+        hl.eval(hl.nd.hstack((hl.nd.ones((1, 10)),
+                              hl.nd.ones((1, 1, 10)))))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.hstack: all matrices must have same number of dimensions, found: [2, 3]'
+
+
+def test_hstack_length_zero():
+    try:
+        hl.eval(hl.nd.hstack(hl.literal([])))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.hstack: must provide at least one matrix'
+
+
+def test_vstack_no_broadcasting_1_2():
+    try:
+        hl.eval(hl.nd.vstack((hl.nd.ones((10,)),
+                              hl.nd.ones((1, 10)))))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.vstack: all matrices must have same number of dimensions, found: [1, 2]'
+
+
+def test_vstack_no_broadcasting_2_1():
+    try:
+        hl.eval(hl.nd.vstack((hl.nd.ones((1, 10)),
+                              hl.nd.ones((10)))))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.vstack: all matrices must have same number of dimensions, found: [2, 1]'
+
+
+def test_vstack_no_broadcasting_2_3():
+    try:
+        hl.eval(hl.nd.vstack((hl.nd.ones((1, 10)),
+                              hl.nd.ones((1, 1, 10)))))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.vstack: all matrices must have same number of dimensions, found: [2, 3]'
+
+
+def test_vstack_length_zero():
+    try:
+        hl.eval(hl.nd.vstack(hl.literal([])))
+    except Exception as exc:
+        assert exc.args[0] == 'hl.nd.vstack: must provide at least one matrix'


### PR DESCRIPTION
CHANGELOG: `hl.nd.vstack` and `hl.nd.hstack` provide clear error messages when used with incompatible matrices or with no arguments.