### PR TITLE
[query] Expand WriteValue beyond hail EType serialization

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -50,11 +50,12 @@ case class BlockMatrixNativeWriter(
   override def lower(ctx: ExecuteContext, s: BlockMatrixStage2, evalCtx: IRBuilder, eltR: TypeWithRequiredness): IR = {
     val etype = EBlockMatrixNDArray(EType.fromTypeAndAnalysis(s.typ.elementType, eltR), encodeRowMajor = forceRowMajor, required = true)
     val spec = TypedCodecSpec(etype, TNDArray(s.typ.elementType, Nat(2)), BlockMatrix.bufferSpec)
+    val writer = ETypeFileValueWriter(spec)
 
     val paths = s.collectBlocks(evalCtx, "block_matrix_native_writer") { (_, idx, block) =>
       val suffix = strConcat("parts/part-", idx, UUID4())
       val filepath = strConcat(s"$path/", suffix)
-      WriteValue(block, filepath, spec,
+      WriteValue(block, filepath, writer,
         if (stageLocally) Some(strConcat(s"${ctx.localTmpdir}/", suffix)) else None
       )
     }
@@ -125,7 +126,8 @@ case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
 
     val etype = ENumpyBinaryNDArray(s.typ.nRows, s.typ.nCols, true)
     val spec = TypedCodecSpec(etype, TNDArray(s.typ.elementType, Nat(2)), new StreamBufferSpec())
-    WriteValue(nd, Str(path), spec)
+    val writer = ETypeFileValueWriter(spec)
+    WriteValue(nd, Str(path), writer)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -402,12 +402,12 @@ object Copy {
       case ReadValue(path, spec, requestedType) =>
         assert(newChildren.length == 1)
         ReadValue(newChildren(0).asInstanceOf[IR], spec, requestedType)
-      case WriteValue(_, _, spec, _) =>
+      case WriteValue(_, _, writer, _) =>
         assert(newChildren.length == 2 || newChildren.length == 3)
         val value = newChildren(0).asInstanceOf[IR]
         val path = newChildren(1).asInstanceOf[IR]
         val stage = if (newChildren.length == 3) Some(newChildren(2).asInstanceOf[IR]) else None
-        WriteValue(value, path, spec, stage)
+        WriteValue(value, path, writer, stage)
       case LiftMeOut(_) =>
         LiftMeOut(newChildren(0).asInstanceOf[IR])
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2294,11 +2294,11 @@ class Emit[C](
           emitI(value).map(cb) { v =>
             val s = stagingFile.map(emitI(_).get(cb).asString)
             val p = EmitCode.present(mb, s.getOrElse(pv))
-            val ret = writer.writeValue(cb, v, p)
+            writer.writeValue(cb, v, p)
             s.foreach { stage =>
               cb += mb.getFS.invoke[String, String, Boolean, Unit]("copy", stage.loadString(cb), pv.loadString(cb), const(true))
             }
-            ret
+            pv
           }
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -210,7 +210,7 @@ class EmitValue protected(missing: Option[Value[Boolean]], val v: SValue) {
 
   def get(cb: EmitCodeBuilder): SValue = {
     missing.foreach { m =>
-      cb.ifx(m, cb._fatal(s"Can't convert missing ${ v.st } to PValue"))
+      cb.ifx(m, cb._fatal(s"Can't convert missing ${ v.st } to SValue"))
     }
     v
   }
@@ -2289,20 +2289,16 @@ class Emit[C](
           decoded
         }
 
-      case WriteValue(value, path, spec, stagingFile) =>
+      case WriteValue(value, path, writer, stagingFile) =>
         emitI(path).flatMap(cb) { case pv: SStringValue =>
           emitI(value).map(cb) { v =>
             val s = stagingFile.map(emitI(_).get(cb).asString)
-            val ob = cb.memoize[OutputBuffer](spec.buildCodeOutputBuffer(mb.createUnbuffered(
-              s.getOrElse(pv).loadString(cb))
-            ))
-            spec.encodedType.buildEncoder(v.st, cb.emb.ecb)
-              .apply(cb, v, ob)
-            cb += ob.invoke[Unit]("close")
+            val p = EmitCode.present(mb, s.getOrElse(pv))
+            val ret = writer.writeValue(cb, v, p)
             s.foreach { stage =>
               cb += mb.getFS.invoke[String, String, Boolean, Unit]("copy", stage.loadString(cb), pv.loadString(cb), const(true))
             }
-            pv
+            ret
           }
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -922,7 +922,7 @@ final case class WritePartition(value: IR, writeCtx: IR, writer: PartitionWriter
 final case class WriteMetadata(writeAnnotations: IR, writer: MetadataWriter) extends IR
 
 final case class ReadValue(path: IR, spec: AbstractTypedCodecSpec, requestedType: Type) extends IR
-final case class WriteValue(value: IR, path: IR, spec: AbstractTypedCodecSpec, stagingFile: Option[IR] = None) extends IR
+final case class WriteValue(value: IR, path: IR, writer: ValueWriter, stagingFile: Option[IR] = None) extends IR
 
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = {

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -286,7 +286,7 @@ object InferType {
       case WritePartition(value, writeCtx, writer) => writer.returnType
       case _: WriteMetadata => TVoid
       case ReadValue(_, _, typ) => typ
-      case _: WriteValue => TString
+      case WriteValue(_, _, writer, _) => writer.returnType
       case LiftMeOut(child) => child.typ
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -1498,6 +1498,7 @@ case class MatrixBlockMatrixWriter(
     val elementType = tm.entryType.fieldType(entryField)
     val etype = EBlockMatrixNDArray(EType.fromTypeAndAnalysis(elementType, rm.entryType.field(entryField)), encodeRowMajor = true, required = true)
     val spec = TypedCodecSpec(etype, TNDArray(tm.entryType.fieldType(entryField), Nat(2)), BlockMatrix.bufferSpec)
+    val writer = ETypeFileValueWriter(spec)
 
     val pathsWithColMajorIndices = tableOfNDArrays.mapCollect("matrix_block_matrix_writer") { partition =>
      ToArray(mapIR(partition) { singleNDArrayTuple =>
@@ -1505,7 +1506,7 @@ case class MatrixBlockMatrixWriter(
          val blockPath =
            Str(s"$path/parts/part-") +
              invoke("str", TString, colMajorIndex) + Str("-") + UUID4()
-         maketuple(colMajorIndex, WriteValue(GetField(singleNDArrayTuple, "ndBlock"), blockPath, spec))
+         maketuple(colMajorIndex, WriteValue(GetField(singleNDArrayTuple, "ndBlock"), blockPath, writer))
        }
       })
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1549,7 +1549,7 @@ object IRParser {
           ReadValue(path, spec, typ)
         }
       case "WriteValue" =>
-        import PartitionReader.formats
+        import ValueWriter.formats
         val writer = JsonMethods.parse(string_literal(it)).extract[ValueWriter]
         ir_value_children(env)(it).map {
           case Array(value, path) => WriteValue(value, path, writer)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1549,11 +1549,11 @@ object IRParser {
           ReadValue(path, spec, typ)
         }
       case "WriteValue" =>
-        import AbstractRVDSpec.formats
-        val spec = JsonMethods.parse(string_literal(it)).extract[AbstractTypedCodecSpec]
+        import PartitionReader.formats
+        val writer = JsonMethods.parse(string_literal(it)).extract[ValueWriter]
         ir_value_children(env)(it).map {
-          case Array(value, path) => WriteValue(value, path, spec)
-          case Array(value, path, stagingFile) => WriteValue(value, path, spec, Some(stagingFile))
+          case Array(value, path) => WriteValue(value, path, writer)
+          case Array(value, path, stagingFile) => WriteValue(value, path, writer, Some(stagingFile))
         }
       case "LiftMeOut" => ir_value_expr(env)(it).map(LiftMeOut)
       case "ReadPartition" =>

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -430,7 +430,8 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
       single(prettyStringLiteral(JsonMethods.compact(writer.toJValue), elide = elideLiterals))
     case ReadValue(_, spec, reqType) =>
       FastSeq(prettyStringLiteral(spec.toString), reqType.parsableString())
-    case WriteValue(_, _, spec, _) => single(prettyStringLiteral(spec.toString))
+    case WriteValue(_, _, writer, _) =>
+      single(prettyStringLiteral(JsonMethods.compact(writer.toJValue)))
     case MakeNDArray(_, _, _, errorId) => FastSeq(errorId.toString)
 
     case _ => Iterable.empty

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -549,9 +549,10 @@ object TypeCheck {
       case x@ReadValue(path, spec, requestedType) =>
         assert(path.typ == TString)
         assert(spec.encodedType.decodedPType(requestedType).virtualType == requestedType)
-      case WriteValue(_, path, _, stagingFile) =>
+      case WriteValue(_, path, writer, stagingFile) =>
         assert(path.typ == TString)
         assert(stagingFile.forall(_.typ == TString))
+        assert(writer.returnType == TString || writer.returnType == TBinary || writer.returnType == TVoid)
       case LiftMeOut(_) =>
       case Consume(_) =>
       case TableMapRows(child, newRow) =>

--- a/hail/src/main/scala/is/hail/expr/ir/ValueWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ValueWriter.scala
@@ -1,0 +1,69 @@
+package is.hail.expr.ir
+
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
+import is.hail.io.{AbstractTypedCodecSpec, BufferSpec, TypedCodecSpec}
+import is.hail.types.encoded._
+import is.hail.types.physical._
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.types.physical.stypes.concrete.SStackStruct
+import is.hail.types.virtual._
+import is.hail.utils._
+
+import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+
+object ValueWriter {
+  implicit val formats: Formats = new DefaultFormats() {
+    override val typeHints = ShortTypeHints(List(
+      classOf[ETypeFileValueWriter],
+      classOf[AbstractTypedCodecSpec],
+      classOf[TypedCodecSpec]),
+      typeHintFieldName = "name"
+    ) + BufferSpec.shortTypeHints
+  }  +
+    new TStructSerializer +
+    new TypeSerializer +
+    new PTypeSerializer +
+    new ETypeSerializer
+}
+
+abstract class ValueWriter {
+  final def writeValue(cb: EmitCodeBuilder, value: SValue, _args: EmitCode*): SValue = {
+    val args = _args.toIndexedSeq
+    val argsTypes = args.map(_.st.virtualType)
+    assert(argsTypes == argumentTypes, s"argument mismatch, required argument types $argumentTypes, got $argsTypes")
+    _writeValue(cb, value, args)
+  }
+  protected def _writeValue(cb: EmitCodeBuilder, value: SValue, args: IndexedSeq[EmitCode]): SValue
+  def argumentTypes: IndexedSeq[Type]
+  def returnType: Type
+
+  def toJValue: JValue = Extraction.decompose(this)(ValueWriter.formats)
+
+  require(returnType == TVoid || returnType == TString || returnType == TBinary)
+}
+
+abstract class ETypeValueWriter(spec: AbstractTypedCodecSpec) extends ValueWriter {
+  final def serialize(cb: EmitCodeBuilder, value: SValue, os: Value[OutputStream]) = {
+    val encoder = spec.encodedType.buildEncoder(value.st, cb.emb.ecb)
+    val ob = cb.memoize(spec.buildCodeOutputBuffer(os))
+    encoder.apply(cb, value, ob)
+    cb += ob.invoke[Unit]("close")
+  }
+}
+
+final case class ETypeFileValueWriter(spec: AbstractTypedCodecSpec) extends ETypeValueWriter(spec) {
+  protected def _writeValue(cb: EmitCodeBuilder, value: SValue, args: IndexedSeq[EmitCode]): SValue = {
+    val IndexedSeq(path_) = args
+    val path = path_.toI(cb).get(cb).asString
+    val os = cb.memoize(cb.emb.createUnbuffered(path.loadString(cb)))
+    serialize(cb, value, os) // takes ownership and closes the stream
+    path
+  }
+
+  val argumentTypes: IndexedSeq[Type] = FastIndexedSeq(/*path=*/TString)
+  val returnType: Type = TString
+}

--- a/hail/src/main/scala/is/hail/expr/ir/ValueWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ValueWriter.scala
@@ -45,7 +45,9 @@ abstract class ValueWriter {
   def toJValue: JValue = Extraction.decompose(this)(ValueWriter.formats)
 }
 
-abstract class ETypeValueWriter(spec: AbstractTypedCodecSpec) extends ValueWriter {
+abstract class ETypeValueWriter extends ValueWriter {
+  def spec: AbstractTypedCodecSpec
+
   final def serialize(cb: EmitCodeBuilder, value: SValue, os: Value[OutputStream]) = {
     val encoder = spec.encodedType.buildEncoder(value.st, cb.emb.ecb)
     val ob = cb.memoize(spec.buildCodeOutputBuffer(os))
@@ -54,7 +56,7 @@ abstract class ETypeValueWriter(spec: AbstractTypedCodecSpec) extends ValueWrite
   }
 }
 
-final case class ETypeFileValueWriter(spec: AbstractTypedCodecSpec) extends ETypeValueWriter(spec) {
+final case class ETypeFileValueWriter(spec: AbstractTypedCodecSpec) extends ETypeValueWriter {
   protected def _writeValue(cb: EmitCodeBuilder, value: SValue, args: IndexedSeq[EmitCode]): SValue = {
     val IndexedSeq(path_) = args
     val path = path_.toI(cb).get(cb).asString

--- a/hail/src/main/scala/is/hail/expr/ir/ValueWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ValueWriter.scala
@@ -39,11 +39,10 @@ abstract class ValueWriter {
   }
   protected def _writeValue(cb: EmitCodeBuilder, value: SValue, args: IndexedSeq[EmitCode]): SValue
   def argumentTypes: IndexedSeq[Type]
+  // one of void, binary, or string, checked in TypeCheck
   def returnType: Type
 
   def toJValue: JValue = Extraction.decompose(this)(ValueWriter.formats)
-
-  require(returnType == TVoid || returnType == TString || returnType == TBinary)
 }
 
 abstract class ETypeValueWriter(spec: AbstractTypedCodecSpec) extends ValueWriter {

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -174,7 +174,7 @@ class BlockMatrixIRSuite extends HailSuite {
     val read = ReadValue(Str(path), spec, typ)
     assertNDEvals(read, expected)
     assertNDEvals(ReadValue(
-      WriteValue(read, Str(ctx.createTmpPath("read-blockmatrix-ir", "hv")) + UUID4(), spec),
+      WriteValue(read, Str(ctx.createTmpPath("read-blockmatrix-ir", "hv")) + UUID4(), ETypeFileValueWriter(spec)),
       spec, typ), expected)
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -145,6 +145,7 @@ class RequirednessSuite extends HailSuite {
     )
 
     val spec = TypedCodecSpec(pDisc, BufferSpec.default)
+    val vr = ETypeFileValueWriter(spec)
     val pr = PartitionNativeReader(spec, "rowUID")
     val contextType = pr.contextType
     val rt1 = TStruct("a" -> TInt32, "b" -> TArray(TInt32))
@@ -167,9 +168,9 @@ class RequirednessSuite extends HailSuite {
     }
 
     val value = Literal(pDisc.virtualType, Row(null, IndexedSeq(1), IndexedSeq(Row(1, IndexedSeq(1)))))
-    nodes += Array(WriteValue(value, Str("foo"), spec), PCanonicalString(required))
-    nodes += Array(WriteValue(NA(pDisc.virtualType), Str("foo"), spec), PCanonicalString(optional))
-    nodes += Array(WriteValue(value, NA(TString), spec), PCanonicalString(optional))
+    nodes += Array(WriteValue(value, Str("foo"), vr), PCanonicalString(required))
+    nodes += Array(WriteValue(NA(pDisc.virtualType), Str("foo"), vr), PCanonicalString(optional))
+    nodes += Array(WriteValue(value, NA(TString), vr), PCanonicalString(optional))
 
     // test bindings
     nodes += Array(bindIR(nestedarray(required, optional, optional)) { v => ArrayRef(v, I32(0)) },


### PR DESCRIPTION
WriteValue has always been a weird bit of functionality. It takes a path and writes a single value to that path. This change does not change that quirk, however this change expands the possibilities of hail value serialization through the introduction of ValueWriter, analogous to PartitionWriter.

ValueWriters serialize hail values and are responsible for the allocation and cleanup of any resources required to do that.

One ValueWriter has been implemented as part of this change. The ETypeFileValueWriter, the minimum necessary functionality for ensuring WriteValue still works exactly as it used to.

The short term here is to implement the BlockMatrixRectanglesWriter with a value writer that dumps an NDArray in either binary or text. The longer term is to develop more faculties within the IR to (de)serialize values.