### PR TITLE
[query] tableaggregate o tableparallelize should be local

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -616,19 +616,19 @@ object Simplify {
         AggLet(uid, newRow, Subst(query, BindingEnv(agg = Some(Env("row" -> Ref(uid, newRow.typ))))), isScan = false))
 
     // NOTE: The below rule should be reintroduced when it is possible to put an ArrayAgg inside a TableAggregate
-    // case TableAggregate(TableParallelize(rowsAndGlobal, _), query) =>
-    //   rowsAndGlobal match {
-    //     // match because we currently don't optimize MakeStruct through Let, and this is a common pattern
-    //     case MakeStruct(Seq((_, rows), (_, global))) =>
-    //       Let("global", global, ArrayAgg(rows, "row", query))
-    //     case other =>
-    //       val uid = genUID()
-    //       Let(uid,
-    //         rowsAndGlobal,
-    //         Let("global",
-    //           GetField(Ref(uid, rowsAndGlobal.typ), "global"),
-    //           ArrayAgg(GetField(Ref(uid, rowsAndGlobal.typ), "rows"), "row", query)))
-    //   }
+    case TableAggregate(TableParallelize(rowsAndGlobal, _), query) =>
+      rowsAndGlobal match {
+        // match because we currently don't optimize MakeStruct through Let, and this is a common pattern
+        case MakeStruct(Seq((_, rows), (_, global))) =>
+          Let("global", global, StreamAgg(ToStream(rows), "row", query))
+        case other =>
+          val uid = genUID()
+          Let(uid,
+            rowsAndGlobal,
+            Let("global",
+              GetField(Ref(uid, rowsAndGlobal.typ), "global"),
+              StreamAgg(ToStream(GetField(Ref(uid, rowsAndGlobal.typ), "rows")), "row", query)))
+      }
 
     case ApplyIR("annotate", _, Seq(s, MakeStruct(fields)), _) =>
       InsertFields(s, fields)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3184,7 +3184,7 @@ class IRSuite extends HailSuite {
           TableRange(1, 1),
           InsertFields(
             Ref("row", TStruct("idx" -> TInt32)),
-            FastSeq("x", RelationalRef("x", t))))),
+            FastSeq("x" -> RelationalRef("x", t))))),
       ApplyAggOp(FastIndexedSeq(), FastIndexedSeq(), AggSignature(Count(), FastIndexedSeq(), FastIndexedSeq())))
     assertEvalsTo(ir, 1L)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3177,9 +3177,14 @@ class IRSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.interpretOnly
 
     val t = TArray(TStruct("x" -> TInt32))
-    val ir = TableAggregate(RelationalLetTable("x",
-      Literal(t, FastIndexedSeq(Row(1))),
-      TableParallelize(MakeStruct(FastSeq("rows" -> RelationalRef("x", t), "global" -> MakeStruct(FastSeq()))))),
+    val ir = TableAggregate(
+      RelationalLetTable("x",
+        Literal(t, FastIndexedSeq(Row(1))),
+        TableMapRows(
+          TableRange(1, 1),
+          InsertFields(
+            Ref("row", TStruct("idx" -> TInt32)),
+            FastSeq("x", RelationalRef("x", t))))),
       ApplyAggOp(FastIndexedSeq(), FastIndexedSeq(), AggSignature(Count(), FastIndexedSeq(), FastIndexedSeq())))
     assertEvalsTo(ir, 1L)
   }


### PR DESCRIPTION
For example, the following should not do a 16-way parallel operation.
```
In [1]:     import hail as hl
   ...:     mt = hl.utils.range_matrix_table(10, 10, n_partitions=3)
   ...:     mt = mt.annotate_globals(n=mt.aggregate_cols(hl.struct(
   ...:         n=hl.agg.count()
   ...:     ), _localize=False))
   ...:     mt.n.collect()
```