### PR TITLE
[infra] create subnetworks manually

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -83,6 +83,7 @@ resource "google_compute_network" "default" {
   name = "default"
   description = "Default network for the project"
   enable_ula_internal_ipv6 = false
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default_region" {


### PR DESCRIPTION
This allows us to fully control subnet parameters. In particular, we want VPC flow logs enabled on all subnets. I already made this change in the console and deleted the asia, europe, me, northamerica, and southamerica subnets which were not in use and which lacked VPC flow logs.