### PR TITLE
[qob] Allow a hail session to be reused after ctrl-c

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -481,6 +481,7 @@ class ServiceBackend(Backend):
             if self._batch is not None:
                 print("Received a keyboard interrupt, cancelling the batch...")
                 async_to_blocking(self._batch.cancel())
+                self._batch = None
             raise
 
     def execute(self, ir: BaseIR, timed: bool = False):


### PR DESCRIPTION
CHANGELOG: An interactive hail session is no longer unusable after hitting CTRL-C during a batch execution in Query-on-Batch.