### PR TITLE
[qob] restart JVM if an OOM occurs

### DIFF
--- a/batch/src/main/java/is/hail/JVMEntryway.java
+++ b/batch/src/main/java/is/hail/JVMEntryway.java
@@ -208,6 +208,7 @@ class JVMEntryway {
 
   private static void finishException(int type, DataOutputStream out, Throwable t) throws IOException {
     out.writeInt(type);
+    out.writeByte(type instanceof java.lang.OutOfMemoryError);
     String s = throwableToString(t);
     byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
     out.writeInt(bytes.length);


### PR DESCRIPTION
I often observe the JVM getting stuck in a high memory state unable to recover from after an OOM. Best to just kill the JVM.