### PR TITLE
[batch] Add timeouts to ensure that post_job_complete is reached

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1544,13 +1544,17 @@ class Job(abc.ABC):
 
         if self.format_version.has_full_status_in_gcs():
             assert self.worker.file_store
-            await retry_transient_errors(
-                self.worker.file_store.write_status_file,
-                self.batch_id,
-                self.job_id,
-                self.attempt_id,
-                json.dumps(full_status),
-            )
+            try:
+                async with async_timeout.timeout(120):
+                    await retry_transient_errors(
+                        self.worker.file_store.write_status_file,
+                        self.batch_id,
+                        self.job_id,
+                        self.attempt_id,
+                        json.dumps(full_status),
+                    )
+            except Exception:
+                log.exception('Encountered error while writing status file')
 
         if not self.deleted:
             self.task_manager.ensure_future(self.worker.post_job_complete(self, mjs_fut, full_status))
@@ -1890,8 +1894,9 @@ class DockerJob(Job):
     async def cleanup(self):
         if self.disk:
             try:
-                await self.disk.delete()
-                log.info(f'deleted disk {self.disk.name} for {self.id}')
+                async with async_timeout.timeout(120):
+                    await self.disk.delete()
+                    log.info(f'deleted disk {self.disk.name} for {self.id}')
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -1908,18 +1913,24 @@ class DockerJob(Job):
 
                     try:
                         assert CLOUD_WORKER_API
-                        await CLOUD_WORKER_API.unmount_cloudfuse(mount_path)
-                        log.info(f'unmounted fuse blob storage {bucket} from {mount_path}')
-                        config['mounted'] = False
+                        async with async_timeout.timeout(120):
+                            await CLOUD_WORKER_API.unmount_cloudfuse(mount_path)
+                            log.info(f'unmounted fuse blob storage {bucket} from {mount_path}')
+                            config['mounted'] = False
                     except asyncio.CancelledError:
                         raise
                     except Exception:
                         log.exception(f'while unmounting fuse blob storage {bucket} from {mount_path}')
 
-        await check_shell(f'xfs_quota -x -c "limit -p bsoft=0 bhard=0 {self.project_id}" /host')
+        try:
+            async with async_timeout.timeout(120):
+                await check_shell(f'xfs_quota -x -c "limit -p bsoft=0 bhard=0 {self.project_id}" /host')
+        except Exception:
+            log.exception(f'while resetting xfs_quota project {self.project_id}')
 
         try:
-            await blocking_to_async(self.pool, shutil.rmtree, self.scratch, ignore_errors=True)
+            async with async_timeout.timeout(120):
+                await blocking_to_async(self.pool, shutil.rmtree, self.scratch, ignore_errors=True)
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/build.yaml
+++ b/build.yaml
@@ -599,17 +599,17 @@ steps:
     dependsOn:
       - merge_code
       - hail_ubuntu_image
-  - kind: buildImage2
-    name: hailgenetics_vep_grch38_95_image
-    dockerFile: /io/repo/docker/hailgenetics/vep/grch38/95/Dockerfile
-    contextPath: /io/repo/docker/vep/
-    publishAs: hailgenetics/vep-grch38-95
-    inputs:
-      - from: /repo
-        to: /io/repo
-    dependsOn:
-      - merge_code
-      - hail_ubuntu_image
+  # - kind: buildImage2
+  #   name: hailgenetics_vep_grch38_95_image
+  #   dockerFile: /io/repo/docker/hailgenetics/vep/grch38/95/Dockerfile
+  #   contextPath: /io/repo/docker/vep/
+  #   publishAs: hailgenetics/vep-grch38-95
+  #   inputs:
+  #     - from: /repo
+  #       to: /io/repo
+  #   dependsOn:
+  #     - merge_code
+  #     - hail_ubuntu_image
   - kind: buildImage2
     name: monitoring_image
     dockerFile: /io/repo/monitoring/Dockerfile
@@ -2341,7 +2341,6 @@ steps:
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
       export HAIL_GENETICS_VEP_GRCH37_85_IMAGE={{ hailgenetics_vep_grch37_85_image.image }}
-      export HAIL_GENETICS_VEP_GRCH38_95_IMAGE={{ hailgenetics_vep_grch38_95_image.image }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
 
       if [[ "$HAIL_CLOUD" = "gcp" ]]
@@ -2412,7 +2411,6 @@ steps:
       - upload_test_resources_to_blob_storage
       - build_hail_jar_and_wheel_only
       - hailgenetics_vep_grch37_85_image
-      - hailgenetics_vep_grch38_95_image
   - kind: buildImage2
     name: netcat_ubuntu_image
     publishAs: netcat
@@ -3213,7 +3211,6 @@ steps:
                              docker://{{ hailgenetics_hail_image.image }} \
                              docker://{{ hailgenetics_hailtop_image.image }} \
                              docker://{{ hailgenetics_vep_grch37_85_image.image }} \
-                             docker://{{ hailgenetics_vep_grch38_95_image.image }} \
                              /io/wheel-for-azure/hail-*-py3-none-any.whl \
                              /io/www.tar.gz
     inputs:
@@ -3259,7 +3256,6 @@ steps:
       - hailgenetics_hail_image
       - hailgenetics_hailtop_image
       - hailgenetics_vep_grch37_85_image
-      - hailgenetics_vep_grch38_95_image
       - build_wheel_for_azure
       - make_docs
     clouds:


### PR DESCRIPTION
We always ensure that `cleanup` is run, but in order to ensure that `post_job_complete` is run we need to ensure we get through any computation in cleanup and `mark_complete` that could potentially hang. So we add timeouts to any yield points in those functions and broadly catch exceptions so we always continue in the cleanup/mark_complete process regardless of failure.