### PR TITLE
[query] Remove old implementation of TableJoin

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -7,7 +7,7 @@ import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.backend.{ExecuteContext, HailStateManager, HailTaskContext, TaskFinalizer}
 import is.hail.expr.ir
 import is.hail.expr.ir.functions.{BlockMatrixToTableFunction, IntervalFunctions, MatrixToTableFunction, TableToTableFunction}
-import is.hail.expr.ir.lowering.{DArrayLowering, LowerTableIR, LowererUnsupportedOperation, TableStage, TableStageDependency}
+import is.hail.expr.ir.lowering.{DArrayLowering, LowerTableIR, LowerTableIRHelpers, LowererUnsupportedOperation, TableStage, TableStageDependency}
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.io._
 import is.hail.io.avro.AvroTableReader
@@ -57,10 +57,11 @@ abstract sealed class TableIR extends BaseIR {
 
   final def analyzeAndExecute(ctx: ExecuteContext): TableExecuteIntermediate = {
     val r = Requiredness(this, ctx)
-    execute(ctx, new TableRunContext(r))
+    val d = DistinctlyKeyed(this)
+    execute(ctx, LoweringAnalyses(r, d))
   }
 
-  protected[ir] def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate =
+  protected[ir] def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate =
     fatal("tried to execute unexecutable IR:\n" + Pretty(ctx, this))
 
   override def copy(newChildren: IndexedSeq[BaseIR]): TableIR
@@ -74,8 +75,6 @@ abstract sealed class TableIR extends BaseIR {
 
   def pyUnpersist(): TableIR = unpersist()
 }
-
-class TableRunContext(val req: RequirednessAnalysis)
 
 object TableLiteral {
   def apply(value: TableValue, theHailClassLoader: HailClassLoader): TableLiteral = {
@@ -93,7 +92,7 @@ case class TableLiteral(typ: TableType, rvd: RVD, enc: AbstractTypedCodecSpec, e
     TableLiteral(typ, rvd, enc, encodedGlobals)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val (globalPType: PStruct, dec) = enc.buildDecoder(ctx, typ.globalType)
 
     val bais = new ArrayOfByteArrayInputStream(encodedGlobals)
@@ -1666,7 +1665,7 @@ case class TableRead(typ: TableType, dropRows: Boolean, tr: TableReader) extends
     TableRead(typ, dropRows, tr)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate =
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate =
     new TableValueIntermediate(tr.apply(ctx, typ, dropRows))
 }
 
@@ -1692,7 +1691,7 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
     FastIndexedSeq(),
     globalsType)
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val (ptype: PStruct, res) = CompileAndEvaluate._apply(ctx, rowsAndGlobal, optimize = false) match {
       case Right((t, off)) => (t.fields(0).typ, t.loadField(off, 0))
     }
@@ -1779,7 +1778,7 @@ case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolea
     TableKeyBy(newChildren(0).asInstanceOf[TableIR], keys, isSorted)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val tv = child.execute(ctx, r).asTableValue(ctx)
     new TableValueIntermediate(tv.copy(typ = typ, rvd = tv.rvd.enforceKey(ctx, keys, isSorted)))
   }
@@ -1838,7 +1837,7 @@ case class TableGen(contexts: IR,
   override def children: IndexedSeq[BaseIR] =
     FastSeq(contexts, globals, body)
 
-  override protected[ir] def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate =
+  override protected[ir] def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate =
     new TableStageIntermediate(LowerTableIR.applyTable(this, DArrayLowering.All, ctx, LoweringAnalyses(this, ctx)))
 }
 
@@ -1864,7 +1863,7 @@ case class TableRange(n: Int, nPartitions: Int) extends TableIR {
     Array("idx"),
     TStruct.empty)
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val localRowType = PCanonicalStruct(true, "idx" -> PInt32Required)
     val localPartCounts = partCounts
     val partStarts = partCounts.scanLeft(0)(_ + _)
@@ -1906,7 +1905,7 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
     TableFilter(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[IR])
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val tv = child.execute(ctx, r).asTableValue(ctx)
 
     if (pred == True())
@@ -1951,7 +1950,7 @@ trait TableSubset extends TableIR {
     case None => Some(n)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val prev = child.execute(ctx, r).asTableValue(ctx)
     new TableValueIntermediate(prev.copy(rvd = subsetKind match {
       case TableSubset.HEAD => prev.rvd.head(n, child.partitionCounts)
@@ -1998,7 +1997,7 @@ case class TableRepartition(child: TableIR, n: Int, strategy: Int) extends Table
     TableRepartition(newChild, n, strategy)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val prev = child.execute(ctx, r).asTableValue(ctx)
     val rvd = strategy match {
       case RepartitionStrategy.SHUFFLE => prev.rvd.coalesce(ctx, n, shuffle = true)
@@ -2082,113 +2081,10 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
       joinKey)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
-    val leftTV = left.execute(ctx, r).asTableValue(ctx)
-    val rightTV = right.execute(ctx, r).asTableValue(ctx)
-
-    val combinedRow = Row.fromSeq(leftTV.globals.javaValue.toSeq ++ rightTV.globals.javaValue.toSeq)
-    val newGlobals = BroadcastRow(ctx, combinedRow, newGlobalType)
-
-    val leftRVDType = leftTV.rvd.typ.copy(key = left.typ.key.take(joinKey))
-    val rightRVDType = rightTV.rvd.typ.copy(key = right.typ.key.take(joinKey))
-
-    val leftRowType = leftRVDType.rowType
-    val rightRowType = rightRVDType.rowType
-    val leftKeyFieldIdx = leftRVDType.kFieldIdx
-    val rightKeyFieldIdx = rightRVDType.kFieldIdx
-    val leftValueFieldIdx = leftRVDType.valueFieldIdx
-    val rightValueFieldIdx = rightRVDType.valueFieldIdx
-
-    def noIndex(pfs: IndexedSeq[PField]): IndexedSeq[(String, PType)] =
-      pfs.map(pf => (pf.name, pf.typ))
-
-    def unionFieldPTypes(ps: PStruct, ps2: PStruct): IndexedSeq[(String, PType)] =
-      ps.fields.zip(ps2.fields).map { case (pf1, pf2) =>
-        (pf1.name, InferPType.getCompatiblePType(Seq(pf1.typ, pf2.typ)))
-      }
-
-    def castFieldRequiredeness(ps: PStruct, required: Boolean): IndexedSeq[(String, PType)] =
-      ps.fields.map(pf => (pf.name, pf.typ.setRequired(required)))
-
-    val (lkT, lvT, rvT) = joinType match {
-      case "inner" =>
-        val keyTypeFields = castFieldRequiredeness(leftRVDType.kType, true)
-        (keyTypeFields, noIndex(leftRVDType.valueType.fields), noIndex(rightRVDType.valueType.fields))
-      case "left" =>
-        val rValueTypeFields = castFieldRequiredeness(rightRVDType.valueType, false)
-        (noIndex(leftRVDType.kType.fields), noIndex(leftRVDType.valueType.fields), rValueTypeFields)
-      case "right" =>
-        val keyTypeFields = leftRVDType.kType.fields.zip(rightRVDType.kType.fields).map({
-          case (pf1, pf2) => {
-            assert(pf1.typ isOfType pf2.typ)
-            (pf1.name, pf2.typ)
-          }
-        })
-        val lValueTypeFields = castFieldRequiredeness(leftRVDType.valueType, false)
-        (keyTypeFields, lValueTypeFields, noIndex(rightRVDType.valueType.fields))
-      case "outer" =>
-        val keyTypeFields = unionFieldPTypes(leftRVDType.kType, rightRVDType.kType)
-        val lValueTypeFields = castFieldRequiredeness(leftRVDType.valueType, false)
-        val rValueTypeFields = castFieldRequiredeness(rightRVDType.valueType, false)
-        (keyTypeFields, lValueTypeFields, rValueTypeFields)
-    }
-
-    val newRowPType = PCanonicalStruct(true, lkT ++ lvT ++ rvT: _*)
-
-    assert(newRowPType.virtualType == newRowType)
-
-    val sm = ctx.stateManager
-    val rvMerger = { (_: RVDContext, it: Iterator[JoinedRegionValue]) =>
-      val rvb = new RegionValueBuilder(sm)
-      val rv = RegionValue()
-      it.map { joined =>
-        val lrv = joined._1
-        val rrv = joined._2
-
-        if (lrv != null)
-          rvb.set(lrv.region)
-        else {
-          assert(rrv != null)
-          rvb.set(rrv.region)
-        }
-
-        rvb.start(newRowPType)
-        rvb.startStruct()
-
-        if (lrv != null)
-          rvb.addFields(leftRowType, lrv, leftKeyFieldIdx)
-        else {
-          assert(rrv != null)
-          rvb.addFields(rightRowType, rrv, rightKeyFieldIdx)
-        }
-
-        if (lrv != null)
-          rvb.addFields(leftRowType, lrv, leftValueFieldIdx)
-        else
-          rvb.skipFields(leftValueFieldIdx.length)
-
-        if (rrv != null)
-          rvb.addFields(rightRowType, rrv, rightValueFieldIdx)
-        else
-          rvb.skipFields(rightValueFieldIdx.length)
-
-        rvb.endStruct()
-        rv.set(rvb.region, rvb.end())
-        rv
-      }
-    }
-
-    val leftRVD = leftTV.rvd
-    val rightRVD = rightTV.rvd
-    val joinedRVD = leftRVD.orderedJoin(
-      rightRVD,
-      joinKey,
-      joinType,
-      rvMerger,
-      RVDType(newRowPType, newKey),
-      ctx)
-
-    new TableValueIntermediate(TableValue(ctx, typ, newGlobals, joinedRVD))
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
+    val leftTV = left.execute(ctx, r).asTableStage(ctx)
+    val rightTV = right.execute(ctx, r).asTableStage(ctx)
+    TableExecuteIntermediate(LowerTableIRHelpers.lowerTableJoin(ctx, r, this, leftTV, rightTV))
   }
 }
 
@@ -2210,7 +2106,7 @@ case class TableIntervalJoin(
 
   override def partitionCounts: Option[IndexedSeq[Long]] = left.partitionCounts
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val leftValue = left.execute(ctx, r).asTableValue(ctx)
     val rightValue = right.execute(ctx, r).asTableValue(ctx)
 
@@ -2308,7 +2204,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
   def copy(newChildren: IndexedSeq[BaseIR]): TableMultiWayZipJoin =
     TableMultiWayZipJoin(newChildren.asInstanceOf[IndexedSeq[TableIR]], fieldName, globalName)
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val sm = ctx.stateManager
     val childValues = children.map(_.execute(ctx, r).asTableValue(ctx))
 
@@ -2401,7 +2297,7 @@ case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: Strin
     TableLeftJoinRightDistinct(newLeft, newRight, root)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val leftValue = left.execute(ctx, r).asTableValue(ctx)
     val rightValue = right.execute(ctx, r).asTableValue(ctx)
 
@@ -2444,7 +2340,7 @@ case class TableMapPartitions(child: TableIR,
       globalName, partitionStreamName, newChildren(1).asInstanceOf[IR], requestedKey, allowedOverlap)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val tv = child.execute(ctx, r).asTableValue(ctx)
     val rowPType = tv.rvd.rowPType
     val globalPType = tv.globals.t
@@ -2509,7 +2405,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val tv = child.execute(ctx, r).asTableValue(ctx)
     val fsBc = ctx.fsBc
     val scanRef = genUID()
@@ -2829,7 +2725,7 @@ case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val tv = child.execute(ctx, r).asTableValue(ctx)
 
     val (Some(PTypeReferenceSingleCodeType(resultPType: PStruct)), f) = Compile[AsmFunction2RegionLongLong](ctx,
@@ -2886,7 +2782,7 @@ case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableI
     TableExplode(newChildren(0).asInstanceOf[TableIR], path)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val prev = child.execute(ctx, r).asTableValue(ctx)
 
     val (len, l) = Compile[AsmFunction2RegionLongInt](ctx,
@@ -2951,7 +2847,7 @@ case class TableUnion(children: IndexedSeq[TableIR]) extends TableIR {
 
   val typ: TableType = children(0).typ
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val tvs = children.map(_.execute(ctx, r).asTableValue(ctx))
     new TableValueIntermediate(
       tvs(0).copy(
@@ -3012,7 +2908,7 @@ case class TableDistinct(child: TableIR) extends TableIR {
 
   val typ: TableType = child.typ
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val prev = child.execute(ctx, r).asTableValue(ctx)
     new TableValueIntermediate(prev.copy(rvd = prev.rvd.truncateKey(prev.typ.key).distinctByKey(ctx)))
   }
@@ -3043,7 +2939,7 @@ case class TableKeyByAndAggregate(
     key = keyType.fieldNames
   )
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val prev = child.execute(ctx, r).asTableValue(ctx)
     val fsBc = ctx.fsBc
     val sm = ctx.stateManager
@@ -3198,7 +3094,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
 
   val typ: TableType = child.typ.copy(rowType = child.typ.keyType ++ tcoerce[TStruct](expr.typ))
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val prev = child.execute(ctx, r).asTableValue(ctx)
     val prevRVD = prev.rvd.truncateKey(child.typ.key)
     val fsBc = ctx.fsBc
@@ -3328,7 +3224,7 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
 
   val typ: TableType = child.typ.copy(key = FastIndexedSeq())
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val prev = child.execute(ctx, r).asTableValue(ctx)
 
     val physicalKey = prev.rvd.typ.key
@@ -3403,7 +3299,7 @@ case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: M
     TableRename(newChild, rowMap, globalMap)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate =
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate =
     new TableValueIntermediate(
       child.execute(ctx, r).asTableValue(ctx).rename(globalMap, rowMap))
 }
@@ -3420,7 +3316,7 @@ case class TableFilterIntervals(child: TableIR, intervals: IndexedSeq[Interval],
 
   override lazy val typ: TableType = child.typ
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val tv = child.execute(ctx, r).asTableValue(ctx)
     val partitioner = RVDPartitioner.union(
       ctx.stateManager,
@@ -3463,7 +3359,7 @@ case class TableToTableApply(child: TableIR, function: TableToTableFunction) ext
 
   lazy val rowCountUpperBound: Option[Long] = if (function.preservesPartitionCounts) child.rowCountUpperBound else None
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     new TableValueIntermediate(function.execute(ctx, child.execute(ctx, r).asTableValue(ctx)))
   }
 }
@@ -3485,7 +3381,7 @@ case class BlockMatrixToTableApply(
 
   override lazy val typ: TableType = function.typ(bm.typ, aux.typ)
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     val b = bm.execute(ctx)
     val a = CompileAndEvaluate[Any](ctx, aux, optimize = false)
     new TableValueIntermediate(function.execute(ctx, b, a))
@@ -3507,7 +3403,7 @@ case class BlockMatrixToTable(child: BlockMatrixIR) extends TableIR {
     TableType(rvType, Array[String](), TStruct.empty)
   }
 
-  protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
+  protected[ir] override def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate = {
     new TableValueIntermediate(child.execute(ctx).entriesTable(ctx))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1537,37 +1537,7 @@ object LowerTableIR {
       case tj@TableJoin(left, right, joinType, joinKey) =>
         val loweredLeft = lower(left)
         val loweredRight = lower(right)
-
-        val lKeyFields = left.typ.key.take(joinKey)
-        val lValueFields = left.typ.rowType.fieldNames.filter(f => !lKeyFields.contains(f))
-        val rKeyFields = right.typ.key.take(joinKey)
-        val rValueFields = right.typ.rowType.fieldNames.filter(f => !rKeyFields.contains(f))
-        val lReq = analyses.requirednessAnalysis.lookup(left).asInstanceOf[RTable]
-        val rReq = analyses.requirednessAnalysis.lookup(right).asInstanceOf[RTable]
-        val rightKeyIsDistinct = analyses.distinctKeyedAnalysis.contains(right)
-
-        val joinedStage = loweredLeft.orderedJoin(ctx,
-          loweredRight, joinKey, joinType,
-          (lGlobals, rGlobals) => {
-            val rGlobalType = rGlobals.typ.asInstanceOf[TStruct]
-            val rGlobalRef = Ref(genUID(), rGlobalType)
-            Let(rGlobalRef.name, rGlobals,
-              InsertFields(lGlobals, rGlobalType.fieldNames.map(f => f -> GetField(rGlobalRef, f))))
-          },
-          (lEltRef, rEltRef) => {
-            MakeStruct(
-              (lKeyFields, rKeyFields).zipped.map { (lKey, rKey) =>
-                if (joinType == "outer" && lReq.field(lKey).required && rReq.field(rKey).required)
-                  lKey -> Coalesce(FastSeq(GetField(lEltRef, lKey), GetField(rEltRef, rKey), Die("TableJoin expected non-missing key", left.typ.rowType.fieldType(lKey), -1)))
-                else
-                  lKey -> Coalesce(FastSeq(GetField(lEltRef, lKey), GetField(rEltRef, rKey)))
-              }
-                ++ lValueFields.map(f => f -> GetField(lEltRef, f))
-                ++ rValueFields.map(f => f -> GetField(rEltRef, f)))
-          }, rightKeyIsDistinct)
-
-        assert(joinedStage.rowType == tj.typ.rowType)
-        joinedStage
+        LowerTableIRHelpers.lowerTableJoin(ctx, analyses, tj, loweredLeft, loweredRight)
 
       case x@TableUnion(children) =>
         val lowered = children.map(lower)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIRHelpers.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIRHelpers.scala
@@ -1,0 +1,44 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir._
+import is.hail.types.RTable
+import is.hail.types.virtual.TStruct
+import is.hail.utils.FastSeq
+
+object LowerTableIRHelpers {
+
+  def lowerTableJoin(ctx: ExecuteContext, analyses: LoweringAnalyses, tj: TableJoin, loweredLeft: TableStage, loweredRight: TableStage): TableStage = {
+    val TableJoin(left, right, joinType, joinKey) = tj
+    val lKeyFields = left.typ.key.take(joinKey)
+    val lValueFields = left.typ.rowType.fieldNames.filter(f => !lKeyFields.contains(f))
+    val rKeyFields = right.typ.key.take(joinKey)
+    val rValueFields = right.typ.rowType.fieldNames.filter(f => !rKeyFields.contains(f))
+    val lReq = analyses.requirednessAnalysis.lookup(left).asInstanceOf[RTable]
+    val rReq = analyses.requirednessAnalysis.lookup(right).asInstanceOf[RTable]
+    val rightKeyIsDistinct = analyses.distinctKeyedAnalysis.contains(right)
+
+    val joinedStage = loweredLeft.orderedJoin(ctx,
+      loweredRight, joinKey, joinType,
+      (lGlobals, rGlobals) => {
+        val rGlobalType = rGlobals.typ.asInstanceOf[TStruct]
+        val rGlobalRef = Ref(genUID(), rGlobalType)
+        Let(rGlobalRef.name, rGlobals,
+          InsertFields(lGlobals, rGlobalType.fieldNames.map(f => f -> GetField(rGlobalRef, f))))
+      },
+      (lEltRef, rEltRef) => {
+        MakeStruct(
+          (lKeyFields, rKeyFields).zipped.map { (lKey, rKey) =>
+            if (joinType == "outer" && lReq.field(lKey).required && rReq.field(rKey).required)
+              lKey -> Coalesce(FastSeq(GetField(lEltRef, lKey), GetField(rEltRef, rKey), Die("TableJoin expected non-missing key", left.typ.rowType.fieldType(lKey), -1)))
+            else
+              lKey -> Coalesce(FastSeq(GetField(lEltRef, lKey), GetField(rEltRef, rKey)))
+          }
+            ++ lValueFields.map(f => f -> GetField(lEltRef, f))
+            ++ rValueFields.map(f => f -> GetField(rEltRef, f)))
+      }, rightKeyIsDistinct)
+
+    assert(joinedStage.rowType == tj.typ.rowType)
+    joinedStage
+  }
+}

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -825,25 +825,6 @@ class RVD(
       typ.copy(rowType = newRowType))
   }
 
-  def orderedJoin(
-    right: RVD,
-    joinType: String,
-    joiner: (RVDContext, Iterator[JoinedRegionValue]) => Iterator[RegionValue],
-    joinedType: RVDType,
-    ctx: ExecuteContext
-  ): RVD =
-    orderedJoin(right, typ.key.length, joinType, joiner, joinedType, ctx)
-
-  def orderedJoin(
-    right: RVD,
-    joinKey: Int,
-    joinType: String,
-    joiner: (RVDContext, Iterator[JoinedRegionValue]) => Iterator[RegionValue],
-    joinedType: RVDType,
-    ctx: ExecuteContext
-  ): RVD =
-    keyBy(joinKey).orderedJoin(right.keyBy(joinKey), joinType, joiner, joinedType, ctx)
-
   def orderedLeftJoinDistinct(
     right: RVD,
     joinKey: Int,

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -32,19 +32,4 @@ class PartitioningSuite extends HailSuite {
       ctx, optimize = false)
       .rvd.count()
   }
-
-  @Test def testEmptyRDDOrderedJoin() {
-    val tv = Interpret.apply(TableRange(100, 6), ctx)
-
-    val nonEmptyRVD = tv.rvd
-    val rvdType = nonEmptyRVD.typ
-
-    ExecuteContext.scoped() { ctx =>
-      val emptyRVD = RVD.empty(ctx, rvdType)
-      emptyRVD.orderedJoin(nonEmptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()
-      emptyRVD.orderedJoin(nonEmptyRVD, "inner", (_, it) => it.map(_._1), rvdType, ctx).count()
-      nonEmptyRVD.orderedJoin(emptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()
-      nonEmptyRVD.orderedJoin(emptyRVD, "inner", (_, it) => it.map(_._1), rvdType, ctx).count()
-    }
-  }
 }


### PR DESCRIPTION
Provides an example and template for doing the rest.