### PR TITLE
[ci] Remove unused Spark 3.2 base image

### DIFF
--- a/docker/Dockerfile.base-with-spark-3-2
+++ b/docker/Dockerfile.base-with-spark-3-2
@@ -1,9 +1,0 @@
-FROM {{ base_image.image }}
-
-RUN hail-pip-install pyspark==3.2.1
-ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
-ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
-ENV PYSPARK_PYTHON python3
-
-RUN curl >${SPARK_HOME}/jars/gcs-connector-hadoop2-2.2.7.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.7.jar
-COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml


### PR DESCRIPTION
Missed this when deleting all the Spark 3.2 related stuff when upgrading to 3.3.0