### PR TITLE
[aiogoogle] Fix bucket name parsing

### DIFF
--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -617,9 +617,10 @@ class GoogleStorageAsyncFS(AsyncFS):
         end_of_bucket = rest.find('/', 2)
         if end_of_bucket != -1:
             bucket = rest[2:end_of_bucket]
+            name = rest[(end_of_bucket + 1):]
         else:
             bucket = rest[2:]
-        name = rest[(end_of_bucket + 1):]
+            name = ''
 
         return (bucket, name)
 

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -615,7 +615,10 @@ class GoogleStorageAsyncFS(AsyncFS):
             raise ValueError(f'Google Cloud Storage URI must be of the form: gs://bucket/path, found: {url}')
 
         end_of_bucket = rest.find('/', 2)
-        bucket = rest[2:end_of_bucket]
+        if end_of_bucket != -1:
+            bucket = rest[2:end_of_bucket]
+        else:
+            bucket = rest[2:]
         name = rest[(end_of_bucket + 1):]
 
         return (bucket, name)

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -46,7 +46,7 @@ def test_bucket_path_parsing():
     assert bucket == 'foo' and prefix == ''
 
     bucket, prefix = GoogleStorageAsyncFS.get_bucket_and_name('gs://foo/bar/baz')
-    assert bucket == 'foo' and prefix == 'foo/bar/baz'
+    assert bucket == 'foo' and prefix == 'bar/baz'
 
 
 @pytest.mark.asyncio

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -41,6 +41,14 @@ def bucket_and_temporary_file():
     return bucket, prefix + '/' + secrets.token_hex(16)
 
 
+def test_bucket_path_parsing():
+    bucket, prefix = GoogleStorageAsyncFS.get_bucket_and_name('gs://foo')
+    assert bucket == 'foo' and prefix == ''
+
+    bucket, prefix = GoogleStorageAsyncFS.get_bucket_and_name('gs://foo/bar/baz')
+    assert bucket == 'foo' and prefix == 'foo/bar/baz'
+
+
 @pytest.mark.asyncio
 async def test_get_object_metadata(bucket_and_temporary_file):
     bucket, file = bucket_and_temporary_file


### PR DESCRIPTION
This code was broken if the URL only had a bucket name like `gs://foo`. It truncated the last character of the bucket because the `find` operation returned -1 for not being able to find another `/` in the URL after `gs://`.