### PR TITLE
[qob] only use highmem for one test

### DIFF
--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -131,7 +131,7 @@ def analyze(caller: str,
 
 
 @typecheck(expression=expr_any)
-def eval_timed(expression):
+def eval_timed(expression, *, _execute_kwargs=None):
     """Evaluate a Hail expression, returning the result and the times taken for
     each stage in the evaluation process.
 
@@ -158,11 +158,12 @@ def eval_timed(expression):
         uid = Env.get_uid()
         ir = expression._indices.source.select_globals(**{uid: expression}).index_globals()[uid]._ir
 
-    return Env.backend().execute(MakeTuple([ir]), timed=True)[0]
+    _execute_kwargs = _execute_kwargs or {}
+    return Env.backend().execute(MakeTuple([ir]), timed=True, **_execute_kwargs)[0]
 
 
 @typecheck(expression=expr_any)
-def eval(expression):
+def eval(expression, *, _execute_kwargs=None):
     """Evaluate a Hail expression, returning the result.
 
     This method is extremely useful for learning about Hail expressions and
@@ -188,7 +189,7 @@ def eval(expression):
     -------
     Any
     """
-    return eval_timed(expression)[0]
+    return eval_timed(expression, _execute_kwargs=_execute_kwargs)[0]
 
 
 @typecheck(expression=expr_any)

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -1,5 +1,5 @@
 from typing import Set, Dict
-from hail.typecheck import typecheck, setof
+from hail.typecheck import typecheck, setof, nullable
 
 from .indices import Indices, Aggregation
 from ..expressions import Expression, ExpressionException, expr_any
@@ -130,7 +130,7 @@ def analyze(caller: str,
         raise errors[0]
 
 
-@typecheck(expression=expr_any)
+@typecheck(expression=expr_any, _execute_kwargs=nullable(dict))
 def eval_timed(expression, *, _execute_kwargs=None):
     """Evaluate a Hail expression, returning the result and the times taken for
     each stage in the evaluation process.
@@ -162,7 +162,7 @@ def eval_timed(expression, *, _execute_kwargs=None):
     return Env.backend().execute(MakeTuple([ir]), timed=True, **_execute_kwargs)[0]
 
 
-@typecheck(expression=expr_any)
+@typecheck(expression=expr_any, _execute_kwargs=nullable(dict))
 def eval(expression, *, _execute_kwargs=None):
     """Evaluate a Hail expression, returning the result.
 

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -24,19 +24,14 @@ def test_tiny_driver_has_tiny_memory():
 def test_big_driver_has_big_memory():
     backend = hl.current_backend()
     assert isinstance(backend, ServiceBackend)
-    old_driver_cores = backend.driver_cores
-    old_driver_memory = backend.driver_memory
-    try:
-        backend.driver_cores = 8
-        backend.driver_memory = 'highmem'
-        t = hl.utils.range_table(100_000_000, 50)
-        # The pytest (client-side) worker dies if we try to realize all 100M rows in memory.
-        # Instead, we realize the 100M rows in memory on the driver and then take just the first 10M
-        # rows back to the client.
-        hl.eval(t.aggregate(hl.agg.collect(t.idx), _localize=False)[:10_000_000])
-    finally:
-        backend.driver_cores = old_driver_cores
-        backend.driver_memory = old_driver_memory
+    t = hl.utils.range_table(100_000_000, 50)
+    # The pytest (client-side) worker dies if we try to realize all 100M rows in memory.
+    # Instead, we realize the 100M rows in memory on the driver and then take just the first 10M
+    # rows back to the client.
+    hl.eval(
+        t.aggregate(hl.agg.collect(t.idx), _localize=False)[:10_000_000],
+        _execute_kwargs={'driver_cores': 8, 'driver_memory': 'highmem'}
+    )
 
 
 @skip_unless_service_backend()
@@ -55,19 +50,14 @@ def test_tiny_worker_has_tiny_memory():
 def test_big_worker_has_big_memory():
     backend = hl.current_backend()
     assert isinstance(backend, ServiceBackend)
-    old_driver_cores = backend.driver_cores
-    old_driver_memory = backend.driver_memory
-    try:
-        backend.worker_cores = 8
-        backend.worker_memory = 'highmem'
-        t = hl.utils.range_table(2, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
-        t = t.annotate(nd_sum=t.nd.sum())
-        # We only eval the small thing so that we trigger an OOM on the worker
-        # but not the driver or client
-        t.aggregate(hl.agg.sum(t.nd_sum))
-    finally:
-        backend.driver_cores = old_driver_cores
-        backend.driver_memory = old_driver_memory
+    t = hl.utils.range_table(2, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
+    t = t.annotate(nd_sum=t.nd.sum())
+    # We only eval the small thing so that we trigger an OOM on the worker
+    # but not the driver or client
+    hl.eval(
+        t.aggregate(hl.agg.sum(t.nd_sum), _localize=False),
+        _execute_kwargs={'worker_cores': 8, 'worker_memory': 'highmem'}
+    )
 
 
 @skip_unless_service_backend()


### PR DESCRIPTION
The service backend is shared among all the threads which means we were changing the resource requests of random other tests. This substantially delays certain tests when, say, 16 quick partitions require 8 highmem cores each.