### PR TITLE
[query] frozenlist.__repr__ should be eval-able

### DIFF
--- a/hail/python/hailtop/hail_frozenlist.py
+++ b/hail/python/hailtop/hail_frozenlist.py
@@ -9,3 +9,6 @@ class frozenlist(_FrozenList, Sequence[T]):
     def __init__(self, items: List[T]):
         super().__init__(items)
         self.freeze()
+
+    def __repr__(self) -> str:
+        return f'frozenlist({list(self)})'


### PR DESCRIPTION
CHANGELOG: Hail `frozenlist` now has an eval-able `repr`.

`hailtop.hail_frozenlist.frozenlist` previously inherited the `repr` of the `frozenlist` library:

    > frozenlist([1, 2, 3])
    <FrozenList(frozen=True, [1, 2, 3])>

With this change, I both use the fact that `frozen=True` for Hail frozenlists and use a printed form that is actually eval-able:

    > frozenlist([1, 2, 3])
    frozenlist([1, 2, 3])
    > eval(repr(frozenlist([1, 2, 3])))
    frozenlist([1, 2, 3])