### PR TITLE
[auth] Add internal hail identity UIDs to the users table

### DIFF
--- a/auth/sql/add-hail-identity-uid.sql
+++ b/auth/sql/add-hail-identity-uid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD COLUMN `hail_identity_uid` VARCHAR(300) DEFAULT NULL;

--- a/auth/sql/estimated-current.sql
+++ b/auth/sql/estimated-current.sql
@@ -11,6 +11,7 @@ CREATE TABLE `users` (
   `tokens_secret_name` varchar(255) DEFAULT NULL,
   -- identity
   `hail_identity` varchar(255) DEFAULT NULL,
+  `hail_identity_uid` VARCHAR(255) DEFAULT NULL,
   `hail_credentials_secret_name` varchar(255) DEFAULT NULL,
   -- namespace, for developers
   `namespace_name` varchar(255) DEFAULT NULL,

--- a/build.yaml
+++ b/build.yaml
@@ -375,6 +375,8 @@ steps:
         script: /io/sql/support-azure-oauth.sql
       - name: change-username-collation
         script: /io/sql/change-username-collation.sql
+      - name: add-hail-identity-uid
+        script: /io/sql/add-hail-identity-uid.sql
     inputs:
       - from: /repo/auth/sql
         to: /io/sql

--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -12,11 +12,7 @@ def get_identity_client(credentials_file: Optional[str] = None):
     cloud = get_global_config()['cloud']
 
     if cloud == 'azure':
-        scopes = ['https://graph.microsoft.com/.default']
-        return aioazure.AzureGraphClient(
-            credentials_file=credentials_file,
-            scopes=scopes,
-        )
+        return aioazure.AzureGraphClient(credentials_file=credentials_file)
 
     assert cloud == 'gcp', cloud
     project = get_gcp_config().project

--- a/hail/python/hailtop/aiocloud/aioazure/client/graph_client.py
+++ b/hail/python/hailtop/aiocloud/aioazure/client/graph_client.py
@@ -5,6 +5,12 @@ from .base_client import AzureBaseClient
 
 
 class AzureGraphClient(AzureBaseClient):
+    required_scopes = ['https://graph.microsoft.com/.default']
+
     def __init__(self, session: Optional[AzureSession] = None, **kwargs):
+        if 'scopes' in kwargs:
+            kwargs['scopes'] += AzureGraphClient.required_scopes
+        else:
+            kwargs['scopes'] = AzureGraphClient.required_scopes
         session = session or AzureSession(**kwargs)
         super().__init__('https://graph.microsoft.com/v1.0', session=session)


### PR DESCRIPTION
In order to start using Google or AAD access tokens instead of hail-minted tokens, we need to be able to identify a service account in the system by its UID at their identity provider. In Google, this UID is the `uniqueId` field of the Service Account. In AAD, it is the Service Principal Object ID. In an upcoming change, we'll update the user creation process to add this ID upon user creation, at which point we will be able to safely remove this code that updates existing records.

I've marked this PR as `full-deploy` so the AUS folks can roll this commit out specifically before this column is relied on. This way we can safely remove the loop in a follow-up PR and know they will have run this code to populate the column.