### PR TITLE
[db] Add namespace to migrations environment

### DIFF
--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -265,6 +265,7 @@ kubectl -n {namespace} get -o json secret {shq(admin_secret_name)}
     os.environ['HAIL_DATABASE_CONFIG_FILE'] = '/sql-config.json'
     os.environ['HAIL_SCOPE'] = scope
     os.environ['HAIL_CLOUD'] = cloud
+    os.environ['HAIL_NAMESPACE'] = namespace
 
     db = Database()
     await db.async_init()


### PR DESCRIPTION
This is part of a minor bug-fix for how CI tracks active namespaces in development environments. #12093 added a table in CI's database that tracks the namespaces that CI is currently aware exists and that it manages. Non-production CIs don't really use this table (dev CIs don't update gateway routing or anything), but it's useful in development to see that CI is properly updating its database tables as it would in prod. In #12093, the migration that adds the `active_namespaces` table explicitly adds entries for the `default` namespace. However, I'm now realizing that this is a mistake, because a CI in the `dgoldste` namespace shouldn't have an entry for `default`, it should instead have an entry for `dgoldste`. That migration should have been parametrized by the  namespace the migration is happening in. To do this, I need to expose the current namespace to the migration scripts, hence this PR.

This is unfortunately a change to CI that needs to be deployed before it can be used by migrations. If this seems good then I'll alert the australians that they should fully deploy this PR prior to the following ones.