### PR TITLE
[query] suggest --only-binary=:all: if pip fails to build from source

### DIFF
--- a/hail/python/hail/docs/install/macosx.rst
+++ b/hail/python/hail/docs/install/macosx.rst
@@ -12,5 +12,5 @@ Install Hail on Mac OS X
     brew install --cask temurin8
 
 - Install Python 3.8 or later. We recommend `Miniconda <https://docs.conda.io/en/latest/miniconda.html#macosx-installers>`__.
-- Open Terminal.app and execute ``pip install hail``.
+- Open Terminal.app and execute ``pip install hail``. If this command fails with a message about "Rust", please try this instead: ``pip install hail --only-binary=:all:``.
 - `Run your first Hail query! <try.rst>`__


### PR DESCRIPTION
`orjson` is a perennial issue. We could (and probably should) set an upper limit pin that is compatible with most Broad-issued Macbooks. In the meantime, hopefully this doc improvement will help users avoid the issue themselves.