### PR TITLE
[ci] Fix dev deploy options

### DIFF
--- a/hail/python/hailtop/hailctl/dev/cli.py
+++ b/hail/python/hailtop/hailctl/dev/cli.py
@@ -36,7 +36,7 @@ def deploy(
         Optional[List[str]],
         Opt(
             '--extra-config',
-            '-e',
+            '-c',
             help='Comma-separated list of key=value pairs to add as extra config parameters.',
         ),
     ] = None,


### PR DESCRIPTION
The `--extra-config` short option used to be `-c` and I accidentally made it `-e`, which likely shadows the previous option. This broke using `-e` for `--excluded_steps`.