### PR TITLE
[github] apply needs-triage label to each bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a bug
+labels: needs-triage
 body:
   - type: textarea
     id: what-happened
@@ -19,5 +20,5 @@ body:
     id: log
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output.
+      description: Please copy and paste any relevant log output. If too large, please put in https://gist.github.com and provide the link.
       render: shell


### PR DESCRIPTION
I also suggested gist.github.com for large logs.

This will allow us to quickly see new issues from users. We might want other forms / to generalize this form if we want support requests to go to GitHub too.

cc: @jigold