### PR TITLE
[ci] Create a test MySQL server in test and dev namespaces

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2674,6 +2674,7 @@ steps:
       cp -R /io/repo/ci/* ./ci/
       cp /io/repo/tls/Dockerfile ./ci/test/resources/Dockerfile.certs
       cp /io/repo/tls/create_certs.py ./ci/test/resources/
+      cp /io/repo/tls/create_test_db_config.sh ./ci/test/resources/
       cp /io/repo/pylintrc ./
       cp /io/repo/setup.cfg ./
       cp /io/repo/pyproject.toml ./

--- a/build.yaml
+++ b/build.yaml
@@ -1732,6 +1732,7 @@ steps:
       - delete_monitoring_tables
       - ci_utils_image
       - create_test_database_server_config
+      - deploy_test_db
   - kind: deploy
     name: deploy_monitoring
     namespace:
@@ -1978,6 +1979,7 @@ steps:
       - delete_ci_tables
       - ci_utils_image
       - create_test_database_server_config
+      - deploy_test_db
   - kind: createDatabase2
     name: batch_database
     databaseName: batch
@@ -2213,6 +2215,7 @@ steps:
       - delete_batch_tables
       - ci_utils_image
       - create_test_database_server_config
+      - deploy_test_db
   - kind: deploy
     name: deploy_batch
     namespace:
@@ -3041,6 +3044,7 @@ steps:
       - merge_code
       - ci_utils_image
       - create_test_database_server_config
+      - deploy_test_db
   - kind: deploy
     name: deploy_notebook
     namespace:

--- a/build.yaml
+++ b/build.yaml
@@ -255,35 +255,43 @@ steps:
     dependsOn:
       - base_image
       - merge_code
-  - kind: createDatabase
-    name: test_database_instance
-    databaseName: test-instance
-    image:
-      valueFrom: ci_utils_image.image
-    migrations: []
-    namespace:
-      valueFrom: default_ns.name
-    scopes:
-      - test
-    dependsOn:
-      - default_ns
-      - ci_utils_image
   - kind: runImage
-    name: create_database_server_config
+    name: create_test_database_server_config
     image:
-      valueFrom: ci_utils_image.image
+      valueFrom: create_certs_image.image
     script: |
-     kubectl -n {{ default_ns.name }} get -o json secret {{ test_database_instance.admin_secret_name }} | jq '{apiVersion, kind, type, data, metadata: {name: "database-server-config"}}' | kubectl -n {{ default_ns.name }} apply -f -
+      set -ex
+
+      if ! kubectl get secret -n {{ default_ns.name }} database-server-config;
+      then
+          NAMESPACE={{ default_ns.name }} bash /create_test_db_config.sh
+      fi
     serviceAccount:
       name: admin
       namespace:
         valueFrom: default_ns.name
     scopes:
+      - dev
       - test
     dependsOn:
       - default_ns
-      - ci_utils_image
-      - test_database_instance
+      - create_certs_image
+  - kind: deploy
+    name: deploy_test_db
+    namespace:
+      valueFrom: default_ns.name
+    config: docker/mysql/db.yaml
+    wait:
+      - kind: Service
+        name: db
+        for: alive
+        resource_type: statefulset
+    scopes:
+      - dev
+      - test
+    dependsOn:
+      - default_ns
+      - create_test_database_server_config
   - kind: buildImage2
     name: admin_pod_image
     dockerFile: /io/repo/admin-pod/Dockerfile
@@ -316,8 +324,8 @@ steps:
       - default_ns
       - admin_pod_image
       - merge_code
-      - create_database_server_config
-  - kind: createDatabase
+      - create_test_database_server_config
+  - kind: createDatabase2
     name: auth_database
     databaseName: auth
     image:
@@ -354,6 +362,8 @@ steps:
       - merge_code
       - delete_auth_tables
       - ci_utils_image
+      - create_test_database_server_config
+      - deploy_test_db
   - kind: runImage
     name: create_deploy_config
     image:
@@ -525,7 +535,7 @@ steps:
       - create_deploy_config
       - deploy_auth_driver_service_account
       - create_test_gsa_keys
-      - create_database_server_config
+      - create_test_database_server_config
   - kind: runImage
     name: create_initial_user
     runIfRequested: true
@@ -1697,8 +1707,8 @@ steps:
       - default_ns
       - admin_pod_image
       - merge_code
-      - create_database_server_config
-  - kind: createDatabase
+      - create_test_database_server_config
+  - kind: createDatabase2
     name: monitoring_database
     databaseName: monitoring
     image:
@@ -1721,6 +1731,7 @@ steps:
       - merge_code
       - delete_monitoring_tables
       - ci_utils_image
+      - create_test_database_server_config
   - kind: deploy
     name: deploy_monitoring
     namespace:
@@ -1908,7 +1919,7 @@ steps:
       - default_ns
       - admin_pod_image
       - merge_code
-      - create_database_server_config
+      - create_test_database_server_config
   - kind: runImage
     name: delete_ci_tables
     image:
@@ -1931,8 +1942,8 @@ steps:
       - default_ns
       - admin_pod_image
       - merge_code
-      - create_database_server_config
-  - kind: createDatabase
+      - create_test_database_server_config
+  - kind: createDatabase2
     name: ci_database
     databaseName: ci
     image:
@@ -1966,7 +1977,8 @@ steps:
       - merge_code
       - delete_ci_tables
       - ci_utils_image
-  - kind: createDatabase
+      - create_test_database_server_config
+  - kind: createDatabase2
     name: batch_database
     databaseName: batch
     image:
@@ -2200,6 +2212,7 @@ steps:
       - merge_code
       - delete_batch_tables
       - ci_utils_image
+      - create_test_database_server_config
   - kind: deploy
     name: deploy_batch
     namespace:
@@ -2725,7 +2738,6 @@ steps:
         for: alive
     dependsOn:
       - default_ns
-      - create_database_server_config
       - ci_image
       - ci_utils_image
       - create_accounts
@@ -3005,7 +3017,7 @@ steps:
     inputs:
       - from: /repo/hail/python/hailtop
         to: /io/hailtop
-  - kind: createDatabase
+  - kind: createDatabase2
     name: notebook_database
     databaseName: notebook
     image:
@@ -3027,6 +3039,7 @@ steps:
       - default_ns
       - merge_code
       - ci_utils_image
+      - create_test_database_server_config
   - kind: deploy
     name: deploy_notebook
     namespace:

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1190,14 +1190,10 @@ class CreateDatabase2Step(Step):
         self.create_database_job = None
         self.cleanup_job = None
 
-        self.cant_create_database = is_test_deployment
+        self.cant_create_database = False
 
         # MySQL user name can be up to 16 characters long before MySQL 5.7.8 (32 after)
-        if self.cant_create_database:
-            self._name = None
-            self.admin_username = None
-            self.user_username = None
-        elif params.scope == 'deploy':
+        if params.scope == 'deploy':
             self._name = database_name
             self.admin_username = f'{database_name}-admin'
             self.user_username = f'{database_name}-user'

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -66,13 +66,33 @@ async def create_database():
     database_name = create_database_config['database_name']
     cant_create_database = create_database_config['cant_create_database']
 
+    if cant_create_database:
+        await db.just_execute(f'CREATE DATABASE IF NOT EXISTS `{_name}`')
+        sql_config_with_db = SQLConfig(
+            host=sql_config.host,
+            port=sql_config.port,
+            instance=sql_config.instance,
+            connection_name=sql_config.connection_name,
+            user=sql_config.user,
+            password=sql_config.password,
+            db=database_name,
+            ssl_ca=sql_config.ssl_ca,
+            ssl_cert=sql_config.ssl_cert,
+            ssl_key=sql_config.ssl_key,
+            ssl_mode=sql_config.ssl_mode,
+        )
+
+        await write_user_config(namespace, database_name, 'admin', sql_config_with_db)
+        await write_user_config(namespace, database_name, 'user', sql_config_with_db)
+        return
+
     scope = create_database_config['scope']
     _name = create_database_config['_name']
 
     db = Database()
     await db.async_init()
 
-    if scope == 'deploy' and not cant_create_database:
+    if scope == 'deploy':
         assert _name == database_name
 
         # create if not exists

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -64,15 +64,6 @@ async def create_database():
 
     namespace = create_database_config['namespace']
     database_name = create_database_config['database_name']
-    cant_create_database = create_database_config['cant_create_database']
-
-    if cant_create_database:
-        assert sql_config.db is not None
-
-        await write_user_config(namespace, database_name, 'admin', sql_config)
-        await write_user_config(namespace, database_name, 'user', sql_config)
-        return
-
     scope = create_database_config['scope']
     _name = create_database_config['_name']
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -64,7 +64,6 @@ async def create_database():
 
     namespace = create_database_config['namespace']
     database_name = create_database_config['database_name']
-    cant_create_database = create_database_config['cant_create_database']
     scope = create_database_config['scope']
     _name = create_database_config['_name']
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -67,7 +67,6 @@ async def create_database():
     cant_create_database = create_database_config['cant_create_database']
 
     if cant_create_database:
-        assert sql_config.db is not None
         sql_config_with_db = SQLConfig(
             host=sql_config.host,
             port=sql_config.port,

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -85,9 +85,9 @@ async def create_database():
             assert len(rows) == 1
             return
 
-    async def create_user_idempotent(admin_or_user, mysql_username, mysql_password):
-        existing_user = await db.execute_and_fetchone('SELECT user FROM mysql.user WHERE user=%s', (mysql_username,))
-        if existing_user is not None and existing_user.get('user') == mysql_username:
+    async def create_user_if_doesnt_exist(admin_or_user, mysql_username, mysql_password):
+        existing_user = await db.execute_and_fetchone('SELECT 1 FROM mysql.user WHERE user=%s', (mysql_username,))
+        if existing_user is not None:
             return
 
         if admin_or_user == 'admin':
@@ -131,8 +131,8 @@ async def create_database():
         user_password = f.read()
 
     await db.just_execute(f'CREATE DATABASE IF NOT EXISTS `{_name}`')
-    await create_user_idempotent('admin', admin_username, admin_password)
-    await create_user_idempotent('user', user_username, user_password)
+    await create_user_if_doesnt_exist('admin', admin_username, admin_password)
+    await create_user_if_doesnt_exist('user', user_username, user_password)
 
 
 did_shutdown = False

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -71,26 +71,6 @@ async def create_database():
     db = Database()
     await db.async_init()
 
-    if cant_create_database:
-        await db.just_execute(f'CREATE DATABASE IF NOT EXISTS `{_name}`')
-        sql_config_with_db = SQLConfig(
-            host=sql_config.host,
-            port=sql_config.port,
-            instance=sql_config.instance,
-            connection_name=sql_config.connection_name,
-            user=sql_config.user,
-            password=sql_config.password,
-            db=database_name,
-            ssl_ca=sql_config.ssl_ca,
-            ssl_cert=sql_config.ssl_cert,
-            ssl_key=sql_config.ssl_key,
-            ssl_mode=sql_config.ssl_mode,
-        )
-
-        await write_user_config(namespace, database_name, 'admin', sql_config_with_db)
-        await write_user_config(namespace, database_name, 'user', sql_config_with_db)
-        return
-
     if scope == 'deploy':
         assert _name == database_name
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -65,6 +65,8 @@ async def create_database():
     namespace = create_database_config['namespace']
     database_name = create_database_config['database_name']
     cant_create_database = create_database_config['cant_create_database']
+    scope = create_database_config['scope']
+    _name = create_database_config['_name']
 
     db = Database()
     await db.async_init()
@@ -88,9 +90,6 @@ async def create_database():
         await write_user_config(namespace, database_name, 'admin', sql_config_with_db)
         await write_user_config(namespace, database_name, 'user', sql_config_with_db)
         return
-
-    scope = create_database_config['scope']
-    _name = create_database_config['_name']
 
     if scope == 'deploy':
         assert _name == database_name

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -66,6 +66,9 @@ async def create_database():
     database_name = create_database_config['database_name']
     cant_create_database = create_database_config['cant_create_database']
 
+    db = Database()
+    await db.async_init()
+
     if cant_create_database:
         await db.just_execute(f'CREATE DATABASE IF NOT EXISTS `{_name}`')
         sql_config_with_db = SQLConfig(
@@ -88,9 +91,6 @@ async def create_database():
 
     scope = create_database_config['scope']
     _name = create_database_config['_name']
-
-    db = Database()
-    await db.async_init()
 
     if scope == 'deploy':
         assert _name == database_name

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -67,6 +67,10 @@ async def create_database():
     cant_create_database = create_database_config['cant_create_database']
 
     if cant_create_database:
+        assert sql_config.db is not None
+
+        await write_user_config(namespace, database_name, 'admin', sql_config)
+        await write_user_config(namespace, database_name, 'user', sql_config)
         return
 
     scope = create_database_config['scope']

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -8,7 +8,9 @@ import sys
 from shlex import quote as shq
 from typing import Optional
 
-from gear import Database
+import orjson
+
+from gear import Database, resolve_test_db_endpoint
 from hailtop.auth.sql_config import SQLConfig, create_secret_data_from_config
 from hailtop.utils import check_shell, check_shell_output
 
@@ -65,16 +67,10 @@ async def create_database():
     cant_create_database = create_database_config['cant_create_database']
 
     if cant_create_database:
-        assert sql_config.db is not None
-
-        await write_user_config(namespace, database_name, 'admin', sql_config)
-        await write_user_config(namespace, database_name, 'user', sql_config)
         return
 
     scope = create_database_config['scope']
     _name = create_database_config['_name']
-    admin_username = create_database_config['admin_username']
-    user_username = create_database_config['user_username']
 
     db = Database()
     await db.async_init()
@@ -89,79 +85,54 @@ async def create_database():
             assert len(rows) == 1
             return
 
+    async def create_user_idempotent(admin_or_user, mysql_username, mysql_password):
+        existing_user = await db.execute_and_fetchone('SELECT user FROM mysql.user WHERE user=%s', (mysql_username,))
+        if existing_user is not None and existing_user.get('user') == mysql_username:
+            return
+
+        if admin_or_user == 'admin':
+            allowed_operations = 'ALL'
+        else:
+            assert admin_or_user == 'user'
+            allowed_operations = 'SELECT, INSERT, UPDATE, DELETE, EXECUTE'
+
+        await db.just_execute(
+            f'''
+            CREATE USER '{mysql_username}'@'%' IDENTIFIED BY '{mysql_password}';
+            GRANT {allowed_operations} ON `{_name}`.* TO '{mysql_username}'@'%';
+            '''
+        )
+
+        await write_user_config(
+            namespace,
+            database_name,
+            admin_or_user,
+            SQLConfig(
+                host=sql_config.host,
+                port=sql_config.port,
+                instance=sql_config.instance,
+                connection_name=sql_config.connection_name,
+                user=mysql_username,
+                password=mysql_password,
+                db=_name,
+                ssl_ca=sql_config.ssl_ca,
+                ssl_cert=sql_config.ssl_cert,
+                ssl_key=sql_config.ssl_key,
+                ssl_mode=sql_config.ssl_mode,
+            ),
+        )
+
+    admin_username = create_database_config['admin_username']
+    user_username = create_database_config['user_username']
+
     with open(create_database_config['admin_password_file'], encoding='utf-8') as f:
         admin_password = f.read()
-
     with open(create_database_config['user_password_file'], encoding='utf-8') as f:
         user_password = f.read()
 
-    admin_exists = await db.execute_and_fetchone("SELECT user FROM mysql.user WHERE user=%s", (admin_username,))
-    admin_exists = admin_exists and admin_exists.get('user') == admin_username
-
-    user_exists = await db.execute_and_fetchone("SELECT user FROM mysql.user WHERE user=%s", (user_username,))
-    user_exists = user_exists and user_exists.get('user') == user_username
-
-    create_admin_or_alter_password = (
-        f"CREATE USER '{admin_username}'@'%' IDENTIFIED BY '{admin_password}';"
-        if not admin_exists
-        else "ALTER USER '{admin_username}'@'%' IDENTIFIED BY '{admin_password}';"
-    )
-
-    create_user_or_alter_password = (
-        f"CREATE USER '{user_username}'@'%' IDENTIFIED BY '{user_password}';"
-        if not user_exists
-        else "ALTER USER '{user_username}'@'%' IDENTIFIED BY '{user_password}';"
-    )
-
-    await db.just_execute(
-        f'''
-        CREATE DATABASE IF NOT EXISTS `{_name}`;
-
-        {create_admin_or_alter_password}
-        GRANT ALL ON `{_name}`.* TO '{admin_username}'@'%';
-
-        {create_user_or_alter_password}
-        GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON `{_name}`.* TO '{user_username}'@'%';
-        '''
-    )
-
-    await write_user_config(
-        namespace,
-        database_name,
-        'admin',
-        SQLConfig(
-            host=sql_config.host,
-            port=sql_config.port,
-            instance=sql_config.instance,
-            connection_name=sql_config.connection_name,
-            user=admin_username,
-            password=admin_password,
-            db=_name,
-            ssl_ca=sql_config.ssl_ca,
-            ssl_cert=sql_config.ssl_cert,
-            ssl_key=sql_config.ssl_key,
-            ssl_mode=sql_config.ssl_mode,
-        ),
-    )
-
-    await write_user_config(
-        namespace,
-        database_name,
-        'user',
-        SQLConfig(
-            host=sql_config.host,
-            port=sql_config.port,
-            instance=sql_config.instance,
-            connection_name=sql_config.connection_name,
-            user=user_username,
-            password=user_password,
-            db=_name,
-            ssl_ca=sql_config.ssl_ca,
-            ssl_cert=sql_config.ssl_cert,
-            ssl_key=sql_config.ssl_key,
-            ssl_mode=sql_config.ssl_mode,
-        ),
-    )
+    await db.just_execute(f'CREATE DATABASE IF NOT EXISTS `{_name}`')
+    await create_user_idempotent('admin', admin_username, admin_password)
+    await create_user_idempotent('user', user_username, user_password)
 
 
 did_shutdown = False
@@ -256,11 +227,15 @@ kubectl -n {namespace} get -o json secret {shq(admin_secret_name)}
     )
     admin_secret = json.loads(out)
 
+    admin_sql_config = SQLConfig.from_json(base64.b64decode(admin_secret['data']['sql-config.json']).decode())
+    if namespace != 'default' and admin_sql_config.host.endswith('.svc.cluster.local'):
+        admin_sql_config = await resolve_test_db_endpoint(admin_sql_config)
+
     with open('/sql-config.json', 'wb') as f:
-        f.write(base64.b64decode(admin_secret['data']['sql-config.json']))
+        f.write(orjson.dumps(admin_sql_config.to_dict()))
 
     with open('/sql-config.cnf', 'wb') as f:
-        f.write(base64.b64decode(admin_secret['data']['sql-config.cnf']))
+        f.write(admin_sql_config.to_cnf().encode('utf-8'))
 
     os.environ['HAIL_DATABASE_CONFIG_FILE'] = '/sql-config.json'
     os.environ['HAIL_SCOPE'] = scope

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -66,32 +66,13 @@ async def create_database():
     database_name = create_database_config['database_name']
     cant_create_database = create_database_config['cant_create_database']
 
-    if cant_create_database:
-        sql_config_with_db = SQLConfig(
-            host=sql_config.host,
-            port=sql_config.port,
-            instance=sql_config.instance,
-            connection_name=sql_config.connection_name,
-            user=sql_config.user,
-            password=sql_config.password,
-            db=database_name,
-            ssl_ca=sql_config.ssl_ca,
-            ssl_cert=sql_config.ssl_cert,
-            ssl_key=sql_config.ssl_key,
-            ssl_mode=sql_config.ssl_mode,
-        )
-
-        await write_user_config(namespace, database_name, 'admin', sql_config_with_db)
-        await write_user_config(namespace, database_name, 'user', sql_config_with_db)
-        return
-
     scope = create_database_config['scope']
     _name = create_database_config['_name']
 
     db = Database()
     await db.async_init()
 
-    if scope == 'deploy':
+    if scope == 'deploy' and not cant_create_database:
         assert _name == database_name
 
         # create if not exists

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -64,6 +64,28 @@ async def create_database():
 
     namespace = create_database_config['namespace']
     database_name = create_database_config['database_name']
+    cant_create_database = create_database_config['cant_create_database']
+
+    if cant_create_database:
+        assert sql_config.db is not None
+        sql_config_with_db = SQLConfig(
+            host=sql_config.host,
+            port=sql_config.port,
+            instance=sql_config.instance,
+            connection_name=sql_config.connection_name,
+            user=sql_config.user,
+            password=sql_config.password,
+            db=database_name,
+            ssl_ca=sql_config.ssl_ca,
+            ssl_cert=sql_config.ssl_cert,
+            ssl_key=sql_config.ssl_key,
+            ssl_mode=sql_config.ssl_mode,
+        )
+
+        await write_user_config(namespace, database_name, 'admin', sql_config_with_db)
+        await write_user_config(namespace, database_name, 'user', sql_config_with_db)
+        return
+
     scope = create_database_config['scope']
     _name = create_database_config['_name']
 

--- a/ci/create_initial_account.py
+++ b/ci/create_initial_account.py
@@ -19,6 +19,14 @@ async def copy_identity_from_default(hail_credentials_secret_name: str) -> str:
 
     secret = await k8s_client.read_namespaced_secret(hail_credentials_secret_name, 'default')
 
+    try:
+        await k8s_client.delete_namespaced_secret(hail_credentials_secret_name, NAMESPACE)
+    except kubernetes_asyncio.client.rest.ApiException as e:
+        if e.status == 404:
+            pass
+        else:
+            raise
+
     await k8s_client.create_namespaced_secret(
         NAMESPACE,
         kubernetes_asyncio.client.V1Secret(

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -236,6 +236,10 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /sql-config
+    serviceAccount:
+      name: admin
+      namespace:
+        valueFrom: default_ns.name
     dependsOn:
       - default_ns
       - hello_database

--- a/docker/mysql/db.yaml
+++ b/docker/mysql/db.yaml
@@ -51,7 +51,10 @@ spec:
             - name: MYSQL_ROOT_PASSWORD
               value: pw
             - name: MYSQL_ROOT_HOST
-              value: "%"
+              valueFrom:
+                secretKeyRef:
+                  name: database-server-config
+                  key: db-root-password
           volumeMounts:
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql

--- a/docker/mysql/db.yaml
+++ b/docker/mysql/db.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-server-conf
+data:
+  my.cnf: |
+    [mysqld]
+    ssl_ca=/sql-config/server-ca.pem
+    ssl_cert=/sql-config/server-cert.pem
+    ssl_key=/sql-config/server-key.pem
+    require_secure_transport=ON
+    log_bin_trust_function_creators=ON
+    max_connections=100
+    bind-address=0.0.0.0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+  labels:
+    app: db
+spec:
+  selector:
+    matchLabels:
+      app: db
+  serviceName: db
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      nodeSelector:
+        preemptible: "false"
+      containers:
+        - name: db
+          image: mysql:8.0.28
+          livenessProbe:
+            exec:
+              command: ["mysqladmin", "ping"]
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: "1.5"
+              memory: "1G"
+            limits:
+              cpu: "2"
+              memory: "1.5G"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: pw
+            - name: MYSQL_ROOT_HOST
+              value: "%"
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
+            - name: database-server-config
+              mountPath: /sql-config
+            - name: mysql-conf
+              mountPath: /etc/mysql/conf.d
+            - name: mysql-client-conf
+              mountPath: /root
+      volumes:
+       - name: mysql-persistent-storage
+         persistentVolumeClaim:
+           claimName: mysql-pv-claim
+       - name: database-server-config
+         secret:
+           secretName: database-server-config
+       - name: mysql-client-conf
+         secret:
+           secretName: database-server-config
+           items:
+             - key: sql-config.cnf
+               path: .my.cnf
+       - name: mysql-conf
+         configMap:
+           name: mysql-server-conf
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-persistent-storage
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+  selector:
+    app: db

--- a/docker/mysql/db.yaml
+++ b/docker/mysql/db.yaml
@@ -49,12 +49,12 @@ spec:
               memory: "1.5G"
           env:
             - name: MYSQL_ROOT_PASSWORD
-              value: pw
-            - name: MYSQL_ROOT_HOST
               valueFrom:
                 secretKeyRef:
                   name: database-server-config
                   key: db-root-password
+            - name: MYSQL_ROOT_HOST
+              value: "%"
           volumeMounts:
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -1,7 +1,7 @@
 from .auth import AuthClient, maybe_parse_bearer_header
 from .auth_utils import create_session, insert_user
 from .csrf import check_csrf_token, new_csrf_token
-from .database import Database, Transaction, create_database_pool, transaction
+from .database import Database, Transaction, create_database_pool, resolve_test_db_endpoint, transaction
 from .http_server_utils import json_request, json_response
 from .metrics import monitor_endpoints_middleware
 from .session import setup_aiohttp_session
@@ -21,4 +21,5 @@ __all__ = [
     'monitor_endpoints_middleware',
     'json_request',
     'json_response',
+    'resolve_test_db_endpoint',
 ]

--- a/hail/python/hailtop/auth/sql_config.py
+++ b/hail/python/hailtop/auth/sql_config.py
@@ -39,6 +39,7 @@ class SQLConfig(NamedTuple):
         cnf = f'''[client]
 host={self.host}
 user={self.user}
+port={self.port}
 password="{self.password}"
 ssl-ca={self.ssl_ca}
 ssl-mode={self.ssl_mode}

--- a/tls/Dockerfile
+++ b/tls/Dockerfile
@@ -8,5 +8,5 @@ RUN curl -LO https://dl.k8s.io/release/v1.21.14/bin/linux/amd64/kubectl && \
     sed -i 's/^RANDFILE/#RANDFILE/' /etc/ssl/openssl.cnf && \
     hail-pip-install pyyaml
 
-COPY config.yaml .
-COPY create_certs.py .
+COPY config.yaml /
+COPY create_certs.py create_test_db_config.sh /

--- a/tls/create_test_db_config.sh
+++ b/tls/create_test_db_config.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "Must specify a NAMESPACE environment variable"
+    exit 1;
+elif [ "${NAMESPACE}" == "default" ]; then
+    echo "This script is only for creating test database configs"
+    exit 1;
+fi
+
+function create_key_and_cert() {
+    local name=$1
+    local key_file=${name}-key.pem
+    local csr_file=${name}-csr.csr
+    local cert_file=${name}-cert.pem
+
+    openssl genrsa -out ${key_file} 4096
+    openssl req -new -subj /CN=$name -key $key_file -out $csr_file
+    openssl x509 -req -in $csr_file \
+        -CA server-ca.pem -CAkey server-ca-key.pem \
+        -CAcreateserial \
+        -out $cert_file \
+        -days 365 -sha256
+}
+
+dir=$(mktemp -d)
+cd $dir
+
+# Create the MySQL server CA
+openssl req -new -x509 \
+    -subj /CN=db-root -nodes -newkey rsa:4096 \
+    -keyout server-ca-key.pem -out server-ca.pem
+
+create_key_and_cert server db
+create_key_and_cert client client
+
+cat >sql-config.cnf <<EOF
+[client]
+host=db.$NAMESPACE
+user=root
+password=pw
+ssl-ca=/sql-config/server-ca.pem
+ssl-cert=/sql-config/client-cert.pem
+ssl-key=/sql-config/client-key.pem
+ssl-mode=VERIFY_CA
+EOF
+
+cat >sql-config.json <<EOF
+{
+    "host": "db.$NAMESPACE.svc.cluster.local",
+    "port": 3306,
+    "user": "root",
+    "password": "pw",
+    "ssl-ca": "/sql-config/server-ca.pem",
+    "ssl-cert": "/sql-config/client-cert.pem",
+    "ssl-key": "/sql-config/client-key.pem",
+    "ssl-mode": "VERIFY_CA",
+    "instance": "dummy",
+    "connection_name": "dummy"
+}
+EOF
+
+kubectl create secret generic database-server-config \
+    --namespace=$NAMESPACE \
+    --from-file=server-ca.pem \
+    --from-file=server-cert.pem \
+    --from-file=server-key.pem \
+    --from-file=client-cert.pem \
+    --from-file=client-key.pem \
+    --from-file=sql-config.cnf \
+    --from-file=sql-config.json

--- a/tls/create_test_db_config.sh
+++ b/tls/create_test_db_config.sh
@@ -42,6 +42,7 @@ cat >sql-config.cnf <<EOF
 [client]
 host=db.$NAMESPACE
 user=root
+port=3306
 password=$password
 ssl-ca=/sql-config/server-ca.pem
 ssl-cert=/sql-config/client-cert.pem


### PR DESCRIPTION
This change creates mysql pods for test and dev namespaces, instead of sharing the CloudSQL database server. The areas of change are as follows:

### Generation of the namespace's database-server-config
The current approach in main does a little trick. Since the current `createDatabase` step uses the `database-server-config` from default to generate admin/user sql configs, the CI pipeline creates a dummy database `test-database-instance` to create a `sql-test-instance-admin-config` that inherits the credentials from the production `database-server-config`, and then copies that within the test namespace to `database-server-config`.

In this change, since we are creating the server ourselves, we can just replace these with a step that creates a `database-server-config` from scratch, and then uses that for the DB pod.

Overall making these changes really gave me the heebie jeebies that the test and dev namespaces have all these credentials to the CloudSQL server. I'm glad this gets rid of that.

### Accessing the database server
We use the DB pod's service DNS name as the `host` so inside Kubernetes this Just Works. The one caveat is the CI pipeline in which we run migrations in batch jobs. Those jobs need a way to reach the DB pod. I achieve this with a NodePort and then use the job's K8s credentials to resolve the node and port that the DB is on. The code I've added to do this resolution feels a bit janky, wouldn't mind some feedback on that. In terms of security, if a user job was able to somehow resolve the address of a test db, they would still not have the credentials to access it, and this is currently also the case with the production database. Nevertheless, this does raise an action item that we should only allow traffic to the k8s and DB subnets for `network=private` jobs, but I think we should make that a separate PR.

### Database creation
In order to test this properly in a dev deploy, I needed to make some changes to `create_database.py`. In main, dev deploys can't create databases. I think they should be able to, and those operations should just be idempotent. When allowing dev deploys to create databases, I hit the `ALTER USER` lines in `create_database.py` which lock out any already-deployed application, which feels silly. Instead, I create the mysql user and create the corresponding secret iff the mysql username does not already exist.

### create_initial_account.py
When starting off with a fresh database, we encounter a bootstrapping problem where we need to add the developer's user. The current way to add the developer's user is through `create_initial_account.py` which assumes that the developer's gsa key secret is not already in the namespace, but now it could be, so I delete the key in the namespace if it exists before creating it. This could all change with my other PR to add devs to test namespaces. But this change to allow ephemeral dev databases will make testing that other PR *way* easier.