### PR TITLE
[pip] Tell the user how to regenerate pinned requirements file

### DIFF
--- a/check_pip_requirements.sh
+++ b/check_pip_requirements.sh
@@ -19,7 +19,8 @@ do
         cat $new_pinned
         echo '--------------------------------------'
         echo "$pinned is no longer up to date with $reqs"
-        echo "Please regenerate the pinned requirements file."
+        echo "Please regenerate the pinned requirements file by running:"
+        echo "> make $pinned"
         exit 1
     }
 done


### PR DESCRIPTION
I noticed that this step blew up in the benchmarking PR and thought I'd provide a better error message.