### PR TITLE
[batch] Dont schedule on instances that dont match the current instance version

### DIFF
--- a/batch/batch/driver/instance_collection/job_private.py
+++ b/batch/batch/driver/instance_collection/job_private.py
@@ -219,7 +219,8 @@ LIMIT %s;
         return should_wait
 
     def max_instances_to_create(self):
-        n_live_instances = self.n_instances_by_state['pending'] + self.n_instances_by_state['active']
+        pool_stats = self.current_worker_version_stats
+        n_live_instances = pool_stats.n_instances_by_state['pending'] + pool_stats.n_instances_by_state['active']
 
         return min(
             self.max_live_instances - n_live_instances,

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -21,6 +21,7 @@ from hailtop.utils import (
 )
 
 from ...batch_format_version import BatchFormatVersion
+from ...globals import INSTANCE_VERSION
 from ...inst_coll_config import PoolConfig
 from ...utils import ExceededSharesCounter, regions_bits_rep_to_regions
 from ..instance import Instance
@@ -205,7 +206,7 @@ WHERE removed = 0 AND inst_coll = %s;
         while i < len(self.healthy_instances_by_free_cores):
             instance = self.healthy_instances_by_free_cores[i]
             assert cores_mcpu <= instance.free_cores_mcpu
-            if instance.region in regions:
+            if instance.region in regions and instance.version == INSTANCE_VERSION:
                 return instance
             i += 1
         return None
@@ -237,9 +238,9 @@ WHERE removed = 0 AND inst_coll = %s;
         regions: List[str],
         remaining_max_new_instances_per_autoscaler_loop: int,
     ):
-        n_live_instances = self.n_instances_by_state['pending'] + self.n_instances_by_state['active']
-
-        live_free_cores_mcpu = sum(self.live_free_cores_mcpu_by_region[region] for region in regions)
+        pool_stats = self.current_worker_version_stats
+        n_live_instances = pool_stats.n_instances_by_state['pending'] + pool_stats.n_instances_by_state['active']
+        live_free_cores_mcpu = sum(pool_stats.live_free_cores_mcpu_by_region[region] for region in regions)
 
         instances_needed = (ready_cores_mcpu - live_free_cores_mcpu + (self.worker_cores * 1000) - 1) // (
             self.worker_cores * 1000
@@ -432,7 +433,8 @@ GROUP BY user;
                 if remaining_instances_per_autoscaler_loop <= 0:
                     break
 
-        n_live_instances = self.n_instances_by_state['pending'] + self.n_instances_by_state['active']
+        pool_stats = self.current_worker_version_stats
+        n_live_instances = pool_stats.n_instances_by_state['pending'] + pool_stats.n_instances_by_state['active']
 
         capacity_for_live_instances = max(0, self.max_live_instances - n_live_instances)
         capacity_for_any_instances = max(0, self.max_instances - self.n_instances)
@@ -457,8 +459,8 @@ GROUP BY user;
                 )
 
         log.info(
-            f'{self} n_instances {self.n_instances} {self.n_instances_by_state}'
-            f' free_cores {free_cores} live_free_cores {self.live_free_cores_mcpu / 1000}'
+            f'{self} n_instances {self.n_instances} {pool_stats.n_instances_by_state}'
+            f' free_cores {free_cores} live_free_cores {pool_stats.live_free_cores_mcpu / 1000}'
             f' full_job_queue_ready_cores {sum(ready_cores_mcpu_per_user.values()) / 1000}'
             f' head_job_queue_ready_cores {sum(head_job_queue_ready_cores_mcpu.values()) / 1000}'
         )

--- a/batch/batch/driver/templates/index.html
+++ b/batch/batch/driver/templates/index.html
@@ -48,12 +48,12 @@
       <td><a href="{{ base_path }}/inst_coll/pool/{{ pool.name }}">{{ pool.name }}</a></td>
       <td>{{ pool.worker_type }}</td>
       <td>{{ pool.preemptible }}</td>
-      <td class="numeric-cell">{{ pool.n_instances_by_state['pending'] }}</td>
-      <td class="numeric-cell">{{ pool.n_instances_by_state['active'] }}</td>
-      <td class="numeric-cell">{{ pool.n_instances_by_state['inactive'] }}</td>
-      <td class="numeric-cell">{{ pool.n_instances_by_state['deleted'] }}</td>
-      <td class="numeric-cell">{{ pool.live_total_cores_mcpu / 1000 }}</td>
-      <td class="numeric-cell">{{ pool.live_free_cores_mcpu / 1000 }}</td>
+      <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['pending'] }}</td>
+      <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['active'] }}</td>
+      <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['inactive'] }}</td>
+      <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['deleted'] }}</td>
+      <td class="numeric-cell">{{ pool.current_worker_version_stats.live_total_cores_mcpu / 1000 }}</td>
+      <td class="numeric-cell">{{ pool.current_worker_version_stats.live_free_cores_mcpu / 1000 }}</td>
     </tr>
     {% endfor %}
     </tbody>
@@ -75,12 +75,12 @@
     <tbody>
     <tr>
       <td><a href="{{ base_path }}/inst_coll/jpim">{{ jpim.name }}</a></td>
-      <td class="numeric-cell">{{ jpim.n_instances_by_state['pending'] }}</td>
-      <td class="numeric-cell">{{ jpim.n_instances_by_state['active'] }}</td>
-      <td class="numeric-cell">{{ jpim.n_instances_by_state['inactive'] }}</td>
-      <td class="numeric-cell">{{ jpim.n_instances_by_state['deleted'] }}</td>
-      <td class="numeric-cell">{{ jpim.live_total_cores_mcpu / 1000 }}</td>
-      <td class="numeric-cell">{{ jpim.live_free_cores_mcpu / 1000 }}</td>
+      <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['pending'] }}</td>
+      <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['active'] }}</td>
+      <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['inactive'] }}</td>
+      <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['deleted'] }}</td>
+      <td class="numeric-cell">{{ jpim.current_worker_version_stats.live_total_cores_mcpu / 1000 }}</td>
+      <td class="numeric-cell">{{ jpim.current_worker_version_stats.live_free_cores_mcpu / 1000 }}</td>
     </tr>
     </tbody>
   </table>

--- a/batch/batch/driver/templates/job_private.html
+++ b/batch/batch/driver/templates/job_private.html
@@ -63,12 +63,12 @@
   </thead>
   <tbody>
   <tr>
-    <td class="numeric-cell">{{ jpim.n_instances_by_state['pending'] }}</td>
-    <td class="numeric-cell">{{ jpim.n_instances_by_state['active'] }}</td>
-    <td class="numeric-cell">{{ jpim.n_instances_by_state['inactive'] }}</td>
-    <td class="numeric-cell">{{ jpim.n_instances_by_state['deleted'] }}</td>
-    <td class="numeric-cell">{{ jpim.live_total_cores_mcpu / 1000 }}</td>
-    <td class="numeric-cell">{{ jpim.live_free_cores_mcpu / 1000 }}</td>
+    <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['pending'] }}</td>
+    <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['active'] }}</td>
+    <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['inactive'] }}</td>
+    <td class="numeric-cell">{{ jpim.current_worker_version_stats.n_instances_by_state['deleted'] }}</td>
+    <td class="numeric-cell">{{ jpim.current_worker_version_stats.live_total_cores_mcpu / 1000 }}</td>
+    <td class="numeric-cell">{{ jpim.current_worker_version_stats.live_free_cores_mcpu / 1000 }}</td>
   </tr>
   </tbody>
 </table>

--- a/batch/batch/driver/templates/pool.html
+++ b/batch/batch/driver/templates/pool.html
@@ -80,12 +80,12 @@
   </thead>
   <tbody>
   <tr>
-    <td class="numeric-cell">{{ pool.n_instances_by_state['pending'] }}</td>
-    <td class="numeric-cell">{{ pool.n_instances_by_state['active'] }}</td>
-    <td class="numeric-cell">{{ pool.n_instances_by_state['inactive'] }}</td>
-    <td class="numeric-cell">{{ pool.n_instances_by_state['deleted'] }}</td>
-    <td class="numeric-cell">{{ pool.live_total_cores_mcpu / 1000 }}</td>
-    <td class="numeric-cell">{{ pool.live_free_cores_mcpu / 1000 }}</td>
+    <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['pending'] }}</td>
+    <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['active'] }}</td>
+    <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['inactive'] }}</td>
+    <td class="numeric-cell">{{ pool.current_worker_version_stats.n_instances_by_state['deleted'] }}</td>
+    <td class="numeric-cell">{{ pool.current_worker_version_stats.live_total_cores_mcpu / 1000 }}</td>
+    <td class="numeric-cell">{{ pool.current_worker_version_stats.live_free_cores_mcpu / 1000 }}</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Long awaited, this change prompts the batch driver to only schedule jobs on workers with the most recent instance version, i.e. matches the `INSTANCE_VERSION` global variable. This way we can make backwards incompatible changes between the worker and driver without having to manually kill the whole fleet. This will allow pre-existing workers to finish gracefully, as they will just stop receiving work when the new batch driver is deployed and eventually die off.

### Scheduler changes
Just skips instances where the instance version doesn't match `INSTANCE_VERSION`

### Autoscaler changes
Cluster stats like free mcpu and live instances are tracked per instance version. The autoscaler now only looks at instances of the latest version when deciding whether it needs more workers. This way we don't get stuck unable to schedule new jobs until the old workers die off because there technically are enough cores available to meet demand but they are from old workers.