### PR TITLE
[lint] runs black on hail/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,22 @@ check-all: check-hail check-services
 
 .PHONY: check-hail-fast
 check-hail-fast:
-	ruff check hail/python/hail
-	ruff check hail/python/hailtop
+	for SUBDIR in hail hailtop cluster-tests test; do \
+		DIR=hail/python/$$SUBDIR; \
+		ruff check $$DIR; \
+	done
+	$(PYTHON) -m black hail --check --diff
 	$(PYTHON) -m mypy --config-file setup.cfg hail/python/hailtop
 
-.PHONY: pylint-hailtop
-pylint-hailtop:
+.PHONY: pylint-hail
+pylint-hail:
 	# pylint on hail is still a work in progress
-	$(PYTHON) -m pylint --rcfile pylintrc hail/python/hailtop --score=n
+	for DIR in hail hailtop cluster-tests test; do \
+		$(PYTHON) -m pylint --rcfile pylintrc hail/python/$$DIR --score=n; \
+	done
 
 .PHONY: check-hail
-check-hail: check-hail-fast pylint-hailtop
+check-hail: check-hail-fast pylint-hail pylint-hailtop
 
 .PHONY: check-services
 check-services: $(CHECK_SERVICES_MODULES)

--- a/build.yaml
+++ b/build.yaml
@@ -1042,9 +1042,15 @@ steps:
 
       exit_status=0
 
-      ruff check --config pyproject.toml --ignore I --ignore PL --ignore RUF $SITE_PACKAGES/hail || exit_status=$?
-      ruff check --config pyproject.toml --ignore I $SITE_PACKAGES/hailtop || exit_status=$?
-      python3 -m pylint --rcfile pylintrc hailtop || exit_status=$?
+      for SUBDIR in hail hailtop
+      do
+        DIR=$SITE_PACKAGES/$SUBDIR
+        ruff check --config pyproject.toml $DIR || exit_status=$?
+        python3 -m pylint --rcfile pylintrc $DIR || exit_status=$?
+      done
+
+      python3 -m black . --check --diff || exit_status=$?
+
       # working around this: https://github.com/python/mypy/issues/7087
       ln -s $SITE_PACKAGES/hailtop hailtop
       mypy --config-file /setup.cfg -p hailtop || exit_status=$?
@@ -1062,9 +1068,15 @@ steps:
 
       exit_status=0
 
-      ruff check --config pyproject.toml --ignore I --ignore PL --ignore RUF $SITE_PACKAGES/hail || exit_status=$?
-      ruff check --config pyproject.toml --ignore I $SITE_PACKAGES/hailtop || exit_status=$?
-      python3 -m pylint --rcfile pylintrc hailtop || exit_status=$?
+      for SUBDIR in hail hailtop
+      do
+        DIR=$SITE_PACKAGES/$SUBDIR
+        ruff check --config pyproject.toml $DIR || exit_status=$?
+        python3 -m pylint --rcfile pylintrc $DIR || exit_status=$?
+      done
+
+      python3 -m black . --check --diff || exit_status=$?
+
       # working around this: https://github.com/python/mypy/issues/7087
       ln -s $SITE_PACKAGES/hailtop hailtop
       mypy --config-file /setup.cfg -p hailtop || exit_status=$?

--- a/hail/generate_splits.py
+++ b/hail/generate_splits.py
@@ -15,27 +15,21 @@ def partition(k, ls):
     out = []
     start = 0
     for part in parts:
-        out.append(ls[start:start + part])
+        out.append(ls[start : start + part])
         start += part
     return out
 
 
-sp.run("find src/test \\( -name \"*.scala\" -o -name \"*.java\" \\) -type f > classes",
-       shell=True,
-       check=True)
+sp.run("find src/test \\( -name \"*.scala\" -o -name \"*.java\" \\) -type f > classes", shell=True, check=True)
 
 n_splits = int(os.environ['TESTNG_SPLITS'])
 
 with open('classes', 'r') as f:
     foo = f.readlines()
-    classes = [x.replace('src/test/scala/', '')
-                .replace('.scala\n', '')
-                .replace('.java\n', '')
-                .replace('/', '.')
-               for x in foo]
-    classes = [cls for cls in classes
-               if not cls.startswith('is.hail.services')
-               if not cls.startswith('is.hail.fs')]
+    classes = [
+        x.replace('src/test/scala/', '').replace('.scala\n', '').replace('.java\n', '').replace('/', '.') for x in foo
+    ]
+    classes = [cls for cls in classes if not cls.startswith('is.hail.services') if not cls.startswith('is.hail.fs')]
 
 random.shuffle(classes, lambda: 0.0)
 

--- a/hail/python/setup-hailtop.py
+++ b/hail/python/setup-hailtop.py
@@ -14,20 +14,14 @@ setup(
         'Repository': 'https://github.com/hail-is/hail',
     },
     packages=find_packages('.'),
-    package_dir={
-        'hailtop': 'hailtop'},
-    package_data={
-        "hailtop": ["py.typed", "hail_version"],
-        'hailtop.hailctl': ['hail_version', 'deploy.yaml']
-    },
+    package_dir={'hailtop': 'hailtop'},
+    package_data={"hailtop": ["py.typed", "hail_version"], 'hailtop.hailctl': ['hail_version', 'deploy.yaml']},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
     ],
     python_requires=">=3.8",
-    entry_points={
-        'console_scripts': ['hailctl = hailtop.hailctl.__main__:main']
-    },
+    entry_points={'console_scripts': ['hailctl = hailtop.hailctl.__main__:main']},
     setup_requires=["pytest-runner", "wheel"],
     include_package_data=True,
 )

--- a/hail/python/setup.py
+++ b/hail/python/setup.py
@@ -19,6 +19,7 @@ with open('requirements.txt', 'r') as f:
 
         pkg = stripped
 
+
 def add_dependencies(fname):
     with open(fname, 'r') as f:
         for line in f:
@@ -28,7 +29,7 @@ def add_dependencies(fname):
             if stripped.startswith('-c'):
                 continue
             if stripped.startswith('-r'):
-                additional_requirements = stripped[len('-r'):].strip()
+                additional_requirements = stripped[len('-r') :].strip()
                 add_dependencies(additional_requirements)
                 continue
             pkg = stripped
@@ -39,6 +40,8 @@ def add_dependencies(fname):
                 dependencies.append(f'pyspark>={major}.{minor},<{int(major)+1}')
             else:
                 dependencies.append(pkg)
+
+
 add_dependencies('requirements.txt')
 
 setup(
@@ -56,26 +59,20 @@ setup(
         'Change Log': 'https://hail.is/docs/0.2/change_log.html',
     },
     packages=find_packages('.'),
-    package_dir={
-        'hail': 'hail',
-        'hailtop': 'hailtop'},
+    package_dir={'hail': 'hail', 'hailtop': 'hailtop'},
     package_data={
-        'hail': ['hail_pip_version',
-                 'hail_version',
-                 'hail_revision',
-                 'experimental/datasets.json'],
+        'hail': ['hail_pip_version', 'hail_version', 'hail_revision', 'experimental/datasets.json'],
         'hail.backend': ['hail-all-spark.jar'],
         'hailtop': ['hail_version', 'py.typed'],
-        'hailtop.hailctl': ['hail_version', 'deploy.yaml']},
+        'hailtop.hailctl': ['hail_version', 'deploy.yaml'],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
     ],
     python_requires=">=3.8",
     install_requires=dependencies,
-    entry_points={
-        'console_scripts': ['hailctl = hailtop.hailctl.__main__:main']
-    },
+    entry_points={'console_scripts': ['hailctl = hailtop.hailctl.__main__:main']},
     setup_requires=["pytest-runner", "wheel"],
     tests_require=["pytest"],
     include_package_data=True,

--- a/hail/scripts/test_requester_pays_parsing.py
+++ b/hail/scripts/test_requester_pays_parsing.py
@@ -9,11 +9,14 @@ from hailtop.config.user_config import configuration_of, _load_user_config
 
 
 if 'YOU_MAY_OVERWRITE_MY_SPARK_DEFAULTS_CONF_AND_HAILCTL_SETTINGS' not in os.environ:
-    print('This script will overwrite your spark-defaults.conf and hailctl settings. It is intended to be executed inside a container.')
+    print(
+        'This script will overwrite your spark-defaults.conf and hailctl settings. It is intended to be executed inside a container.'
+    )
     sys.exit(1)
 
 
 SPARK_CONF_PATH = spark_conf_path()
+
 
 async def unset_hailctl():
     await check_exec_output(
@@ -43,7 +46,6 @@ async def test_no_configuration():
     assert actual is None
 
 
-
 @pytest.mark.asyncio
 async def test_no_project_is_error():
     with open(SPARK_CONF_PATH, 'w') as f:
@@ -65,7 +67,6 @@ async def test_auto_with_project():
 
     actual = get_gcs_requester_pays_configuration()
     assert actual == 'my_project'
-
 
 
 @pytest.mark.asyncio
@@ -93,7 +94,6 @@ async def test_custom_with_buckets():
     assert actual == ('my_project', ['abc', 'def'])
 
 
-
 @pytest.mark.asyncio
 async def test_disabled():
     with open(SPARK_CONF_PATH, 'w') as f:
@@ -105,7 +105,6 @@ async def test_disabled():
 
     actual = get_gcs_requester_pays_configuration()
     assert actual is None
-
 
 
 @pytest.mark.asyncio
@@ -121,7 +120,6 @@ async def test_enabled():
     assert actual == 'my_project'
 
 
-
 @pytest.mark.asyncio
 async def test_hailctl_takes_precedence_1():
     await unset_hailctl()
@@ -131,24 +129,19 @@ async def test_hailctl_takes_precedence_1():
         f.write('spark.hadoop.fs.gs.requester.pays.mode ENABLED\n')
         f.write('spark.hadoop.fs.gs.requester.pays.buckets abc,def\n')
 
-    await check_exec_output(
-        'hailctl',
-        'config',
-        'set',
-        'gcs_requester_pays/project',
-        'hailctl_project',
-        echo=True
-    )
+    await check_exec_output('hailctl', 'config', 'set', 'gcs_requester_pays/project', 'hailctl_project', echo=True)
 
     _load_user_config()  # force reload of user config
 
     actual = get_gcs_requester_pays_configuration()
-    assert actual == 'hailctl_project', str((
-        configuration_of('gcs_requester_pays', 'project', None, None),
-        configuration_of('gcs_requester_pays', 'buckets', None, None),
-        get_spark_conf_gcs_requester_pays_configuration(),
-        open('/Users/dking/.config/hail/config.ini', 'r').readlines()
-    ))
+    assert actual == 'hailctl_project', str(
+        (
+            configuration_of('gcs_requester_pays', 'project', None, None),
+            configuration_of('gcs_requester_pays', 'buckets', None, None),
+            get_spark_conf_gcs_requester_pays_configuration(),
+            open('/Users/dking/.config/hail/config.ini', 'r').readlines(),
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -160,23 +153,9 @@ async def test_hailctl_takes_precedence_2():
         f.write('spark.hadoop.fs.gs.requester.pays.mode ENABLED\n')
         f.write('spark.hadoop.fs.gs.requester.pays.buckets abc,def\n')
 
-    await check_exec_output(
-        'hailctl',
-        'config',
-        'set',
-        'gcs_requester_pays/project',
-        'hailctl_project2',
-        echo=True
-    )
+    await check_exec_output('hailctl', 'config', 'set', 'gcs_requester_pays/project', 'hailctl_project2', echo=True)
 
-    await check_exec_output(
-        'hailctl',
-        'config',
-        'set',
-        'gcs_requester_pays/buckets',
-        'bucket1,bucket2',
-        echo=True
-    )
+    await check_exec_output('hailctl', 'config', 'set', 'gcs_requester_pays/buckets', 'bucket1,bucket2', echo=True)
 
     _load_user_config()  # force reload of user config
 

--- a/hail/scripts/update-terra-image.py
+++ b/hail/scripts/update-terra-image.py
@@ -26,13 +26,15 @@ with open(f'{image_name}/CHANGELOG.md') as fobj:
 
 with open(f'{image_name}/CHANGELOG.md', 'w') as fobj:
     todays_date = datetime.date.today().strftime('%Y-%m-%d')
-    fobj.write(f"""## {image_version} - {todays_date}
+    fobj.write(
+        f"""## {image_version} - {todays_date}
 - Update `hail` to `{hail_pip_version}`
   - See https://hail.is/docs/0.2/change_log.html#version-{hail_pip_version.replace('.', '-')}) for details
 
 Image URL: `us.gcr.io/broad-dsp-gcr-public/{image_name}:{image_version}`
 
-""")
+"""
+    )
     fobj.write(changelog)
 
 
@@ -46,8 +48,4 @@ with open(f'{image_name}/Dockerfile') as fobj:
     dockerfile = fobj.read()
 
 with open(f'{image_name}/Dockerfile', 'w') as fobj:
-    fobj.write(
-        '\n'.join(
-            [update_version_line(line) for line in dockerfile.split('\n')]
-        )
-    )
+    fobj.write('\n'.join([update_version_line(line) for line in dockerfile.split('\n')]))

--- a/hail/src/test/resources/balding-nichols-1024-variants-4-samples-3-populations.py
+++ b/hail/src/test/resources/balding-nichols-1024-variants-4-samples-3-populations.py
@@ -1,4 +1,5 @@
 import hail as hl
+
 hl.set_global_seed(0)
 mt = hl.balding_nichols_model(n_populations=3, n_variants=(1 << 10), n_samples=4)
 mt = mt.key_cols_by(s='s' + hl.str(mt.sample_idx))

--- a/hail/src/test/resources/makeTestInfoScore.py
+++ b/hail/src/test/resources/makeTestInfoScore.py
@@ -11,12 +11,18 @@ root = sys.argv[4]
 
 random.seed(seed)
 
+
 def homRef(maf):
     return (1.0 - maf) * (1.0 - maf)
+
+
 def het(maf):
     return 2 * maf * (1.0 - maf)
+
+
 def homAlt(maf):
     return maf * maf
+
 
 def randomGen(missingRate):
     gps = []
@@ -28,6 +34,7 @@ def randomGen(missingRate):
             d2 = random.uniform(0, 1.0 - d1)
             gps += [d1, d2, 1.0 - d1 - d2]
     return gps
+
 
 def hweGen(maf, missingRate):
     bb = homAlt(maf)
@@ -49,8 +56,9 @@ def hweGen(maf, missingRate):
                 gps += [d2, d1, d3]
             else:
                 gps += [d3, d2, d1]
-    
+
     return gps
+
 
 def constantGen(triple, missingRate):
     gps = []
@@ -60,6 +68,7 @@ def constantGen(triple, missingRate):
         else:
             gps += triple
     return gps
+
 
 variants = {}
 for i in range(nVariants * 0, nVariants * 1):
@@ -83,17 +92,18 @@ for i in range(nVariants * 4, nVariants * 5):
     variants[i] = constantGen([1, 0, 0], missingRate)
 
 for i in range(nVariants * 5, nVariants * 6):
-    missingRate= random.random()
-    variants[i]= constantGen([0, 1, 0], missingRate)
+    missingRate = random.random()
+    variants[i] = constantGen([0, 1, 0], missingRate)
 
 for i in range(nVariants * 6, nVariants * 7):
-    missingRate= random.random()
-    variants[i]= constantGen([0, 0, 1], missingRate)
+    missingRate = random.random()
+    variants[i] = constantGen([0, 0, 1], missingRate)
 
 variants[i + 1] = constantGen([0, 0, 0], 0.0)
-variants[i + 2]= constantGen([1, 0, 0], 0.0)
-variants[i + 3]= constantGen([0, 1, 0], 0.0)
-variants[i + 4]= constantGen([0, 0, 1], 0.0)
+variants[i + 2] = constantGen([1, 0, 0], 0.0)
+variants[i + 3] = constantGen([0, 1, 0], 0.0)
+variants[i + 4] = constantGen([0, 0, 1], 0.0)
+
 
 def transformDosage(dx):
     w0 = dx[0]
@@ -107,9 +117,10 @@ def transformDosage(dx):
         l1 = int((w0 + w1) * 32768 / sumDx + 0.5) - l0
         l2 = 32768 - l0 - l1
     except:
-        print dx
+        print(dx)
         sys.exit()
     return [l0 / 32768.0, l1 / 32768.0, l2 / 32768.0]
+
 
 def calcInfoScore(gps):
     nIncluded = 0
@@ -119,13 +130,13 @@ def calcInfoScore(gps):
     totalDosage = 0.0
 
     for i in range(0, len(gps), 3):
-        dx = gps[i:i + 3]
+        dx = gps[i : i + 3]
         if sum(dx) != 0.0:
             dxt = transformDosage(dx)
             nIncluded += 1
             e.append(dxt[1] + 2 * dxt[2])
             f.append(dxt[1] + 4 * dxt[2])
-            altAllele += (dxt[1] + 2 *dxt[2])
+            altAllele += dxt[1] + 2 * dxt[2]
             totalDosage += sum(dxt)
 
     z = zip(e, f)
@@ -141,7 +152,7 @@ def calcInfoScore(gps):
             infoScore = 1.0
 
     return (infoScore, nIncluded)
-        
+
 
 genOutput = open(root + ".gen", 'w')
 sampleOutput = open(root + ".sample", 'w')

--- a/pylintrc
+++ b/pylintrc
@@ -3,6 +3,7 @@
 # I also tried extension-pkg-allow-list, but it had no effect. https://stackoverflow.com/a/35259944/6823256
 generated-members=orjson
 ignore=sql
+ignore-paths=hail/python/hail,hail/python/cluster-tests,hail/python/test
 
 [MESSAGES CONTROL]
 # C0111 Missing docstring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-force-exclude = 'hail|datasets|sql|\.mypy'
+force-exclude = 'hail/python/hail|hail/python/cluster-tests|hail/python/test|datasets|sql|\.mypy'
 
 [tool.ruff]
 line-length = 120
@@ -27,11 +27,11 @@ known-first-party = ["auth", "batch", "ci", "gear", "hailtop", "monitoring", "we
 
 [tool.ruff.per-file-ignores]
 "hail/python/hail/**/*" = ["I", "PL", "RUF"]
+"dist-packages/hail/**/*" = ["I", "PL", "RUF"]
 "hail/python/hailtop/**/*" = ["I"]
+"dist-packages/hailtop/**/*" = ["I"]
 "hail/python/test/**/*" = ["ALL"]
 "hail/python/cluster-tests/**/*" = ["ALL"]
-"hail/python/setup-hailtop.py" = ["ALL"]
-"hail/python/setup.py" = ["ALL"]
 "hail/scripts/update-terra-image.py" = ["ALL"]
 "hail/src/**/*" = ["ALL"]
 "benchmark/**/*" = ["ALL"]


### PR DESCRIPTION
This change also updates the `make pylint-hail` target to include the `hail/python/(hail|test|cluster-tests)` directories, rather than the `hail/` directory.

This is because the latter would require adding `hail/__init__.py` and/or `hail/python/__init__.py` files, which creates issues because some modules in `hail/python/hail` and `hail/python/hailtop` have the same name but are at different paths, which breaks the package resolution for `ruff` and `mypy`.

For this reason, although `black` is run on the files in the `hail/` and `hail/python/` directories, `pylint` cannot be.