### PR TITLE
[batch] Allow more than one standing worker

### DIFF
--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import prometheus_client as pc
 import sortedcontainers

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -260,7 +260,7 @@ WHERE removed = 0 AND inst_coll = %s;
         cores: int,
         data_disk_size_gb: int,
         regions: List[str],
-        max_idle_time_msecs: Optional[int],
+        max_idle_time_msecs: int,
     ):
         if n_instances > 0:
             log.info(f'creating {n_instances} new instances')

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import prometheus_client as pc
 import sortedcontainers
@@ -127,7 +127,6 @@ WHERE removed = 0 AND inst_coll = %s;
         self.worker_cores = config.worker_cores
         self.worker_local_ssd_data_disk = config.worker_local_ssd_data_disk
         self.worker_external_ssd_data_disk_size_gb = config.worker_external_ssd_data_disk_size_gb
-        self.enable_standing_worker = config.enable_standing_worker
         self.standing_worker_cores = config.standing_worker_cores
         self.boot_disk_size_gb = config.boot_disk_size_gb
         self.data_disk_size_gb = config.data_disk_size_gb
@@ -138,6 +137,7 @@ WHERE removed = 0 AND inst_coll = %s;
         self.standing_worker_max_idle_time_secs = config.standing_worker_max_idle_time_secs
         self.worker_max_idle_time_secs = config.worker_max_idle_time_secs
         self.job_queue_scheduling_window_secs = config.job_queue_scheduling_window_secs
+        self.min_instances = config.min_instances
 
         self.all_supported_regions = self.inst_coll_manager.regions
 
@@ -156,8 +156,8 @@ WHERE removed = 0 AND inst_coll = %s;
             'boot_disk_size_gb': self.boot_disk_size_gb,
             'worker_local_ssd_data_disk': self.worker_local_ssd_data_disk,
             'worker_external_ssd_data_disk_size_gb': self.worker_external_ssd_data_disk_size_gb,
-            'enable_standing_worker': self.enable_standing_worker,
             'standing_worker_cores': self.standing_worker_cores,
+            'min_instances': self.min_instances,
             'max_instances': self.max_instances,
             'max_live_instances': self.max_live_instances,
             'preemptible': self.preemptible,
@@ -176,11 +176,11 @@ WHERE removed = 0 AND inst_coll = %s;
         self.worker_cores = pool_config.worker_cores
         self.worker_local_ssd_data_disk = pool_config.worker_local_ssd_data_disk
         self.worker_external_ssd_data_disk_size_gb = pool_config.worker_external_ssd_data_disk_size_gb
-        self.enable_standing_worker = pool_config.enable_standing_worker
         self.standing_worker_cores = pool_config.standing_worker_cores
         self.boot_disk_size_gb = pool_config.boot_disk_size_gb
         self.data_disk_size_gb = pool_config.data_disk_size_gb
         self.data_disk_size_standing_gb = pool_config.data_disk_size_standing_gb
+        self.min_instances = pool_config.min_instances
         self.max_instances = pool_config.max_instances
         self.max_live_instances = pool_config.max_live_instances
         self.preemptible = pool_config.preemptible
@@ -254,17 +254,24 @@ WHERE removed = 0 AND inst_coll = %s;
         )
         return max(0, instances_needed)
 
-    async def _create_instances(self, n_instances: int, regions: List[str]):
+    async def _create_instances(
+        self,
+        n_instances: int,
+        cores: int,
+        data_disk_size_gb: int,
+        regions: List[str],
+        max_idle_time_msecs: Optional[int],
+    ):
         if n_instances > 0:
             log.info(f'creating {n_instances} new instances')
             # parallelism will be bounded by thread pool
             await asyncio.gather(
                 *[
                     self.create_instance(
-                        cores=self.worker_cores,
-                        data_disk_size_gb=self.data_disk_size_gb,
+                        cores=cores,
+                        data_disk_size_gb=data_disk_size_gb,
                         regions=regions,
-                        max_idle_time_msecs=self.worker_max_idle_time_secs * 1000,
+                        max_idle_time_msecs=max_idle_time_msecs,
                     )
                     for _ in range(n_instances)
                 ]
@@ -279,7 +286,13 @@ WHERE removed = 0 AND inst_coll = %s;
             remaining_max_new_instances_per_autoscaler_loop,
         )
 
-        await self._create_instances(instances_needed, regions)
+        await self._create_instances(
+            instances_needed,
+            self.worker_cores,
+            self.data_disk_size_gb,
+            regions,
+            max_idle_time_msecs=self.worker_max_idle_time_secs * 1000,
+        )
         return instances_needed
 
     async def regions_to_ready_cores_mcpu_from_estimated_job_queue(self) -> List[Tuple[List[str], int]]:
@@ -406,7 +419,9 @@ GROUP BY user;
         if head_job_queue_regions_ready_cores_mcpu_ordered and free_cores < 500:
             for regions, ready_cores_mcpu in head_job_queue_regions_ready_cores_mcpu_ordered:
                 n_instances_created = await self.create_instances_from_ready_cores(
-                    ready_cores_mcpu, regions, remaining_instances_per_autoscaler_loop
+                    ready_cores_mcpu,
+                    regions,
+                    remaining_instances_per_autoscaler_loop,
                 )
 
                 n_regions = len(regions)
@@ -418,8 +433,18 @@ GROUP BY user;
                     break
 
         n_live_instances = self.n_instances_by_state['pending'] + self.n_instances_by_state['active']
-        if self.enable_standing_worker and n_live_instances == 0 and self.max_instances > 0:
-            await self.create_instance(
+        n_standing_instances_needed = max(0, self.min_instances - self.n_instances)
+        n_standing_instances_needed = min(
+            n_standing_instances_needed,
+            self.max_live_instances - n_live_instances,
+            self.max_instances - self.n_instances,
+            remaining_instances_per_autoscaler_loop,
+            # 20 queries/s; our GCE long-run quota
+            300,
+        )
+        if n_standing_instances_needed > 0:
+            await self._create_instances(
+                n_instances=n_standing_instances_needed,
                 cores=self.standing_worker_cores,
                 data_disk_size_gb=self.data_disk_size_standing_gb,
                 regions=self.all_supported_regions,

--- a/batch/batch/driver/templates/pool.html
+++ b/batch/batch/driver/templates/pool.html
@@ -20,15 +20,8 @@
       value="true" />
     </div>
     <div>Worker External SSD data disk size (in GB): <input name="worker_external_ssd_data_disk_size_gb" value="{{ pool.worker_external_ssd_data_disk_size_gb }}" /></div>
-    <div>
-      <label for="enable_standing_worker">Enable standing worker: </label>
-      <input type="checkbox"
-             id="enable_standing_worker"
-             name="enable_standing_worker"
-             {% if pool.enable_standing_worker %}checked{% endif %}
-      value="true" />
-    </div>
     <div>Standing worker cores: <input name="standing_worker_cores" value="{{ pool.standing_worker_cores }}" /></div>
+    <div>Min instances: <input name="min_instances" value="{{ pool.min_instances }}" /></div>
     <div>Max instances: <input name="max_instances" value="{{ pool.max_instances }}" /></div>
     <div>Max live instances: <input name="max_live_instances" value="{{ pool.max_live_instances }}" /></div>
     <div>Max new instances per autoscaler loop: <input name="max_new_instances_per_autoscaler_loop" value="{{ pool.max_new_instances_per_autoscaler_loop }}" /></div>

--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -72,9 +72,9 @@ class PoolConfig(InstanceCollectionConfig):
             worker_cores=record['worker_cores'],
             worker_local_ssd_data_disk=record['worker_local_ssd_data_disk'],
             worker_external_ssd_data_disk_size_gb=record['worker_external_ssd_data_disk_size_gb'],
-            enable_standing_worker=record['enable_standing_worker'],
             standing_worker_cores=record['standing_worker_cores'],
             boot_disk_size_gb=record['boot_disk_size_gb'],
+            min_instances=record['min_instances'],
             max_instances=record['max_instances'],
             max_live_instances=record['max_live_instances'],
             preemptible=bool(record['preemptible']),
@@ -93,9 +93,9 @@ INNER JOIN inst_colls ON pools.name = inst_colls.name
 SET worker_cores = %s,
     worker_local_ssd_data_disk = %s,
     worker_external_ssd_data_disk_size_gb = %s,
-    enable_standing_worker = %s,
     standing_worker_cores = %s,
     boot_disk_size_gb = %s,
+    min_instances = %s,
     max_instances = %s,
     max_live_instances = %s,
     preemptible = %s,
@@ -110,9 +110,9 @@ WHERE pools.name = %s;
                 self.worker_cores,
                 self.worker_local_ssd_data_disk,
                 self.worker_external_ssd_data_disk_size_gb,
-                self.enable_standing_worker,
                 self.standing_worker_cores,
                 self.boot_disk_size_gb,
+                self.min_instances,
                 self.max_instances,
                 self.max_live_instances,
                 self.preemptible,
@@ -134,9 +134,9 @@ WHERE pools.name = %s;
         worker_cores: int,
         worker_local_ssd_data_disk: bool,
         worker_external_ssd_data_disk_size_gb: int,
-        enable_standing_worker: bool,
         standing_worker_cores: int,
         boot_disk_size_gb: int,
+        min_instances: int,
         max_instances: int,
         max_live_instances: int,
         preemptible: bool,
@@ -146,15 +146,18 @@ WHERE pools.name = %s;
         standing_worker_max_idle_time_secs: int,
         job_queue_scheduling_window_secs: int,
     ):
+        assert (
+            min_instances <= max_live_instances <= max_instances
+        ), f'{(min_instances, max_live_instances, max_instances)}'
         self.name = name
         self.cloud = cloud
         self.worker_type = worker_type
         self.worker_cores = worker_cores
         self.worker_local_ssd_data_disk = worker_local_ssd_data_disk
         self.worker_external_ssd_data_disk_size_gb = worker_external_ssd_data_disk_size_gb
-        self.enable_standing_worker = enable_standing_worker
         self.standing_worker_cores = standing_worker_cores
         self.boot_disk_size_gb = boot_disk_size_gb
+        self.min_instances = min_instances
         self.max_instances = max_instances
         self.max_live_instances = max_live_instances
         self.preemptible = preemptible

--- a/batch/sql/config-pool-min-instances.sql
+++ b/batch/sql/config-pool-min-instances.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pools ADD COLUMN min_instances BIGINT NOT NULL DEFAULT 0;
+UPDATE pools SET min_instances = CAST(enable_standing_worker=1 AS SIGNED INTEGER);

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS `pools` (
   `preemptible` BOOLEAN NOT NULL DEFAULT TRUE,
   `standing_worker_max_idle_time_secs` INT NOT NULL,
   `job_queue_scheduling_window_secs` INT NOT NULL,
+  `min_instances` BIGINT NOT NULL,
   PRIMARY KEY (`name`),
   FOREIGN KEY (`name`) REFERENCES inst_colls(name) ON DELETE CASCADE
 ) ENGINE = InnoDB;

--- a/build.yaml
+++ b/build.yaml
@@ -2045,6 +2045,9 @@ steps:
       - name: create-resource-dedup-mapping
         script: /io/sql/create_resource_dedup_mapping.py
         online: true
+      - name: config-pool-min-instances
+        script: /io/sql/config-pool-min-instances.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
I added the configuration option for the minimum number of workers that should be present at any time. I tested this in my namespace. I'd like you to double check the logic is correct for the number of workers needed as I derived it by working through examples:

```python3
        n_live_instances = self.n_instances_by_state['pending'] + self.n_instances_by_state['active']
        n_standing_instances_needed = max(0, self.min_instances - self.n_instances)
        n_standing_instances_needed = min(
            n_standing_instances_needed,
            self.max_live_instances - n_live_instances,
            self.max_instances - self.n_instances,
            remaining_instances_per_autoscaler_loop,
            # 20 queries/s; our GCE long-run quota
            300,
        )
```