### PR TITLE
[batch] Give cloud-specific API implementations more control over container registry credentials

### DIFF
--- a/batch/batch/cloud/azure/worker/worker_api.py
+++ b/batch/batch/cloud/azure/worker/worker_api.py
@@ -10,7 +10,7 @@ from hailtop import httpx
 from hailtop.aiocloud import aioazure
 from hailtop.utils import check_exec_output, request_retry_transient_errors, time_msecs
 
-from ....worker.worker_api import CloudWorkerAPI
+from ....worker.worker_api import CloudWorkerAPI, ContainerRegistryCredentials
 from ..instance_config import AzureSlimInstanceConfig
 from .credentials import AzureUserCredentials
 from .disk import AzureDisk
@@ -47,11 +47,19 @@ class AzureWorkerAPI(CloudWorkerAPI[AzureUserCredentials]):
     def user_credentials(self, credentials: Dict[str, str]) -> AzureUserCredentials:
         return AzureUserCredentials(credentials)
 
-    async def worker_access_token(self, session: httpx.ClientSession) -> Dict[str, str]:
+    async def worker_container_registry_credentials(self, session: httpx.ClientSession) -> ContainerRegistryCredentials:
         # https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#az-acr-login-with---expose-token
         return {
             'username': '00000000-0000-0000-0000-000000000000',
             'password': await self.acr_refresh_token.token(session),
+        }
+
+    async def user_container_registry_credentials(
+        self, user_credentials: AzureUserCredentials
+    ) -> ContainerRegistryCredentials:
+        return {
+            'username': user_credentials.username,
+            'password': user_credentials.password,
         }
 
     def instance_config_from_config_dict(self, config_dict: Dict[str, str]) -> AzureSlimInstanceConfig:

--- a/batch/batch/cloud/gcp/worker/credentials.py
+++ b/batch/batch/cloud/gcp/worker/credentials.py
@@ -14,14 +14,6 @@ class GCPUserCredentials(CloudUserCredentials):
         return 'GOOGLE_APPLICATION_CREDENTIALS'
 
     @property
-    def username(self):
-        return '_json_key'
-
-    @property
-    def password(self) -> str:
-        return self._key
-
-    @property
     def mount_path(self):
         return '/gsa-key/key.json'
 

--- a/batch/batch/cloud/gcp/worker/worker_api.py
+++ b/batch/batch/cloud/gcp/worker/worker_api.py
@@ -8,7 +8,7 @@ from hailtop import httpx
 from hailtop.aiocloud import aiogoogle
 from hailtop.utils import check_exec_output, request_retry_transient_errors
 
-from ....worker.worker_api import CloudWorkerAPI
+from ....worker.worker_api import CloudWorkerAPI, ContainerRegistryCredentials
 from ..instance_config import GCPSlimInstanceConfig
 from .credentials import GCPUserCredentials
 from .disk import GCPDisk
@@ -52,7 +52,7 @@ class GCPWorkerAPI(CloudWorkerAPI[GCPUserCredentials]):
     def user_credentials(self, credentials: Dict[str, str]) -> GCPUserCredentials:
         return GCPUserCredentials(credentials)
 
-    async def worker_access_token(self, session: httpx.ClientSession) -> Dict[str, str]:
+    async def worker_container_registry_credentials(self, session: httpx.ClientSession) -> ContainerRegistryCredentials:
         async with await request_retry_transient_errors(
             session,
             'POST',
@@ -62,6 +62,11 @@ class GCPWorkerAPI(CloudWorkerAPI[GCPUserCredentials]):
         ) as resp:
             access_token = (await resp.json())['access_token']
             return {'username': 'oauth2accesstoken', 'password': access_token}
+
+    async def user_container_registry_credentials(
+        self, user_credentials: GCPUserCredentials
+    ) -> ContainerRegistryCredentials:
+        return {'username': '_json_key', 'password': user_credentials.key}
 
     def instance_config_from_config_dict(self, config_dict: Dict[str, str]) -> GCPSlimInstanceConfig:
         return GCPSlimInstanceConfig.from_dict(config_dict)

--- a/batch/batch/worker/credentials.py
+++ b/batch/batch/worker/credentials.py
@@ -9,15 +9,5 @@ class CloudUserCredentials(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def username(self) -> str:
-        raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def password(self) -> str:
-        raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
     def mount_path(self):
         raise NotImplementedError

--- a/batch/batch/worker/worker_api.py
+++ b/batch/batch/worker/worker_api.py
@@ -1,6 +1,8 @@
 import abc
 from typing import Dict, Generic, TypeVar
 
+from typing_extensions import TypedDict
+
 from hailtop import httpx
 from hailtop.aiotools.fs import AsyncFS
 from hailtop.utils import CalledProcessError, sleep_and_backoff
@@ -10,6 +12,11 @@ from .credentials import CloudUserCredentials
 from .disk import CloudDisk
 
 CredsType = TypeVar("CredsType", bound=CloudUserCredentials)
+
+
+class ContainerRegistryCredentials(TypedDict):
+    username: str
+    password: str
 
 
 class CloudWorkerAPI(abc.ABC, Generic[CredsType]):
@@ -32,7 +39,11 @@ class CloudWorkerAPI(abc.ABC, Generic[CredsType]):
         raise NotImplementedError
 
     @abc.abstractmethod
-    async def worker_access_token(self, session: httpx.ClientSession) -> Dict[str, str]:
+    async def worker_container_registry_credentials(self, session: httpx.ClientSession) -> ContainerRegistryCredentials:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def user_container_registry_credentials(self, user_credentials: CredsType) -> ContainerRegistryCredentials:
         raise NotImplementedError
 
     @abc.abstractmethod


### PR DESCRIPTION
Just some more shoving of implementation details into `CloudWorkerAPI` so that credential objects are more of a black box to `worker.py`. Can e.g. change up certain implementations to use oauth2tokens for users.