### PR TITLE
[query/ggplot] Shows legend group for single-value columns

### DIFF
--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -185,7 +185,8 @@ class GeomPoint(Geom):
             traces.append([fig_so_far, df, facet_row, facet_col, values, trace_categories])
 
         non_empty_legend_groups = [
-            legend_group for legend_group in legends.values() if len(legend_group) > 1
+            legend_group for legend_group in legends.values()
+            if len(legend_group) > 1 or (len(legend_group) == 1 and list(legend_group.keys())[0] is not None)
         ]
         dummy_legend = is_faceted or len(non_empty_legend_groups) >= 2
 


### PR DESCRIPTION
CHANGELOG: `hail.ggplot.geom_point` now displays a legend group for a column even when it has only one value in it.

Currently, if a column with only one value in it is passed to either the `color` or the `shape` aesthetic for `geom_point`, the generated legend will not include a group with a single entry for that aesthetic. However, R's ggplot2 library in the same situation includes such a legend group.

This change brings our ggplot implementation into line with R's ggplot2 in that regard.

For example, this code:

```python
import hail as hl
from hail.ggplot import ggplot, aes, geom_point
ht = hl.utils.range_table(10)
ht = ht.annotate(squared=ht.idx ** 2)
ht = ht.annotate(even=hl.if_else(ht.idx % 2 == 0, "yes", "no"))
ht = ht.annotate(threeven="good")
fig = (
    ggplot(ht, aes(x=ht.idx, y=ht.squared))
    + geom_point(aes(color=ht.even, shape=ht.threeven))
)
fig.show()
```

generates a plot legend like this on `main`:

<img width="90" alt="Screenshot 2023-05-24 at 13 19 49" src="https://github.com/hail-is/hail/assets/84595986/f17ccbd4-3df7-4e3f-af32-a0b33adccff9">

but generates one like this on this branch:

<img width="101" alt="Screenshot 2023-05-24 at 13 19 16" src="https://github.com/hail-is/hail/assets/84595986/6d020270-24c8-490c-a411-0bdb7baaa24c">