### PR TITLE
[batch] Satisfy route signature for Worker.kill

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2722,14 +2722,12 @@ class Worker:
             deploy_config.url('batch-driver', '/api/v1alpha/instances/deactivate'), headers=self.headers
         )
 
-    async def kill_1(self, request):  # pylint: disable=unused-argument
-        log.info('killed')
-        self.stop_event.set()
-
     async def kill(self, request):
         if not self.active:
             raise web.HTTPServiceUnavailable
-        return await asyncio.shield(self.kill_1(request))
+        log.info('killed')
+        self.stop_event.set()
+        return web.Response()
 
     async def post_job_complete_1(self, job: Job, full_status):
         assert job.end_time


### PR DESCRIPTION
aiohttp doesn't like void routes, so I made kill return an http response. aiohttp must be weirdly permissive in this regard but my editor was complaining about types not matching up. Also removed `kill_1` because it didn't need to be async/shielded.