### PR TITLE
[ci/ui] filters jobs by status

### DIFF
--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -1,4 +1,4 @@
-{% from "job-table.html" import job_table with context %}
+{% from "filtered-jobs.html" import filtered_jobs with context %}
 {% extends "layout.html" %}
 {% block title %}Batch {{ batch['id'] }}{% endblock %}
 {% block head %}
@@ -29,7 +29,7 @@
     {% endif %}
 
     <h2>Jobs</h2>
-    {{ job_table(jobs, "jobs", "jobsSearchBar") }}
+    {{ filtered_jobs(running, failed, pending, completed) }}
     <script type="text/javascript">
       focusOnSlash("jobsSearchBar");
     </script>

--- a/ci/ci/templates/filtered-jobs.html
+++ b/ci/ci/templates/filtered-jobs.html
@@ -1,0 +1,17 @@
+{% from "job-table.html" import job_table with context %}
+{% macro filtered_jobs(running, failed, pending, completed) %}
+{% if failed is not none %}
+  <h3>Failed</h3>
+  {{ job_table(failed, "failed-jobs", "failedJobsSearchBar") }}
+{% endif %}
+{% if running is not none %}
+  <h3>Running</h3>
+  {{ job_table(running, "running-jobs", "runningJobsSearchBar") }}
+{% endif %}
+{% if pending is not none %}
+  <h3>Pending</h3>
+  {{ job_table(pending, "pending-jobs", "pendingJobsSearchBar") }}
+{% endif %}
+<h3>Completed</h3>
+{{ job_table(completed, "completed-jobs", "completedJobsSearchBar") }}
+{% endmacro %}

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -1,4 +1,4 @@
-{% from "job-table.html" import job_table with context %}
+{% from "filtered-jobs.html" import filtered_jobs with context %}
 {% extends "layout.html" %}
 {% block title %}PR {{ number }}{% endblock %}
 {% block head %}
@@ -25,7 +25,7 @@
       <button type="submit">Retry</button>
     </form>
     <h2>Jobs</h2>
-    {{ job_table(jobs, "jobs", "jobsSearchBar") }}
+    {{ filtered_jobs(running, failed, pending, completed) }}
     {% elif exception is defined %}
     <p>Build error:</p>
     <pre>


### PR DESCRIPTION
Currently, when the user views the jobs for a CI pipeline, either on the `pr.html` page or the `batch.html` page, they are displayed all together in a big table, like so:

<img width="618" alt="Screenshot 2023-06-06 at 15 30 21" src="https://github.com/hail-is/hail/assets/84595986/8c3f45a8-756d-4e10-ac27-a57791f3965c">

This change filters the jobs out into smaller tables, with any failed jobs displayed first, followed by any jobs that are currently running, then any pending jobs, then the rest.

Example with failed job:

<img width="728" alt="Screenshot 2023-06-06 at 15 12 36" src="https://github.com/hail-is/hail/assets/84595986/5b20f95e-e530-43c2-bc96-4fcd639083d3">

Example with running/pending jobs:

<img width="643" alt="Screenshot 2023-06-06 at 15 10 54" src="https://github.com/hail-is/hail/assets/84595986/7b5790e6-a5e0-426f-b290-a28fee19e967">