### PR TITLE
[query] Extend `func_spec` to support functions with default arguments

### DIFF
--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -356,9 +356,16 @@ class FunctionChecker(TypeChecker):
     def check(self, x, caller, param):
         if not callable(x):
             raise TypecheckFailure
-        spec = inspect.signature(x)
-        if not len(spec.parameters) == self.nargs:
-            raise TypecheckFailure
+
+        params = inspect.signature(x).parameters
+        if self.nargs != len(params):
+            n_required_params = len([
+                p for p in params.values()
+                if p.default == inspect.Parameter.empty
+            ])
+
+            if not (self.nargs >= n_required_params and self.nargs < len(params)):
+                raise TypecheckFailure
 
         def f(*args):
             ret = x(*args)

--- a/hail/python/test/hail/typecheck/test_typecheck.py
+++ b/hail/python/test/hail/typecheck/test_typecheck.py
@@ -257,6 +257,20 @@ class Tests(unittest.TestCase):
         self.assertRaises(TypeError, lambda: foo(l2))
         foo(l3)
 
+        @typecheck(f=func_spec(0, int))
+        def eval(f):
+            return f()
+
+        self.assertEqual(eval(lambda x=1: x), 1)
+        self.assertEqual(eval(lambda x=None: 1), 1)
+        self.assertRaises(TypeError, lambda: eval(lambda x: 1))
+
+        @typecheck(f=func_spec(1, int), k=int)
+        def apply(f, k):
+            return f(k)
+
+        self.assertEqual(apply(lambda x, y=1: x + y, 1), 2)
+
     def test_complex_signature(self):
         @typecheck(a=int, b=str, c=sequenceof(int), d=tupleof(str), e=dict)
         def f(a, b='5', c=[10], *d, **e):

--- a/hail/python/test/hail/typecheck/test_typecheck.py
+++ b/hail/python/test/hail/typecheck/test_typecheck.py
@@ -265,11 +265,11 @@ class Tests(unittest.TestCase):
         self.assertEqual(eval(lambda x=None: 1), 1)
         self.assertRaises(TypeError, lambda: eval(lambda x: 1))
 
-        @typecheck(f=func_spec(1, int), k=int)
-        def apply(f, k):
-            return f(k)
+        @typecheck(f=func_spec(2, int), a=int, b=int)
+        def apply(f, a, b):
+            return f(a, b)
 
-        self.assertEqual(apply(lambda x, y=1: x + y, 1), 2)
+        self.assertEqual(apply(lambda x, y=2, z=3: x + y + z, 5, 7), 15)
 
     def test_complex_signature(self):
         @typecheck(a=int, b=str, c=sequenceof(int), d=tupleof(str), e=dict)


### PR DESCRIPTION
Extend `FunctionChecker` to assert that at least the number of non-default parameters are specified, up to the maximum number of parameters.