### PR TITLE
[query] fix ggplot geom_bar, geom_col, and geom_point use of color

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -299,7 +299,7 @@ class GeomBar(Geom):
 
     aes_to_arg = {
         "fill": ("marker_color", "black"),
-        "color": ("marker_line_color", None),
+        "color": ("marker_color", None),
         "tooltip": ("hovertext", None),
         "fill_legend": ("name", None),
         "alpha": ("marker_opacity", None)
@@ -325,6 +325,10 @@ class GeomBar(Geom):
                 "row": facet_row,
                 "col": facet_col
             }
+
+            if 'color' in df.attrs:
+                assert 'color_legend' in df.attrs
+                trace_args['name'] = df.attrs['color_legend']
 
             self._add_aesthetics_to_trace_args(trace_args, df)
             self._update_legend_trace_args(trace_args, legend_cache)

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -37,6 +37,7 @@ def should_use_scale_for_grouping(scale):
 def continuous_nums_to_colors(min_color, max_color, continuous_color_scale):
     assert min_color is not None
     assert max_color is not None
+
     def adjust_color(input_color):
         return (input_color - min_color) / max_color - min_color
 

--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -31,10 +31,12 @@ def should_use_for_grouping(name, type, scale):
 
 
 def should_use_scale_for_grouping(scale):
-    return (scale.aesthetic_name not in excluded_from_grouping) and scale.is_discrete()
+    return (scale.aesthetic_name not in excluded_from_grouping) and scale.is_discrete_output()
 
 
 def continuous_nums_to_colors(min_color, max_color, continuous_color_scale):
+    assert min_color is not None
+    assert max_color is not None
     def adjust_color(input_color):
         return (input_color - min_color) / max_color - min_color
 


### PR DESCRIPTION
- `geom_point` did not correctly include color in the legend when the color was a continuous variable that had been mapped to a discrete one, e.g. an integer that the user specified as the color.

- `geom_bar` and `geom_col` suffered the same issue but additionally lacked the ability to name each color group in the legend.