### PR TITLE
[benchmark] Allow configuration of `BENCHMARK_DOCKER_TAG`

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -29,7 +29,7 @@ cleanup_image:
 	rm -f pushed_image
 
 BENCHMARK_PROJECT ?= hail-vdc
-BENCHMARK_DOCKER_TAG := benchmark_$(shell whoami)
+BENCHMARK_DOCKER_TAG ?= benchmark_$(shell whoami)
 BENCHMARK_REPO_BASE = gcr.io/$(BENCHMARK_PROJECT)/$(BENCHMARK_DOCKER_TAG)
 DOCKER_ROOT_IMAGE := ubuntu:20.04
 


### PR DESCRIPTION
I develop accross a couple of OSes and my username isn't always the same. I'd like to expose this make variable so that I can push images to the same location.