### PR TITLE
[query] Add bounds checks to local_to_global

### DIFF
--- a/hail/python/test/hail/vds/test_vds_functions.py
+++ b/hail/python/test/hail/vds/test_vds_functions.py
@@ -1,3 +1,5 @@
+import pytest
+
 import hail as hl
 
 def test_lgt_to_gt():
@@ -49,3 +51,14 @@ def test_local_to_global_missing_fill():
     local_alleles = [0, 3, 1]
     lad = [1, 10, 9]
     assert hl.eval(hl.vds.local_to_global(lad, local_alleles, 4, hl.missing('int32'), number='R')) == [1, 9, None, 10]
+
+def test_local_to_global_out_of_bounds():
+    local_alleles = [0, 2]
+    lad = [1, 9]
+    lpl = [1001, 0, 1002]
+
+    with pytest.raises(hl.utils.HailUserError, match='local_to_global: local allele of 2 out of bounds given n_total_alleles of 2'):
+        assert hl.eval(hl.vds.local_to_global(lad, local_alleles, 2, 0, number='R')) == [1, 0]
+
+    with pytest.raises(hl.utils.HailUserError, match='local_to_global: local allele of 2 out of bounds given n_total_alleles of 2'):
+        assert hl.eval(hl.vds.local_to_global(lpl, local_alleles, 2, 10001, number='G')) == [1001, 10001, 0, 10001, 10001, 1002]

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -355,6 +355,7 @@ object ArrayFunctions extends RegistryFunctions {
             val laGIndexer = cb.newLocal[Int]("g_indexer", 0)
             cb.whileLoop(i < laLen, {
               val lai = localAlleles.loadElement(cb, i).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
+              cb.ifx(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
 
               val j = cb.newLocal[Int]("la_j", 0)
               cb.whileLoop(j <= i, {
@@ -414,6 +415,7 @@ object ArrayFunctions extends RegistryFunctions {
             val i = cb.newLocal[Int]("la_i", 0)
             cb.whileLoop(i < localLen, {
               val lai = localAlleles.loadElement(cb, i + idxAdjustmentForOmitFirst).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
+              cb.ifx(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
               push(cb, cb.memoize(lai - idxAdjustmentForOmitFirst), array.loadElement(cb, i))
 
               cb.assign(i, i + 1)


### PR DESCRIPTION
Make sure that all local alleles are less than the n_total_alleles parameter passed to the function.

This error will often occur if a vds is split with regular split_multi rather than vds.split_multi

Closes #13479