### PR TITLE
[infra] apply a PDB to kube-dns

### DIFF
--- a/infra/azure/modules/vdc/main.tf
+++ b/infra/azure/modules/vdc/main.tf
@@ -157,3 +157,18 @@ resource "azurerm_public_ip" "gateway_ip" {
   sku                 = "Standard"
   allocation_method   = "Static"
 }
+
+resource "kubernetes_pod_disruption_budget" "kube_dns_pdb" {
+  metadata {
+    name = "kube-dns"
+    namespace = "kube-system"
+  }
+  spec {
+    max_unavailable = "1"
+    selector {
+      match_labels = {
+        k8s-app = "kube-dns"
+      }
+    }
+  }
+}

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -710,6 +710,21 @@ resource "kubernetes_cluster_role_binding" "batch" {
   }
 }
 
+resource "kubernetes_pod_disruption_budget" "kube_dns_pdb" {
+  metadata {
+    name = "kube-dns"
+    namespace = "kube-system"
+  }
+  spec {
+    max_unavailable = "1"
+    selector {
+      match_labels = {
+        k8s-app = "kube-dns"
+      }
+    }
+  }
+}
+
 data "sops_file" "ci_config_sops" {
   count = fileexists("${var.github_organization}/ci_config.enc.json") ? 1 : 0
   source_file = "${var.github_organization}/ci_config.enc.json"


### PR DESCRIPTION
This pod is constantly blocking scale down.

There are two of them running anyway, there is no reason not to take one down to allow scale down:
```
(base) dking@wm28c-761 hail % k get pods -n kube-system -l k8s-app=kube-dns
NAME                        READY   STATUS    RESTARTS   AGE
kube-dns-7d44cdb5d5-twvfd   4/4     Running   0          14d
kube-dns-7d44cdb5d5-xjq25   4/4     Running   0          14d
```