### PR TITLE
[query] fix ./gradlew test

### DIFF
--- a/hail/testng.xml
+++ b/hail/testng.xml
@@ -2,7 +2,7 @@
     <test name="TestAll">
         <packages>
           <package name="is.hail.*">
-            <exclude name="is.hail.shadedazure"></exclude>
+            <exclude name="is.hail.shadedazure.*"></exclude>
             <exclude name="is.hail.fs.azure"></exclude>
             <exclude name="is.hail.fs.gs"></exclude>
             <exclude name="is.hail.services.*"></exclude>

--- a/hail/testng.xml
+++ b/hail/testng.xml
@@ -2,6 +2,7 @@
     <test name="TestAll">
         <packages>
           <package name="is.hail.*">
+            <exclude name="is.hail.shadedazure"></exclude>
             <exclude name="is.hail.fs.azure"></exclude>
             <exclude name="is.hail.fs.gs"></exclude>
             <exclude name="is.hail.services.*"></exclude>


### PR DESCRIPTION
TestNG (appears to) allocates every class in the classpath matching the package glob. I assume this is to check if any of these are `instanceof` `TestNGSuite`.

The Azure SDK depends on `rector-netty-core` which includes some classes which reference interfaces *not included in its required dependencies*. These classes are meant to be used only when those optional dependencies are present. They should not be willy-nilly allocated, but, of course, we told TestNG to go willy-nilly allocating everything.