### PR TITLE
[ci] Handle errors in heal loop

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -871,7 +871,10 @@ url: {url}
         self.n_running_batches = sum(1 for pr in self.prs.values() if pr.batch and not pr.build_state)
 
         for pr in self.prs.values():
-            await pr._heal(batch_client, db, pr == merge_candidate, gh)
+            try:
+                await pr._heal(batch_client, db, pr == merge_candidate, gh)
+            except:
+                log.exception(f'error while trying to heal {pr.short_str()}')
 
         # cancel orphan builds
         running_batches = batch_client.list_batches(


### PR DESCRIPTION
I'm not sure if this is the right change, but I'm pretty sure the Azure deployment was stuck because `_heal` kept aborting early on a GitHub post error. See #13050 for context.