### PR TITLE
[query] relax parsimonious pin

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -11,7 +11,7 @@ Jinja2==3.0.3
 nest_asyncio>=1.5.4,<2
 numpy<2
 pandas>=1.3.0,<1.6.0
-parsimonious<0.9
+parsimonious<1
 plotly>=5.5.0,<5.11
 protobuf==3.20.2
 PyJWT


### PR DESCRIPTION
CHANGELOG: Update parsimonious to a verison that supports Python 3.11.

Fixes #12759.