### PR TITLE
[query] improve the memory client

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -115,26 +115,24 @@ class ServiceBackend(
     val root = s"${ backendContext.remoteTmpDir }parallelizeAndComputeWithIndex/$token"
 
     // FIXME: HACK
-    val (open, create) = if (n <= 50) {
-      (fs.openCachedNoCompression _, fs.createCachedNoCompression _)
+    val (open, write) = if (n <= 50) {
+      (fs.openCachedNoCompression _, fs.writeCached _)
     } else {
-      ((x: String) => fs.openNoCompression(x), fs.createNoCompression _)
+      ((x: String) => fs.openNoCompression(x), fs.writePDOS _)
     }
 
     log.info(s"parallelizeAndComputeWithIndex: $token: nPartitions $n")
     log.info(s"parallelizeAndComputeWithIndex: $token: writing f and contexts")
 
     val uploadFunction = scalaConcurrent.Future {
-      retryTransientErrors {
-        using(new ObjectOutputStream(create(s"$root/f"))) { os =>
-          os.writeObject(f)
-        }
+      write(s"$root/f") { fos =>
+        using(new ObjectOutputStream(fos)) { oos => oos.writeObject(f) }
       }
     }
 
     val uploadContexts = scalaConcurrent.Future {
       retryTransientErrors {
-        using(create(s"$root/contexts")) { os =>
+        write(s"$root/contexts") { os =>
           var o = 12L * n
           var i = 0
           while (i < n) {
@@ -144,7 +142,6 @@ class ServiceBackend(
             i += 1
             o += len
           }
-          log.info(s"parallelizeAndComputeWithIndex: $token: writing contexts")
           collection.foreach { context =>
             os.write(context)
           }

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -36,6 +36,27 @@ class WrappedPositionedDataOutputStream(os: PositionedOutputStream) extends Data
   def getPosition: Long = os.getPosition
 }
 
+class WrappedPositionOutputStream(os: OutputStream) extends OutputStream with Positioned {
+  private[this] var count: Long = 0L
+
+  override def flush(): Unit = os.flush()
+
+  override def write(i: Int): Unit = {
+    os.write(i)
+    count += 1
+  }
+
+  override def write(bytes: Array[Byte], off: Int, len: Int): Unit = {
+    os.write(bytes, off, len)
+  }
+
+  override def close(): Unit = {
+    os.close()
+  }
+
+  def getPosition: Long = count
+}
+
 trait FileStatus {
   def getPath: String
   def getModificationTime: java.lang.Long
@@ -380,6 +401,12 @@ trait FS extends Serializable {
     else
       os
   }
+
+  def write(filename: String)(writer: OutputStream => Unit) =
+    using(create(filename))(writer)
+
+  def writePDOS(filename: String)(writer: PositionedDataOutputStream => Unit) =
+    using(create(filename))(os => writer(outputStreamToPositionedDataOutputStream(os)))
 
   def getFileSize(filename: String): Long = fileStatus(filename).getLen
 

--- a/hail/src/main/scala/is/hail/io/fs/ServiceCacheableFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/ServiceCacheableFS.scala
@@ -1,14 +1,21 @@
 package is.hail.io.fs
 
-import java.io.{InputStream, OutputStream}
+import java.io._
+import java.util.{concurrent => javaConcurrent}
+import org.apache.commons.io.IOUtils
 import org.apache.log4j.Logger
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.{Duration}
+import scala.concurrent.{Future, Await, ExecutionContext}
 
 import is.hail.services.memory_client.MemoryClient
 import is.hail.services.ClientResponseException
 import is.hail.utils._
 
 trait ServiceCacheableFS extends FS {
+
+  private[this] implicit val ec = ExecutionContext.fromExecutorService(
+    javaConcurrent.Executors.newCachedThreadPool())
 
   def sessionID: String
 
@@ -24,38 +31,50 @@ trait ServiceCacheableFS extends FS {
     client.open(filename).map(new WrappedSeekableDataInputStream(_)).getOrElse(openNoCompression(filename))
   }
 
+  def writeCached(filename: String)(writer: PositionedDataOutputStream => Unit) = {
+    try {
+      client.writeToStream(filename) { os =>
+        writer(outputStreamToPositionedDataOutputStream(os))
+      }
+    } catch {
+      case exc: Exception =>
+        log.error(f"Unexpected failure $filename writing to memory. Retrying directly to GCS.", exc)
+        using(createNoCompression(filename))(writer)
+    }
+  }
+
   def createCachedNoCompression(filename: String): PositionedDataOutputStream = {
+    val pis = new PipedInputStream()
+    val pos = new PipedOutputStream(pis)
+    val writerFuture = Future {
+      client.writeToStream(filename) { os => IOUtils.copy(pis, os) }
+    }
     val os: PositionedOutputStream = new OutputStream with Positioned {
-      private[this] var closed: Boolean = false
-      private[this] val bb: ArrayBuffer[Byte] = new ArrayBuffer()
+      private[this] var count: Long = 0L
 
-      override def flush(): Unit = {}
-
-      override def write(i: Int): Unit = {
-        bb += i.toByte
-      }
-
-      override def write(bytes: Array[Byte], off: Int, len: Int): Unit = {
-        bb ++= bytes.slice(off, off + len)
-      }
-
-      override def close(): Unit = {
-        if (!closed) {
-          val data = bb.toArray
-          try {
-            client.write(filename, data)
-          } catch { case e: Exception =>
-            log.error(s"Failed to upload $filename to memory service, falling back to GCS")
-            using(createNoCompression(filename)) { os =>
-              os.write(data)
-            }
-            log.info(s"Successfully fell back to GCS")
-          }
-          closed = true
+      override def flush(): Unit = {
+        pos.flush()
+        if (writerFuture.isCompleted) {
+          // there might be an exception, we should eagerly retrieve that and report it
+          Await.result(writerFuture, Duration.Inf)
         }
       }
 
-      def getPosition: Long = bb.length
+      override def write(i: Int): Unit = {
+        pos.write(i)
+        count += 1
+      }
+
+      override def write(bytes: Array[Byte], off: Int, len: Int): Unit = {
+        pos.write(bytes, off, len)
+      }
+
+      override def close(): Unit = {
+        pos.close()
+        Await.result(writerFuture, Duration.Inf)
+      }
+
+      def getPosition: Long = count
     }
 
     new WrappedPositionedDataOutputStream(os)

--- a/hail/src/main/scala/is/hail/io/fs/package.scala
+++ b/hail/src/main/scala/is/hail/io/fs/package.scala
@@ -12,4 +12,9 @@ package object fs {
   type PositionedOutputStream = OutputStream with Positioned
 
   type PositionedDataOutputStream = DataOutputStream with Positioned
+
+  def outputStreamToPositionedDataOutputStream(os: OutputStream): PositionedDataOutputStream =
+    new WrappedPositionedDataOutputStream(
+      new WrappedPositionOutputStream(
+        os))
 }


### PR DESCRIPTION
Currently, the memory client buffers the entire output in memory which is likely to cause OOMs. For reasons that are not entirely clear to me, sometimes these OOMs get muffled by our system and instead lead to non-termination. I vaguely remember this happening before with `using`. I suspect there is something somewhat subtle wrong with that method, but I am not certain.

Anyway, there are two big changes here:
1. Do not buffer the entire request body in memory when writing to memory.
2. Because of (1) we have to pull retry behavior all the way up to the top-level where we know how to recreate the body.
3. Because of (2) it is easier to provide a `write(url)(writerFunction)` style API, which I do here.
4. Again, because of (2), and because I want to preserve the file-object-like interface, I added a somewhat funky anonymous class which uses a second thread to facilitate the movement of data written into the OutputStream returned by `create` into the OutputStream of the HTTP connection.

Point (4) probably bears more explanation. The root issue is the bad Apache HTTP Client interface. Instead of `request` returning an OutputStream, it takes an "entity". An entity knows how to write itself into the OutputStream of an HTTP request. This works fine if the "writer" code is pased as a function (as in my new `write` method), but that does not work if the control flow looks like:

    f = create(...)
    f.write(...)
    r.close()

We avoid this limited API by initiating the request in a second thread which will eventually block waiting to receive data from a PipedInputStream. That PipedInputStream produces the data written to a PipedOutputStream. The `create` call returns a positioned OutputStream which just writes data into the PipedOutputStream and handles cleaning up the thread when it is closed.

In a multi-core system, network requests should proceed in parallel to the client code. In a single-core system, the written data will buffer until `close` is called which will definitely yield control to the other thread.