### PR TITLE
[db] encode our three database flags in TF & add two more

### DIFF
--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -237,6 +237,26 @@ resource "google_sql_database_instance" "db" {
       private_network = google_compute_network.default.id
       require_ssl = true
     }
+    database_flags {
+      name = "innodb_log_buffer_size"
+      value = "536870912"
+    }
+    database_flags {
+      name = "innodb_log_file_size"
+      value = "5368709120"
+    }
+    database_flags {
+      name = "event_scheduler"
+      value = "on"
+    }
+    database_flags {
+      name = "skip_show_database"
+      value = "on"
+    }
+    database_flags {
+      name = "local_infile"
+      value = "off"
+    }
   }
 }
 


### PR DESCRIPTION
Both of these were noted by Bernick as a part of his security review.

1. `local_infile`: if this is on, a client could in theory read any file on the instance by loading it into a table.
2. `skip_show_database`: this disables `SHOW DATABASES` by default; we can still grant certain users (e.g. the admin-pod) the `SHOW DATABASES` privilege. A bit of security by obscurity, IMO, but it does not bother me much. I can always see the list of databases via the GCP console.