### PR TITLE
[azure] Add connection timeouts for Azure FS in both Python and Scala

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -344,7 +344,8 @@ def handle_public_access_error(fun):
             #  https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob#other-client--per-operation-configuration
             anon_client = BlobServiceClient(f'https://{fs_url.account}.blob.core.windows.net',
                                             credential=None,
-                                            connection_timeout=5)
+                                            connection_timeout=5,
+                                            read_timeout=5)
             self._blob_service_clients[(fs_url.account, fs_url.container, fs_url.query)] = anon_client
             return await fun(self, url, *args, **kwargs)
     return wrapped
@@ -457,7 +458,8 @@ class AzureAsyncFS(AsyncFS):
             #  https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob#other-client--per-operation-configuration
             self._blob_service_clients[k] = BlobServiceClient(f'https://{account}.blob.core.windows.net',
                                                               credential=credential,
-                                                              connection_timeout=5)
+                                                              connection_timeout=5,
+                                                              read_timeout=5)
         return self._blob_service_clients[k]
 
     def get_blob_client(self, url: AzureAsyncFSURL) -> BlobClient:

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -341,7 +341,10 @@ def handle_public_access_error(fun):
             return await fun(self, url, *args, **kwargs)
         except azure.core.exceptions.ClientAuthenticationError:
             fs_url = self.parse_url(url)
-            anon_client = BlobServiceClient(f'https://{fs_url.account}.blob.core.windows.net', credential=None)
+            #  https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob#other-client--per-operation-configuration
+            anon_client = BlobServiceClient(f'https://{fs_url.account}.blob.core.windows.net',
+                                            credential=None,
+                                            connection_timeout=5)
             self._blob_service_clients[(fs_url.account, fs_url.container, fs_url.query)] = anon_client
             return await fun(self, url, *args, **kwargs)
     return wrapped
@@ -451,7 +454,10 @@ class AzureAsyncFS(AsyncFS):
         credential = token if token else self._credential
         k = account, container, token
         if k not in self._blob_service_clients:
-            self._blob_service_clients[k] = BlobServiceClient(f'https://{account}.blob.core.windows.net', credential=credential)
+            #  https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob#other-client--per-operation-configuration
+            self._blob_service_clients[k] = BlobServiceClient(f'https://{account}.blob.core.windows.net',
+                                                              credential=credential,
+                                                              connection_timeout=5)
         return self._blob_service_clients[k]
 
     def get_blob_client(self, url: AzureAsyncFSURL) -> BlobClient:


### PR DESCRIPTION
I hope this helps. The regular `timeout` parameter on the Python methods like `stage_block` is for the server-side timeout of the operation. We want the client side timeout to be shorter. I picked 5 seconds, but that was arbitrary. I'm not sure I implemented the Scala code correctly, but that's along the right lines of what needs to happen.