### PR TITLE
[compiler] fix overly strict CSE bug

### DIFF
--- a/hail/python/hail/ir/renderer.py
+++ b/hail/python/hail/ir/renderer.py
@@ -455,12 +455,6 @@ class CSEPrintPass:
                             lift_type = 'agg'
 
             if lift_to_frame:
-                insert_lets = (id(child) in binding_sites
-                               and (len(binding_sites[id(child)].lifted_lets) > 0
-                                    or len(binding_sites[id(child)].agg_lifted_lets) > 0
-                                    or len(binding_sites[id(child)].scan_lifted_lets > 0)))
-                assert not insert_lets
-
                 if lift_type == 'value':
                     visited = lift_to_frame.visited
                     name = lift_to_frame.lifted_lets[id(child)]

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -429,6 +429,27 @@ class CSETests(unittest.TestCase):
                 ' (Ref __cse_1)))')
         assert expected == CSERenderer()(x)
 
+    def test_cse_debug(self):
+        x = hl.nd.array([0, 1])
+        y = hl.tuple((x, x))
+        dlen = y[0]
+        hl.eval(hl.tuple([hl.if_else(dlen[0] > 1, 1, 1), hl.if_else(dlen[0] > 1, hl.nd.array([0]), dlen)]))
+
+    def test_cse_complex_lifting(self):
+        x = ir.I32(5)
+        sum = ir.ApplyBinaryPrimOp('+', x, x)
+        prod = ir.ApplyBinaryPrimOp('*', sum, sum)
+        cond = ir.If(ir.ApplyComparisonOp('EQ', prod, x), sum, x)
+        expected = (
+            '(Let __cse_1 (I32 5)'
+            ' (Let __cse_2 (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
+             ' (If (ApplyComparisonOp EQ (ApplyBinaryPrimOp `*` (Ref __cse_2) (Ref __cse_2)) (Ref __cse_1))'
+              ' (Let __cse_3 (I32 5)'
+               ' (ApplyBinaryPrimOp `+` (Ref __cse_3) (Ref __cse_3)))'
+              ' (I32 5))))'
+        )
+        assert expected == CSERenderer()(cond)
+
     def test_stream_cse(self):
         x = ir.StreamRange(ir.I32(0), ir.I32(10), ir.I32(1))
         a1 = ir.ToArray(x)


### PR DESCRIPTION
The deleted assertion says that a node can't both be lifted to a let, and be the destination of lets being lifted from below. When I added it, I figured any lets being lifted from below should be able to lift all the way to the destination of this node, and I hadn't thought carefully through what would happen if that assumption weren't true.

The example that breaks that assumption is when some expression `x` is used as the top level of a branch of an if, or any other spot that prevents lets from being lifted any higher, while also being used >1 times elsewhere, and `x` also contains a repeated subexpression. The other uses of `x` will be lifted out somewhere above, so `x` gets marked as being lifted. The use in the if cannot be lifted, and moreover is the destination of the lifted repeated subexpression, so `x` gets marked as being a destination. It's still true that the uses being lifted are disjoint from the uses which are destinations, but there is only one object in memory.

I deleted the assertion, added a test case that would have violated it, and convinced myself that this case is actually handled correctly in general.