### PR TITLE
[query] fix read from undefined memory

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -64,19 +64,19 @@ def test_ndarray_ref_bounds_check():
 
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([[1], [2], [3]])[4, :])
-    assert "Index 4 is out of bounds for axis 0 with size 1" in str(exc.value)
+    assert "Index 4 is out of bounds for axis 0 with size 3" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([[1], [2], [3]])[-1, :])
-    assert "Index -1 is out of bounds for axis 0 with size 1" in str(exc.value)
+    assert "Index -1 is out of bounds for axis 0 with size 3" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([[1], [2], [3]])[:, 4])
-    assert "Index 4 is out of bounds for axis 1 with size 3" in str(exc.value)
+    assert "Index 4 is out of bounds for axis 1 with size 1" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([[1], [2], [3]])[:, -1])
-    assert "Index -1 is out of bounds for axis 1 with size 3" in str(exc.value)
+    assert "Index -1 is out of bounds for axis 1 with size 1" in str(exc.value)
 
 
 def test_ndarray_slice():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -53,9 +53,30 @@ def test_ndarray_ref():
         (h_cube[0, 0, hl.missing(hl.tint32)], None)
     )
 
+def test_ndarray_ref_bounds_check():
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([1, 2, 3])[4])
     assert "Index 4 is out of bounds for axis 0 with size 3" in str(exc.value)
+
+    with pytest.raises(HailUserError) as exc:
+        hl.eval(hl.nd.array([1, 2, 3])[-1])
+    assert "Index -1 is out of bounds for axis 0 with size 3" in str(exc.value)
+
+    with pytest.raises(HailUserError) as exc:
+        hl.eval(hl.nd.array([[1], [2], [3]])[4, :])
+    assert "Index 4 is out of bounds for axis 0 with size 1" in str(exc.value)
+
+    with pytest.raises(HailUserError) as exc:
+        hl.eval(hl.nd.array([[1], [2], [3]])[-1, :])
+    assert "Index -1 is out of bounds for axis 0 with size 1" in str(exc.value)
+
+    with pytest.raises(HailUserError) as exc:
+        hl.eval(hl.nd.array([[1], [2], [3]])[:, 4])
+    assert "Index 4 is out of bounds for axis 1 with size 3" in str(exc.value)
+
+    with pytest.raises(HailUserError) as exc:
+        hl.eval(hl.nd.array([[1], [2], [3]])[:, -1])
+    assert "Index -1 is out of bounds for axis 1 with size 3" in str(exc.value)
 
 
 def test_ndarray_slice():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -53,6 +53,7 @@ def test_ndarray_ref():
         (h_cube[0, 0, hl.missing(hl.tint32)], None)
     )
 
+
 def test_ndarray_ref_bounds_check():
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([1, 2, 3])[4])
@@ -63,20 +64,24 @@ def test_ndarray_ref_bounds_check():
     assert "Index -1 is out of bounds for axis 0 with size 3" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
+        hl.eval(hl.nd.array([1, 2, 3])[-4])
+    assert "Index -4 is out of bounds for axis 0 with size 3" in str(exc.value)
+
+    with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([[1], [2], [3]])[4, :])
     assert "Index 4 is out of bounds for axis 0 with size 3" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
-        hl.eval(hl.nd.array([[1], [2], [3]])[-1, :])
-    assert "Index -1 is out of bounds for axis 0 with size 3" in str(exc.value)
+        hl.eval(hl.nd.array([[1], [2], [3]])[-4, :])
+    assert "Index -4 is out of bounds for axis 0 with size 3" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array([[1], [2], [3]])[:, 4])
     assert "Index 4 is out of bounds for axis 1 with size 1" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
-        hl.eval(hl.nd.array([[1], [2], [3]])[:, -1])
-    assert "Index -1 is out of bounds for axis 1 with size 1" in str(exc.value)
+        hl.eval(hl.nd.array([[1], [2], [3]])[:, -4])
+    assert "Index -4 is out of bounds for axis 1 with size 1" in str(exc.value)
 
 
 def test_ndarray_slice():

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -613,7 +613,7 @@ trait SNDArrayValue extends SValue {
   def assertInBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder, errorId: Int): Unit = {
     val shape = this.shapes
     for (dimIndex <- 0 until st.nDims) {
-      cb.ifx(indices(dimIndex) >= shape(dimIndex), {
+      cb.ifx(indices(dimIndex) >= shape(dimIndex) || indices(dimIndex) < 0, {
         cb._fatalWithError(errorId,
           "Index ", indices(dimIndex).toS,
           s" is out of bounds for axis $dimIndex with size ",


### PR DESCRIPTION
CHANGELOG: Raise an error instead of silently returning bad results when using a negative index with an `hl.nd.array`.

In practice, I always saw this return a positive value very close to zero. We should fix this to just support Python-style indexing, but I wanted to fix ASAP given the severity.