### PR TITLE
[infra] Add resource group to azure terraform state remote config

### DIFF
--- a/infra/azure/bootstrap.sh
+++ b/infra/azure/bootstrap.sh
@@ -35,6 +35,7 @@ create_terraform_remote_storage() {
         --account-name $STORAGE_ACCOUNT_NAME \
         --account-key $STORAGE_ACCOUNT_KEY
     cat >remote_storage.tfvars <<EOF
+resource_group_name  = "$RESOURCE_GROUP"
 storage_account_name = "$STORAGE_ACCOUNT_NAME"
 container_name       = "$STORAGE_CONTAINER_NAME"
 key                  = "haildev.tfstate"


### PR DESCRIPTION
Unclear to me exactly why (perhaps a terraform update on my machine) but running terraform against azure was complaining that it didn't know the resource group that the terraform state storage account lives in. Unclear to me why this is necessary because the storage account is globally unique but it was easy enough to add and fixed my problem *shrug*. Let me know if you'd like me to look into this further.