### PR TITLE
[query] Stop silently exporting null bgens if no GP field exists

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -126,7 +126,9 @@ def export_gen(dataset, output, precision=4, gp=None, id1=None, id2=None,
         if 'GP' in dataset.entry and dataset.GP.dtype == tarray(tfloat64):
             entry_exprs = {'GP': dataset.GP}
         else:
-            entry_exprs = {}
+            raise ValueError('exporting to GEN requires a GP (genotype probability) array<float64> field in the entry'
+                             '\n  of the matrix table. If you only have hard calls (GT), BGEN is probably not the'
+                             '\n  right format.')
     else:
         entry_exprs = {'GP': gp}
 

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -218,9 +218,9 @@ def export_bgen(mt, output, gp=None, varid=None, rsid=None, parallel=None, compr
         if 'GP' in mt.entry and mt.GP.dtype == tarray(tfloat64):
             entry_exprs = {'GP': mt.GP}
         else:
-            raise ValueError(f'exporting to BGEN requires a GP (genotype probability) array<float64> field in the entry'
-                             f'\n  of the matrix table. If you only have hard calls (GT), BGEN is probably not the'
-                             f'\n  right format.')
+            raise ValueError('exporting to BGEN requires a GP (genotype probability) array<float64> field in the entry'
+                             '\n  of the matrix table. If you only have hard calls (GT), BGEN is probably not the'
+                             '\n  right format.')
     else:
         entry_exprs = {'GP': gp}
 

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -218,7 +218,9 @@ def export_bgen(mt, output, gp=None, varid=None, rsid=None, parallel=None, compr
         if 'GP' in mt.entry and mt.GP.dtype == tarray(tfloat64):
             entry_exprs = {'GP': mt.GP}
         else:
-            entry_exprs = {}
+            raise ValueError(f'exporting to BGEN requires a GP (genotype probability) array<float64> field in the entry'
+                             f'\n  of the matrix table. If you only have hard calls (GT), BGEN is probably not the'
+                             f'\n  right format.')
     else:
         entry_exprs = {'GP': gp}
 

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1059,6 +1059,10 @@ class BGENTests(unittest.TestCase):
         with pytest.raises(ValueError, match="BGEN requires a GP"):
             hl.export_bgen(mt, "dummy_path")
 
+        with pytest.raises(ValueError, match="GEN requires a GP"):
+            hl.export_gen(mt, "dummy_path")
+
+
     @fails_service_backend()
     @fails_local_backend()
     def test_import_bgen_dosage_entry(self):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1053,6 +1053,12 @@ class BGENTests(unittest.TestCase):
                       contig_recoding={'01': '1'},
                       reference_genome='GRCh37')
 
+    def test_error_if_no_gp(self):
+        mt = hl.balding_nichols_model(3, 3, 3)
+        mt = mt.key_cols_by(s=hl.str(mt.sample_idx))
+        with pytest.raises(ValueError, match="BGEN requires a GP"):
+            hl.export_bgen(mt, "dummy_path")
+
     @fails_service_backend()
     @fails_local_backend()
     def test_import_bgen_dosage_entry(self):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1053,6 +1053,7 @@ class BGENTests(unittest.TestCase):
                       contig_recoding={'01': '1'},
                       reference_genome='GRCh37')
 
+    @fails_service_backend()
     def test_error_if_no_gp(self):
         mt = hl.balding_nichols_model(3, 3, 3)
         mt = mt.key_cols_by(s=hl.str(mt.sample_idx))


### PR DESCRIPTION
could use a second look here -- am I crazy? 

If GP is missing from the MT and no expression is passed, there's no GP in the MT passed into the writer.

And if there's no GP in the writer, we export a file worth of nulls.

https://github.com/hail-is/hail/blob/eee0924c119d8aa2ba1cdaf4f30a4f2be4ba347f/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala#L1123-L1149