### PR TITLE
[query] revert to skopeo 1.11.2

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -61,7 +61,7 @@ steps:
           - azure
   - kind: runImage
     name: copy_third_party_images
-    image: quay.io/skopeo/stable:v1.12.0
+    image: quay.io/skopeo/stable:v1.11.2
     script: |
       set -ex
 
@@ -3270,7 +3270,7 @@ steps:
       - gcp
   - kind: runImage
     name: mirror_hailgenetics_images
-    image: quay.io/skopeo/stable:v1.12.0
+    image: quay.io/skopeo/stable:v1.11.2
     script: |
       set -ex
 

--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -26,7 +26,7 @@ FROM golang:1.18 AS skopeo-build
 
 WORKDIR /usr/src/skopeo
 
-ARG SKOPEO_VERSION="1.12.0"
+ARG SKOPEO_VERSION="1.11.2"
 RUN curl -fsSL "https://github.com/containers/skopeo/archive/v${SKOPEO_VERSION}.tar.gz" \
   | tar -xzf - --strip-components=1
 


### PR DESCRIPTION
I should have checked quay.io for 1.12.0, which doesn't exist: https://quay.io/repository/skopeo/stable?tab=tags&tag=v1.12.0

Even though 1.12.0 was released two weeks ago https://github.com/containers/skopeo/releases