### PR TITLE
[batch] Fix bitrot in VM image creation script

### DIFF
--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -2,14 +2,29 @@
 
 set -e
 
-source $HAIL/devbin/functions.sh
+cd "$(dirname "$0")"
+source ../devbin/functions.sh
 
-PROJECT=$(get_global_config_field gcp_project)
-ZONE=$(get_global_config_field gcp_zone)
-DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image)
+if [ -z "${NAMESPACE}" ]; then
+    echo "Must specify a NAMESPACE environment variable"
+    exit 1;
+fi
+
+PROJECT=$(get_global_config_field gcp_project $NAMESPACE)
+ZONE=$(get_global_config_field gcp_zone $NAMESPACE)
+DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image $NAMESPACE)
 
 WORKER_IMAGE_VERSION=12
-BUILDER=build-batch-worker-image
+
+if [ "$NAMESPACE" == "default" ]; then
+    WORKER_IMAGE=batch-worker-${WORKER_IMAGE_VERSION}
+    BUILDER=build-batch-worker-image
+else
+    WORKER_IMAGE=batch-worker-$NAMESPACE-${WORKER_IMAGE_VERSION}
+    BUILDER=build-batch-worker-$NAMESPACE-image
+fi
+
+UBUNTU_IMAGE=ubuntu-minimal-2004-focal-v20230725
 
 create_build_image_instance() {
     gcloud -q compute --project ${PROJECT} instances delete \
@@ -18,16 +33,12 @@ create_build_image_instance() {
     python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"'${DOCKER_ROOT_IMAGE}'"}}' \
         build-batch-worker-image-startup-gcp.sh build-batch-worker-image-startup-gcp.sh.out
 
-    UBUNTU_IMAGE=$(gcloud compute images list \
-        --standard-images \
-        --filter 'family="ubuntu-minimal-2004-lts"' \
-        --format='value(name)')
-
     gcloud -q compute instances create ${BUILDER} \
         --project ${PROJECT}  \
         --zone=${ZONE} \
         --machine-type=n1-standard-1 \
         --network=default \
+        --subnet=default \
         --network-tier=PREMIUM \
         --metadata-from-file startup-script=build-batch-worker-image-startup-gcp.sh.out \
         --no-restart-on-failure \
@@ -40,10 +51,10 @@ create_build_image_instance() {
 }
 
 create_worker_image() {
-    gcloud -q compute images delete batch-worker-${WORKER_IMAGE_VERSION} \
+    gcloud -q compute images delete $WORKER_IMAGE \
         --project ${PROJECT} || true
 
-    gcloud -q compute images create batch-worker-${WORKER_IMAGE_VERSION} \
+    gcloud -q compute images create $WORKER_IMAGE \
         --project ${PROJECT} \
         --source-disk-zone=${ZONE} \
         --source-disk=${BUILDER}
@@ -63,4 +74,4 @@ main() {
     create_worker_image
 }
 
-confirm "Building image with properties:\n Version: ${WORKER_IMAGE_VERSION}\n Project: ${PROJECT}\n Zone: ${ZONE}" && main
+confirm "Building image $WORKER_IMAGE with properties:\n Version: ${WORKER_IMAGE_VERSION}\n Project: ${PROJECT}\n Zone: ${ZONE}" && main

--- a/devbin/functions.sh
+++ b/devbin/functions.sh
@@ -197,7 +197,7 @@ download-configmap() {
 }
 
 get_global_config_field() {
-    kubectl get secret global-config --template={{.data.$1}} | base64 --decode
+    kubectl -n ${2:-default} get secret global-config --template={{.data.$1}} | base64 --decode
 }
 
 gcpsetcluster() {
@@ -235,10 +235,6 @@ azsshworker() {
         | jq -jr '.[0].virtualMachine.network.publicIpAddresses[0].ipAddress')
 
     ssh -i ~/.ssh/batch_worker_ssh_rsa batch-worker@$worker_ip
-}
-
-get_global_config_field() {
-    kubectl get secret global-config --template={{.data.$1}} | base64 --decode
 }
 
 confirm() {

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -246,7 +246,7 @@ You can now install Hail:
 - Create the batch worker VM image. Run:
 
   ```
-  $HAIL/batch/gcp-create-worker-image.sh
+  NAMESPACE=default $HAIL/batch/gcp-create-worker-image.sh
   ```
 
 - Download the global-config to be used by `bootstrap.py`.


### PR DESCRIPTION
Did a few things here:

- Specifying a namespace is necessary to run the script, and must be supplied as `default` if you want to change the production images
- Explicitly specify the `subnet` in the VM creation. This was optional before but BITS changed some settings in GCP such that you *have* to specify subnets when creating a VM.
- I hard-coded the ubuntu image. I think this is better for reproducibility/auditing, but this actually broke because the `gcloud` query that used to return one image now returns two (they added an ARM ubuntu).