### PR TITLE
[query] Fix copy_log when log path is relative.

### DIFF
--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -287,12 +287,12 @@ def copy_log(path: str) -> None:
     ----------
     path: :class:`str`
     """
-    log = Env.hc()._log
+    log = os.path.realpath(Env.hc()._log)
     try:
         if hadoop_is_dir(path):
             _, tail = os.path.split(log)
             path = os.path.join(path, tail)
         info(f"copying log to {repr(path)}...")
-        hadoop_copy(local_path_uri(Env.hc()._log), path)
+        hadoop_copy(local_path_uri(log), path)
     except Exception as e:
         sys.stderr.write(f'Could not copy log: encountered error:\n  {e}')


### PR DESCRIPTION
the local_path_uri function simply prepends 'file://' to the path provided. This leads to an odd situation were a relative path is transformed into 'file://relative/path/to/log', which parses as:

SCHEME: file
HOST  : relative
PATH  : path/to/log

To fix this, compute the real path of the log file and use that as the path for the local_path_uri