### PR TITLE
[qob] Enable liftovers for Query-on-Batch

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -99,6 +99,9 @@ ifdef HAIL_DEBUG_MODE
 	$(JAR) -uf $(SHADOW_JAR) -C $(BUILD_DEBUG_PREFIX) is/hail/annotations/Memory.class
 endif
 
+.PHONY: shadowTestJar
+shadowTestJar: $(SHADOW_TEST_JAR)
+
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_TEST_JAR): native-lib-prebuilt
 endif

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -59,6 +59,7 @@ class Backend(abc.ABC):
     @abc.abstractmethod
     def __init__(self):
         self._persisted_locations = dict()
+        self._references: Dict[str, 'ReferenceGenome'] = {}
 
     @abc.abstractmethod
     def stop(self):
@@ -85,10 +86,6 @@ class Backend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def add_reference(self, config):
-        pass
-
-    @abc.abstractmethod
     def load_references_from_dataset(self, path):
         pass
 
@@ -96,23 +93,30 @@ class Backend(abc.ABC):
     def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
         pass
 
-    @abc.abstractmethod
-    def remove_reference(self, name):
+    def add_reference(self, rg):
+        self._references[rg.name] = rg
+        self._add_reference_to_scala_backend(rg)
+
+    def _add_reference_to_scala_backend(self, rg):
         pass
 
     def get_reference(self, name):
-        if name in BUILTIN_REFERENCE_RESOURCE_PATHS:
-            path_in_jar = BUILTIN_REFERENCE_RESOURCE_PATHS[name]
-            jar_path = pkg_resources.resource_filename(__name__, 'hail-all-spark.jar')
-            return orjson.loads(zipfile.ZipFile(jar_path).open(path_in_jar).read())
-        return self._get_non_builtin_reference(name)
+        return self._references[name]
 
-    @abc.abstractmethod
-    def _get_non_builtin_reference(self, name):
+    def initialize_references(self):
+        from hail.genetics.reference_genome import ReferenceGenome
+        jar_path = pkg_resources.resource_filename(__name__, 'hail-all-spark.jar')
+        for path_in_jar in BUILTIN_REFERENCE_RESOURCE_PATHS.values():
+            rg_config = orjson.loads(zipfile.ZipFile(jar_path).open(path_in_jar).read())
+            rg = ReferenceGenome._from_config(rg_config, _builtin=True)
+            self._references[rg.name] = rg
+
+    def remove_reference(self, name):
+        del self._references[name]
+        self._remove_reference_from_scala_backend(name)
+
+    def _remove_reference_from_scala_backend(self, name):
         pass
-
-    def get_references(self, names):
-        return [self.get_reference(name) for name in names]
 
     @abc.abstractmethod
     def add_sequence(self, name, fasta_file, index_file):

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -59,7 +59,7 @@ class Backend(abc.ABC):
     @abc.abstractmethod
     def __init__(self):
         self._persisted_locations = dict()
-        self._references: Dict[str, 'ReferenceGenome'] = {}
+        self._references = {}
 
     @abc.abstractmethod
     def stop(self):

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -249,21 +249,11 @@ class LocalBackend(Py4JBackend):
         jir = self._to_java_blockmatrix_ir(bmir)
         return tblockmatrix._from_java(jir.typ())
 
-    def add_reference(self, config):
-        self._jbackend.pyAddReference(json.dumps(config))
-
     def load_references_from_dataset(self, path):
         return json.loads(self._jbackend.pyLoadReferencesFromDataset(path))
 
     def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
         return json.loads(self._jbackend.pyFromFASTAFile(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par))
-
-    def remove_reference(self, name):
-        self._jbackend.pyRemoveReference(name)
-
-    def _get_non_builtin_reference(self, name):
-        from hail.genetics.reference_genome import ReferenceGenome
-        return ReferenceGenome._references[name]._config
 
     def add_sequence(self, name, fasta_file, index_file):
         self._jbackend.pyAddSequence(name, fasta_file, index_file)

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -249,24 +249,6 @@ class LocalBackend(Py4JBackend):
         jir = self._to_java_blockmatrix_ir(bmir)
         return tblockmatrix._from_java(jir.typ())
 
-    def load_references_from_dataset(self, path):
-        return json.loads(self._jbackend.pyLoadReferencesFromDataset(path))
-
-    def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
-        return json.loads(self._jbackend.pyFromFASTAFile(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par))
-
-    def add_sequence(self, name, fasta_file, index_file):
-        self._jbackend.pyAddSequence(name, fasta_file, index_file)
-
-    def remove_sequence(self, name):
-        self._jbackend.pyRemoveSequence(name)
-
-    def add_liftover(self, name, chain_file, dest_reference_genome):
-        self._jbackend.pyAddLiftover(name, chain_file, dest_reference_genome)
-
-    def remove_liftover(self, name, dest_reference_genome):
-        self._jbackend.pyRemoveLiftover(name, dest_reference_genome)
-
     def parse_vcf_metadata(self, path):
         return json.loads(self._jhc.pyParseVCFMetadataJSON(self._jbackend.fs(), path))
 

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -16,7 +16,7 @@ from hail.expr.table_type import ttable
 from hail.expr.types import dtype
 from hail.ir import finalize_randomness
 from hail.ir.renderer import CSERenderer
-from hail.utils.java import scala_package_object, scala_object
+from hail.utils.java import scala_package_object
 from .py4j_backend import Py4JBackend, handle_java_exception
 from ..fs.local_fs import LocalFS
 from ..hail_logging import Logger
@@ -250,33 +250,32 @@ class LocalBackend(Py4JBackend):
         return tblockmatrix._from_java(jir.typ())
 
     def add_reference(self, config):
-        self._hail_package.variant.ReferenceGenome.fromJSON(json.dumps(config))
+        self._jbackend.pyAddReference(json.dumps(config))
 
     def load_references_from_dataset(self, path):
         return json.loads(self._jbackend.pyLoadReferencesFromDataset(path))
 
     def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
-        self._jbackend.pyFromFASTAFile(
-            name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par)
+        return json.loads(self._jbackend.pyFromFASTAFile(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par))
 
     def remove_reference(self, name):
-        self._hail_package.variant.ReferenceGenome.removeReference(name)
+        self._jbackend.pyRemoveReference(name)
 
     def _get_non_builtin_reference(self, name):
-        return json.loads(self._hail_package.variant.ReferenceGenome.getReference(name).toJSONString())
+        from hail.genetics.reference_genome import ReferenceGenome
+        return ReferenceGenome._references[name]._config
 
     def add_sequence(self, name, fasta_file, index_file):
         self._jbackend.pyAddSequence(name, fasta_file, index_file)
 
     def remove_sequence(self, name):
-        scala_object(self._hail_package.variant, 'ReferenceGenome').removeSequence(name)
+        self._jbackend.pyRemoveSequence(name)
 
     def add_liftover(self, name, chain_file, dest_reference_genome):
-        self._jbackend.pyReferenceAddLiftover(name, chain_file, dest_reference_genome)
+        self._jbackend.pyAddLiftover(name, chain_file, dest_reference_genome)
 
     def remove_liftover(self, name, dest_reference_genome):
-        scala_object(self._hail_package.variant, 'ReferenceGenome').referenceRemoveLiftover(
-            name, dest_reference_genome)
+        self._jbackend.pyRemoveLiftover(name, dest_reference_genome)
 
     def parse_vcf_metadata(self, path):
         return json.loads(self._jhc.pyParseVCFMetadataJSON(self._jbackend.fs(), path))

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -1,5 +1,4 @@
-from typing import Optional
-import json
+from typing import Optional, Union, Tuple, List
 import os
 import socket
 import socketserver
@@ -10,16 +9,14 @@ import pkg_resources
 import py4j
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 
-from hail.expr.blockmatrix_type import tblockmatrix
-from hail.expr.matrix_type import tmatrix
-from hail.expr.table_type import ttable
-from hail.expr.types import dtype
-from hail.ir import finalize_randomness
-from hail.ir.renderer import CSERenderer
 from hail.utils.java import scala_package_object
+from hail.ir.renderer import CSERenderer
+from hail.ir import finalize_randomness
 from .py4j_backend import Py4JBackend, handle_java_exception
 from ..fs.local_fs import LocalFS
 from ..hail_logging import Logger
+from ..expr import Expression
+from ..expr.types import HailType
 from hailtop.utils import find_spark_home
 
 
@@ -183,26 +180,30 @@ class LocalBackend(Py4JBackend):
     def utils_package_object(self):
         return self._utils_package_object
 
+    def register_ir_function(self,
+                             name: str,
+                             type_parameters: Union[Tuple[HailType, ...], List[HailType]],
+                             value_parameter_names: Union[Tuple[str, ...], List[str]],
+                             value_parameter_types: Union[Tuple[HailType, ...], List[HailType]],
+                             return_type: HailType,
+                             body: Expression):
+        r = CSERenderer(stop_at_jir=True)
+        code = r(finalize_randomness(body._ir))
+        jbody = (self._parse_value_ir(code, ref_map=dict(zip(value_parameter_names, value_parameter_types)), ir_map=r.jirs))
+
+        self.hail_package().expr.ir.functions.IRFunctionRegistry.pyRegisterIR(
+            name,
+            [ta._parsable_string() for ta in type_parameters],
+            value_parameter_names,
+            [pt._parsable_string() for pt in value_parameter_types],
+            return_type._parsable_string(),
+            jbody)
+
     def stop(self):
         self._jhc.stop()
         self._jhc = None
         self._gateway.shutdown()
         uninstall_exception_handler()
-
-    def _parse_value_ir(self, code, ref_map={}, ir_map={}):
-        return self._jbackend.parse_value_ir(
-            code,
-            {k: t._parsable_string() for k, t in ref_map.items()},
-            ir_map)
-
-    def _parse_table_ir(self, code, ir_map={}):
-        return self._jbackend.parse_table_ir(code, ir_map)
-
-    def _parse_matrix_ir(self, code, ir_map={}):
-        return self._jbackend.parse_matrix_ir(code, ir_map)
-
-    def _parse_blockmatrix_ir(self, code, ir_map={}):
-        return self._jbackend.parse_blockmatrix_ir(code, ir_map)
 
     @property
     def logger(self):
@@ -213,50 +214,6 @@ class LocalBackend(Py4JBackend):
     @property
     def fs(self):
         return self._fs
-
-    def _to_java_ir(self, ir, parse):
-        if not hasattr(ir, '_jir'):
-            r = CSERenderer(stop_at_jir=True)
-            # FIXME parse should be static
-            ir._jir = parse(r(finalize_randomness(ir)), ir_map=r.jirs)
-        return ir._jir
-
-    def _to_java_value_ir(self, ir):
-        return self._to_java_ir(ir, self._parse_value_ir)
-
-    def _to_java_table_ir(self, ir):
-        return self._to_java_ir(ir, self._parse_table_ir)
-
-    def _to_java_matrix_ir(self, ir):
-        return self._to_java_ir(ir, self._parse_matrix_ir)
-
-    def _to_java_blockmatrix_ir(self, ir):
-        return self._to_java_ir(ir, self._parse_blockmatrix_ir)
-
-    def value_type(self, ir):
-        jir = self._to_java_value_ir(ir)
-        return dtype(jir.typ().toString())
-
-    def table_type(self, tir):
-        jir = self._to_java_table_ir(tir)
-        return ttable._from_java(jir.typ())
-
-    def matrix_type(self, mir):
-        jir = self._to_java_matrix_ir(mir)
-        return tmatrix._from_java(jir.typ())
-
-    def blockmatrix_type(self, bmir):
-        jir = self._to_java_blockmatrix_ir(bmir)
-        return tblockmatrix._from_java(jir.typ())
-
-    def parse_vcf_metadata(self, path):
-        return json.loads(self._jhc.pyParseVCFMetadataJSON(self._jbackend.fs(), path))
-
-    def index_bgen(self, files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci):
-        self._jbackend.pyIndexBgen(files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci)
-
-    def import_fam(self, path: str, quant_pheno: bool, delimiter: str, missing: str):
-        return json.loads(self._jbackend.pyImportFam(path, quant_pheno, delimiter, missing))
 
     @property
     def requires_lowering(self):

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Union, Tuple, List
+from typing import Mapping
 import abc
 import json
 
@@ -14,8 +14,6 @@ from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.matrix_type import tmatrix
 from hail.expr.table_type import ttable
 from hail.expr.types import dtype
-from hail.ir import finalize_randomness
-from hail.ir.renderer import CSERenderer
 
 from .backend import Backend, fatal_error_from_java_error_triplet
 

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -1,5 +1,6 @@
 from typing import Mapping, Union, Tuple, List
 import abc
+import json
 
 import py4j
 import py4j.java_gateway
@@ -133,7 +134,6 @@ class Py4JBackend(Backend):
 
     def _remove_reference_from_scala_backend(self, name):
         self._jbackend.pyRemoveReference(name)
-
 
     @property
     def requires_lowering(self):

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -128,6 +128,13 @@ class Py4JBackend(Backend):
     def get_flags(self, *flags) -> Mapping[str, str]:
         return {flag: self._jbackend.getFlag(flag) for flag in flags}
 
+    def _add_reference_to_scala_backend(self, rg):
+        self._jbackend.pyAddReference(json.dumps(rg._config))
+
+    def _remove_reference_from_scala_backend(self, name):
+        self._jbackend.pyRemoveReference(name)
+
+
     @property
     def requires_lowering(self):
         return True

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -135,6 +135,24 @@ class Py4JBackend(Backend):
     def _remove_reference_from_scala_backend(self, name):
         self._jbackend.pyRemoveReference(name)
 
+    def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
+        return json.loads(self._jbackend.pyFromFASTAFile(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par))
+
+    def load_references_from_dataset(self, path):
+        return json.loads(self._jbackend.pyLoadReferencesFromDataset(path))
+
+    def add_sequence(self, name, fasta_file, index_file):
+        self._jbackend.pyAddSequence(name, fasta_file, index_file)
+
+    def remove_sequence(self, name):
+        self._jbackend.pyRemoveSequence(name)
+
+    def add_liftover(self, name, chain_file, dest_reference_genome):
+        self._jbackend.pyAddLiftover(name, chain_file, dest_reference_genome)
+
+    def remove_liftover(self, name, dest_reference_genome):
+        self._jbackend.pyRemoveLiftover(name, dest_reference_genome)
+
     @property
     def requires_lowering(self):
         return True

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -10,9 +10,14 @@ from hail.expr import construct_expr
 from hail.ir import JavaIR, finalize_randomness
 from hail.ir.renderer import CSERenderer
 from hail.utils.java import FatalError, Env
+from hail.expr.blockmatrix_type import tblockmatrix
+from hail.expr.matrix_type import tmatrix
+from hail.expr.table_type import ttable
+from hail.expr.types import dtype
+from hail.ir import finalize_randomness
+from hail.ir.renderer import CSERenderer
+
 from .backend import Backend, fatal_error_from_java_error_triplet
-from ..expr import Expression
-from ..expr.types import HailType
 
 
 def handle_java_exception(f):
@@ -64,33 +69,6 @@ class Py4JBackend(Backend):
     @abc.abstractmethod
     def utils_package_object(self):
         pass
-
-    @abc.abstractmethod
-    def _parse_value_ir(self, code, ref_map={}, ir_map={}):
-        pass
-
-    @abc.abstractmethod
-    def _to_java_value_ir(self, ir):
-        pass
-
-    def register_ir_function(self,
-                             name: str,
-                             type_parameters: Union[Tuple[HailType, ...], List[HailType]],
-                             value_parameter_names: Union[Tuple[str, ...], List[str]],
-                             value_parameter_types: Union[Tuple[HailType, ...], List[HailType]],
-                             return_type: HailType,
-                             body: Expression):
-        r = CSERenderer(stop_at_jir=True)
-        code = r(finalize_randomness(body._ir))
-        jbody = (self._parse_value_ir(code, ref_map=dict(zip(value_parameter_names, value_parameter_types)), ir_map=r.jirs))
-
-        Env.hail().expr.ir.functions.IRFunctionRegistry.pyRegisterIR(
-            name,
-            [ta._parsable_string() for ta in type_parameters],
-            value_parameter_names,
-            [pt._parsable_string() for pt in value_parameter_types],
-            return_type._parsable_string(),
-            jbody)
 
     def execute(self, ir, timed=False):
         jir = self._to_java_value_ir(ir)
@@ -152,6 +130,65 @@ class Py4JBackend(Backend):
 
     def remove_liftover(self, name, dest_reference_genome):
         self._jbackend.pyRemoveLiftover(name, dest_reference_genome)
+
+    def parse_vcf_metadata(self, path):
+        return json.loads(self._jhc.pyParseVCFMetadataJSON(self._jbackend.fs(), path))
+
+    def index_bgen(self, files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci):
+        self._jbackend.pyIndexBgen(files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci)
+
+    def import_fam(self, path: str, quant_pheno: bool, delimiter: str, missing: str):
+        return json.loads(self._jbackend.pyImportFam(path, quant_pheno, delimiter, missing))
+
+    def _to_java_ir(self, ir, parse):
+        if not hasattr(ir, '_jir'):
+            r = CSERenderer(stop_at_jir=True)
+            # FIXME parse should be static
+            ir._jir = parse(r(finalize_randomness(ir)), ir_map=r.jirs)
+        return ir._jir
+
+    def _parse_value_ir(self, code, ref_map={}, ir_map={}):
+        return self._jbackend.parse_value_ir(
+            code,
+            {k: t._parsable_string() for k, t in ref_map.items()},
+            ir_map)
+
+    def _parse_table_ir(self, code, ir_map={}):
+        return self._jbackend.parse_table_ir(code, ir_map)
+
+    def _parse_matrix_ir(self, code, ir_map={}):
+        return self._jbackend.parse_matrix_ir(code, ir_map)
+
+    def _parse_blockmatrix_ir(self, code, ir_map={}):
+        return self._jbackend.parse_blockmatrix_ir(code, ir_map)
+
+    def _to_java_value_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_value_ir)
+
+    def _to_java_table_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_table_ir)
+
+    def _to_java_matrix_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_matrix_ir)
+
+    def _to_java_blockmatrix_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_blockmatrix_ir)
+
+    def value_type(self, ir):
+        jir = self._to_java_value_ir(ir)
+        return dtype(jir.typ().toString())
+
+    def table_type(self, tir):
+        jir = self._to_java_table_ir(tir)
+        return ttable._from_java(jir.typ())
+
+    def matrix_type(self, mir):
+        jir = self._to_java_matrix_ir(mir)
+        return tmatrix._from_java(jir.typ())
+
+    def blockmatrix_type(self, bmir):
+        jir = self._to_java_blockmatrix_ir(bmir)
+        return tblockmatrix._from_java(jir.typ())
 
     @property
     def requires_lowering(self):

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional, Callable, Awaitable, Mapping, Any, List, Union, Tuple
 import abc
+import collections
 import struct
 from hail.expr.expressions.base_expression import Expression
 import orjson
@@ -276,6 +277,8 @@ class ServiceBackend(Backend):
         self.worker_memory = worker_memory
         self.name_prefix = name_prefix
         self._custom_reference_configs = dict()
+        # Source genome -> [Destination Genome -> Chain file]
+        self._liftovers: Dict[str, Dict[str, str]] = collections.defaultdict(dict)
 
     def debug_info(self) -> Dict[str, Any]:
         return {
@@ -328,6 +331,14 @@ class ServiceBackend(Backend):
                     await write_int(infile, len(self._custom_reference_configs))
                     for reference_config in self._custom_reference_configs.values():
                         await write_str(infile, orjson.dumps(reference_config).decode('utf-8'))
+                    non_empty_liftovers = {name: liftovers for name, liftovers in self._liftovers.items() if len(liftovers) > 0}
+                    await write_int(infile, len(non_empty_liftovers))
+                    for source_genome_name, liftovers in non_empty_liftovers.items():
+                        await write_str(infile, source_genome_name)
+                        await write_int(infile, len(liftovers))
+                        for dest_reference_genome, chain_file in liftovers.items():
+                            await write_str(infile, dest_reference_genome)
+                            await write_str(infile, chain_file)
                     await write_str(infile, str(self.worker_cores))
                     await write_str(infile, str(self.worker_memory))
                     await inputs(infile, token)
@@ -520,11 +531,16 @@ class ServiceBackend(Backend):
     def remove_sequence(self, name):
         raise NotImplementedError("ServiceBackend does not support 'remove_sequence'")
 
-    def add_liftover(self, name, chain_file, dest_reference_genome):
-        raise NotImplementedError("ServiceBackend does not support 'add_liftover'")
+    def add_liftover(self, name: str, chain_file: str, dest_reference_genome: str):
+        if name == dest_reference_genome:
+            raise ValueError(f'Destination reference genome cannot have the same name as this reference {name}.')
+        if dest_reference_genome in self._liftovers[name]:
+            raise ValueError(f'Chain file already exists for destination reference {dest_reference_genome}.')
+        self._liftovers[name][dest_reference_genome] = chain_file
 
     def remove_liftover(self, name, dest_reference_genome):
-        raise NotImplementedError("ServiceBackend does not support 'remove_liftover'")
+        assert dest_reference_genome in self._liftovers[name]
+        del self._liftovers[name][dest_reference_genome]
 
     def parse_vcf_metadata(self, path):
         return async_to_blocking(self._async_parse_vcf_metadata(path))

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -318,34 +318,6 @@ class SparkBackend(Py4JBackend):
             t = t.flatten()
         return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._to_java_table_ir(t._tir)), self._spark_session)
 
-    def add_reference(self, config):
-        self._jbackend.pyAddReference(json.dumps(config))
-
-    def load_references_from_dataset(self, path):
-        return json.loads(self._jbackend.pyLoadReferencesFromDataset(path))
-
-    def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
-        return json.loads(self._jbackend.pyFromFASTAFile(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par))
-
-    def remove_reference(self, name):
-        self._jbackend.pyRemoveReference(name)
-
-    def _get_non_builtin_reference(self, name):
-        from hail.genetics.reference_genome import ReferenceGenome
-        return ReferenceGenome._references[name]._config
-
-    def add_sequence(self, name, fasta_file, index_file):
-        self._jbackend.pyAddSequence(name, fasta_file, index_file)
-
-    def remove_sequence(self, name):
-        self._jbackend.pyRemoveSequence(name)
-
-    def add_liftover(self, name, chain_file, dest_reference_genome):
-        self._jbackend.pyAddLiftover(name, chain_file, dest_reference_genome)
-
-    def remove_liftover(self, name, dest_reference_genome):
-        self._jbackend.pyRemoveLiftover(name, dest_reference_genome)
-
     def parse_vcf_metadata(self, path):
         return json.loads(self._jhc.pyParseVCFMetadataJSON(self.fs._jfs, path))
 

--- a/hail/python/hail/genetics/locus.py
+++ b/hail/python/hail/genetics/locus.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import hail as hl
 from hail.genetics.reference_genome import reference_genome_type, ReferenceGenome
 from hail.typecheck import typecheck_method
@@ -27,7 +29,7 @@ class Locus(object):
      - :func:`.locus_from_global_position`
     """
 
-    def __init__(self, contig, position, reference_genome='default'):
+    def __init__(self, contig, position, reference_genome: Union[str, ReferenceGenome] = 'default'):
         if isinstance(contig, int):
             contig = str(contig)
 

--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -93,7 +93,6 @@ class ReferenceGenome(object):
                       par=sequenceof(sized_tupleof(str, int, int)),
                       _builtin=bool)
     def __init__(self, name, contigs, lengths, x_contigs=[], y_contigs=[], mt_contigs=[], par=[], _builtin=False):
-        super(ReferenceGenome, self).__init__()
 
         contigs = wrap_to_list(contigs)
         x_contigs = wrap_to_list(x_contigs)
@@ -422,9 +421,9 @@ class ReferenceGenome(object):
         :class:`.ReferenceGenome`
         """
         par_strings = ["{}:{}-{}".format(contig, start, end) for (contig, start, end) in par]
-        Env.backend().from_fasta_file(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par_strings)
+        config = Env.backend().from_fasta_file(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par_strings)
 
-        rg = ReferenceGenome._from_config(Env.backend().get_reference(name), _builtin=True)
+        rg = ReferenceGenome._from_config(config, _builtin=True)
         rg._sequence_files = (fasta_file, index_file)
         return rg
 

--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -10,7 +10,7 @@ rg_type = lazy()
 reference_genome_type = oneof(transformed((str, lambda x: hl.get_reference(x))), rg_type)
 
 
-class ReferenceGenome(object):
+class ReferenceGenome:
     """An object that represents a `reference genome <https://en.wikipedia.org/wiki/Reference_genome>`__.
 
     Examples
@@ -67,8 +67,6 @@ class ReferenceGenome(object):
         List of tuples with (contig, start, end)
     """
 
-    _references = {}
-
     @classmethod
     def _from_config(cls, config, _builtin=False):
         def par_tuple(p):
@@ -114,10 +112,8 @@ class ReferenceGenome(object):
         self._par = [hl.Interval(hl.Locus(c, s, self), hl.Locus(c, e, self)) for (c, s, e) in par]
         self._global_positions = None
 
-        ReferenceGenome._references[name] = self
-
         if not _builtin:
-            Env.backend().add_reference(self._config)
+            Env.backend().add_reference(self)
 
         self._sequence_files = None
         self._liftovers = dict()

--- a/hail/python/test/hail/genetics/test_reference_genome.py
+++ b/hail/python/test/hail/genetics/test_reference_genome.py
@@ -63,7 +63,6 @@ def test_reference_genome_sequence():
     assert gr4._sequence_files == (resource("fake_reference.fasta"), resource("fake_reference.fasta.fai"))
 
 
-@fails_service_backend()
 def test_reference_genome_liftover():
     grch37 = hl.get_reference('GRCh37')
     grch38 = hl.get_reference('GRCh38')
@@ -124,7 +123,6 @@ def test_reference_genome_liftover():
     grch38.remove_liftover("GRCh37")
 
 
-@fails_service_backend()
 def test_liftover_strand():
     grch37 = hl.get_reference('GRCh37')
     grch37.add_liftover(resource('grch37_to_grch38_chr20.over.chain.gz'), 'GRCh38')
@@ -143,12 +141,8 @@ def test_liftover_strand():
                              is_negative_strand=True)
         assert actual == expected
 
-        try:
+        with pytest.raises(FatalError):
             hl.eval(hl.liftover(hl.parse_locus_interval('1:10000-10000', reference_genome='GRCh37'), 'GRCh38'))
-        except FatalError:
-            pass
-        else:
-            assert False
     finally:
         grch37.remove_liftover("GRCh38")
 
@@ -176,12 +170,8 @@ def test_read_custom_reference_genome():
 
     # loading different reference genome with same name should fail
     # (different `test_rg_o` definition)
-    try:
+    with pytest.raises(FatalError):
         hl.read_matrix_table(resource('custom_references_2.t')).count()
-    except FatalError:
-        pass
-    else:
-        assert False
 
     assert hl.read_matrix_table(resource('custom_references.mt')).count_rows() == 14
     assert_rg_loaded_correctly('test_rg_1')

--- a/hail/python/test/hail/genetics/test_reference_genome.py
+++ b/hail/python/test/hail/genetics/test_reference_genome.py
@@ -149,7 +149,7 @@ def test_liftover_strand():
 
 def test_read_custom_reference_genome():
     # this test doesn't behave properly if these reference genomes are already defined in scope.
-    available_rgs = set(hl.ReferenceGenome._references.keys())
+    available_rgs = set(hl.current_backend()._references.keys())
     assert 'test_rg_0' not in available_rgs
     assert 'test_rg_1' not in available_rgs
     assert 'test_rg_2' not in available_rgs

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -136,13 +136,12 @@ object HailContext {
     info(s"Running Hail version ${ theContext.version }")
 
     // needs to be after `theContext` is set, since this creates broadcasts
-    ReferenceGenome.addDefaultReferences()
+    backend.addDefaultReferences()
 
     theContext
   }
 
   def stop(): Unit = synchronized {
-    ReferenceGenome.reset()
     IRFunctionRegistry.clearUserFunctions()
     backend.stop()
 

--- a/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
@@ -28,7 +28,7 @@ object BroadcastRow {
 
   def apply(ctx: ExecuteContext, value: Row, t: TBaseStruct): BroadcastRow = {
     val pType = PType.literalPType(t, value).asInstanceOf[PStruct]
-    val offset = pType.unstagedStoreJavaObject(value, ctx.r)
+    val offset = pType.unstagedStoreJavaObject(ctx.stateManager, value, ctx.r)
     BroadcastRow(ctx, RegionValue(ctx.r, offset), pType)
   }
 }
@@ -83,7 +83,7 @@ trait BroadcastRegionValue {
   def safeJavaValue: Any
 
   override def equals(obj: Any): Boolean = obj match {
-    case b: BroadcastRegionValue => t == b.t && (ctx eq b.ctx) && t.unsafeOrdering().compare(value, b.value) == 0
+    case b: BroadcastRegionValue => t == b.t && (ctx eq b.ctx) && t.unsafeOrdering(ctx.stateManager).compare(value, b.value) == 0
     case _ => false
   }
 
@@ -105,7 +105,7 @@ case class BroadcastRow(ctx: ExecuteContext,
       return this
 
     BroadcastRow(ctx,
-      RegionValue(value.region, newT.copyFromAddress(value.region, t, value.offset, deepCopy = false)),
+      RegionValue(value.region, newT.copyFromAddress(ctx.stateManager, value.region, t, value.offset, deepCopy = false)),
       newT)
   }
 
@@ -130,7 +130,7 @@ case class BroadcastIndexedSeq(
       return this
 
     BroadcastIndexedSeq(ctx,
-      RegionValue(value.region, newT.copyFromAddress(value.region, t, value.offset, deepCopy = false)),
+      RegionValue(value.region, newT.copyFromAddress(ctx.stateManager, value.region, t, value.offset, deepCopy = false)),
       newT)
   }
 }

--- a/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
@@ -7,6 +7,8 @@ import is.hail.backend.local.LocalTaskContext
 import is.hail.expr.ir.Threefry
 import is.hail.io.fs.FS
 import is.hail.utils._
+import is.hail.types.MapTypes
+import is.hail.types.virtual.{TLocus, Type}
 import is.hail.variant.ReferenceGenome
 
 import java.io._
@@ -36,7 +38,6 @@ class NonOwningTempFileManager(owner: TempFileManager) extends TempFileManager {
 
   override def cleanup(): Unit = ()
 }
-
 
 object ExecuteContext {
   def scoped[T]()(f: ExecuteContext => T): T = {
@@ -118,6 +119,8 @@ class ExecuteContext(
     case exc: NumberFormatException =>
       fatal(s"Could not parse flag rng_nonce as a 64-bit signed integer: ${getFlag("rng_nonce")}", exc)
   }
+
+  val stateManager = HailStateManager(referenceGenomes)
 
   private val tempFileManager: TempFileManager = if (_tempFileManager != null)
     _tempFileManager

--- a/hail/src/main/scala/is/hail/backend/HailStateManager.scala
+++ b/hail/src/main/scala/is/hail/backend/HailStateManager.scala
@@ -1,0 +1,6 @@
+package is.hail.backend
+
+import is.hail.variant.ReferenceGenome
+
+case class HailStateManager(val referenceGenomes: Map[String, ReferenceGenome]) extends Serializable {
+}

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -20,7 +20,7 @@ import is.hail.types.virtual.TVoid
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.apache.hadoop
-import org.json4s.DefaultFormats
+import org.json4s._
 import org.json4s.jackson.{JsonMethods, Serialization}
 
 import java.io.PrintWriter
@@ -99,7 +99,7 @@ class LocalBackend(
   val fs: FS = new HadoopFS(new SerializableHadoopConfiguration(hadoopConf))
 
   def withExecuteContext[T](timer: ExecutionTimer)(f: ExecuteContext => T): T = {
-    ExecuteContext.scoped(tmpdir, tmpdir, this, fs, timer, null, theHailClassLoader, ReferenceGenome.references, flags)(f)
+    ExecuteContext.scoped(tmpdir, tmpdir, this, fs, timer, null, theHailClassLoader, this.references, flags)(f)
   }
 
   def broadcast[T: ClassTag](value: T): BroadcastValue[T] = new LocalBroadcastValue[T](value)
@@ -255,21 +255,27 @@ class LocalBackend(
     }
   }
 
-  def pyReferenceAddLiftover(name: String, chainFile: String, destRGName: String): Unit = {
+  def pyAddReference(jsonConfig: String): Unit = addReference(ReferenceGenome.fromJSON(jsonConfig))
+  def pyRemoveReference(name: String): Unit = removeReference(name)
+
+  def pyAddLiftover(name: String, chainFile: String, destRGName: String): Unit = {
     ExecutionTimer.logTime("LocalBackend.pyReferenceAddLiftover") { timer =>
       withExecuteContext(timer) { ctx =>
-        ReferenceGenome.referenceAddLiftover(ctx, name, chainFile, destRGName)
+        references(name).addLiftover(ctx, chainFile, destRGName)
       }
     }
   }
+  def pyRemoveLiftover(name: String, destRGName: String) = references(name).removeLiftover(destRGName)
 
   def pyFromFASTAFile(name: String, fastaFile: String, indexFile: String,
     xContigs: java.util.List[String], yContigs: java.util.List[String], mtContigs: java.util.List[String],
-    parInput: java.util.List[String]): ReferenceGenome = {
+    parInput: java.util.List[String]): String = {
     ExecutionTimer.logTime("LocalBackend.pyFromFASTAFile") { timer =>
       withExecuteContext(timer) { ctx =>
-        ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
+        val rg = ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
           xContigs.asScala.toArray, yContigs.asScala.toArray, mtContigs.asScala.toArray, parInput.asScala.toArray)
+        addReference(rg)
+        rg.toJSONString
       }
     }
   }
@@ -277,10 +283,11 @@ class LocalBackend(
   def pyAddSequence(name: String, fastaFile: String, indexFile: String): Unit = {
     ExecutionTimer.logTime("LocalBackend.pyAddSequence") { timer =>
       withExecuteContext(timer) { ctx =>
-        ReferenceGenome.addSequence(ctx, name, fastaFile, indexFile)
+        references(name).addSequence(ctx, fastaFile, indexFile)
       }
     }
   }
+  def pyRemoveSequence(name: String) = references(name).removeSequence()
 
   def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
     ExecutionTimer.logTime("LocalBackend.parse_value_ir") { timer =>
@@ -327,8 +334,13 @@ class LocalBackend(
     LowerDistributedSort.distributedSort(ctx, stage, sortFields, relationalLetsAbove, rowTypeRequiredness)
   }
 
-  def pyLoadReferencesFromDataset(path: String): String =
-    ReferenceGenome.fromHailDataset(fs, path)
+  def pyLoadReferencesFromDataset(path: String): String = {
+    val rgs = ReferenceGenome.fromHailDataset(fs, path)
+    rgs.foreach(addReference)
+
+    implicit val formats: Formats = defaultJSONFormats
+    Serialization.write(rgs.map(_.toJSON).toFastIndexedSeq)
+  }
 
   def pyImportFam(path: String, isQuantPheno: Boolean, delimiter: String, missingValue: String): String =
     LoadPlink.importFamJSON(fs, path, isQuantPheno, delimiter, missingValue)

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -33,7 +33,7 @@ import org.apache.commons.io.IOUtils
 import org.apache.log4j.Logger
 import org.json4s.Extraction
 import org.json4s.JsonAST._
-import org.json4s.jackson.JsonMethods
+import org.json4s.jackson.{JsonMethods, Serialization}
 import org.json4s.{DefaultFormats, Formats}
 import org.newsclub.net.unix.{AFUNIXServerSocket, AFUNIXSocketAddress}
 
@@ -359,7 +359,13 @@ class ServiceBackend(
   def loadReferencesFromDataset(
     ctx: ExecuteContext,
     path: String
-  ): String = ReferenceGenome.fromHailDataset(ctx.fs, path)
+  ): String = {
+    val rgs = ReferenceGenome.fromHailDataset(ctx.fs, path)
+    rgs.foreach(addReference)
+
+    implicit val formats: Formats = defaultJSONFormats
+    Serialization.write(rgs.map(_.toJSON).toFastIndexedSeq)
+  }
 
   def parseVCFMetadata(
     ctx: ExecuteContext,
@@ -428,9 +434,11 @@ object ServiceBackendSocketAPI2 {
       jarLocation, name, new HailClassLoader(getClass().getClassLoader()), batchClient, batchId, scratchDir)
     if (HailContext.isInitialized) {
       HailContext.get.backend = backend
+      backend.addDefaultReferences()
     } else {
       HailContext(backend, "hail.log", false, false, 50, skipLoggingConfiguration = true, 3)
     }
+
     retryTransientErrors {
       using(fs.openNoCompression(input)) { in =>
         retryTransientErrors {
@@ -530,11 +538,25 @@ class ServiceBackendSocketAPI2(
       nFlagsRemaining -= 1
     }
     val nCustomReferences = readInt()
-    val customReferences = mutable.Map[String, ReferenceGenome](ReferenceGenome.references.toSeq: _*)
     var i = 0
     while (i < nCustomReferences) {
-      val reference = ReferenceGenome.fromJSON(readString())
-      customReferences(reference.name) = reference
+      backend.addReference(ReferenceGenome.fromJSON(readString()))
+      i += 1
+    }
+    val nLiftoverSourceGenomes = readInt()
+    val liftovers = mutable.Map[String, mutable.Map[String, String]]()
+    i = 0
+    while (i < nLiftoverSourceGenomes) {
+      val sourceGenome = readString()
+      val nLiftovers = readInt()
+      liftovers(sourceGenome) = mutable.Map[String, String]()
+      var j = 0
+      while (j < nLiftovers) {
+        val destGenome = readString()
+        val chainFile = readString()
+        liftovers(sourceGenome)(destGenome) = chainFile
+        j += 1
+      }
       i += 1
     }
     val workerCores = readString()
@@ -557,9 +579,14 @@ class ServiceBackendSocketAPI2(
         timer,
         null,
         backend.theHailClassLoader,
-        customReferences.toMap,
+        backend.references,
         flags
       ) { ctx =>
+        liftovers.foreach { case (sourceGenome, liftoversForSource) =>
+          liftoversForSource.foreach { case (destGenome, chainFile) =>
+            ctx.getReference(sourceGenome).addLiftover(ctx, chainFile, destGenome)
+          }
+        }
         ctx.backendContext = new ServiceBackendContext(sessionId, billingProject, remoteTmpDir, workerCores, workerMemory)
         method(ctx)
       }

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -46,6 +46,11 @@ class WorkerTimer() {
   }
 }
 
+// Java's ObjectInputStream does not properly use the context classloader that
+// we set on the thread and knows about the hail jar. We need to explicitly force
+// the ObjectInputStream to use the correct classloader, but it is not configurable
+// so we override the behavior ourselves.
+// For more context, see: https://github.com/scala/bug/issues/9237#issuecomment-292436652
 object ExplicitClassLoaderInputStream {
   val primClasses: util.HashMap[String, Class[_]] = {
     val m = new util.HashMap[String, Class[_]](8, 1.0F)
@@ -72,7 +77,6 @@ class ExplicitClassLoaderInputStream(is: InputStream, cl: ClassLoader) extends O
         if (cl != null) return cl
         else throw ex
     }
-
   }
 }
 

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -40,6 +40,7 @@ import org.apache.spark.util.TaskCompletionListener
 import org.apache.hadoop
 import org.apache.hadoop.conf.Configuration
 import org.json4s
+import org.json4s.Formats
 import org.json4s.JsonAST.{JInt, JObject}
 
 
@@ -323,7 +324,7 @@ class SparkBackend(
     timer,
     if (selfContainedExecution) null else new NonOwningTempFileManager(longLifeTempFileManager),
     theHailClassLoader,
-    ReferenceGenome.references,
+    this.references,
     flags
   )
 
@@ -336,7 +337,7 @@ class SparkBackend(
       timer,
       if (selfContainedExecution) null else new NonOwningTempFileManager(longLifeTempFileManager),
       theHailClassLoader,
-      ReferenceGenome.references,
+      this.references,
       flags
     )(f)
   }
@@ -618,21 +619,35 @@ class SparkBackend(
     matrixReaders.asJava
   }
 
-  def pyReferenceAddLiftover(name: String, chainFile: String, destRGName: String): Unit = {
+  def pyLoadReferencesFromDataset(path: String): String = {
+    val rgs = ReferenceGenome.fromHailDataset(fs, path)
+    rgs.foreach(addReference)
+
+    implicit val formats: Formats = defaultJSONFormats
+    Serialization.write(rgs.map(_.toJSON).toFastIndexedSeq)
+  }
+
+  def pyAddReference(jsonConfig: String): Unit = addReference(ReferenceGenome.fromJSON(jsonConfig))
+  def pyRemoveReference(name: String): Unit = removeReference(name)
+
+  def pyAddLiftover(name: String, chainFile: String, destRGName: String): Unit = {
     ExecutionTimer.logTime("SparkBackend.pyReferenceAddLiftover") { timer =>
       withExecuteContext(timer) { ctx =>
-        ReferenceGenome.referenceAddLiftover(ctx, name, chainFile, destRGName)
+        references(name).addLiftover(ctx, chainFile, destRGName)
       }
     }
   }
+  def pyRemoveLiftover(name: String, destRGName: String) = references(name).removeLiftover(destRGName)
 
   def pyFromFASTAFile(name: String, fastaFile: String, indexFile: String,
     xContigs: java.util.List[String], yContigs: java.util.List[String], mtContigs: java.util.List[String],
-    parInput: java.util.List[String]): ReferenceGenome = {
+    parInput: java.util.List[String]): String = {
     ExecutionTimer.logTime("SparkBackend.pyFromFASTAFile") { timer =>
       withExecuteContext(timer) { ctx =>
-        ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
+        val rg = ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
           xContigs.asScala.toArray, yContigs.asScala.toArray, mtContigs.asScala.toArray, parInput.asScala.toArray)
+        addReference(rg)
+        rg.toJSONString
       }
     }
   }
@@ -640,10 +655,11 @@ class SparkBackend(
   def pyAddSequence(name: String, fastaFile: String, indexFile: String): Unit = {
     ExecutionTimer.logTime("SparkBackend.pyAddSequence") { timer =>
       withExecuteContext(timer) { ctx =>
-        ReferenceGenome.addSequence(ctx, name, fastaFile, indexFile)
+        references(name).addSequence(ctx, fastaFile, indexFile)
       }
     }
   }
+  def pyRemoveSequence(name: String) = references(name).removeSequence()
 
   def pyExportBlockMatrix(
     pathIn: String, pathOut: String, delimiter: String, header: String, addIndex: Boolean, exportType: String,
@@ -729,7 +745,7 @@ class SparkBackend(
     val sortColIndexOrd = sortFields.map { case SortField(n, so) =>
       val i = rowType.fieldIdx(n)
       val f = rowType.fields(i)
-      val fo = f.typ.ordering
+      val fo = f.typ.ordering(ctx.stateManager)
       if (so == Ascending) fo else fo.reverse
     }.toArray
 

--- a/hail/src/main/scala/is/hail/compatibility/LegacyEncodedTypeParser.scala
+++ b/hail/src/main/scala/is/hail/compatibility/LegacyEncodedTypeParser.scala
@@ -1,7 +1,7 @@
 package is.hail.compatibility
 
 import is.hail.expr.ir.IRParser._
-import is.hail.expr.ir.{IRParser, PunctuationToken, TokenIterator, TypeParserEnvironment}
+import is.hail.expr.ir.{IRParser, PunctuationToken, TokenIterator}
 import is.hail.types.encoded._
 import is.hail.types.virtual._
 import is.hail.rvd.RVDType
@@ -9,7 +9,7 @@ import is.hail.utils.FastIndexedSeq
 
 object LegacyEncodedTypeParser {
 
-  def legacy_type_expr(env: TypeParserEnvironment)(it: TokenIterator): (Type, EType) = {
+  def legacy_type_expr(it: TokenIterator): (Type, EType) = {
     val req = it.head match {
       case x: PunctuationToken if x.value == "+" =>
         consumeToken(it)
@@ -20,7 +20,7 @@ object LegacyEncodedTypeParser {
     val (vType, eType) = identifier(it) match {
       case "Interval" =>
         punctuation(it, "[")
-        val (pointType, ePointType) = legacy_type_expr(env)(it)
+        val (pointType, ePointType) = legacy_type_expr(it)
         punctuation(it, "]")
         (TInterval(pointType), EBaseStruct(FastIndexedSeq(
           EField("start", ePointType, 0),
@@ -39,25 +39,25 @@ object LegacyEncodedTypeParser {
         punctuation(it, "(")
         val rg = identifier(it)
         punctuation(it, ")")
-        (env.getReferenceGenome(rg).locusType, EBaseStruct(FastIndexedSeq(
+        (TLocus(rg), EBaseStruct(FastIndexedSeq(
           EField("contig", EBinaryRequired, 0),
           EField("position", EInt32Required, 1)), req))
       case "Call" => (TCall, EInt32(req))
       case "Array" =>
         punctuation(it, "[")
-        val (elementType, elementEType) = legacy_type_expr(env)(it)
+        val (elementType, elementEType) = legacy_type_expr(it)
         punctuation(it, "]")
         (TArray(elementType), EArray(elementEType, req))
       case "Set" =>
         punctuation(it, "[")
-        val (elementType, elementEType) = legacy_type_expr(env)(it)
+        val (elementType, elementEType) = legacy_type_expr(it)
         punctuation(it, "]")
         (TSet(elementType), EArray(elementEType, req))
       case "Dict" =>
         punctuation(it, "[")
-        val (keyType, keyEType) = legacy_type_expr(env)(it)
+        val (keyType, keyEType) = legacy_type_expr(it)
         punctuation(it, ",")
-        val (valueType, valueEType) = legacy_type_expr(env)(it)
+        val (valueType, valueEType) = legacy_type_expr(it)
         punctuation(it, "]")
         (TDict(keyType, valueType), EArray(EBaseStruct(FastIndexedSeq(
           EField("key", keyEType, 0),
@@ -65,12 +65,12 @@ object LegacyEncodedTypeParser {
           req))
       case "Tuple" =>
         punctuation(it, "[")
-        val types = repsepUntil(it, legacy_type_expr(env), PunctuationToken(","), PunctuationToken("]"))
+        val types = repsepUntil(it, legacy_type_expr, PunctuationToken(","), PunctuationToken("]"))
         punctuation(it, "]")
         (TTuple(types.map(_._1): _*), EBaseStruct(types.zipWithIndex.map { case ((_, t), idx) => EField(idx.toString, t, idx) }, req))
       case "Struct" =>
         punctuation(it, "{")
-        val args = repsepUntil(it, struct_field(legacy_type_expr(env)), PunctuationToken(","), PunctuationToken("}"))
+        val args = repsepUntil(it, struct_field(legacy_type_expr), PunctuationToken(","), PunctuationToken("}"))
         punctuation(it, "}")
         val (vFields, eFields) = args.zipWithIndex.map { case ((id, (vt, et)), i) => (Field(id, vt, i), EField(id, et, i)) }.unzip
         (TStruct(vFields), EBaseStruct(eFields, req))
@@ -79,7 +79,7 @@ object LegacyEncodedTypeParser {
     (vType, eType)
   }
 
-  def rvd_type_expr(env: TypeParserEnvironment)(it: TokenIterator): LegacyRVDType = {
+  def rvd_type_expr(it: TokenIterator): LegacyRVDType = {
     identifier(it) match {
       case "RVDType" | "OrderedRVDType" =>
         punctuation(it, "{")
@@ -92,17 +92,15 @@ object LegacyEncodedTypeParser {
         punctuation(it, ",")
         identifier(it, "row")
         punctuation(it, ":")
-        val (rowType: TStruct, rowEType) = legacy_type_expr(env)(it)
+        val (rowType: TStruct, rowEType) = legacy_type_expr(it)
         LegacyRVDType(rowType, rowEType, partitionKey ++ restKey)
     }
   }
 
 
-  def parseTypeAndEType(str: String, env: TypeParserEnvironment): (Type, EType) = {
-    IRParser.parse(str, it => legacy_type_expr(env)(it))
+  def parseTypeAndEType(str: String): (Type, EType) = {
+    IRParser.parse(str, it => legacy_type_expr(it))
   }
 
-  def parseTypeAndEType(str: String): (Type, EType) = parseTypeAndEType(str, TypeParserEnvironment.default)
-
-  def parseLegacyRVDType(str: String): LegacyRVDType = IRParser.parse(str, it => rvd_type_expr(TypeParserEnvironment.default)(it))
+  def parseLegacyRVDType(str: String): LegacyRVDType = IRParser.parse(str, it => rvd_type_expr(it))
 }

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -323,25 +323,4 @@ object TableAnnotationImpex {
       }
     }
   }
-
-  def importAnnotation(a: String, t: Type): Annotation = {
-    (t: @unchecked) match {
-      case TString => a
-      case TInt32 => UtilFunctions.parseInt32(a, -1)
-      case TInt64 => UtilFunctions.parseInt64(a, -1)
-      case TFloat32 => UtilFunctions.parseFloat32(a, -1)
-      case TFloat64 => UtilFunctions.parseFloat64(a, -1)
-      case TBoolean => UtilFunctions.parseBoolean(a, -1)
-      case tl: TLocus => Locus.parse(a, tl.rg)
-      // FIXME legacy
-      case TInterval(l: TLocus) => Locus.parseInterval(a, l.rg, invalidMissing = false)
-      case t: TInterval => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
-      case TCall => Call.parse(a)
-      case t: TArray => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
-      case t: TSet => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
-      case t: TDict => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
-      case t: TBaseStruct => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
-      case t: TNDArray => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
-    }
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -59,11 +59,6 @@ object RelationalSpec {
     val jv = readMetadata(fs, path)
     val references = readReferences(fs, path, jv)
 
-    references.foreach { rg =>
-      if (!ReferenceGenome.hasReference(rg.name))
-        ReferenceGenome.addReference(rg)
-    }
-
     (jv \ "name").extract[String] match {
       case "TableSpec" => TableSpec.fromJValue(fs, path, jv)
       case "MatrixTableSpec" => MatrixTableSpec.fromJValue(fs, path, jv)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -20,6 +20,7 @@ import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
 import is.hail.types.{RIterable, TypeWithRequiredness, VirtualTypeWithReq, tcoerce}
 import is.hail.utils._
+import is.hail.variant.ReferenceGenome
 
 import java.io._
 import scala.collection.mutable
@@ -1149,8 +1150,8 @@ class Emit[C](
                 MakeTuple.ordered(FastSeq(tieBreaker)))
               assert(t.virtualType == TTuple(TFloat64))
               val resultType = t.asInstanceOf[PTuple]
-              Code.invokeScalaObject8[UnsafeIndexedSeq, HailClassLoader, FS, HailTaskContext, Region, PTuple, PTuple, (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction3RegionLongLongLong, IndexedSeq[Any]](
-                Graph.getClass, "maximalIndependentSet",
+              Code.invokeScalaObject9[Map[String, ReferenceGenome], UnsafeIndexedSeq, HailClassLoader, FS, HailTaskContext, Region, PTuple, PTuple, (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction3RegionLongLongLong, IndexedSeq[Any]](
+                Graph.getClass, "maximalIndependentSet", cb.emb.ecb.emodb.referenceGenomeMap,
                   jEdges, mb.getHailClassLoader, mb.getFS, mb.getTaskContext, region,
                   mb.getPType[PTuple](wrappedNodeType), mb.getPType[PTuple](resultType), mb.getObject(f))
           }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -475,23 +475,9 @@ class EmitClassBuilder[C](
     }
   }
 
-  def getPType[T <: PType : TypeInfo](t: T): Code[T] = {
-    ReferenceGenome.getReferences(t.virtualType).toArray.map(getReferenceGenome)
-    val setup = Code.checkcast[T](
-        Code.invokeScalaObject1[String, PType](
-          IRParser.getClass, "parsePType", t.toString))
-    Code.checkcast[T](pTypeMap.getOrElseUpdate(t,
-      genLazyFieldThisRef[T](setup)).get)
-  }
+  def getPType[T <: PType : TypeInfo](t: T): Code[T] = mb.getObject(t)
 
-  def getType[T <: Type : TypeInfo](t: T): Code[T] = {
-    ReferenceGenome.getReferences(t).toArray.map(getReferenceGenome)
-    val setup = Code.checkcast[T](
-        Code.invokeScalaObject1[String, Type](
-          IRParser.getClass, "parseType", t.parsableString()))
-    Code.checkcast[T](typMap.getOrElseUpdate(t,
-      genLazyFieldThisRef[T](setup)).get)
-  }
+  def getType[T <: Type : TypeInfo](t: T): Code[T] = mb.getObject(t)
 
   def getOrdering(t1: SType,
     t2: SType,

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -475,9 +475,9 @@ class EmitClassBuilder[C](
     }
   }
 
-  def getPType[T <: PType : TypeInfo](t: T): Code[T] = mb.getObject(t)
+  def getPType[T <: PType : TypeInfo](t: T): Code[T] = emodb.getObject(t)
 
-  def getType[T <: Type : TypeInfo](t: T): Code[T] = mb.getObject(t)
+  def getType[T <: Type : TypeInfo](t: T): Code[T] = emodb.getObject(t)
 
   def getOrdering(t1: SType,
     t2: SType,

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -47,20 +47,30 @@ class EmitModuleBuilder(val ctx: ExecuteContext, val modb: ModuleBuilder) {
 
   def getFS: Value[FS] = new StaticFieldRef(_staticFS)
 
-  private val rgContainers: mutable.Map[ReferenceGenome, StaticField[ReferenceGenome]] = mutable.Map.empty
+  private val rgContainers: mutable.Map[String, StaticField[ReferenceGenome]] = mutable.Map.empty
 
   def hasReferences: Boolean = rgContainers.nonEmpty
 
-  def getReferenceGenome(rg: ReferenceGenome): Value[ReferenceGenome] = {
+  def getReferenceGenome(rg: String): Value[ReferenceGenome] = {
     val rgField = rgContainers.getOrElseUpdate(rg, {
-      val cls = genEmitClass[Unit](s"RGContainer_${rg.name}")
+      val cls = genEmitClass[Unit](s"RGContainer_${rg}")
       cls.newStaticField("reference_genome", Code._null[ReferenceGenome])
     })
     new StaticFieldRef(rgField)
   }
 
-  def referenceGenomes(): IndexedSeq[ReferenceGenome] = rgContainers.keys.toFastIndexedSeq.sortBy(_.name)
-  def referenceGenomeFields(): IndexedSeq[StaticField[ReferenceGenome]] = rgContainers.toFastIndexedSeq.sortBy(_._1.name).map(_._2)
+  def referenceGenomes(): IndexedSeq[ReferenceGenome] = rgContainers.keys.map(ctx.getReference(_)).toIndexedSeq.sortBy(_.name)
+  def referenceGenomeFields(): IndexedSeq[StaticField[ReferenceGenome]] = rgContainers.toFastIndexedSeq.sortBy(_._1).map(_._2)
+
+  var _rgMapField: StaticFieldRef[Map[String, ReferenceGenome]] = null
+
+  def referenceGenomeMap: Value[Map[String, ReferenceGenome]] = {
+    if (_rgMapField == null) {
+      val cls = genEmitClass[Unit](s"RGMapContainer")
+      _rgMapField = new StaticFieldRef(cls.newStaticField("reference_genome_map", Code._null[Map[String, ReferenceGenome]]))
+    }
+    _rgMapField
+  }
 
   def setObjects(cb: EmitCodeBuilder, objects: Code[Array[AnyRef]]): Unit = modb.setObjects(cb, objects)
 
@@ -78,7 +88,7 @@ trait WrappedEmitModuleBuilder {
 
   def genEmitClass[C](baseName: String)(implicit cti: TypeInfo[C]): EmitClassBuilder[C] = emodb.genEmitClass[C](baseName)
 
-  def getReferenceGenome(rg: ReferenceGenome): Value[ReferenceGenome] = emodb.getReferenceGenome(rg)
+  def getReferenceGenome(rg: String): Value[ReferenceGenome] = emodb.getReferenceGenome(rg)
 }
 
 trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
@@ -259,12 +269,6 @@ class EmitClassBuilder[C](
 
   def numTypes: Int = typMap.size
 
-  private[this] def addReferenceGenome(rg: ReferenceGenome): Code[Unit] = {
-    val rgExists = Code.invokeScalaObject1[String, Boolean](ReferenceGenome.getClass, "hasReference", rg.name)
-    val addRG = Code.invokeScalaObject1[ReferenceGenome, Unit](ReferenceGenome.getClass, "addReference", getReferenceGenome(rg))
-    rgExists.mux(Code._empty, addRG)
-  }
-
   private[this] val literalsMap: mutable.Map[(VirtualTypeWithReq, Any), SSettable] =
     mutable.Map[(VirtualTypeWithReq, Any), SSettable]()
   private[this] val encodedLiteralsMap: mutable.Map[EncodedLiteral, SSettable] =
@@ -326,7 +330,7 @@ class EmitClassBuilder[C](
     val baos = new ByteArrayOutputStream()
     val enc = spec.buildEncoder(ctx, litType)(baos, ctx.theHailClassLoader)
     this.emodb.ctx.r.pool.scopedRegion { region =>
-      val rvb = new RegionValueBuilder(region)
+      val rvb = new RegionValueBuilder(ctx.stateManager, region)
       rvb.start(litType)
       rvb.startTuple()
       literals.foreach { case ((typ, a), _) => rvb.addAnnotation(typ.t, a) }
@@ -472,21 +476,19 @@ class EmitClassBuilder[C](
   }
 
   def getPType[T <: PType : TypeInfo](t: T): Code[T] = {
-    val references = ReferenceGenome.getReferences(t.virtualType).toArray
-    val setup = Code(Code(references.map(addReferenceGenome)),
-      Code.checkcast[T](
+    ReferenceGenome.getReferences(t.virtualType).toArray.map(getReferenceGenome)
+    val setup = Code.checkcast[T](
         Code.invokeScalaObject1[String, PType](
-          IRParser.getClass, "parsePType", t.toString)))
+          IRParser.getClass, "parsePType", t.toString))
     Code.checkcast[T](pTypeMap.getOrElseUpdate(t,
       genLazyFieldThisRef[T](setup)).get)
   }
 
   def getType[T <: Type : TypeInfo](t: T): Code[T] = {
-    val references = ReferenceGenome.getReferences(t).toArray
-    val setup = Code(Code(references.map(addReferenceGenome)),
-      Code.checkcast[T](
+    ReferenceGenome.getReferences(t).toArray.map(getReferenceGenome)
+    val setup = Code.checkcast[T](
         Code.invokeScalaObject1[String, Type](
-          IRParser.getClass, "parseType", t.parsableString())))
+          IRParser.getClass, "parseType", t.parsableString()))
     Code.checkcast[T](typMap.getOrElseUpdate(t,
       genLazyFieldThisRef[T](setup)).get)
   }
@@ -651,6 +653,10 @@ class EmitClassBuilder[C](
       for ((fld, i) <- rgFields.zipWithIndex) {
         cb += rgs(i).invoke[String, FS, Unit]("heal", ctx.localTmpdir, getFS)
         cb += fld.put(rgs(i))
+      }
+
+      Option(emodb._rgMapField).foreach { fld =>
+        cb.assign(fld, Code.invokeStatic1[ReferenceGenome, Array[ReferenceGenome], Map[String, ReferenceGenome]]("getMapFromArray", rgs))
       }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.asm4s.{coerce => _, _}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.lir
@@ -42,6 +43,8 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   }
 
   def mb: MethodBuilder[_] = emb.mb
+
+  val stateManager: Value[HailStateManager] = null
 
   def uncheckedAppend(c: Code[Unit]): Unit = {
     code = Code(code, c)

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -192,7 +192,7 @@ class GenericTableValue(
       case Some(partitioner) =>
         p = partitioner
       case None if requestedType.key.isEmpty =>
-        p = RVDPartitioner.unkeyed(contexts.length)
+        p = RVDPartitioner.unkeyed(ctx.stateManager, contexts.length)
       case None =>
     }
     if (p != null) {
@@ -239,7 +239,7 @@ class GenericTableValue(
       case None if requestedType.key.isEmpty =>
         RVD(
           RVDType(requestedRowPType, fullTableType.key),
-          RVDPartitioner.unkeyed(contexts.length),
+          RVDPartitioner.unkeyed(ctx.stateManager, contexts.length),
           crdd)
       case None =>
         getRVDCoercer(ctx).coerce(RVDType(requestedRowPType, fullTableType.key), crdd)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -770,12 +770,12 @@ object PartitionReader {
     new ETypeSerializer +
     new AvroSchemaSerializer
 
-  def extract(fs: FS, jv: JValue): PartitionReader = {
+  def extract(ctx: ExecuteContext, jv: JValue): PartitionReader = {
     (jv \ "name").extract[String] match {
       case "PartitionNativeIntervalReader" =>
         val path = (jv \ "path").extract[String]
-        val spec = TableNativeReader.read(fs, path, None).spec
-        PartitionNativeIntervalReader(path, spec, (jv \ "uidFieldName").extract[String])
+        val spec = TableNativeReader.read(ctx.fs, path, None).spec
+        PartitionNativeIntervalReader(ctx.stateManager, path, spec, (jv \ "uidFieldName").extract[String])
       case _ => jv.extract[PartitionReader]
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -230,15 +230,15 @@ object Interpret {
           null
         else
           op match {
-            case EQ(t, _) => t.ordering.equiv(lValue, rValue)
-            case EQWithNA(t, _) => t.ordering.equiv(lValue, rValue)
-            case NEQ(t, _) => !t.ordering.equiv(lValue, rValue)
-            case NEQWithNA(t, _) => !t.ordering.equiv(lValue, rValue)
-            case LT(t, _) => t.ordering.lt(lValue, rValue)
-            case GT(t, _) => t.ordering.gt(lValue, rValue)
-            case LTEQ(t, _) => t.ordering.lteq(lValue, rValue)
-            case GTEQ(t, _) => t.ordering.gteq(lValue, rValue)
-            case Compare(t, _) => t.ordering.compare(lValue, rValue)
+            case EQ(t, _) => t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case EQWithNA(t, _) => t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case NEQ(t, _) => !t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case NEQWithNA(t, _) => !t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case LT(t, _) => t.ordering(ctx.stateManager).lt(lValue, rValue)
+            case GT(t, _) => t.ordering(ctx.stateManager).gt(lValue, rValue)
+            case LTEQ(t, _) => t.ordering(ctx.stateManager).lteq(lValue, rValue)
+            case GTEQ(t, _) => t.ordering(ctx.stateManager).gteq(lValue, rValue)
+            case Compare(t, _) => t.ordering(ctx.stateManager).compare(lValue, rValue)
           }
 
       case MakeArray(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
@@ -345,7 +345,7 @@ object Interpret {
         if (cValue == null)
           null
         else {
-          val ordering = tcoerce[TIterable](c.typ).elementType.ordering.toOrdering
+          val ordering = tcoerce[TIterable](c.typ).elementType.ordering(ctx.stateManager).toOrdering
           cValue match {
             case s: Set[_] =>
               s.asInstanceOf[Set[Any]].toFastIndexedSeq.sorted(ordering)
@@ -363,10 +363,10 @@ object Interpret {
           cValue match {
             case s: Set[_] =>
               assert(!onKey)
-              s.count(elem.typ.ordering.lt(_, eValue))
+              s.count(elem.typ.ordering(ctx.stateManager).lt(_, eValue))
             case d: Map[_, _] =>
               assert(onKey)
-              d.count { case (k, _) => elem.typ.ordering.lt(k, eValue) }
+              d.count { case (k, _) => elem.typ.ordering(ctx.stateManager).lt(k, eValue) }
             case a: IndexedSeq[_] =>
               if (onKey) {
                 val (eltF, eltT) = orderedCollection.typ.asInstanceOf[TContainer].elementType match {
@@ -379,11 +379,11 @@ object Interpret {
                     if (i == null) null else i.start
                   }, i.pointType)
                 }
-                val ordering = eltT.ordering
+                val ordering = eltT.ordering(ctx.stateManager)
                 val lb = a.count(elem => ordering.lt(eltF(elem), eValue))
                 lb
               } else
-                a.count(elem.typ.ordering.lt(_, eValue))
+                a.count(elem.typ.ordering(ctx.stateManager).lt(_, eValue))
           }
         }
 
@@ -434,7 +434,7 @@ object Interpret {
             val outer = new BoxedArrayBuilder[IndexedSeq[Row]]()
             val inner = new BoxedArrayBuilder[Row]()
             val (kType, getKey) = structType.select(key)
-            val keyOrd = TBaseStruct.getJoinOrdering(kType.types, missingEqual)
+            val keyOrd = TBaseStruct.getJoinOrdering(ctx.stateManager, kType.types, missingEqual)
             var curKey: Row = getKey(seq.head)
 
             seq.foreach { elt =>
@@ -491,7 +491,7 @@ object Interpret {
           val structType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
           val (kType, getKey) = structType.select(key)
           val heads = Array.fill[Int](k)(-1)
-          val ordering = kType.ordering.toOrdering.on[Row](getKey)
+          val ordering = kType.ordering(ctx.stateManager).toOrdering.on[Row](getKey)
 
           def get(i: Int): Row = streams(i)(heads(i))
           def lt(li: Int, lv: Row, ri: Int, rv: Row): Boolean = {
@@ -535,8 +535,8 @@ object Interpret {
           val structType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
           val (kType, getKey) = structType.select(key)
           val heads = Array.fill[Int](k)(-1)
-          val ordering = kType.ordering.toOrdering.on[Row](getKey)
-          val hasKey = TBaseStruct.getJoinOrdering(kType.types).equivNonnull _
+          val ordering = kType.ordering(ctx.stateManager).toOrdering.on[Row](getKey)
+          val hasKey = TBaseStruct.getJoinOrdering(ctx.stateManager, kType.types).equivNonnull _
 
           def get(i: Int): Row = streams(i)(heads(i))
 
@@ -664,7 +664,7 @@ object Interpret {
           val (lKeyTyp, lGetKey) = tcoerce[TStruct](tcoerce[TStream](left.typ).elementType).select(lKey)
           val (rKeyTyp, rGetKey) = tcoerce[TStruct](tcoerce[TStream](right.typ).elementType).select(rKey)
           assert(lKeyTyp isIsomorphicTo rKeyTyp)
-          val keyOrd = TBaseStruct.getJoinOrdering(lKeyTyp.types)
+          val keyOrd = TBaseStruct.getJoinOrdering(ctx.stateManager, lKeyTyp.types)
 
           def compF(lelt: Any, relt: Any): Int =
             keyOrd.compare(lGetKey(lelt.asInstanceOf[Row]), rGetKey(relt.asInstanceOf[Row]))
@@ -830,7 +830,7 @@ object Interpret {
               optimize = false)
             (rt.get, makeFunction(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, region))
           })
-          val rvb = new RegionValueBuilder()
+          val rvb = new RegionValueBuilder(ctx.stateManager)
           rvb.set(region)
           rvb.start(argTuple)
           rvb.startTuple()

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -92,7 +92,7 @@ case class MatrixNativeWriter(
         val jv = JsonMethods.parse(partitions)
         val rangeBounds = JSONAnnotationImpex.importAnnotation(jv, partitionsType)
           .asInstanceOf[IndexedSeq[Interval]]
-        tablestage.repartitionNoShuffle(new RVDPartitioner(tm.rowKey.toArray, tm.rowKeyStruct, rangeBounds))
+        tablestage.repartitionNoShuffle(new RVDPartitioner(ctx.stateManager, tm.rowKey.toArray, tm.rowKeyStruct, rangeBounds))
       } else tablestage
 
     if (checkpointFile != null) {
@@ -153,17 +153,17 @@ case class MatrixNativeWriter(
                   bindIR(parts) { partInfo =>
                     Begin(FastIndexedSeq(
                       WriteMetadata(MakeArray(GetField(writeEmpty, "filePath")),
-                        RVDSpecWriter(s"$path/globals/globals", RVDSpecMaker(emptySpec, RVDPartitioner.unkeyed(1)))),
+                        RVDSpecWriter(s"$path/globals/globals", RVDSpecMaker(emptySpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
                       WriteMetadata(MakeArray(GetField(writeGlobals, "filePath")),
-                        RVDSpecWriter(s"$path/globals/rows", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(1)))),
+                        RVDSpecWriter(s"$path/globals/rows", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
                       WriteMetadata(MakeArray(MakeStruct(Seq("partitionCounts" -> I64(1), "distinctlyKeyed" -> True(), "firstKey" -> MakeStruct(Seq()), "lastKey" -> MakeStruct(Seq())))), globalTableWriter),
                       WriteMetadata(MakeArray(GetField(colInfo, "filePath")),
-                        RVDSpecWriter(s"$path/cols/rows", RVDSpecMaker(colSpec, RVDPartitioner.unkeyed(1)))),
+                        RVDSpecWriter(s"$path/cols/rows", RVDSpecMaker(colSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
                       WriteMetadata(MakeArray(SelectFields(colInfo, IndexedSeq("partitionCounts", "distinctlyKeyed", "firstKey", "lastKey"))), colTableWriter),
                       bindIR(ToArray(mapIR(ToStream(partInfo)) { fc => GetField(fc, "filePath") })) { files =>
                         Begin(FastIndexedSeq(
                           WriteMetadata(files, RVDSpecWriter(s"$path/rows/rows", RVDSpecMaker(rowSpec, lowered.partitioner, rowsIndexSpec))),
-                          WriteMetadata(files, RVDSpecWriter(s"$path/entries/rows", RVDSpecMaker(entrySpec, RVDPartitioner.unkeyed(lowered.numPartitions), entriesIndexSpec)))))
+                          WriteMetadata(files, RVDSpecWriter(s"$path/entries/rows", RVDSpecMaker(entrySpec, RVDPartitioner.unkeyed(ctx.stateManager, lowered.numPartitions), entriesIndexSpec)))))
                       },
                       bindIR(ToArray(mapIR(ToStream(partInfo)) { fc => SelectFields(fc, Seq("partitionCounts", "distinctlyKeyed", "firstKey", "lastKey")) })) { countsAndKeyInfo =>
                         Begin(FastIndexedSeq(
@@ -527,7 +527,7 @@ case class VCFPartitionWriter(typ: MatrixType, entriesFieldName: String, writeHe
         val headerStr = Code.invokeScalaObject6[TStruct, TStruct, ReferenceGenome, Option[String], Option[VCFMetadata], Array[String], String](
           ExportVCF.getClass, "makeHeader",
           mb.getType[TStruct](typ.rowType), mb.getType[TStruct](typ.entryType),
-          mb.getReferenceGenome(typ.referenceGenome), mb.getObject(append),
+          mb.getReferenceGenome(typ.referenceGenomeName), mb.getObject(append),
           mb.getObject(metadata), stringSampleIds)
         cb += os.invoke[Array[Byte], Unit]("write", headerStr.invoke[Array[Byte]]("getBytes"))
         cb += os.invoke[Int, Unit]("write", '\n')
@@ -760,7 +760,7 @@ case class VCFExportFinalizer(typ: MatrixType, outputPath: String, append: Optio
     Code.invokeScalaObject6[TStruct, TStruct, ReferenceGenome, Option[String], Option[VCFMetadata], Array[String], String](
       ExportVCF.getClass, "makeHeader",
       mb.getType[TStruct](typ.rowType), mb.getType[TStruct](typ.entryType),
-      mb.getReferenceGenome(typ.referenceGenome), mb.getObject(append),
+      mb.getReferenceGenome(typ.referenceGenomeName), mb.getObject(append),
       mb.getObject(metadata), stringSampleIds)
   }
 
@@ -1442,7 +1442,7 @@ case class MatrixBlockMatrixWriter(
     val inputRowIntervals = inputPartStarts.zip(inputPartStops).map{ case (intervalStart, intervalEnd) =>
       Interval(Row(intervalStart.toInt), Row(intervalEnd.toInt), true, false)
     }
-    val rowIdxPartitioner = RVDPartitioner.generate(TStruct((perRowIdxId, TInt32)), inputRowIntervals)
+    val rowIdxPartitioner = RVDPartitioner.generate(ctx.stateManager, TStruct((perRowIdxId, TInt32)), inputRowIntervals)
 
     val keyedByRowIdx = partsZippedWithIdx.changePartitionerNoRepartition(rowIdxPartitioner)
 
@@ -1453,7 +1453,7 @@ case class MatrixBlockMatrixWriter(
       case (intervalStart, intervalEnd) =>  Interval(Row(intervalStart), Row(intervalEnd), true, false)
     }
 
-    val blockSizeGroupsPartitioner = RVDPartitioner.generate(TStruct((perRowIdxId, TInt32)), desiredRowIntervals)
+    val blockSizeGroupsPartitioner = RVDPartitioner.generate(ctx.stateManager, TStruct((perRowIdxId, TInt32)), desiredRowIntervals)
     val rowsInBlockSizeGroups: TableStage = keyedByRowIdx.repartitionNoShuffle(blockSizeGroupsPartitioner)
 
     def createBlockMakingContexts(tablePartsStreamIR: IR): IR = {

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -125,26 +125,12 @@ object IRLexer extends JavaTokenParsers {
   }
 }
 
-object TypeParserEnvironment {
-  def empty: TypeParserEnvironment = TypeParserEnvironment(Map.empty)
-
-  // FIXME: This will go away when references are no longer kept on global object
-  def default: TypeParserEnvironment = TypeParserEnvironment(ReferenceGenome.references)
-}
-
-case class TypeParserEnvironment(
-  rgMap: Map[String, ReferenceGenome]
-) {
-  def getReferenceGenome(name: String): ReferenceGenome = rgMap(name)
-
-}
-
 case class IRParserEnvironment(
   ctx: ExecuteContext,
   refMap: BindingEnv[Type] = BindingEnv.empty[Type],
   irMap: Map[String, BaseIR] = Map.empty,
-  typEnv: TypeParserEnvironment = TypeParserEnvironment.default
 ) {
+
   def promoteAgg: IRParserEnvironment = copy(refMap = refMap.promoteAgg)
 
   def promoteScan: IRParserEnvironment = copy(refMap = refMap.promoteScan)
@@ -388,18 +374,18 @@ object IRParser {
     (name, desc)
   }
 
-  def ptuple_subset_field(env: TypeParserEnvironment)(it: TokenIterator): (Int, PType) = {
+  def ptuple_subset_field(it: TokenIterator): (Int, PType) = {
     val i = int32_literal(it)
     punctuation(it, ":")
-    val t = ptype_expr(env)(it)
+    val t = ptype_expr(it)
     i -> t
   }
 
 
-  def tuple_subset_field(env: TypeParserEnvironment)(it: TokenIterator): (Int, Type) = {
+  def tuple_subset_field(it: TokenIterator): (Int, Type) = {
     val i = int32_literal(it)
     punctuation(it, ":")
-    val t = type_expr(env)(it)
+    val t = type_expr(it)
     i -> t
   }
 
@@ -413,20 +399,20 @@ object IRParser {
     (name, typ)
   }
 
-  def ptype_field(env: TypeParserEnvironment)(it: TokenIterator): (String, PType) = {
-    struct_field(ptype_expr(env))(it)
+  def ptype_field(it: TokenIterator): (String, PType) = {
+    struct_field(ptype_expr)(it)
   }
 
-  def type_field(env: TypeParserEnvironment)(it: TokenIterator): (String, Type) = {
-    struct_field(type_expr(env))(it)
+  def type_field(it: TokenIterator): (String, Type) = {
+    struct_field(type_expr)(it)
   }
 
-  def vtwr_expr(env: TypeParserEnvironment)(it: TokenIterator): VirtualTypeWithReq = {
-    val pt = ptype_expr(env)(it)
+  def vtwr_expr(it: TokenIterator): VirtualTypeWithReq = {
+    val pt = ptype_expr(it)
     VirtualTypeWithReq(pt)
   }
 
-  def ptype_expr(env: TypeParserEnvironment)(it: TokenIterator): PType = {
+  def ptype_expr(it: TokenIterator): PType = {
     val req = it.head match {
       case x: PunctuationToken if x.value == "+" =>
         consumeToken(it)
@@ -437,7 +423,7 @@ object IRParser {
     val typ = identifier(it) match {
       case "PCInterval" =>
         punctuation(it, "[")
-        val pointType = ptype_expr(env)(it)
+        val pointType = ptype_expr(it)
         punctuation(it, "]")
         PCanonicalInterval(pointType, req)
       case "PBoolean" => PBoolean(req)
@@ -451,46 +437,46 @@ object IRParser {
         punctuation(it, "(")
         val rg = identifier(it)
         punctuation(it, ")")
-        PCanonicalLocus(env.getReferenceGenome(rg), req)
+        PCanonicalLocus(rg, req)
       case "PCCall" => PCanonicalCall(req)
       case "PCArray" =>
         punctuation(it, "[")
-        val elementType = ptype_expr(env)(it)
+        val elementType = ptype_expr(it)
         punctuation(it, "]")
         PCanonicalArray(elementType, req)
       case "PCNDArray" =>
         punctuation(it, "[")
-        val elementType = ptype_expr(env)(it)
+        val elementType = ptype_expr(it)
         punctuation(it, ",")
         val nDims = int32_literal(it)
         punctuation(it, "]")
         PCanonicalNDArray(elementType, nDims, req)
       case "PCSet" =>
         punctuation(it, "[")
-        val elementType = ptype_expr(env)(it)
+        val elementType = ptype_expr(it)
         punctuation(it, "]")
         PCanonicalSet(elementType, req)
       case "PCDict" =>
         punctuation(it, "[")
-        val keyType = ptype_expr(env)(it)
+        val keyType = ptype_expr(it)
         punctuation(it, ",")
-        val valueType = ptype_expr(env)(it)
+        val valueType = ptype_expr(it)
         punctuation(it, "]")
         PCanonicalDict(keyType, valueType, req)
       case "PCTuple" =>
         punctuation(it, "[")
-        val fields = repsepUntil(it, ptuple_subset_field(env), PunctuationToken(","), PunctuationToken("]"))
+        val fields = repsepUntil(it, ptuple_subset_field, PunctuationToken(","), PunctuationToken("]"))
         punctuation(it, "]")
         PCanonicalTuple(fields.map { case (idx, t) => PTupleField(idx, t)}, req)
       case "PCStruct" =>
         punctuation(it, "{")
-        val args = repsepUntil(it, ptype_field(env), PunctuationToken(","), PunctuationToken("}"))
+        val args = repsepUntil(it, ptype_field, PunctuationToken(","), PunctuationToken("}"))
         punctuation(it, "}")
         val fields = args.zipWithIndex.map { case ((id, t), i) => PField(id, t, i) }
         PCanonicalStruct(fields, req)
       case "PSubsetStruct" =>
         punctuation(it, "{")
-        val parent = ptype_expr(env)(it).asInstanceOf[PStruct]
+        val parent = ptype_expr(it).asInstanceOf[PStruct]
         punctuation(it, "{")
         val args = repsepUntil(it, identifier, PunctuationToken(","), PunctuationToken("}"))
         punctuation(it, "}")
@@ -500,13 +486,13 @@ object IRParser {
     typ
   }
 
-  def ptype_exprs(env: TypeParserEnvironment)(it: TokenIterator): Array[PType] =
-    base_seq_parser(ptype_expr(env))(it)
+  def ptype_exprs(it: TokenIterator): Array[PType] =
+    base_seq_parser(ptype_expr)(it)
 
-  def type_exprs(env: TypeParserEnvironment)(it: TokenIterator): Array[Type] =
-    base_seq_parser(type_expr(env))(it)
+  def type_exprs(it: TokenIterator): Array[Type] =
+    base_seq_parser(type_expr)(it)
 
-  def type_expr(env: TypeParserEnvironment)(it: TokenIterator): Type = {
+  def type_expr(it: TokenIterator): Type = {
     // skip requiredness token for back-compatibility
     it.head match {
       case x: PunctuationToken if x.value == "+" =>
@@ -517,7 +503,7 @@ object IRParser {
     val typ = identifier(it) match {
       case "Interval" =>
         punctuation(it, "[")
-        val pointType = type_expr(env)(it)
+        val pointType = type_expr(it)
         punctuation(it, "]")
         TInterval(pointType)
       case "Boolean" => TBoolean
@@ -531,56 +517,56 @@ object IRParser {
         punctuation(it, "(")
         val rg = identifier(it)
         punctuation(it, ")")
-        env.getReferenceGenome(rg).locusType
+        TLocus(rg)
       case "Call" => TCall
       case "Stream" =>
         punctuation(it, "[")
-        val elementType = type_expr(env)(it)
+        val elementType = type_expr(it)
         punctuation(it, "]")
         TStream(elementType)
       case "Array" =>
         punctuation(it, "[")
-        val elementType = type_expr(env)(it)
+        val elementType = type_expr(it)
         punctuation(it, "]")
         TArray(elementType)
       case "NDArray" =>
         punctuation(it, "[")
-        val elementType = type_expr(env)(it)
+        val elementType = type_expr(it)
         punctuation(it, ",")
         val nDims = int32_literal(it)
         punctuation(it, "]")
         TNDArray(elementType, Nat(nDims))
       case "Set" =>
         punctuation(it, "[")
-        val elementType = type_expr(env)(it)
+        val elementType = type_expr(it)
         punctuation(it, "]")
         TSet(elementType)
       case "Dict" =>
         punctuation(it, "[")
-        val keyType = type_expr(env)(it)
+        val keyType = type_expr(it)
         punctuation(it, ",")
-        val valueType = type_expr(env)(it)
+        val valueType = type_expr(it)
         punctuation(it, "]")
         TDict(keyType, valueType)
       case "Tuple" =>
         punctuation(it, "[")
-        val types = repsepUntil(it, type_expr(env), PunctuationToken(","), PunctuationToken("]"))
+        val types = repsepUntil(it, type_expr, PunctuationToken(","), PunctuationToken("]"))
         punctuation(it, "]")
         TTuple(types: _*)
       case "TupleSubset" =>
         punctuation(it, "[")
-        val fields = repsepUntil(it, tuple_subset_field(env), PunctuationToken(","), PunctuationToken("]"))
+        val fields = repsepUntil(it, tuple_subset_field, PunctuationToken(","), PunctuationToken("]"))
         punctuation(it, "]")
         TTuple(fields.map { case (idx, t) => TupleField(idx, t)})
       case "Struct" =>
         punctuation(it, "{")
-        val args = repsepUntil(it, type_field(env), PunctuationToken(","), PunctuationToken("}"))
+        val args = repsepUntil(it, type_field, PunctuationToken(","), PunctuationToken("}"))
         punctuation(it, "}")
         val fields = args.zipWithIndex.map { case ((id, t), i) => Field(id, t, i) }
         TStruct(fields)
       case "Union" =>
         punctuation(it, "{")
-        val args = repsepUntil(it, type_field(env), PunctuationToken(","), PunctuationToken("}"))
+        val args = repsepUntil(it, type_field, PunctuationToken(","), PunctuationToken("}"))
         punctuation(it, "}")
         val cases = args.zipWithIndex.map { case ((id, t), i) => Case(id, t, i) }
         TUnion(cases)
@@ -616,7 +602,7 @@ object IRParser {
     }
   }
 
-  def rvd_type_expr(env: TypeParserEnvironment)(it: TokenIterator): RVDType = {
+  def rvd_type_expr(it: TokenIterator): RVDType = {
     identifier(it) match {
       case "RVDType" | "OrderedRVDType" =>
         punctuation(it, "{")
@@ -629,18 +615,18 @@ object IRParser {
         punctuation(it, ",")
         identifier(it, "row")
         punctuation(it, ":")
-        val rowType = tcoerce[PStruct](ptype_expr(env)(it))
+        val rowType = tcoerce[PStruct](ptype_expr(it))
         RVDType(rowType, partitionKey ++ restKey)
     }
   }
 
-  def table_type_expr(env: TypeParserEnvironment)(it: TokenIterator): TableType = {
+  def table_type_expr(it: TokenIterator): TableType = {
     identifier(it, "Table")
     punctuation(it, "{")
 
     identifier(it, "global")
     punctuation(it, ":")
-    val globalType = tcoerce[TStruct](type_expr(env)(it))
+    val globalType = tcoerce[TStruct](type_expr(it))
     punctuation(it, ",")
 
     identifier(it, "key")
@@ -650,18 +636,18 @@ object IRParser {
 
     identifier(it, "row")
     punctuation(it, ":")
-    val rowType = tcoerce[TStruct](type_expr(env)(it))
+    val rowType = tcoerce[TStruct](type_expr(it))
     punctuation(it, "}")
     TableType(rowType, key.toFastIndexedSeq, tcoerce[TStruct](globalType))
   }
 
-  def matrix_type_expr(env: TypeParserEnvironment)(it: TokenIterator): MatrixType = {
+  def matrix_type_expr(it: TokenIterator): MatrixType = {
     identifier(it, "Matrix")
     punctuation(it, "{")
 
     identifier(it, "global")
     punctuation(it, ":")
-    val globalType = tcoerce[TStruct](type_expr(env)(it))
+    val globalType = tcoerce[TStruct](type_expr(it))
     punctuation(it, ",")
 
     identifier(it, "col_key")
@@ -671,7 +657,7 @@ object IRParser {
 
     identifier(it, "col")
     punctuation(it, ":")
-    val colType = tcoerce[TStruct](type_expr(env)(it))
+    val colType = tcoerce[TStruct](type_expr(it))
     punctuation(it, ",")
 
     identifier(it, "row_key")
@@ -684,12 +670,12 @@ object IRParser {
 
     identifier(it, "row")
     punctuation(it, ":")
-    val rowType = tcoerce[TStruct](type_expr(env)(it))
+    val rowType = tcoerce[TStruct](type_expr(it))
     punctuation(it, ",")
 
     identifier(it, "entry")
     punctuation(it, ":")
-    val entryType = tcoerce[TStruct](type_expr(env)(it))
+    val entryType = tcoerce[TStruct](type_expr(it))
     punctuation(it, "}")
 
     MatrixType(tcoerce[TStruct](globalType), colKey, colType, rowPartitionKey ++ rowRestKey, rowType, entryType)
@@ -702,38 +688,38 @@ object IRParser {
     punctuation(it, "(")
     val sig = identifier(it) match {
       case "TypedStateSig" =>
-        val pt = vtwr_expr(env.typEnv)(it)
+        val pt = vtwr_expr(it)
         TypedStateSig(pt)
       case "DownsampleStateSig" =>
-        val labelType = vtwr_expr(env.typEnv)(it)
+        val labelType = vtwr_expr(it)
         DownsampleStateSig(labelType)
       case "TakeStateSig" =>
-        val pt = vtwr_expr(env.typEnv)(it)
+        val pt = vtwr_expr(it)
         TakeStateSig(pt)
       case "DensifyStateSig" =>
-        val pt = vtwr_expr(env.typEnv)(it)
+        val pt = vtwr_expr(it)
         DensifyStateSig(pt)
       case "TakeByStateSig" =>
-        val vt = vtwr_expr(env.typEnv)(it)
-        val kt = vtwr_expr(env.typEnv)(it)
+        val vt = vtwr_expr(it)
+        val kt = vtwr_expr(it)
         TakeByStateSig(vt, kt, Ascending)
       case "CollectStateSig" =>
-        val pt = vtwr_expr(env.typEnv)(it)
+        val pt = vtwr_expr(it)
         CollectStateSig(pt)
       case "CollectAsSetStateSig" =>
-        val pt = vtwr_expr(env.typEnv)(it)
+        val pt = vtwr_expr(it)
         CollectAsSetStateSig(pt)
       case "CallStatsStateSig" => CallStatsStateSig()
       case "ArrayAggStateSig" =>
         val nested = agg_state_signatures(env)(it)
         ArrayAggStateSig(nested)
       case "GroupedStateSig" =>
-        val kt = vtwr_expr(env.typEnv)(it)
+        val kt = vtwr_expr(it)
         val nested = agg_state_signatures(env)(it)
         GroupedStateSig(kt, nested)
       case "ApproxCDFStateSig" => ApproxCDFStateSig()
       case "FoldStateSig" =>
-        val vtwr = vtwr_expr(env.typEnv)(it)
+        val vtwr = vtwr_expr(it)
         val accumName = identifier(it)
         val otherAccumName = identifier(it)
         val combIR = ir_value_expr(env.empty.bindEval(accumName -> vtwr.t, otherAccumName -> vtwr.t))(it).run()
@@ -753,7 +739,7 @@ object IRParser {
     punctuation(it, "(")
     val sig = identifier(it) match {
       case "Grouped" =>
-        val pt = vtwr_expr(env.typEnv)(it)
+        val pt = vtwr_expr(it)
         val nested = p_agg_sigs(env)(it)
         GroupedAggSig(pt, nested)
       case "ArrayLen" =>
@@ -771,20 +757,20 @@ object IRParser {
     sig
   }
 
-  def agg_signature(env: TypeParserEnvironment)(it: TokenIterator): AggSignature = {
+  def agg_signature(it: TokenIterator): AggSignature = {
     punctuation(it, "(")
     val op = agg_op(it)
-    val initArgs = type_exprs(env)(it)
-    val seqOpArgs = type_exprs(env)(it)
+    val initArgs = type_exprs(it)
+    val seqOpArgs = type_exprs(it)
     punctuation(it, ")")
     AggSignature(op, initArgs, seqOpArgs)
   }
 
-  def agg_signatures(env: TypeParserEnvironment)(it: TokenIterator): Array[AggSignature] =
-    base_seq_parser(agg_signature(env))(it)
+  def agg_signatures(it: TokenIterator): Array[AggSignature] =
+    base_seq_parser(agg_signature)(it)
 
-  def ir_value(env: TypeParserEnvironment)(it: TokenIterator): (Type, Any) = {
-    val typ = type_expr(env)(it)
+  def ir_value(it: TokenIterator): (Type, Any) = {
+    val typ = type_expr(it)
     val s = string_literal(it)
     val vJSON = JsonMethods.parse(s)
     val v = JSONAnnotationImpex.importAnnotation(vJSON, typ)
@@ -833,18 +819,18 @@ object IRParser {
       case "True" => done(True())
       case "False" => done(False())
       case "Literal" =>
-        val (t, v) = ir_value(env.typEnv)(it)
+        val (t, v) = ir_value(it)
         done(Literal.coerce(t, v))
       case "EncodedLiteral" =>
         throw new UnsupportedOperationException("Not currently parsable")
       case "Void" => done(Void())
       case "Cast" =>
-        val typ = type_expr(env.typEnv)(it)
+        val typ = type_expr(it)
         ir_value_expr(env)(it).map(Cast(_, typ))
       case "CastRename" =>
-        val typ = type_expr(env.typEnv)(it)
+        val typ = type_expr(it)
         ir_value_expr(env)(it).map(CastRename(_, typ))
-      case "NA" => done(NA(type_expr(env.typEnv)(it)))
+      case "NA" => done(NA(type_expr(it)))
       case "IsNA" => ir_value_expr(env)(it).map(IsNA)
       case "Coalesce" =>
         for {
@@ -881,7 +867,7 @@ object IRParser {
         } yield TailLoop(name, params, body)
       case "Recur" =>
         val name = identifier(it)
-        val typ = type_expr(env.typEnv)(it)
+        val typ = type_expr(it)
         ir_value_children(env)(it).map { args =>
           Recur(name, args, typ)
         }
@@ -890,7 +876,7 @@ object IRParser {
         done(Ref(id, env.refMap.eval(id)))
       case "RelationalRef" =>
         val id = identifier(it)
-        val t = type_expr(env.typEnv)(it)
+        val t = type_expr(it)
         done(RelationalRef(id, t))
       case "RelationalLet" =>
         val name = identifier(it)
@@ -914,12 +900,12 @@ object IRParser {
           r <- ir_value_expr(env)(it)
         } yield ApplyComparisonOp(ComparisonOp.fromStringAndTypes((opName, l.typ, r.typ)), l, r)
       case "MakeArray" =>
-        val typ = opt(it, type_expr(env.typEnv)).map(_.asInstanceOf[TArray]).orNull
+        val typ = opt(it, type_expr).map(_.asInstanceOf[TArray]).orNull
         ir_value_children(env)(it).map { args =>
           MakeArray.unify(env.ctx, args, typ)
         }
       case "MakeStream" =>
-        val typ = opt(it, type_expr(env.typEnv)).map(_.asInstanceOf[TStream]).orNull
+        val typ = opt(it, type_expr).map(_.asInstanceOf[TStream]).orNull
         val requiresMemoryManagementPerElement = boolean_literal(it)
         ir_value_children(env)(it).map { args =>
           MakeStream(args, typ, requiresMemoryManagementPerElement)
@@ -1378,7 +1364,7 @@ object IRParser {
           GetTupleElement(tuple, idx)
         }
       case "Die" =>
-        val typ = type_expr(env.typEnv)(it)
+        val typ = type_expr(it)
         val errorID = int32_literal(it)
         ir_value_expr(env)(it).map { msg =>
           Die(msg, typ, errorID)
@@ -1395,7 +1381,7 @@ object IRParser {
       case "ApplySeeded" =>
         val function = identifier(it)
         val staticUID = int64_literal(it)
-        val rt = type_expr(env.typEnv)(it)
+        val rt = type_expr(it)
         for {
           rngState <- ir_value_expr(env)(it)
           args <- ir_value_children(env)(it)
@@ -1403,8 +1389,8 @@ object IRParser {
       case "ApplyIR" | "ApplySpecial" | "Apply" =>
         val errorID = int32_literal(it)
         val function = identifier(it)
-        val typeArgs = type_exprs(env.typEnv)(it)
-        val rt = type_expr(env.typEnv)(it)
+        val typeArgs = type_exprs(it)
+        val rt = type_expr(it)
         ir_value_children(env)(it).map { args =>
           invoke(function, rt, typeArgs, errorID, args: _*)
         }
@@ -1502,9 +1488,9 @@ object IRParser {
             consumeToken(it)
             Left(x.value)
           case _ =>
-            Right(type_expr(env.typEnv)(it))
+            Right(type_expr(it))
         }
-        val reader = PartitionReader.extract(env.ctx.fs, JsonMethods.parse(string_literal(it)))
+        val reader = PartitionReader.extract(env.ctx, JsonMethods.parse(string_literal(it)))
         ir_value_expr(env)(it).map { context =>
           ReadPartition(context, requestedTypeRaw match {
             case Left("None") => reader.fullRowType
@@ -1528,7 +1514,7 @@ object IRParser {
       case "ReadValue" =>
         import AbstractRVDSpec.formats
         val spec = JsonMethods.parse(string_literal(it)).extract[AbstractTypedCodecSpec]
-        val typ = type_expr(env.typEnv)(it)
+        val typ = type_expr(it)
         ir_value_expr(env)(it).map { path =>
           ReadValue(path, spec, typ)
         }
@@ -1541,7 +1527,7 @@ object IRParser {
         } yield WriteValue(value, path, spec)
       case "LiftMeOut" => ir_value_expr(env)(it).map(LiftMeOut)
       case "ReadPartition" =>
-        val rowType = tcoerce[TStruct](type_expr(env.typEnv)(it))
+        val rowType = tcoerce[TStruct](type_expr(it))
         import PartitionReader.formats
         val reader = JsonMethods.parse(string_literal(it)).extract[PartitionReader]
         ir_value_expr(env)(it).map { context =>
@@ -1589,7 +1575,7 @@ object IRParser {
             consumeToken(it)
             Left(x.value)
           case _ =>
-            Right(table_type_expr(env.typEnv)(it))
+            Right(table_type_expr(it))
         }
         val dropRows = boolean_literal(it)
         val readerStr = string_literal(it)
@@ -1681,8 +1667,7 @@ object IRParser {
         val n = int32_literal(it)
         val nPartitions = opt(it, int32_literal)
         val optRgStr = opt(it, identifier)
-        val optRg = optRgStr.map(env.typEnv.getReferenceGenome)
-        done(TableGenomicRange(n, nPartitions.getOrElse(HailContext.backend.defaultParallelism), optRg))
+        done(TableGenomicRange(n, nPartitions.getOrElse(HailContext.backend.defaultParallelism), optRgStr))
       case "TableUnion" => table_ir_children(env.onlyRelational)(it).map(TableUnion(_))
       case "TableOrderBy" =>
         val sortFields = sort_fields(it)
@@ -1839,7 +1824,7 @@ object IRParser {
             consumeToken(it)
             Left(x.value)
           case _ =>
-            Right(matrix_type_expr(env.typEnv)(it))
+            Right(matrix_type_expr(it))
         }
         val dropCols = boolean_literal(it)
         val dropRows = boolean_literal(it)
@@ -2131,33 +2116,19 @@ object IRParser {
 
   def parse_blockmatrix_ir(ctx: ExecuteContext, s: String): BlockMatrixIR = parse_blockmatrix_ir(s, IRParserEnvironment(ctx))
 
-  def parseType(code: String, env: TypeParserEnvironment): Type = parse(code, type_expr(env))
+  def parseType(code: String): Type = parse(code, type_expr)
 
-  def parsePType(code: String, env: TypeParserEnvironment): PType = parse(code, ptype_expr(env))
+  def parsePType(code: String): PType = parse(code, ptype_expr)
 
-  def parseStructType(code: String, env: TypeParserEnvironment): TStruct = tcoerce[TStruct](parse(code, type_expr(env)))
+  def parseStructType(code: String): TStruct = tcoerce[TStruct](parse(code, type_expr))
 
-  def parseUnionType(code: String, env: TypeParserEnvironment): TUnion = tcoerce[TUnion](parse(code, type_expr(env)))
+  def parseUnionType(code: String): TUnion = tcoerce[TUnion](parse(code, type_expr))
 
-  def parseRVDType(code: String, env: TypeParserEnvironment): RVDType = parse(code, rvd_type_expr(env))
+  def parseRVDType(code: String): RVDType = parse(code, rvd_type_expr)
 
-  def parseTableType(code: String, env: TypeParserEnvironment): TableType = parse(code, table_type_expr(env))
+  def parseTableType(code: String): TableType = parse(code, table_type_expr)
 
-  def parseMatrixType(code: String, env: TypeParserEnvironment): MatrixType = parse(code, matrix_type_expr(env))
-
-  def parseType(code: String): Type = parseType(code, TypeParserEnvironment.default)
+  def parseMatrixType(code: String): MatrixType = parse(code, matrix_type_expr)
 
   def parseSortField(code: String): SortField = parse(code, sort_field)
-
-  def parsePType(code: String): PType = parsePType(code, TypeParserEnvironment.default)
-
-  def parseStructType(code: String): TStruct = parseStructType(code, TypeParserEnvironment.default)
-
-  def parseUnionType(code: String): TUnion = parseUnionType(code, TypeParserEnvironment.default)
-
-  def parseRVDType(code: String): RVDType = parseRVDType(code, TypeParserEnvironment.default)
-
-  def parseTableType(code: String): TableType = parseTableType(code, TypeParserEnvironment.default)
-
-  def parseMatrixType(code: String): MatrixType = parseMatrixType(code, TypeParserEnvironment.default)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -347,7 +347,7 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
       FastSeq(prettyIdentifiers(keys), Pretty.prettyBooleanLiteral(isSorted))
     case TableRange(n, nPartitions) => FastSeq(n.toString, nPartitions.toString)
     case TableGenomicRange(n, nPartitions, referenceGenome) => FastSeq(
-      n.toString, nPartitions.toString, referenceGenome.map(_.name).getOrElse("None").toString)
+      n.toString, nPartitions.toString, referenceGenome.getOrElse("None").toString)
     case TableRepartition(_, n, strategy) => FastSeq(n.toString, strategy.toString)
     case TableHead(_, n) => single(n.toString)
     case TableTail(_, n) => single(n.toString)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -843,7 +843,7 @@ object Simplify {
     case TableFilterIntervals(TableAggregateByKey(child, expr), intervals, keep) =>
       TableAggregateByKey(TableFilterIntervals(child, intervals, keep), expr)
     case TableFilterIntervals(TableFilterIntervals(child, _i1, keep1), _i2, keep2) if keep1 == keep2 =>
-      val ord = PartitionBoundOrdering(child.typ.keyType).intervalEndpointOrdering
+      val ord = PartitionBoundOrdering(ctx, child.typ.keyType).intervalEndpointOrdering
       val i1 = Interval.union(_i1.toArray[Interval], ord)
       val i2 = Interval.union(_i2.toArray[Interval], ord)
       val intervals = if (keep1)
@@ -873,9 +873,9 @@ object Simplify {
       val newOpts = tr.params.options match {
         case None =>
           val pt = t.keyType
-          NativeReaderOptions(Interval.union(intervals.toArray, PartitionBoundOrdering(pt).intervalEndpointOrdering), pt, true)
+          NativeReaderOptions(Interval.union(intervals.toArray, PartitionBoundOrdering(ctx, pt).intervalEndpointOrdering), pt, true)
         case Some(NativeReaderOptions(preIntervals, intervalPointType, _)) =>
-          val iord = PartitionBoundOrdering(intervalPointType).intervalEndpointOrdering
+          val iord = PartitionBoundOrdering(ctx, intervalPointType).intervalEndpointOrdering
           NativeReaderOptions(
             Interval.intersection(Interval.union(preIntervals.toArray, iord), Interval.union(intervals.toArray, iord), iord),
             intervalPointType, true)
@@ -889,9 +889,9 @@ object Simplify {
       val newOpts = tr.options match {
         case None =>
           val pt = t.keyType
-          NativeReaderOptions(Interval.union(intervals.toArray, PartitionBoundOrdering(pt).intervalEndpointOrdering), pt, true)
+          NativeReaderOptions(Interval.union(intervals.toArray, PartitionBoundOrdering(ctx, pt).intervalEndpointOrdering), pt, true)
         case Some(NativeReaderOptions(preIntervals, intervalPointType, _)) =>
-          val iord = PartitionBoundOrdering(intervalPointType).intervalEndpointOrdering
+          val iord = PartitionBoundOrdering(ctx, intervalPointType).intervalEndpointOrdering
           NativeReaderOptions(
             Interval.intersection(Interval.union(preIntervals.toArray, iord), Interval.union(intervals.toArray, iord), iord),
             intervalPointType, true)

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -159,7 +159,7 @@ class StringTableReader(
     val lines = GenericLines.read(fs, fileStatuses, None, None, params.minPartitions, params.forceBGZ, params.forceGZ,
       params.filePerPartition)
     TableStage(globals = MakeStruct(FastSeq()),
-      partitioner = RVDPartitioner.unkeyed(lines.nPartitions),
+      partitioner = RVDPartitioner.unkeyed(ctx.stateManager, lines.nPartitions),
       dependency = TableStageDependency.none,
       contexts = ToStream(Literal.coerce(TArray(lines.contextType), lines.contexts)),
       body = { partitionContext: Ref => ReadPartition(partitionContext, requestedType.rowType, StringTablePartitionReader(lines, uidFieldName))

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -74,7 +74,7 @@ object TableNativeWriter {
         bindIR(parts) { fileCountAndDistinct =>
           Begin(FastIndexedSeq(
             WriteMetadata(MakeArray(GetField(writeGlobals, "filePath")),
-              RVDSpecWriter(s"$path/globals", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(1)))),
+              RVDSpecWriter(s"$path/globals", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
             WriteMetadata(ToArray(mapIR(ToStream(fileCountAndDistinct)) { fc => GetField(fc, "filePath") }),
               RVDSpecWriter(s"$path/rows", RVDSpecMaker(rowSpec, partitioner, IndexSpec.emptyAnnotation("../index", tcoerce[PStruct](pKey))))),
             WriteMetadata(ToArray(mapIR(ToStream(fileCountAndDistinct)) { fc =>
@@ -126,8 +126,8 @@ case class TableNativeWriter(
 
     val referencesPath = path + "/references"
     fs.mkDir(referencesPath)
-    ReferenceGenome.exportReferences(fs, referencesPath, tv.typ.rowType)
-    ReferenceGenome.exportReferences(fs, referencesPath, tv.typ.globalType)
+    ReferenceGenome.exportReferences(fs, referencesPath, ReferenceGenome.getReferences(tv.typ.rowType).map(ctx.getReference(_)))
+    ReferenceGenome.exportReferences(fs, referencesPath, ReferenceGenome.getReferences(tv.typ.rowType).map(ctx.getReference(_)))
 
     val spec = TableSpecParameters(
       FileFormat.version.rep,
@@ -447,7 +447,7 @@ object RelationalWriter {
     write, RelationalWriter(path, overwrite, refs.map(typ => "references" -> (ReferenceGenome.getReferences(typ.rowType) ++ ReferenceGenome.getReferences(typ.globalType)))))
 }
 
-case class RelationalWriter(path: String, overwrite: Boolean, maybeRefs: Option[(String, Set[ReferenceGenome])]) extends MetadataWriter {
+case class RelationalWriter(path: String, overwrite: Boolean, maybeRefs: Option[(String, Set[String])]) extends MetadataWriter {
   def annotationType: Type = TVoid
 
   def writeMetadata(
@@ -691,7 +691,7 @@ case class TableNativeFanoutWriter(
                   "filePath"
                 )
               ),
-              RVDSpecWriter(s"${target.path}/globals", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(1)))
+              RVDSpecWriter(s"${target.path}/globals", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))
             ),
             WriteMetadata(
               ToArray(mapIR(ToStream(fileCountAndDistinct)) { fc => GetField(GetTupleElement(fc, index), "filePath") }),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.agg
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.{DoubleArrayBuilder, IntArrayBuilder, LongArrayBuilder}
 import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, PFloat64, PInt32, PInt64, PStruct, PType}
 import is.hail.types.virtual._
@@ -645,7 +646,7 @@ class ApproxCDFStateManager(val k: Int) {
   }
 
   def rvResult(r: Region): Long = {
-    val rvb = new RegionValueBuilder(r)
+    val rvb = new RegionValueBuilder(HailStateManager(Map.empty), r)
     rvb.start(QuantilesAggregator.resultPType)
     result(rvb)
     rvb.end()
@@ -800,4 +801,3 @@ object QuantilesAggregator {
     total
   }
 }
-

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.agg
 import breeze.linalg.{DenseMatrix, DenseVector, diag, inv}
 import is.hail.annotations.{Region, RegionValueBuilder, UnsafeRow}
 import is.hail.asm4s._
-import is.hail.backend.ExecuteContext
+import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, IEmitCode}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{EmitType, SCode, SValue}
@@ -31,7 +31,7 @@ object LinearRegressionAggregator {
     val xtx = DenseMatrix.create(k, k, UnsafeRow.readArray(vector, null, xtxPtr)
       .asInstanceOf[IndexedSeq[Double]].toArray[Double])
 
-    val rvb = new RegionValueBuilder(region)
+    val rvb = new RegionValueBuilder(HailStateManager(Map.empty), region)
     rvb.start(resultPType)
     rvb.startStruct()
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -6,7 +6,7 @@ import is.hail.expr.ir._
 import is.hail.types._
 import is.hail.utils._
 import is.hail.asm4s.coerce
-import is.hail.backend.ExecuteContext
+import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.experimental.ExperimentalFunctions
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
@@ -14,7 +14,7 @@ import is.hail.types.physical.stypes.concrete._
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
-import is.hail.variant.Locus
+import is.hail.variant.{Locus, ReferenceGenome}
 import org.apache.spark.sql.Row
 
 import scala.collection.JavaConverters._
@@ -257,14 +257,14 @@ object IRFunctionRegistry {
 }
 
 object RegistryHelpers {
-  def stupidUnwrapStruct(r: Region, value: Row, ptype: PType): Long = {
+  def stupidUnwrapStruct(rgs: Map[String, ReferenceGenome], r: Region, value: Row, ptype: PType): Long = {
     assert(value != null)
-    ptype.unstagedStoreJavaObject(value, r)
+    ptype.unstagedStoreJavaObject(HailStateManager(rgs), value, r)
   }
 
-  def stupidUnwrapArray(r: Region, value: IndexedSeq[Annotation], ptype: PType): Long = {
+  def stupidUnwrapArray(rgs: Map[String, ReferenceGenome], r: Region, value: IndexedSeq[Annotation], ptype: PType): Long = {
     assert(value != null)
-    ptype.unstagedStoreJavaObject(value, r)
+    ptype.unstagedStoreJavaObject(HailStateManager(rgs), value, r)
   }
 }
 
@@ -364,14 +364,14 @@ abstract class RegistryFunctions {
     case t: TBaseStruct =>
       val sst = st.asInstanceOf[SBaseStructPointer]
       val pt = sst.pType.asInstanceOf[PCanonicalBaseStruct]
-      val addr = cb.memoize(Code.invokeScalaObject3[Region, Row, PType, Long](
-        RegistryHelpers.getClass, "stupidUnwrapStruct", r.region, coerce[Row](value), cb.emb.ecb.getPType(pt)))
+      val addr = cb.memoize(Code.invokeScalaObject4[Map[String, ReferenceGenome], Region, Row, PType, Long](
+        RegistryHelpers.getClass, "stupidUnwrapStruct", cb.emb.ecb.emodb.referenceGenomeMap, r.region, coerce[Row](value), cb.emb.ecb.getPType(pt)))
       new SBaseStructPointerValue(SBaseStructPointer(pt.setRequired(false).asInstanceOf[PBaseStruct]), addr)
     case TArray(t: TBaseStruct) =>
       val ast = st.asInstanceOf[SIndexablePointer]
       val pca = ast.pType.asInstanceOf[PCanonicalArray]
-      val array = cb.memoize(Code.invokeScalaObject3[Region, IndexedSeq[Annotation], PType, Long](
-        RegistryHelpers.getClass, "stupidUnwrapArray", r.region, coerce[IndexedSeq[Annotation]](value), cb.emb.ecb.getPType(pca)))
+      val array = cb.memoize(Code.invokeScalaObject4[Map[String, ReferenceGenome], Region, IndexedSeq[Annotation], PType, Long](
+        RegistryHelpers.getClass, "stupidUnwrapArray", cb.emb.ecb.emodb.referenceGenomeMap, r.region, coerce[IndexedSeq[Annotation]](value), cb.emb.ecb.getPType(pca)))
       new SIndexablePointerValue(ast, array, cb.memoize(pca.loadLength(array)), cb.memoize(pca.firstElementOffset(array)))
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -12,7 +12,7 @@ import is.hail.types.virtual._
 import is.hail.variant.ReferenceGenome
 
 object ReferenceGenomeFunctions extends RegistryFunctions {
-  def rgCode(mb: EmitMethodBuilder[_], rg: ReferenceGenome): Code[ReferenceGenome] = mb.getReferenceGenome(rg)
+  def rgCode(mb: EmitMethodBuilder[_], rg: String): Code[ReferenceGenome] = mb.getReferenceGenome(rg)
 
   def registerAll() {
     registerSCode1t("isValidContig", Array(LocusFunctions.tlocus("R")), TString, TBoolean, (_: Type, _: SType) => SBoolean) {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
@@ -28,11 +28,11 @@ case class TableCalculateNewPartitions(
     if (rvd.typ.key.isEmpty)
       FastIndexedSeq()
     else {
-      val ki = RVD.getKeyInfo(rvd.typ, rvd.typ.key.length, RVD.getKeys(rvd.typ, rvd.crdd))
+      val ki = RVD.getKeyInfo(ctx, rvd.typ, rvd.typ.key.length, RVD.getKeys(ctx, rvd.typ, rvd.crdd))
       if (ki.isEmpty)
         FastIndexedSeq()
       else
-        RVD.calculateKeyRanges(rvd.typ, ki, nPartitions, rvd.typ.key.length).rangeBounds.toIndexedSeq
+        RVD.calculateKeyRanges(ctx, rvd.typ, ki, nPartitions, rvd.typ.key.length).rangeBounds.toIndexedSeq
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -839,7 +839,7 @@ object LowerBlockMatrixIR {
         s
       ), TStream(s.typ))
     }
-    val ts = TableStage(letBindings, bcFields, Ref(globalsId, emptyGlobals.typ), RVDPartitioner.unkeyed(blocksRowMajor.size), TableStageDependency.none, contextsIR, tsPartitionFunction)
+    val ts = TableStage(letBindings, bcFields, Ref(globalsId, emptyGlobals.typ), RVDPartitioner.unkeyed(ctx.stateManager, blocksRowMajor.size), TableStageDependency.none, contextsIR, tsPartitionFunction)
     ts
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -252,7 +252,7 @@ class TableStage(
 
     val startAndEnd = partitioner.rangeBounds.map(newPartitioner.intervalRange)
       .zipWithIndex
-    val ord = PartitionBoundOrdering.apply(newPartitioner.kType)
+    val ord = PartitionBoundOrdering.apply(newPartitioner.sm, newPartitioner.kType)
     if (startAndEnd.forall { case ((start, end), index) =>
       start + 1 == end && newPartitioner.rangeBounds(start).includes(ord, partitioner.rangeBounds(index)) }) {
       val newToOld = startAndEnd
@@ -348,7 +348,7 @@ class TableStage(
     require(newKey.forall(rowType.fieldNames.contains))
 
     val newKeyType = rowType.typeAfterSelectNames(newKey)
-    if (RVDPartitioner.isValid(newKeyType, partitioner.rangeBounds)) {
+    if (RVDPartitioner.isValid(partitioner.sm, newKeyType, partitioner.rangeBounds)) {
       changePartitionerNoRepartition(partitioner.copy(kType = newKeyType))
     } else {
       val adjustedPartitioner = partitioner.strictify
@@ -375,6 +375,7 @@ class TableStage(
         case "right" => rightPart
         case "inner" => leftPart.intersect(rightPart)
         case "outer" => RVDPartitioner.generate(
+          partitioner.sm,
           this.kType.fieldNames.take(joinKey),
           this.kType,
           leftPart.rangeBounds ++ rightPart.rangeBounds)
@@ -472,12 +473,13 @@ class TableStage(
       rightRowRTypeWithPartNum)
     assert(sorted.kType.fieldNames.sameElements("__partNum" +: right.key))
     val newRightPartitioner = new RVDPartitioner(
+      ctx.stateManager,
       Some(1),
       TStruct.concat(TStruct("__partNum" -> TInt32), right.kType),
       Array.tabulate[Interval](partitioner.numPartitions)(i => Interval(Row(i), Row(i), true, true))
       )
     val repartitioned = sorted.repartitionNoShuffle(newRightPartitioner)
-      .changePartitionerNoRepartition(RVDPartitioner.unkeyed(newRightPartitioner.numPartitions))
+      .changePartitionerNoRepartition(RVDPartitioner.unkeyed(ctx.stateManager, newRightPartitioner.numPartitions))
       .mapPartition(None) { part =>
         mapIR(part) { row =>
           SelectFields(row, right.rowType.fieldNames)
@@ -743,7 +745,7 @@ object LowerTableIR {
 
           TableStage(
             globals,
-            RVDPartitioner.empty(typ.keyType),
+            RVDPartitioner.empty(ctx, typ.keyType),
             TableStageDependency.none,
             MakeStream(FastIndexedSeq(), TStream(TStruct.empty)),
             (_: Ref) => MakeStream(FastIndexedSeq(), TStream(typ.rowType)))
@@ -790,7 +792,7 @@ object LowerTableIR {
             globalsRef.name -> GetField(loweredRowsAndGlobalRef, "global")),
           FastIndexedSeq(globalsRef.name -> globalsRef),
           globalsRef,
-          RVDPartitioner.unkeyed(nPartitionsAdj),
+          RVDPartitioner.unkeyed(ctx.stateManager, nPartitionsAdj),
           TableStageDependency.none,
           context,
           ctxRef => ToStream(ctxRef, true))
@@ -808,7 +810,7 @@ object LowerTableIR {
 
         TableStage(
           MakeStruct(FastSeq()),
-          new RVDPartitioner(Array("idx"), tir.typ.rowType,
+          new RVDPartitioner(ctx.stateManager, Array("idx"), tir.typ.rowType,
             ranges.map { case (start, end) =>
               Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
             }),
@@ -826,7 +828,7 @@ object LowerTableIR {
         val partStarts = partCounts.scanLeft(0)(_ + _)
 
         val contextType = TStruct("start" -> TInt32, "end" -> TInt32)
-        val toLocus = TableGenomicRange.toLocus(referenceGenome)
+        val toLocus = TableGenomicRange.toLocus(referenceGenome.map(ctx.getReference))
 
         val globalPosRanges = Array.tabulate(nPartitionsAdj) { i =>
           partStarts(i) -> partStarts(i + 1)
@@ -837,7 +839,7 @@ object LowerTableIR {
 
         TableStage(
           MakeStruct(FastSeq()),
-          new RVDPartitioner(Array("locus"), tir.typ.rowType,
+          new RVDPartitioner(ctx.stateManager, Array("locus"), tir.typ.rowType,
             locusRanges.map { case (start, end) =>
               Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
             }),
@@ -981,10 +983,10 @@ object LowerTableIR {
         val loweredChild = lower(child)
         val part = loweredChild.partitioner
         val kt = child.typ.keyType
-        val ord = PartitionBoundOrdering(kt)
+        val ord = PartitionBoundOrdering(ctx.stateManager, kt)
         val iord = ord.intervalEndpointOrdering
 
-        val filterPartitioner = new RVDPartitioner(kt, Interval.union(intervals.toArray, ord.intervalEndpointOrdering))
+        val filterPartitioner = new RVDPartitioner(ctx.stateManager, kt, Interval.union(intervals.toArray, ord.intervalEndpointOrdering))
         val boundsType = TArray(RVDPartitioner.intervalIRRepresentation(kt))
         val filterIntervalsRef = Ref(genUID(), boundsType)
         val filterIntervals: IndexedSeq[Interval] = filterPartitioner.rangeBounds.map { i =>
@@ -1018,7 +1020,7 @@ object LowerTableIR {
           (newRangeBounds, includedIndices, startAndEndInterval, f _)
         }
 
-        val newPart = new RVDPartitioner(kt, newRangeBounds)
+        val newPart = new RVDPartitioner(ctx.stateManager, kt, newRangeBounds)
 
         TableStage(
           letBindings = loweredChild.letBindings,
@@ -1624,7 +1626,7 @@ object LowerTableIR {
       case x@TableUnion(children) =>
         val lowered = children.map(lower)
         val keyType = x.typ.keyType
-        val newPartitioner = RVDPartitioner.generate(keyType, lowered.flatMap(_.partitioner.rangeBounds))
+        val newPartitioner = RVDPartitioner.generate(ctx.stateManager, keyType, lowered.flatMap(_.partitioner.rangeBounds))
         val repartitioned = lowered.map(_.repartitionNoShuffle(newPartitioner))
 
         TableStage(
@@ -1643,7 +1645,7 @@ object LowerTableIR {
       case x@TableMultiWayZipJoin(children, fieldName, globalName) =>
         val lowered = children.map(lower)
         val keyType = x.typ.keyType
-        val newPartitioner = RVDPartitioner.generate(keyType, lowered.flatMap(_.partitioner.rangeBounds))
+        val newPartitioner = RVDPartitioner.generate(ctx.stateManager, keyType, lowered.flatMap(_.partitioner.rangeBounds))
         val repartitioned = lowered.map(_.repartitionNoShuffle(newPartitioner))
         val newGlobals = MakeStruct(FastSeq(
           globalName -> MakeArray(lowered.map(_.globals), TArray(lowered.head.globalType))))
@@ -1676,7 +1678,7 @@ object LowerTableIR {
       case TableOrderBy(child, sortFields) =>
         val loweredChild = lower(child)
         if (TableOrderBy.isAlreadyOrdered(sortFields, loweredChild.partitioner.kType.fieldNames)) {
-          loweredChild.changePartitionerNoRepartition(RVDPartitioner.unkeyed(loweredChild.partitioner.numPartitions))
+          loweredChild.changePartitionerNoRepartition(RVDPartitioner.unkeyed(ctx.stateManager, loweredChild.partitioner.numPartitions))
         } else {
           val rowRType = analyses.requirednessAnalysis.lookup(child).asInstanceOf[RTable].rowType
           ctx.backend.lowerDistributedSort(

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -177,7 +177,7 @@ object RichContextRDDRegionValue {
     rowsSpec.write(fs, path + "/rows/rows")
 
     val entriesSpec = MakeRVDSpec(entriesCodecSpec, partFiles,
-      RVDPartitioner.unkeyed(partitioner.numPartitions), entriesIndexSpec)
+      RVDPartitioner.unkeyed(partitioner.sm, partitioner.numPartitions), entriesIndexSpec)
     entriesSpec.write(fs, path + "/entries/rows")
   }
 }

--- a/hail/src/main/scala/is/hail/io/avro/AvroTableReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroTableReader.scala
@@ -19,9 +19,9 @@ class AvroTableReader(
   private val partitioner: RVDPartitioner = unsafeOptions.map { case UnsafeAvroTableReaderOptions(key, intervals, _) =>
     require(intervals.length == paths.length,
       s"There must be one partition interval per avro file, have ${paths.length} ${plural(paths.length, "file")} and ${intervals.length} ${plural(intervals.length, "interval")}")
-    RVDPartitioner.generate(partitionReader.fullRowType.typeAfterSelectNames(key), intervals)
+    RVDPartitioner.generate(null, partitionReader.fullRowType.typeAfterSelectNames(key), intervals)
   }.getOrElse {
-    RVDPartitioner.unkeyed(paths.length)
+    RVDPartitioner.unkeyed(null, paths.length)
   }
 
   def pathsUsed: Seq[String] = paths

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -2,7 +2,7 @@ package is.hail.io.bgen
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.backend.{BroadcastValue, ExecuteContext, HailTaskContext}
+import is.hail.backend.{BroadcastValue, ExecuteContext, HailStateManager, HailTaskContext}
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.expr.ir.PruneDeadFields
 import is.hail.io.fs.FS
@@ -28,7 +28,7 @@ object BgenSettings {
   val ZSTD_COMPRESSION = 0x2
 
   def indexKeyType(rg: Option[ReferenceGenome]): TStruct = TStruct(
-    "locus" -> rg.map(TLocus(_)).getOrElse(TLocus.representation),
+    "locus" -> rg.map(rg => TLocus(rg.name)).getOrElse(TLocus.representation),
     "alleles" -> TArray(TString))
   val indexAnnotationType: Type = TStruct.empty
 
@@ -103,7 +103,7 @@ case class BgenSettings(
 
   val rowPType: PCanonicalStruct = PCanonicalStruct(required = true,
     Array(
-      "locus" -> PCanonicalLocus.schemaFromRG(rg, required = false),
+      "locus" -> PCanonicalLocus.schemaFromRG(rg.map(_.name), required = false),
       "alleles" -> PCanonicalArray(PCanonicalString(false), false),
       "rsid" -> PCanonicalString(),
       "varid" -> PCanonicalString(),
@@ -139,7 +139,7 @@ object BgenRDD {
       val (leafCodec, internalNodeCodec) = BgenSettings.indexCodecSpecs(settings.rg)
       val (leafPType: PStruct, leafDec) = leafCodec.buildDecoder(ctx, leafCodec.encodedVirtualType)
       val (intPType: PStruct, intDec) = internalNodeCodec.buildDecoder(ctx, internalNodeCodec.encodedVirtualType)
-      IndexReaderBuilder.withDecoders(leafDec, intDec, BgenSettings.indexKeyType(settings.rg), BgenSettings.indexAnnotationType, leafPType, intPType)
+      IndexReaderBuilder.withDecoders(ctx, leafDec, intDec, BgenSettings.indexKeyType(settings.rg), BgenSettings.indexAnnotationType, leafPType, intPType)
     }
 
     ContextRDD(new BgenRDD(ctx.fsBc, f, indexBuilder, partitions, settings, keys))
@@ -246,7 +246,7 @@ private class BgenRecordIteratorWithFilter(
   private[this] var isEnd = false
   private[this] var current: LeafChild = _
   private[this] var key: Annotation = _
-  private[this] val ordering = PartitionBoundOrdering(index.keyType)
+  private[this] val ordering = PartitionBoundOrdering(index.sm, index.keyType)
 
   def next(): Option[RegionValue] = {
     val recordOffset = current.recordOffset

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -52,9 +52,9 @@ private case class LoadBgenPartition(
 }
 
 object BgenRDDPartitions extends Logging {
-  def checkFilesDisjoint(fs: FS, fileMetadata: Seq[BgenFileMetadata], keyType: Type): Array[Interval] = {
+  def checkFilesDisjoint(ctx: ExecuteContext, fileMetadata: Seq[BgenFileMetadata], keyType: Type): Array[Interval] = {
     assert(fileMetadata.nonEmpty)
-    val pord = keyType.ordering
+    val pord = keyType.ordering(ctx.stateManager)
     val bounds = fileMetadata.map(md => (md.path, md.rangeBounds))
 
     val overlappingBounds = new BoxedArrayBuilder[(String, Interval, String, Interval)]
@@ -94,8 +94,8 @@ object BgenRDDPartitions extends Logging {
     val fs = ctx.fs
     val fsBc = fs.broadcast
 
-    val fileRangeBounds = checkFilesDisjoint(fs, files, keyType)
-    val intervalOrdering = TInterval(keyType).ordering
+    val fileRangeBounds = checkFilesDisjoint(ctx, files, keyType)
+    val intervalOrdering = TInterval(keyType).ordering(ctx.stateManager)
 
     val sortedFiles = files.zip(fileRangeBounds)
       .sortWith { case ((_, i1), (_, i2)) => intervalOrdering.lt(i1, i2) }
@@ -124,7 +124,7 @@ object BgenRDDPartitions extends Logging {
       val (leafCodec, internalNodeCodec) = BgenSettings.indexCodecSpecs(rg)
       val (leafPType: PStruct, leafDec) = leafCodec.buildDecoder(ctx, leafCodec.encodedVirtualType)
       val (intPType: PStruct, intDec) = internalNodeCodec.buildDecoder(ctx, internalNodeCodec.encodedVirtualType)
-      IndexReaderBuilder.withDecoders(leafDec, intDec, BgenSettings.indexKeyType(rg), BgenSettings.indexAnnotationType, leafPType, intPType)
+      IndexReaderBuilder.withDecoders(ctx, leafDec, intDec, BgenSettings.indexKeyType(rg), BgenSettings.indexAnnotationType, leafPType, intPType)
     }
     if (nonEmptyFilesAfterFilter.isEmpty) {
       (Array.empty, Array.empty)
@@ -548,4 +548,3 @@ object CompileDecoder {
     fb.resultWithIndex()
   }
 }
-

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -69,7 +69,7 @@ object IndexBgen {
     val settings: BgenSettings = BgenSettings(
       0, // nSamples not used if there are no entries
       TableType(rowType = TStruct(
-        "locus" -> TLocus.schemaFromRG(referenceGenome),
+        "locus" -> TLocus.schemaFromRG(rg),
         "alleles" -> TArray(TString),
         "offset" -> TInt64,
         "file_idx" -> TInt32),
@@ -106,7 +106,7 @@ object IndexBgen {
       "skip_invalid_loci" -> skipInvalidLoci)
 
     val rangeBounds = bgenFilePaths.zipWithIndex.map { case (_, i) => Interval(Row(i), Row(i), includesStart = true, includesEnd = true) }
-    val partitioner = new RVDPartitioner(Array("file_idx"), keyType.asInstanceOf[TStruct], rangeBounds)
+    val partitioner = new RVDPartitioner(ctx.stateManager, Array("file_idx"), keyType.asInstanceOf[TStruct], rangeBounds)
     val crvd = BgenRDD(ctx, partitions, settings, null).toCRDDPtr
 
     val makeIW = IndexWriter.builder(ctx, indexKeyType, annotationType, attributes = attributes)

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -27,7 +27,7 @@ case class FamFileConfig(isQuantPheno: Boolean = false,
 object LoadPlink {
   def expectedBedSize(nSamples: Int, nVariants: Long): Long = 3 + nVariants * ((nSamples + 3) / 4)
 
-  def parseBim(fs: FS, bimPath: String, a2Reference: Boolean,
+  def parseBim(ctx: ExecuteContext, fs: FS, bimPath: String, a2Reference: Boolean,
     contigRecoding: Map[String, String], rg: Option[ReferenceGenome], locusAllelesType: TStruct,
     skipInvalidLoci: Boolean): (Int, Array[PlinkVariant]) = {
     val vs = new BoxedArrayBuilder[PlinkVariant]()
@@ -58,7 +58,7 @@ object LoadPlink {
       }
     }
     val variants = vs.result()
-    (n, variants.sortBy(_.locusAlleles)(locusAllelesType.ordering.toOrdering))
+    (n, variants.sortBy(_.locusAlleles)(locusAllelesType.ordering(ctx.stateManager).toOrdering))
   }
 
   val numericRegex =
@@ -156,10 +156,10 @@ object MatrixPLINKReader {
     implicit val formats: Formats = DefaultFormats
     val params = jv.extract[MatrixPLINKReaderParameters]
 
-    val referenceGenome = params.rg.map(ReferenceGenome.getReference)
+    val referenceGenome = params.rg.map(ctx.getReference)
     referenceGenome.foreach(_.validateContigRemap(params.contigRecoding))
 
-    val locusType = TLocus.schemaFromRG(referenceGenome)
+    val locusType = TLocus.schemaFromRG(params.rg)
     val locusAllelesType = TStruct(
       "locus" -> locusType,
       "alleles" -> TArray(TString))
@@ -175,7 +175,7 @@ object MatrixPLINKReader {
     if (nSamples <= 0)
       fatal("FAM file does not contain any samples")
 
-    val (nTotalVariants, variants) = LoadPlink.parseBim(fs, params.bim, params.a2Reference, params.contigRecoding,
+    val (nTotalVariants, variants) = LoadPlink.parseBim(ctx, fs, params.bim, params.a2Reference, params.contigRecoding,
       referenceGenome, locusAllelesType, params.skipInvalidLoci)
     val nVariants = variants.length
     if (nTotalVariants <= 0)
@@ -224,7 +224,7 @@ object MatrixPLINKReader {
 
     var p = 0
     var prevEnd = 0
-    val lOrd = locusType.ordering
+    val lOrd = locusType.ordering(ctx.stateManager)
     while (p < nPartitions && prevEnd < nVariants) {
       val start = prevEnd
 
@@ -234,7 +234,7 @@ object MatrixPLINKReader {
           && lOrd.equiv(variants(end - 1).locusAlleles.asInstanceOf[Row].get(0),
             variants(end).locusAlleles.asInstanceOf[Row].get(0)))
           end += 1
-        
+
         cb += Row(params.bed, start, end)
 
         ib += Interval(
@@ -251,7 +251,7 @@ object MatrixPLINKReader {
 
     val contexts = cb.result().map(r => r: Any)
 
-    val partitioner = new RVDPartitioner(locusAllelesType, ib.result(), 0)
+    val partitioner = new RVDPartitioner(ctx.stateManager, locusAllelesType, ib.result(), 0)
 
     val fullMatrixType: MatrixType = MatrixType(
       globalType = TStruct.empty,
@@ -332,8 +332,9 @@ class MatrixPLINKReader(
     val localA2Reference = params.a2Reference
     val variantsBc = ctx.backend.broadcast(variants)
     val localNSamples = nSamples
+    val sm = ctx.stateManager
 
-    val localLocusType = TLocus.schemaFromRG(referenceGenome)
+    val localLocusType = TLocus.schemaFromRG(referenceGenome.map(_.name))
 
     val contextType = TStruct(
       "bed" -> TString,
@@ -346,7 +347,7 @@ class MatrixPLINKReader(
     }
 
     val fullRowPType = PCanonicalStruct(true,
-      "locus" -> PCanonicalLocus.schemaFromRG(referenceGenome, true),
+      "locus" -> PCanonicalLocus.schemaFromRG(referenceGenome.map(_.name), true),
       "alleles" -> PCanonicalArray(PCanonicalString(true), true),
       "rsid" -> PCanonicalString(true),
       "cm_position" -> PFloat64(true),
@@ -376,7 +377,7 @@ class MatrixPLINKReader(
 
         val blockLength = (localNSamples + 3) / 4
 
-        val rvb = new RegionValueBuilder(region)
+        val rvb = new RegionValueBuilder(sm, region)
 
         val is = fs.open(bed)
         if (TaskContext.get != null) {

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -415,16 +415,16 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   val nCols: Long) extends Serializable {
 
   import BlockMatrix._
-
+  
   require(blocks.partitioner.isDefined)
   require(blocks.partitioner.get.isInstanceOf[GridPartitioner])
 
   val gp: GridPartitioner = blocks.partitioner.get.asInstanceOf[GridPartitioner]
-
+  
   require(gp.blockSize == blockSize && gp.nRows == nRows && gp.nCols == nCols)
-
+  
   val isSparse: Boolean = gp.partitionIndexToBlockIndex.isDefined
-
+  
   def requireDense(name: String): Unit =
     if (isSparse)
       fatal(s"$name is not supported for block-sparse matrices.")
@@ -435,7 +435,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       realizeBlocks(None)
     } else
       this
-
+  
   // if Some(bis), unrealized blocks in bis are replaced with zero blocks
   // if None, all unrealized blocks are replaced with zero blocks
   def realizeBlocks(maybeBlocksToRealize: Option[IndexedSeq[Int]]): BlockMatrix = {
@@ -443,7 +443,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       if (maybeBlocksToRealize.exists(_.length == gp.maxNBlocks)) None else maybeBlocksToRealize)
 
     val newGP = gp.union(realizeGP)
-
+    
     if (newGP.numPartitions == gp.numPartitions)
       this
     else {
@@ -464,7 +464,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       this
     else
       subsetBlocks(gp.intersect(gp.copy(partitionIndexToBlockIndex = Some(blocksToKeep))))
-
+    
   // assumes subsetGP blocks are subset of gp blocks, as with subsetGP = gp.intersect(gp2)
   def subsetBlocks(subsetGP: GridPartitioner): BlockMatrix = {
     if (subsetGP.numPartitions == gp.numPartitions)
@@ -475,7 +475,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         blockSize, nRows, nCols)
     }
   }
-
+  
   // filter to blocks overlapping diagonal band of all elements with lower <= jj - ii <= upper
   // if not blocksOnly, also zero out all remaining elements outside band
   def filterBand(lower: Long, upper: Long, blocksOnly: Boolean): BlockMatrix = {
@@ -488,25 +488,25 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     else
       filteredBM.zeroBand(lower, upper)
   }
-
-  def zeroBand(lower: Long, upper: Long): BlockMatrix = {
+  
+  def zeroBand(lower: Long, upper: Long): BlockMatrix = {    
     val zeroedBlocks = blocks.mapPartitions( { it =>
       assert(it.hasNext)
       val ((i, j), lm0) = it.next()
       assert(!it.hasNext)
-
+      
       val nRowsInBlock = lm0.rows
       val nColsInBlock = lm0.cols
 
       val diagIndex = (j - i).toLong * blockSize
       val lowestDiagIndex = diagIndex - (nRowsInBlock - 1)
       val highestDiagIndex = diagIndex + (nColsInBlock - 1)
-
+      
       if (lowestDiagIndex >= lower && highestDiagIndex <= upper)
         Iterator.single(((i, j), lm0))
       else {
         val lm = lm0.copy // avoidable?
-
+        
         if (lower > lowestDiagIndex) {
           val iiLeft = math.max(diagIndex - lower, 0).toInt
           val iiRight = math.min(diagIndex - lower + nColsInBlock, nRowsInBlock).toInt
@@ -518,16 +518,16 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
             ii += 1
             jj += 1
           }
-
+          
           lm(iiRight until nRowsInBlock, ::) := 0.0
         }
-
+        
         if (upper < highestDiagIndex) {
           val iiLeft = math.max(diagIndex - upper, 0).toInt
           val iiRight = math.min(diagIndex - upper + nColsInBlock, nRowsInBlock).toInt
 
           lm(0 until iiLeft, ::) := 0.0
-
+          
           var ii = iiLeft
           var jj = math.max(upper - diagIndex, 0).toInt + 1
           while (ii < iiRight) {
@@ -539,10 +539,10 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         Iterator.single(((i, j), lm))
       }
     }, preservesPartitioning = true)
-
+    
     new BlockMatrix(zeroedBlocks, blockSize, nRows, nCols)
   }
-
+  
   // for row i, filter to indices [starts[i], stops[i]) by dropping non-overlapping blocks
   // if not blocksOnly, also zero out elements outside ranges in overlapping blocks
   // checked in Python: start >= 0 && start <= stop && stop <= nCols
@@ -558,8 +558,8 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     else
       filteredBM.zeroRowIntervals(starts, stops)
   }
-
-  def zeroRowIntervals(starts: Array[Long], stops: Array[Long]): BlockMatrix = {
+  
+  def zeroRowIntervals(starts: Array[Long], stops: Array[Long]): BlockMatrix = {    
     val backend = HailContext.backend
     val startBlockIndexBc = backend.broadcast(starts.map(gp.indexBlockIndex))
     val stopBlockIndexBc = backend.broadcast(stops.map(stop => (stop / blockSize).toInt))
@@ -597,17 +597,17 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         row += 1
         ii += 1
       }
-
+      
       Iterator.single(((i, j), lm))
     }, preservesPartitioning = true)
-
+    
     new BlockMatrix(zeroedBlocks, blockSize, nRows, nCols)
   }
-
+  
   def filterRectangles(flattenedRectangles: Array[Long]): BlockMatrix = {
     require(flattenedRectangles.length % 4 == 0)
     val rectangles = flattenedRectangles.grouped(4).toArray
-
+    
     filterBlocks(gp.rectanglesBlocks(rectangles))
   }
 
@@ -663,7 +663,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
   // element-wise ops
   def unary_+(): M = this
-
+  
   def unary_-(): M = blockMap(-_,
     "negation",
     reqDense = false)
@@ -684,7 +684,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       )
       new BlockMatrix(addBlocks, blockSize, nRows, nCols)
     }
-
+  
   def sub(that: M): M =
     if (sameBlocks(that)) {
       blockMap2(that, _ - _,
@@ -701,7 +701,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       )
       new BlockMatrix(subBlocks, blockSize, nRows, nCols)
     }
-
+  
   def mul(that: M): M = {
     val newGP = gp.intersect(that.gp)
     subsetBlocks(newGP).blockMap2(
@@ -709,42 +709,42 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       "element-wise multiplication",
       reqDense = false)
   }
-
+  
   def div(that: M): M = blockMap2(that, _ /:/ _,
     "element-wise division")
-
+  
   // row broadcast
   def rowVectorAdd(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::) + lv,
     "broadcasted addition of row-vector")(a)
-
+  
   def rowVectorSub(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::) - lv,
     "broadcasted subtraction of row-vector")(a)
-
+  
   def rowVectorMul(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) *:* lv,
     "broadcasted multiplication by row-vector containing nan, or infinity",
     reqDense = a.exists(i => i.isNaN | i.isInfinity))(a)
-
-  def rowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) /:/ lv,
+  
+  def rowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) /:/ lv, 
     "broadcasted division by row-vector containing zero, nan, or infinity",
     reqDense = a.exists(i => i == 0.0 | i.isNaN | i.isInfinity))(a)
 
   def reverseRowVectorSub(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::).map(lv - _),
     "broadcasted row-vector minus block matrix")(a)
-
+ 
   def reverseRowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::).map(lv /:/ _),
     "broadcasted row-vector divided by block matrix")(a)
-
+  
   // column broadcast
   def colVectorAdd(a: Array[Double]): M = densify().colVectorOp((lm, lv) => lm(::, *) + lv,
     "broadcasted addition of column-vector")(a)
-
+  
   def colVectorSub(a: Array[Double]): M = densify().colVectorOp((lm, lv) => lm(::, *) - lv,
     "broadcasted subtraction of column-vector")(a)
-
+  
   def colVectorMul(a: Array[Double]): M = colVectorOp((lm, lv) => lm(::, *) *:* lv,
     "broadcasted multiplication column-vector containing nan or infinity",
     reqDense = a.exists(i => i.isNaN | i.isInfinity))(a)
-
+  
   def colVectorDiv(a: Array[Double]): M = colVectorOp((lm, lv) => lm(::, *) /:/ lv,
     "broadcasted division by column-vector containing zero, nan, or infinity",
     reqDense = a.exists(i => i == 0.0 | i.isNaN | i.isInfinity))(a)
@@ -758,21 +758,21 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   // scalar
   def scalarAdd(i: Double): M = densify().blockMap(_ + i,
     "scalar addition")
-
+  
   def scalarSub(i: Double): M = densify().blockMap(_ - i,
     "scalar subtraction")
-
+  
   def scalarMul(i: Double): M = blockMap(_ *:* i,
       s"multiplication by scalar $i",
       reqDense = i.isNaN | i.isInfinity)
-
+  
   def scalarDiv(i: Double): M = blockMap(_ /:/ i,
       s"division by scalar $i",
       reqDense = i == 0.0 | i.isNaN | i.isInfinity)
-
+  
   def reverseScalarSub(i: Double): M = densify().blockMap(i - _,
     s"scalar minus block matrix")
-
+  
   def reverseScalarDiv(i: Double): M = blockMap(i /:/ _,
     s"scalar divided by block matrix")
 
@@ -792,14 +792,14 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   def pow(exponent: Double): M = blockMap(breezePow(_, exponent),
     s"exponentiation by negative power $exponent",
     reqDense = exponent < 0)
-
+  
   def log(): M = blockMap(breezeLog(_),
     "natural logarithm")
 
   def abs(): M = blockMap(breezeAbs(_),
     "absolute value",
     reqDense = false)
-
+  
   // matrix ops
   def dot(that: M): M = new BlockMatrix(new BlockMatrixMultiplyRDD(this, that), blockSize, nRows, that.nCols)
 
@@ -826,10 +826,10 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     }
 
     val result = new Array[Double](nDiagElements)
-
+    
     val nDiagBlocks = math.min(gp.nBlockRows, gp.nBlockCols)
     val diagBlocks = Array.tabulate(nDiagBlocks)(i => gp.coordinatesBlock(i, i))
-
+    
     filterBlocks(diagBlocks).blocks
       .map { case ((i, j), lm) =>
         assert(i == j)
@@ -837,7 +837,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       }
       .collect()
       .foreach { case (i, a) => System.arraycopy(a, 0, result, i * blockSize, a.length) }
-
+    
     result
   }
 
@@ -945,7 +945,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     if (!sameBlocks(that))
       fatal(s"$name requires block matrices to have the same set of blocks present")
   }
-
+  
   private def sameBlocks(that: M): Boolean = {
     (gp.partitionIndexToBlockIndex, that.gp.partitionIndexToBlockIndex) match {
       case (Some(bis), Some(bis2)) => bis sameElements bis2
@@ -953,7 +953,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       case _ => false
     }
   }
-
+  
   def blockMap(op: BDM[Double] => BDM[Double],
     name: String = "operation",
     reqDense: Boolean = true): M = {
@@ -961,7 +961,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       requireDense(name)
     new BlockMatrix(blocks.mapValues(op), blockSize, nRows, nCols)
   }
-
+  
   def blockMapWithIndex(op: ((Int, Int), BDM[Double]) => BDM[Double],
     name: String = "operation",
     reqDense: Boolean = true): M = {
@@ -1254,15 +1254,15 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         .reduceByKey(GridPartitioner(blockSize, 1, nCols, gp.maybeBlockCols()), vectorOp)
         .mapValues(v => new BDM[Double](1, v.length, v.data)),
       blockSize, 1, nCols)
-
-  def colReduce(blockOp: BDM[Double] => BDV[Double], vectorOp: (BDV[Double], BDV[Double]) => BDV[Double]): BlockMatrix =
+  
+  def colReduce(blockOp: BDM[Double] => BDV[Double], vectorOp: (BDV[Double], BDV[Double]) => BDV[Double]): BlockMatrix =    
     new BlockMatrix(
       blocks
         .map { case ((i, j), lm) => ((i, 0), blockOp(lm)) }
         .reduceByKey(GridPartitioner(blockSize, nRows, 1, gp.maybeBlockRows()), vectorOp)
         .mapValues(v => new BDM[Double](v.length, 1, v.data)),
       blockSize, nRows, 1)
-
+  
   def toIndexedRowMatrix(): IndexedRowMatrix = {
     require(nCols <= Integer.MAX_VALUE)
     val nColsInt = nCols.toInt
@@ -1310,7 +1310,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     } else
       0.0
   }
-
+  
   def filterRows(keep: Array[Long]): BlockMatrix = {
     new BlockMatrix(new BlockMatrixFilterRowsRDD(this, keep), blockSize, keep.length, nCols)
   }
@@ -1326,7 +1326,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
   def entriesTable(ctx: ExecuteContext): TableValue = {
     val rowType = PCanonicalStruct(true, "i" -> PInt64Required, "j" -> PInt64Required, "entry" -> PFloat64Required)
-
+    
     val sm = ctx.stateManager
     val entriesRDD = ContextRDD.weaken(blocks).cflatMap { case (rvdContext, ((blockRow, blockCol), block)) =>
       val rowOffset = blockRow * blockSize.toLong
@@ -1417,7 +1417,7 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
   log.info("Constructing BlockMatrixFilterRDD")
 
   val t0 = System.nanoTime()
-
+  
   private val originalGP = bm.gp
 
   if (bm.isSparse) {
@@ -1777,7 +1777,7 @@ private class BlockMatrixUnionOpRDD(
 
   private val lParts = l.blocks.partitions
   private val rParts = r.blocks.partitions
-
+  
   override def getDependencies: Seq[Dependency[_]] =
     Array[Dependency[_]](
       new NarrowDependency(l.blocks) {
@@ -1813,7 +1813,7 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
   private val lGP = l.gp
   private val rGP = r.gp
   private val gp = GridPartitioner(l.blockSize, l.nRows, r.nCols)
-
+  
   private val lParts = l.blocks.partitions
   private val rParts = r.blocks.partitions
   private val nProducts = lGP.nBlockCols

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -6,7 +6,7 @@ import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import is.hail._
 import is.hail.annotations._
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
-import is.hail.backend.{BroadcastValue, ExecuteContext}
+import is.hail.backend.{BroadcastValue, ExecuteContext, HailStateManager}
 import is.hail.expr.ir.{IntArrayBuilder, TableReader, TableValue, ThreefryRandomEngine}
 import is.hail.io._
 import is.hail.io.fs.FS
@@ -415,16 +415,16 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   val nCols: Long) extends Serializable {
 
   import BlockMatrix._
-  
+
   require(blocks.partitioner.isDefined)
   require(blocks.partitioner.get.isInstanceOf[GridPartitioner])
 
   val gp: GridPartitioner = blocks.partitioner.get.asInstanceOf[GridPartitioner]
-  
+
   require(gp.blockSize == blockSize && gp.nRows == nRows && gp.nCols == nCols)
-  
+
   val isSparse: Boolean = gp.partitionIndexToBlockIndex.isDefined
-  
+
   def requireDense(name: String): Unit =
     if (isSparse)
       fatal(s"$name is not supported for block-sparse matrices.")
@@ -435,7 +435,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       realizeBlocks(None)
     } else
       this
-  
+
   // if Some(bis), unrealized blocks in bis are replaced with zero blocks
   // if None, all unrealized blocks are replaced with zero blocks
   def realizeBlocks(maybeBlocksToRealize: Option[IndexedSeq[Int]]): BlockMatrix = {
@@ -443,7 +443,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       if (maybeBlocksToRealize.exists(_.length == gp.maxNBlocks)) None else maybeBlocksToRealize)
 
     val newGP = gp.union(realizeGP)
-    
+
     if (newGP.numPartitions == gp.numPartitions)
       this
     else {
@@ -464,7 +464,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       this
     else
       subsetBlocks(gp.intersect(gp.copy(partitionIndexToBlockIndex = Some(blocksToKeep))))
-    
+
   // assumes subsetGP blocks are subset of gp blocks, as with subsetGP = gp.intersect(gp2)
   def subsetBlocks(subsetGP: GridPartitioner): BlockMatrix = {
     if (subsetGP.numPartitions == gp.numPartitions)
@@ -475,7 +475,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         blockSize, nRows, nCols)
     }
   }
-  
+
   // filter to blocks overlapping diagonal band of all elements with lower <= jj - ii <= upper
   // if not blocksOnly, also zero out all remaining elements outside band
   def filterBand(lower: Long, upper: Long, blocksOnly: Boolean): BlockMatrix = {
@@ -488,25 +488,25 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     else
       filteredBM.zeroBand(lower, upper)
   }
-  
-  def zeroBand(lower: Long, upper: Long): BlockMatrix = {    
+
+  def zeroBand(lower: Long, upper: Long): BlockMatrix = {
     val zeroedBlocks = blocks.mapPartitions( { it =>
       assert(it.hasNext)
       val ((i, j), lm0) = it.next()
       assert(!it.hasNext)
-      
+
       val nRowsInBlock = lm0.rows
       val nColsInBlock = lm0.cols
 
       val diagIndex = (j - i).toLong * blockSize
       val lowestDiagIndex = diagIndex - (nRowsInBlock - 1)
       val highestDiagIndex = diagIndex + (nColsInBlock - 1)
-      
+
       if (lowestDiagIndex >= lower && highestDiagIndex <= upper)
         Iterator.single(((i, j), lm0))
       else {
         val lm = lm0.copy // avoidable?
-        
+
         if (lower > lowestDiagIndex) {
           val iiLeft = math.max(diagIndex - lower, 0).toInt
           val iiRight = math.min(diagIndex - lower + nColsInBlock, nRowsInBlock).toInt
@@ -518,16 +518,16 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
             ii += 1
             jj += 1
           }
-          
+
           lm(iiRight until nRowsInBlock, ::) := 0.0
         }
-        
+
         if (upper < highestDiagIndex) {
           val iiLeft = math.max(diagIndex - upper, 0).toInt
           val iiRight = math.min(diagIndex - upper + nColsInBlock, nRowsInBlock).toInt
 
           lm(0 until iiLeft, ::) := 0.0
-          
+
           var ii = iiLeft
           var jj = math.max(upper - diagIndex, 0).toInt + 1
           while (ii < iiRight) {
@@ -539,10 +539,10 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         Iterator.single(((i, j), lm))
       }
     }, preservesPartitioning = true)
-    
+
     new BlockMatrix(zeroedBlocks, blockSize, nRows, nCols)
   }
-  
+
   // for row i, filter to indices [starts[i], stops[i]) by dropping non-overlapping blocks
   // if not blocksOnly, also zero out elements outside ranges in overlapping blocks
   // checked in Python: start >= 0 && start <= stop && stop <= nCols
@@ -558,8 +558,8 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     else
       filteredBM.zeroRowIntervals(starts, stops)
   }
-  
-  def zeroRowIntervals(starts: Array[Long], stops: Array[Long]): BlockMatrix = {    
+
+  def zeroRowIntervals(starts: Array[Long], stops: Array[Long]): BlockMatrix = {
     val backend = HailContext.backend
     val startBlockIndexBc = backend.broadcast(starts.map(gp.indexBlockIndex))
     val stopBlockIndexBc = backend.broadcast(stops.map(stop => (stop / blockSize).toInt))
@@ -597,17 +597,17 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         row += 1
         ii += 1
       }
-      
+
       Iterator.single(((i, j), lm))
     }, preservesPartitioning = true)
-    
+
     new BlockMatrix(zeroedBlocks, blockSize, nRows, nCols)
   }
-  
+
   def filterRectangles(flattenedRectangles: Array[Long]): BlockMatrix = {
     require(flattenedRectangles.length % 4 == 0)
     val rectangles = flattenedRectangles.grouped(4).toArray
-    
+
     filterBlocks(gp.rectanglesBlocks(rectangles))
   }
 
@@ -663,7 +663,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
   // element-wise ops
   def unary_+(): M = this
-  
+
   def unary_-(): M = blockMap(-_,
     "negation",
     reqDense = false)
@@ -684,7 +684,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       )
       new BlockMatrix(addBlocks, blockSize, nRows, nCols)
     }
-  
+
   def sub(that: M): M =
     if (sameBlocks(that)) {
       blockMap2(that, _ - _,
@@ -701,7 +701,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       )
       new BlockMatrix(subBlocks, blockSize, nRows, nCols)
     }
-  
+
   def mul(that: M): M = {
     val newGP = gp.intersect(that.gp)
     subsetBlocks(newGP).blockMap2(
@@ -709,42 +709,42 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       "element-wise multiplication",
       reqDense = false)
   }
-  
+
   def div(that: M): M = blockMap2(that, _ /:/ _,
     "element-wise division")
-  
+
   // row broadcast
   def rowVectorAdd(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::) + lv,
     "broadcasted addition of row-vector")(a)
-  
+
   def rowVectorSub(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::) - lv,
     "broadcasted subtraction of row-vector")(a)
-  
+
   def rowVectorMul(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) *:* lv,
     "broadcasted multiplication by row-vector containing nan, or infinity",
     reqDense = a.exists(i => i.isNaN | i.isInfinity))(a)
-  
-  def rowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) /:/ lv, 
+
+  def rowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) /:/ lv,
     "broadcasted division by row-vector containing zero, nan, or infinity",
     reqDense = a.exists(i => i == 0.0 | i.isNaN | i.isInfinity))(a)
 
   def reverseRowVectorSub(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::).map(lv - _),
     "broadcasted row-vector minus block matrix")(a)
- 
+
   def reverseRowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::).map(lv /:/ _),
     "broadcasted row-vector divided by block matrix")(a)
-  
+
   // column broadcast
   def colVectorAdd(a: Array[Double]): M = densify().colVectorOp((lm, lv) => lm(::, *) + lv,
     "broadcasted addition of column-vector")(a)
-  
+
   def colVectorSub(a: Array[Double]): M = densify().colVectorOp((lm, lv) => lm(::, *) - lv,
     "broadcasted subtraction of column-vector")(a)
-  
+
   def colVectorMul(a: Array[Double]): M = colVectorOp((lm, lv) => lm(::, *) *:* lv,
     "broadcasted multiplication column-vector containing nan or infinity",
     reqDense = a.exists(i => i.isNaN | i.isInfinity))(a)
-  
+
   def colVectorDiv(a: Array[Double]): M = colVectorOp((lm, lv) => lm(::, *) /:/ lv,
     "broadcasted division by column-vector containing zero, nan, or infinity",
     reqDense = a.exists(i => i == 0.0 | i.isNaN | i.isInfinity))(a)
@@ -758,21 +758,21 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   // scalar
   def scalarAdd(i: Double): M = densify().blockMap(_ + i,
     "scalar addition")
-  
+
   def scalarSub(i: Double): M = densify().blockMap(_ - i,
     "scalar subtraction")
-  
+
   def scalarMul(i: Double): M = blockMap(_ *:* i,
       s"multiplication by scalar $i",
       reqDense = i.isNaN | i.isInfinity)
-  
+
   def scalarDiv(i: Double): M = blockMap(_ /:/ i,
       s"division by scalar $i",
       reqDense = i == 0.0 | i.isNaN | i.isInfinity)
-  
+
   def reverseScalarSub(i: Double): M = densify().blockMap(i - _,
     s"scalar minus block matrix")
-  
+
   def reverseScalarDiv(i: Double): M = blockMap(i /:/ _,
     s"scalar divided by block matrix")
 
@@ -792,14 +792,14 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   def pow(exponent: Double): M = blockMap(breezePow(_, exponent),
     s"exponentiation by negative power $exponent",
     reqDense = exponent < 0)
-  
+
   def log(): M = blockMap(breezeLog(_),
     "natural logarithm")
 
   def abs(): M = blockMap(breezeAbs(_),
     "absolute value",
     reqDense = false)
-  
+
   // matrix ops
   def dot(that: M): M = new BlockMatrix(new BlockMatrixMultiplyRDD(this, that), blockSize, nRows, that.nCols)
 
@@ -826,10 +826,10 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     }
 
     val result = new Array[Double](nDiagElements)
-    
+
     val nDiagBlocks = math.min(gp.nBlockRows, gp.nBlockCols)
     val diagBlocks = Array.tabulate(nDiagBlocks)(i => gp.coordinatesBlock(i, i))
-    
+
     filterBlocks(diagBlocks).blocks
       .map { case ((i, j), lm) =>
         assert(i == j)
@@ -837,7 +837,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       }
       .collect()
       .foreach { case (i, a) => System.arraycopy(a, 0, result, i * blockSize, a.length) }
-    
+
     result
   }
 
@@ -945,7 +945,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     if (!sameBlocks(that))
       fatal(s"$name requires block matrices to have the same set of blocks present")
   }
-  
+
   private def sameBlocks(that: M): Boolean = {
     (gp.partitionIndexToBlockIndex, that.gp.partitionIndexToBlockIndex) match {
       case (Some(bis), Some(bis2)) => bis sameElements bis2
@@ -953,7 +953,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       case _ => false
     }
   }
-  
+
   def blockMap(op: BDM[Double] => BDM[Double],
     name: String = "operation",
     reqDense: Boolean = true): M = {
@@ -961,7 +961,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       requireDense(name)
     new BlockMatrix(blocks.mapValues(op), blockSize, nRows, nCols)
   }
-  
+
   def blockMapWithIndex(op: ((Int, Int), BDM[Double]) => BDM[Double],
     name: String = "operation",
     reqDense: Boolean = true): M = {
@@ -1254,15 +1254,15 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         .reduceByKey(GridPartitioner(blockSize, 1, nCols, gp.maybeBlockCols()), vectorOp)
         .mapValues(v => new BDM[Double](1, v.length, v.data)),
       blockSize, 1, nCols)
-  
-  def colReduce(blockOp: BDM[Double] => BDV[Double], vectorOp: (BDV[Double], BDV[Double]) => BDV[Double]): BlockMatrix =    
+
+  def colReduce(blockOp: BDM[Double] => BDV[Double], vectorOp: (BDV[Double], BDV[Double]) => BDV[Double]): BlockMatrix =
     new BlockMatrix(
       blocks
         .map { case ((i, j), lm) => ((i, 0), blockOp(lm)) }
         .reduceByKey(GridPartitioner(blockSize, nRows, 1, gp.maybeBlockRows()), vectorOp)
         .mapValues(v => new BDM[Double](v.length, 1, v.data)),
       blockSize, nRows, 1)
-  
+
   def toIndexedRowMatrix(): IndexedRowMatrix = {
     require(nCols <= Integer.MAX_VALUE)
     val nColsInt = nCols.toInt
@@ -1310,7 +1310,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     } else
       0.0
   }
-  
+
   def filterRows(keep: Array[Long]): BlockMatrix = {
     new BlockMatrix(new BlockMatrixFilterRowsRDD(this, keep), blockSize, keep.length, nCols)
   }
@@ -1326,12 +1326,13 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
   def entriesTable(ctx: ExecuteContext): TableValue = {
     val rowType = PCanonicalStruct(true, "i" -> PInt64Required, "j" -> PInt64Required, "entry" -> PFloat64Required)
-    
-    val entriesRDD = ContextRDD.weaken(blocks).cflatMap { case (ctx, ((blockRow, blockCol), block)) =>
+
+    val sm = ctx.stateManager
+    val entriesRDD = ContextRDD.weaken(blocks).cflatMap { case (rvdContext, ((blockRow, blockCol), block)) =>
       val rowOffset = blockRow * blockSize.toLong
       val colOffset = blockCol * blockSize.toLong
 
-      val rvb = new RegionValueBuilder(ctx.region)
+      val rvb = new RegionValueBuilder(sm, rvdContext.region)
 
       block.activeIterator
         .map { case ((i, j), entry) =>
@@ -1416,7 +1417,7 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
   log.info("Constructing BlockMatrixFilterRDD")
 
   val t0 = System.nanoTime()
-  
+
   private val originalGP = bm.gp
 
   if (bm.isSparse) {
@@ -1776,7 +1777,7 @@ private class BlockMatrixUnionOpRDD(
 
   private val lParts = l.blocks.partitions
   private val rParts = r.blocks.partitions
-  
+
   override def getDependencies: Seq[Dependency[_]] =
     Array[Dependency[_]](
       new NarrowDependency(l.blocks) {
@@ -1812,7 +1813,7 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
   private val lGP = l.gp
   private val rGP = r.gp
   private val gp = GridPartitioner(l.blockSize, l.nRows, r.nCols)
-  
+
   private val lParts = l.blocks.partitions
   private val rParts = r.blocks.partitions
   private val nProducts = lGP.nBlockCols
@@ -2132,7 +2133,7 @@ class BlockMatrixReadRowBlockedRDD(
     }
     Iterator.single { ctx =>
       val region = ctx.region
-      val rvb = new RegionValueBuilder(region)
+      val rvb = new RegionValueBuilder(HailStateManager(Map.empty), region)
       val rv = RegionValue(region)
       val firstRow = rowsForPartition(0)
       var blockRow = (firstRow / blockSize).toInt

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -16,18 +16,18 @@ import org.apache.spark.{Partition, Partitioner, SparkContext, TaskContext}
 object RowMatrix {
   def apply(rows: RDD[(Long, Array[Double])], nCols: Int): RowMatrix =
     new RowMatrix(rows, nCols, None, None)
-  
+
   def apply(rows: RDD[(Long, Array[Double])], nCols: Int, nRows: Long): RowMatrix =
     new RowMatrix(rows, nCols, Some(nRows), None)
-  
+
   def apply(rows: RDD[(Long, Array[Double])], nCols: Int, nRows: Long, partitionCounts: Array[Long]): RowMatrix =
     new RowMatrix(rows, nCols, Some(nRows), Some(partitionCounts))
-  
+
   def computePartitionCounts(partSize: Long, nRows: Long): Array[Long] = {
     val nParts = ((nRows - 1) / partSize).toInt + 1
     val partitionCounts = Array.fill[Long](nParts)(partSize)
     partitionCounts(nParts - 1) = nRows - partSize * (nParts - 1)
-    
+
     partitionCounts
   }
 
@@ -53,51 +53,51 @@ class RowMatrix(val rows: RDD[(Long, Array[Double])],
   private var _partitionCounts: Option[Array[Long]]) extends Serializable {
 
   require(nCols > 0)
-  
+
   def nRows: Long = _nRows match {
     case Some(nRows) => nRows
     case None =>
       _nRows = Some(partitionCounts().sum)
       nRows
     }
-  
+
   def partitionCounts(): Array[Long] = _partitionCounts match {
     case Some(partitionCounts) => partitionCounts
     case None =>
       _partitionCounts = Some(rows.countPerPartition())
       partitionCounts()
   }
-  
+
   // length nPartitions + 1, first element 0, last element rdd2 count
   def partitionStarts(): Array[Long] = partitionCounts().scanLeft(0L)(_ + _)
 
   def partitioner(
     partitionKey: Array[String] = Array("idx"),
     kType: TStruct = TStruct("idx" -> TInt64)): RVDPartitioner = {
-    
+
     val partStarts = partitionStarts()
 
-    new RVDPartitioner(partitionKey, kType,
+    new RVDPartitioner(null, partitionKey, kType,
       Array.tabulate(partStarts.length - 1) { i =>
         val start = partStarts(i)
         val end = partStarts(i + 1)
         Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
       })
   }
-  
+
   def toBreezeMatrix(): DenseMatrix[Double] = {
     require(_nRows.forall(_ <= Int.MaxValue), "The number of rows of this matrix should be less than or equal to " +
         s"Int.MaxValue. Currently numRows: ${ _nRows.get }")
-    
+
     val a = rows.map(_._2).collect()
     val nRowsInt = a.length
-    
+
     require(nRowsInt * nCols.toLong <= Int.MaxValue, "The length of the values array must be " +
-      s"less than or equal to Int.MaxValue. Currently rows * cols: ${ nRowsInt * nCols.toLong }")    
-    
+      s"less than or equal to Int.MaxValue. Currently rows * cols: ${ nRowsInt * nCols.toLong }")
+
     new DenseMatrix[Double](nRowsInt, nCols, a.flatten, 0, nCols, isTranspose = true)
   }
-  
+
   def export(ctx: ExecuteContext, path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(ctx, path, columnDelimiter, header, addIndex, exportType, _ => 0, _ => localNCols)
@@ -118,24 +118,24 @@ class RowMatrix(val rows: RDD[(Long, Array[Double])],
   def exportUpperTriangle(ctx: ExecuteContext, path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(ctx, path, columnDelimiter, header, addIndex, exportType, i => math.min(i, localNCols.toLong).toInt, _ => localNCols)
-  }  
-  
+  }
+
   def exportStrictUpperTriangle(ctx: ExecuteContext, path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(ctx, path, columnDelimiter, header, addIndex, exportType, i => math.min(i + 1, localNCols.toLong).toInt, _ => localNCols)
   }
-  
+
   // convert elements in [start, end) of each array to a string, delimited by columnDelimiter, and export
   def exportDelimitedRowSlices(
     ctx: ExecuteContext,
-    path: String, 
+    path: String,
     columnDelimiter: String,
     header: Option[String],
     addIndex: Boolean,
     exportType: String,
-    start: (Long) => Int, 
+    start: (Long) => Int,
     end: (Long) => Int) {
-    
+
     genericExport(ctx, path, header, exportType, { (sb, i, v) =>
       if (addIndex) {
         sb.append(i)
@@ -156,11 +156,11 @@ class RowMatrix(val rows: RDD[(Long, Array[Double])],
   // uses writeRow to convert each row to a string and writes that string to a file if non-empty
   def genericExport(
     ctx: ExecuteContext,
-    path: String, 
-    header: Option[String], 
+    path: String,
+    header: Option[String],
     exportType: String,
     writeRow: (StringBuilder, Long, Array[Double]) => Unit) {
-    
+
     rows.mapPartitions { it =>
       val sb = new StringBuilder()
       it.map { case (index, v) =>
@@ -181,15 +181,15 @@ class ReadBlocksAsRowsRDD(
   partFiles: IndexedSeq[String],
   partitionCounts: Array[Long],
   gp: GridPartitioner) extends RDD[(Long, Array[Double])](SparkBackend.sparkContext("ReadBlocksAsRowsRDD"), Nil) {
-  
+
   private val partitionStarts = partitionCounts.scanLeft(0L)(_ + _)
-  
+
   if (partitionStarts.last != gp.nRows)
     fatal(s"Error reading BlockMatrix as RowMatrix: expected ${partitionStarts.last} rows in RowMatrix, but found ${gp.nRows} rows in BlockMatrix")
 
   if (gp.nCols > Int.MaxValue)
       fatal(s"Cannot read BlockMatrix with ${gp.nCols} > Int.MaxValue columns as a RowMatrix")
-  
+
   private val nCols = gp.nCols.toInt
   private val nBlockCols = gp.nBlockCols
   private val blockSize = gp.blockSize
@@ -199,7 +199,7 @@ class ReadBlocksAsRowsRDD(
 
   def compute(split: Partition, context: TaskContext): Iterator[(Long, Array[Double])] = {
     val ReadBlocksAsRowsRDDPartition(_, start, end) = split.asInstanceOf[ReadBlocksAsRowsRDDPartition]
-    
+
     var inPerBlockCol: IndexedSeq[(InputBuffer, Int, Int)] = null
     var i = start
 
@@ -210,7 +210,7 @@ class ReadBlocksAsRowsRDD(
         if (i == start || i % blockSize == 0) {
           val blockRow = (i / blockSize).toInt
           val nRowsInBlock = gp.blockRowNRows(blockRow)
-          
+
           inPerBlockCol = (0 until nBlockCols)
             .flatMap { blockCol =>
               val pi = gp.coordinatesPart(blockRow, blockCol)
@@ -240,22 +240,22 @@ class ReadBlocksAsRowsRDD(
         }
 
         val row = new Array[Double](nCols)
-        
+
         inPerBlockCol.foreach { case (in, blockCol, nColsInBlock) =>
           in.readDoubles(row, blockCol * blockSize, nColsInBlock)
         }
-        
+
         val iRow = (i, row)
-        
+
         i += 1
-        
+
         if (i % blockSize == 0 || i == end)
           inPerBlockCol.foreach(_._1.close())
-        
+
         iRow
       }
     }
   }
-  
+
   @transient override val partitioner: Option[Partitioner] = Some(RowPartitioner(partitionStarts))
 }

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -82,10 +82,11 @@ case class LinearRegressionRowsSingle(
     val copiedFieldIndices = (mv.typ.rowKey ++ passThrough).map(fullRowType.fieldIdx(_)).toArray
     val nDependentVariables = yFields.length
 
+    val sm = ctx.stateManager
     val newRVD = mv.rvd.mapPartitionsWithContext(
       rvdType) { (consumerCtx, it) =>
         val producerCtx = consumerCtx.freshContext
-        val rvb = new RegionValueBuilder()
+        val rvb = new RegionValueBuilder(sm)
 
         val missingCompleteCols = new IntArrayBuilder()
         val data = new Array[Double](n * rowBlockSize)
@@ -93,7 +94,7 @@ case class LinearRegressionRowsSingle(
         val blockWRVs = new Array[WritableRegionValue](rowBlockSize)
         var i = 0
         while (i < rowBlockSize) {
-          blockWRVs(i) = WritableRegionValue(fullRowType, producerCtx.freshRegion())
+          blockWRVs(i) = WritableRegionValue(sm, fullRowType, producerCtx.freshRegion())
           i += 1
         }
 
@@ -239,10 +240,11 @@ case class LinearRegressionRowsChained(
     val rvdType = tableType.canonicalRVDType
     val copiedFieldIndices = (mv.typ.rowKey ++ passThrough).map(fullRowType.fieldIdx(_)).toArray
 
+    val sm = ctx.stateManager
     val newRVD = mv.rvd.mapPartitionsWithContext(
       rvdType) { (consumerCtx, it) =>
         val producerCtx = consumerCtx.freshContext
-        val rvb = new RegionValueBuilder()
+        val rvb = new RegionValueBuilder(sm)
 
         val inputData = bc.value
         val builder = new IntArrayBuilder()
@@ -251,7 +253,7 @@ case class LinearRegressionRowsChained(
         val blockWRVs = new Array[WritableRegionValue](rowBlockSize)
         var i = 0
         while (i < rowBlockSize) {
-          blockWRVs(i) = WritableRegionValue(fullRowType, producerCtx.freshRegion())
+          blockWRVs(i) = WritableRegionValue(sm, fullRowType, producerCtx.freshRegion())
           i += 1
         }
 

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -405,7 +405,7 @@ object Nirvana {
     val localRowType = tv.rvd.rowPType
     val localBlockSize = blockSize
 
-    val rowKeyOrd = tv.typ.keyType.ordering
+    val rowKeyOrd = tv.typ.keyType.ordering(ctx.stateManager)
 
     info("Running Nirvana")
 
@@ -459,8 +459,8 @@ object Nirvana {
     val nirvanaRVD: RVD = RVD(
       nirvanaRVDType,
       prev.partitioner,
-      ContextRDD.weaken(annotations).cmapPartitions { (ctx, it) =>
-        val rvb = new RegionValueBuilder(ctx.region)
+      ContextRDD.weaken(annotations).cmapPartitions { (rvdContext, it) =>
+        val rvb = new RegionValueBuilder(ctx.stateManager, rvdContext.region)
 
         it.map { case (v, nirvana) =>
           rvb.start(nirvanaRowType)

--- a/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
@@ -47,6 +47,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
   ): RVD = {
     checkJoinCompatability(right)
 
+    val sm = ctx.stateManager
     val newPartitioner = {
       def leftPart = this.rvd.partitioner.strictify
       def rightPart = right.rvd.partitioner.coarsen(key).extendKey(realType.kType.virtualType)
@@ -55,6 +56,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
         case "right" => rightPart
         case "inner" => leftPart.intersect(rightPart)
         case "outer" => RVDPartitioner.generate(
+          sm,
           kType.fieldNames,
           realType.kType.virtualType,
           leftPart.rangeBounds ++ rightPart.rangeBounds)
@@ -81,14 +83,14 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
       joiner(
         ctx,
         compute(
-          OrderedRVIterator(lTyp, leftIt, ctx),
-          OrderedRVIterator(rTyp, rightIt, ctx),
-          new RegionValueArrayBuffer(rRowPType, sideBuffer)))
+          OrderedRVIterator(lTyp, leftIt, ctx, sm),
+          OrderedRVIterator(rTyp, rightIt, ctx, sm),
+          new RegionValueArrayBuffer(rRowPType, sideBuffer, sm)))
     }.extendKeyPreservesPartitioning(ctx, joinedType.key)
   }
 
   def orderedLeftIntervalJoin(
-    ctx: ExecuteContext,
+    executeContext: ExecuteContext,
     right: KeyedRVD,
     joiner: PStruct => (RVDType, (RVDContext, Iterator[Muple[RegionValue, Iterable[RegionValue]]]) => Iterator[RegionValue])
   ): RVD = {
@@ -97,21 +99,22 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
     val lTyp = virtType
     val rTyp = right.virtType
 
-    rvd.intervalAlignAndZipPartitions(ctx, right.rvd) {
+    val sm = executeContext.stateManager
+    rvd.intervalAlignAndZipPartitions(executeContext, right.rvd) {
       t: PStruct => {
         val (newTyp, f) = joiner(t)
 
         (newTyp, (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
           f(
             ctx,
-            OrderedRVIterator(lTyp, it, ctx)
-              .leftIntervalJoin(OrderedRVIterator(rTyp, intervals, ctx))))
+            OrderedRVIterator(lTyp, it, ctx, sm)
+              .leftIntervalJoin(OrderedRVIterator(rTyp, intervals, ctx, sm))))
       }
     }
   }
 
   def orderedLeftIntervalJoinDistinct(
-    ctx: ExecuteContext,
+    executeContext: ExecuteContext,
     right: KeyedRVD,
     joiner: PStruct => (RVDType, (RVDContext, Iterator[JoinedRegionValue]) => Iterator[RegionValue])
   ): RVD = {
@@ -120,15 +123,16 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
     val lTyp = virtType
     val rTyp = right.virtType
 
-    rvd.intervalAlignAndZipPartitions(ctx, right.rvd) {
+    val sm = executeContext.stateManager
+    rvd.intervalAlignAndZipPartitions(executeContext, right.rvd) {
       t: PStruct => {
         val (newTyp, f) = joiner(t)
 
         (newTyp, (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
           f(
             ctx,
-            OrderedRVIterator(lTyp, it, ctx)
-              .leftIntervalJoinDistinct(OrderedRVIterator(rTyp, intervals, ctx))))
+            OrderedRVIterator(lTyp, it, ctx, sm)
+              .leftIntervalJoinDistinct(OrderedRVIterator(rTyp, intervals, ctx, sm))))
       }
     }
   }
@@ -141,6 +145,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
     checkJoinCompatability(right)
     val lTyp = virtType
     val rTyp = right.virtType
+    val sm = right.rvd.partitioner.sm
 
     rvd.alignAndZipPartitions(
       joinedType,
@@ -149,7 +154,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
     ) { (ctx, leftIt, rightIt) =>
       joiner(
         ctx,
-        OrderedRVIterator(lTyp, leftIt, ctx).leftJoinDistinct(OrderedRVIterator(rTyp, rightIt, ctx)))
+        OrderedRVIterator(lTyp, leftIt, ctx, sm).leftJoinDistinct(OrderedRVIterator(rTyp, rightIt, ctx, sm)))
     }
   }
 
@@ -169,19 +174,20 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
 
     val ranges = this.rvd.partitioner.coarsenedRangeBounds(key) ++
       right.rvd.partitioner.coarsenedRangeBounds(key)
-    val newPartitioner = RVDPartitioner.generate(virtType.key, kType, ranges)
+    val newPartitioner = RVDPartitioner.generate(ctx.stateManager, virtType.key, kType, ranges)
 
     val repartitionedLeft = this.rvd.repartition(ctx, newPartitioner)
     val lType = this.virtType
     val rType = right.virtType
+    val sm = ctx.stateManager
 
     repartitionedLeft.alignAndZipPartitions(
       this.virtType,
       right.rvd,
       key
     ) { (ctx, leftIt, rightIt) =>
-      OrderedRVIterator(lType, leftIt, ctx)
-        .merge(OrderedRVIterator(rType, rightIt, ctx))
+      OrderedRVIterator(lType, leftIt, ctx, sm)
+        .merge(OrderedRVIterator(rType, rightIt, ctx, sm))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/rvd/PartitionBoundOrdering.scala
+++ b/hail/src/main/scala/is/hail/rvd/PartitionBoundOrdering.scala
@@ -1,15 +1,20 @@
 package is.hail.rvd
 
 import is.hail.annotations.{ExtendedOrdering, IntervalEndpointOrdering, SafeRow}
+import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.types.physical.{PStruct, PType}
 import is.hail.types.virtual._
 import is.hail.utils._
 import org.apache.spark.sql.Row
 
 object PartitionBoundOrdering {
-  def apply(_kType: Type): ExtendedOrdering = {
+  def apply(ctx: ExecuteContext, _kType: Type): ExtendedOrdering = {
+    apply(ctx.stateManager, _kType)
+  }
+
+  def apply(sm: HailStateManager, _kType: Type): ExtendedOrdering = {
     val kType = _kType.asInstanceOf[TBaseStruct]
-    val fieldOrd = kType.types.map(_.ordering)
+    val fieldOrd = kType.types.map(_.ordering(sm))
 
     new ExtendedOrdering {
       outer =>

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -4,7 +4,7 @@ import java.util
 import is.hail.asm4s.{HailClassLoader, theHailClassLoaderForSparkWorkers}
 import is.hail.HailContext
 import is.hail.annotations._
-import is.hail.backend.{ExecuteContext, HailTaskContext}
+import is.hail.backend.{ExecuteContext, HailStateManager, HailTaskContext}
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.expr.ir.PruneDeadFields.isSupertype
 import is.hail.types._
@@ -150,7 +150,7 @@ class RVD(
     require(newKey startsWith typ.key)
     require(newKey.forall(typ.rowType.fieldNames.contains))
     val rvdType = typ.copy(key = newKey)
-    if (RVDPartitioner.isValid(rvdType.kType.virtualType, partitioner.rangeBounds))
+    if (RVDPartitioner.isValid(ctx.stateManager, rvdType.kType.virtualType, partitioner.rangeBounds))
       copy(typ = rvdType, partitioner = partitioner.copy(kType = rvdType.kType.virtualType))
     else {
       val adjustedPartitioner = partitioner.strictify
@@ -163,14 +163,15 @@ class RVD(
     val partitionerBc = partitioner.broadcast(crdd.sparkContext)
     val localType = typ
     val localKPType = typ.kType
+    val stateManager = partitioner.sm
 
-    val ord = PartitionBoundOrdering(localType.kType.virtualType)
+    val ord = PartitionBoundOrdering(stateManager, localType.kType.virtualType)
     new RVD(
       typ,
       partitioner,
       crdd.cmapPartitionsWithIndex { case (i, ctx, it) =>
         val regionForWriting = ctx.freshRegion() // This one gets cleaned up when context is freed.
-        val prevK = WritableRegionValue(localType.kType, regionForWriting)
+        val prevK = WritableRegionValue(stateManager, localType.kType, regionForWriting)
         val kUR = new UnsafeRow(localKPType)
 
         new Iterator[Long] {
@@ -184,7 +185,7 @@ class RVD(
             if (first)
               first = false
             else {
-              if (localType.kRowOrd.gt(prevK.value.offset, ptr)) {
+              if (localType.kRowOrd(stateManager).gt(prevK.value.offset, ptr)) {
                 val prevKeyString = Region.pretty(localKPType, prevK.value.offset)
 
                 prevK.setSelect(localType.rowType, localType.kFieldIdx, ptr, deepCopy = true)
@@ -243,7 +244,7 @@ class RVD(
       val newType = typ.copy(key = newPartitioner.kType.fieldNames)
 
       val localRowPType = rowPType
-      val kOrdering = PartitionBoundOrdering(newType.kType.virtualType)
+      val kOrdering = PartitionBoundOrdering(ctx.stateManager, newType.kType.virtualType)
 
       val partBc = newPartitioner.broadcast(crdd.sparkContext)
       val enc = TypedCodecSpec(rowPType, BufferSpec.wireSpec)
@@ -270,7 +271,7 @@ class RVD(
         new RVD(
           typ.copy(key = typ.key.take(newPartitioner.kType.size)),
           newPartitioner,
-          RepartitionedOrderedRDD2(this, newPartitioner.rangeBounds))
+          RepartitionedOrderedRDD2(ctx.stateManager, this, newPartitioner.rangeBounds))
       else
         this
     }
@@ -318,11 +319,11 @@ class RVD(
         return RVD.unkeyed(newRowPType, shuffled)
 
       val newType = RVDType(newRowPType, typ.key)
-      val keyInfo = RVD.getKeyInfo(newType, newType.key.length, RVD.getKeys(newType, shuffled))
+      val keyInfo = RVD.getKeyInfo(ctx, newType, newType.key.length, RVD.getKeys(ctx, newType, shuffled))
       if (keyInfo.isEmpty)
-        return RVD.empty(typ)
+        return RVD.empty(ctx, typ)
       val newPartitioner = RVD.calculateKeyRanges(
-        newType, keyInfo, shuffled.getNumPartitions, newType.key.length)
+        ctx, newType, keyInfo, shuffled.getNumPartitions, newType.key.length)
 
       if (newPartitioner.numPartitions< maxPartitions)
         warn(s"coalesced to ${ newPartitioner.numPartitions} " +
@@ -374,10 +375,11 @@ class RVD(
   // Key-wise operations
 
   def distinctByKey(execCtx: ExecuteContext): RVD = {
+    val sm = execCtx.stateManager
     val localType = typ
     repartition(execCtx, partitioner.strictify)
       .mapPartitions(typ)((ctx, it) =>
-        OrderedRVIterator(localType, it.toIteratorRV(ctx.r), ctx)
+        OrderedRVIterator(localType, it.toIteratorRV(ctx.r), ctx, sm)
           .staircase
           .map(_.value.offset)
       )
@@ -390,7 +392,7 @@ class RVD(
 
     val localTyp = typ
     val sortedRDD = crdd.toCRDDRegionValue.cmapPartitions { (consumerCtx, it) =>
-      OrderedRVIterator(localTyp, it, consumerCtx).localKeySort(newKey)
+      OrderedRVIterator(localTyp, it, consumerCtx, partitioner.sm).localKeySort(newKey)
     }.toCRDDPtr
 
     val newType = typ.copy(key = newKey)
@@ -479,7 +481,7 @@ class RVD(
     require(n >= 0)
 
     if (n == 0)
-      return RVD.empty(typ)
+      return RVD.empty(partitioner.sm, typ)
 
     val (idxLast, nTake) = partitionCounts match {
       case Some(pcs) =>
@@ -518,7 +520,7 @@ class RVD(
     require(n >= 0)
 
     if (n == 0)
-      return RVD.empty(typ)
+      return RVD.empty(partitioner.sm, typ)
 
     val (idxFirst, nDrop) = partitionCounts match {
       case Some(pcs) =>
@@ -631,7 +633,7 @@ class RVD(
     info(s"reading ${ newPartitionIndices.length } of $nPartitions data partitions")
 
     if (newPartitionIndices.isEmpty)
-      RVD.empty(typ)
+      RVD.empty(intervals.sm, typ)
     else {
       subsetPartitions(newPartitionIndices).filter(pred)
     }
@@ -859,7 +861,7 @@ class RVD(
         val outputFirstBc = sc.broadcast(outputFirst)
         val outputLastBc = sc.broadcast(outputLast)
 
-        val kOrd = PartitionBoundOrdering(localTyp.kType.virtualType)
+        val kOrd = PartitionBoundOrdering(execCtx.stateManager, localTyp.kType.virtualType)
         crdd.blocked(inputFirst, inputLast)
           .cmapPartitionsWithIndex { (i, ctx, it) =>
             val s = outputFirstBc.value(i)
@@ -1098,12 +1100,13 @@ class RVD(
     require(joinKey <= this.typ.key.length)
     require(joinKey <= that.typ.key.length)
 
+    val sm = partitioner.sm
     val left = this.truncateKey(newTyp.key)
     RVD(
       typ = newTyp,
       partitioner = left.partitioner,
       crdd = left.crdd.toCRDDRegionValue.czipPartitions(
-        RepartitionedOrderedRDD2(that, this.partitioner.coarsenedRangeBounds(joinKey)).toCRDDRegionValue
+        RepartitionedOrderedRDD2(sm, that, this.partitioner.coarsenedRangeBounds(joinKey)).toCRDDRegionValue
       )(zipper).toCRDDPtr)
   }
 
@@ -1123,6 +1126,7 @@ class RVD(
     val rightTyp = that.typ
     val codecSpec = TypedCodecSpec(that.rowPType, BufferSpec.wireSpec)
     val makeEnc = codecSpec.buildEncoder(ctx, that.rowPType)
+    val sm = ctx.stateManager
     val partitionKeyedIntervals = that.crdd.cmapPartitions { (ctx, it) =>
       val encoder = new ByteArrayEncoder(theHailClassLoaderForSparkWorkers, makeEnc)
       TaskContext.get.addTaskCompletionListener[Unit] { _ =>
@@ -1143,7 +1147,7 @@ class RVD(
     }.run
 
     val nParts = getNumPartitions
-    val intervalOrd = rightTyp.kType.types(0).virtualType.ordering.toOrdering.asInstanceOf[Ordering[Interval]]
+    val intervalOrd = rightTyp.kType.types(0).virtualType.ordering(sm).toOrdering.asInstanceOf[Ordering[Interval]]
     val sorted: RDD[((Int, Interval), Array[Byte])] = new ShuffledRDD(
       partitionKeyedIntervals,
       new Partitioner {
@@ -1189,27 +1193,33 @@ class RVD(
 }
 
 object RVD {
-  def empty(typ: RVDType): RVD = {
+  def empty(ctx: ExecuteContext, typ: RVDType): RVD = {
+    RVD.empty(ctx.stateManager, typ)
+  }
+
+  def empty(sm: HailStateManager, typ: RVDType): RVD = {
     RVD(typ,
-      RVDPartitioner.empty(typ.kType.virtualType),
+      RVDPartitioner.empty(sm, typ.kType.virtualType),
       ContextRDD.empty[Long]())
   }
 
   def unkeyed(rowType: PStruct, crdd: ContextRDD[Long]): RVD =
     new RVD(
       RVDType(rowType, FastIndexedSeq()),
-      RVDPartitioner.unkeyed(crdd.getNumPartitions),
+      RVDPartitioner.unkeyed(null, crdd.getNumPartitions),
       crdd)
 
   def getKeys(
+    ctx: ExecuteContext,
     typ: RVDType,
     crdd: ContextRDD[Long]
   ): ContextRDD[Long] = {
     // The region values in 'crdd' are of type `typ.rowType`
     val localType = typ
+    val sm = ctx.stateManager
     crdd.cmapPartitionsWithContext { (consumerCtx, it) =>
       val producerCtx = consumerCtx.freshContext
-      val wrv = WritableRegionValue(localType.kType, consumerCtx.region)
+      val wrv = WritableRegionValue(sm, localType.kType, consumerCtx.region)
       it(producerCtx).map { ptr =>
         wrv.setSelect(localType.rowType, localType.kFieldIdx, ptr, deepCopy = true)
         producerCtx.region.clear()
@@ -1219,6 +1229,7 @@ object RVD {
   }
 
   def getKeyInfo(
+    ctx: ExecuteContext,
     typ: RVDType,
     // 'partitionKey' is used to check whether the rows are ordered by the first
     // 'partitionKey' key fields, even if they aren't ordered by the full key.
@@ -1238,14 +1249,15 @@ object RVD {
 
     val localType = typ
 
-    val keyInfo = keys.crunJobWithIndex { (i, ctx, it) =>
+    val sm = ctx.stateManager
+    val keyInfo = keys.crunJobWithIndex { (i, rvdContext, it) =>
       if (it.hasNext)
-        Some(RVDPartitionInfo(localType, partitionKey, samplesPerPartition, i, it, partitionSeed(i), ctx))
+        Some(RVDPartitionInfo(sm, localType, partitionKey, samplesPerPartition, i, it, partitionSeed(i), rvdContext))
       else
         None
     }.flatten
 
-    val kOrd = PartitionBoundOrdering(typ.kType.virtualType).toOrdering
+    val kOrd = PartitionBoundOrdering(sm, typ.kType.virtualType).toOrdering
     keyInfo.sortBy(_.min)(kOrd  )
   }
 
@@ -1268,7 +1280,7 @@ object RVD {
     partitionKey: Int,
     crdd: ContextRDD[Long]
   ): RVD = {
-    val keys = getKeys(typ, crdd)
+    val keys = getKeys(execCtx, typ, crdd)
     makeCoercer(execCtx, typ, partitionKey, keys).coerce(typ, crdd)
   }
 
@@ -1309,11 +1321,11 @@ object RVD {
       return unkeyedCoercer
 
     val emptyCoercer: RVDCoercer = new RVDCoercer(fullType) {
-      def _coerce(typ: RVDType, crdd: CRDD): RVD = empty(typ)
+      def _coerce(typ: RVDType, crdd: CRDD): RVD = empty(execCtx, typ)
     }
 
     val numPartitions = keys.getNumPartitions
-    val keyInfo = getKeyInfo(fullType, partitionKey, keys)
+    val keyInfo = getKeyInfo(execCtx, fullType, partitionKey, keys)
 
     if (keyInfo.isEmpty)
       return emptyCoercer
@@ -1340,14 +1352,14 @@ object RVD {
     val contextStr = minInfo.contextStr
 
     if (intraPartitionSortedness == RVDPartitionInfo.KSORTED
-      && RVDPartitioner.isValid(fullType.kType.virtualType, bounds)) {
+      && RVDPartitioner.isValid(execCtx.stateManager, fullType.kType.virtualType, bounds)) {
 
       info("Coerced sorted dataset")
 
       new RVDCoercer(fullType) {
         val unfixedPartitioner =
-          new RVDPartitioner(fullType.kType.virtualType, bounds)
-        val newPartitioner = RVDPartitioner.generate(
+          new RVDPartitioner(execCtx.stateManager, fullType.kType.virtualType, bounds)
+        val newPartitioner = RVDPartitioner.generate(execCtx.stateManager,
           fullType.key.take(partitionKey), fullType.kType.virtualType, bounds)
 
         def _coerce(typ: RVDType, crdd: CRDD): RVD = {
@@ -1357,17 +1369,19 @@ object RVD {
       }
 
     } else if (intraPartitionSortedness >= RVDPartitionInfo.TSORTED
-      && RVDPartitioner.isValid(fullType.kType.virtualType.truncate(partitionKey), pkBounds)) {
+      && RVDPartitioner.isValid(execCtx.stateManager, fullType.kType.virtualType.truncate(partitionKey), pkBounds)) {
 
       info(s"Coerced almost-sorted dataset")
       log.info(s"Unsorted keys: $contextStr")
 
       new RVDCoercer(fullType) {
         val unfixedPartitioner = new RVDPartitioner(
+          execCtx.stateManager,
           fullType.kType.virtualType.truncate(partitionKey),
           pkBounds
         )
         val newPartitioner = RVDPartitioner.generate(
+          execCtx.stateManager,
           fullType.key.take(partitionKey),
           fullType.kType.virtualType.truncate(partitionKey),
           pkBounds
@@ -1390,7 +1404,7 @@ object RVD {
 
       new RVDCoercer(fullType) {
         val newPartitioner =
-          calculateKeyRanges(fullType, keyInfo, keys.getNumPartitions, partitionKey)
+          calculateKeyRanges(execCtx, fullType, keyInfo, keys.getNumPartitions, partitionKey)
 
         def _coerce(typ: RVDType, crdd: CRDD): RVD = {
           RVD.unkeyed(typ.rowType, crdd)
@@ -1401,6 +1415,7 @@ object RVD {
   }
 
   def calculateKeyRanges(
+    ctx: ExecuteContext,
     typ: RVDType,
     pInfo: Array[RVDPartitionInfo],
     nPartitions: Int,
@@ -1409,12 +1424,12 @@ object RVD {
     assert(nPartitions > 0)
     assert(pInfo.nonEmpty)
 
-    val kord = PartitionBoundOrdering(typ.kType.virtualType).toOrdering
+    val kord = PartitionBoundOrdering(ctx, typ.kType.virtualType).toOrdering
     val min = pInfo.map(_.min).min(kord)
     val max = pInfo.map(_.max).max(kord)
     val samples = pInfo.flatMap(_.samples)
 
-    RVDPartitioner.fromKeySamples(typ, min, max, samples, nPartitions, partitionKey)
+    RVDPartitioner.fromKeySamples(ctx, typ, min, max, samples, nPartitions, partitionKey)
   }
 
   def apply(
@@ -1428,16 +1443,17 @@ object RVD {
       new RVD(typ, partitioner, crdd).checkKeyOrdering()
   }
 
-  def unify(rvds: Seq[RVD]): Seq[RVD] = {
+  def unify(execCtx: ExecuteContext, rvds: Seq[RVD]): Seq[RVD] = {
     if (rvds.length == 1 || rvds.forall(_.rowPType == rvds.head.rowPType))
       return rvds
 
+    val sm = execCtx.stateManager
     val unifiedRowPType = InferPType.getCompatiblePType(rvds.map(_.rowPType)).asInstanceOf[PStruct]
     val unifiedKey = rvds.map(_.typ.key).reduce((l, r) => commonPrefix(l, r))
     rvds.map { rvd =>
       val srcRowPType = rvd.rowPType
       val newRVDType = rvd.typ.copy(rowType = unifiedRowPType, key = unifiedKey)
-      rvd.map(newRVDType)((ctx, ptr) => unifiedRowPType.copyFromAddress(ctx.r, srcRowPType, ptr, false))
+      rvd.map(newRVDType)((ctx, ptr) => unifiedRowPType.copyFromAddress(sm, ctx.r, srcRowPType, ptr, false))
     }
   }
 

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -1,6 +1,7 @@
 package is.hail.rvd
 
 import is.hail.annotations.{Region, RegionPool, RegionValueBuilder}
+import is.hail.backend.HailStateManager
 import is.hail.utils._
 
 import scala.collection.mutable
@@ -38,7 +39,7 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
 
   def region: Region = r
 
-  private[this] val theRvb = new RegionValueBuilder(r)
+  private[this] val theRvb = new RegionValueBuilder(HailStateManager(Map.empty), r)
   def rvb = theRvb
 
   // frees the memory associated with this context

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitionInfo.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitionInfo.scala
@@ -3,6 +3,7 @@ package is.hail.rvd
 import net.sourceforge.jdistlib.rng.MersenneTwister
 
 import is.hail.annotations.{Region, RegionValue, SafeRow, WritableRegionValue}
+import is.hail.backend.HailStateManager
 import is.hail.types.virtual.Type
 import is.hail.utils._
 
@@ -29,6 +30,7 @@ object RVDPartitionInfo {
   final val KSORTED = 2
 
   def apply(
+    sm: HailStateManager,
     typ: RVDType,
     partitionKey: Int,
     sampleSize: Int,
@@ -39,10 +41,10 @@ object RVDPartitionInfo {
   ): RVDPartitionInfo = {
     using(RVDContext.default(producerContext.r.pool)) { localctx =>
       val kPType = typ.kType
-      val pkOrd = typ.copy(key = typ.key.take(partitionKey)).kOrd
-      val minF = WritableRegionValue(kPType, localctx.freshRegion())
-      val maxF = WritableRegionValue(kPType, localctx.freshRegion())
-      val prevF = WritableRegionValue(kPType, localctx.freshRegion())
+      val pkOrd = typ.copy(key = typ.key.take(partitionKey)).kOrd(sm)
+      val minF = WritableRegionValue(sm, kPType, localctx.freshRegion())
+      val maxF = WritableRegionValue(sm, kPType, localctx.freshRegion())
+      val prevF = WritableRegionValue(sm, kPType, localctx.freshRegion())
 
       assert(it.hasNext)
       val f0 = it.next()
@@ -60,7 +62,7 @@ object RVDPartitionInfo {
       var i: Long = 0
 
       if (sampleSize > 0) {
-        samples(0) = WritableRegionValue(kPType, f0, localctx.freshRegion())
+        samples(0) = WritableRegionValue(sm, kPType, f0, localctx.freshRegion())
         i += 1
       }
 
@@ -68,7 +70,8 @@ object RVDPartitionInfo {
       while (it.hasNext) {
         val f = it.next()
 
-        if (sortedness > UNSORTED && typ.kOrd.lt(f, prevF.value.offset)) {
+        val kOrd = typ.kOrd(sm)
+        if (sortedness > UNSORTED && kOrd.lt(f, prevF.value.offset)) {
           if (pkOrd.lt(f, prevF.value.offset)) {
             val curr = Region.pretty(typ.kType, f)
             val prev = prevF.pretty
@@ -84,15 +87,15 @@ object RVDPartitionInfo {
           }
         }
 
-        if (typ.kOrd.lt(f, minF.value.offset))
+        if (kOrd.lt(f, minF.value.offset))
           minF.set(f, deepCopy = true)
-        if (typ.kOrd.gt(f, maxF.value.offset))
+        if (kOrd.gt(f, maxF.value.offset))
           maxF.set(f, deepCopy = true)
 
         prevF.set(f, deepCopy = true)
 
         if (i < sampleSize)
-          samples(i.toInt) = WritableRegionValue(kPType, f, localctx.freshRegion())
+          samples(i.toInt) = WritableRegionValue(sm, kPType, f, localctx.freshRegion())
         else {
           val j: Long = if (i > 0) rng.nextLong(i) else 0
           if (j < sampleSize)

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -1,6 +1,7 @@
 package is.hail.rvd
 
 import is.hail.annotations._
+import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.expr.ir.Literal
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -10,6 +11,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.{Partitioner, SparkContext}
 
 class RVDPartitioner(
+  val sm: HailStateManager,
   val kType: TStruct,
   // rangeBounds: Array[Interval[kType]]
   // rangeBounds is interval containing all keys within a partition
@@ -23,35 +25,39 @@ class RVDPartitioner(
     s"RVDPartitioner($kType, ${rangeBounds.mkString("[", ",\n", "]")})"
 
   def this(
+    sm: HailStateManager,
     kType: TStruct,
     rangeBounds: IndexedSeq[Interval],
     allowedOverlap: Int
-  ) = this(kType, rangeBounds.toArray, allowedOverlap)
+  ) = this(sm, kType, rangeBounds.toArray, allowedOverlap)
 
   def this(
+    sm: HailStateManager,
     kType: TStruct,
     rangeBounds: IndexedSeq[Interval]
-  ) = this(kType, rangeBounds.toArray, kType.size)
+  ) = this(sm, kType, rangeBounds.toArray, kType.size)
 
   def this(
+    sm: HailStateManager,
     partitionKey: Array[String],
     kType: TStruct,
     rangeBounds: IndexedSeq[Interval]
-  ) = this(kType, rangeBounds.toArray, math.max(partitionKey.length - 1, 0))
+  ) = this(sm, kType, rangeBounds.toArray, math.max(partitionKey.length - 1, 0))
 
   def this(
+    sm: HailStateManager,
     partitionKey: Option[Int],
     kType: TStruct,
     rangeBounds: IndexedSeq[Interval]
-  ) = this(kType, rangeBounds.toArray, partitionKey.map(_ - 1).getOrElse(kType.size))
+  ) = this(sm, kType, rangeBounds.toArray, partitionKey.map(_ - 1).getOrElse(kType.size))
 
   require(rangeBounds.forall { case Interval(l, r, _, _) =>
     kType.relaxedTypeCheck(l) && kType.relaxedTypeCheck(r)
   })
   require(allowedOverlap >= 0 && allowedOverlap <= kType.size)
-  require(RVDPartitioner.isValid(kType, rangeBounds, allowedOverlap))
+  require(RVDPartitioner.isValid(sm, kType, rangeBounds, allowedOverlap))
 
-  val kord: ExtendedOrdering = PartitionBoundOrdering(kType)
+  val kord: ExtendedOrdering = PartitionBoundOrdering(sm, kType)
   val intervalKeyLT: (Interval, Any) => Boolean = (i, k) => i.isBelowPosition(kord, k)
   val keyIntervalLT: (Any, Interval) => Boolean = (k, i) => i.isAbovePosition(kord, k)
   val intervalLT: (Interval, Interval) => Boolean = (i1, i2) => i1.isBelow(kord, i2)
@@ -63,7 +69,7 @@ class RVDPartitioner(
       Some(Interval(rangeBounds.head.left, rangeBounds.last.right))
 
   def satisfiesAllowedOverlap(testAllowedOverlap: Int): Boolean =
-    RVDPartitioner.isValid(kType, rangeBounds, testAllowedOverlap)
+    RVDPartitioner.isValid(sm, kType, rangeBounds, testAllowedOverlap)
 
   def isStrict: Boolean = satisfiesAllowedOverlap(kType.size - 1)
 
@@ -117,6 +123,7 @@ class RVDPartitioner(
     else {
       assert(newKeyLen < kType.size)
       new RVDPartitioner(
+        sm,
         kType.truncate(newKeyLen),
         coarsenedRangeBounds(newKeyLen),
         math.min(allowedOverlap, newKeyLen))
@@ -130,12 +137,13 @@ class RVDPartitioner(
   // adjusts 'rangeBounds'.
   def extendKey(newKType: TStruct): RVDPartitioner = {
     require(kType isPrefixOf newKType)
-    RVDPartitioner.generate(newKType, rangeBounds)
+    RVDPartitioner.generate(sm, newKType, rangeBounds)
   }
 
   def extendKeySamePartitions(newKType: TStruct): RVDPartitioner = {
     require(kType isPrefixOf newKType)
     new RVDPartitioner(
+      sm,
       newKType,
       rangeBounds,
       allowedOverlap)
@@ -174,17 +182,18 @@ class RVDPartitioner(
       } yield interval
     }
 
-    new RVDPartitioner(kType, newBounds, allowedOverlap)
+    new RVDPartitioner(sm, kType, newBounds, allowedOverlap)
   }
 
   def intersect(other: RVDPartitioner): RVDPartitioner = {
     if (!kType.isIsomorphicTo(other.kType))
       throw new AssertionError(s"key types not isomorphic: $kType, ${other.kType}")
 
-    new RVDPartitioner(kType, Interval.intersection(this.rangeBounds, other.rangeBounds, kord.intervalEndpointOrdering))
+    new RVDPartitioner(sm, kType, Interval.intersection(this.rangeBounds, other.rangeBounds, kord.intervalEndpointOrdering))
   }
 
   def rename(nameMap: Map[String, String]): RVDPartitioner = new RVDPartitioner(
+    sm,
     kType.rename(nameMap),
     rangeBounds,
     allowedOverlap
@@ -195,7 +204,7 @@ class RVDPartitioner(
     rangeBounds: IndexedSeq[Interval] = rangeBounds,
     allowedOverlap: Int = allowedOverlap
   ): RVDPartitioner =
-    new RVDPartitioner(kType, rangeBounds, allowedOverlap)
+    new RVDPartitioner(sm, kType, rangeBounds, allowedOverlap)
 
   def coalesceRangeBounds(newPartEnd: IndexedSeq[Int]): RVDPartitioner = {
     val newRangeBounds = (-1 +: newPartEnd.init).zip(newPartEnd).map { case (s, e) =>
@@ -291,22 +300,28 @@ class RVDPartitioner(
 }
 
 object RVDPartitioner {
-  def empty(typ: TStruct): RVDPartitioner = {
-    new RVDPartitioner(typ, Array.empty[Interval])
+  def empty(ctx: ExecuteContext, typ: TStruct): RVDPartitioner = {
+    RVDPartitioner.empty(ctx.stateManager, typ)
   }
 
-  def unkeyed(numPartitions: Int): RVDPartitioner = {
+  def empty(sm: HailStateManager, typ: TStruct): RVDPartitioner = {
+    new RVDPartitioner(sm, typ, Array.empty[Interval])
+  }
+
+  def unkeyed(sm: HailStateManager, numPartitions: Int): RVDPartitioner = {
     val unkeyedInterval = Interval(Row(), Row(), true, true)
     new RVDPartitioner(
+      sm,
       TStruct.empty,
       Array.fill(numPartitions)(unkeyedInterval),
       0)
   }
 
-  def generate(kType: TStruct, intervals: IndexedSeq[Interval]): RVDPartitioner =
-    generate(kType.fieldNames, kType, intervals)
+  def generate(sm: HailStateManager, kType: TStruct, intervals: IndexedSeq[Interval]): RVDPartitioner =
+    generate(sm, kType.fieldNames, kType, intervals)
 
   def generate(
+    sm: HailStateManager,
     partitionKey: IndexedSeq[String],
     kType: TStruct,
     intervals: IndexedSeq[Interval]
@@ -316,15 +331,16 @@ object RVDPartitioner {
     })
 
     val allowedOverlap = math.max(partitionKey.length - 1, 0)
-    union(kType, intervals, allowedOverlap).subdivide(intervals.map(_.right), allowedOverlap)
+    union(sm, kType, intervals, allowedOverlap).subdivide(intervals.map(_.right), allowedOverlap)
   }
 
   def union(
+    sm: HailStateManager,
     kType: TStruct,
     intervals: IndexedSeq[Interval],
     allowedOverlap: Int
   ): RVDPartitioner = {
-    val kord = PartitionBoundOrdering(kType)
+    val kord = PartitionBoundOrdering(sm, kType)
     val eord = kord.intervalEndpointOrdering
     val iord = Interval.ordering(kord, startPrimary = true)
     val pk = allowedOverlap + 1
@@ -348,10 +364,11 @@ object RVDPartitioner {
         ab.result()
       }
 
-    new RVDPartitioner(kType, rangeBounds, allowedOverlap)
+    new RVDPartitioner(sm, kType, rangeBounds, allowedOverlap)
   }
 
   def fromKeySamples(
+    ctx: ExecuteContext,
     typ: RVDType,
     min: Any,
     max: Any,
@@ -364,7 +381,7 @@ object RVDPartitioner {
     require(typ.kType.virtualType.relaxedTypeCheck(max))
     require(keys.forall(typ.kType.virtualType.relaxedTypeCheck))
 
-    val kOrd = PartitionBoundOrdering(typ.kType.virtualType).toOrdering
+    val kOrd = PartitionBoundOrdering(ctx.stateManager, typ.kType.virtualType).toOrdering
     val sortedKeys = keys.sorted(kOrd)
     val step = (sortedKeys.length - 1).toDouble / nPartitions
     val partitionEdges = Array.tabulate(nPartitions - 1) { i =>
@@ -373,22 +390,24 @@ object RVDPartitioner {
 
     val interval = Interval(min, max, true, true)
     new RVDPartitioner(
+      ctx.stateManager,
       typ.kType.virtualType,
       FastIndexedSeq(interval)
     ).subdivide(partitionEdges, math.max(partitionKey - 1, 0))
   }
 
-  def isValid(kType: TStruct, rangeBounds: IndexedSeq[Interval]): Boolean =
-    isValid(kType, rangeBounds, kType.size)
+  def isValid(sm: HailStateManager, kType: TStruct, rangeBounds: IndexedSeq[Interval]): Boolean =
+    isValid(sm, kType, rangeBounds, kType.size)
 
   def isValid(
+    sm: HailStateManager,
     kType: TStruct,
     rangeBounds: IndexedSeq[Interval],
     allowedOverlap: Int
   ): Boolean = {
     rangeBounds.isEmpty ||
       rangeBounds.zip(rangeBounds.tail).forall { case (left: Interval, right: Interval) =>
-        val r = PartitionBoundOrdering(kType).intervalEndpointOrdering.lteqWithOverlap(allowedOverlap)(left.right, right.left)
+        val r = PartitionBoundOrdering(sm, kType).intervalEndpointOrdering.lteqWithOverlap(allowedOverlap)(left.right, right.left)
         if (!r)
           log.info(s"invalid partitioner: !lteqWithOverlap($allowedOverlap)(${ left }.right, ${ right }.left)")
         r

--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -1,6 +1,7 @@
 package is.hail.rvd
 
 import is.hail.annotations._
+import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.expr.ir.IRParser
 import is.hail.types.physical.{PInterval, PStruct, PType}
 import is.hail.types.virtual.TStruct
@@ -28,22 +29,25 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
     .filter(i => !keySet.contains(rowType.fields(i).name))
     .toArray
 
-  val kOrd: UnsafeOrdering = kType.unsafeOrdering()
-  val kInRowOrd: UnsafeOrdering =
-    RVDType.selectUnsafeOrdering(rowType, kFieldIdx, rowType, kFieldIdx)
-  val kRowOrd: UnsafeOrdering =
-    RVDType.selectUnsafeOrdering(kType, Array.range(0, kType.size), rowType, kFieldIdx)
+  def kInRowOrd(sm: HailStateManager): UnsafeOrdering =
+    RVDType.selectUnsafeOrdering(sm, rowType, kFieldIdx, rowType, kFieldIdx)
+  def kRowOrd(sm: HailStateManager): UnsafeOrdering =
+    RVDType.selectUnsafeOrdering(sm, kType, Array.range(0, kType.size), rowType, kFieldIdx)
 
-  def kComp(other: RVDType): UnsafeOrdering =
+  def kOrd(sm: HailStateManager): UnsafeOrdering = kType.unsafeOrdering(sm)
+
+  def kComp(sm: HailStateManager, other: RVDType): UnsafeOrdering =
     RVDType.selectUnsafeOrdering(
+      sm,
       this.rowType,
       this.kFieldIdx,
       other.rowType,
       other.kFieldIdx,
       true)
 
-  def joinComp(other: RVDType): UnsafeOrdering =
+  def joinComp(sm: HailStateManager, other: RVDType): UnsafeOrdering =
     RVDType.selectUnsafeOrdering(
+      sm,
       this.rowType,
       this.kFieldIdx,
       other.rowType,
@@ -53,7 +57,7 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
   /** Comparison of a point with an interval, for use in joins where one side
     * is keyed by intervals.
     */
-  def intervalJoinComp(other: RVDType): UnsafeOrdering = {
+  def intervalJoinComp(sm: HailStateManager, other: RVDType): UnsafeOrdering = {
     require(other.key.length == 1)
     require(other.rowType.field(other.key(0)).typ.asInstanceOf[PInterval].pointType.virtualType == rowType.field(key(0)).typ.virtualType)
 
@@ -63,7 +67,7 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
       val f1 = kFieldIdx(0)
       val f2 = other.kFieldIdx(0)
       val intervalType = t2.types(f2).asInstanceOf[PInterval]
-      val pord = t1.types(f1).unsafeOrdering(intervalType.pointType)
+      val pord = t1.types(f1).unsafeOrdering(sm, intervalType.pointType)
 
       // Left is a point, right is an interval.
       // Returns -1 if point is below interval, 0 if it is inside, and 1 if it
@@ -97,13 +101,14 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
   }
 
 
-  def kRowOrdView(region: Region) = new OrderingView[RegionValue] {
-    val wrv = WritableRegionValue(kType, region)
+  def kRowOrdView(sm: HailStateManager, region: Region) = new OrderingView[RegionValue] {
+    val wrv = WritableRegionValue(sm, kType, region)
+    val kRowOrdering = kRowOrd(sm)
     def setFiniteValue(representative: RegionValue) {
       wrv.setSelect(rowType, kFieldIdx, representative)
     }
     def compareFinite(rv: RegionValue): Int =
-      kRowOrd.compare(wrv.value, rv)
+      kRowOrdering.compare(wrv.value, rv)
   }
 
   def toJSON: JValue =
@@ -127,12 +132,13 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
 
 object RVDType {
   def selectUnsafeOrdering(
+    sm: HailStateManager,
     t1: PStruct, fields1: Array[Int],
     t2: PStruct, fields2: Array[Int],
     missingEqual: Boolean=true
   ): UnsafeOrdering = {
     val fieldOrderings = Range(0, fields1.length).map { i =>
-      t1.types(fields1(i)).unsafeOrdering(t2.types(fields2(i)))
+      t1.types(fields1(i)).unsafeOrdering(sm, t2.types(fields2(i)))
     }.toArray
 
     selectUnsafeOrdering(t1, fields1, t2, fields2, fieldOrderings, missingEqual)

--- a/hail/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
@@ -1,6 +1,7 @@
 package is.hail.sparkextras
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.rvd.{PartitionBoundOrdering, RVD, RVDContext, RVDPartitioner, RVDType}
 import is.hail.utils._
 import org.apache.spark._
@@ -26,8 +27,8 @@ class OrderedDependency[T](
 }
 
 object RepartitionedOrderedRDD2 {
-  def apply(prev: RVD, newRangeBounds: IndexedSeq[Interval]): ContextRDD[Long] =
-    ContextRDD(new RepartitionedOrderedRDD2(prev, newRangeBounds))
+  def apply(sm: HailStateManager, prev: RVD, newRangeBounds: IndexedSeq[Interval]): ContextRDD[Long] =
+    ContextRDD(new RepartitionedOrderedRDD2(sm, prev, newRangeBounds))
 }
 
 /**
@@ -35,12 +36,12 @@ object RepartitionedOrderedRDD2 {
   * Assumes new key type is a prefix of old key type, so no reordering is
   * needed.
   */
-class RepartitionedOrderedRDD2 private (@transient val prev: RVD, @transient val newRangeBounds: IndexedSeq[Interval])
+class RepartitionedOrderedRDD2 private (sm: HailStateManager, @transient val prev: RVD, @transient val newRangeBounds: IndexedSeq[Interval])
   extends RDD[ContextRDD.ElementType[Long]](prev.crdd.sparkContext, Nil) { // Nil since we implement getDependencies
 
   val prevCRDD: ContextRDD[Long] = prev.crdd
   val typ: RVDType = prev.typ
-  val kOrd: ExtendedOrdering = PartitionBoundOrdering(typ.kType.virtualType)
+  val kOrd: ExtendedOrdering = PartitionBoundOrdering(sm, typ.kType.virtualType)
 
 
   def getPartitions: Array[Partition] = {

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -72,7 +72,7 @@ class LinearMixedModel(lmmData: LMMData) {
 
       val region = Region(pool = SparkTaskContext.get().getRegionPool())
       val rv = RegionValue(region)
-      val rvb = new RegionValueBuilder(region)
+      val rvb = new RegionValueBuilder(ctx.stateManager, region)
 
       itPAt.zip(itAt).map { case ((i, pa0), (i2, a0)) =>
         assert(i == i2)
@@ -140,7 +140,7 @@ class LinearMixedModel(lmmData: LMMData) {
 
       val region = Region(pool = SparkTaskContext.get().getRegionPool())
       val rv = RegionValue(region)
-      val rvb = new RegionValueBuilder(region)
+      val rvb = new RegionValueBuilder(ctx.stateManager, region)
 
       itPAt.map { case (i, pa0) =>
         val pa = BDV(pa0)

--- a/hail/src/main/scala/is/hail/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/MatrixType.scala
@@ -200,9 +200,9 @@ case class MatrixType(
     }
   }
 
-  def referenceGenome: ReferenceGenome = {
+  def referenceGenomeName: String = {
     val firstKeyField = rowKeyStruct.types(0)
-    firstKeyField.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
+    firstKeyField.asInstanceOf[TLocus].rg
   }
 
   def pyJson: JObject = {

--- a/hail/src/main/scala/is/hail/types/physical/PArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArray.scala
@@ -1,6 +1,7 @@
 package is.hail.types.physical
 
 import is.hail.annotations.Annotation
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.ir.orderings.CodeOrdering
@@ -19,6 +20,6 @@ abstract class PArray extends PContainer {
 
   def elementIterator(aoff: Long, length: Int): PArrayIterator
 
-  override def genNonmissingValue: Gen[IndexedSeq[Annotation]] =
-    Gen.buildableOf[Array](elementType.genValue).map(x => x: IndexedSeq[Annotation])
+  override def genNonmissingValue(sm: HailStateManager): Gen[IndexedSeq[Annotation]] =
+    Gen.buildableOf[Array](elementType.genValue(sm)).map(x => x: IndexedSeq[Annotation])
 }

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region, UnsafeOrdering}
 import is.hail.asm4s.{Code, Value}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
@@ -120,14 +121,14 @@ trait PArrayBackedContainer extends PContainer {
   override def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean] =
     arrayRep.hasMissingValues(sourceOffset)
 
-  override def unsafeOrdering: UnsafeOrdering =
-    unsafeOrdering(this)
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering =
+    unsafeOrdering(sm, this)
 
-  override def unsafeOrdering(rightType: PType): UnsafeOrdering =
-    arrayRep.unsafeOrdering(rightType)
+  override def unsafeOrdering(sm: HailStateManager, rightType: PType): UnsafeOrdering =
+    arrayRep.unsafeOrdering(sm, rightType)
 
-  override def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
-    arrayRep.copyFromAddress(region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)
+  override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
+    arrayRep.copyFromAddress(sm, region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)
 
   override def nextElementAddress(currentOffset: Long): Long =
     arrayRep.nextElementAddress(currentOffset)
@@ -135,8 +136,8 @@ trait PArrayBackedContainer extends PContainer {
   override def nextElementAddress(currentOffset: Code[Long]): Code[Long] =
     arrayRep.nextElementAddress(currentOffset)
 
-  override def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
-    arrayRep.unstagedStoreAtAddress(addr, region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)
+  override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
+    arrayRep.unstagedStoreAtAddress(sm, addr, region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)
 
   override def sType: SIndexablePointer = SIndexablePointer(setRequired(false).asInstanceOf[PArrayBackedContainer])
 
@@ -157,7 +158,7 @@ trait PArrayBackedContainer extends PContainer {
 
   override def unstagedLoadFromNested(addr: Long): Long = arrayRep.unstagedLoadFromNested(addr)
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
-    Region.storeAddress(addr, unstagedStoreJavaObject(annotation, region))
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
+    Region.storeAddress(addr, unstagedStoreJavaObject(sm, annotation, region))
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces.SBaseStructValue
@@ -74,15 +75,15 @@ abstract class PBaseStruct extends PType {
   def isCompatibleWith(other: PBaseStruct): Boolean =
     fields.zip(other.fields).forall{ case (l, r) => l.typ isOfType r.typ }
 
-  override def unsafeOrdering(): UnsafeOrdering =
-    unsafeOrdering(this)
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering =
+    unsafeOrdering(sm, this)
 
-  override def unsafeOrdering(rightType: PType): UnsafeOrdering = {
+  override def unsafeOrdering(sm: HailStateManager, rightType: PType): UnsafeOrdering = {
     require(this isOfType rightType)
 
     val right = rightType.asInstanceOf[PBaseStruct]
     val fieldOrderings: Array[UnsafeOrdering] =
-      types.zip(right.types).map { case (l, r) => l.unsafeOrdering(r)}
+      types.zip(right.types).map { case (l, r) => l.unsafeOrdering(sm, r)}
 
     new UnsafeOrdering {
       def compare(o1: Long, o2: Long): Int = {
@@ -147,10 +148,10 @@ abstract class PBaseStruct extends PType {
 
   override lazy val containsPointers: Boolean = types.exists(_.containsPointers)
 
-  override def genNonmissingValue: Gen[Annotation] = {
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = {
     if (types.isEmpty) {
       Gen.const(Annotation.empty)
     } else
-      Gen.uniformSequence(types.map(t => t.genValue)).map(a => Annotation(a: _*))
+      Gen.uniformSequence(types.map(t => t.genValue(sm))).map(a => Annotation(a: _*))
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBinary.scala
@@ -2,13 +2,14 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Region, UnsafeOrdering}
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.virtual.TBinary
 
 abstract class PBinary extends PType {
   lazy val virtualType: TBinary.type = TBinary
 
-  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
     def compare(o1: Long, o2: Long): Int = {
       val l1 = loadLength(o1)
       val l2 = loadLength(o2)

--- a/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.Code
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.primitives.{SBoolean, SBooleanValue}
@@ -18,7 +19,7 @@ class PBoolean(override val required: Boolean) extends PType with PPrimitive {
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = sb.append("PBoolean")
 
-  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
     def compare(o1: Long, o2: Long): Int = {
       java.lang.Boolean.compare(Region.loadBoolean(o1), Region.loadBoolean(o2))
     }
@@ -35,7 +36,7 @@ class PBoolean(override val required: Boolean) extends PType with PPrimitive {
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBooleanValue =
     new SBooleanValue(cb.memoize(Region.loadBoolean(addr)))
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeByte(addr, annotation.asInstanceOf[Boolean].toByte)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region, UnsafeRow, UnsafeUtils}
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
 import is.hail.types.BaseStruct
 import is.hail.types.physical.stypes.SValue
@@ -106,34 +107,34 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
     }
   }
 
-  def deepPointerCopy(region: Region, dstStructAddress: Long) {
+  def deepPointerCopy(sm: HailStateManager, region: Region, dstStructAddress: Long) {
     var i = 0
     while (i < this.size) {
       val dstFieldType = this.fields(i).typ
       if (dstFieldType.containsPointers && this.isFieldDefined(dstStructAddress, i)) {
         val dstFieldAddress = this.fieldOffset(dstStructAddress, i)
         val dstFieldAddressFromNested = dstFieldType.unstagedLoadFromNested(dstFieldAddress)
-        dstFieldType.unstagedStoreAtAddress(dstFieldAddress, region, dstFieldType, dstFieldAddressFromNested, true)
+        dstFieldType.unstagedStoreAtAddress(sm, dstFieldAddress, region, dstFieldType, dstFieldAddressFromNested, true)
       }
       i += 1
     }
   }
 
-  override def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
+  override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
     if (equalModuloRequired(srcPType) && !deepCopy)
       return srcAddress
 
     val newAddr = allocate(region)
-    unstagedStoreAtAddress(newAddr, region, srcPType.asInstanceOf[PBaseStruct], srcAddress, deepCopy)
+    unstagedStoreAtAddress(sm, newAddr, region, srcPType.asInstanceOf[PBaseStruct], srcAddress, deepCopy)
     newAddr
   }
 
-  override def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
+  override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
     val srcStruct = srcPType.asInstanceOf[PBaseStruct]
     if (equalModuloRequired(srcStruct)) {
       Region.copyFrom(srcAddress, addr, byteSize)
       if (deepCopy)
-        deepPointerCopy(region, addr)
+        deepPointerCopy(sm, region, addr)
     } else {
       initialize(addr, setMissing = true)
       var idx = 0
@@ -141,7 +142,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
         if (srcStruct.isFieldDefined(srcAddress, idx)) {
           setFieldPresent(addr, idx)
           types(idx).unstagedStoreAtAddress(
-            fieldOffset(addr, idx), region, srcStruct.types(idx), srcStruct.loadField(srcAddress, idx), deepCopy)
+            sm, fieldOffset(addr, idx), region, srcStruct.types(idx), srcStruct.loadField(srcAddress, idx), deepCopy)
         } else
           assert(!fieldRequired(idx))
         idx += 1
@@ -208,18 +209,18 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
     new SBaseStructPointerValue(sType, addr)
   }
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long = {
     val addr = allocate(region)
-    unstagedStoreJavaObjectAtAddress(addr, annotation, region)
+    unstagedStoreJavaObjectAtAddress(sm, addr, annotation, region)
     addr
   }
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     initialize(addr)
     val row = annotation.asInstanceOf[Row]
     row match {
       case ur: UnsafeRow => {
-        this.unstagedStoreAtAddress(addr, region, ur.t, ur.offset, region.ne(ur.region))
+        this.unstagedStoreAtAddress(sm, addr, region, ur.t, ur.offset, region.ne(ur.region))
       }
       case sr: Row => {
         this.types.zipWithIndex.foreach { case (fieldPt, fieldIdx) =>
@@ -228,7 +229,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
           }
           else {
             val fieldAddress = fieldOffset(addr, fieldIdx)
-            fieldPt.unstagedStoreJavaObjectAtAddress(fieldAddress, row(fieldIdx), region)
+            fieldPt.unstagedStoreJavaObjectAtAddress(sm, fieldAddress, row(fieldIdx), region)
           }
         }
       }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region, UnsafeOrdering}
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete.{SCanonicalCall, SCanonicalCallValue}
@@ -20,22 +21,22 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
   def byteSize: Long = representation.byteSize
   override def alignment: Long = representation.alignment
 
-  override def unsafeOrdering(): UnsafeOrdering = representation.unsafeOrdering() // this was a terrible idea
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = representation.unsafeOrdering(sm) // this was a terrible idea
 
   def setRequired(required: Boolean) = if (required == this.required) this else PCanonicalCall(required)
 
-  override def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
+  override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
     srcPType match {
       case pt: PCanonicalCall =>
-        representation.unstagedStoreAtAddress(addr, region, pt.representation, srcAddress, deepCopy)
+        representation.unstagedStoreAtAddress(sm, addr, region, pt.representation, srcAddress, deepCopy)
     }
   }
 
   override def containsPointers: Boolean = representation.containsPointers
 
-  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
+  override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
     srcPType match {
-      case pt: PCanonicalCall => representation._copyFromAddress(region, pt.representation, srcAddress, deepCopy)
+      case pt: PCanonicalCall => representation._copyFromAddress(sm, region, pt.representation, srcAddress, deepCopy)
     }
   }
 
@@ -61,11 +62,11 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
 
   override def unstagedLoadFromNested(addr: Long): Long = representation.unstagedLoadFromNested(addr)
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
-    representation.unstagedStoreJavaObject(annotation, region)
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long = {
+    representation.unstagedStoreJavaObject(sm, annotation, region)
   }
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
-    representation.unstagedStoreJavaObjectAtAddress(addr, annotation, region)
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
+    representation.unstagedStoreJavaObjectAtAddress(sm, addr, annotation, region)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
 import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete.{SIntervalPointer, SIntervalPointerValue, SStackStruct}
@@ -115,17 +116,17 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
     }
   }
 
-  override def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
+  override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
     srcPType match {
       case t: PCanonicalInterval =>
-        representation.unstagedStoreAtAddress(addr, region, t.representation, srcAddress, deepCopy)
+        representation.unstagedStoreAtAddress(sm, addr, region, t.representation, srcAddress, deepCopy)
     }
   }
 
-  override def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
+  override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
     srcPType match {
       case t: PCanonicalInterval =>
-        representation._copyFromAddress(region, t.representation, srcAddress, deepCopy)
+        representation._copyFromAddress(sm, region, t.representation, srcAddress, deepCopy)
     }
   }
 
@@ -133,18 +134,19 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
 
   override def unstagedLoadFromNested(addr: Long): Long = representation.unstagedLoadFromNested(addr)
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     val jInterval = annotation.asInstanceOf[Interval]
     representation.unstagedStoreJavaObjectAtAddress(
+      sm,
       addr,
       Row(jInterval.start, jInterval.end, jInterval.includesStart, jInterval.includesEnd),
       region
     )
   }
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long = {
     val addr = representation.allocate(region)
-    unstagedStoreJavaObjectAtAddress(addr, annotation, region)
+    unstagedStoreJavaObjectAtAddress(sm, addr, annotation, region)
     addr
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, NDArray, Region, UnsafeOrdering}
 import is.hail.asm4s.{Code, _}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.{CodeParam, CodeParamType, EmitCode, EmitCodeBuilder, Param, ParamType, SCodeParam}
 import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete._
@@ -71,7 +72,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   override lazy val alignment: Long = representation.alignment
 
-  override def unsafeOrdering(): UnsafeOrdering = representation.unsafeOrdering()
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = representation.unsafeOrdering(sm)
 
   def numElements(shape: IndexedSeq[Value[Long]]): Code[Long] = {
     shape.foldLeft(1L: Code[Long])(_ * _)
@@ -285,7 +286,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     )
   }
 
-  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long  = {
+  def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long  = {
     val srcNDPType = srcPType.asInstanceOf[PCanonicalNDArray]
     assert(nDims == srcNDPType.nDims)
 
@@ -294,7 +295,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     }
 
     val newAddress = this.representation.allocate(region)
-    unstagedStoreAtAddress(newAddress, region, srcPType, srcAddress, deepCopy)
+    unstagedStoreAtAddress(sm, newAddress, region, srcPType, srcAddress, deepCopy)
     newAddress
   }
 
@@ -306,7 +307,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   def setRequired(required: Boolean): PCanonicalNDArray =
     if(required == this.required) this else PCanonicalNDArray(elementType, nDims, required)
 
-  def unstagedStoreAtAddress(destAddress: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
+  def unstagedStoreAtAddress(sm: HailStateManager, destAddress: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
     val srcNDPType = srcPType.asInstanceOf[PCanonicalNDArray]
     assert(nDims == srcNDPType.nDims)
 
@@ -329,8 +330,8 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       val srcShape = srcPType.asInstanceOf[PNDArray].unstagedLoadShapes(srcAddress)
       val srcStrides = srcPType.asInstanceOf[PNDArray].unstagedLoadStrides(srcAddress)
 
-      shapeType.unstagedStoreJavaObjectAtAddress(destAddress, Row(srcShape:_*), region)
-      strideType.unstagedStoreJavaObjectAtAddress(destAddress + shapeType.byteSize, Row(srcStrides:_*), region)
+      shapeType.unstagedStoreJavaObjectAtAddress(sm, destAddress, Row(srcShape:_*), region)
+      strideType.unstagedStoreJavaObjectAtAddress(sm, destAddress + shapeType.byteSize, Row(srcStrides:_*), region)
 
       val newDataPointer = this.allocateData(srcShape, region)
       Region.storeLong(this.representation.fieldOffset(destAddress, 2), newDataPointer)
@@ -341,7 +342,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
       SNDArray.unstagedForEachIndex(srcShape) { indices =>
         val srcElementAddress = srcNDPType.getElementAddress(indices, srcAddress)
-        this.elementType.unstagedStoreAtAddress(currentAddressToWrite, region, srcNDPType.elementType, srcElementAddress, true)
+        this.elementType.unstagedStoreAtAddress(sm, currentAddressToWrite, region, srcNDPType.elementType, srcElementAddress, true)
         currentAddressToWrite += elementType.byteSize
       }
     }
@@ -406,13 +407,13 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   override def unstagedLoadFromNested(addr: Long): Long = addr
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long = {
     val addr = this.representation.allocate(region)
-    this.unstagedStoreJavaObjectAtAddress(addr, annotation, region)
+    this.unstagedStoreJavaObjectAtAddress(sm, addr, annotation, region)
     addr
   }
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     val aNDArray = annotation.asInstanceOf[NDArray]
 
     var runningProduct = this.elementType.byteSize
@@ -424,12 +425,12 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     val dataFirstElementAddress = this.allocateData(aNDArray.shape, region)
     var curElementAddress = dataFirstElementAddress
     aNDArray.getRowMajorElements().foreach{ element =>
-      elementType.unstagedStoreJavaObjectAtAddress(curElementAddress, element, region)
+      elementType.unstagedStoreJavaObjectAtAddress(sm, curElementAddress, element, region)
       curElementAddress += elementType.byteSize
     }
     val shapeRow = Row(aNDArray.shape: _*)
     val stridesRow = Row(stridesArray: _*)
-    this.representation.unstagedStoreJavaObjectAtAddress(addr, Row(shapeRow, stridesRow, dataFirstElementAddress), region)
+    this.representation.unstagedStoreJavaObjectAtAddress(sm, addr, Row(shapeRow, stridesRow, dataFirstElementAddress), region)
   }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
@@ -1,6 +1,7 @@
 package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
+import is.hail.backend.HailStateManager
 import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
 import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TSet, Type}
@@ -33,11 +34,11 @@ final case class PCanonicalSet(elementType: PType,  required: Boolean = false) e
   private def deepRenameSet(t: TSet) =
     PCanonicalSet(this.elementType.deepRename(t.elementType), this.required)
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long = {
     val s: IndexedSeq[Annotation] = annotation.asInstanceOf[Set[Annotation]]
       .toFastIndexedSeq
-      .sorted(elementType.virtualType.ordering.toOrdering)
-    arrayRep.unstagedStoreJavaObject(s, region)
+      .sorted(elementType.virtualType.ordering(sm).toOrdering)
+    arrayRep.unstagedStoreJavaObject(sm, s, region)
   }
 
   def construct(_contents: SIndexableValue): SIndexableValue = {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s.{Code, Value}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete.{SStringPointer, SStringPointerValue}
@@ -19,8 +20,8 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   lazy val binaryRepresentation: PCanonicalBinary = PCanonicalBinary(required)
 
-  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
-    binaryRepresentation.copyFromAddress(region, srcPType.asInstanceOf[PString].binaryRepresentation, srcAddress, deepCopy)
+  override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
+    binaryRepresentation.copyFromAddress(sm, region, srcPType.asInstanceOf[PString].binaryRepresentation, srcAddress, deepCopy)
 
   override def copiedType: PType = this
 
@@ -54,8 +55,8 @@ class PCanonicalString(val required: Boolean) extends PString {
     dstAddress
   }
 
-  def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
-    binaryRepresentation.unstagedStoreAtAddress(addr, region, srcPType.asInstanceOf[PString].binaryRepresentation, srcAddress, deepCopy)
+  override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
+    binaryRepresentation.unstagedStoreAtAddress(sm, addr, region, srcPType.asInstanceOf[PString].binaryRepresentation, srcAddress, deepCopy)
 
   def setRequired(required: Boolean): PCanonicalString =
     if (required == this.required) this else PCanonicalString(required)
@@ -82,12 +83,12 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   override def unstagedLoadFromNested(addr: Long): Long = binaryRepresentation.unstagedLoadFromNested(addr)
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
-    binaryRepresentation.unstagedStoreJavaObject(annotation.asInstanceOf[String].getBytes(), region)
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long = {
+    binaryRepresentation.unstagedStoreJavaObject(sm, annotation.asInstanceOf[String].getBytes(), region)
   }
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
-    binaryRepresentation.unstagedStoreJavaObjectAtAddress(addr, annotation.asInstanceOf[String].getBytes(), region)
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
+    binaryRepresentation.unstagedStoreJavaObjectAtAddress(sm, addr, annotation.asInstanceOf[String].getBytes(), region)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PDict.scala
@@ -1,6 +1,7 @@
 package is.hail.types.physical
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.types.physical.stypes.interfaces.SContainer
 import is.hail.types.virtual.TDict
@@ -15,6 +16,6 @@ abstract class PDict extends PContainer {
 
   def elementType: PStruct
 
-  override def genNonmissingValue: Gen[Annotation] =
-    Gen.buildableOf2[Map](Gen.zip(keyType.genValue, valueType.genValue))
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] =
+    Gen.buildableOf2[Map](Gen.zip(keyType.genValue(sm), valueType.genValue(sm)))
 }

--- a/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SFloat32, SFloat32Value}
 import is.hail.types.physical.stypes.{SType, SValue}
@@ -19,7 +20,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = sb.append("PFloat32")
 
-  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
     def compare(o1: Long, o2: Long): Int = {
       java.lang.Float.compare(Region.loadFloat(o1), Region.loadFloat(o2))
     }
@@ -45,7 +46,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat32Value =
     new SFloat32Value(cb.memoize(Region.loadFloat(addr)))
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeFloat(addr, annotation.asInstanceOf[Float])
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SFloat64, SFloat64Value}
 import is.hail.types.physical.stypes.{SType, SValue}
@@ -20,7 +21,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = sb.append("PFloat64")
 
-  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
     def compare(o1: Long, o2: Long): Int = {
       java.lang.Double.compare(Region.loadDouble(o1), Region.loadDouble(o2))
     }
@@ -46,7 +47,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat64Value =
     new SFloat64Value(cb.memoize(Region.loadDouble(addr)))
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeDouble(addr, annotation.asInstanceOf[Double])
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt32.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, coerce, const, _}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Value}
 import is.hail.types.physical.stypes.{SType, SValue}
@@ -16,7 +17,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = sb.append("PInt32")
   override type NType = PInt32
 
-  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
     def compare(o1: Long, o2: Long): Int = {
       Integer.compare(Region.loadInt(o1), Region.loadInt(o2))
     }
@@ -42,7 +43,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt32Value =
     new SInt32Value(cb.memoize(Region.loadInt(addr)))
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeInt(addr, annotation.asInstanceOf[Int])
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt64.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, coerce, const, _}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SInt64, SInt64Value}
 import is.hail.types.physical.stypes.{SType, SValue}
@@ -17,7 +18,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = sb.append("PInt64")
   override type NType = PInt64
 
-  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
     def compare(o1: Long, o2: Long): Int = {
       java.lang.Long.compare(Region.loadLong(o1), Region.loadLong(o2))
     }
@@ -43,7 +44,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt64Value =
     new SInt64Value(cb.memoize(Region.loadLong(addr)))
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeLong(addr, annotation.asInstanceOf[Long])
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInterval.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.virtual.TInterval
@@ -12,9 +13,9 @@ abstract class PInterval extends PType {
 
   lazy val virtualType: TInterval = TInterval(pointType.virtualType)
 
-  override def unsafeOrdering(): UnsafeOrdering =
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering =
     new UnsafeOrdering {
-      private val pOrd = pointType.unsafeOrdering()
+      private val pOrd = pointType.unsafeOrdering(sm)
       def compare(o1: Long, o2: Long): Int = {
         val sdef1 = startDefined(o1)
         if (sdef1 == startDefined(o2)) {
@@ -40,9 +41,9 @@ abstract class PInterval extends PType {
       }
     }
 
-  def endPrimaryUnsafeOrdering(): UnsafeOrdering =
+  def endPrimaryUnsafeOrdering(sm: HailStateManager): UnsafeOrdering =
     new UnsafeOrdering {
-      private val pOrd = pointType.unsafeOrdering()
+      private val pOrd = pointType.unsafeOrdering(sm)
       def compare(o1: Long, o2: Long): Int = {
         val edef1 = endDefined(o1)
         if (edef1 == endDefined(o2)) {
@@ -95,6 +96,4 @@ abstract class PInterval extends PType {
   def includesStart(off: Code[Long]): Code[Boolean]
 
   def includesEnd(off: Code[Long]): Code[Boolean]
-
-  override def genNonmissingValue: Gen[Annotation] = Interval.gen(pointType.virtualType.ordering, pointType.genValue)
 }

--- a/hail/src/main/scala/is/hail/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PLocus.scala
@@ -2,15 +2,14 @@ package is.hail.types.physical
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.types.virtual.TLocus
 import is.hail.variant._
 
 abstract class PLocus extends PType {
-  def rgBc: BroadcastRG
+  lazy val virtualType: TLocus = TLocus(rg)
 
-  lazy val virtualType: TLocus = TLocus(rgBc)
-
-  def rg: ReferenceGenome
+  def rg: String
 
   def contig(value: Long): String
 
@@ -22,5 +21,5 @@ abstract class PLocus extends PType {
 
   def positionType: PInt32
 
-  def unstagedStoreLocus(addr: Long, contig: String, position: Int, region: Region): Unit
+  def unstagedStoreLocus(sm: HailStateManager, addr: Long, contig: String, position: Int, region: Region): Unit
 }

--- a/hail/src/main/scala/is/hail/types/physical/PSet.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSet.scala
@@ -1,11 +1,12 @@
 package is.hail.types.physical
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.types.virtual.TSet
 
 abstract class PSet extends PContainer {
   lazy val virtualType: TSet = TSet(elementType.virtualType)
 
-  override def genNonmissingValue: Gen[Annotation] = Gen.buildableOf[Set](elementType.genValue)
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = Gen.buildableOf[Set](elementType.genValue(sm))
 }

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -2,13 +2,14 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.virtual.TString
 
 abstract class PString extends PType {
   lazy val virtualType: TString.type = TString
 
-  override def unsafeOrdering(): UnsafeOrdering = PCanonicalBinary(required).unsafeOrdering()
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = PCanonicalBinary(required).unsafeOrdering(sm)
 
   val binaryRepresentation: PBinary
 

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s.{Code, Value}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete.SSubsetStruct
@@ -108,10 +109,10 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
   override def setRequired(required: Boolean): PType =
     PSubsetStruct(ps.setRequired(required).asInstanceOf[PStruct], _fieldNames)
 
-  override def copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
+  override def copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
     throw new UnsupportedOperationException
 
-  override def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
+  override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
     throw new UnsupportedOperationException
 
   def sType: SSubsetStruct = SSubsetStruct(ps.sType.asInstanceOf[SBaseStruct], _fieldNames)
@@ -126,7 +127,7 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
   def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructValue =
     throw new UnsupportedOperationException
 
-  def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
+  def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
     throw new UnsupportedOperationException
   }
 
@@ -134,10 +135,10 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
 
   override def unstagedLoadFromNested(addr: Long): Long = addr
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long =
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long =
     throw new UnsupportedOperationException
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit =
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit =
     throw new UnsupportedOperationException
 
   override def copiedType: PType = ??? // PSubsetStruct on its way out

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s.{Code, TypeInfo, Value}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.expr.ir.{Ascending, Descending, EmitCodeBuilder, EmitMethodBuilder, SortOrder}
 import is.hail.types.physical.stypes.{SCode, SValue}
@@ -14,19 +15,19 @@ trait PUnrealizable extends PType {
 
   override def alignment: Long = unsupported
 
-  protected[physical] def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
+  protected[physical] def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
     unsupported
 
-  override def copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
+  override def copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
     unsupported
 
-  def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
+  def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
     unsupported
 
-  override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long =
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long =
     unsupported
 
-  override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit =
+  override def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit =
     unsupported
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SValue = unsupported

--- a/hail/src/main/scala/is/hail/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PVoid.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.UnsafeOrdering
 import is.hail.asm4s.{Code, TypeInfo, UnitInfo}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.SType
 import is.hail.types.physical.stypes.interfaces.SVoid
@@ -21,10 +22,9 @@ case object PVoid extends PType with PUnrealizable {
 
   def setRequired(required: Boolean) = PVoid
 
-  override def unsafeOrdering(): UnsafeOrdering = throw new NotImplementedError()
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = throw new NotImplementedError()
 
   def loadFromNested(addr: Code[Long]): Code[Long] = throw new NotImplementedError()
 
   override def unstagedLoadFromNested(addr: Long): Long = throw new NotImplementedError()
 }
-

--- a/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region, UnsafeOrdering}
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
 import is.hail.types.virtual.Type
@@ -120,19 +121,19 @@ case class StoredSTypePType(sType: SType, required: Boolean) extends PType {
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = sb.append(sType.toString)
 
-  override def unsafeOrdering(rightType: PType): UnsafeOrdering = unsupportedCanonicalMethod
+  override def unsafeOrdering(sm: HailStateManager, rightType: PType): UnsafeOrdering = unsupportedCanonicalMethod
 
-  override def unsafeOrdering(): UnsafeOrdering = unsupportedCanonicalMethod
+  override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = unsupportedCanonicalMethod
 
   def unstagedLoadFromNested(addr: Long): Long = unsupportedCanonicalMethod
 
-  def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = unsupportedCanonicalMethod
+  def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long = unsupportedCanonicalMethod
 
-  def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = unsupportedCanonicalMethod
+  def unstagedStoreJavaObjectAtAddress(sm: HailStateManager, addr: Long, annotation: Annotation, region: Region): Unit = unsupportedCanonicalMethod
 
-  override def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = unsupportedCanonicalMethod
+  override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = unsupportedCanonicalMethod
 
-  override def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = unsupportedCanonicalMethod
+  override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = unsupportedCanonicalMethod
 
   override def _asIdent: String = "stored_stype_ptype"
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -20,7 +20,7 @@ final case class SCanonicalLocusPointer(pType: PCanonicalLocus) extends SLocus {
 
   override def castRename(t: Type): SType = this
 
-  override def rg: ReferenceGenome = pType.rg
+  override def rg: String = pType.rg
 
   override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): SValue =
     value match {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -131,7 +131,7 @@ case class SUnreachableLocus(virtualType: TLocus) extends SUnreachable with SLoc
 
   override def contigType: SString = SUnreachableString
 
-  override def rg: ReferenceGenome = virtualType.rg
+  override def rg: String = virtualType.rg
 }
 
 class SUnreachableLocusValue(override val st: SUnreachableLocus) extends SUnreachableValue with SLocusValue {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
@@ -8,7 +8,7 @@ import is.hail.types.{RPrimitive, TypeWithRequiredness}
 import is.hail.variant.{Locus, ReferenceGenome}
 
 trait SLocus extends SType {
-  def rg: ReferenceGenome
+  def rg: String
   def contigType: SString
   override def _typeWithRequiredness: TypeWithRequiredness = RPrimitive()
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TArray.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.{Annotation, ExtendedOrdering}
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import org.json4s.jackson.JsonMethods
 
@@ -43,13 +44,11 @@ final case class TArray(elementType: Type) extends TContainer {
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  override def genNonmissingValue: Gen[IndexedSeq[Annotation]] =
-    Gen.buildableOf[Array](elementType.genValue).map(x => x: IndexedSeq[Annotation])
+  override def genNonmissingValue(sm: HailStateManager): Gen[IndexedSeq[Annotation]] =
+    Gen.buildableOf[Array](elementType.genValue(sm)).map(x => x: IndexedSeq[Annotation])
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
-    ExtendedOrdering.iterableOrdering(elementType.ordering, missingEqual)
+  def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.iterableOrdering(elementType.ordering(sm), missingEqual)
 
   override def scalaClassTag: ClassTag[IndexedSeq[AnyRef]] = classTag[IndexedSeq[AnyRef]]
 

--- a/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.types.physical.PBaseStruct
 import is.hail.utils._
@@ -15,11 +16,11 @@ object TBaseStruct {
     * of types of r is a prefix of types, or types is a prefix of the list of
     * types of r.
     */
-  def getOrdering(types: Array[Type], missingEqual: Boolean = true): ExtendedOrdering =
-    ExtendedOrdering.rowOrdering(types.map(_.ordering), missingEqual)
+  def getOrdering(sm: HailStateManager, types: Array[Type], missingEqual: Boolean = true): ExtendedOrdering =
+    ExtendedOrdering.rowOrdering(types.map(_.ordering(sm)), missingEqual)
 
-  def getJoinOrdering(types: Array[Type], missingEqual: Boolean = false): ExtendedOrdering =
-    ExtendedOrdering.rowOrdering(types.map(_.mkOrdering(missingEqual = missingEqual)), _missingEqual = missingEqual)
+  def getJoinOrdering(sm: HailStateManager, types: Array[Type], missingEqual: Boolean = false): ExtendedOrdering =
+    ExtendedOrdering.rowOrdering(types.map(_.mkOrdering(sm, missingEqual = missingEqual)), _missingEqual = missingEqual)
 }
 
 abstract class TBaseStruct extends Type {
@@ -83,7 +84,7 @@ abstract class TBaseStruct extends Type {
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  override def genNonmissingValue: Gen[Annotation] = {
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = {
     if (types.isEmpty) {
       Gen.const(Annotation.empty)
     } else
@@ -91,7 +92,7 @@ abstract class TBaseStruct extends Type {
         if (types.length > fuel)
           Gen.uniformSequence(types.map(t => Gen.const(null))).map(a => Annotation(a: _*))
         else
-          Gen.uniformSequence(types.map(t => t.genValue)).map(a => Annotation(a: _*)))
+          Gen.uniformSequence(types.map(t => t.genValue(sm))).map(a => Annotation(a: _*)))
   }
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =

--- a/hail/src/main/scala/is/hail/types/virtual/TBinary.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBinary.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.types.physical.PBinary
@@ -12,11 +13,11 @@ case object TBinary extends Type {
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Array[Byte]]
 
-  override def genNonmissingValue: Gen[Annotation] = Gen.buildableOf(arbitrary[Byte])
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = Gen.buildableOf(arbitrary[Byte])
 
   override def scalaClassTag: ClassTag[Array[Byte]] = classTag[Array[Byte]]
 
-  def mkOrdering(_missingEqual: Boolean = true): ExtendedOrdering = ExtendedOrdering.iterableOrdering(new ExtendedOrdering {
+  def mkOrdering(sm: HailStateManager, _missingEqual: Boolean = true): ExtendedOrdering = ExtendedOrdering.iterableOrdering(new ExtendedOrdering {
     val missingEqual = _missingEqual
 
     override def compareNonnull(x: Any, y: Any): Int =
@@ -24,6 +25,4 @@ case object TBinary extends Type {
         java.lang.Byte.toUnsignedInt(x.asInstanceOf[Byte]),
         java.lang.Byte.toUnsignedInt(y.asInstanceOf[Byte]))
   })
-
-  override val ordering: ExtendedOrdering = mkOrdering()
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBoolean.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.types.physical.PBoolean
@@ -20,12 +21,10 @@ case object TBoolean extends Type {
 
   def parse(s: String): Annotation = s.toBoolean
 
-  override def genNonmissingValue: Gen[Annotation] = arbitrary[Boolean]
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Boolean]
 
   override def scalaClassTag: ClassTag[java.lang.Boolean] = classTag[java.lang.Boolean]
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Boolean]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TCall.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TCall.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.types._
 import is.hail.types.physical.PCall
@@ -18,14 +19,12 @@ case object TCall extends Type {
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
 
-  override def genNonmissingValue: Gen[Annotation] = Call.genNonmissingValue
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = Call.genNonmissingValue
 
   override def scalaClassTag: ClassTag[java.lang.Integer] = classTag[java.lang.Integer]
 
   override def str(a: Annotation): String = if (a == null) "NA" else Call.toString(a.asInstanceOf[Call])
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TFloat32.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.types.physical.PFloat32
@@ -21,7 +22,7 @@ case object TFloat32 extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Float].formatted("%.5e")
 
-  override def genNonmissingValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
     a1 == a2 || (a1 != null && a2 != null && {
@@ -39,9 +40,6 @@ case object TFloat32 extends TNumeric {
 
   override def scalaClassTag: ClassTag[java.lang.Float] = classTag[java.lang.Float]
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Float]], missingEqual)
 }
-

--- a/hail/src/main/scala/is/hail/types/virtual/TFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TFloat64.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.types.physical.PFloat64
@@ -21,7 +22,7 @@ case object TFloat64 extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Double].formatted("%.5e")
 
-  override def genNonmissingValue: Gen[Annotation] = arbitrary[Double]
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Double]
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
     a1 == a2 || (a1 != null && a2 != null && {
@@ -39,8 +40,6 @@ case object TFloat64 extends TNumeric {
 
   override def scalaClassTag: ClassTag[java.lang.Double] = classTag[java.lang.Double]
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Double]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TInt32.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TInt32.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.{Region, _}
+import is.hail.backend.HailStateManager
 import is.hail.asm4s.Code
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
@@ -18,12 +19,10 @@ case object TInt32 extends TIntegral {
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
 
-  override def genNonmissingValue: Gen[Annotation] = arbitrary[Int]
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Int]
 
   override def scalaClassTag: ClassTag[java.lang.Integer] = classTag[java.lang.Integer]
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TInt64.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TInt64.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.types.physical.PInt64
@@ -16,13 +17,10 @@ case object TInt64 extends TIntegral {
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Long]
 
-  override def genNonmissingValue: Gen[Annotation] = arbitrary[Long]
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Long]
 
   override def scalaClassTag: ClassTag[java.lang.Long] = classTag[java.lang.Long]
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Long]], missingEqual)
 }
-

--- a/hail/src/main/scala/is/hail/types/virtual/TInterval.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TInterval.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.{Annotation, ExtendedOrdering}
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.types.physical.PInterval
 import is.hail.types.virtual.TCall.representation
@@ -30,14 +31,12 @@ case class TInterval(pointType: Type) extends Type {
     pointType.typeCheck(i.start) && pointType.typeCheck(i.end)
   }
 
-  override def genNonmissingValue: Gen[Annotation] = Interval.gen(pointType.ordering, pointType.genValue)
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = Interval.gen(pointType.ordering(sm), pointType.genValue(sm))
 
   override def scalaClassTag: ClassTag[Interval] = classTag[Interval]
 
-  override lazy val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
-    Interval.ordering(pointType.ordering, startPrimary=true, missingEqual)
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
+    Interval.ordering(pointType.ordering(sm), startPrimary=true, missingEqual)
 
   lazy val structRepresentation: TStruct = {
     TStruct(

--- a/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
@@ -1,7 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, HailStateManager}
 import is.hail.check._
 import is.hail.types.physical.PLocus
 import is.hail.types.virtual.TCall.representation
@@ -11,49 +11,45 @@ import is.hail.variant._
 import scala.reflect.{ClassTag, classTag}
 
 object TLocus {
-  def apply(rg: ReferenceGenome): TLocus = TLocus(rg.broadcastRG)
-
   val representation: TStruct = {
     TStruct(
       "contig" -> TString,
       "position" -> TInt32)
   }
 
-  def schemaFromRG(rg: Option[ReferenceGenome], required: Boolean = false): Type = rg match {
+  def schemaFromRG(rg: Option[String], required: Boolean = false): Type = rg match {
     // must match tlocus.schema_from_rg
-    case Some(ref) => TLocus(ref)
+    case Some(name) => TLocus(name)
     case None => TLocus.representation
   }
 }
 
-case class TLocus(rgBc: BroadcastRG) extends Type {
+case class TLocus(rgName: String) extends Type {
 
-  def rg: ReferenceGenome = rgBc.value
+  def _toPretty = s"Locus($rgName)"
 
-  def _toPretty = s"Locus($rg)"
+  def rg: String = rgName
 
   override def pyString(sb: StringBuilder): Unit = {
     sb.append("locus<")
-    sb.append(prettyIdentifier(rg.name))
+    sb.append(prettyIdentifier(rgName))
     sb.append('>')
   }
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Locus]
 
-  override def genNonmissingValue: Gen[Annotation] = Locus.gen(rg)
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = Locus.gen(sm.referenceGenomes(rgName))
 
   override def scalaClassTag: ClassTag[Locus] = classTag[Locus]
 
-  override lazy val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
-    ExtendedOrdering.extendToNull(rg.locusOrdering, missingEqual)
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(sm.referenceGenomes(rgName).locusOrdering, missingEqual)
 
   lazy val representation: TStruct = TLocus.representation
 
-  def locusOrdering: Ordering[Locus] = rg.locusOrdering
+  def locusOrdering(sm: HailStateManager): Ordering[Locus] = sm.referenceGenomes(rgName).locusOrdering
 
   override def unify(concrete: Type): Boolean = concrete match {
-    case TLocus(crgBc) => rg == crgBc.value
+    case TLocus(crgName) => rgName == crgName
     case _ => false
   }
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
@@ -44,6 +44,9 @@ case class TLocus(rgName: String) extends Type {
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering =
     ExtendedOrdering.extendToNull(sm.referenceGenomes(rgName).locusOrdering, missingEqual)
 
+  override def mkOrdering(rg: ReferenceGenome, missingEqual: Boolean = true): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(rg.locusOrdering, missingEqual)
+
   lazy val representation: TStruct = TLocus.representation
 
   def locusOrdering(sm: HailStateManager): Ordering[Locus] = sm.referenceGenomes(rgName).locusOrdering

--- a/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
@@ -42,10 +42,7 @@ case class TLocus(rgName: String) extends Type {
   override def scalaClassTag: ClassTag[Locus] = classTag[Locus]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering =
-    ExtendedOrdering.extendToNull(sm.referenceGenomes(rgName).locusOrdering, missingEqual)
-
-  override def mkOrdering(rg: ReferenceGenome, missingEqual: Boolean = true): ExtendedOrdering =
-    ExtendedOrdering.extendToNull(rg.locusOrdering, missingEqual)
+    sm.referenceGenomes(rgName).extendedLocusOrdering
 
   lazy val representation: TStruct = TLocus.representation
 

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -1,7 +1,9 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.{Annotation, ExtendedOrdering, NDArray, UnsafeIndexedSeq}
+import is.hail.backend.HailStateManager
 import is.hail.expr.{Nat, NatBase}
+import is.hail.check.Gen
 import is.hail.types.physical.PNDArray
 import org.apache.spark.sql.Row
 
@@ -114,7 +116,9 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   }
 
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering = null
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = ???
+
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = null
 
   lazy val shapeType: TTuple = TTuple(Array.fill(nDims)(TInt64): _*)
 

--- a/hail/src/main/scala/is/hail/types/virtual/TRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TRNGState.scala
@@ -1,12 +1,18 @@
 package is.hail.types.virtual
 
+import is.hail.annotations.Annotation
+import is.hail.backend.HailStateManager
+import is.hail.check.Gen
+
 case object TRNGState extends Type {
   override def _toPretty = "RNGState"
 
   override def pyString(sb: StringBuilder): Unit = {
     sb.append("rng_state")
   }
+
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = ???
   def _typeCheck(a: Any): Boolean = ???
-  def mkOrdering(missingEqual: Boolean): is.hail.annotations.ExtendedOrdering = ???
+  def mkOrdering(sm: HailStateManager, missingEqual: Boolean): is.hail.annotations.ExtendedOrdering = ???
   def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] = ???
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TSet.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TSet.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.{Annotation, ExtendedOrdering}
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.types.physical.PSet
 import is.hail.utils._
@@ -38,10 +39,8 @@ final case class TSet(elementType: Type) extends TContainer {
     sb.append("]")
   }
 
-  override lazy val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
-    ExtendedOrdering.setOrdering(elementType.ordering, missingEqual)
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.setOrdering(elementType.ordering(sm), missingEqual)
 
   override def _showStr(a: Annotation): String =
     a.asInstanceOf[Set[Annotation]]
@@ -51,7 +50,7 @@ final case class TSet(elementType: Type) extends TContainer {
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  override def genNonmissingValue: Gen[Annotation] = Gen.buildableOf[Set](elementType.genValue)
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = Gen.buildableOf[Set](elementType.genValue(sm))
 
   override def scalaClassTag: ClassTag[Set[AnyRef]] = classTag[Set[AnyRef]]
 

--- a/hail/src/main/scala/is/hail/types/virtual/TStream.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStream.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.{Annotation, ExtendedOrdering}
+import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import org.json4s.jackson.JsonMethods
 
@@ -38,12 +39,11 @@ final case class TStream(elementType: Type) extends TIterable {
 
   override def isRealizable = false
 
-  override def genNonmissingValue: Gen[Annotation] =
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] =
     throw new UnsupportedOperationException("Streams don't have associated annotations.")
 
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     throw new UnsupportedOperationException("Stream comparison is currently undefined.")
 
   override def scalaClassTag: ClassTag[Iterator[AnyRef]] = classTag[Iterator[AnyRef]]
 }
-

--- a/hail/src/main/scala/is/hail/types/virtual/TString.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TString.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.types.physical.PString
@@ -19,12 +20,10 @@ case object TString extends Type {
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[String]
 
-  override def genNonmissingValue: Gen[Annotation] = arbitrary[String]
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[String]
 
   override def scalaClassTag: ClassTag[String] = classTag[String]
 
-  override val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[String]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.{Annotation, AnnotationPathException, _}
+import is.hail.backend.HailStateManager
 import is.hail.expr.ir.{Env, IRParser, IntArrayBuilder}
 import is.hail.types.physical.{PField, PStruct}
 import is.hail.utils._
@@ -50,10 +51,8 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
 
   override def truncate(newSize: Int): TStruct = TStruct(fields.take(newSize))
 
-  override lazy val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
-    TBaseStruct.getOrdering(types, missingEqual)
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
+    TBaseStruct.getOrdering(sm, types, missingEqual)
 
   override def canCompare(other: Type): Boolean = other match {
     case t: TStruct => size == t.size && fields.zip(t.fields).forall { case (f1, f2) =>

--- a/hail/src/main/scala/is/hail/types/virtual/TTuple.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TTuple.scala
@@ -1,6 +1,7 @@
 package is.hail.types.virtual
 
 import is.hail.annotations.ExtendedOrdering
+import is.hail.backend.HailStateManager
 import is.hail.utils._
 import org.apache.spark.sql.Row
 
@@ -19,10 +20,8 @@ final case class TTuple(_types: IndexedSeq[TupleField]) extends TBaseStruct {
 
   lazy val fieldIndex: Map[Int, Int] = _types.zipWithIndex.map { case (tf, idx) => tf.index -> idx }.toMap
 
-  override lazy val ordering: ExtendedOrdering = mkOrdering()
-
-  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
-    TBaseStruct.getOrdering(types, missingEqual)
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
+    TBaseStruct.getOrdering(sm, types, missingEqual)
 
   override lazy val _isCanonical: Boolean = _types.indices.forall(i => i == _types(i).index)
 

--- a/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
@@ -1,6 +1,8 @@
 package is.hail.types.virtual
 
-import is.hail.annotations.ExtendedOrdering
+import is.hail.annotations.{Annotation, ExtendedOrdering}
+import is.hail.backend.HailStateManager
+import is.hail.check.Gen
 import is.hail.expr.ir.IRParser
 import is.hail.types.physical.PType
 import is.hail.utils._
@@ -121,7 +123,9 @@ final case class TUnion(cases: IndexedSeq[Case]) extends Type {
     }
   }
 
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = ???
+
   override def scalaClassTag: ClassTag[AnyRef] = ???
 
-  def mkOrdering(missingEqual: Boolean): ExtendedOrdering = ???
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = ???
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TVariable.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TVariable.scala
@@ -1,6 +1,8 @@
 package is.hail.types.virtual
 
-import is.hail.annotations.ExtendedOrdering
+import is.hail.annotations.{Annotation, ExtendedOrdering}
+import is.hail.backend.HailStateManager
+import is.hail.check.Gen
 import is.hail.types.Box
 import is.hail.types.physical.PType
 
@@ -71,7 +73,9 @@ final case class TVariable(name: String, cond: String = null) extends Type {
     t
   }
 
+  override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = ???
+
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TVariable is not realizable")
 
-  def mkOrdering(missingEqual: Boolean): ExtendedOrdering = null
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = null
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TVoid.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TVoid.scala
@@ -1,6 +1,8 @@
 package is.hail.types.virtual
 
-import is.hail.annotations.ExtendedOrdering
+import is.hail.annotations.{Annotation, ExtendedOrdering}
+import is.hail.backend.HailStateManager
+import is.hail.check.Gen
 import is.hail.types.physical.PVoid
 
 case object TVoid extends Type {
@@ -10,7 +12,9 @@ case object TVoid extends Type {
     sb.append("void")
   }
 
-  def mkOrdering(missingEqual: Boolean): ExtendedOrdering = null
+  def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = ???
+
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = null
 
   override def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] = throw new UnsupportedOperationException("No ClassTag for Void")
 

--- a/hail/src/main/scala/is/hail/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/Type.scala
@@ -199,7 +199,11 @@ abstract class Type extends BaseType with Serializable {
 
   def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering
 
-  def ordering(sm: HailStateManager): ExtendedOrdering = mkOrdering(sm)
+  @transient protected var ord: ExtendedOrdering = _
+  def ordering(sm: HailStateManager): ExtendedOrdering = {
+    if (ord == null) ord = mkOrdering(sm)
+    ord
+  }
 
   def jsonReader: JSONReader[Annotation] = new JSONReader[Annotation] {
     def fromJSON(a: JValue): Annotation = JSONAnnotationImpex.importAnnotation(a, self)

--- a/hail/src/main/scala/is/hail/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/Type.scala
@@ -2,6 +2,7 @@ package is.hail.types.virtual
 
 import is.hail.annotations._
 import is.hail.asm4s._
+import is.hail.backend.HailStateManager
 import is.hail.check.{Arbitrary, Gen}
 import is.hail.expr.ir._
 import is.hail.types._
@@ -25,8 +26,7 @@ object Type {
       TFloat64, TString, TCall)
 
   def genComplexType(): Gen[Type] = {
-    val rgDependents = ReferenceGenome.references.values.toArray.map(rg =>
-      TLocus(rg))
+    val rgDependents = ReferenceGenome.hailReferences.toArray.map(TLocus(_))
     val others = Array(TCall)
     Gen.oneOfSeq(rgDependents ++ others)
   }
@@ -89,14 +89,14 @@ object Type {
 
   val genRequired: Gen[Type] = preGenArb()
 
-  def genWithValue: Gen[(Type, Annotation)] = for {
+  def genWithValue(sm: HailStateManager): Gen[(Type, Annotation)] = for {
     s <- Gen.size
     // prefer smaller type and bigger values
     fraction <- Gen.choose(0.1, 0.3)
     x = (fraction * s).toInt
     y = s - x
     t <- Type.genStruct.resize(x)
-    v <- t.genValue.resize(y)
+    v <- t.genValue(sm).resize(y)
   } yield (t, v)
 
   implicit def arbType = Arbitrary(genArb)
@@ -183,10 +183,10 @@ abstract class Type extends BaseType with Serializable {
 
   def toJSON(a: Annotation): JValue = JSONAnnotationImpex.exportAnnotation(a, this)
 
-  def genNonmissingValue: Gen[Annotation] = ???
+  def genNonmissingValue(sm: HailStateManager): Gen[Annotation]
 
-  def genValue: Gen[Annotation] =
-    Gen.nextCoin(0.05).flatMap(isEmpty => if (isEmpty) Gen.const(null) else genNonmissingValue)
+  def genValue(sm: HailStateManager): Gen[Annotation] =
+    Gen.nextCoin(0.05).flatMap(isEmpty => if (isEmpty) Gen.const(null) else genNonmissingValue(sm))
 
   def isRealizable: Boolean = children.forall(_.isRealizable)
 
@@ -197,9 +197,9 @@ abstract class Type extends BaseType with Serializable {
 
   def canCompare(other: Type): Boolean = this == other
 
-  def mkOrdering(missingEqual: Boolean = true): ExtendedOrdering
+  def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering
 
-  def ordering: ExtendedOrdering = mkOrdering()
+  def ordering(sm: HailStateManager): ExtendedOrdering = mkOrdering(sm)
 
   def jsonReader: JSONReader[Annotation] = new JSONReader[Annotation] {
     def fromJSON(a: JValue): Annotation = JSONAnnotationImpex.importAnnotation(a, self)

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
@@ -3,6 +3,7 @@ package is.hail.utils.richUtils
 import java.io.PrintWriter
 
 import is.hail.annotations.{Region, RegionValue, RegionValueBuilder}
+import is.hail.backend.HailStateManager
 import is.hail.types.physical.PStruct
 import is.hail.types.virtual.TStruct
 import is.hail.rvd.RVDContext
@@ -151,7 +152,7 @@ class RichIterator[T](val it: Iterator[T]) extends AnyVal {
 class RichRowIterator(val it: Iterator[Row]) extends AnyVal {
   def copyToRegion(region: Region, rowTyp: PStruct): Iterator[Long] = {
     it.map { row =>
-      rowTyp.unstagedStoreJavaObject(row, region)
+      rowTyp.unstagedStoreJavaObject(null, row, region)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -115,7 +115,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     }
   }
 
-  lazy val extendedLocusOrdering = ExtendedOrdering.extendToNull(locusOrdering)
+  val extendedLocusOrdering = ExtendedOrdering.extendToNull(locusOrdering)
 
   // must be constructed after orderings
   @transient @volatile var _locusType: TLocus = _

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -4,7 +4,7 @@ import java.io.InputStream
 import htsjdk.samtools.reference.FastaSequenceIndex
 import is.hail.HailContext
 import is.hail.asm4s.Code
-import is.hail.backend.{BroadcastValue, ExecuteContext}
+import is.hail.backend.{BroadcastValue, ExecuteContext, HailStateManager}
 import is.hail.check.Gen
 import is.hail.expr.ir.{EmitClassBuilder, RelationalSpec}
 import is.hail.expr.{JSONExtractContig, JSONExtractIntervalLocus, JSONExtractReferenceGenome, Parser}
@@ -121,7 +121,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     if (_locusType == null) {
       synchronized {
         if (_locusType == null)
-          _locusType = TLocus(this)
+          _locusType = TLocus(this.name)
       }
     }
     _locusType
@@ -154,8 +154,6 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
   }
 
   val nBases = lengths.map(_._2.toLong).sum
-
-  private val globalPosOrd = TInt64.ordering
 
   @transient private var globalContigEnds: Array[Long] = _
 
@@ -271,7 +269,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
       }
     }
 
-    if (!Interval.isValid(locusType.ordering, start, end, includesStart, includesEnd))
+    if (!Interval.isValid(locusType.ordering(HailStateManager(Map(this.name -> this))), start, end, includesStart, includesEnd))
       if (invalidMissing)
         return null
       else
@@ -292,9 +290,19 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
   def isMitochondrial(contig: String): Boolean = mtContigs.contains(contig)
 
-  def inXPar(l: Locus): Boolean = inX(l.contig) && par.exists(_.contains(locusType.ordering, l))
+  def isAutosomal(contig: String): Boolean = !(inX(contig) || inY(contig) || isMitochondrial(contig))
 
-  def inYPar(l: Locus): Boolean = inY(l.contig) && par.exists(_.contains(locusType.ordering, l))
+  def inPar(l: Locus): Boolean = par.exists(_.contains(locusType.ordering(HailStateManager(Map(this.name -> this))), l))
+
+  def inXPar(l: Locus): Boolean = inX(l.contig) && inPar(l)
+
+  def inYPar(l: Locus): Boolean = inY(l.contig) && inPar(l)
+
+  def inXNonPar(l: Locus): Boolean = inX(l.contig) && !inPar(l)
+
+  def inYNonPar(l: Locus): Boolean = inY(l.contig) && !inPar(l)
+
+  def isAutosomalOrPseudoAutosomal(l: Locus): Boolean = isAutosomal(l.contig) || ((inX(l.contig) || inY(l.contig)) && inPar(l))
 
   def compare(contig1: String, contig2: String): Int = ReferenceGenome.compare(contigsIndex, contig1, contig2)
 
@@ -401,7 +409,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
       fatal(s"Chain file '$chainFile' does not exist.")
 
     val chainFilePath = fs.fileStatus(chainFile).getPath
-    val lo = LiftOver(tmpdir, fs, chainFilePath)
+    val lo = LiftOver(fs, chainFilePath)
     val destRG = ctx.getReference(destRGName)
     lo.checkChainFile(this, destRG)
 
@@ -441,7 +449,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
       val chainFilePath = fs.fileStatus(chainFile).getPath
       liftoverMap.get(destRGName) match {
         case Some(lo) if lo.chainFile == chainFilePath => // do nothing
-        case _ => liftoverMap += destRGName -> LiftOver(tmpdir, fs, chainFilePath)
+        case _ => liftoverMap += destRGName -> LiftOver(fs, chainFilePath)
       }
     }
 
@@ -511,52 +519,24 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 }
 
 object ReferenceGenome {
-  var references: Map[String, ReferenceGenome] = Map()
-  var GRCh37: ReferenceGenome = _
-  var GRCh38: ReferenceGenome = _
-  var GRCm38: ReferenceGenome = _
-  var CanFam3: ReferenceGenome = _
-  var hailReferences: Set[String] = _
+  var GRCh37: String = "GRCh37"
+  var GRCh38: String = "GRCh38"
+  var GRCm38: String = "GRCm38"
+  var CanFam3: String = "CanFam3"
+  val hailReferences: Set[String] = Set(GRCh37, GRCh38, GRCm38, CanFam3)
 
-  def addDefaultReferences() : Unit = {
-    assert(references.isEmpty)
-    GRCh37 = fromResource("reference/grch37.json")
-    GRCh38 = fromResource("reference/grch38.json")
-    GRCm38 = fromResource("reference/grcm38.json")
-    CanFam3 = fromResource("reference/canfam3.json")
-    hailReferences = references.keySet
-  }
-
-  def reset(): Unit = {
-    references = Map()
-    GRCh37 = null
-    GRCh38 = null
-    GRCm38 = null
-    CanFam3 = null
-    hailReferences = null
-  }
-
-  def addReference(rg: ReferenceGenome) {
-    references.get(rg.name) match {
-      case Some(rg2) =>
-        if (rg != rg2) {
-          fatal(s"Cannot add reference genome '${ rg.name }', a different reference with that name already exists. Choose a reference name NOT in the following list:\n  " +
-            s"@1", references.keys.truncatable("\n  "))
-        }
-      case None =>
-        references += (rg.name -> rg)
+  def builtinReferences(): Map[String, ReferenceGenome] = {
+    var builtin: Map[String, ReferenceGenome] = Map()
+    val files = Array(
+      "reference/grch37.json", "reference/grch38.json",
+      "reference/grcm38.json", "reference/canfam3.json"
+    )
+    for (filename <- files) {
+      val rg = loadFromResource[ReferenceGenome](filename)(read)
+      builtin += (rg.name -> rg)
     }
+    builtin
   }
-
-  def getReference(name: String): ReferenceGenome = {
-    references.get(name) match {
-      case Some(rg) => rg
-      case None => fatal(s"Reference genome '$name' does not exist. Choose a reference name from the following list:\n  " +
-        s"@1", references.keys.truncatable("\n  "))
-    }
-  }
-
-  def hasReference(name: String): Boolean = references.contains(name)
 
   def read(is: InputStream): ReferenceGenome = {
     implicit val formats = defaultJSONFormats
@@ -569,27 +549,19 @@ object ReferenceGenome {
   }
 
   def fromResource(file: String): ReferenceGenome = {
-    val rg = loadFromResource[ReferenceGenome](file)(read)
-    addReference(rg)
-    rg
+    loadFromResource[ReferenceGenome](file)(read)
   }
 
   def fromFile(fs: FS, file: String): ReferenceGenome = {
-    val rg = using(fs.open(file))(read)
-    addReference(rg)
-    rg
+    using(fs.open(file))(read)
   }
 
-  def fromHailDataset(fs: FS, path: String): String = {
-    val references = RelationalSpec.readReferences(fs, path)
-    implicit val formats: Formats = defaultJSONFormats
-    Serialization.write(references.map(_.toJSON).toFastIndexedSeq)
+  def fromHailDataset(fs: FS, path: String): Array[ReferenceGenome] = {
+    RelationalSpec.readReferences(fs, path)
   }
 
   def fromJSON(config: String): ReferenceGenome = {
-    val rg = parse(config)
-    addReference(rg)
-    rg
+    parse(config)
   }
 
   def fromFASTAFile(ctx: ExecuteContext, name: String, fastaFile: String, indexFile: String,
@@ -622,22 +594,6 @@ object ReferenceGenome {
     rg
   }
 
-  def addSequence(ctx: ExecuteContext, name: String, fastaFile: String, indexFile: String): Unit = {
-    references(name).addSequence(ctx, fastaFile, indexFile)
-  }
-
-  def removeSequence(name: String): Unit = {
-    references(name).removeSequence()
-  }
-
-  def referenceAddLiftover(ctx: ExecuteContext, name: String, chainFile: String, destRGName: String): Unit = {
-    references(name).addLiftover(ctx, chainFile, destRGName)
-  }
-
-  def referenceRemoveLiftover(name: String, destRGName: String): Unit = {
-    references(name).removeLiftover(destRGName)
-  }
-
   def readReferences(fs: FS, path: String): Array[ReferenceGenome] = {
     if (fs.exists(path)) {
       val refs = fs.listStatus(path)
@@ -646,8 +602,8 @@ object ReferenceGenome {
         val rgPath = fileSystem.getPath.toString
         val rg = using(fs.open(rgPath))(read)
         val name = rg.name
-        if (ReferenceGenome.hasReference(name) && ReferenceGenome.getReference(name) != rg)
-          fatal(s"'$name' already exists and is not identical to the imported reference from '$rgPath'.")
+        // if (ReferenceGenome.hasReference(name) && ReferenceGenome.getReference(name) != rg)
+        //   fatal(s"'$name' already exists and is not identical to the imported reference from '$rgPath'.")
         if (!rgs.contains(rg) && !hailReferences.contains(name))
           rgs += rg
       }
@@ -655,31 +611,23 @@ object ReferenceGenome {
     } else Array()
   }
 
-  def importReferences(fs: FS, path: String) {
-    readReferences(fs, path).foreach { rg =>
-      if (!ReferenceGenome.hasReference(rg.name))
-        addReference(rg)
-    }
-  }
-
-  def writeReference(fs: is.hail.io.fs.FS, path: String, rg: ReferenceGenome) {
+  def writeReference(fs: FS, path: String, rg: ReferenceGenome) {
     val rgPath = path + "/" + rg.name + ".json.gz"
     if (!hailReferences.contains(rg.name) && !fs.exists(rgPath))
       rg.asInstanceOf[ReferenceGenome].write(fs, rgPath)
   }
 
-  def getReferences(t: Type): Set[ReferenceGenome] = {
-    var rgs = Set[ReferenceGenome]()
+  def getReferences(t: Type): Set[String] = {
+    var rgs = Set[String]()
     MapTypes.foreach {
       case tl: TLocus =>
-        rgs += tl.rg.asInstanceOf[ReferenceGenome]
+        rgs += tl.rg
       case _ =>
     }(t)
     rgs
   }
 
-  def exportReferences(fs: is.hail.io.fs.FS, path: String, t: Type) {
-    val rgs = getReferences(t)
+  def exportReferences(fs: FS, path: String, rgs: Set[ReferenceGenome]) {
     rgs.foreach(writeReference(fs, path, _))
   }
 
@@ -700,7 +648,7 @@ object ReferenceGenome {
   }
 
   def gen: Gen[ReferenceGenome] = for {
-    name <- Gen.identifier.filter(!ReferenceGenome.hasReference(_))
+    name <- Gen.identifier.filter(!ReferenceGenome.hailReferences.contains(_))
     nContigs <- Gen.choose(3, 10)
     contigs <- Gen.distinctBuildableOfN[Array](nContigs, Gen.identifier)
     lengths <- Gen.buildableOfN[Array](nContigs, Gen.choose(1000000, 500000000))
@@ -728,9 +676,7 @@ object ReferenceGenome {
       case _ => fatal("expected PAR input of form contig:start-end")
     }
 
-    val rg = ReferenceGenome(name, contigs, lengths, xContigs.toSet, yContigs.toSet, mtContigs.toSet, par)
-    addReference(rg)
-    rg
+    ReferenceGenome(name, contigs, lengths, xContigs.toSet, yContigs.toSet, mtContigs.toSet, par)
   }
 
   def apply(name: java.lang.String, contigs: java.util.List[String], lengths: java.util.Map[String, Int],
@@ -738,4 +684,6 @@ object ReferenceGenome {
     mtContigs: java.util.List[String], parInput: java.util.List[String]): ReferenceGenome =
     ReferenceGenome(name, contigs.asScala.toArray, lengths.asScala.toMap, xContigs.asScala.toArray, yContigs.asScala.toArray,
       mtContigs.asScala.toArray, parInput.asScala.toArray)
+
+  def getMapFromArray(arr: Array[ReferenceGenome]): Map[String, ReferenceGenome] = arr.map(rg => (rg.name, rg)).toMap
 }

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -177,7 +177,7 @@ object TestUtils {
           assert(resultType2.virtualType == resultType)
 
           ctx.r.pool.scopedRegion { region =>
-            val rvb = new RegionValueBuilder(region)
+            val rvb = new RegionValueBuilder(ctx.stateManager, region)
             rvb.start(argsPType)
             rvb.startTuple()
             var i = 0
@@ -210,7 +210,7 @@ object TestUtils {
           assert(resultType2.virtualType == resultType)
 
           ctx.r.pool.scopedRegion { region =>
-            val rvb = new RegionValueBuilder(region)
+            val rvb = new RegionValueBuilder(ctx.stateManager, region)
             rvb.start(argsPType)
             rvb.startTuple()
             var i = 0
@@ -299,15 +299,12 @@ object TestUtils {
     minPartitions: Option[Int] = None,
     dropSamples: Boolean = false,
     callFields: Set[String] = Set.empty[String],
-    rg: Option[ReferenceGenome] = Some(ReferenceGenome.GRCh37),
+    rg: Option[String] = Some(ReferenceGenome.GRCh37),
     contigRecoding: Option[Map[String, String]] = None,
     arrayElementsRequired: Boolean = true,
     skipInvalidLoci: Boolean = false,
     partitionsJSON: Option[String] = None,
     partitionsTypeStr: Option[String] = None): MatrixIR = {
-    rg.foreach { referenceGenome =>
-      ReferenceGenome.addReference(referenceGenome)
-    }
     val entryFloatType = TFloat64._toPretty
 
     val reader = MatrixVCFReader(ctx,
@@ -319,7 +316,7 @@ object TestUtils {
       nPartitions,
       blockSizeInMB,
       minPartitions,
-      rg.map(_.name),
+      rg,
       contigRecoding.getOrElse(Map.empty[String, String]),
       arrayElementsRequired,
       skipInvalidLoci,

--- a/hail/src/test/scala/is/hail/annotations/ScalaToRegionValue.scala
+++ b/hail/src/test/scala/is/hail/annotations/ScalaToRegionValue.scala
@@ -1,9 +1,10 @@
 package is.hail.annotations
 
 import is.hail.types.physical.PType
+import is.hail.backend.HailStateManager
 
 object ScalaToRegionValue {
-  def apply(region: Region, t: PType, a: Annotation): Long = {
-    t.unstagedStoreJavaObject(a, region)
+  def apply(sm: HailStateManager, region: Region, t: PType, a: Annotation): Long = {
+    t.unstagedStoreJavaObject(sm, a, region)
   }
 }

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -139,7 +139,7 @@ class CodeSuite extends HailSuite {
       hash.value
     })
     val region = Region(pool=pool)
-    val arrayPointer = pArray.unstagedStoreJavaObject(toHash, region)
+    val arrayPointer = pArray.unstagedStoreJavaObject(ctx.stateManager, toHash, region)
     fb.result(ctx)(theHailClassLoader)(arrayPointer)
   }
 
@@ -154,7 +154,7 @@ class CodeSuite extends HailSuite {
       hash.value
     })
     val region = Region(pool=pool)
-    val structPointer = pStruct.unstagedStoreJavaObject(toHash, region)
+    val structPointer = pStruct.unstagedStoreJavaObject(ctx.stateManager, toHash, region)
     fb.result(ctx)(theHailClassLoader)(structPointer)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -57,7 +57,7 @@ class Aggregators2Suite extends HailSuite {
       assert(resultType.virtualType.typeCheck(expected), s"expected type ${ resultType.virtualType.parsableString() }, got ${expected}")
 
     pool.scopedRegion { region =>
-      val argOff = ScalaToRegionValue(region, argT, argVs)
+      val argOff = ScalaToRegionValue(ctx.stateManager, region, argT, argVs)
 
       def withArgs(foo: IR) = {
         CompileWithAggregators[AsmFunction2RegionLongUnit](ctx,

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -57,7 +57,7 @@ class ETypeSuite extends HailSuite {
       Code._empty
     }
 
-    val x = inPType.unstagedStoreJavaObject(data, ctx.r)
+    val x = inPType.unstagedStoreJavaObject(ctx.stateManager, data, ctx.r)
 
     val buffer = new MemoryBuffer
     val ob = new MemoryOutputBuffer(buffer)

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -93,7 +93,7 @@ class EmitStreamSuite extends HailSuite {
       if (arg == null)
         f(r, 0L, true)
       else
-        f(r, ScalaToRegionValue(r, inputType, arg), false)
+        f(r, ScalaToRegionValue(ctx.stateManager, r, inputType, arg), false)
     }
   }
 
@@ -114,7 +114,7 @@ class EmitStreamSuite extends HailSuite {
             eos = true
             0L
           } else
-            ScalaToRegionValue(_eltRegion, elementType, it.next())
+            ScalaToRegionValue(ctx.stateManager, _eltRegion, elementType, it.next())
         }
         override def close(): Unit = ()
       }
@@ -756,7 +756,7 @@ class EmitStreamSuite extends HailSuite {
       ir)
 
     pool.scopedSmallRegion { r =>
-      val input = t.unstagedStoreJavaObject(Row(null, IndexedSeq(1d, 2d), IndexedSeq(3d, 4d)), r)
+      val input = t.unstagedStoreJavaObject(ctx.stateManager, Row(null, IndexedSeq(1d, 2d), IndexedSeq(3d, 4d)), r)
 
       assert(SafeRow.read(pt, f(theHailClassLoader, ctx.fs, ctx.taskContext, r)(r, input)) == Row(null))
     }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3128,8 +3128,8 @@ class IRSuite extends HailSuite {
 
     val t1 = TableType(TStruct("a" -> TInt32), FastIndexedSeq("a"), TStruct("g1" -> TInt32, "g2" -> TFloat64))
     val t2 = TableType(TStruct("a" -> TInt32), FastIndexedSeq("a"), TStruct("g3" -> TInt32, "g4" -> TFloat64))
-    val tab1 = TableLiteral(TableValue(ctx, t1, BroadcastRow(ctx, Row(1, 1.1), t1.globalType), RVD.empty(t1.canonicalRVDType)), theHailClassLoader)
-    val tab2 = TableLiteral(TableValue(ctx, t2, BroadcastRow(ctx, Row(2, 2.2), t2.globalType), RVD.empty(t2.canonicalRVDType)), theHailClassLoader)
+    val tab1 = TableLiteral(TableValue(ctx, t1, BroadcastRow(ctx, Row(1, 1.1), t1.globalType), RVD.empty(ctx, t1.canonicalRVDType)), theHailClassLoader)
+    val tab2 = TableLiteral(TableValue(ctx, t2, BroadcastRow(ctx, Row(2, 2.2), t2.globalType), RVD.empty(ctx, t2.canonicalRVDType)), theHailClassLoader)
 
     assertEvalsTo(TableGetGlobals(TableJoin(tab1, tab2, "left")), Row(1, 1.1, 2, 2.2))
     assertEvalsTo(TableGetGlobals(TableMapGlobals(tab1, InsertFields(Ref("global", t1.globalType), Seq("g1" -> I32(3))))), Row(3, 1.1))
@@ -3265,7 +3265,7 @@ class IRSuite extends HailSuite {
       backend.execute(timer, ir, optimize = true)
     }
     assert(
-      ir.typ.ordering.equiv(
+      ir.typ.ordering(ctx.stateManager).equiv(
         FastIndexedSeq(
           Interval(
             Row(Locus("20", 10277621)), Row(Locus("20", 11898992)), includesStart = true, includesEnd = false)),
@@ -3482,7 +3482,7 @@ class IRSuite extends HailSuite {
     val spec = TypedCodecSpec(PCanonicalStruct(("rowIdx", PInt32Required), ("extraInfo", PInt32Required)), BufferSpec.default)
     val dist = StreamDistribute(child, pivots, Str(ctx.localTmpdir), Compare(pivots.typ.asInstanceOf[TArray].elementType), spec)
     val result = eval(dist).asInstanceOf[IndexedSeq[Row]].map(row => (row(0).asInstanceOf[Interval], row(1).asInstanceOf[String], row(2).asInstanceOf[Int], row(3).asInstanceOf[Long]))
-    val kord: ExtendedOrdering = PartitionBoundOrdering(pivots.typ.asInstanceOf[TArray].elementType)
+    val kord: ExtendedOrdering = PartitionBoundOrdering(ctx, pivots.typ.asInstanceOf[TArray].elementType)
 
     var dataIdx = 0
 

--- a/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
@@ -13,8 +13,8 @@ class LocusFunctionsSuite extends HailSuite {
 
   implicit val execStrats = ExecStrategy.javaOnly
 
-  private def grch38: ReferenceGenome = ReferenceGenome.GRCh38
-  private def tlocus = TLocus(grch38)
+  private def grch38: ReferenceGenome = ctx.getReference(ReferenceGenome.GRCh38)
+  private def tlocus = TLocus(grch38.name)
   private def tvariant = TStruct("locus" -> tlocus, "alleles" -> TArray(TString))
 
   def locusIR: Apply = Apply("Locus", FastSeq(), FastSeq(Str("chr22"), I32(1)), tlocus, ErrorIDs.NO_ERROR)
@@ -62,11 +62,11 @@ class LocusFunctionsSuite extends HailSuite {
     assertEvalsTo(invoke("min_rep", tvariant, locusIR, alleles), Row(Locus("chr22", 2), FastIndexedSeq("A", "T")))
     assertEvalsTo(invoke("min_rep", tvariant, locusIR, NA(TArray(TString))), null)
   }
-  
+
   @Test def globalPosition() {
     assertEvalsTo(invoke("locusToGlobalPos", TInt64, locusIR), grch38.locusToGlobalPos(locus))
   }
-  
+
   @Test def reverseGlobalPosition() {
     val globalPosition = 2824183054L
     assertEvalsTo(invoke("globalPosToLocus", tlocus, I64(globalPosition)), grch38.globalPosToLocus(globalPosition))
@@ -79,20 +79,20 @@ class LocusFunctionsSuite extends HailSuite {
       invoke("Locus", TLocus(ReferenceGenome.GRCh37), Str("1"), I32(1)),
       invoke("Locus", TLocus(ReferenceGenome.GRCh38), Str("chr1"), I32(1))))
 
-    assertEvalsTo(ir, Row(Locus("1", 1, ReferenceGenome.GRCh37), Locus("chr1", 1, ReferenceGenome.GRCh38)))
+    assertEvalsTo(ir, Row(Locus("1", 1, ctx.getReference(ReferenceGenome.GRCh37)), Locus("chr1", 1, ctx.getReference(ReferenceGenome.GRCh38))))
   }
 
   @Test def testMakeInterval() {
     // TString, TInt32, TInt32, TBoolean, TBoolean, TBoolean
     val ir = MakeTuple.ordered(FastSeq(
-      invoke("LocusInterval", TInterval(TLocus(grch38)), NA(TString), I32(1), I32(100), True(), True(), False()),
-      invoke("LocusInterval", TInterval(TLocus(grch38)), Str("chr1"), NA(TInt32), I32(100), True(), True(), False()),
-      invoke("LocusInterval", TInterval(TLocus(grch38)), Str("chr1"), I32(1), NA(TInt32), True(), True(), False()),
-      invoke("LocusInterval", TInterval(TLocus(grch38)), Str("chr1"), I32(1), I32(100), NA(TBoolean), True(), False()),
-      invoke("LocusInterval", TInterval(TLocus(grch38)), Str("chr1"), I32(1), I32(100), True(), NA(TBoolean), False()),
-      invoke("LocusInterval", TInterval(TLocus(grch38)), Str("chr1"), I32(1), I32(100), True(), True(), NA(TBoolean)),
-      invoke("LocusInterval", TInterval(TLocus(grch38)), Str("chr1"), I32(-1), I32(0), True(), True(), True()),
-      invoke("LocusInterval", TInterval(TLocus(grch38)), Str("chr1"), I32(1), I32(100), True(), True(), True())
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), NA(TString), I32(1), I32(100), True(), True(), False()),
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), Str("chr1"), NA(TInt32), I32(100), True(), True(), False()),
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), Str("chr1"), I32(1), NA(TInt32), True(), True(), False()),
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), Str("chr1"), I32(1), I32(100), NA(TBoolean), True(), False()),
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), Str("chr1"), I32(1), I32(100), True(), NA(TBoolean), False()),
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), Str("chr1"), I32(1), I32(100), True(), True(), NA(TBoolean)),
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), Str("chr1"), I32(-1), I32(0), True(), True(), True()),
+      invoke("LocusInterval", TInterval(TLocus(grch38.name)), Str("chr1"), I32(1), I32(100), True(), True(), True())
     ))
 
     assertEvalsTo(ir,

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy
 import is.hail.HailSuite
 import is.hail.annotations._
+import is.hail.backend.HailStateManager
 import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
 import is.hail.TestUtils._
@@ -13,12 +14,15 @@ import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.interfaces.SBaseStructValue
 import is.hail.types.virtual._
 import is.hail.utils._
+import is.hail.variant.ReferenceGenome
 import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 
 class OrderingSuite extends HailSuite {
 
   implicit val execStrats = ExecStrategy.values
+
+  def sm = ctx.stateManager
 
   def recursiveSize(t: Type): Int = {
     val inner = t match {
@@ -72,16 +76,16 @@ class OrderingSuite extends HailSuite {
 
     val compareGen = for {
       t <- Type.genStruct
-      a <- t.genNonmissingValue
+      a <- t.genNonmissingValue(sm)
     } yield (t, a)
     val p = Prop.forAll(compareGen) { case (t, a) => pool.scopedRegion { region =>
       val pType = PType.canonical(t).asInstanceOf[PStruct]
-      val rvb = new RegionValueBuilder(region)
+      val rvb = new RegionValueBuilder(sm, region)
 
-      val v = pType.unstagedStoreJavaObject(a, region)
+      val v = pType.unstagedStoreJavaObject(sm, a, region)
 
-      val eordME = t.mkOrdering()
-      val eordMNE = t.mkOrdering(missingEqual = false)
+      val eordME = t.mkOrdering(sm)
+      val eordMNE = t.mkOrdering(sm, missingEqual = false)
 
       def checkCompare(compResult: Int, expected: Int) {
         assert(java.lang.Integer.signum(compResult) == expected,
@@ -221,45 +225,45 @@ class OrderingSuite extends HailSuite {
   @Test def testRandomOpsAgainstExtended() {
     val compareGen = for {
       t <- Type.genArb
-      a1 <- t.genNonmissingValue
-      a2 <- t.genNonmissingValue
+      a1 <- t.genNonmissingValue(sm)
+      a2 <- t.genNonmissingValue(sm)
     } yield (t, a1, a2)
     val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
       pool.scopedRegion { region =>
         val pType = PType.canonical(t)
-        val rvb = new RegionValueBuilder(region)
+        val rvb = new RegionValueBuilder(sm, region)
 
-        val v1 = pType.unstagedStoreJavaObject(a1, region)
+        val v1 = pType.unstagedStoreJavaObject(sm, a1, region)
 
-        val v2 = pType.unstagedStoreJavaObject(a2, region)
+        val v2 = pType.unstagedStoreJavaObject(sm, a2, region)
 
-        val compare = java.lang.Integer.signum(t.ordering.compare(a1, a2))
+        val compare = java.lang.Integer.signum(t.ordering(sm).compare(a1, a2))
         val fcompare = getStagedOrderingFunction(pType, CodeOrdering.Compare(), region)
         val result = java.lang.Integer.signum(fcompare(region, v1, v2))
 
         assert(result == compare, s"compare expected: $compare vs $result\n  t=${t.parsableString()}\n  v1=${a1}\n  v2=$a2")
 
-        val equiv = t.ordering.equiv(a1, a2)
+        val equiv = t.ordering(sm).equiv(a1, a2)
         val fequiv = getStagedOrderingFunction(pType, CodeOrdering.Equiv(), region)
 
         assert(fequiv(region, v1, v2) == equiv, s"equiv expected: $equiv")
 
-        val lt = t.ordering.lt(a1, a2)
+        val lt = t.ordering(sm).lt(a1, a2)
         val flt = getStagedOrderingFunction(pType, CodeOrdering.Lt(), region)
 
         assert(flt(region, v1, v2) == lt, s"lt expected: $lt")
 
-        val lteq = t.ordering.lteq(a1, a2)
+        val lteq = t.ordering(sm).lteq(a1, a2)
         val flteq = getStagedOrderingFunction(pType, CodeOrdering.Lteq(), region)
 
         assert(flteq(region, v1, v2) == lteq, s"lteq expected: $lteq")
 
-        val gt = t.ordering.gt(a1, a2)
+        val gt = t.ordering(sm).gt(a1, a2)
         val fgt = getStagedOrderingFunction(pType, CodeOrdering.Gt(), region)
 
         assert(fgt(region, v1, v2) == gt, s"gt expected: $gt")
 
-        val gteq = t.ordering.gteq(a1, a2)
+        val gteq = t.ordering(sm).gteq(a1, a2)
         val fgteq = getStagedOrderingFunction(pType, CodeOrdering.Gteq(), region)
 
         assert(fgteq(region, v1, v2) == gteq, s"gteq expected: $gteq")
@@ -273,19 +277,19 @@ class OrderingSuite extends HailSuite {
   @Test def testReverseIsSwappedArgumentsOfExtendedOrdering() {
     val compareGen = for {
       t <- Type.genArb
-      a1 <- t.genNonmissingValue
-      a2 <- t.genNonmissingValue
+      a1 <- t.genNonmissingValue(sm)
+      a2 <- t.genNonmissingValue(sm)
     } yield (t, a1, a2)
     val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
       pool.scopedRegion { region =>
         val pType = PType.canonical(t)
-        val rvb = new RegionValueBuilder(region)
+        val rvb = new RegionValueBuilder(sm, region)
 
-        val v1 = pType.unstagedStoreJavaObject(a1, region)
+        val v1 = pType.unstagedStoreJavaObject(sm, a1, region)
 
-        val v2 = pType.unstagedStoreJavaObject(a2, region)
+        val v2 = pType.unstagedStoreJavaObject(sm, a2, region)
 
-        val reversedExtendedOrdering = t.ordering.reverse
+        val reversedExtendedOrdering = t.ordering(sm).reverse
 
         val compare = java.lang.Integer.signum(reversedExtendedOrdering.compare(a2, a1))
         val fcompare = getStagedOrderingFunction(pType, CodeOrdering.Compare(), region, Descending)
@@ -329,11 +333,11 @@ class OrderingSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.javaOnly
     val compareGen = for {
       elt <- Type.genArb
-      a <- TArray(elt).genNonmissingValue
+      a <- TArray(elt).genNonmissingValue(sm)
       asc <- Gen.coin()
     } yield (elt, a, asc)
     val p = Prop.forAll(compareGen) { case (t, a: IndexedSeq[Any], asc: Boolean) =>
-      val ord = if (asc) t.ordering.toOrdering else t.ordering.reverse.toOrdering
+      val ord = if (asc) t.ordering(sm).toOrdering else t.ordering(sm).reverse.toOrdering
       assertEvalsTo(ArraySort(ToStream(In(0, TArray(t))), Literal.coerce(TBoolean, asc)),
         FastIndexedSeq(a -> TArray(t)),
         expected = a.sorted(ord))
@@ -346,13 +350,13 @@ class OrderingSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.javaOnly
     val compareGen = for {
       elt <- Type.genArb
-      a <- TArray(elt).genNonmissingValue
+      a <- TArray(elt).genNonmissingValue(sm)
     } yield (elt, a)
     val p = Prop.forAll(compareGen) { case (t, a: IndexedSeq[Any]) =>
       val array = a ++ a
       assertEvalsTo(ToArray(ToSet(In(0, TArray(t)))),
         FastIndexedSeq(array -> TArray(t)),
-        expected = array.sorted(t.ordering.toOrdering).distinct)
+        expected = array.sorted(t.ordering(sm).toOrdering).distinct)
       true
     }
     p.check()
@@ -364,7 +368,7 @@ class OrderingSuite extends HailSuite {
       kt <- Type.genArb
       vt <- Type.genArb
       telt = TTuple(kt, vt)
-      a <- TArray(telt).genNonmissingValue
+      a <- TArray(telt).genNonmissingValue(sm)
     } yield (telt, a)
     val p = Prop.forAll(compareGen) { case (telt: TTuple, a: IndexedSeq[Row]@unchecked) =>
       val tdict = TDict(telt.types(0), telt.types(1))
@@ -374,7 +378,7 @@ class OrderingSuite extends HailSuite {
         ToArray(StreamMap(ToStream(In(0, TArray(telt))),
         "x", GetField(Ref("x", tdict.elementType), "key"))),
         FastIndexedSeq(array -> TArray(telt)),
-        expected = expectedMap.keys.toFastIndexedSeq.sorted(telt.types(0).ordering.toOrdering))
+        expected = expectedMap.keys.toFastIndexedSeq.sorted(telt.types(0).ordering(sm).toOrdering))
       true
     }
     p.check()
@@ -391,7 +395,7 @@ class OrderingSuite extends HailSuite {
   @Test def testSetContainsOnRandomSet() {
     implicit val execStrats = ExecStrategy.javaOnly
     val compareGen = Type.genArb
-      .flatMap(t => Gen.zip(Gen.const(TSet(t)), TSet(t).genNonmissingValue, t.genValue))
+      .flatMap(t => Gen.zip(Gen.const(TSet(t)), TSet(t).genNonmissingValue(sm), t.genValue(sm)))
     val p = Prop.forAll(compareGen) { case (tset: TSet, set: Set[Any]@unchecked, test1) =>
       val telt = tset.elementType
 
@@ -416,7 +420,7 @@ class OrderingSuite extends HailSuite {
 
     val compareGen = Gen.zip(Type.genArb, Type.genArb).flatMap {
       case (k, v) =>
-        Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue, k.genNonmissingValue)
+        Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue(sm), k.genNonmissingValue(sm))
     }
     val p = Prop.forAll(compareGen) { case (tdict: TDict, dict: Map[Any, Any]@unchecked, testKey1) =>
       assertEvalsTo(invoke("get", tdict.valueType, In(0, tdict), In(1, tdict.keyType)),
@@ -438,7 +442,7 @@ class OrderingSuite extends HailSuite {
   }
 
   def testBinarySearchOnSet() {
-    val compareGen = Type.genArb.flatMap(t => Gen.zip(Gen.const(t), TSet(t).genNonmissingValue, t.genNonmissingValue))
+    val compareGen = Type.genArb.flatMap(t => Gen.zip(Gen.const(t), TSet(t).genNonmissingValue(sm), t.genNonmissingValue(sm)))
     val p = Prop.forAll(compareGen.filter { case (t, a, elem) => a.asInstanceOf[Set[Any]].nonEmpty }) { case (t, a, elem) =>
       val set = a.asInstanceOf[Set[Any]]
       val pt = PType.canonical(t)
@@ -448,11 +452,11 @@ class OrderingSuite extends HailSuite {
       val pArray = PCanonicalArray(pt)
 
       pool.scopedRegion { region =>
-        val rvb = new RegionValueBuilder(region)
+        val rvb = new RegionValueBuilder(sm, region)
 
-        val soff = pset.unstagedStoreJavaObject(set, region)
+        val soff = pset.unstagedStoreJavaObject(sm, set, region)
 
-        val eoff = pTuple.unstagedStoreJavaObject(Row(elem), region)
+        val eoff = pTuple.unstagedStoreJavaObject(sm, Row(elem), region)
 
         val fb = EmitFunctionBuilder[Region, Long, Long, Int](ctx, "binary_search")
         val cregion = fb.getCodeParam[Region](1).load()
@@ -473,7 +477,7 @@ class OrderingSuite extends HailSuite {
         val maybeEqual = asArray(closestI)
 
         set.contains(elem) ==> (elem == maybeEqual) &&
-          (t.ordering.compare(elem, maybeEqual) <= 0 || (closestI == set.size - 1))
+          (t.ordering(sm).compare(elem, maybeEqual) <= 0 || (closestI == set.size - 1))
       }
     }
     p.check()
@@ -481,16 +485,16 @@ class OrderingSuite extends HailSuite {
 
   @Test def testBinarySearchOnDict() {
     val compareGen = Gen.zip(Type.genArb, Type.genArb)
-      .flatMap { case (k, v) => Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue, k.genValue) }
+      .flatMap { case (k, v) => Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue(sm), k.genValue(sm)) }
     val p = Prop.forAll(compareGen.filter { case (tdict, a, key) => a.asInstanceOf[Map[Any, Any]].nonEmpty }) { case (tDict, a, key) =>
       val dict = a.asInstanceOf[Map[Any, Any]]
       val pDict = PType.canonical(tDict).asInstanceOf[PDict]
 
       pool.scopedRegion { region =>
-        val soff = pDict.unstagedStoreJavaObject(dict, region)
+        val soff = pDict.unstagedStoreJavaObject(sm, dict, region)
 
         val ptuple = PCanonicalTuple(false, FastIndexedSeq(pDict.keyType): _*)
-        val eoff = ptuple.unstagedStoreJavaObject(Row(key), region)
+        val eoff = ptuple.unstagedStoreJavaObject(sm, Row(key), region)
 
         val fb = EmitFunctionBuilder[Region, Long, Long, Int](ctx, "binary_search_dict")
         val cdict = fb.getCodeParam[Long](2)
@@ -515,17 +519,17 @@ class OrderingSuite extends HailSuite {
         if (closestI == asArray.length) {
           !dict.contains(key) ==> asArray.forall { keyI =>
             val otherKey = keyI.asInstanceOf[Row].get(0)
-            pDict.keyType.virtualType.ordering.compare(key, otherKey) > 0
+            pDict.keyType.virtualType.ordering(sm).compare(key, otherKey) > 0
           }
         } else {
           def getKey(i: Int) = asArray(i).asInstanceOf[Row].get(0)
           val maybeEqual = getKey(closestI)
           val closestIIsClosest =
-            (pDict.keyType.virtualType.ordering.compare(key, maybeEqual) <= 0 || closestI == dict.size - 1) &&
-              (closestI == 0 || pDict.keyType.virtualType.ordering.compare(key, getKey(closestI - 1)) > 0)
+            (pDict.keyType.virtualType.ordering(sm).compare(key, maybeEqual) <= 0 || closestI == dict.size - 1) &&
+              (closestI == 0 || pDict.keyType.virtualType.ordering(sm).compare(key, getKey(closestI - 1)) > 0)
 
           // FIXME: -0.0 and 0.0 count as the same in scala Map, but not off-heap Hail data structures
-          val kord = tDict.keyType.ordering
+          val kord = tDict.keyType.ordering(sm)
           (dict.contains(key) && dict.keysIterator.exists(kord.compare(_, key) == 0)) ==> (key == maybeEqual) && closestIIsClosest
         }
       }

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -136,7 +136,7 @@ class PruneSuite extends HailSuite {
     TStruct("e1" -> TFloat64, "e2" -> TFloat64))
   lazy val mat = MatrixLiteral(ctx,
     mType,
-    RVD.empty(mType.canonicalTableType.canonicalRVDType),
+    RVD.empty(ctx, mType.canonicalTableType.canonicalRVDType),
     Row(1, 1.0),
     FastIndexedSeq(Row("1", 2, FastIndexedSeq(Row(3)))))
 

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -54,7 +54,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
 
       val f = fb.result(ctx)(theHailClassLoader)
       ({ (r, ptr, elt) =>
-        f(r, ptr, if(elt == null) 0L else ScalaToRegionValue(r, elemPType, elt))
+        f(r, ptr, if(elt == null) 0L else ScalaToRegionValue(ctx.stateManager, r, elemPType, elt))
       })
     }
 

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -20,12 +20,6 @@ object LocalLDPruneSuite {
   val variantByteOverhead = 50
   val fractionMemoryToUse = 0.25
 
-  val rvRowType = TStruct(
-    "locus" -> ReferenceGenome.GRCh37.locusType,
-    "alleles" -> TArray(TString),
-    MatrixType.entriesIdentifier -> TArray(Genotype.htsGenotypeType)
-  )
-
   def fromCalls(calls: IndexedSeq[BoxedCall]): Option[BitPackedVector] = {
     val locus = Locus("1", 1)
     val alleles = Array("A", "T")

--- a/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
@@ -19,7 +19,7 @@ class PContainerTest extends PhysicalTestUtils {
 
   def testContainsNonZeroBits(sourceType: PArray, data: IndexedSeq[Any]) = {
     val srcRegion = Region(pool=pool)
-    val src = ScalaToRegionValue(srcRegion, sourceType, data)
+    val src = ScalaToRegionValue(ctx.stateManager, srcRegion, sourceType, data)
 
     log.info(s"Testing $data")
 
@@ -29,7 +29,7 @@ class PContainerTest extends PhysicalTestUtils {
 
   def testContainsNonZeroBitsStaged(sourceType: PArray, data: IndexedSeq[Any]) = {
     val srcRegion = Region(pool=pool)
-    val src = ScalaToRegionValue(srcRegion, sourceType, data)
+    val src = ScalaToRegionValue(ctx.stateManager, srcRegion, sourceType, data)
 
     log.info(s"Testing $data")
 
@@ -44,7 +44,7 @@ class PContainerTest extends PhysicalTestUtils {
 
   def testHasMissingValues(sourceType: PArray, data: IndexedSeq[Any]) = {
     val srcRegion = Region(pool=pool)
-    val src = ScalaToRegionValue(srcRegion, sourceType, data)
+    val src = ScalaToRegionValue(ctx.stateManager, srcRegion, sourceType, data)
 
     log.info(s"\nTesting $data")
 
@@ -118,7 +118,7 @@ class PContainerTest extends PhysicalTestUtils {
         missing <- 1 to num
     } assert(testHasMissingValues(sourceType, nullInByte(num, missing)) == true)
   }
-  
+
   @Test def arrayCopyTest() {
     // Note: can't test where data is null due to ArrayStack.top semantics (ScalaToRegionValue: assert(size_ > 0))
     def runTests(deepCopy: Boolean, interpret: Boolean) {

--- a/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
@@ -84,7 +84,7 @@ class PNDArraySuite extends PhysicalTestUtils {
 
     assert(region3.memory.listNDArrayRefs().size == 0)
     // Do an unstaged copy into region3
-    nd.copyFromAddress(region3, nd, result1, true)
+    nd.copyFromAddress(ctx.stateManager, region3, nd, result1, true)
     assert(region3.memory.listNDArrayRefs().size == 1)
 
     // Check that clearing region2 removes both ndarrays
@@ -97,8 +97,8 @@ class PNDArraySuite extends PhysicalTestUtils {
     val region2 = Region(pool=this.pool)
     val x = SafeNDArray(IndexedSeq(3L, 2L), (0 until 6).map(_.toDouble))
     val pNd = PCanonicalNDArray(PFloat64Required, 2, true)
-    val ndAddr1 = pNd.unstagedStoreJavaObject(x, region=region1)
-    val ndAddr2 = pNd.copyFromAddress(region2, pNd, ndAddr1, true)
+    val ndAddr1 = pNd.unstagedStoreJavaObject(ctx.stateManager, x, region=region1)
+    val ndAddr2 = pNd.copyFromAddress(ctx.stateManager, region2, pNd, ndAddr1, true)
     val unsafe1 = UnsafeRow.read(pNd, region1, ndAddr1)
     val unsafe2 = UnsafeRow.read(pNd, region2, ndAddr2)
     // Deep copy same ptype just increments reference count, doesn't change the address.
@@ -128,9 +128,9 @@ class PNDArraySuite extends PhysicalTestUtils {
     val pNDOfStructs2 = PCanonicalNDArray(PCanonicalStruct(true, ("x", PInt32()), ("y", PInt32Required)), 1)
     val annotationNDOfStructs = new SafeNDArray(IndexedSeq(5L), (0 until 5).map(idx => Row(idx, idx + 100)))
 
-    val addr5 = pNDOfStructs1.unstagedStoreJavaObject(annotationNDOfStructs, region=region1)
+    val addr5 = pNDOfStructs1.unstagedStoreJavaObject(ctx.stateManager, annotationNDOfStructs, region=region1)
     val unsafe5 = UnsafeRow.read(pNDOfStructs1, region1, addr5)
-    val addr6 = pNDOfStructs2.copyFromAddress(region2, pNDOfStructs1, addr5, true)
+    val addr6 = pNDOfStructs2.copyFromAddress(ctx.stateManager, region2, pNDOfStructs1, addr5, true)
     val unsafe6 = UnsafeRow.read(pNDOfStructs2, region2, addr6)
     assert(unsafe5 == unsafe6)
   }

--- a/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
@@ -14,13 +14,13 @@ abstract class PhysicalTestUtils extends HailSuite {
     val region = Region(pool=pool)
 
     val srcAddress = sourceType match {
-      case x: PSubsetStruct => ScalaToRegionValue(srcRegion, x.ps, sourceValue)
-      case _ => ScalaToRegionValue(srcRegion, sourceType, sourceValue)
+      case x: PSubsetStruct => ScalaToRegionValue(ctx.stateManager, srcRegion, x.ps, sourceValue)
+      case _ => ScalaToRegionValue(ctx.stateManager, srcRegion, sourceType, sourceValue)
     }
 
     if (interpret) {
       try {
-        val copyOff = destType.copyFromAddress(region, sourceType, srcAddress, deepCopy = deepCopy)
+        val copyOff = destType.copyFromAddress(ctx.stateManager, region, sourceType, srcAddress, deepCopy = deepCopy)
         val copy = UnsafeRow.read(destType, region, copyOff)
 
         log.info(s"Copied value: ${copy}, Source value: ${sourceValue}")

--- a/hail/src/test/scala/is/hail/utils/RowIntervalSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/RowIntervalSuite.scala
@@ -13,7 +13,7 @@ import is.hail.expr.ir.In
 
 class RowIntervalSuite extends HailSuite {
   lazy val t = TStruct("a" -> TInt32, "b" -> TInt32, "c" -> TInt32)
-  lazy val pord = PartitionBoundOrdering(t)
+  lazy val pord = PartitionBoundOrdering(ctx, t)
 
   def assertContains(i: Interval, point: Row, shouldContain: Boolean = true): Unit = {
     val c = i.contains(pord, point)

--- a/hail/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
@@ -5,7 +5,7 @@ import is.hail.utils._
 import org.testng.annotations.Test
 
 class LocusIntervalSuite extends HailSuite {
-  def rg = ReferenceGenome.GRCh37
+  def rg = ctx.getReference(ReferenceGenome.GRCh37)
 
   @Test def testParser() {
     val xMax = rg.contigLength("X")
@@ -67,8 +67,8 @@ class LocusIntervalSuite extends HailSuite {
       Locus.parseInterval("1:1.1111111M-2M", rg)
     }
 
-    val gr37 = ReferenceGenome.GRCh37
-    val gr38 = ReferenceGenome.GRCh38
+    val gr37 = ctx.getReference(ReferenceGenome.GRCh37)
+    val gr38 = ctx.getReference(ReferenceGenome.GRCh38)
 
     val x = "[GL000197.1:3739-GL000202.1:7538)"
     assert(Locus.parseInterval(x, gr37) ==

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -19,7 +19,7 @@ class PartitioningSuite extends HailSuite {
         ctx,
         typ,
         BroadcastRow.empty(ctx),
-        RVD.empty(typ.canonicalRVDType)),
+        RVD.empty(ctx, typ.canonicalRVDType)),
       theHailClassLoader
     )
     val rangeReader = ir.MatrixRangeReader(100, 10, Some(10))
@@ -38,9 +38,9 @@ class PartitioningSuite extends HailSuite {
 
     val nonEmptyRVD = tv.rvd
     val rvdType = nonEmptyRVD.typ
-    val emptyRVD = RVD.empty(rvdType)
 
     ExecuteContext.scoped() { ctx =>
+      val emptyRVD = RVD.empty(ctx, rvdType)
       emptyRVD.orderedJoin(nonEmptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()
       emptyRVD.orderedJoin(nonEmptyRVD, "inner", (_, it) => it.map(_._1), rvdType, ctx).count()
       nonEmptyRVD.orderedJoin(emptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()


### PR DESCRIPTION
The bulk of this PR is plumbing to change `TLocus(ReferenceGenome) => TLocus(String)` and bring reference genomes off of global mutable state onto the Backend (both in scala and python). This allows mutable reference genomes in QoB and by extension liftovers. This also removes some duplication between local_backend and spark_backend in python and simplifies the initialization of reference genomes.