### PR TITLE
[services] retry five times instead of once

### DIFF
--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -14,7 +14,7 @@ from .utils import (unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool
                     url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home,
                     TransientError, bounded_gather2, OnlineBoundedGather2,
                     unpack_comma_delimited_inputs, unpack_key_value_inputs,
-                    retry_all_errors_n_times, Timings, is_retry_once_error, am_i_interactive,
+                    retry_all_errors_n_times, Timings, is_limited_retries_error, am_i_interactive,
                     is_delayed_warning_error, retry_transient_errors_with_delayed_warnings,
                     periodically_call_with_dynamic_sleep)
 from .process import (
@@ -96,7 +96,7 @@ __all__ = [
     'retry_all_errors_n_times',
     'parse_timestamp_msecs',
     'Timings',
-    'is_retry_once_error',
+    'is_limited_retries_error',
     'rich_progress_bar',
     'time_ns',
     'am_i_interactive',

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -579,7 +579,7 @@ RETRY_ONCE_BAD_REQUEST_ERROR_MESSAGES = {
 }
 
 
-def is_retry_once_error(e):
+def is_limited_retries_error(e):
     # An exception is a "retry once error" if a rare, known bug in a dependency or in a cloud
     # provider can manifest as this exception *and* that manifestation is indistinguishable from a
     # true error.
@@ -796,7 +796,7 @@ async def retry_transient_errors_with_debug_string(debug_string: str, warning_de
             raise
         except Exception as e:
             errors += 1
-            if errors == 1 and is_retry_once_error(e):
+            if errors <= 5 and is_limited_retries_error(e):
                 return await f(*args, **kwargs)
             if not is_transient_error(e):
                 raise

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -797,19 +797,24 @@ async def retry_transient_errors_with_debug_string(debug_string: str, warning_de
         except Exception as e:
             errors += 1
             if errors <= 5 and is_limited_retries_error(e):
-                return await f(*args, **kwargs)
-            if not is_transient_error(e):
+                log.warning(
+                    f'A limited retry error has occured. We will automatically retry '
+                    f'{5 - errors} more times. Do not be alarmed. (current delay: '
+                    f'{delay}). The most recent error was {type(e)} {e}. {debug_string}'
+                )
+            elif not is_transient_error(e):
                 raise
-            log_warnings = (time_msecs() - start_time >= warning_delay_msecs) or not is_delayed_warning_error(e)
-            if log_warnings and errors == 2:
-                log.warning(f'A transient error occured. We will automatically retry. Do not be alarmed. '
-                            f'We have thus far seen {errors} transient errors (current delay: '
-                            f'{delay}). The most recent error was {type(e)} {e}. {debug_string}')
-            elif log_warnings and errors % 10 == 0:
-                st = ''.join(traceback.format_stack())
-                log.warning(f'A transient error occured. We will automatically retry. '
-                            f'We have thus far seen {errors} transient errors (current delay: '
-                            f'{delay}). The stack trace for this call is {st}. The most recent error was {type(e)} {e}. {debug_string}', exc_info=True)
+            else:
+                log_warnings = (time_msecs() - start_time >= warning_delay_msecs) or not is_delayed_warning_error(e)
+                if log_warnings and errors == 2:
+                    log.warning(f'A transient error occured. We will automatically retry. Do not be alarmed. '
+                                f'We have thus far seen {errors} transient errors (current delay: '
+                                f'{delay}). The most recent error was {type(e)} {e}. {debug_string}')
+                elif log_warnings and errors % 10 == 0:
+                    st = ''.join(traceback.format_stack())
+                    log.warning(f'A transient error occured. We will automatically retry. '
+                                f'We have thus far seen {errors} transient errors (current delay: '
+                                f'{delay}). The stack trace for this call is {st}. The most recent error was {type(e)} {e}. {debug_string}', exc_info=True)
         delay = await sleep_and_backoff(delay)
 
 

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -125,12 +125,16 @@ package object services {
       } catch {
         case e: Exception =>
           errors += 1
-          if (errors <= 5 && isLimitedRetriesError(e))
-            return f
-          if (!isTransientError(e))
+          if (errors <= 5 && isLimitedRetriesError(e)) {
+            log.warn(
+              s"A limited retry error has occured. We will automatically retry " +
+                s"${5 - errors} more times. Do not be alarmed. (current delay: " +
+                s"$delay). The most recent error was $e.")
+          } else if (!isTransientError(e)) {
             throw e
-          if (errors % 10 == 0)
-            log.warn(s"encountered $errors transient errors, most recent one was $e")
+          } else if (errors % 10 == 0) {
+            log.warn(s"Encountered $errors transient errors, most recent one was $e.")
+          }
       }
       delay = sleepAndBackoff(delay)
     }


### PR DESCRIPTION
CHANGELOG: In Query-on-Batch, retries of certain errors has been increased from once to five times. This should reduce the occurrence of transient errors such as "Connection reset" and `SocketException`.

---

The old approach doesn't work because it doesn't have the retry logic around the invocation. Moreover, the old approach wouldn't retry transient errors encountered after a retry once error. The new approach address both.