### PR TITLE
[batch] Specify batch-driver as the default container in the batch-driver pod

### DIFF
--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -106,6 +106,8 @@ spec:
         app: batch-driver
         hail.is/sha: "{{ code.sha }}"
         grafanak8sapp: "true"
+      annotations:
+        kubectl.kubernetes.io/default-container: batch-driver
     spec:
       serviceAccountName: batch
 {% if deploy %}


### PR DESCRIPTION
`kubectl` commands like `exec` that deal with containers in pods will generally default to the first container in the pod. The `batch-driver` deployment has two containers, the envoy sidecar and the batch-driver python app. Since the `envoy` container is listed first, `kssh` and `sync.py` default to that container, but we basically always intend `batch-driver`. Instead of switching up the order, or adding a bunch of explicit container specification, this annotates `batch-driver` as the default container in the pod, so `kssh` and `sync.py` work with the batch driver.