### PR TITLE
[vds] Fix bug in vds.filter_intervals with reference block max len

### DIFF
--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -599,7 +599,7 @@ def _parameterized_filter_intervals(vds: 'VariantDataset',
                 f"'filter_intervals': expect a table with a single key of type {expected}; "
                 f"found {list(intervals.key.dtype.values())}")
         intervals_table = intervals
-        intervals = intervals.aggregate(hl.agg.collect(intervals.key[0]))
+        intervals = hl.literal(intervals.aggregate(hl.agg.collect(intervals.key[0]), _localize=False))
 
     if mode == 'unchecked_filter_both':
         return VariantDataset(hl.filter_intervals(vds.reference_data, intervals, keep),

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -668,3 +668,12 @@ def test_ref_block_max_len_patch():
 
         vds2 = hl.vds.read_vds(vds_path)
         assert hl.eval(vds2.reference_data.index_globals()[hl.vds.VariantDataset.ref_block_max_length_field]) == max_rb_len
+
+
+def test_filter_intervals_table():
+    vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
+    filter_vars = vds.variant_data.rows().head(10).select()
+    filter_intervals = filter_vars.key_by(interval=hl.interval(filter_vars.locus, filter_vars.locus, includes_end=True))
+    vds_filt = hl.vds.filter_intervals(vds, filter_intervals)
+
+    assert vds_filt.variant_data.rows().select()._same(filter_vars)

--- a/hail/src/test/resources/vds/1kg_chr22_5_samples.vds/extra_reference_globals.json
+++ b/hail/src/test/resources/vds/1kg_chr22_5_samples.vds/extra_reference_globals.json
@@ -1,0 +1,1 @@
+{"ref_block_max_length": 147492}


### PR DESCRIPTION
CHANGELOG: Fix crash in `hl.vds.filter_intervals` when using a table to filter a VDS that stores the max ref block length.

Fixes #12920