### PR TITLE
[docs] Update instructions for installing dev python requirements

### DIFF
--- a/dev-docs/development_process.md
+++ b/dev-docs/development_process.md
@@ -30,16 +30,10 @@ develop effectively.
 Hail currently supports Python version 3.7 or greater.
 
 ```
-make install-dev-deps
+make install-dev-requirements
 ```
 
-to install the python dependencies.
-
-If you are doing Batch or services development, run the following command to install relevant python dependencies
-
-```
-pip install -r docker/requirements.txt
-```
+to install the full set of python dependencies across the Hail repo.
 
 To make sure that certain formatting requirements are caught early, run
 

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -380,14 +380,6 @@ test-dataproc-38: install-hailctl
 deploy: test-dataproc $(WHEEL)
 	bash scripts/deploy.sh $(HAIL_PIP_VERSION) $(HAIL_VERSION) $(REVISION) $(DEPLOY_REMOTE) $(WHEEL) $(GITHUB_OAUTH_HEADER_FILE) $(HAIL_GENETICS_HAIL_IMAGE) $(WHEEL_FOR_AZURE) $(WEBSITE_TAR)
 
-.PHONY: install-dev-deps
-install-dev-deps:
-	$(PIP) install -U -r python/dev/requirements.txt
-
-.PHONY: install-deps
-install-deps: install-dev-deps
-	sed "s/^pyspark.*/pyspark==$(SPARK_VERSION)/" python/requirements.txt | xargs $(PIP) install -U
-
 .PHONY: benchmark
 benchmark: $(WHEEL)
 	HAIL_WHEEL=../hail/$(WHEEL) HAIL_PIP_VERSION=$(HAIL_PIP_VERSION) $(MAKE) -C ../benchmark benchmark

--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -59,7 +59,7 @@ Running the tests
 
 Install development dependencies::
 
-    make install-dev-deps
+    make -C .. install-dev-requirements
 
 A couple Hail tests compare to PLINK 1.9 (not PLINK 2.0 [ignore the confusing
 URL]):


### PR DESCRIPTION
I made recent changes such that all targets for anything hail are now in sync and installable in one go (earlier we had separate requirements files between query and batch that could accidentally diverge and were possibly not installable together). Forgot to update the docs