### PR TITLE
[batch] Drop remaining attempt_resources infra for deduping resource ids

### DIFF
--- a/batch/sql/cleanup-attempt-resources-deduped-ids.sql
+++ b/batch/sql/cleanup-attempt-resources-deduped-ids.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS attempt_resources_before_insert;
+
+ALTER TABLE attempt_resources DROP COLUMN deduped_resource_id, ALGORITHM=INPLACE, LOCK=NONE;

--- a/batch/sql/cleanup-deduped-resource-ids-migration.sql
+++ b/batch/sql/cleanup-deduped-resource-ids-migration.sql
@@ -1,0 +1,210 @@
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_after_update $$
+CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  DECLARE job_cores_mcpu INT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_billing_date DATE;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SET msec_diff_rollup = (GREATEST(COALESCE(NEW.rollup_time - NEW.start_time, 0), 0) -
+                          GREATEST(COALESCE(OLD.rollup_time - OLD.start_time, 0), 0));
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    SELECT batch_id,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    SELECT batch_id,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    SELECT batch_id, job_id,
+      resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    SELECT batch_id, job_id,
+      resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      billing_project,
+      `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      billing_project,
+      `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_rollup_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE cur_user VARCHAR(100);
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_billing_date DATE;
+
+  SELECT billing_project, user INTO cur_billing_project, cur_user
+  FROM batches WHERE id = NEW.batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT start_time, rollup_time INTO cur_start_time, cur_rollup_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff_rollup = GREATEST(COALESCE(cur_rollup_time - cur_start_time, 0), 0);
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+  END IF;
+END $$
+
+DELIMITER ;
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_after_update;
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_after_update;
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_after_update;
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_after_update;
+
+ALTER TABLE aggregated_billing_project_user_resources_v2 DROP COLUMN migrated, ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE aggregated_billing_project_user_resources_by_date_v2 DROP COLUMN migrated, ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE aggregated_batch_resources_v2 DROP COLUMN migrated, ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE aggregated_job_resources_v2 DROP COLUMN migrated, ALGORITHM=INPLACE, LOCK=NONE;
+
+-- The attempt_resources_before_insert trigger requires that resource_id and deduped_resource_id are present
+-- At this point, they should be writing the exact same value. So a column swap is fine, but the new name "deduped_resource_id"
+-- has to stay despite being the original non-deduped resource id column. It will be deleted once the trigger that uses the
+-- deduped_resource_id is dropped
+ALTER TABLE attempt_resources RENAME COLUMN resource_id TO deduped_resource_id,
+                              RENAME COLUMN deduped_resource_id TO resource_id;
+
+ALTER TABLE attempt_resources DROP PRIMARY KEY,
+                              MODIFY COLUMN resource_id INT NOT NULL,
+                              ADD PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource_id`),
+                              ALGORITHM=INPLACE, LOCK=NONE;
+
+-- Even though we did not explicitly delete the old foreign key constraint, it is now pointing at "deduped_resource_id"
+-- instead of the new "resource_id" column (which was the original deduped_resource_id)
+SET foreign_key_checks = 0;
+ALTER TABLE attempt_resources ADD FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE, ALGORITHM=INPLACE;
+SET foreign_key_checks = 1;

--- a/batch/sql/dedup_resources.py
+++ b/batch/sql/dedup_resources.py
@@ -1,0 +1,425 @@
+import asyncio
+import functools
+import os
+import random
+import time
+from typing import List, Optional, Tuple
+
+from gear import Database, transaction
+from hailtop.utils import bounded_gather
+
+
+MYSQL_CONFIG_FILE = os.environ.get('MYSQL_CONFIG_FILE')
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+
+def offsets_to_where_statement(table, primary_key, start_offset, end_offset):
+    assert start_offset != end_offset, str((start_offset, end_offset))
+
+    if start_offset is None:
+        start_offset = [None] * len(primary_key)
+    if end_offset is None:
+        end_offset = [None] * len(primary_key)
+
+    def build_statement(offset, is_start):
+        where_statement = []
+        query_args = []
+        for i, key in enumerate(primary_key):
+            conds = [f'{table}.{primary_key[prev_i]} = %s' for prev_i in range(i)]
+            query_args += offset[:i]
+            if is_start:
+                if i == len(primary_key) - 1:
+                    conds.append(f'{table}.{primary_key[i]} >= %s')
+                    query_args.append(offset[i])
+                else:
+                    conds.append(f'{table}.{primary_key[i]} > %s')
+                    query_args.append(offset[i])
+            else:
+                conds.append(f'{table}.{primary_key[i]} < %s')
+                query_args.append(offset[i])
+            cond = '(' + ' AND '.join(conds) + ')'
+            where_statement.append(cond)
+        return where_statement, query_args
+
+    if None in start_offset:
+        assert end_offset[0] is not None
+        where_statements, query_args = build_statement(end_offset, False)
+        where_statement = f'WHERE {" OR ".join(where_statements)}'
+    elif None in end_offset:
+        assert start_offset[0] is not None
+        where_statements, query_args = build_statement(start_offset, True)
+        where_statement = f'WHERE {" OR ".join(where_statements)}'
+    else:
+        start_where_statements, start_query_args = build_statement(start_offset, True)
+        end_where_statements, end_query_args = build_statement(end_offset, False)
+        where_statement = f'WHERE ({" OR ".join(start_where_statements)}) AND ({" OR ".join(end_where_statements)})'
+        query_args = start_query_args + end_query_args
+
+    return where_statement, query_args
+
+
+async def process_chunk(counter, db, query, query_args, start, end, quiet=True):
+    start_time = time.time()
+
+    await db.just_execute(query, query_args)
+
+    if not quiet and counter.n % 100 == 0:
+        print(f'processed chunk ({start}, {end}) in {time.time() - start_time}s')
+
+    counter.n += 1
+    if counter.n % 500 == 0:
+        print(f'processed {counter.n} complete chunks')
+
+
+async def process_chunk_attempt_resources(counter, db, start, end, quiet=True):
+    where_statement, query_args = offsets_to_where_statement('attempt_resources',
+                                                             ['batch_id', 'job_id', 'attempt_id', 'resource_id'],
+                                                             start,
+                                                             end)
+    query = f'''
+UPDATE attempt_resources
+LEFT JOIN resources ON attempt_resources.resource_id = resources.resource_id
+SET attempt_resources.deduped_resource_id = resources.deduped_resource_id
+{where_statement}
+'''
+
+    await process_chunk(counter, db, query, query_args, start, end, quiet)
+
+
+async def process_chunk_aggregated_billing_project_user_resources(counter, db, start, end, quiet=True):
+    where_statement, query_args = offsets_to_where_statement('aggregated_billing_project_user_resources_v2',
+                                                             ['billing_project', 'user', 'resource_id', 'token'],
+                                                             start,
+                                                             end)
+    query = f'''
+UPDATE aggregated_billing_project_user_resources_v2
+SET migrated = 1
+{where_statement}
+'''
+
+    await process_chunk(counter, db, query, query_args, start, end, quiet)
+
+
+async def process_chunk_aggregated_billing_project_user_resources_by_date(counter, db, start, end, quiet=True):
+    where_statement, query_args = offsets_to_where_statement('aggregated_billing_project_user_resources_by_date_v2',
+                                                             ['billing_date', 'billing_project', 'user', 'resource_id', 'token'],
+                                                             start,
+                                                             end)
+    query = f'''
+UPDATE aggregated_billing_project_user_resources_by_date_v2
+SET migrated = 1
+{where_statement}
+'''
+
+    await process_chunk(counter, db, query, query_args, start, end, quiet)
+
+
+async def process_chunk_aggregated_batch_resources(counter, db, start, end, quiet=True):
+    where_statement, query_args = offsets_to_where_statement('aggregated_batch_resources_v2',
+                                                             ['batch_id', 'resource_id', 'token'],
+                                                             start,
+                                                             end)
+    query = f'''
+UPDATE aggregated_batch_resources_v2
+SET migrated = 1
+{where_statement}
+'''
+
+    await process_chunk(counter, db, query, query_args, start, end, quiet)
+
+
+async def process_chunk_aggregated_job_resources(counter, db, start, end, quiet=True):
+    where_statement, query_args = offsets_to_where_statement('aggregated_job_resources_v2',
+                                                             ['batch_id', 'job_id' ,'resource_id'],
+                                                             start,
+                                                             end)
+    query = f'''
+UPDATE aggregated_job_resources_v2
+SET migrated = 1
+{where_statement}
+'''
+
+    await process_chunk(counter, db, query, query_args, start, end, quiet)
+
+
+async def audit_changes(db):
+    job_audit_start = time.time()
+    print('starting auditing job records')
+
+    bad_job_records = db.select_and_fetchall(
+        '''
+SELECT old.batch_id, old.job_id, old.cost, new.cost, ABS(new.cost - old.cost) AS cost_diff
+FROM (
+  SELECT batch_id, job_id, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT batch_id, job_id, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_job_resources_v2
+    GROUP BY batch_id, job_id, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY batch_id, job_id
+) AS old
+LEFT JOIN (
+  SELECT batch_id, job_id, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT batch_id, job_id, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_job_resources_v3
+    GROUP BY batch_id, job_id, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY batch_id, job_id
+) AS new ON old.batch_id = new.batch_id AND old.job_id = new.job_id
+WHERE ABS(new.cost - old.cost) >= 0.00001
+LIMIT 100;
+''')
+
+    bad_job_records = [record async for record in bad_job_records]
+    failing_job_ids = []
+    for record in bad_job_records:
+        print(f'found bad job record {record}')
+        failing_job_ids.append((record['batch_id'], record['job_id']))
+
+    print(f'finished auditing job records in {time.time() - job_audit_start}s')
+
+    batch_audit_start = time.time()
+    print('starting auditing batch records')
+
+    bad_batch_records = db.select_and_fetchall(
+        '''
+SELECT old.batch_id, old.cost, new.cost, ABS(new.cost - old.cost) AS cost_diff
+FROM (
+  SELECT batch_id, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT batch_id, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_batch_resources_v2
+    GROUP BY batch_id, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY batch_id
+) AS old
+LEFT JOIN (
+  SELECT batch_id, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT batch_id, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_batch_resources_v3
+    GROUP BY batch_id, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY batch_id
+) AS new ON old.batch_id = new.batch_id
+WHERE ABS(new.cost - old.cost) >= 0.00001
+LIMIT 100;
+''')
+
+    bad_batch_records = [record async for record in bad_batch_records]
+    failing_batch_ids = []
+    for record in bad_batch_records:
+        print(f'found bad batch record {record}')
+        failing_batch_ids.append(record['batch_id'])
+
+    print(f'finished auditing batch records in {time.time() - batch_audit_start}s')
+
+    bp_user_audit_start = time.time()
+    print('starting auditing billing project user records')
+
+    bad_bp_user_records = db.select_and_fetchall(
+        '''
+SELECT old.billing_project, old.user, old.cost, new.cost, ABS(new.cost - old.cost) AS cost_diff
+FROM (
+  SELECT billing_project, user, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT billing_project, user, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_billing_project_user_resources_by_date_v2
+    GROUP BY billing_project, user, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY billing_project, user
+) AS old
+LEFT JOIN (
+  SELECT billing_project, user, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT billing_project, user, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_billing_project_user_resources_by_date_v3
+    GROUP BY billing_project, user, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY billing_project, user
+) AS new ON old.billing_project = new.billing_project AND old.user = new.user
+WHERE ABS(new.cost - old.cost) >= 0.00001
+LIMIT 100;
+''')
+
+    bad_bp_user_records = [record async for record in bad_bp_user_records]
+    failing_bp_users = []
+    for record in bad_bp_user_records:
+        print(f'found bad bp user record {record}')
+        failing_bp_users.append((record['billing_project'], record['user']))
+
+    print(f'finished auditing bp user records in {time.time() - bp_user_audit_start}s')
+
+    bp_user_by_date_audit_start = time.time()
+    print('starting auditing bp user by date records')
+
+    bad_bp_user_by_date_records = db.select_and_fetchall(
+        '''
+SELECT old.billing_project, old.user, old.cost, new.cost, ABS(new.cost - old.cost) AS cost_diff
+FROM (
+  SELECT billing_date, billing_project, user, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT billing_date, billing_project, user, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_billing_project_user_resources_by_date_v2
+    GROUP BY billing_date, billing_project, user, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY billing_date, billing_project, user
+) AS old
+LEFT JOIN (
+  SELECT billing_date, billing_project, user, CAST(COALESCE(SUM(`usage` * rate), 0) AS SIGNED) AS cost
+  FROM (
+    SELECT billing_date, billing_project, user, resource_id, COALESCE(SUM(`usage`), 0) AS `usage`
+    FROM aggregated_billing_project_user_resources_by_date_v3
+    GROUP BY billing_date, billing_project, user, resource_id
+  ) AS usage_t
+  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
+  GROUP BY billing_date, billing_project, user
+) AS new ON old.billing_project = new.billing_project AND old.user = new.user
+WHERE ABS(new.cost - old.cost) >= 0.00001
+LIMIT 100;
+''')
+
+    bad_bp_user_by_date_records = [record async for record in bad_bp_user_by_date_records]
+    failing_bp_users_by_date = []
+    for record in bad_bp_user_by_date_records:
+        print(f'found bad bp user by date record {record}')
+        failing_bp_users_by_date.append((record['billing_date'], record['billing_project'], record['user']))
+
+    print(f'finished auditing bp user by date records in {time.time() - bp_user_by_date_audit_start}s')
+
+    if failing_job_ids or failing_batch_ids or failing_bp_users or failing_bp_users_by_date:
+        raise Exception(f'errors found in audit')
+
+
+async def find_chunk_offsets(db, size, table, primary_key):
+    @transaction(db)
+    async def _find_chunks(tx) -> List[Optional[Tuple[int, int, str]]]:
+        start_time = time.time()
+
+        await tx.just_execute('SET @rank=0;')
+
+        primary_key_str = ', '.join(primary_key)
+        primary_key_t_str = ', '.join(f't.{key}' for key in primary_key)
+
+        query = f'''
+SELECT {primary_key_t_str} FROM (
+  SELECT {primary_key_str}
+  FROM {table}
+  ORDER BY {primary_key_str}
+) AS t
+WHERE MOD((@rank := @rank + 1), %s) = 0;
+'''
+
+        offsets = tx.execute_and_fetchall(query, (size,))
+        offsets = [tuple(offset[pk] for pk in primary_key) async for offset in offsets]
+        offsets.append(None)
+
+        print(f'found chunk offsets in {round(time.time() - start_time, 4)}s')
+        return offsets
+
+    return await _find_chunks()
+
+
+async def run_migration(db, chunk_size, table, primary_key, processor_f):
+    populate_start_time = time.time()
+
+    chunk_counter = Counter()
+    chunk_offsets = [None]
+    for offset in await find_chunk_offsets(db, chunk_size, table, primary_key):
+        chunk_offsets.append(offset)
+
+    chunk_offsets = list(zip(chunk_offsets[:-1], chunk_offsets[1:]))
+
+    if chunk_offsets != [(None, None)]:
+        print(f'found {len(chunk_offsets)} chunks to process for table {table} with primary key {primary_key}')
+
+        random.shuffle(chunk_offsets)
+
+        burn_in_start = time.time()
+        n_burn_in_chunks = 10000
+
+        burn_in_chunk_offsets = chunk_offsets[:n_burn_in_chunks]
+        chunk_offsets = chunk_offsets[n_burn_in_chunks:]
+
+        for start_offset, end_offset in burn_in_chunk_offsets:
+            await processor_f(chunk_counter, db, start_offset, end_offset, quiet=False)
+
+        print(f'finished burn-in in {time.time() - burn_in_start}s for table {table} with primary key {primary_key}')
+
+        parallel_insert_start = time.time()
+
+        # 4 core database, parallelism = 10 maxes out CPU
+        await bounded_gather(
+            *[functools.partial(processor_f, chunk_counter, db, start_offset, end_offset, quiet=False)
+              for start_offset, end_offset in chunk_offsets],
+            parallelism=10
+        )
+        print(
+            f'took {time.time() - parallel_insert_start}s to insert the remaining complete records in parallel ({(chunk_size * len(chunk_offsets)) / (time.time() - parallel_insert_start)}) attempts / sec')
+
+    print(f'finished populating records in {time.time() - populate_start_time}s')
+
+
+async def main(chunk_size=100):
+    db = Database()
+    await db.async_init(config_file=MYSQL_CONFIG_FILE)
+
+    start_time = time.time()
+
+    try:
+        migration_start_time = time.time()
+
+        await run_migration(db,
+                            chunk_size,
+                            'attempt_resources',
+                            ['batch_id', 'job_id', 'attempt_id', 'resource_id'],
+                            process_chunk_attempt_resources)
+
+        await run_migration(db,
+                            chunk_size,
+                            'aggregated_billing_project_user_resources_v2',
+                            ['billing_project', 'user', 'resource_id', 'token'],
+                            process_chunk_aggregated_billing_project_user_resources)
+
+        await run_migration(db,
+                            chunk_size,
+                            'aggregated_billing_project_user_resources_by_date_v2',
+                            ['billing_date', 'billing_project', 'user', 'resource_id', 'token'],
+                            process_chunk_aggregated_billing_project_user_resources_by_date)
+
+        await run_migration(db,
+                            chunk_size,
+                            'aggregated_batch_resources_v2',
+                            ['batch_id', 'resource_id', 'token'],
+                            process_chunk_aggregated_batch_resources)
+
+        await run_migration(db,
+                            chunk_size,
+                            'aggregated_job_resources_v2',
+                            ['batch_id', 'job_id', 'resource_id'],
+                            process_chunk_aggregated_job_resources)
+
+        print(f'finished populating records in {time.time() - migration_start_time}s')
+
+        audit_start_time = time.time()
+        await audit_changes(db)
+        print(f'finished auditing changes in {time.time() - audit_start_time}')
+    finally:
+        print(f'finished migration in {time.time() - start_time}s')
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -21,7 +21,15 @@ DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
 DROP TRIGGER IF EXISTS jobs_after_update;
 DROP TRIGGER IF EXISTS attempt_resources_after_insert;
-DROP TRIGGER IF EXISTS attempt_resources_before_insert;  # deprecated
+DROP TRIGGER IF EXISTS attempt_resources_before_insert;
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_before_insert;
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_after_update;
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_after_update;
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_after_update;
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_after_update;
 
 DROP TABLE IF EXISTS `aggregated_job_resources_by_date`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_by_date`;
@@ -31,11 +39,15 @@ DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v2`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v3`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v2`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v3`;
 DROP TABLE IF EXISTS `aggregated_batch_resources`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_v2`;
+DROP TABLE IF EXISTS `aggregated_batch_resources_v3`;
 DROP TABLE IF EXISTS `aggregated_job_resources`;
 DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
+DROP TABLE IF EXISTS `aggregated_job_resources_v3`;
 DROP TABLE IF EXISTS `attempt_resources`;
 DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources`;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -549,7 +549,7 @@ BEGIN
       aggregated_billing_project_user_resources_v2.user = batches.user AND
       aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
@@ -571,7 +571,7 @@ BEGIN
       aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_batch_resources_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
@@ -592,7 +592,7 @@ BEGIN
       aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
       aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_job_resources_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
@@ -622,7 +622,7 @@ BEGIN
       aggregated_billing_project_user_resources_by_date_v2.user = batches.user AND
       aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_by_date_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v3.`usage` + msec_diff_rollup * quantity;
   END IF;
 END $$

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -349,6 +349,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v2` (
   `resource_id` INT NOT NULL,
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
+  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -363,6 +364,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v2
   `resource_id` INT NOT NULL,
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
+  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`billing_date`, `billing_project`, `user`, `resource_id`, `token`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -375,6 +377,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v2` (
   `resource_id` INT NOT NULL,
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
+  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`batch_id`, `resource_id`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -382,6 +385,53 @@ CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v2` (
 
 DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
 CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v2` (
+  `batch_id` BIGINT NOT NULL,
+  `job_id` INT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  `migrated` BOOLEAN DEFAULT FALSE,
+  PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v3` (
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_v3 ON `aggregated_billing_project_user_resources_v3` (`user`);
+
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v3` (
+  `billing_date` DATE NOT NULL,
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_date`, `billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_by_date_v3_user ON `aggregated_billing_project_user_resources_by_date_v3` (`billing_date`, `user`);
+
+CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v3` (
+  `batch_id` BIGINT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `resource_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v3` (
   `batch_id` BIGINT NOT NULL,
   `job_id` INT NOT NULL,
   `resource_id` INT NOT NULL,
@@ -398,6 +448,7 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
   `attempt_id` VARCHAR(40) NOT NULL,
   `quantity` BIGINT NOT NULL,
   `resource_id` INT NOT NULL,
+  `deduped_resource_id` INT DEFAULT NULL,
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
@@ -486,6 +537,22 @@ BEGIN
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
+    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    INNER JOIN aggregated_billing_project_user_resources_v2 ON
+      aggregated_billing_project_user_resources_v2.billing_project = batches.billing_project AND
+      aggregated_billing_project_user_resources_v2.user = batches.user AND
+      aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_billing_project_user_resources_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
       resource_id,
@@ -495,12 +562,40 @@ BEGIN
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
+    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    SELECT attempt_resources.batch_id,
+      resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN aggregated_batch_resources_v2 ON
+      aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
+      aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_batch_resources_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
       resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+      resources.deduped_resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN aggregated_job_resources_v2 ON
+      aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
+      aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
+      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_job_resources_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
@@ -513,6 +608,25 @@ BEGIN
     FROM attempt_resources
     JOIN batches ON batches.id = attempt_resources.batch_id
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      batches.billing_project,
+      `user`,
+      resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    JOIN aggregated_billing_project_user_resources_by_date_v2 ON
+      aggregated_billing_project_user_resources_by_date_v2.billing_date = cur_billing_date AND
+      aggregated_billing_project_user_resources_by_date_v2.billing_project = batches.billing_project AND
+      aggregated_billing_project_user_resources_by_date_v2.user = batches.user AND
+      aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_billing_project_user_resources_by_date_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
   END IF;
 END $$
@@ -686,6 +800,13 @@ BEGIN
   END IF;
 END $$
 
+DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
+CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  SET NEW.deduped_resource_id = NEW.resource_id;
+END $$
+
 DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
 CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
 FOR EACH ROW
@@ -699,6 +820,10 @@ BEGIN
   DECLARE rand_token INT;
   DECLARE cur_resource VARCHAR(100);
   DECLARE cur_billing_date DATE;
+  DECLARE bp_user_resources_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE bp_user_resources_by_date_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE batch_resources_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE job_resources_migrated BOOLEAN DEFAULT FALSE;
 
   SELECT billing_project, user INTO cur_billing_project, cur_user
   FROM batches WHERE id = NEW.batch_id;
@@ -706,7 +831,7 @@ BEGIN
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
-  SELECT resource INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+  SELECT deduped_resource_id INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
   SELECT start_time, rollup_time INTO cur_start_time, cur_rollup_time
   FROM attempts
@@ -723,20 +848,177 @@ BEGIN
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
+    SELECT migrated INTO bp_user_resources_migrated
+    FROM aggregated_billing_project_user_resources_v2
+    WHERE billing_project = cur_billing_project AND user = cur_user AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF bp_user_resources_migrated THEN
+      INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_project, cur_user, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated INTO batch_resources_migrated
+    FROM aggregated_batch_resources_v2
+    WHERE batch_id = NEW.batch_id AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF batch_resources_migrated THEN
+      INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+      VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
+    SELECT migrated INTO job_resources_migrated
+    FROM aggregated_job_resources_v2
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF job_resources_migrated THEN
+      INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+      VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
     VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated INTO bp_user_resources_by_date_migrated
+    FROM aggregated_billing_project_user_resources_by_date_v2
+    WHERE billing_date = cur_billing_date AND billing_project = cur_billing_project AND user = cur_user
+      AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF bp_user_resources_by_date_migrated THEN
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_date, cur_billing_project, cur_user, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_bp_user_resources_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_before_insert $$
+CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_by_date_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_batch_resources_v2_before_insert BEFORE INSERT on aggregated_batch_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_job_resources_v2_before_insert BEFORE INSERT on aggregated_job_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_after_update $$
+CREATE TRIGGER aggregated_bp_user_resources_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    VALUES (NEW.billing_project, NEW.user, new_resource_id, rand_token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_after_update $$
+CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_by_date_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    VALUES (NEW.billing_date, NEW.billing_project, NEW.user, new_resource_id, rand_token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_after_update $$
+CREATE TRIGGER aggregated_batch_resources_v2_after_update AFTER UPDATE ON aggregated_batch_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, new_resource_id, rand_token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_after_update $$
+CREATE TRIGGER aggregated_job_resources_v2_after_update AFTER UPDATE ON aggregated_job_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, new_resource_id, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
   END IF;
 END $$
 

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -553,7 +553,7 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
-    SELECT attempt_resources.batch_id,
+    SELECT batch_id,
       resource_id,
       rand_token,
       msec_diff_rollup * quantity
@@ -575,7 +575,7 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
-    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+    SELECT batch_id, job_id,
       resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -590,8 +590,7 @@ BEGIN
     JOIN aggregated_job_resources_v2 ON
       aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
-      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
-      aggregated_job_resources_v2.token = rand_token
+      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id
     WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
 

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -538,12 +538,11 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
-    SELECT billing_project, `user`,
-      resources.deduped_resource_id,
+    SELECT batches.billing_project, `user`,
+      resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
-    JOIN resources ON resources.resource_id = attempt_resources.resource_id
     JOIN batches ON batches.id = attempt_resources.batch_id
     INNER JOIN aggregated_billing_project_user_resources_v2 ON
       aggregated_billing_project_user_resources_v2.billing_project = batches.billing_project AND
@@ -564,11 +563,10 @@ BEGIN
 
     INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
-      resources.deduped_resource_id,
+      resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
-    JOIN resources ON resources.resource_id = attempt_resources.resource_id
     JOIN aggregated_batch_resources_v2 ON
       aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
@@ -586,10 +584,9 @@ BEGIN
 
     INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
-      resources.deduped_resource_id,
+      resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
-    JOIN resources ON resources.resource_id = attempt_resources.resource_id
     JOIN aggregated_job_resources_v2 ON
       aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
@@ -614,11 +611,10 @@ BEGIN
     SELECT cur_billing_date,
       batches.billing_project,
       `user`,
-      resources.deduped_resource_id,
+      resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
-    JOIN resources ON resources.resource_id = attempt_resources.resource_id
     JOIN batches ON batches.id = attempt_resources.batch_id
     JOIN aggregated_billing_project_user_resources_by_date_v2 ON
       aggregated_billing_project_user_resources_by_date_v2.billing_date = cur_billing_date AND
@@ -818,7 +814,6 @@ BEGIN
   DECLARE msec_diff_rollup BIGINT;
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
-  DECLARE cur_resource VARCHAR(100);
   DECLARE cur_billing_date DATE;
   DECLARE bp_user_resources_migrated BOOLEAN DEFAULT FALSE;
   DECLARE bp_user_resources_by_date_migrated BOOLEAN DEFAULT FALSE;
@@ -830,8 +825,6 @@ BEGIN
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
-
-  SELECT deduped_resource_id INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
 
   SELECT start_time, rollup_time INTO cur_start_time, cur_rollup_time
   FROM attempts
@@ -854,7 +847,7 @@ BEGIN
 
     IF bp_user_resources_migrated THEN
       INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
-      VALUES (cur_billing_project, cur_user, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
     END IF;
@@ -870,7 +863,7 @@ BEGIN
 
     IF batch_resources_migrated THEN
       INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
-      VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
     END IF;
@@ -886,7 +879,7 @@ BEGIN
 
     IF job_resources_migrated THEN
       INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
-      VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff_rollup)
+      VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
     END IF;
@@ -903,7 +896,7 @@ BEGIN
 
     IF bp_user_resources_by_date_migrated THEN
       INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
-      VALUES (cur_billing_date, cur_billing_project, cur_user, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
     END IF;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -550,7 +550,7 @@ BEGIN
       aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
@@ -572,7 +572,7 @@ BEGIN
       aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_batch_resources_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
@@ -593,7 +593,7 @@ BEGIN
       aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_job_resources_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
@@ -623,7 +623,7 @@ BEGIN
       aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_by_date_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v3.`usage` + msec_diff_rollup * quantity;
   END IF;
 END $$
 

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -444,7 +444,6 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
   `attempt_id` VARCHAR(40) NOT NULL,
   `quantity` BIGINT NOT NULL,
   `resource_id` INT NOT NULL,
-  `deduped_resource_id` INT DEFAULT NULL,
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
@@ -769,13 +768,6 @@ BEGIN
         n_creating_jobs = n_creating_jobs + 1;
     END IF;
   END IF;
-END $$
-
-DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
-CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
-FOR EACH ROW
-BEGIN
-  SET NEW.deduped_resource_id = NEW.resource_id;
 END $$
 
 DROP TRIGGER IF EXISTS attempt_resources_after_insert $$

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -538,8 +538,8 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
-    SELECT batches.billing_project, `user`,
-      resource_id,
+    SELECT batches.billing_project, batches.`user`,
+      attempt_resources.resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -563,7 +563,7 @@ BEGIN
 
     INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
-      resource_id,
+      attempt_resources.resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -584,7 +584,7 @@ BEGIN
 
     INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
-      resource_id,
+      attempt_resources.resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
     JOIN aggregated_job_resources_v2 ON
@@ -610,8 +610,8 @@ BEGIN
     INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
       batches.billing_project,
-      `user`,
-      resource_id,
+      batches.`user`,
+      attempt_resources.resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -349,7 +349,6 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v2` (
   `resource_id` INT NOT NULL,
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -364,7 +363,6 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v2
   `resource_id` INT NOT NULL,
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`billing_date`, `billing_project`, `user`, `resource_id`, `token`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -377,7 +375,6 @@ CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v2` (
   `resource_id` INT NOT NULL,
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`batch_id`, `resource_id`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -389,7 +386,6 @@ CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v2` (
   `job_id` INT NOT NULL,
   `resource_id` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  `migrated` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
@@ -538,19 +534,14 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
-    SELECT batches.billing_project, batches.`user`,
-      attempt_resources.resource_id,
+    SELECT billing_project, `user`,
+      resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
     JOIN batches ON batches.id = attempt_resources.batch_id
-    INNER JOIN aggregated_billing_project_user_resources_v2 ON
-      aggregated_billing_project_user_resources_v2.billing_project = batches.billing_project AND
-      aggregated_billing_project_user_resources_v2.user = batches.user AND
-      aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
-      aggregated_billing_project_user_resources_v2.token = rand_token
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT batch_id,
@@ -562,17 +553,13 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
-    SELECT attempt_resources.batch_id,
-      attempt_resources.resource_id,
+    SELECT batch_id,
+      resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
-    JOIN aggregated_batch_resources_v2 ON
-      aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
-      aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
-      aggregated_batch_resources_v2.token = rand_token
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT batch_id, job_id,
@@ -583,16 +570,11 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
-    SELECT attempt_resources.batch_id, attempt_resources.job_id,
-      attempt_resources.resource_id,
+    SELECT batch_id, job_id,
+      resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
-    JOIN aggregated_job_resources_v2 ON
-      aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
-      aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
-      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
@@ -608,21 +590,15 @@ BEGIN
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
-      batches.billing_project,
-      batches.`user`,
-      attempt_resources.resource_id,
+      billing_project,
+      `user`,
+      resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
     JOIN batches ON batches.id = attempt_resources.batch_id
-    JOIN aggregated_billing_project_user_resources_by_date_v2 ON
-      aggregated_billing_project_user_resources_by_date_v2.billing_date = cur_billing_date AND
-      aggregated_billing_project_user_resources_by_date_v2.billing_project = batches.billing_project AND
-      aggregated_billing_project_user_resources_by_date_v2.user = batches.user AND
-      aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
-      aggregated_billing_project_user_resources_by_date_v2.token = rand_token
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v3.`usage` + msec_diff_rollup * quantity;
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
   END IF;
 END $$
 
@@ -814,10 +790,6 @@ BEGIN
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
   DECLARE cur_billing_date DATE;
-  DECLARE bp_user_resources_migrated BOOLEAN DEFAULT FALSE;
-  DECLARE bp_user_resources_by_date_migrated BOOLEAN DEFAULT FALSE;
-  DECLARE batch_resources_migrated BOOLEAN DEFAULT FALSE;
-  DECLARE job_resources_migrated BOOLEAN DEFAULT FALSE;
 
   SELECT billing_project, user INTO cur_billing_project, cur_user
   FROM batches WHERE id = NEW.batch_id;
@@ -840,177 +812,40 @@ BEGIN
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO bp_user_resources_migrated
-    FROM aggregated_billing_project_user_resources_v2
-    WHERE billing_project = cur_billing_project AND user = cur_user AND resource_id = NEW.resource_id AND token = rand_token;
-
-    IF bp_user_resources_migrated THEN
-      INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
-      VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
-      ON DUPLICATE KEY UPDATE
-        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
-    END IF;
+    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO batch_resources_migrated
-    FROM aggregated_batch_resources_v2
-    WHERE batch_id = NEW.batch_id AND resource_id = NEW.resource_id AND token = rand_token;
-
-    IF batch_resources_migrated THEN
-      INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
-      VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
-      ON DUPLICATE KEY UPDATE
-        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
-    END IF;
+    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO job_resources_migrated
-    FROM aggregated_job_resources_v2
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND resource_id = NEW.resource_id AND token = rand_token;
-
-    IF job_resources_migrated THEN
-      INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
-      VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
-      ON DUPLICATE KEY UPDATE
-        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
-    END IF;
+    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
     VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO bp_user_resources_by_date_migrated
-    FROM aggregated_billing_project_user_resources_by_date_v2
-    WHERE billing_date = cur_billing_date AND billing_project = cur_billing_project AND user = cur_user
-      AND resource_id = NEW.resource_id AND token = rand_token;
-
-    IF bp_user_resources_by_date_migrated THEN
-      INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
-      VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
-      ON DUPLICATE KEY UPDATE
-        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
-    END IF;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_before_insert $$
-CREATE TRIGGER aggregated_bp_user_resources_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_v2
-FOR EACH ROW
-BEGIN
-  SET NEW.migrated = 1;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_before_insert $$
-CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_by_date_v2
-FOR EACH ROW
-BEGIN
-  SET NEW.migrated = 1;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_before_insert $$
-CREATE TRIGGER aggregated_batch_resources_v2_before_insert BEFORE INSERT on aggregated_batch_resources_v2
-FOR EACH ROW
-BEGIN
-  SET NEW.migrated = 1;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_job_resources_v2_before_insert $$
-CREATE TRIGGER aggregated_job_resources_v2_before_insert BEFORE INSERT on aggregated_job_resources_v2
-FOR EACH ROW
-BEGIN
-  SET NEW.migrated = 1;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_after_update $$
-CREATE TRIGGER aggregated_bp_user_resources_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_v2
-FOR EACH ROW
-BEGIN
-  DECLARE new_resource_id INT;
-  DECLARE cur_n_tokens INT;
-  DECLARE rand_token INT;
-
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
-    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-    SET rand_token = FLOOR(RAND() * cur_n_tokens);
-
-    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
-
-    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
-    VALUES (NEW.billing_project, NEW.user, new_resource_id, rand_token, NEW.usage)
-    ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.usage;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_after_update $$
-CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_by_date_v2
-FOR EACH ROW
-BEGIN
-  DECLARE new_resource_id INT;
-  DECLARE cur_n_tokens INT;
-  DECLARE rand_token INT;
-
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
-    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-    SET rand_token = FLOOR(RAND() * cur_n_tokens);
-
-    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
-
     INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
-    VALUES (NEW.billing_date, NEW.billing_project, NEW.user, new_resource_id, rand_token, NEW.usage)
+    VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
     ON DUPLICATE KEY UPDATE
-        `usage` = `usage` + NEW.usage;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_after_update $$
-CREATE TRIGGER aggregated_batch_resources_v2_after_update AFTER UPDATE ON aggregated_batch_resources_v2
-FOR EACH ROW
-BEGIN
-  DECLARE new_resource_id INT;
-  DECLARE cur_n_tokens INT;
-  DECLARE rand_token INT;
-
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
-    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-    SET rand_token = FLOOR(RAND() * cur_n_tokens);
-
-    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
-
-    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
-    VALUES (NEW.batch_id, new_resource_id, rand_token, NEW.usage)
-    ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.usage;
-  END IF;
-END $$
-
-DROP TRIGGER IF EXISTS aggregated_job_resources_v2_after_update $$
-CREATE TRIGGER aggregated_job_resources_v2_after_update AFTER UPDATE ON aggregated_job_resources_v2
-FOR EACH ROW
-BEGIN
-  DECLARE new_resource_id INT;
-  DECLARE cur_n_tokens INT;
-  DECLARE rand_token INT;
-
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
-    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-    SET rand_token = FLOOR(RAND() * cur_n_tokens);
-
-    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
-
-    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
-    VALUES (NEW.batch_id, NEW.job_id, new_resource_id, NEW.usage)
-    ON DUPLICATE KEY UPDATE
-      `usage` = `usage` + NEW.usage;
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
   END IF;
 END $$
 

--- a/batch/sql/setup-deduped-resources-migration.sql
+++ b/batch/sql/setup-deduped-resources-migration.sql
@@ -116,7 +116,7 @@ BEGIN
       aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
@@ -138,7 +138,7 @@ BEGIN
       aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_batch_resources_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
@@ -159,7 +159,7 @@ BEGIN
       aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_job_resources_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
@@ -189,7 +189,7 @@ BEGIN
       aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_by_date_v2.token = rand_token
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v3.`usage` + msec_diff_rollup * quantity;
   END IF;
 END $$
 

--- a/batch/sql/setup-deduped-resources-migration.sql
+++ b/batch/sql/setup-deduped-resources-migration.sql
@@ -104,8 +104,8 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
-    SELECT batches.billing_project, `user`,
-      resource_id,
+    SELECT batches.billing_project, batches.`user`,
+      attempt_resources.resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -129,7 +129,7 @@ BEGIN
 
     INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
-      resource_id,
+      attempt_resources.resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -150,7 +150,7 @@ BEGIN
 
     INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
-      resource_id,
+      attempt_resources.resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
     JOIN aggregated_job_resources_v2 ON
@@ -176,8 +176,8 @@ BEGIN
     INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
       batches.billing_project,
-      `user`,
-      resource_id,
+      batches.`user`,
+      attempt_resources.resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources

--- a/batch/sql/setup-deduped-resources-migration.sql
+++ b/batch/sql/setup-deduped-resources-migration.sql
@@ -115,7 +115,7 @@ BEGIN
       aggregated_billing_project_user_resources_v2.user = batches.user AND
       aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
@@ -137,7 +137,7 @@ BEGIN
       aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_batch_resources_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
@@ -158,7 +158,7 @@ BEGIN
       aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
       aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_job_resources_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
@@ -188,7 +188,7 @@ BEGIN
       aggregated_billing_project_user_resources_by_date_v2.user = batches.user AND
       aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_by_date_v2.token = rand_token
-    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v3.`usage` + msec_diff_rollup * quantity;
   END IF;
 END $$

--- a/batch/sql/setup-deduped-resources-migration.sql
+++ b/batch/sql/setup-deduped-resources-migration.sql
@@ -1,0 +1,415 @@
+--  don't need the migrated flag as the billing trigger is only on inserting into attempt_resources
+ALTER TABLE attempt_resources ADD COLUMN deduped_resource_id INT DEFAULT NULL, ALGORITHM=INSTANT;
+
+ALTER TABLE aggregated_billing_project_user_resources_v2 ADD COLUMN migrated BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
+ALTER TABLE aggregated_billing_project_user_resources_by_date_v2 ADD COLUMN migrated BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
+ALTER TABLE aggregated_batch_resources_v2 ADD COLUMN migrated BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
+ALTER TABLE aggregated_job_resources_v2 ADD COLUMN migrated BOOLEAN DEFAULT FALSE, ALGORITHM=INSTANT;
+
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v3`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v3` (
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_v3 ON `aggregated_billing_project_user_resources_v3` (`user`);
+
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v3`;
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v3` (
+  `billing_date` DATE NOT NULL,
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_date`, `billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_by_date_v3_user ON `aggregated_billing_project_user_resources_by_date_v3` (`billing_date`, `user`);
+
+DROP TABLE IF EXISTS `aggregated_batch_resources_v3`;
+CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v3` (
+  `batch_id` BIGINT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `resource_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DROP TABLE IF EXISTS `aggregated_job_resources_v3`;
+CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v3` (
+  `batch_id` BIGINT NOT NULL,
+  `job_id` INT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DELIMITER $$
+
+-- This is okay here because the deduplication mitigation in batch will have already merged
+DROP TRIGGER IF EXISTS attempt_resources_before_insert $$
+CREATE TRIGGER attempt_resources_before_insert BEFORE INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  SET NEW.deduped_resource_id = NEW.resource_id;
+END $$
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_after_update $$
+CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  DECLARE job_cores_mcpu INT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_billing_date DATE;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SET msec_diff_rollup = (GREATEST(COALESCE(NEW.rollup_time - NEW.start_time, 0), 0) -
+                          GREATEST(COALESCE(OLD.rollup_time - OLD.start_time, 0), 0));
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    INNER JOIN aggregated_billing_project_user_resources_v2 ON
+      aggregated_billing_project_user_resources_v2.billing_project = batches.billing_project AND
+      aggregated_billing_project_user_resources_v2.user = batches.user AND
+      aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_billing_project_user_resources_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    SELECT attempt_resources.batch_id,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    SELECT attempt_resources.batch_id,
+      resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN aggregated_batch_resources_v2 ON
+      aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
+      aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_batch_resources_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+      resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+      resources.deduped_resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN aggregated_job_resources_v2 ON
+      aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
+      aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
+      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_job_resources_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      billing_project,
+      `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      batches.billing_project,
+      `user`,
+      resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN resources ON resources.resource_id = attempt_resources.resource_id
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    JOIN aggregated_billing_project_user_resources_by_date_v2 ON
+      aggregated_billing_project_user_resources_by_date_v2.billing_date = cur_billing_date AND
+      aggregated_billing_project_user_resources_by_date_v2.billing_project = batches.billing_project AND
+      aggregated_billing_project_user_resources_by_date_v2.user = batches.user AND
+      aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_billing_project_user_resources_by_date_v2.token = rand_token
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_rollup_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE cur_user VARCHAR(100);
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_resource VARCHAR(100);
+  DECLARE cur_billing_date DATE;
+  DECLARE bp_user_resources_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE bp_user_resources_by_date_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE batch_resources_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE job_resources_migrated BOOLEAN DEFAULT FALSE;
+
+  SELECT billing_project, user INTO cur_billing_project, cur_user
+  FROM batches WHERE id = NEW.batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT deduped_resource_id INTO cur_resource FROM resources WHERE resource_id = NEW.resource_id;
+
+  SELECT start_time, rollup_time INTO cur_start_time, cur_rollup_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff_rollup = GREATEST(COALESCE(cur_rollup_time - cur_start_time, 0), 0);
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated INTO bp_user_resources_migrated
+    FROM aggregated_billing_project_user_resources_v2
+    WHERE billing_project = cur_billing_project AND user = cur_user AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF bp_user_resources_migrated THEN
+      INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_project, cur_user, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated INTO batch_resources_migrated
+    FROM aggregated_batch_resources_v2
+    WHERE batch_id = NEW.batch_id AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF batch_resources_migrated THEN
+      INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+      VALUES (NEW.batch_id, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated INTO job_resources_migrated
+    FROM aggregated_job_resources_v2
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF job_resources_migrated THEN
+      INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+      VALUES (NEW.batch_id, NEW.job_id, cur_resource, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated INTO bp_user_resources_by_date_migrated
+    FROM aggregated_billing_project_user_resources_by_date_v2
+    WHERE billing_date = cur_billing_date AND billing_project = cur_billing_project AND user = cur_user
+      AND resource_id = NEW.resource_id AND token = rand_token;
+
+    IF bp_user_resources_by_date_migrated THEN
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_date, cur_billing_project, cur_user, cur_resource, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_bp_user_resources_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_before_insert $$
+CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_by_date_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_batch_resources_v2_before_insert BEFORE INSERT on aggregated_batch_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_job_resources_v2_before_insert BEFORE INSERT on aggregated_job_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_after_update $$
+CREATE TRIGGER aggregated_bp_user_resources_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    VALUES (NEW.billing_project, NEW.user, new_resource_id, rand_token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_after_update $$
+CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_by_date_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    VALUES (NEW.billing_date, NEW.billing_project, NEW.user, new_resource_id, rand_token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_after_update $$
+CREATE TRIGGER aggregated_batch_resources_v2_after_update AFTER UPDATE ON aggregated_batch_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, new_resource_id, rand_token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_after_update $$
+CREATE TRIGGER aggregated_job_resources_v2_after_update AFTER UPDATE ON aggregated_job_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_resource_id INT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+    SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+    SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+    SELECT deduped_resource_id INTO new_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, new_resource_id, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/batch/sql/setup-deduped-resources-migration.sql
+++ b/batch/sql/setup-deduped-resources-migration.sql
@@ -119,7 +119,7 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
-    SELECT attempt_resources.batch_id,
+    SELECT batch_id,
       resource_id,
       rand_token,
       msec_diff_rollup * quantity
@@ -141,7 +141,7 @@ BEGIN
     ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
-    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+    SELECT batch_id, job_id,
       resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -156,8 +156,7 @@ BEGIN
     JOIN aggregated_job_resources_v2 ON
       aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
-      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id AND
-      aggregated_job_resources_v2.token = rand_token
+      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id
     WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
     ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
 

--- a/build.yaml
+++ b/build.yaml
@@ -2045,6 +2045,9 @@ steps:
       - name: setup-deduped-resources-migration
         script: /io/sql/setup-deduped-resources-migration.sql
         online: true
+      - name: dedup-resources
+        script: /io/sql/dedup_resources.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/build.yaml
+++ b/build.yaml
@@ -2051,6 +2051,9 @@ steps:
       - name: cleanup-deduped-resource-ids-migration
         script: /io/sql/cleanup-deduped-resource-ids-migration.sql
         online: true
+      - name: cleanup-attempt-resources-deduped-ids
+        script: /io/sql/cleanup-attempt-resources-deduped-ids.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/build.yaml
+++ b/build.yaml
@@ -2048,6 +2048,9 @@ steps:
       - name: dedup-resources
         script: /io/sql/dedup_resources.py
         online: true
+      - name: cleanup-deduped-resource-ids-migration
+        script: /io/sql/cleanup-deduped-resource-ids-migration.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/build.yaml
+++ b/build.yaml
@@ -2042,6 +2042,9 @@ steps:
       - name: create-resource-dedup-mapping
         script: /io/sql/create_resource_dedup_mapping.py
         online: true
+      - name: setup-deduped-resources-migration
+        script: /io/sql/setup-deduped-resources-migration.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
- This PR is stacked on #12762. It just removes the `deduped_resource_id` column from the attempt_resources table. Note that the trigger here is still correct even though it's backwards from the original column mapping (we renamed the columns in #12762) because resource_id == deduped_resource_id.