### PR TITLE
[batch] Fix and reset migrations to dedup resource ids in billing tables

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -89,9 +89,15 @@ async def add_attempt_resources(app, db, batch_id, job_id, attempt_id, resources
             # This must be sorted in order to match the order of values in the actual SQL table!
             _resources = dict(sorted(_resources.items()))
 
-            # the deduped resource id is the same as the resource id as the mitigation for duplicate resource ids already merged
             resource_args = [
-                (batch_id, job_id, attempt_id, resource_name_to_id[name], resource_name_to_id[name], quantity)
+                (
+                    batch_id,
+                    job_id,
+                    attempt_id,
+                    resource_name_to_id[name].resource_id,
+                    resource_name_to_id[name].deduped_resource_id,
+                    quantity,
+                )
                 for name, quantity in _resources.items()
             ]
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 import signal
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from functools import wraps
 from typing import Any, Dict, Set, Tuple
 
@@ -1325,12 +1325,15 @@ async def scheduling_cancelling_bump(app):
     app['cancel_running_state_changed'].set()
 
 
+Resource = namedtuple('Resource', ['resource_id', 'deduped_resource_id'])
+
+
 async def refresh_globals_from_db(app, db):
     resource_ids = {
-        record['resource']: record['resource_id']
+        record['resource']: Resource(record['resource_id'], record['deduped_resource_id'])
         async for record in db.select_and_fetchall(
             '''
-SELECT resource, resource_id FROM resources;
+SELECT resource, resource_id, deduped_resource_id FROM resources;
 '''
         )
     }

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -40,14 +40,18 @@ DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources_staging`;
 DROP TABLE IF EXISTS `aggregated_billing_project_resources`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v2`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v3`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_v4`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v2`;
 DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v3`;
+DROP TABLE IF EXISTS `aggregated_billing_project_user_resources_by_date_v4`;
 DROP TABLE IF EXISTS `aggregated_batch_resources`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_v2`;
 DROP TABLE IF EXISTS `aggregated_batch_resources_v3`;
+DROP TABLE IF EXISTS `aggregated_batch_resources_v4`;
 DROP TABLE IF EXISTS `aggregated_job_resources`;
 DROP TABLE IF EXISTS `aggregated_job_resources_v2`;
 DROP TABLE IF EXISTS `aggregated_job_resources_v3`;
+DROP TABLE IF EXISTS `aggregated_job_resources_v4`;
 DROP TABLE IF EXISTS `attempt_resources`;
 DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
 DROP TABLE IF EXISTS `batch_inst_coll_cancellable_resources`;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -351,6 +351,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v2` (
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
   `migrated` BOOLEAN DEFAULT FALSE,
+  `migrated_att_2` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -366,6 +367,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v2
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
   `migrated` BOOLEAN DEFAULT FALSE,
+  `migrated_att_2` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`billing_date`, `billing_project`, `user`, `resource_id`, `token`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -379,6 +381,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v2` (
   `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
   `migrated` BOOLEAN DEFAULT FALSE,
+  `migrated_att_2` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`batch_id`, `resource_id`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
@@ -391,6 +394,7 @@ CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v2` (
   `resource_id` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
   `migrated` BOOLEAN DEFAULT FALSE,
+  `migrated_att_2` BOOLEAN DEFAULT FALSE,
   PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
@@ -433,6 +437,52 @@ CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v3` (
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v3` (
+  `batch_id` BIGINT NOT NULL,
+  `job_id` INT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v4` (
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_v4 ON `aggregated_billing_project_user_resources_v4` (`user`);
+
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v4` (
+  `billing_date` DATE NOT NULL,
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_date`, `billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_by_date_v4_user ON `aggregated_billing_project_user_resources_by_date_v4` (`billing_date`, `user`);
+
+CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v4` (
+  `batch_id` BIGINT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `resource_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v4` (
   `batch_id` BIGINT NOT NULL,
   `job_id` INT NOT NULL,
   `resource_id` INT NOT NULL,
@@ -538,9 +588,9 @@ BEGIN
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
-    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    INSERT INTO aggregated_billing_project_user_resources_v4 (billing_project, user, resource_id, token, `usage`)
     SELECT batches.billing_project, batches.`user`,
-      attempt_resources.resource_id,
+      attempt_resources.deduped_resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -550,8 +600,8 @@ BEGIN
       aggregated_billing_project_user_resources_v2.user = batches.user AND
       aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_v2.token = rand_token
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v3.`usage` + msec_diff_rollup * quantity;
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v4.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
     SELECT batch_id,
@@ -562,9 +612,9 @@ BEGIN
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
-    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    INSERT INTO aggregated_batch_resources_v4 (batch_id, resource_id, token, `usage`)
     SELECT attempt_resources.batch_id,
-      attempt_resources.resource_id,
+      attempt_resources.deduped_resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -572,8 +622,8 @@ BEGIN
       aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
       aggregated_batch_resources_v2.token = rand_token
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v3.`usage` + msec_diff_rollup * quantity;
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v4.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
     SELECT batch_id, job_id,
@@ -583,17 +633,17 @@ BEGIN
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
-    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    INSERT INTO aggregated_job_resources_v4 (batch_id, job_id, resource_id, `usage`)
     SELECT attempt_resources.batch_id, attempt_resources.job_id,
-      attempt_resources.resource_id,
+      attempt_resources.deduped_resource_id,
       msec_diff_rollup * quantity
     FROM attempt_resources
     JOIN aggregated_job_resources_v2 ON
       aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
       aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
       aggregated_job_resources_v2.resource_id = attempt_resources.resource_id
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v3.`usage` + msec_diff_rollup * quantity;
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v4.`usage` + msec_diff_rollup * quantity;
 
     INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
@@ -607,11 +657,11 @@ BEGIN
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
     ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
 
-    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v4 (billing_date, billing_project, user, resource_id, token, `usage`)
     SELECT cur_billing_date,
       batches.billing_project,
       batches.`user`,
-      attempt_resources.resource_id,
+      attempt_resources.deduped_resource_id,
       rand_token,
       msec_diff_rollup * quantity
     FROM attempt_resources
@@ -622,8 +672,8 @@ BEGIN
       aggregated_billing_project_user_resources_by_date_v2.user = batches.user AND
       aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
       aggregated_billing_project_user_resources_by_date_v2.token = rand_token
-    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated = 1
-    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v3.`usage` + msec_diff_rollup * quantity;
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v4.`usage` + msec_diff_rollup * quantity;
   END IF;
 END $$
 
@@ -834,13 +884,13 @@ BEGIN
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO bp_user_resources_migrated
+    SELECT migrated_att_2 INTO bp_user_resources_migrated
     FROM aggregated_billing_project_user_resources_v2
     WHERE billing_project = cur_billing_project AND user = cur_user AND resource_id = NEW.resource_id AND token = rand_token
     FOR UPDATE;
 
     IF bp_user_resources_migrated THEN
-      INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+      INSERT INTO aggregated_billing_project_user_resources_v4 (billing_project, user, resource_id, token, `usage`)
       VALUES (cur_billing_project, cur_user, NEW.deduped_resource_id, rand_token, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
@@ -851,13 +901,13 @@ BEGIN
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO batch_resources_migrated
+    SELECT migrated_att_2 INTO batch_resources_migrated
     FROM aggregated_batch_resources_v2
     WHERE batch_id = NEW.batch_id AND resource_id = NEW.resource_id AND token = rand_token
     FOR UPDATE;
 
     IF batch_resources_migrated THEN
-      INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+      INSERT INTO aggregated_batch_resources_v4 (batch_id, resource_id, token, `usage`)
       VALUES (NEW.batch_id, NEW.deduped_resource_id, rand_token, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
@@ -868,13 +918,13 @@ BEGIN
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO job_resources_migrated
+    SELECT migrated_att_2 INTO job_resources_migrated
     FROM aggregated_job_resources_v2
     WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND resource_id = NEW.resource_id
     FOR UPDATE;
 
     IF job_resources_migrated THEN
-      INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+      INSERT INTO aggregated_job_resources_v4 (batch_id, job_id, resource_id, `usage`)
       VALUES (NEW.batch_id, NEW.job_id, NEW.deduped_resource_id, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
@@ -885,14 +935,14 @@ BEGIN
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.quantity * msec_diff_rollup;
 
-    SELECT migrated INTO bp_user_resources_by_date_migrated
+    SELECT migrated_att_2 INTO bp_user_resources_by_date_migrated
     FROM aggregated_billing_project_user_resources_by_date_v2
     WHERE billing_date = cur_billing_date AND billing_project = cur_billing_project AND user = cur_user
       AND resource_id = NEW.resource_id AND token = rand_token
     FOR UPDATE;
 
     IF bp_user_resources_by_date_migrated THEN
-      INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v4 (billing_date, billing_project, user, resource_id, token, `usage`)
       VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.deduped_resource_id, rand_token, NEW.quantity * msec_diff_rollup)
       ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.quantity * msec_diff_rollup;
@@ -904,28 +954,28 @@ DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_before_insert $$
 CREATE TRIGGER aggregated_bp_user_resources_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_v2
 FOR EACH ROW
 BEGIN
-  SET NEW.migrated = 1;
+  SET NEW.migrated_att_2 = 1;
 END $$
 
 DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_before_insert $$
 CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_by_date_v2
 FOR EACH ROW
 BEGIN
-  SET NEW.migrated = 1;
+  SET NEW.migrated_att_2 = 1;
 END $$
 
 DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_before_insert $$
 CREATE TRIGGER aggregated_batch_resources_v2_before_insert BEFORE INSERT on aggregated_batch_resources_v2
 FOR EACH ROW
 BEGIN
-  SET NEW.migrated = 1;
+  SET NEW.migrated_att_2 = 1;
 END $$
 
 DROP TRIGGER IF EXISTS aggregated_job_resources_v2_before_insert $$
 CREATE TRIGGER aggregated_job_resources_v2_before_insert BEFORE INSERT on aggregated_job_resources_v2
 FOR EACH ROW
 BEGIN
-  SET NEW.migrated = 1;
+  SET NEW.migrated_att_2 = 1;
 END $$
 
 DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_after_update $$
@@ -934,10 +984,10 @@ FOR EACH ROW
 BEGIN
   DECLARE new_deduped_resource_id INT;
 
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
     SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
 
-    INSERT INTO aggregated_billing_project_user_resources_v3 (billing_project, user, resource_id, token, `usage`)
+    INSERT INTO aggregated_billing_project_user_resources_v4 (billing_project, user, resource_id, token, `usage`)
     VALUES (NEW.billing_project, NEW.user, new_deduped_resource_id, NEW.token, NEW.usage)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.usage;
@@ -950,10 +1000,10 @@ FOR EACH ROW
 BEGIN
   DECLARE new_deduped_resource_id INT;
 
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
     SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
 
-    INSERT INTO aggregated_billing_project_user_resources_by_date_v3 (billing_date, billing_project, user, resource_id, token, `usage`)
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v4 (billing_date, billing_project, user, resource_id, token, `usage`)
     VALUES (NEW.billing_date, NEW.billing_project, NEW.user, new_deduped_resource_id, NEW.token, NEW.usage)
     ON DUPLICATE KEY UPDATE
         `usage` = `usage` + NEW.usage;
@@ -966,10 +1016,10 @@ FOR EACH ROW
 BEGIN
   DECLARE new_deduped_resource_id INT;
 
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
     SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
 
-    INSERT INTO aggregated_batch_resources_v3 (batch_id, resource_id, token, `usage`)
+    INSERT INTO aggregated_batch_resources_v4 (batch_id, resource_id, token, `usage`)
     VALUES (NEW.batch_id, new_deduped_resource_id, NEW.token, NEW.usage)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.usage;
@@ -982,10 +1032,10 @@ FOR EACH ROW
 BEGIN
   DECLARE new_deduped_resource_id INT;
 
-  IF OLD.migrated = 0 AND NEW.migrated = 1 THEN
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
     SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
 
-    INSERT INTO aggregated_job_resources_v3 (batch_id, job_id, resource_id, `usage`)
+    INSERT INTO aggregated_job_resources_v4 (batch_id, job_id, resource_id, `usage`)
     VALUES (NEW.batch_id, NEW.job_id, new_deduped_resource_id, NEW.usage)
     ON DUPLICATE KEY UPDATE
       `usage` = `usage` + NEW.usage;

--- a/batch/sql/fix-reset-dedup-resource-triggers.sql
+++ b/batch/sql/fix-reset-dedup-resource-triggers.sql
@@ -1,0 +1,378 @@
+START TRANSACTION;
+
+ALTER TABLE aggregated_billing_project_user_resources_v2 ADD COLUMN `migrated_att_2`, ALGORITHM=INSTANT;
+ALTER TABLE aggregated_batch_resources_v2 ADD COLUMN `migrated_att_2`, ALGORITHM=INSTANT;
+ALTER TABLE aggregated_job_resources_v2 ADD COLUMN `migrated_att_2`, ALGORITHM=INSTANT;
+ALTER TABLE aggregated_billing_project_user_resources_by_date_v2 ADD COLUMN `migrated_att_2`, ALGORITHM=INSTANT;
+
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_v4` (
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_v4 ON `aggregated_billing_project_user_resources_v4` (`user`);
+
+CREATE TABLE IF NOT EXISTS `aggregated_billing_project_user_resources_by_date_v4` (
+  `billing_date` DATE NOT NULL,
+  `billing_project` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`billing_date`, `billing_project`, `user`, `resource_id`, `token`),
+  FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+CREATE INDEX aggregated_billing_project_user_resources_by_date_v4_user ON `aggregated_billing_project_user_resources_by_date_v4` (`billing_date`, `user`);
+
+CREATE TABLE IF NOT EXISTS `aggregated_batch_resources_v4` (
+  `batch_id` BIGINT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `token` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `resource_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `aggregated_job_resources_v4` (
+  `batch_id` BIGINT NOT NULL,
+  `job_id` INT NOT NULL,
+  `resource_id` INT NOT NULL,
+  `usage` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `job_id`, `resource_id`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`, `job_id`) REFERENCES jobs(`batch_id`, `job_id`) ON DELETE CASCADE,
+  FOREIGN KEY (`resource_id`) REFERENCES resources(`resource_id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_after_update $$
+CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  DECLARE job_cores_mcpu INT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_billing_date DATE;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  SELECT billing_project INTO cur_billing_project FROM batches WHERE id = NEW.batch_id;
+
+  SET msec_diff_rollup = (GREATEST(COALESCE(NEW.rollup_time - NEW.start_time, 0), 0) -
+                          GREATEST(COALESCE(OLD.rollup_time - OLD.start_time, 0), 0));
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    SELECT billing_project, `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_v4 (billing_project, user, resource_id, token, `usage`)
+    SELECT batches.billing_project, batches.`user`,
+      attempt_resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    INNER JOIN aggregated_billing_project_user_resources_v2 ON
+      aggregated_billing_project_user_resources_v2.billing_project = batches.billing_project AND
+      aggregated_billing_project_user_resources_v2.user = batches.user AND
+      aggregated_billing_project_user_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_billing_project_user_resources_v2.token = rand_token
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_v4.`usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    SELECT batch_id,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_batch_resources_v4 (batch_id, resource_id, token, `usage`)
+    SELECT attempt_resources.batch_id,
+      attempt_resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN aggregated_batch_resources_v2 ON
+      aggregated_batch_resources_v2.batch_id = attempt_resources.batch_id AND
+      aggregated_batch_resources_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_batch_resources_v2.token = rand_token
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_batch_resources_v4.`usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    SELECT batch_id, job_id,
+      resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_job_resources_v4 (batch_id, job_id, resource_id, `usage`)
+    SELECT attempt_resources.batch_id, attempt_resources.job_id,
+      attempt_resources.deduped_resource_id,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN aggregated_job_resources_v2 ON
+      aggregated_job_resources_v2.batch_id = attempt_resources.batch_id AND
+      aggregated_job_resources_v2.job_id = attempt_resources.job_id AND
+      aggregated_job_resources_v2.resource_id = attempt_resources.resource_id
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_job_resources_v4.`usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      billing_project,
+      `user`,
+      resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+    ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff_rollup * quantity;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v4 (billing_date, billing_project, user, resource_id, token, `usage`)
+    SELECT cur_billing_date,
+      batches.billing_project,
+      batches.`user`,
+      attempt_resources.deduped_resource_id,
+      rand_token,
+      msec_diff_rollup * quantity
+    FROM attempt_resources
+    JOIN batches ON batches.id = attempt_resources.batch_id
+    JOIN aggregated_billing_project_user_resources_by_date_v2 ON
+      aggregated_billing_project_user_resources_by_date_v2.billing_date = cur_billing_date AND
+      aggregated_billing_project_user_resources_by_date_v2.billing_project = batches.billing_project AND
+      aggregated_billing_project_user_resources_by_date_v2.user = batches.user AND
+      aggregated_billing_project_user_resources_by_date_v2.resource_id = attempt_resources.resource_id AND
+      aggregated_billing_project_user_resources_by_date_v2.token = rand_token
+    WHERE attempt_resources.batch_id = NEW.batch_id AND attempt_resources.job_id = NEW.job_id AND attempt_id = NEW.attempt_id AND migrated_att_2 = 1
+    ON DUPLICATE KEY UPDATE `usage` = aggregated_billing_project_user_resources_by_date_v4.`usage` + msec_diff_rollup * quantity;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_rollup_time BIGINT;
+  DECLARE cur_billing_project VARCHAR(100);
+  DECLARE cur_user VARCHAR(100);
+  DECLARE msec_diff_rollup BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+  DECLARE cur_billing_date DATE;
+  DECLARE bp_user_resources_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE bp_user_resources_by_date_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE batch_resources_migrated BOOLEAN DEFAULT FALSE;
+  DECLARE job_resources_migrated BOOLEAN DEFAULT FALSE;
+
+  SELECT billing_project, user INTO cur_billing_project, cur_user
+  FROM batches WHERE id = NEW.batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT start_time, rollup_time INTO cur_start_time, cur_rollup_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff_rollup = GREATEST(COALESCE(cur_rollup_time - cur_start_time, 0), 0);
+
+  SET cur_billing_date = CAST(UTC_DATE() AS DATE);
+
+  IF msec_diff_rollup != 0 THEN
+    INSERT INTO aggregated_billing_project_user_resources_v2 (billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated_att_2 INTO bp_user_resources_migrated
+    FROM aggregated_billing_project_user_resources_v2
+    WHERE billing_project = cur_billing_project AND user = cur_user AND resource_id = NEW.resource_id AND token = rand_token
+    FOR UPDATE;
+
+    IF bp_user_resources_migrated THEN
+      INSERT INTO aggregated_billing_project_user_resources_v4 (billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_project, cur_user, NEW.deduped_resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
+    INSERT INTO aggregated_batch_resources_v2 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated_att_2 INTO batch_resources_migrated
+    FROM aggregated_batch_resources_v2
+    WHERE batch_id = NEW.batch_id AND resource_id = NEW.resource_id AND token = rand_token
+    FOR UPDATE;
+
+    IF batch_resources_migrated THEN
+      INSERT INTO aggregated_batch_resources_v4 (batch_id, resource_id, token, `usage`)
+      VALUES (NEW.batch_id, NEW.deduped_resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
+    INSERT INTO aggregated_job_resources_v2 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, NEW.resource_id, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated_att_2 INTO job_resources_migrated
+    FROM aggregated_job_resources_v2
+    WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND resource_id = NEW.resource_id
+    FOR UPDATE;
+
+    IF job_resources_migrated THEN
+      INSERT INTO aggregated_job_resources_v4 (batch_id, job_id, resource_id, `usage`)
+      VALUES (NEW.batch_id, NEW.job_id, NEW.deduped_resource_id, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v2 (billing_date, billing_project, user, resource_id, token, `usage`)
+    VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+
+    SELECT migrated_att_2 INTO bp_user_resources_by_date_migrated
+    FROM aggregated_billing_project_user_resources_by_date_v2
+    WHERE billing_date = cur_billing_date AND billing_project = cur_billing_project AND user = cur_user
+      AND resource_id = NEW.resource_id AND token = rand_token
+    FOR UPDATE;
+
+    IF bp_user_resources_by_date_migrated THEN
+      INSERT INTO aggregated_billing_project_user_resources_by_date_v4 (billing_date, billing_project, user, resource_id, token, `usage`)
+      VALUES (cur_billing_date, cur_billing_project, cur_user, NEW.deduped_resource_id, rand_token, NEW.quantity * msec_diff_rollup)
+      ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.quantity * msec_diff_rollup;
+    END IF;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_bp_user_resources_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated_att_2 = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_before_insert $$
+CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_before_insert BEFORE INSERT ON aggregated_billing_project_user_resources_by_date_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated_att_2 = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_batch_resources_v2_before_insert BEFORE INSERT on aggregated_batch_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated_att_2 = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_before_insert $$
+CREATE TRIGGER aggregated_job_resources_v2_before_insert BEFORE INSERT on aggregated_job_resources_v2
+FOR EACH ROW
+BEGIN
+  SET NEW.migrated_att_2 = 1;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_v2_after_update $$
+CREATE TRIGGER aggregated_bp_user_resources_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_deduped_resource_id INT;
+
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
+    SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_billing_project_user_resources_v4 (billing_project, user, resource_id, token, `usage`)
+    VALUES (NEW.billing_project, NEW.user, new_deduped_resource_id, NEW.token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_bp_user_resources_by_date_v2_after_update $$
+CREATE TRIGGER aggregated_bp_user_resources_by_date_v2_after_update AFTER UPDATE ON aggregated_billing_project_user_resources_by_date_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_deduped_resource_id INT;
+
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
+    SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_billing_project_user_resources_by_date_v4 (billing_date, billing_project, user, resource_id, token, `usage`)
+    VALUES (NEW.billing_date, NEW.billing_project, NEW.user, new_deduped_resource_id, NEW.token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+        `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_batch_resources_v2_after_update $$
+CREATE TRIGGER aggregated_batch_resources_v2_after_update AFTER UPDATE ON aggregated_batch_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_deduped_resource_id INT;
+
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
+    SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_batch_resources_v4 (batch_id, resource_id, token, `usage`)
+    VALUES (NEW.batch_id, new_deduped_resource_id, NEW.token, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DROP TRIGGER IF EXISTS aggregated_job_resources_v2_after_update $$
+CREATE TRIGGER aggregated_job_resources_v2_after_update AFTER UPDATE ON aggregated_job_resources_v2
+FOR EACH ROW
+BEGIN
+  DECLARE new_deduped_resource_id INT;
+
+  IF OLD.migrated_att_2 = 0 AND NEW.migrated_att_2 = 1 THEN
+    SELECT deduped_resource_id INTO new_deduped_resource_id FROM resources WHERE resource_id = OLD.resource_id;
+
+    INSERT INTO aggregated_job_resources_v4 (batch_id, job_id, resource_id, `usage`)
+    VALUES (NEW.batch_id, NEW.job_id, new_deduped_resource_id, NEW.usage)
+    ON DUPLICATE KEY UPDATE
+      `usage` = `usage` + NEW.usage;
+  END IF;
+END $$
+
+DELIMITER ;
+
+COMMIT;

--- a/build.yaml
+++ b/build.yaml
@@ -2198,6 +2198,9 @@ steps:
       - name: set-test-and-dev-pools-to-16-core-max-3
         script: /io/sql/set-test-and-dev-pools-to-16-core-max-3.py
         online: true
+      - name: fix-reset-dedup-resource-triggers
+        script: /io/sql/fix-reset-dedup-resource-triggers.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
This PR needs to be broken up into two separate changes to make sure the Python client is adding the correct deduped ID before resetting and restarting the database migrations. I chose to make new v4 billing tables as I think it would be more challenging to delete the data from the v3 tables. Happy to discuss different strategies as there could be an easy way to do this with `TRUNCATE`.