### PR TITLE
[batch] Add identifying metadata to Batch requests

### DIFF
--- a/batch/batch/driver/instance_collection/job_private.py
+++ b/batch/batch/driver/instance_collection/job_private.py
@@ -181,6 +181,7 @@ WHERE name = %s;
 SELECT jobs.*, batches.format_version, batches.userdata, batches.user, attempts.instance_name, time_ready
 FROM batches
 INNER JOIN jobs ON batches.id = jobs.batch_id
+LEFT JOIN jobs_telemetry ON jobs.batch_id = jobs_telemetry.batch_id AND jobs.job_id = jobs_telemetry.job_id
 LEFT JOIN attempts ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id
 LEFT JOIN instances ON attempts.instance_name = instances.name
 WHERE batches.state = 'running'

--- a/batch/batch/driver/instance_collection/job_private.py
+++ b/batch/batch/driver/instance_collection/job_private.py
@@ -178,7 +178,7 @@ WHERE name = %s;
 
         async for record in self.db.select_and_fetchall(
             '''
-SELECT jobs.*, batches.format_version, batches.userdata, batches.user, attempts.instance_name
+SELECT jobs.*, batches.format_version, batches.userdata, batches.user, attempts.instance_name, time_ready
 FROM batches
 INNER JOIN jobs ON batches.id = jobs.batch_id
 LEFT JOIN attempts ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -618,7 +618,7 @@ WHERE user = %s AND `state` = 'running';
             ):
                 async for record in self.db.select_and_fetchall(
                     '''
-SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep
+SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep, time_ready
 FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_inst_coll_cancelled)
 WHERE jobs.batch_id = %s AND inst_coll = %s AND jobs.state = 'Ready' AND always_run = 1
 ORDER BY jobs.batch_id, inst_coll, state, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id
@@ -635,7 +635,7 @@ LIMIT 300;
                 if not batch['cancelled']:
                     async for record in self.db.select_and_fetchall(
                         '''
-SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep
+SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep, time_ready
 FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
 WHERE jobs.batch_id = %s AND inst_coll = %s AND jobs.state = 'Ready' AND always_run = 0 AND cancelled = 0
 ORDER BY jobs.batch_id, inst_coll, state, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -620,6 +620,7 @@ WHERE user = %s AND `state` = 'running';
                     '''
 SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep, time_ready
 FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_inst_coll_cancelled)
+LEFT JOIN jobs_telemetry ON jobs.batch_id = jobs_telemetry.batch_id AND jobs.job_id = jobs_telemetry.job_id
 WHERE jobs.batch_id = %s AND inst_coll = %s AND jobs.state = 'Ready' AND always_run = 1
 ORDER BY jobs.batch_id, inst_coll, state, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id
 LIMIT 300;
@@ -637,6 +638,7 @@ LIMIT 300;
                         '''
 SELECT jobs.job_id, spec, cores_mcpu, regions_bits_rep, time_ready
 FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
+LEFT JOIN jobs_telemetry ON jobs.batch_id = jobs_telemetry.batch_id AND jobs.job_id = jobs_telemetry.job_id
 WHERE jobs.batch_id = %s AND inst_coll = %s AND jobs.state = 'Ready' AND always_run = 0 AND cancelled = 0
 ORDER BY jobs.batch_id, inst_coll, state, always_run, -n_regions DESC, regions_bits_rep, jobs.job_id
 LIMIT 300;

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -434,6 +434,7 @@ users:
         'user': record['user'],
         'gsa_key': gsa_key,
         'job_spec': job_spec,
+        'queue_time': time_msecs() - record['time_ready'] if record['time_ready'] else None,
     }
 
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -185,8 +185,8 @@ async def get_check_invariants(request, userdata):  # pylint: disable=unused-arg
 
 
 @routes.patch('/api/v1alpha/batches/{user}/{batch_id}/update')
-@add_metadata_to_request
 @batch_only
+@add_metadata_to_request
 async def update_batch(request):
     db = request.app['db']
 
@@ -270,8 +270,8 @@ async def get_credentials(request, instance):  # pylint: disable=unused-argument
 
 
 @routes.post('/api/v1alpha/instances/activate')
-@add_metadata_to_request
 @activating_instances_only
+@add_metadata_to_request
 async def activate_instance(request, instance):
     return await asyncio.shield(activate_instance_1(request, instance))
 
@@ -283,8 +283,8 @@ async def deactivate_instance_1(instance):
 
 
 @routes.post('/api/v1alpha/instances/deactivate')
-@add_metadata_to_request
 @active_instances_only
+@add_metadata_to_request
 async def deactivate_instance(request, instance):  # pylint: disable=unused-argument
     await asyncio.shield(deactivate_instance_1(instance))
     return web.Response()
@@ -361,8 +361,8 @@ async def job_complete_1(request, instance):
 
 
 @routes.post('/api/v1alpha/instances/job_complete')
-@add_metadata_to_request
 @active_instances_only
+@add_metadata_to_request
 async def job_complete(request, instance):
     return await asyncio.shield(job_complete_1(request, instance))
 
@@ -388,8 +388,8 @@ async def job_started_1(request, instance):
 
 
 @routes.post('/api/v1alpha/instances/job_started')
-@add_metadata_to_request
 @active_instances_only
+@add_metadata_to_request
 async def job_started(request, instance):
     return await asyncio.shield(job_started_1(request, instance))
 
@@ -426,8 +426,8 @@ SET rollup_time = %s
 
 
 @routes.post('/api/v1alpha/billing_update')
-@add_metadata_to_request
 @active_instances_only
+@add_metadata_to_request
 async def billing_update(request, instance):
     return await asyncio.shield(billing_update_1(request, instance))
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -270,6 +270,7 @@ async def get_credentials(request, instance):  # pylint: disable=unused-argument
 
 
 @routes.post('/api/v1alpha/instances/activate')
+@add_metadata_to_request
 @activating_instances_only
 async def activate_instance(request, instance):
     return await asyncio.shield(activate_instance_1(request, instance))
@@ -282,6 +283,7 @@ async def deactivate_instance_1(instance):
 
 
 @routes.post('/api/v1alpha/instances/deactivate')
+@add_metadata_to_request
 @active_instances_only
 async def deactivate_instance(request, instance):  # pylint: disable=unused-argument
     await asyncio.shield(deactivate_instance_1(instance))
@@ -424,6 +426,7 @@ SET rollup_time = %s
 
 
 @routes.post('/api/v1alpha/billing_update')
+@add_metadata_to_request
 @active_instances_only
 async def billing_update(request, instance):
     return await asyncio.shield(billing_update_1(request, instance))

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1124,8 +1124,8 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
             try:
                 await tx.execute_many(
                     '''
-INSERT INTO jobs (batch_id, job_id, update_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll, n_regions, regions_bits_rep, time_ready)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+INSERT INTO jobs (batch_id, job_id, update_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll, n_regions, regions_bits_rep)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
 ''',
                     jobs_args,
                     query_name='insert_jobs',

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -268,8 +268,8 @@ WHERE id = %s AND NOT deleted;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def get_jobs_v1(request, userdata, batch_id):  # pylint: disable=unused-argument
     q = request.query.get('q', '')
     last_job_id = request.query.get('last_job_id')
@@ -280,8 +280,8 @@ async def get_jobs_v1(request, userdata, batch_id):  # pylint: disable=unused-ar
 
 
 @routes.get('/api/v2alpha/batches/{batch_id}/jobs')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def get_jobs_v2(request, userdata, batch_id):  # pylint: disable=unused-argument
     q = request.query.get('q', '')
     last_job_id = request.query.get('last_job_id')
@@ -565,8 +565,8 @@ async def _get_full_job_status(app, record):
 
 # deprecated
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def get_job_log(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
     job_log_bytes = await _get_job_log(request.app, batch_id, job_id)
@@ -594,8 +594,8 @@ async def get_job_container_log(request, batch_id):
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log/{container}')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def rest_get_job_container_log(request, userdata, batch_id):  # pylint: disable=unused-argument
     return await get_job_container_log(request, batch_id)
 
@@ -732,8 +732,8 @@ ORDER BY id DESC;
 
 
 @routes.get('/api/v1alpha/batches')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def get_batches(request, userdata):  # pylint: disable=unused-argument
     user = userdata['username']
     q = request.query.get('q', f'user:{user}')
@@ -758,8 +758,8 @@ def check_service_account_permissions(user, sa):
 
 # Deprecated. Use create_jobs_for_update instead
 @routes.post('/api/v1alpha/batches/{batch_id}/jobs/create')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def create_jobs(request: aiohttp.web.Request, userdata: dict):
     app = request.app
     batch_id = int(request.match_info['batch_id'])
@@ -768,8 +768,8 @@ async def create_jobs(request: aiohttp.web.Request, userdata: dict):
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/updates/{update_id}/jobs/create')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def create_jobs_for_update(request: aiohttp.web.Request, userdata: dict):
     app = request.app
 
@@ -1249,8 +1249,8 @@ VALUES (%s, %s, %s);
 
 
 @routes.post('/api/v1alpha/batches/create-fast')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def create_batch_fast(request, userdata):
     app = request.app
     db: Database = app['db']
@@ -1273,8 +1273,8 @@ async def create_batch_fast(request, userdata):
 
 
 @routes.post('/api/v1alpha/batches/create')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def create_batch(request, userdata):
     app = request.app
     db: Database = app['db']
@@ -1407,8 +1407,8 @@ VALUES (%s, %s, %s)
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/update-fast')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def update_batch_fast(request, userdata):
     app = request.app
     db: Database = app['db']
@@ -1440,8 +1440,8 @@ async def update_batch_fast(request, userdata):
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/updates/create')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def create_update(request, userdata):
     app = request.app
     db: Database = app['db']
@@ -1597,15 +1597,15 @@ WHERE id = %s AND NOT deleted;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def get_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     return json_response(await _get_batch(request.app, batch_id))
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     await _handle_api_error(_cancel_batch, request.app, batch_id)
     return web.Response()
@@ -1613,8 +1613,8 @@ async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-a
 
 # deprecated
 @routes.patch('/api/v1alpha/batches/{batch_id}/close')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def close_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1649,8 +1649,8 @@ WHERE batch_id = %s AND update_id = 1;
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/updates/{update_id}/commit')
-@add_metadata_to_request
 @auth.rest_authenticated_users_only
+@add_metadata_to_request
 async def commit_update(request: web.Request, userdata):
     app = request.app
     db: Database = app['db']
@@ -1704,8 +1704,8 @@ async def _commit_update(app: web.Application, batch_id: int, update_id: int, us
 
 
 @routes.delete('/api/v1alpha/batches/{batch_id}')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def delete_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     await _delete_batch(request.app, batch_id)
     return web.Response()
@@ -1907,8 +1907,8 @@ async def get_attempts(request, userdata, batch_id):  # pylint: disable=unused-a
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
-@add_metadata_to_request
 @rest_billing_project_users_only
+@add_metadata_to_request
 async def get_job(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
     status = await _get_job(request.app, batch_id, job_id)

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -52,11 +52,11 @@ def add_metadata_to_request(fun):
 
         batch_id = request.match_info.get('batch_id')
         if batch_id is not None:
-            request['batch_id'] = batch_id
+            request['batch_telemetry']['batch_id'] = batch_id
 
         job_id = request.match_info.get('job_id')
         if job_id is not None:
-            request['job_id'] = job_id
+            request['batch_telemetry']['job_id'] = job_id
 
         return await fun(request, *args, **kwargs)
 

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -45,6 +45,24 @@ def batch_only(fun):
     return wrapped
 
 
+def add_metadata_to_request(fun):
+    @wraps(fun)
+    async def wrapped(request, *args, **kwargs):
+        request['batch_telemetry'] = {'operation': fun.__name__}
+
+        batch_id = request.match_info.get('batch_id')
+        if batch_id is not None:
+            request['batch_id'] = batch_id
+
+        job_id = request.match_info.get('job_id')
+        if job_id is not None:
+            request['job_id'] = job_id
+
+        return await fun(request, *args, **kwargs)
+
+    return wrapped
+
+
 def coalesce(x, default):
     if x is not None:
         return x

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -84,7 +84,7 @@ from ..instance_config import InstanceConfig
 from ..publicly_available_images import publicly_available_images
 from ..resource_usage import ResourceUsageMonitor
 from ..semaphore import FIFOWeightedSemaphore
-from ..utils import Box
+from ..utils import Box, add_metadata_to_request
 from ..worker.worker_api import CloudDisk, CloudWorkerAPI, ContainerRegistryCredentials
 from .credentials import CloudUserCredentials
 from .jvm_entryway_protocol import EndOfStream, read_bool, read_int, read_str, write_int, write_str
@@ -2977,6 +2977,7 @@ class Worker:
             if not user_error(e):
                 log.exception(f'while running {job}, ignoring')
 
+    @add_metadata_to_request
     async def create_job_1(self, request):
         body = await json_request(request)
 
@@ -3009,7 +3010,6 @@ class Worker:
 
         request['batch_id'] = str(batch_id)
         request['job_id'] = str(job_id)
-        request['batch_operation'] = 'worker_create_job'
         request['job_queue_time'] = str(body['queue_time'])
 
         # already running
@@ -3082,6 +3082,7 @@ class Worker:
         job = self._job_from_request(request)
         return json_response(job.status())
 
+    @add_metadata_to_request
     async def delete_job_1(self, request):
         batch_id = int(request.match_info['batch_id'])
         job_id = int(request.match_info['job_id'])
@@ -3089,7 +3090,6 @@ class Worker:
 
         request['batch_id'] = str(batch_id)
         request['job_id'] = str(job_id)
-        request['batch_operation'] = 'worker_delete_job'
 
         if id not in self.jobs:
             raise web.HTTPNotFound()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -114,11 +114,13 @@ warnings.warn = deeper_stack_level_warn
 class BatchWorkerAccessLogger(AccessLogger):
     def __init__(self, logger: logging.Logger, log_format: str):
         super().__init__(logger, log_format)
-
-        self.exclude = [
-            ('GET', re.compile('/healthcheck')),
-            ('POST', re.compile('/api/v1alpha/batches/jobs/create')),
-        ]
+        if NAMESPACE == 'default':
+            self.exclude = [
+                ('GET', re.compile('/healthcheck')),
+                ('POST', re.compile('/api/v1alpha/batches/jobs/create')),
+            ]
+        else:
+            self.exclude = []
 
     def log(self, request, response, time):
         for method, path_expr in self.exclude:
@@ -3005,6 +3007,11 @@ class Worker:
         assert job_spec['job_id'] == job_id
         id = (batch_id, job_id)
 
+        request['batch_id'] = str(batch_id)
+        request['job_id'] = str(job_id)
+        request['batch_operation'] = 'worker_create_job'
+        request['job_queue_time'] = str(body['queue_time'])
+
         # already running
         if id in self.jobs:
             return web.HTTPForbidden()
@@ -3079,6 +3086,10 @@ class Worker:
         batch_id = int(request.match_info['batch_id'])
         job_id = int(request.match_info['job_id'])
         id = (batch_id, job_id)
+
+        request['batch_id'] = str(batch_id)
+        request['job_id'] = str(job_id)
+        request['batch_operation'] = 'worker_delete_job'
 
         if id not in self.jobs:
             raise web.HTTPNotFound()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -3008,9 +3008,9 @@ class Worker:
         assert job_spec['job_id'] == job_id
         id = (batch_id, job_id)
 
-        request['batch_id'] = str(batch_id)
-        request['job_id'] = str(job_id)
-        request['job_queue_time'] = str(body['queue_time'])
+        request['batch_telemetry']['batch_id'] = str(batch_id)
+        request['batch_telemetry']['job_id'] = str(job_id)
+        request['batch_telemetry']['job_queue_time'] = str(body['queue_time'])
 
         # already running
         if id in self.jobs:

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -3008,6 +3008,7 @@ class Worker:
         id = (batch_id, job_id)
 
         request['batch_telemetry'] = {
+            'operation': 'create_job',
             'batch_id': str(batch_id),
             'job_id': str(job_id),
             'job_queue_time': str(body['queue_time']),
@@ -3089,6 +3090,7 @@ class Worker:
         id = (batch_id, job_id)
 
         request['batch_telemetry'] = {
+            'operation': 'delete_job',
             'batch_id': str(batch_id),
             'job_id': str(job_id),
         }

--- a/batch/sql/add-jobs-ready-time.sql
+++ b/batch/sql/add-jobs-ready-time.sql
@@ -1,4 +1,10 @@
-ALTER TABLE `jobs` ADD COLUMN `time_ready` BIGINT DEFAULT NULL, ALGORITHM=INSTANT;
+CREATE TABLE IF NOT EXISTS `jobs_telemetry` (
+  `batch_id` BIGINT NOT NULL,
+  `job_id` INT NOT NULL,
+  `time_ready` BIGINT DEFAULT NULL,
+  PRIMARY KEY (`batch_id`, `job_id`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
+) ENGINE = InnoDB;
 
 DELIMITER $$
 
@@ -56,7 +62,7 @@ BEGIN
       IF in_update_id != 1 THEN
         SELECT start_job_id INTO cur_update_start_job_id FROM batch_updates WHERE batch_id = in_batch_id AND update_id = in_update_id;
 
-        UPDATE jobs
+        UPDATE jobs, jobs_telemetry
           LEFT JOIN (
             SELECT `job_parents`.batch_id, `job_parents`.job_id,
               COALESCE(SUM(1), 0) AS n_parents,
@@ -75,7 +81,7 @@ BEGIN
           SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
               jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
               jobs.cancelled = IF(COALESCE(t.n_succeeded, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1),
-              jobs.time_ready = IF(COALESCE(t.n_pending_parents, 0) = 0 AND jobs.time_ready IS NULL, in_timestamp, jobs.time_ready)
+              jobs_telemetry.time_ready = IF(COALESCE(t.n_pending_parents, 0) = 0 AND jobs_telemetry.time_ready IS NULL, in_timestamp, jobs_telemetry.time_ready)
           WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
               jobs.job_id < cur_update_start_job_id + staging_n_jobs;
       END IF;
@@ -171,14 +177,14 @@ BEGIN
       WHERE id = in_batch_id;
     END IF;
 
-    UPDATE jobs
+    UPDATE jobs, jobs_telemetry
       INNER JOIN `job_parents`
         ON jobs.batch_id = `job_parents`.batch_id AND
            jobs.job_id = `job_parents`.job_id
       SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
           jobs.n_pending_parents = jobs.n_pending_parents - 1,
           jobs.cancelled = IF(new_state = 'Success', jobs.cancelled, 1),
-          jobs.time_ready = IF(jobs.n_pending_parents = 1, new_timestamp, jobs.time_ready)
+          jobs_telemetry.time_ready = IF(jobs.n_pending_parents = 1, new_timestamp, jobs_telemetry.time_ready)
       WHERE jobs.batch_id = in_batch_id AND
             `job_parents`.batch_id = in_batch_id AND
             `job_parents`.parent_id = in_job_id;

--- a/batch/sql/add-jobs-ready-time.sql
+++ b/batch/sql/add-jobs-ready-time.sql
@@ -1,0 +1,205 @@
+ALTER TABLE `jobs` ADD COLUMN `time_ready` BIGINT DEFAULT NULL, ALGORITHM=INSTANT;
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS commit_batch_update $$
+CREATE PROCEDURE commit_batch_update(
+  IN in_batch_id BIGINT,
+  IN in_update_id INT,
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_update_committed BOOLEAN;
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE cur_update_start_job_id INT;
+
+  START TRANSACTION;
+
+  SELECT committed, n_jobs INTO cur_update_committed, expected_n_jobs
+  FROM batch_updates
+  WHERE batch_id = in_batch_id AND update_id = in_update_id
+  FOR UPDATE;
+
+  IF cur_update_committed THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT COALESCE(SUM(n_jobs), 0) INTO staging_n_jobs
+    FROM batches_inst_coll_staging
+    WHERE batch_id = in_batch_id AND update_id = in_update_id
+    FOR UPDATE;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      UPDATE batch_updates
+      SET committed = 1, time_committed = in_timestamp
+      WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+      UPDATE batches SET
+        `state` = 'running',
+        time_completed = NULL,
+        n_jobs = n_jobs + expected_n_jobs
+      WHERE id = in_batch_id;
+
+      INSERT INTO user_inst_coll_resources (user, inst_coll, token, n_ready_jobs, ready_cores_mcpu)
+      SELECT user, inst_coll, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
+      FROM batches_inst_coll_staging
+      JOIN batches ON batches.id = batches_inst_coll_staging.batch_id
+      WHERE batch_id = in_batch_id AND update_id = in_update_id
+      GROUP BY `user`, inst_coll
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
+
+      DELETE FROM batches_inst_coll_staging WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+      IF in_update_id != 1 THEN
+        SELECT start_job_id INTO cur_update_start_job_id FROM batch_updates WHERE batch_id = in_batch_id AND update_id = in_update_id;
+
+        UPDATE jobs
+          LEFT JOIN (
+            SELECT `job_parents`.batch_id, `job_parents`.job_id,
+              COALESCE(SUM(1), 0) AS n_parents,
+              COALESCE(SUM(state IN ('Pending', 'Ready', 'Creating', 'Running')), 0) AS n_pending_parents,
+              COALESCE(SUM(state = 'Success'), 0) AS n_succeeded
+            FROM `job_parents`
+            LEFT JOIN `jobs` ON jobs.batch_id = `job_parents`.batch_id AND jobs.job_id = `job_parents`.parent_id
+            WHERE job_parents.batch_id = in_batch_id AND
+              `job_parents`.job_id >= cur_update_start_job_id AND
+              `job_parents`.job_id < cur_update_start_job_id + staging_n_jobs
+            GROUP BY `job_parents`.batch_id, `job_parents`.job_id
+            FOR UPDATE
+          ) AS t
+            ON jobs.batch_id = t.batch_id AND
+               jobs.job_id = t.job_id
+          SET jobs.state = IF(COALESCE(t.n_pending_parents, 0) = 0, 'Ready', 'Pending'),
+              jobs.n_pending_parents = COALESCE(t.n_pending_parents, 0),
+              jobs.cancelled = IF(COALESCE(t.n_succeeded, 0) = COALESCE(t.n_parents - t.n_pending_parents, 0), jobs.cancelled, 1),
+              jobs.time_ready = IF(COALESCE(t.n_pending_parents, 0) = 0 AND jobs.time_ready IS NULL, in_timestamp, jobs.time_ready)
+          WHERE jobs.batch_id = in_batch_id AND jobs.job_id >= cur_update_start_job_id AND
+              jobs.job_id < cur_update_start_job_id + staging_n_jobs;
+      END IF;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 1 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS mark_job_complete $$
+CREATE PROCEDURE mark_job_complete(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_state VARCHAR(40),
+  IN new_status TEXT,
+  IN new_start_time BIGINT,
+  IN new_end_time BIGINT,
+  IN new_reason VARCHAR(40),
+  IN new_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE delta_cores_mcpu INT DEFAULT 0;
+  DECLARE total_jobs_in_batch INT;
+  DECLARE expected_attempt_id VARCHAR(40);
+
+  START TRANSACTION;
+
+  SELECT n_jobs INTO total_jobs_in_batch FROM batches WHERE id = in_batch_id;
+
+  SELECT state, cores_mcpu
+  INTO cur_job_state, cur_cores_mcpu
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  SELECT end_time INTO cur_end_time FROM attempts
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id
+  FOR UPDATE;
+
+  UPDATE attempts
+  SET start_time = new_start_time, rollup_time = new_end_time, end_time = new_end_time, reason = new_reason
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+  IF cur_instance_state = 'active' AND cur_end_time IS NULL THEN
+    UPDATE instances_free_cores_mcpu
+    SET free_cores_mcpu = free_cores_mcpu + cur_cores_mcpu
+    WHERE instances_free_cores_mcpu.name = in_instance_name;
+
+    SET delta_cores_mcpu = delta_cores_mcpu + cur_cores_mcpu;
+  END IF;
+
+  SELECT attempt_id INTO expected_attempt_id FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  IF expected_attempt_id IS NOT NULL AND expected_attempt_id != in_attempt_id THEN
+    COMMIT;
+    SELECT 2 as rc,
+      expected_attempt_id,
+      delta_cores_mcpu,
+      'input attempt id does not match expected attempt id' as message;
+  ELSEIF cur_job_state = 'Ready' OR cur_job_state = 'Creating' OR cur_job_state = 'Running' THEN
+    UPDATE jobs
+    SET state = new_state, status = new_status, attempt_id = in_attempt_id
+    WHERE batch_id = in_batch_id AND job_id = in_job_id;
+
+    UPDATE batches_n_jobs_in_complete_states
+      SET n_completed = (@new_n_completed := n_completed + 1),
+          n_cancelled = n_cancelled + (new_state = 'Cancelled'),
+          n_failed    = n_failed + (new_state = 'Error' OR new_state = 'Failed'),
+          n_succeeded = n_succeeded + (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed')
+      WHERE id = in_batch_id;
+
+    # Grabbing an exclusive lock on batches here could deadlock,
+    # but this IF should only execute for the last job
+    IF @new_n_completed = total_jobs_in_batch THEN
+      UPDATE batches
+      SET time_completed = new_timestamp,
+          `state` = 'complete'
+      WHERE id = in_batch_id;
+    END IF;
+
+    UPDATE jobs
+      INNER JOIN `job_parents`
+        ON jobs.batch_id = `job_parents`.batch_id AND
+           jobs.job_id = `job_parents`.job_id
+      SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
+          jobs.n_pending_parents = jobs.n_pending_parents - 1,
+          jobs.cancelled = IF(new_state = 'Success', jobs.cancelled, 1),
+          jobs.time_ready = IF(jobs.n_pending_parents = 1, new_timestamp, jobs.time_ready)
+      WHERE jobs.batch_id = in_batch_id AND
+            `job_parents`.batch_id = in_batch_id AND
+            `job_parents`.parent_id = in_job_id;
+
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSEIF cur_job_state = 'Cancelled' OR cur_job_state = 'Error' OR
+         cur_job_state = 'Failed' OR cur_job_state = 'Success' THEN
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc,
+      cur_job_state,
+      delta_cores_mcpu,
+      'job state not Ready, Creating, Running or complete' as message;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/batch/sql/add-jobs-ready-time.sql
+++ b/batch/sql/add-jobs-ready-time.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `jobs_telemetry` (
   `job_id` INT NOT NULL,
   `time_ready` BIGINT DEFAULT NULL,
   PRIMARY KEY (`batch_id`, `job_id`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
 DELIMITER $$

--- a/batch/sql/add-jobs-ready-time.sql
+++ b/batch/sql/add-jobs-ready-time.sql
@@ -62,7 +62,8 @@ BEGIN
       IF in_update_id != 1 THEN
         SELECT start_job_id INTO cur_update_start_job_id FROM batch_updates WHERE batch_id = in_batch_id AND update_id = in_update_id;
 
-        UPDATE jobs, jobs_telemetry
+        UPDATE jobs
+          LEFT JOIN `jobs_telemetry` ON `jobs_telemetry`.batch_id = jobs.batch_id AND `jobs_telemetry`.job_id = jobs.job_id
           LEFT JOIN (
             SELECT `job_parents`.batch_id, `job_parents`.job_id,
               COALESCE(SUM(1), 0) AS n_parents,
@@ -177,7 +178,8 @@ BEGIN
       WHERE id = in_batch_id;
     END IF;
 
-    UPDATE jobs, jobs_telemetry
+    UPDATE jobs
+      LEFT JOIN `jobs_telemetry` ON `jobs_telemetry`.batch_id = jobs.batch_id AND `jobs_telemetry`.job_id = jobs.job_id
       INNER JOIN `job_parents`
         ON jobs.batch_id = `job_parents`.batch_id AND
            jobs.job_id = `job_parents`.job_id

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -279,7 +279,7 @@ CREATE TABLE IF NOT EXISTS `jobs_telemetry` (
   `job_id` INT NOT NULL,
   `time_ready` BIGINT DEFAULT NULL,
   PRIMARY KEY (`batch_id`, `job_id`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `batch_bunches` (

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1226,7 +1226,8 @@ BEGIN
       IF in_update_id != 1 THEN
         SELECT start_job_id INTO cur_update_start_job_id FROM batch_updates WHERE batch_id = in_batch_id AND update_id = in_update_id;
 
-        UPDATE jobs, jobs_telemetry
+        UPDATE jobs
+          LEFT JOIN `jobs_telemetry` ON `jobs_telemetry`.batch_id = jobs.batch_id AND `jobs_telemetry`.job_id = jobs.job_id
           LEFT JOIN (
             SELECT `job_parents`.batch_id, `job_parents`.job_id,
               COALESCE(SUM(1), 0) AS n_parents,
@@ -1719,7 +1720,8 @@ BEGIN
       WHERE id = in_batch_id;
     END IF;
 
-    UPDATE jobs, jobs_telemetry
+    UPDATE jobs
+      LEFT JOIN `jobs_telemetry` ON `jobs_telemetry`.batch_id = jobs.batch_id AND `jobs_telemetry`.job_id = jobs.job_id
       INNER JOIN `job_parents`
         ON jobs.batch_id = `job_parents`.batch_id AND
            jobs.job_id = `job_parents`.job_id

--- a/build.yaml
+++ b/build.yaml
@@ -2267,6 +2267,9 @@ steps:
       - name: dedup-billing-project-users-by-date
         script: /io/sql/dedup_billing_project_users_by_date.py
         online: true
+      - name: add-jobs-ready-time
+        script: /io/sql/add-jobs-ready-time.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -60,22 +60,6 @@ class AccessLogger(AbstractAccessLogger):
             'x_real_ip': request.headers.get("X-Real-IP")
         }
 
-        batch_id = request.get('batch_id')
-        if batch_id:
-            extra['batch_id'] = batch_id
-
-        job_id = request.get('job_id')
-        if job_id:
-            extra['job_id'] = job_id
-
-        batch_operation = request.get('batch_operation')
-        if batch_operation:
-            extra['batch_operation'] = batch_operation
-
-        job_queue_time = request.get('job_queue_time')
-        if job_queue_time:
-            extra['job_queue_time'] = job_queue_time
-
         self.logger.info(f'{request.scheme} {request.method} {request.path} '
                          f'done in {time}s: {response.status}',
-                         extra=extra)
+                         extra={**extra, **request.get('batch_telemetry', {})})

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -51,10 +51,31 @@ class AccessLogger(AbstractAccessLogger):
         now = datetime.datetime.now(tz)
         start_time = now - datetime.timedelta(seconds=time)
         start_time_str = start_time.strftime('[%d/%b/%Y:%H:%M:%S %z]')
+
+        extra = {
+            'remote_address': request.remote,
+            'request_start_time': start_time_str,
+            'request_duration': time,
+            'response_status': response.status,
+            'x_real_ip': request.headers.get("X-Real-IP")
+        }
+
+        batch_id = request.get('batch_id')
+        if batch_id:
+            extra['batch_id'] = batch_id
+
+        job_id = request.get('job_id')
+        if job_id:
+            extra['job_id'] = job_id
+
+        batch_operation = request.get('batch_operation')
+        if batch_operation:
+            extra['batch_operation'] = batch_operation
+
+        job_queue_time = request.get('job_queue_time')
+        if job_queue_time:
+            extra['job_queue_time'] = job_queue_time
+
         self.logger.info(f'{request.scheme} {request.method} {request.path} '
                          f'done in {time}s: {response.status}',
-                         extra={'remote_address': request.remote,
-                                'request_start_time': start_time_str,
-                                'request_duration': time,
-                                'response_status': response.status,
-                                'x_real_ip': request.headers.get("X-Real-IP")})
+                         extra=extra)


### PR DESCRIPTION
I realize this looks like a lot of code changes, but it's mostly copying and pasting two SQL procedures and changing one line in each.

This adds 4 bits of metadata to requests that then can be queried as extra metadata:
- batch_id
- job_id
- batch_operation
- job_queue_time

Should be self-explanatory except job_queue time is the time in which the job is first set to ready to when it was scheduled on the worker (exact moment is when the job config is made to send to the worker).

Example logging query. Note that the search on "batch_id" is not optimized so you definitely want to add some kind of time limit that's short on the window to search. I can add my Python script that scrapes these logs and makes a Plotly figure in a separate PR once this goes in.

```
(
resource.labels.container_name="batch"
resource.labels.namespace_name="{namespace}"
) OR (
resource.labels.container_name="batch-driver"
resource.labels.namespace_name="{namespace}"
) OR (
resource.type="gce_instance"
logName:"worker.log"
labels."compute.googleapis.com/resource_name":"{namespace}"
)
jsonPayload.batch_id="{batch_id}"
timestamp >= "{start_timestamp}" {end_timestamp}
```