### PR TITLE
update scala version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -823,7 +823,7 @@ steps:
       cd /io/repo/hail
       chmod 755 ./gradlew
       time retry ./gradlew --version
-      export SPARK_VERSION="3.0.2" SCALA_VERSION="2.12.10"
+      export SPARK_VERSION="3.3.0" SCALA_VERSION="2.12.15"
       time retry make wheel
       (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
     inputs:

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -11,7 +11,7 @@ MAKEFLAGS += --no-builtin-rules
 REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-SCALA_VERSION ?= 2.12.13
+SCALA_VERSION ?= 2.12.15
 SPARK_VERSION ?= 3.3.0
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 115

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -47,7 +47,7 @@ project.ext {
     if (sparkVersion != "3.3.0") {
         project.logger.lifecycle("WARNING: Hail primarily tested with Spark 3.3.0, use other versions at your own risk.")
     }
-    scalaVersion = System.getProperty("scala.version", "2.12.13")
+    scalaVersion = System.getProperty("scala.version", "2.12.15")
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
     assert(scalaMajorVersion == "2.12")
 }

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -36,7 +36,7 @@ The next block of commands downloads, builds, and installs Hail from source.
 
     git clone https://github.com/hail-is/hail.git
     cd hail/hail
-    make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.12.13 SPARK_VERSION=3.1.1
+    make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.12.15 SPARK_VERSION=3.3.0
 
 If you forget to install any of the requirements before running `make install-on-cluster`, it's possible
 to get into a bad state where `make` insists you don't have a requirement that you have in fact installed.


### PR DESCRIPTION
Summary:
The correct default scala version for Spark 3.3.0 is 2.12.15
The main change is in `hail/build.gradle` the remaining is just for consistency.

References:
https://github.com/apache/spark/blob/v3.3.0/pom.xml#L3527 (show scala version pinned by Spark)
https://github.com/hail-is/hail/blob/0.2.115/hail/build.gradle#L45-L50

This mismatch causing an issue in our environment when opening spark-shell because hail-all-spark.jar is bundled with scala-reflect that has missing classes. The ideal solution is to remove scala language packages as part of the shadow jar because these already come with the Spark distribution, but proposing to have them in-sync as a workaround for now.

```
$ spark-shell
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/opt/spark-hadoop/jars/log4j-slf4j-impl-2.17.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Ignoring binding found at [jar:file:/opt/spark-hadoop/hadoop/share/hadoop/common/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Exception in thread "main" java.lang.NoSuchMethodError: 'scala.reflect.internal.settings.MutableSettings scala.reflect.internal.settings.MutableSettings$.SettingsOps(scala.reflect.internal.settings.MutableSettings)'
        at scala.tools.nsc.interpreter.ILoop.$anonfun$chooseReader$1(ILoop.scala:914)
        at scala.tools.nsc.interpreter.ILoop.mkReader$1(ILoop.scala:920)
        at scala.tools.nsc.interpreter.ILoop.$anonfun$chooseReader$4(ILoop.scala:926)
        at scala.tools.nsc.interpreter.ILoop.$anonfun$chooseReader$3(ILoop.scala:926)
        at scala.tools.nsc.interpreter.ILoop.chooseReader(ILoop.scala:926)
        at org.apache.spark.repl.SparkILoop.$anonfun$process$1(SparkILoop.scala:138)
```

The error is caused by the change in between 2.12.13 and 2.12.15 in the scala-reflect package that has an additional implicit class:
https://github.com/scala/scala/blob/v2.12.13/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
https://github.com/scala/scala/blob/v2.12.15/src/reflect/scala/reflect/internal/settings/MutableSettings.scala#L88

See also this thread in zulipchat that I posted a while back:
https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query-0.2E2-support/topic/scala.20class.20files.20bundled.20in.20hail-all-spark.2Ejar