### PR TITLE
[nd] docs should use \ge not \gte

### DIFF
--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -342,7 +342,7 @@ def qr(nd, mode="reduced"):
 
     .. math::
 
-        m \gte n \\
+        m \ge n \\
         nd : \mathbb{R}^{m \times n} \\
         Q : \mathbb{R}^{m \times n} \\
         R : \mathbb{R}^{n \times n} \\
@@ -353,7 +353,7 @@ def qr(nd, mode="reduced"):
 
     .. math::
 
-        m \gte n \\
+        m \ge n \\
         nd : \mathbb{R}^{m \times n} \\
         Q : \mathbb{R}^{m \times m} \\
         R : \mathbb{R}^{m \times n} \\


### PR DESCRIPTION
See supported operators of KaTeX [here](https://katex.org/docs/supported.html#relations). See that the docs currently do not render [here](https://hail.is/docs/0.2/nd/index.html#hail.nd.qr).