### PR TITLE
[fs] Add support for SAS tokens in Scala AzureStorageFS

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2437,11 +2437,14 @@ steps:
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
       export HAIL_GENETICS_VEP_GRCH37_85_IMAGE={{ hailgenetics_vep_grch37_85_image.image }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
 
-      if [[ "$HAIL_CLOUD" = "gcp" ]]
-      then
-          export GCS_REQUESTER_PAYS_PROJECT=broad-ctsa
-      fi
+      {% if global.cloud == "gcp" %}
+      export GCS_REQUESTER_PAYS_PROJECT=broad-ctsa
+      {% elif global.cloud == "azure" %}
+      export HAIL_AZURE_SUBSCRIPTION_ID={{ global.azure_subscription_id }}
+      export HAIL_AZURE_RESOURCE_GROUP={{ global.azure_resource_group }}
+      {% endif %}
 
       export HAIL_SHUFFLE_MAX_BRANCH=4
       export HAIL_SHUFFLE_CUTOFF=1000000

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -395,7 +395,8 @@ class AzureAsyncFS(AsyncFS):
             expiry=datetime.utcnow() + valid_interval)
         return token
 
-    def parse_url(self, url: str) -> AzureAsyncFSURL:
+    @staticmethod
+    def parse_url(url: str) -> AzureAsyncFSURL:
         colon_index = url.find(':')
         if colon_index == -1:
             raise ValueError(f'invalid URL: {url}')

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -1,7 +1,7 @@
 package is.hail.io.fs
 
-import is.hail.shadedazure.com.azure.core.credential.TokenCredential
-import is.hail.shadedazure.com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder, DefaultAzureCredential, DefaultAzureCredentialBuilder}
+import is.hail.shadedazure.com.azure.core.credential.{AzureSasCredential, TokenCredential}
+import is.hail.shadedazure.com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder, DefaultAzureCredential, DefaultAzureCredentialBuilder, ManagedIdentityCredentialBuilder}
 import is.hail.shadedazure.com.azure.storage.blob.models.{BlobProperties, BlobRange, ListBlobsOptions, BlobStorageException}
 import is.hail.shadedazure.com.azure.storage.blob.specialized.BlockBlobClient
 import is.hail.shadedazure.com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientBuilder}
@@ -10,9 +10,10 @@ import is.hail.shadedazure.reactor.netty.http.client.HttpClient
 import is.hail.services.retryTransientErrors
 import is.hail.io.fs.FSUtil.{containsWildcard, dropTrailingSlash}
 import org.apache.log4j.Logger
+import org.apache.commons.io.IOUtils
 
 import java.net.URI
-import is.hail.utils.{defaultJSONFormats, fatal}
+import is.hail.utils._
 import org.json4s
 import org.json4s.jackson.JsonMethods
 import org.json4s.Formats
@@ -22,12 +23,13 @@ import java.nio.file.Paths
 import java.time.Duration
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-
+import org.json4s.{DefaultFormats, Formats, JInt, JObject, JString, JValue}
 
 abstract class AzureStorageFSURL(
   val account: String,
   val container: String,
-  val path: String
+  val path: String,
+  val sasToken: Option[String]
 ) extends FSURL[AzureStorageFSURL] {
 
   def addPathComponent(c: String): AzureStorageFSURL = {
@@ -53,11 +55,12 @@ abstract class AzureStorageFSURL(
 class AzureStorageFSHailAzURL(
   account: String,
   container: String,
-  path: String
-) extends AzureStorageFSURL(account, container, path) {
+  path: String,
+  sasToken: Option[String]
+) extends AzureStorageFSURL(account, container, path, sasToken) {
 
   override def withPath(newPath: String): AzureStorageFSHailAzURL = {
-    new AzureStorageFSHailAzURL(account, container, newPath)
+    new AzureStorageFSHailAzURL(account, container, newPath, sasToken)
   }
 
   override def prefix: String = s"hail-az://$account/$container"
@@ -66,11 +69,12 @@ class AzureStorageFSHailAzURL(
 class AzureStorageFSHttpsURL(
   account: String,
   container: String,
-  path: String
-) extends AzureStorageFSURL(account, container, path) {
+  path: String,
+  sasToken: Option[String]
+) extends AzureStorageFSURL(account, container, path, sasToken) {
 
   override def withPath(newPath: String): AzureStorageFSHttpsURL = {
-    new AzureStorageFSHttpsURL(account, container, newPath)
+    new AzureStorageFSHttpsURL(account, container, newPath, sasToken)
   }
 
   override def prefix: String = s"https://$account.blob.core.windows.net/$container"
@@ -99,20 +103,39 @@ object AzureStorageFS {
   private[this] def parseHttpsUrl(filename: String): AzureStorageFSHttpsURL = {
     AZURE_HTTPS_URI_REGEX
       .findFirstMatchIn(filename)
-      .map(m => new AzureStorageFSHttpsURL(m.group(1), m.group(2), parsePath(m.group(3))))
+      .map(m => {
+        val (path, sasToken) = parsePathAndQuery(m.group(3))
+        new AzureStorageFSHttpsURL(m.group(1), m.group(2), path, sasToken)
+      })
       .getOrElse(throw new IllegalArgumentException("ABS URI must be of the form https://<ACCOUNT>.blob.core.windows.net/<CONTAINER>/<PATH>"))
   }
 
   private[this] def parseHailAzUrl(filename: String): AzureStorageFSHailAzURL = {
     HAIL_AZ_URI_REGEX
       .findFirstMatchIn(filename)
-      .map(m => new AzureStorageFSHailAzURL(m.group(1), m.group(2), parsePath(m.group(3))))
+      .map(m => {
+        val (path, sasToken) = parsePathAndQuery(m.group(3))
+        new AzureStorageFSHailAzURL(m.group(1), m.group(2), path, sasToken)
+      })
       .getOrElse(throw new IllegalArgumentException("hail-az URI must be of the form hail-az://<ACCOUNT>/<CONTAINER>/<PATH>"))
   }
 
-  private[this] def parsePath(maybeNullPath: String): String = {
-    val path = if (maybeNullPath == null) "" else maybeNullPath.stripPrefix("/")
-    Paths.get(path).normalize().toString
+  private[this] def parsePathAndQuery(maybeNullPath: String): (String, Option[String]) = {
+    val pathAndMaybeQuery = Paths.get(if (maybeNullPath == null) "" else maybeNullPath.stripPrefix("/")).normalize.toString
+
+    // Unfortunately it is difficult to tell the difference between a glob pattern and a SAS token,
+    // so we make the imperfect assumption that if the query string starts with at least one
+    // key-value pair we will interpret it as a SAS token and not a glob pattern
+    val indexOfLastQuestionMark = pathAndMaybeQuery.lastIndexOf("?")
+    if (indexOfLastQuestionMark == -1) {
+      (pathAndMaybeQuery, None)
+    } else {
+      val (path, queryString) = pathAndMaybeQuery.splitAt(indexOfLastQuestionMark)
+      queryString.split("&")(0).split("=") match {
+        case Array(k, v) => (path, Some(queryString))
+        case _ => (pathAndMaybeQuery, None)
+      }
+    }
   }
 }
 
@@ -126,26 +149,32 @@ object AzureStorageFileStatus {
 }
 
 class AzureBlobServiceClientCache(credential: TokenCredential) {
-  private[this] lazy val clients = mutable.Map[(String, String), BlobServiceClient]()
+  private[this] lazy val clients = mutable.Map[(String, String, Option[String]), BlobServiceClient]()
 
-  def getServiceClient(account: String, container: String): BlobServiceClient = {
-    clients.get((account, container)) match {
+  def getServiceClient(url: AzureStorageFSURL): BlobServiceClient = {
+    val k = (url.account, url.container, url.sasToken)
+
+    clients.get(k) match {
       case Some(client) => client
       case None =>
-        val blobServiceClient = new BlobServiceClientBuilder()
-          .credential(credential)
-          .endpoint(s"https://$account.blob.core.windows.net")
+        val clientBuilder = url.sasToken match {
+          case Some(sasToken) => new BlobServiceClientBuilder().credential(new AzureSasCredential(sasToken))
+          case None => new BlobServiceClientBuilder().credential(credential)
+        }
+
+        val blobServiceClient = clientBuilder
+          .endpoint(s"https://${url.account}.blob.core.windows.net")
           .buildClient()
-        clients += ((account, container) -> blobServiceClient)
+        clients += (k -> blobServiceClient)
         blobServiceClient
     }
   }
 
-  def setPublicAccessServiceClient(account: String, container: String): Unit = {
+  def setPublicAccessServiceClient(url: AzureStorageFSURL): Unit = {
     val blobServiceClient = new BlobServiceClientBuilder()
-      .endpoint(s"https://$account.blob.core.windows.net")
+      .endpoint(s"https://${url.account}.blob.core.windows.net")
       .buildClient()
-    clients += ((account, container) -> blobServiceClient)
+    clients += ((url.account, url.container, url.sasToken) -> blobServiceClient)
   }
 }
 
@@ -177,8 +206,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
         f
       } catch {
         case e: BlobStorageException if e.getStatusCode == 401 =>
-          val url = AzureStorageFS.parseUrl(filename)
-          serviceClientCache.setPublicAccessServiceClient(url.account, url.container)
+          serviceClientCache.setPublicAccessServiceClient(AzureStorageFS.parseUrl(filename))
           f
       }
     }
@@ -207,16 +235,12 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
   // https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-blob-service-operations
   private val timeout = Duration.ofSeconds(30)
 
-  def getBlobServiceClient(account: String, container: String): BlobServiceClient = retryTransientErrors {
-    serviceClientCache.getServiceClient(account, container)
-  }
-
   def getBlobClient(url: AzureStorageFSURL): BlobClient = retryTransientErrors {
-    getBlobServiceClient(url.account, url.container).getBlobContainerClient(url.container).getBlobClient(url.path)
+    serviceClientCache.getServiceClient(url).getBlobContainerClient(url.container).getBlobClient(url.path)
   }
 
   def getContainerClient(url: AzureStorageFSURL): BlobContainerClient = retryTransientErrors {
-    getBlobServiceClient(url.account, url.container).getBlobContainerClient(url.container)
+    serviceClientCache.getServiceClient(url).getBlobContainerClient(url.container)
   }
 
   def openNoCompression(filename: String, _debug: Boolean): SeekableDataInputStream = handlePublicAccessError(filename) {

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -57,6 +57,14 @@ class WrappedPositionOutputStream(os: OutputStream) extends OutputStream with Po
   def getPosition: Long = count
 }
 
+trait FSURL[T <: FSURL[T]] {
+  def getPath: String
+  def addPathComponent(component: String): T
+  def fromString(s: String): T
+
+  override def toString(): String
+}
+
 trait FileStatus {
   def getPath: String
   def getModificationTime: java.lang.Long
@@ -257,6 +265,7 @@ object FS {
 }
 
 trait FS extends Serializable {
+  type URL <: FSURL[URL]
 
   def validUrl(filename: String): Boolean
 
@@ -336,9 +345,11 @@ trait FS extends Serializable {
 
   def listStatus(filename: String): Array[FileStatus]
 
+  def listStatus(url: URL): Array[FileStatus] = listStatus(url.toString)
+
   def glob(filename: String): Array[FileStatus]
 
-  def globWithPrefix(prefix: String, path: String) = {
+  def globWithPrefix(prefix: URL, path: String) = {
     val components =
       if (path == "")
         Array.empty[String]
@@ -348,8 +359,8 @@ trait FS extends Serializable {
     val javaFS = FileSystems.getDefault
 
     val ab = new mutable.ArrayBuffer[FileStatus]()
-    def f(prefix: String, fs: FileStatus, i: Int): Unit = {
-      assert(!prefix.endsWith("/"), prefix)
+    def f(prefix: URL, fs: FileStatus, i: Int): Unit = {
+      assert(!prefix.getPath.endsWith("/"), prefix)
 
       if (i == components.length) {
         var t = fs
@@ -370,17 +381,17 @@ trait FS extends Serializable {
           val m = javaFS.getPathMatcher(s"glob:$c")
           for (cfs <- listStatus(prefix)) {
             val p = dropTrailingSlash(cfs.getPath)
-            val d = p.drop(prefix.length + 1)
+            val d = p.drop(prefix.toString.length + 1)
             if (m.matches(javaFS.getPath(d))) {
-              f(p, cfs, i + 1)
+              f(prefix.fromString(p), cfs, i + 1)
             }
           }
         } else
-          f(s"$prefix/$c", null, i + 1)
+          f(prefix.addPathComponent(c), null, i + 1)
       }
     }
 
-    f(s"$prefix", null, 0)
+    f(prefix, null, 0)
     ab.toArray
   }
 
@@ -390,6 +401,8 @@ trait FS extends Serializable {
   def globAllStatuses(filenames: Iterable[String]): Array[FileStatus] = filenames.flatMap(glob).toArray
 
   def fileStatus(filename: String): FileStatus
+
+  def fileStatus(url: URL): FileStatus = fileStatus(url.toString)
 
   def makeQualified(path: String): String
 

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -22,11 +22,32 @@ import scala.collection.mutable
 import scala.{concurrent => scalaConcurrent}
 import scala.reflect.ClassTag
 
+
+case class GoogleStorageFSURL(val bucket: String, val path: String) extends FSURL[GoogleStorageFSURL] {
+  def addPathComponent(c: String): GoogleStorageFSURL = {
+    if (path == "")
+      withPath(c)
+    else
+      withPath(s"$path/$c")
+  }
+  def withPath(newPath: String): GoogleStorageFSURL = GoogleStorageFSURL(bucket, newPath)
+  def fromString(s: String): GoogleStorageFSURL = GoogleStorageFS.parseUrl(s)
+
+  def getPath: String = path
+
+  override def toString(): String = if (path.isEmpty) {
+    s"gs://$bucket"
+  } else {
+    s"gs://$bucket/$path"
+  }
+}
+
+
 object GoogleStorageFS {
   private val log = Logger.getLogger(getClass.getName())
   private[this] val GCS_URI_REGEX = "^gs:\\/\\/([a-z0-9_\\-\\.]+)(\\/.*)?".r
 
-  def getBucketPath(filename: String): (String, String) = {
+  def parseUrl(filename: String): GoogleStorageFSURL = {
     val scheme = new URI(filename).getScheme
     if (scheme == null || scheme != "gs") {
       throw new IllegalArgumentException(s"Invalid scheme, expected gs: $scheme")
@@ -37,7 +58,7 @@ object GoogleStorageFS {
         val bucket = m.group(1)
         val maybePath = m.group(2)
         val path = Paths.get(if (maybePath == null) "" else maybePath.stripPrefix("/"))
-        (bucket, path.normalize().toString)
+        GoogleStorageFSURL(bucket, path.normalize().toString)
       case None => throw new IllegalArgumentException(s"GCS URI must be of the form: gs://bucket/path, found $filename")
     }
   }
@@ -79,6 +100,7 @@ object RequesterPaysConfiguration {
   }
 }
 
+
 case class RequesterPaysConfiguration(
   val project: String,
   val buckets: Option[Set[String]] = None
@@ -88,6 +110,8 @@ class GoogleStorageFS(
   private[this] val serviceAccountKey: Option[String] = None,
   private[this] var requesterPaysConfiguration: Option[RequesterPaysConfiguration] = None
 ) extends FS {
+  type URL = GoogleStorageFSURL
+
   import GoogleStorageFS._
 
   def validUrl(filename: String): Boolean = {
@@ -195,7 +219,7 @@ class GoogleStorageFS(
 
   def openNoCompression(filename: String, _debug: Boolean = false): SeekableDataInputStream = retryTransientErrors {
     assert(!_debug)
-    val (bucket, path) = getBucketPath(filename)
+    val url = parseUrl(filename)
 
     val is: SeekableInputStream = new FSSeekableInputStream {
       private[this] var reader: ReadChannel = null
@@ -213,12 +237,12 @@ class GoogleStorageFS(
         } else {
           handleRequesterPays(
             { (options: Seq[BlobSourceOption]) =>
-              reader = retryTransientErrors { storage.reader(bucket, path, options:_*) }
+              reader = retryTransientErrors { storage.reader(url.bucket, url.path, options:_*) }
               reader.seek(getPosition)
               retryingRead()
             },
             BlobSourceOption.userProject _,
-            bucket
+            url.bucket
           )
         }
       }
@@ -260,15 +284,15 @@ class GoogleStorageFS(
   }
 
   override def readNoCompression(filename: String): Array[Byte] = retryTransientErrors {
-    val (bucket, path) = getBucketPath(filename)
-    storage.readAllBytes(bucket, path)
+    val url = parseUrl(filename)
+    storage.readAllBytes(url.bucket, url.path)
   }
 
   def createNoCompression(filename: String): PositionedDataOutputStream = retryTransientErrors {
     log.info(f"createNoCompression: ${filename}")
-    val (bucket, path) = getBucketPath(filename)
+    val url = parseUrl(filename)
 
-    val blobId = BlobId.of(bucket, path)
+    val blobId = BlobId.of(url.bucket, url.path)
     val blobInfo = BlobInfo.newBuilder(blobId)
       .build()
 
@@ -285,7 +309,7 @@ class GoogleStorageFS(
               f
             },
             BlobWriteOption.userProject _,
-            bucket
+            url.bucket
           )
         }
       }
@@ -320,10 +344,10 @@ class GoogleStorageFS(
   }
 
   override def copy(src: String, dst: String, deleteSource: Boolean = false): Unit = {
-    val (srcBucket, srcPath) = getBucketPath(src)
-    val (dstBucket, dstPath) = getBucketPath(dst)
-    val srcId = BlobId.of(srcBucket, srcPath)
-    val dstId = BlobId.of(dstBucket, dstPath)
+    val srcUrl = parseUrl(src)
+    val dstUrl = parseUrl(dst)
+    val srcId = BlobId.of(srcUrl.bucket, srcUrl.path)
+    val dstId = BlobId.of(dstUrl.bucket, dstUrl.path)
 
     // There is only one userProject for the whole request, the source takes precedence over the target.
     // https://github.com/googleapis/java-storage/blob/0bd17b1f70e47081941a44f018e3098b37ba2c47/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java#L1016-L1019
@@ -347,14 +371,14 @@ class GoogleStorageFS(
             .setTarget(dstId)
             .build()
         case Some(RequesterPaysConfiguration(project, Some(buckets))) =>
-          if (buckets.contains(srcBucket) && buckets.contains(dstBucket)) {
+          if (buckets.contains(srcUrl.bucket) && buckets.contains(dstUrl.bucket)) {
             Storage.CopyRequest.newBuilder()
               .setSourceOptions(BlobSourceOption.userProject(project))
               .setSource(srcId)
               .setTarget(dstId)
               .build()
-          } else if (buckets.contains(srcBucket) || buckets.contains(dstBucket)) {
-            throw new RuntimeException(s"both $srcBucket and $dstBucket must be specified in the requester_pays_buckets to copy between these buckets", exc)
+          } else if (buckets.contains(srcUrl.bucket) || buckets.contains(dstUrl.bucket)) {
+            throw new RuntimeException(s"both ${srcUrl.bucket} and ${dstUrl.bucket} must be specified in the requester_pays_buckets to copy between these buckets", exc)
           } else {
             throw exc
           }
@@ -391,13 +415,13 @@ class GoogleStorageFS(
   }
 
   def delete(filename: String, recursive: Boolean): Unit = retryTransientErrors {
-    val (bucket, path) = getBucketPath(filename)
+    val url = parseUrl(filename)
     if (recursive) {
       var page = retryTransientErrors {
         handleRequesterPays(
-          (options: Seq[BlobListOption]) => storage.list(bucket, (BlobListOption.prefix(path) +: options):_*),
+          (options: Seq[BlobListOption]) => storage.list(url.bucket, (BlobListOption.prefix(url.path) +: options):_*),
           BlobListOption.userProject _,
-          bucket
+          url.bucket
         )
       }
       while (page != null) {
@@ -413,7 +437,7 @@ class GoogleStorageFS(
                 }
               },
               BlobSourceOption.userProject _,
-              bucket
+              url.bucket
             )
           }
         }
@@ -422,30 +446,28 @@ class GoogleStorageFS(
     } else {
       // Storage.delete is idempotent. it returns a Boolean which is false if the file did not exist
       handleRequesterPays(
-        (options: Seq[BlobSourceOption]) => storage.delete(bucket, path, options:_*),
+        (options: Seq[BlobSourceOption]) => storage.delete(url.bucket, url.path, options:_*),
         BlobSourceOption.userProject _,
-        bucket
+        url.bucket
       )
     }
   }
 
   def glob(filename: String): Array[FileStatus] = retryTransientErrors {
-    var (bucket, path) = getBucketPath(filename)
-    path = dropTrailingSlash(path)
-
-    globWithPrefix(prefix = s"gs://$bucket", path = path)
+    val url = parseUrl(filename)
+    globWithPrefix(url.withPath(""), path = dropTrailingSlash(url.path))
   }
 
-  def listStatus(filename: String): Array[FileStatus] = retryTransientErrors {
-    var (bucket, path) = getBucketPath(filename)
-    if (!path.endsWith("/"))
-      path = path + "/"
+  def listStatus(filename: String): Array[FileStatus] = listStatus(parseUrl(filename))
+
+  override def listStatus(url: GoogleStorageFSURL): Array[FileStatus] = retryTransientErrors {
+    val path = if (url.path.endsWith("/")) url.path else url.path + "/"
 
     val blobs = retryTransientErrors {
       handleRequesterPays(
-        (options: Seq[BlobListOption]) => storage.list(bucket, (BlobListOption.prefix(path) +: BlobListOption.currentDirectory() +: options):_*),
+        (options: Seq[BlobListOption]) => storage.list(url.bucket, (BlobListOption.prefix(path) +: BlobListOption.currentDirectory() +: options):_*),
         BlobListOption.userProject _,
-        bucket
+        url.bucket
       )
     }
 
@@ -456,17 +478,17 @@ class GoogleStorageFS(
   }
 
   def fileStatus(filename: String): FileStatus = retryTransientErrors {
-    var (bucket, path) = getBucketPath(filename)
-    path = dropTrailingSlash(path)
+    var url = parseUrl(filename)
+    url = url.withPath(dropTrailingSlash(url.path))
 
-    if (path == "")
-      return new BlobStorageFileStatus(s"gs://$bucket", null, 0, true)
+    if (url.path == "")
+      return new BlobStorageFileStatus(s"gs://${url.bucket}", null, 0, true)
 
     val blobs = retryTransientErrors {
       handleRequesterPays(
-        (options: Seq[BlobListOption]) => storage.list(bucket, (BlobListOption.prefix(path) +: BlobListOption.currentDirectory() +: options):_*),
+        (options: Seq[BlobListOption]) => storage.list(url.bucket, (BlobListOption.prefix(url.path) +: BlobListOption.currentDirectory() +: options):_*),
         BlobListOption.userProject _,
-        bucket
+        url.bucket
       )
     }
 
@@ -476,7 +498,7 @@ class GoogleStorageFS(
       var name = b.getName
       while (name.endsWith("/"))
         name = name.dropRight(1)
-      if (name == path)
+      if (name == url.path)
         return GoogleStorageFileStatus(b)
     }
 

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -69,7 +69,18 @@ object HadoopFS {
     }
 }
 
+
+case class LocalFSURL(val path: String) extends FSURL[LocalFSURL] {
+  def addPathComponent(c: String): LocalFSURL = LocalFSURL(s"$path/$c")
+  def getPath: String = path
+  def fromString(s: String): LocalFSURL = LocalFSURL(s)
+  override def toString(): String = path
+}
+
+
 class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends FS {
+  type URL = LocalFSURL
+
   def validUrl(filename: String): Boolean = {
     val uri = new java.net.URI(filename)
     uri.getScheme == null || uri.getScheme == "file"

--- a/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
@@ -1,6 +1,8 @@
 package is.hail.io.fs
 
 class RouterFS(fss: IndexedSeq[FS]) extends FS {
+  // This is never actually used
+  type URL = LocalFSURL
 
   def lookupFS(path: String): FS = {
     fss.find(_.validUrl(path)) match {


### PR DESCRIPTION
This PR adds support for Azure SAS tokens in QoB. A SAS token is basically a blob storage URI with a short-lived credential to access that resource appended as a URL query string. In such a scenario where the FS receives a blob URI with a SAS token, that token should be used instead of the latent credentials on the system. Most of the changes to the `AzureStorageFS.scala` are to parse out a SAS token from blob names.

This change brings with it a couple caveats. Unfortunately it is not possible to truly disambiguate a SAS token from a glob pattern, or even just a normal blob filename. So we take what is probably a safe assumption and look to see if there exists a query-parameter style key-value pair after the last `?` in the blob name. If this is the case, we treat everything after the last `?` as a SAS token. If this condition is not satsified, we say there is no SAS token and treat the whole path as the blob name. This logic already exists in python, but I'm open to alternatives.

Introducing SAS tokens also breaks the way globbing is currently implemented, where it is deemed safe to iteratively append components to the end of a blob URI string. I added an abstract type member to `FS` and instead of a `String` have `globWithPrefix` accept that associated URL type that can properly handle path updates. I'm unclear on the best way to do this w.r.t. the type system, and wasn't quite sure what to put as the associated type for `RouterFS`, which ideally would accept a union of the URL types for the filesystems that it wraps, so some guidance on that would be great if you have any.