### PR TITLE
[fs] Only use posix_fadvise on linux

### DIFF
--- a/hail/python/hailtop/aiotools/fs/stream.py
+++ b/hail/python/hailtop/aiotools/fs/stream.py
@@ -3,6 +3,7 @@ from types import TracebackType
 import abc
 import io
 import os
+import sys
 from concurrent.futures import ThreadPoolExecutor
 import janus
 from hailtop.utils import blocking_to_async
@@ -162,7 +163,8 @@ class _WritableStreamFromBlocking(WritableStream):
     async def _wait_closed(self) -> None:
         await blocking_to_async(self._thread_pool, self._f.flush)
         await blocking_to_async(self._thread_pool, os.fsync, self._f.fileno())
-        os.posix_fadvise(self._f.fileno(), self._start, self._f.tell() - self._start, os.POSIX_FADV_DONTNEED)
+        if sys.platform == 'linux':
+            os.posix_fadvise(self._f.fileno(), self._start, self._f.tell() - self._start, os.POSIX_FADV_DONTNEED)
         await blocking_to_async(self._thread_pool, self._f.close)
         del self._f
 


### PR DESCRIPTION
It's not supported on macOS, despite the python documentation. This fix makes `make check-hail` pass for me on my laptop.