### PR TITLE
[batch] Mitigate possible corrupt containerd image cache

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -694,6 +694,8 @@ def is_transient_error(e):
             return False
         if e.status == 500 and 'Permission "artifactregistry.repositories.downloadArtifacts" denied on resource' in e.message:
             return False
+        if e.status == 500 and 'denied: retrieving permissions failed' in e.message:
+            return False
         return e.status in RETRYABLE_HTTP_STATUS_CODES
     if isinstance(e, TransientError):
         return True


### PR DESCRIPTION
This PR tries to address the error we saw last Friday on Azure where there was a stuck worker that could not pull ubuntu:20.04 from Dockerhub. The error message in the worker logs was

```
DockerError(500, 'Head \"https://haildev.azurecr.io/v2/ubuntu/manifests/20.04\": denied: retrieving permissions failed')
```

I looked at the system logs and the actual error message was this:

```
Mar 03 16:56:12 batch-worker-default-standard-nj0qy dockerd[4066]: time="2023-03-03T16:56:12.112691249Z" level=info msg="Attempting next endpoint for pull after error: Head \"https://haildev.azurecr.io/v2/ubuntu/manifests/20.04\": denied: retrieving permissions failed"
```

Higher up in the logs was:

```
Mar 03 16:54:50 batch-worker-default-standard-nj0qy dockerd[4066]: time="2023-03-03T16:54:50.520878176Z" level=debug msg="Fetching manifest from remote" digest="sha256:9fa30fcef427e5e88c76bc41ad37b7cc573e1d79cecb23035e413c4be6e476ab" error="<nil>" remote="docker.io/library/ubuntu:20.04"
Mar 03 16:54:50 batch-worker-default-standard-nj0qy dockerd[4066]: time="2023-03-03T16:54:50.762789745Z" level=debug msg="Fetching manifest from remote" digest="sha256:9fa30fcef427e5e88c76bc41ad37b7cc573e1d79cecb23035e413c4be6e476ab" error="ref moby/1/index-sha256:9fa30fcef427e5e88c76bc41ad37b7cc573e1d79cecb23035e413c4be6e476ab locked: unavailable" remote="docker.io/library/ubuntu:20.04"
```


My working hypothesis is described in detail here that the image cache with locks got corrupted with the simultaneous pulls: https://hail.zulipchat.com/#narrow/stream/300487-Hail-Batch-Dev/topic/Azure.20CI.20appears.20hung/near/339452619

To mitigate this, when we get the error "denied: retrieving permissions failed", we try and delete the image and then try pulling again once more before erroring gracefully. At least for now, this errors the user's job, but that's better than the status quo where the job is stuck.