### PR TITLE
[batch] Mitigate siwei bug by removing cache

### DIFF
--- a/batch/batch/spec_writer.py
+++ b/batch/batch/spec_writer.py
@@ -1,8 +1,5 @@
-import collections
 import logging
-from typing import Dict, Literal, Tuple
-
-import sortedcontainers
+from typing import Literal, Tuple
 
 from hailtop.utils import secret_alnum_string
 

--- a/batch/batch/spec_writer.py
+++ b/batch/batch/spec_writer.py
@@ -31,7 +31,7 @@ class SpecWriter:
     async def get_token_start_id(db, batch_id, job_id) -> Tuple[str, int]:
         bunch_record = await db.select_and_fetchone(
             '''
-SELECT batch_bunches.start_job_id, batch_bunches.token,
+SELECT batch_bunches.start_job_id, batch_bunches.token
 FROM batch_bunches
 WHERE batch_bunches.batch_id = %s AND batch_bunches.start_job_id <= %s
 ORDER BY batch_bunches.start_job_id DESC


### PR DESCRIPTION
Before open batches, the `n_jobs` of a batch was a constant known before any jobs were added. Moreover, we did not start scheduling jobs until all the jobs were added to the database. Therefore, it was always safe to assume that the final "bunch" of jobs in the database was the last "bunch" ergo it spanned from its `start_job_id` to the job with id `n_jobs` (nb: job ids are 1-indexed).

When open batches were added, the `n_jobs` became a mutable value. Moreover, `n_jobs` includes jobs in bunches *which have not yet been added to the database*. In particular, suppose two clients are each submitting a bunch of size 10. Each client independently "reserves" 10 job slots by atomically incrementing `n_jobs` by ten. `n_jobs` is now 20. Further suppose that the first bunch is added to the database and begins scheduling before the second bunch is added to the database. In this case, when calculating the size of this bunch (for use in the bunch cache, and *only* in the bunch cache), we see that this is the last (and only) bunch in the database and assume that `n_jobs` is the last job id in this bunch. This is incorrect because `n_jobs` includes the not-yet-visible second bunch.