### PR TITLE
[ci] Add developers to test namespaces

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -51,13 +51,11 @@ log = logging.getLogger('auth')
 
 uvloop.install()
 
-
-deploy_config = get_deploy_config()
-
-
 CLOUD = get_global_config()['cloud']
 ORGANIZATION_DOMAIN = os.environ['HAIL_ORGANIZATION_DOMAIN']
 OAUTH2_CALLBACK_URL = os.environ['HAIL_OAUTH2_CALLBACK_URL']
+
+deploy_config = get_deploy_config()
 
 routes = web.RouteTableDef()
 

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -183,6 +183,11 @@ spec:
               secretKeyRef:
                 name: global-config
                 key: organization_domain
+          - name: HAIL_OAUTH2_CALLBACK_URL
+            valueFrom:
+              secretKeyRef:
+                name: auth-config
+                key: oauth2_callback_url
           - name: CLOUD
             valueFrom:
               secretKeyRef:

--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -18,11 +18,7 @@ create_build_image_instance() {
     python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"'${DOCKER_ROOT_IMAGE}'"}}' \
         build-batch-worker-image-startup-gcp.sh build-batch-worker-image-startup-gcp.sh.out
 
-    UBUNTU_IMAGE=$(gcloud compute images list \
-        --standard-images \
-        --filter 'family="ubuntu-minimal-2004-lts"' \
-        --format='value(name)')
-
+    UBUNTU_IMAGE=ubuntu-minimal-2004-focal-v20230216
     gcloud -q compute instances create ${BUILDER} \
         --project ${PROJECT}  \
         --zone=${ZONE} \

--- a/build.yaml
+++ b/build.yaml
@@ -1652,15 +1652,26 @@ steps:
       - create_certs
       - copy_third_party_images
   - kind: runImage
-    name: create_dummy_oauth2_client_secret
+    name: create_auth_config
     image:
       valueFrom: ci_utils_image.image
     script: |
-      set -ex
-      kubectl -n {{ default_ns.name }} create secret generic auth-oauth2-client-secret || true
-    scopes:
-      - test
-      - dev
+      {% if deploy %}
+      OAUTH2_CALLBACK_URL="https://auth.{{ global.domain }}/oauth2callback"
+      {% elif 'oauth2_callback_url' in code %}
+      OAUTH2_CALLBACK_URL="{{ code['oauth2_callback_url'] }}"
+      {% else %}
+      OAUTH2_CALLBACK_URL="https://internal.{{ global.domain }}/{{ default_ns.name }}/auth/oauth2callback"
+      {% endif %}
+
+      kubectl -n {{ default_ns.name }} create secret generic auth-config \
+          --from-literal=oauth2_callback_url="$OAUTH2_CALLBACK_URL" \
+          --save-config --dry-run=client -o yaml \
+        | kubectl -n {{ default_ns.name }} apply -f -
+    serviceAccount:
+      name: admin
+      namespace:
+        valueFrom: default_ns.name
     dependsOn:
       - default_ns
       - ci_utils_image
@@ -1682,7 +1693,7 @@ steps:
       - create_session_key
       - auth_database
       - auth_image
-      - create_dummy_oauth2_client_secret
+      - create_auth_config
       - create_certs
       - create_accounts
   - kind: runImage
@@ -1962,6 +1973,8 @@ steps:
         online: true
       - name: fix-default-namespace-record
         script: /io/sql/fix-default-namespace.py
+      - name: test-oauth2-callback-urls
+        script: /io/sql/add-oauth2-callback-urls-to-namespaces.sql
         online: true
     inputs:
       - from: /repo/ci/sql
@@ -2240,6 +2253,59 @@ steps:
       - batch_database
       - deploy_auth
       - create_certs
+  - kind: runImage
+    name: add_users
+    image:
+      valueFrom: hailgenetics_hailtop_image.image
+    script: |
+      set -ex
+      cat >add_users.py <<EOF
+      import asyncio
+      from hailtop.auth import async_create_user
+      from hailtop.batch_client.aioclient import BatchClient
+
+      async def main():
+          bc = await BatchClient.create('test')
+          namespace = '{{ default_ns.name }}'
+
+          users = [
+            {% for user in code.get("users", []) %}
+              ('{{ user["username"] }}', '{{ user["login_id"] }}'),
+            {% endfor %}
+          ]
+
+          await asyncio.gather(*(
+              async_create_user(username, login_id, True, False, namespace, wait=True)
+              for username, login_id in users
+          ))
+          print('Added all users')
+
+          await bc.create_billing_project('hail')
+          for username, _ in users:
+              await bc.add_user(username, 'test')
+              print(f'Added {username} to test billing project')
+              await bc.add_user(username, 'hail')
+              print(f'Added {username} to hail billing project')
+
+      asyncio.get_event_loop().run_until_complete(main())
+      EOF
+      python3 add_users.py
+    secrets:
+      - name: worker-deploy-config
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /deploy-config
+      - name: test-dev-tokens
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /user-tokens
+    scopes:
+      - dev
+      - test
+    dependsOn:
+      - default_ns
+      - hailgenetics_hailtop_image
+      - deploy_batch
   - kind: runImage
     name: create_billing_projects
     image:
@@ -2718,11 +2784,18 @@ steps:
     image:
       valueFrom: ci_utils_image.image
     script: |
+      {% if 'oauth2_callback_url' in code %}
+      OAUTH2_CALLBACK_URL="{{ code['oauth2_callback_url'] }}"
+      {% else %}
+      OAUTH2_CALLBACK_URL="https://internal.{{ global.domain }}/{{ default_ns.name }}/auth/oauth2callback"
+      {% endif %}
+
       kubectl -n {{ default_ns.name }} create secret generic ci-config \
           --from-literal=github_context="ci-test" \
           --from-literal=storage_uri="{{ global.test_storage_uri }}" \
           --from-literal=deploy_steps="[]" \
           --from-literal=watched_branches="[[\"hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master\", true, true]]" \
+          --from-literal=test_oauth2_callback_urls="[\"$OAUTH2_CALLBACK_URL\"]" \
           --save-config --dry-run=client -o yaml \
         | kubectl -n {{ default_ns.name }} apply -f -
     serviceAccount:
@@ -3718,4 +3791,48 @@ steps:
       - test_batch
       - test_ci
       - test_hailtop_batch
+      - test_hail_python_service_backend
+      - cancel_all_running_test_batches
+  - kind: runImage
+    name: delete_users
+    image:
+      valueFrom: hailgenetics_hailtop_image.image
+    alwaysRun: true
+    script: |
+      set -ex
+      cat >delete_users.py <<EOF
+      import asyncio
+      from hailtop.auth import async_delete_user
+
+      async def main():
+          namespace = '{{ default_ns.name }}'
+          assert namespace != 'default'
+          await asyncio.gather(
+          {% for user in code.get("users", []) %}
+            async_delete_user('{{ user["username"] }}', namespace, wait=True),
+          {% endfor %}
+          )
+      asyncio.get_event_loop().run_until_complete(main())
+      EOF
+      python3 delete_users.py
+    secrets:
+      - name: worker-deploy-config
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /deploy-config
+      - name: test-dev-tokens
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /user-tokens
+    scopes:
+      - dev
+      - test
+    dependsOn:
+      - default_ns
+      - hailgenetics_hailtop_image
+      - test_batch_invariants
+      - test_batch
+      - test_ci
+      - test_hailtop_batch
+      - test_hail_python_service_backend
       - cancel_all_running_test_batches

--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -364,14 +364,15 @@ async def main():
     extra_code_config = json.loads(args.extra_code_config)
 
     scope = 'deploy'
+    namespace = 'default'
+    token = generate_token()
     code = Branch(owner, repo_name, branch_name, args.sha, extra_code_config)
 
     steps = [s.strip() for s in args.steps.split(',')]
 
     with open('build.yaml', 'r', encoding='utf-8') as f:
-        config = BuildConfiguration(code, f.read(), scope, requested_step_names=steps)
+        config = BuildConfiguration(code, f.read(), namespace, token, scope, requested_step_names=steps)
 
-    token = generate_token()
     batch = LocalBatchBuilder(attributes={'token': token}, callback=None)
     config.build(batch, code, scope)
 

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -184,7 +184,7 @@ class Step(abc.ABC):
         self.clouds = json.get('clouds')
         self.run_if_requested = json.get('runIfRequested', False)
 
-        self.token = params.token
+        self.token = generate_token()
 
     def input_config(self, code, scope):
         config = {}

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -751,7 +751,6 @@ SELECT frozen_merge_deploy FROM globals;
 
     async with await retry_transient_errors(
         app['client_session'].get_read_json,
-        'GET',
         deploy_config.url('auth', '/api/v1alpha/users'),
         headers=headers,
     ) as users:

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -6,7 +6,7 @@ import os
 import traceback
 from typing import Callable, Dict, List, Optional, Set
 
-import aiohttp_session  # type: ignore
+import aiohttp_session
 import kubernetes_asyncio
 import uvloop  # type: ignore
 import yaml
@@ -28,17 +28,19 @@ from gear import (
 )
 from gear.profiling import install_profiler_if_requested
 from hailtop import aiotools, httpx
+from hailtop.auth import hail_credentials
 from hailtop.batch_client.aioclient import Batch, BatchClient
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
-from hailtop.utils import collect_agen, humanize_timedelta_msecs, periodically_call
+from hailtop.utils import collect_agen, humanize_timedelta_msecs, periodically_call, retry_transient_errors
 from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
 from .constants import AUTHORIZED_USERS, TEAMS
 from .environment import DEFAULT_NAMESPACE, STORAGE_URI
-from .envoy import create_cds_response, create_rds_response
+from .envoy import NamespaceRoutingConfig, create_cds_response, create_rds_response
 from .github import PR, WIP, FQBranch, MergeFailureBatch, Repo, UnwatchedBranch, WatchedBranch, select_random_teammate
+from .utils import release_namespace, reserve_namespace
 
 with open(os.environ.get('HAIL_CI_OAUTH_TOKEN', 'oauth-token/oauth-token'), 'r', encoding='utf-8') as f:
     oauth_token = f.read().strip()
@@ -396,14 +398,6 @@ async def github_callback(request):
     return web.Response(status=200)
 
 
-async def remove_namespace_from_db(db: Database, namespace: str):
-    assert namespace != 'default'
-    await db.just_execute(
-        'DELETE FROM active_namespaces WHERE namespace = %s',
-        (namespace,),
-    )
-
-
 async def batch_callback_handler(request):
     app = request.app
     db: Database = app['db']
@@ -422,7 +416,7 @@ async def batch_callback_handler(request):
                         assert 'dev' not in attrs
                         namespace = attrs['namespace']
                         if DEFAULT_NAMESPACE == 'default':
-                            await remove_namespace_from_db(db, namespace)
+                            await release_namespace(db, namespace)
 
                     await wb.notify_batch_changed(app)
 
@@ -492,6 +486,7 @@ async def dev_deploy_branch(request, userdata):
         steps = params['steps']
         excluded_steps = params['excluded_steps']
         extra_config = params.get('extra_config', {})
+        namespace = userdata['username']
     except asyncio.CancelledError:
         raise
     except Exception as e:
@@ -512,7 +507,10 @@ async def dev_deploy_branch(request, userdata):
         log.info('dev deploy failed: ' + message, exc_info=True)
         raise web.HTTPBadRequest(text=message) from e
 
-    unwatched_branch = UnwatchedBranch(branch, sha, userdata, extra_config)
+    oauth2_callback_url = await reserve_namespace(app['db'], namespace)
+    unwatched_branch = UnwatchedBranch(
+        branch, sha, userdata, namespace, oauth2_callback_url, app['developers'], extra_config=extra_config
+    )
 
     batch_client = app['batch_client']
 
@@ -670,7 +668,7 @@ async def cleanup_expired_namespaces(db: Database):
     for namespace in expired_namespaces:
         assert namespace != 'default'
         log.info(f'Cleaning up expired namespace: {namespace}')
-        await remove_namespace_from_db(db, namespace)
+        await release_namespace(db, namespace)
 
 
 async def update_envoy_configs(db: Database, k8s_client):
@@ -680,11 +678,11 @@ async def update_envoy_configs(db: Database, k8s_client):
     live_namespaces = tuple(ns.metadata.name for ns in api_response.items)
     namespace_arg_list = "(" + ",".join('%s' for _ in live_namespaces) + ")"
 
-    services_per_namespace = {
-        r['namespace']: [s for s in json.loads(r['services']) if s is not None]
+    records = [
+        r
         async for r in db.execute_and_fetchall(
             f'''
-SELECT active_namespaces.namespace, JSON_ARRAYAGG(service) as services
+SELECT active_namespaces.namespace, active_namespaces.oauth2_callback_url, JSON_ARRAYAGG(service) as services
 FROM active_namespaces
 LEFT JOIN deployed_services
 ON active_namespaces.namespace = deployed_services.namespace
@@ -692,9 +690,17 @@ WHERE active_namespaces.namespace IN {namespace_arg_list}
 GROUP BY active_namespaces.namespace''',
             live_namespaces,
         )
+    ]
+
+    namespaces = {
+        r['namespace']: NamespaceRoutingConfig(
+            r['namespace'], [s for s in json.loads(r['services']) if s is not None], r['oauth2_callback_url']
+        )
+        for r in records
     }
-    assert 'default' in services_per_namespace
-    default_services = services_per_namespace.pop('default')
+
+    assert 'default' in namespaces
+    default_services = namespaces.pop('default').deployed_services
     assert set(['batch', 'auth', 'batch-driver', 'ci']).issubset(set(default_services)), default_services
 
     for proxy in ('gateway', 'internal-gateway'):
@@ -703,8 +709,8 @@ GROUP BY active_namespaces.namespace''',
             name=configmap_name,
             namespace=DEFAULT_NAMESPACE,
         )
-        cds = create_cds_response(default_services, services_per_namespace, proxy)
-        rds = create_rds_response(default_services, services_per_namespace, proxy)
+        cds = create_cds_response(proxy, default_services, list(namespaces.values()))
+        rds = create_rds_response(proxy, default_services, list(namespaces.values()))
         configmap.data['cds.yaml'] = yaml.dump(cds)
         configmap.data['rds.yaml'] = yaml.dump(rds)
         await k8s_client.patch_namespaced_config_map(
@@ -740,6 +746,16 @@ async def on_startup(app):
 SELECT frozen_merge_deploy FROM globals;
 '''
     )
+
+    headers = await hail_credentials().auth_headers()
+
+    async with await retry_transient_errors(
+        app['client_session'].get_read_json,
+        'GET',
+        deploy_config.url('auth', '/api/v1alpha/users'),
+        headers=headers,
+    ) as users:
+        app['developers'] = [u for u in users if u['is_developer'] == 1 and u['username'] != 'test-dev']
 
     app['frozen_merge_deploy'] = row['frozen_merge_deploy']
 

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -1,9 +1,14 @@
 import datetime
+import json
+import os
+import random
 import secrets
 import string
-from typing import List, Optional
+from typing import Dict, List, Optional, Set
 
-from gear import Database
+from gear import Database, transaction
+
+TEST_OAUTH2_CALLBACK_URLS: Set[str] = set(json.loads(os.environ.get('HAIL_TEST_OAUTH2_CALLBACK_URLS', '[]')))
 
 
 def generate_token(size=12):
@@ -13,21 +18,52 @@ def generate_token(size=12):
     return secrets.choice(alpha) + ''.join([secrets.choice(alnum) for _ in range(size - 1)])
 
 
+async def reserve_namespace(
+    db: Database,
+    namespace: str,
+    expiration_time: Optional[datetime.datetime] = None,
+) -> str:
+    if namespace == 'default':
+        raise ValueError('Cannot reserve the default namespace')
+
+    @transaction(db)
+    async def reserve(tx) -> str:
+        in_use: Dict[str, str] = {
+            record['namespace']: record['oauth2_callback_url']
+            async for record in tx.execute_and_fetchall(
+                'SELECT namespace, oauth2_callback_url FROM active_namespaces FOR UPDATE'
+            )
+        }
+        # This namespace might already be deployed
+        callback_url: str = in_use.get(namespace) or random.choice(
+            list(TEST_OAUTH2_CALLBACK_URLS.difference(in_use.values()))
+        )
+
+        expiration = expiration_time.strftime('%Y-%m-%d %H:%M:%S') if expiration_time else None
+        await tx.execute_insertone(
+            '''
+INSERT INTO active_namespaces (`namespace`, `oauth2_callback_url`, `expiration_time`)
+VALUES (%s, %s, %s) as new_ns
+ON DUPLICATE KEY UPDATE expiration_time = new_ns.expiration_time, oauth2_callback_url = new_ns.oauth2_callback_url
+''',
+            (namespace, callback_url, expiration),
+        )
+
+        return callback_url
+
+    return await reserve()  # pylint: disable=no-value-for-parameter
+
+
+async def release_namespace(db: Database, namespace: str):
+    assert namespace != 'default'
+    await db.just_execute('DELETE FROM active_namespaces WHERE namespace = %s', (namespace,))
+
+
 async def add_deployed_services(
     db: Database,
     namespace: str,
     services: List[str],
-    expiration_time: Optional[datetime.datetime],
 ):
-    expiration = expiration_time.strftime('%Y-%m-%d %H:%M:%S') if expiration_time else None
-    await db.execute_insertone(
-        '''
-INSERT INTO active_namespaces (`namespace`, `expiration_time`)
-VALUES (%s, %s) as new_ns
-ON DUPLICATE KEY UPDATE expiration_time = new_ns.expiration_time
-        ''',
-        (namespace, expiration),
-    )
     await db.execute_many(
         '''
 INSERT INTO deployed_services (`namespace`, `service`)

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -65,6 +65,11 @@ spec:
                secretKeyRef:
                  name: ci-config
                  key: deploy_steps
+           - name: HAIL_TEST_OAUTH2_CALLBACK_URLS
+             valueFrom:
+               secretKeyRef:
+                 name: ci-config
+                 key: test_oauth2_callback_urls
            - name: HAIL_CI_STORAGE_URI
              valueFrom:
                secretKeyRef:

--- a/ci/sql/add-oauth2-callback-urls-to-namespaces.sql
+++ b/ci/sql/add-oauth2-callback-urls-to-namespaces.sql
@@ -1,0 +1,1 @@
+ALTER TABLE active_namespaces ADD COLUMN `oauth2_callback_url` VARCHAR(100);

--- a/ci/sql/estimated-current.sql
+++ b/ci/sql/estimated-current.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS `active_namespaces` (
   `namespace` VARCHAR(100) NOT NULL,
   `creation_time` TIMESTAMP NOT NULL DEFAULT (UTC_TIMESTAMP),
   `expiration_time` TIMESTAMP,
+  `oauth2_callback_url` VARCHAR(100),
   PRIMARY KEY (`namespace`)
 ) ENGINE = InnoDB;
 

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -6,7 +6,7 @@ from hailtop import httpx
 from hailtop.aiocloud.common.credentials import CloudCredentials
 from hailtop.aiocloud.common import Session
 from hailtop.config import get_deploy_config, DeployConfig
-from hailtop.utils import async_to_blocking, retry_transient_errors
+from hailtop.utils import async_to_blocking, retry_transient_errors, sleep_and_backoff
 
 from .tokens import Tokens, get_tokens
 
@@ -45,6 +45,14 @@ def hail_credentials(*, credentials_file: Optional[str] = None, namespace: Optio
         namespace=namespace,
         authorize_target=authorize_target
     )
+
+
+class CreateUserException(Exception):
+    pass
+
+
+class DeleteUserException(Exception):
+    pass
 
 
 def namespace_auth_headers(deploy_config: DeployConfig,
@@ -137,35 +145,60 @@ def create_user(username: str, login_id: str, is_developer: bool, is_service_acc
     return async_to_blocking(async_create_user(username, login_id, is_developer, is_service_account, namespace=namespace))
 
 
-async def async_create_user(username: str, login_id: str, is_developer: bool, is_service_account: bool, namespace: Optional[str] = None):
+async def async_create_user(username: str, login_id: str, is_developer: bool, is_service_account: bool, namespace: Optional[str] = None, *, wait: bool = False):
     deploy_config, headers, _ = deploy_config_and_headers_from_namespace(namespace)
 
-    body = {
-        'login_id': login_id,
-        'is_developer': is_developer,
-        'is_service_account': is_service_account,
-    }
+    try:
+        body = {
+            'login_id': login_id,
+            'is_developer': is_developer,
+            'is_service_account': is_service_account,
+        }
 
-    async with httpx.client_session(
-            timeout=aiohttp.ClientTimeout(total=30),
-            headers=headers) as session:
-        await retry_transient_errors(
-            session.post,
-            deploy_config.url('auth', f'/api/v1alpha/users/{username}/create'),
-            json=body
-        )
+        async with httpx.client_session(
+                timeout=aiohttp.ClientTimeout(total=30),
+                headers=headers) as session:
+            await retry_transient_errors(
+                session.post,
+                deploy_config.url('auth', f'/api/v1alpha/users/{username}/create'),
+                json=body
+            )
+
+        if wait:
+            await _wait_user_state_transition(username, namespace, 'creating', 'active')
+            print(f'Created user {username}')
+    except Exception as e:
+        raise CreateUserException(f"Error while creating user '{username}'") from e
 
 
 def delete_user(username: str, namespace: Optional[str] = None):
     return async_to_blocking(async_delete_user(username, namespace=namespace))
 
 
-async def async_delete_user(username: str, namespace: Optional[str] = None):
+async def async_delete_user(username: str, namespace: Optional[str] = None, *, wait: bool = False):
     deploy_config, headers, _ = deploy_config_and_headers_from_namespace(namespace)
-    async with httpx.client_session(
-            timeout=aiohttp.ClientTimeout(total=300),
-            headers=headers) as session:
-        await retry_transient_errors(
-            session.delete,
-            deploy_config.url('auth', f'/api/v1alpha/users/{username}')
-        )
+
+    try:
+        async with httpx.client_session(
+                timeout=aiohttp.ClientTimeout(total=300),
+                headers=headers) as session:
+            await retry_transient_errors(
+                session.delete,
+                deploy_config.url('auth', f'/api/v1alpha/users/{username}')
+            )
+
+        if wait:
+            await _wait_user_state_transition(username, namespace, 'deleting', 'deleted')
+            print(f'Deleted user {username}')
+    except Exception as e:
+        raise DeleteUserException(f"Error while deleting user '{username}'") from e
+
+
+async def _wait_user_state_transition(username: str, namespace: Optional[str], transitory_state: str, final_state: str):
+    delay = 5
+    while True:
+        user = await async_get_user(username, namespace)
+        if user['state'] == final_state:
+            return
+        assert user['state'] == transitory_state
+        delay = await sleep_and_backoff(delay)

--- a/hail/python/hailtop/hailctl/auth/create_user.py
+++ b/hail/python/hailtop/hailctl/auth/create_user.py
@@ -1,7 +1,6 @@
 import asyncio
 
-from hailtop.utils import sleep_and_backoff
-from hailtop.auth import async_create_user, async_get_user
+from hailtop.auth import async_create_user
 
 
 class CreateUserException(Exception):
@@ -23,28 +22,6 @@ def init_parser(parser):
                         help="Wait for the creation of the user to finish")
 
 
-async def async_main(args):
-    try:
-        await async_create_user(args.username, args.login_id, args.developer, args.service_account, args.namespace)
-
-        if not args.wait:
-            return
-
-        async def _poll():
-            delay = 5
-            while True:
-                user = await async_get_user(args.username, args.namespace)
-                if user['state'] == 'active':
-                    print(f"Created user '{args.username}'")
-                    return
-                assert user['state'] == 'creating'
-                delay = await sleep_and_backoff(delay)
-
-        await _poll()
-    except Exception as e:
-        raise CreateUserException(f"Error while creating user '{args.username}'") from e
-
-
 def main(args, pass_through_args):  # pylint: disable=unused-argument
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_main(args))
+    loop.run_until_complete(async_create_user(args.username, args.login_id, args.developer, args.service_account, args.namespace, wait=args.wait))

--- a/hail/python/hailtop/hailctl/auth/delete_user.py
+++ b/hail/python/hailtop/hailctl/auth/delete_user.py
@@ -1,11 +1,6 @@
 import asyncio
 
-from hailtop.utils import sleep_and_backoff
-from hailtop.auth import async_delete_user, async_get_user
-
-
-class DeleteUserException(Exception):
-    pass
+from hailtop.auth import async_delete_user
 
 
 def init_parser(parser):
@@ -17,28 +12,6 @@ def init_parser(parser):
                         help="Wait for the creation of the user to finish")
 
 
-async def async_main(args):
-    try:
-        await async_delete_user(args.username, args.namespace)
-
-        if not args.wait:
-            return
-
-        async def _poll():
-            delay = 5
-            while True:
-                user = await async_get_user(args.username, args.namespace)
-                if user['state'] == 'deleted':
-                    print(f"Deleted user '{args.username}'")
-                    return
-                assert user['state'] == 'deleting'
-                delay = await sleep_and_backoff(delay)
-
-        await _poll()
-    except Exception as e:
-        raise DeleteUserException(f"Error while deleting user '{args.username}'") from e
-
-
 def main(args, pass_through_args):  # pylint: disable=unused-argument
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_main(args))
+    loop.run_until_complete(async_delete_user(args.username, args.namespace, wait=args.wait))

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -85,6 +85,7 @@ module "auth" {
   resource_group_name  = data.azurerm_resource_group.rg.name
   oauth2_redirect_uris = concat(
     var.oauth2_developer_redirect_uris,
+    var.ci_config != null ? var.ci_config.test_oauth2_callback_urls : [],
     ["https://auth.${var.domain}/oauth2callback", "http://127.0.0.1/oauth2callback"])
 }
 
@@ -130,6 +131,7 @@ module "ci" {
 
   deploy_steps                            = var.ci_config.deploy_steps
   watched_branches                        = var.ci_config.watched_branches
+  test_oauth2_callback_urls               = var.ci_config.test_oauth2_callback_urls
   github_context                          = var.ci_config.github_context
   ci_and_deploy_github_oauth_token        = var.ci_config.ci_and_deploy_github_oauth_token
   ci_test_repo_creator_github_oauth_token = var.ci_config.ci_test_repo_creator_github_oauth_token

--- a/infra/azure/modules/ci/main.tf
+++ b/infra/azure/modules/ci/main.tf
@@ -52,6 +52,7 @@ module "k8s_resources" {
   storage_uri                             = "hail-az://${azurerm_storage_account.ci.name}/${azurerm_storage_container.ci_artifacts.name}"
   deploy_steps                            = var.deploy_steps
   watched_branches                        = var.watched_branches
+  test_oauth2_callback_urls               = var.test_oauth2_callback_urls
   github_context                          = var.github_context
   ci_and_deploy_github_oauth_token        = var.ci_and_deploy_github_oauth_token
   ci_test_repo_creator_github_oauth_token = var.ci_test_repo_creator_github_oauth_token

--- a/infra/azure/modules/ci/variables.tf
+++ b/infra/azure/modules/ci/variables.tf
@@ -29,6 +29,10 @@ variable "watched_branches" {
   type = list(tuple([string, bool, bool]))
 }
 
+variable "test_oauth2_callback_urls" {
+  type = list(string)
+}
+
 variable "deploy_steps" {
   type = list(string)
 }

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -49,12 +49,14 @@ variable "ci_config" {
     ci_and_deploy_github_oauth_token = string
     ci_test_repo_creator_github_oauth_token = string
     watched_branches = list(tuple([string, bool, bool]))
+    test_oauth2_callback_urls = list(string)
     deploy_steps = list(string)
     github_context = string
   })
   default = null
 }
 
+# Deprecated
 variable oauth2_developer_redirect_uris {
   type    = list(string)
   default = []

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -41,6 +41,9 @@ Instructions:
    - https://auth.<domain>/oauth2callback
    - http://127.0.0.1/oauth2callback
 
+  as well as any number of test oauth2callbacks under `https://internal.<domain>/` to be used
+  by test namespaces if you are deploying CI (see ci_config.json below).
+
   Download the client secret as `/tmp/auth_oauth2_client_secret.json`.
 
 - Create `infra/gcp/$GITHUB_ORGANIZATION/global.tfvars` based on the template below, where `$GITHUB_ORGANIZATION` corresponds to the GitHub organization used for your Hail Batch deployment (e.g. [`hail-is`](https://github.com/hail-is/hail)). This avoids collisions between configuration files from different Hail deployments.
@@ -109,6 +112,10 @@ Instructions:
               true,
               false
           ]
+      ],
+      "test_oauth2_callback_urls": [
+        "https://internal.hail.is/alpha/oauth2callback",
+        "https://internal.hail.is/beta/oauth2callback"
       ]
   }
   ```
@@ -228,14 +235,16 @@ You can now install Hail:
 - Create the batch worker VM image. Run:
 
   ```
-  $HAIL/batch/gcp-create-worker-image.sh
+  cd $HAIL/batch
+  ./gcp-create-worker-image.sh
+  cd -
   ```
 
 - Download the global-config to be used by `bootstrap.py`.
 
   ```
-  mkdir /global-config
-  kubectl -n default get secret global-config -o json | jq -r '.data | map_values(@base64d) | to_entries|map("echo -n \(.value) > /global-config/\(.key)") | .[]' | bash
+  download-secret global-config && sudo cp -r contents /global-config
+  download-secret database-server-config && sudo cp -r contents /sql-config
   ```
 
 - Bootstrap the cluster.

--- a/infra/gcp/ci/main.tf
+++ b/infra/gcp/ci/main.tf
@@ -23,10 +23,11 @@ resource "kubernetes_secret" "ci_config" {
   }
 
   data = {
-    storage_uri      = "gs://${module.bucket.name}"
-    deploy_steps     = jsonencode(var.deploy_steps)
-    watched_branches = jsonencode(var.watched_branches)
-    github_context   = var.github_context
+    storage_uri               = "gs://${module.bucket.name}"
+    deploy_steps              = jsonencode(var.deploy_steps)
+    watched_branches          = jsonencode(var.watched_branches)
+    test_oauth2_callback_urls = jsonencode(var.test_oauth2_callback_urls)
+    github_context            = var.github_context
   }
 }
 

--- a/infra/gcp/ci/variables.tf
+++ b/infra/gcp/ci/variables.tf
@@ -24,6 +24,10 @@ variable "deploy_steps" {
   type = list(string)
 }
 
+variable "test_oauth2_callback_urls" {
+  type = list(string)
+}
+
 variable "ci_email" {
   type = string
 }

--- a/infra/gcp/create_bootstrap_vm.sh
+++ b/infra/gcp/create_bootstrap_vm.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+gcloud compute instances create bootstrap-vm \
+    --image=ubuntu-2004-focal-v20220118 \
+    --image-project=ubuntu-os-cloud \
+    --machine-type=n1-standard-8 \
+    --network=default \
+    --boot-disk-size=200GB \
+    --service-account=terraform@${PROJECT}.iam.gserviceaccount.com \
+    --scopes cloud-platform

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -491,7 +491,8 @@ module "test_gsa_secret" {
   project = var.gcp_project
   iam_roles = [
     "compute.instanceAdmin.v1",
-    "iam.serviceAccountUser",
+    "iam.serviceAccountAdmin",
+    "iam.serviceAccountKeyAdmin",
     "logging.viewer",
     "serviceusage.serviceUsageConsumer",
   ]
@@ -679,6 +680,7 @@ module "ci" {
   github_user1_oauth_token = local.ci_config.data["github_user1_oauth_token"]
   watched_branches = jsondecode(local.ci_config.raw).watched_branches
   deploy_steps = jsondecode(local.ci_config.raw).deploy_steps
+  test_oauth2_callback_urls = jsondecode(local.ci_config.raw).test_oauth2_callback_urls
   bucket_location = local.ci_config.data["bucket_location"]
   bucket_storage_class = local.ci_config.data["bucket_storage_class"]
 

--- a/infra/install_bootstrap_dependencies.sh
+++ b/infra/install_bootstrap_dependencies.sh
@@ -8,8 +8,12 @@ umask 022
 echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 
+# For gcloud
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
 sudo apt update
-sudo apt install -y docker.io python3-pip openjdk-8-jdk-headless jq skopeo
+sudo apt install -y docker.io python3-pip openjdk-8-jdk-headless jq skopeo google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
 sudo snap install --classic kubectl
 sudo usermod -a -G docker $USER
 

--- a/infra/k8s/ci/main.tf
+++ b/infra/k8s/ci/main.tf
@@ -4,10 +4,11 @@ resource "kubernetes_secret" "ci_config" {
   }
 
   data = {
-    storage_uri      = var.storage_uri
-    deploy_steps     = jsonencode(var.deploy_steps)
-    watched_branches = jsonencode(var.watched_branches)
-    github_context   = var.github_context
+    storage_uri               = var.storage_uri
+    deploy_steps              = jsonencode(var.deploy_steps)
+    watched_branches          = jsonencode(var.watched_branches)
+    test_oauth2_callback_urls = jsonencode(var.test_oauth2_callback_urls)
+    github_context            = var.github_context
   }
 }
 

--- a/infra/k8s/ci/variables.tf
+++ b/infra/k8s/ci/variables.tf
@@ -14,6 +14,10 @@ variable "deploy_steps" {
   type = list(string)
 }
 
+variable "test_oauth2_callback_urls" {
+  type = list(string)
+}
+
 variable "storage_uri" {
   type = string
 }


### PR DESCRIPTION
The only noticeable change after this PR is that devs will be able to access `internal.hail.is/<PR-namespace>/<service>` while it is running and see jobs submitted by tests. Well, that and you can add another developer to a dev namespace as a developer without destroying the developer's existing namespace. Subsequent PRs will introduce on-demand dev namespaces and the ability to suspend the deletion of a test namespace. New context added to the CI pipeline is treated as optional to be backward compatible with the current CI. So devs won't be able to log in to test namespaces on *this* PR but will be able to once this PR becomes main.

### What has changed
- All developers from default are now added to all test namespaces using the `add_users` build.yaml step and removed at the end of the PR run through the `delete_users` step. These use the normal create and delete API instead of copying the user's gsa from the production namespace. This relies on / tests that the delete user endpoint is properly deleting cloud identities when the users are deleted (previously broken in GCP but fixed in this PR.
- The developer role no longer implicitly deletes and recreates a corresponding namespace. I wanted adding developers to test namespaces not to have side-effects that leaked out of the namespace. A follow-up PR will incorporate the ability for a developer to request an on-demand dev namespace, which should be made a lot easier after these changes. I think this also means that we can remove some permissions from the auth K8s ServiceAccount since it no longer needs the ability to create and delete namespaces.
- A fixed-but-sufficient number of oauth2 callbacks are hard-coded into the oauth2 secret from GCP/azure and then allocated to a given namespace. This is fairly self-contained, all that needs to happen is to tell `auth` what callback to use and rewrite those callback urls in gateway to route back to the appropriate auth. This is done only for test namespaces, production still just uses `auth.hail.is/oauth2callback`. This gets around a long-standing limitation of Google oauth2 clients where there is no programmatic way to change the oauth2 callbacks.

### What has stayed the same
- The lifecycle of dev and test namespaces has not changed (future PR).
- The semantics of a dev deploy has not changed (other than a different oauth2 callback which the user will not notice)


### Testing
I've tested this branch in my own google project both by deploying main and updating to this branch and by deploying this branch from the beginning. The CI in my project ran both some dev deploys and a test batch because I PR'd this branch against my fork. Tested that I could access both my dev namespace and the test namespace in that deployment. I manually verified that dev cloud identities in the test namespace were deleted after the namespace was cleaned up. I dev deployed this branch in Azure and made sure that create-user and delete-user created and deleted an SP.

cc: @jigold I know you have a lot on your plate with the migrations so no action required but cc'ing you here in case you have thoughts or concerns about this.