### PR TITLE
[docker] Add rsync to hail-ubuntu image

### DIFF
--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -13,7 +13,7 @@ RUN chmod 755 /bin/retry && \
     chmod 755 /controller.sh && \
     echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     mkdir -p /usr/share/keyrings/ && \
-    hail-apt-get-install curl gpg jq && \
+    hail-apt-get-install curl gpg jq rsync && \
     curl 'https://keyserver.ubuntu.com/pks/lookup?search=0xF23C5A6CF475977595C89F51BA6932366A755776&hash=on&exact=on&options=mr&op=get' \
          | gpg --dearmor > /usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg && \
     echo 'deb [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main' \


### PR DESCRIPTION
It seems that the latest version of Ubuntu doesn't have rsync installed. I need this for developing on Batch to get the sync.py script to work.