### PR TITLE
[build.yaml] finally fix up the namespace autoscaler

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3690,16 +3690,19 @@ steps:
       valueFrom: ci_utils_image.image
     script: |
       set -ex
-      cat > dev-namespace-scalers.yaml <<'EOF'
       {% for user in code.get("developers", []) %}
       {% if user['username'] != 'test-dev' %}
+
+      if kubectl get namespace {{ user["username"] }} 2>/dev/null
+      then
+      cat > the.yaml <<'EOF'
       apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: dev-namespace-scaledown-{{ user["username"] }}
         namespace: {{ user["username"] }}
       spec:
-        schedule: 0 20 * * 1,2,3,4,5"  # Weekdays at 8p
+        schedule: "0 20 * * 1,2,3,4,5"  # Weekdays at 8p
         concurrencyPolicy: Forbid
         successfulJobsHistoryLimit: 1
         failedJobsHistoryLimit: 1
@@ -3709,7 +3712,7 @@ steps:
               spec:
                 serviceAccountName: admin
                 containers:
-                - name: dev-namespace-scaledown-dking
+                - name: dev-namespace-scaledown-{{ user["username"] }}
                   image: bitnami/kubectl:latest
                   command:
                   - /bin/sh
@@ -3741,10 +3744,18 @@ steps:
                   - set -ex ; kubectl scale deployments --all -n {{ user["username"] }} --replicas=1 && kubectl scale statefulsets --all -n {{ user["username"] }} --replicas=1
                 restartPolicy: OnFailure
       ---
+      EOF
+
+      kubectl apply -f the.yaml
+      echo "For {{ user["username"] }}, applied:"
+      echo "---"
+      cat the.yaml
+      else
+      echo "Skipping {{ user["username"] }} because they have no namespace."
+      fi
+
       {% endif %}
       {% endfor %}
-      EOF
-      kubectl apply -f dev-namespace-scalers.yaml
     scopes:
       - deploy
     serviceAccount:


### PR DESCRIPTION
Alright! I stopped being lazy and actually tested all this.

I copied the code from the step into a file and removed the left-hand indentation. I called that file `/tmp/foo.sh`. I ran this:

```
python3 ~/projects/hail/ci/jinja2_render.py '{"code":{"developers":[{"username":"cchurch"},{"username":"dking"},{"username":"jigold"},{"username":"dgoldste"}, {"username":"irademac"},{"username":"parsa"},{"username":"test-dev"},{"username":"cseed"},{"username":"cvittal"},{"username":"ehigham"},{"username":"gsmith"},{"username":"jwander"},{"username":"nwatts"},{"username":"pschultz"}]}}' \
        /tmp/foo.sh \
	/tmp/foo.sh.out
sh /tmp/foo.sh.out
```

And it correctly skipped test-dev entirely, it printed "Skipping cchurch because they have no namespace." and it created the appropriate cronjobs for everyone else. I then re-ran it to verify it indicated no changes. I then listed all the cronjobs:

```
(base) dking@wm28c-761 hail % k get cronjob --all-namespaces
NAMESPACE   NAME                               SCHEDULE             SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cseed       dev-namespace-scaledown-cseed      0 20 * * 1,2,3,4,5   False     0        <none>          13s
cseed       dev-namespace-scaleup-cseed        0 9 * * 1,2,3,4,5    False     0        <none>          90m
cvittal     dev-namespace-scaledown-cvittal    0 20 * * 1,2,3,4,5   False     0        <none>          12s
cvittal     dev-namespace-scaleup-cvittal      0 9 * * 1,2,3,4,5    False     0        <none>          90m
dgoldste    dev-namespace-scaledown-dgoldste   0 20 * * 1,2,3,4,5   False     0        <none>          4m2s
dgoldste    dev-namespace-scaleup-dgoldste     0 9 * * 1,2,3,4,5    False     0        <none>          90m
dking       dev-namespace-scaledown-dking      0 20 * * 1,2,3,4,5   False     0        <none>          9m22s
dking       dev-namespace-scaleup-dking        0 9 * * 1,2,3,4,5    False     0        <none>          90m
ehigham     dev-namespace-scaledown-ehigham    0 20 * * 1,2,3,4,5   False     0        <none>          11s
ehigham     dev-namespace-scaleup-ehigham      0 9 * * 1,2,3,4,5    False     0        <none>          90m
gsmith      dev-namespace-scaledown-gsmith     0 20 * * 1,2,3,4,5   False     0        <none>          10s
gsmith      dev-namespace-scaleup-gsmith       0 9 * * 1,2,3,4,5    False     0        <none>          90m
irademac    dev-namespace-scaledown-irademac   0 20 * * 1,2,3,4,5   False     0        <none>          4m2s
irademac    dev-namespace-scaleup-irademac     0 9 * * 1,2,3,4,5    False     0        <none>          90m
jigold      dev-namespace-scaledown-jigold     0 20 * * 1,2,3,4,5   False     0        <none>          4m3s
jigold      dev-namespace-scaleup-jigold       0 9 * * 1,2,3,4,5    False     0        <none>          90m
jwander     dev-namespace-scaledown-jwander    0 20 * * 1,2,3,4,5   False     0        <none>          10s
jwander     dev-namespace-scaleup-jwander      0 9 * * 1,2,3,4,5    False     0        <none>          90m
nwatts      dev-namespace-scaledown-nwatts     0 20 * * 1,2,3,4,5   False     0        <none>          9s
nwatts      dev-namespace-scaleup-nwatts       0 9 * * 1,2,3,4,5    False     0        <none>          90m
parsa       dev-namespace-scaledown-parsa      0 20 * * 1,2,3,4,5   False     0        <none>          4m1s
parsa       dev-namespace-scaleup-parsa        0 9 * * 1,2,3,4,5    False     0        <none>          90m
pschultz    dev-namespace-scaledown-pschultz   0 20 * * 1,2,3,4,5   False     0        <none>          8s
pschultz    dev-namespace-scaleup-pschultz     0 9 * * 1,2,3,4,5    False     0        <none>          90m
```