### PR TITLE
[query] warn about force=True in hl.import_vcf

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2807,6 +2807,12 @@ def import_vcf(path,
     -------
     :class:`.MatrixTable`
     """
+    if force:
+        hl.utils.warning(
+            f'You are trying to read {path} with *ONE* core of parallelism. This '
+            'will be very slow. If this file is block-gzipped (bgzip-ed), use '
+            'force_bgz=True instead.'
+        )
 
     reader = ir.MatrixVCFReader(path, call_fields, entry_float_type, header_file,
                                 n_partitions, block_size, min_partitions,


### PR DESCRIPTION
```
2023-05-18 10:03:19.490 Hail: WARN: You are trying to read ./hail/src/test/resources/sample.vcf.gz with *ONE* core of parallelism. This will be very slow. If this file is block-gzipped (bgzip-ed), use force_bgz=True instead.

```