### PR TITLE
[ci] Fix default namespace record for dev namespaces

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1830,6 +1830,9 @@ steps:
       - name: active-namespaces
         script: /io/sql/active-namespaces.sql
         online: true
+      - name: fix-default-namespace-record
+        script: /io/sql/fix-default-namespace.py
+        online: true
     inputs:
       - from: /repo/ci/sql
         to: /io/sql

--- a/ci/sql/fix-default-namespace.py
+++ b/ci/sql/fix-default-namespace.py
@@ -1,0 +1,28 @@
+import os
+import asyncio
+from gear import Database
+
+
+async def main():
+    default_namespace = os.environ['HAIL_NAMESPACE']
+
+    # This fix is only necessary for dev/test namespaces
+    if default_namespace == 'default':
+        return
+
+    db = Database()
+    await db.async_init()
+
+    await db.just_execute(
+        '''
+DELETE FROM `active_namespaces` WHERE `namespace` = 'default';
+INSERT INTO `active_namespaces` (`namespace`) VALUES (%s);
+INSERT INTO `deployed_services` (`namespace`, `service`) VALUES
+(%s, 'auth'), (%s, 'batch'), (%s, 'batch-driver'), (%s, 'ci');
+''',
+        (default_namespace,
+         default_namespace, default_namespace, default_namespace, default_namespace),
+    )
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/ci/sql/fix-default-namespace.py
+++ b/ci/sql/fix-default-namespace.py
@@ -23,6 +23,7 @@ INSERT INTO `deployed_services` (`namespace`, `service`) VALUES
         (default_namespace,
          default_namespace, default_namespace, default_namespace, default_namespace),
     )
+    await db.async_close()
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())


### PR DESCRIPTION
Stacked on #12755, this shouldn't have an impact on production, but is just meant to replace `default` in test CI databases with the actual name of the namespace that the CI is in. Should mimic [the prior migration](https://github.com/hail-is/hail/blob/main/ci/sql/active-namespaces.sql) just parametrized by namespace.