### PR TITLE
[batch] Use same size VMs in dev and PR as we use in prod

### DIFF
--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -319,11 +319,7 @@ spec:
   selector:
     matchLabels:
       app: batch
-{% if deploy %}
   replicas: 3
-{% else %}
-  replicas: 1
-{% endif %}
   template:
     metadata:
       labels:
@@ -444,8 +440,8 @@ spec:
          - containerPort: 443
         resources:
           requests:
-            cpu: "20m"
-            memory: "20M"
+            cpu: "100m"
+            memory: "200M"
           limits:
             cpu: "1"
             memory: "1G"

--- a/batch/sql/set-test-and-dev-pools-to-16-core-max-3.py
+++ b/batch/sql/set-test-and-dev-pools-to-16-core-max-3.py
@@ -1,0 +1,31 @@
+import os
+import asyncio
+from gear import Database
+
+
+async def main():
+    if os.environ['HAIL_SCOPE'] == 'deploy':
+        return
+
+    worker_cores = 16
+    max_instances = 3
+    max_live_instances = 3
+
+    db = Database()
+    await db.async_init()
+
+    await db.execute_update(
+        '''
+UPDATE pools
+SET worker_cores = %s
+''', (worker_cores))
+
+    await db.execute_update(
+        '''
+UPDATE inst_colls
+SET max_instances = %s, max_live_instances = %s
+''', (max_instances, max_live_instances))
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -147,7 +147,6 @@ def test_invalid_resource_requests(client: BatchClient):
         bb.submit()
 
 
-@skip_in_azure  # https://github.com/hail-is/hail/issues/12958
 def test_out_of_memory(client: BatchClient):
     bb = create_batch(client)
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
@@ -1062,7 +1061,6 @@ def test_pool_highcpu_instance(client: BatchClient):
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
 
-@skip_in_azure  # https://github.com/hail-is/hail/issues/12958
 def test_pool_highcpu_instance_cheapest(client: BatchClient):
     bb = create_batch(client)
     resources = {'cpu': '0.25', 'memory': '50Mi'}

--- a/build.yaml
+++ b/build.yaml
@@ -2195,6 +2195,9 @@ steps:
       - name: mitigate-bad-attempt-resources-trigger
         script: /io/sql/mitigate-bad-attempt-resources-trigger.sql
         online: true
+      - name: set-test-and-dev-pools-to-16-core-max-3
+        script: /io/sql/set-test-and-dev-pools-to-16-core-max-3.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql
@@ -2348,11 +2351,11 @@ steps:
       - create_certs
   - kind: runImage
     name: test_hail_python_service_backend
-    numSplits: 5
+    numSplits: 8
     image:
       valueFrom: hail_run_image.image
     resources:
-      cpu: '1'
+      cpu: '0.5'
       preemptible: False
     script: |
       set -ex
@@ -2398,7 +2401,7 @@ steps:
               -vv \
               --instafail \
               --durations=50 \
-              -n 4 \
+              -n 6 \
               --ignore=test/hailtop/ \
               test
     timeout: 5400

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -40,7 +40,7 @@ if os.path.exists("/zulip-config/.zuliprc"):
 
 TRACKED_PRS = pc.Gauge('ci_tracked_prs', 'PRs currently being monitored by CI', ['build_state', 'review_state'])
 
-MAX_CONCURRENT_PR_BATCHES = 3
+MAX_CONCURRENT_PR_BATCHES = 6
 
 
 class GithubStatus(Enum):


### PR DESCRIPTION
Now that test databases are hosted on their own servers instead of the single cloud-hosted MySQL, we can ramp up the parallelism both in our tests and in the number of PRs that we run at once. I recall that even before we had this DB bottleneck we still restricted the number of PRs running at once for cost reasons, but if that's not the case we could remove that restriction entirely.