### PR TITLE
[query] Add manifest files with parallel export

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1494,7 +1494,7 @@ class BGENTests(unittest.TestCase):
             fs = hl.current_backend().fs
 
             with fs.open(f'{tmp}.bgen/shard-manifest.txt') as lines:
-                manifest_files = [line.strip() for line in lines]
+                manifest_files = [os.path.join(f'{tmp}.bgen/', line.strip()) for line in lines]
             bgen3 = hl.import_bgen(manifest_files,
                                    entry_fields=['GP'],
                                    sample_file=tmp + '.sample')

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -582,7 +582,7 @@ class VCFTests(unittest.TestCase):
 
         assert hl.import_vcf(nf)._same(mt)
 
-        manifest_files = [line.strip() for line in fs.open(os.path.join(f, 'shard-manifest.txt'))]
+        manifest_files = [os.path.join(f, line.strip()) for line in fs.open(os.path.join(f, 'shard-manifest.txt'))]
         assert hl.import_vcf(manifest_files[1:], header_file=manifest_files[0])._same(mt)
         assert [p.split('/')[-1] for p in shard_paths] == [p.split('/')[-1] for p in manifest_files]
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -914,6 +914,29 @@ class Tests(unittest.TestCase):
         with hl.hadoop_open(tmp_file, 'r') as f_in:
             assert f_in.read() == 'idx,foo\n0,3\n'
 
+    def test_export_parallel_manifest(self):
+        t = hl.utils.range_table(10, n_partitions=8).key_by()
+        values = t.collect()
+        fs = hl.current_backend().fs
+
+        tmp_file = new_temp_file()
+        t.export(tmp_file, parallel='separate_header')
+
+        with fs.open(f'{tmp_file}/shard-manifest.txt') as lines:
+            manifest_files = [line.strip() for line in lines]
+        ht2 = hl.import_table(manifest_files,
+                              types={'idx': hl.tint32})
+        assert ht2.collect() == values
+
+        tmp_file2 = new_temp_file()
+        t.export(tmp_file2, parallel='header_per_shard')
+
+        with fs.open(f'{tmp_file2}/shard-manifest.txt') as lines:
+            manifest_files = [line.strip() for line in lines]
+        ht3 = hl.import_table(manifest_files,
+                              types={'idx': hl.tint32})
+        assert ht3.collect() == values
+
     def test_write_stage_locally(self):
         t = hl.utils.range_table(5)
         f = new_temp_file(extension='ht')

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -923,7 +923,7 @@ class Tests(unittest.TestCase):
         t.export(tmp_file, parallel='separate_header')
 
         with fs.open(f'{tmp_file}/shard-manifest.txt') as lines:
-            manifest_files = [line.strip() for line in lines]
+            manifest_files = [os.path.join(tmp_file, line.strip()) for line in lines]
         ht2 = hl.import_table(manifest_files,
                               types={'idx': hl.tint32})
         assert ht2.collect() == values
@@ -932,7 +932,7 @@ class Tests(unittest.TestCase):
         t.export(tmp_file2, parallel='header_per_shard')
 
         with fs.open(f'{tmp_file2}/shard-manifest.txt') as lines:
-            manifest_files = [line.strip() for line in lines]
+            manifest_files = [os.path.join(tmp_file2, line.strip()) for line in lines]
         ht3 = hl.import_table(manifest_files,
                               types={'idx': hl.tint32})
         assert ht3.collect() == values

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -803,6 +803,8 @@ case class VCFExportFinalizer(typ: MatrixType, outputPath: String, append: Optio
 
     val partPaths = annotations.loadField(cb, "partFiles").get(cb).asIndexable
     val partFiles = partPaths.castTo(cb, region, SJavaArrayString(true), false).asInstanceOf[SJavaArrayStringValue].array
+    cb.ifx(partPaths.hasMissingValues(cb), cb._fatal("matrixwriter part paths contains missing values"))
+
     val allFiles = if (tabix && exportType != ExportType.CONCATENATED) {
       val len = partPaths.loadLength()
       val files = cb.memoize(Code.newArray[String](len * 2))

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -802,18 +802,21 @@ case class VCFExportFinalizer(typ: MatrixType, outputPath: String, append: Optio
     val annotations = writeAnnotations.get(cb).asBaseStruct
 
     val partPaths = annotations.loadField(cb, "partFiles").get(cb).asIndexable
-    val files = if (tabix && exportType != ExportType.CONCATENATED) {
+    val partFiles = partPaths.castTo(cb, region, SJavaArrayString(true), false).asInstanceOf[SJavaArrayStringValue].array
+    val allFiles = if (tabix && exportType != ExportType.CONCATENATED) {
       val len = partPaths.loadLength()
       val files = cb.memoize(Code.newArray[String](len * 2))
-      partPaths.forEachDefined(cb) { case (cb, i, file: SStringValue) =>
-        val path = file.loadString(cb)
+      val i = cb.newLocal[Int]("i", 0)
+      cb.whileLoop(i < len, {
+        val path = cb.memoize(partFiles(i))
         cb += files.update(i, path)
         // FIXME(chrisvittal): this will put the string ".tbi" in generated code, we should just access the htsjdk value
         cb += files.update(cb.memoize(i + len), Code.invokeStatic2[htsjdk.tribble.util.ParsingUtils, String, String, String]("appendToPath", path, htsjdk.samtools.util.FileExtensions.TABIX_INDEX))
-      }
+        cb.assign(i, i+1)
+      })
       files
     } else {
-      partPaths.castTo(cb, region, SJavaArrayString(true), false).asInstanceOf[SJavaArrayStringValue].array
+      partFiles
     }
     exportType match {
       case ExportType.CONCATENATED =>
@@ -825,10 +828,10 @@ case class VCFExportFinalizer(typ: MatrixType, outputPath: String, append: Optio
         cb += os.invoke[Int, Unit]("write", '\n')
         cb += os.invoke[Unit]("close")
 
-        val jFiles = cb.memoize(Code.newArray[String](files.length + 1))
+        val jFiles = cb.memoize(Code.newArray[String](partFiles.length + 1))
         cb += (jFiles(0) = const(headerFilePath))
         cb += Code.invokeStatic5[System, Any, Int, Any, Int, Int, Unit](
-          "arraycopy", files /*src*/, 0 /*srcPos*/, jFiles /*dest*/, 1 /*destPos*/, files.length /*len*/)
+          "arraycopy", partFiles /*src*/, 0 /*srcPos*/, jFiles /*dest*/, 1 /*destPos*/, partFiles.length /*len*/)
 
         cb += cb.emb.getFS.invoke[Array[String], String, Unit]("concatenateFiles", jFiles, const(outputPath))
 
@@ -842,11 +845,12 @@ case class VCFExportFinalizer(typ: MatrixType, outputPath: String, append: Optio
         }
 
       case ExportType.PARALLEL_HEADER_IN_SHARD =>
-        cb += Code.invokeScalaObject3[FS, String, Array[String], Unit](TableTextFinalizer.getClass, "cleanup", cb.emb.getFS, outputPath, files)
+        cb += Code.invokeScalaObject3[FS, String, Array[String], Unit](TableTextFinalizer.getClass, "cleanup", cb.emb.getFS, outputPath, allFiles)
+        cb += Code.invokeScalaObject4[FS, String, Array[String], String, Unit](TableTextFinalizer.getClass, "writeManifest", cb.emb.getFS, outputPath, partFiles, Code._null[String])
         cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
 
       case ExportType.PARALLEL_SEPARATE_HEADER =>
-        cb += Code.invokeScalaObject3[FS, String, Array[String], Unit](TableTextFinalizer.getClass, "cleanup", cb.emb.getFS, outputPath, files)
+        cb += Code.invokeScalaObject3[FS, String, Array[String], Unit](TableTextFinalizer.getClass, "cleanup", cb.emb.getFS, outputPath, allFiles)
         val headerFilePath = s"$outputPath/header$ext"
         val headerStr = header(cb, annotations)
 
@@ -854,6 +858,7 @@ case class VCFExportFinalizer(typ: MatrixType, outputPath: String, append: Optio
         cb += os.invoke[Array[Byte], Unit]("write", headerStr.invoke[Array[Byte]]("getBytes"))
         cb += os.invoke[Int, Unit]("write", '\n')
         cb += os.invoke[Unit]("close")
+        cb += Code.invokeScalaObject4[FS, String, Array[String], String, Unit](TableTextFinalizer.getClass, "writeManifest", cb.emb.getFS, outputPath, partFiles, headerFilePath)
 
         cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
     }
@@ -1211,15 +1216,19 @@ case class BGENExportFinalizer(typ: MatrixType, path: String, exportType: String
         cb += files.update(i, res.asBaseStruct.loadField(cb, "partFile").get(cb).asString.loadString(cb))
       }
 
+      val headerStr = if (exportType == ExportType.PARALLEL_SEPARATE_HEADER) {
+        val headerStr = cb.memoize(const(path + ".bgen").concat("/header"))
+        val os = cb.memoize(cb.emb.create(headerStr))
+        val header = Code.invokeScalaObject3[Array[String], Long, Int, Array[Byte]](BgenWriter.getClass, "headerBlock", sampleIds, numVariants, compression)
+        cb += os.invoke[Array[Byte], Unit]("write", header)
+        cb += os.invoke[Unit]("close")
+        headerStr
+      } else Code._null[String]
       cb += Code.invokeScalaObject3[FS, String, Array[String], Unit](TableTextFinalizer.getClass, "cleanup", cb.emb.getFS, path + ".bgen", files)
+      cb += Code.invokeScalaObject4[FS, String, Array[String], String, Unit](TableTextFinalizer.getClass, "writeManifest", cb.emb.getFS, path + ".bgen", files, headerStr)
+
     }
 
-    if (exportType == ExportType.PARALLEL_SEPARATE_HEADER) {
-      val os = cb.memoize(cb.emb.create(const(path + ".bgen").concat("/header")))
-      val header = Code.invokeScalaObject3[Array[String], Long, Int, Array[Byte]](BgenWriter.getClass, "headerBlock", sampleIds, numVariants, compression)
-      cb += os.invoke[Array[Byte], Unit]("write", header)
-      cb += os.invoke[Unit]("close")
-    }
 
     if (exportType == ExportType.CONCATENATED) {
       val os = cb.memoize(cb.emb.create(const(path + ".bgen")))

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -25,7 +25,7 @@ import is.hail.utils.richUtils.ByteTrackingOutputStream
 import is.hail.variant.ReferenceGenome
 import org.json4s.{DefaultFormats, Formats, JBool, JObject, ShortTypeHints}
 
-import java.io.OutputStream
+import java.io.{BufferedOutputStream, OutputStream}
 import java.nio.file.{FileSystems, Path}
 import java.util.UUID
 import scala.language.existentials
@@ -504,6 +504,22 @@ case class TableTextPartitionWriter(rowType: TStruct, delimiter: String, writeHe
 }
 
 object TableTextFinalizer {
+  def writeManifest(fs: FS, outputPath: String, files: Array[String], header: String): Unit = {
+    using(fs.createNoCompression(fs.makeQualified(outputPath + "/shard-manifest.txt"))) { os =>
+      val bos = new BufferedOutputStream(os)
+
+      if (header != null) {
+        bos.write(header.getBytes)
+        bos.write('\n')
+      }
+      files.foreach { f =>
+        bos.write(f.getBytes())
+        bos.write('\n')
+      }
+      bos.flush()
+    }
+  }
+
   def cleanup(fs: FS, outputPath: String, files: Array[String]): Unit = {
     val outputFiles = fs.listStatus(fs.makeQualified(outputPath)).map(_.getPath).toSet
     val fileSet = files.map(fs.makeQualified(_)).toSet
@@ -547,19 +563,23 @@ case class TableTextFinalizer(outputPath: String, rowType: TStruct, delimiter: S
 
       case ExportType.PARALLEL_HEADER_IN_SHARD =>
         cb += Code.invokeScalaObject3[FS, String, Array[String], Unit](TableTextFinalizer.getClass, "cleanup", cb.emb.getFS, outputPath, files)
+        cb += Code.invokeScalaObject4[FS, String, Array[String], String, Unit](TableTextFinalizer.getClass, "writeManifest", cb.emb.getFS, outputPath, files, Code._null[String])
+
         cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
 
       case ExportType.PARALLEL_SEPARATE_HEADER =>
         cb += Code.invokeScalaObject3[FS, String, Array[String], Unit](TableTextFinalizer.getClass, "cleanup", cb.emb.getFS, outputPath, files)
-        if (header) {
-          val headerFilePath = s"$outputPath/header$ext"
+        val headerPath = if (header) {
+          val headerFilePath = const(s"$outputPath/header$ext")
           val headerStr = rowType.fields.map(_.name).mkString(delimiter)
-          val os = cb.memoize(cb.emb.create(const(headerFilePath)))
+          val os = cb.memoize(cb.emb.create(headerFilePath))
           cb += os.invoke[Array[Byte], Unit]("write", const(headerStr).invoke[Array[Byte]]("getBytes"))
           cb += os.invoke[Int, Unit]("write", '\n')
           cb += os.invoke[Unit]("close")
-        }
+          headerFilePath
+        } else Code._null[String]
 
+        cb += Code.invokeScalaObject4[FS, String, Array[String], String, Unit](TableTextFinalizer.getClass, "writeManifest", cb.emb.getFS, outputPath, files, headerPath)
         cb += cb.emb.getFS.invoke[String, Unit]("touch", const(outputPath).concat("/_SUCCESS"))
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -504,16 +504,19 @@ case class TableTextPartitionWriter(rowType: TStruct, delimiter: String, writeHe
 }
 
 object TableTextFinalizer {
-  def writeManifest(fs: FS, outputPath: String, files: Array[String], header: String): Unit = {
+  def writeManifest(fs: FS, outputPath: String, files: Array[String], optionalAdditionalFirstPath: String): Unit = {
+
+    def basename(f: String): String = (new java.io.File(f)).getName
+
     using(fs.createNoCompression(fs.makeQualified(outputPath + "/shard-manifest.txt"))) { os =>
       val bos = new BufferedOutputStream(os)
 
-      if (header != null) {
-        bos.write(header.getBytes)
+      if (optionalAdditionalFirstPath != null) {
+        bos.write(basename(optionalAdditionalFirstPath).getBytes())
         bos.write('\n')
       }
       files.foreach { f =>
-        bos.write(f.getBytes())
+        bos.write(basename(f).getBytes())
         bos.write('\n')
       }
       bos.flush()


### PR DESCRIPTION
Parallel export modes now write a manifest file, "shard-manifest.txt" to the folder where generated shards live. These manifest files are text files with one filename per line, containing name of each shard written successfully to the directory. These filenames are relative to the export directory.

If a header is written, that is the first filename in the shard manifest.