### PR TITLE
[ci] Put ci-utils on top of base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,9 @@ $(SERVICES_IMAGES): %-image: $(SERVICES_IMAGE_DEPS) $(shell git ls-files $$*)
 	./docker-build.sh . $*/Dockerfile.out $(IMAGE)
 	echo $(IMAGE) > $@
 
-ci-utils-image: hail-ubuntu-image $(SERVICES_IMAGE_DEPS) $(shell git ls-files ci)
+ci-utils-image: base-image $(SERVICES_IMAGE_DEPS) $(shell git ls-files ci)
 	$(eval CI_UTILS_IMAGE := $(DOCKER_PREFIX)/ci-utils:$(TOKEN))
-	python3 ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat hail-ubuntu-image)'"}}' ci/Dockerfile.ci-utils ci/Dockerfile.ci-utils.out
+	python3 ci/jinja2_render.py '{"base_image":{"image":"'$$(cat base-image)'"}}' ci/Dockerfile.ci-utils ci/Dockerfile.ci-utils.out
 	./docker-build.sh . ci/Dockerfile.ci-utils.out $(CI_UTILS_IMAGE)
 	echo $(CI_UTILS_IMAGE) > $@
 

--- a/build.yaml
+++ b/build.yaml
@@ -253,7 +253,7 @@ steps:
       - from: /repo/gear
         to: /io/repo/gear
     dependsOn:
-      - hail_ubuntu_image
+      - base_image
       - merge_code
   - kind: createDatabase
     name: test_database_instance

--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -1,4 +1,4 @@
-FROM {{ hail_ubuntu_image.image }} AS base
+FROM {{ base_image.image }} AS base
 
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN curl --remote-name https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-421.0.0-linux-x86_64.tar.gz && \

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -103,7 +103,7 @@ steps:
       cpu: "2"
       memory: standard
     dependsOn:
-      - hail_ubuntu_image
+      - base_image
       - merge_code
     inputs:
       - from: /repo/ci


### PR DESCRIPTION
the `test_dataproc` steps need what is in ci-utils but also the tools in base_image to build hail. Tested with a dev deploy of `test_dataproc-37`