### PR TITLE
[batch] Add new ResourceGroup items to `_resources_inverse`

### DIFF
--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -711,6 +711,7 @@ class BashJob(Job):
             self._resources[name] = rg
             for rname, r in rg._resources.items():
                 self._resources_inverse[r] = f'{name}["{rname}"]'
+                self._mentioned.add(r)
             _add_resource_to_set(self._valid, rg)
         return self
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -709,6 +709,8 @@ class BashJob(Job):
                 raise BatchException(f"value for name '{name}' is not a dict. Found '{type(d)}' instead.")
             rg = self._batch._new_resource_group(self, d, root=name)
             self._resources[name] = rg
+            for rname, r in rg._resources.items():
+                self._resources_inverse[r] = f'{name}["{rname}"]'
             _add_resource_to_set(self._valid, rg)
         return self
 


### PR DESCRIPTION
This is used to print the resource name in several error messages, which failed when the error occurred for an item within a ResourceGroup.

Proposed fix addressing part of #13191, for your consideration.

Fixes #13191 