### PR TITLE
[query] add `hl.utils.genomic_range_table`

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -16,7 +16,7 @@ from hailtop.hail_frozenlist import frozenlist
 from .nat import NatBase, NatLiteral
 from .type_parsing import type_grammar, type_node_visitor
 from .. import genetics
-from ..typecheck import typecheck, typecheck_method, oneof, transformed
+from ..typecheck import typecheck, typecheck_method, oneof, transformed, nullable
 from ..utils.struct import Struct
 from ..utils.byte_reader import ByteReader
 from ..utils.misc import lookup_bit
@@ -1779,6 +1779,14 @@ class tlocus(HailType):
     """
 
     struct_repr = tstruct(contig=_tstr(), pos=_tint32())
+
+    @classmethod
+    @typecheck_method(reference_genome=nullable(reference_genome_type))
+    def _schema_from_rg(cls, reference_genome='default'):
+        # must match TLocus.schemaFromRG
+        if reference_genome is None:
+            return hl.tstruct(contig=hl.tstr, position=hl.tint32)
+        return cls(reference_genome)
 
     @typecheck_method(reference_genome=reference_genome_type)
     def __init__(self, reference_genome='default'):

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -22,15 +22,13 @@ from .ir import MatrixWrite, MatrixMultiWrite, BlockMatrixWrite, \
     PartitionNativeIntervalReader, StreamMultiMerge, StreamZipJoin
 from .register_functions import register_functions
 from .register_aggregators import register_aggregators
-from .table_ir import MatrixRowsTable, TableJoin, TableLeftJoinRightDistinct, \
-    TableIntervalJoin, TableUnion, TableRange, TableMapGlobals, TableExplode, \
-    TableKeyBy, TableMapRows, TableRead, MatrixEntriesTable, \
-    TableFilter, TableKeyByAndAggregate, \
-    TableAggregateByKey, MatrixColsTable, TableParallelize, TableHead, \
-    TableTail, TableOrderBy, TableDistinct, RepartitionStrategy, \
-    TableRepartition, CastMatrixToTable, TableRename, TableMultiWayZipJoin, \
-    TableFilterIntervals, TableToTableApply, MatrixToTableApply, \
-    BlockMatrixToTableApply, BlockMatrixToTable, JavaTable, TableMapPartitions
+from .table_ir import (MatrixRowsTable, TableJoin, TableLeftJoinRightDistinct, TableIntervalJoin,
+                       TableUnion, TableRange, TableMapGlobals, TableExplode, TableKeyBy, TableMapRows, TableRead,
+                       MatrixEntriesTable, TableFilter, TableKeyByAndAggregate, TableAggregateByKey, MatrixColsTable,
+                       TableParallelize, TableHead, TableTail, TableOrderBy, TableDistinct, RepartitionStrategy,
+                       TableRepartition, CastMatrixToTable, TableRename, TableMultiWayZipJoin, TableFilterIntervals,
+                       TableToTableApply, MatrixToTableApply, BlockMatrixToTableApply, BlockMatrixToTable, JavaTable,
+                       TableMapPartitions, TableGenomicRange)
 from .matrix_ir import MatrixAggregateRowsByKey, MatrixRead, MatrixFilterRows, \
     MatrixChooseCols, MatrixMapCols, MatrixUnionCols, MatrixMapEntries, \
     MatrixFilterEntries, MatrixKeyRowsBy, MatrixMapRows, MatrixMapGlobals, \
@@ -285,6 +283,7 @@ __all__ = [
     'TableKeyBy',
     'TableMapRows',
     'TableMapPartitions',
+    'TableGenomicRange',
     'TableRead',
     'MatrixEntriesTable',
     'TableFilter',

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -5,6 +5,7 @@ from hail.ir.base_ir import BaseIR, TableIR
 import hail.ir.ir as ir
 from hail.ir.utils import modify_deep_field, zip_with_index, default_row_uid, default_col_uid
 from hail.ir.ir import unify_uid_types, pad_uid, concat_uids
+from hail.genetics import ReferenceGenome
 from hail.utils import FatalError
 from hail.utils.java import Env
 from hail.utils.misc import escape_str, parsable_strings, escape_id
@@ -195,6 +196,46 @@ class TableRange(TableIR):
         return hl.ttable(hl.tstruct(),
                          hl.tstruct(idx=hl.tint32),
                          ['idx'])
+
+
+class TableGenomicRange(TableIR):
+    def __init__(self, n: int, n_partitions: Optional[int], reference_genome: Optional[ReferenceGenome]):
+        super().__init__()
+        self.n = n
+        self.n_partitions = n_partitions
+        self.reference_genome = reference_genome
+
+    def _handle_randomness(self, uid_field_name):
+        assert(uid_field_name is not None)
+        if self.reference_genome is not None:
+            global_position = ir.Apply(
+                'locusToGlobalPos',
+                tint64,
+                ir.GetField(ir.Ref('row', self.typ.row_type), 'locus'))
+        else:
+            global_position = ir.Cast(
+                ir.GetField(ir.GetField(ir.Ref('row', self.typ.row_type), 'locus'), 'position'),
+                tint64)
+
+        new_row = ir.InsertFields(
+            ir.Ref('row', self.typ.row_type),
+            [(uid_field_name, global_position)],
+            None)
+        return TableMapRows(self, new_row)
+
+    def head_str(self):
+        reference_genome = self.reference_genome.name if self.reference_genome else None
+        return f'{self.n} {self.n_partitions} {reference_genome}'
+
+    def _eq(self, other):
+        return self.n == other.n and \
+            self.n_partitions == other.n_partitions and \
+            self.reference_genome == other.reference_genome
+
+    def _compute_type(self, deep_typecheck):
+        return hl.ttable(hl.tstruct(),
+                         hl.tstruct(locus=hl.tlocus._schema_from_rg(self.reference_genome)),
+                         ['locus'])
 
 
 class TableMapGlobals(TableIR):

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -3330,13 +3330,13 @@ def balding_nichols_model(n_populations: int,
                      mixture=mixture))
     # col info
     pop_f = hl.rand_dirichlet if mixture else hl.rand_cat
-    bn = bn.annotate_globals(cols = hl.range(n_samples).map(
+    bn = bn.annotate_globals(cols=hl.range(n_samples).map(
         lambda idx: hl.struct(
             sample_idx=idx,
             pop=pop_f(pop_dist)
         )
     ))
-    bn = bn.annotate(entries = hl.range(n_samples).map(lambda _: hl.struct()))
+    bn = bn.annotate(entries=hl.range(n_samples).map(lambda _: hl.struct()))
     bn = bn._unlocalize_entries('entries', 'cols', ['sample_idx'])
     # row info
     bn = bn.select_rows(ancestral_af=af_dist,

--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -12,6 +12,7 @@ from .java import error, warning, info, FatalError, HailUserError
 from .tutorial import get_1kg, get_hgdp, get_movie_lens
 from .deduplicate import deduplicate
 from .jsonx import JSONEncoder
+from .genomic_range_table import genomic_range_table
 
 __all__ = ['hadoop_open',
            'hadoop_copy',
@@ -53,4 +54,5 @@ __all__ = ['hadoop_open',
            'guess_cloud_spark_provider',
            'no_service_backend',
            'JSONEncoder',
+           'genomic_range_table',
            ]

--- a/hail/python/hail/utils/genomic_range_table.py
+++ b/hail/python/hail/utils/genomic_range_table.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+import hail as hl
+from .misc import check_nonnegative_and_in_range, check_positive_and_in_range
+from ..genetics.reference_genome import reference_genome_type
+from ..typecheck import typecheck, nullable
+
+
+@typecheck(n=int, n_partitions=nullable(int), reference_genome=nullable(reference_genome_type))
+def genomic_range_table(n: int,
+                        n_partitions: Optional[int] = None,
+                        reference_genome='default'
+                        ) -> 'hl.Table':
+    """Construct a table with a locus and no other fields.
+
+    Examples
+    --------
+
+    >>> ht = hl.utils.range_table(100)
+    >>> ht.count()
+    100
+
+    Notes
+    -----
+    The resulting table contains one field:
+
+     - `locus` (:py:data:`.tlocus`) - Row index (key).
+
+    The loci appear in sequential ascending order.
+
+    Parameters
+    ----------
+    n : int
+        Number of loci. Must be less than 2 ** 31.
+    n_partitions : int, optional
+        Number of partitions (uses Spark default parallelism if None).
+    reference_genome : :class:`str` or :class:`.ReferenceGenome`
+        Reference genome to use for creating the loci.
+
+    Returns
+    -------
+    :class:`.Table`
+    """
+    check_nonnegative_and_in_range('range_table', 'n', n)
+    if n_partitions is not None:
+        check_positive_and_in_range('range_table', 'n_partitions', n_partitions)
+    if n >= (1 << 31):
+        raise ValueError(f'`n`, {n}, must be less than 2 ** 31.')
+
+    return hl.Table(hl.ir.TableGenomicRange(n, n_partitions, reference_genome))

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -147,7 +147,7 @@ class Tests(unittest.TestCase):
             return hl.import_vcf(resource('sample2.vcf'), reference_genome=rg).locus.dtype
 
         assert tlocus._schema_from_rg(None) == locus_from_import_vcf(None)
-        assert tlocus._schema_from_rg('GRCh37') == locus_from_import_vcf('GRCh38')
+        assert tlocus._schema_from_rg('GRCh37') == locus_from_import_vcf('GRCh37')
         assert tlocus._schema_from_rg('GRCh38') == locus_from_import_vcf('GRCh38')
         assert tlocus._schema_from_rg('GRCm38') == locus_from_import_vcf('GRCm38')
         assert tlocus._schema_from_rg('CanFam3') == locus_from_import_vcf('CanFam3')

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import unittest
 
 from hail.expr import coercer_from_dtype
@@ -142,8 +143,8 @@ class Tests(unittest.TestCase):
                 self.assertEqual(t.get_context().references, rgs)
 
     def test_tlocus_schema_from_rg_matches_scala(self):
-        def locus_from_import_vcf(rg: str) -> HailType:
-            return hl.import_vcf(resource('sample2.vcf'), reference_genome=None).locus.dtype
+        def locus_from_import_vcf(rg: Optional[str]) -> HailType:
+            return hl.import_vcf(resource('sample2.vcf'), reference_genome=rg).locus.dtype
 
         assert tlocus._schema_from_rg(None) == locus_from_import_vcf(None)
         assert tlocus._schema_from_rg('GRCh37') == locus_from_import_vcf('GRCh38')

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -2,6 +2,7 @@ import unittest
 
 from hail.expr import coercer_from_dtype
 from hail.expr.types import *
+from hail.genetics import reference_genome
 from ..helpers import *
 from hail.utils.java import Env
 
@@ -139,3 +140,14 @@ class Tests(unittest.TestCase):
         for types, rgs in types_and_rgs:
             for t in types:
                 self.assertEqual(t.get_context().references, rgs)
+
+    def test_tlocus_schema_from_rg_matches_scala(self):
+        def locus_from_import_vcf(rg: str) -> HailType:
+            return hl.import_vcf(resource('sample2.vcf'), reference_genome=None).locus.dtype
+
+        assert tlocus._schema_from_rg(None) == locus_from_import_vcf(None)
+        assert tlocus._schema_from_rg('GRCh37') == locus_from_import_vcf('GRCh38')
+        assert tlocus._schema_from_rg('GRCh38') == locus_from_import_vcf('GRCh38')
+        assert tlocus._schema_from_rg('GRCm38') == locus_from_import_vcf('GRCm38')
+        assert tlocus._schema_from_rg('CanFam3') == locus_from_import_vcf('CanFam3')
+        assert tlocus._schema_from_rg('default') == locus_from_import_vcf('default')

--- a/hail/python/test/hail/utils/test_genomic_range_table.py
+++ b/hail/python/test/hail/utils/test_genomic_range_table.py
@@ -1,8 +1,29 @@
 import hail as hl
 
 
-def test_genomic_range_table():
+def test_genomic_range_table_grch38():
     actual = hl.utils.genomic_range_table(10, reference_genome='GRCh38').collect()
-    expected = [hl.Struct(locus=hl.locus("chr1", pos + 1))
+    expected = [hl.Struct(locus=hl.Locus("chr1", pos + 1, reference_genome='GRCh38'))
+                for pos in range(10)]
+    assert actual == expected
+
+
+def test_genomic_range_table_grch37():
+    actual = hl.utils.genomic_range_table(10, reference_genome='GRCh37').collect()
+    expected = [hl.Struct(locus=hl.Locus("1", pos + 1, reference_genome='GRCh37'))
+                for pos in range(10)]
+    assert actual == expected
+
+
+def test_genomic_range_table_canfam3():
+    actual = hl.utils.genomic_range_table(10, reference_genome='CanFam3').collect()
+    expected = [hl.Struct(locus=hl.Locus("chr1", pos + 1, reference_genome='CanFam3'))
+                for pos in range(10)]
+    assert actual == expected
+
+
+def test_genomic_range_table_grcm38():
+    actual = hl.utils.genomic_range_table(10, reference_genome='GRCm38').collect()
+    expected = [hl.Struct(locus=hl.Locus("1", pos + 1, reference_genome='GRCm38'))
                 for pos in range(10)]
     assert actual == expected

--- a/hail/python/test/hail/utils/test_genomic_range_table.py
+++ b/hail/python/test/hail/utils/test_genomic_range_table.py
@@ -1,0 +1,8 @@
+import hail as hl
+
+
+def test_genomic_range_table():
+    actual = hl.utils.genomic_range_table(10, reference_genome='GRCh38').collect()
+    expected = [hl.Struct(locus=hl.locus("chr1", pos + 1))
+                for pos in range(10)]
+    assert actual == expected

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1663,6 +1663,12 @@ object IRParser {
         val n = int32_literal(it)
         val nPartitions = opt(it, int32_literal)
         done(TableRange(n, nPartitions.getOrElse(HailContext.backend.defaultParallelism)))
+      case "TableGenomicRange" =>
+        val n = int32_literal(it)
+        val nPartitions = opt(it, int32_literal)
+        val optRgStr = opt(it, identifier)
+        val optRg = optRgStr.map(env.typEnv.getReferenceGenome)
+        done(TableGenomicRange(n, nPartitions.getOrElse(HailContext.backend.defaultParallelism), optRg))
       case "TableUnion" => table_ir_children(env.onlyRelational)(it).map(TableUnion(_))
       case "TableOrderBy" =>
         val sortFields = sort_fields(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -346,6 +346,8 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
     case TableKeyBy(_, keys, isSorted) =>
       FastSeq(prettyIdentifiers(keys), Pretty.prettyBooleanLiteral(isSorted))
     case TableRange(n, nPartitions) => FastSeq(n.toString, nPartitions.toString)
+    case TableGenomicRange(n, nPartitions, referenceGenome) => FastSeq(
+      n.toString, nPartitions.toString, referenceGenome.map(_.name).getOrElse("None").toString)
     case TableRepartition(_, n, strategy) => FastSeq(n.toString, strategy.toString)
     case TableHead(_, n) => single(n.toString)
     case TableTail(_, n) => single(n.toString)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -334,6 +334,7 @@ object PruneDeadFields {
       case TableParallelize(rowsAndGlobal, _) =>
         memoizeValueIR(ctx, rowsAndGlobal, TStruct("rows" -> TArray(requestedType.rowType), "global" -> requestedType.globalType), memo)
       case TableRange(_, _) =>
+      case TableGenomicRange(_, _, _) =>
       case TableRepartition(child, _, _) => memoizeTableIR(ctx, child, requestedType, memo)
       case TableHead(child, _) => memoizeTableIR(ctx, child, TableType(
         key = child.typ.key,

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -313,6 +313,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.rowType.unionFields(rowReq.r.asInstanceOf[RStruct])
         requiredness.globalType.unionFields(globalReq.r.asInstanceOf[RStruct])
       case TableRange(_, _) =>
+      case TableGenomicRange(_, _, _) =>
 
       // pass through TableIR child
       case TableKeyBy(child, _, _) => requiredness.unionFrom(lookup(child))

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -434,6 +434,7 @@ object Simplify {
     case TableCount(TableLeftJoinRightDistinct(child, _, _)) => TableCount(child)
     case TableCount(TableIntervalJoin(child, _, _, _)) => TableCount(child)
     case TableCount(TableRange(n, _)) => I64(n)
+    case TableCount(TableGenomicRange(n, _, _)) => I64(n)
     case TableCount(TableParallelize(rowsAndGlobal, _)) => Cast(ArrayLen(GetField(rowsAndGlobal, "rows")), TInt64)
     case TableCount(TableRename(child, _, _)) => TableCount(child)
     case TableCount(TableAggregateByKey(child, _)) => TableCount(TableDistinct(child))
@@ -743,6 +744,7 @@ object Simplify {
     case MatrixColsTable(MatrixKeyRowsBy(child, _, _)) => MatrixColsTable(child)
 
     case TableRepartition(TableRange(nRows, _), nParts, _) => TableRange(nRows, nParts)
+    case TableRepartition(TableGenomicRange(nRows, _, referenceGenome), nParts, _) => TableGenomicRange(nRows, nParts, referenceGenome)
 
     case TableMapGlobals(TableMapGlobals(child, ng1), ng2) =>
       val uid = genUID()
@@ -760,6 +762,12 @@ object Simplify {
     case TableHead(tr@TableRange(nRows, nPar), n) if canRepartition =>
       if (n < nRows)
         TableRange(n.toInt, (nPar.toFloat * n / nRows).toInt.max(1))
+      else
+        tr
+
+    case TableHead(tr@TableGenomicRange(nRows, nPar, referenceGenome), n) if canRepartition =>
+      if (n < nRows)
+        TableGenomicRange(n.toInt, (nPar.toFloat * n / nRows).toInt.max(1), referenceGenome)
       else
         tr
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1826,6 +1826,97 @@ case class TableRange(n: Int, nPartitions: Int) extends TableIR {
   }
 }
 
+object TableGenomicRange {
+  def toLocus(
+    referenceGenome: Option[ReferenceGenome]
+  ): Int => Annotation = referenceGenome match {
+    case Some(rg) => (x: Int) => rg.globalPosToLocus(x.toLong)
+    case None => (idx: Int) =>
+      Row("1", idx.toInt + 1)
+  }
+}
+
+case class TableGenomicRange(
+  n: Int,
+  nPartitions: Int,
+  referenceGenome: Option[ReferenceGenome]
+) extends TableIR {
+  require(n < Int.MaxValue)
+  require(n >= 0)
+  require(nPartitions > 0)
+  private val nPartitionsAdj = math.max(math.min(n, nPartitions), 1)
+  val children: IndexedSeq[BaseIR] = Array.empty[BaseIR]
+
+  def copy(newChildren: IndexedSeq[BaseIR]): TableGenomicRange = {
+    assert(newChildren.isEmpty)
+    TableGenomicRange(n, nPartitions, referenceGenome)
+  }
+
+  private[this] val partCounts = partition(n, nPartitionsAdj)
+
+  override val partitionCounts  = Some(partCounts.map(_.toLong).toFastIndexedSeq)
+
+  lazy val rowCountUpperBound: Option[Long] = Some(n.toLong)
+
+  val typ: TableType = TableType(
+    TStruct("locus" -> TLocus.schemaFromRG(referenceGenome)),
+    Array("locus"),
+    TStruct.empty)
+
+  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+    val localLocusType = PCanonicalLocus.schemaFromRG(referenceGenome, true)
+    val unstagedStoreLocusFromGlobalPos: (Long, Int, Region) => Unit = localLocusType match {
+      case x: PCanonicalLocus =>
+        val rgBc = x.rgBc
+
+        { (off: Long, globalPos: Int, region: Region) =>
+          val l = rgBc.value.globalPosToLocus(globalPos)
+          x.unstagedStoreJavaObjectAtAddress(off, l, region)
+        }
+      case x: PCanonicalStruct =>
+        { (off: Long, globalPos: Int, region: Region) =>
+          Region.storeLong(
+            x.fieldOffset(off, 0),
+            x.field("locus").asInstanceOf[PCanonicalString].unstagedStoreJavaObject("1", region))
+          Region.storeInt(x.fieldOffset(off, 1), globalPos)
+        }
+    }
+    val localRowType = PCanonicalStruct(true, "locus" -> localLocusType)
+    val localPartCounts = partCounts
+    val partStarts = partCounts.scanLeft(0)(_ + _)
+
+    val partLocusStarts = partStarts.map(TableGenomicRange.toLocus(referenceGenome))
+    new TableValueIntermediate(TableValue(ctx, typ,
+      BroadcastRow.empty(ctx),
+      new RVD(
+        RVDType(localRowType, Array("locus")),
+        new RVDPartitioner(
+          Array("locus"),
+          typ.rowType,
+          Array.tabulate(nPartitionsAdj) { i =>
+            val start = partLocusStarts(i)
+            val end = partLocusStarts(i + 1)
+            Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
+          }
+        ),
+        ContextRDD.parallelize(Range(0, nPartitionsAdj), nPartitionsAdj)
+          .cmapPartitionsWithIndex { case (i, ctx, _) =>
+            val region = ctx.region
+
+            val start = partStarts(i)
+            Iterator.range(start, (start + localPartCounts(i)))
+              .map { j =>
+                val off = localRowType.allocate(region)
+                unstagedStoreLocusFromGlobalPos(
+                  localRowType.fieldOffset(off, 0),
+                  j,
+                  region)
+                off
+              }
+          })))
+  }
+}
+
 case class TableFilter(child: TableIR, pred: IR) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child, pred)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -29,6 +29,7 @@ import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SIntervalValu
 import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.utils.prettyPrint.ArrayOfByteArrayInputStream
+import is.hail.variant._
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.Row
 import org.json4s.JsonAST.JString

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
@@ -42,6 +42,7 @@ object CanLowerEfficiently {
         case t: TableRepartition => fail(s"TableRepartition has no lowered implementation")
         case t: TableParallelize =>
         case t: TableRange =>
+        case t: TableGenomicRange =>
         case TableKeyBy(child, keys, isSorted) =>
         case t: TableOrderBy =>
         case t: TableFilter =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -819,6 +819,50 @@ object LowerTableIR {
             MakeStruct(FastSeq("idx" -> i))
           })
 
+      case TableGenomicRange(n, nPartitions, referenceGenome) =>
+        assert(n < Int.MaxValue)
+        val nPartitionsAdj = math.max(math.min(n, nPartitions), 1)
+        val partCounts = partition(n, nPartitionsAdj)
+        val partStarts = partCounts.scanLeft(0)(_ + _)
+
+        val contextType = TStruct("start" -> TInt32, "end" -> TInt32)
+        val toLocus = TableGenomicRange.toLocus(referenceGenome)
+
+        val globalPosRanges = Array.tabulate(nPartitionsAdj) { i =>
+          partStarts(i) -> partStarts(i + 1)
+        }.toFastIndexedSeq
+        val locusRanges = Array.tabulate(nPartitionsAdj) { i =>
+          toLocus(partStarts(i)) -> toLocus(partStarts(i + 1))
+        }.toFastIndexedSeq
+
+        TableStage(
+          MakeStruct(FastSeq()),
+          new RVDPartitioner(Array("locus"), tir.typ.rowType,
+            locusRanges.map { case (start, end) =>
+              Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
+            }),
+          TableStageDependency.none,
+          ToStream(
+            Literal(
+              TArray(contextType),
+              globalPosRanges.map { case (start, end) => Row(start, end) }
+            )
+          ),
+          { (ctxRef: Ref) =>
+            mapIR(StreamRange(GetField(ctxRef, "start"), GetField(ctxRef, "end"), I32(1), true)) { globalPos =>
+              val locusIR = referenceGenome match {
+                case Some(rg) =>
+                  val locusType = tir.typ.rowType.field("locus").typ.asInstanceOf[TLocus]
+                  invoke("globalPosToLocus", locusType, Cast(globalPos, TInt64))
+                case None =>
+                  MakeStruct(FastSeq(
+                    "contig" -> Str("1"),
+                    "position" -> Cast(globalPos, TInt32)))
+              }
+              MakeStruct(FastSeq("locus" -> locusIR))
+            }
+          })
+
       case TableMapGlobals(child, newGlobals) =>
         lower(child).mapGlobals(old => Let("global", old, newGlobals))
 

--- a/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
@@ -20,6 +20,7 @@ object TLocus {
   }
 
   def schemaFromRG(rg: Option[ReferenceGenome], required: Boolean = false): Type = rg match {
+    // must match tlocus.schema_from_rg
     case Some(ref) => TLocus(ref)
     case None => TLocus.representation
   }


### PR DESCRIPTION
CHANGELOG: In Query on Batch, `hl.balding_nichols_model` is slightly faster. Also added `hl.utils.genomic_range_table` to quickly create a table keyed by locus.

It has grated on me for a while that `hl.balding_nichols_models` requires a whole pass to verify it is sorted even though it is plainly so. This change introduces the necessary infrastructure to convince Hail of that fact.