### PR TITLE
[batch] Add aiomonitor to worker process

### DIFF
--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -20,7 +20,7 @@ aiosignal==1.3.1
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -c hail/batch/../web_common/pinned-requirements.txt
     #   aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -c hail/batch/../gear/pinned-requirements.txt
     #   -c hail/batch/../hail/python/pinned-requirements.txt
@@ -78,7 +78,7 @@ pandas==2.0.3
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt
-plotly==5.15.0
+plotly==5.16.0
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt
@@ -99,12 +99,13 @@ six==1.16.0
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   python-dateutil
-tenacity==8.2.2
+tenacity==8.2.3
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   plotly
 typing-extensions==4.7.1
     # via
+    #   -c hail/batch/../gear/pinned-requirements.txt
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   aiodocker

--- a/ci/pinned-requirements.txt
+++ b/ci/pinned-requirements.txt
@@ -24,6 +24,7 @@ charset-normalizer==3.2.0
     #   requests
 click==8.1.6
     # via
+    #   -c hail/ci/../gear/pinned-requirements.txt
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt
     #   zulip
@@ -62,6 +63,7 @@ requests[security]==2.31.0
     #   zulip
 typing-extensions==4.7.1
     # via
+    #   -c hail/ci/../gear/pinned-requirements.txt
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt
     #   zulip

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=hail/gear/pinned-requirements.txt hail/gear/requirements.txt
 #
+aioconsole==0.6.1
+    # via aiomonitor
 aiohttp==3.8.5
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
@@ -11,6 +13,8 @@ aiohttp==3.8.5
     #   aiohttp-session
     #   kubernetes-asyncio
 aiohttp-session==2.12.0
+    # via -r hail/gear/requirements.txt
+aiomonitor==0.4.5
     # via -r hail/gear/requirements.txt
 aiomysql==0.2.0
     # via -r hail/gear/requirements.txt
@@ -175,6 +179,16 @@ sortedcontainers==2.4.0
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   -r hail/gear/requirements.txt
+terminaltables==3.1.10
+    # via aiomonitor
+typing-extensions==4.5.0
+    # via
+    #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
+    #   -c hail/gear/../hail/python/pinned-requirements.txt
+    #   aiohttp
+    #   aiohttp-session
+    #   async-timeout
+    #   yarl
 uritemplate==4.1.1
     # via google-api-python-client
 urllib3==1.26.16

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=hail/gear/pinned-requirements.txt hail/gear/requirements.txt
 #
-aioconsole==0.6.1
+aioconsole==0.6.2
     # via aiomonitor
 aiohttp==3.8.5
     # via
@@ -14,7 +14,7 @@ aiohttp==3.8.5
     #   kubernetes-asyncio
 aiohttp-session==2.12.0
     # via -r hail/gear/requirements.txt
-aiomonitor==0.4.5
+aiomonitor==0.5.0
     # via -r hail/gear/requirements.txt
 aiomysql==0.2.0
     # via -r hail/gear/requirements.txt
@@ -23,7 +23,7 @@ aiosignal==1.3.1
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
@@ -34,6 +34,7 @@ attrs==23.1.0
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
+    #   aiomonitor
 cachetools==5.3.1
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
@@ -53,6 +54,12 @@ charset-normalizer==3.2.0
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   requests
+click==8.1.6
+    # via
+    #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
+    #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
+    #   -c hail/gear/../hail/python/pinned-requirements.txt
+    #   aiomonitor
 frozenlist==1.4.0
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
@@ -64,7 +71,7 @@ google-api-core==2.11.1
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   google-api-python-client
-google-api-python-client==2.95.0
+google-api-python-client==2.96.0
     # via google-cloud-profiler
 google-auth==2.22.0
     # via
@@ -80,7 +87,7 @@ google-auth-httplib2==0.1.0
     #   google-cloud-profiler
 google-cloud-profiler==3.1.0
     # via -r hail/gear/requirements.txt
-googleapis-common-protos==1.59.1
+googleapis-common-protos==1.60.0
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
@@ -96,6 +103,11 @@ idna==3.4
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   requests
     #   yarl
+janus==1.0.0
+    # via
+    #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
+    #   -c hail/gear/../hail/python/pinned-requirements.txt
+    #   aiomonitor
 kubernetes-asyncio==19.15.1
     # via -r hail/gear/requirements.txt
 multidict==6.0.4
@@ -104,7 +116,7 @@ multidict==6.0.4
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   yarl
-orjson==3.9.2
+orjson==3.9.4
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
@@ -116,6 +128,10 @@ prometheus-client==0.17.1
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
     #   -r hail/gear/requirements.txt
     #   prometheus-async
+prompt-toolkit==3.0.39
+    # via
+    #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
+    #   aiomonitor
 protobuf==3.20.2
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
@@ -181,14 +197,13 @@ sortedcontainers==2.4.0
     #   -r hail/gear/requirements.txt
 terminaltables==3.1.10
     # via aiomonitor
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
+    #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
-    #   aiohttp
-    #   aiohttp-session
-    #   async-timeout
-    #   yarl
+    #   aiomonitor
+    #   janus
 uritemplate==4.1.1
     # via google-api-python-client
 urllib3==1.26.16
@@ -199,6 +214,10 @@ urllib3==1.26.16
     #   google-auth
     #   kubernetes-asyncio
     #   requests
+wcwidth==0.2.6
+    # via
+    #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
+    #   prompt-toolkit
 wrapt==1.15.0
     # via
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt

--- a/gear/requirements.txt
+++ b/gear/requirements.txt
@@ -7,6 +7,7 @@
 -c ../hail/python/dev/pinned-requirements.txt
 
 aiohttp_session>=2.7,<2.13
+aiomonitor>=0.4.5,<1
 aiomysql>=0.0.20,<1
 google-cloud-profiler<4.0.0
 kubernetes-asyncio>=19.15.1,<20

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -56,7 +56,7 @@ click==8.1.6
     #   -r hail/hail/python/dev/requirements.txt
     #   black
     #   curlylint
-comm==0.1.3
+comm==0.1.4
     # via
     #   ipykernel
     #   ipywidgets
@@ -68,7 +68,7 @@ curlylint==0.13.1
     # via -r hail/hail/python/dev/requirements.txt
 cycler==0.11.0
     # via matplotlib
-debugpy==1.6.7
+debugpy==1.6.7.post1
     # via ipykernel
 decorator==4.4.2
     # via
@@ -85,7 +85,7 @@ docutils==0.18.1
     #   nbsphinx
     #   sphinx
     #   sphinx-rtd-theme
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
@@ -95,7 +95,7 @@ executing==1.2.0
     # via stack-data
 fastjsonschema==2.18.0
     # via nbformat
-fonttools==4.41.1
+fonttools==4.42.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -117,7 +117,7 @@ importlib-metadata==6.8.0
     #   jupyterlab-server
     #   nbconvert
     #   sphinx
-importlib-resources==6.0.0
+importlib-resources==6.0.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -126,7 +126,7 @@ importlib-resources==6.0.0
     #   notebook
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.25.0
+ipykernel==6.25.1
     # via
     #   jupyter
     #   jupyter-console
@@ -160,7 +160,7 @@ json5==0.9.14
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
-jsonschema[format-nongpl]==4.18.4
+jsonschema[format-nongpl]==4.19.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -193,7 +193,7 @@ jupyter-events==0.7.0
     # via jupyter-server
 jupyter-lsp==2.2.0
     # via jupyterlab
-jupyter-server==2.7.0
+jupyter-server==2.7.1
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -202,7 +202,7 @@ jupyter-server==2.7.0
     #   notebook-shim
 jupyter-server-terminals==0.4.4
     # via jupyter-server
-jupyterlab==4.0.3
+jupyterlab==4.0.5
     # via notebook
 jupyterlab-pygments==0.2.2
     # via nbconvert
@@ -252,11 +252,11 @@ nbformat==5.9.2
     #   nbsphinx
 nbsphinx==0.9.2
     # via -r hail/hail/python/dev/requirements.txt
-nest-asyncio==1.5.6
+nest-asyncio==1.5.7
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   ipykernel
-notebook==7.0.1
+notebook==7.0.2
     # via jupyter
 notebook-shim==0.2.3
     # via
@@ -267,7 +267,7 @@ numpy==1.24.4
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   contourpy
     #   matplotlib
-overrides==7.3.1
+overrides==7.4.0
     # via jupyter-server
 packaging==23.1
     # via
@@ -329,7 +329,7 @@ pycparser==2.21
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   cffi
-pygments==2.15.1
+pygments==2.16.1
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   ipython
@@ -384,7 +384,7 @@ pyyaml==6.0.1
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   jupyter-events
-pyzmq==25.1.0
+pyzmq==25.1.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -395,7 +395,7 @@ qtconsole==5.4.3
     # via jupyter
 qtpy==2.3.1
     # via qtconsole
-referencing==0.30.0
+referencing==0.30.2
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -417,7 +417,7 @@ rpds-py==0.9.2
     # via
     #   jsonschema
     #   referencing
-ruff==0.0.282
+ruff==0.0.284
     # via -r hail/hail/python/dev/requirements.txt
 send2trash==1.8.2
     # via jupyter-server
@@ -481,7 +481,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.1
     # via pylint
-tornado==6.3.2
+tornado==6.3.3
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   ipykernel

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -10,19 +10,19 @@ aiohttp==3.8.5
     # via -r hail/hail/python/hailtop/requirements.txt
 aiosignal==1.3.1
     # via aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
     # via aiohttp
 azure-common==1.1.28
     # via azure-mgmt-storage
-azure-core==1.28.0
+azure-core==1.29.2
     # via
     #   azure-identity
     #   azure-mgmt-core
     #   azure-storage-blob
     #   msrest
-azure-identity==1.13.0
+azure-identity==1.14.0
     # via -r hail/hail/python/hailtop/requirements.txt
 azure-mgmt-core==1.4.0
     # via azure-mgmt-storage
@@ -30,9 +30,9 @@ azure-mgmt-storage==20.1.0
     # via -r hail/hail/python/hailtop/requirements.txt
 azure-storage-blob==12.17.0
     # via -r hail/hail/python/hailtop/requirements.txt
-boto3==1.28.11
+boto3==1.28.26
     # via -r hail/hail/python/hailtop/requirements.txt
-botocore==1.31.11
+botocore==1.31.26
     # via
     #   -r hail/hail/python/hailtop/requirements.txt
     #   boto3
@@ -86,7 +86,7 @@ google-crc32c==1.5.0
     # via google-resumable-media
 google-resumable-media==2.5.0
     # via google-cloud-storage
-googleapis-common-protos==1.59.1
+googleapis-common-protos==1.60.0
     # via google-api-core
 humanize==1.1.0
     # via -r hail/hail/python/hailtop/requirements.txt
@@ -118,11 +118,11 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-nest-asyncio==1.5.6
+nest-asyncio==1.5.7
     # via -r hail/hail/python/hailtop/requirements.txt
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.9.2
+orjson==3.9.4
     # via -r hail/hail/python/hailtop/requirements.txt
 portalocker==2.7.0
     # via msal-extensions
@@ -141,7 +141,7 @@ pycares==4.3.0
     # via aiodns
 pycparser==2.21
     # via cffi
-pygments==2.15.1
+pygments==2.16.1
     # via rich
 pyjwt[crypto]==2.8.0
     # via msal
@@ -170,7 +170,6 @@ s3transfer==0.6.1
 six==1.16.0
     # via
     #   azure-core
-    #   azure-identity
     #   google-auth
     #   isodate
     #   jproperties

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -16,7 +16,7 @@ aiosignal==1.3.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   aiohttp
@@ -32,14 +32,14 @@ azure-common==1.1.28
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-mgmt-storage
-azure-core==1.28.0
+azure-core==1.29.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
     #   azure-mgmt-core
     #   azure-storage-blob
     #   msrest
-azure-identity==1.13.0
+azure-identity==1.14.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -57,11 +57,11 @@ azure-storage-blob==12.17.0
     #   -r hail/hail/python/hailtop/requirements.txt
 bokeh==3.1.1
     # via -r hail/hail/python/requirements.txt
-boto3==1.28.11
+boto3==1.28.26
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-botocore==1.31.11
+botocore==1.31.26
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -147,7 +147,7 @@ google-resumable-media==2.5.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   google-cloud-storage
-googleapis-common-protos==1.59.1
+googleapis-common-protos==1.60.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   google-api-core
@@ -200,7 +200,7 @@ multidict==6.0.4
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   aiohttp
     #   yarl
-nest-asyncio==1.5.6
+nest-asyncio==1.5.7
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -215,7 +215,7 @@ oauthlib==3.2.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   requests-oauthlib
-orjson==3.9.2
+orjson==3.9.4
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -231,7 +231,7 @@ parsimonious==0.10.0
     # via -r hail/hail/python/requirements.txt
 pillow==10.0.0
     # via bokeh
-plotly==5.15.0
+plotly==5.16.0
     # via -r hail/hail/python/requirements.txt
 portalocker==2.7.0
     # via
@@ -263,7 +263,7 @@ pycparser==2.21
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   cffi
-pygments==2.15.1
+pygments==2.16.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   rich
@@ -289,7 +289,7 @@ pyyaml==6.0.1
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
     #   bokeh
-regex==2023.6.3
+regex==2023.8.8
     # via parsimonious
 requests==2.31.0
     # via
@@ -323,7 +323,6 @@ six==1.16.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-core
-    #   azure-identity
     #   google-auth
     #   isodate
     #   jproperties
@@ -336,9 +335,9 @@ tabulate==0.9.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-tenacity==8.2.2
+tenacity==8.2.3
     # via plotly
-tornado==6.3.2
+tornado==6.3.3
     # via bokeh
 typer==0.9.0
     # via

--- a/web_common/pinned-requirements.txt
+++ b/web_common/pinned-requirements.txt
@@ -16,7 +16,7 @@ aiosignal==1.3.1
     #   -c hail/web_common/../gear/pinned-requirements.txt
     #   -c hail/web_common/../hail/python/pinned-requirements.txt
     #   aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -c hail/web_common/../gear/pinned-requirements.txt
     #   -c hail/web_common/../hail/python/pinned-requirements.txt


### PR DESCRIPTION
This allows a developer with access inside of the batch worker container to examine currently running `asyncio` tasks inside the worker, get stack traces, examine locals, etc. E.g.

```
monitor >>> ps
367 tasks running
+---------------------------------------------------------------------------------------------------------------------------------+
| Task ID          State    Name         Coroutine                                                        Created Location  Since |
+---------------------------------------------------------------------------------------------------------------------------------+
| 140063857549376  PENDING  Task-755614  Worker.post_job_started()                                        -                 -     |
| 140063857549584  PENDING  Task-755568  Worker.run_job()                                                 -                 -     |
| 140063857549792  PENDING  Task-755590  Worker.run_job()                                                 -                 -     |
| 140063857550000  PENDING  Task-755592  Worker.run_job()                                                 -                 -     |
| 140063857550208  PENDING  Task-755372  RequestHandler._handle_request()                                 -                 -     |
| 140063857550416  PENDING  Task-755637  Worker.run_job()                                                 -                 -     |
| 140063857550624  PENDING  Task-755580  BaseSubprocessTransport._connect_pipes()                         -                 -     |
| 140063857550832  PENDING  Task-752239  Worker.run_job()                                                 -                 -     |
| 140063857551040  PENDING  Task-755612  Worker.post_job_started()                                        -                 -     |
| 140063857551248  PENDING  Task-755610  Worker.post_job_started()                                        -                 -     |
| 140063857551456  PENDING  Task-755589  Worker.run_job()                                                 -                 -     |
| 140063857551664  PENDING  Task-755613  BaseSubprocessTransport._connect_pipes()                         -                 -     |
| 140063857552288  PENDING  Task-755591  Worker.run_job()                                                 -                 -     |
```

Wondering do we want this for production or just to activate in test namespaces?