### PR TITLE
[vds/combiner] Teach VDS combiner how to handle custom call fields

### DIFF
--- a/hail/python/hail/vds/combiner/combine.py
+++ b/hail/python/hail/vds/combiner/combine.py
@@ -50,7 +50,7 @@ def make_variants_matrix_table(mt: MatrixTable,
                              'LPGT', 'PGT'}
 
             if 'GT' not in e:
-                raise hl.utils.FatalError("the Hail GVCF combiner expects GVCFs to have a 'GT' field in FORMAT.")
+                raise hl.utils.FatalError("the Hail VDS combiner expects input GVCFs to have a 'GT' field in FORMAT.")
 
             handled_fields['LA'] = hl.range(0, alleles_len - hl.if_else(has_non_ref, 1, 0))
             handled_fields['LGT'] = get_lgt(e, alleles_len, has_non_ref, row)

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -156,7 +156,7 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
         A list of intervals defining how to partition the GVCF files. The same partitioning is used
         for all GVCF files. Finer partitioning yields more parallelism but less work per task.
     gvcf_info_to_keep : :class:`list` of :class:`str` or :obj:`None`
-        GVCF ``INFO`` fields to keep in the ``gvcf_info`` entry field. By default, all fields are
+        GVCF ``INFO`` fields to keep in the ``gvcf_info`` entry field. By default, all fields
         except ``END`` and ``DP`` are kept.
     gvcf_reference_entry_fields_to_keep : :class:`list` of :class:`str` or :obj:`None`
         Genotype fields to keep in the reference table. If empty, the first 10,000 reference block

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -192,3 +192,20 @@ def test_ref_block_max_len_propagates_in_combiner():
                             reference_genome='GRCh38').run()
         vds = hl.vds.read_vds(final_path)
         assert hl.vds.VariantDataset.ref_block_max_length_field in vds.reference_data.globals
+
+
+def test_custom_call_fields():
+    _paths = ['gvcfs/HG00096.g.vcf.gz', 'gvcfs/HG00268.g.vcf.gz']
+    paths = [resource(p) for p in _paths]
+    parts = [
+        hl.Interval(start=hl.Locus('chr20', 17821257, reference_genome='GRCh38'),
+                    end=hl.Locus('chr20', 21144633, reference_genome='GRCh38'),
+                    includes_end=True),
+    ]
+    with hl.TemporaryDirectory() as tmpdir:
+        out = os.path.join(tmpdir, 'out.vds')
+        hl.vds.new_combiner(temp_path=tmpdir, output_path=out, gvcf_paths=paths, intervals=parts, call_fields=[], reference_genome='GRCh38').run()
+        comb = hl.vds.read_vds(out)
+
+        assert 'LPGT' in comb.variant_data.entry
+        assert comb.variant_data.LPGT.dtype == hl.tstr


### PR DESCRIPTION
Add the call_fields argument.

Much like refrence entries, when passing a VDS to the combiner, we check it's call fields to ensure that there is a match between the passed argument and the VDS's call fields.