### PR TITLE
[batch] Use default regions in python jobs

### DIFF
--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -342,6 +342,9 @@ class Batch:
         if self._default_timeout is not None:
             j.timeout(self._default_timeout)
 
+        if isinstance(self._backend, _backend.ServiceBackend):
+            j.regions(self._backend.regions)
+
         self._jobs.append(j)
         return j
 


### PR DESCRIPTION
CHANGELOG: :class:`.PythonJob` now correctly uses the default region when a specific region for the job is not given.

I noticed this was missing when I was looking at Siwei's pipeline.