### PR TITLE
[batch] Default to using the test method name for the name of the batch

### DIFF
--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -14,7 +14,7 @@ from hailtop.utils import secret_alnum_string
 from hailtop.utils.rich_progress_bar import BatchProgressBar
 
 from .billing_projects import get_billing_project_prefix
-from .utils import DOCKER_ROOT_IMAGE
+from .utils import DOCKER_ROOT_IMAGE, create_batch
 
 pytestmark = pytest.mark.asyncio
 
@@ -77,7 +77,7 @@ async def test_bad_token():
     token = session_id_encode_to_str(secrets.token_bytes(32))
     bc = await BatchClient.create('test', _token=token)
     try:
-        bb = bc.create_batch()
+        bb = create_batch(bc)
         bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
         b = await bb.submit()
         assert False, str(await b.debug_info())
@@ -180,7 +180,7 @@ async def test_close_billing_project_with_pending_batch_update_does_not_error(
     project = new_billing_project
     await dev_client.add_user("test", project)
     client = await make_client(project)
-    bb = client.create_batch()
+    bb = create_batch(client)
     bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
     b = await bb._open_batch()
     update_id = await bb._create_update(b.id)
@@ -354,12 +354,12 @@ async def test_billing_project_accrued_costs(
     def approx_equal(x, y, tolerance=1e-10):
         return abs(x - y) <= tolerance
 
-    bb = client.create_batch()
+    bb = create_batch(client)
     j1_1 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
     j1_2 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
     b1 = await bb.submit()
 
-    bb = client.create_batch()
+    bb = create_batch(client)
     j2_1 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
     j2_2 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
     b2 = await bb.submit()
@@ -408,7 +408,7 @@ async def test_billing_limit_zero(
     client = await make_client(project)
 
     try:
-        bb = client.create_batch()
+        bb = create_batch(client)
         b = await bb.submit()
     except httpx.ClientResponseError as e:
         assert e.status == 403 and 'has exceeded the budget' in e.body
@@ -433,7 +433,7 @@ async def test_billing_limit_tiny(
 
     client = await make_client(project)
 
-    bb = client.create_batch()
+    bb = create_batch(client)
     j1 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
     j2 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j1])
     j3 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j2])
@@ -473,7 +473,7 @@ async def test_user_can_access_batch_made_by_other_user_in_shared_billing_projec
     assert r['billing_project'] == project
 
     user1_client = await make_client(project)
-    b = user1_client.create_batch()
+    b = create_batch(user1_client)
     j = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
     b_handle = await b.submit()
 
@@ -542,7 +542,7 @@ async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(
     assert r['billing_project'] == project
 
     user1_client = await make_client(project)
-    bb = user1_client.create_batch()
+    bb = create_batch(user1_client)
     j = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
     b = await bb.submit()
 
@@ -620,7 +620,7 @@ async def test_deleted_open_batches_do_not_prevent_billing_project_closure(
     try:
         await dev_client.add_user('test', project)
         client = await make_client(project)
-        open_batch = await client.create_batch()._open_batch()
+        open_batch = await create_batch(client)._open_batch()
         await open_batch.delete()
     finally:
         await dev_client.close_billing_project(project)
@@ -636,7 +636,7 @@ async def test_billing_project_case_sensitive(dev_client: BatchClient, new_billi
     dev_client.reset_billing_project(new_billing_project)
 
     # create one batch with the correct billing project
-    bb = dev_client.create_batch()
+    bb = create_batch(dev_client)
     bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
     await bb.submit()
 
@@ -644,7 +644,7 @@ async def test_billing_project_case_sensitive(dev_client: BatchClient, new_billi
 
     # create batch
     try:
-        bb = dev_client.create_batch()
+        bb = create_batch(dev_client)
         bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
         await bb.submit()
     except aiohttp.ClientResponseError as e:

--- a/batch/test/test_aioclient.py
+++ b/batch/test/test_aioclient.py
@@ -2,7 +2,7 @@ import pytest
 
 from hailtop.batch_client.aioclient import BatchClient
 
-from .utils import DOCKER_ROOT_IMAGE
+from .utils import DOCKER_ROOT_IMAGE, create_batch
 
 pytestmark = pytest.mark.asyncio
 
@@ -15,7 +15,7 @@ async def client():
 
 
 async def test_job(client: BatchClient):
-    bb = client.create_batch()
+    bb = create_batch(client)
     j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
     b = await bb.submit()
     status = await j.wait()

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -141,7 +141,9 @@ async def test_callback(client):
 
     try:
         token = secrets.token_urlsafe(32)
-        b = create_batch(client, callback=url_for('/test'), attributes={'foo': 'bar'}, token=token)
+        b = create_batch(
+            client, callback=url_for('/test'), attributes={'foo': 'bar', 'name': 'test_callback'}, token=token
+        )
         head = b.create_job('alpine:3.8', command=['echo', 'head'])
         b.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
         b = b.submit()
@@ -168,7 +170,7 @@ async def test_callback(client):
             'n_succeeded': 2,
             'n_failed': 0,
             'n_cancelled': 0,
-            'attributes': {'foo': 'bar'},
+            'attributes': {'foo': 'bar', 'name': 'test_callback'},
         }, callback_body
     finally:
         await runner.cleanup()

--- a/batch/test/test_scale.py
+++ b/batch/test/test_scale.py
@@ -4,7 +4,7 @@ import pytest
 
 from hailtop.batch_client.client import BatchClient
 
-from .utils import batch_status_job_counter, legacy_batch_status
+from .utils import batch_status_job_counter, create_batch, legacy_batch_status
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def client():
 
 def test_scale(client):
     n_jobs = 10
-    batch = client.create_batch()
+    batch = create_batch(client)
     for _ in range(n_jobs):
         sleep_time = random.uniform(0, 30)
         batch.create_job('alpine:3.8', command=['sleep', str(round(sleep_time))])

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -1,9 +1,31 @@
+import inspect
 import os
+from typing import Union, overload
 
 from hailtop import pip_version
+import hailtop.batch_client.client as bc
+import hailtop.batch_client.aioclient as aiobc
 
 DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:20.04')
 HAIL_GENETICS_HAIL_IMAGE = os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{pip_version()}')
+
+
+@overload
+def create_batch(client: bc.BatchClient, **kwargs) -> bc.BatchBuilder:
+    ...
+
+
+@overload
+def create_batch(client: aiobc.BatchClient, **kwargs) -> aiobc.BatchBuilder:
+    ...
+
+
+def create_batch(
+    client: Union[bc.BatchClient, aiobc.BatchClient], **kwargs
+) -> Union[bc.BatchBuilder, aiobc.BatchBuilder]:
+    name_of_test_method = inspect.stack()[1][3]
+    attrs = kwargs.pop('attributes', {})  # Tests should be able to override the name
+    return client.create_batch(attributes={'name': name_of_test_method, **attrs}, **kwargs)
 
 
 def batch_status_job_counter(batch_status, job_state):

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -2,9 +2,9 @@ import inspect
 import os
 from typing import Union, overload
 
-from hailtop import pip_version
-import hailtop.batch_client.client as bc
 import hailtop.batch_client.aioclient as aiobc
+import hailtop.batch_client.client as bc
+from hailtop import pip_version
 
 DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:20.04')
 HAIL_GENETICS_HAIL_IMAGE = os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{pip_version()}')

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import secrets
 import unittest
 import pytest
@@ -498,7 +499,9 @@ class ServiceTests(unittest.TestCase):
 
     def batch(self, requester_pays_project=None, default_python_image=None,
               cancel_after_n_failures=None):
-        return Batch(backend=self.backend,
+        name_of_test_method = inspect.stack()[1][3]
+        return Batch(name=name_of_test_method,
+                     backend=self.backend,
                      default_image=DOCKER_ROOT_IMAGE,
                      attributes={'foo': 'a', 'bar': 'b'},
                      requester_pays_project=requester_pays_project,


### PR DESCRIPTION
very helpful when executing tests locally. Most of the lines here are noise because I added a function that wraps `client.create_batch` so needed to replace usages everywhere.