### PR TITLE
[query/ggplot] fixes legend behavior for single-category columns

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -173,15 +173,16 @@ class GeomPoint(Geom):
         legends = {}
         for df in grouped_data:
             values = self._get_aes_values(df)
-            trace_category = "trace1"
+            trace_categories = []
             for aes_name in self.aes_legend_groups:
                 category = self._get_aes_value(df, f"{aes_name}_legend")
-                trace_category = category if category is not None else trace_category
+                if category is not None:
+                    trace_categories.append(category)
                 legends[aes_name] = ({
                     **legends.get(aes_name, {}),
                     category: values[aes_name]
                 })
-            traces.append([fig_so_far, df, facet_row, facet_col, values, trace_category])
+            traces.append([fig_so_far, df, facet_row, facet_col, values, trace_categories])
 
         non_empty_legend_groups = [
             legend_group for legend_group in legends.values() if len(legend_group) > 1
@@ -198,6 +199,15 @@ class GeomPoint(Geom):
                         self._add_legend(fig_so_far, aes_name, category, value)
                 legend_cache[aes_name] = {**prev, **legend_group}
         else:
+            main_categories = non_empty_legend_groups[0].keys() if len(non_empty_legend_groups) == 1 else None
+            for trace in traces:
+                trace_categories = trace[-1]
+                if main_categories is not None:
+                    trace[-1] = [category for category in trace_categories if category in main_categories][0]
+                elif len(trace_categories) == 1:
+                    trace[-1] = [trace_categories][0]
+                else:
+                    trace[-1] = "trace1"
             for trace in traces:
                 self._add_trace(*trace)
 


### PR DESCRIPTION
CHANGELOG: Fixed bug in `hail.ggplot` where all legend entries would have the same text if one column had exactly one value for all rows and was mapped to either the `shape` or the `color` aesthetic for `geom_point`.

This change fixes [an edge case that was encountered](https://hail.zulipchat.com/#narrow/stream/123000-general/topic/plotting.20legend.20bug/near/340198585) where, if the user creates a scatter plot and assigns one column with multiple values in it to the `color` aesthetic and one column with exactly one value in it to the `shape` aesthetic (or vice versa), the plot has a legend which contains the correct visual entries, but they are all labelled with the value from the single-value column, instead of the labels from the other column.

For a concrete example, this code:

```python3
import hail as hl
from hail.ggplot import ggplot, aes, geom_point

ht = hl.utils.range_table(10).annotate(x = hl.rand_norm(0, 1), y = hl.rand_norm(0, 1))

ht = ht.annotate(proj_title = 'constant')
ht = ht.annotate(subpop = hl.str(ht.idx % 3))

p = (
    hl.ggplot.ggplot(ht, hl.ggplot.aes(x=ht.x, y=ht.y, color=ht.subpop, shape=ht.proj_title))
    + hl.ggplot.geom_point()
)
p.show()
```

Produces a graph like this one:

<img width="1624" alt="Screen-Shot-2023-03-07-at-13 58 48" src="https://user-images.githubusercontent.com/84595986/233422332-ae7ab2ca-67f1-4c58-8691-3c52eae29a20.png">

When it should instead produce one like this:

![newplot](https://user-images.githubusercontent.com/84595986/233422599-7c327186-8d03-47ca-b682-f80ce4849b43.png)

Further complicating matters, the first graph cannot be reproduced consistently due to the nature of the bug. See my comment on the code below for more information.