### PR TITLE
[qob] actually do a naive_coalsece

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2567,9 +2567,6 @@ class Table(ExprContainer):
         :class:`.Table`
             Table with at most `max_partitions` partitions.
         """
-        if hl.current_backend().requires_lowering:
-            return self.repartition(max_partitions)
-
         return Table(ir.TableRepartition(
             self._tir, max_partitions, ir.RepartitionStrategy.NAIVE_COALESCE))
 


### PR DESCRIPTION
CHANGELOG: In Query-on-Batch, `naive_coalsce` no longer performs a full write/read of the dataset. It now operates identically to the Query-on-Spark implementation.