### PR TITLE
[lint] Add aiohttp handler types and remove some pylint disable directives

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -5,7 +5,6 @@ import os
 import re
 from typing import List, Optional
 
-import aiohttp
 import aiohttp_session
 import kubernetes_asyncio.client
 import kubernetes_asyncio.client.rest
@@ -19,6 +18,7 @@ from gear import (
     Database,
     K8sCache,
     Transaction,
+    UserData,
     check_csrf_token,
     create_session,
     json_request,
@@ -180,20 +180,20 @@ def cleanup_session(session):
 
 
 @routes.get('/healthcheck')
-async def get_healthcheck(request):  # pylint: disable=W0613
+async def get_healthcheck(_):
     return web.Response()
 
 
 @routes.get('')
 @routes.get('/')
 @auth.web_maybe_authenticated_user
-async def get_index(request, userdata):  # pylint: disable=unused-argument
+async def get_index(request: web.Request, userdata: Optional[UserData]):
     return await render_template('auth', request, userdata, 'index.html', {})
 
 
 @routes.get('/creating')
 @auth.web_maybe_authenticated_user
-async def creating_account(request, userdata):
+async def creating_account(request: web.Request, userdata: Optional[UserData]):
     db = request.app['db']
     session = await aiohttp_session.get_session(request)
     if 'pending' in session:
@@ -207,7 +207,7 @@ async def creating_account(request, userdata):
 
         if user is None:
             set_message(session, f'Account does not exist for login id {login_id}.', 'error')
-            return aiohttp.web.HTTPFound(deploy_config.external_url('auth', ''))
+            return web.HTTPFound(deploy_config.external_url('auth', ''))
 
         page_context = {'username': user['username'], 'state': user['state'], 'login_id': user['login_id']}
 
@@ -218,7 +218,7 @@ async def creating_account(request, userdata):
             session_id = await create_session(db, user['id'])
             session['session_id'] = session_id
             set_message(session, f'Account has been created for {user["username"]}.', 'info')
-            return aiohttp.web.HTTPFound(next_page)
+            return web.HTTPFound(next_page)
 
         assert user['state'] == 'creating'
         session['pending'] = True
@@ -226,7 +226,7 @@ async def creating_account(request, userdata):
         session['next'] = next_page
         return await render_template('auth', request, userdata, 'account-creating.html', page_context)
 
-    return aiohttp.web.HTTPUnauthorized()
+    return web.HTTPUnauthorized()
 
 
 @routes.get('/creating/wait')
@@ -287,7 +287,7 @@ async def signup(request):
     session['caller'] = 'signup'
     session['flow'] = flow_data
 
-    return aiohttp.web.HTTPFound(flow_data['authorization_url'])
+    return web.HTTPFound(flow_data['authorization_url'])
 
 
 @routes.get('/login')
@@ -302,7 +302,7 @@ async def login(request):
     session['caller'] = 'login'
     session['flow'] = flow_data
 
-    return aiohttp.web.HTTPFound(flow_data['authorization_url'])
+    return web.HTTPFound(flow_data['authorization_url'])
 
 
 @routes.get('/oauth2callback')
@@ -336,7 +336,7 @@ async def callback(request):
     if user is None:
         if caller == 'login':
             set_message(session, f'Account does not exist for login id {login_id}', 'error')
-            return aiohttp.web.HTTPFound(deploy_config.external_url('auth', ''))
+            return web.HTTPFound(deploy_config.external_url('auth', ''))
 
         assert caller == 'signup'
 
@@ -375,12 +375,12 @@ async def callback(request):
         set_message(session, f'Account has already been created for {user["username"]}.', 'info')
     session_id = await create_session(db, user['id'])
     session['session_id'] = session_id
-    return aiohttp.web.HTTPFound(next_page)
+    return web.HTTPFound(next_page)
 
 
 @routes.post('/api/v1alpha/users/{user}/create')
 @auth.rest_authenticated_developers_only
-async def create_user(request: web.Request, userdata):  # pylint: disable=unused-argument
+async def create_user(request: web.Request, _):
     db: Database = request.app['db']
     username = request.match_info['user']
 
@@ -420,7 +420,7 @@ async def create_user(request: web.Request, userdata):  # pylint: disable=unused
 
 @routes.get('/user')
 @auth.web_authenticated_users_only()
-async def user_page(request, userdata):
+async def user_page(request: web.Request, userdata: UserData):
     return await render_template('auth', request, userdata, 'user.html', {'cloud': CLOUD})
 
 
@@ -436,7 +436,7 @@ async def create_copy_paste_token(db, session_id, max_age_secs=300):
 @routes.post('/copy-paste-token')
 @check_csrf_token
 @auth.web_authenticated_users_only()
-async def get_copy_paste_token(request, userdata):
+async def get_copy_paste_token(request: web.Request, userdata: UserData):
     session = await aiohttp_session.get_session(request)
     session_id = session['session_id']
     db = request.app['db']
@@ -447,7 +447,7 @@ async def get_copy_paste_token(request, userdata):
 
 @routes.post('/api/v1alpha/copy-paste-token')
 @auth.rest_authenticated_users_only
-async def get_copy_paste_token_api(request, userdata):
+async def get_copy_paste_token_api(request: web.Request, userdata: UserData):
     session_id = userdata['session_id']
     db = request.app['db']
     copy_paste_token = await create_copy_paste_token(db, session_id)
@@ -457,7 +457,7 @@ async def get_copy_paste_token_api(request, userdata):
 @routes.post('/logout')
 @check_csrf_token
 @auth.web_maybe_authenticated_user
-async def logout(request, userdata):
+async def logout(request: web.Request, userdata: Optional[UserData]):
     if not userdata:
         return web.HTTPFound(deploy_config.external_url('auth', ''))
 
@@ -472,7 +472,7 @@ async def logout(request, userdata):
 
 
 @routes.get('/api/v1alpha/login')
-async def rest_login(request):
+async def rest_login(request: web.Request):
     callback_port = request.query['callback_port']
     callback_uri = f'http://127.0.0.1:{callback_port}/oauth2callback'
     flow_data = request.app['flow_client'].initiate_flow(callback_uri)
@@ -486,7 +486,7 @@ async def rest_login(request):
 
 @routes.get('/roles')
 @auth.web_authenticated_developers_only()
-async def get_roles(request, userdata):
+async def get_roles(request: web.Request, userdata: UserData):
     db = request.app['db']
     roles = [x async for x in db.select_and_fetchall('SELECT * FROM roles;')]
     page_context = {'roles': roles}
@@ -496,11 +496,11 @@ async def get_roles(request, userdata):
 @routes.post('/roles')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def post_create_role(request, userdata):  # pylint: disable=unused-argument
+async def post_create_role(request: web.Request, _):
     session = await aiohttp_session.get_session(request)
     db = request.app['db']
     post = await request.post()
-    name = post['name']
+    name = str(post['name'])
 
     role_id = await db.execute_insertone(
         '''
@@ -517,7 +517,7 @@ VALUES (%s);
 
 @routes.get('/users')
 @auth.web_authenticated_developers_only()
-async def get_users(request, userdata):
+async def get_users(request: web.Request, userdata: UserData):
     db = request.app['db']
     users = [x async for x in db.select_and_fetchall('SELECT * FROM users;')]
     page_context = {'users': users}
@@ -527,18 +527,16 @@ async def get_users(request, userdata):
 @routes.post('/users')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def post_create_user(request, userdata):  # pylint: disable=unused-argument
+async def post_create_user(request: web.Request, _):
     session = await aiohttp_session.get_session(request)
     db = request.app['db']
     post = await request.post()
-    username = post['username']
-    login_id = post.get('login_id', '')
+    username = str(post['username'])
+    login_id = str(post['login_id']) if 'login_id' in post else None
     is_developer = post.get('is_developer') == '1'
     is_service_account = post.get('is_service_account') == '1'
 
     try:
-        if login_id == '':
-            login_id = None
         created_user = await insert_new_user(db, username, login_id, is_developer, is_service_account)
     except AuthUserError as e:
         set_message(session, e.message, 'error')
@@ -554,7 +552,7 @@ async def post_create_user(request, userdata):  # pylint: disable=unused-argumen
 
 @routes.get('/api/v1alpha/users')
 @auth.rest_authenticated_developers_only
-async def rest_get_users(request, userdata):  # pylint: disable=unused-argument
+async def rest_get_users(request: web.Request, _):
     db: Database = request.app['db']
     _query = '''
 SELECT id, username, login_id, state, is_developer, is_service_account, hail_identity
@@ -566,7 +564,7 @@ FROM users;
 
 @routes.get('/api/v1alpha/users/{user}')
 @auth.rest_authenticated_developers_only
-async def rest_get_user(request, userdata):  # pylint: disable=unused-argument
+async def rest_get_user(request: web.Request, _):
     db: Database = request.app['db']
     username = request.match_info['user']
 
@@ -606,12 +604,12 @@ WHERE {' AND '.join(where_conditions)};
 @routes.post('/users/delete')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def delete_user(request, userdata):  # pylint: disable=unused-argument
+async def delete_user(request: web.Request, _):
     session = await aiohttp_session.get_session(request)
     db = request.app['db']
     post = await request.post()
-    id = post['id']
-    username = post['username']
+    id = str(post['id'])
+    username = str(post['username'])
 
     try:
         await _delete_user(db, username, id)
@@ -624,7 +622,7 @@ async def delete_user(request, userdata):  # pylint: disable=unused-argument
 
 @routes.delete('/api/v1alpha/users/{user}')
 @auth.rest_authenticated_developers_only
-async def rest_delete_user(request: web.Request, userdata):  # pylint: disable=unused-argument
+async def rest_delete_user(request: web.Request, _):
     db = request.app['db']
     username = request.match_info['user']
 
@@ -702,7 +700,7 @@ WHERE copy_paste_tokens.id = %s
 
 @routes.post('/api/v1alpha/logout')
 @auth.rest_authenticated_users_only
-async def rest_logout(request, userdata):
+async def rest_logout(request: web.Request, userdata: UserData):
     session_id = userdata['session_id']
     db = request.app['db']
     await db.just_execute('DELETE FROM sessions WHERE session_id = %s;', session_id)
@@ -710,7 +708,7 @@ async def rest_logout(request, userdata):
     return web.Response(status=200)
 
 
-async def get_userinfo(request, session_id):
+async def get_userinfo(request: web.Request, session_id: str) -> UserData:
     # b64 encoding of 32-byte session ID is 44 bytes
     if len(session_id) != 44:
         log.info('Session id != 44 bytes')

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -33,7 +33,7 @@ from gear import (
     setup_aiohttp_session,
     transaction,
 )
-from gear.auth import AiohttpHandler
+from gear.auth import AIOHTTPHandler
 from gear.clients import get_cloud_async_fs
 from gear.profiling import install_profiler_if_requested
 from hailtop import aiotools, httpx
@@ -109,7 +109,7 @@ def instance_token(request):
     return request.headers.get('X-Hail-Instance-Token') or authorization_token(request)
 
 
-def activating_instances_only(fun: Callable[[web.Request, Instance], Awaitable[web.StreamResponse]]) -> AiohttpHandler:
+def activating_instances_only(fun: Callable[[web.Request, Instance], Awaitable[web.StreamResponse]]) -> AIOHTTPHandler:
     @wraps(fun)
     async def wrapped(request):
         instance = instance_from_request(request)
@@ -140,7 +140,7 @@ def activating_instances_only(fun: Callable[[web.Request, Instance], Awaitable[w
     return wrapped
 
 
-def active_instances_only(fun: Callable[[web.Request, Instance], Awaitable[web.StreamResponse]]) -> AiohttpHandler:
+def active_instances_only(fun: Callable[[web.Request, Instance], Awaitable[web.StreamResponse]]) -> AIOHTTPHandler:
     @wraps(fun)
     async def wrapped(request):
         instance = instance_from_request(request)
@@ -172,13 +172,13 @@ def active_instances_only(fun: Callable[[web.Request, Instance], Awaitable[web.S
 
 
 @routes.get('/healthcheck')
-async def get_healthcheck(_):
+async def get_healthcheck(_) -> web.Response:
     return web.Response()
 
 
 @routes.get('/check_invariants')
 @auth.rest_authenticated_developers_only
-async def get_check_invariants(request, _):
+async def get_check_invariants(request: web.Request, _) -> web.Response:
     db: Database = request.app['db']
     incremental_result, resource_agg_result = await asyncio.gather(
         check_incremental(db), check_resource_aggregation(db), return_exceptions=True
@@ -265,14 +265,14 @@ async def activate_instance_1(request, instance):
 # deprecated
 @routes.get('/api/v1alpha/instances/gsa_key')
 @activating_instances_only
-async def get_gsa_key(_, instance):
+async def get_gsa_key(_, instance: Instance) -> web.Response:
     return await asyncio.shield(get_gsa_key_1(instance))
 
 
 # deprecated
 @routes.get('/api/v1alpha/instances/credentials')
 @activating_instances_only
-async def get_credentials(_, instance):
+async def get_credentials(_, instance: Instance) -> web.Response:
     return await asyncio.shield(get_credentials_1(instance))
 
 
@@ -292,7 +292,7 @@ async def deactivate_instance_1(instance):
 @routes.post('/api/v1alpha/instances/deactivate')
 @active_instances_only
 @add_metadata_to_request
-async def deactivate_instance(_, instance):
+async def deactivate_instance(_, instance: Instance) -> web.Response:
     await asyncio.shield(deactivate_instance_1(instance))
     return web.Response()
 
@@ -300,14 +300,14 @@ async def deactivate_instance(_, instance):
 @routes.post('/instances/{instance_name}/kill')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def kill_instance(request, _):
+async def kill_instance(request: web.Request, _) -> web.HTTPFound:
     instance_name = request.match_info['instance_name']
 
     inst_coll_manager: InstanceCollectionManager = request.app['driver'].inst_coll_manager
     instance = inst_coll_manager.get_instance(instance_name)
 
     if instance is None:
-        return web.HTTPNotFound()
+        raise web.HTTPNotFound()
 
     session = await aiohttp_session.get_session(request)
     if instance.state == 'active':
@@ -563,7 +563,7 @@ def validate_int(session, name, value, predicate, description):
 @routes.post('/configure-feature-flags')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def configure_feature_flags(request: web.Request, _):
+async def configure_feature_flags(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     db: Database = app['db']
     post = await request.post()
@@ -586,7 +586,7 @@ UPDATE feature_flags SET compact_billing_tables = %s;
 @routes.post('/config-update/pool/{pool}')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def pool_config_update(request: web.Request, _):
+async def pool_config_update(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     db: Database = app['db']
     inst_coll_manager: InstanceCollectionManager = app['driver'].inst_coll_manager
@@ -792,7 +792,7 @@ async def pool_config_update(request: web.Request, _):
 @routes.post('/config-update/jpim')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def job_private_config_update(request: web.Request, _):
+async def job_private_config_update(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     jpim: JobPrivateInstanceManager = app['driver'].job_private_inst_manager
 
@@ -937,7 +937,7 @@ async def get_job_private_inst_manager(request, userdata):
 @routes.post('/freeze')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def freeze_batch(request: web.Request, _):
+async def freeze_batch(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     db: Database = app['db']
     session = await aiohttp_session.get_session(request)
@@ -962,7 +962,7 @@ UPDATE globals SET frozen = 1;
 @routes.post('/unfreeze')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def unfreeze_batch(request: web.Request, _):
+async def unfreeze_batch(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     db: Database = app['db']
     session = await aiohttp_session.get_session(request)

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -14,6 +14,7 @@ from numbers import Number
 from typing import Awaitable, Callable, Dict, Optional, Tuple, TypeVar, Union
 
 import aiohttp
+import aiohttp.web_exceptions
 import aiohttp_session
 import humanize
 import pandas as pd
@@ -31,6 +32,7 @@ from gear import (
     AuthClient,
     Database,
     Transaction,
+    UserData,
     check_csrf_token,
     json_request,
     json_response,
@@ -118,12 +120,12 @@ T = TypeVar('T')
 P = ParamSpec('P')
 
 
-def rest_authenticated_developers_or_auth_only(fun):
+def rest_authenticated_developers_or_auth_only(fun: Callable[[web.Request], Awaitable[web.StreamResponse]]):
     @auth.rest_authenticated_users_only
     @wraps(fun)
-    async def wrapped(request, userdata, *args, **kwargs):
+    async def wrapped(request: web.Request, userdata: UserData):
         if userdata['is_developer'] == 1 or userdata['username'] == 'auth':
-            return await fun(request, userdata, *args, **kwargs)
+            return await fun(request)
         raise web.HTTPUnauthorized()
 
     return wrapped
@@ -161,33 +163,33 @@ WHERE id = %s AND billing_project_users.`user_cs` = %s;
     return record is not None
 
 
-def rest_billing_project_users_only(fun):
+def rest_billing_project_users_only(fun: Callable[[web.Request, UserData, int], Awaitable[web.StreamResponse]]):
     @auth.rest_authenticated_users_only
     @wraps(fun)
-    async def wrapped(request, userdata, *args, **kwargs):
+    async def wrapped(request: web.Request, userdata: UserData):
         db = request.app['db']
         batch_id = int(request.match_info['batch_id'])
         user = userdata['username']
         permitted_user = await _user_can_access(db, batch_id, user)
         if not permitted_user:
             raise web.HTTPNotFound()
-        return await fun(request, userdata, batch_id, *args, **kwargs)
+        return await fun(request, userdata, batch_id)
 
     return wrapped
 
 
 def web_billing_project_users_only(redirect=True):
-    def wrap(fun):
+    def wrap(fun: Callable[[web.Request, UserData, int], Awaitable[web.StreamResponse]]):
         @auth.web_authenticated_users_only(redirect)
         @wraps(fun)
-        async def wrapped(request, userdata, *args, **kwargs):
+        async def wrapped(request: web.Request, userdata: UserData):
             db = request.app['db']
             batch_id = int(request.match_info['batch_id'])
             user = userdata['username']
             permitted_user = await _user_can_access(db, batch_id, user)
             if not permitted_user:
                 raise web.HTTPNotFound()
-            return await fun(request, userdata, batch_id, *args, **kwargs)
+            return await fun(request, userdata, batch_id)
 
         return wrapped
 
@@ -201,23 +203,23 @@ def cast_query_param_to_int(param: Optional[str]) -> Optional[int]:
 
 
 @routes.get('/healthcheck')
-async def get_healthcheck(request):  # pylint: disable=W0613
+async def get_healthcheck(_):
     return web.Response()
 
 
 @routes.get('/api/v1alpha/version')
-async def rest_get_version(request):  # pylint: disable=W0613
+async def rest_get_version(_):
     return web.Response(text=version())
 
 
 @routes.get('/api/v1alpha/cloud')
-async def rest_cloud(request):  # pylint: disable=W0613
+async def rest_cloud(_):
     return web.Response(text=CLOUD)
 
 
 @routes.get('/api/v1alpha/supported_regions')
 @auth.rest_authenticated_users_only
-async def rest_get_supported_regions(request, userdata):  # pylint: disable=unused-argument
+async def rest_get_supported_regions(request: web.Request, _):
     return json_response(list(request.app['regions'].keys()))
 
 
@@ -292,7 +294,7 @@ WHERE id = %s AND NOT deleted;
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def get_jobs_v1(request: web.Request, userdata: dict, batch_id: int):  # pylint: disable=unused-argument
+async def get_jobs_v1(request: web.Request, _, batch_id: int):
     q = request.query.get('q', '')
     last_job_id = cast_query_param_to_int(request.query.get('last_job_id'))
     resp = await _handle_api_error(_get_jobs, request, batch_id, 1, q, last_job_id)
@@ -303,7 +305,7 @@ async def get_jobs_v1(request: web.Request, userdata: dict, batch_id: int):  # p
 @routes.get('/api/v2alpha/batches/{batch_id}/jobs')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def get_jobs_v2(request: web.Request, userdata: dict, batch_id: int):  # pylint: disable=unused-argument
+async def get_jobs_v2(request: web.Request, _, batch_id: int):
     q = request.query.get('q', '')
     last_job_id = cast_query_param_to_int(request.query.get('last_job_id'))
     resp = await _handle_api_error(_get_jobs, request, batch_id, 2, q, last_job_id)
@@ -587,7 +589,7 @@ async def _get_full_job_status(app, record):
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def get_job_log(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def get_job_log(request, _, batch_id):
     job_id = int(request.match_info['job_id'])
     job_log_bytes = await _get_job_log(request.app, batch_id, job_id)
     job_log_strings: Dict[str, Optional[str]] = {}
@@ -616,7 +618,7 @@ async def get_job_container_log(request, batch_id):
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log/{container}')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def rest_get_job_container_log(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def rest_get_job_container_log(request, _, batch_id):
     return await get_job_container_log(request, batch_id)
 
 
@@ -687,7 +689,7 @@ def check_service_account_permissions(user, sa):
 @routes.post('/api/v1alpha/batches/{batch_id}/jobs/create')
 @auth.rest_authenticated_users_only
 @add_metadata_to_request
-async def create_jobs(request: aiohttp.web.Request, userdata: dict):
+async def create_jobs(request: web.Request, userdata: UserData):
     app = request.app
     batch_id = int(request.match_info['batch_id'])
     job_specs = await json_request(request)
@@ -697,7 +699,7 @@ async def create_jobs(request: aiohttp.web.Request, userdata: dict):
 @routes.post('/api/v1alpha/batches/{batch_id}/updates/{update_id}/jobs/create')
 @auth.rest_authenticated_users_only
 @add_metadata_to_request
-async def create_jobs_for_update(request: aiohttp.web.Request, userdata: dict):
+async def create_jobs_for_update(request: web.Request, userdata: UserData):
     app = request.app
 
     if app['frozen']:
@@ -718,7 +720,7 @@ def assert_is_sha_1_hex_string(revision: str):
         raise web.HTTPBadRequest(reason=f'revision must be 40 character hexadecimal encoded SHA-1, got: {revision}')
 
 
-async def _create_jobs(userdata: dict, job_specs: dict, batch_id: int, update_id: int, app: aiohttp.web.Application):
+async def _create_jobs(userdata, job_specs: dict, batch_id: int, update_id: int, app: web.Application):
     db: Database = app['db']
     file_store: FileStore = app['file_store']
     user = userdata['username']
@@ -1155,7 +1157,7 @@ VALUES (%s, %s, %s);
                 )
         except asyncio.CancelledError:
             raise
-        except aiohttp.web.HTTPException:
+        except web.HTTPException:
             raise
         except Exception as err:
             raise ValueError(
@@ -1219,7 +1221,7 @@ async def create_batch(request, userdata):
     return json_response({'id': id, 'update_id': update_id})
 
 
-async def _create_batch(batch_spec: dict, userdata: dict, db: Database):
+async def _create_batch(batch_spec: dict, userdata, db: Database) -> int:
     try:
         validate_batch(batch_spec)
     except ValidationError as e:
@@ -1526,14 +1528,14 @@ WHERE id = %s AND NOT deleted;
 @routes.get('/api/v1alpha/batches/{batch_id}')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def get_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def get_batch(request, _, batch_id):
     return json_response(await _get_batch(request.app, batch_id))
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def cancel_batch(request, _, batch_id):
     await _handle_api_error(_cancel_batch, request.app, batch_id)
     return web.Response()
 
@@ -1633,7 +1635,7 @@ async def _commit_update(app: web.Application, batch_id: int, update_id: int, us
 @routes.delete('/api/v1alpha/batches/{batch_id}')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def delete_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def delete_batch(request, _, batch_id):  # pylint: disable=unused-argument
     await _delete_batch(request.app, batch_id)
     return web.Response()
 
@@ -1675,7 +1677,7 @@ async def ui_batch(request, userdata, batch_id):
 @check_csrf_token
 @web_billing_project_users_only(redirect=False)
 @catch_ui_error_in_dev
-async def ui_cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def ui_cancel_batch(request, _, batch_id):
     post = await request.post()
     q = post.get('q')
     params = {}
@@ -1694,7 +1696,7 @@ async def ui_cancel_batch(request, userdata, batch_id):  # pylint: disable=unuse
 @check_csrf_token
 @web_billing_project_users_only(redirect=False)
 @catch_ui_error_in_dev
-async def ui_delete_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def ui_delete_batch(request, _, batch_id):
     post = await request.post()
     q = post.get('q')
     params = {}
@@ -1710,7 +1712,7 @@ async def ui_delete_batch(request, userdata, batch_id):  # pylint: disable=unuse
 @routes.get('/batches', name='batches')
 @auth.web_authenticated_users_only()
 @catch_ui_error_in_dev
-async def ui_batches(request: web.Request, userdata: dict):
+async def ui_batches(request: web.Request, userdata: UserData):
     session = await aiohttp_session.get_session(request)
     user = userdata['username']
     q = request.query.get('q', f'user:{user}')
@@ -1837,7 +1839,7 @@ WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/attempts')
 @rest_billing_project_users_only
-async def get_attempts(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def get_attempts(request, _, batch_id):
     job_id = int(request.match_info['job_id'])
     attempts = await _get_attempts(request.app, batch_id, job_id)
     return json_response(attempts)
@@ -1846,7 +1848,7 @@ async def get_attempts(request, userdata, batch_id):  # pylint: disable=unused-a
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
 @rest_billing_project_users_only
 @add_metadata_to_request
-async def get_job(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def get_job(request, _, batch_id):
     job_id = int(request.match_info['job_id'])
     status = await _get_job(request.app, batch_id, job_id)
     return json_response(status)
@@ -2015,11 +2017,11 @@ def plot_resource_usage(
 
         limit_props = {'color': 'black', 'width': 2}
         if memory_limit_bytes is not None:
-            fig.add_hline(memory_limit_bytes, row=1, col=2, line=limit_props)
+            fig.add_hline(memory_limit_bytes, row=1, col=2, line=limit_props)  # type: ignore
         if non_io_storage_limit_bytes is not None:
-            fig.add_hline(non_io_storage_limit_bytes, row=3, col=1, line=limit_props)
+            fig.add_hline(non_io_storage_limit_bytes, row=3, col=1, line=limit_props)  # type: ignore
         if io_storage_limit_bytes is not None:
-            fig.add_hline(io_storage_limit_bytes, row=3, col=2, line=limit_props)
+            fig.add_hline(io_storage_limit_bytes, row=3, col=2, line=limit_props)  # type: ignore
 
     fig.update_layout(
         showlegend=True,
@@ -2044,7 +2046,7 @@ def plot_resource_usage(
 @routes.get('/batches/{batch_id}/jobs/{job_id}/jvm_profile')
 @web_billing_project_users_only()
 @catch_ui_error_in_dev
-async def ui_get_jvm_profile(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def ui_get_jvm_profile(request, _, batch_id):
     app = request.app
     job_id = int(request.match_info['job_id'])
     profile = await _get_jvm_profile(app, batch_id, job_id)
@@ -2171,7 +2173,7 @@ async def ui_get_job(request, userdata, batch_id):
 @routes.get('/batches/{batch_id}/jobs/{job_id}/log/{container}')
 @web_billing_project_users_only()
 @catch_ui_error_in_dev
-async def ui_get_job_log(request, userdata, batch_id):  # pylint: disable=unused-argument
+async def ui_get_job_log(request, _, batch_id):
     return await get_job_container_log(request, batch_id)
 
 
@@ -2246,7 +2248,7 @@ UPDATE billing_projects SET `limit` = %s WHERE name_cs = %s;
 
 @routes.post('/api/v1alpha/billing_limits/{billing_project}/edit')
 @rest_authenticated_developers_or_auth_only
-async def post_edit_billing_limits(request, userdata):  # pylint: disable=unused-argument
+async def post_edit_billing_limits(request: web.Request):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
     data = await json_request(request)
@@ -2259,7 +2261,7 @@ async def post_edit_billing_limits(request, userdata):  # pylint: disable=unused
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
-async def post_edit_billing_limits_ui(request, userdata):  # pylint: disable=unused-argument
+async def post_edit_billing_limits_ui(request, _):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
     post = await request.post()
@@ -2272,7 +2274,7 @@ async def post_edit_billing_limits_ui(request, userdata):  # pylint: disable=unu
         return web.HTTPFound(deploy_config.external_url('batch', '/billing_limits'))  # pylint: disable=lost-exception
 
 
-async def _query_billing(request, user=None):
+async def _query_billing(request: web.Request, user=None) -> Tuple[list, str, Optional[str]]:
     db: Database = request.app['db']
 
     date_format = '%m/%d/%Y'
@@ -2282,7 +2284,7 @@ async def _query_billing(request, user=None):
 
     default_end = None
 
-    async def parse_error(msg):
+    async def parse_error(msg: str) -> Tuple[list, str, None]:
         session = await aiohttp_session.get_session(request)
         set_message(session, msg, 'error')
         return ([], default_start_str, default_end)
@@ -2485,7 +2487,7 @@ WHERE billing_projects.name_cs = %s AND user_cs = %s;
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
-async def post_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
+async def post_billing_projects_remove_user(request, _):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
     user = request.match_info['user']
@@ -2500,7 +2502,7 @@ async def post_billing_projects_remove_user(request, userdata):  # pylint: disab
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/remove')
 @rest_authenticated_developers_or_auth_only
-async def api_get_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
+async def api_get_billing_projects_remove_user(request: web.Request):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
     user = request.match_info['user']
@@ -2555,7 +2557,7 @@ VALUES (%s, %s, %s);
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
-async def post_billing_projects_add_user(request, userdata):  # pylint: disable=unused-argument
+async def post_billing_projects_add_user(request, _):
     db: Database = request.app['db']
     post = await request.post()
     user = post['user']
@@ -2572,7 +2574,7 @@ async def post_billing_projects_add_user(request, userdata):  # pylint: disable=
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/add')
 @rest_authenticated_developers_or_auth_only
-async def api_billing_projects_add_user(request, userdata):  # pylint: disable=unused-argument
+async def api_billing_projects_add_user(request: web.Request):
     db: Database = request.app['db']
     user = request.match_info['user']
     billing_project = request.match_info['billing_project']
@@ -2613,7 +2615,7 @@ VALUES (%s, %s);
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
-async def post_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
+async def post_create_billing_projects(request, _):
     db: Database = request.app['db']
     post = await request.post()
     billing_project = post['billing_project']
@@ -2628,7 +2630,7 @@ async def post_create_billing_projects(request, userdata):  # pylint: disable=un
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/create')
 @rest_authenticated_developers_or_auth_only
-async def api_get_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
+async def api_get_create_billing_projects(request: web.Request):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
     await _handle_api_error(_create_billing_project, db, billing_project)
@@ -2674,7 +2676,7 @@ FOR UPDATE;
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
-async def post_close_billing_projects(request, userdata):  # pylint: disable=unused-argument
+async def post_close_billing_projects(request, _):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
 
@@ -2688,7 +2690,7 @@ async def post_close_billing_projects(request, userdata):  # pylint: disable=unu
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/close')
 @rest_authenticated_developers_or_auth_only
-async def api_close_billing_projects(request, userdata):  # pylint: disable=unused-argument
+async def api_close_billing_projects(request: web.Request):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
 
@@ -2733,7 +2735,7 @@ async def post_reopen_billing_projects(request, userdata):  # pylint: disable=un
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/reopen')
 @rest_authenticated_developers_or_auth_only
-async def api_reopen_billing_projects(request, userdata):  # pylint: disable=unused-argument
+async def api_reopen_billing_projects(request: web.Request):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
     await _handle_api_error(_reopen_billing_project, db, billing_project)
@@ -2763,7 +2765,7 @@ async def _delete_billing_project(db, billing_project):
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/delete')
 @rest_authenticated_developers_or_auth_only
-async def api_delete_billing_projects(request, userdata):  # pylint: disable=unused-argument
+async def api_delete_billing_projects(request: web.Request):
     db: Database = request.app['db']
     billing_project = request.match_info['billing_project']
 
@@ -2793,7 +2795,7 @@ SELECT frozen FROM globals;
 @routes.get('/')
 @auth.web_authenticated_users_only()
 @catch_ui_error_in_dev
-async def index(request, userdata):  # pylint: disable=unused-argument
+async def index(request, _):
     location = request.app.router['batches'].url_for()
     raise web.HTTPFound(location=location)
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1682,9 +1682,9 @@ async def ui_batch(request, userdata, batch_id):
 async def ui_cancel_batch(request: web.Request, _, batch_id: int) -> web.HTTPFound:
     post = await request.post()
     q = post.get('q')
-    params = {}
+    params: Dict[str, str] = {}
     if q is not None:
-        params['q'] = q
+        params['q'] = str(q)
     session = await aiohttp_session.get_session(request)
     try:
         await _handle_ui_error(session, _cancel_batch, request.app, batch_id)
@@ -1701,9 +1701,9 @@ async def ui_cancel_batch(request: web.Request, _, batch_id: int) -> web.HTTPFou
 async def ui_delete_batch(request: web.Request, _, batch_id: int) -> web.HTTPFound:
     post = await request.post()
     q = post.get('q')
-    params = {}
+    params: Dict[str, str] = {}
     if q is not None:
-        params['q'] = q
+        params['q'] = str(q)
     await _delete_batch(request.app, batch_id)
     session = await aiohttp_session.get_session(request)
     set_message(session, f'Batch {batch_id} deleted.', 'info')
@@ -2271,7 +2271,7 @@ async def post_edit_billing_limits_ui(request: web.Request, _) -> web.HTTPFound:
     session = await aiohttp_session.get_session(request)
     try:
         await _handle_ui_error(session, _edit_billing_limit, db, billing_project, limit)
-        set_message(session, f'Modified limit {limit} for billing project {billing_project}.', 'info')
+        set_message(session, f'Modified limit {limit} for billing project {billing_project}.', 'info')  # type: ignore
     finally:
         return web.HTTPFound(deploy_config.external_url('batch', '/billing_limits'))  # pylint: disable=lost-exception
 
@@ -2313,7 +2313,7 @@ async def _query_billing(request: web.Request, user: Optional[str] = None) -> Tu
         "billing_projects.`status` != 'deleted'",
         "billing_date >= %s",
     ]
-    where_args = [start]
+    where_args: List[Any] = [start]
 
     if end is not None:
         where_conditions.append("billing_date <= %s")
@@ -2569,7 +2569,7 @@ async def post_billing_projects_add_user(request: web.Request, _) -> web.HTTPFou
 
     try:
         await _handle_ui_error(session, _add_user_to_billing_project, db, billing_project, user)
-        set_message(session, f'Added user {user} to billing project {billing_project}.', 'info')
+        set_message(session, f'Added user {user} to billing project {billing_project}.', 'info')  # type: ignore
     finally:
         return web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))  # pylint: disable=lost-exception
 
@@ -2625,7 +2625,7 @@ async def post_create_billing_projects(request: web.Request, _) -> web.HTTPFound
     session = await aiohttp_session.get_session(request)
     try:
         await _handle_ui_error(session, _create_billing_project, db, billing_project)
-        set_message(session, f'Added billing project {billing_project}.', 'info')
+        set_message(session, f'Added billing project {billing_project}.', 'info')  # type: ignore
     finally:
         return web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))  # pylint: disable=lost-exception
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import traceback
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 import aiohttp_session  # type: ignore
 import kubernetes_asyncio
@@ -135,13 +135,13 @@ async def watched_branch_config(app, wb: WatchedBranch, index: int) -> WatchedBr
 @routes.get('')
 @routes.get('/')
 @auth.web_authenticated_developers_only()
-async def index(request: web.Request, userdata: UserData):
+async def index(request: web.Request, userdata: UserData) -> web.Response:
     wb_configs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
     page_context = {'watched_branches': wb_configs, 'frozen_merge_deploy': request.app['frozen_merge_deploy']}
     return await render_template('ci', request, userdata, 'index.html', page_context)
 
 
-def wb_and_pr_from_request(request: web.Request):
+def wb_and_pr_from_request(request: web.Request) -> Tuple[WatchedBranch, PR]:
     watched_branch_index = int(request.match_info['watched_branch_index'])
     pr_number = int(request.match_info['pr_number'])
 
@@ -163,7 +163,7 @@ def filter_jobs(jobs):
 
 @routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
 @auth.web_authenticated_developers_only()
-async def get_pr(request: web.Request, userdata: UserData):
+async def get_pr(request: web.Request, userdata: UserData) -> web.Response:
     wb, pr = wb_and_pr_from_request(request)
 
     page_context = {}
@@ -226,7 +226,7 @@ async def retry_pr(wb, pr, request):
 @routes.post('/watched_branches/{watched_branch_index}/pr/{pr_number}/retry')
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
-async def post_retry_pr(request, _):
+async def post_retry_pr(request: web.Request, _) -> web.HTTPFound:
     wb, pr = wb_and_pr_from_request(request)
 
     await asyncio.shield(retry_pr(wb, pr, request))
@@ -312,7 +312,7 @@ def pr_requires_action(gh_username: str, pr_config: PRConfig) -> bool:
 
 @routes.get('/me')
 @auth.web_authenticated_developers_only()
-async def get_user(request: web.Request, userdata: UserData):
+async def get_user(request: web.Request, userdata: UserData) -> web.Response:
     for authorized_user in AUTHORIZED_USERS:
         if authorized_user.hail_username == userdata['username']:
             user = authorized_user
@@ -346,7 +346,7 @@ async def get_user(request: web.Request, userdata: UserData):
 @routes.post('/authorize_source_sha')
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
-async def post_authorized_source_sha(request: web.Request, _):
+async def post_authorized_source_sha(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     db: Database = app['db']
     post = await request.post()
@@ -359,7 +359,7 @@ async def post_authorized_source_sha(request: web.Request, _):
 
 
 @routes.get('/healthcheck')
-async def healthcheck(_):
+async def healthcheck(_) -> web.Response:
     return web.Response(status=200)
 
 
@@ -442,7 +442,7 @@ async def batch_callback_handler(request):
 
 @routes.get('/api/v1alpha/deploy_status')
 @auth.rest_authenticated_developers_only
-async def deploy_status(request: web.Request, _):
+async def deploy_status(request: web.Request, _) -> web.Response:
     batch_client = request.app['batch_client']
 
     async def get_failure_information(batch):
@@ -476,7 +476,7 @@ async def deploy_status(request: web.Request, _):
 
 @routes.post('/api/v1alpha/update')
 @auth.rest_authenticated_developers_only
-async def post_update(request: web.Request, _):
+async def post_update(request: web.Request, _) -> web.Response:
     log.info('developer triggered update')
 
     async def update_all():
@@ -489,7 +489,7 @@ async def post_update(request: web.Request, _):
 
 @routes.post('/api/v1alpha/dev_deploy_branch')
 @auth.rest_authenticated_developers_only
-async def dev_deploy_branch(request: web.Request, userdata: UserData):
+async def dev_deploy_branch(request: web.Request, userdata: UserData) -> web.Response:
     app = request.app
     try:
         params = await json_request(request)
@@ -548,7 +548,7 @@ async def batch_callback(request):
 @routes.post('/freeze_merge_deploy')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def freeze_deploys(request: web.Request, _):
+async def freeze_deploys(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     db: Database = app['db']
     session = await aiohttp_session.get_session(request)
@@ -573,7 +573,7 @@ UPDATE globals SET frozen_merge_deploy = 1;
 @routes.post('/unfreeze_merge_deploy')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def unfreeze_deploys(request: web.Request, _):
+async def unfreeze_deploys(request: web.Request, _) -> web.HTTPFound:
     app = request.app
     db: Database = app['db']
     session = await aiohttp_session.get_session(request)
@@ -597,7 +597,7 @@ UPDATE globals SET frozen_merge_deploy = 0;
 
 @routes.get('/namespaces')
 @auth.web_authenticated_developers_only()
-async def get_active_namespaces(request: web.Request, userdata: UserData):
+async def get_active_namespaces(request: web.Request, userdata: UserData) -> web.Response:
     db: Database = request.app['db']
     namespaces = [
         r
@@ -621,7 +621,7 @@ GROUP BY active_namespaces.namespace'''
 @routes.post('/namespaces/{namespace}/services/add')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def add_namespaced_service(request: web.Request, _):
+async def add_namespaced_service(request: web.Request, _) -> web.HTTPFound:
     db: Database = request.app['db']
     post = await request.post()
     service = post['service']
@@ -650,7 +650,7 @@ WHERE namespace = %s AND service = %s
 @routes.post('/namespaces/add')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def add_namespace(request: web.Request, _):
+async def add_namespace(request: web.Request, _) -> web.HTTPFound:
     db: Database = request.app['db']
     post = await request.post()
     namespace = post['namespace']

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -8,6 +8,8 @@ from typing import Callable, Dict, List, Optional, Set
 
 import aiohttp_session  # type: ignore
 import kubernetes_asyncio
+import kubernetes_asyncio.client
+import kubernetes_asyncio.config
 import uvloop  # type: ignore
 import yaml
 from aiohttp import web
@@ -20,6 +22,7 @@ from typing_extensions import TypedDict
 from gear import (
     AuthClient,
     Database,
+    UserData,
     check_csrf_token,
     json_request,
     json_response,
@@ -132,13 +135,13 @@ async def watched_branch_config(app, wb: WatchedBranch, index: int) -> WatchedBr
 @routes.get('')
 @routes.get('/')
 @auth.web_authenticated_developers_only()
-async def index(request, userdata):  # pylint: disable=unused-argument
+async def index(request: web.Request, userdata: UserData):
     wb_configs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
     page_context = {'watched_branches': wb_configs, 'frozen_merge_deploy': request.app['frozen_merge_deploy']}
     return await render_template('ci', request, userdata, 'index.html', page_context)
 
 
-def wb_and_pr_from_request(request):
+def wb_and_pr_from_request(request: web.Request):
     watched_branch_index = int(request.match_info['watched_branch_index'])
     pr_number = int(request.match_info['pr_number'])
 
@@ -160,7 +163,7 @@ def filter_jobs(jobs):
 
 @routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
 @auth.web_authenticated_developers_only()
-async def get_pr(request, userdata):  # pylint: disable=unused-argument
+async def get_pr(request: web.Request, userdata: UserData):
     wb, pr = wb_and_pr_from_request(request)
 
     page_context = {}
@@ -223,7 +226,7 @@ async def retry_pr(wb, pr, request):
 @routes.post('/watched_branches/{watched_branch_index}/pr/{pr_number}/retry')
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
-async def post_retry_pr(request, userdata):  # pylint: disable=unused-argument
+async def post_retry_pr(request, _):
     wb, pr = wb_and_pr_from_request(request)
 
     await asyncio.shield(retry_pr(wb, pr, request))
@@ -309,7 +312,7 @@ def pr_requires_action(gh_username: str, pr_config: PRConfig) -> bool:
 
 @routes.get('/me')
 @auth.web_authenticated_developers_only()
-async def get_user(request, userdata):
+async def get_user(request: web.Request, userdata: UserData):
     for authorized_user in AUTHORIZED_USERS:
         if authorized_user.hail_username == userdata['username']:
             user = authorized_user
@@ -343,11 +346,11 @@ async def get_user(request, userdata):
 @routes.post('/authorize_source_sha')
 @check_csrf_token
 @auth.web_authenticated_developers_only(redirect=False)
-async def post_authorized_source_sha(request, userdata):  # pylint: disable=unused-argument
+async def post_authorized_source_sha(request: web.Request, _):
     app = request.app
     db: Database = app['db']
     post = await request.post()
-    sha = post['sha'].strip()
+    sha = str(post['sha']).strip()
     await db.execute_insertone('INSERT INTO authorized_shas (sha) VALUES (%s);', sha)
     log.info(f'authorized sha: {sha}')
     session = await aiohttp_session.get_session(request)
@@ -356,7 +359,7 @@ async def post_authorized_source_sha(request, userdata):  # pylint: disable=unus
 
 
 @routes.get('/healthcheck')
-async def healthcheck(request):  # pylint: disable=unused-argument
+async def healthcheck(_):
     return web.Response(status=200)
 
 
@@ -439,7 +442,7 @@ async def batch_callback_handler(request):
 
 @routes.get('/api/v1alpha/deploy_status')
 @auth.rest_authenticated_developers_only
-async def deploy_status(request, userdata):  # pylint: disable=unused-argument
+async def deploy_status(request: web.Request, _):
     batch_client = request.app['batch_client']
 
     async def get_failure_information(batch):
@@ -473,7 +476,7 @@ async def deploy_status(request, userdata):  # pylint: disable=unused-argument
 
 @routes.post('/api/v1alpha/update')
 @auth.rest_authenticated_developers_only
-async def post_update(request, userdata):  # pylint: disable=unused-argument
+async def post_update(request: web.Request, _):
     log.info('developer triggered update')
 
     async def update_all():
@@ -486,7 +489,7 @@ async def post_update(request, userdata):  # pylint: disable=unused-argument
 
 @routes.post('/api/v1alpha/dev_deploy_branch')
 @auth.rest_authenticated_developers_only
-async def dev_deploy_branch(request, userdata):
+async def dev_deploy_branch(request: web.Request, userdata: UserData):
     app = request.app
     try:
         params = await json_request(request)
@@ -545,7 +548,7 @@ async def batch_callback(request):
 @routes.post('/freeze_merge_deploy')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def freeze_deploys(request, userdata):  # pylint: disable=unused-argument
+async def freeze_deploys(request: web.Request, _):
     app = request.app
     db: Database = app['db']
     session = await aiohttp_session.get_session(request)
@@ -570,7 +573,7 @@ UPDATE globals SET frozen_merge_deploy = 1;
 @routes.post('/unfreeze_merge_deploy')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def unfreeze_deploys(request, userdata):  # pylint: disable=unused-argument
+async def unfreeze_deploys(request: web.Request, _):
     app = request.app
     db: Database = app['db']
     session = await aiohttp_session.get_session(request)
@@ -594,7 +597,7 @@ UPDATE globals SET frozen_merge_deploy = 0;
 
 @routes.get('/namespaces')
 @auth.web_authenticated_developers_only()
-async def get_active_namespaces(request, userdata):
+async def get_active_namespaces(request: web.Request, userdata: UserData):
     db: Database = request.app['db']
     namespaces = [
         r
@@ -618,7 +621,7 @@ GROUP BY active_namespaces.namespace'''
 @routes.post('/namespaces/{namespace}/services/add')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def add_namespaced_service(request, userdata):  # pylint: disable=unused-argument
+async def add_namespaced_service(request: web.Request, _):
     db: Database = request.app['db']
     post = await request.post()
     service = post['service']
@@ -647,7 +650,7 @@ WHERE namespace = %s AND service = %s
 @routes.post('/namespaces/add')
 @check_csrf_token
 @auth.web_authenticated_developers_only()
-async def add_namespace(request, userdata):  # pylint: disable=unused-argument
+async def add_namespace(request: web.Request, _):
     db: Database = request.app['db']
     post = await request.post()
     namespace = post['namespace']
@@ -725,6 +728,7 @@ GROUP BY active_namespaces.namespace''',
 
 
 async def update_loop(app):
+    wb: Optional[WatchedBranch] = None
     while True:
         try:
             for wb in watched_branches:
@@ -733,7 +737,8 @@ async def update_loop(app):
         except concurrent.futures.CancelledError:
             raise
         except Exception:  # pylint: disable=broad-except
-            log.exception(f'{wb.branch.short_str()} update failed due to exception')
+            if wb:
+                log.exception(f'{wb.branch.short_str()} update failed due to exception')
         await asyncio.sleep(300)
 
 

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -1,4 +1,4 @@
-from .auth import AuthClient, maybe_parse_bearer_header
+from .auth import AuthClient, UserData, maybe_parse_bearer_header
 from .auth_utils import create_session, insert_user
 from .csrf import check_csrf_token, new_csrf_token
 from .database import Database, Transaction, create_database_pool, resolve_test_db_endpoint, transaction
@@ -19,6 +19,7 @@ __all__ = [
     'transaction',
     'maybe_parse_bearer_header',
     'AuthClient',
+    'UserData',
     'monitor_endpoints_middleware',
     'json_request',
     'json_response',

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import urllib.parse
 from functools import wraps
-from typing import Optional, Tuple
+from typing import Awaitable, Callable, Optional, Tuple, TypedDict
 
 import aiohttp
 import aiohttp_session
@@ -23,10 +23,22 @@ BEARER = 'Bearer '
 TEN_SECONDS_IN_NANOSECONDS = int(1e10)
 
 
+class UserData(TypedDict):
+    username: str
+    is_developer: bool
+    is_service_account: bool
+    hail_credentials_secret_name: str
+    tokens_secret_name: str
+    session_id: str
+
+
 def maybe_parse_bearer_header(value: str) -> Optional[str]:
     if value.startswith(BEARER):
         return value[len(BEARER) :]
     return None
+
+
+AiohttpHandler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 
 
 class AuthClient:
@@ -35,35 +47,39 @@ class AuthClient:
             self._load_userdata, TEN_SECONDS_IN_NANOSECONDS, 100, 'session_userdata_cache'
         )
 
-    def rest_authenticated_users_only(self, fun):
-        async def wrapped(request, *args, **kwargs):
+    def rest_authenticated_users_only(
+        self, fun: Callable[[web.Request, UserData], Awaitable[web.StreamResponse]]
+    ) -> AiohttpHandler:
+        async def wrapped(request: web.Request):
             userdata = await self._userdata_from_rest_request(request)
             if not userdata:
                 web_userdata = await self._userdata_from_web_request(request)
                 if web_userdata:
                     return web.HTTPUnauthorized(reason="provided web auth to REST endpoint")
                 raise web.HTTPUnauthorized()
-            return await fun(request, userdata, *args, **kwargs)
+            return await fun(request, userdata)
 
         return wrapped
 
     def web_authenticated_users_only(self, redirect=True):
-        def wrap(fun):
+        def wrap(fun: Callable[[web.Request, UserData], Awaitable[web.StreamResponse]]):
             @wraps(fun)
-            async def wrapped(request, *args, **kwargs):
+            async def wrapped(request: web.Request):
                 userdata = await self._userdata_from_web_request(request)
                 if not userdata:
                     rest_userdata = await self._userdata_from_rest_request(request)
                     if rest_userdata:
                         return web.HTTPUnauthorized(reason="provided REST auth to web endpoint")
                     raise _web_unauthenticated(request, redirect)
-                return await fun(request, userdata, *args, **kwargs)
+                return await fun(request, userdata)
 
             return wrapped
 
         return wrap
 
-    def web_maybe_authenticated_user(self, fun):
+    def web_maybe_authenticated_user(
+        self, fun: Callable[[web.Request, Optional[UserData]], Awaitable[web.StreamResponse]]
+    ) -> AiohttpHandler:
         @wraps(fun)
         async def wrapped(request, *args, **kwargs):
             return await fun(request, await self._userdata_from_web_request(request), *args, **kwargs)
@@ -100,7 +116,7 @@ class AuthClient:
 
         return await self._userdata_cache.lookup((session['session_id'], request.app['client_session']))
 
-    async def _userdata_from_rest_request(self, request):
+    async def _userdata_from_rest_request(self, request) -> Optional[UserData]:
         if 'Authorization' not in request.headers:
             return None
         auth_header = request.headers['Authorization']

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -38,7 +38,9 @@ def maybe_parse_bearer_header(value: str) -> Optional[str]:
     return None
 
 
-AiohttpHandler = Callable[[web.Request], Awaitable[web.StreamResponse]]
+AIOHTTPHandler = Callable[[web.Request], Awaitable[web.StreamResponse]]
+AuthenticatedAIOHTTPHandler = Callable[[web.Request, UserData], Awaitable[web.StreamResponse]]
+MaybeAuthenticatedAIOHTTPHandler = Callable[[web.Request, Optional[UserData]], Awaitable[web.StreamResponse]]
 
 
 class AuthClient:
@@ -47,10 +49,8 @@ class AuthClient:
             self._load_userdata, TEN_SECONDS_IN_NANOSECONDS, 100, 'session_userdata_cache'
         )
 
-    def rest_authenticated_users_only(
-        self, fun: Callable[[web.Request, UserData], Awaitable[web.StreamResponse]]
-    ) -> AiohttpHandler:
-        async def wrapped(request: web.Request):
+    def rest_authenticated_users_only(self, fun: AuthenticatedAIOHTTPHandler) -> AIOHTTPHandler:
+        async def wrapped(request: web.Request) -> web.StreamResponse:
             userdata = await self._userdata_from_rest_request(request)
             if not userdata:
                 web_userdata = await self._userdata_from_web_request(request)
@@ -61,15 +61,17 @@ class AuthClient:
 
         return wrapped
 
-    def web_authenticated_users_only(self, redirect=True):
-        def wrap(fun: Callable[[web.Request, UserData], Awaitable[web.StreamResponse]]):
+    def web_authenticated_users_only(
+        self, redirect: bool = True
+    ) -> Callable[[AuthenticatedAIOHTTPHandler], AIOHTTPHandler]:
+        def wrap(fun: AuthenticatedAIOHTTPHandler):
             @wraps(fun)
-            async def wrapped(request: web.Request):
+            async def wrapped(request: web.Request) -> web.StreamResponse:
                 userdata = await self._userdata_from_web_request(request)
                 if not userdata:
                     rest_userdata = await self._userdata_from_rest_request(request)
                     if rest_userdata:
-                        return web.HTTPUnauthorized(reason="provided REST auth to web endpoint")
+                        raise web.HTTPUnauthorized(reason="provided REST auth to web endpoint")
                     raise _web_unauthenticated(request, redirect)
                 return await fun(request, userdata)
 
@@ -77,12 +79,10 @@ class AuthClient:
 
         return wrap
 
-    def web_maybe_authenticated_user(
-        self, fun: Callable[[web.Request, Optional[UserData]], Awaitable[web.StreamResponse]]
-    ) -> AiohttpHandler:
+    def web_maybe_authenticated_user(self, fun: MaybeAuthenticatedAIOHTTPHandler) -> AIOHTTPHandler:
         @wraps(fun)
-        async def wrapped(request, *args, **kwargs):
-            return await fun(request, await self._userdata_from_web_request(request), *args, **kwargs)
+        async def wrapped(request: web.Request) -> web.StreamResponse:
+            return await fun(request, await self._userdata_from_web_request(request))
 
         return wrapped
 
@@ -116,7 +116,7 @@ class AuthClient:
 
         return await self._userdata_cache.lookup((session['session_id'], request.app['client_session']))
 
-    async def _userdata_from_rest_request(self, request) -> Optional[UserData]:
+    async def _userdata_from_rest_request(self, request: web.Request) -> Optional[UserData]:
         if 'Authorization' not in request.headers:
             return None
         auth_header = request.headers['Authorization']
@@ -154,7 +154,7 @@ async def impersonate_user_and_get_info(session_id: str, client_session: httpx.C
 
 def _web_unauthenticated(request, redirect):
     if not redirect:
-        return web.HTTPUnauthorized()
+        raise web.HTTPUnauthorized()
 
     login_url = deploy_config.external_url('auth', '/login')
 

--- a/gear/gear/auth_utils.py
+++ b/gear/gear/auth_utils.py
@@ -1,6 +1,9 @@
 import secrets
+from typing import Optional
 
 from hailtop.auth import session_id_encode_to_str
+
+from .database import Database
 
 
 async def insert_user(db, spec):
@@ -16,7 +19,7 @@ VALUES ({', '.join([f'%({k})s' for k in spec.keys()])})
 
 
 # 2592000s = 30d
-async def create_session(db, user_id, max_age_secs=2592000):
+async def create_session(db: Database, user_id: str, max_age_secs: Optional[int] = 2592000):
     session_id = session_id_encode_to_str(secrets.token_bytes(32))
     await db.just_execute(
         'INSERT INTO sessions (session_id, user_id, max_age_secs) VALUES (%s, %s, %s);',

--- a/gear/gear/auth_utils.py
+++ b/gear/gear/auth_utils.py
@@ -19,7 +19,7 @@ VALUES ({', '.join([f'%({k})s' for k in spec.keys()])})
 
 
 # 2592000s = 30d
-async def create_session(db: Database, user_id: str, max_age_secs: Optional[int] = 2592000):
+async def create_session(db: Database, user_id: str, max_age_secs: Optional[int] = 2592000) -> str:
     session_id = session_id_encode_to_str(secrets.token_bytes(32))
     await db.just_execute(
         'INSERT INTO sessions (session_id, user_id, max_age_secs) VALUES (%s, %s, %s);',

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -2,12 +2,14 @@ import importlib
 import os
 
 import aiohttp
+from aiohttp import web
 import aiohttp_jinja2
 import aiohttp_session
 import jinja2
 import sass
+from typing import Optional
 
-from gear import new_csrf_token
+from gear import UserData, new_csrf_token
 from hailtop.config import get_deploy_config
 
 deploy_config = get_deploy_config()
@@ -74,7 +76,7 @@ def base_context(session, userdata, service):
     return context
 
 
-async def render_template(service, request, userdata, file, page_context):
+async def render_template(service: str, request: web.Request, userdata: Optional[UserData], file: str, page_context):
     if '_csrf' in request.cookies:
         csrf_token = request.cookies['_csrf']
     else:

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -1,8 +1,7 @@
 import importlib
 import os
-from typing import Optional
+from typing import Any, Dict, Optional
 
-import aiohttp
 import aiohttp_jinja2
 import aiohttp_session
 import jinja2
@@ -31,7 +30,7 @@ def sass_compile(module_name):
     sass.compile(dirname=(scss_path, css_path), output_style='compressed', include_paths=[f'{WEB_COMMON_ROOT}/styles'])
 
 
-def setup_aiohttp_jinja2(app: aiohttp.web.Application, module: str, *extra_loaders: jinja2.BaseLoader):
+def setup_aiohttp_jinja2(app: web.Application, module: str, *extra_loaders: jinja2.BaseLoader):
     aiohttp_jinja2.setup(
         app,
         loader=jinja2.ChoiceLoader([jinja2.PackageLoader('web_common'), jinja2.PackageLoader(module), *extra_loaders]),
@@ -76,7 +75,9 @@ def base_context(session, userdata, service):
     return context
 
 
-async def render_template(service: str, request: web.Request, userdata: Optional[UserData], file: str, page_context):
+async def render_template(
+    service: str, request: web.Request, userdata: Optional[UserData], file: str, page_context: Dict[str, Any]
+) -> web.Response:
     if '_csrf' in request.cookies:
         csrf_token = request.cookies['_csrf']
     else:

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -1,13 +1,13 @@
 import importlib
 import os
+from typing import Optional
 
 import aiohttp
-from aiohttp import web
 import aiohttp_jinja2
 import aiohttp_session
 import jinja2
 import sass
-from typing import Optional
+from aiohttp import web
 
 from gear import UserData, new_csrf_token
 from hailtop.config import get_deploy_config


### PR DESCRIPTION
Post-vacation brain is mushy so I squashed some poor typing that my nvim lsp has been mad at me about for ages. Specifically, added sufficient type signatures to our aiohttp handler decorators, removed some unnecessary pylint ignore directives, and added a bit of typing to the `userdata` dict. There should be no changes in functionality.