### PR TITLE
[services] update azure-storage-blob 12.22.0 to mitigate "Stream is already closed"

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -199,20 +199,20 @@ dependencies {
     }
 
     bundled 'commons-io:commons-io:2.11.0'
-    bundled(group: 'com.azure', name: 'azure-storage-blob', version: '12.13.0') {
+    bundled(group: 'com.azure', name: 'azure-storage-blob', version: '12.22.0') {
         exclude group: 'com.fasterxml.jackson'
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.databind'
     }
 
-    bundled(group: 'com.azure', name: 'azure-core-http-netty', version: '1.10.0') {
+    bundled(group: 'com.azure', name: 'azure-core-http-netty', version: '1.13.3') {
         exclude group: 'com.fasterxml.jackson'
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.databind'
     }
 
 
-    bundled(group: 'com.azure', name: 'azure-identity', version:'1.2.1') {
+    bundled(group: 'com.azure', name: 'azure-identity', version:'1.8.3') {
         exclude group: 'com.fasterxml.jackson'
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.databind'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -199,30 +199,14 @@ dependencies {
     }
 
     bundled 'commons-io:commons-io:2.11.0'
-    bundled(group: 'com.azure', name: 'azure-storage-blob', version: '12.22.0') {
-        exclude group: 'com.fasterxml.jackson'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.databind'
-    }
-
-    bundled(group: 'com.azure', name: 'azure-core-http-netty', version: '1.13.3') {
-        exclude group: 'com.fasterxml.jackson'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.databind'
-    }
-
-
-    bundled(group: 'com.azure', name: 'azure-identity', version:'1.8.3') {
-        exclude group: 'com.fasterxml.jackson'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.databind'
-    }
 
     bundled group: 'org.freemarker', name: 'freemarker', version: '2.3.31'
 
     bundled 'com.kohlschutter.junixsocket:junixsocket-core:2.6.1'
 
     bundled 'com.github.luben:zstd-jni:1.5.2-1'
+
+    bundled ':shadedazure'
 }
 
 task(checkSettings) doLast {

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -206,7 +206,7 @@ dependencies {
 
     bundled 'com.github.luben:zstd-jni:1.5.2-1'
 
-    bundled ':shadedazure'
+    bundled project(':shadedazure')
 }
 
 task(checkSettings) doLast {

--- a/hail/settings.gradle
+++ b/hail/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name='hail'
+include 'shadedazure'

--- a/hail/shadedazure/build.gradle
+++ b/hail/shadedazure/build.gradle
@@ -1,0 +1,57 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+plugins {
+  id 'java'
+  id 'com.github.johnrengelman.shadow'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.22.0'
+    implementation group: 'com.azure', name: 'azure-core-http-netty', version: '1.13.3'
+    implementation group: 'com.azure', name: 'azure-identity', version:'1.8.3'
+}
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+tasks.withType(ShadowJar) {
+    archiveBaseName = 'shadedazure'
+    zip64 true
+
+    // generate the jar then lightly prune the output of:
+    // jar tf shadedazure/build/libs/shadedazure-all.jar \
+    //     | awk -F'/' '{print "relocate '\''"$1"."$2"'\''", "'\''is.hail.shadedazure."$1"."$2"'\''"}' \
+    //     | sort -u
+    relocate 'com.azure', 'is.hail.shadedazure.com.azure'
+    relocate 'com.ctc', 'is.hail.shadedazure.com.ctc'
+    relocate 'com.fasterxml', 'is.hail.shadedazure.com.fasterxml'
+    relocate 'com.microsoft', 'is.hail.shadedazure.com.microsoft'
+    relocate 'com.nimbusds', 'is.hail.shadedazure.com.nimbusds'
+    relocate 'com.sun', 'is.hail.shadedazure.com.sun'
+    relocate 'io.netty', 'is.hail.shadedazure.io.netty'
+    relocate 'is.hail', 'is.hail.shadedazure.is.hail'
+    relocate 'net.jcip', 'is.hail.shadedazure.net.jcip'
+    relocate 'net.minidev', 'is.hail.shadedazure.net.minidev'
+    relocate 'org.apache', 'is.hail.shadedazure.org.apache'
+    relocate 'org.codehaus', 'is.hail.shadedazure.org.codehaus'
+    relocate 'org.objectweb', 'is.hail.shadedazure.org.objectweb'
+    relocate 'org.reactivestreams', 'is.hail.shadedazure.org.reactivestreams'
+    relocate 'org.slf4j', 'is.hail.shadedazure.org.slf4j'
+    relocate 'reactor.adapter', 'is.hail.shadedazure.reactor.adapter'
+    relocate 'reactor.core', 'is.hail.shadedazure.reactor.core'
+    relocate 'reactor.netty', 'is.hail.shadedazure.reactor.netty'
+    relocate 'reactor.util', 'is.hail.shadedazure.reactor.util'
+
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+}
+
+// you can make the jar from the parent directory with ./gradlew :shadedazure:shadowJar
+shadowJar {}

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -1,10 +1,10 @@
 package is.hail.io.fs
 
-import com.azure.core.credential.TokenCredential
-import com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder, DefaultAzureCredential, DefaultAzureCredentialBuilder}
-import com.azure.storage.blob.models.{BlobProperties, BlobRange, ListBlobsOptions, BlobStorageException}
-import com.azure.storage.blob.specialized.BlockBlobClient
-import com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientBuilder}
+import is.hail.shadedazure.com.azure.core.credential.TokenCredential
+import is.hail.shadedazure.com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder, DefaultAzureCredential, DefaultAzureCredentialBuilder}
+import is.hail.shadedazure.com.azure.storage.blob.models.{BlobProperties, BlobRange, ListBlobsOptions, BlobStorageException}
+import is.hail.shadedazure.com.azure.storage.blob.specialized.BlockBlobClient
+import is.hail.shadedazure.com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientBuilder}
 import is.hail.services.retryTransientErrors
 import is.hail.io.fs.FSUtil.{containsWildcard, dropTrailingSlash}
 import org.apache.log4j.Logger


### PR DESCRIPTION
I do not fully understand the Azure git tagging scheme, but [this commit](https://github.com/Azure/azure-sdk-for-java/commit/054df3fb74098f4ee30eeb1df70df1e40438d169) appears to have made `close` idempotent. It was merged in June of 2022. That commit resolved [an issue](https://github.com/Azure/azure-sdk-for-java/issues/24782) reporting an error very similar to our own.

All the azure version changes update the Azure packages to their latest versions as of 2023-05-09 1713 ET.

Fixes #12976