### PR TITLE
[query] teach hl.array to convert 1-d ndarrays

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4773,7 +4773,7 @@ def empty_set(t: Union[HailType, builtins.str]) -> SetExpression:
     return hl.set(empty_array(t))
 
 
-@typecheck(collection=expr_oneof(expr_set(), expr_array(), expr_dict()))
+@typecheck(collection=expr_oneof(expr_set(), expr_array(), expr_dict(), expr_ndarray()))
 def array(collection) -> ArrayExpression:
     """Construct an array expression.
 
@@ -4797,6 +4797,10 @@ def array(collection) -> ArrayExpression:
         return collection
     elif isinstance(collection.dtype, tset):
         return apply_expr(lambda c: ir.CastToArray(c), tarray(collection.dtype.element_type), collection)
+    elif isinstance(collection.dtype, tndarray):
+        if collection.dtype.ndim != 1:
+            raise ValueError(f'array: only one dimensional ndarrays are supported: {collection.dtype}')
+        return collection._data_array()
     else:
         assert isinstance(collection.dtype, tdict)
         return _func('dictToArray', tarray(ttuple(collection.dtype.key_type, collection.dtype.value_type)), collection)

--- a/hail/python/test/hail/expr/test_functions.py
+++ b/hail/python/test/hail/expr/test_functions.py
@@ -64,3 +64,22 @@ def test_pgenchisq():
         assert test.genchisq_result.fault == 0, str(test)
         assert test.genchisq_result.converged == True, str(test)
         assert test.genchisq_result.n_iterations == test.expected_n_iterations, str(test)
+
+
+def test_array():
+    actual = hl.eval((
+        hl.array(hl.array([1, 2, 3, 3])),
+        hl.array(hl.set([1, 2, 3])),
+        hl.array(hl.dict({1: 5, 7: 4})),
+        hl.array(hl.nd.array([1, 2, 3, 3])),
+    ))
+
+    expected = (
+        [1, 2, 3, 3],
+        [1, 2, 3],
+        [1, 7],
+        [1, 2, 3, 3]
+    )
+
+    with pytest.raises(ValueError, match='array: only one dimensional ndarrays are supported: ndarray<float64, 2>'):
+        hl.eval(hl.array(hl.nd.array([[1.0], [2.0]])))


### PR DESCRIPTION
CHANGELOG: hl.array can now convert 1-d ndarrays into the equivalent list.

We leave the improvement of the implementation of `_data_array` to a future PR.