### PR TITLE
[auth] Only resolve the identity UID for active users

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -547,7 +547,10 @@ async def update_users(app):
         await delete_user(app, user)
 
     users_without_hail_identity_uid = [
-        x async for x in db.execute_and_fetchall('SELECT * FROM users WHERE hail_identity_uid IS NULL')
+        x
+        async for x in db.execute_and_fetchall(
+            "SELECT * FROM users WHERE state = 'active' AND hail_identity_uid IS NULL"
+        )
     ]
     for user in users_without_hail_identity_uid:
         await resolve_identity_uid(app, user['hail_identity'])


### PR DESCRIPTION
For deleted users the request to look up the AAD application can fail with a 404, and we don't need to gather this information for deleted users anyway.