### PR TITLE
[fs] do not unlink the directory if there was an exception

### DIFF
--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -374,10 +374,7 @@ class LocalAsyncFS(AsyncFS):
             listener(1)
             if contents_tasks:
                 await pool.wait(contents_tasks)
-            try:
-                await self.rmdir(path)
-                listener(-1)
-            finally:
+
                 def raise_them_all(exceptions: List[BaseException]):
                     if exceptions:
                         try:
@@ -389,6 +386,8 @@ class LocalAsyncFS(AsyncFS):
                         for exc in [t.exception()]
                         if exc is not None]
                 raise_them_all(excs)
+            await self.rmdir(path)
+            listener(-1)
 
         async with OnlineBoundedGather2(sema) as pool:
             contents_tasks_by_dir: Dict[str, List[asyncio.Task]] = {}


### PR DESCRIPTION
I created this bug when I added exception handling. I incorrectly put the exception handling *after* the `rmdir`. If an exception occurred while removing one of the children of a directory, in all likelihood, the directory is non-empty.

With this change, we raise any exceptions before unlinking the directory. It is the responsibility of the caller to decide what to do if we were unable to remove one of our children.

I saw this while debugging another transient error on another PR: https://github.com/hail-is/hail/issues/13361.