### PR TITLE
[qob] retry `storage.writer` and `storage.reader`

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -202,7 +202,7 @@ class GoogleStorageFS(
         } else {
           handleRequesterPays(
             { (options: Seq[BlobSourceOption]) =>
-              reader = storage.reader(bucket, path, options:_*)
+              reader = retryTransientErrors { storage.reader(bucket, path, options:_*) }
               reader.seek(lazyPosition)
               reader.read(bb)
             },
@@ -276,7 +276,7 @@ class GoogleStorageFS(
         } else {
           handleRequesterPays(
             { (options: Seq[BlobWriteOption]) =>
-              writer = storage.writer(blobInfo, options:_*)
+              writer = retryTransientErrors { storage.writer(blobInfo, options:_*) }
               f
             },
             BlobWriteOption.userProject _,


### PR DESCRIPTION
I do not think we frequently get errors in `storage.reader`, but I think `storage.writer` was always flaky and we were protected by the `retryTransientErrors` on `createNoCompression`. My change to fix requester pays delayed the error until either the first `write` or the `close` which do not have a `retryTransientErrors` (and it is not obvious to me that it is safe to retry a `flush`).