### PR TITLE
[docs, minor] Prefer missing() rather than deprecated null()

### DIFF
--- a/hail/python/hail/docs/_templates/req_unphased_diploid_gt.rst
+++ b/hail/python/hail/docs/_templates/req_unphased_diploid_gt.rst
@@ -1,5 +1,5 @@
 .. note::
 
     Requires the dataset to contain only diploid and unphased genotype calls.
-    Use :func:`.call` to recode genotype calls or :func:`.null` to set genotype
+    Use :func:`.call` to recode genotype calls or :func:`.missing` to set genotype
     calls to missing.

--- a/hail/python/hail/docs/overview/expressions.rst
+++ b/hail/python/hail/docs/overview/expressions.rst
@@ -263,7 +263,7 @@ Missingness
 ===========
 
 In Hail, all expressions can be missing. An expression representing a missing
-value of a given type can be generated with the :func:`.null` function, which
+value of a given type can be generated with the :func:`.missing` function, which
 takes the type as its single argument.
 
 An example of generating a :class:`.Float64Expression` that is missing is:

--- a/hail/python/hail/docs/types.rst
+++ b/hail/python/hail/docs/types.rst
@@ -12,7 +12,7 @@ Fields and expressions in Hail have types. Throughout the documentation, you
 will find type descriptions like ``array<str>`` or :class:`.tlocus`. It is
 generally more important to know how to use expressions of various types than to
 know how to manipulate the types themselves, but some operations like
-:func:`.null` require type arguments.
+:func:`.missing` require type arguments.
 
 In Python, ``5`` is of type :obj:`int` while ``"hello"`` is of type :obj:`str`.
 Python is a dynamically-typed language, meaning that a function like:
@@ -89,7 +89,7 @@ There are a few situations where you may want to specify types explicitly:
   infer the type you want.
 - When converting a Python value to a Hail expression with :func:`.literal`,
   if you don't wish to rely on the inferred type.
-- With functions like :func:`.null` and :func:`.empty_array`.
+- With functions like :func:`.missing` and :func:`.empty_array`.
 
 Viewing an object's type
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
https://hail.is/docs/0.2/overview/expressions.html#missingness says:

> In Hail, all expressions can be missing. An expression representing a missing value of a given type can be generated with the [`null()`](https://hail.is/docs/0.2/functions/core.html#hail.expr.functions.null) function, which takes the type as its single argument.

It then proceeds to show a number of examples, all of which use `missing()` rather than `null()`, which is confusing.

PR #9936 added `hl.missing`, which supersedes `hl.null`, and replaced instances of `null(...)` invocations in the documentation. However `:func:'.null'` instances in the surrounding documentation text were missed.