### PR TITLE
[qob] use a regional bucket with uniform access control

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -585,12 +585,17 @@ resource "google_storage_bucket" "batch_logs" {
 }
 
 
+resource "random_string" "hail_query_bucket_suffix" {
+  length = 5
+}
+
 resource "google_storage_bucket" "hail_query" {
-  name = "hail-query"
+  name = "hail-query-${random_string.hail_query_bucket_suffix.result}"
   location = var.hail_query_bucket_location
   storage_class = var.hail_query_bucket_storage_class
+  uniform_bucket_level_access = true
   labels = {
-    "name" = "hail-query"
+    "name" = "hail-query-${random_string.hail_query_bucket_suffix.result}"
   }
   timeouts {}
 }


### PR DESCRIPTION
The old bucket did not use uniform access control and also was multi-regional (us). I created a new bucket using the random suffix ger0g which has uniform access control. I also switched the location to us-central1 (not pictured here because that is a variable).

I copied all the JARs from `gs://hail-query/jars` to `gs://hail-query-ger0g/jars` using a GCE VM.

Again, global-config is not present in our terraform, so I'll have to manually edit that to reflect this new location: `gs://hail-query-ger0g`.

The deployment process is:

1. Edit global-config to reflect new bucket.
2. Delete batch and batch-driver pods.
3. Delete old workers.

The rollback process (if necessary) is the same.

Since this requires wiping the workers, I'll wait for a time when no one is on the cluster to do it.

Any users using explicit JAR URLs will need to switch to `gs://hail-query-ger0g/...`.