### PR TITLE
[batch] remove use of smart quotes in docs

### DIFF
--- a/hail/python/hailtop/batch/docs/advanced_search_help.rst
+++ b/hail/python/hailtop/batch/docs/advanced_search_help.rst
@@ -14,7 +14,7 @@ Exact Match Expression
 A single word enclosed with double quotes that is an exact match for either the name or
 value of an attribute.
 
-**Example:** ``“pca_pipeline”``
+**Example:** ``"pca_pipeline"``
 
 Partial Match Expression
 ------------------------


### PR DESCRIPTION
I presume this was meant to be normal double quotes.