### PR TITLE
[batch_client.aioclient] Get rid of BatchBuilder

### DIFF
--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -77,9 +77,9 @@ async def test_bad_token():
     token = session_id_encode_to_str(secrets.token_bytes(32))
     bc = await BatchClient.create('test', _token=token)
     try:
-        bb = create_batch(bc)
-        bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-        b = await bb.submit()
+        b = create_batch(bc)
+        b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+        await b.submit()
         assert False, str(await b.debug_info())
     except httpx.ClientResponseError as e:
         assert e.status == 401
@@ -180,10 +180,10 @@ async def test_close_billing_project_with_pending_batch_update_does_not_error(
     project = new_billing_project
     await dev_client.add_user("test", project)
     client = await make_client(project)
-    bb = create_batch(client)
-    bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    b = await bb._open_batch()
-    update_id = await bb._create_update(b.id)
+    b = create_batch(client)
+    b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    await b._open_batch()
+    update_id = await b._create_update()
     with BatchProgressBar() as pbar:
         process = {
             'type': 'docker',
@@ -193,7 +193,7 @@ async def test_close_billing_project_with_pending_batch_update_does_not_error(
         }
         spec = {'always_run': False, 'job_id': 1, 'parent_ids': [], 'process': process}
         with pbar.with_task('submitting jobs', total=1) as pbar_task:
-            await bb._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
+            await b._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
     try:
         await dev_client.close_billing_project(project)
     except httpx.ClientResponseError as e:
@@ -355,15 +355,15 @@ async def test_billing_project_accrued_costs(
     def approx_equal(x, y, tolerance=1e-10):
         return abs(x - y) <= tolerance
 
-    bb = create_batch(client)
-    j1_1 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    j1_2 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    b1 = await bb.submit()
+    b1 = create_batch(client)
+    j1_1 = b1.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
+    j1_2 = b1.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
+    await b1.submit()
 
-    bb = create_batch(client)
-    j2_1 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    j2_2 = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    b2 = await bb.submit()
+    b2 = create_batch(client)
+    j2_1 = b2.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
+    j2_2 = b2.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
+    await b2.submit()
 
     await b1.wait()
     await b2.wait()
@@ -409,8 +409,8 @@ async def test_billing_limit_zero(
     client = await make_client(project)
 
     try:
-        bb = create_batch(client)
-        b = await bb.submit()
+        b = create_batch(client)
+        await b.submit()
     except httpx.ClientResponseError as e:
         assert e.status == 403 and 'has exceeded the budget' in e.body
     else:
@@ -434,20 +434,20 @@ async def test_billing_limit_tiny(
 
     client = await make_client(project)
 
-    bb = create_batch(client)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j1])
-    j3 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j2])
-    j4 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j3])
-    j5 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j4])
-    j6 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j5])
-    j7 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j6])
-    j8 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j7])
-    j9 = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j8])
-    bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '5'], parents=[j9])
-    batch = await bb.submit()
-    batch_status = await batch.wait()
-    assert batch_status['state'] == 'cancelled', str(await batch.debug_info())
+    b = create_batch(client)
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j1])
+    j3 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j2])
+    j4 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j3])
+    j5 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j4])
+    j6 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j5])
+    j7 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j6])
+    j8 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j7])
+    j9 = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'], parents=[j8])
+    b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '5'], parents=[j9])
+    await b.submit()
+    batch_status = await b.wait()
+    assert batch_status['state'] == 'cancelled', str(await b.debug_info())
 
 
 async def search_batches(client, expected_batch_id, q) -> Tuple[bool, List[int]]:
@@ -476,10 +476,10 @@ async def test_user_can_access_batch_made_by_other_user_in_shared_billing_projec
     user1_client = await make_client(project)
     b = create_batch(user1_client)
     j = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    b_handle = await b.submit()
+    await b.submit()
 
     user2_client = dev_client
-    user2_batch = await user2_client.get_batch(b_handle.id)
+    user2_batch = await user2_client.get_batch(b.id)
     user2_job = await user2_client.get_job(j.batch_id, j.job_id)
 
     await user2_job.attempts()
@@ -487,50 +487,50 @@ async def test_user_can_access_batch_made_by_other_user_in_shared_billing_projec
     await user2_job.status()
 
     # list batches results for user1
-    found, batches = await search_batches(user1_client, b_handle.id, q='')
-    assert found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user1_client, b.id, q='')
+    assert found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user1_client, b_handle.id, q=f'billing_project:{project}')
-    assert found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user1_client, b.id, q=f'billing_project:{project}')
+    assert found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user1_client, b_handle.id, q='user:test')
-    assert found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user1_client, b.id, q='user:test')
+    assert found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user1_client, b_handle.id, q='billing_project:foo')
-    assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user1_client, b.id, q='billing_project:foo')
+    assert not found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user1_client, b_handle.id, q=None)
-    assert found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user1_client, b.id, q=None)
+    assert found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user1_client, b_handle.id, q='user:test-dev')
-    assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user1_client, b.id, q='user:test-dev')
+    assert not found, str((b.id, batches, await b.debug_info()))
 
     # list batches results for user2
-    found, batches = await search_batches(user2_client, b_handle.id, q='')
-    assert found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user2_client, b.id, q='')
+    assert found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user2_client, b_handle.id, q=f'billing_project:{project}')
-    assert found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user2_client, b.id, q=f'billing_project:{project}')
+    assert found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user2_client, b_handle.id, q='user:test')
-    assert found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user2_client, b.id, q='user:test')
+    assert found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user2_client, b_handle.id, q='billing_project:foo')
-    assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user2_client, b.id, q='billing_project:foo')
+    assert not found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user2_client, b_handle.id, q=None)
-    assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user2_client, b.id, q=None)
+    assert not found, str((b.id, batches, await b.debug_info()))
 
-    found, batches = await search_batches(user2_client, b_handle.id, q='user:test-dev')
-    assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user2_client, b.id, q='user:test-dev')
+    assert not found, str((b.id, batches, await b.debug_info()))
 
     await user2_batch.status()
     await user2_batch.cancel()
     await user2_batch.delete()
 
     # make sure deleted batches don't show up
-    found, batches = await search_batches(user1_client, b_handle.id, q='')
-    assert not found, str((b_handle.id, batches, await b_handle.debug_info()))
+    found, batches = await search_batches(user1_client, b.id, q='')
+    assert not found, str((b.id, batches, await b.debug_info()))
 
 
 async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(
@@ -543,12 +543,12 @@ async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(
     assert r['billing_project'] == project
 
     user1_client = await make_client(project)
-    bb = create_batch(user1_client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    b = await bb.submit()
+    b = create_batch(user1_client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    await b.submit()
 
     user2_client = dev_client
-    user2_batch = Batch(user2_client, b.id, b.attributes, b.token)
+    user2_batch = Batch(user2_client, b.id, attributes=b.attributes, token=b.token)
 
     try:
         try:
@@ -621,7 +621,8 @@ async def test_deleted_open_batches_do_not_prevent_billing_project_closure(
     try:
         await dev_client.add_user('test', project)
         client = await make_client(project)
-        open_batch = await create_batch(client)._open_batch()
+        open_batch = create_batch(client)
+        await open_batch._open_batch()
         await open_batch.delete()
     finally:
         await dev_client.close_billing_project(project)
@@ -637,17 +638,17 @@ async def test_billing_project_case_sensitive(dev_client: BatchClient, new_billi
     dev_client.reset_billing_project(new_billing_project)
 
     # create one batch with the correct billing project
-    bb = create_batch(dev_client)
-    bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    await bb.submit()
+    b = create_batch(dev_client)
+    b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    await b.submit()
 
     dev_client.reset_billing_project(upper_case_project)
 
     # create batch
     try:
-        bb = create_batch(dev_client)
-        bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-        await bb.submit()
+        b = create_batch(dev_client)
+        b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+        await b.submit()
     except aiohttp.ClientResponseError as e:
         assert e.status == 403, e
     else:

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -193,7 +193,7 @@ async def test_close_billing_project_with_pending_batch_update_does_not_error(
         }
         spec = {'always_run': False, 'job_id': 1, 'parent_ids': [], 'process': process}
         with pbar.with_task('submitting jobs', total=1) as pbar_task:
-            await b._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
+            await b._submit_jobs(update_id, [orjson.dumps(spec)], 1, pbar_task)
     try:
         await dev_client.close_billing_project(project)
     except httpx.ClientResponseError as e:

--- a/batch/test/test_aioclient.py
+++ b/batch/test/test_aioclient.py
@@ -15,9 +15,9 @@ async def client():
 
 
 async def test_job(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b = await bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    await b.submit()
     status = await j.wait()
     assert 'attributes' not in status, str((status, await b.debug_info()))
     assert status['state'] == 'Success', str((status, await b.debug_info()))

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1481,10 +1481,10 @@ def test_job_private_instance_cancel(client: BatchClient):
 
 
 def test_always_run_job_private_instance_cancel(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'machine_type': smallest_machine_type()}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources, always_run=True)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources, always_run=True)
+    b.submit()
     b.cancel()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -10,7 +10,7 @@ import pytest
 from hailtop import httpx
 from hailtop.auth import hail_credentials
 from hailtop.batch.backend import HAIL_GENETICS_HAILTOP_IMAGE
-from hailtop.batch_client.client import BatchClient
+from hailtop.batch_client.client import Batch, BatchClient
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.test_utils import skip_in_azure
 from hailtop.utils import delay_ms_for_try, external_requests_client_session, retry_response_returning_functions
@@ -30,9 +30,9 @@ def client():
 
 
 def test_job(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b.submit()
 
     status = j.wait()
     assert 'attributes' not in status, str((status, b.debug_info()))
@@ -44,9 +44,9 @@ def test_job(client: BatchClient):
 
 
 def test_job_running_logs(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])
+    b.submit()
 
     wait_status = j._wait_for_states('Running')
     if wait_status['state'] != 'Running':
@@ -61,9 +61,9 @@ def test_job_running_logs(client: BatchClient):
 
 
 def test_exit_code_duration(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'exit 7'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'exit 7'])
+    b.submit()
     status = j.wait()
     assert status['exit_code'] == 7, str((status, b.debug_info()))
     assert isinstance(status['duration'], int), str((status, b.debug_info()))
@@ -72,16 +72,16 @@ def test_exit_code_duration(client: BatchClient):
 
 def test_attributes(client: BatchClient):
     a = {'name': 'test_attributes', 'foo': 'bar'}
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], attributes=a)
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], attributes=a)
+    b.submit()
     assert j.attributes() == a, str(b.debug_info())
 
 
 def test_garbage_image(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job('dsafaaadsf', ['echo', 'test'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job('dsafaaadsf', ['echo', 'test'])
+    b.submit()
     status = j.wait()
     assert j._get_exit_codes(status) == {'main': None}, str((status, b.debug_info()))
     assert j._get_error(status, 'main') is not None, str((status, b.debug_info()))
@@ -89,74 +89,74 @@ def test_garbage_image(client: BatchClient):
 
 
 def test_bad_command(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
 
 
 def test_invalid_resource_requests(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '1', 'memory': '250Gi', 'storage': '1Gi'}
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(httpx.ClientResponseError, match='resource requests.*unsatisfiable'):
-        bb.submit()
+        b.submit()
 
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0', 'memory': '1Gi', 'storage': '1Gi'}
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         httpx.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
-        bb.submit()
+        b.submit()
 
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.1', 'memory': '1Gi', 'storage': '1Gi'}
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         httpx.ClientResponseError,
         match='bad resource request for job.*cpu must be a power of two with a min of 0.25; found.*',
     ):
-        bb.submit()
+        b.submit()
 
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'memory': 'foo', 'storage': '1Gi'}
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(
         httpx.ClientResponseError,
         match=".*.resources.memory must match regex:.*.resources.memory must be one of:.*",
     ):
-        bb.submit()
+        b.submit()
 
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'memory': '500Mi', 'storage': '10000000Gi'}
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(httpx.ClientResponseError, match='resource requests.*unsatisfiable'):
-        bb.submit()
+        b.submit()
 
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'storage': '10000000Gi', 'machine_type': smallest_machine_type()}
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(httpx.ClientResponseError, match='resource requests.*unsatisfiable'):
-        bb.submit()
+        b.submit()
 
 
 def test_out_of_memory(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25'}
-    j = bb.create_job('python:3.6-slim-stretch', ['python', '-c', 'x = "a" * (2 * 1024**3)'], resources=resources)
-    b = bb.submit()
+    j = b.create_job('python:3.6-slim-stretch', ['python', '-c', 'x = "a" * (2 * 1024**3)'], resources=resources)
+    b.submit()
     status = j.wait()
     assert j._get_out_of_memory(status, 'main'), str((status, b.debug_info()))
 
 
 def test_out_of_storage(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 100GiB /foo'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 100GiB /foo'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -164,12 +164,12 @@ def test_out_of_storage(client: BatchClient):
 
 
 def test_quota_applies_to_volume(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25'}
-    j = bb.create_job(
+    j = b.create_job(
         os.environ['HAIL_VOLUME_IMAGE'], ['/bin/sh', '-c', 'fallocate -l 100GiB /data/foo'], resources=resources
     )
-    b = bb.submit()
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -178,41 +178,41 @@ def test_quota_applies_to_volume(client: BatchClient):
 
 def test_relative_volume_path_is_actually_absolute(client: BatchClient):
     # https://github.com/hail-is/hail/pull/12990#issuecomment-1540332989
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25'}
-    j = bb.create_job(
+    j = b.create_job(
         os.environ['HAIL_VOLUME_IMAGE'],
         ['/bin/sh', '-c', 'ls / && ls . && ls /relative_volume && ! ls relative_volume'],
         resources=resources,
     )
-    b = bb.submit()
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_quota_shared_by_io_and_rootfs(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'storage': '10Gi'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /foo'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /foo'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'storage': '10Gi'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'storage': '10Gi'}
-    j = bb.create_job(
+    j = b.create_job(
         DOCKER_ROOT_IMAGE,
         ['/bin/sh', '-c', 'fallocate -l 7GiB /foo; fallocate -l 7GiB /io/foo'],
         resources=resources,
     )
-    b = bb.submit()
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -220,28 +220,28 @@ def test_quota_shared_by_io_and_rootfs(client: BatchClient):
 
 
 def test_nonzero_storage(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'storage': '20Gi'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 @skip_in_azure
 def test_attached_disk(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'storage': '400Gi'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'df -h; fallocate -l 390GiB /io/foo'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'df -h; fallocate -l 390GiB /io/foo'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_cwd_from_image_workdir(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(os.environ['HAIL_WORKDIR_IMAGE'], ['/bin/sh', '-c', 'pwd'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(os.environ['HAIL_WORKDIR_IMAGE'], ['/bin/sh', '-c', 'pwd'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -249,8 +249,8 @@ def test_cwd_from_image_workdir(client: BatchClient):
 
 
 def test_unsubmitted_state(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
 
     with pytest.raises(ValueError):
         j.batch_id  # pylint: disable=pointless-statement
@@ -268,13 +268,13 @@ def test_unsubmitted_state(client: BatchClient):
 
 def test_list_batches_v1(client: BatchClient):
     tag = secrets.token_urlsafe(64)
-    bb1 = create_batch(client, attributes={'tag': tag, 'name': 'b1'})
-    bb1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b1 = bb1.submit()
+    b1 = create_batch(client, attributes={'tag': tag, 'name': 'b1'})
+    b1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b1.submit()
 
-    bb2 = create_batch(client, attributes={'tag': tag, 'name': 'b2'})
-    bb2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b2 = bb2.submit()
+    b2 = create_batch(client, attributes={'tag': tag, 'name': 'b2'})
+    b2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b2.submit()
 
     batch_id_test_universe = {b1.id, b2.id}
 
@@ -316,17 +316,13 @@ def test_list_batches_v1(client: BatchClient):
 def test_list_batches_v2(client: BatchClient):
     tag = secrets.token_urlsafe(64)
     partial_match_prefix = secrets.token_urlsafe(10)
-    bb1 = create_batch(
-        client, attributes={'tag': tag, 'name': 'b1', 'partial_match_name': f'{partial_match_prefix}-b1'}
-    )
-    bb1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b1 = bb1.submit()
+    b1 = create_batch(client, attributes={'tag': tag, 'name': 'b1', 'partial_match_name': f'{partial_match_prefix}-b1'})
+    b1.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b1.submit()
 
-    bb2 = create_batch(
-        client, attributes={'tag': tag, 'name': 'b2', 'partial_match_name': f'{partial_match_prefix}-b2'}
-    )
-    bb2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b2 = bb2.submit()
+    b2 = create_batch(client, attributes={'tag': tag, 'name': 'b2', 'partial_match_name': f'{partial_match_prefix}-b2'})
+    b2.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b2.submit()
 
     batch_id_test_universe = {b1.id, b2.id}
 
@@ -556,13 +552,13 @@ tag = {tag}
 
 
 def test_list_jobs_v1(client: BatchClient):
-    bb = create_batch(client)
-    j_success = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    j_failure = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    j_error = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
-    j_running = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
+    b = create_batch(client)
+    j_success = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    j_failure = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    j_error = b.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
+    j_running = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
 
-    b = bb.submit()
+    b.submit()
 
     def assert_job_ids(expected, q=None):
         jobs = b.jobs(q=q)
@@ -585,13 +581,13 @@ def test_list_jobs_v1(client: BatchClient):
 
 
 def test_list_jobs_v2(client: BatchClient):
-    bb = create_batch(client)
-    j_success = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    j_failure = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    j_error = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
-    j_running = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
+    b = create_batch(client)
+    j_success = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    j_failure = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    j_error = b.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'], attributes={'tag': 'bar'})
+    j_running = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1800'], attributes={'tag': 'foo'})
 
-    b = bb.submit()
+    b.submit()
 
     def assert_job_ids(expected, q=None):
         jobs = b.jobs(q=q, version=2)
@@ -695,27 +691,27 @@ end_time <= 2023-02-24T17:18:25Z
 
 
 def test_include_jobs(client: BatchClient):
-    bb1 = create_batch(client)
+    b1 = create_batch(client)
     for _ in range(2):
-        bb1.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b1 = bb1.submit()
+        b1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b1.submit()
     s = b1.status()
     assert 'jobs' not in s, str((s, b1.debug_info()))
 
 
 def test_fail(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    b.submit()
     status = j.wait()
     assert j._get_exit_code(status, 'main') == 1, str((status, b.debug_info()))
 
 
 def test_unknown_image(client: BatchClient):
     DOCKER_PREFIX = os.environ['DOCKER_PREFIX']
-    bb = create_batch(client)
-    j = bb.create_job(f'{DOCKER_PREFIX}/does-not-exist', ['echo', 'test'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(f'{DOCKER_PREFIX}/does-not-exist', ['echo', 'test'])
+    b.submit()
     status = j.wait()
     try:
         assert j._get_exit_code(status, 'main') is None
@@ -728,10 +724,10 @@ def test_unknown_image(client: BatchClient):
 
 @skip_in_azure
 def test_invalid_gar(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     # GCP projects can't be strictly numeric
-    j = bb.create_job('us-docker.pkg.dev/1/does-not-exist', ['echo', 'test'])
-    b = bb.submit()
+    j = b.create_job('us-docker.pkg.dev/1/does-not-exist', ['echo', 'test'])
+    b.submit()
     status = j.wait()
     try:
         assert j._get_exit_code(status, 'main') is None
@@ -743,9 +739,9 @@ def test_invalid_gar(client: BatchClient):
 
 
 def test_running_job_log_and_status(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '300'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '300'])
+    b.submit()
 
     while True:
         if j.status()['state'] == 'Running' or j.is_complete():
@@ -757,9 +753,9 @@ def test_running_job_log_and_status(client: BatchClient):
 
 
 def test_deleted_job_log(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b.submit()
     j.wait()
     b.delete()
 
@@ -773,9 +769,9 @@ def test_deleted_job_log(client: BatchClient):
 
 
 def test_delete_batch(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b.submit()
     b.delete()
 
     # verify doesn't exist
@@ -789,9 +785,9 @@ def test_delete_batch(client: BatchClient):
 
 
 def test_cancel_batch(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b.submit()
 
     status = j.status()
     assert status['state'] in ('Ready', 'Running'), str((status, b.debug_info()))
@@ -823,9 +819,9 @@ def test_get_nonexistent_job(client: BatchClient):
 
 
 def test_get_job(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
 
     j2 = client.get_job(*j.id)
     status2 = j2.status()
@@ -833,11 +829,11 @@ def test_get_job(client: BatchClient):
 
 
 def test_batch(client: BatchClient):
-    bb = create_batch(client)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1'])
-    bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b = bb.submit()
+    b = create_batch(client)
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '1'])
+    b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b.submit()
 
     j1.wait()
     j2.wait()
@@ -857,31 +853,31 @@ def test_batch(client: BatchClient):
 
 
 def test_batch_status(client: BatchClient):
-    bb1 = create_batch(client)
-    bb1.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b1 = bb1.submit()
+    b1 = create_batch(client)
+    b1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b1.submit()
     b1.wait()
     b1s = b1.status()
     assert b1s['complete'] and b1s['state'] == 'success', str((b1s, b1.debug_info()))
 
-    bb2 = create_batch(client)
-    bb2.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    bb2.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b2 = bb2.submit()
+    b2 = create_batch(client)
+    b2.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    b2.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b2.submit()
     b2.wait()
     b2s = b2.status()
     assert b2s['complete'] and b2s['state'] == 'failure', str((b2s, b2.debug_info()))
 
-    bb3 = create_batch(client)
-    bb3.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b3 = bb3.submit()
+    b3 = create_batch(client)
+    b3.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b3.submit()
     b3s = b3.status()
     assert not b3s['complete'] and b3s['state'] == 'running', str((b3s, b3.debug_info()))
     b3.cancel()
 
-    bb4 = create_batch(client)
-    bb4.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
-    b4 = bb4.submit()
+    b4 = create_batch(client)
+    b4.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'])
+    b4.submit()
     b4.cancel()
     b4.wait()
     b4s = b4.status()
@@ -889,9 +885,9 @@ def test_batch_status(client: BatchClient):
 
 
 def test_log_after_failing_job(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'echo test; exit 127'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'echo test; exit 127'])
+    b.submit()
     status = j.wait()
     assert 'attributes' not in status, str((status, b.debug_info()))
     assert status['state'] == 'Failed', str((status, b.debug_info()))
@@ -904,9 +900,9 @@ def test_log_after_failing_job(client: BatchClient):
 
 
 def test_non_utf_8_log(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', "echo -n 'hello \\x80'"])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', "echo -n 'hello \\x80'"])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
@@ -915,9 +911,9 @@ def test_non_utf_8_log(client: BatchClient):
 
 
 def test_long_log_line(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
@@ -942,6 +938,11 @@ def test_authorized_users_only():
         (session.get, '/api/v1alpha/batches/0', 401),
         (session.delete, '/api/v1alpha/batches/0', 401),
         (session.patch, '/api/v1alpha/batches/0/close', 401),
+        (session.get, '/api/v1alpha/batches/0/job_groups', 401),
+        (session.patch, '/api/v1alpha/batches/0/job_groups/1/cancel', 401),
+        (session.post, '/api/v1alpha/batches/0/job_groups', 401),
+        (session.get, '/api/v1alpha/batches/0/job_groups/1', 401),
+        (session.get, '/api/v1alpha/batches/0/job_groups/resources', 401),
         # redirect to auth/login
         (session.get, '/batches', 302),
         (session.get, '/batches/0', 302),
@@ -955,29 +956,29 @@ def test_authorized_users_only():
 
 
 def test_cloud_image(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['echo', 'test'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(os.environ['HAIL_CURL_IMAGE'], ['echo', 'test'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_service_account(client: BatchClient):
     NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
-    bb = create_batch(client)
-    j = bb.create_job(
+    b = create_batch(client)
+    j = b.create_job(
         os.environ['CI_UTILS_IMAGE'],
         ['/bin/sh', '-c', 'kubectl version'],
         service_account={'namespace': NAMESPACE, 'name': 'test-batch-sa'},
     )
-    b = bb.submit()
+    b.submit()
     status = j.wait()
     assert j._get_exit_code(status, 'main') == 0, str((status, b.debug_info()))
 
 
 def test_port(client: BatchClient):
-    bb = create_batch(client)
-    bb.create_job(
+    b = create_batch(client)
+    b.create_job(
         DOCKER_ROOT_IMAGE,
         [
             'bash',
@@ -989,15 +990,15 @@ echo $HAIL_BATCH_WORKER_IP
         ],
         port=5000,
     )
-    b = bb.submit()
+    b.submit()
     batch = b.wait()
     assert batch['state'] == 'success', str((batch, b.debug_info()))
 
 
 def test_timeout(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'], timeout=5)
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '30'], timeout=5)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Error', str((status, b.debug_info()))
     error_msg = j._get_error(status, 'main')
@@ -1006,10 +1007,10 @@ def test_timeout(client: BatchClient):
 
 
 def test_client_max_size(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     for _ in range(4):
-        bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
-    bb.submit()
+        b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
+    b.submit()
 
 
 def test_restartable_insert(client: BatchClient):
@@ -1024,12 +1025,12 @@ def test_restartable_insert(client: BatchClient):
 
     with FailureInjectingClientSession(every_third_time) as session:
         client = BatchClient('test', session=session)
-        bb = create_batch(client)
+        b = create_batch(client)
 
         for _ in range(9):
-            bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a'])
+            b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a'])
 
-        b = bb.submit(max_bunch_size=1)
+        b.submit(max_bunch_size=1)
         b = client.get_batch(b.id)  # get a batch untainted by the FailureInjectingClientSession
         status = b.wait()
         assert status['state'] == 'success', str((status, b.debug_info()))
@@ -1039,10 +1040,8 @@ def test_restartable_insert(client: BatchClient):
 
 def test_create_idempotence(client: BatchClient):
     token = secrets.token_urlsafe(32)
-    bb1 = create_batch(client, token=token)
-    bb2 = create_batch(client, token=token)
-    b1 = bb1._open_batch()
-    b2 = bb2._open_batch()
+    b1 = Batch._open_batch(client, token=token)
+    b2 = Batch._open_batch(client, token=token)
     assert b1.id == b2.id
 
 
@@ -1087,22 +1086,22 @@ async def test_batch_create_validation():
 
 
 def test_duplicate_parents(client: BatchClient):
-    bb = create_batch(client)
-    head = bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
-    bb.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head, head])
+    b = create_batch(client)
+    head = b.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
+    b.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head, head])
     try:
-        batch = bb.submit()
+        b.submit()
     except httpx.ClientResponseError as e:
         assert e.status == 400
     else:
-        assert False, f'should receive a 400 Bad Request {batch.id}'
+        assert False, f'should receive a 400 Bad Request {b.id}'
 
 
 @skip_in_azure
 def test_verify_no_access_to_google_metadata_server(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'metadata.google.internal', '--max-time', '10'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'metadata.google.internal', '--max-time', '10'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -1110,9 +1109,9 @@ def test_verify_no_access_to_google_metadata_server(client: BatchClient):
 
 
 def test_verify_no_access_to_metadata_server(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -1120,7 +1119,7 @@ def test_verify_no_access_to_metadata_server(client: BatchClient):
 
 
 def test_submit_batch_in_job(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     script = f'''import hailtop.batch as hb
 backend = hb.ServiceBackend("test", remote_tmpdir="{remote_tmpdir}")
@@ -1130,12 +1129,12 @@ j.command("echo hi")
 b.run()
 backend.close()
 '''
-    j = bb.create_job(
+    j = b.create_job(
         HAIL_GENETICS_HAILTOP_IMAGE,
         ['/bin/bash', '-c', f'''python3 -c \'{script}\''''],
         mount_tokens=True,
     )
-    b = bb.submit()
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
@@ -1154,8 +1153,8 @@ b.run()
 backend.close()
 '''
 
-    bb = create_batch(client)
-    j = bb.create_job(
+    b = create_batch(client)
+    j = b.create_job(
         HAIL_GENETICS_HAILTOP_IMAGE,
         [
             '/bin/bash',
@@ -1167,7 +1166,7 @@ python3 -c \'{script}\'''',
         ],
         mount_tokens=True,
     )
-    b = bb.submit()
+    b.submit()
     status = j.wait()
     if NAMESPACE == 'default':
         assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -1177,8 +1176,8 @@ python3 -c \'{script}\'''',
 
 
 def test_deploy_config_is_mounted_as_readonly(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(
+    b = create_batch(client)
+    j = b.create_job(
         HAIL_GENETICS_HAILTOP_IMAGE,
         [
             '/bin/bash',
@@ -1190,7 +1189,7 @@ mv tmp.json /deploy-config/deploy-config.json''',
         ],
         mount_tokens=True,
     )
-    b = bb.submit()
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -1199,7 +1198,7 @@ mv tmp.json /deploy-config/deploy-config.json''',
 
 def test_cannot_contact_other_internal_ips(client: BatchClient):
     internal_ips = [f'10.128.0.{i}' for i in (10, 11, 12)]
-    bb = create_batch(client)
+    b = create_batch(client)
     script = f'''
 if [ "$HAIL_BATCH_WORKER_IP" != "{internal_ips[0]}" ] && ! grep -Fq {internal_ips[0]} /etc/hosts; then
     OTHER_IP={internal_ips[0]}
@@ -1211,8 +1210,8 @@ fi
 
 curl -fsSL -m 5 $OTHER_IP
 '''
-    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['/bin/bash', '-c', script], port=5000)
-    b = bb.submit()
+    j = b.create_job(os.environ['HAIL_CURL_IMAGE'], ['/bin/bash', '-c', script], port=5000)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str((status, b.debug_info()))
     job_log = j.log()
@@ -1223,7 +1222,7 @@ curl -fsSL -m 5 $OTHER_IP
 def test_hadoop_can_use_cloud_credentials(client: BatchClient):
     token = os.environ["HAIL_TOKEN"]
     remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
-    bb = create_batch(client)
+    b = create_batch(client)
     script = f'''import hail as hl
 import secrets
 attempt_token = secrets.token_urlsafe(5)
@@ -1231,8 +1230,8 @@ location = f"{remote_tmpdir}/{ token }/{{ attempt_token }}/test_can_use_hailctl_
 hl.utils.range_table(10).write(location)
 hl.read_table(location).show()
 '''
-    j = bb.create_job(HAIL_GENETICS_HAIL_IMAGE, ['/bin/bash', '-c', f'python3 -c >out 2>err \'{script}\'; cat out err'])
-    b = bb.submit()
+    j = b.create_job(HAIL_GENETICS_HAIL_IMAGE, ['/bin/bash', '-c', f'python3 -c >out 2>err \'{script}\'; cat out err'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', f'{j.log(), status}'
     expected_log = '''+-------+
@@ -1257,25 +1256,25 @@ hl.read_table(location).show()
 
 
 def test_user_authentication_within_job(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     cmd = ['bash', '-c', 'hailctl auth user']
-    no_token = bb.create_job(HAIL_GENETICS_HAILTOP_IMAGE, cmd, mount_tokens=False)
-    b = bb.submit()
+    no_token = b.create_job(HAIL_GENETICS_HAILTOP_IMAGE, cmd, mount_tokens=False)
+    b.submit()
 
     no_token_status = no_token.wait()
     assert no_token_status['state'] == 'Failed', str((no_token_status, b.debug_info()))
 
 
 def test_verify_access_to_public_internet(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'example.com'])
-    b = bb.submit()
+    b = create_batch(client)
+    j = b.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'example.com'])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_verify_can_tcp_to_localhost(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     script = '''
 set -e
 nc -l -p 5000 &
@@ -1284,8 +1283,8 @@ echo "hello" | nc -q 1 localhost 5000
 '''.lstrip(
         '\n'
     )
-    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
-    b = bb.submit()
+    j = b.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -1293,7 +1292,7 @@ echo "hello" | nc -q 1 localhost 5000
 
 
 def test_verify_can_tcp_to_127_0_0_1(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     script = '''
 set -e
 nc -l -p 5000 &
@@ -1302,8 +1301,8 @@ echo "hello" | nc -q 1 127.0.0.1 5000
 '''.lstrip(
         '\n'
     )
-    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
-    b = bb.submit()
+    j = b.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/bash', '-c', script])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -1311,7 +1310,7 @@ echo "hello" | nc -q 1 127.0.0.1 5000
 
 
 def test_verify_can_tcp_to_self_ip(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     script = '''
 set -e
 nc -l -p 5000 &
@@ -1320,8 +1319,8 @@ echo "hello" | nc -q 1 $(hostname -i) 5000
 '''.lstrip(
         '\n'
     )
-    j = bb.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/sh', '-c', script])
-    b = bb.submit()
+    j = b.create_job(os.environ['HAIL_NETCAT_UBUNTU_IMAGE'], command=['/bin/sh', '-c', script])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     job_log = j.log()
@@ -1329,12 +1328,12 @@ echo "hello" | nc -q 1 $(hostname -i) 5000
 
 
 def test_verify_private_network_is_restricted(client: BatchClient):
-    bb = create_batch(client)
-    bb.create_job(
+    b = create_batch(client)
+    b.create_job(
         os.environ['HAIL_CURL_IMAGE'], command=['curl', 'internal.hail', '--connect-timeout', '60'], network='private'
     )
     try:
-        bb.submit()
+        b.submit()
     except httpx.ClientResponseError as err:
         assert err.status == 400
         assert 'unauthorized network private' in err.body
@@ -1343,10 +1342,10 @@ def test_verify_private_network_is_restricted(client: BatchClient):
 
 
 async def test_old_clients_that_submit_mount_docker_socket_false_is_ok(client: BatchClient):
-    bb = create_batch(client)._async_builder
-    b = await bb._open_batch()
-    bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    update_id = await bb._create_update(b.id)
+    b = create_batch(client)._async_batch
+    await b._open_batch()
+    b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    update_id = await b._create_update()
     with BatchProgressBar() as pbar:
         process = {
             'type': 'docker',
@@ -1356,14 +1355,14 @@ async def test_old_clients_that_submit_mount_docker_socket_false_is_ok(client: B
         }
         spec = {'always_run': False, 'job_id': 1, 'parent_ids': [], 'process': process}
         with pbar.with_task('submitting jobs', total=1) as pbar_task:
-            await bb._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
+            await b._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
 
 
 async def test_old_clients_that_submit_mount_docker_socket_true_is_rejected(client: BatchClient):
-    bb = create_batch(client)._async_builder
-    b = await bb._open_batch()
-    bb.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
-    update_id = await bb._create_update(b.id)
+    b = create_batch(client)._async_batch
+    await b._open_batch()
+    b.create_job(DOCKER_ROOT_IMAGE, command=['sleep', '30'])
+    update_id = await b._create_update(b.id)
     with BatchProgressBar() as pbar:
         process = {
             'type': 'docker',
@@ -1377,34 +1376,34 @@ async def test_old_clients_that_submit_mount_docker_socket_true_is_rejected(clie
                 httpx.ClientResponseError,
                 match='mount_docker_socket is no longer supported but was set to True in request. Please upgrade.',
             ):
-                await bb._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
+                await b._submit_jobs(b.id, update_id, [orjson.dumps(spec)], 1, pbar_task)
 
 
 def test_pool_highmem_instance(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'memory': 'highmem'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highmem_instance_cheapest(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '1', 'memory': '5Gi'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highcpu_instance(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'memory': 'lowmem'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
@@ -1412,60 +1411,60 @@ def test_pool_highcpu_instance(client: BatchClient):
 
 @pytest.mark.xfail(os.environ.get('HAIL_CLOUD') == 'azure', strict=True, reason='prices changed in Azure 2023-06-01')
 def test_pool_highcpu_instance_cheapest(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'memory': '50Mi'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_standard_instance(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '0.25', 'memory': 'standard'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_standard_instance_cheapest(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'cpu': '1', 'memory': '2.5Gi'}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_preemptible(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'machine_type': smallest_machine_type()}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'job-private' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_nonpreemptible(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'machine_type': smallest_machine_type(), 'preemptible': False}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'job-private' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_job_private_instance_cancel(client: BatchClient):
-    bb = create_batch(client)
+    b = create_batch(client)
     resources = {'machine_type': smallest_machine_type()}
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b.submit()
 
     tries = 0
     start = time.time()
@@ -1497,21 +1496,21 @@ def test_always_run_job_private_instance_cancel(client: BatchClient):
 
 
 def test_create_fast_path_more_than_one_job(client: BatchClient):
-    bb = create_batch(client)
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
-    assert b.submission_info.used_fast_create, b.submission_info
+    b = create_batch(client)
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
+    assert b._submission_info.used_fast_path, b._submission_info
 
 
 def test_update_batch_no_deps(client: BatchClient):
-    bb = create_batch(client)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    bb.submit()
+    b = create_batch(client)
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    b.submit()
     j1.wait()
 
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
     j2_status = j2.wait()
 
     assert j2_status['state'] == 'Success', str((j2_status, b.debug_info()))
@@ -1519,12 +1518,12 @@ def test_update_batch_no_deps(client: BatchClient):
 
 
 def test_update_batch_w_submitted_job_deps(client: BatchClient):
-    bb = create_batch(client)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
+    b = create_batch(client)
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
     j1.wait()
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
-    b = bb.submit()
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
+    b.submit()
     status = j2.wait()
 
     assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -1532,12 +1531,12 @@ def test_update_batch_w_submitted_job_deps(client: BatchClient):
 
 
 def test_update_batch_w_failing_submitted_job_deps(client: BatchClient):
-    bb = create_batch(client)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    bb.submit()
+    b = create_batch(client)
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    b.submit()
 
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
-    b = bb.submit()
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
+    b.submit()
     status = j2.wait()
 
     assert status['state'] == 'Cancelled', str((status, b.debug_info()))
@@ -1545,13 +1544,13 @@ def test_update_batch_w_failing_submitted_job_deps(client: BatchClient):
 
 
 def test_update_batch_w_deps_in_update(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
 
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j, j1])
-    b = bb.submit()
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j, j1])
+    b.submit()
     status = j2.wait()
 
     assert status['state'] == 'Success', str((status, b.debug_info()))
@@ -1560,15 +1559,15 @@ def test_update_batch_w_deps_in_update(client: BatchClient):
 
 
 def test_update_batch_w_deps_in_update_always_run(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['false'])
-    bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['false'])
+    b.submit()
 
     j.wait()
 
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], always_run=True)
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j, j1])
-    b = bb.submit()
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], always_run=True)
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j, j1])
+    b.submit()
     j2.wait()
 
     assert j1.status()['state'] == 'Success', str((j1.status(), b.debug_info()))
@@ -1577,13 +1576,13 @@ def test_update_batch_w_deps_in_update_always_run(client: BatchClient):
 
 
 def test_update_batch_w_failing_deps_in_same_update_and_deps_across_updates(client: BatchClient):
-    bb = create_batch(client)
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    bb.submit()
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
 
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['false'], parents=[j])
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
-    b = bb.submit()
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['false'], parents=[j])
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], parents=[j1])
+    b.submit()
     j2_status = j2.wait()
 
     assert j.status()['state'] == 'Success', str((j.status(), b.debug_info()))
@@ -1592,12 +1591,12 @@ def test_update_batch_w_failing_deps_in_same_update_and_deps_across_updates(clie
 
 
 def test_update_with_always_run(client: BatchClient):
-    bb = create_batch(client)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b = bb.submit()
+    b = create_batch(client)
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b.submit()
 
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'], always_run=True, parents=[j1])
-    b = bb.submit()
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'], always_run=True, parents=[j1])
+    b.submit()
 
     wait_status = j1._wait_for_states('Running')
     if wait_status['state'] != 'Running':
@@ -1613,12 +1612,12 @@ def test_update_with_always_run(client: BatchClient):
 
 
 def test_update_jobs_are_not_serialized(client: BatchClient):
-    bb = create_batch(client)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b = bb.submit()
+    b = create_batch(client)
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b.submit()
 
-    j2 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
+    j2 = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
 
     j2.wait()
 
@@ -1633,90 +1632,88 @@ def test_update_jobs_are_not_serialized(client: BatchClient):
 
 
 def test_update_batch_w_empty_initial_batch(client: BatchClient):
-    bb = create_batch(client)
-    b = bb.submit()
+    b = create_batch(client)
+    b.submit()
 
-    bb = client.update_batch(b.id)
-    j1 = bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
+    j1 = b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
     status = j1.wait()
 
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_update_batch_w_multiple_empty_updates(client: BatchClient):
-    bb = create_batch(client)
-    b = bb.submit()
-    b = bb.submit()
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
+    b = create_batch(client)
+    b.submit()
+    b.submit()
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
     status = b.wait()
 
     assert status['state'] == 'success', str((status, b.debug_info()))
 
 
 def test_update_batch_w_new_batch_builder(client: BatchClient):
-    bb = create_batch(client)
-    b = bb.submit()
-    bb = client.update_batch(b.id)
-    bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b = bb.submit()
+    b = create_batch(client)
+    b.submit()
+    b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
     status = b.wait()
 
     assert status['state'] == 'success', str((status, b.debug_info()))
 
 
 def test_update_batch_wout_fast_path(client: BatchClient):
-    bb = create_batch(client)
-    bb.submit()
+    b = create_batch(client)
+    b.submit()
     for _ in range(4):
-        bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
-    b = bb.submit()
-    assert not next(iter(b.submission_info.used_fast_update.values()))
+        b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
+    b.submit()
+    assert not b._submission_info.used_fast_path
 
 
 def test_update_cancelled_batch_wout_fast_path(client: BatchClient):
-    bb = create_batch(client)
-    bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b = bb.submit()
+    b = create_batch(client)
+    b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b.submit()
     b.cancel()
 
     try:
         for _ in range(4):
-            bb.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
-        b = bb.submit()
+            b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'a' * (900 * 1024)])
+        b.submit()
     except httpx.ClientResponseError as err:
         assert err.status == 400
-        assert 'Cannot submit new jobs to a cancelled batch' in err.body
+        assert 'bunch contains job where the job group has already been cancelled' in err.body
     else:
         assert False
 
 
 def test_submit_update_to_cancelled_batch(client: BatchClient):
-    bb = create_batch(client)
-    bb.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
-    b = bb.submit()
+    b = create_batch(client)
+    b.create_job(DOCKER_ROOT_IMAGE, ['sleep', '3600'])
+    b.submit()
     b.cancel()
 
     try:
-        bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-        b = bb.submit()
+        b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+        b.submit()
     except httpx.ClientResponseError as err:
         assert err.status == 400
-        assert 'Cannot submit new jobs to a cancelled batch' in err.body
+        assert 'bunch contains job where the job group has already been cancelled' in err.body
     else:
         assert False
 
 
 def test_submit_update_to_deleted_batch(client: BatchClient):
-    bb = create_batch(client)
-    b = bb.submit()
+    b = create_batch(client)
+    b.submit()
     b.cancel()
     b.delete()
 
     try:
-        bb.create_job(DOCKER_ROOT_IMAGE, ['true'])
-        b = bb.submit()
+        b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+        b.submit()
     except httpx.ClientResponseError as err:
         assert err.status == 404
     else:
@@ -1727,14 +1724,14 @@ def test_submit_update_to_deleted_batch(client: BatchClient):
 def test_region(client: BatchClient):
     CLOUD = os.environ['HAIL_CLOUD']
 
-    bb = create_batch(client)
+    b = create_batch(client)
     if CLOUD == 'gcp':
         region = 'us-east1'
     else:
         assert CLOUD == 'azure'
         region = 'eastus'
-    j = bb.create_job(DOCKER_ROOT_IMAGE, ['printenv', 'HAIL_REGION'], regions=[region])
-    b = bb.submit()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['printenv', 'HAIL_REGION'], regions=[region])
+    b.submit()
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert status['status']['region'] == region, str((status, b.debug_info()))

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -24,7 +24,7 @@ def test_simple(client):
     batch = create_batch(client)
     head = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'])
     batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head])
-    batch = batch.submit()
+    batch.submit()
     batch.wait()
     status = legacy_batch_status(batch)
     assert batch_status_job_counter(status, 'Success') == 2, str((status, batch.debug_info()))
@@ -37,7 +37,7 @@ def test_missing_parent_is_400(client):
         fake_job = aioclient.Job.unsubmitted_job(batch._async_batch, 10000)
         fake_job = Job.from_async_job(fake_job)
         batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'], parents=[fake_job])
-        batch = batch.submit()
+        batch.submit()
     except ValueError as err:
         assert re.search('parents with invalid job ids', str(err))
         return
@@ -50,7 +50,7 @@ def test_dag(client):
     left = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'left'], parents=[head])
     right = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'right'], parents=[head])
     tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[left, right])
-    batch = batch.submit()
+    batch.submit()
     batch.wait()
     status = legacy_batch_status(batch)
 
@@ -75,7 +75,7 @@ def test_cancel_tail(client):
         DOCKER_ROOT_IMAGE, command=['/bin/sh', '-c', 'while true; do sleep 86000; done'], parents=[left, right]
     )
     try:
-        batch = batch.submit()
+        batch.submit()
         left.wait()
         right.wait()
     finally:
@@ -100,7 +100,7 @@ def test_cancel_left_after_tail(client):
     right = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'right'], parents=[head])
     tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[left, right])
     try:
-        batch = batch.submit()
+        batch.submit()
         head.wait()
         right.wait()
     finally:
@@ -206,7 +206,7 @@ def test_input_dependency(client):
         input_files=[(f'{remote_tmpdir}data1', '/io/data1'), (f'{remote_tmpdir}data2', '/io/data2')],
         parents=[head],
     )
-    batch = batch.submit()
+    batch.submit()
     tail.wait()
     head_status = head.status()
     assert head._get_exit_code(head_status, 'main') == 0, str((head_status, batch.debug_info()))
@@ -228,7 +228,7 @@ def test_input_dependency_wildcard(client):
         input_files=[(f'{remote_tmpdir}data1', '/io/data1'), (f'{remote_tmpdir}data2', '/io/data2')],
         parents=[head],
     )
-    batch = batch.submit()
+    batch.submit()
     tail.wait()
     head_status = head.status()
     assert head._get_exit_code(head_status, 'input') != 0, str((head_status, batch.debug_info()))
@@ -250,7 +250,7 @@ def test_input_dependency_directory(client):
         input_files=[(f'{remote_tmpdir}test', '/io/test')],
         parents=[head],
     )
-    batch = batch.submit()
+    batch.submit()
     tail.wait()
     head_status = head.status()
     assert head._get_exit_code(head_status, 'main') == 0, str((head_status, batch.debug_info()))
@@ -267,7 +267,7 @@ def test_always_run_cancel(client):
     right = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'right'], parents=[head])
     tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[left, right], always_run=True)
     try:
-        batch = batch.submit()
+        batch.submit()
         right.wait()
     finally:
         batch.cancel()
@@ -286,7 +286,7 @@ def test_always_run_error(client):
     batch = create_batch(client)
     head = batch.create_job(DOCKER_ROOT_IMAGE, command=['/bin/sh', '-c', 'exit 1'])
     tail = batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'tail'], parents=[head], always_run=True)
-    batch = batch.submit()
+    batch.submit()
     batch.wait()
     status = legacy_batch_status(batch)
     assert batch_status_job_counter(status, 'Failed') == 1, str((status, batch.debug_info()))

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -150,7 +150,7 @@ async def test_callback(client):
         )
         head = b.create_job('alpine:3.8', command=['echo', 'head'])
         b.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
-        await b.submit()
+        b.submit()
         await asyncio.wait_for(callback_event.wait(), 5 * 60)
         callback_body = callback_bodies[0]
 

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -34,7 +34,7 @@ def test_simple(client):
 def test_missing_parent_is_400(client):
     try:
         batch = create_batch(client)
-        fake_job = aioclient.Job.unsubmitted_job(batch._async_builder, 10000)
+        fake_job = aioclient.Job.unsubmitted_job(batch._async_batch, 10000)
         fake_job = Job.from_async_job(fake_job)
         batch.create_job(DOCKER_ROOT_IMAGE, command=['echo', 'head'], parents=[fake_job])
         batch = batch.submit()
@@ -150,7 +150,7 @@ async def test_callback(client):
         )
         head = b.create_job('alpine:3.8', command=['echo', 'head'])
         b.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
-        b = b.submit()
+        await b.submit()
         await asyncio.wait_for(callback_event.wait(), 5 * 60)
         callback_body = callback_bodies[0]
 

--- a/batch/test/test_scale.py
+++ b/batch/test/test_scale.py
@@ -21,7 +21,7 @@ def test_scale(client):
         sleep_time = random.uniform(0, 30)
         batch.create_job('alpine:3.8', command=['sleep', str(round(sleep_time))])
 
-    batch = batch.submit()
+    batch.submit()
     batch.wait()
     status = legacy_batch_status(batch)
 

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -11,18 +11,16 @@ HAIL_GENETICS_HAIL_IMAGE = os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgene
 
 
 @overload
-def create_batch(client: bc.BatchClient, **kwargs) -> bc.BatchBuilder:
+def create_batch(client: bc.BatchClient, **kwargs) -> bc.Batch:
     ...
 
 
 @overload
-def create_batch(client: aiobc.BatchClient, **kwargs) -> aiobc.BatchBuilder:
+def create_batch(client: aiobc.BatchClient, **kwargs) -> aiobc.Batch:
     ...
 
 
-def create_batch(
-    client: Union[bc.BatchClient, aiobc.BatchClient], **kwargs
-) -> Union[bc.BatchBuilder, aiobc.BatchBuilder]:
+def create_batch(client: Union[bc.BatchClient, aiobc.BatchClient], **kwargs) -> Union[bc.Batch, aiobc.Batch]:
     name_of_test_method = inspect.stack()[1][3]
     attrs = kwargs.pop('attributes', {})  # Tests should be able to override the name
     return client.create_batch(attributes={'name': name_of_test_method, **attrs}, **kwargs)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -538,7 +538,7 @@ mkdir -p {shq(repo_dir)}
                 callback=CALLBACK_URL,
             )
             config.build(batch, self, scope='test')
-            batch = await batch.submit()
+            await batch.submit()
             self.batch = batch
         except concurrent.futures.CancelledError:
             raise

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -975,7 +975,7 @@ def _service_vep(backend: ServiceBackend,
 
     starting_job_id = async_to_blocking(backend._batch.status())['n_jobs'] + 1
 
-    b = backend._batch
+    b = bc.client.Batch(backend._batch)
     build_vep_batch(b, temp_input_directory, temp_output_directory)
 
     b.submit(disable_progress_bar=True)

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -802,7 +802,7 @@ class ServiceBackend(Backend[bc.Batch]):
                 print(f'Waiting for batch {batch_id}...')
             starting_job_id = min(j._client_job.job_id for j in unsubmitted_jobs)
             await asyncio.sleep(0.6)  # it is not possible for the batch to be finished in less than 600ms
-            status = await batch_handle.wait(disable_progress_bar=disable_progress_bar, starting_job=starting_job_id)
+            status = await batch_handle._async_batch.wait(disable_progress_bar=disable_progress_bar, starting_job=starting_job_id)
             print(f'batch {batch_id} complete: {status["state"]}')
 
         batch._python_function_defs.clear()

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -365,7 +365,8 @@ class BatchAlreadyCreatedError(Exception):
 
 def submitted_batch_only(fun):
     @functools.wraps(fun)
-    async def wrapped(batch, *args, **kwargs):
+    async def wrapped(*args, **kwargs):
+        batch = args[0]
         if not batch.submitted:
             raise BatchNotSubmittedError
         return await fun(batch, *args, **kwargs)
@@ -374,7 +375,8 @@ def submitted_batch_only(fun):
 
 def unsubmitted_batch_only(fun):
     @functools.wraps(fun)
-    async def wrapped(batch, *args, **kwargs):
+    async def wrapped(*args, **kwargs):
+        batch = args[0]
         if batch.submitted:
             raise BatchAlreadyCreatedError
         return await fun(batch, *args, **kwargs)
@@ -533,7 +535,7 @@ class Batch:
     async def debug_info(self):
         batch_status = await self.status()
         jobs = []
-        async for j_status in self.jobs():
+        async for j_status in await self.jobs():
             id = j_status['job_id']
             log, job = await asyncio.gather(self.get_job_log(id), self.get_job(id))
             jobs.append({'log': log, 'status': job._status})

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -691,7 +691,7 @@ class Batch:
         batch_json = await resp.json()
         job_progress_task.update(n_jobs)
 
-        self.id = batch_json['id']
+        self._id = batch_json['id']
         self._submission_info = BatchSubmissionInfo(used_fast_path=True)
 
     @submitted_batch_only
@@ -789,7 +789,7 @@ class Batch:
     async def _open_batch(self) -> int:
         batch_spec = self._batch_spec()
         batch_json = await (await self._client._post('/api/v1alpha/batches/create', json=batch_spec)).json()
-        self.id = batch_json['id']
+        self._id = batch_json['id']
         return int(batch_json['update_id'])
 
     def _update_spec(self) -> dict:

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -369,7 +369,7 @@ def submitted_batch_only(fun):
         batch = args[0]
         if not batch.submitted:
             raise BatchNotSubmittedError
-        return await fun(batch, *args, **kwargs)
+        return await fun(*args, **kwargs)
     return wrapped
 
 
@@ -379,7 +379,7 @@ def unsubmitted_batch_only(fun):
         batch = args[0]
         if batch.submitted:
             raise BatchAlreadyCreatedError
-        return await fun(batch, *args, **kwargs)
+        return await fun(*args, **kwargs)
     return wrapped
 
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -882,6 +882,8 @@ class Batch:
         self._jobs = []
         self._job_idx = 0
 
+        return self
+
 
 class HailExplicitTokenCredentials(CloudCredentials):
     def __init__(self, token: str):

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1077,7 +1077,7 @@ class ServiceTests(unittest.TestCase):
             long_str = secrets.token_urlsafe(256 * 1024)
             j1.command(f'echo "{long_str}" > /dev/null')
         batch = b.run()
-        assert not batch.submission_info.used_fast_create
+        assert not batch._submission_info.used_fast_path
         batch_status = batch.status()
         assert batch_status['state'] == 'success', str((batch.debug_info()))
 


### PR DESCRIPTION
This PR refactors the aioclient to merge the functionality of Batch and BatchBuilder into just a single Batch object. The reason for making this change is to make adding job groups simpler. I will follow up with a change to Jobs after this merges. I apologize for the number of line changes. Most are just renaming `bb -> b` in the tests. 