### PR TITLE
[batch] Support job logs that are not UTF-8 compatible

### DIFF
--- a/batch/batch/file_store.py
+++ b/batch/batch/file_store.py
@@ -39,14 +39,13 @@ class FileStore:
             return f'{self.batch_log_dir(batch_id)}/{job_id}/{task}/resource_usage'
         return f'{self.batch_log_dir(batch_id)}/{job_id}/{attempt_id}/{task}/resource_usage'
 
-    async def read_log_file(self, format_version, batch_id, job_id, attempt_id, task):
+    async def read_log_file(self, format_version, batch_id, job_id, attempt_id, task) -> bytes:
         url = self.log_path(format_version, batch_id, job_id, attempt_id, task)
-        data = await self.fs.read(url)
-        return data.decode('utf-8')
+        return await self.fs.read(url)
 
-    async def write_log_file(self, format_version, batch_id, job_id, attempt_id, task, data):
+    async def write_log_file(self, format_version, batch_id, job_id, attempt_id, task, data: bytes):
         url = self.log_path(format_version, batch_id, job_id, attempt_id, task)
-        await self.fs.write(url, data.encode('utf-8'))
+        await self.fs.write(url, data)
 
     async def read_resource_usage_file(
         self, format_version, batch_id, job_id, attempt_id, task

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -617,7 +617,7 @@ async def get_job_log(request, userdata, batch_id):  # pylint: disable=unused-ar
     return web.json_response(job_log_strings)
 
 
-async def get_job_container_log(request, userdata, batch_id):
+async def get_job_container_log(request, batch_id):
     app = request.app
     job_id = int(request.match_info['job_id'])
     container = request.match_info['container']
@@ -632,7 +632,7 @@ async def get_job_container_log(request, userdata, batch_id):
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log/{container}')
 @rest_billing_project_users_only
 async def rest_get_job_container_log(request, userdata, batch_id):  # pylint: disable=unused-argument
-    return await get_job_container_log(request, userdata, batch_id)
+    return await get_job_container_log(request, batch_id)
 
 
 async def _query_batches(request, user, q):
@@ -2207,7 +2207,7 @@ async def ui_get_job(request, userdata, batch_id):
 @web_billing_project_users_only()
 @catch_ui_error_in_dev
 async def ui_get_job_log(request, userdata, batch_id):  # pylint: disable=unused-argument
-    return await get_job_container_log(request, userdata, batch_id)
+    return await get_job_container_log(request, batch_id)
 
 
 @routes.get('/billing_limits')

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2248,7 +2248,10 @@ class JVM:
                     attempts += 1
                     if attempts == 240:
                         # NOTE we assume that the JVM logs hail emits will be valid utf-8
-                        jvm_output = (await fs.read(container.container.log_path)).decode('utf-8')
+                        if os.path.exists(container.container.log_path):
+                            jvm_output = (await fs.read(container.container.log_path)).decode('utf-8')
+                        else:
+                            jvm_output = ''
                         raise ValueError(
                             f'JVM-{index}: failed to establish connection after {240 * delay} seconds. '
                             'JVM output:\n\n' + jvm_output

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -545,7 +545,7 @@ def test_log_after_failing_job(client: BatchClient):
 
 def test_non_utf_8_log(client: BatchClient):
     bb = client.create_batch()
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', "echo -n -e 'hello \\x80'"])
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', "echo -n 'hello \\x80'"])
     b = bb.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -543,6 +543,19 @@ def test_log_after_failing_job(client: BatchClient):
     assert j.is_complete(), str(b.debug_info())
 
 
+def test_non_utf_8_log(client: BatchClient):
+    bb = client.create_batch()
+    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', "echo -n -e 'hello \\x80'"])
+    b = bb.submit()
+    status = j.wait()
+    assert status['state'] == 'Success', str((status, b.debug_info()))
+
+    job_main_log = j.container_log('main')
+    job_log = j.log()
+    assert job_log['main'] == job_main_log
+    assert job_main_log == b'hello \\x80'
+
+
 def test_long_log_line(client: BatchClient):
     bb = client.create_batch()
     j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -551,8 +551,6 @@ def test_non_utf_8_log(client: BatchClient):
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
     job_main_log = j.container_log('main')
-    job_log = j.log()
-    assert job_log['main'] == job_main_log
     assert job_main_log == b'hello \\x80'
 
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -334,13 +334,9 @@ class SubmittedJob:
             return await resp.read()
 
     async def log(self) -> Dict[str, bytes]:
-        async def get_container_log(c):
-            async with await self._batch._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/log/{c}') as resp:
-                return await resp.read()
-
         assert self._status
         containers = self._status['status']['container_statuses'].keys()
-        logs = await asyncio.gather(*(get_container_log(c) for c in containers))
+        logs = await asyncio.gather(*(self.container_log(c) for c in containers))
         return dict(zip(containers, logs))
 
     async def attempts(self):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -333,11 +333,9 @@ class SubmittedJob:
         async with await self._batch._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/log/{container_name}') as resp:
             return await resp.read()
 
-    async def log(self) -> Dict[str, bytes]:
-        assert self._status
-        containers = self._status['status']['container_statuses'].keys()
-        logs = await asyncio.gather(*(self.container_log(c) for c in containers))
-        return dict(zip(containers, logs))
+    async def log(self):
+        resp = await self._batch._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/log')
+        return await resp.json()
 
     async def attempts(self):
         resp = await self._batch._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/attempts')

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -106,6 +106,9 @@ class Job:
     def wait(self):
         return async_to_blocking(self._async_job.wait())
 
+    def container_log(self, container_name):
+        return async_to_blocking(self._async_job.container_log(container_name))
+
     def log(self):
         return async_to_blocking(self._async_job.log())
 

--- a/hail/python/hailtop/hailctl/batch/log.py
+++ b/hail/python/hailtop/hailctl/batch/log.py
@@ -4,6 +4,7 @@ from .batch_cli_utils import get_job_if_exists, make_formatter
 def init_parser(parser):
     parser.add_argument('batch_id', type=int, help="ID number of the desired batch")
     parser.add_argument('job_id', type=int, help="ID number of the desired job")
+    parser.add_argument('-c', type=str, default='', help="Container name of the desired job (input, main, output)")
     parser.add_argument('-o', type=str, default='yaml', help="Specify output format",
                         choices=["yaml", "json"])
 
@@ -14,4 +15,7 @@ def main(args, pass_through_args, client):  # pylint: disable=unused-argument
         print(f"Job with ID {args.job_id} on batch {args.batch_id} not found")
         return
 
-    print(make_formatter(args.o)(maybe_job.log()))
+    if args.c:
+        print(maybe_job.container_log(args.c))
+    else:
+        print(make_formatter(args.o)(maybe_job.log()))


### PR DESCRIPTION
The crux of this PR is the 9 line change in `file_store.py` -- we shouldn't decode job logs to `str` before uploading because we can't trust jobs to output only valid UTF-8 to stdout. The FS can take bytes anyway so it is an unnecessary conversion. The rest of the complexity of this PR is figuring out how to communicate those logs over the Batch API in a backwards-compatible and straight-forward way. What makes that tricky is that when we say "job log" in the code we mostly talk about a dictionary or JSON object of container to log string. Valid JSON must be UTF-8, so JSON starts to make less and less sense for sending log files. Log files are easy to send though if we just want one, so I added an endpoint to request the log for a specific container in a job and we can easily fulfill that without unnecessary encoding/decoding between str and bytes.

Resolves #12666