### PR TITLE
[query] Upgrade spark to 3.3.0 and dataproc to 2.1

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -8,7 +8,7 @@ RUN hail-apt-get-install \
 
 COPY docker/requirements.txt .
 RUN chmod 755 /bin/hail-pip-install && \
-    hail-pip-install -r requirements.txt pyspark==3.2.1
+    hail-pip-install -r requirements.txt pyspark==3.3.0
 
 ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"

--- a/build.yaml
+++ b/build.yaml
@@ -107,23 +107,6 @@ steps:
     dependsOn:
       - hail_ubuntu_image
       - merge_code
-  - kind: buildImage2
-    name: base_spark_3_2
-    dockerFile: /io/repo/docker/Dockerfile.base-with-spark-3-2
-    contextPath: /io/repo
-    publishAs: base_spark_3_2
-    resources:
-      storage: 10Gi
-      cpu: "2"
-      memory: standard
-    inputs:
-      - from: /repo/docker/Dockerfile.base-with-spark-3-2
-        to: /io/repo/docker/Dockerfile.base-with-spark-3-2
-      - from: /repo/docker/core-site.xml
-        to: /io/repo/docker/core-site.xml
-    dependsOn:
-      - base_image
-      - merge_code
   - kind: runImage
     name: check_pip_dependencies
     image:
@@ -703,34 +686,6 @@ steps:
         to: /just-jar/hail.jar
       - from: /io/repo/hail/build/deploy/dist/wheel-container.tar
         to: /just-wheel/wheel-container.tar
-    dependsOn:
-      - hail_build_image
-      - merge_code
-  - kind: runImage
-    name: build_hail_jar_and_wheel_only_spark_3_2
-    image:
-      valueFrom: hail_build_image.image
-    resources:
-      memory: standard
-      cpu: '4'
-    script: |
-      set -ex
-      cd /io/repo/hail
-      chmod 755 ./gradlew
-      time retry ./gradlew --version
-      export SPARK_VERSION="3.2.1" SCALA_VERSION="2.12.12"
-      time retry make jars wheel
-      (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
-    inputs:
-      - from: /repo
-        to: /io/repo
-    outputs:
-      - from: /io/repo/hail/build/libs/hail-all-spark.jar
-        to: /just-jar/spark-32/hail.jar
-      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
-        to: /just-jar/spark-32/hail-test.jar
-      - from: /io/repo/hail/build/deploy/dist/wheel-container.tar
-        to: /just-wheel/spark-32/wheel-container.tar
     dependsOn:
       - hail_build_image
       - merge_code
@@ -2201,7 +2156,7 @@ steps:
           valueFrom: default_ns.name
         mountPath: /batch-gsa-key
     inputs:
-      - from: /just-jar/spark-32/hail.jar
+      - from: /just-jar/hail.jar
         to: /io/hail.jar
       - from: /git_version
         to: /io/git_version
@@ -2209,7 +2164,7 @@ steps:
       - default_ns
       - deploy_batch
       - hailgenetics_hailtop_image
-      - build_hail_jar_and_wheel_only_spark_3_2
+      - build_hail_jar_and_wheel_only
       - merge_code
       - create_test_gsa_keys
   - kind: deploy
@@ -2264,7 +2219,7 @@ steps:
               test
     timeout: 5400
     inputs:
-      - from: /just-wheel/spark-32/wheel-container.tar
+      - from: /just-wheel/wheel-container.tar
         to: /io/wheel-container.tar
       - from: /repo/hail/python/test
         to: /io/repo/hail/python/test
@@ -2295,7 +2250,7 @@ steps:
       - hail_run_image
       - upload_query_jar
       - upload_test_resources_to_blob_storage
-      - build_hail_jar_and_wheel_only_spark_3_2
+      - build_hail_jar_and_wheel_only
   - kind: buildImage2
     name: netcat_ubuntu_image
     publishAs: netcat
@@ -3194,7 +3149,7 @@ steps:
   - kind: runImage
     name: test_hail_scala_fs
     image:
-      valueFrom: base_spark_3_2.image
+      valueFrom: hail_run_image.image
     resources:
       memory: standard
       cpu: '2'
@@ -3228,7 +3183,7 @@ steps:
     inputs:
       - from: /resources.tar.gz
         to: /io/resources.tar.gz
-      - from: /just-jar/spark-32/hail-test.jar
+      - from: /hail-test.jar
         to: /io/hail-test.jar
       - from: /testng-fs.xml
         to: /io/testng-fs.xml
@@ -3254,9 +3209,9 @@ steps:
       - default_ns
       - create_certs
       - create_accounts
-      - base_spark_3_2
+      - hail_run_image
       - build_hail
-      - build_hail_jar_and_wheel_only_spark_3_2
+      - build_hail_jar_and_wheel_only
       - upload_test_resources_to_blob_storage
   - kind: runImage
     name: test_hail_services_java

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -12,7 +12,7 @@ REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 SCALA_VERSION ?= 2.12.13
-SPARK_VERSION ?= 3.1.3
+SPARK_VERSION ?= 3.3.0
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 109
 HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)
@@ -314,7 +314,6 @@ upload-qob-test-resources: $(JAR_TEST_SOURCES)
 # target must be run at least once a day if using a dev NAMESPACE.
 # To trigger this target to re-run,
 # > rm upload-qob-jar
-upload-qob-jar: SPARK_VERSION := 3.2.1
 upload-qob-jar: $(SHADOW_JAR)
 	! [ -z $(NAMESPACE) ]  # call this like: make upload-qob-jar NAMESPACE=default
 	gsutil -m cp $(SHADOW_JAR) $(JAR_LOCATION)

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -42,10 +42,10 @@ tasks.withType(JavaCompile) {
 project.ext {
     breezeVersion = "1.1"
 
-    sparkVersion = System.getProperty("spark.version", "3.1.3")
+    sparkVersion = System.getProperty("spark.version", "3.3.0")
 
-    if (sparkVersion != "3.1.3") {
-        project.logger.lifecycle("WARNING: Hail primarily tested with Spark 3.1.3, use other versions at your own risk.")
+    if (sparkVersion != "3.3.0") {
+        project.logger.lifecycle("WARNING: Hail primarily tested with Spark 3.3.0, use other versions at your own risk.")
     }
     scalaVersion = System.getProperty("scala.version", "2.12.13")
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
@@ -203,20 +203,12 @@ dependencies {
         exclude group: 'com.fasterxml.jackson'
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.databind'
-        if (sparkVersion.startsWith("3.1")) {
-            exclude group: 'com.fasterxml.jackson.dataformat'
-            exclude group: 'org.codehaus.woodstox'
-        }
     }
 
     bundled(group: 'com.azure', name: 'azure-core-http-netty', version: '1.10.0') {
         exclude group: 'com.fasterxml.jackson'
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.databind'
-        if (sparkVersion.startsWith("3.1")) {
-            exclude group: 'com.fasterxml.jackson.dataformat'
-            exclude group: 'org.codehaus.woodstox'
-        }
     }
 
 
@@ -224,10 +216,6 @@ dependencies {
         exclude group: 'com.fasterxml.jackson'
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.databind'
-        if (sparkVersion.startsWith("3.1")) {
-            exclude group: 'com.fasterxml.jackson.dataformat'
-            exclude group: 'org.codehaus.woodstox'
-        }
     }
 
     bundled group: 'org.freemarker', name: 'freemarker', version: '2.3.31'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -222,7 +222,7 @@ dependencies {
 
     bundled 'com.kohlschutter.junixsocket:junixsocket-core:2.6.1'
 
-    bundled 'com.github.luben:zstd-jni:1.4.8-1'
+    bundled 'com.github.luben:zstd-jni:1.5.2-1'
 }
 
 task(checkSettings) doLast {

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -54,9 +54,9 @@ black==22.12.0
     # via -r python/dev/requirements.txt
 bleach==6.0.0
     # via nbconvert
-boto3==1.26.72
+boto3==1.26.73
     # via -r python/dev/../hailtop/requirements.txt
-botocore==1.29.72
+botocore==1.29.73
     # via
     #   -r python/dev/../hailtop/requirements.txt
     #   boto3

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=python/dev/pinned-requirements.txt python/dev/requirements.txt
 #
-aiohttp==3.8.3
+aiohttp==3.8.4
     # via
     #   -r python/dev/../hailtop/requirements.txt
     #   aiohttp-session
@@ -12,7 +12,7 @@ aiohttp-session==2.12.0
     # via -r python/dev/../hailtop/requirements.txt
 aiosignal==1.3.1
     # via aiohttp
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 anyio==3.6.2
     # via jupyter-server
@@ -23,19 +23,19 @@ argon2-cffi==21.3.0
     #   notebook
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-astroid==2.12.13
+astroid==2.14.2
     # via pylint
 async-timeout==4.0.2
     # via aiohttp
 asynctest==0.13.0
     # via aiohttp
-attrs==22.1.0
+attrs==22.2.0
     # via
     #   aiohttp
     #   curlylint
     #   jsonschema
     #   pytest
-azure-core==1.26.1
+azure-core==1.26.3
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -48,20 +48,20 @@ babel==2.11.0
     # via sphinx
 backcall==0.2.0
     # via ipython
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via nbconvert
 black==22.12.0
     # via -r python/dev/requirements.txt
-bleach==5.0.1
+bleach==6.0.0
     # via nbconvert
-boto3==1.26.26
+boto3==1.26.72
     # via -r python/dev/../hailtop/requirements.txt
-botocore==1.29.26
+botocore==1.29.72
     # via
     #   -r python/dev/../hailtop/requirements.txt
     #   boto3
     #   s3transfer
-cachetools==5.2.0
+cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
     # via
@@ -71,7 +71,7 @@ cffi==1.15.1
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   aiohttp
     #   requests
@@ -82,7 +82,7 @@ click==8.1.3
     #   curlylint
 commonmark==0.9.1
     # via rich
-cryptography==38.0.4
+cryptography==39.0.1
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -90,7 +90,7 @@ cryptography==38.0.4
     #   pyjwt
 curlylint==0.13.1
     # via -r python/dev/requirements.txt
-debugpy==1.6.4
+debugpy==1.6.6
     # via ipykernel
 decorator==4.4.2
     # via
@@ -109,7 +109,7 @@ docutils==0.16
     #   sphinx-rtd-theme
 entrypoints==0.4
     # via jupyter-client
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 execnet==1.9.0
     # via pytest-xdist
@@ -140,9 +140,9 @@ google-cloud-storage==2.7.0
     # via -r python/dev/../hailtop/requirements.txt
 google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.4.0
+google-resumable-media==2.4.1
     # via google-cloud-storage
-googleapis-common-protos==1.57.0
+googleapis-common-protos==1.58.0
     # via google-api-core
 humanize==1.1.0
     # via -r python/dev/../hailtop/requirements.txt
@@ -163,9 +163,9 @@ importlib-metadata==3.10.1
     #   nbformat
     #   pluggy
     #   pytest
-importlib-resources==5.10.1
+importlib-resources==5.10.2
     # via jsonschema
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 ipykernel==6.16.2
     # via
@@ -185,11 +185,11 @@ ipython-genutils==0.2.0
     #   nbclassic
     #   notebook
     #   qtconsole
-ipywidgets==8.0.3
+ipywidgets==8.0.4
     # via jupyter
 isodate==0.6.1
     # via msrest
-isort==5.10.1
+isort==5.11.5
     # via
     #   -r python/dev/requirements.txt
     #   pylint
@@ -214,7 +214,7 @@ jsonschema==4.17.3
     # via nbformat
 jupyter==1.0.0
     # via -r python/dev/requirements.txt
-jupyter-client==7.4.8
+jupyter-client==7.4.9
     # via
     #   ipykernel
     #   jupyter-console
@@ -223,11 +223,12 @@ jupyter-client==7.4.8
     #   nbclient
     #   notebook
     #   qtconsole
-jupyter-console==6.4.4
+jupyter-console==6.5.1
     # via jupyter
 jupyter-core==4.12.0
     # via
     #   jupyter-client
+    #   jupyter-console
     #   jupyter-server
     #   nbclassic
     #   nbclient
@@ -235,17 +236,17 @@ jupyter-core==4.12.0
     #   nbformat
     #   notebook
     #   qtconsole
-jupyter-server==1.23.3
+jupyter-server==1.23.6
     # via
     #   nbclassic
     #   notebook-shim
 jupyterlab-pygments==0.2.2
     # via nbconvert
-jupyterlab-widgets==3.0.4
+jupyterlab-widgets==3.0.5
     # via ipywidgets
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   jinja2
     #   nbconvert
@@ -257,9 +258,9 @@ mccabe==0.6.1
     # via
     #   flake8
     #   pylint
-mistune==2.0.4
+mistune==2.0.5
     # via nbconvert
-msal==1.20.0
+msal==1.21.0
     # via
     #   azure-identity
     #   msal-extensions
@@ -267,28 +268,28 @@ msal-extensions==1.0.0
     # via azure-identity
 msrest==0.7.1
     # via azure-storage-blob
-multidict==6.0.3
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
 mypy==0.990
     # via -r python/dev/requirements.txt
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-nbclassic==0.4.8
+nbclassic==0.5.1
     # via notebook
 nbclient==0.7.2
     # via nbconvert
-nbconvert==7.2.6
+nbconvert==7.2.9
     # via
     #   jupyter
     #   jupyter-server
     #   nbclassic
     #   nbsphinx
     #   notebook
-nbformat==5.7.0
+nbformat==5.7.3
     # via
     #   jupyter-server
     #   nbclassic
@@ -296,7 +297,7 @@ nbformat==5.7.0
     #   nbconvert
     #   nbsphinx
     #   notebook
-nbsphinx==0.8.10
+nbsphinx==0.8.12
     # via -r python/dev/requirements.txt
 nest-asyncio==1.5.6
     # via
@@ -311,9 +312,9 @@ notebook-shim==0.2.2
     # via nbclassic
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.8.3
+orjson==3.8.6
     # via -r python/dev/../hailtop/requirements.txt
-packaging==22.0
+packaging==23.0
     # via
     #   ipykernel
     #   jupyter-server
@@ -327,7 +328,7 @@ parso==0.8.3
     # via jedi
 parsy==1.1.0
     # via curlylint
-pathspec==0.10.2
+pathspec==0.11.0
     # via
     #   black
     #   curlylint
@@ -337,15 +338,15 @@ pickleshare==0.7.5
     # via ipython
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==2.6.0
+platformdirs==3.0.0
     # via
     #   black
     #   pylint
 pluggy==1.0.0
     # via pytest
-portalocker==2.6.0
+portalocker==2.7.0
     # via msal-extensions
-prometheus-client==0.15.0
+prometheus-client==0.16.0
     # via
     #   jupyter-server
     #   nbclassic
@@ -379,7 +380,7 @@ pycparser==2.21
     # via cffi
 pyflakes==2.4.0
     # via flake8
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   ipython
     #   jupyter-console
@@ -391,11 +392,11 @@ pyjwt[crypto]==2.6.0
     # via
     #   -c python/dev/../requirements.txt
     #   msal
-pylint==2.15.8
+pylint==2.16.2
     # via -r python/dev/requirements.txt
-pyrsistent==0.19.2
+pyrsistent==0.19.3
     # via jsonschema
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   -r python/dev/requirements.txt
     #   pytest-asyncio
@@ -406,7 +407,7 @@ pytest==7.2.0
     #   pytest-xdist
 pytest-asyncio==0.20.3
     # via -r python/dev/requirements.txt
-pytest-forked==1.4.0
+pytest-forked==1.6.0
     # via pytest-xdist
 pytest-html==1.22.1
     # via -r python/dev/requirements.txt
@@ -420,14 +421,15 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   jupyter-client
-python-json-logger==2.0.4
+python-json-logger==2.0.6
     # via -r python/dev/../hailtop/requirements.txt
-pytz==2022.6
+pytz==2022.7.1
     # via babel
-pyzmq==24.0.1
+pyzmq==25.0.0
     # via
     #   ipykernel
     #   jupyter-client
+    #   jupyter-console
     #   jupyter-server
     #   nbclassic
     #   notebook
@@ -436,7 +438,7 @@ qtconsole==5.4.0
     # via jupyter
 qtpy==2.3.0
     # via qtconsole
-requests==2.28.1
+requests==2.28.2
     # via
     #   -c python/dev/../requirements.txt
     #   azure-core
@@ -473,7 +475,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
     # via -r python/dev/../hailtop/requirements.txt
-soupsieve==2.3.2.post1
+soupsieve==2.4
     # via beautifulsoup4
 sphinx==3.5.4
     # via
@@ -484,7 +486,7 @@ sphinx==3.5.4
     #   sphinxcontrib-katex
 sphinx-autodoc-typehints==1.11.1
     # via -r python/dev/requirements.txt
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.2.0
     # via -r python/dev/requirements.txt
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -492,9 +494,11 @@ sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
+sphinxcontrib-jquery==2.0.0
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-katex==0.9.3
+sphinxcontrib-katex==0.9.4
     # via -r python/dev/requirements.txt
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
@@ -527,12 +531,13 @@ tornado==6.2
     #   nbclassic
     #   notebook
     #   terminado
-traitlets==5.7.0
+traitlets==5.9.0
     # via
     #   ipykernel
     #   ipython
     #   ipywidgets
     #   jupyter-client
+    #   jupyter-console
     #   jupyter-core
     #   jupyter-server
     #   matplotlib-inline
@@ -550,29 +555,31 @@ typed-ast==1.5.4
     #   mypy
 types-chardet==5.0.4.1
     # via -r python/dev/requirements.txt
-types-decorator==5.1.8.1
+types-decorator==5.1.8.2
     # via -r python/dev/requirements.txt
 types-deprecated==1.2.9
     # via -r python/dev/requirements.txt
-types-pymysql==1.0.19.1
+types-docutils==0.19.1.4
+    # via types-setuptools
+types-pymysql==1.0.19.3
     # via -r python/dev/requirements.txt
-types-python-dateutil==2.8.19.4
+types-python-dateutil==2.8.19.7
     # via -r python/dev/requirements.txt
-types-pyyaml==6.0.12.2
+types-pyyaml==6.0.12.6
     # via -r python/dev/requirements.txt
-types-requests==2.28.11.5
+types-requests==2.28.11.13
     # via -r python/dev/requirements.txt
-types-setuptools==65.6.0.2
+types-setuptools==67.3.0.1
     # via -r python/dev/requirements.txt
 types-six==1.16.21.4
     # via -r python/dev/requirements.txt
 types-tabulate==0.9.0.0
     # via -r python/dev/requirements.txt
-types-urllib3==1.26.25.4
+types-urllib3==1.26.25.6
     # via
     #   -r python/dev/requirements.txt
     #   types-requests
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   aiohttp
     #   aiohttp-session
@@ -586,31 +593,32 @@ typing-extensions==4.4.0
     #   janus
     #   jsonschema
     #   mypy
+    #   platformdirs
     #   pylint
     #   pytest-asyncio
     #   rich
     #   yarl
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   botocore
     #   requests
 uvloop==0.17.0 ; sys_platform != "win32"
     # via -r python/dev/../hailtop/requirements.txt
-wcwidth==0.2.5
+wcwidth==0.2.6
     # via prompt-toolkit
 webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.4.2
+websocket-client==1.5.1
     # via jupyter-server
-widgetsnbextension==4.0.4
+widgetsnbextension==4.0.5
     # via ipywidgets
 wrapt==1.14.1
     # via astroid
 yarl==1.8.2
     # via aiohttp
-zipp==3.11.0
+zipp==3.13.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -134,7 +134,7 @@ class LocalBackend(Py4JBackend):
         port = launch_gateway(
             redirect_stdout=sys.stdout,
             redirect_stderr=sys.stderr,
-            jarpath=f'{spark_home}/jars/py4j-0.10.9.jar',
+            jarpath=f'{spark_home}/jars/py4j-0.10.9.5.jar',
             classpath=f'{spark_home}/jars/*:{hail_jar_path}',
             die_on_exit=True)
         self._gateway = JavaGateway(

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -7,6 +7,7 @@ import socketserver
 from threading import Thread
 import py4j
 import pyspark
+import pyspark.sql
 
 from typing import List, Optional
 
@@ -314,8 +315,7 @@ class SparkBackend(Py4JBackend):
         t = t.expand_types()
         if flatten:
             t = t.flatten()
-        return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._to_java_table_ir(t._tir)),
-                                     Env.spark_session()._wrapped)
+        return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._to_java_table_ir(t._tir)), self._spark_session)
 
     def add_reference(self, config):
         self.hail_package().variant.ReferenceGenome.fromJSON(json.dumps(config))

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -12,7 +12,7 @@ import pyspark.sql
 from typing import List, Optional
 
 import hail as hl
-from hail.utils.java import Env, scala_package_object, scala_object
+from hail.utils.java import scala_package_object, scala_object
 from hail.expr.types import dtype
 from hail.expr.table_type import ttable
 from hail.expr.matrix_type import tmatrix

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -281,8 +281,7 @@ class AsyncFS(abc.ABC):
             await self.statfile(url)
         except FileNotFoundError:
             return False
-        else:
-            return True
+        return True
 
     async def close(self) -> None:
         pass

--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -82,15 +82,15 @@ RUN pip install --upgrade --no-cache-dir -r requirements.txt && \
     python3 -m pip check
 ''')
 
-            sync_check_exec('docker', 'build', '-t', fullname, docker_path, capture_output=(not show_docker_output))
+            sync_check_exec('docker', 'build', '-t', fullname, docker_path, capture_output=not show_docker_output)
             print(f'finished building image {fullname}')
         else:
-            sync_check_exec('docker', 'pull', base_image, capture_output=(not show_docker_output))
-            sync_check_exec('docker', 'tag', base_image, fullname, capture_output=(not show_docker_output))
+            sync_check_exec('docker', 'pull', base_image, capture_output=not show_docker_output)
+            sync_check_exec('docker', 'tag', base_image, fullname, capture_output=not show_docker_output)
             print(f'finished pulling image {fullname}')
 
         if '/' in fullname:
-            sync_check_exec('docker', 'push', fullname, capture_output=(not show_docker_output))
+            sync_check_exec('docker', 'push', fullname, capture_output=not show_docker_output)
             print(f'finished pushing image {fullname}')
     finally:
         shutil.rmtree(docker_path, ignore_errors=True)

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -931,7 +931,7 @@ class BatchClient:
     async def update_batch(self, batch: Union[int, Batch]) -> BatchBuilder:
         if isinstance(batch, Batch):
             return BatchBuilder(self, batch=batch)
-        return BatchBuilder(self, batch=(await self.get_batch(batch)))
+        return BatchBuilder(self, batch=await self.get_batch(batch))
 
     async def get_billing_project(self, billing_project):
         bp_resp = await self._get(f'/api/v1alpha/billing_projects/{billing_project}')

--- a/hail/python/hailtop/hailctl/auth/create_user.py
+++ b/hail/python/hailtop/hailctl/auth/create_user.py
@@ -4,6 +4,10 @@ from hailtop.utils import sleep_and_backoff
 from hailtop.auth import async_create_user, async_get_user
 
 
+class CreateUserException(Exception):
+    pass
+
+
 def init_parser(parser):
     parser.add_argument("username", type=str,
                         help="User name to create.")
@@ -20,22 +24,25 @@ def init_parser(parser):
 
 
 async def async_main(args):
-    await async_create_user(args.username, args.login_id, args.developer, args.service_account, args.namespace)
+    try:
+        await async_create_user(args.username, args.login_id, args.developer, args.service_account, args.namespace)
 
-    if not args.wait:
-        return
+        if not args.wait:
+            return
 
-    async def _poll():
-        delay = 5
-        while True:
-            user = await async_get_user(args.username, args.namespace)
-            if user['state'] == 'active':
-                print(f"Created user '{args.username}'")
-                return
-            assert user['state'] == 'creating'
-            delay = await sleep_and_backoff(delay)
+        async def _poll():
+            delay = 5
+            while True:
+                user = await async_get_user(args.username, args.namespace)
+                if user['state'] == 'active':
+                    print(f"Created user '{args.username}'")
+                    return
+                assert user['state'] == 'creating'
+                delay = await sleep_and_backoff(delay)
 
-    await _poll()
+        await _poll()
+    except Exception as e:
+        raise CreateUserException(f"Error while creating user '{args.username}'") from e
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument

--- a/hail/python/hailtop/hailctl/auth/create_user.py
+++ b/hail/python/hailtop/hailctl/auth/create_user.py
@@ -20,25 +20,22 @@ def init_parser(parser):
 
 
 async def async_main(args):
-    try:
-        await async_create_user(args.username, args.login_id, args.developer, args.service_account, args.namespace)
+    await async_create_user(args.username, args.login_id, args.developer, args.service_account, args.namespace)
 
-        if not args.wait:
-            return
+    if not args.wait:
+        return
 
-        async def _poll():
-            delay = 5
-            while True:
-                user = await async_get_user(args.username, args.namespace)
-                if user['state'] == 'active':
-                    print(f"Created user '{args.username}'")
-                    return
-                assert user['state'] == 'creating'
-                delay = await sleep_and_backoff(delay)
+    async def _poll():
+        delay = 5
+        while True:
+            user = await async_get_user(args.username, args.namespace)
+            if user['state'] == 'active':
+                print(f"Created user '{args.username}'")
+                return
+            assert user['state'] == 'creating'
+            delay = await sleep_and_backoff(delay)
 
-        await _poll()
-    except Exception as e:
-        raise Exception(f"Error while creating user '{args.username}'") from e
+    await _poll()
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument

--- a/hail/python/hailtop/hailctl/auth/delete_user.py
+++ b/hail/python/hailtop/hailctl/auth/delete_user.py
@@ -4,6 +4,10 @@ from hailtop.utils import sleep_and_backoff
 from hailtop.auth import async_delete_user, async_get_user
 
 
+class DeleteUserException(Exception):
+    pass
+
+
 def init_parser(parser):
     parser.add_argument("username", type=str,
                         help="User name to delete.")
@@ -14,22 +18,25 @@ def init_parser(parser):
 
 
 async def async_main(args):
-    await async_delete_user(args.username, args.namespace)
+    try:
+        await async_delete_user(args.username, args.namespace)
 
-    if not args.wait:
-        return
+        if not args.wait:
+            return
 
-    async def _poll():
-        delay = 5
-        while True:
-            user = await async_get_user(args.username, args.namespace)
-            if user['state'] == 'deleted':
-                print(f"Deleted user '{args.username}'")
-                return
-            assert user['state'] == 'deleting'
-            delay = await sleep_and_backoff(delay)
+        async def _poll():
+            delay = 5
+            while True:
+                user = await async_get_user(args.username, args.namespace)
+                if user['state'] == 'deleted':
+                    print(f"Deleted user '{args.username}'")
+                    return
+                assert user['state'] == 'deleting'
+                delay = await sleep_and_backoff(delay)
 
-    await _poll()
+        await _poll()
+    except Exception as e:
+        raise DeleteUserException(f"Error while deleting user '{args.username}'") from e
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument

--- a/hail/python/hailtop/hailctl/auth/delete_user.py
+++ b/hail/python/hailtop/hailctl/auth/delete_user.py
@@ -14,25 +14,22 @@ def init_parser(parser):
 
 
 async def async_main(args):
-    try:
-        await async_delete_user(args.username, args.namespace)
+    await async_delete_user(args.username, args.namespace)
 
-        if not args.wait:
-            return
+    if not args.wait:
+        return
 
-        async def _poll():
-            delay = 5
-            while True:
-                user = await async_get_user(args.username, args.namespace)
-                if user['state'] == 'deleted':
-                    print(f"Deleted user '{args.username}'")
-                    return
-                assert user['state'] == 'deleting'
-                delay = await sleep_and_backoff(delay)
+    async def _poll():
+        delay = 5
+        while True:
+            user = await async_get_user(args.username, args.namespace)
+            if user['state'] == 'deleted':
+                print(f"Deleted user '{args.username}'")
+                return
+            assert user['state'] == 'deleting'
+            delay = await sleep_and_backoff(delay)
 
-        await _poll()
-    except Exception as e:
-        raise Exception(f"Error while deleting user '{args.username}'") from e
+    await _poll()
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -135,7 +135,7 @@ REGION_TO_REPLICATE_MAPPING = {
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us", "hail-datasets-eu"]
 
-IMAGE_VERSION = '2.0.44-debian10'
+IMAGE_VERSION = '2.1.2-debian11'
 
 
 def init_parser(parser):

--- a/hail/python/hailtop/hailctl/describe.py
+++ b/hail/python/hailtop/hailctl/describe.py
@@ -50,7 +50,7 @@ def parse_schema(s):
             else:
                 i += 1
 
-        raise Exception(f'End of {element_type} not found')
+        raise ValueError(f'End of {element_type} not found')
 
     start_schema_index = s.index('{')
     return parse_type(s[start_schema_index + 1:], "}", s[:start_schema_index])[0]

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -27,9 +27,9 @@ azure-identity==1.12.0
     # via -r python/hailtop/requirements.txt
 azure-storage-blob==12.14.1
     # via -r python/hailtop/requirements.txt
-boto3==1.26.72
+boto3==1.26.73
     # via -r python/hailtop/requirements.txt
-botocore==1.29.72
+botocore==1.29.73
     # via
     #   -r python/hailtop/requirements.txt
     #   boto3
@@ -110,7 +110,7 @@ orjson==3.8.6
     # via -r python/hailtop/requirements.txt
 portalocker==2.7.0
     # via msal-extensions
-protobuf==4.21.12
+protobuf==4.22.0
     # via
     #   google-api-core
     #   googleapis-common-protos

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=python/hailtop/pinned-requirements.txt python/hailtop/requirements.txt
 #
-aiohttp==3.8.3
+aiohttp==3.8.4
     # via
     #   -r python/hailtop/requirements.txt
     #   aiohttp-session
@@ -16,9 +16,9 @@ async-timeout==4.0.2
     # via aiohttp
 asynctest==0.13.0
     # via aiohttp
-attrs==22.1.0
+attrs==22.2.0
     # via aiohttp
-azure-core==1.26.1
+azure-core==1.26.3
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -27,14 +27,14 @@ azure-identity==1.12.0
     # via -r python/hailtop/requirements.txt
 azure-storage-blob==12.14.1
     # via -r python/hailtop/requirements.txt
-boto3==1.26.26
+boto3==1.26.72
     # via -r python/hailtop/requirements.txt
-botocore==1.29.26
+botocore==1.29.72
     # via
     #   -r python/hailtop/requirements.txt
     #   boto3
     #   s3transfer
-cachetools==5.2.0
+cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
     # via
@@ -42,13 +42,13 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   aiohttp
     #   requests
 commonmark==0.9.1
     # via rich
-cryptography==38.0.4
+cryptography==39.0.1
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -74,9 +74,9 @@ google-cloud-storage==2.7.0
     # via -r python/hailtop/requirements.txt
 google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.4.0
+google-resumable-media==2.4.1
     # via google-cloud-storage
-googleapis-common-protos==1.57.0
+googleapis-common-protos==1.58.0
     # via google-api-core
 humanize==1.1.0
     # via -r python/hailtop/requirements.txt
@@ -92,7 +92,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-msal==1.20.0
+msal==1.21.0
     # via
     #   azure-identity
     #   msal-extensions
@@ -100,17 +100,17 @@ msal-extensions==1.0.0
     # via azure-identity
 msrest==0.7.1
     # via azure-storage-blob
-multidict==6.0.3
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.8.3
+orjson==3.8.6
     # via -r python/hailtop/requirements.txt
-portalocker==2.6.0
+portalocker==2.7.0
     # via msal-extensions
-protobuf==4.21.11
+protobuf==4.21.12
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -122,15 +122,15 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.14.0
     # via rich
 pyjwt[crypto]==2.6.0
     # via msal
 python-dateutil==2.8.2
     # via botocore
-python-json-logger==2.0.4
+python-json-logger==2.0.6
     # via -r python/hailtop/requirements.txt
-requests==2.28.1
+requests==2.28.2
     # via
     #   azure-core
     #   google-api-core
@@ -157,7 +157,7 @@ sortedcontainers==2.4.0
     # via -r python/hailtop/requirements.txt
 tabulate==0.9.0
     # via -r python/hailtop/requirements.txt
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   aiohttp
     #   aiohttp-session
@@ -166,7 +166,7 @@ typing-extensions==4.4.0
     #   janus
     #   rich
     #   yarl
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   botocore
     #   requests

--- a/hail/python/hailtop/timex.py
+++ b/hail/python/hailtop/timex.py
@@ -59,7 +59,7 @@ def parse_rfc3339(s: str) -> datetime.datetime:
                 microsecond += 1
         else:
             fractional_second = int(fractional_second)
-            magnitude_relative_to_micro = (10 ** (6 - n_digits))
+            magnitude_relative_to_micro = 10 ** (6 - n_digits)
             microsecond = int(fractional_second) * magnitude_relative_to_micro
 
     return datetime.datetime(

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -33,9 +33,9 @@ azure-storage-blob==12.14.1
     # via -r python/hailtop/requirements.txt
 bokeh==1.4.0
     # via -r python/requirements.txt
-boto3==1.26.72
+boto3==1.26.73
     # via -r python/hailtop/requirements.txt
-botocore==1.29.72
+botocore==1.29.73
     # via
     #   -r python/hailtop/requirements.txt
     #   boto3
@@ -170,7 +170,7 @@ pyjwt[crypto]==2.6.0
     # via
     #   -r python/requirements.txt
     #   msal
-pyspark==3.3.0
+pyspark==3.3.2
     # via -r python/requirements.txt
 python-dateutil==2.8.2
     # via

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=python/pinned-requirements.txt python/requirements.txt
 #
-aiohttp==3.8.3
+aiohttp==3.8.4
     # via
     #   -r python/hailtop/requirements.txt
     #   aiohttp-session
@@ -18,11 +18,11 @@ asyncinit==0.2.4
     # via -r python/requirements.txt
 asynctest==0.13.0
     # via aiohttp
-attrs==22.1.0
+attrs==22.2.0
     # via aiohttp
 avro==1.11.1
     # via -r python/requirements.txt
-azure-core==1.26.1
+azure-core==1.26.3
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -33,14 +33,14 @@ azure-storage-blob==12.14.1
     # via -r python/hailtop/requirements.txt
 bokeh==1.4.0
     # via -r python/requirements.txt
-boto3==1.26.26
+boto3==1.26.72
     # via -r python/hailtop/requirements.txt
-botocore==1.29.26
+botocore==1.29.72
     # via
     #   -r python/hailtop/requirements.txt
     #   boto3
     #   s3transfer
-cachetools==5.2.0
+cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
     # via
@@ -48,13 +48,13 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   aiohttp
     #   requests
 commonmark==0.9.1
     # via rich
-cryptography==38.0.4
+cryptography==39.0.1
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -87,9 +87,9 @@ google-cloud-storage==2.7.0
     # via -r python/hailtop/requirements.txt
 google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.4.0
+google-resumable-media==2.4.1
     # via google-cloud-storage
-googleapis-common-protos==1.57.0
+googleapis-common-protos==1.58.0
     # via google-api-core
 humanize==1.1.0
     # via -r python/hailtop/requirements.txt
@@ -111,9 +111,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
-msal==1.20.0
+msal==1.21.0
     # via
     #   azure-identity
     #   msal-extensions
@@ -121,7 +121,7 @@ msal-extensions==1.0.0
     # via azure-identity
 msrest==0.7.1
     # via azure-storage-blob
-multidict==6.0.3
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
@@ -135,26 +135,26 @@ numpy==1.21.6
     #   scipy
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.8.3
+orjson==3.8.6
     # via -r python/hailtop/requirements.txt
-packaging==22.0
+packaging==23.0
     # via bokeh
 pandas==1.3.5
     # via -r python/requirements.txt
 parsimonious==0.8.1
     # via -r python/requirements.txt
-pillow==9.3.0
+pillow==9.4.0
     # via bokeh
 plotly==5.10.0
     # via -r python/requirements.txt
-portalocker==2.6.0
+portalocker==2.7.0
     # via msal-extensions
 protobuf==3.20.2
     # via
     #   -r python/requirements.txt
     #   google-api-core
     #   googleapis-common-protos
-py4j==0.10.9
+py4j==0.10.9.5
     # via pyspark
 pyasn1==0.4.8
     # via
@@ -164,26 +164,26 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
-pygments==2.13.0
+pygments==2.14.0
     # via rich
 pyjwt[crypto]==2.6.0
     # via
     #   -r python/requirements.txt
     #   msal
-pyspark==3.1.3
+pyspark==3.3.0
     # via -r python/requirements.txt
 python-dateutil==2.8.2
     # via
     #   bokeh
     #   botocore
     #   pandas
-python-json-logger==2.0.4
+python-json-logger==2.0.6
     # via -r python/hailtop/requirements.txt
-pytz==2022.6
+pytz==2022.7.1
     # via pandas
 pyyaml==6.0
     # via bokeh
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r python/requirements.txt
     #   azure-core
@@ -215,11 +215,11 @@ sortedcontainers==2.4.0
     # via -r python/hailtop/requirements.txt
 tabulate==0.9.0
     # via -r python/hailtop/requirements.txt
-tenacity==8.1.0
+tenacity==8.2.1
     # via plotly
 tornado==6.2
     # via bokeh
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   aiohttp
     #   aiohttp-session
@@ -229,7 +229,7 @@ typing-extensions==4.4.0
     #   janus
     #   rich
     #   yarl
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   botocore
     #   requests

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -15,6 +15,6 @@ parsimonious<0.9
 plotly>=5.5.0,<5.11
 protobuf==3.20.2
 PyJWT
-pyspark==3.3.0
+pyspark>=3.3.0,<3.4
 requests>=2.25.1,<3
 scipy>1.2,<1.10

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -15,6 +15,6 @@ parsimonious<0.9
 plotly>=5.5.0,<5.11
 protobuf==3.20.2
 PyJWT
-pyspark>=3.1.1,<3.2.0
+pyspark==3.3.0
 requests>=2.25.1,<3
 scipy>1.2,<1.10


### PR DESCRIPTION
CHANGELOG: Query on Spark now officially supports Spark 3.3.0 and Dataproc 2.1.x


Tested on dataproc via `make -C hail test-dataproc-37`. Updating the dependencies introduced a few new linting checks that I fixed here. Updating pyspark necessitated a couple of changes, namely a different py4j jar and they removed `SparkSession._wrapped` (but maybe we didn't need that anyway? not sure). Most importantly, the newer spark version brings with it a newer jackson version which is sufficient for the azure-storage-blob dependency, meaning we don't need to build against two different spark versions for spark and batch.