### PR TITLE
[batch] improve billing projects query

### DIFF
--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -143,7 +143,7 @@ FROM billing_projects
 LEFT JOIN billing_project_users
   on billing_project_users.billing_project = billing_projects.name
 {where_condition}
-group by billing_projects.name, billing_projects.`status`, `limit`
+GROUP BY billing_projects.name, billing_projects.`status`, `limit`
 LOCK IN SHARE MODE
 )
 SELECT base_t.*, COALESCE(SUM(`usage` * rate), 0) as accrued_cost

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -137,17 +137,13 @@ async def query_billing_projects(db, user=None, billing_project=None):
 WITH base_t AS (
 SELECT billing_projects.name as billing_project,
   billing_projects.`status` as `status`,
-  users, `limit`
-FROM (
-  SELECT billing_project, JSON_ARRAYAGG(`user_cs`) as users
-  FROM billing_project_users
-  GROUP BY billing_project
-  LOCK IN SHARE MODE
-) AS t
-RIGHT JOIN billing_projects
-  ON t.billing_project = billing_projects.name
+  `limit`,
+  JSON_ARRAYAGG(`user_cs`)
+FROM billing_projects
+LEFT JOIN billing_project_users
+  on billing_project_users.billing_project = billing_projects.name
 {where_condition}
-GROUP BY billing_projects.name, billing_projects.status, `limit`
+group by billing_projects.name, billing_projects.`status`, `limit`
 LOCK IN SHARE MODE
 )
 SELECT base_t.*, COALESCE(SUM(`usage` * rate), 0) as accrued_cost


### PR DESCRIPTION
```
+----+-------------+-----------------------+------------+------+-------------------------------------------------------+-----------------------------------------------+---------+-----------------------------+-------+----------+-----------------------------+
| id | select_type | table                 | partitions | type | possible_keys                                         | key                                           | key_len | ref                         | rows  | filtered | Extra                       |
+----+-------------+-----------------------+------------+------+-------------------------------------------------------+-----------------------------------------------+---------+-----------------------------+-------+----------+-----------------------------+
|  1 | SIMPLE      | billing_projects      | NULL       | ALL  | billing_project_status                                | NULL                                          | NULL    | NULL                        | 30733 |    66.67 | Using where; Using filesort |
|  1 | SIMPLE      | billing_project_users | NULL       | ref  | PRIMARY,billing_project_users_billing_project_user_cs | billing_project_users_billing_project_user_cs | 302     | batch.billing_projects.name |     1 |   100.00 | Using index                 |
+----+-------------+-----------------------+------------+------+-------------------------------------------------------+-----------------------------------------------+---------+-----------------------------+-------+----------+-----------------------------+
```

versus

```
+----+-------------+-----------------------+------------+-------+-------------------------------------------------------+-----------------------------------------------+---------+-----------------------------+-------+----------+------------------------------+
| id | select_type | table                 | partitions | type  | possible_keys                                         | key                                           | key_len | ref                         | rows  | filtered | Extra                        |
+----+-------------+-----------------------+------------+-------+-------------------------------------------------------+-----------------------------------------------+---------+-----------------------------+-------+----------+------------------------------+
|  1 | PRIMARY     | billing_projects      | NULL       | ALL   | billing_project_status                                | NULL                                          | NULL    | NULL                        | 30733 |    66.67 | Using where; Using temporary |
|  1 | PRIMARY     | <derived2>            | NULL       | ref   | <auto_key0>                                           | <auto_key0>                                   | 302     | batch.billing_projects.name |    10 |   100.00 | NULL                         |
|  2 | DERIVED     | billing_project_users | NULL       | index | PRIMARY,billing_project_users_billing_project_user_cs | billing_project_users_billing_project_user_cs | 704     | NULL                        | 21519 |   100.00 | Using index; Using filesort  |
+----+-------------+-----------------------+------------+-------+-------------------------------------------------------+-----------------------------------------------+---------+-----------------------------+-------+----------+------------------------------+
```

Timing difference was 3s to 20s.