### PR TITLE
[query] better local testing experience

### DIFF
--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -19,7 +19,9 @@ def startTestHailContext():
 def stopTestHailContext():
     hl.stop()
 
-_test_dir = os.environ.get('HAIL_TEST_RESOURCES_DIR', '../src/test/resources')
+_test_dir = os.environ.get('HAIL_TEST_RESOURCES_DIR',
+                           os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(hl.__file__))),
+                                        'src/test/resources'))
 _doctest_dir = os.environ.get('HAIL_DOCTEST_DATA_DIR', 'hail/docs/data')
 
 


### PR DESCRIPTION
I sometimes iterate quickly with `pytest -k testname` from the `hail/python` directory. I cannot do that if the test directory is hard coded.