### PR TITLE
[query/vds] Fix local_to_global with missing fill

### DIFF
--- a/hail/python/test/hail/vds/test_vds_functions.py
+++ b/hail/python/test/hail/vds/test_vds_functions.py
@@ -44,3 +44,8 @@ def test_local_to_global_alleles_non_increasing():
     assert hl.eval(hl.vds.local_to_global(lpl, local_alleles, 4, 999, number='G')) == [1001, 1002, 1005, 999, 999, 999, 1004, 1003, 999, 0]
 
     assert hl.eval(hl.vds.local_to_global([0, 1, 2, 3, 4, 5], [0, 2, 1], 3, 0, number='G')) == [0, 3, 5, 1, 4, 2]
+
+def test_local_to_global_missing_fill():
+    local_alleles = [0, 3, 1]
+    lad = [1, 10, 9]
+    assert hl.eval(hl.vds.local_to_global(lad, local_alleles, 4, hl.missing('int32'), number='R')) == [1, 9, None, 10]

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -491,6 +491,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
         iec.consume(cb,
           setElementMissing(cb, addr, idx),
           { sc =>
+            setElementPresent(cb, addr, idx)
             elementType.storeAtAddress(cb, firstElementAddress + idx.toL * elementByteSize, region, sc, deepCopy = deepCopy)
           })
     }


### PR DESCRIPTION
There was a logic error in constructFromIndicesUnsafe, if a missing value was pushed, pushing a present value with the same index would not clear the missing bit.