### PR TITLE
[ci] Dont use in-pipeline images for cleanup jobs

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1148,7 +1148,7 @@ done
 '''
 
         self.cleanup_job = batch.create_job(
-            self.image,
+            CI_UTILS_IMAGE,
             command=['bash', '-c', cleanup_script],
             attributes={'name': f'cleanup_{self.name}'},
             secrets=[


### PR DESCRIPTION
#13008 Started using the ci-utils from the CI pipeline for the database jobs, but we actually can't use it safely for the database cleanup step because we might untag the image before the database cleanup jobs run.