### PR TITLE
[compiler] fix TableUnion lowering

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1054,17 +1054,19 @@ class Tests(unittest.TestCase):
         self.assertTrue(t._same(ref_tab))
 
     def test_union(self):
-        t1 = hl.utils.range_table(5)
+        t1 = hl.utils.range_table(5, 2)
 
-        t2 = hl.utils.range_table(5)
-        t2 = t2.key_by(idx = t2.idx + 5)
+        t2 = hl.utils.range_table(5, 2)
+        t2 = t2.key_by(idx=t2.idx + 5)
 
-        t3 = hl.utils.range_table(5)
-        t3 = t3.key_by(idx = t3.idx + 10)
+        t3 = hl.utils.range_table(5, 2)
+        t3 = t3.key_by(idx=t3.idx + 10)
 
         self.assertTrue(t1.union(t2, t3)._same(hl.utils.range_table(15)))
-        self.assertTrue(t1.key_by().union(t2.key_by(), t3.key_by())
-                        ._same(hl.utils.range_table(15).key_by()))
+
+        no_key = t1.key_by().union(t2.key_by(), t3.key_by())
+        assert no_key.n_partitions() == 6
+        self.assertTrue(no_key._same(hl.utils.range_table(15).key_by()))
 
     def nested_union(self, N, M):
         t = hl.utils.range_table(N, n_partitions=1)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.lowering
 import is.hail.HailContext
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.ArrayZipBehavior.AssertSameLength
-import is.hail.expr.ir.functions.{TableCalculateNewPartitions, WrappedMatrixToTableFunction}
+import is.hail.expr.ir.functions.{ArrayFunctions, TableCalculateNewPartitions, WrappedMatrixToTableFunction}
 import is.hail.expr.ir.{TableNativeWriter, agg, _}
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.methods.{ForceCountTable, LocalLDPrune, NPartitionsTable, TableFilterPartitions}
@@ -53,6 +53,46 @@ object TableStage {
   }
   def wrapInBindings(body: IR, letBindings: IndexedSeq[(String, IR)]): IR = letBindings.foldRight[IR](body) {
     case ((name, value), body) => Let(name, value, body)
+  }
+
+  def concatenate(ctx: ExecuteContext, children: IndexedSeq[TableStage]): TableStage = {
+    val keyType = children.head.kType
+    assert(keyType.size == 0)
+
+    val ctxType = TTuple(children.map(_.ctxType): _*)
+    val ctxArrays = children.view.zipWithIndex.map { case (child, idx) =>
+      ToArray(mapIR(child.contexts) { ctx =>
+        MakeTuple.ordered(children.indices.map { idx2 =>
+          if (idx == idx2) ctx else NA(children(idx2).ctxType)
+        })
+      })
+    }
+    val ctxs = flatMapIR(MakeStream(ctxArrays.toFastIndexedSeq, TStream(TArray(ctxType)))) { ctxArray =>
+      ToStream(ctxArray)
+    }
+
+    val newGlobals = children.head.globals
+    val globalsRef = Ref(genUID(), newGlobals.typ)
+    val newPartitioner = new RVDPartitioner(ctx.stateManager, keyType, children.flatMap(_.partitioner.rangeBounds))
+
+    TableStage(
+      children.flatMap(_.letBindings) :+ globalsRef.name -> newGlobals,
+      children.flatMap(_.broadcastVals) :+ globalsRef.name -> globalsRef,
+      globalsRef,
+      newPartitioner,
+      TableStageDependency.union(children.map(_.dependency)),
+      ctxs,
+      (ctxRef: Ref) => {
+        StreamMultiMerge(
+          children.indices.map { i =>
+            bindIR(GetTupleElement(ctxRef, i)) { ctx =>
+              If(IsNA(ctx),
+                 MakeStream(IndexedSeq(), TStream(children(i).rowType)),
+                 children(i).partition(ctx))
+            }
+          },
+          IndexedSeq())
+      })
   }
 }
 
@@ -1542,21 +1582,26 @@ object LowerTableIR {
       case x@TableUnion(children) =>
         val lowered = children.map(lower)
         val keyType = x.typ.keyType
-        val newPartitioner = RVDPartitioner.generate(ctx.stateManager, keyType, lowered.flatMap(_.partitioner.rangeBounds))
-        val repartitioned = lowered.map(_.repartitionNoShuffle(ctx, newPartitioner))
 
-        TableStage(
-          repartitioned.flatMap(_.letBindings),
-          repartitioned.flatMap(_.broadcastVals),
-          repartitioned.head.globals,
-          newPartitioner,
-          TableStageDependency.union(repartitioned.map(_.dependency)),
-          zipIR(repartitioned.map(_.contexts), ArrayZipBehavior.AssumeSameLength) { ctxRefs =>
-            MakeTuple.ordered(ctxRefs)
-          },
-          ctxRef =>
-            StreamMultiMerge(repartitioned.indices.map(i => repartitioned(i).partition(GetTupleElement(ctxRef, i))), keyType.fieldNames)
-        )
+        if (keyType.size == 0) {
+          TableStage.concatenate(ctx, lowered)
+        } else {
+          val newPartitioner = RVDPartitioner.generate(ctx.stateManager, keyType, lowered.flatMap(_.partitioner.rangeBounds))
+          val repartitioned = lowered.map(_.repartitionNoShuffle(ctx, newPartitioner))
+
+          TableStage(
+            repartitioned.flatMap(_.letBindings),
+            repartitioned.flatMap(_.broadcastVals),
+            repartitioned.head.globals,
+            newPartitioner,
+            TableStageDependency.union(repartitioned.map(_.dependency)),
+            zipIR(repartitioned.map(_.contexts), ArrayZipBehavior.AssumeSameLength) { ctxRefs =>
+              MakeTuple.ordered(ctxRefs)
+            },
+            ctxRef =>
+              StreamMultiMerge(repartitioned.indices.map(i => repartitioned(i).partition(GetTupleElement(ctxRef, i))), keyType.fieldNames)
+            )
+        }
 
       case x@TableMultiWayZipJoin(children, fieldName, globalName) =>
         val lowered = children.map(lower)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -58,6 +58,7 @@ object TableStage {
   def concatenate(ctx: ExecuteContext, children: IndexedSeq[TableStage]): TableStage = {
     val keyType = children.head.kType
     assert(keyType.size == 0)
+    assert(children.forall(_.kType == keyType))
 
     val ctxType = TTuple(children.map(_.ctxType): _*)
     val ctxArrays = children.view.zipWithIndex.map { case (child, idx) =>


### PR DESCRIPTION
fixes #13407

CHANGELOG: Resolves #13407 in which uses of `union_rows` could reduce parallelism to one partition resulting in severely degraded performance.

TableUnion was always collapsing to a single partition when the key was empty. This adds a special case handling, which just concatenates partitions.

The body of the resulting TableStage is a little hacky: it does a StreamMultiMerge, but where exactly one input stream is non-empty. I think that should have fine performance, and I didn’t see any simpler ways to do it.