### PR TITLE
[fs] Support reading from public containers in azure

### DIFF
--- a/hail/python/hailtop/test_utils.py
+++ b/hail/python/hailtop/test_utils.py
@@ -11,3 +11,7 @@ fails_in_azure = pytest.mark.xfail(
 skip_in_azure = pytest.mark.skipif(
     os.environ.get('HAIL_CLOUD') == 'azure',
     reason="not applicable to azure")
+
+run_if_azure = pytest.mark.skipif(
+    os.environ.get('HAIL_CLOUD') != 'azure',
+    reason="only applicable to azure")

--- a/hail/python/test/hail/fs/test_worker_driver_fs.py
+++ b/hail/python/test/hail/fs/test_worker_driver_fs.py
@@ -1,6 +1,6 @@
 import hail as hl
 from hailtop.utils import secret_alnum_string
-from hailtop.test_utils import skip_in_azure
+from hailtop.test_utils import skip_in_azure, run_if_azure
 
 from ..helpers import fails_local_backend, fails_service_backend
 
@@ -116,3 +116,12 @@ def test_requester_pays_with_project_more_than_one_partition():
     hl.stop()
     hl.init(gcs_requester_pays_configuration='hail-vdc')
     assert hl.import_table('gs://hail-services-requester-pays/zero-to-nine', no_header=True, min_partitions=8).collect() == expected_file_contents
+
+
+@run_if_azure
+@fails_local_backend
+def test_can_access_public_blobs():
+    public_mt = 'hail-az://azureopendatastorage/gnomad/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt'
+    assert hl.hadoop_exists(public_mt)
+    mt = hl.read_matrix_table(public_mt)
+    mt.describe()

--- a/hail/python/test/hail/fs/test_worker_driver_fs.py
+++ b/hail/python/test/hail/fs/test_worker_driver_fs.py
@@ -123,5 +123,7 @@ def test_requester_pays_with_project_more_than_one_partition():
 def test_can_access_public_blobs():
     public_mt = 'hail-az://azureopendatastorage/gnomad/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt'
     assert hl.hadoop_exists(public_mt)
+    with hl.hadoop_open(f'{public_mt}/README.txt') as readme:
+        assert len(readme.read()) > 0
     mt = hl.read_matrix_table(public_mt)
     mt.describe()


### PR DESCRIPTION
CHANGELOG: Reading data from public blobs is now supported in Azure

On current main, the following test fails:
```python
def test_can_access_public_blobs():
    public_mt = 'hail-az://azureopendatastorage/gnomad/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt'
    assert hl.hadoop_exists(public_mt)
    mt = hl.read_matrix_table(public_mt)
    mt.describe()
```

The `hadoop_exists` fails in the python fs with a `ClientAuthenticationError` and the QoB pipeline fails on the Query Driver with a 401. See [zulip](https://hail.zulipchat.com/#narrow/stream/300487-Hail-Batch-Dev/topic/Azure.20public.20blobs/near/284186815) for additional context. I contemplated whether we should have a public container in our infrastructure for running tests, but the lack of requester pays makes that feel not great. Azure's paying for the opendatastorage account so I figured it would be ok for us to test against it (and the test only reads metadata), but happy to take alternative suggestions.