### PR TITLE
[query] allow inteval filters to work with indirect row key

### DIFF
--- a/hail/python/test/hail/extract_intervals/test_key_prefix.py
+++ b/hail/python/test/hail/extract_intervals/test_key_prefix.py
@@ -115,3 +115,9 @@ def test_ht_ge_with_bindings(ht, probe_locus):
     expr = ht.filter((locus >= probe_locus) & hl.is_defined(locus))
     assert expr.n_partitions() == 6
     assert expr.count() == 101
+
+
+def test_GRCh38():
+    mt = hl.balding_nichols_model(1, 10, 100, n_partitions=10, reference_genome='GRCh38')
+    mt = mt.filter_rows(hl.all(mt.locus.contig == 'chr1', mt.locus.position < 5))
+    assert mt.n_partitions() == 1

--- a/hail/python/test/hail/extract_intervals/test_key_prefix.py
+++ b/hail/python/test/hail/extract_intervals/test_key_prefix.py
@@ -99,3 +99,11 @@ def test_ht_gt(ht, probe_locus):
     expr = ht.filter(ht.locus > probe_locus)
     assert expr.n_partitions() == 6
     assert expr.count() == 100
+
+
+def test_ht_ge_with_bindings(ht, probe_locus):
+    row = ht.row
+    locus = row.locus
+    expr = ht.filter((locus >= probe_locus) & hl.is_defined(locus))
+    assert expr.n_partitions() == 6
+    assert expr.count() == 101

--- a/hail/python/test/hail/extract_intervals/test_key_prefix.py
+++ b/hail/python/test/hail/extract_intervals/test_key_prefix.py
@@ -33,6 +33,14 @@ def test_mt_gt(mt, probe_locus):
     assert expr.count() == (100, 100)
 
 
+def test_mt_ge_with_bindings(mt, probe_locus):
+    row = mt.row
+    locus = row.locus
+    expr = mt.filter_rows((locus >= probe_locus) & hl.is_defined(locus))
+    assert expr.n_partitions() == 6
+    assert expr.count() == (101, 100)
+
+
 def test_ht_lt(ht, probe_locus):
     expr = ht.filter(ht.locus < probe_locus)
     assert expr.n_partitions() == 15

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.backend.ExecuteContext
 import is.hail.annotations.IntervalEndpointOrdering
+import is.hail.rvd.PartitionBoundOrdering
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, Interval, IntervalEndpoint, _}
 import is.hail.variant.{Locus, ReferenceGenome}
@@ -32,7 +33,7 @@ object ExtractIntervalFilters {
     val rowType: TStruct = rowRef.typ.asInstanceOf[TStruct]
     val rowKeyType: TStruct = rowType.select(keyFields)._1
     val firstKeyType: Type = rowKeyType.types.head
-    val iOrd: IntervalEndpointOrdering = rowKeyType.ordering(ctx.stateManager).intervalEndpointOrdering
+    val iOrd: IntervalEndpointOrdering = PartitionBoundOrdering(ctx, rowKeyType).intervalEndpointOrdering
 
     def getReferenceGenome(rg: String): ReferenceGenome = ctx.stateManager.referenceGenomes(rg)
 
@@ -194,7 +195,6 @@ object ExtractIntervalFilters {
         val rr = extractAndRewrite(r, es)
         (ll, rr) match {
           case (Some((ir1, i1)), Some((ir2, i2))) =>
-            println(s"left: ${i1.mkString("(", ", ", ")")}, right: ${i2.mkString("(", ", ", ")")}")
             log.info(s"intersecting list of ${ i1.length } intervals with list of ${ i2.length } intervals")
             val intersection = Interval.intersection(i1, i2, es.iOrd)
             log.info(s"intersect generated ${ intersection.length } intersected intervals")

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -65,12 +65,14 @@ object ExtractIntervalFilters {
     def isFirstKey(ir: IR): Boolean = isKeyField(ir, rowKeyType.fieldNames.head)
 
     def isKeyStructPrefix(ir: IR): Boolean = ir match {
-      case MakeStruct(fields) => fields.view.zipWithIndex.forall { case ((_, fd), idx) =>
-        idx < rowKeyType.size && isKeyField(fd, rowKeyType.fieldNames(idx))
-      }
-      case SelectFields(old, fields) => fields.view.zipWithIndex.forall { case (fd, idx) =>
-        idx < rowKeyType.size && fieldIsKeyField(old, fd, rowKeyType.fieldNames(idx))
-      }
+      case MakeStruct(fields) =>
+        fields.size <= rowKeyType.size && fields.view.zipWithIndex.forall { case ((_, fd), idx) =>
+          isKeyField(fd, rowKeyType.fieldNames(idx))
+        }
+      case SelectFields(old, fields) =>
+        fields.size <= rowKeyType.size && fields.view.zipWithIndex.forall { case (fd, idx) =>
+          fieldIsKeyField(old, fd, rowKeyType.fieldNames(idx))
+        }
       case _ => false
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -7,11 +7,28 @@ import is.hail.utils.{FastSeq, Interval, IntervalEndpoint, _}
 import is.hail.variant.{Locus, ReferenceGenome}
 import org.apache.spark.sql.Row
 
+import scala.Option.option2Iterable
+
 object ExtractIntervalFilters {
 
   val MAX_LITERAL_SIZE = 4096
 
-  case class ExtractionState(ctx: ExecuteContext, rowRef: Ref, keyFields: IndexedSeq[String]) {
+  object ExtractionState {
+    def apply(
+      ctx: ExecuteContext,
+      rowRef: Ref,
+      keyFields: IndexedSeq[String]
+    ): ExtractionState = {
+      new ExtractionState(ctx, Env.empty[IR], rowRef, keyFields)
+    }
+  }
+
+  class ExtractionState(
+    val ctx: ExecuteContext,
+    env: Env[IR],
+    rowRef: Ref,
+    keyFields: IndexedSeq[String]
+  ) {
     val rowType: TStruct = rowRef.typ.asInstanceOf[TStruct]
     val rowKeyType: TStruct = rowType.select(keyFields)._1
     val firstKeyType: Type = rowKeyType.types.head
@@ -19,15 +36,40 @@ object ExtractIntervalFilters {
 
     def getReferenceGenome(rg: String): ReferenceGenome = ctx.stateManager.referenceGenomes(rg)
 
-    def isFirstKey(ir: IR): Boolean = ir == GetField(rowRef, rowKeyType.fieldNames.head)
+    def bind(name: String, v: IR): ExtractionState =
+      new ExtractionState(ctx, env.bind(name, v), rowRef, keyFields)
+
+    private def isRowRef(ir: IR): Boolean = ir match {
+      case ref: Ref =>
+        ref == rowRef || env.lookupOption(ref.name).exists(isRowRef)
+      case _ => false
+    }
+
+    private def isKeyField(ir: IR, keyFieldName: String): Boolean = ir match {
+      case GetField(struct, name) => fieldIsKeyField(struct, name, keyFieldName)
+      case Ref(name, _) => env.lookupOption(name).exists(isKeyField(_, keyFieldName))
+      case _ => false
+    }
+
+    private def fieldIsKeyField(struct: IR, fieldName: String, keyFieldName: String): Boolean = struct match {
+      case MakeStruct(fields) => fields.exists { case (n, f) =>
+        n == fieldName && isKeyField(f, keyFieldName)
+      }
+      case SelectFields(o, fields) => fields.exists { f =>
+        f == fieldName && fieldIsKeyField(o, fieldName, keyFieldName)
+      }
+      case _ => isRowRef(struct) && fieldName == keyFieldName
+    }
+
+    def isFirstKey(ir: IR): Boolean = isKeyField(ir, rowKeyType.fieldNames.head)
 
     def isKeyStructPrefix(ir: IR): Boolean = ir match {
-      case MakeStruct(fields) => fields
-        .iterator
-        .map(_._2)
-        .zipWithIndex
-        .forall { case (fd, idx) => idx < rowKeyType.size && fd == GetField(rowRef, rowKeyType.fieldNames(idx)) }
-      case SelectFields(`rowRef`, fields) => keyFields.startsWith(fields)
+      case MakeStruct(fields) => fields.view.zipWithIndex.forall { case ((_, fd), idx) =>
+        idx < rowKeyType.size && isKeyField(fd, rowKeyType.fieldNames(idx))
+      }
+      case SelectFields(old, fields) => fields.view.zipWithIndex.forall { case (fd, idx) =>
+        idx < rowKeyType.size && fieldIsKeyField(old, fd, rowKeyType.fieldNames(idx))
+      }
       case _ => false
     }
   }
@@ -152,6 +194,7 @@ object ExtractIntervalFilters {
         val rr = extractAndRewrite(r, es)
         (ll, rr) match {
           case (Some((ir1, i1)), Some((ir2, i2))) =>
+            println(s"left: ${i1.mkString("(", ", ", ")")}, right: ${i2.mkString("(", ", ", ")")}")
             log.info(s"intersecting list of ${ i1.length } intervals with list of ${ i2.length } intervals")
             val intersection = Interval.intersection(i1, i2, es.iOrd)
             log.info(s"intersect generated ${ intersection.length } intersected intervals")
@@ -267,10 +310,10 @@ object ExtractIntervalFilters {
             case _ => None
           }
         }
-      case Let(name, value, body) if name != es.rowRef.name =>
+      case Let(name, value, body) =>
         // TODO: thread key identity through values, since this will break when CSE arrives
         // TODO: thread predicates in `value` through `body` as a ref
-        extractAndRewrite(body, es)
+        extractAndRewrite(body, es.bind(name, value))
           .map { case (ir, intervals) => (Let(name, value, ir), intervals) }
       case _ => None
     }

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -311,8 +311,7 @@ object ExtractIntervalFilters {
           }
         }
       case Let(name, value, body) =>
-        // TODO: thread key identity through values, since this will break when CSE arrives
-        // TODO: thread predicates in `value` through `body` as a ref
+        // FIXME: ignores predicates in value
         extractAndRewrite(body, es.bind(name, value))
           .map { case (ir, intervals) => (Let(name, value, ir), intervals) }
       case _ => None


### PR DESCRIPTION
E.g. when the row key, and/or the row itself, in a predicate is hidden behind Refs, MakeStructs, SelectFields. For example, before matching the first key field "kf" only worked for exactly `GetField(Ref("row", ...), "kf")`. Now the following all work (meaning the analysis recognizes these all as being the first key field):
```
Let("foo",
  SelectFields(Ref("row"), [..., "kf", ...]),
  GetField(Ref("foo"), "kf"))

Let("foo",
  Ref("row"),
  Let("bar",
    MakeStruct("baz" -> GetField(Ref("foo"), "kf"), ...)
    GetField(Ref("bar"), "baz")))
```

Edit:
A note on how serious the issue was in practice: Any filter that uses more than one field (or the same field twice) was broken, where broken means it does no interval filter and reads all the data. E.g. `ht.filter((ht.locus >= hl.locus('20', 1)) & (ht.locus < hl.locus('20', 10200000)))`. This is because the repeated field is pulled out into a let by CSE. If it was two different fields, the underlying `Ref("row")` is pulled out.

Other restrictions this PR doesn't address:
* The predicate can't have a repeated sub-predicate, e.g. 
   ```
   subcond = ht.locus.contig == '20'
   ht.filter((subcond & (ht.locus.position < 10)) | (subcond & (ht.locus.position > 10200000)))
   ```
* The predicate can't use negation or `If`
* The key type being filtered can only be Locus or numeric (or structs of those), doesn't work for e.g. gene Strings.