### PR TITLE
[boostrap-gateway|notebook|grafana] Fix broken references to images in Makefiles

### DIFF
--- a/bootstrap-gateway/Makefile
+++ b/bootstrap-gateway/Makefile
@@ -6,8 +6,8 @@ GATEWAY_IMAGE := $(DOCKER_PREFIX)/gateway:$(TOKEN)
 IP := $(shell kubectl get secret global-config --template={{.data.ip}} | base64 --decode)
 
 build:
-	$(MAKE) -C ../docker hail-ubuntu
-	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../docker/hail-ubuntu-image-ref)'"}}' Dockerfile Dockerfile.out
+	$(MAKE) -C .. hail-ubuntu-image
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../hail-ubuntu-image)'"}}' Dockerfile Dockerfile.out
 	../docker-build.sh . Dockerfile.out $(GATEWAY_IMAGE)
 
 deploy: build

--- a/build.yaml
+++ b/build.yaml
@@ -1645,7 +1645,7 @@ steps:
       - dev
     dependsOn:
       - default_ns
-      - base_image
+      - hail_ubuntu_image
       - create_certs
       - copy_third_party_images
   - kind: deploy

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -5,9 +5,9 @@ include ../config.mk
 CLOUD := $(shell kubectl get secret global-config --template={{.data.cloud}} | base64 --decode)
 
 build:
-	$(MAKE) -C ../docker base
+	$(MAKE) -C .. hail-ubuntu-image
 
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"global": {"cloud": "$(CLOUD)", "domain": "$(DOMAIN)", "docker_prefix":"$(DOCKER_PREFIX)"},"default_ns":{"name":"$(NAMESPACE)"},"base_image":{"image":"'$$(cat ../docker/base-image-ref)'"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"global": {"cloud": "$(CLOUD)", "domain": "$(DOMAIN)", "docker_prefix":"$(DOCKER_PREFIX)"},"default_ns":{"name":"$(NAMESPACE)"},"hail_ubuntu_image":{"image":"'$$(cat ../hail-ubuntu-image)'"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -155,7 +155,7 @@ spec:
             name: grafana-envoy-sidecar-config
       initContainers:
        - name: setup-tokens
-         image: {{ base_image.image }}
+         image: {{ hail_ubuntu_image.image }}
          command: ["/bin/bash"]
          args: ["-c", "jq -r '.{{ default_ns.name }}' /grafana-tokens/tokens.json > /grafana-shared/token"]
          volumeMounts:

--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -8,8 +8,8 @@ build-notebook:
 
 .PHONY: build-nginx
 build-nginx:
-	$(MAKE) -C ../docker hail-ubuntu
-	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../docker/hail-ubuntu-image-ref)'"}}' Dockerfile.nginx Dockerfile.nginx.out
+	$(MAKE) -C .. hail-ubuntu-image
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../hail-ubuntu-image)'"}}' Dockerfile.nginx Dockerfile.nginx.out
 	python3 ../ci/jinja2_render.py '{"deploy": $(DEPLOY), "default_ns": {"name": "$(NAMESPACE)"}}' nginx.conf nginx.conf.out
 	../docker-build.sh . Dockerfile.nginx.out $(NOTEBOOK_NGINX_IMAGE)
 

--- a/website/Makefile
+++ b/website/Makefile
@@ -17,7 +17,6 @@ run-docker: build
 
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	$(MAKE) -C ../docker hail-ubuntu
 	python3 ../ci/jinja2_render.py '{"default_ns":{"name":"$(NAMESPACE)"},"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"scope":"$(SCOPE)","website_image":{"image":"$(WEBSITE_IMAGE)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out
 


### PR DESCRIPTION
Manual image building for these three images was broken because they weren't fully converted to use the new image targets in the top-level Makefile. I manually ran the build targets for these images. I also changed Grafana to use hail-ubuntu because it has everything it needs now. I ripgrepped the codebase for `image-ref` and `$(MAKE) -C ../docker` after this change and can find no more matches.