### PR TITLE
[services] update azure-storage-blob 12.22.0 to mitigate "Stream is already closed"

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -199,30 +199,14 @@ dependencies {
     }
 
     bundled 'commons-io:commons-io:2.11.0'
-    bundled(group: 'com.azure', name: 'azure-storage-blob', version: '12.13.0') {
-        exclude group: 'com.fasterxml.jackson'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.databind'
-    }
-
-    bundled(group: 'com.azure', name: 'azure-core-http-netty', version: '1.10.0') {
-        exclude group: 'com.fasterxml.jackson'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.databind'
-    }
-
-
-    bundled(group: 'com.azure', name: 'azure-identity', version:'1.2.1') {
-        exclude group: 'com.fasterxml.jackson'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.databind'
-    }
 
     bundled group: 'org.freemarker', name: 'freemarker', version: '2.3.31'
 
     bundled 'com.kohlschutter.junixsocket:junixsocket-core:2.6.1'
 
     bundled 'com.github.luben:zstd-jni:1.5.2-1'
+
+    bundled project(path: ':shadedazure', configuration: 'shadow')
 }
 
 task(checkSettings) doLast {

--- a/hail/scripts/upload_qob_jar.sh
+++ b/hail/scripts/upload_qob_jar.sh
@@ -22,5 +22,5 @@ else
     JAR_LOCATION="${TEST_STORAGE_URI}/${NAMESPACE}/jars/${TOKEN}/${REVISION}.jar"
 fi
 
-az storage blob upload --file ${SHADOW_JAR} --account-name haildevbatch --container-name query --name jars/dking/lfrxrx935eaq/74f44922afbdceb900661e28011ed4004e6ecb25.jar
+python3 -m hailtop.aiotools.copy -vvv 'null' '[{"from":"'${SHADOW_JAR}'", "to":"'${JAR_LOCATION}'"}]'
 echo ${JAR_LOCATION} > ${PATH_FILE}

--- a/hail/scripts/upload_qob_jar.sh
+++ b/hail/scripts/upload_qob_jar.sh
@@ -22,5 +22,5 @@ else
     JAR_LOCATION="${TEST_STORAGE_URI}/${NAMESPACE}/jars/${TOKEN}/${REVISION}.jar"
 fi
 
-gcloud storage cp ${SHADOW_JAR} ${JAR_LOCATION}
+az storage blob upload --file ${SHADOW_JAR} --account-name haildevbatch --container-name query --name jars/dking/lfrxrx935eaq/74f44922afbdceb900661e28011ed4004e6ecb25.jar
 echo ${JAR_LOCATION} > ${PATH_FILE}

--- a/hail/settings.gradle
+++ b/hail/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name='hail'
+include 'shadedazure'

--- a/hail/shadedazure/build.gradle
+++ b/hail/shadedazure/build.gradle
@@ -1,0 +1,57 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+plugins {
+  id 'java'
+  id 'com.github.johnrengelman.shadow'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.22.0'
+    implementation group: 'com.azure', name: 'azure-core-http-netty', version: '1.13.3'
+    implementation group: 'com.azure', name: 'azure-identity', version:'1.8.3'
+}
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+tasks.withType(ShadowJar) {
+    archiveBaseName = 'shadedazure'
+    zip64 true
+
+    // generate the jar then lightly prune the output of:
+    // jar tf shadedazure/build/libs/shadedazure-all.jar \
+    //     | awk -F'/' '{print "relocate '\''"$1"."$2"'\'', '\''is.hail.shadedazure."$1"."$2"'\''"}' \
+    //     | sort -u
+    relocate 'com.azure', 'is.hail.shadedazure.com.azure'
+    relocate 'com.ctc', 'is.hail.shadedazure.com.ctc'
+    relocate 'com.fasterxml', 'is.hail.shadedazure.com.fasterxml'
+    relocate 'com.microsoft', 'is.hail.shadedazure.com.microsoft'
+    relocate 'com.nimbusds', 'is.hail.shadedazure.com.nimbusds'
+    relocate 'com.sun', 'is.hail.shadedazure.com.sun'
+    relocate 'io.netty', 'is.hail.shadedazure.io.netty'
+    relocate 'is.hail', 'is.hail.shadedazure.is.hail'
+    relocate 'net.jcip', 'is.hail.shadedazure.net.jcip'
+    relocate 'net.minidev', 'is.hail.shadedazure.net.minidev'
+    relocate 'org.apache', 'is.hail.shadedazure.org.apache'
+    relocate 'org.codehaus', 'is.hail.shadedazure.org.codehaus'
+    relocate 'org.objectweb', 'is.hail.shadedazure.org.objectweb'
+    relocate 'org.reactivestreams', 'is.hail.shadedazure.org.reactivestreams'
+    relocate 'org.slf4j', 'is.hail.shadedazure.org.slf4j'
+    relocate 'reactor.adapter', 'is.hail.shadedazure.reactor.adapter'
+    relocate 'reactor.core', 'is.hail.shadedazure.reactor.core'
+    relocate 'reactor.netty', 'is.hail.shadedazure.reactor.netty'
+    relocate 'reactor.util', 'is.hail.shadedazure.reactor.util'
+
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+}
+
+// you can make the jar from the parent directory with ./gradlew :shadedazure:shadowJar
+shadowJar {}

--- a/hail/src/main/resources/META-INF.services/com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF.services/com.azure.core.http.HttpClientProvider
@@ -1,1 +1,0 @@
-is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF.services/com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF.services/com.azure.core.http.HttpClientProvider
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF.services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF.services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
@@ -1,1 +1,0 @@
-is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF.services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF.services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF/services/com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF/services/com.azure.core.http.HttpClientProvider
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF/services/com.ctc.wstx.shaded.msv.relaxng_datatype.DatatypeLibraryFactory
+++ b/hail/src/main/resources/META-INF/services/com.ctc.wstx.shaded.msv.relaxng_datatype.DatatypeLibraryFactory
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.shaded.msv_core.datatype.xsd.ngimpl.DataTypeLibraryImpl

--- a/hail/src/main/resources/META-INF/services/com.ctc.wstx.stax.WstxInputFactory
+++ b/hail/src/main/resources/META-INF/services/com.ctc.wstx.stax.WstxInputFactory
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.stax.WstxInputFactory

--- a/hail/src/main/resources/META-INF/services/com.fasterxml.jackson.core.JsonFactory
+++ b/hail/src/main/resources/META-INF/services/com.fasterxml.jackson.core.JsonFactory
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.fasterxml.jackson.core.JsonFactory

--- a/hail/src/main/resources/META-INF/services/com.fasterxml.jackson.core.ObjectCodec
+++ b/hail/src/main/resources/META-INF/services/com.fasterxml.jackson.core.ObjectCodec
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.fasterxml.jackson.databind.ObjectMapper

--- a/hail/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/hail/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule

--- a/hail/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor
+++ b/hail/src/main/resources/META-INF/services/io.micrometer.context.ContextAccessor
@@ -1,0 +1,1 @@
+is.hail.shadedazure.reactor.netty.contextpropagation.ChannelContextAccessor

--- a/hail/src/main/resources/META-INF/services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF/services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
@@ -1,1 +1,0 @@
-is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF/services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF/services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF/services/javax.xml.stream.XMLEventFactory
+++ b/hail/src/main/resources/META-INF/services/javax.xml.stream.XMLEventFactory
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.stax.WstxEventFactory

--- a/hail/src/main/resources/META-INF/services/javax.xml.stream.XMLInputFactory
+++ b/hail/src/main/resources/META-INF/services/javax.xml.stream.XMLInputFactory
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.stax.WstxInputFactory

--- a/hail/src/main/resources/META-INF/services/javax.xml.stream.XMLOutputFactory
+++ b/hail/src/main/resources/META-INF/services/javax.xml.stream.XMLOutputFactory
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.stax.WstxOutputFactory

--- a/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory
+++ b/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory
@@ -1,0 +1,3 @@
+is.hail.shadedazure.com.ctc.wstx.dtd.DTDSchemaFactory
+is.hail.shadedazure.com.ctc.wstx.msv.RelaxNGSchemaFactory
+is.hail.shadedazure.com.ctc.wstx.msv.W3CSchemaFactory

--- a/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory.dtd
+++ b/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory.dtd
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.dtd.DTDSchemaFactory

--- a/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory.relaxng
+++ b/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory.relaxng
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.msv.RelaxNGSchemaFactory

--- a/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory.w3c
+++ b/hail/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory.w3c
@@ -1,0 +1,1 @@
+is.hail.shadedazure.com.ctc.wstx.msv.W3CSchemaFactory

--- a/hail/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/hail/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,0 +1,1 @@
+is.hail.shadedazure.reactor.core.scheduler.ReactorBlockHoundIntegration

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -1,10 +1,10 @@
 package is.hail.io.fs
 
-import com.azure.core.credential.TokenCredential
-import com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder, DefaultAzureCredential, DefaultAzureCredentialBuilder}
-import com.azure.storage.blob.models.{BlobProperties, BlobRange, ListBlobsOptions, BlobStorageException}
-import com.azure.storage.blob.specialized.BlockBlobClient
-import com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientBuilder}
+import is.hail.shadedazure.com.azure.core.credential.TokenCredential
+import is.hail.shadedazure.com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder, DefaultAzureCredential, DefaultAzureCredentialBuilder}
+import is.hail.shadedazure.com.azure.storage.blob.models.{BlobProperties, BlobRange, ListBlobsOptions, BlobStorageException}
+import is.hail.shadedazure.com.azure.storage.blob.specialized.BlockBlobClient
+import is.hail.shadedazure.com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientBuilder}
 import is.hail.services.retryTransientErrors
 import is.hail.io.fs.FSUtil.{containsWildcard, dropTrailingSlash}
 import org.apache.log4j.Logger

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -5,6 +5,7 @@ import is.hail.shadedazure.com.azure.identity.{ClientSecretCredential, ClientSec
 import is.hail.shadedazure.com.azure.storage.blob.models.{BlobProperties, BlobRange, ListBlobsOptions, BlobStorageException}
 import is.hail.shadedazure.com.azure.storage.blob.specialized.BlockBlobClient
 import is.hail.shadedazure.com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientBuilder}
+import is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientBuilder
 import is.hail.shadedazure.reactor.netty.http.client.HttpClient
 import is.hail.services.retryTransientErrors
 import is.hail.io.fs.FSUtil.{containsWildcard, dropTrailingSlash}

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -135,7 +135,6 @@ class AzureBlobServiceClientCache(credential: TokenCredential) {
         val blobServiceClient = new BlobServiceClientBuilder()
           .credential(credential)
           .endpoint(s"https://$account.blob.core.windows.net")
-          .httpClient(new NettyAsyncHttpClientBuilder(HttpClient.create()).build())
           .buildClient()
         clients += ((account, container) -> blobServiceClient)
         blobServiceClient
@@ -145,7 +144,6 @@ class AzureBlobServiceClientCache(credential: TokenCredential) {
   def setPublicAccessServiceClient(account: String, container: String): Unit = {
     val blobServiceClient = new BlobServiceClientBuilder()
       .endpoint(s"https://$account.blob.core.windows.net")
-      .httpClient(new NettyAsyncHttpClientBuilder(HttpClient.create()).build())
       .buildClient()
     clients += ((account, container) -> blobServiceClient)
   }

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -134,7 +134,7 @@ class AzureBlobServiceClientCache(credential: TokenCredential) {
         val blobServiceClient = new BlobServiceClientBuilder()
           .credential(credential)
           .endpoint(s"https://$account.blob.core.windows.net")
-          .httpClient(HttpClient.create())
+          .httpClient(new NettyAsyncHttpClientBuilder(HttpClient.create()).build())
           .buildClient()
         clients += ((account, container) -> blobServiceClient)
         blobServiceClient
@@ -144,7 +144,7 @@ class AzureBlobServiceClientCache(credential: TokenCredential) {
   def setPublicAccessServiceClient(account: String, container: String): Unit = {
     val blobServiceClient = new BlobServiceClientBuilder()
       .endpoint(s"https://$account.blob.core.windows.net")
-      .httpClient(HttpClient.create())
+      .httpClient(new NettyAsyncHttpClientBuilder(HttpClient.create()).build())
       .buildClient()
     clients += ((account, container) -> blobServiceClient)
   }

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -11,7 +11,7 @@ import org.apache.http.ConnectionClosedException
 import org.apache.http.conn.HttpHostConnectException
 import org.apache.log4j.{LogManager, Logger}
 
-import reactor.core.Exceptions.ReactiveException
+import is.hail.shadedazure.reactor.core.Exceptions.ReactiveException
 import scala.util.Random
 import java.io._
 import com.google.cloud.storage.StorageException
@@ -39,7 +39,7 @@ package object services {
     // An exception is a "retry once error" if a rare, known bug in a dependency or in a cloud
     // provider can manifest as this exception *and* that manifestation is indistinguishable from a
     // true error.
-    val e = reactor.core.Exceptions.unwrap(_e)
+    val e = is.hail.shadedazure.reactor.core.Exceptions.unwrap(_e)
     e match {
       case e: SocketException =>
         e.getMessage != null && e.getMessage.contains("Connection reset")
@@ -63,7 +63,7 @@ package object services {
     //
     // If the argument is a ReactiveException, it returns its cause. If the argument is not a
     // ReactiveException it returns the exception unmodified.
-    val e = reactor.core.Exceptions.unwrap(_e)
+    val e = is.hail.shadedazure.reactor.core.Exceptions.unwrap(_e)
     e match {
       case e: NoHttpResponseException =>
         true


### PR DESCRIPTION
Fixes #12976

I do not fully understand the Azure git tagging scheme, but [this commit](https://github.com/Azure/azure-sdk-for-java/commit/054df3fb74098f4ee30eeb1df70df1e40438d169) appears to have made `close` idempotent. It was merged in June of 2022. That commit resolved [an issue](https://github.com/Azure/azure-sdk-for-java/issues/24782) reporting an error very similar to our own.

All the azure version changes update the Azure packages to their latest versions as of 2023-05-09 1713 ET.

Unfortunately, newer Azure versions and Spark 3.3.0 have inconsistent `io.netty` requirements. Spark is stuck back in February 2022. Spark 3.4.0 does support a compatible version of `io.netty`, but we're months from seeing that in Dataproc.

This change packages up Azure and all its dependencies into one JAR of relocated classes. We must refer to those classes by their relocated names.