### PR TITLE
[git] ignore .metals and .bloop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .gradle/
 .idea/
 .vscode/
+.bloop
+.metals
 hail/libs/
 .pytest_cache/
 build/


### PR DESCRIPTION
These show up because I use metals and bloop for Emacs code completion.