### PR TITLE
[hailtop] Keep strong references to tasks

### DIFF
--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -10,9 +10,9 @@ import aiomysql
 import pymysql
 
 from gear.metrics import DB_CONNECTION_QUEUE_SIZE, SQL_TRANSACTIONS, PrometheusSQLTimer
+from hailtop.aiotools import BackgroundTaskManager
 from hailtop.auth.sql_config import SQLConfig
 from hailtop.utils import sleep_and_backoff
-from hailtop.aiotools import BackgroundTaskManager
 
 log = logging.getLogger('gear.database')
 

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -12,6 +12,7 @@ import pymysql
 from gear.metrics import DB_CONNECTION_QUEUE_SIZE, SQL_TRANSACTIONS, PrometheusSQLTimer
 from hailtop.auth.sql_config import SQLConfig
 from hailtop.utils import sleep_and_backoff
+from hailtop.aiotools import BackgroundTaskManager
 
 log = logging.getLogger('gear.database')
 
@@ -127,13 +128,14 @@ async def create_database_pool(config_file: str = None, autocommit: bool = True,
 
 
 class TransactionAsyncContextManager:
-    def __init__(self, db_pool, read_only):
+    def __init__(self, db_pool, read_only, task_manager: BackgroundTaskManager):
         self.db_pool = db_pool
         self.read_only = read_only
         self.tx = None
+        self.task_manager = task_manager
 
     async def __aenter__(self):
-        tx = Transaction()
+        tx = Transaction(self.task_manager)
         await tx.async_init(self.db_pool, self.read_only)
         self.tx = tx
         return tx
@@ -153,9 +155,10 @@ async def _release_connection(conn_context_manager):
 
 
 class Transaction:
-    def __init__(self):
+    def __init__(self, task_manager: BackgroundTaskManager):
         self.conn_context_manager = None
         self.conn = None
+        self._task_manager = task_manager
 
     async def async_init(self, db_pool, read_only):
         try:
@@ -173,7 +176,7 @@ class Transaction:
             self.conn = None
             conn_context_manager = self.conn_context_manager
             self.conn_context_manager = None
-            asyncio.ensure_future(_release_connection(conn_context_manager))
+            self._task_manager.ensure_future(_release_connection(conn_context_manager))
             raise
 
     async def _aexit_1(self, exc_type):
@@ -190,7 +193,7 @@ class Transaction:
             self.conn = None
             conn_context_manager = self.conn_context_manager
             self.conn_context_manager = None
-            asyncio.ensure_future(_release_connection(conn_context_manager))
+            self._task_manager.ensure_future(_release_connection(conn_context_manager))
 
     async def _aexit(self, exc_type, exc_val, exc_tb):  # pylint: disable=unused-argument
         # cancelling cleanup could leak a connection
@@ -268,9 +271,10 @@ class Database:
 
     async def async_init(self, config_file=None, maxsize=10):
         self.pool = await create_database_pool(config_file=config_file, autocommit=False, maxsize=maxsize)
+        self.connection_release_task_manager = BackgroundTaskManager()
 
     def start(self, read_only=False):
-        return TransactionAsyncContextManager(self.pool, read_only)
+        return TransactionAsyncContextManager(self.pool, read_only, self.connection_release_task_manager)
 
     @retry_transient_mysql_errors
     async def just_execute(self, sql, args=None):
@@ -320,5 +324,7 @@ class Database:
         return rv
 
     async def async_close(self):
+        assert self.pool
+        self.connection_release_task_manager.shutdown()
         self.pool.close()
         await self.pool.wait_closed()

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -24,7 +24,6 @@ import google.auth.exceptions
 import google.api_core.exceptions
 import botocore.exceptions
 import time
-import weakref
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 
@@ -236,9 +235,7 @@ class AsyncThrottledGather(Generic[T]):
 class AsyncWorkerPool:
     def __init__(self, parallelism, queue_size=1000):
         self._queue: asyncio.Queue[Tuple[Callable, Tuple[Any, ...], Mapping[str, Any]]] = asyncio.Queue(maxsize=queue_size)
-        self.workers = weakref.WeakSet([
-            asyncio.ensure_future(self._worker())
-            for _ in range(parallelism)])
+        self.workers = {asyncio.ensure_future(self._worker()) for _ in range(parallelism)}
 
     async def _worker(self):
         while True:


### PR DESCRIPTION
The asyncio event loop only keeps weak references to tasks, so wherever we call `asyncio.create_task` we need to ensure that we keep a strong reference to its result. Specifically, `BackgroundTaskManager` needs to keep strong references not weak references to the tasks it creates. This is easy to do without accumulating garbage by using a done callback on the task to remove itself from the set. However, this felt iffy with the threadsafe futures, which were only used in sync.py anyway, so I pushed that functionality directly into sync.py and removed it from the `BackgroundTaskManager`.


To simplify the ownership story for tasks, this changes `BackgroundTaskManager` to *not* return the task and instead hold onto strong references. If a client wants a reference to the task it creates, it should call `asyncio.create_task` directly and manage the lifecycle of the spawned task. This required only a few small changes in worker.py since most of the codebase does not assign the result of `task_manager.ensure_future`. The only change that gave me pause was the handling of `mjs_fut`, whose lifetime is a little tricky since it is potentially passed to yet another task. I think this shows a general weakness in the handling of ownership and lifetimes in between the Job and Worker classes and think a larger refactor can make this less error-prone but is out of scope for this fix. So I'd appreciate an especially scrutinizing look at that piece of the code.