### PR TITLE
[qob] Fix new transiencies

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -435,14 +435,7 @@ class ServiceBackend(Backend):
         async with driver_output as outfile:
             success = await read_bool(outfile)
             if success:
-                result_bytes = await read_bytes(outfile)
-                try:
-                    return result_bytes
-                except orjson.JSONDecodeError as err:
-                    raise FatalError('Hail internal error. Please contact the Hail team and provide the following information.\n\n' + yamlx.dump({
-                        'service_backend_debug_info': self.debug_info(),
-                        'batch_debug_info': await self._batch.debug_info()
-                    })) from err
+                return await read_bytes(outfile)
 
             short_message = await read_str(outfile)
             expanded_message = await read_str(outfile)

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -202,7 +202,7 @@ class GoogleStorageFS(
         } else {
           handleRequesterPays(
             { (options: Seq[BlobSourceOption]) =>
-              reader = storage.reader(bucket, path, options:_*)
+              reader = retryTransientErrors { storage.reader(bucket, path, options:_*) }
               reader.seek(lazyPosition)
               reader.read(bb)
             },
@@ -276,7 +276,7 @@ class GoogleStorageFS(
         } else {
           handleRequesterPays(
             { (options: Seq[BlobWriteOption]) =>
-              writer = storage.writer(blobInfo, options:_*)
+              writer = retryTransientErrors { storage.writer(blobInfo, options:_*) }
               f
             },
             BlobWriteOption.userProject _,


### PR DESCRIPTION
Merge of https://github.com/hail-is/hail/pull/12868 and https://github.com/hail-is/hail/pull/12867 because I expect each is likely to fail due to the other's error.

---

    [qob] retry `storage.writer` and `storage.reader`
    
    I do not think we frequently get errors in `storage.reader`, but I think `storage.writer` was
    always flaky and we were protected by the `retryTransientErrors` on `createNoCompression`. My
    change to fix requester pays delayed the error until either the first `write` or the `close`
    which do not have a `retryTransientErrors` (and it is not obvious to me that it is safe to retry
    a `flush`).

---

    [qob] retry transient errors reading the results file

---