### PR TITLE
[hailctl] Improve startup time by removing big top-level imports

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -20,8 +20,6 @@ import urllib3
 import secrets
 import socket
 import requests
-import google.auth.exceptions
-import google.api_core.exceptions
 import botocore.exceptions
 import time
 from requests.adapters import HTTPAdapter
@@ -636,6 +634,8 @@ def is_transient_error(e):
     #
     # OSError: [Errno 51] Connect call failed ('35.188.91.25', 443)
     # https://hail.zulipchat.com/#narrow/stream/223457-Batch-support/topic/ssl.20error
+    import google.api_core.exceptions  # pylint: disable=import-outside-toplevel
+    import google.auth.exceptions  # pylint: disable=import-outside-toplevel
     import hailtop.aiocloud.aiogoogle.client.compute_client  # pylint: disable=import-outside-toplevel,cyclic-import
     import hailtop.httpx  # pylint: disable=import-outside-toplevel,cyclic-import
     if isinstance(e, aiohttp.ClientResponseError) and (


### PR DESCRIPTION
`google.api_core.exceptions` imports `pkg_resources` on import which is horrendously slow. Moving these imports out of the top level yields a 60% (almost half a second) improvement in startup time for `hailctl`.