### PR TITLE
[batch] Fix billing projects query to be fast with lateral joins

### DIFF
--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -152,6 +152,7 @@ LEFT JOIN LATERAL (
     FROM aggregated_billing_project_user_resources_v2
     WHERE billing_projects.name = aggregated_billing_project_user_resources_v2.billing_project
     GROUP BY billing_project, resource_id
+    LOCK IN SHARE MODE
   ) AS usage_t
   LEFT JOIN resources ON resources.resource_id = usage_t.resource_id
   GROUP BY usage_t.billing_project
@@ -166,8 +167,6 @@ LOCK IN SHARE MODE;
         else:
             record['users'] = json.loads(record['users'])
         return record
-
-    log.info(f'sql {sql} args {args}')
 
     billing_projects = [record_to_dict(record) async for record in db.execute_and_fetchall(sql, tuple(args))]
 

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -171,6 +171,8 @@ LATERAL (
             record['users'] = json.loads(record['users'])
         return record
 
+    log.info(f'sql {sql} args {args}')
+
     billing_projects = [record_to_dict(record) async for record in db.execute_and_fetchall(sql, tuple(args))]
 
     return billing_projects


### PR DESCRIPTION
This query is the slowest one we have right now and is making the billing projects pages to be slow. I saw substantial speed improvements using lateral joins.

- For querying all open billing projects for a given user, it went from 1.8 seconds to 0.87 seconds.
- For querying all open billing projects (i.e. billing projects page), it went from 5.5 seconds to 2.6 seconds.

The speed of the queries should go down further once the aggregated billing project user resources table has been deduped and further improvements after compaction.