### PR TITLE
[batch] Treat unauthorized in docker error message as permission denied

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -456,9 +456,9 @@ class Image:
         except DockerError as e:
             if e.status == 404 and 'pull access denied' in e.message:
                 raise ImageCannotBePulled from e
-            if (
-                e.status == 500
-                and 'Permission "artifactregistry.repositories.downloadArtifacts" denied on resource' in e.message
+            if e.status == 500 and (
+                'Permission "artifactregistry.repositories.downloadArtifacts" denied on resource' in e.message
+                or 'unauthorized' in e.message
             ):
                 raise ImageCannotBePulled from e
             if 'Invalid repository name' in e.message:


### PR DESCRIPTION
Error messages from GCR and AR are different, and sometimes it looks like this from GCR:

```
"unauthorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials
```