### PR TITLE
[query] improve type hinting for tables

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -30,9 +30,13 @@ To report a bug, please open an issue: https://github.com/hail-is/hail/issues
 # F403 'from .expr import *' used; unable to detect undefined names
 # F401 '.expr.*' imported but unused
 # E402 module level import not at top of file
+from .expr import *
+from .expr import aggregators
+from hail.utils import (Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls,  # noqa: E402
+                        hadoop_stat, hadoop_exists, hadoop_is_file,
+                        hadoop_is_dir, hadoop_scheme_supported, copy_log, ANY_REGION)
 from .table import Table, GroupedTable, asc, desc  # noqa: E402
 from .matrixtable import MatrixTable, GroupedMatrixTable  # noqa: E402
-from .expr import *  # noqa: F403, E402
 from .genetics import *  # noqa: F403, E402
 from .methods import *  # noqa: F403, E402
 from . import expr  # noqa: E402
@@ -47,10 +51,6 @@ from . import ir  # noqa: E402
 from . import backend  # noqa: E402
 from . import nd  # noqa: E402
 from . import vds  # noqa: E402
-from hail.expr import aggregators as agg  # noqa: E402
-from hail.utils import (Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls,  # noqa: E402
-                        hadoop_stat, hadoop_exists, hadoop_is_file,
-                        hadoop_is_dir, hadoop_scheme_supported, copy_log, ANY_REGION)
 
 from .context import (init, init_local, init_batch, stop, spark_context, tmp_dir,  # noqa: E402
                       default_reference, get_reference, set_global_seed, reset_global_randomness,
@@ -58,7 +58,8 @@ from .context import (init, init_local, init_batch, stop, spark_context, tmp_dir
                       current_backend, debug_info, citation, cite_hail, cite_hail_bibtex,
                       version, TemporaryFilename, TemporaryDirectory)
 
-scan = agg.aggregators.ScanFunctions({name: getattr(agg, name) for name in agg.__all__})
+agg = aggregators
+scan = aggregators.aggregators.ScanFunctions({name: getattr(agg, name) for name in agg.__all__})
 
 __all__ = [
     'init',

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -30,8 +30,8 @@ To report a bug, please open an issue: https://github.com/hail-is/hail/issues
 # F403 'from .expr import *' used; unable to detect undefined names
 # F401 '.expr.*' imported but unused
 # E402 module level import not at top of file
-from .expr import *
-from .expr import aggregators
+from .expr import *  # noqa: E402, F403
+from .expr import aggregators  # noqa: E402
 from hail.utils import (Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls,  # noqa: E402
                         hadoop_stat, hadoop_exists, hadoop_is_file,
                         hadoop_is_dir, hadoop_scheme_supported, copy_log, ANY_REGION)

--- a/hail/python/hail/experimental/function.py
+++ b/hail/python/hail/experimental/function.py
@@ -1,25 +1,35 @@
-from typing import Optional
-from hail.expr.expressions import construct_expr, expr_any, unify_all
-from hail.expr.types import hail_type
+from typing import Optional, Tuple, Sequence, Callable
+from hail.expr.expressions import construct_expr, expr_any, unify_all, Expression
+from hail.expr.types import hail_type, HailType
 from hail.ir import Apply, Ref
 from hail.typecheck import typecheck, nullable, tupleof, anytype
 from hail.utils.java import Env
 
 
-class Function(object):
-    def __init__(self, f, param_types, ret_type, name, type_args=()):
+class Function():
+    def __init__(self,
+                 f: Callable[..., Expression],
+                 param_types: Sequence[HailType],
+                 ret_type: HailType,
+                 name: str,
+                 type_args: Tuple[HailType, ...] = ()
+                 ):
         self._f = f
         self._name = name
         self._type_args = type_args
         self._param_types = param_types
         self._ret_type = ret_type
 
-    def __call__(self, *args):
+    def __call__(self, *args: Expression) -> Expression:
         return self._f(*args)
 
 
 @typecheck(f=anytype, param_types=hail_type, _name=nullable(str), type_args=tupleof(hail_type))
-def define_function(f, *param_types, _name: Optional[str] = None, type_args=()) -> Function:
+def define_function(f: Callable[..., Expression],
+                    *param_types: HailType,
+                    _name: Optional[str] = None,
+                    type_args: Tuple[HailType, ...] = ()
+                    ) -> Function:
     mname = _name if _name is not None else Env.get_uid()
     param_names = [Env.get_uid(mname) for _ in param_types]
     body = f(*(construct_expr(Ref(pn), pt) for pn, pt in zip(param_names, param_types)))
@@ -28,8 +38,8 @@ def define_function(f, *param_types, _name: Optional[str] = None, type_args=()) 
     Env.backend().register_ir_function(mname, type_args, param_names, param_types, ret_type, body)
 
     @typecheck(args=expr_any)
-    def f(*args):
+    def fun(*args: Expression) -> Expression:
         indices, aggregations = unify_all(*args)
         return construct_expr(Apply(mname, ret_type, *(a._ir for a in args), type_args=type_args), ret_type, indices, aggregations)
 
-    return Function(f, param_types, ret_type, mname, type_args)
+    return Function(fun, param_types, ret_type, mname, type_args)

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Mapping
+from typing import Tuple, Mapping, overload, Any, List
 import numpy as np
 import pandas as pd
 
@@ -1101,6 +1101,12 @@ class Expression(object):
             return hl.eval(e)
         return e
 
+    @overload
+    def collect(self) -> List[Any]:
+        ...
+    @overload
+    def collect(self, _localize=False) -> 'Expression':
+        ...
     @typecheck_method(_localize=bool)
     def collect(self, _localize=True):
         """Collect all records of an expression into a local list.

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1,4 +1,5 @@
-from typing import Callable, TypeVar, ParamSpec, cast
+from typing import Callable, TypeVar, cast
+from typing_extensions import ParamSpec
 import copy
 import json
 from collections import defaultdict

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1,3 +1,4 @@
+from typing import Callable, TypeVar
 import copy
 import json
 from collections import defaultdict
@@ -2972,7 +2973,10 @@ def register_seeded_function(name, param_types, ret_type):
     _register(_seeded_function_registry, name, (param_types, ret_type))
 
 
-def udf(*param_types):
+T = TypeVar('T')
+
+
+def udf(*param_types) -> Callable[[Callable[..., T]], Callable[..., T]]:
 
     uid = Env.get_uid()
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -4,7 +4,7 @@ import pandas
 import numpy as np
 import pyspark
 import pprint
-from typing import Optional, Dict, Callable, Sequence, Union
+from typing import Optional, Dict, Callable, Sequence, Union, List, overload
 
 from hail.expr.expressions import Expression, StructExpression, \
     BooleanExpression, expr_struct, expr_any, expr_bool, analyze, Indices, \
@@ -2127,6 +2127,12 @@ class Table(ExprContainer):
         """
         return Env.backend().unpersist(self)
 
+    @overload
+    def collect(self) -> List[hl.Struct]:
+        ...
+    @overload
+    def collect(self, _localize=False) -> hl.ArrayExpression:
+        ...
     @typecheck_method(_localize=bool, _timed=bool)
     def collect(self, _localize=True, *, _timed=False):
         """Collect the rows of the table into a local list.

--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -582,7 +582,7 @@ def _make_dec(checkers, is_method: bool) -> Callable[[Callable[..., T]], Callabl
     checkers = {k: only(v) for k, v in checkers.items()}
 
     @decorator
-    def wrapper(__original_func: Callable[..., T], *args, **kwargs) -> T:
+    def wrapper(__original_func, *args, **kwargs):
         args_, kwargs_ = check_all(__original_func, args, kwargs, checkers, is_method=is_method)
         return __original_func(*args_, **kwargs_)
 

--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -3,7 +3,7 @@ import re
 import inspect
 import abc
 import collections
-from decorator import decorator
+from hailtop.hail_decorator import decorator
 
 
 class TypecheckFailure(Exception):
@@ -582,7 +582,7 @@ def _make_dec(checkers, is_method: bool) -> Callable[[Callable[..., T]], Callabl
     checkers = {k: only(v) for k, v in checkers.items()}
 
     @decorator
-    def wrapper(__original_func, *args, **kwargs):
+    def wrapper(__original_func: Callable[..., T], *args, **kwargs) -> T:
         args_, kwargs_ = check_all(__original_func, args, kwargs, checkers, is_method=is_method)
         return __original_func(*args_, **kwargs_)
 

--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -1,3 +1,4 @@
+from typing import TypeVar, Callable
 import re
 import inspect
 import abc
@@ -566,7 +567,6 @@ def check_all(f, args, kwargs, checks, is_method):
                 kwargs_[kwarg_name] = kwargs_check(arg, name, kwarg_name, checker)
     return args_, kwargs_
 
-
 def typecheck_method(**checkers):
     return _make_dec(checkers, is_method=True)
 
@@ -575,11 +575,14 @@ def typecheck(**checkers):
     return _make_dec(checkers, is_method=False)
 
 
-def _make_dec(checkers, is_method):
+T = TypeVar('T')
+
+
+def _make_dec(checkers, is_method: bool) -> Callable[[Callable[..., T]], Callable[..., T]]:
     checkers = {k: only(v) for k, v in checkers.items()}
 
     @decorator
-    def wrapper(__original_func, *args, **kwargs):
+    def wrapper(__original_func: Callable[..., T], *args, **kwargs) -> T:
         args_, kwargs_ = check_all(__original_func, args, kwargs, checkers, is_method=is_method)
         return __original_func(*args_, **kwargs_)
 

--- a/hail/python/hailtop/hail_decorator.py
+++ b/hail/python/hailtop/hail_decorator.py
@@ -1,0 +1,15 @@
+from typing import ParamSpec, TypeVar, Callable, cast, Protocol
+from decorator import decorator as _decorator
+
+P = ParamSpec('P')
+T = TypeVar('T')
+
+class Wrapper(Protocol[P, T]):
+    def __call__(self, fun: Callable[P, T], /, *args: P.args, **kwargs: P.kwargs) -> T:
+        ...
+
+
+def decorator(
+    fun: Wrapper[P, T]
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    return cast(Callable[[Callable[P, T]], Callable[P, T]], _decorator(fun))

--- a/hail/python/hailtop/hail_decorator.py
+++ b/hail/python/hailtop/hail_decorator.py
@@ -1,4 +1,5 @@
-from typing import ParamSpec, TypeVar, Callable, cast, Protocol
+from typing import TypeVar, Callable, cast, Protocol
+from typing_extensions import ParamSpec
 from decorator import decorator as _decorator
 
 P = ParamSpec('P')

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -1,8 +1,9 @@
+from typing import Callable, ParamSpec, TypeVar
 import os
 from timeit import default_timer as timer
 import unittest
 import pytest
-from decorator import decorator
+from hailtop.hail_decorator import decorator
 
 from hail.utils.java import choose_backend
 import hail as hl
@@ -121,10 +122,14 @@ def create_all_values_datasets():
     return (create_all_values_table(), create_all_values_matrix_table())
 
 
+P = ParamSpec('P')
+T = TypeVar('T')
+
+
 def skip_unless_spark_backend(reason='requires Spark'):
     from hail.backend.spark_backend import SparkBackend
     @decorator
-    def wrapper(func, *args, **kwargs):
+    def wrapper(func, *args, **kwargs) -> T:
         if isinstance(hl.utils.java.Env.backend(), SparkBackend):
             return func(*args, **kwargs)
         else:

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -1,4 +1,5 @@
-from typing import Callable, ParamSpec, TypeVar
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
 import os
 from timeit import default_timer as timer
 import unittest


### PR DESCRIPTION
Without these changes, my IDE cannot deduce that the return value of, say, `select` is a `Table` which prevents jump-to-definition on subsequent method calls.

I also received an error about `Table.collect` returning an `ArrayExpression` which it will only do when `_localize=False`. `overload` teaches this fact to the type system.

I didn't use the specific expression in `base_expression.py` because that would require an import circularity.