### PR TITLE
[batch] Fix list batches query and test

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -11,7 +11,7 @@ import signal
 import traceback
 from functools import wraps
 from numbers import Number
-from typing import Awaitable, Callable, Dict, Optional, ParamSpec, Tuple, TypeVar, Union
+from typing import Awaitable, Callable, Dict, Optional, Tuple, TypeVar, Union
 
 import aiohttp
 import aiohttp_session
@@ -25,6 +25,7 @@ import uvloop
 from aiohttp import web
 from plotly.subplots import make_subplots
 from prometheus_async.aio.web import server_stats  # type: ignore
+from typing_extensions import ParamSpec
 
 from gear import (
     AuthClient,

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -634,7 +634,11 @@ async def _query_batches(request, user: str, q: str, version: int, last_batch_id
 async def get_batches_v1(request, userdata):  # pylint: disable=unused-argument
     user = userdata['username']
     q = request.query.get('q', f'user:{user}')
+
     last_batch_id = request.query.get('last_batch_id')
+    if last_batch_id is not None:
+        last_batch_id = int(last_batch_id)
+
     batches, last_batch_id = await _handle_api_error(_query_batches, request, user, q, 1, last_batch_id)
     body = {'batches': batches}
     if last_batch_id is not None:
@@ -649,6 +653,8 @@ async def get_batches_v2(request, userdata):  # pylint: disable=unused-argument
     user = userdata['username']
     q = request.query.get('q', f'user = {user}')
     last_batch_id = request.query.get('last_batch_id')
+    if last_batch_id is not None:
+        last_batch_id = int(last_batch_id)
     batches, last_batch_id = await _handle_api_error(_query_batches, request, user, q, 2, last_batch_id)
     body = {'batches': batches}
     if last_batch_id is not None:

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -481,24 +481,50 @@ tag={tag}
 
         assert_batch_ids(
             {b1.id, b2.id},
-            '''
+            f'''
 start_time >= 2023-02-24T17:15:25Z
 end_time < 3000-02-24T17:15:25Z
+tag = {tag}
 ''',
         )
 
         assert_batch_ids(
             set(),
-            '''
+            f'''
 start_time >= 2023-02-24T17:15:25Z
 end_time == 2023-02-24T17:15:25Z
+tag = {tag}
 ''',
         )
 
-        assert_batch_ids(set(), 'duration > 50000')
-        assert_batch_ids(set(), 'cost > 1000')
-        assert_batch_ids({b1.id}, f'batch_id = {b1.id}')
-        assert_batch_ids({b1.id}, f'batch_id == {b1.id}')
+        assert_batch_ids(
+            set(),
+            f'''
+duration > 50000
+tag = {tag}
+''',
+        )
+        assert_batch_ids(
+            set(),
+            f'''
+cost > 1000
+tag = {tag}
+''',
+        )
+        assert_batch_ids(
+            {b1.id},
+            f'''
+batch_id = {b1.id}
+tag = {tag}
+''',
+        )
+        assert_batch_ids(
+            {b1.id},
+            f'''
+batch_id == {b1.id}
+tag = {tag}
+''',
+        )
 
         with pytest.raises(httpx.ClientResponseError, match='could not parse term'):
             assert_batch_ids(batch_id_test_universe, 'batch_id >= 1 abcde')


### PR DESCRIPTION
The test that lists batches timed out. The main problem is the limit in the aioclient used by the test_batch tests was passing a string rather than an integer. I assumed downstream the function was passing an integer. Therefore, we were doing this:

batch_id < "137"
and not batch_id < 137.

So the query was running forever and scanning all batches from the test user.

I also was missing a tag annotation on the queries, but that was not causing the timeout.