### PR TITLE
[query] Enable use of aggregators on array expressions

### DIFF
--- a/hail/python/hail/expr/aggregators/__init__.py
+++ b/hail/python/hail/expr/aggregators/__init__.py
@@ -1,7 +1,8 @@
 from .aggregators import approx_cdf, approx_quantiles, approx_median, collect, collect_as_set, count, count_where, \
     counter, any, all, take, _densify, min, max, sum, array_sum, ndarray_sum, mean, stats, product, fraction, \
     hardy_weinberg_test, explode, filter, inbreeding, call_stats, info_score, \
-    hist, linreg, corr, group_by, downsample, array_agg, _prev_nonnull, _impute_type, fold, _reservoir_sample
+    hist, linreg, corr, group_by, downsample, array_agg, _prev_nonnull, _impute_type, fold, _reservoir_sample, \
+    aggregate_local_array
 
 __all__ = [
     'approx_cdf',
@@ -40,5 +41,6 @@ __all__ = [
     '_prev_nonnull',
     '_impute_type',
     'fold',
-    '_reservoir_sample'
+    '_reservoir_sample',
+    'aggregate_local_array'
 ]

--- a/hail/python/hail/expr/aggregators/__init__.py
+++ b/hail/python/hail/expr/aggregators/__init__.py
@@ -2,7 +2,7 @@ from .aggregators import approx_cdf, approx_quantiles, approx_median, collect, c
     counter, any, all, take, _densify, min, max, sum, array_sum, ndarray_sum, mean, stats, product, fraction, \
     hardy_weinberg_test, explode, filter, inbreeding, call_stats, info_score, \
     hist, linreg, corr, group_by, downsample, array_agg, _prev_nonnull, _impute_type, fold, _reservoir_sample, \
-    aggregate_local_array
+    _aggregate_local_array
 
 __all__ = [
     'approx_cdf',
@@ -42,5 +42,5 @@ __all__ = [
     '_impute_type',
     'fold',
     '_reservoir_sample',
-    'aggregate_local_array'
+    '_aggregate_local_array'
 ]

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -239,6 +239,18 @@ class AggFunc(object):
 
 
 def aggregate_local_array(array, f):
+    """Compute a summary of an array using aggregators. Useful for accessing
+    functionality that exists in `hl.agg` but not elsewhere, like `hl.agg.call_stats`.
+
+    Parameters
+    ----------
+    array
+    f
+
+    Returns
+    -------
+    Aggregation result.
+    """
     elt = array.dtype.element_type
 
     var = Env.get_uid(base='agg')
@@ -246,8 +258,8 @@ def aggregate_local_array(array, f):
     aggregated = f(ref)
 
     if not aggregated._aggregations:
-        raise ExpressionException(f"'hl.aggregate_local_array' "
-                                  f"must take mapping that contains aggregation expression.")
+        raise ExpressionException("'hl.aggregate_local_array' "
+                                  "must take a mapping that contains aggregation expression.")
 
     indices, _ = unify_all(array, aggregated)
     return construct_expr(ir.StreamAgg(ir.ToStream(array._ir), var, aggregated._ir),

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -262,7 +262,11 @@ def _aggregate_local_array(array, f):
                                   "must take a mapping that contains aggregation expression.")
 
     indices, _ = unify_all(array, aggregated)
-    return construct_expr(ir.StreamAgg(ir.ToStream(array._ir), var, aggregated._ir),
+    if isinstance(array.dtype, tarray):
+        stream = ir.toStream(array._ir)
+    else:
+        stream = array._ir
+    return construct_expr(ir.StreamAgg(stream, var, aggregated._ir),
                           aggregated.dtype,
                           Indices(indices.source, indices.axes),
                           array._aggregations)

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -238,7 +238,7 @@ class AggFunc(object):
             return 'agg'
 
 
-def aggregate_local_array(array, f):
+def _aggregate_local_array(array, f):
     """Compute a summary of an array using aggregators. Useful for accessing
     functionality that exists in `hl.agg` but not elsewhere, like `hl.agg.call_stats`.
 

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -4637,6 +4637,10 @@ class StreamExpression(Expression):
         indices, aggregations = unify_all(self, zero, body)
         return construct_expr(x, tstream(body.dtype), indices, aggregations)
 
+    @typecheck_method(f=func_spec(1, expr_any))
+    def aggregate(self, f):
+        return hl.agg._aggregate_local_array(self, f)
+
     def to_array(self):
         return construct_expr(ir.toArray(self._ir), tarray(self.dtype.element_type), self._indices, self._aggregations)
 

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -463,6 +463,25 @@ class ArrayExpression(CollectionExpression):
 
         return construct_expr(slice_ir, self.dtype, indices, aggregations)
 
+    @typecheck_method(f=func_spec(1, expr_any))
+    def aggregate(self, f):
+        """Uses the aggregator library to compute a summary from an array.
+
+        This method is useful for accessing functionality that exists in the aggregator library
+        but not the basic expression library, for instance, :func:`.call_stats`.
+
+        Parameters
+        ----------
+        f
+            Aggregation function
+
+        Returns
+        -------
+        :class:`.Expression`
+        """
+        return hl.agg._aggregate_local_array(self, f)
+
+
     @typecheck_method(item=expr_any)
     def contains(self, item):
         """Returns a boolean indicating whether `item` is found in the array.

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -18,7 +18,7 @@ from .ir import MatrixWrite, MatrixMultiWrite, BlockMatrixWrite, \
     GetTupleElement, Die, ConsoleLog, Apply, ApplySeeded, RNGStateLiteral, RNGSplit,\
     TableCount, TableGetGlobals, TableCollect, TableAggregate, MatrixCount, \
     MatrixAggregate, TableWrite, udf, subst, clear_session_functions, ReadPartition, \
-    PartitionNativeIntervalReader, StreamMultiMerge, StreamZipJoin
+    PartitionNativeIntervalReader, StreamMultiMerge, StreamZipJoin, StreamAgg
 from .register_functions import register_functions
 from .register_aggregators import register_aggregators
 from .table_ir import (MatrixRowsTable, TableJoin, TableLeftJoinRightDistinct, TableIntervalJoin,
@@ -190,6 +190,7 @@ __all__ = [
     'AggExplode',
     'AggGroupBy',
     'AggArrayPerElement',
+    'StreamAgg',
     'BaseApplyAggOp',
     'ApplyAggOp',
     'ApplyScanOp',

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2080,10 +2080,11 @@ class StreamAgg(IR):
         a = a.handle_randomness(body.uses_randomness)
         if body.uses_randomness:
             tup, uid, elt = unpack_uid(a.typ)
+            body = AggLet(value_name, elt, body)
             if body.uses_value_randomness:
                 body = Let('__rng_state', RNGStateLiteral(), body)
             if body.uses_agg_randomness(is_scan=False):
-                body = AggLet('__rng_state', RNGSplit(RNGStateLiteral(), uid), body, is_scan=False)
+                body = with_split_rng_state(body, is_scan=False)
             value_name = tup
 
         super().__init__(a, body)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2077,14 +2077,11 @@ class StreamFor(IR):
 class StreamAgg(IR):
     @typecheck_method(a=IR, value_name=str, body=IR)
     def __init__(self, a, value_name, body):
-        a = a.handle_randomness(body.uses_randomness)
-        if body.uses_randomness:
+        a = a.handle_randomness(body.uses_agg_randomness)
+        if body.uses_agg_randomness:
             tup, uid, elt = unpack_uid(a.typ)
-            body = AggLet(value_name, elt, body)
-            if body.uses_value_randomness:
-                body = Let('__rng_state', RNGStateLiteral(), body)
-            if body.uses_agg_randomness(is_scan=False):
-                body = with_split_rng_state(body, is_scan=False)
+            body = AggLet(value_name, elt, body, is_scan=False)
+            body = with_split_rng_state(body, uid, is_scan=False)
             value_name = tup
 
         super().__init__(a, body)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2074,6 +2074,78 @@ class StreamFor(IR):
             return {}
 
 
+class StreamAgg(IR):
+    @typecheck_method(a=IR, value_name=str, body=IR)
+    def __init__(self, a, value_name, body):
+        a = a.handle_randomness(body.uses_randomness)
+        if body.uses_randomness:
+            tuple, uid, elt = unpack_uid(a.typ)
+            body = AggLet(value_name, elt, body)
+            body = with_split_rng_state(body, uid)
+            value_name = tuple
+
+        super().__init__(a, body)
+        self.a = a
+        self.value_name = value_name
+        self.body = body
+
+    @typecheck_method(a=IR, body=IR)
+    def copy(self, a, body):
+        return StreamAgg(a, self.value_name, body)
+
+    def head_str(self):
+        return escape_id(self.value_name)
+
+    def _eq(self, other):
+        return self.value_name == other.value_name
+
+    @property
+    def bound_variables(self):
+        return {self.value_name} | super().bound_variables
+
+    def _compute_type(self, env, agg_env, deep_typecheck):
+        self.a.compute_type(env, agg_env, deep_typecheck)
+        self.body.compute_type(env, _env_bind(env, self.bindings(1)), deep_typecheck)
+        return self.body.typ
+
+    @property
+    def free_agg_vars(self):
+        return set()
+
+    @property
+    def free_vars(self):
+        fv = (self.body.free_agg_vars.difference({self.value_name})).union(self.a.free_vars)
+        return fv
+
+    def renderable_child_context_without_bindings(self, i: int, parent_context):
+        if i == 0:
+            return parent_context
+        (eval_c, agg_c, scan_c) = parent_context
+        return (eval_c, eval_c, None)
+
+    def renderable_agg_bindings(self, i, default_value=None):
+        if i == 1:
+            if default_value is None:
+                value = self.a.typ.element_type
+            else:
+                value = default_value
+            return {self.value_name: value}
+        else:
+            return {}
+
+    def renderable_bindings(self, i, default_value=None):
+        if i == 1:
+            return {BaseIR.agg_capability: default_value}
+        else:
+            return {}
+
+    def renderable_uses_agg_context(self, i: int):
+        return i == 0
+
+    def renderable_new_block(self, i: int) -> bool:
+        return i == 1
+
+
 class AggFilter(IR):
     @typecheck_method(cond=IR, agg_ir=IR, is_scan=bool)
     def __init__(self, cond, agg_ir, is_scan):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -4090,3 +4090,8 @@ def test_reservoir_sampling():
         mean = np.mean(sample)
         expected_stdev = math.sqrt(sample_variance / sample_size)
         assert abs(mean - sample_mean) / expected_stdev < 4 , (iteration, sample_size, abs(mean - sample_mean) / expected_stdev)
+
+
+def test_local_agg():
+    x = hl.literal([1,2,3,4])
+    assert hl.eval(x.aggregate(lambda x: hl.agg.sum(x))) == 10

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3958,6 +3958,15 @@ def test_stream_randomness():
     assert_contains_node(a, ir.StreamScan)
     assert(len(set(hl.eval(a.to_array())[-1])) == 5)
 
+    # test StreamAgg
+    a = hl._stream_range(10)
+    a = a.aggregate(lambda x: hl.agg.collect(hl.rand_int64()))
+    assert_contains_node(a, ir.StreamAgg)
+    assert(len(set(hl.eval(a))) == 10)
+    a = hl._stream_range(10)
+    a = a.map(lambda x: hl._stream_range(10).aggregate(lambda y: hl.agg.count() + hl.rand_int64()))
+    assert_contains_node(a, ir.StreamAgg)
+
     # test AggExplode
     t = hl.utils.range_table(5)
     t = t.annotate(a = hl.range(t.idx))


### PR DESCRIPTION
This method is useful for accessing functionality that exists in the aggregator library but not the basic expression library, for instance, `call_stats`.