### PR TITLE
[query] fix gsutil cp invocation

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -306,8 +306,8 @@ upload-artifacts: $(WHEEL)
 # > rm upload-qob-test-resources
 upload-qob-test-resources: $(JAR_TEST_SOURCES)
 	! [ -z $(NAMESPACE) ]  # call this like: make upload-qob-test-resources NAMESPACE=default
-	gsutil -m cp -r src/test/resources $(HAIL_TEST_RESOURCES_DIR)
-	gsutil -m cp -r python/hail/docs/data $(HAIL_DOCTEST_DATA_DIR)
+	gsutil -m cp -r src/test/resources/\* $(HAIL_TEST_RESOURCES_DIR)
+	gsutil -m cp -r python/hail/docs/data/\* $(HAIL_DOCTEST_DATA_DIR)
 	touch $@
 
 # NOTE: 1-day expiration of the test bucket means that this


### PR DESCRIPTION
`gsutil` is one of the most user hostile tools I have ever used. Here are some examples of why. I think what I now have committed is the only way to achieve the behavior we want without assuming anything about which objects are present at the target.

```
$ gsutil -m cp -r baz gs://danking/baz/
$ gsutil ls gs://danking/baz/
gs://danking/baz/baz/
```
```
$ gsutil rm -rf gs://danking/baz
$ gsutil -m cp -r baz/ gs://danking/baz/
$ gsutil ls gs://danking/baz/
gs://danking/baz/baz/
```
```
$ gsutil rm -rf gs://danking/baz
$ gsutil -m cp -r baz gs://danking/baz
$ gsutil ls gs://danking/baz/
gs://danking/baz/1
gs://danking/baz/2
```
```
$ gsutil rm -rf gs://danking/baz
$ touch foo
$ gsutil cp foo gs://danking/baz/foo
$ gsutil -m cp -r baz gs://danking/baz
$ gsutil ls gs://danking/baz
gs://danking/baz/foo
gs://danking/baz/baz/
```
```
$ gsutil rm -rf gs://danking/baz
$ gsutil cp foo gs://danking/baz/foo
$ gsutil -m cp -r baz/\* gs://danking/baz/
$ gsutil ls gs://danking/baz
gs://danking/baz/1
gs://danking/baz/2
gs://danking/baz/foo
```