### PR TITLE
Fix cloud driver abstraction

### DIFF
--- a/batch/batch/cloud/azure/driver/driver.py
+++ b/batch/batch/cloud/azure/driver/driver.py
@@ -148,9 +148,17 @@ ON DUPLICATE KEY UPDATE region = region;
         self.resource_group = resource_group
         self.namespace = namespace
         self.region_monitor = region_monitor
-        self.inst_coll_manager = inst_coll_manager
         self.job_private_inst_manager = job_private_inst_manager
-        self.billing_manager = billing_manager
+        self._billing_manager = billing_manager
+        self._inst_coll_manager = inst_coll_manager
+
+    @property
+    def billing_manager(self) -> AzureBillingManager:
+        return self._billing_manager
+
+    @property
+    def inst_coll_manager(self) -> InstanceCollectionManager:
+        return self._inst_coll_manager
 
     async def shutdown(self) -> None:
         try:

--- a/batch/batch/cloud/gcp/driver/driver.py
+++ b/batch/batch/cloud/gcp/driver/driver.py
@@ -137,9 +137,17 @@ ON DUPLICATE KEY UPDATE region = region;
         self.project = project
         self.namespace = namespace
         self.zone_monitor = zone_monitor
-        self.inst_coll_manager = inst_coll_manager
         self.job_private_inst_manager = job_private_inst_manager
-        self.billing_manager = billing_manager
+        self._billing_manager = billing_manager
+        self._inst_coll_manager = inst_coll_manager
+
+    @property
+    def billing_manager(self) -> GCPBillingManager:
+        return self._billing_manager
+
+    @property
+    def inst_coll_manager(self) -> InstanceCollectionManager:
+        return self._inst_coll_manager
 
     async def shutdown(self) -> None:
         try:

--- a/batch/batch/driver/driver.py
+++ b/batch/batch/driver/driver.py
@@ -3,9 +3,7 @@ import datetime
 from typing import Awaitable, Callable
 
 from gear import Database
-from hailtop import aiotools
 
-from ..inst_coll_config import InstanceCollectionConfigs
 from .billing_manager import CloudBillingManager
 from .instance_collection import InstanceCollectionManager
 
@@ -33,19 +31,6 @@ class CloudDriver(abc.ABC):
     @property
     @abc.abstractmethod
     def billing_manager(self) -> CloudBillingManager:
-        raise NotImplementedError
-
-    @staticmethod
-    @abc.abstractmethod
-    async def create(
-        app,
-        db: Database,
-        machine_name_prefix: str,
-        namespace: str,
-        inst_coll_configs: InstanceCollectionConfigs,
-        credentials_file: str,
-        task_manager: aiotools.BackgroundTaskManager,
-    ) -> 'CloudDriver':
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/batch/batch/driver/driver.py
+++ b/batch/batch/driver/driver.py
@@ -25,8 +25,15 @@ async def process_outstanding_events(db: Database, process_events_since: Callabl
 
 
 class CloudDriver(abc.ABC):
-    inst_coll_manager: InstanceCollectionManager
-    billing_manager: CloudBillingManager
+    @property
+    @abc.abstractmethod
+    def inst_coll_manager(self) -> InstanceCollectionManager:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def billing_manager(self) -> CloudBillingManager:
+        raise NotImplementedError
 
     @staticmethod
     @abc.abstractmethod


### PR DESCRIPTION
Abstract properties need to be declared [this way](https://stackoverflow.com/questions/2736255/abstract-attributes-in-python) to be enforceable. If I delete `self.billing_manager` in one of the driver subclasses it still typechecks but would error at runtime.

I also deleted the `create` method on the `CloudDriver` interface because it is never really used as an interface method (we only ever explicitly use the method from the concrete classes). As such it doesn't really enforce a contract and can be a little restrictive (in terra there is no sensible `credentials_file` input to such a method to create a terra driver.