### PR TITLE
[query] tndarray equality includes number of dimensions

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -616,7 +616,7 @@ class ArrayExpression(CollectionExpression):
         -------
         :class:`.ArrayExpression`
         """
-        if not item._type == self._type.element_type:
+        if item._type != self._type.element_type:
             raise TypeError("'ArrayExpression.append' expects 'item' to be the same type as its elements\n"
                             "    array element type: '{}'\n"
                             "    type of arg 'item': '{}'".format(self._type._element_type, item._type))

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -724,7 +724,9 @@ class tndarray(HailType):
         return "ndarray<{}, {}>".format(self.element_type, self.ndim)
 
     def _eq(self, other):
-        return isinstance(other, tndarray) and self.element_type == other.element_type
+        return (isinstance(other, tndarray) and
+                self.element_type == other.element_type and
+                self.ndim == other.ndim)
 
     def _pretty(self, b, indent, increment):
         b.append('ndarray<')

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -724,9 +724,9 @@ class tndarray(HailType):
         return "ndarray<{}, {}>".format(self.element_type, self.ndim)
 
     def _eq(self, other):
-        return (isinstance(other, tndarray) and
-                self.element_type == other.element_type and
-                self.ndim == other.ndim)
+        return (isinstance(other, tndarray)
+                and self.element_type == other.element_type
+                and self.ndim == other.ndim)
 
     def _pretty(self, b, indent, increment):
         b.append('ndarray<')


### PR DESCRIPTION
The compiler still catches this at runtime, but it is hard to understand because it lacks a meaningful stacktrace.