### PR TITLE
[batch] JVM container logs streamed with fluentd

### DIFF
--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from shlex import quote as shq
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from gear.cloud_config import get_global_config
 
@@ -80,12 +80,12 @@ def create_vm_config(
 
     assert instance_config.is_valid_configuration(resource_rates.keys())
 
-    touch_commands = []
+    touch_commands: List[str] = []
     for jvm_cores in (1, 2, 4, 8):
         for _ in range(cores // jvm_cores):
             idx = len(touch_commands)
             log_path = f'/batch/jvm-container-logs/jvm-{idx}.log'
-            touch_commands.append(f'touch {log_path}')
+            touch_commands.append(f'sudo touch {log_path}')
 
     jvm_touch_command = '\n'.join(touch_commands)
 

--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -80,6 +80,15 @@ def create_vm_config(
 
     assert instance_config.is_valid_configuration(resource_rates.keys())
 
+    touch_commands = []
+    for jvm_cores in (1, 2, 4, 8):
+        for _ in range(cores // jvm_cores):
+            idx = len(touch_commands)
+            log_path = f'/batch/jvm-container-logs/jvm-{idx}.log'
+            touch_commands.append(f'touch {log_path}')
+
+    jvm_touch_command = '\n'.join(touch_commands)
+
     startup_script = r'''#cloud-config
 
 mounts:
@@ -138,6 +147,7 @@ sudo service docker start
 # reconfigure /batch and /logs to use data disk
 sudo mkdir -p /mnt/disks/$WORKER_DATA_DISK_NAME/batch/
 sudo ln -s /mnt/disks/$WORKER_DATA_DISK_NAME/batch /batch
+{jvm_touch_command}
 
 sudo mkdir -p /mnt/disks/$WORKER_DATA_DISK_NAME/logs/
 sudo ln -s /mnt/disks/$WORKER_DATA_DISK_NAME/logs /logs

--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -147,6 +147,8 @@ sudo service docker start
 # reconfigure /batch and /logs to use data disk
 sudo mkdir -p /mnt/disks/$WORKER_DATA_DISK_NAME/batch/
 sudo ln -s /mnt/disks/$WORKER_DATA_DISK_NAME/batch /batch
+
+sudo mkdir -p /batch/jvm-container-logs/
 {jvm_touch_command}
 
 sudo mkdir -p /mnt/disks/$WORKER_DATA_DISK_NAME/logs/

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from shlex import quote as shq
-from typing import Dict
+from typing import Dict, List
 
 from gear.cloud_config import get_global_config
 
@@ -75,7 +75,7 @@ def create_vm_config(
 
     assert instance_config.is_valid_configuration(resource_rates.keys())
 
-    configs = []
+    configs: List[str] = []
     touch_commands = []
     for jvm_cores in (1, 2, 4, 8):
         for _ in range(cores // jvm_cores):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2500,7 +2500,7 @@ class JVMContainer:
             memory_in_bytes=total_memory_bytes,
             env=[f'HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB={off_heap_memory_per_core_mib}', f'HAIL_CLOUD={CLOUD}'],
             volume_mounts=volume_mounts,
-            log_path=f'/batch/jvm-container-logs/jvm-{index}.log'
+            log_path=f'/batch/jvm-container-logs/jvm-{index}.log',
         )
 
         await c.create()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -773,6 +773,7 @@ class Container:
         volume_mounts: Optional[List[MountSpecification]] = None,
         env: Optional[List[str]] = None,
         stdin: Optional[str] = None,
+        log_path: Optional[str] = None,
     ):
         self.task_manager = task_manager
         self.fs = fs
@@ -809,7 +810,7 @@ class Container:
         self.container_scratch = scratch_dir
         self.container_overlay_path = f'{self.container_scratch}/rootfs_overlay'
         self.config_path = f'{self.container_scratch}/config'
-        self.log_path = f'{self.container_scratch}/container.log'
+        self.log_path = log_path or f'{self.container_scratch}/container.log'
         self.resource_usage_path = f'{self.container_scratch}/resource_usage'
 
         self.overlay_mounted = False
@@ -2499,6 +2500,7 @@ class JVMContainer:
             memory_in_bytes=total_memory_bytes,
             env=[f'HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB={off_heap_memory_per_core_mib}', f'HAIL_CLOUD={CLOUD}'],
             volume_mounts=volume_mounts,
+            log_path=f'/batch/jvm-container-logs/jvm-{index}.log'
         )
 
         await c.create()


### PR DESCRIPTION
The goal of this PR is to have all of the JVM container logs available where all the worker logs are. I tagged the entries with "worker.log" so they show up with the other worker log entries. However, it's plain text with no timestamp. We can improve the formatting as a separate project. Notice the two entries with "*" on the left instead of the normal "I".

The design choice I made is to have the JVM containers write to a location that is static. We cannot easily change the fluentd configuration dynamically. It requires restarting the daemon which takes 1.5 seconds. Furthermore, the configuration for fluentd is on /etc/ on the host which the batch worker container cannot access. Hence, why I took the approach of specifying it in the startup script at known locations. 

Before we merge this, I'd like to confirm that (a) we want these logs and (b) they don't contain any secrets.
<img width="1585" alt="Screenshot 2023-06-16 at 4 06 43 PM" src="https://github.com/hail-is/hail/assets/1693348/0ce9f7dc-1188-4c66-ae6f-83fcc3744f95">
