### PR TITLE
[ci] Run service backend tests on non-preemptibles

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2333,6 +2333,7 @@ steps:
       valueFrom: hail_run_image.image
     resources:
       cpu: '1'
+      preemptible: False
     script: |
       set -ex
       tar xvf /io/wheel-container.tar


### PR DESCRIPTION
These tests spin up a lot of non-preemptible Query Driver jobs. This makes these tests feel not really preemptible safe, as a preemption of the test job will end up submitting duplicate Query Drivers.