### PR TITLE
[batch] treat search field as plaintext: no spellcheck, no autocorrect

### DIFF
--- a/batch/batch/front_end/templates/table_search.html
+++ b/batch/batch/front_end/templates/table_search.html
@@ -49,7 +49,7 @@
       <form method="GET" action="{{ endpoint }}">
         <div id="{{ component_name }}-inner">
           <div>
-            <textarea id="{{ component_name }}-input-box" spellcheck="false" autocorrect="false" autofocus name="q">{% if q %}{{ q }}{% endif %}</textarea>
+            <textarea id="{{ component_name }}-input-box" spellcheck="off" autocorrect="off" autofocus name="q">{% if q %}{{ q }}{% endif %}</textarea>
           </div>
           <div id="{{ component_name }}-buttons">
             <a href="https://hail.is/docs/batch/advanced_search_help.html" target="_blank">

--- a/batch/batch/front_end/templates/table_search.html
+++ b/batch/batch/front_end/templates/table_search.html
@@ -49,7 +49,7 @@
       <form method="GET" action="{{ endpoint }}">
         <div id="{{ component_name }}-inner">
           <div>
-            <textarea id="{{ component_name }}-input-box" spellcheck="off" autocorrect="off" autofocus name="q">{% if q %}{{ q }}{% endif %}</textarea>
+            <textarea id="{{ component_name }}-input-box" spellcheck="false" autocorrect="off" autofocus name="q">{% if q %}{{ q }}{% endif %}</textarea>
           </div>
           <div id="{{ component_name }}-buttons">
             <a href="https://hail.is/docs/batch/advanced_search_help.html" target="_blank">

--- a/batch/batch/front_end/templates/table_search.html
+++ b/batch/batch/front_end/templates/table_search.html
@@ -49,7 +49,7 @@
       <form method="GET" action="{{ endpoint }}">
         <div id="{{ component_name }}-inner">
           <div>
-            <textarea id="{{ component_name }}-input-box" autofocus name="q">{% if q %}{{ q }}{% endif %}</textarea>
+            <textarea id="{{ component_name }}-input-box" spellcheck="false" autocorrect="false" autofocus name="q">{% if q %}{{ q }}{% endif %}</textarea>
           </div>
           <div id="{{ component_name }}-buttons">
             <a href="https://hail.is/docs/batch/advanced_search_help.html" target="_blank">


### PR DESCRIPTION
Without this my browser keeps trying to put periods everywhere.