### PR TITLE
[query] relax requirements of variant_qc

### DIFF
--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -196,6 +196,17 @@ def require_row_key_variant(dataset, method):
                              "\n    '{}': {}".format(k, str(dataset[k].dtype)) for k in key)))
 
 
+def require_alleles_field(dataset, method):
+    if 'alleles' not in dataset.row:
+        raise ValueError(
+            f"Method '{method}' requires a field 'alleles' (type 'array<str>')\n")
+    if dataset.alleles.dtype != tarray(tstr):
+        raise ValueError(
+            f"Method '{method}' requires a field 'alleles' (type 'array<str>')\n"
+            f"  Found:\n"
+            f"    'alleles': {dataset.alleles.dtype}")
+
+
 def require_row_key_variant_w_struct_locus(dataset, method):
     if (list(dataset.row_key) != ['locus', 'alleles']
         or not dataset['alleles'].dtype == tarray(tstr)

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -9,7 +9,7 @@ from hail.utils.misc import divide_null, guess_cloud_spark_provider
 from hail.matrixtable import MatrixTable
 from hail.table import Table
 from hail.ir import TableToTableApply
-from .misc import require_biallelic, require_row_key_variant, require_col_key_str, require_table_key_variant
+from .misc import require_biallelic, require_row_key_variant, require_col_key_str, require_table_key_variant, require_alleles_field
 
 
 @typecheck(mt=MatrixTable, name=str)
@@ -251,7 +251,7 @@ def variant_qc(mt, name='variant_qc') -> MatrixTable:
     -------
     :class:`.MatrixTable`
     """
-    require_row_key_variant(mt, 'variant_qc')
+    require_alleles_field(mt, 'variant_qc')
 
     bound_exprs = {}
     gq_dp_exprs = {}

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -107,6 +107,16 @@ class Tests(unittest.TestCase):
         self.assertEqual(r[1].vqc.gq_stats.mean, 10)
         self.assertEqual(r[1].vqc.gq_stats.stdev, 0)
 
+    def test_variant_qc_alleles_field(self):
+        mt = hl.balding_nichols_model(1, 1, 1)
+        mt = mt.key_rows_by().drop('alleles')
+        with pytest.raises(ValueError, match="Method 'variant_qc' requires a field 'alleles' \\(type 'array<str>'\\).*"):
+            hl.variant_qc(mt).variant_qc.collect()
+
+        mt = hl.balding_nichols_model(1, 1, 1)
+        mt = mt.key_rows_by().drop('locus')
+        hl.variant_qc(mt).variant_qc.collect()
+
     def test_concordance(self):
         dataset = get_dataset()
         glob_conc, cols_conc, rows_conc = hl.concordance(dataset, dataset)


### PR DESCRIPTION
CHANGELOG: `hl.variant_qc` no longer requires a `locus` field.

Fixes #12844.