### PR TITLE
[query] Add to_pandas(types={}) argument to specify user-supplied pandas dtypes

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3475,15 +3475,18 @@ class Table(ExprContainer):
         """
         return Env.spark_backend('to_spark').to_spark(self, flatten)
 
-    @typecheck_method(flatten=bool)
-    def to_pandas(self, flatten=True):
+    @typecheck_method(flatten=bool, types=dictof(oneof(str, hail_type), str))
+    def to_pandas(self, flatten=True, types={}):
         """Converts this table to a Pandas DataFrame.
 
         Parameters
         ----------
         flatten : :obj:`bool`
             If ``True``, :meth:`flatten` before converting to Pandas DataFrame.
-
+        types : :obj:`dict` mapping :class:`str` or :class:`.HailType` to :class:`str`
+            Dictionary defining Pandas DataFrame dtypes.
+            If a key is :class:`str`, a field with the specified key name is mapped to a Pandas dtype.
+            If a key is :class:`.HailType`, all fields with the specified :class:`.HailType` are mapped to a Pandas dtype.
         Returns
         -------
         :class:`.pandas.DataFrame`
@@ -3495,21 +3498,22 @@ class Table(ExprContainer):
         column_struct_array = table.aggregate(hl.struct(**collect_dict))
         columns = list(column_struct_array.keys())
         data_dict = {}
+        hl_default_dtypes = {
+            hl.tstr: "string",
+            hl.tint32: "Int32",
+            hl.tint64: "Int64",
+            hl.tfloat32: "Float32",
+            hl.tfloat64: "Float64",
+            hl.tbool: "boolean"
+        }
+        all_types = dict(hl_default_dtypes, **types)
 
         for column in columns:
             hl_dtype = dtypes_struct[column]
-            if hl_dtype == hl.tstr:
-                pd_dtype = 'string'
-            elif hl_dtype == hl.tint32:
-                pd_dtype = 'Int32'
-            elif hl_dtype == hl.tint64:
-                pd_dtype = 'Int64'
-            elif hl_dtype == hl.tfloat32:
-                pd_dtype = 'Float32'
-            elif hl_dtype == hl.tfloat64:
-                pd_dtype = 'Float64'
-            elif hl_dtype == hl.tbool:
-                pd_dtype = 'boolean'
+            if column in all_types:
+                pd_dtype = all_types[column]
+            if hl_dtype in all_types:
+                pd_dtype = all_types[hl_dtype]
             else:
                 pd_dtype = hl_dtype.to_numpy()
             data_dict[column] = pandas.Series(column_struct_array[column], dtype=pd_dtype)

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3506,13 +3506,13 @@ class Table(ExprContainer):
             hl.tfloat64: "Float64",
             hl.tbool: "boolean"
         }
-        all_types = dict(hl_default_dtypes, **types)
+        all_types = {**hl_default_dtypes, **types}
 
         for column in columns:
             hl_dtype = dtypes_struct[column]
             if column in all_types:
                 pd_dtype = all_types[column]
-            if hl_dtype in all_types:
+            elif hl_dtype in all_types:
                 pd_dtype = all_types[hl_dtype]
             else:
                 pd_dtype = hl_dtype.to_numpy()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1878,8 +1878,6 @@ def test_to_pandas():
     strs = ["foo", "bar", "baz"]
     ht = ht.annotate(s = hl.array(strs)[ht.idx], nested=hl.struct(foo = ht.idx, bar=hl.range(ht.idx)))
     df_from_hail = ht.to_pandas(flatten=False)
-    print(df_from_hail)
-    print(df_from_hail.dtypes)
 
     python_data = {
         "idx": pd.Series([0, 1, 2], dtype='Int32'),
@@ -1890,6 +1888,36 @@ def test_to_pandas():
 
     df_from_python = pd.DataFrame(python_data)
     pd.testing.assert_frame_equal(df_from_hail, df_from_python)
+
+
+def test_to_pandas_types_type_to_type():
+    ht = hl.utils.range_table(3)
+    reveal_type(ht)
+    ht = ht.annotate(
+        s=hl.array(["foo", "bar", "baz"])[ht.idx],
+        nested=hl.struct(foo=ht.idx,
+                         bar=hl.range(ht.idx))
+    )
+    actual = dict(ht.to_pandas(types={hl.tint32: 'Int64'}).dtypes)
+    assert isinstance(actual['idx'], pd.Int64Dtype)
+    assert isinstance(actual['s'], pd.StringDtype)
+    assert isinstance(actual['nested.foo'], pd.Int64Dtype)
+    assert isinstance(actual['nested.bar'], p.dtype('O'))
+
+
+def test_to_pandas_types_column_to_type():
+    ht = hl.utils.range_table(3)
+    reveal_type(ht)
+    ht = ht.annotate(
+        s=hl.array(["foo", "bar", "baz"])[ht.idx],
+        nested=hl.struct(foo=ht.idx,
+                         bar=hl.range(ht.idx))
+    )
+    actual = dict(ht.to_pandas(types={'nested.foo': 'Int64'}).dtypes)
+    assert isinstance(actual['idx'], pd.Int64Dtype)
+    assert isinstance(actual['s'], pd.StringDtype)
+    assert isinstance(actual['nested.foo'], pd.Int64Dtype)
+    assert isinstance(actual['nested.bar'], p.dtype('O'))
 
 
 def test_to_pandas_flatten():

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1901,7 +1901,7 @@ def test_to_pandas_types_type_to_type():
     assert isinstance(actual['idx'], pd.Int64Dtype)
     assert isinstance(actual['s'], pd.StringDtype)
     assert isinstance(actual['nested.foo'], pd.Int64Dtype)
-    assert isinstance(actual['nested.bar'], p.dtype('O'))
+    assert isinstance(actual['nested.bar'], pd.dtype('O'))
 
 
 def test_to_pandas_types_column_to_type():
@@ -1912,10 +1912,10 @@ def test_to_pandas_types_column_to_type():
                          bar=hl.range(ht.idx))
     )
     actual = dict(ht.to_pandas(types={'nested.foo': 'Int64'}).dtypes)
-    assert isinstance(actual['idx'], pd.Int64Dtype)
+    assert isinstance(actual['idx'], pd.Int32Dtype)
     assert isinstance(actual['s'], pd.StringDtype)
     assert isinstance(actual['nested.foo'], pd.Int64Dtype)
-    assert isinstance(actual['nested.bar'], p.dtype('O'))
+    assert isinstance(actual['nested.bar'], pd.dtype('O'))
 
 
 def test_to_pandas_flatten():

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1901,7 +1901,7 @@ def test_to_pandas_types_type_to_type():
     assert isinstance(actual['idx'], pd.Int64Dtype)
     assert isinstance(actual['s'], pd.StringDtype)
     assert isinstance(actual['nested.foo'], pd.Int64Dtype)
-    assert isinstance(actual['nested.bar'], pd.dtype('O'))
+    assert actual['nested.bar'] == np.dtype('O')
 
 
 def test_to_pandas_types_column_to_type():
@@ -1915,7 +1915,7 @@ def test_to_pandas_types_column_to_type():
     assert isinstance(actual['idx'], pd.Int32Dtype)
     assert isinstance(actual['s'], pd.StringDtype)
     assert isinstance(actual['nested.foo'], pd.Int64Dtype)
-    assert isinstance(actual['nested.bar'], pd.dtype('O'))
+    assert actual['nested.bar'] == np.dtype('O')
 
 
 def test_to_pandas_flatten():

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1892,7 +1892,6 @@ def test_to_pandas():
 
 def test_to_pandas_types_type_to_type():
     ht = hl.utils.range_table(3)
-    reveal_type(ht)
     ht = ht.annotate(
         s=hl.array(["foo", "bar", "baz"])[ht.idx],
         nested=hl.struct(foo=ht.idx,
@@ -1907,7 +1906,6 @@ def test_to_pandas_types_type_to_type():
 
 def test_to_pandas_types_column_to_type():
     ht = hl.utils.range_table(3)
-    reveal_type(ht)
     ht = ht.annotate(
         s=hl.array(["foo", "bar", "baz"])[ht.idx],
         nested=hl.struct(foo=ht.idx,


### PR DESCRIPTION
This PR fixes #11738. Now users can specify arbitrary type conversation between Hail and Pandas dtypes via:
```
ht.to_pandas(types={"col1": "int32", "col2": np.float64, hl.tstring: "object"})
```
This maps `col1` and `col2` to `int32` and `np.float64`, respectively, and all `hl.tstring` fields to `object`.

One design question might be whether to have separate arguments for column name and Hail type specifications or not. Any thoughts? cc: @danking 

Also, I don't think the current type check would work for `np.float64`-like numpy dtype specifications...
