### PR TITLE
[batch] Remove unnecessary get_compute_client method on CloudWorkerAPI

### DIFF
--- a/batch/batch/cloud/azure/worker/worker_api.py
+++ b/batch/batch/cloud/azure/worker/worker_api.py
@@ -5,7 +5,6 @@ from typing import Dict, Optional, Tuple
 
 import aiohttp
 
-from gear.cloud_config import get_azure_config
 from hailtop import httpx
 from hailtop.aiocloud import aioazure
 from hailtop.utils import check_exec_output, retry_transient_errors, time_msecs
@@ -39,10 +38,6 @@ class AzureWorkerAPI(CloudWorkerAPI[AzureUserCredentials]):
 
     def get_cloud_async_fs(self) -> aioazure.AzureAsyncFS:
         return aioazure.AzureAsyncFS(credentials=self.azure_credentials)
-
-    def get_compute_client(self) -> aioazure.AzureComputeClient:
-        azure_config = get_azure_config()
-        return aioazure.AzureComputeClient(azure_config.subscription_id, azure_config.resource_group)
 
     def user_credentials(self, credentials: Dict[str, str]) -> AzureUserCredentials:
         return AzureUserCredentials(credentials)
@@ -119,6 +114,9 @@ class AzureWorkerAPI(CloudWorkerAPI[AzureUserCredentials]):
         finally:
             os.remove(self._blobfuse_credential_files[mount_base_path_data])
             del self._blobfuse_credential_files[mount_base_path_data]
+
+    async def close(self):
+        pass
 
     def __str__(self):
         return f'subscription_id={self.subscription_id} resource_group={self.resource_group}'

--- a/batch/batch/cloud/gcp/worker/worker_api.py
+++ b/batch/batch/cloud/gcp/worker/worker_api.py
@@ -46,9 +46,6 @@ class GCPWorkerAPI(CloudWorkerAPI[GCPUserCredentials]):
     def get_cloud_async_fs(self) -> aiogoogle.GoogleStorageAsyncFS:
         return aiogoogle.GoogleStorageAsyncFS(session=self._google_session)
 
-    def get_compute_client(self) -> aiogoogle.GoogleComputeClient:
-        return self._compute_client
-
     def user_credentials(self, credentials: Dict[str, str]) -> GCPUserCredentials:
         return GCPUserCredentials(credentials)
 
@@ -121,6 +118,9 @@ class GCPWorkerAPI(CloudWorkerAPI[GCPUserCredentials]):
         finally:
             os.remove(self._gcsfuse_credential_files[mount_base_path_data])
             del self._gcsfuse_credential_files[mount_base_path_data]
+
+    async def close(self):
+        await self._compute_client.close()
 
     def __str__(self):
         return f'project={self.project} zone={self.zone}'

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2815,7 +2815,6 @@ class Worker:
             ],
         )
         self.file_store = FileStore(fs, BATCH_LOGS_STORAGE_URI, INSTANCE_ID)
-        self.compute_client = CLOUD_WORKER_API.get_compute_client()
 
         self.headers: Optional[Dict[str, str]] = None
 
@@ -2872,17 +2871,12 @@ class Worker:
                         log.info('closed file store')
                 finally:
                     try:
-                        if self.compute_client:
-                            await self.compute_client.close()
-                            log.info('closed compute client')
+                        if self.fs:
+                            await self.fs.close()
+                            log.info('closed worker file system')
                     finally:
-                        try:
-                            if self.fs:
-                                await self.fs.close()
-                                log.info('closed worker file system')
-                        finally:
-                            await self.client_session.close()
-                            log.info('closed client session')
+                        await self.client_session.close()
+                        log.info('closed client session')
 
     async def run_job(self, job):
         try:
@@ -3307,22 +3301,27 @@ async def async_main():
             log.info('worker shutdown', exc_info=True)
         finally:
             try:
-                await network_allocator_task_manager.shutdown_and_wait()
+                await CLOUD_WORKER_API.close()
             finally:
                 try:
-                    await docker.close()
-                    log.info('docker closed')
+                    await network_allocator_task_manager.shutdown_and_wait()
                 finally:
-                    asyncio.get_event_loop().set_debug(True)
-                    other_tasks = [t for t in asyncio.all_tasks() if t != asyncio.current_task()]
-                    if other_tasks:
-                        log.warning('Tasks immediately after docker close')
-                        dump_all_stacktraces()
-                        _, pending = await asyncio.wait(other_tasks, timeout=10 * 60, return_when=asyncio.ALL_COMPLETED)
-                        for t in pending:
-                            log.warning('Dangling task:')
-                            t.print_stack()
-                            t.cancel()
+                    try:
+                        await docker.close()
+                        log.info('docker closed')
+                    finally:
+                        asyncio.get_event_loop().set_debug(True)
+                        other_tasks = [t for t in asyncio.all_tasks() if t != asyncio.current_task()]
+                        if other_tasks:
+                            log.warning('Tasks immediately after docker close')
+                            dump_all_stacktraces()
+                            _, pending = await asyncio.wait(
+                                other_tasks, timeout=10 * 60, return_when=asyncio.ALL_COMPLETED
+                            )
+                            for t in pending:
+                                log.warning('Dangling task:')
+                                t.print_stack()
+                                t.cancel()
 
 
 loop = asyncio.get_event_loop()

--- a/batch/batch/worker/worker_api.py
+++ b/batch/batch/worker/worker_api.py
@@ -23,10 +23,6 @@ class CloudWorkerAPI(abc.ABC, Generic[CredsType]):
     nameserver_ip: str
 
     @abc.abstractmethod
-    def get_compute_client(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def create_disk(self, instance_name: str, disk_name: str, size_in_gb: int, mount_path: str) -> CloudDisk:
         raise NotImplementedError
 
@@ -81,4 +77,8 @@ class CloudWorkerAPI(abc.ABC, Generic[CredsType]):
 
     @abc.abstractmethod
     async def unmount_cloudfuse(self, mount_base_path_data: str) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def close(self):
         raise NotImplementedError


### PR DESCRIPTION
worker.py requests the compute client from the worker API just so it can close it at the end. Having a close method instead on the worker API means we don't need to create a compute client in environments that don't support disks (azure and azure-terra).