### PR TITLE
[azure] Optimize file status operations

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2605,7 +2605,6 @@ steps:
     scopes:
       - deploy
       - dev
-      - test
     clouds:
       - azure
   - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -2605,6 +2605,7 @@ steps:
     scopes:
       - deploy
       - dev
+      - test
     clouds:
       - azure
   - kind: runImage

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -154,7 +154,7 @@ object AzureStorageFileStatus {
       new BlobStorageFileStatus(blobPath.getPath, null, 0, true)
     } else {
       val properties = blobItem.getProperties
-      new BlobStorageFileStatus(blobPath.getPath, properties.getLastModified.toEpochSecond, properties.getContentLength, true)
+      new BlobStorageFileStatus(blobPath.getPath, properties.getLastModified.toEpochSecond, properties.getContentLength, false)
     }
   }
 }
@@ -435,7 +435,9 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
             throw new FileNotFoundException(s"File not found: $filename")
           else
             throw e
-    } else null
+      }
+    } else
+      null
 
     AzureStorageFileStatus(filename, isDir, blobProperties)
   }

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -151,10 +151,10 @@ object AzureStorageFileStatus {
 
   def apply(blobPath: AzureStorageFSURL, blobItem: BlobItem): BlobStorageFileStatus = {
     if (blobItem.isPrefix) {
-      new BlobStorageFileStatus(blobPath.getPath, null, 0, true)
+      new BlobStorageFileStatus(blobPath.toString(), null, 0, true)
     } else {
       val properties = blobItem.getProperties
-      new BlobStorageFileStatus(blobPath.getPath, properties.getLastModified.toEpochSecond, properties.getContentLength, false)
+      new BlobStorageFileStatus(blobPath.toString(), properties.getLastModified.toEpochSecond, properties.getContentLength, false)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -2,7 +2,7 @@ package is.hail.io.fs
 
 import is.hail.shadedazure.com.azure.core.credential.{AzureSasCredential, TokenCredential}
 import is.hail.shadedazure.com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder, DefaultAzureCredential, DefaultAzureCredentialBuilder, ManagedIdentityCredentialBuilder}
-import is.hail.shadedazure.com.azure.storage.blob.models.{BlobProperties, BlobRange, BlobStorageException, ListBlobsOptions}
+import is.hail.shadedazure.com.azure.storage.blob.models.{BlobItem, BlobProperties, BlobRange, BlobStorageException, ListBlobsOptions}
 import is.hail.shadedazure.com.azure.storage.blob.specialized.BlockBlobClient
 import is.hail.shadedazure.com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientBuilder}
 import is.hail.shadedazure.com.azure.core.http.HttpClient
@@ -141,11 +141,21 @@ object AzureStorageFS {
 }
 
 object AzureStorageFileStatus {
-  def apply(blobProperties: BlobProperties, path: String, isDir: Boolean): BlobStorageFileStatus = {
-    val modificationTime = blobProperties.getLastModified.toEpochSecond
-    val size = blobProperties.getBlobSize
+  def apply(path: String, isDir: Boolean, blobProperties: BlobProperties): BlobStorageFileStatus = {
+    if (isDir) {
+      new BlobStorageFileStatus(path, null, 0, true)
+    } else {
+      new BlobStorageFileStatus(path, blobProperties.getLastModified.toEpochSecond, blobProperties.getBlobSize, false)
+    }
+  }
 
-    new BlobStorageFileStatus(path, modificationTime, size, isDir)
+  def apply(blobItem: BlobItem): BlobStorageFileStatus = {
+    val properties = blobItem.getProperties
+    if (blobItem.isPrefix) {
+      new BlobStorageFileStatus(blobItem.getName, null, 0, true)
+    } else {
+      new BlobStorageFileStatus(blobItem.getName, properties.getLastModified.toEpochSecond, properties.getContentLength, true)
+    }
   }
 }
 
@@ -389,8 +399,9 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
     val prefixMatches = blobContainerClient.listBlobsByHierarchy(prefix)
 
     prefixMatches.forEach(blobItem => {
-      statList += fileStatus(url.withPath(blobItem.getName))
+      statList += AzureStorageFileStatus(blobItem)
     })
+
     statList.toArray
   }
 
@@ -408,21 +419,25 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
     val blobContainerClient: BlobContainerClient = getContainerClient(url)
 
     val prefix = dropTrailingSlash(url.path) + "/"
-    val options: ListBlobsOptions = new ListBlobsOptions().setPrefix(prefix)
-    val prefixMatches = blobContainerClient.listBlobs(options, null)
+    val options: ListBlobsOptions = new ListBlobsOptions().setPrefix(prefix).setMaxResultsPerPage(1)
+    val prefixMatches = blobContainerClient.listBlobs(options, timeout)
     val isDir = prefixMatches.iterator().hasNext
 
     val filename = dropTrailingSlash(url.toString)
-    if (!isDir && !blobClient.exists()) {
-      throw new FileNotFoundException(s"File not found: $filename")
-    }
 
-    if (isDir) {
-      new BlobStorageFileStatus(path = filename, null, 0, isDir = true)
-    } else {
-      val blobProperties: BlobProperties = blobClient.getProperties
-      AzureStorageFileStatus(blobProperties, path = filename, isDir = false)
-    }
+    val blobProperties = if (!isDir) {
+      try {
+        blobClient.getProperties
+      } catch {
+        case e: BlobStorageException =>
+          if (e.getStatusCode == 404)
+            throw new FileNotFoundException(s"File not found: $filename")
+          else
+            throw e
+      }
+    } else null
+
+    AzureStorageFileStatus(filename, isDir, blobProperties)
   }
 
   def fileStatus(filename: String): FileStatus = handlePublicAccessError(filename) {

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -149,12 +149,12 @@ object AzureStorageFileStatus {
     }
   }
 
-  def apply(blobPath: AzureStorageFSURL, blobItem: BlobItem): BlobStorageFileStatus = {
+  def apply(blobPath: String, blobItem: BlobItem): BlobStorageFileStatus = {
     if (blobItem.isPrefix) {
-      new BlobStorageFileStatus(blobPath.toString(), null, 0, true)
+      new BlobStorageFileStatus(blobPath, null, 0, true)
     } else {
       val properties = blobItem.getProperties
-      new BlobStorageFileStatus(blobPath.toString(), properties.getLastModified.toEpochSecond, properties.getContentLength, false)
+      new BlobStorageFileStatus(blobPath, properties.getLastModified.toEpochSecond, properties.getContentLength, false)
     }
   }
 }
@@ -399,7 +399,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
     val prefixMatches = blobContainerClient.listBlobsByHierarchy(prefix)
 
     prefixMatches.forEach(blobItem => {
-      val blobPath = url.withPath(blobItem.getName)
+      val blobPath = dropTrailingSlash(url.withPath(blobItem.getName).toString())
       statList += AzureStorageFileStatus(blobPath, blobItem)
     })
 


### PR DESCRIPTION
I think this change will help the number of operations we're making substantially. My Scala skills are not great, so I don't know if this is written correctly.

Basically, we were making a call to list the blobs recursively to test if the path was a directory which was streaming through the first 5000 records. I made the page size equal to 1 record as we don't care about all records. The next thing I did was to just get the blob properties rather than calling exists + get blob properties. So that will cut the number of HTTP calls by half for every blob. Lastly, listing items in a directory which is used for globbing was making a call to get the metadata for each file and then it was making the 3 API calls above to check whether it's a directory, whether it exists, and what the blob properties are. All of this information is in the original result from listing the blobs in the hierarchy so I just use that information directly.