### PR TITLE
[auth] Make HailCredentials for refreshable auth tokens

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -7,8 +7,8 @@ from typing import Set
 import pytest
 
 from hailtop import httpx
-from hailtop.auth import service_auth_headers
 from hailtop.batch.backend import HAIL_GENETICS_HAILTOP_IMAGE
+from hailtop.auth import hail_credentials
 from hailtop.batch_client.client import BatchClient
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.test_utils import skip_in_azure
@@ -690,7 +690,7 @@ def test_create_idempotence(client: BatchClient):
     assert b1.id == b2.id
 
 
-def test_batch_create_validation():
+async def test_batch_create_validation():
     bad_configs = [
         # unexpected field fleep
         {'billing_project': 'foo', 'n_jobs': 5, 'token': 'baz', 'fleep': 'quam'},
@@ -723,7 +723,7 @@ def test_batch_create_validation():
         {'attributes': {'k': None}, 'billing_project': 'foo', 'n_jobs': 5, 'token': 'baz'},
     ]
     url = deploy_config.url('batch', '/api/v1alpha/batches/create')
-    headers = service_auth_headers(deploy_config, 'batch')
+    headers = await hail_credentials().auth_headers()
     session = external_requests_client_session()
     for config in bad_configs:
         r = retry_response_returning_functions(session.post, url, json=config, allow_redirects=True, headers=headers)

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -7,8 +7,8 @@ from typing import Set
 import pytest
 
 from hailtop import httpx
-from hailtop.batch.backend import HAIL_GENETICS_HAILTOP_IMAGE
 from hailtop.auth import hail_credentials
+from hailtop.batch.backend import HAIL_GENETICS_HAILTOP_IMAGE
 from hailtop.batch_client.client import BatchClient
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.test_utils import skip_in_azure

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -4,7 +4,7 @@ import aiohttp
 import pytest
 
 import hailtop.utils as utils
-from hailtop.auth import service_auth_headers
+from hailtop.auth import hail_credentials
 from hailtop.config import get_deploy_config
 from hailtop.httpx import client_session
 
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 async def test_invariants():
     deploy_config = get_deploy_config()
     url = deploy_config.url('batch-driver', '/check_invariants')
-    headers = service_auth_headers(deploy_config, 'batch-driver')
+    headers = await hail_credentials().auth_headers()
     async with client_session(timeout=aiohttp.ClientTimeout(total=60)) as session:
 
         resp = await utils.request_retry_transient_errors(session, 'GET', url, headers=headers)

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 import hailtop.utils as utils
-from hailtop.auth import service_auth_headers
+from hailtop.auth import hail_credentials
 from hailtop.config import get_deploy_config
 from hailtop.httpx import client_session
 
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 async def test_deploy():
     deploy_config = get_deploy_config()
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
-    headers = service_auth_headers(deploy_config, 'ci')
+    headers = await hail_credentials().auth_headers()
     async with client_session() as session:
 
         async def wait_forever():

--- a/hail/python/hailtop/auth/__init__.py
+++ b/hail/python/hailtop/auth/__init__.py
@@ -2,19 +2,17 @@ from . import sql_config
 from .tokens import (get_tokens, session_id_encode_to_str,
                      session_id_decode_from_str)
 from .auth import (
-    async_get_userinfo, get_userinfo, namespace_auth_headers,
-    service_auth_headers, copy_paste_login, async_copy_paste_login,
+    get_userinfo, hail_credentials,
+    copy_paste_login, async_copy_paste_login,
     async_create_user, async_delete_user, async_get_user)
 
 __all__ = [
     'get_tokens',
-    'async_get_userinfo',
     'async_create_user',
     'async_delete_user',
     'async_get_user',
     'get_userinfo',
-    'namespace_auth_headers',
-    'service_auth_headers',
+    'hail_credentials',
     'async_copy_paste_login',
     'copy_paste_login',
     'sql_config',

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -1,35 +1,62 @@
 from typing import Optional, Dict, Tuple
 import os
 import aiohttp
+
+from hailtop.aiocloud.common.credentials import CloudCredentials
+from hailtop.aiocloud.common import Session
 from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.utils import async_to_blocking, request_retry_transient_errors
-from hailtop import httpx
 
-from .tokens import get_tokens
+from .tokens import Tokens, get_tokens
+
+
+class HailStoredTokenCredentials(CloudCredentials):
+    def __init__(self, tokens: Tokens, namespace: Optional[str], authorize_target: bool):
+        self._tokens = tokens
+        self._namespace = namespace
+        self._authorize_target = authorize_target
+
+    @staticmethod
+    def from_file(credentials_file: str, *, namespace: Optional[str] = None, authorize_target: bool = True):
+        return HailStoredTokenCredentials(get_tokens(credentials_file), namespace, authorize_target)
+
+    @staticmethod
+    def default_credentials(*, namespace: Optional[str] = None, authorize_target: bool = True):
+        return HailStoredTokenCredentials(get_tokens(), namespace, authorize_target)
+
+    async def auth_headers(self) -> Dict[str, str]:
+        deploy_config = get_deploy_config()
+        ns = self._namespace or deploy_config.default_namespace()
+        return namespace_auth_headers(deploy_config, ns, self._tokens, authorize_target=self._authorize_target)
+
+    async def close(self):
+        pass
+
+
+def hail_credentials(*, credentials_file: Optional[str] = None, namespace: Optional[str] = None, authorize_target: bool = True) -> CloudCredentials:
+    if credentials_file is not None:
+        return HailStoredTokenCredentials.from_file(
+            credentials_file,
+            namespace=namespace,
+            authorize_target=authorize_target
+        )
+    return HailStoredTokenCredentials.default_credentials(
+        namespace=namespace,
+        authorize_target=authorize_target
+    )
 
 
 def namespace_auth_headers(deploy_config: DeployConfig,
                            ns: str,
+                           tokens: Tokens,
                            authorize_target: bool = True,
-                           *,
-                           token_file: Optional[str] = None
                            ) -> Dict[str, str]:
     headers = {}
     if authorize_target:
-        headers['Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error(ns)}'
+        headers['Authorization'] = f'Bearer {tokens.namespace_token_or_error(ns)}'
     if deploy_config.location() == 'external' and ns != 'default':
-        headers['X-Hail-Internal-Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error("default")}'
+        headers['X-Hail-Internal-Authorization'] = f'Bearer {tokens.namespace_token_or_error("default")}'
     return headers
-
-
-def service_auth_headers(deploy_config: DeployConfig,
-                         service: str,
-                         authorize_target: bool = True,
-                         *,
-                         token_file: Optional[str] = None
-                         ) -> Dict[str, str]:
-    ns = deploy_config.service_ns(service)
-    return namespace_auth_headers(deploy_config, ns, authorize_target, token_file=token_file)
 
 
 def deploy_config_and_headers_from_namespace(namespace: Optional[str] = None, *, authorize_target: bool = True) -> Tuple[DeployConfig, Dict[str, str], str]:
@@ -40,45 +67,28 @@ def deploy_config_and_headers_from_namespace(namespace: Optional[str] = None, *,
     else:
         namespace = deploy_config.default_namespace()
 
-    headers = namespace_auth_headers(deploy_config, namespace, authorize_target=authorize_target)
+    headers = namespace_auth_headers(deploy_config, namespace, get_tokens(), authorize_target=authorize_target)
 
     return (deploy_config, headers, namespace)
 
 
-async def async_get_userinfo(*,
-                             deploy_config: Optional[DeployConfig] = None,
-                             session_id: Optional[str] = None,
-                             client_session: Optional[httpx.ClientSession] = None):
-    if deploy_config is None:
-        deploy_config = get_deploy_config()
-    if session_id is None:
-        headers = service_auth_headers(deploy_config, 'auth')
-    else:
-        headers = {'Authorization': f'Bearer {session_id}'}
-
+async def async_get_userinfo():
+    deploy_config = get_deploy_config()
+    credentials = hail_credentials()
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
 
-    async def request(session):
+    async with Session(credentials=credentials) as session:
         try:
-            resp = await request_retry_transient_errors(
-                session, 'GET', userinfo_url, headers=headers)
-            return await resp.json()
-        except aiohttp.client_exceptions.ClientResponseError as err:
+            async with await session.get(userinfo_url) as resp:
+                return await resp.json()
+        except aiohttp.ClientResponseError as err:
             if err.status == 401:
                 return None
             raise
 
-    if client_session is None:
-        async with httpx.client_session() as session:
-            return await request(session)
-    return await request(client_session)
 
-
-def get_userinfo(deploy_config=None, session_id=None, client_session=None):
-    return async_to_blocking(async_get_userinfo(
-        deploy_config=deploy_config,
-        session_id=session_id,
-        client_session=client_session))
+def get_userinfo():
+    return async_to_blocking(async_get_userinfo())
 
 
 def copy_paste_login(copy_paste_token: str, namespace: Optional[str] = None):

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -6,7 +6,7 @@ import webbrowser
 from aiohttp import web
 
 from hailtop.config import get_deploy_config
-from hailtop.auth import get_tokens, namespace_auth_headers
+from hailtop.auth import get_tokens, hail_credentials
 from hailtop.httpx import client_session
 
 
@@ -96,9 +96,10 @@ async def async_main(args):
     deploy_config = get_deploy_config()
     if args.namespace:
         deploy_config = deploy_config.with_default_namespace(args.namespace)
-    headers = namespace_auth_headers(deploy_config, deploy_config.default_namespace(), authorize_target=False)
+    namespace = args.namespace or deploy_config.default_namespace()
+    headers = await hail_credentials(namespace=namespace, authorize_target=False).auth_headers()
     async with client_session(headers=headers) as session:
-        await auth_flow(deploy_config, deploy_config.default_namespace(), session)
+        await auth_flow(deploy_config, namespace, session)
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from hailtop.config import get_deploy_config
-from hailtop.auth import get_tokens, service_auth_headers
+from hailtop.auth import get_tokens, hail_credentials
 from hailtop.httpx import client_session
 
 
@@ -18,7 +18,7 @@ async def async_main():
         print('Not logged in.')
         return
 
-    headers = service_auth_headers(deploy_config, 'auth')
+    headers = await hail_credentials().auth_headers()
     async with client_session(headers=headers) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):
             pass

--- a/hail/python/hailtop/hailctl/curl.py
+++ b/hail/python/hailtop/hailctl/curl.py
@@ -1,8 +1,9 @@
 import sys
 import os
 
-from hailtop.auth import namespace_auth_headers
+from hailtop.auth import hail_credentials
 from hailtop.config import get_deploy_config
+from hailtop.utils import async_to_blocking
 
 
 def main(args):
@@ -12,11 +13,9 @@ def main(args):
     ns = args[0]
     svc = args[1]
     path = args[2]
-    deploy_config = get_deploy_config()
-    deploy_config = deploy_config.with_default_namespace(ns)
-    headers_dict = namespace_auth_headers(deploy_config, ns)
+    headers_dict = async_to_blocking(hail_credentials(namespace=ns).auth_headers())
     headers = [x
                for k, v in headers_dict.items()
                for x in ['-H', f'{k}: {v}']]
-    path = deploy_config.url(svc, path)
+    path = get_deploy_config().url(svc, path)
     os.execvp('curl', ['curl', *headers, *args[3:], path])

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from hailtop import httpx
 from hailtop.config import get_deploy_config
-from hailtop.auth import service_auth_headers
+from hailtop.auth import hail_credentials
 from hailtop.httpx import client_session
 from hailtop.utils import unpack_comma_delimited_inputs, unpack_key_value_inputs
 
@@ -34,7 +34,7 @@ class CIClient:
         self._session: Optional[httpx.ClientSession] = None
 
     async def __aenter__(self):
-        headers = service_auth_headers(self._deploy_config, 'ci')
+        headers = await hail_credentials().auth_headers()
         self._session = client_session(
             raise_for_status=False,
             timeout=aiohttp.ClientTimeout(total=60), headers=headers)  # type: ignore

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -1,14 +1,14 @@
 import aiohttp
 
 from hailtop.aiocloud.aiogoogle import GoogleStorageAsyncFS
-from hailtop.auth import service_auth_headers
+from hailtop.auth import hail_credentials
 from hailtop.config import get_deploy_config
 from hailtop.httpx import client_session
 from hailtop.utils import request_retry_transient_errors
 
 
 class MemoryClient:
-    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None, headers=None, _token=None):
+    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None, headers=None):
         if not deploy_config:
             self._deploy_config = get_deploy_config()
         else:
@@ -25,14 +25,11 @@ class MemoryClient:
         self._headers = {}
         if headers:
             self._headers.update(headers)
-        if _token:
-            self._headers['Authorization'] = f'Bearer {_token}'
 
     async def async_init(self):
         if self._session is None:
             self._session = client_session()
-        if 'Authorization' not in self._headers:
-            self._headers.update(service_auth_headers(self._deploy_config, 'memory'))
+        self._headers.update(await hail_credentials().auth_headers())
 
     async def _get_file_if_exists(self, filename):
         params = {'q': filename}

--- a/memory/test/test_memory.py
+++ b/memory/test/test_memory.py
@@ -9,8 +9,8 @@ from memory.client import MemoryClient
 
 
 class BlockingMemoryClient:
-    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None, headers=None, _token=None):
-        self._client = MemoryClient(gcs_project, fs, deploy_config, session, headers, _token)
+    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None, headers=None):
+        self._client = MemoryClient(gcs_project, fs, deploy_config, session, headers)
         async_to_blocking(self._client.async_init())
 
     def _get_file_if_exists(self, filename):

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -1,11 +1,10 @@
 import asyncio
 import logging
 
-import aiohttp
 import pytest
 
 import hailtop.utils as utils
-from hailtop.auth import service_auth_headers
+from hailtop.auth import hail_credentials
 from hailtop.config import get_deploy_config
 from hailtop.httpx import client_session
 
@@ -17,7 +16,7 @@ log = logging.getLogger(__name__)
 async def test_billing_monitoring():
     deploy_config = get_deploy_config()
     monitoring_deploy_config_url = deploy_config.url('monitoring', '/api/v1alpha/billing')
-    headers = service_auth_headers(deploy_config, 'monitoring')
+    headers = await hail_credentials().auth_headers()
     async with client_session() as session:
 
         async def wait_forever():

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -7,7 +7,7 @@ import time
 import aiohttp
 import numpy as np
 
-from hailtop.auth import service_auth_headers
+from hailtop.auth import hail_credentials
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import configure_logging
 from hailtop.httpx import client_session
@@ -26,7 +26,7 @@ def get_cookie(session, name):
 
 
 async def run(args, i):
-    headers = service_auth_headers(deploy_config, 'workshop', authorize_target=False)
+    headers = await hail_credentials(authorize_target=False).auth_headers()
 
     async with client_session() as session:
         # make sure notebook is up


### PR DESCRIPTION
My motivation here is that in Terra we aren't going to be using hail authentication tokens, rather an authentication from gcloud or az. So I want our batch client to be able to use a `CloudCredentials` just as easily as it uses the hail auth token that we store on the user's machine. So I introduce HailCredentials which subclasses CloudCredentials but the behavior is the same. It also lets us re-use some of the retry logic that we have baked into `aiocloud.common.Session`.