### PR TITLE
[k8s] Give auth and CI more CPU shares

### DIFF
--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 key: domain
          resources:
            requests:
-             cpu: "5m"
+             cpu: "50m"
              memory: "20M"
            limits:
              cpu: "1"

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           image: "{{ ci_image.image }}"
           resources:
             requests:
-              cpu: "10m"
+              cpu: "50m"
               memory: "200M"
             limits:
               cpu: "1"


### PR DESCRIPTION
Starving auth of the cycles to complete authentication requests causes cascading failures in the system.