### PR TITLE
[compiler] Don't generate IRs with reference sharing during agg lowering

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -506,7 +506,7 @@ object Extract {
         ab += InitOp(i, FastIndexedSeq(Begin(initOps)), groupSig) -> groupSig
         seqBuilder += SeqOp(i, FastIndexedSeq(key, Begin(newSeq.result().toFastIndexedSeq)), groupSig)
 
-        ToDict(StreamMap(ToStream(GetTupleElement(result, i)), newRef.name, MakeTuple.ordered(FastSeq(GetField(newRef.deepCopy(), "key"), transformed))))
+        ToDict(StreamMap(ToStream(GetTupleElement(result, i)), newRef.name, MakeTuple.ordered(FastSeq(GetField(newRef, "key"), transformed))))
 
       case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, _) =>
         val newAggs = new BoxedArrayBuilder[(InitOp, PhysicalAggSig)]()
@@ -527,8 +527,7 @@ object Extract {
         val checkSig = ArrayLenAggSig(knownLength.isDefined, pAggSigs)
         val eltSig = AggElementsAggSig(pAggSigs)
 
-        val aRefUID = genUID()
-        def aRef = Ref(aRefUID, a.typ)
+        val aRef = Ref(genUID(), a.typ)
 
         ab += InitOp(i, knownLength.map(FastSeq(_)).getOrElse(FastSeq[IR]()) :+ Begin(initOps), checkSig) -> checkSig
         seqBuilder +=
@@ -546,17 +545,16 @@ object Extract {
                     FastIndexedSeq(Ref(indexName, TInt32), Begin(newSeq.result().toFastIndexedSeq)),
                     eltSig), dependent))))))
 
-        val resUID = genUID()
-        def resRef = Ref(resUID, rt)
+        val rUID = Ref(genUID(), rt)
         Let(
-          resRef.name,
+          rUID.name,
           GetTupleElement(result, i),
           ToArray(StreamMap(
-            StreamRange(0, ArrayLen(resRef), 1),
+            StreamRange(0, ArrayLen(rUID), 1),
             indexName,
             Let(
               newRef.name,
-              ArrayRef(resRef, Ref(indexName, TInt32)),
+              ArrayRef(rUID, Ref(indexName, TInt32)),
               transformed))))
 
       case x: StreamAgg =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -116,7 +116,7 @@ case object LowerArrayAggsToRunAggsPass extends LoweringPass {
 
         if (newNode.typ != x.typ)
           throw new RuntimeException(s"types differ:\n  new: ${newNode.typ}\n  old: ${x.typ}")
-        Some(newNode)
+        Some(newNode.noSharing)
       case x@StreamAggScan(a, name, query) =>
         val res = genUID()
         val aggs = Extract(query, res, r, isScan=true)
@@ -132,7 +132,7 @@ case object LowerArrayAggsToRunAggsPass extends LoweringPass {
         }
         if (newNode.typ != x.typ)
           throw new RuntimeException(s"types differ:\n  new: ${ newNode.typ }\n  old: ${ x.typ }")
-        Some(newNode)
+        Some(newNode.noSharing)
       case _ => None
     })
   }


### PR DESCRIPTION
This fixes a bug Mike W was hitting with a gnomAD pipeline. I wasn't able to replicate with a trivial example, and would prefer not to spend another half-day poring through that huge IR to try to minimize. Verified that this fixes the problem, though.

https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query-0.2E2-support/topic/.E2.9C.94.20Summing.20number.20of.20entries.20meeting.20criteria.20.20by.20group