### PR TITLE
[hailctl] Dont show local variables in stacktraces

### DIFF
--- a/hail/python/hailtop/hailctl/__main__.py
+++ b/hail/python/hailtop/hailctl/__main__.py
@@ -10,7 +10,11 @@ from .dev import cli as dev_cli
 from .hdinsight import cli as hdinsight_cli
 
 
-app = typer.Typer(help='Manage and monitor hail deployments.', no_args_is_help=True)
+app = typer.Typer(
+    help='Manage and monitor hail deployments.',
+    no_args_is_help=True,
+    pretty_exceptions_show_locals=False,
+)
 
 for cli in (
     auth_cli.app,

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -12,6 +12,7 @@ app = typer.Typer(
     name='auth',
     no_args_is_help=True,
     help='Manage Hail credentials.',
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/hail/python/hailtop/hailctl/batch/billing/cli.py
+++ b/hail/python/hailtop/hailctl/batch/billing/cli.py
@@ -7,6 +7,7 @@ app = typer.Typer(
     name='billing',
     no_args_is_help=True,
     help='Manage billing on the service managed by the Hail team.',
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -27,6 +27,7 @@ app = typer.Typer(
     name='batch',
     no_args_is_help=True,
     help='Manage batches running on the batch service managed by the Hail team.',
+    pretty_exceptions_show_locals=False,
 )
 app.add_typer(billing.cli.app)
 

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -14,6 +14,7 @@ app = typer.Typer(
     name='config',
     no_args_is_help=True,
     help='Manage Hail configuration.',
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -49,7 +49,12 @@ NumSecondaryWorkersOption = Ann[
 ]
 
 
-app = typer.Typer(name='dataproc', no_args_is_help=True, help='Manage Hail Dataproc clusters.')
+app = typer.Typer(
+    name='dataproc',
+    no_args_is_help=True,
+    help='Manage Hail Dataproc clusters.',
+    pretty_exceptions_show_locals=False,
+)
 
 
 @app.callback()

--- a/hail/python/hailtop/hailctl/dev/cli.py
+++ b/hail/python/hailtop/hailctl/dev/cli.py
@@ -14,6 +14,7 @@ app = typer.Typer(
     name='dev',
     no_args_is_help=True,
     help='Manage Hail development utilities.',
+    pretty_exceptions_show_locals=False,
 )
 app.add_typer(
     config.app,

--- a/hail/python/hailtop/hailctl/hdinsight/cli.py
+++ b/hail/python/hailtop/hailctl/hdinsight/cli.py
@@ -10,7 +10,12 @@ from .start import start as hdinsight_start, VepVersion
 from .submit import submit as hdinsight_submit
 
 
-app = typer.Typer(name='hdinsight', no_args_is_help=True, help='Manage and monitor Hail HDInsight clusters.')
+app = typer.Typer(
+    name='hdinsight',
+    no_args_is_help=True,
+    help='Manage and monitor Hail HDInsight clusters.',
+    pretty_exceptions_show_locals=False,
+)
 
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})


### PR DESCRIPTION
`rich` stacktraces will by default show the local variables at each level of scope, which is nice for debugging but can leak things like tokens. Best not to have that show up in logs or accidentally pasted into zulip