### PR TITLE
[qob] noisier ServiceBackend startup

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -420,6 +420,8 @@ class EndOfInputException extends RuntimeException
 class HailBatchFailure(message: String) extends RuntimeException(message)
 
 object ServiceBackendSocketAPI2 {
+  private[this] val log = Logger.getLogger(getClass.getName())
+
   def main(argv: Array[String]): Unit = {
     assert(argv.length == 7, argv.toFastIndexedSeq)
 
@@ -439,20 +441,27 @@ object ServiceBackendSocketAPI2 {
     val userTokens = Tokens.fromFile(s"$scratchDir/secrets/user-tokens/tokens.json")
     Tokens.set(userTokens)
     tls.setSSLConfigFromDir(s"$scratchDir/secrets/ssl-config")
+    log.info("TLS configured.")
 
     val sessionId = userTokens.namespaceToken(deployConfig.defaultNamespace)
+    log.info("Namespace token acquired.")
     val batchClient = BatchClient.fromSessionID(sessionId)
+    log.info("BatchClient allocated.")
 
     var batchId = BatchConfig.fromConfigFile(s"$scratchDir/batch-config/batch-config.json").map(_.batchId)
+    log.info("BatchConfig parsed.")
 
     // FIXME: when can the classloader be shared? (optimizer benefits!)
     val backend = new ServiceBackend(
       jarLocation, name, new HailClassLoader(getClass().getClassLoader()), batchClient, batchId, scratchDir)
+    log.info("ServiceBackend allocated.")
     if (HailContext.isInitialized) {
       HailContext.get.backend = backend
       backend.addDefaultReferences()
+      log.info("Default references added to already initialized HailContexet.")
     } else {
       HailContext(backend, 50, 3)
+      log.info("HailContexet initialized.")
     }
 
     retryTransientErrors {


### PR DESCRIPTION
A test timed out with this in the logs. This is some driver job. It just hangs for 2 minutes trying to talk to Azure Blob Storage presumably? Let us get some more information:

```
2023-06-08 20:22:28.209 JVMEntryway: INFO: Yielding control to the QoB Job.
2023-06-08 20:22:28.210 Tokens: INFO: tokens found for namespaces {pr-12991-default-ei61x1qrplk9}
2023-06-08 20:22:28.210 tls: INFO: ssl config file found at /batch/240df6ec091b49d8a6062b781e6700d3/secrets/ssl-config/ssl-config.json
2023-06-08 20:24:30.873 : INFO: RegionPool: initialized for thread 10: pool-2-thread-2
2023-06-08 20:24:31.016 ServiceBackend$: INFO: executing: iaU8w3QX6Y6hRrB9jczJds ArrayBuffer((), is.hail.utils.SerializableHadoopConfiguration@5ad5cde6)
2023-06-08 20:24:31.153 : INFO: JSON: JObject(List((name,JString(TableFilterPartitions)), (parts,JArray(List(JInt(0)))), (keep,JBool(true))))
```