### PR TITLE
[k8s] Dont require access to default secrets when make deploying

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,9 +1,9 @@
 # These values should be lazy so you don't need kubectl for targets that don't
 # require it but also only evaluated at most once every make invocation
 # https://make.mad-scientist.net/deferred-simple-variable-expansion/
-DOCKER_PREFIX = $(eval DOCKER_PREFIX := $$(shell kubectl get secret global-config --template={{.data.docker_prefix}} | base64 --decode))$(DOCKER_PREFIX)
-DOMAIN = $(eval DOMAIN := $$(shell kubectl get secret global-config --template={{.data.domain}} | base64 --decode))$(DOMAIN)
-CLOUD = $(eval CLOUD := $$(shell kubectl get secret global-config --template={{.data.cloud}} | base64 --decode))$(CLOUD)
+DOCKER_PREFIX = $(eval DOCKER_PREFIX := $$(shell kubectl -n $(NAMESPACE) get secret global-config --template={{.data.docker_prefix}} | base64 --decode))$(DOCKER_PREFIX)
+DOMAIN = $(eval DOMAIN := $$(shell kubectl -n $(NAMESPACE) get secret global-config --template={{.data.domain}} | base64 --decode))$(DOMAIN)
+CLOUD = $(eval CLOUD := $$(shell kubectl -n $(NAMESPACE) get secret global-config --template={{.data.cloud}} | base64 --decode))$(CLOUD)
 
 ifeq ($(NAMESPACE),default)
 SCOPE = deploy


### PR DESCRIPTION
The values of the global config are the same across namespaces, but it does feel more correct to use the `global-config` from the namespace you're targeting than the one in production. This should also enable `make` deploying into a dev namespace without having any permissions for `default`.