### PR TITLE
[query] reduce wall time for local, scala, and spark tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -661,7 +661,7 @@ steps:
       valueFrom: hail_build_image.image
     resources:
       memory: standard
-      cpu: '4'
+      cpu: '2'
     script: |
       set -ex
       cd /io/repo/hail

--- a/build.yaml
+++ b/build.yaml
@@ -688,6 +688,7 @@ steps:
       memory: standard
       cpu: '2'
     script: |
+      cd /io/repo/hail
       set -ex
       chmod 755 ./gradlew
       cd /io/repo/hail
@@ -750,9 +751,9 @@ steps:
       - from: /repo
         to: /io/repo
     outputs:
-      - from: /io/repo/hail/build/debug/hail-all-spark-test.jar
+      - from: /io/repo/hail/build/hail-all-spark-test.jar
         to: /hail-debug-test.jar
-      - from: /io/repo/hail/build/debug/debug-wheel-container.tar
+      - from: /io/repo/hail/build/debug-wheel-container.tar
         to: /debug-wheel-container.tar
     dependsOn:
       - hail_build_image

--- a/build.yaml
+++ b/build.yaml
@@ -689,6 +689,7 @@ steps:
       cpu: '2'
     script: |
       set -ex
+      chmod 755 ./gradlew
       cd /io/repo/hail
       time retry make jars python-version-info wheel
       (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)

--- a/build.yaml
+++ b/build.yaml
@@ -686,22 +686,14 @@ steps:
       valueFrom: hail_build_image.image
     resources:
       memory: standard
-      cpu: '4'
+      cpu: '2'
     script: |
       set -ex
       cd /io/repo/hail
-      chmod 755 ./gradlew
-      time retry ./gradlew --version
-      time retry make jars wheel HAIL_DEBUG_MODE=1
-      (cd build/deploy/dist/ && tar -cvf debug-wheel-container.tar hail-*-py3-none-any.whl)
-      cd /io/repo/hail
-      mkdir build/debug_libs
-      mv build/libs/hail-all-spark.jar build/debug_libs/
-      mv build/libs/hail-all-spark-test.jar build/debug_libs/
-      mv build/deploy/dist/debug-wheel-container.tar build/debug_libs
       time retry make jars python-version-info wheel
+      (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
 
-      # Check wheel size is small enough for pypi (< 100 MB)
+      # Check wheel size is small enough for pypi (< 200 MiB)
       HAIL_PIP_VERSION=$(cat python/hail/hail_pip_version)
       WHEEL_PATH="build/deploy/dist/hail-$HAIL_PIP_VERSION-py3-none-any.whl"
       du -h $WHEEL_PATH
@@ -712,8 +704,6 @@ steps:
       time tar czf resources.tar.gz -C src/test resources
       time tar czf data.tar.gz -C python/hail/docs data
       (cd .. && time tar czf hail/website-src.tar.gz website)
-      time tar czf cluster-tests.tar.gz python/cluster-tests
-      (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
       time TESTNG_SPLITS=5 python3 generate_splits.py
       time tar czf splits.tar.gz testng-splits-*.xml
     inputs:
@@ -724,32 +714,45 @@ steps:
         to: /hail.jar
       - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
         to: /hail-test.jar
-      - from: /io/repo/hail/build/debug_libs/hail-all-spark-test.jar
-        to: /hail-debug-test.jar
-      - from: /io/repo/hail/testng-build.xml
-        to: /testng-build.xml
-      - from: /io/repo/hail/testng-services.xml
-        to: /testng-services.xml
-      - from: /io/repo/hail/testng-fs.xml
-        to: /testng-fs.xml
-      - from: /io/repo/hail/python/hail.zip
-        to: /hail.zip
       - from: /io/repo/hail/build/deploy/dist/wheel-container.tar
         to: /wheel-container.tar
-      - from: /io/repo/hail/build/debug_libs/debug-wheel-container.tar
-        to: /debug-wheel-container.tar
+      - from: /io/repo/hail/python/hail.zip
+        to: /hail.zip
       - from: /io/repo/hail/test.tar.gz
         to: /test.tar.gz
       - from: /io/repo/hail/resources.tar.gz
         to: /resources.tar.gz
-      - from: /io/repo/hail/splits.tar.gz
-        to: /splits.tar.gz
       - from: /io/repo/hail/data.tar.gz
         to: /data.tar.gz
       - from: /io/repo/hail/website-src.tar.gz
         to: /website-src.tar.gz
-      - from: /io/repo/hail/cluster-tests.tar.gz
-        to: /cluster-tests.tar.gz
+      - from: /io/repo/hail/splits.tar.gz
+        to: /splits.tar.gz
+    dependsOn:
+      - hail_build_image
+      - merge_code
+  - kind: runImage
+    name: build_hail_debug
+    image:
+      valueFrom: hail_build_image.image
+    resources:
+      memory: standard
+      cpu: '2'
+    script: |
+      set -ex
+      cd /io/repo/hail
+      chmod 755 ./gradlew
+      time retry ./gradlew --version
+      time retry make jars wheel HAIL_DEBUG_MODE=1
+      (cd build/deploy/dist/ && tar -cvf debug-wheel-container.tar hail-*-py3-none-any.whl)
+    inputs:
+      - from: /repo
+        to: /io/repo
+    outputs:
+      - from: /io/repo/hail/build/debug/hail-all-spark-test.jar
+        to: /hail-debug-test.jar
+      - from: /io/repo/hail/build/debug/debug-wheel-container.tar
+        to: /debug-wheel-container.tar
     dependsOn:
       - hail_build_image
       - merge_code
@@ -934,6 +937,7 @@ steps:
       - default_ns
       - hail_run_image
       - build_hail
+      - build_hail_debug
   - kind: buildImage2
     name: hail_base_image
     dockerFile: /io/repo/hail/Dockerfile.hail-base
@@ -1149,6 +1153,7 @@ steps:
       - default_ns
       - hail_run_image
       - build_hail
+      - build_hail_debug
     clouds:
       - gcp
   - kind: runImage
@@ -1312,6 +1317,7 @@ steps:
       - default_ns
       - hail_run_image
       - build_hail
+      - build_hail_debug
   - kind: runImage
     name: test_python_docs
     image:
@@ -3255,7 +3261,7 @@ steps:
         to: /io/resources.tar.gz
       - from: /hail-test.jar
         to: /io/hail-test.jar
-      - from: /testng-fs.xml
+      - from: /io/repo/hail/testng-fs.xml
         to: /io/testng-fs.xml
     secrets:
       - name: test-tokens
@@ -3305,7 +3311,7 @@ steps:
         to: /io/resources.tar.gz
       - from: /hail-test.jar
         to: /io/hail-test.jar
-      - from: /testng-services.xml
+      - from: /io/repo/hail/testng-services.xml
         to: /io/testng-services.xml
     secrets:
       - name: test-tokens


### PR DESCRIPTION
In practice, scalac appears to, at best, use 2.5 CPUs. The `build_hail` task compiles Hail twice, once in debug mode and once not. For reasons unclear to me, the second compilation does not appear to be able to reuse class files from the first one because it takes almost as long! This change runs the two in separate jobs in parallel. This should save ~5 minutes from the local, scala, and spark paths which have recently become slower, in wall-time terms, than service backend.