### PR TITLE
[terraform] enable VPC Flow logs in all our US subnets

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -92,6 +92,40 @@ resource "google_compute_subnetwork" "default_region" {
   ip_cidr_range = var.default_subnet_ip_cidr_range
   private_ip_google_access = true
 
+  log_config {
+    aggregation_interval = "INTERVAL_15_MIN"
+    flow_sampling        = 0.5
+    metadata             = "EXCLUDE_ALL_METADATA"
+  }
+
+  timeouts {}
+}
+
+resource "google_compute_subnetwork" "us_nondefault_subnets" {
+  for_each = {
+    us-east1 = "10.142.0.0/20",
+    us-east4 = "10.150.0.0/20",
+    us-east5 = "10.202.0.0/20",
+    us-east7 = "10.196.0.0/20",
+    us-south1 = "10.206.0.0/20",
+    us-west1 = "10.138.0.0/20",
+    us-west2 = "10.168.0.0/20",
+    us-west3 = "10.180.0.0/20",
+    us-west4 = "10.182.0.0/20",
+  }
+
+  name = "default"
+  region = each.key
+  network = google_compute_network.default.id
+  ip_cidr_range = each.value
+  private_ip_google_access = true
+
+  log_config {
+    aggregation_interval = "INTERVAL_15_MIN"
+    flow_sampling        = 0.5
+    metadata             = "EXCLUDE_ALL_METADATA"
+  }
+
   timeouts {}
 }
 


### PR DESCRIPTION
NB, this is a stacked PR. To see just these changes see [this commit](https://github.com/hail-is/hail/pull/12883/commits/ae51e0a9af12e4c89a44e7ce3235f3f665ff4830)

---

[VPC Flow Logs](https://cloud.google.com/vpc/docs/flow-logs):

> VPC Flow Logs records a sample of network flows sent from and received by VM instances, including
> instances used as Google Kubernetes Engine nodes. These logs can be used for network monitoring,
> forensics, real-time security analysis, and expense optimization

I found the collection process the most elucidating part of the documentation. My summary of that
process follows:

1. Packets are sampled on the network interface of a VM. Google claims an average sampling rate of
   1/30. This rate reduces if the VM is under load. This rate is immutable to us.

2. Within an "aggregation interval", packets are aggregated into "records" which are keyed (my term)
   by source & destination. There are currently six choices for aggregation interval: 5s, 30s, 1m,
   5m, 10m, and 15m.

3. Records are sampled. The sampling rate is a user configured floating point number (precision
   unclear) between 0 and 1.

4. Metadata is optionally added to the records. The metadata captures information about the source
   and destination VM such as project id, VM name, zone, region, GKE pod, GKE service, and geographic
   information of external parties. The user may elect to receive all metadata, no metadata, or a
   specific set of metadata fields.

5. The records are written to Google Cloud Logging.

The pricing of VPC Flow Logs is described at the [network pricing page](https://cloud.google.com/vpc/network-pricing#network-telemetry). Notice that, if logs are only sent to Cloud Logging (not to BigQuery, Pub/Sub, or Cloud Storage):

> If you store your logs in Cloud Logging, logs generation charges are waived, and only Logging charges apply.

I believe in this phrase "logs generation charges" refers to *VPC Flow logs* generation charges. The Google Cloud Logging [pricing page](https://cloud.google.com/stackdriver/pricing#google-clouds-operations-suite-pricing) indicates that, after 50 GiB of free logs, the user is charged 0.50 USD per GiB of logs. Storage is free for thirty days and 0.01 USD per GiB for each additional day.

We can calculate the cost of our logs as follows. Refer to the [definition of the record format](https://cloud.google.com/vpc/docs/flow-logs#record_format) for details.

```python3
ip_string = len("123.123.123.123")
ip_connection = 4 + ip_string + ip_string + 4 + 4
date_time = len("1937-01-01T12:00:27.87+00:20")
record_bytes = sum((
    ip_connection,
    max(len('SRC'), len('DEST')),
    8,
    8,
    8,
    date_time,
    date_time,
))
assert record_bytes == 126

hours_per_month = 24 * 60
seconds_per_hour = 60 * 60

seconds_per_interval = 15 * 60
vms = 10000
sampling_rate = 0.5
connections_per_vm_per_aggregation_interval = 100

intervals_per_hour = seconds_per_hour / seconds_per_interval
records_per_hour = intervals_per_hour * vms * connections_per_vm_per_aggregation_interval * sampling_rate
bytes_per_hour = records_per_hour * record_bytes
bytes_per_month = bytes_per_hour * hours_per_month
GiB_per_month = bytes_per_month / 1024. / 1024 / 1024

USD_per_month = max(0, GiB_per_month - 50) * 0.5

print(GiB_per_month)
print(USD_per_month)
```

This works out to 143 USD to run a 10,000 VM cluster 24 hours a day for 30 days.

I suspect our average VM count in a month is closer to 10 which is within the free tier (340 MiB). I
might be wrong abou the connections per vm per aggregation interval, but this is straightforward to
monitor once we have the logs.

For a sense of the cost landscape, these are all free:

1. 1000 VMs.
2. 500 VMs, with a sampling rate of 1.
3. 200 VMs, with a sampling rate of 1, with an interval of 5 minutes.
4. 10 VMs, with a sampling rate of 1, with an interval of 30 seconds.

It's all linear, so if we need to halve the interval we can either change the sampling rate, reasses
our expected number of VM-hours, or adjust the service fee accordingly.

We can also assess the landscape of fees necessary to cover costs (ignoring the free 50 GiB):

1. 15 minute intervals, 0.5 sampling rate, 100 expected connections per vm per interval: 0.0000008
   USD per core per hour.

2. 30 second intervals, 1.0 sampling rate, 100 expected connections per vm per interval: 0.00005 USD
   per core per hour.

2. 5 second intervals, 1.0 sampling rate, 100 expected connections per vm per interval: 0.0003 USD
   per core per hour.

2. 5 second intervals, 1.0 sampling rate, 1000 expected connections per vm per interval (1000 unique
   connections per second honestly seems to me quite remarkable performance): 0.003 USD per core per
   hour.

```
USD_per_core_per_hour = bytes_per_hour / vms / 1024. / 1024 / 1024 * 0.5 / 16

print(USD_per_core_per_hour)
```

---

# Conclusion

I think we're safe to enable this with the parameters in this PR (15 minute intervals, 50%
sampling). We can assess unknown parameters, like connections per vm, and get comfortable looking at
these logs.

Security constraints or observability demands may push us towards desiring more logs. If that
occurs, we can assess the need for a new fee. Regardless, this fee appears to be small relative to
the current cost of preemptible cores.
