### PR TITLE
[query] removes unnecessary serialization in is.hail.rvd.RVD.localSort

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -35,6 +35,11 @@ _FLOAT_INFO_FIELDS = [
 _FLOAT_ARRAY_INFO_FIELDS = ['AF', 'MLEAF']
 
 
+def _vcf_unsorted_alleles():
+    mt = hl.import_vcf(resource('sample.pksorted.vcf'), n_partitions=4)
+    mt.rows()._force_count()
+
+
 class VCFTests(unittest.TestCase):
     def test_info_char(self):
         self.assertEqual(hl.import_vcf(resource('infochar.vcf')).count_rows(), 1)
@@ -208,8 +213,10 @@ class VCFTests(unittest.TestCase):
         self.assertTrue(mt.entries()._same(expected))
 
     def test_vcf_unsorted_alleles(self):
-        mt = hl.import_vcf(resource('sample.pksorted.vcf'), n_partitions=4)
-        mt.rows()._force_count()
+        _vcf_unsorted_alleles()
+
+    def test_vcf_unsorted_alleles_no_codegen(self):
+        with_flags(no_whole_stage_codegen="1")(_vcf_unsorted_alleles)()
 
     def test_import_vcf_skip_invalid_loci(self):
         mt = hl.import_vcf(resource('skip_invalid_loci.vcf'), reference_genome='GRCh37',

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -392,8 +392,9 @@ class RVD(
     require(partitioner.satisfiesAllowedOverlap(typ.key.length - 1))
 
     val localTyp = typ
+    val localSm = partitioner.sm
     val sortedRDD = crdd.toCRDDRegionValue.cmapPartitions { (consumerCtx, it) =>
-      OrderedRVIterator(localTyp, it, consumerCtx, partitioner.sm).localKeySort(newKey)
+      OrderedRVIterator(localTyp, it, consumerCtx, localSm).localKeySort(newKey)
     }.toCRDDPtr
 
     val newType = typ.copy(key = newKey)


### PR DESCRIPTION
On the current release (0.2.119), `is.hail.rvd.RVD.localSort` attempts to serialize an entire `is.hail.rvd.RVD` object when called, which causes some operations, like reading a set of VCF files, to fail. That particular operation no longer fails due to some combination of the changes made to reading VCF files in https://github.com/hail-is/hail/pull/13206 and https://github.com/hail-is/hail/pull/13229, but the serialization could still cause issues if `is.hail.rvd.RVD.localSort` is called in another context. 

See https://hail.zulipchat.com/#narrow/stream/123011-Hail-Query-Dev/topic/Possible.20bug.20in.20Hail.200.2E2.2E119/near/378610151 for more information.