### PR TITLE
[ci] Remove unnecessary worker-deploy-config secret

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2470,10 +2470,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-tokens
         namespace:
           valueFrom: default_ns.name

--- a/build.yaml
+++ b/build.yaml
@@ -2420,6 +2420,7 @@ steps:
       cd /io/repo/hail/python
 
       export HAIL_CLOUD={{ global.cloud }}
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"

--- a/build.yaml
+++ b/build.yaml
@@ -416,15 +416,6 @@ steps:
               --from-file=./deploy-config.json \
               --save-config --dry-run=client -o yaml \
           | kubectl -n {{ default_ns.name }} apply -f -
-
-      # worker deploy config
-      cat > deploy-config.json <<EOF
-      {"location":"gce","default_namespace":"{{ default_ns.name }}","domain":"{{ global.domain }}"}
-      EOF
-      kubectl -n {{ default_ns.name }} create secret generic worker-deploy-config \
-              --from-file=./deploy-config.json \
-              --save-config --dry-run=client -o yaml \
-          | kubectl -n {{ default_ns.name }} apply -f -
     serviceAccount:
       name: admin
       namespace:
@@ -559,10 +550,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /database-server-config
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: auth-gsa-key
         namespace:
           valueFrom: default_ns.name
@@ -1708,6 +1695,8 @@ steps:
       valueFrom: hailgenetics_hailtop_image.image
     script: |
       set -ex
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+
       {% if default_ns.name == "default" %}
       hailctl auth create-user --developer {{ code.username }} {{ code.login_id }}
       {% else %}
@@ -1718,10 +1707,6 @@ steps:
         {{ code.username }} {{ code.login_id }}
       {% endif %}
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-dev-tokens
         namespace:
           valueFrom: default_ns.name
@@ -1806,6 +1791,8 @@ steps:
       valueFrom: hail_dev_image.image
     script: |
       set -ex
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+
       python3 -m pytest \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
@@ -1817,10 +1804,6 @@ steps:
               --timeout=120 \
               /io/monitoring/test
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-dev-tokens
         namespace:
           valueFrom: default_ns.name
@@ -1848,6 +1831,7 @@ steps:
     script: |
       set -ex
 
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
 
       COPY_PASTE_TOKEN=$(hailctl curl {{ default_ns.name }} \
@@ -1890,10 +1874,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
     dependsOn:
       - default_ns
       - create_accounts
@@ -1910,6 +1890,7 @@ steps:
     script: |
       set -ex
 
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
 
       COPY_PASTE_TOKEN=$(hailctl curl {{ default_ns.name }} \
@@ -1940,10 +1921,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
     dependsOn:
       - default_ns
       - create_accounts
@@ -2340,6 +2317,8 @@ steps:
       valueFrom: hailgenetics_hailtop_image.image
     script: |
       set -ex
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+
       # create billing projects and add users to them
       cat > create-billing-projects.py <<EOF
       import sys
@@ -2385,10 +2364,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
     dependsOn:
       - default_ns
       - hailgenetics_hailtop_image
@@ -2532,6 +2507,7 @@ steps:
       cd /io/repo/hail/python
 
       export HAIL_CLOUD={{ global.cloud }}
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
       export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
@@ -2582,10 +2558,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-tokens
         namespace:
           valueFrom: default_ns.name
@@ -2726,10 +2698,6 @@ steps:
     port: 5000
     timeout: 1500
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-tokens
         namespace:
           valueFrom: default_ns.name
@@ -2765,6 +2733,7 @@ steps:
       valueFrom: batch_image.image
     script: |
       set -ex
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ test_batch.token }}"
@@ -2778,10 +2747,6 @@ steps:
       - from: /repo/batch/test
         to: /io/test
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-dev-tokens
         namespace:
           valueFrom: default_ns.name
@@ -2918,6 +2883,7 @@ steps:
     script: |
       set -ex
       export ORGANIZATION=hail-ci-test
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export REPO_NAME=ci-test-"{{ create_ci_test_repo.token }}"
       export NAMESPACE="{{ default_ns.name }}"
       python3 -m pytest \
@@ -2930,10 +2896,6 @@ steps:
               --durations=50 \
               /io/ci/test
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-dev-tokens
         namespace:
           valueFrom: default_ns.name
@@ -2966,6 +2928,7 @@ steps:
       cd /io/hailtop
       set -ex
       export HAIL_CLOUD={{ global.cloud }}
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       export HAIL_GENETICS_HAIL_IMAGE="{{ hailgenetics_hail_image.image }}"
@@ -2991,10 +2954,6 @@ steps:
         to: /io/hailtop
     timeout: 1200
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-tokens
         namespace:
           valueFrom: default_ns.name
@@ -3022,6 +2981,7 @@ steps:
     script: |
       set -ex
 
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_GENETICS_HAIL_IMAGE="{{ hailgenetics_hail_image.image }}"
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
 
@@ -3108,10 +3068,6 @@ steps:
           exit 1;
       fi
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-tokens
         namespace:
           valueFrom: default_ns.name
@@ -3134,6 +3090,7 @@ steps:
       valueFrom: hail_dev_image.image
     script: |
       set -ex
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       cd /io/hailtop/batch
       hailctl config set batch/billing_project test
@@ -3152,10 +3109,6 @@ steps:
               --timeout=120 \
               --ignore=docs/conf.py
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-tokens
         namespace:
           valueFrom: default_ns.name
@@ -3554,10 +3507,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
     dependsOn:
       - default_ns
       - create_accounts
@@ -3579,6 +3528,7 @@ steps:
       tar xzf resources.tar.gz -C src/test
 
       export HAIL_CLOUD={{ global.cloud }}
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export HAIL_FS_TEST_CLOUD_RESOURCES_URI={{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/fs
@@ -3611,10 +3561,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-gsa-key
         namespace:
           valueFrom: default_ns.name
@@ -3637,6 +3583,8 @@ steps:
       cpu: '2'
     script: |
       set -ex
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+
       cd /io
       mkdir -p src/test
       tar xzf resources.tar.gz -C src/test
@@ -3657,10 +3605,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
     timeout: 1200
     dependsOn:
       - default_ns
@@ -3674,6 +3618,8 @@ steps:
     image:
       valueFrom: hailgenetics_hailtop_image.image
     script: |
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+
       cat >cancel_all_running_test_batches.py <<'EOF'
       from hailtop.batch_client.aioclient import BatchClient
       import asyncio
@@ -3694,10 +3640,6 @@ steps:
 
       python3 cancel_all_running_test_batches.py
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-dev-tokens
         namespace:
           valueFrom: default_ns.name
@@ -3723,6 +3665,7 @@ steps:
     image:
       valueFrom: hail_dev_image.image
     script: |
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       python3 -m pytest \
@@ -3742,10 +3685,6 @@ steps:
         to: /io/test
     timeout: 300
     secrets:
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
       - name: test-dev-tokens
         namespace:
           valueFrom: default_ns.name

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -280,7 +280,6 @@ steps:
       valueFrom: ci_utils_image.image
     script: |
       set -ex
-      export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
       hailctl curl {{ default_ns.name }} \
           hello /healthcheck \
           -fsSL \
@@ -292,10 +291,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /user-tokens
-      - name: worker-deploy-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /deploy-config
     dependsOn:
       - ci_utils_image
       - default_ns

--- a/hail/src/main/scala/is/hail/services/DeployConfig.scala
+++ b/hail/src/main/scala/is/hail/services/DeployConfig.scala
@@ -52,18 +52,26 @@ object DeployConfig {
         fromConfig(JsonMethods.parse(in))
       }
     } else
-      new DeployConfig(
-        "external",
-        "default",
-        "hail.is")
+      fromConfig("external", "default", "hail.is")
   }
 
   def fromConfig(config: JValue): DeployConfig = {
     implicit val formats: Formats = DefaultFormats
-    new DeployConfig(
+    fromConfig(
       (config \ "location").extract[String],
       (config \ "default_namespace").extract[String],
       (config \ "domain").extract[Option[String]].getOrElse("hail.is"))
+  }
+
+  def fromConfig(location: String, defaultNamespace: String, domain: String): DeployConfig = {
+    new DeployConfig(
+      sys.env.getOrElse(toEnvVarName("location"), location),
+      sys.env.getOrElse(toEnvVarName("default_namespace"), defaultNamespace),
+      sys.env.getOrElse(toEnvVarName("domain"), domain))
+  }
+
+  private[this] def toEnvVarName(s: String): String = {
+    "HAIL_" + s.toUpperCase
   }
 }
 


### PR DESCRIPTION
Since #13211, all jobs by default have a deploy config mounted into the container. The `worker-deploy-config` secret is no longer necessary, so long as we properly configure the namespace that CI jobs need to talk to.