### PR TITLE
[gear] Add typing to the transaction decorator

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -162,7 +162,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s);
             ),
         )
 
-    await _insert()  # pylint: disable=no-value-for-parameter
+    await _insert()
     return True
 
 
@@ -696,7 +696,7 @@ WHERE copy_paste_tokens.id = %s
         await tx.just_execute("DELETE FROM copy_paste_tokens WHERE id = %s;", copy_paste_token)
         return session
 
-    session = await maybe_pop_token()  # pylint: disable=no-value-for-parameter
+    session = await maybe_pop_token()
     return json_response({'token': session['session_id'], 'username': session['username']})
 
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -112,4 +112,4 @@ FOR UPDATE;
 
         await tx.just_execute('CALL cancel_batch(%s);', (batch_id,))
 
-    await cancel()  # pylint: disable=no-value-for-parameter
+    await cancel()

--- a/batch/batch/driver/billing_manager.py
+++ b/batch/batch/driver/billing_manager.py
@@ -149,7 +149,7 @@ ON DUPLICATE KEY UPDATE version = VALUES(version)
                     product_version_updates,
                 )
 
-        await insert_or_update()  # pylint: disable=no-value-for-parameter
+        await insert_or_update()
 
         if resource_updates or product_version_updates:
             await self.refresh_resources()
@@ -164,7 +164,7 @@ ON DUPLICATE KEY UPDATE version = VALUES(version)
             self.product_versions.update(latest_product_versions)
             log.info('refreshed product versions')
 
-        await refresh()  # pylint: disable=no-value-for-parameter
+        await refresh()
 
 
 async def refresh_product_versions_from_db(db: Database) -> Dict[str, str]:

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -95,7 +95,7 @@ VALUES (%s, %s);
                 ),
             )
 
-        await insert()  # pylint: disable=no-value-for-parameter
+        await insert()
 
         return Instance(
             app,

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1076,7 +1076,7 @@ LOCK IN SHARE MODE;
         if len(failures) > 0:
             raise ValueError(json.dumps(failures))
 
-    await check()  # pylint: disable=no-value-for-parameter
+    await check()
 
 
 async def check_resource_aggregation(db):
@@ -1217,7 +1217,7 @@ LOCK IN SHARE MODE;
             agg_billing_project_resources,
         )
 
-    await check()  # pylint: disable=no-value-for-parameter
+    await check()
 
 
 async def _cancel_batch(app, batch_id):

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1170,7 +1170,12 @@ VALUES (%s, %s, %s);
         # must rollback. See https://github.com/hail-is/hail-production-issues/issues/9
         await asyncio.gather(write_spec_to_cloud(), insert_jobs_into_db(tx))
 
-    await write_and_insert()  # pylint: disable=no-value-for-parameter
+    await write_and_insert()
+
+    def foo(x):
+        return x
+
+    foo()
 
     return web.Response()
 
@@ -1330,7 +1335,7 @@ VALUES (%s, %s, %s)
             )
         return id
 
-    return await insert()  # pylint: disable=no-value-for-parameter
+    return await insert()
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/update-fast')
@@ -1456,7 +1461,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s);
 
         return (update_id, update_start_job_id)
 
-    return await update()  # pylint: disable=no-value-for-parameter
+    return await update()
 
 
 async def _get_batch(app, batch_id):
@@ -2241,7 +2246,7 @@ UPDATE billing_projects SET `limit` = %s WHERE name_cs = %s;
             (limit, billing_project),
         )
 
-    await insert()  # pylint: disable=no-value-for-parameter
+    await insert()
 
 
 @routes.post('/api/v1alpha/billing_limits/{billing_project}/edit')
@@ -2478,7 +2483,7 @@ WHERE billing_projects.name_cs = %s AND user_cs = %s;
             (billing_project, user),
         )
 
-    await delete()  # pylint: disable=no-value-for-parameter
+    await delete()
 
 
 @routes.post('/billing_projects/{billing_project}/users/{user}/remove')
@@ -2548,7 +2553,7 @@ VALUES (%s, %s, %s);
             (billing_project, user, user),
         )
 
-    await insert()  # pylint: disable=no-value-for-parameter
+    await insert()
 
 
 @routes.post('/billing_projects/{billing_project}/users/add')
@@ -2606,7 +2611,7 @@ VALUES (%s, %s);
             (billing_project, billing_project),
         )
 
-    await insert()  # pylint: disable=no-value-for-parameter
+    await insert()
 
 
 @routes.post('/billing_projects/create')
@@ -2667,7 +2672,7 @@ FOR UPDATE;
             "UPDATE billing_projects SET `status` = 'closed' WHERE name_cs = %s;", (billing_project,)
         )
 
-    await close_project()  # pylint: disable=no-value-for-parameter
+    await close_project()
 
 
 @routes.post('/billing_projects/{billing_project}/close')
@@ -2712,7 +2717,7 @@ async def _reopen_billing_project(db, billing_project):
 
         await tx.execute_update("UPDATE billing_projects SET `status` = 'open' WHERE name_cs = %s;", (billing_project,))
 
-    await open_project()  # pylint: disable=no-value-for-parameter
+    await open_project()
 
 
 @routes.post('/billing_projects/{billing_project}/reopen')
@@ -2758,7 +2763,7 @@ async def _delete_billing_project(db, billing_project):
             "UPDATE billing_projects SET `status` = 'deleted' WHERE name_cs = %s;", (billing_project,)
         )
 
-    await delete_project()  # pylint: disable=no-value-for-parameter
+    await delete_project()
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/delete')

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1172,11 +1172,6 @@ VALUES (%s, %s, %s);
 
     await write_and_insert()
 
-    def foo(x):
-        return x
-
-    foo()
-
     return web.Response()
 
 

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -62,7 +62,7 @@ async def insert_user_if_not_exists(app, username, login_id, is_developer, is_se
             ),
         )
 
-    return await insert()  # pylint: disable=no-value-for-parameter
+    return await insert()
 
 
 async def main():

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -231,7 +231,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
                 records,
             )
 
-        await insert()  # pylint: disable=no-value-for-parameter
+        await insert()
 
     log.info('updating billing information')
     now = datetime.datetime.now()

--- a/pylintrc
+++ b/pylintrc
@@ -17,6 +17,9 @@ ignore=sql
 # C1801 Do not use len(SEQUENCE) as condition value
 # W0221 Parameters differ from overridden method
 
+# Reasons for disabling:
+# no-value-for-parameter -- See bug in pylint https://github.com/pylint-dev/pylint/issues/259 and this is covered by mypy
+
 disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,unnecessary-lambda-assignment,too-many-public-methods,broad-except,too-many-return-statements,bare-except,invalid-name,unsubscriptable-object,consider-using-f-string,try-except-raise,no-value-for-parameter
 
 [FORMAT]

--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,7 @@ ignore=sql
 # C1801 Do not use len(SEQUENCE) as condition value
 # W0221 Parameters differ from overridden method
 
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,unnecessary-lambda-assignment,too-many-public-methods,broad-except,too-many-return-statements,bare-except,invalid-name,unsubscriptable-object,consider-using-f-string,try-except-raise
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,unnecessary-lambda-assignment,too-many-public-methods,broad-except,too-many-return-statements,bare-except,invalid-name,unsubscriptable-object,consider-using-f-string,try-except-raise,no-value-for-parameter
 
 [FORMAT]
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1


### PR DESCRIPTION
Adding this signature appeases `pyright` in my editor. Unfortunately, `pylint` still [gets confused](https://github.com/pylint-dev/pylint/issues/259) so I disabled this particular check. I made sure that `mypy` still errors when forgetting to provide a required parameter to a function call.