### PR TITLE
[hailctl/dataproc] upgrades `notebook` to version 6.0.*

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -43,7 +43,7 @@ if role == 'Master':
         'ipywidgets==7.5.*',
         'jupyter-console==6.0.*',
         'nbconvert==5.6.*',
-        'notebook==5.7.*',
+        'notebook==6.0.*',
         'qtconsole==4.5.*'
     ]
 


### PR DESCRIPTION
Attempting to install hail on dataproc using the `init_notebook.py` script errors out because hail depends on a more recent version of `jinja2` than the version of `notebook` pinned in the script allows for. This change upgrades the pinned version of `notebook` in the script to be compatible with hail's pinned `jinja2` version.

Fixes #12926.