### PR TITLE
Correct the 0.2.116 release date [very minor]

### DIFF
--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -35,7 +35,7 @@ an earlier version of Hail to read files written in a later version.
 
 ## Version 0.2.116
 
-Released 2023-05-04
+Released 2023-05-08
 
 ### New Features
 


### PR DESCRIPTION
For posterity, update the date in the change log to reflect when PR #12987 was merged and the release made.

Very minor, and probably already less important than it was last week, but for future readers it's useful for these to be aligned…