### PR TITLE
[query] eliminate irrelevant META-INF.services

### DIFF
--- a/hail/src/main/resources/META-INF.services/com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF.services/com.azure.core.http.HttpClientProvider
@@ -1,1 +1,0 @@
-is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider

--- a/hail/src/main/resources/META-INF.services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
+++ b/hail/src/main/resources/META-INF.services/is.hail.shadedazure.com.azure.core.http.HttpClientProvider
@@ -1,1 +1,0 @@
-is.hail.shadedazure.com.azure.core.http.netty.NettyAsyncHttpClientProvider


### PR DESCRIPTION
This appears unnecessary. I was mislead by a website about the correct path at which to store Serivce Provider Interface implementations.