### PR TITLE
[hailctl] Add basic tests for hailctl config

### DIFF
--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -19,8 +19,7 @@ def get_user_config_path() -> Path:
     return Path(xdg_config_home(), 'hail', 'config.ini')
 
 
-def _load_user_config():
-    global user_config
+def get_user_config() -> configparser.ConfigParser:
     user_config = configparser.ConfigParser()
     config_file = get_user_config_path()
     # in older versions, the config file was accidentally named
@@ -30,12 +29,6 @@ def _load_user_config():
     if old_path.exists() and not config_file.exists():
         old_path.rename(config_file)
     user_config.read(config_file)
-
-
-def get_user_config() -> configparser.ConfigParser:
-    if user_config is None:
-        _load_user_config()
-        assert user_config is not None
     return user_config
 
 

--- a/hail/python/test/hailtop/hailctl/config/conftest.py
+++ b/hail/python/test/hailtop/hailctl/config/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+import tempfile
+
+from typer.testing import CliRunner
+
+
+@pytest.fixture()
+def config_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+@pytest.fixture
+def runner(config_dir):
+    yield CliRunner(mix_stderr=False, env={'XDG_CONFIG_HOME': config_dir})

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -1,0 +1,61 @@
+import pytest
+
+from typer.testing import CliRunner
+
+from hailtop.hailctl.config import cli
+
+
+def test_config_location(runner: CliRunner, config_dir: str):
+    res = runner.invoke(cli.app, 'config-location', catch_exceptions=False)
+    assert res.exit_code == 0
+    assert res.stdout.strip() == f'{config_dir}/hail/config.ini'
+
+
+def test_config_list_empty_config(runner: CliRunner):
+    res = runner.invoke(cli.app, 'list', catch_exceptions=False)
+    assert res.exit_code == 0
+    assert res.stdout.strip() == ''
+
+
+@pytest.mark.parametrize(
+    'name,value',
+    [
+        ('batch/backend', 'batch'),
+        ('batch/billing_project', 'test'),
+        ('batch/remote_tmpdir', 'gs://foo/bar'),
+        ('query/backend', 'spark'),
+
+        # hailctl currently accepts arbitrary settings
+        ('foo/bar', 'baz'),
+    ],
+)
+def test_config_set(name: str, value: str, runner: CliRunner):
+    runner.invoke(cli.app, ['set', name, value], catch_exceptions=False)
+
+    res = runner.invoke(cli.app, 'list', catch_exceptions=False)
+    assert res.exit_code == 0
+    assert res.stdout.strip() == f'{name}={value}'
+
+    res = runner.invoke(cli.app, ['get', name], catch_exceptions=False)
+    assert res.exit_code == 0
+    assert res.stdout.strip() == value
+
+
+def test_config_get_bad_names(runner: CliRunner):
+    res = runner.invoke(cli.app, ['get', 'foo'], catch_exceptions=False)
+    assert res.exit_code == 0
+    assert res.stdout.strip() == ''
+
+    res = runner.invoke(cli.app, ['get', '/a/b/c'], catch_exceptions=False)
+    assert res.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    'name,value',
+    [
+        ('batch/remote_tmpdir', 'asdf://foo/bar'),
+    ],
+)
+def test_config_set_bad_value(name: str, value: str, runner: CliRunner):
+    res = runner.invoke(cli.app, ['set', name, value], catch_exceptions=False)
+    assert res.exit_code == 1

--- a/hail/scripts/test_requester_pays_parsing.py
+++ b/hail/scripts/test_requester_pays_parsing.py
@@ -5,7 +5,7 @@ import os
 from hailtop.aiocloud.aiogoogle import get_gcs_requester_pays_configuration
 from hailtop.aiocloud.aiogoogle.user_config import spark_conf_path, get_spark_conf_gcs_requester_pays_configuration
 from hailtop.utils.process import check_exec_output
-from hailtop.config.user_config import configuration_of, _load_user_config
+from hailtop.config.user_config import configuration_of
 
 
 if 'YOU_MAY_OVERWRITE_MY_SPARK_DEFAULTS_CONF_AND_HAILCTL_SETTINGS' not in os.environ:
@@ -29,7 +29,6 @@ async def unset_hailctl():
         'unset',
         'gcs_requester_pays/buckets',
     )
-    _load_user_config()  # force reload of user config
 
 
 @pytest.mark.asyncio
@@ -140,8 +139,6 @@ async def test_hailctl_takes_precedence_1():
         echo=True
     )
 
-    _load_user_config()  # force reload of user config
-
     actual = get_gcs_requester_pays_configuration()
     assert actual == 'hailctl_project', str((
         configuration_of('gcs_requester_pays', 'project', None, None),
@@ -177,8 +174,6 @@ async def test_hailctl_takes_precedence_2():
         'bucket1,bucket2',
         echo=True
     )
-
-    _load_user_config()  # force reload of user config
 
     actual = get_gcs_requester_pays_configuration()
     assert actual == ('hailctl_project2', ['bucket1', 'bucket2'])


### PR DESCRIPTION
This is pretty bare bones but I thought this might help a lot with the testing of all your upcoming `hailctl config` changes rather than having to manually test various possible combinations.

Run by just invoking pytest: `pytest hail/python/test/hailtop/hailctl/config`