### PR TITLE
[qob] immediateFlush=true for QoB logger

### DIFF
--- a/batch/jvm-entryway/src/main/resources/log4j2.properties
+++ b/batch/jvm-entryway/src/main/resources/log4j2.properties
@@ -4,6 +4,7 @@ packages=is.hail
 appenders = QoBAppender
 appender.QoBAppender.type=QoBAppender
 appender.QoBAppender.name=QoBAppender
+appender.QoBAppender.immediateFlush=true
 appender.QoBAppender.layout.type=PatternLayout
 appender.QoBAppender.layout.pattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1}: %p: %m%n
 

--- a/batch/jvm-entryway/src/main/scala/is/hail/QoBAppender.scala
+++ b/batch/jvm-entryway/src/main/scala/is/hail/QoBAppender.scala
@@ -58,10 +58,11 @@ object QoBAppender {
   def createAppender(
     @PluginAttribute("name") name: String,
     @PluginAttribute("ignoreExceptions") ignoreExceptions: Boolean,
+    @PluginAttribute("immediateFlush") immediateFlush: Boolean,
     @PluginElement("Layout") layout: Layout[_],
     @PluginElement("Filters") filter: Filter
   ): QoBAppender = {
-    return new QoBAppender(name, ignoreExceptions, layout, filter)
+    return new QoBAppender(name, ignoreExceptions, immediateFlush, layout, filter)
   }
 }
 
@@ -69,6 +70,7 @@ object QoBAppender {
 class QoBAppender(
   name: String,
   ignoreExceptions: Boolean,
+  immediateFlush: Boolean,
   layout: Layout[_],
   filter: Filter
 ) extends AbstractOutputStreamAppender[QoBOutputStreamManager](
@@ -76,7 +78,7 @@ class QoBAppender(
   layout,
   filter,
   ignoreExceptions,
-  false,
+  immediateFlush,
   Array[Property](),
   QoBOutputStreamManager.getInstance(layout)
 ) {


### PR DESCRIPTION
CHANGELOG: In Query-on-Batch, driver and worker logs no longer buffer so messages should arrive in the UI after a fixed delay rather than proportional to the frequency of log messages.