### PR TITLE
[ci] Run the local backend tests much more in parallel

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1307,12 +1307,9 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_python_local_backend
-    numSplits: 7
+    numSplits: 14
     image:
       valueFrom: hail_run_image.image
-    resources:
-      memory: standard
-      cpu: '2'
     script: |
       set -ex
       cd /io


### PR DESCRIPTION
The local backend tests only use 1 core, so this dedicates the same resources for much more parallelism.