### PR TITLE
[batch/test] Wait for job to be running in list_jobs_v2 test

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -604,6 +604,12 @@ def test_list_jobs_v2(client: BatchClient):
         j_failure.wait()
         j_error.wait()
 
+        delay = 0.1
+        while True:
+            if j_running.status()['state'] == 'Running' or j_running.is_complete():
+                break
+            delay = sync_sleep_and_backoff(delay)
+
         assert_job_ids({j_success.job_id}, 'state = success')
         assert_job_ids({j_success.job_id}, 'state == success')
         assert_job_ids({j_success.job_id}, 'state=success')

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -13,7 +13,7 @@ from hailtop.batch.backend import HAIL_GENETICS_HAILTOP_IMAGE
 from hailtop.batch_client.client import BatchClient
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.test_utils import skip_in_azure
-from hailtop.utils import external_requests_client_session, retry_response_returning_functions, sync_sleep_and_backoff
+from hailtop.utils import external_requests_client_session, retry_response_returning_functions
 from hailtop.utils.rich_progress_bar import BatchProgressBar
 
 from .failure_injecting_client_session import FailureInjectingClientSession
@@ -48,17 +48,13 @@ def test_job_running_logs(client: BatchClient):
     j = bb.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])
     b = bb.submit()
 
-    delay = 1
-    while True:
-        status = j.status()
-        if status['state'] == 'Running':
-            log = j.log()
-            if log is not None and log['main'] != '':
-                assert log['main'] == 'test\n', str((log, b.debug_info()))
-                break
-        elif status['state'] != 'Ready':
-            assert False, str((j.log(), b.debug_info()))
-        delay = sync_sleep_and_backoff(delay)
+    wait_status = j._wait_for_states('Running')
+    if wait_status.prev_completed:
+        assert False, str((j.log(), b.debug_info()))
+
+    log = j.log()
+    if log is not None and log['main'] != '':
+        assert log['main'] == 'test\n', str((log, b.debug_info()))
 
     b.cancel()
     b.wait()
@@ -603,12 +599,9 @@ def test_list_jobs_v2(client: BatchClient):
         j_success.wait()
         j_failure.wait()
         j_error.wait()
-
-        delay = 0.1
-        while True:
-            if j_running.status()['state'] == 'Running' or j_running.is_complete():
-                break
-            delay = sync_sleep_and_backoff(delay)
+        wait_status = j_running._wait_for_states('Running')
+        if wait_status.prev_completed:
+            assert False, str((b.debug_info(), wait_status))
 
         assert_job_ids({j_success.job_id}, 'state = success')
         assert_job_ids({j_success.job_id}, 'state == success')
@@ -1471,16 +1464,10 @@ def test_job_private_instance_cancel(client: BatchClient):
     j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     b = bb.submit()
 
-    delay = 0.1
-    start = time.time()
-    while True:
-        status = j.status()
-        if status['state'] == 'Creating':
-            break
-        now = time.time()
-        if now + delay - start > 60:
-            assert False, str((status, b.debug_info()))
-        delay = sync_sleep_and_backoff(delay)
+    wait_status = j._wait_for_states('Creating', timeout=60)
+    if wait_status.timed_out:
+        assert False, str((wait_status.status, b.debug_info()))
+
     b.cancel()
     status = j.wait()
     assert status['state'] == 'Cancelled', str((status, b.debug_info()))
@@ -1589,13 +1576,9 @@ def test_update_with_always_run(client: BatchClient):
     j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], always_run=True, parents=[j1])
     b = bb.submit()
 
-    delay = 0.1
-    while True:
-        if j1.is_complete():
-            assert False, str(j1.status(), b.debug_info())
-        if j1.is_running():
-            break
-        delay = sync_sleep_and_backoff(delay)
+    wait_status = j1._wait_for_states('Running')
+    if wait_status.prev_completed:
+        assert False, str(j1.status(), b.debug_info())
 
     assert j2.is_pending(), str(j2.status(), b.debug_info())
 
@@ -1616,13 +1599,9 @@ def test_update_jobs_are_not_serialized(client: BatchClient):
 
     j2.wait()
 
-    delay = 0.1
-    while True:
-        if j1.is_complete():
-            assert False, str(j1.status(), b.debug_info())
-        if j1.is_running():
-            break
-        delay = sync_sleep_and_backoff(delay)
+    wait_status = j1._wait_for_states('Running')
+    if wait_status.prev_completed:
+        assert False, str(j1.status(), b.debug_info())
 
     b.cancel()
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -1,5 +1,3 @@
-import time
-
 from typing import Optional, Dict, Any, List, Tuple, Union
 import math
 import random
@@ -329,8 +327,7 @@ class SubmittedJob:
         return self._status
 
     async def wait(self):
-        wait_status = await self._wait_for_states(*complete_states)
-        return wait_status.status
+        return await self._wait_for_states(*complete_states)
 
     async def _wait_for_states(self, *states: str):
         delay = 0.1

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -115,8 +115,8 @@ class Job:
     def wait(self):
         return async_to_blocking(self._async_job.wait())
 
-    def _wait_for_states(self, *states: str, timeout: Optional[float] = None) -> aioclient.WaitJobStatus:
-        return async_to_blocking(self._async_job._wait_for_states(*states, timeout=timeout))
+    def _wait_for_states(self, *states: str):
+        return async_to_blocking(self._async_job._wait_for_states(*states))
 
     def container_log(self, container_name):
         return async_to_blocking(self._async_job.container_log(container_name))

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -115,6 +115,9 @@ class Job:
     def wait(self):
         return async_to_blocking(self._async_job.wait())
 
+    def _wait_for_states(self, *states: str, timeout: Optional[float] = None) -> aioclient.WaitJobStatus:
+        return async_to_blocking(self._async_job._wait_for_states(*states, timeout=timeout))
+
     def container_log(self, container_name):
         return async_to_blocking(self._async_job.container_log(container_name))
 


### PR DESCRIPTION
EDIT: We changed the behavior of wait in this PR to use the same backoff we use in the rest of the code base.

Context: The list_jobs_v2 test failed in production because SQL treats NULL values as False and those records don't end up in the result set. For example, a ready job will not be in the result set for `start_time != 1970-01-01`. So we need to ensure the job is actually running before executing the tests.