### PR TITLE
[hailctl] pass through the pass through args

### DIFF
--- a/hail/python/hailtop/hailctl/hdinsight/submit.py
+++ b/hail/python/hailtop/hailctl/hdinsight/submit.py
@@ -27,7 +27,8 @@ async def main(args, pass_through_args):  # pylint: disable=unused-argument
                   # NB: Only the local protocol is permitted, the file protocol is banned #security
                   'spark.jars': 'local:/usr/bin/anaconda/envs/py37/lib/python3.7/site-packages/hail/backend/hail-all-spark.jar',
                   'spark.pyspark.driver.python': '/usr/bin/anaconda/envs/py37/bin/python3',
-              }},
+              },
+              'args': pass_through_args},
         auth=requests.auth.HTTPBasicAuth('admin', args.http_password),
         timeout=60)
     batch = resp.json()


### PR DESCRIPTION
CHANGELOG: Fix `hailctl hdinsight submit` to pass args to the files.

See `/batches` at https://livy.incubator.apache.org/docs/latest/rest-api.html