### PR TITLE
[batch] Fix google-cloud-storage version requirement

### DIFF
--- a/hail/python/hailtop/requirements.txt
+++ b/hail/python/hailtop/requirements.txt
@@ -5,7 +5,7 @@ azure-storage-blob>=12.11.0,<13
 boto3>=1.17,<2.0
 botocore>=1.20,<2.0
 google-auth==2.14.1
-google-cloud-storage>=1.25.*
+google-cloud-storage>=1.25.0
 humanize>=1.0.0,<2
 janus>=0.6,<1.1
 orjson>=3.6.4,<4


### PR DESCRIPTION
`>=` is not compatible with wildcards:
```
cd build/deploy; rm -rf build; python3 setup.py -q sdist bdist_wheel
/usr/local/lib/python3.7/dist-packages/setuptools/installer.py:30: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
  SetuptoolsDeprecationWarning,
error in hail setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
    google-cloud-storage>=1.25.*
                        ~~~~~~^
make: *** [Makefile:248: build/deploy/dist/hail-0.2.109-py3-none-any.whl] Error 1
```

I'm not sure why this hasn't shown up before, but we couldn't deploy 0.2.109 without this fix.

#assign services