### PR TITLE
[hailctl] Dont change the current python environment in test fixture

### DIFF
--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -17,8 +17,8 @@ def xdg_config_home() -> Path:
     return Path(value)
 
 
-def get_user_config_path() -> Path:
-    return Path(xdg_config_home(), 'hail', 'config.ini')
+def get_user_config_path(*, _config_dir: Optional[str] = None) -> Path:
+    return Path(_config_dir or xdg_config_home(), 'hail', 'config.ini')
 
 
 def get_user_config() -> configparser.ConfigParser:

--- a/hail/python/test/hailtop/hailctl/config/conftest.py
+++ b/hail/python/test/hailtop/hailctl/config/conftest.py
@@ -13,8 +13,3 @@ def config_dir():
 @pytest.fixture
 def runner(config_dir):
     yield CliRunner(mix_stderr=False, env={'XDG_CONFIG_HOME': config_dir})
-
-
-@pytest.fixture
-def bc_runner(config_dir):
-    yield CliRunner(mix_stderr=False, env={'XDG_CONFIG_HOME': config_dir})

--- a/hail/python/test/hailtop/hailctl/config/conftest.py
+++ b/hail/python/test/hailtop/hailctl/config/conftest.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import tempfile
 
@@ -18,30 +17,4 @@ def runner(config_dir):
 
 @pytest.fixture
 def bc_runner(config_dir):
-    from hailtop.config import get_user_config, get_user_config_path  # pylint: disable=import-outside-toplevel
-
-    # necessary for backwards compatibility test
-    os.environ['XDG_CONFIG_HOME'] = config_dir
-
-    config = get_user_config()
-    config_file = get_user_config_path()
-
-    items = [
-        ('global', 'email', 'johndoe@gmail.com'),
-        ('batch', 'foo', '5')
-    ]
-
-    for section, key, value in items:
-        if section not in config:
-            config[section] = {}
-        config[section][key] = value
-
-        try:
-            f = open(config_file, 'w', encoding='utf-8')
-        except FileNotFoundError:
-            os.makedirs(config_file.parent, exist_ok=True)
-            f = open(config_file, 'w', encoding='utf-8')
-        with f:
-            config.write(f)
-
     yield CliRunner(mix_stderr=False, env={'XDG_CONFIG_HOME': config_dir})

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -62,7 +62,7 @@ def test_config_set_get_list_unset(name: str, value: str, runner: CliRunner):
 
 
 # backwards compatibility
-def test_config_get_unknown_names(bc_runner: CliRunner, config_dir: str):
+def test_config_get_unknown_names(runner: CliRunner, config_dir: str):
     config_path = get_user_config_path(_config_dir=config_dir)
     os.makedirs(os.path.dirname(config_path))
     with open(config_path, 'w', encoding='utf-8') as config:
@@ -74,11 +74,11 @@ email = johndoe@gmail.com
 foo = 5
 ''')
 
-    res = bc_runner.invoke(cli.app, ['get', 'email'], catch_exceptions=False)
+    res = runner.invoke(cli.app, ['get', 'email'], catch_exceptions=False)
     assert res.exit_code == 0
     assert res.stdout.strip() == 'johndoe@gmail.com'
 
-    res = bc_runner.invoke(cli.app, ['get', 'batch/foo'], catch_exceptions=False)
+    res = runner.invoke(cli.app, ['get', 'batch/foo'], catch_exceptions=False)
     assert res.exit_code == 0
     assert res.stdout.strip() == '5'
 

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -1,8 +1,10 @@
+import os
 import pytest
 
 from typer.testing import CliRunner
 
 from hailtop.config.variables import ConfigVariable
+from hailtop.config.user_config import get_user_config_path
 from hailtop.hailctl.config import cli, config_variables
 
 
@@ -60,7 +62,18 @@ def test_config_set_get_list_unset(name: str, value: str, runner: CliRunner):
 
 
 # backwards compatibility
-def test_config_get_unknown_names(bc_runner: CliRunner):
+def test_config_get_unknown_names(bc_runner: CliRunner, config_dir: str):
+    config_path = get_user_config_path(_config_dir=config_dir)
+    os.makedirs(os.path.dirname(config_path))
+    with open(config_path, 'w', encoding='utf-8') as config:
+        config.write(f'''
+[global]
+email = johndoe@gmail.com
+
+[batch]
+foo = 5
+''')
+
     res = bc_runner.invoke(cli.app, ['get', 'email'], catch_exceptions=False)
     assert res.exit_code == 0
     assert res.stdout.strip() == 'johndoe@gmail.com'


### PR DESCRIPTION
Sorry missed this in the initial PR. `os.environ` is global to the whole python session so setting it directly could inadvertently affect the environment for unrelated tests. There seems to be safe ways to do this using `monkeypatch` and whatever `CliRunner` is doing, but I decided just not to set it.