### PR TITLE
[ci] Add easier way to add all production developers to a dev namespace

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2327,10 +2327,6 @@ steps:
       {% endif %}
       {% endfor %}
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-dev-tokens
         namespace:
           valueFrom: default_ns.name

--- a/build.yaml
+++ b/build.yaml
@@ -2312,6 +2312,37 @@ steps:
       - deploy_auth
       - create_certs
   - kind: runImage
+    name: add_developers
+    image:
+      valueFrom: hailgenetics_hailtop_image.image
+    script: |
+      set -ex
+      {% for user in code.get("developers", []) %}
+      {% if user['username'] != 'test-dev' %}
+      hailctl auth create-user \
+        --developer \
+        --hail-identity {{ user["hail_identity"] }} \
+        --hail-credentials-secret-name {{ user["username"] }}-gsa-key \
+        {{ user["username"] }} {{ user["login_id"] }}
+      {% endif %}
+      {% endfor %}
+    secrets:
+      - name: worker-deploy-config
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /deploy-config
+      - name: test-dev-tokens
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /user-tokens
+    scopes:
+      - dev
+      - test
+    dependsOn:
+      - default_ns
+      - hailgenetics_hailtop_image
+      - deploy_batch
+  - kind: runImage
     name: create_billing_projects
     resources:
       memory: standard

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -8,7 +8,7 @@ import random
 import secrets
 from enum import Enum
 from shlex import quote as shq
-from typing import Dict, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union
 
 import aiohttp
 import gidgethub
@@ -669,11 +669,12 @@ git merge {shq(self.source_sha)} -m 'merge PR'
 
 
 class WatchedBranch(Code):
-    def __init__(self, index, branch, deployable, mergeable):
+    def __init__(self, index, branch, deployable, mergeable, developers):
         self.index: int = index
         self.branch: FQBranch = branch
         self.deployable: bool = deployable
         self.mergeable: bool = mergeable
+        self.developers: List[dict] = developers
 
         self.prs: Dict[int, PR] = {}
         self.sha: Optional[str] = None
@@ -713,6 +714,7 @@ class WatchedBranch(Code):
             'repo': self.branch.repo.short_str(),
             'repo_url': self.branch.repo.url,
             'sha': self.sha,
+            'developers': self.developers,
         }
 
     async def notify_github_changed(self, app):
@@ -993,10 +995,11 @@ git checkout {shq(self.sha)}
 
 
 class UnwatchedBranch(Code):
-    def __init__(self, branch, sha, userdata, extra_config=None):
+    def __init__(self, branch, sha, userdata, developers, extra_config=None):
         self.branch = branch
         self.user = userdata['username']
         self.namespace = userdata['namespace_name']
+        self.developers = developers
         self.sha = sha
         self.extra_config = extra_config
 
@@ -1016,6 +1019,7 @@ class UnwatchedBranch(Code):
             'repo_url': self.branch.repo.url,
             'sha': self.sha,
             'user': self.user,
+            'developers': self.developers,
         }
         if self.extra_config is not None:
             config.update(self.extra_config)

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -295,3 +295,15 @@ steps:
       - ci_utils_image
       - default_ns
       - deploy_hello
+  - kind: runImage
+    name: test_jinja_state_contains_developers
+    image:
+      valueFrom: hail_ubuntu_image.image
+    script: |
+      set -ex
+
+      {% for user in code['developers'] %}
+      echo {{ user['username'] }}
+      {% endfor %}
+    dependsOn:
+      - hail_ubuntu_image


### PR DESCRIPTION
I broke my previous PR into littler pieces some of which has already merged. This PR adds developers from production to test namespaces (only programmatic access, browser OAuth flow does not work yet for test namespaces) and makes it easier to add developers to dev namespaces.