### PR TITLE
[services] retry five times instead of once

### DIFF
--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -14,7 +14,7 @@ from .utils import (unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool
                     url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home,
                     TransientError, bounded_gather2, OnlineBoundedGather2,
                     unpack_comma_delimited_inputs, unpack_key_value_inputs,
-                    retry_all_errors_n_times, Timings, is_retry_once_error, am_i_interactive,
+                    retry_all_errors_n_times, Timings, is_limited_retries_error, am_i_interactive,
                     is_delayed_warning_error, retry_transient_errors_with_delayed_warnings,
                     periodically_call_with_dynamic_sleep)
 from .process import (
@@ -96,7 +96,7 @@ __all__ = [
     'retry_all_errors_n_times',
     'parse_timestamp_msecs',
     'Timings',
-    'is_retry_once_error',
+    'is_limited_retries_error',
     'rich_progress_bar',
     'time_ns',
     'am_i_interactive',

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -579,7 +579,7 @@ RETRY_ONCE_BAD_REQUEST_ERROR_MESSAGES = {
 }
 
 
-def is_retry_once_error(e):
+def is_limited_retries_error(e):
     # An exception is a "retry once error" if a rare, known bug in a dependency or in a cloud
     # provider can manifest as this exception *and* that manifestation is indistinguishable from a
     # true error.
@@ -796,7 +796,7 @@ async def retry_transient_errors_with_debug_string(debug_string: str, warning_de
             raise
         except Exception as e:
             errors += 1
-            if errors == 1 and is_retry_once_error(e):
+            if errors <= 5 and is_limited_retries_error(e):
                 return await f(*args, **kwargs)
             if not is_transient_error(e):
                 raise


### PR DESCRIPTION
CHANGELOG: In Query-on-Batch, retries of certain errors has been increased from once to five times. This should reduce the occurrence of transient errors such as "Connection reset" and `SocketException`.