### PR TITLE
[query] back off spectral moments timeout for local, spark, and batch

### DIFF
--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -261,31 +261,31 @@ def spectral_moments_helper(spec_func):
 
 
 @skip_when_service_backend(reason='v slow & OOms')
-@test_timeout(local=3 * 60)
+@test_timeout(4 * 60, batch=8 * 60)
 def test_spectral_moments_1():
     spectral_moments_helper(spec1)
 
 
 @skip_when_service_backend(reason='v slow & OOms')
-@test_timeout(local=3 * 60)
+@test_timeout(4 * 60, batch=8 * 60)
 def test_spectral_moments_2():
     spectral_moments_helper(spec2)
 
 
 @skip_when_service_backend(reason='v slow & OOms')
-@test_timeout(local=3 * 60)
+@test_timeout(4 * 60, batch=8 * 60)
 def test_spectral_moments_3():
     spectral_moments_helper(spec3)
 
 
 @skip_when_service_backend(reason='v slow & OOms')
-@test_timeout(local=3 * 60)
+@test_timeout(4 * 60, batch=8 * 60)
 def test_spectral_moments_4():
     spectral_moments_helper(spec4)
 
 
 @skip_when_service_backend(reason='v slow & OOms')
-@test_timeout(local=3 * 60)
+@test_timeout(4 * 60, batch=8 * 60)
 def test_spectral_moments_5():
     spectral_moments_helper(spec5)
 


### PR DESCRIPTION
Replaces https://github.com/hail-is/hail/pull/13260.

- `test_spectral_moments` times out in a PR: (QoB) https://hail.zulipchat.com/#narrow/stream/127527-team/topic/timeouts/near/376698259, (spark) https://ci.hail.is/batches/7653376/jobs/74, (spark) https://ci.hail.is/batches/7653376/jobs/72, (spark) https://ci.hail.is/batches/7653376/jobs/62

I also backed local off to 4m even though it has no evidence of time outs. Seems simpler for Spark and local to be the same.