### PR TITLE
[vds] Add function to patch old VDSes to store max reference block length

### DIFF
--- a/hail/python/hail/docs/vds/index.rst
+++ b/hail/python/hail/docs/vds/index.rst
@@ -49,6 +49,7 @@ large as 955,000 whole exomes. The :class:`.VariantDatasetCombiner` produces a
     merge_reference_blocks
     lgt_to_gt
     local_to_global
+    store_ref_block_max_len
 
 .. currentmodule:: hail.vds.combiner
 

--- a/hail/python/hail/docs/vds/index.rst
+++ b/hail/python/hail/docs/vds/index.rst
@@ -49,7 +49,7 @@ large as 955,000 whole exomes. The :class:`.VariantDatasetCombiner` produces a
     merge_reference_blocks
     lgt_to_gt
     local_to_global
-    store_ref_block_max_len
+    store_ref_block_max_length
 
 .. currentmodule:: hail.vds.combiner
 

--- a/hail/python/hail/vds/__init__.py
+++ b/hail/python/hail/vds/__init__.py
@@ -4,7 +4,7 @@ from .methods import filter_intervals, filter_samples, filter_variants, sample_q
     to_merged_sparse_mt, segment_reference_blocks, write_variant_datasets, interval_coverage, \
     impute_sex_chr_ploidy_from_interval_coverage, impute_sex_chromosome_ploidy, filter_chromosomes, \
     truncate_reference_blocks, merge_reference_blocks
-from .variant_dataset import VariantDataset, read_vds, store_ref_block_max_len
+from .variant_dataset import VariantDataset, read_vds, store_ref_block_max_length
 from .combiner import load_combiner, new_combiner
 
 __all__ = [
@@ -30,5 +30,5 @@ __all__ = [
     'merge_reference_blocks',
     'lgt_to_gt',
     'local_to_global',
-    'store_ref_block_max_len',
+    'store_ref_block_max_length',
 ]

--- a/hail/python/hail/vds/__init__.py
+++ b/hail/python/hail/vds/__init__.py
@@ -4,7 +4,7 @@ from .methods import filter_intervals, filter_samples, filter_variants, sample_q
     to_merged_sparse_mt, segment_reference_blocks, write_variant_datasets, interval_coverage, \
     impute_sex_chr_ploidy_from_interval_coverage, impute_sex_chromosome_ploidy, filter_chromosomes, \
     truncate_reference_blocks, merge_reference_blocks
-from .variant_dataset import VariantDataset, read_vds
+from .variant_dataset import VariantDataset, read_vds, store_ref_block_max_len
 from .combiner import load_combiner, new_combiner
 
 __all__ = [
@@ -29,5 +29,6 @@ __all__ = [
     'truncate_reference_blocks',
     'merge_reference_blocks',
     'lgt_to_gt',
-    'local_to_global'
+    'local_to_global',
+    'store_ref_block_max_len',
 ]

--- a/hail/python/hail/vds/combiner/combine.py
+++ b/hail/python/hail/vds/combiner/combine.py
@@ -215,7 +215,7 @@ def combine_r(ts, ref_block_max_len_field):
 
 
 def combine_references(mts: List[MatrixTable]) -> MatrixTable:
-    fd = 'ref_block_max_length'
+    fd = hl.vds.VariantDataset.ref_block_max_length_field
     n_with_ref_max_len = len([mt for mt in mts if fd in mt.globals])
     any_ref_max = n_with_ref_max_len > 0
     all_ref_max = n_with_ref_max_len == len(mts)

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -614,8 +614,9 @@ def _parameterized_filter_intervals(vds: 'VariantDataset',
                                              interval.includes_end))
             reference_data = hl.filter_intervals(reference_data, ref_intervals, keep)
         else:
-            warning("'hl.vds.filter_intervals': filtering intervals when reference blocks have not been truncated"
-                    "\n  (by 'hl.vds.truncate_reference_blocks') requires a full pass over the reference data (expensive!)")
+            warning("'hl.vds.filter_intervals': filtering intervals without a know max reference block length"
+                    "\n  (computed by `hl.vds.store_ref_block_max_length` or 'hl.vds.truncate_reference_blocks')"
+                    "\n  requires a full pass over the reference data (expensive!)")
 
     if mode == 'variants_only':
         variant_data = hl.filter_intervals(vds.variant_data, intervals, keep)
@@ -967,6 +968,11 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None,
     stored in the global fields, which permits :func:`.vds.filter_intervals` to filter to intervals of the reference
     data by reading `ref_block_max_length` bases ahead of each interval. This allows narrow interval queries
     to run in roughly O(data kept) work rather than O(all reference data) work.
+
+    See Also
+    --------
+    It is also possible to patch an existing VDS to store the max reference block length with
+    :func:`.vds.store_ref_block_max_len`.
 
     Parameters
     ----------

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -971,7 +971,7 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None,
     to run in roughly O(data kept) work rather than O(all reference data) work.
 
     It is also possible to patch an existing VDS to store the max reference block length with :func:`.vds.store_ref_block_max_length`.
-    
+
     See Also
     --------
     :func:`.vds.store_ref_block_max_length`.

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -616,7 +616,7 @@ def _parameterized_filter_intervals(vds: 'VariantDataset',
             reference_data = hl.filter_intervals(reference_data, ref_intervals, keep)
         else:
             warning("'hl.vds.filter_intervals': filtering intervals without a known max reference block length"
-                    "\n  (computed by `hl.vds.store_ref_block_max_length` or 'hl.vds.truncate_reference_blocks')"
+                    "\n  (computed by `hl.vds.store_ref_block_max_lengthgth` or 'hl.vds.truncate_reference_blocks')"
                     "\n  requires a full pass over the reference data (expensive!)")
 
     if mode == 'variants_only':
@@ -970,10 +970,11 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None,
     data by reading `ref_block_max_length` bases ahead of each interval. This allows narrow interval queries
     to run in roughly O(data kept) work rather than O(all reference data) work.
 
+    It is also possible to patch an existing VDS to store the max reference block length with :func:`.vds.store_ref_block_max_length`.
+    
     See Also
     --------
-    It is also possible to patch an existing VDS to store the max reference block length with
-    :func:`.vds.store_ref_block_max_len`.
+    :func:`.vds.store_ref_block_max_length`.
 
     Parameters
     ----------

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -615,7 +615,7 @@ def _parameterized_filter_intervals(vds: 'VariantDataset',
                                              interval.includes_end))
             reference_data = hl.filter_intervals(reference_data, ref_intervals, keep)
         else:
-            warning("'hl.vds.filter_intervals': filtering intervals without a know max reference block length"
+            warning("'hl.vds.filter_intervals': filtering intervals without a known max reference block length"
                     "\n  (computed by `hl.vds.store_ref_block_max_length` or 'hl.vds.truncate_reference_blocks')"
                     "\n  requires a full pass over the reference data (expensive!)")
 

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -79,8 +79,8 @@ def to_dense_mt(vds: 'VariantDataset') -> 'MatrixTable':
     dr = dr._key_by_assert_sorted('locus', 'alleles')
     fields_to_drop = ['_var_entries', '_ref_entries', 'dense_ref', '_variant_defined']
 
-    if 'ref_block_max_length' in dr.globals:
-        fields_to_drop.append('ref_block_max_length')
+    if hl.vds.VariantDataset.ref_block_max_length_field in dr.globals:
+        fields_to_drop.append(hl.vds.VariantDataset.ref_block_max_length_field)
 
     if 'ref_allele' in dr.row:
         fields_to_drop.append('ref_allele')
@@ -607,8 +607,9 @@ def _parameterized_filter_intervals(vds: 'VariantDataset',
 
     reference_data = vds.reference_data
     if keep:
-        if 'ref_block_max_length' in vds.reference_data.globals:
-            max_len = hl.eval(vds.reference_data.index_globals()['ref_block_max_length'])
+        rbml = hl.vds.VariantDataset.ref_block_max_length_field
+        if rbml in vds.reference_data.globals:
+            max_len = hl.eval(vds.reference_data.index_globals()[rbml])
             ref_intervals = intervals.map(
                 lambda interval: hl.interval(interval.start - (max_len - 1), interval.end, interval.includes_start,
                                              interval.includes_end))
@@ -1029,7 +1030,7 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None,
         lambda idx: hl.coalesce(joined.moved_blocks_dict.get(idx), joined.fixed_blocks[idx])))
     new_rd = joined._unlocalize_entries(entries_field_name='merged_blocks', cols_field_name='cols',
                                         col_key=list(rd.col_key))
-    new_rd = new_rd.annotate_globals(ref_block_max_length=max_ref_block_base_pairs)
+    new_rd = new_rd.annotate_globals(**{hl.vds.VariantDataset.ref_block_max_length_field: max_ref_block_base_pairs})
 
     if isinstance(ds, hl.vds.VariantDataset):
         return VariantDataset(reference_data=new_rd, variant_data=ds.variant_data)
@@ -1151,8 +1152,9 @@ def merge_reference_blocks(ds, equivalence_function, merge_functions=None):
     new_rd = ht_joined._unlocalize_entries(entries_field_name='new_entries', cols_field_name='cols',
                                            col_key=list(rd.col_key))
 
-    if 'ref_block_max_length' in new_rd.globals:
-        new_rd = new_rd.drop('ref_block_max_length')
+    rbml = hl.vds.VariantDataset.ref_block_max_length_field
+    if rbml in new_rd.globals:
+        new_rd = new_rd.drop(rbml)
 
     if isinstance(ds, VariantDataset):
         return VariantDataset(reference_data=new_rd, variant_data=ds.variant_data)

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -46,12 +46,12 @@ def read_vds(path, *, intervals=None, n_partitions=None,
             warning("You are reading a VDS written with an older version of Hail."
                     "\n  Hail now supports much faster interval filters on VDS, but you'll need to run either"
                     "\n  `hl.vds.truncate_reference_blocks(vds, ...)` and write a copy (see docs) or patch the"
-                    "\n  existing VDS in place with `hl.vds.store_ref_block_max_len(vds_path)`.")
+                    "\n  existing VDS in place with `hl.vds.store_ref_block_max_length(vds_path)`.")
 
     return vds
 
 
-def store_ref_block_max_len(vds_path):
+def store_ref_block_max_length(vds_path):
     """Patches an existing VDS file to store the max reference block length for faster interval filters.
 
     This method permits :func:`.vds.filter_intervals` to remove reference data not overlapping a target interval.
@@ -64,7 +64,7 @@ def store_ref_block_max_len(vds_path):
 
     Examples
     --------
-    >>> hl.vds.store_ref_block_max_len('gs://path/to/my.vds')  # doctest: +SKIP
+    >>> hl.vds.store_ref_block_max_length('gs://path/to/my.vds')  # doctest: +SKIP
 
     See Also
     --------
@@ -102,6 +102,7 @@ class VariantDataset:
         MatrixTable containing only variant data.
     """
 
+    #: Name of global field that indicates max reference block length.
     ref_block_max_length_field = 'ref_block_max_length'
 
     @staticmethod

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -3,8 +3,12 @@ import os
 import hail as hl
 from hail.matrixtable import MatrixTable
 from hail.typecheck import typecheck_method
-from hail.utils.java import info
+from hail.utils.java import info, warning
 from hail.genetics import ReferenceGenome
+
+import json
+
+extra_ref_globals_file = 'extra_reference_globals.json'
 
 
 def read_vds(path, *, intervals=None, n_partitions=None,
@@ -29,7 +33,58 @@ def read_vds(path, *, intervals=None, n_partitions=None,
         assert len(intervals) > 0
         reference_data = hl.read_matrix_table(VariantDataset._reference_path(path), _intervals=intervals)
         variant_data = hl.read_matrix_table(VariantDataset._variants_path(path), _intervals=intervals)
-    return VariantDataset(reference_data, variant_data)
+
+    vds = VariantDataset(reference_data, variant_data)
+    if 'max_ref_block_len' not in vds.reference_data.globals:
+        fs = hl.current_backend().fs
+        metadata_file = os.path.join(path, extra_ref_globals_file)
+        if fs.exists(metadata_file):
+            with fs.open(metadata_file, 'r') as f:
+                metadata = json.load(f)
+                vds.reference_data = vds.reference_data.annotate_globals(**metadata)
+        else:
+            warning("You are reading a VDS written with an older version of Hail."
+                    "\n  Hail now supports much faster interval filters on VDS, but you'll need to run either"
+                    "\n  `hl.vds.truncate_reference_blocks(vds, ...)` and write a copy (see docs) or patch the"
+                    "\n  existing VDS in place with `hl.vds.store_ref_block_max_len(vds_path)`.")
+
+    return vds
+
+
+def store_ref_block_max_len(vds_path):
+    """Patches an existing VDS file to store the max reference block length for faster interval filters.
+
+    This method permits :func:`.vds.filter_intervals` to remove reference data not overlapping a target interval.
+
+    This method is able to patch an existing VDS file in-place, without copying all the data. However,
+    if significant downstream interval filtering is anticipated, it may be advantageous to run
+    :func:`.vds.truncate_reference_blocks` to truncate long reference blocks and make interval filters
+    even faster. However, truncation requires rewriting the entire VDS.
+
+
+    Examples
+    --------
+    >>> hl.vds.store_ref_block_max_len('gs://path/to/my.vds')  # doctest: +SKIP
+
+    See Also
+    --------
+    :func:`.vds.filter_intervals`, :func:`.vds.truncate_reference_blocks`.
+
+    Parameters
+    ----------
+    vds_path : :obj:`str`
+    """
+    vds = hl.vds.read_vds(vds_path)
+
+    if 'max_ref_block_len' in vds.reference_data.globals:
+        warning(f"VDS at {vds_path} already contains a global annotation with the max reference block length")
+        return
+    rd = vds.reference_data
+    rd = rd.annotate_rows(__start_pos=rd.locus.position)
+    fs = hl.current_backend().fs
+    max_ref_block_len = rd.aggregate_entries(hl.agg.max(rd.END - rd.__start_pos + 1))
+    with fs.open(os.path.join(vds_path, extra_ref_globals_file), 'w') as f:
+        json.dump({'max_ref_block_len': max_ref_block_len}, f)
 
 
 class VariantDataset:

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -664,7 +664,7 @@ def test_ref_block_max_len_patch():
         vds_path = os.path.join(tmpdir, 'to_patch.vds')
         vds.write(vds_path)
 
-        hl.vds.store_ref_block_max_len(vds_path)
+        hl.vds.store_ref_block_max_length(vds_path)
 
         vds2 = hl.vds.read_vds(vds_path)
-        assert hl.eval(vds2.reference_data.index_globals().ref_block_max_len) == max_rb_len
+        assert hl.eval(vds2.reference_data.index_globals()[hl.vds.VariantDataset.ref_block_max_length_field]) == max_rb_len

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -614,7 +614,7 @@ def test_union_rows():
     vds2_trunc = hl.vds.truncate_reference_blocks(vds1, max_ref_block_base_pairs=75)
 
     vds_trunc_union = vds1_trunc.union_rows(vds2_trunc)
-    assert hl.eval(vds_trunc_union.reference_data.index_globals().ref_block_max_length) == 75
+    assert hl.eval(vds_trunc_union.reference_data.index_globals()[hl.vds.VariantDataset.ref_block_max_length_field]) == 75
 
     assert 'max_ref_block_length' not in vds1_trunc.union_rows(vds2).reference_data.globals
 
@@ -634,10 +634,10 @@ def test_combiner_max_len():
     from hail.vds.combiner.combine import combine_references
 
     combined1 = combine_references([vds1_trunc.reference_data, vds2_trunc.reference_data])
-    assert hl.eval(combined1.index_globals().ref_block_max_length) == 75
+    assert hl.eval(combined1.index_globals()[hl.vds.VariantDataset.ref_block_max_length_field]) == 75
 
     combined2 = combine_references([vds1_trunc.reference_data, vds2.reference_data])
-    assert 'ref_block_max_length' not in combined2.globals
+    assert hl.vds.VariantDataset.ref_block_max_length_field not in combined2.globals
 
 
 def test_split_sparse_roundtrip():
@@ -667,4 +667,4 @@ def test_ref_block_max_len_patch():
         hl.vds.store_ref_block_max_len(vds_path)
 
         vds2 = hl.vds.read_vds(vds_path)
-        assert hl.eval(vds2.reference_data.index_globals().max_ref_block_len) == max_rb_len
+        assert hl.eval(vds2.reference_data.index_globals().ref_block_max_len) == max_rb_len


### PR DESCRIPTION
CHANGELOG: Added `hl.vds.store_ref_block_max_len` to patch old VDSes to make interval filtering faster.