### PR TITLE
[batch] use specialized query for monitor_billing_limits

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1118,9 +1118,9 @@ FROM (
   SELECT billing_project, resource_id, CAST(COALESCE(SUM(`usage`), 0) AS SIGNED) AS `usage`, `limit`
   FROM billing_projects
   LEFT JOIN aggregated_billing_project_user_resources_v2
-    ON billing_projects.billing_project = aggregated_billing_project_user_resources_v2.billing_project
+    ON billing_projects.name = aggregated_billing_project_user_resources_v2.billing_project
   WHERE billing_projects.`status` != 'deleted'
-  GROUP BY billing_projects.billing_project, resource_id
+  GROUP BY billing_projects.name, resource_id
 ) AS usage_t
 LEFT JOIN resources
   ON resources.resource_id = usage_t.resource_id

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1113,7 +1113,7 @@ async def monitor_billing_limits(app):
     db: Database = app['db']
 
     sql = '''
-SELECT billing_project, COALESCE(SUM(`usage` * rate), 0) as accrued_cost
+SELECT billing_project, COALESCE(SUM(`usage` * rate), 0) as accrued_cost, limit
 FROM (
   SELECT billing_project, resource_id, CAST(COALESCE(SUM(`usage`), 0) AS SIGNED) AS `usage`, `limit`
   FROM billing_projects

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -63,7 +63,7 @@ from ..exceptions import BatchUserError
 from ..file_store import FileStore
 from ..globals import HTTP_CLIENT_MAX_SIZE
 from ..inst_coll_config import InstanceCollectionConfigs, PoolConfig
-from ..utils import authorization_token, batch_only, json_to_value, query_billing_projects
+from ..utils import authorization_token, batch_only, json_to_value
 from .canceller import Canceller
 from .driver import CloudDriver
 from .instance_collection import InstanceCollectionManager, JobPrivateInstanceManager, Pool

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1112,7 +1112,7 @@ async def _cancel_batch(app, batch_id):
 async def monitor_billing_limits(app):
     db: Database = app['db']
 
-    sql = f'''
+    sql = '''
 SELECT billing_project, COALESCE(SUM(`usage` * rate), 0) as accrued_cost
 FROM (
   SELECT billing_project, resource_id, CAST(COALESCE(SUM(`usage`), 0) AS SIGNED) AS `usage`, `limit`


### PR DESCRIPTION
This should lighten the database load a bit by avoiding a couple joins and a CTE.