### PR TITLE
[query] Refactor and fix Backend's persist and unpersist 

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -20,10 +20,9 @@ from hail.ir import (BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, F64,
                      TableFromBlockMatrixNativeReader, TableRead, BlockMatrixSlice,
                      BlockMatrixSparsify, BlockMatrixDensify, RectangleSparsifier,
                      RowIntervalSparsifier, BandSparsifier, PerBlockSparsifier)
-from hail.ir.blockmatrix_reader import (BlockMatrixNativeReader,
-                                        BlockMatrixBinaryReader, BlockMatrixPersistReader)
+from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
 from hail.ir.blockmatrix_writer import (BlockMatrixBinaryWriter,
-                                        BlockMatrixNativeWriter, BlockMatrixRectanglesWriter, BlockMatrixPersistWriter)
+                                        BlockMatrixNativeWriter, BlockMatrixRectanglesWriter)
 from hail.ir import ExportType
 from hail.table import Table
 from hail.typecheck import (typecheck, typecheck_method, nullable, oneof,
@@ -1337,9 +1336,7 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
             Persisted block matrix.
         """
-        id = Env.get_uid()
-        Env.backend().execute(BlockMatrixWrite(self._bmir, BlockMatrixPersistWriter(id, storage_level)))
-        return BlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id, self._bmir), _assert_type=self._bmir._type))
+        return Env.backend().persist_blockmatrix(self)
 
     def unpersist(self):
         """Unpersists this block matrix from memory/disk.
@@ -1354,10 +1351,7 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
             Unpersisted block matrix.
         """
-        if isinstance(self._bmir, BlockMatrixRead) and isinstance(self._bmir.reader, BlockMatrixPersistReader):
-            Env.backend().unpersist_block_matrix(self._bmir.reader.id)
-            return self._bmir.reader.unpersisted()
-        return self
+        return Env.backend().unpersist_blockmatrix(self)
 
     def __pos__(self):
         return self

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3643,7 +3643,7 @@ class MatrixTable(ExprContainer):
         :class:`.MatrixTable`
             Persisted dataset.
         """
-        return Env.backend().persist_matrix_table(self)
+        return Env.backend().persist(self)
 
     def unpersist(self) -> 'MatrixTable':
         """
@@ -3659,7 +3659,7 @@ class MatrixTable(ExprContainer):
         :class:`.MatrixTable`
             Unpersisted dataset.
         """
-        return Env.backend().unpersist_matrix_table(self)
+        return Env.backend().unpersist(self)
 
     @typecheck_method(name=str)
     def add_row_index(self, name: str = 'row_idx') -> 'MatrixTable':

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2124,7 +2124,7 @@ class Table(ExprContainer):
         :class:`.Table`
             Persisted table.
         """
-        return Env.backend().persist_table(self)
+        return Env.backend().persist(self)
 
     def unpersist(self) -> 'Table':
         """
@@ -2140,7 +2140,7 @@ class Table(ExprContainer):
         :class:`.Table`
             Unpersisted table.
         """
-        return Env.backend().unpersist_table(self)
+        return Env.backend().unpersist(self)
 
     @typecheck_method(_localize=bool, _timed=bool)
     def collect(self, _localize=True, *, _timed=False):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -375,8 +375,6 @@ class BlockMatrixIRTests(unittest.TestCase):
         for x in (self.blockmatrix_irs() + [persist]):
             backend._parse_blockmatrix_ir(str(x))
 
-        backend.unpersist_block_matrix('x')
-
 
 class ValueTests(unittest.TestCase):
 


### PR DESCRIPTION
- There is now one persist method that accepts any of a Table,
  MatrixTable, or BlockMatrix.
- Backend.unpersist was incorrect with respect to unpersist docs, it was
  not accepting the persisted dataset, or returning the unpersisted
  dataset, or doing nothing if the dataset wasn't persisted.