### PR TITLE
[fs] remove Azure _debug parameters

### DIFF
--- a/hail/src/main/scala/is/hail/io/bgen/StagedBGENReader.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/StagedBGENReader.scala
@@ -481,7 +481,7 @@ object BGENFunctions extends RegistryFunctions {
         val bufferSize = _bufferSize.asInt.value
 
         val cbfis = cb.memoize(Code.newInstance[HadoopFSDataBinaryReader, SeekableDataInputStream](
-          mb.getFS.invoke[String, Boolean, SeekableDataInputStream]("openNoCompression", path, false)))
+          mb.getFS.invoke[String, SeekableDataInputStream]("openNoCompression", path)))
 
         val header = cb.memoize(Code.invokeScalaObject3[HadoopFSDataBinaryReader, String, Long, BgenHeader](
           LoadBgen.getClass, "readState", cbfis, path, mb.getFS.invoke[String, Long]("getFileSize", path)))

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -262,7 +262,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
     serviceClientCache.getServiceClient(url).getBlobContainerClient(url.container)
   }
 
-  def openNoCompression(filename: String, _debug: Boolean): SeekableDataInputStream = handlePublicAccessError(filename) {
+  def openNoCompression(filename: String): SeekableDataInputStream = handlePublicAccessError(filename) {
     val url = AzureStorageFS.parseUrl(filename)
     val blobClient: BlobClient = getBlobClient(url)
     val blobSize = blobClient.getProperties.getBlobSize
@@ -296,16 +296,8 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
           bb.flip()
           assert(bb.position() == 0 && bb.remaining() > 0)
 
-          if (_debug) {
-            val byteContents = bb.array().map("%02X" format _).mkString
-            log.info(s"AzureStorageFS.openNoCompression SeekableInputStream: pos=$pos blobSize=$blobSize count=$count response.getStatusCode()=${response.getStatusCode()} bb.toString()=${bb} byteContents=${byteContents}")
-          }
-
           bb.remaining()
         } else {
-          if (_debug) {
-            log.info(s"AzureStorageFS.openNoCompression SeekableInputStream: pos=$pos blobSize=$blobSize count=$count response.getStatusCode()=${response.getStatusCode()}")
-          }
           -1
         }
       }

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -328,7 +328,7 @@ trait FS extends Serializable {
       ""
   }
 
-  final def openNoCompression(filename: String): SeekableDataInputStream = openNoCompression(filename, false)
+  final def openNoCompression(filename: String): SeekableDataInputStream = openNoCompression(filename)
   def readNoCompression(filename: String): Array[Byte] = retryTransientErrors {
     using(openNoCompression(filename)) { is =>
       IOUtils.toByteArray(is)

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -329,8 +329,6 @@ trait FS extends Serializable {
   }
 
   final def openNoCompression(filename: String): SeekableDataInputStream = openNoCompression(filename, false)
-  def openNoCompression(filename: String, _debug: Boolean): SeekableDataInputStream
-
   def readNoCompression(filename: String): Array[Byte] = retryTransientErrors {
     using(openNoCompression(filename)) { is =>
       IOUtils.toByteArray(is)
@@ -411,8 +409,8 @@ trait FS extends Serializable {
       new Thread(() => delete(filename, recursive = false)))
   }
 
-  def open(path: String, codec: CompressionCodec, _debug: Boolean = false): InputStream = {
-    val is = openNoCompression(path, _debug)
+  def open(path: String, codec: CompressionCodec): InputStream = {
+    val is = openNoCompression(path)
     if (codec != null)
       codec.makeInputStream(is)
     else

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -328,7 +328,8 @@ trait FS extends Serializable {
       ""
   }
 
-  final def openNoCompression(filename: String): SeekableDataInputStream = openNoCompression(filename)
+  def openNoCompression(filename: String): SeekableDataInputStream
+
   def readNoCompression(filename: String): Array[Byte] = retryTransientErrors {
     using(openNoCompression(filename)) { is =>
       IOUtils.toByteArray(is)

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -213,8 +213,7 @@ class GoogleStorageFS(
     }
   }
 
-  def openNoCompression(filename: String, _debug: Boolean = false): SeekableDataInputStream = retryTransientErrors {
-    assert(!_debug)
+  def openNoCompression(filename: String): SeekableDataInputStream = retryTransientErrors {
     val url = parseUrl(filename)
 
     val is: SeekableInputStream = new FSSeekableInputStream {

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -100,8 +100,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
       HadoopFS.toPositionedOutputStream(os))
   }
 
-  def openNoCompression(filename: String, _debug: Boolean = false): SeekableDataInputStream = {
-    assert(!_debug)
+  def openNoCompression(filename: String): SeekableDataInputStream = {
     val fs = getFileSystem(filename)
     val hPath = new hadoop.fs.Path(filename)
     val is = try {

--- a/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
@@ -19,6 +19,8 @@ class RouterFS(fss: IndexedSeq[FS]) extends FS {
 
   override def createCachedNoCompression(filename: String): PositionedDataOutputStream = lookupFS(filename).createCachedNoCompression(filename)
 
+  def openNoCompression(filename: String): SeekableDataInputStream = lookupFS(filename).openNoCompression(filename)
+
   def createNoCompression(filename: String): PositionedDataOutputStream = lookupFS(filename).createNoCompression(filename)
 
   override def readNoCompression(filename: String): Array[Byte] = lookupFS(filename).readNoCompression(filename)

--- a/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
@@ -19,8 +19,6 @@ class RouterFS(fss: IndexedSeq[FS]) extends FS {
 
   override def createCachedNoCompression(filename: String): PositionedDataOutputStream = lookupFS(filename).createCachedNoCompression(filename)
 
-  def openNoCompression(filename: String, _debug: Boolean = false): SeekableDataInputStream = lookupFS(filename).openNoCompression(filename, _debug)
-
   def createNoCompression(filename: String): PositionedDataOutputStream = lookupFS(filename).createNoCompression(filename)
 
   override def readNoCompression(filename: String): Array[Byte] = lookupFS(filename).readNoCompression(filename)

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -354,9 +354,7 @@ trait FSSuite extends TestNGSuite {
 
     assert(fs.exists(f))
 
-    val debug = this.isInstanceOf[AzureStorageFSSuite]
-
-    using(fs.open(f, fs.getCodecFromPath(f), _debug=debug)) { is =>
+    using(fs.open(f, fs.getCodecFromPath(f))) { is =>
       is match {
         case base: Seekable => base.seek(Int.MaxValue + 2.toLong)
         case base: org.apache.hadoop.fs.Seekable => base.seek(Int.MaxValue + 2.toLong)


### PR DESCRIPTION
This was added in https://github.com/hail-is/hail/pull/12421 to help debug errors in `testSeekMoreThanMaxInt`. We have not seen that transient error in a while and I think the switch to https://github.com/hail-is/hail/pull/12590 might have fixed some underlying misuse of `AppendBlobClient` (by not using it).