### PR TITLE
[query] GoogleFS: recreate reader on transient error

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -225,7 +225,7 @@ class GoogleStorageFS(
       private[this] var reader: ReadChannel = null
       private[this] var requesterPaysOptions: Seq[BlobSourceOption] = Seq()
 
-      private[this] def retryingRead(bb: ByteBuffer): Int = {
+      private[this] def retryingRead(): Int = {
         retryTransientErrors(
           { reader.read(bb) },
           reset = Some({ () =>
@@ -235,16 +235,16 @@ class GoogleStorageFS(
         )
       }
 
-      private[this] def readHandlingRequesterPays(bb: ByteBuffer): Int = {
+      private[this] def readHandlingRequesterPays(): Int = {
         if (reader != null) {
-          retryingRead(bb)
+          retryingRead()
         } else {
           handleRequesterPays(
             { (options: Seq[BlobSourceOption]) =>
               requesterPaysOptions = options
               reader = retryTransientErrors { storage.reader(url.bucket, url.path, options:_*) }
               reader.seek(getPosition)
-              retryingRead(bb)
+              retryingRead()
             },
             BlobSourceOption.userProject _,
             url.bucket
@@ -267,7 +267,7 @@ class GoogleStorageFS(
         // read some bytes
         var n = 0
         while (n == 0) {
-          n = readHandlingRequesterPays(bb)
+          n = readHandlingRequesterPays()
           if (n == -1) {
             return -1
           }

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -229,7 +229,6 @@ class GoogleStorageFS(
         retryTransientErrors(
           { reader.read(bb) },
           reset = Some({ () =>
-            bb.clear()
             reader = retryTransientErrors { storage.reader(url.bucket, url.path, requesterPaysOptions:_*) }
             reader.seek(getPosition)
           })


### PR DESCRIPTION
While running QoB jobs, we observed some errors relating to compression validation or unexpected end of line/file. It was suggested that after certain errors, the reader may be in an unsuable state, so we recreate it after an error.

