### PR TITLE
[batch] use headings instead of captions

### DIFF
--- a/hail/python/hailtop/batch/docs/advanced_search_help.rst
+++ b/hail/python/hailtop/batch/docs/advanced_search_help.rst
@@ -43,7 +43,10 @@ listed in the tables below. Allowed operators are dependent on the type of the v
 keyword, but can be one of ``=``, ``==``, ``!=``, ``>``, ``>=``, ``<``, ``<=``, ``=~``, ``!~``.
 The right hand side is the value to search against.
 
-.. list-table:: Keywords
+Keywords
+^^^^^^^^
+
+.. list-table::
     :widths: 25 25 50 50
     :header-rows: 1
 
@@ -75,8 +78,10 @@ The right hand side is the value to search against.
 
 **Example:** ``start_time >= 2023-02-24T17:15:25Z``
 
+Keywords specific to searching for batches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. list-table:: Keywords specific to searching for batches
+.. list-table::
     :widths: 25 25 50 50
     :header-rows: 1
 
@@ -108,9 +113,10 @@ The right hand side is the value to search against.
 
 **Example:** ``billing_project = johndoe-trial``
 
+Keywords specific to searching for jobs in a batch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-.. list-table:: Keywords specific to searching for jobs in a batch
+.. list-table::
     :widths: 25 25 50 50
     :header-rows: 1
 


### PR DESCRIPTION
Captions render haphazardly, at least on my browser.
<img width="2032" alt="Screenshot 2023-08-25 at 10 14 59" src="https://github.com/hail-is/hail/assets/106194/7cf49685-677c-472a-9e87-a317617b03a7">
