### PR TITLE
[ci] Test pip-installed lints against python 3.9

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1002,13 +1002,13 @@ steps:
       - build_hail
       - merge_code
   - kind: buildImage2
-    name: hail_pip_installed_python37_image
-    dockerFile: /io/repo/hail/Dockerfile.hail-pip-installed-python37
+    name: hail_pip_installed_python39_image
+    dockerFile: /io/repo/hail/Dockerfile.hail-pip-installed-python39
     contextPath: /io/repo
-    publishAs: hail-pip-installed-python37
+    publishAs: hail-pip-installed-python39
     inputs:
-      - from: /repo/hail/Dockerfile.hail-pip-installed-python37
-        to: /io/repo/hail/Dockerfile.hail-pip-installed-python37
+      - from: /repo/hail/Dockerfile.hail-pip-installed-python39
+        to: /io/repo/hail/Dockerfile.hail-pip-installed-python39
       - from: /repo/hail/python/pinned-requirements.txt
         to: /io/repo/hail/python/pinned-requirements.txt
       - from: /repo/hail/python/dev/pinned-requirements.txt
@@ -1046,9 +1046,9 @@ steps:
       - hail_ubuntu_image
       - merge_code
   - kind: runImage
-    name: check_hail_python37
+    name: check_hail_python39
     image:
-      valueFrom: hail_pip_installed_python37_image.image
+      valueFrom: hail_pip_installed_python39_image.image
     script: |
       set -x
       SITE_PACKAGES=$(pip3 show hail | grep Location | sed 's/Location: //')
@@ -1063,7 +1063,7 @@ steps:
 
       exit $exit_status
     dependsOn:
-      - hail_pip_installed_python37_image
+      - hail_pip_installed_python39_image
   - kind: runImage
     name: check_hail_python38
     image:

--- a/hail/Dockerfile.hail-pip-installed-python38
+++ b/hail/Dockerfile.hail-pip-installed-python38
@@ -1,10 +1,7 @@
 FROM {{ hail_ubuntu_image.image }}
 
 ENV LANG C.UTF-8
-RUN hail-apt-get-install \
-    openjdk-8-jdk-headless \
-    python3.8 python3-pip \
-  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+RUN hail-apt-get-install openjdk-8-jdk-headless
 
 COPY hail/python/pinned-requirements.txt requirements.txt
 COPY hail/python/dev/pinned-requirements.txt dev-requirements.txt

--- a/hail/Dockerfile.hail-pip-installed-python39
+++ b/hail/Dockerfile.hail-pip-installed-python39
@@ -2,7 +2,10 @@ FROM {{ hail_ubuntu_image.image }}
 
 ENV LANG C.UTF-8
 
-RUN hail-apt-get-install openjdk-8-jdk-headless
+RUN hail-apt-get-install \
+    openjdk-8-jdk-headless \
+    python3.9 \
+  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 
 COPY hail/python/pinned-requirements.txt requirements.txt
 COPY hail/python/dev/pinned-requirements.txt dev-requirements.txt


### PR DESCRIPTION
Because the python version in hail-ubuntu changed from 3.7 to 3.8, both of the `hail-pip-installed` dockerfiles were running 3.8. I changed the old 3.7 dockerfile to try to use 3.9