### PR TITLE
[batch] Use the root directory for the working directory in dockerized local backend jobs

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -329,7 +329,6 @@ class LocalBackend(Backend[None]):
                                 "--entrypoint=''"
                                 f"{self._extra_docker_run_flags} "
                                 f"-v {tmpdir}:{tmpdir} "
-                                f"-w {tmpdir} "
                                 f"{memory} "
                                 f"{cpu} "
                                 f"{job._image} "


### PR DESCRIPTION
CHANGELOG: The Batch LocalBackend now sets the working directory for dockerized jobs to the root directory instead of the temp directory

Tested with the following:

```
In [1]: import hailtop.batch as hb
   ...: b = hb.Batch(backend=hb.LocalBackend())
   ...: j = b.new_job()
   ...: j.image('ubuntu:20.04')
   ...: j.command('pwd')
   ...: b.run()
   ...:
   ...:
/
Batch completed successfully!
```