### PR TITLE
[infra] fix workload_identity_config

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -173,7 +173,9 @@ resource "google_container_cluster" "vdc" {
     }
   }
 
-  workload_identity_config {}
+  workload_identity_config {
+    workload_pool = "hail-vdc.svc.id.goog"
+  }
 
   timeouts {}
 }


### PR DESCRIPTION
Without this I get a diff because it wants to set workload_pool to null.