### PR TITLE
[batch] Increase max worker idle time to 2 mins in test and dev

### DIFF
--- a/batch/sql/increase_test_max_idle_time.py
+++ b/batch/sql/increase_test_max_idle_time.py
@@ -16,13 +16,6 @@ UPDATE inst_colls
 SET worker_max_idle_time_secs = 120
 ''')
 
-    await db.execute_update(
-        '''
-UPDATE pools
-SET standing_worker_cores = 16, min_instances = 4
-WHERE name = "standard-np" OR name = "standard";
-''')
-
     await db.async_close()
 
 

--- a/batch/sql/increase_test_max_idle_time.py
+++ b/batch/sql/increase_test_max_idle_time.py
@@ -1,0 +1,23 @@
+import os
+import asyncio
+from gear import Database
+
+
+async def main():
+    if os.environ['HAIL_SCOPE'] == 'deploy':
+        return
+
+    db = Database()
+    await db.async_init()
+
+    await db.execute_update(
+        '''
+UPDATE inst_colls
+SET worker_max_idle_time_secs = 120
+''')
+
+    await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/sql/increase_test_max_idle_time.py
+++ b/batch/sql/increase_test_max_idle_time.py
@@ -16,6 +16,13 @@ UPDATE inst_colls
 SET worker_max_idle_time_secs = 120
 ''')
 
+    await db.execute_update(
+        '''
+UPDATE pools
+SET standing_worker_cores = 16, min_instances = 4
+WHERE name = "standard-np" OR name = "standard";
+''')
+
     await db.async_close()
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -2307,6 +2307,9 @@ steps:
       - name: add-oms-agent-flag
         script: /io/sql/add-oms-agent-flag.sql
         online: true
+      - name: increase-test-max-idle-time
+        script: /io/sql/increase_test_max_idle_time.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
I observed a cluster with it set to the default idle time of 30 seconds in Azure and the workers were continuously thrashing leading up to 49 instances being created over the course of a PR. With an idle time of 120 seconds, there was no thrashing and 28 instances were created over the course of the PR (16 standard + job private etc.). The cluster nicely scaled down at the end of the PR. It looked like a couple of times the `standard-np` pool scaled up and then scaled down so I assume the `standard` pool wasn't at full capacity while that was happening. It might be worth configuring the `standard-np` pool to be 4 or 5 standing instances with 16 cores and see what happens -- that might help as well.

