### PR TITLE
[db] Make the test and dev DB certs last a year

### DIFF
--- a/tls/create_test_db_config.sh
+++ b/tls/create_test_db_config.sh
@@ -29,6 +29,7 @@ cd $dir
 # Create the MySQL server CA
 openssl req -new -x509 \
     -subj /CN=db-root -nodes -newkey rsa:4096 \
+    -days 365 \
     -keyout server-ca-key.pem -out server-ca.pem
 
 create_key_and_cert server


### PR DESCRIPTION
These are intended to ultimately be pretty short lived anyway so the expiration is more annoying than useful, but the default of 30 days is a little tight.