### PR TITLE
[batch] Ignore device not found errors in resource usage code

### DIFF
--- a/batch/batch/resource_usage.py
+++ b/batch/batch/resource_usage.py
@@ -121,9 +121,15 @@ class ResourceUsageMonitor:
 
     def memory_usage_bytes(self) -> Optional[int]:
         usage_file = f'/sys/fs/cgroup/memory/{self.container_name}/memory.usage_in_bytes'
-        if os.path.exists(usage_file):
-            with open(usage_file, 'r', encoding='utf-8') as f:
-                return int(f.read().rstrip())
+        try:
+            if os.path.exists(usage_file):
+                with open(usage_file, 'r', encoding='utf-8') as f:
+                    return int(f.read().rstrip())
+        except OSError as e:
+            # OSError: [Errno 19] No such device
+            if e.errno == 19:
+                return None
+            raise
         return None
 
     def overlay_storage_usage_bytes(self) -> int:


### PR DESCRIPTION
Removes this error from the logs:

```
Traceback (most recent call last):
--
File "/usr/local/lib/python3.7/dist-packages/batch/resource_usage.py", line 220, in periodically_measure
await self.measure()
File "/usr/local/lib/python3.7/dist-packages/batch/resource_usage.py", line 187, in measure
memory_usage_bytes = self.memory_usage_bytes()
File "/usr/local/lib/python3.7/dist-packages/batch/resource_usage.py", line 126, in memory_usage_bytes
return int(f.read().rstrip())
OSError: [Errno 19] No such device
```