### PR TITLE
[ci][hello] allow more time for hello to start up

### DIFF
--- a/ci/test/resources/deployment.yaml
+++ b/ci/test/resources/deployment.yaml
@@ -38,13 +38,13 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 5000
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
           readinessProbe:
             tcpSocket:
               port: 5000
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
           volumeMounts:
            - mountPath: /deploy-config
              name: deploy-config


### PR DESCRIPTION
Consider, for example, https://ci.hail.is/batches/7490668/jobs/240 and https://cloudlogging.app.goo.gl/BZfqkc6SCM5RfPs79 in which a PR fails because hello does not come alive fast enough. Presumably the 10mCPU is a little limiting.