### PR TITLE
[query] Improve _same to make exactly one pass over the data

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3665,18 +3665,32 @@ class Table(ExprContainer):
 
         t = left.join(right, how='outer')
 
-        if not hl.eval(_values_similar(t[left_global_value], t[right_global_value], tolerance, absolute)):
-            g = hl.eval(t.globals)
-            print(f'Table._same: globals differ:\n{pprint.pformat(g[left_global_value])}\n{pprint.pformat(g[right_global_value])}')
+        mismatched_globals, mismatched_rows = t.aggregate(hl.tuple((
+            hl.or_missing(
+                ~_values_similar(t[left_global_value], t[right_global_value], tolerance, absolute),
+                hl.struct(left=t[left_global_value], right=t[right_global_value])
+            ),
+            hl.agg.filter(
+                ~hl.all(
+                    hl.is_defined(t[left_value]),
+                    hl.is_defined(t[right_value]),
+                    _values_similar(t[left_value], t[right_value], tolerance, absolute),
+                ),
+                hl.agg.take(
+                    hl.struct(_key=t._key, left=t[left_value], right=t[right_value]),
+                    10
+                )
+            )
+        )))
+
+        if mismatched_globals is not None:
+            print(f'Table._same: globals differ:\n{pprint.pformat(mismatched_globals.left)}\n{pprint.pformat(mismatched_globals.right)}')
             return False
 
-        if not t.all(hl.is_defined(t[left_value]) & hl.is_defined(t[right_value])
-                     & _values_similar(t[left_value], t[right_value], tolerance, absolute)):
+        if len(mismatched_rows) > 0:
             print('Table._same: rows differ:')
-            t = t.filter(~ _values_similar(t[left_value], t[right_value], tolerance, absolute))
-            bad_rows = t.take(10)
-            for r in bad_rows:
-                print(f'  Row mismatch at key={r._key}:\n    Left:\n{pprint.pformat(r[left_value])}\n    Right:\n{pprint.pformat(r[right_value])}')
+            for r in mismatched_rows:
+                print(f'  Row mismatch at key={r._key}:\n    Left:\n{pprint.pformat(r.left)}\n    Right:\n{pprint.pformat(r.right)}')
             return False
 
         return True


### PR DESCRIPTION
This both avoids an extra pass to find the failing rows as well as avoiding a an extra pass if the globals depend on non-global data. In particular, this pipeline would run the column aggregations four times (IMO, at most twice is OK):

```
mt = hl.utils.range_matrix_table(2,2)
mt = mt.annotate_entries(x = mt.row_idx * mt.col_idx)
mt = mt.annotate_cols(mean_x = hl.agg.mean(mt.x))
mt = mt.annotate_entries(x = mt.x - mt.mean_x)
mt._same(mt)
```