### PR TITLE
[batch] without auto-create subnetworks, you must specify a subnet

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -111,6 +111,7 @@ def create_vm_config(
         'networkInterfaces': [
             {
                 'network': 'global/networks/default',
+                'subnetwork': f'regions/{region}/subnetworks/default',
                 'networkTier': 'PREMIUM',
                 'accessConfigs': [{'type': 'ONE_TO_ONE_NAT', 'name': 'external-nat'}],
             }


### PR DESCRIPTION
This bug was introduced by https://github.com/hail-is/hail/pull/13016 .