### PR TITLE
[services] indicate how many errors we have seen

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -799,7 +799,7 @@ async def retry_transient_errors_with_debug_string(debug_string: str, warning_de
             if errors == 1 and is_retry_once_error(e):
                 return await f(*args, **kwargs)
             if not is_transient_error(e):
-                raise
+                raise ValueError(f"errors={errors}, delay={delay}") from e
             log_warnings = (time_msecs() - start_time >= warning_delay_msecs) or not is_delayed_warning_error(e)
             if log_warnings and errors == 2:
                 log.warning(f'A transient error occured. We will automatically retry. Do not be alarmed. '

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -125,10 +125,15 @@ package object services {
       } catch {
         case e: Exception =>
           errors += 1
-          if (errors == 1 && isRetryOnceError(e))
-            return f
+          if (isRetryOnceError(e)) {
+            if (errors == 1) {
+              return f
+            } else {
+              throw new RuntimeException(s"errors=$errors, delay=$delay", e)
+            }
+          }
           if (!isTransientError(e))
-            throw new RuntimeException(s"errors=$errors, delay=$delay", e)
+            throw e
           if (errors % 10 == 0)
             log.warn(s"encountered $errors transient errors, most recent one was $e")
       }

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -128,7 +128,7 @@ package object services {
           if (errors == 1 && isRetryOnceError(e))
             return f
           if (!isTransientError(e))
-            throw e
+            throw new RuntimeException(s"errors=$errors, delay=$delay", e)
           if (errors % 10 == 0)
             log.warn(s"encountered $errors transient errors, most recent one was $e")
       }


### PR DESCRIPTION
We are increasingly seeing errors from "Connection reset" which we switched from "transient" to "retry once". The current code makes it impossible to determine if we are correctly retrying this error once.

If we see that there are a lot of "Connection reset" errors that happen twice we should perhaps change "retry once" to "retry five times" or use a more generous delay.