### PR TITLE
[ci] Use the ci-utils image from the new branch for db creation

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -258,6 +258,8 @@ steps:
   - kind: createDatabase
     name: test_database_instance
     databaseName: test-instance
+    image:
+      valueFrom: ci_utils_image.image
     migrations: []
     namespace:
       valueFrom: default_ns.name
@@ -265,6 +267,7 @@ steps:
       - test
     dependsOn:
       - default_ns
+      - ci_utils_image
   - kind: runImage
     name: create_database_server_config
     image:
@@ -317,6 +320,8 @@ steps:
   - kind: createDatabase
     name: auth_database
     databaseName: auth
+    image:
+      valueFrom: ci_utils_image.image
     migrations:
       - name: initial
         script: /io/sql/initial.sql
@@ -348,6 +353,7 @@ steps:
       - default_ns
       - merge_code
       - delete_auth_tables
+      - ci_utils_image
   - kind: runImage
     name: create_deploy_config
     image:
@@ -1695,6 +1701,8 @@ steps:
   - kind: createDatabase
     name: monitoring_database
     databaseName: monitoring
+    image:
+      valueFrom: ci_utils_image.image
     migrations:
       - name: initial
         script: /io/sql/initial.sql
@@ -1712,6 +1720,7 @@ steps:
       - default_ns
       - merge_code
       - delete_monitoring_tables
+      - ci_utils_image
   - kind: deploy
     name: deploy_monitoring
     namespace:
@@ -1926,6 +1935,8 @@ steps:
   - kind: createDatabase
     name: ci_database
     databaseName: ci
+    image:
+      valueFrom: ci_utils_image.image
     migrations:
       - name: initial
         script: /io/sql/initial.sql
@@ -1954,9 +1965,12 @@ steps:
       - default_ns
       - merge_code
       - delete_ci_tables
+      - ci_utils_image
   - kind: createDatabase
     name: batch_database
     databaseName: batch
+    image:
+      valueFrom: ci_utils_image.image
     migrations:
       - name: initial
         script: /io/sql/initial.sql
@@ -2185,6 +2199,7 @@ steps:
       - default_ns
       - merge_code
       - delete_batch_tables
+      - ci_utils_image
   - kind: deploy
     name: deploy_batch
     namespace:
@@ -2992,6 +3007,8 @@ steps:
   - kind: createDatabase
     name: notebook_database
     databaseName: notebook
+    image:
+      valueFrom: ci_utils_image.image
     migrations:
       - name: initial
         script: /io/sql/initial.sql
@@ -3008,6 +3025,7 @@ steps:
     dependsOn:
       - default_ns
       - merge_code
+      - ci_utils_image
   - kind: deploy
     name: deploy_notebook
     namespace:

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -193,6 +193,8 @@ steps:
   - kind: createDatabase
     name: hello_database
     databaseName: hello
+    image:
+      valueFrom: ci_utils_image.image
     migrations:
       - name: create-tables
         script: /io/sql/create-hello-tables.sql
@@ -211,6 +213,7 @@ steps:
     dependsOn:
       - default_ns
       - merge_code
+      - ci_utils_image
   - kind: runImage
     name: test_hello_database
     image:


### PR DESCRIPTION
Currently a change to `create_database.py` will only be tested once the change is in production, as opposed to in the PR where it was changed. This should fix that.