### PR TITLE
[batch] Delete old unused docker socket field in job spec

### DIFF
--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -72,7 +72,7 @@ job_validator = keyed(
                 'docker': {
                     required('command'): listof(str_type),
                     required('image'): image_str,
-                    required('mount_docker_socket'): bool_type,
+                    'mount_docker_socket': bool_type,  # DEPRECATED
                 },
                 'jvm': {
                     required('jar_spec'): keyed(
@@ -149,8 +149,8 @@ def handle_deprecated_job_keys(i, job):
         del job['pvc_size']
 
     if 'process' not in job:
-        process_keys = ['command', 'image', 'mount_docker_socket']
-        if 'command' not in job or 'image' not in job or 'mount_docker_socket' not in job:
+        process_keys = ['command', 'image']
+        if 'command' not in job or 'image' not in job:
             raise ValidationError(
                 f'jobs[{i}].process is not defined, but '
                 f'deprecated keys {[k for k in process_keys if k not in job]} '
@@ -158,33 +158,36 @@ def handle_deprecated_job_keys(i, job):
             )
         command = job['command']
         image = job['image']
-        mount_docker_socket = job['mount_docker_socket']
         try:
             for k in process_keys:
                 job_validator['process']['docker'][k].validate(f"jobs[{i}].{k}", job[k])
         except ValidationError as e:
             raise ValidationError(
-                f"[command, image, mount_docker_socket keys are "
+                f"[command, image keys are "
                 f"DEPRECATED. Use process.command, process.image, "
-                f"process.mount_docker_socket with process.type = 'docker'.] "
+                f"with process.type = 'docker'.] "
                 f"{e.reason}"
             ) from e
 
         job['process'] = {
             'command': command,
             'image': image,
-            'mount_docker_socket': mount_docker_socket,
             'type': 'docker',
         }
         del job['command']
         del job['image']
-        del job['mount_docker_socket']
-    elif 'command' in job or 'image' in job or 'mount_docker_socket' in job:
+    elif 'command' in job or 'image' in job:
         raise ValidationError(
             f"jobs[{i}].process is already defined, but "
-            f"deprecated keys 'command', 'image', "
-            f"'mount_docker_socket' are also present. "
+            f"deprecated keys 'command', 'image' "
+            f"are also present. "
             f"Please remove deprecated keys."
+        )
+
+    mount_docker_socket = job['process'].pop('mount_docker_socket', False)
+    if mount_docker_socket:
+        raise ValidationError(
+            "mount_docker_socket is no longer supported but was set to True in request. Please upgrade."
         )
 
     if 'gcsfuse' in job:

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -4,6 +4,7 @@ import secrets
 import time
 from typing import Set
 
+import orjson
 import pytest
 
 from hailtop import httpx
@@ -13,6 +14,7 @@ from hailtop.batch_client.client import BatchClient
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.test_utils import skip_in_azure
 from hailtop.utils import external_requests_client_session, retry_response_returning_functions, sync_sleep_and_backoff
+from hailtop.utils.rich_progress_bar import BatchProgressBar
 
 from .failure_injecting_client_session import FailureInjectingClientSession
 from .utils import DOCKER_ROOT_IMAGE, HAIL_GENETICS_HAIL_IMAGE, create_batch, legacy_batch_status, smallest_machine_type
@@ -976,6 +978,44 @@ def test_verify_private_network_is_restricted(client: BatchClient):
         assert 'unauthorized network private' in err.body
     else:
         assert False
+
+
+async def test_old_clients_that_submit_mount_docker_socket_false_is_ok(client: BatchClient):
+    bb = create_batch(client)._async_builder
+    b = await bb._open_batch()
+    bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    update_id = await bb._create_update(b.id)
+    with BatchProgressBar() as pbar:
+        process = {
+            'type': 'docker',
+            'command': ['sleep', '30'],
+            'image': DOCKER_ROOT_IMAGE,
+            'mount_docker_socket': False,
+        }
+        spec = {'always_run': False, 'job_id': 1, 'parent_ids': [], 'process': process}
+        with pbar.with_task('submitting jobs', total=1) as pbar_task:
+            await bb._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
+
+
+async def test_old_clients_that_submit_mount_docker_socket_true_is_rejected(client: BatchClient):
+    bb = create_batch(client)._async_builder
+    b = await bb._open_batch()
+    bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    update_id = await bb._create_update(b.id)
+    with BatchProgressBar() as pbar:
+        process = {
+            'type': 'docker',
+            'command': ['sleep', '30'],
+            'image': DOCKER_ROOT_IMAGE,
+            'mount_docker_socket': True,
+        }
+        spec = {'always_run': False, 'job_id': 1, 'parent_ids': [], 'process': process}
+        with pbar.with_task('submitting jobs', total=1) as pbar_task:
+            with pytest.raises(
+                httpx.ClientResponseError,
+                match='mount_docker_socket is no longer supported but was set to True in request. Please upgrade.',
+            ):
+                await bb._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
 
 
 def test_pool_highmem_instance(client: BatchClient):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -495,9 +495,9 @@ class BatchBuilder:
 
         self._cancel_after_n_failures = cancel_after_n_failures
 
-    def create_job(self, image: str, command: List[str], *, mount_docker_socket: bool = False, **kwargs):
+    def create_job(self, image: str, command: List[str], **kwargs):
         return self._create_job(
-            {'command': command, 'image': image, 'mount_docker_socket': mount_docker_socket, 'type': 'docker'}, **kwargs
+            {'command': command, 'image': image, 'type': 'docker'}, **kwargs
         )
 
     def create_jvm_job(self, jar_spec: Dict[str, str], argv: List[str], **kwargs):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -232,7 +232,7 @@ class BatchBuilder:
                    image,
                    command,
                    *,
-                   env=None, mount_docker_socket=False,
+                   env=None,
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False,
@@ -245,7 +245,7 @@ class BatchBuilder:
             parents = [parent._async_job for parent in parents]
 
         async_job = self._async_builder.create_job(
-            image, command, env=env, mount_docker_socket=mount_docker_socket,
+            image, command, env=env,
             port=port, resources=resources, secrets=secrets,
             service_account=service_account,
             attributes=attributes, parents=parents,

--- a/hail/src/test/scala/is/hail/services/batch_client/BatchClientSuite.scala
+++ b/hail/src/test/scala/is/hail/services/batch_client/BatchClientSuite.scala
@@ -23,7 +23,6 @@ class BatchClientSuite extends TestNGSuite {
           "parent_ids" -> JArray(List()),
           "process" -> JObject(
             "image" -> JString("ubuntu:20.04"),
-            "mount_docker_socket" -> JBool(false),
             "command" -> JArray(List(
               JString("/bin/bash"),
               JString("-c"),


### PR DESCRIPTION
This has been unused for a long time and I wanted to rid the world of it. This changes the client to no longer send the `mount_docker_socket` field, updates the validator so it's ok for that field to be missing, and explicitly rejects any requests where `mount_docker_socket` is set to true. The reason I couldn't remove `mount_docker_socket` entirely from the codebase is older clients would break if it was not at least optional in the validator spec, which is kind of annoying.

Dev deployed this and successfully submitted jobs using the client from this branch and the client from main.