### PR TITLE
[batch] Error if PythonJob functions are called with incompatible signature

### DIFF
--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1077,8 +1077,13 @@ class PythonJob(Job):
             if isinstance(value, Job):
                 raise BatchException('arguments to a PythonJob cannot be other job objects.')
 
+        # Some builtins like `print` do not have signatures
         try:
             inspect.signature(unapplied).bind(*args, **kwargs)
+        except ValueError as e:
+            # Some builtins like `print` don't have a signature that inspect can read
+            if not 'no signature found for builtin' in e.args[0]:
+                raise e
         except TypeError as e:
             raise BatchException(f'Cannot call {unapplied.__name__} with the supplied arguments') from e
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1082,7 +1082,7 @@ class PythonJob(Job):
             inspect.signature(unapplied).bind(*args, **kwargs)
         except ValueError as e:
             # Some builtins like `print` don't have a signature that inspect can read
-            if not 'no signature found for builtin' in e.args[0]:
+            if 'no signature found for builtin' not in e.args[0]:
                 raise e
         except TypeError as e:
             raise BatchException(f'Cannot call {unapplied.__name__} with the supplied arguments') from e

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1077,6 +1077,11 @@ class PythonJob(Job):
             if isinstance(value, Job):
                 raise BatchException('arguments to a PythonJob cannot be other job objects.')
 
+        try:
+            inspect.signature(unapplied).bind(*args, **kwargs)
+        except TypeError as e:
+            raise BatchException(f'Cannot call {unapplied.__name__} with the supplied arguments') from e
+
         def handle_arg(r):
             if r._source != self:
                 self._add_inputs(r)

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -908,6 +908,30 @@ class ServiceTests(unittest.TestCase):
         res_status = res.status()
         assert res_status['state'] == 'failure', str((res_status, res.debug_info()))
 
+    def test_python_job_incorrect_signature(self):
+        b = self.batch(default_python_image=PYTHON_DILL_IMAGE)
+
+        def foo(pos_arg1, pos_arg2, *, kwarg1, kwarg2=1):
+            print(pos_arg1, pos_arg2, kwarg1, kwarg2)
+
+        j = b.new_python_job()
+
+        with pytest.raises(BatchException):
+            j.call(foo)
+        with pytest.raises(BatchException):
+            j.call(foo, 1)
+        with pytest.raises(BatchException):
+            j.call(foo, 1, 2)
+        with pytest.raises(BatchException):
+            j.call(foo, 1, kwarg1=2)
+        with pytest.raises(BatchException):
+            j.call(foo, 1, 2, 3)
+        with pytest.raises(BatchException):
+            j.call(foo, 1, 2, kwarg1=3, kwarg2=4, kwarg3=5)
+
+        j.call(foo, 1, 2, kwarg1=3)
+        j.call(foo, 1, 2, kwarg1=3, kwarg2=4)
+
     def test_fail_fast(self):
         b = self.batch(cancel_after_n_failures=1)
 

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -932,6 +932,12 @@ class ServiceTests(unittest.TestCase):
         j.call(foo, 1, 2, kwarg1=3)
         j.call(foo, 1, 2, kwarg1=3, kwarg2=4)
 
+        # `print` doesn't have a signature but other builtins like `abs` do
+        j.call(print, 5)
+        j.call(abs, -1)
+        with pytest.raises(BatchException):
+            j.call(abs, -1, 5)
+
     def test_fail_fast(self):
         b = self.batch(cancel_after_n_failures=1)
 


### PR DESCRIPTION
CHANGELOG: `PythonJob.call` now immediately errors when supplied arguments are incompatible with the called function instead of erroring only when the job is run.

inspect.Signature allows you to inspect the signature of some function, and [inspect.Signature.bind](https://docs.python.org/3/library/inspect.html#inspect.Signature.binds) takes arguments to the function and maps those arguments to method parameters. If the invocation is invalid, i.e. would raise a TypeError when *actually* invoking the function with those arguments, this method raises a similar error. This can help a user immediately catch something like not passing the correct number of arguments to a PythonJob call without having to submit and run it.