### PR TITLE
[batch] ignore aiomysql warnings about batch.billing_projects.name

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1,4 +1,3 @@
-import warnings
 import asyncio
 import copy
 import json

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import signal
+import warnings
 from collections import defaultdict, namedtuple
 from functools import wraps
 from typing import Any, Awaitable, Callable, Dict, Set, Tuple

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1,3 +1,4 @@
+import warnings
 import asyncio
 import copy
 import json
@@ -88,6 +89,12 @@ routes = web.RouteTableDef()
 deploy_config = get_deploy_config()
 
 auth = AuthClient()
+
+warnings.filterwarnings(
+    'ignore',
+    ".*Warning: Field or reference 'batch.billing_projects.name' of SELECT #. was resolved in SELECT #.",
+    module='aiomysql.*',
+)
 
 
 def instance_name_from_request(request):


### PR DESCRIPTION
For example, see error messages when batch-driver shuts down: https://cloudlogging.app.goo.gl/kKgJdv34s3a6Vd8n6.