### PR TITLE
[batch] include instance name in labels and label disks

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -48,7 +48,10 @@ def create_vm_config(
             'type': 'SCRATCH',
             'autoDelete': True,
             'interface': 'NVME',
-            'initializeParams': {'diskType': f'zones/{zone}/diskTypes/local-ssd'},
+            'initializeParams': {
+                'diskType': f'zones/{zone}/diskTypes/local-ssd',
+                'labels': {'role': 'batch2-agent', 'namespace': DEFAULT_NAMESPACE, 'instance-name': machine_name},
+            },
         }
         worker_data_disk_name = 'nvme0n1'
     else:
@@ -57,6 +60,7 @@ def create_vm_config(
             'initializeParams': {
                 'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
                 'diskSizeGb': str(data_disk_size_gb),
+                'labels': {'role': 'batch2-agent', 'namespace': DEFAULT_NAMESPACE, 'instance-name': machine_name},
             },
         }
         worker_data_disk_name = 'sdb'
@@ -95,7 +99,7 @@ def create_vm_config(
     return {
         'name': machine_name,
         'machineType': f'projects/{project}/zones/{zone}/machineTypes/{machine_type}',
-        'labels': {'role': 'batch2-agent', 'namespace': DEFAULT_NAMESPACE},
+        'labels': {'role': 'batch2-agent', 'namespace': DEFAULT_NAMESPACE, 'instance-name': machine_name},
         'disks': [
             {
                 'boot': True,
@@ -104,6 +108,7 @@ def create_vm_config(
                     'sourceImage': f'projects/{project}/global/images/batch-worker-12',
                     'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
                     'diskSizeGb': str(boot_disk_size_gb),
+                    'labels': {'role': 'batch2-agent', 'namespace': DEFAULT_NAMESPACE, 'instance-name': machine_name},
                 },
             },
             worker_data_disk,


### PR DESCRIPTION
AFAICT, labels are free. Without this, I cannot narrow the cost of, say, a Local SSD, down to one instance. https://cloud.google.com/resource-manager

Also, just, generally, I need to be able to know to which namespace a disk belongs.