### PR TITLE
[ci/ui] fixes 500 when there are no jobs to display

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -152,10 +152,14 @@ def wb_and_pr_from_request(request: web.Request) -> Tuple[WatchedBranch, PR]:
 
 
 def filter_jobs(jobs):
-    filtered: Dict[str, list] = {"running": [], "failed": [], "pending": [], "jobs": []}
+    filtered: Dict[str, list] = {
+        state: []
+        # the order of this list is the order in which the states will be displayed on the page
+        for state in ["failed", "error", "cancelled", "running", "pending", "ready", "creating", "success"]
+    }
     for job in jobs:
-        filtered.get(job["state"].lower(), filtered["jobs"]).append(job)
-    return {"completed" if k == "jobs" else k: v if len(v) > 0 else None for k, v in filtered.items()}
+        filtered[job["state"].lower()].append(job)
+    return {"jobs": filtered}
 
 
 @routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -228,7 +228,18 @@ fi
 
 class PR(Code):
     def __init__(
-        self, number, title, body, source_branch, source_sha, target_branch, author, assignees, reviewers, labels
+        self,
+        number,
+        title,
+        body,
+        source_branch,
+        source_sha,
+        target_branch,
+        author,
+        assignees,
+        reviewers,
+        labels,
+        developers,
     ):
         self.number: int = number
         self.title: str = title
@@ -257,6 +268,8 @@ class PR(Code):
         # don't need to set github_changed because we are refreshing github
         self.target_branch.batch_changed = True
         self.target_branch.state_changed = True
+
+        self.developers = developers
 
     def set_build_state(self, build_state):
         log.info(f'{self.short_str()}: Build state changing from {self.build_state} => {build_state}')
@@ -355,6 +368,7 @@ class PR(Code):
             {user['login'] for user in gh_json['assignees']},
             {user['login'] for user in gh_json['requested_reviewers']},
             {label['name'] for label in gh_json['labels']},
+            target_branch.developers,
         )
         pr.increment_pr_metric()
         return pr
@@ -368,6 +382,7 @@ class PR(Code):
         target_repo = self.target_branch.branch.repo
         return {
             'checkout_script': self.checkout_script(),
+            'developers': self.developers,
             'number': self.number,
             'source_repo': source_repo.short_str(),
             'source_repo_url': source_repo.url,

--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -30,7 +30,4 @@
 
     <h2>Jobs</h2>
     {{ filtered_jobs(running, failed, pending, completed) }}
-    <script type="text/javascript">
-      focusOnSlash("jobsSearchBar");
-    </script>
 {% endblock %}

--- a/ci/ci/templates/filtered-jobs.html
+++ b/ci/ci/templates/filtered-jobs.html
@@ -1,17 +1,13 @@
 {% from "job-table.html" import job_table with context %}
 {% macro filtered_jobs(running, failed, pending, completed) %}
-{% if failed is not none %}
-  <h3>Failed</h3>
-  {{ job_table(failed, "failed-jobs", "failedJobsSearchBar") }}
+{% if jobs.items()|length %}
+  {% for state, state_jobs in jobs.items() %}
+    {% if state_jobs|length %}
+      <h3>{{ state.capitalize() }}</h3>
+      {{ job_table(state_jobs, "{{ state }}-jobs", "{{ state }}JobsSearchBar") }}
+    {% endif %}
+  {% endfor %}
+{% else %}
+  <div>No jobs found.</div>
 {% endif %}
-{% if running is not none %}
-  <h3>Running</h3>
-  {{ job_table(running, "running-jobs", "runningJobsSearchBar") }}
-{% endif %}
-{% if pending is not none %}
-  <h3>Pending</h3>
-  {{ job_table(pending, "pending-jobs", "pendingJobsSearchBar") }}
-{% endif %}
-<h3>Completed</h3>
-{{ job_table(completed, "completed-jobs", "completedJobsSearchBar") }}
 {% endmacro %}

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -62,7 +62,4 @@
     {% else %}
     No builds.
     {% endif %}
-    <script type="text/javascript">
-      focusOnSlash("jobsSearchBar");
-    </script>
 {% endblock %}


### PR DESCRIPTION
This change sorts the jobs for a PR correctly in the UI, so that all jobs are placed under a header with the correct state (see screenshot). Because jobs are split into separate tables by their state, `focusOnSlash` has been removed from the relevant CI pages, since it is unknown which tables will exist on the page until it is rendered. It also fixes the error that was causing the server to return a 500 when there were no jobs yet (e.g. when a retry had just been requested), which was caused by an assumption in the original job filtering code that there would always be at least one job to display. It also passes the list of developers through to the underlying `PR` object that a `WatchedBranch` has, which was missed in https://github.com/hail-is/hail/pull/13398 but is required for CI to display the PR page correctly in dev deploys only.

<img width="714" alt="Screenshot 2023-08-22 at 15 08 48" src="https://github.com/hail-is/hail/assets/84595986/6bcab38c-a48a-4e10-8f69-770d35ea51b7">