### PR TITLE
[compiler] Redesign Repartition IR nodes to be naive coalesce only

### DIFF
--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -27,7 +27,7 @@ from .table_ir import MatrixRowsTable, TableJoin, TableLeftJoinRightDistinct, \
     TableKeyBy, TableMapRows, TableRead, MatrixEntriesTable, \
     TableFilter, TableKeyByAndAggregate, \
     TableAggregateByKey, MatrixColsTable, TableParallelize, TableHead, \
-    TableTail, TableOrderBy, TableDistinct, RepartitionStrategy, \
+    TableTail, TableOrderBy, TableDistinct, \
     TableRepartition, CastMatrixToTable, TableRename, TableMultiWayZipJoin, \
     TableFilterIntervals, TableToTableApply, MatrixToTableApply, \
     BlockMatrixToTableApply, BlockMatrixToTable, JavaTable, TableMapPartitions
@@ -296,7 +296,6 @@ __all__ = [
     'TableTail',
     'TableOrderBy',
     'TableDistinct',
-    'RepartitionStrategy',
     'TableRepartition',
     'CastMatrixToTable',
     'TableRename',

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -735,27 +735,20 @@ class TableDistinct(TableIR):
         return self.child.typ
 
 
-class RepartitionStrategy:
-    SHUFFLE = 0
-    COALESCE = 1
-    NAIVE_COALESCE = 2
-
-
 class TableRepartition(TableIR):
-    def __init__(self, child, n, strategy):
+    def __init__(self, child, n):
         super().__init__(child)
         self.child = child
         self.n = n
-        self.strategy = strategy
 
     def _handle_randomness(self, uid_field_name):
-        return TableRepartition(self.child.handle_randomness(uid_field_name), self.n, self.strategy)
+        return TableRepartition(self.child.handle_randomness(uid_field_name), self.n)
 
     def head_str(self):
-        return f'{self.n} {self.strategy}'
+        return f'{self.n}'
 
     def _eq(self, other):
-        return self.n == other.n and self.strategy == other.strategy
+        return self.n == other.n
 
     def _compute_type(self, deep_typecheck):
         self.child.compute_type(deep_typecheck)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -2011,13 +2011,6 @@ def test_matrix_randomness():
     assert_contains_node(mt, ir.MatrixExplodeRows)
     assert_unique_uids(mt)
 
-    # test MatrixRepartition
-    if not hl.current_backend().requires_lowering:
-        rmt = hl.utils.range_matrix_table(20, 10, 3)
-        mt = rmt.repartition(5)
-        assert_contains_node(mt, ir.MatrixRepartition)
-        assert_unique_uids(mt)
-
     # test MatrixUnionRows
     r, c = 5, 5
     mt = hl.utils.range_matrix_table(2*r, c)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -2214,14 +2214,6 @@ def test_table_randomness():
     assert_contains_node(t, ir.TableDistinct)
     assert_unique_uids(t)
 
-    # test TableRepartition
-    if not hl.current_backend().requires_lowering:
-        rt = hl.utils.range_table(20, 3)
-        t = rt.repartition(5)
-        print(t._tir)
-        assert_contains_node(t, ir.TableRepartition)
-        assert_unique_uids(t)
-
     # test CastMatrixToTable
     mt = hl.utils.range_matrix_table(10, 10, 3)
     t = mt._localize_entries("entries", "cols")

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -198,7 +198,7 @@ class TableIRTests(unittest.TestCase):
                 ir.MakeStruct([
                     ('foo', ir.NA(hl.tarray(hl.tint32)))])),
             ir.TableRange(100, 10),
-            ir.TableRepartition(table_read, 10, ir.RepartitionStrategy.COALESCE),
+            ir.TableRepartition(table_read, 10),
             ir.TableUnion(
                 [ir.TableRange(100, 10), ir.TableRange(50, 10)]),
             ir.TableExplode(table_read, ['mset']),
@@ -240,7 +240,7 @@ class MatrixIRTests(unittest.TestCase):
 
         matrix_range = ir.MatrixRead(ir.MatrixRangeReader(1, 1, 10))
         matrix_irs = [
-            ir.MatrixRepartition(matrix_range, 100, ir.RepartitionStrategy.SHUFFLE),
+            ir.MatrixRepartition(matrix_range, 100),
             ir.MatrixUnionRows(matrix_range, matrix_range),
             ir.MatrixDistinctByRow(matrix_range),
             ir.MatrixRowsHead(matrix_read, 5),

--- a/hail/src/main/scala/is/hail/expr/ir/DistinctlyKeyed.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/DistinctlyKeyed.scala
@@ -26,7 +26,7 @@ object DistinctlyKeyed {
       case TableFilter(child, _) => basicChildrenCheck(IndexedSeq(child))
       case TableHead(child, _) => basicChildrenCheck(IndexedSeq(child))
       case TableTail(child, _) => basicChildrenCheck(IndexedSeq(child))
-      case TableRepartition(child, _, _) => basicChildrenCheck(IndexedSeq(child))
+      case TableRepartition(child, _) => basicChildrenCheck(IndexedSeq(child))
       case TableJoin(left, right, _, _) => basicChildrenCheck(IndexedSeq(left, right))
       case TableIntervalJoin(left, right, _, _) => basicChildrenCheck(IndexedSeq(left, right))
       case TableMultiWayZipJoin(children, _, _) => basicChildrenCheck(children)

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -552,7 +552,7 @@ object LowerMatrixIR {
             )))))
         )
 
-      case MatrixRepartition(child, n, shuffle) => TableRepartition(lower(ctx, child, ab), n, shuffle)
+      case MatrixRepartition(child, n) => TableRepartition(lower(ctx, child, ab), n)
 
       case MatrixFilterIntervals(child, intervals, keep) => TableFilterIntervals(lower(ctx, child, ab), intervals, keep)
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -827,14 +827,14 @@ case class MatrixExplodeRows(child: MatrixIR, path: IndexedSeq[String]) extends 
   val typ: MatrixType = child.typ.copy(rowType = newRow.typ)
 }
 
-case class MatrixRepartition(child: MatrixIR, n: Int, strategy: Int) extends MatrixIR {
+case class MatrixRepartition(child: MatrixIR, n: Int) extends MatrixIR {
   val typ: MatrixType = child.typ
 
   lazy val children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixRepartition = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
-    MatrixRepartition(newChild, n, strategy)
+    MatrixRepartition(newChild, n)
   }
 
   override def columnCount: Option[Int] = child.columnCount

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1604,9 +1604,8 @@ object IRParser {
         } yield TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize)
       case "TableRepartition" =>
         val n = int32_literal(it)
-        val strategy = int32_literal(it)
         table_ir(env.onlyRelational)(it).map { child =>
-          TableRepartition(child, n, strategy)
+          TableRepartition(child, n)
         }
       case "TableHead" =>
         val n = int64_literal(it)
@@ -1870,9 +1869,8 @@ object IRParser {
         matrix_ir(env.onlyRelational)(it).map(MatrixCollectColsByKey)
       case "MatrixRepartition" =>
         val n = int32_literal(it)
-        val strategy = int32_literal(it)
         matrix_ir(env.onlyRelational)(it).map { child =>
-          MatrixRepartition(child, n, strategy)
+          MatrixRepartition(child, n)
         }
       case "MatrixUnionRows" => matrix_ir_children(env.onlyRelational)(it).map(MatrixUnionRows(_))
       case "MatrixDistinctByRow" => matrix_ir(env.onlyRelational)(it).map(MatrixDistinctByRow)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -329,7 +329,7 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
     case MatrixAnnotateColsTable(_, _, uid) => single(prettyStringLiteral(uid))
     case MatrixExplodeRows(_, path) => single(prettyIdentifiers(path))
     case MatrixExplodeCols(_, path) => single(prettyIdentifiers(path))
-    case MatrixRepartition(_, n, strategy) => single(s"$n $strategy")
+    case MatrixRepartition(_, n) => single(n.toString)
     case MatrixChooseCols(_, oldIndices) => single(prettyInts(oldIndices, elideLiterals))
     case MatrixMapCols(_, _, newKey) => single(prettyStringsOpt(newKey))
     case MatrixUnionCols(l, r, joinType) => single(joinType)
@@ -346,7 +346,7 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
     case TableKeyBy(_, keys, isSorted) =>
       FastSeq(prettyIdentifiers(keys), Pretty.prettyBooleanLiteral(isSorted))
     case TableRange(n, nPartitions) => FastSeq(n.toString, nPartitions.toString)
-    case TableRepartition(_, n, strategy) => FastSeq(n.toString, strategy.toString)
+    case TableRepartition(_, n) => FastSeq(n.toString)
     case TableHead(_, n) => single(n.toString)
     case TableTail(_, n) => single(n.toString)
     case TableJoin(_, _, joinType, joinKey) => FastSeq(joinType, joinKey.toString)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -334,7 +334,7 @@ object PruneDeadFields {
       case TableParallelize(rowsAndGlobal, _) =>
         memoizeValueIR(ctx, rowsAndGlobal, TStruct("rows" -> TArray(requestedType.rowType), "global" -> requestedType.globalType), memo)
       case TableRange(_, _) =>
-      case TableRepartition(child, _, _) => memoizeTableIR(ctx, child, requestedType, memo)
+      case TableRepartition(child, _) => memoizeTableIR(ctx, child, requestedType, memo)
       case TableHead(child, _) => memoizeTableIR(ctx, child, TableType(
         key = child.typ.key,
         rowType = unify(child.typ.rowType, selectKey(child.typ.rowType, child.typ.key), requestedType.rowType),
@@ -794,7 +794,7 @@ object PruneDeadFields {
         val dep = requestedType.copy(colType = unify(child.typ.colType,
           requestedType.colType.insert(prunedPreExplosionFieldType, path.toList)._1.asInstanceOf[TStruct]))
         memoizeMatrixIR(ctx, child, dep, memo)
-      case MatrixRepartition(child, _, _) =>
+      case MatrixRepartition(child, _) =>
         memoizeMatrixIR(ctx, child, requestedType, memo)
       case MatrixUnionRows(children) =>
         memoizeMatrixIR(ctx, children.head, requestedType, memo)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -319,7 +319,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case TableFilter(child, _) => requiredness.unionFrom(lookup(child))
       case TableHead(child, _) => requiredness.unionFrom(lookup(child))
       case TableTail(child, _) => requiredness.unionFrom(lookup(child))
-      case TableRepartition(child, n, strategy) => requiredness.unionFrom(lookup(child))
+      case TableRepartition(child, n) => requiredness.unionFrom(lookup(child))
       case TableDistinct(child) => requiredness.unionFrom(lookup(child))
       case TableOrderBy(child, sortFields) => requiredness.unionFrom(lookup(child))
       case TableRename(child, rMap, gMap) => requiredness.unionFrom(lookup(child))

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
@@ -38,8 +38,7 @@ object CanLowerEfficiently {
           fail(s"no lowering for TableFromBlockMatrixNativeReader")
 
         case t: TableLiteral =>
-        case TableRepartition(_, _, RepartitionStrategy.NAIVE_COALESCE) =>
-        case t: TableRepartition => fail(s"TableRepartition has no lowered implementation")
+        case TableRepartition(_, _) =>
         case t: TableParallelize =>
         case t: TableRange =>
         case TableKeyBy(child, keys, isSorted) =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1660,7 +1660,7 @@ object LowerTableIR {
           }
         }
 
-      case TableRepartition(child, n, RepartitionStrategy.NAIVE_COALESCE) =>
+      case TableRepartition(child, n) =>
         val lc = lower(child)
         val groupSize = (lc.numPartitions + n - 1) / n
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2868,7 +2868,7 @@ class IRSuite extends HailSuite {
         TableMultiWayZipJoin(FastIndexedSeq(read, read), " * data * ", "globals"),
         MatrixEntriesTable(mtRead),
         MatrixRowsTable(mtRead),
-        TableRepartition(read, 10, RepartitionStrategy.COALESCE),
+        TableRepartition(read, 10),
         TableHead(read, 10),
         TableTail(read, 10),
         TableParallelize(
@@ -2959,7 +2959,7 @@ class IRSuite extends HailSuite {
         MatrixMapCols(read, newCol, None),
         MatrixKeyRowsBy(read, FastIndexedSeq("row_m", "row_d"), false),
         MatrixMapRows(read, newRow),
-        MatrixRepartition(read, 10, 0),
+        MatrixRepartition(read, 10),
         MatrixMapEntries(read, MakeStruct(FastIndexedSeq(
           "global_f32" -> ApplyBinaryPrimOp(Add(),
             GetField(Ref("global", read.typ.globalType), "global_f32"),

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -302,18 +302,14 @@ class MatrixIRSuite extends HailSuite {
     val range = rangeMatrix(11, 3, Some(10))
 
     val params = Array(
-      1 -> RepartitionStrategy.SHUFFLE,
-      1 -> RepartitionStrategy.COALESCE,
-      5 -> RepartitionStrategy.SHUFFLE,
-      5 -> RepartitionStrategy.NAIVE_COALESCE,
-      10 -> RepartitionStrategy.SHUFFLE,
-      10 -> RepartitionStrategy.COALESCE
+      5,
+      7,
     )
-    params.foreach { case (n, strat) =>
-      val rvd = Interpret(MatrixRepartition(range, n, strat), ctx, optimize = false).rvd
-      assert(rvd.getNumPartitions == n, n -> strat)
+    params.foreach { n =>
+      val rvd = Interpret(MatrixRepartition(range, n), ctx, optimize = false).rvd
+      assert(rvd.getNumPartitions == n, n)
       val values = rvd.collect(ctx).map(r => r.getAs[Int](0))
-      assert(values.isSorted && values.length == 11, n -> strat)
+      assert(values.isSorted && values.length == 11, n)
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -513,7 +513,7 @@ class PruneSuite extends HailSuite {
 
   @Test def testMatrixRepartitionMemo() {
     checkMemo(
-      MatrixRepartition(mat, 10, RepartitionStrategy.SHUFFLE),
+      MatrixRepartition(mat, 10),
       subsetMatrixTable(mat.typ, "va.r2", "global.g1"),
       Array(subsetMatrixTable(mat.typ, "va.r2", "global.g1"),
         subsetMatrixTable(mat.typ, "va.r2", "global.g1"))

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -295,7 +295,7 @@ class RequirednessSuite extends HailSuite {
     nodes += Array(TableFilter(table, GetField(global, "y") < 0), rowType, globalType)
     nodes += Array(TableHead(table, 5), rowType, globalType)
     nodes += Array(TableTail(table, 5), rowType, globalType)
-    nodes += Array(TableRepartition(table, 5, RepartitionStrategy.SHUFFLE), rowType, globalType)
+    nodes += Array(TableRepartition(table, 5), rowType, globalType)
     nodes += Array(TableDistinct(table), rowType, globalType)
     nodes += Array(TableOrderBy(table, FastIndexedSeq()), rowType, globalType)
     nodes += Array(TableFilterIntervals(table, FastIndexedSeq(), true), rowType, globalType)


### PR DESCRIPTION
This changes the execution semantics for the Spark backend. Instead of dispatching either to (a) a two-pass algorithm that scans and coalesces (shuffle=False) or (b) a two-pass algorithm that shuffles and then rekeys (shuffle=True), we use write/read instead.