### PR TITLE
[query] fix shadowing of field names by methods

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -339,7 +339,7 @@ def approx_cdf(expr, k=100):
         tfloat32: lambda x: x.map(hl.float32),
         tfloat64: identity
     }
-    return hl.struct(values=conv[expr.dtype](res.values), ranks=res.ranks, _compaction_counts=res._compaction_counts)
+    return hl.struct(values=conv[expr.dtype](res['values']), ranks=res.ranks, _compaction_counts=res._compaction_counts)
 
 
 @typecheck(expr=expr_numeric, qs=expr_oneof(expr_numeric, expr_array(expr_numeric)), k=int)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1785,7 +1785,9 @@ class StructExpression(Mapping[Union[str, int], Expression], Expression):
         if key not in self._fields:
             if hasattr(self, key):
                 self._shadowed_fields.add(key)
-        self._fields[key] = value
+            else:
+                self.__dict__[key] = value
+            self._fields[key] = value
 
     def _get_field(self, item):
         if item in self._fields:
@@ -1802,10 +1804,7 @@ class StructExpression(Mapping[Union[str, int], Expression], Expression):
         return super().__getattribute__(item)
 
     def __getattr__(self, item):
-        if item in self._fields:
-            return self._fields[item]
-        else:
-            raise AttributeError(get_nice_attr_error(self, item))
+        raise AttributeError(get_nice_attr_error(self, item))
 
     def __len__(self):
         return len(self._fields)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1743,12 +1743,12 @@ class StructExpression(Mapping[Union[str, int], Expression], Expression):
         x = ir.MakeStruct([(n, expr._ir) for (n, expr) in fields.items()])
         indices, aggregations = unify_all(*fields.values())
         s = StructExpression.__new__(cls)
+        super(StructExpression, s).__init__(x, t, indices, aggregations)
         s._warned_on_shadowed_name = False
         s._shadowed_fields = set()
         s._fields = {}
         for k, v in fields.items():
             s._set_field(k, v)
-        super(StructExpression, s).__init__(x, t, indices, aggregations)
         return s
 
     @typecheck_method(x=ir.IR, type=HailType, indices=Indices, aggregations=LinkedList)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1779,7 +1779,7 @@ class StructExpression(Mapping[Union[str, int], Expression], Expression):
 
     def _set_field(self, key, value):
         self._fields[key] = value
-        if key not in self.__dict__:
+        if key not in self.__dir__():
             self.__dict__[key] = value
 
     def _get_field(self, item):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1783,7 +1783,9 @@ class StructExpression(Mapping[Union[str, int], Expression], Expression):
 
     def _set_field(self, key, value):
         if key not in self._fields:
-            if hasattr(self, key):
+            # Avoid using hasattr on self. Each new field added will fall through to __getattr__,
+            # which has to build a nice error message.
+            if key in self.__dict__ or hasattr(super(), key):
                 self._shadowed_fields.add(key)
             else:
                 self.__dict__[key] = value

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -79,10 +79,10 @@ def _quantile_from_cdf(cdf, q):
     def compute(cdf):
         n = cdf.ranks[cdf.ranks.length() - 1]
         pos = hl.int64(q * n) + 1
-        idx = hl.max(0, hl.min(cdf.values.length() - 1, _lower_bound(cdf.ranks, pos) - 1))
+        idx = hl.max(0, hl.min(cdf['values'].length() - 1, _lower_bound(cdf.ranks, pos) - 1))
         res = hl.if_else(n == 0,
-                         hl.missing(cdf.values.dtype.element_type),
-                         cdf.values[idx])
+                         hl.missing(cdf['values'].dtype.element_type),
+                         cdf['values'][idx])
         return res
     return hl.rbind(cdf, compute)
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1404,6 +1404,21 @@ class Tests(unittest.TestCase):
                      hl.Struct(f1=1, f2=2, f3=3),
                      tstruct(f1=tint32, f2=tint32, f3=tint32))
 
+    def test_shadowed_struct_fields(self):
+        from typing import Callable
+
+        s = hl.struct(foo=1, values=2)
+        assert isinstance(s.foo, hl.Expression)
+        assert not s._warned_on_shadowed_name
+        assert isinstance(s.values, Callable)
+        assert s._warned_on_shadowed_name
+
+        s = hl.struct(foo=1, collect=2)
+        assert isinstance(s.foo, hl.Expression)
+        assert not s._warned_on_shadowed_name
+        assert isinstance(s.collect, Callable)
+        assert s._warned_on_shadowed_name
+
     def test_iter(self):
         a = hl.literal([1, 2, 3])
         self.assertRaises(hl.expr.ExpressionException, lambda: hl.eval(list(a)))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1413,10 +1413,34 @@ class Tests(unittest.TestCase):
         assert isinstance(s.values, Callable)
         assert s._warned_on_shadowed_name
 
+        s = hl.StructExpression._from_fields({'foo': hl.int(1), 'values': hl.int(2)})
+        assert isinstance(s.foo, hl.Expression)
+        assert not s._warned_on_shadowed_name
+        assert isinstance(s.values, Callable)
+        assert s._warned_on_shadowed_name
+
         s = hl.struct(foo=1, collect=2)
         assert isinstance(s.foo, hl.Expression)
         assert not s._warned_on_shadowed_name
         assert isinstance(s.collect, Callable)
+        assert s._warned_on_shadowed_name
+
+        s = hl.StructExpression._from_fields({'foo': hl.int(1), 'collect': hl.int(2)})
+        assert isinstance(s.foo, hl.Expression)
+        assert not s._warned_on_shadowed_name
+        assert isinstance(s.collect, Callable)
+        assert s._warned_on_shadowed_name
+
+        s = hl.struct(foo=1, _ir=2)
+        assert isinstance(s.foo, hl.Expression)
+        assert not s._warned_on_shadowed_name
+        assert isinstance(s._ir, ir.IR)
+        assert s._warned_on_shadowed_name
+
+        s = hl.StructExpression._from_fields({'foo': hl.int(1), '_ir': hl.int(2)})
+        assert isinstance(s.foo, hl.Expression)
+        assert not s._warned_on_shadowed_name
+        assert isinstance(s._ir, ir.IR)
         assert s._warned_on_shadowed_name
 
     def test_iter(self):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1407,41 +1407,31 @@ class Tests(unittest.TestCase):
     def test_shadowed_struct_fields(self):
         from typing import Callable
 
-        s = hl.struct(foo=1, values=2)
+        s = hl.struct(foo=1, values=2, collect=3, _ir=4)
+        assert 'foo' not in s._warn_on_shadowed_name
         assert isinstance(s.foo, hl.Expression)
-        assert not s._warned_on_shadowed_name
+        assert 'values' in s._warn_on_shadowed_name
         assert isinstance(s.values, Callable)
-        assert s._warned_on_shadowed_name
+        assert 'values' not in s._warn_on_shadowed_name
+        assert 'collect' in s._warn_on_shadowed_name
+        assert isinstance(s.collect, Callable)
+        assert 'collect' not in s._warn_on_shadowed_name
+        assert '_ir' in s._warn_on_shadowed_name
+        assert isinstance(s._ir, ir.IR)
+        assert '_ir' not in s._warn_on_shadowed_name
 
-        s = hl.StructExpression._from_fields({'foo': hl.int(1), 'values': hl.int(2)})
+        s = hl.StructExpression._from_fields({'foo': hl.int(1), 'values': hl.int(2), 'collect': hl.int(3), '_ir': hl.int(4)})
+        assert 'foo' not in s._warn_on_shadowed_name
         assert isinstance(s.foo, hl.Expression)
-        assert not s._warned_on_shadowed_name
+        assert 'values' in s._warn_on_shadowed_name
         assert isinstance(s.values, Callable)
-        assert s._warned_on_shadowed_name
-
-        s = hl.struct(foo=1, collect=2)
-        assert isinstance(s.foo, hl.Expression)
-        assert not s._warned_on_shadowed_name
+        assert 'values' not in s._warn_on_shadowed_name
+        assert 'collect' in s._warn_on_shadowed_name
         assert isinstance(s.collect, Callable)
-        assert s._warned_on_shadowed_name
-
-        s = hl.StructExpression._from_fields({'foo': hl.int(1), 'collect': hl.int(2)})
-        assert isinstance(s.foo, hl.Expression)
-        assert not s._warned_on_shadowed_name
-        assert isinstance(s.collect, Callable)
-        assert s._warned_on_shadowed_name
-
-        s = hl.struct(foo=1, _ir=2)
-        assert isinstance(s.foo, hl.Expression)
-        assert not s._warned_on_shadowed_name
+        assert 'collect' not in s._warn_on_shadowed_name
+        assert '_ir' in s._warn_on_shadowed_name
         assert isinstance(s._ir, ir.IR)
-        assert s._warned_on_shadowed_name
-
-        s = hl.StructExpression._from_fields({'foo': hl.int(1), '_ir': hl.int(2)})
-        assert isinstance(s.foo, hl.Expression)
-        assert not s._warned_on_shadowed_name
-        assert isinstance(s._ir, ir.IR)
-        assert s._warned_on_shadowed_name
+        assert '_ir' not in s._warn_on_shadowed_name
 
     def test_iter(self):
         a = hl.literal([1, 2, 3])


### PR DESCRIPTION
In particular, struct field names which clash with methods on `StructExpression`.

close #13495

CHANGELOG: Fix a bug where field names can shadow methods on the StructExpression class, e.g. "items", "keys", "values". Now the only way to access such fields is through the getitem syntax, e.g. "some_struct['items']". It's possible this could break existing code that uses such field names.