### PR TITLE
[batch] Separate closed and open projects on billing limits page

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2212,7 +2212,14 @@ async def ui_get_billing_limits(request, userdata):
 
     billing_projects = await query_billing_projects(db, user=user)
 
-    page_context = {'billing_projects': billing_projects, 'is_developer': userdata['is_developer']}
+    open_billing_projects = [bp for bp in billing_projects if bp['status'] == 'open']
+    closed_billing_projects = [bp for bp in billing_projects if bp['status'] == 'closed']
+
+    page_context = {
+        'open_billing_projects': open_billing_projects,
+        'closed_billing_projects': closed_billing_projects,
+        'is_developer': userdata['is_developer'],
+    }
     return await render_template('batch', request, userdata, 'billing_limits.html', page_context)
 
 

--- a/batch/batch/front_end/templates/billing_limits.html
+++ b/batch/batch/front_end/templates/billing_limits.html
@@ -2,8 +2,10 @@
 {% block title %}Billing Limits{% endblock %}
 {% block content %}
 <h1>Billing Project Limits</h1>
+{% if open_billing_projects %}
 <div class='flex-col' style="overflow: auto;">
-  <table class="data-table" id="billing_limits">
+  <h2>Open Projects</h2>
+  <table class="data-table" id="open-billing-limits">
     <thead>
     <tr>
       <th>Billing Project</th>
@@ -12,7 +14,7 @@
     </tr>
     </thead>
     <tbody>
-    {% for row in billing_projects %}
+    {% for row in open_billing_projects %}
     <tr>
       <td>{{ row['billing_project'] }}</td>
       <td>{{ row['accrued_cost'] }}</td>
@@ -34,4 +36,40 @@
     </tbody>
   </table>
 </div>
+{% endif %}
+{% if closed_billing_projects %}
+<div class='flex-col' style="overflow: auto;">
+  <h2>Closed Projects</h2>
+  <table class="data-table" id="closed-billing-limits">
+    <thead>
+    <tr>
+      <th>Billing Project</th>
+      <th>Accrued Cost</th>
+      <th>Limit</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for row in closed_billing_projects %}
+    <tr>
+      <td>{{ row['billing_project'] }}</td>
+      <td>{{ row['accrued_cost'] }}</td>
+      {% if is_developer %}
+      <td>
+        <form action="{{ base_path }}/billing_limits/{{ row['billing_project'] }}/edit" method="POST">
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+          <input type="text" required name="limit" value="{{ row['limit'] }}">
+          <button>
+            Edit
+          </button>
+        </form>
+      </td>
+      {% else %}
+      <td>{{ row['limit'] }}</td>
+      {% endif %}
+    </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes #13205 

Possible billing project states are defined in the database schema:

```mysql
CREATE TABLE IF NOT EXISTS `billing_projects` (
  `name` VARCHAR(100) NOT NULL,
  `name_cs` VARCHAR(100) NOT NULL COLLATE utf8mb4_0900_as_cs,
  `status` ENUM('open', 'closed', 'deleted') NOT NULL DEFAULT 'open',
  `limit` DOUBLE DEFAULT NULL,
  `msec_mcpu` BIGINT DEFAULT 0,
  PRIMARY KEY (`name`)
) ENGINE = InnoDB;
CREATE INDEX `billing_project_status` ON `billing_projects` (`status`);
CREATE UNIQUE INDEX `billing_project_name_cs` ON `billing_projects` (`name_cs`);
CREATE INDEX `billing_project_name_cs_status` ON `billing_projects` (`name_cs`, `status`);
```