### PR TITLE
[query] Avoid Class A Operations.

### DIFF
--- a/hail/python/hail/fs/hadoop_fs.py
+++ b/hail/python/hail/fs/hadoop_fs.py
@@ -3,23 +3,32 @@ import json
 import time
 from typing import Dict, List, Union, Any
 
-import dateutil
+import dateutil.parser
 
 from hailtop.fs.fs import FS
-from hailtop.fs.stat_result import FileType, StatResult
+from hailtop.fs.stat_result import FileType, FileListEntry, FileStatus
 
 
-def _stat_dict_to_stat_result(stat: Dict[str, Any]) -> StatResult:
-    dt = dateutil.parser.isoparse(stat['modification_time'])
+def _file_status_dict_to_file_status(status: Dict[str, Any]) -> FileStatus:
+    dt = dateutil.parser.isoparse(status['modification_time'])
     mtime = time.mktime(dt.timetuple())
-    if stat['is_dir']:
+    return FileStatus(path=status['path'], owner=status['owner'], size=status['size'], modification_time=mtime)
+
+
+def _file_list_entry_dict_to_file_status(file_list_entry: Dict[str, Any]) -> FileListEntry:
+    dt = dateutil.parser.isoparse(file_list_entry['modification_time'])
+    mtime = time.mktime(dt.timetuple())
+    if file_list_entry['is_dir']:
         typ = FileType.DIRECTORY
-    elif stat['is_link']:
+    elif file_list_entry['is_link']:
         typ = FileType.SYMLINK
     else:
         typ = FileType.FILE
-    return StatResult(path=stat['path'], owner=stat['owner'], size=stat['size'],
-                      typ=typ, modification_time=mtime)
+    return FileListEntry(path=file_list_entry['path'],
+                      owner=file_list_entry['owner'],
+                      size=file_list_entry['size'],
+                      typ=typ,
+                      modification_time=mtime)
 
 
 class HadoopFS(FS):
@@ -60,12 +69,24 @@ class HadoopFS(FS):
     def is_dir(self, path: str) -> bool:
         return self._jfs.isDir(path)
 
-    def stat(self, path: str) -> StatResult:
-        stat_dict = json.loads(self._utils_package_object.stat(self._jfs, path))
-        return _stat_dict_to_stat_result(stat_dict)
+    def fast_stat(self, path: str) -> FileStatus:
+        '''Get information about a path other than its file/directory status.
 
-    def ls(self, path: str) -> List[StatResult]:
-        return [_stat_dict_to_stat_result(st)
+        In the cloud, determining if a given path is a file, a directory, or both is expensive. This
+        method simply returns file metadata if there is a file at this path. If there is no file at
+        this path, this operation will fail. The presence or absence of a directory at this path
+        does not affect the return value of this method at all.
+
+        '''
+        file_status_dict = json.loads(self._utils_package_object.fileStatus(self._jfs, path))
+        return _file_status_dict_to_file_status(file_status_dict)
+
+    def stat(self, path: str) -> FileListEntry:
+        filestatus_dict = json.loads(self._utils_package_object.getFileListEntry(self._jfs, path))
+        return _file_list_entry_dict_to_file_status(filestatus_dict)
+
+    def ls(self, path: str) -> List[FileListEntry]:
+        return [_file_list_entry_dict_to_file_status(st)
                 for st in json.loads(self._utils_package_object.ls(self._jfs, path))]
 
     def mkdir(self, path: str) -> None:

--- a/hail/python/hailtop/fs/fs.py
+++ b/hail/python/hailtop/fs/fs.py
@@ -2,7 +2,7 @@ import abc
 import io
 from typing import List
 
-from .stat_result import StatResult
+from .stat_result import FileListEntry
 
 
 class FS(abc.ABC):
@@ -27,11 +27,11 @@ class FS(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def stat(self, path: str) -> StatResult:
+    def stat(self, path: str) -> FileListEntry:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def ls(self, path: str) -> List[StatResult]:
+    def ls(self, path: str) -> List[FileListEntry]:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/hail/python/hailtop/fs/fs_utils.py
+++ b/hail/python/hailtop/fs/fs_utils.py
@@ -2,7 +2,7 @@ import io
 from typing import List
 
 from .router_fs import RouterFS
-from .stat_result import StatResult
+from .stat_result import FileListEntry
 
 _router_fs = None
 
@@ -150,7 +150,7 @@ def is_dir(path: str) -> bool:
     return _fs().is_dir(path)
 
 
-def stat(path: str) -> StatResult:
+def stat(path: str) -> FileListEntry:
     """Returns information about the file or directory at a given path.
 
     Notes
@@ -177,7 +177,7 @@ def stat(path: str) -> StatResult:
     return _fs().stat(path)
 
 
-def ls(path: str) -> List[StatResult]:
+def ls(path: str) -> List[FileListEntry]:
     """Returns information about files at `path`.
 
     Notes

--- a/hail/python/hailtop/fs/stat_result.py
+++ b/hail/python/hailtop/fs/stat_result.py
@@ -10,7 +10,24 @@ class FileType(Enum):
     SYMLINK = auto()
 
 
-class StatResult(NamedTuple):
+class FileStatus(NamedTuple):
+    path: str
+    owner: Union[None, str, int]
+    size: int
+    # common point between unix, google, and hadoop filesystems, represented as a unix timestamp
+    modification_time: Optional[float]
+
+    def to_legacy_dict(self) -> Dict[str, Any]:
+        return {
+            'path': self.path,
+            'owner': self.owner,
+            'size_bytes': self.size,
+            'size': filesize(self.size),
+            'modification_time': self.modification_time,
+        }
+
+
+class FileListEntry(NamedTuple):
     path: str
     owner: Union[None, str, int]
     size: int
@@ -25,8 +42,11 @@ class StatResult(NamedTuple):
         return {
             'path': self.path,
             'owner': self.owner,
-            'is_dir': self.is_dir(),
             'size_bytes': self.size,
             'size': filesize(self.size),
             'modification_time': self.modification_time,
+            'is_dir': self.is_dir(),
         }
+
+
+StatResult = FileListEntry  # backwards compatibility

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -181,7 +181,7 @@ class HailContext private(
     maxLines: Int
   ): Map[String, Array[WithContext[String]]] = {
     val regexp = regex.r
-    SparkBackend.sparkContext("fileAndLineCounts").textFilesLines(fs.globAll(files))
+    SparkBackend.sparkContext("fileAndLineCounts").textFilesLines(fs.globAll(files).map(_.getPath))
       .filter(line => regexp.findFirstIn(line.value).isDefined)
       .take(maxLines)
       .groupBy(_.source.file)

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -561,7 +561,7 @@ object TableTextFinalizer {
   }
 
   def cleanup(fs: FS, outputPath: String, files: Array[String]): Unit = {
-    val outputFiles = fs.listStatus(fs.makeQualified(outputPath)).map(_.getPath).toSet
+    val outputFiles = fs.listDirectory(fs.makeQualified(outputPath)).map(_.getPath).toSet
     val fileSet = files.map(fs.makeQualified(_)).toSet
     outputFiles.diff(fileSet).foreach(fs.delete(_, false))
   }

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -7,7 +7,7 @@ import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitSettable, EmitValue, IEmitCode, IR, IRParserEnvironment, Literal, LowerMatrixIR, MakeStruct, MatrixHybridReader, MatrixReader, PartitionNativeIntervalReader, PartitionReader, ReadPartition, Ref, StreamTake, TableExecuteIntermediate, TableNativeReader, TableReader, TableValue, ToStream}
 import is.hail.io._
-import is.hail.io.fs.{FS, FileStatus, SeekableDataInputStream}
+import is.hail.io.fs.{FS, FileListEntry, SeekableDataInputStream}
 import is.hail.io.index.{IndexReader, StagedIndexReader}
 import is.hail.io.vcf.LoadVCF
 import is.hail.rvd.RVDPartitioner
@@ -149,24 +149,24 @@ object LoadBgen {
            |  ${ notVersionTwo.mkString("\n  ") }""".stripMargin)
   }
 
-  def getAllFileStatuses(fs: FS, files: Array[String]): Array[FileStatus] = {
+  private[this] def matchGlobAndGetChildrenIfDir(fs: FS, files: Array[String]): Array[FileListEntry] = {
     val badFiles = new BoxedArrayBuilder[String]()
 
-    val statuses = files.flatMap { file =>
+    val fileListEntries = files.flatMap { file =>
       val matches = fs.glob(file)
       if (matches.isEmpty)
         badFiles += file
 
-      matches.flatMap { status =>
-        val file = status.getPath.toString
+      matches.flatMap { fle =>
+        val file = fle.getPath.toString
         if (!file.endsWith(".bgen"))
           warn(s"input file does not have .bgen extension: $file")
 
         if (fs.isDir(file))
-          fs.listStatus(file)
-            .filter(status => ".*part-[0-9]+(-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?".r.matches(status.getPath.toString))
+          fs.listDirectory(file)
+            .filter(childFle => ".*part-[0-9]+(-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?".r.matches(childFle.getPath.toString))
         else
-          Array(status)
+          Array(fle)
       }
     }
 
@@ -175,11 +175,11 @@ object LoadBgen {
         s"""The following paths refer to no files:
            |  ${ badFiles.result().mkString("\n  ") }""".stripMargin)
 
-    statuses
+    fileListEntries
   }
 
   def getAllFilePaths(fs: FS, files: Array[String]): Array[String] =
-    getAllFileStatuses(fs, files).map(_.getPath.toString)
+    matchGlobAndGetChildrenIfDir(fs, files).map(_.getPath.toString)
 
 
   def getBgenFileMetadata(ctx: ExecuteContext, files: Array[String], indexFiles: Array[String]): Array[BgenFileMetadata] = {

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -140,22 +140,18 @@ object AzureStorageFS {
   }
 }
 
-object AzureStorageFileStatus {
-  def apply(path: String, isDir: Boolean, blobProperties: BlobProperties): BlobStorageFileStatus = {
-    if (isDir) {
-      new BlobStorageFileStatus(path, null, 0, true)
+object AzureStorageFileListEntry {
+  def apply(path: String, blobItem: BlobItem): BlobStorageFileListEntry = {
+    if (blobItem.isPrefix) {
+      dir(path)
     } else {
-      new BlobStorageFileStatus(path, blobProperties.getLastModified.toEpochSecond, blobProperties.getBlobSize, false)
+      val properties = blobItem.getProperties
+      new BlobStorageFileListEntry(path, properties.getLastModified.toEpochSecond, properties.getContentLength, false)
     }
   }
 
-  def apply(blobPath: String, blobItem: BlobItem): BlobStorageFileStatus = {
-    if (blobItem.isPrefix) {
-      new BlobStorageFileStatus(blobPath, null, 0, true)
-    } else {
-      val properties = blobItem.getProperties
-      new BlobStorageFileStatus(blobPath, properties.getLastModified.toEpochSecond, properties.getContentLength, false)
-    }
+  def dir(path: String): BlobStorageFileListEntry = {
+    new BlobStorageFileListEntry(path, null, 0, true)
   }
 }
 
@@ -195,11 +191,11 @@ class AzureBlobServiceClientCache(credential: TokenCredential, val httpClientOpt
 class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
   type URL = AzureStorageFSURL
 
-  import AzureStorageFS.log
+  import AzureStorageFS._
 
   def validUrl(filename: String): Boolean = {
     try {
-      AzureStorageFS.parseUrl(filename)
+      parseUrl(filename)
       true
     } catch {
       case _: IllegalArgumentException => false
@@ -219,7 +215,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
         f
       } catch {
         case e: BlobStorageException if e.getStatusCode == 401 =>
-          serviceClientCache.setPublicAccessServiceClient(AzureStorageFS.parseUrl(filename))
+          serviceClientCache.setPublicAccessServiceClient(parseUrl(filename))
           f
       }
     }
@@ -263,7 +259,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
   }
 
   def openNoCompression(filename: String, _debug: Boolean): SeekableDataInputStream = handlePublicAccessError(filename) {
-    val url = AzureStorageFS.parseUrl(filename)
+    val url = parseUrl(filename)
     val blobClient: BlobClient = getBlobClient(url)
     val blobSize = blobClient.getProperties.getBlobSize
 
@@ -315,7 +311,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
   }
 
   override def readNoCompression(filename: String): Array[Byte] = handlePublicAccessError(filename) {
-    val url = AzureStorageFS.parseUrl(filename)
+    val url = parseUrl(filename)
     val client = getBlobClient(url)
     val size = client.getProperties.getBlobSize
     if (size < 2 * 1024 * 1024 * 1024) { // https://learn.microsoft.com/en-us/java/api/com.azure.storage.blob.specialized.blobclientbase?view=azure-java-stable#com-azure-storage-blob-specialized-blobclientbase-downloadcontent()
@@ -332,7 +328,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
   }
 
   def createNoCompression(filename: String): PositionedDataOutputStream = retryTransientErrors {
-    val blockBlobClient = getBlobClient(AzureStorageFS.parseUrl(filename)).getBlockBlobClient
+    val blockBlobClient = getBlobClient(parseUrl(filename)).getBlockBlobClient
 
     val os: PositionedOutputStream = new FSPositionedOutputStream(4 * 1024 * 1024) {
       private[this] val client: BlockBlobClient = blockBlobClient
@@ -362,7 +358,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
   }
 
   def delete(filename: String, recursive: Boolean): Unit = retryTransientErrors {
-    val url = AzureStorageFS.parseUrl(filename)
+    val url = parseUrl(filename)
     val blobClient: BlobClient = getBlobClient(url)
 
     if (recursive) {
@@ -373,13 +369,13 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
       options.setPrefix(prefix)
       val prefixMatches = blobContainerClient.listBlobs(options, timeout)
 
-      prefixMatches.forEach(blobItem => {
+      prefixMatches.forEach { blobItem =>
         assert(!blobItem.isPrefix)
         getBlobClient(url.withPath(blobItem.getName)).delete()
-      })
+      }
     } else {
       try {
-        if (fileStatus(filename).isFile) {
+        if (getFileListEntry(filename).isFile) {
           blobClient.delete()
         }
       } catch {
@@ -388,11 +384,11 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
     }
   }
 
-  def listStatus(filename: String): Array[FileStatus] = handlePublicAccessError(filename) {
-    val url = AzureStorageFS.parseUrl(filename)
+  def listDirectory(filename: String): Array[FileListEntry] = handlePublicAccessError(filename) {
+    val url = parseUrl(filename)
 
     val blobContainerClient: BlobContainerClient = getContainerClient(url)
-    val statList: ArrayBuffer[FileStatus] = ArrayBuffer()
+    val statList: ArrayBuffer[FileListEntry] = ArrayBuffer()
 
     val prefix = dropTrailingSlash(url.path) + "/"
     // collect all children of this directory (blobs and subdirectories)
@@ -400,54 +396,65 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
 
     prefixMatches.forEach(blobItem => {
       val blobPath = dropTrailingSlash(url.withPath(blobItem.getName).toString())
-      statList += AzureStorageFileStatus(blobPath, blobItem)
+      statList += AzureStorageFileListEntry(blobPath, blobItem)
     })
 
     statList.toArray
   }
 
-  def glob(filename: String): Array[FileStatus] = handlePublicAccessError(filename) {
-    val url = AzureStorageFS.parseUrl(filename)
+  def glob(filename: String): Array[FileListEntry] = handlePublicAccessError(filename) {
+    val url = parseUrl(filename)
     globWithPrefix(prefix = url.withPath(""), path = dropTrailingSlash(url.path))
+  }
+
+  override def fileStatus(filename: String): FileStatus = handlePublicAccessError(filename) {
+    fileStatus(parseUrl(filename))
   }
 
   override def fileStatus(url: AzureStorageFSURL): FileStatus = retryTransientErrors {
     if (url.path == "") {
-      return new BlobStorageFileStatus(url.toString, null, 0, true)
+      return AzureStorageFileListEntry.dir(url.toString)
     }
 
-    val blobClient: BlobClient = getBlobClient(url)
-    val blobContainerClient: BlobContainerClient = getContainerClient(url)
+    val blobClient = getBlobClient(url)
+    val blobProperties = try {
+      blobClient.getProperties
+    } catch {
+      case e: BlobStorageException if e.getStatusCode == 404 =>
+        throw new FileNotFoundException(url.toString)
+    }
 
-    val prefix = dropTrailingSlash(url.path) + "/"
-    val options: ListBlobsOptions = new ListBlobsOptions().setPrefix(prefix).setMaxResultsPerPage(1)
-    val prefixMatches = blobContainerClient.listBlobs(options, timeout)
-    val isDir = prefixMatches.iterator().hasNext
-
-    val filename = dropTrailingSlash(url.toString)
-
-    val blobProperties = if (!isDir) {
-      try {
-        blobClient.getProperties
-      } catch {
-        case e: BlobStorageException =>
-          if (e.getStatusCode == 404)
-            throw new FileNotFoundException(s"File not found: $filename")
-          else
-            throw e
-      }
-    } else
-      null
-
-    AzureStorageFileStatus(filename, isDir, blobProperties)
+    new BlobStorageFileStatus(url.path, blobProperties.getLastModified.toEpochSecond, blobProperties.getBlobSize)
   }
 
-  def fileStatus(filename: String): FileStatus = handlePublicAccessError(filename) {
-    fileStatus(AzureStorageFS.parseUrl(filename))
+  def getFileListEntry(filename: String): FileListEntry = getFileListEntry(AzureStorageFS.parseUrl(filename))
+
+  def getFileListEntry(url: URL): FileListEntry = {
+    if (url.path == "") {
+      return AzureStorageFileListEntry.dir(url.toString)
+    }
+
+    val it = {
+      val containerClient = getContainerClient(url)
+      val prefix = dropTrailingSlash(url.path)
+      val options = new ListBlobsOptions().setPrefix(prefix).setMaxResultsPerPage(1)
+      val prefixMatches = containerClient.listBlobsByHierarchy("/", options, timeout)
+      prefixMatches.iterator()
+    }
+
+    if (it.hasNext) {
+      val blobItem = it.next()
+
+      if (blobItem.getName() == url.path) {
+        return AzureStorageFileListEntry(url.toString, blobItem)
+      }
+    }
+
+    throw new FileNotFoundException(url.toString)
   }
 
   def makeQualified(filename: String): String = {
-    AzureStorageFS.parseUrl(filename)
+    parseUrl(filename)
     filename
   }
 }

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -9,7 +9,7 @@ import java.util.concurrent._
 import org.apache.log4j.Logger
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.{ReadChannel, WriteChannel}
-import com.google.cloud.storage.Storage.{BlobListOption, BlobWriteOption, BlobSourceOption}
+import com.google.cloud.storage.Storage.{BlobGetOption, BlobListOption, BlobWriteOption, BlobSourceOption}
 import com.google.cloud.storage.{Option => StorageOption, _}
 import com.google.cloud.http.HttpTransportOptions
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
@@ -64,13 +64,13 @@ object GoogleStorageFS {
   }
 }
 
-object GoogleStorageFileStatus {
-  def apply(blob: Blob): BlobStorageFileStatus = {
+object GoogleStorageFileListEntry {
+  def apply(blob: Blob): BlobStorageFileListEntry = {
     val isDir = blob.isDirectory
 
     val name = dropTrailingSlash(blob.getName)
 
-    new BlobStorageFileStatus(
+    new BlobStorageFileListEntry(
       s"gs://${ blob.getBucket }/$name",
       if (isDir)
         null
@@ -78,6 +78,10 @@ object GoogleStorageFileStatus {
         blob.getUpdateTimeOffsetDateTime.toInstant().toEpochMilli(),
       blob.getSize,
       isDir)
+  }
+
+  def dir(path: String): BlobStorageFileListEntry = {
+    return new BlobStorageFileListEntry(path, null, 0, true)
   }
 }
 
@@ -449,14 +453,14 @@ class GoogleStorageFS(
     }
   }
 
-  def glob(filename: String): Array[FileStatus] = retryTransientErrors {
+  def glob(filename: String): Array[FileListEntry] = retryTransientErrors {
     val url = parseUrl(filename)
     globWithPrefix(url.withPath(""), path = dropTrailingSlash(url.path))
   }
 
-  def listStatus(filename: String): Array[FileStatus] = listStatus(parseUrl(filename))
+  def listDirectory(filename: String): Array[FileListEntry] = listDirectory(parseUrl(filename))
 
-  override def listStatus(url: GoogleStorageFSURL): Array[FileStatus] = retryTransientErrors {
+  override def listDirectory(url: GoogleStorageFSURL): Array[FileListEntry] = retryTransientErrors {
     val path = if (url.path.endsWith("/")) url.path else url.path + "/"
 
     val blobs = retryTransientErrors {
@@ -469,18 +473,43 @@ class GoogleStorageFS(
 
     blobs.getValues.iterator.asScala
       .filter(b => b.getName != path) // elide directory markers created by Hadoop
-      .map(b => GoogleStorageFileStatus(b))
+      .map(b => GoogleStorageFileListEntry(b))
       .toArray
   }
 
-  def fileStatus(filename: String): FileStatus = fileStatus(parseUrl(filename))
+  override def fileStatus(filename: String): FileStatus = fileStatus(parseUrl(filename))
 
   override def fileStatus(url: GoogleStorageFSURL): FileStatus = retryTransientErrors {
-    val path = dropTrailingSlash(url.path)
-
     if (url.path == "")
-      return new BlobStorageFileStatus(s"gs://${url.bucket}", null, 0, true)
+      return GoogleStorageFileListEntry.dir(url.toString)
 
+    val blob = retryTransientErrors {
+      handleRequesterPays(
+        (options: Seq[BlobGetOption]) =>
+        storage.get(url.bucket, url.path, options:_*),
+        BlobGetOption.userProject _,
+        url.bucket
+      )
+    }
+
+    if (blob == null) {
+      throw new FileNotFoundException(url.toString)
+    }
+
+    new BlobStorageFileStatus(
+      dropTrailingSlash(url.toString),
+      blob.getUpdateTimeOffsetDateTime.toInstant().toEpochMilli(),
+      blob.getSize
+    )
+  }
+
+  def getFileListEntry(filename: String): FileListEntry = getFileListEntry(parseUrl(filename))
+
+  def getFileListEntry(url: URL): FileListEntry = {
+    if (url.path == "")
+      return GoogleStorageFileListEntry.dir(url.toString)
+
+    val path = dropTrailingSlash(url.path)
     val blobs = retryTransientErrors {
       handleRequesterPays(
         (options: Seq[BlobListOption]) => storage.list(url.bucket, (BlobListOption.prefix(path) +: BlobListOption.currentDirectory() +: options):_*),
@@ -496,7 +525,7 @@ class GoogleStorageFS(
       while (name.endsWith("/"))
         name = name.dropRight(1)
       if (name == path)
-        return GoogleStorageFileStatus(b)
+        return GoogleStorageFileListEntry(b)
     }
 
     throw new FileNotFoundException(url.toString)

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -7,7 +7,7 @@ import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream}
 
 import java.io._
 
-class HadoopFileStatus(fs: hadoop.fs.FileStatus) extends FileStatus {
+class HadoopFileListEntry(fs: hadoop.fs.FileStatus) extends FileListEntry {
   val normalizedPath = fs.getPath
 
   def getPath: String = fs.getPath.toString
@@ -123,7 +123,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     new hadoop.fs.Path(filename).getFileSystem(conf.value)
   }
 
-  def listStatus(filename: String): Array[FileStatus] = {
+  def listDirectory(filename: String): Array[FileListEntry] = {
     val fs = getFileSystem(filename)
     val hPath = new hadoop.fs.Path(filename)
     var statuses = fs.globStatus(hPath)
@@ -132,7 +132,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     } else {
       statuses.par.map(_.getPath)
         .flatMap(fs.listStatus(_))
-        .map(new HadoopFileStatus(_))
+        .map(new HadoopFileListEntry(_))
         .toArray
     }
   }
@@ -153,27 +153,16 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     getFileSystem(filename).delete(new hadoop.fs.Path(filename), recursive)
   }
 
-  override def globAll(filenames: Iterable[String]): Array[String] = {
-    filenames.iterator
-      .flatMap { arg =>
-        val fss = glob(arg)
-        val files = fss.map(_.getPath.toString)
-        if (files.isEmpty)
-          warn(s"'$arg' refers to no files")
-        files
-      }.toArray
-  }
-
-  override def globAllStatuses(filenames: Iterable[String]): Array[FileStatus] = {
+  override def globAll(filenames: Iterable[String]): Array[FileListEntry] = {
     filenames.flatMap { filename =>
-      val statuses = glob(filename)
-      if (statuses.isEmpty)
+      val fles = glob(filename)
+      if (fles.isEmpty)
         warn(s"'$filename' refers to no files")
-      statuses
+      fles
     }.toArray
   }
 
-  def glob(filename: String): Array[FileStatus] = {
+  def glob(filename: String): Array[FileListEntry] = {
     val fs = getFileSystem(filename)
     val path = new hadoop.fs.Path(filename)
 
@@ -181,13 +170,15 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     if (files == null)
       files = Array.empty
     log.info(s"globbing path $filename returned ${ files.length } files: ${ files.map(_.getPath.getName).mkString(",") }")
-    files.map(fileStatus => new HadoopFileStatus(fileStatus))
+    files.map(fle => new HadoopFileListEntry(fle))
   }
 
-  def fileStatus(filename: String): FileStatus = {
+  override def fileStatus(filename: String): FileStatus = {
     val p = new hadoop.fs.Path(filename)
-    new HadoopFileStatus(p.getFileSystem(conf.value).getFileStatus(p))
+    new HadoopFileListEntry(p.getFileSystem(conf.value).getFileStatus(p))
   }
+
+  override def fileStatus(url: URL): FileStatus = fileStatus(url.toString)
 
   def makeQualified(path: String): String = {
     val ppath = new hadoop.fs.Path(path)

--- a/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
@@ -29,11 +29,17 @@ class RouterFS(fss: IndexedSeq[FS]) extends FS {
 
   def delete(filename: String, recursive: Boolean) = lookupFS(filename).delete(filename, recursive)
 
-  def listStatus(filename: String): Array[FileStatus] = lookupFS(filename).listStatus(filename)
+  def listDirectory(filename: String): Array[FileListEntry] = lookupFS(filename).listDirectory(filename)
 
-  def glob(filename: String): Array[FileStatus] = lookupFS(filename).glob(filename)
+  def glob(filename: String): Array[FileListEntry] = lookupFS(filename).glob(filename)
 
-  def fileStatus(filename: String): FileStatus = lookupFS(filename).fileStatus(filename)
+  override def fileStatus(filename: String): FileStatus = lookupFS(filename).fileStatus(filename)
+
+  override def fileStatus(url: URL): FileStatus = lookupFS(url.toString).fileStatus(url.toString)
+
+  override def getFileListEntry(filename: String): FileStatus = lookupFS(filename).getFileListEntry(filename)
+
+  override def getFileListEntry(url: URL): FileStatus = lookupFS(url.toString).getFileListEntry(url.toString)
 
   def makeQualified(path: String): String = lookupFS(path).makeQualified(path)
 

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -10,7 +10,6 @@ import is.hail.expr.ir.MatrixValue
 import is.hail.expr.ir.functions.MatrixToValueFunction
 import is.hail.types.{MatrixType, RTable, TypeWithRequiredness}
 import is.hail.types.virtual.{TVoid, Type}
-import is.hail.io.fs.FileStatus
 import is.hail.utils._
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.Row

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -592,7 +592,7 @@ object ReferenceGenome {
 
   def readReferences(fs: FS, path: String): Array[ReferenceGenome] = {
     if (fs.exists(path)) {
-      val refs = fs.listStatus(path)
+      val refs = fs.listDirectory(path)
       val rgs = mutable.Set[ReferenceGenome]()
       refs.foreach { fileSystem =>
         val rgPath = fileSystem.getPath.toString

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -5,7 +5,7 @@ import is.hail.fs.azure.AzureStorageFSSuite
 import is.hail.HailSuite
 import is.hail.backend.ExecuteContext
 import is.hail.io.fs.FSUtil.dropTrailingSlash
-import is.hail.io.fs.{FS, FileStatus, GoogleStorageFS, Seekable}
+import is.hail.io.fs.{FS, FileListEntry, GoogleStorageFS, Seekable}
 import is.hail.utils._
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.io.IOUtils
@@ -34,7 +34,7 @@ trait FSSuite extends TestNGSuite {
 
   def t(extension: String = null): String = ExecuteContext.createTmpPathNoCleanup(tmpdir, "fs-suite-tmp", extension)
 
-  def pathsRelRoot(root: String, statuses: Array[FileStatus]): Set[String] = {
+  def pathsRelRoot(root: String, statuses: Array[FileListEntry]): Set[String] = {
     statuses.map { status =>
       var p = status.getPath
       assert(p.startsWith(root), s"$p $root")
@@ -42,7 +42,7 @@ trait FSSuite extends TestNGSuite {
     }.toSet
   }
 
-  def pathsRelResourcesRoot(statuses: Array[FileStatus]): Set[String] = pathsRelRoot(fsResourcesRoot, statuses)
+  def pathsRelResourcesRoot(statuses: Array[FileListEntry]): Set[String] = pathsRelRoot(fsResourcesRoot, statuses)
 
   @Test def testExists(): Unit = {
     assert(fs.exists(r("/a")))
@@ -137,12 +137,12 @@ trait FSSuite extends TestNGSuite {
   }
 
   @Test def testListStatusDir(): Unit = {
-    val statuses = fs.listStatus(r(""))
+    val statuses = fs.listDirectory(r(""))
     assert(pathsRelResourcesRoot(statuses) == Set("/a", "/adir", "/az", "/dir", "/zzz"))
   }
 
   @Test def testListStatusDirWithSlash(): Unit = {
-    val statuses = fs.listStatus(r("/"))
+    val statuses = fs.listDirectory(r("/"))
     assert(pathsRelResourcesRoot(statuses) == Set("/a", "/adir", "/az", "/dir", "/zzz"))
   }
 

--- a/hail/src/test/scala/is/hail/fs/gs/GoogleStorageFSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/gs/GoogleStorageFSSuite.scala
@@ -60,7 +60,7 @@ class GoogleStorageFSSuite extends TestNGSuite with FSSuite {
     }
     assert(fs.exists(prefix))
     fs.delete(prefix, recursive = true)
-    assert(!fs.exists(prefix), s"files not deleted:\n${ fs.listStatus(prefix).map(_.getPath).mkString("\n") }")
+    assert(!fs.exists(prefix), s"files not deleted:\n${ fs.listDirectory(prefix).map(_.getPath).mkString("\n") }")
   }
 
   @Test def testSeekAfterEOF(): Unit = {

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -23,7 +23,7 @@ class TestFileInputFormat extends hd.mapreduce.lib.input.TextInputFormat {
     val splitPoints = hConf.get("bgz.test.splits").split(",").map(_.toLong)
 
     val splits = new mutable.ArrayBuffer[hd.mapreduce.InputSplit]
-    val files = listStatus(job).asScala
+    val files = listDirectory(job).asScala
     assert(files.length == 1)
 
     val file = files.head

--- a/hail/src/test/scala/is/hail/utils/RichRDDSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/RichRDDSuite.scala
@@ -34,7 +34,7 @@ class RichRDDSuite extends HailSuite {
     val merged = ctx.createTmpPath("merged", ".gz")
     val mergeList = Array(separateHeader + "/header.gz",
       separateHeader + "/part-00000.gz",
-      separateHeader + "/part-00001.gz").flatMap(fs.glob)
+      separateHeader + "/part-00001.gz").flatMap(fs.fileStatus)
     fs.copyMergeList(mergeList, merged, deleteSource = false)
 
     assert(read(merged) sameElements read(concatenated))

--- a/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -83,15 +83,13 @@ class UtilsSuite extends HailSuite {
     assert(!rdd1.exists(_ < 0))
   }
 
-  @Test def testSortFileStatus() {
+  @Test def testSortFileListEntry() {
     val fs = new HadoopFS(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
 
     val partFileNames = fs.glob("src/test/resources/part-*")
-      .map { fileStatus =>
-        (fileStatus, new hadoop.fs.Path(fileStatus.getPath))
-      }.sortBy { case (fileStatus, path) =>
-        getPartNumber(path.getName)
-      }.map(_._2.getName)
+      .sortBy { fle =>
+        getPartNumber(fle.getPath)
+      }.map(_.getPath)
 
     assert(partFileNames(0) == "part-40001" && partFileNames(1) == "part-100001")
   }


### PR DESCRIPTION
CHANGELOG: Hail Query-on-Batch previously used Class A Operations for all interaction with blobs. This change ensures that QoB only uses Class A Operations when necessary.

Inspired by @jigold 's file system improvement campaign, I fell down the rabbit hole of not issuing "list" operations unless we really need to know if a file is a directory. This should partly help reduce the flakiness in Azure (which is tracked in #13351) as well as high costs in Azure both of which are at least partly suspected to be caused by our frequent use of "list" operations.