### PR TITLE
[batch] Add deduped resource id column to attempt resources table

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -89,15 +89,16 @@ async def add_attempt_resources(app, db, batch_id, job_id, attempt_id, resources
             # This must be sorted in order to match the order of values in the actual SQL table!
             _resources = dict(sorted(_resources.items()))
 
+            # the deduped resource id is the same as the resource id as the mitigation for duplicate resource ids already merged
             resource_args = [
-                (batch_id, job_id, attempt_id, resource_name_to_id[name], quantity)
+                (batch_id, job_id, attempt_id, resource_name_to_id[name], resource_name_to_id[name], quantity)
                 for name, quantity in _resources.items()
             ]
 
             await db.execute_many(
                 '''
-INSERT INTO `attempt_resources` (batch_id, job_id, attempt_id, resource_id, quantity)
-VALUES (%s, %s, %s, %s, %s)
+INSERT INTO `attempt_resources` (batch_id, job_id, attempt_id, resource_id, deduped_resource_id, quantity)
+VALUES (%s, %s, %s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE quantity = quantity;
 ''',
                 resource_args,

--- a/batch/sql/add-deduped-resource-ids-to-attempt-resources.sql
+++ b/batch/sql/add-deduped-resource-ids-to-attempt-resources.sql
@@ -1,0 +1,1 @@
+ALTER TABLE attempt_resources ADD COLUMN deduped_resource_id INT DEFAULT NULL, ALGORITHM=INSTANT;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -399,6 +399,7 @@ CREATE TABLE IF NOT EXISTS `attempt_resources` (
   `attempt_id` VARCHAR(40) NOT NULL,
   `quantity` BIGINT NOT NULL,
   `resource_id` INT NOT NULL,
+  `deduped_resource_id` INT DEFAULT NULL
   PRIMARY KEY (`batch_id`, `job_id`, `attempt_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,

--- a/build.yaml
+++ b/build.yaml
@@ -2000,6 +2000,9 @@ steps:
       - name: config-pool-min-instances
         script: /io/sql/config-pool-min-instances.sql
         online: true
+      - name: add-deduped-resource-ids-to-attempt-resources
+        script: /io/sql/add-deduped-resource-ids-to-attempt-resources.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
This is now the first PR in the deduping resource ids stack. I decided that we should directly write the new "deduped_resource_id" value rather than in a trigger to make things simpler to reason about later when dropping unused columns. The implication of this is this PR must now be fully deployed before #12757. We need to announce this on Zulip once this PR merges.