### PR TITLE
[batch] Remove unused fields on cloud user credentials

### DIFF
--- a/batch/batch/cloud/azure/worker/credentials.py
+++ b/batch/batch/cloud/azure/worker/credentials.py
@@ -6,29 +6,13 @@ from ....worker.credentials import CloudUserCredentials
 
 
 class AzureUserCredentials(CloudUserCredentials):
-    def __init__(self, data: Dict[str, bytes]):
+    def __init__(self, data: Dict[str, str]):
         self._data = data
         self._credentials = json.loads(base64.b64decode(data['key.json']).decode())
 
     @property
-    def secret_name(self) -> str:
-        return 'azure-credentials'
-
-    @property
-    def secret_data(self) -> Dict[str, bytes]:
-        return self._data
-
-    @property
-    def file_name(self) -> str:
-        return 'key.json'
-
-    @property
     def cloud_env_name(self) -> str:
         return 'AZURE_APPLICATION_CREDENTIALS'
-
-    @property
-    def hail_env_name(self) -> str:
-        return 'HAIL_AZURE_CREDENTIAL_FILE'
 
     @property
     def username(self):
@@ -40,7 +24,7 @@ class AzureUserCredentials(CloudUserCredentials):
 
     @property
     def mount_path(self):
-        return f'/{self.secret_name}/{self.file_name}'
+        return '/azure-credentials/key.json'
 
     def cloudfuse_credentials(self, fuse_config: dict) -> str:
         # https://github.com/Azure/azure-storage-fuse

--- a/batch/batch/cloud/azure/worker/worker_api.py
+++ b/batch/batch/cloud/azure/worker/worker_api.py
@@ -42,7 +42,7 @@ class AzureWorkerAPI(CloudWorkerAPI):
         azure_config = get_azure_config()
         return aioazure.AzureComputeClient(azure_config.subscription_id, azure_config.resource_group)
 
-    def user_credentials(self, credentials: Dict[str, bytes]) -> AzureUserCredentials:
+    def user_credentials(self, credentials: Dict[str, str]) -> AzureUserCredentials:
         return AzureUserCredentials(credentials)
 
     async def worker_access_token(self, session: httpx.ClientSession) -> Dict[str, str]:

--- a/batch/batch/cloud/gcp/worker/credentials.py
+++ b/batch/batch/cloud/gcp/worker/credentials.py
@@ -5,28 +5,12 @@ from ....worker.credentials import CloudUserCredentials
 
 
 class GCPUserCredentials(CloudUserCredentials):
-    def __init__(self, data: Dict[str, bytes]):
+    def __init__(self, data: Dict[str, str]):
         self._data = data
-
-    @property
-    def secret_name(self) -> str:
-        return 'gsa-key'
-
-    @property
-    def secret_data(self) -> Dict[str, bytes]:
-        return self._data
-
-    @property
-    def file_name(self) -> str:
-        return 'key.json'
 
     @property
     def cloud_env_name(self) -> str:
         return 'GOOGLE_APPLICATION_CREDENTIALS'
-
-    @property
-    def hail_env_name(self) -> str:
-        return 'HAIL_GSA_KEY_FILE'
 
     @property
     def username(self):
@@ -34,11 +18,11 @@ class GCPUserCredentials(CloudUserCredentials):
 
     @property
     def password(self) -> str:
-        return base64.b64decode(self.secret_data['key.json']).decode()
+        return base64.b64decode(self._data['key.json']).decode()
 
     @property
     def mount_path(self):
-        return f'/{self.secret_name}/{self.file_name}'
+        return '/gsa-key/key.json'
 
     def cloudfuse_credentials(self, fuse_config: dict) -> str:  # pylint: disable=unused-argument
         return self.password

--- a/batch/batch/cloud/gcp/worker/worker_api.py
+++ b/batch/batch/cloud/gcp/worker/worker_api.py
@@ -47,7 +47,7 @@ class GCPWorkerAPI(CloudWorkerAPI):
     def get_compute_client(self) -> aiogoogle.GoogleComputeClient:
         return self._compute_client
 
-    def user_credentials(self, credentials: Dict[str, bytes]) -> GCPUserCredentials:
+    def user_credentials(self, credentials: Dict[str, str]) -> GCPUserCredentials:
         return GCPUserCredentials(credentials)
 
     async def worker_access_token(self, session: httpx.ClientSession) -> Dict[str, str]:

--- a/batch/batch/worker/credentials.py
+++ b/batch/batch/worker/credentials.py
@@ -1,39 +1,26 @@
 import abc
-from typing import Dict
 
 
 class CloudUserCredentials(abc.ABC):
     @property
-    def secret_name(self) -> str:
-        raise NotImplementedError
-
-    @property
-    def secret_data(self) -> Dict[str, bytes]:
-        raise NotImplementedError
-
-    @property
-    def file_name(self) -> str:
-        raise NotImplementedError
-
-    @property
+    @abc.abstractmethod
     def cloud_env_name(self) -> str:
         raise NotImplementedError
 
     @property
-    def hail_env_name(self) -> str:
-        raise NotImplementedError
-
-    @property
+    @abc.abstractmethod
     def username(self) -> str:
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def password(self) -> str:
         raise NotImplementedError
 
     @property
+    @abc.abstractmethod
     def mount_path(self):
-        return f'/{self.secret_name}/{self.file_name}'
+        raise NotImplementedError
 
     @abc.abstractmethod
     def cloudfuse_credentials(self, fuse_config: dict) -> str:

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1395,12 +1395,6 @@ class Job(abc.ABC):
     def cloudfuse_credentials_path(self, bucket: str) -> str:
         return f'{self.scratch}/cloudfuse/{bucket}'
 
-    def credentials_host_dirname(self) -> str:
-        return f'{self.scratch}/{self.credentials.secret_name}'
-
-    def credentials_host_file_path(self) -> str:
-        return f'{self.credentials_host_dirname()}/{self.credentials.file_name}'
-
     @staticmethod
     def create(
         batch_id,

--- a/batch/batch/worker/worker_api.py
+++ b/batch/batch/worker/worker_api.py
@@ -26,7 +26,7 @@ class CloudWorkerAPI(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def user_credentials(self, credentials: Dict[str, bytes]) -> CloudUserCredentials:
+    def user_credentials(self, credentials: Dict[str, str]) -> CloudUserCredentials:
         raise NotImplementedError
 
     @abc.abstractmethod


### PR DESCRIPTION
`credentials_host_file_path` is unused in `main`. Deleting that allowed me to then delete `credentials_host_dirname`, after which `CloudUserCredentials.file_name` and `CloudUserCredentials.secret_name` were only used for `CloudUserCredentials.mount_path` so I merged those. `CloudUserCredentials.secret_data` and `CloudUserCredentials.hail_env_name` were unused.