### PR TITLE
[query] update jgscm in init_notebook

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -38,7 +38,7 @@ if role == 'Master':
         'setuptools',
         'mkl<2020',
         'lxml<5',
-        'https://github.com/hail-is/jgscm/archive/v0.1.12+hail.zip',
+        'https://github.com/hail-is/jgscm/archive/v0.1.13+hail.zip',
         'ipykernel==4.10.*',
         'ipywidgets==7.5.*',
         'jupyter-console==6.0.*',


### PR DESCRIPTION
The old jgscm used a version incompatible with PEP 440. NB: it was the version in setup.py that was wrong, the tag was fine.