### PR TITLE
[tls] make internal cert config optional

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1821,10 +1821,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: ssl-config-monitoring-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     timeout: 300
     inputs:
       - from: /repo/monitoring/test
@@ -2487,10 +2483,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: ssl-config-batch-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     dependsOn:
       - default_ns
       - merge_code
@@ -2610,10 +2602,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: ssl-config-memory-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
       - name: test-gsa-key
         namespace:
           valueFrom: default_ns.name
@@ -2688,10 +2676,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /dev-tokens
-      - name: ssl-config-batch-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
       - name: test-gsa-key
         namespace:
           valueFrom: default_ns.name
@@ -2740,10 +2724,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /dev-tokens
-      - name: ssl-config-batch-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     alwaysRun: true
     dependsOn:
       - create_deploy_config
@@ -2896,10 +2876,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: ssl-config-ci-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     timeout: 5400
     inputs:
       - from: /repo/ci/test
@@ -2965,10 +2941,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
-      - name: ssl-config-batch-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     dependsOn:
       - hailgenetics_hail_image
       - hailgenetics_hailtop_image
@@ -3086,10 +3058,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
-      - name: ssl-config-batch-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     dependsOn:
       - hailgenetics_hail_image
       - upload_query_jar
@@ -3585,10 +3553,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /deploy-config
-      - name: ssl-config-services-java-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
       - name: test-gsa-key
         namespace:
           valueFrom: default_ns.name
@@ -3635,10 +3599,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /deploy-config
-      - name: ssl-config-services-java-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     timeout: 1200
     dependsOn:
       - default_ns
@@ -3680,10 +3640,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: ssl-config-batch-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     alwaysRun: true
     timeout: 300
     dependsOn:
@@ -3731,10 +3687,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: ssl-config-batch-tests
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ssl-config
     scopes:
       - test
       - dev

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -440,8 +440,7 @@ object ServiceBackendSocketAPI2 {
     DeployConfig.set(deployConfig)
     val userTokens = Tokens.fromFile(s"$scratchDir/secrets/user-tokens/tokens.json")
     Tokens.set(userTokens)
-    tls.setSSLConfigFromDir(s"$scratchDir/secrets/ssl-config")
-    log.info("TLS configured.")
+    sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir(_))
 
     val sessionId = userTokens.namespaceToken(deployConfig.defaultNamespace)
     log.info("Namespace token acquired.")

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -113,7 +113,7 @@ object Worker {
     DeployConfig.set(deployConfig)
     val userTokens = Tokens.fromFile(s"$scratchDir/secrets/user-tokens/tokens.json")
     Tokens.set(userTokens)
-    tls.setSSLConfigFromDir(s"$scratchDir/secrets/ssl-config")
+    sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir(_))
 
     log.info(s"is.hail.backend.service.Worker $myRevision")
     log.info(s"running job $i/$n at root $root with scratch directory '$scratchDir'")

--- a/hail/src/main/scala/is/hail/services/tls/package.scala
+++ b/hail/src/main/scala/is/hail/services/tls/package.scala
@@ -55,6 +55,7 @@ package object tls {
 
   def setSSLConfigFromDir(configDir: String) = {
     _getSSLConfig = sslConfigFromDir(configDir)
+    log.info("TLS configured.")
   }
 
   def getSSLConfig(): SSLConfig = {

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -56,33 +56,13 @@ principals:
     - internal-gateway
   unmanged: True
   kind: nginx
-- name: batch-tests
-  domains:
-    - batch-tests
-  kind: json
-- name: ci-tests
-  domains:
-    - ci-tests
-  kind: json
 - name: memory
   domains:
     - memory
   kind: json
-- name: memory-tests
-  domains:
-    - memory-tests
-  kind: json
-- name: services-java-tests
-  domains:
-    - services-java-tests
-  kind: json
 - name: monitoring
   domains:
     - monitoring
-  kind: json
-- name: monitoring-tests
-  domains:
-    - monitoring-tests
   kind: json
 - name: batch-user-code
   domains:


### PR DESCRIPTION
Pretty sure this is all dead code because we don't currently speak TLS between the worker and internal gateway. I think what's ultimately the right approach here is to start sending the hail root cert to workers and have them mount that at a well known location to all containers, not have it be part of the job spec. Then we should be able to talk https to internal gateway.

I'm not exactly sure what to do in this PR specifically. I want to get rid of this hard dependency on the ssl-config because
    1. Doesn't exist in terra as everything goes through the relay listener
    2. These ssl configs aren't used anyway
but I'd need to put in a bit more work to start sending the root cert to workers and add https to internal-gateway