### PR TITLE
[query] force `aggregate_cols` to be local

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2228,9 +2228,6 @@ class StreamAgg(IR):
         else:
             return {}
 
-    def renderable_uses_agg_context(self, i: int):
-        return i == 0
-
     def renderable_new_block(self, i: int) -> bool:
         return i == 1
 

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2225,8 +2225,11 @@ class MatrixTable(ExprContainer):
         analyze('MatrixTable.aggregate_cols', expr, self._global_indices, {self._col_axis})
 
         cols_field = Env.get_uid()
-        cols = base.localize_entries(columns_array_field_name=cols_field).index_globals()[cols_field]
-        agg_ir = ir.StreamAgg(ir.ToStream(cols._ir), 'sa', expr._ir)
+        globals = base.localize_entries(columns_array_field_name=cols_field).index_globals()
+        agg_ir = ir.Let(
+            'global',
+            globals.drop(cols_field)._ir,
+            ir.StreamAgg(ir.ToStream(globals[cols_field]._ir), 'sa', expr._ir))
 
         if _localize:
             return Env.backend().execute(ir.MakeTuple([agg_ir]))[0]

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2223,14 +2223,15 @@ class MatrixTable(ExprContainer):
         """
         base, _ = self._process_joins(expr)
         analyze('MatrixTable.aggregate_cols', expr, self._global_indices, {self._col_axis})
-        cols_table = ir.MatrixColsTable(base._mir)
-        subst_query = ir.subst(expr._ir, {}, {'sa': ir.Ref('row', cols_table.typ.row_type)})
 
-        agg_ir = ir.TableAggregate(cols_table, subst_query)
+        cols_field = Env.get_uid()
+        cols = base.localize_entries(columns_array_field_name=cols_field).index_globals()[cols_field]
+        agg_ir = ir.StreamAgg(ir.ToStream(cols._ir), 'sa', expr._ir)
+
         if _localize:
             return Env.backend().execute(ir.MakeTuple([agg_ir]))[0]
         else:
-            return construct_expr(ir.LiftMeOut(agg_ir), expr.dtype)
+            return construct_expr(agg_ir, expr.dtype)
 
     @typecheck_method(expr=expr_any, _localize=bool)
     def aggregate_entries(self, expr, _localize=True):

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -204,9 +204,20 @@ class Tests(unittest.TestCase):
 
         qs = mt.aggregate_cols(agg.count())
         self.assertEqual(qs, 100)
+        qs = hl.eval(mt.aggregate_cols(agg.count(), _localize=False))
+        self.assertEqual(qs, 100)
 
         mt.aggregate_cols(hl.Struct(x=agg.collect(mt.s),
                                     y=agg.collect(mt.y1)))
+
+    def test_aggregate_cols_order(self):
+        path = new_temp_file(extension='mt')
+        mt = hl.utils.range_matrix_table(3, 3)
+        mt = mt.choose_cols([2, 1, 0])
+        mt = mt.checkpoint(path)
+        assert(mt.aggregate_cols(hl.agg.collect(mt.col_idx)) == [0, 1, 2])
+        mt = mt.key_cols_by()
+        assert(mt.aggregate_cols(hl.agg.collect(mt.col_idx)) == [2, 1, 0])
 
     def test_aggregate_entries(self):
         mt = self.get_mt()

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -215,9 +215,9 @@ class Tests(unittest.TestCase):
         mt = hl.utils.range_matrix_table(3, 3)
         mt = mt.choose_cols([2, 1, 0])
         mt = mt.checkpoint(path)
-        assert(mt.aggregate_cols(hl.agg.collect(mt.col_idx)) == [0, 1, 2])
+        assert mt.aggregate_cols(hl.agg.collect(mt.col_idx)) == [0, 1, 2]
         mt = mt.key_cols_by()
-        assert(mt.aggregate_cols(hl.agg.collect(mt.col_idx)) == [2, 1, 0])
+        assert mt.aggregate_cols(hl.agg.collect(mt.col_idx)) == [2, 1, 0]
 
     def test_aggregate_entries(self):
         mt = self.get_mt()


### PR DESCRIPTION
CHANGELOG: MatrixTable.aggregate_cols no longer forces a distributed computation. This should be what you want in the majority of cases. In case you know the aggregation is very slow and should be parallelized, use mt.cols().aggregate instead.

Most of the time, `aggregate_cols` will be much faster performing the aggregation locally. Currently, we generate a `TableAggregate` over a `TableParallelize` of the columns. We shouldn't try to optimize that to a local computation during compilation; `TableParallelize` should express the intent that the computation is expensive and really should be parallelized. This should be considered part of the semantics the compiler must preserve.

This PR changes `aggregate_cols` to explicitly generate a local computation using `StreamAgg` (which was only exposed in Python relatively recently, which is why we haven't made this change sooner). Longer term, aggregating columns should probably get its own IR node, especially once we start partitioning along columns.