### PR TITLE
[query/combiner] Fix import_gvcf_interval's default PGT handling

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2837,7 +2837,7 @@ def import_vcf(path,
            filter=nullable(str),
            find=nullable(str),
            replace=nullable(str))
-def import_gvcf_interval(path, file_num, contig, start, end, header_info, call_fields=[], entry_float_type='float64',
+def import_gvcf_interval(path, file_num, contig, start, end, header_info, call_fields=['PGT'], entry_float_type='float64',
                          array_elements_required=True, reference_genome='default', contig_recoding=None,
                          skip_invalid_loci=False, filter=None, find=None, replace=None):
     indices, aggs = hl.expr.unify_all(path, file_num, contig, start, end)

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -41,7 +41,7 @@ def test_combiner_works():
         comb = hl.vds.read_vds(out)
 
         # see https://github.com/hail-is/hail/issues/13367 for why these assertions are here
-        assert 'LPGT' in comb.variant_data
+        assert 'LPGT' in comb.variant_data.entry
         assert comb.variant_data.LPGT == hl.tcall
 
         assert len(parts) == comb.variant_data.n_partitions()

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -39,6 +39,11 @@ def test_combiner_works():
         out = os.path.join(tmpdir, 'out.vds')
         hl.vds.new_combiner(temp_path=tmpdir, output_path=out, gvcf_paths=paths, intervals=parts, reference_genome='GRCh38').run()
         comb = hl.vds.read_vds(out)
+
+        # see https://github.com/hail-is/hail/issues/13367 for why these assertions are here
+        assert 'LPGT' in comb.variant_data
+        assert comb.variant_data.LPGT == hl.tcall
+
         assert len(parts) == comb.variant_data.n_partitions()
         comb.variant_data._force_count_rows()
         comb.reference_data._force_count_rows()

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -42,7 +42,7 @@ def test_combiner_works():
 
         # see https://github.com/hail-is/hail/issues/13367 for why these assertions are here
         assert 'LPGT' in comb.variant_data.entry
-        assert comb.variant_data.LPGT == hl.tcall
+        assert comb.variant_data.LPGT.dtype == hl.tcall
 
         assert len(parts) == comb.variant_data.n_partitions()
         comb.variant_data._force_count_rows()


### PR DESCRIPTION
PGT is a call field by default for import_vcf, the now former import_gvcfs (old combiner start point). Make import_gvcf_interval also treat PGT as a call field.