### PR TITLE
[aiotools] Properly close azure storage clients

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -552,8 +552,8 @@ class AzureAsyncFS(AsyncFS):
             self._credential = None
 
         if self._blob_service_clients:
-            await asyncio.wait([client.close() for client in self._blob_service_clients.values()])
-
+            for client in self._blob_service_clients.values():
+                await client.close()
 
 class AzureAsyncFSFactory(AsyncFSFactory[AzureAsyncFS]):
     def from_credentials_data(self, credentials_data: dict) -> AzureAsyncFS:

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -552,8 +552,8 @@ class AzureAsyncFS(AsyncFS):
             self._credential = None
 
         if self._blob_service_clients:
-            for client in self._blob_service_clients.values():
-                await client.close()
+            await asyncio.wait([asyncio.create_task(client.close())
+                                for client in self._blob_service_clients.values()])
 
 class AzureAsyncFSFactory(AsyncFSFactory[AzureAsyncFS]):
     def from_credentials_data(self, credentials_data: dict) -> AzureAsyncFS:


### PR DESCRIPTION
`asyncio.wait()` can only be used for tasks and not coroutines.