### PR TITLE
[query] xfail should always be strict

### DIFF
--- a/batch/test/pytest.ini
+++ b/batch/test/pytest.ini
@@ -8,3 +8,4 @@ filterwarnings =
     error
     ignore::UserWarning
     ignore::DeprecationWarning
+xfail_strict=true

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1603,7 +1603,7 @@ def test_maybe_flexindex_table_by_expr_prefix_interval_match():
     assert t1._maybe_flexindex_table_by_expr((hl.str(mt1.row_idx), mt1.row_idx)) is None
 
 
-@pytest.mark.parametrize("width", [256, 512, 1024, 2048, pytest.param(3072, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("width", [256, 512, 1024, 2048, pytest.param(3072, marks=pytest.mark.xfail(strict=True))])
 def test_can_process_wide_tables(width):
     path = resource(f'width_scale_tests/{width}.tsv')
     ht = hl.import_table(path, impute=False)

--- a/hail/python/test/pytest.ini
+++ b/hail/python/test/pytest.ini
@@ -8,3 +8,4 @@ filterwarnings =
     error
     ignore::UserWarning
     ignore::DeprecationWarning
+xfail_strict=true


### PR DESCRIPTION
I noticed this while xfail-ing a different test. It is possible this test now passes. We will see!