### PR TITLE
[hailctl] Fix validation for remote_tmpdir to allow azure https scheme

### DIFF
--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -5,11 +5,12 @@ import re
 import warnings
 
 from hailtop.config import get_user_config, get_user_config_path
+from hailtop.aiotools.router_fs import RouterAsyncFS
 
 validations = {
     ('batch', 'bucket'): (lambda x: re.fullmatch(r'[^:/\s]+', x) is not None,
                           'should be valid Google Bucket identifier, with no gs:// prefix'),
-    ('batch', 'remote_tmpdir'): (lambda x: any(re.fullmatch(fr'^{scheme}://.*', x) is not None for scheme in ('gs', 's3', 'hail-az')),
+    ('batch', 'remote_tmpdir'): (RouterAsyncFS.valid_url,
                                  'should be valid cloud storage URI such as gs://my-bucket/batch-tmp/'),
     ('email',): (lambda x: re.fullmatch(r'.+@.+', x) is not None, 'should be valid email address'),
 }


### PR DESCRIPTION
Validation code was not updated when adding azure https support. Made this check a bit more robust and tested locally.

Resolves #13049