### PR TITLE
[qob][batch] do not list all jobs on failure (plus: types!)

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict
 import json
 import logging
 
 from gear import transaction
 from hailtop.utils import humanize_timedelta_msecs, time_msecs_str
+from hailtop.batch_client.types import JobListEntry
 
 from .batch_format_version import BatchFormatVersion
 from .exceptions import NonExistentBatchError, OpenBatchError
@@ -66,7 +68,7 @@ def batch_record_to_dict(record):
     return d
 
 
-def job_record_to_dict(record, name):
+def job_record_to_dict(record: Dict[str, Any], name: str) -> JobListEntry:
     format_version = BatchFormatVersion(record['format_version'])
 
     db_status = record['status']
@@ -77,7 +79,7 @@ def job_record_to_dict(record, name):
         exit_code = None
         duration = None
 
-    result = {
+    return {
         'batch_id': record['batch_id'],
         'job_id': record['job_id'],
         'name': name,
@@ -89,8 +91,6 @@ def job_record_to_dict(record, name):
         'cost': coalesce(record['cost'], 0),
         'msec_mcpu': record['msec_mcpu'],
     }
-
-    return result
 
 
 async def cancel_batch_in_db(db, batch_id):

--- a/batch/batch/batch_format_version.py
+++ b/batch/batch/batch_format_version.py
@@ -1,3 +1,4 @@
+from typing import Tuple, Optional
 from hailtop.batch_client.aioclient import Job
 
 
@@ -117,7 +118,7 @@ class BatchFormatVersion:
 
         return [ec, duration]
 
-    def get_status_exit_code_duration(self, status):
+    def get_status_exit_code_duration(self, status) -> Tuple[Optional[int], Optional[int]]:
         if self.format_version == 1:
             job_status = {'status': status}
             return (Job.exit_code(job_status), Job.total_duration_msecs(job_status))

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -493,7 +493,10 @@ class ServiceBackend(Backend):
         except FileNotFoundError as exc:
             raise FatalError('Hail internal error. Please contact the Hail team and provide the following information.\n\n' + yamlx.dump({
                 'service_backend_debug_info': self.debug_info(),
-                'batch_debug_info': await self._batch.debug_info(),
+                'batch_debug_info': await self._batch.debug_info(
+                    _job_filter=lambda x: x['state'] == 'Failed',
+                    _max_jobs=10
+                ),
                 'input_uri': await self._async_fs.read(input_uri),
             })) from exc
 
@@ -514,7 +517,10 @@ class ServiceBackend(Backend):
         except UnexpectedEOFError as exc:
             raise FatalError('Hail internal error. Please contact the Hail team and provide the following information.\n\n' + yamlx.dump({
                 'service_backend_debug_info': self.debug_info(),
-                'batch_debug_info': await self._batch.debug_info(),
+                'batch_debug_info': await self._batch.debug_info(
+                    _job_filter=lambda x: x['state'] == 'Failed',
+                    _max_jobs=10
+                ),
                 'in': await self._async_fs.read(input_uri),
                 'out': await self._async_fs.read(output_uri),
             })) from exc

--- a/hail/python/hailtop/batch_client/__init__.py
+++ b/hail/python/hailtop/batch_client/__init__.py
@@ -1,4 +1,4 @@
-from . import client, aioclient, parse
+from . import client, aioclient, parse, types
 from .aioclient import BatchAlreadyCreatedError, BatchNotCreatedError, JobAlreadySubmittedError, JobNotSubmittedError
 
 __all__ = [
@@ -9,4 +9,5 @@ __all__ = [
     'client',
     'aioclient',
     'parse',
+    'types',
 ]

--- a/hail/python/hailtop/batch_client/types.py
+++ b/hail/python/hailtop/batch_client/types.py
@@ -1,0 +1,20 @@
+from typing import TypedDict, Literal, Optional, List
+from typing_extensions import NotRequired
+
+
+class JobListEntry(TypedDict):
+    batch_id: int
+    job_id: int
+    name: str
+    user: str
+    billing_project: str
+    state: Literal['Pending', 'Ready', 'Creating', 'Running', 'Failed', 'Cancelled', 'Error', 'Success']
+    exit_code: Optional[int]
+    duration: Optional[int]
+    cost: float
+    msec_mcpu: int
+
+
+class GetJobsResponse(TypedDict):
+    jobs: List[JobListEntry]
+    last_job_id: NotRequired[int]


### PR DESCRIPTION
CHANGELOG: In Query-on-Batch, the client-side Python code will not try to list every job when a QoB batch fails. This could take hours for long-running pipelines or pipelines with many partitions.

I also added API types to the list jobs end point because I have to go hunting for this every time anyway. Seems better to have this information at our digital fingertips.