### PR TITLE
 [query][rfc-0008] permit more INFO and FORMAT array-fields with missing elements

### DIFF
--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1809,8 +1809,12 @@ class MatrixVCFReader(
     IRParser.parseType(params.entryFloatTypeName),
     params.callFields)
 
+  val globalType = TStruct(
+    "vcf_header" -> VCFHeaderInfo.headerType.typeAfterSelectNames(Array("formatAttrs", "filterAttrs", "infoAttrs"))
+  )
+
   def fullMatrixTypeWithoutUIDs: MatrixType = MatrixType(
-    globalType = TStruct.empty,
+    globalType = globalType,
     colType = TStruct("s" -> TString),
     colKey = Array("s"),
     rowType = TStruct(
@@ -1892,7 +1896,14 @@ class MatrixVCFReader(
         GenericLines.read(fs, fileStatuses, params.nPartitions, params.blockSizeInMB, params.minPartitions, params.gzAsBGZ, params.forceGZ)
     }
 
-    val globals = Row(sampleIDs.zipWithIndex.map { case (s, i) => Row(s, i.toLong) }.toFastIndexedSeq)
+    val globals = Row(
+      Row(
+        header.formatAttrs,
+        header.filtersAttrs,
+        header.infoAttrs
+      ),
+      sampleIDs.zipWithIndex.map { case (s, i) => Row(s, i.toLong) }.toFastIndexedSeq
+    )
 
     val fullRowPType: PType = fullRVDType.rowType
 

--- a/hail/src/test/resources/all_possible_ambiguous_info_array_fields.vcf
+++ b/hail/src/test/resources/all_possible_ambiguous_info_array_fields.vcf
@@ -1,0 +1,14 @@
+##fileformat=VCFv4.2
+##INFO=<ID=Number0,Number=0,Type=Flag,Description="">
+##INFO=<ID=Number1,Number=1,Type=String,Description="">
+##INFO=<ID=Number2,Number=2,Type=String,Description="">
+##INFO=<ID=NumberA,Number=A,Type=String,Description="">
+##INFO=<ID=NumberR,Number=R,Type=String,Description="">
+##INFO=<ID=NumberG,Number=G,Type=String,Description="">
+##INFO=<ID=NumberDot,Number=.,Type=String,Description="">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+#Hail cannot parse VCFs with no alts, they are parsed as an empty string allele
+#1	1	.	A		.	LowQual	Number0=.;Number1=.;Number2=.;NumberA=.;NumberR=.;NumberG=.;NumberDot=.
+1	1	.	A	T	.	LowQual	Number0=.;Number1=.;Number2=.;NumberA=.;NumberR=.;NumberG=.;NumberDot=.
+1	1	.	A	T,G	.	LowQual	Number0=.;Number1=.;Number2=.;NumberA=.;NumberR=.;NumberG=.;NumberDot=.
+1	2	.	A	T,G	.	LowQual	Number0;Number1=X;Number2=X,.;NumberA=.,X;NumberR=.,X,.;NumberG=.,X,.,X,.,X;NumberDot=.,X,X,X,.

--- a/hail/src/test/resources/issue_13346.vcf
+++ b/hail/src/test/resources/issue_13346.vcf
@@ -1,0 +1,21 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##FILTER=<ID=ExcessHet,Description="Site has excess het value larger than the threshold">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=NO_HQ_GENOTYPES,Description="Site has no high quality variant genotypes">
+##FILTER=<ID=low_VQSLOD_INDEL,Description="Site failed INDEL model sensitivity cutoff (99.0), corresponding with VQSLOD cutoff of -1.3625">
+##FILTER=<ID=low_VQSLOD_SNP,Description="Site failed SNP model sensitivity cutoff (99.7), corresponding with VQSLOD cutoff of -2.2757">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=FT,Number=1,Type=String,Description="Genotype Filter Field">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=RGQ,Number=1,Type=Integer,Description="Unconditional reference genotype confidence, encoded as a phred quality -10*log10 p(genotype call is wrong)">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AS_QUALapprox,Number=1,Type=String,Description="Allele-specific QUAL approximations">
+##INFO=<ID=AS_VQSLOD,Number=A,Type=String,Description="For each alt allele, the log odds of being a true variant versus being false under the trained gaussian mixture model">
+##INFO=<ID=AS_YNG,Number=A,Type=String,Description="For each alt allele, the yay/nay/grey status (yay are known good alleles, nay are known false positives, grey are unknown)">
+##INFO=<ID=QUALapprox,Number=1,Type=Integer,Description="Sum of PL[0] values; used to approximate the QUAL score">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	1	2	3	4	5	6	7	8	9	10	11	1
+chr1	10403	.	ACCCTAACCCTAACCCTAACCCTAACCCTAACCCTAAC	A,ACCCCTAACCCTAACCCTAACCCTAACCCTAACCCTAAC	.	LowQual	AC=1,1;AF=0.250,0.250;AN=4;AS_QUALapprox=0|23|45;AS_VQSLOD=.,.;AS_YNG=.,.;QUALapprox=45	GT:AD:GQ:RGQ	./.	0/1:23,7,0:20:23	./.	./.	./.	0/2:6,0,4:35:45	./.	./.	./.	./.	./.	./.	./.	./.	./.	./.	./.	./.


### PR DESCRIPTION
CHANGELOG: Fixed #13346. Previously, when parsing VCFs, Hail failed on INFO or FORMAT fields with missing elements because the meaning of "." could be ambiguous. Hail now resovles the ambiguity, when possible, using the number of alleles. If the meaning is still ambiguous after considering the number of alleles, Hail uses a new `hl.import_vcf` parameter to resolve the ambiguity. See the `hl.import_vcf` docs for details.

See https://github.com/hail-is/hail-rfcs/pull/8 for details on the problem and the solution.

I assessed the effect of removing the `array_elements_required=True` fast path by evaluating the following code against this PR's tip commit `cd06c248e4` and `0.2.120` (`f00f916faf`). I ran it three times per commit and report each individual time as well as the average.

```
In [1]: import hail as hl

In [2]: %%time
   ...: mt = hl.import_vcf(
   ...:     '/Users/dking/projects/hail-data/ALL.chr21.raw.HC.vcf.bgz'
   ...: )
   ...: mt._force_count_rows()
```

| commit                   | run 1 (s) | run 2 (s) | run 3 (s) | average (s) | warm average (s) |
|--------------------------|-----------|-----------|-----------|-------------|------------------|
| `cd06c248e4` (this PR)   | 116s      | 80s       | 77s       | 91+-18      | 78.5 +- 1.5      |
| `f00f916faf` (`0.2.120`) | 112s      | 80s       | 79s       | 90+-15      | 79.5 +- 0.5      |

This is what I expected. For a VCF with no ambiguity and few instances of ".", we've added a very minor amount of new work.

---

Note that I had to specifically override the Number setting for certain FORMAT and INFO fields because they were set to `.` in the benchmarked VCF. If this error appears in a 1KG VCF, it must be fairly common.