### PR TITLE
Revert "Bump cryptography from 38.0.4 to 39.0.1 in /hail/python"

### DIFF
--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -82,7 +82,7 @@ click==8.1.3
     #   curlylint
 commonmark==0.9.1
     # via rich
-cryptography==39.0.1
+cryptography==38.0.4
     # via
     #   azure-identity
     #   azure-storage-blob

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -48,7 +48,7 @@ charset-normalizer==2.1.1
     #   requests
 commonmark==0.9.1
     # via rich
-cryptography==39.0.1
+cryptography==38.0.4
     # via
     #   azure-identity
     #   azure-storage-blob

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -54,7 +54,7 @@ charset-normalizer==2.1.1
     #   requests
 commonmark==0.9.1
     # via rich
-cryptography==39.0.1
+cryptography==38.0.4
     # via
     #   azure-identity
     #   azure-storage-blob


### PR DESCRIPTION
Reverts hail-is/hail#12669