### PR TITLE
[batch] Move config.json into the container bundle

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -812,7 +812,6 @@ class Container:
 
         self.container_scratch = scratch_dir
         self.container_overlay_path = f'{self.container_scratch}/rootfs_overlay'
-        self.config_path = f'{self.container_scratch}/config'
         self.log_path = log_path or f'{self.container_scratch}/container.log'
         self.resource_usage_path = f'{self.container_scratch}/resource_usage'
 
@@ -1065,9 +1064,7 @@ class Container:
                         'crun',
                         'run',
                         '--bundle',
-                        f'{self.container_overlay_path}/merged',
-                        '--config',
-                        f'{self.config_path}/config.json',
+                        self.container_scratch,
                         self.name,
                         stdin=stdin,
                         stdout=container_log,
@@ -1101,8 +1098,7 @@ class Container:
         config = await self.container_config()
         self._validate_container_config(config)
 
-        os.makedirs(self.config_path)
-        with open(f'{self.config_path}/config.json', 'w', encoding='utf-8') as f:
+        with open(f'{self.container_scratch}/config.json', 'w', encoding='utf-8') as f:
             f.write(json.dumps(config))
 
     # https://github.com/opencontainers/runtime-spec/blob/master/config.md
@@ -1132,7 +1128,7 @@ class Container:
         config: Dict[str, Any] = {
             'ociVersion': '1.0.1',
             'root': {
-                'path': '.',
+                'path': f'{self.container_overlay_path}/merged',
                 'readonly': False,
             },
             'hostname': self.netns.hostname,

--- a/dev-docs/batch-container-design.md
+++ b/dev-docs/batch-container-design.md
@@ -40,8 +40,7 @@ scratch/
 │  │  │  ├─ io/ (bind mount)
 │  │  ├─ workdir/
 │  ├─ volumes/
-│  ├─ config/
-│  │  ├─ config.json
+│  ├─ config.json
 ├─ main/
 │  ├─ rootfs_overlay/
 │  │  ├─ upperdir/ (writeable layer)
@@ -54,8 +53,7 @@ scratch/
 │  │  ├─ workdir/
 │  ├─ volumes/
 │  │  ├─ image/specified/volume/
-│  ├─ config/
-│  │  ├─ config.json
+│  ├─ config.json
 ├─ output/
 │  ├─ ...
 ```


### PR DESCRIPTION
### Background

In the world of low-level container runtimes there exists the term "bundle", which basically means the pair of a root filesystem and a `config.json` file containing all of the other necessary information to run the container. If you invoke `crun` or `runc` with `--bundle /path/to/bundle`, the runtime assumes the following:

- The configuration file for the container is located at `/path/to/bundle/config.json`
- That `config.json` contains a field [`root.path`](https://github.com/opencontainers/runtime-spec/blob/main/config.md#root) that specifies the location of the root filesystem, most commonly as a path relative to `/path/to/bundle`.

`crun` offers a way to explicitly reference the location of `config.json` through its `--config` flag. This seems fairly innocuous, but specifying a custom `--config` path can have some unfortunate unintended consequences because it invalidates the assumption in the specification that the configuration resides at `/path/to/bundle/config.json`. Specifically, it breaks [Hooks](https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-platform-hooks). When a hook is run, the runtime (crun) feeds it the [container state](https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#state), a JSON of information about the container including the `bundle` path. Any hook that attempts to load the `config.json`, like for example, the `nvidia-container-runtime-hook`, will crash.

### Change

This change stops using the `--config` flag for crun and instead does the following to create a well-formed bundle:

- Instead of the bundle being the merged directory of the container overlay, it is the container's scratch directory
- `root.path` is adjusted inside of `config.json` to now point to the merged directory of the container overlay. I've opted to use an absolute path here because why use a relative path.
- Move `config.json` into the container scratch directory so that it is inside the root of the bundle directory.
