### PR TITLE
[batch] report unclosed ClientSession alloc location in batch-driver

### DIFF
--- a/batch/batch/driver/__main__.py
+++ b/batch/batch/driver/__main__.py
@@ -4,5 +4,20 @@ from hailtop.hail_logging import configure_logging
 configure_logging()
 
 from .main import run  # noqa: E402 pylint: disable=wrong-import-position
+import aiohttp  # noqa: E402 pylint: disable=wrong-import-position
+import traceback  # noqa: E402 pylint: disable=wrong-import-position
+import sys  # noqa: E402 pylint: disable=wrong-import-position
+
+
+oldinit = aiohttp.ClientSession.__init__
+
+
+def newinit(self, *args, **kwargs):
+    oldinit(self, *args, **kwargs)
+    self._source_traceback = traceback.extract_stack(sys._getframe(1))
+
+
+aiohttp.ClientSession.__init__ = newinit
+
 
 run()

--- a/batch/batch/driver/__main__.py
+++ b/batch/batch/driver/__main__.py
@@ -10,7 +10,7 @@ import aiohttp  # noqa: E402 pylint: disable=wrong-import-position
 
 from .main import run  # noqa: E402 pylint: disable=wrong-import-position
 
-oldinit = aiohttp.ClientSession.__init__
+oldinit = aiohttp.ClientSession.__init__  # type: ignore
 
 
 def newinit(self, *args, **kwargs):

--- a/batch/batch/driver/__main__.py
+++ b/batch/batch/driver/__main__.py
@@ -18,7 +18,7 @@ def newinit(self, *args, **kwargs):
     self._source_traceback = traceback.extract_stack(sys._getframe(1))
 
 
-aiohttp.ClientSession.__init__ = newinit
+aiohttp.ClientSession.__init__ = newinit  # type: ignore
 
 
 run()

--- a/batch/batch/driver/__main__.py
+++ b/batch/batch/driver/__main__.py
@@ -3,11 +3,12 @@ from hailtop.hail_logging import configure_logging
 # configure logging before importing anything else
 configure_logging()
 
-from .main import run  # noqa: E402 pylint: disable=wrong-import-position
-import aiohttp  # noqa: E402 pylint: disable=wrong-import-position
-import traceback  # noqa: E402 pylint: disable=wrong-import-position
 import sys  # noqa: E402 pylint: disable=wrong-import-position
+import traceback  # noqa: E402 pylint: disable=wrong-import-position
 
+import aiohttp  # noqa: E402 pylint: disable=wrong-import-position
+
+from .main import run  # noqa: E402 pylint: disable=wrong-import-position
 
 oldinit = aiohttp.ClientSession.__init__
 


### PR DESCRIPTION
We get a lot of spurious Grafana alerts because batch-driver has unclosed `aiohttp.ClientSession` objects. `aiohttp` can [report the creation location](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L242-L247), but only when aysncio is in debug mode.

I am hesitant to enable debug mode because I suspect it will slow down everything by grabbing stack traces for every coroutine (so that it can report an error later).

I adapted the code from the linked asyncio code and tested it as follows:

```
In [1]: import aiohttp
   ...: import traceback
   ...: import sys
   ...:
   ...: oldinit = aiohttp.ClientSession.__init__
   ...: def newinit(self, *args, **kwargs):
   ...:      oldinit(self, *args, **kwargs)
   ...:      self._source_traceback: Optional[
   ...:                 traceback.StackSummary
   ...:             ] = traceback.extract_stack(sys._getframe(1))
   ...: aiohttp.ClientSession.__init__ = newinit

In [2]: aiohttp.ClientSession()
<ipython-input-1-028690903e5f>:7: DeprecationWarning: The object should be created within an async function
  oldinit(self, *args, **kwargs)
Out[2]: <aiohttp.client.ClientSession at 0x104ab3850>

In [3]: aiohttp.ClientSession()
<ipython-input-1-028690903e5f>:7: DeprecationWarning: The object should be created within an async function
  oldinit(self, *args, **kwargs)
Out[3]: <aiohttp.client.ClientSession at 0x104dac8b0>

In [4]: aiohttp.ClientSession()
<ipython-input-1-028690903e5f>:7: DeprecationWarning: The object should be created within an async function
  oldinit(self, *args, **kwargs)
Out[4]: <aiohttp.client.ClientSession at 0x104daeec0>

In [5]:

Do you really want to exit ([y]/n)? y
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x104ab3850>
source_traceback: Object created at (most recent call last):
  File "/Users/dking/miniconda3/bin/ipython", line 8, in <module>
    sys.exit(start_ipython())
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/__init__.py", line 128, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/traitlets/config/application.py", line 1043, in launch_instance
    app.start()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/ipapp.py", line 318, in start
    self.shell.mainloop()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/interactiveshell.py", line 888, in mainloop
    self.interact()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/interactiveshell.py", line 881, in interact
    self.run_cell(code, store_history=True)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3009, in run_cell
    result = self._run_cell(
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3064, in _run_cell
    result = runner(coro)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/async_helpers.py", line 129, in _pseudo_sync_runner
    coro.send(None)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3269, in run_cell_async
    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3448, in run_ast_nodes
    if await self.run_code(code, result, async_=asy):
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-40c87378e50b>", line 1, in <module>
    aiohttp.ClientSession()
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x104dac8b0>
source_traceback: Object created at (most recent call last):
  File "/Users/dking/miniconda3/bin/ipython", line 8, in <module>
    sys.exit(start_ipython())
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/__init__.py", line 128, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/traitlets/config/application.py", line 1043, in launch_instance
    app.start()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/ipapp.py", line 318, in start
    self.shell.mainloop()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/interactiveshell.py", line 888, in mainloop
    self.interact()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/interactiveshell.py", line 881, in interact
    self.run_cell(code, store_history=True)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3009, in run_cell
    result = self._run_cell(
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3064, in _run_cell
    result = runner(coro)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/async_helpers.py", line 129, in _pseudo_sync_runner
    coro.send(None)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3269, in run_cell_async
    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3448, in run_ast_nodes
    if await self.run_code(code, result, async_=asy):
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-40c87378e50b>", line 1, in <module>
    aiohttp.ClientSession()
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x104daeec0>
source_traceback: Object created at (most recent call last):
  File "/Users/dking/miniconda3/bin/ipython", line 8, in <module>
    sys.exit(start_ipython())
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/__init__.py", line 128, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/traitlets/config/application.py", line 1043, in launch_instance
    app.start()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/ipapp.py", line 318, in start
    self.shell.mainloop()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/interactiveshell.py", line 888, in mainloop
    self.interact()
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/terminal/interactiveshell.py", line 881, in interact
    self.run_cell(code, store_history=True)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3009, in run_cell
    result = self._run_cell(
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3064, in _run_cell
    result = runner(coro)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/async_helpers.py", line 129, in _pseudo_sync_runner
    coro.send(None)
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3269, in run_cell_async
    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3448, in run_ast_nodes
    if await self.run_code(code, result, async_=asy):
  File "/Users/dking/miniconda3/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-4-40c87378e50b>", line 1, in <module>
    aiohttp.ClientSession()
```

Without the monkey path we only see:

```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x102db7550>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x102db79d0>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x102db7850>
```