### PR TITLE
[hailctl] Dont copy the user's config file into hailctl batch submit jobs

### DIFF
--- a/hail/python/hailtop/config/__init__.py
+++ b/hail/python/hailtop/config/__init__.py
@@ -1,5 +1,5 @@
 from .user_config import (get_user_config, get_user_config_path,
-                          get_remote_tmpdir, configuration_of)
+                          get_remote_tmpdir, configuration_of, config_option_environment_variable_name)
 from .deploy_config import get_deploy_config, DeployConfig
 from .variables import ConfigVariable
 
@@ -7,6 +7,7 @@ __all__ = [
     'get_deploy_config',
     'get_user_config',
     'get_user_config_path',
+    'config_option_environment_variable_name',
     'get_remote_tmpdir',
     'DeployConfig',
     'ConfigVariable',

--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -38,6 +38,10 @@ VALID_SECTION_AND_OPTION_RE = re.compile('[a-z0-9_]+')
 T = TypeVar('T')
 
 
+def config_option_environment_variable_name(section: str, option: str) -> str:
+    return 'HAIL_' + section.upper() + '_' + option.upper()
+
+
 def unchecked_configuration_of(section: str,
                                option: str,
                                explicit_argument: Optional[T],
@@ -47,7 +51,7 @@ def unchecked_configuration_of(section: str,
     if explicit_argument is not None:
         return explicit_argument
 
-    envvar = 'HAIL_' + section.upper() + '_' + option.upper()
+    envvar = config_option_environment_variable_name(section, option)
     envval = os.environ.get(envvar, None)
     deprecated_envval = None if deprecated_envvar is None else os.environ.get(deprecated_envvar)
     if envval is not None:
@@ -73,11 +77,7 @@ def configuration_of(config_variable: ConfigVariable,
                      fallback: T,
                      *,
                      deprecated_envvar: Optional[str] = None) -> Union[str, T]:
-    if '/' in config_variable.value:
-        section, option = config_variable.value.split('/')
-    else:
-        section = 'global'
-        option = config_variable.value
+    section, option = config_variable.to_section_option()
     return unchecked_configuration_of(section, option, explicit_argument, fallback, deprecated_envvar=deprecated_envvar)
 
 

--- a/hail/python/hailtop/config/variables.py
+++ b/hail/python/hailtop/config/variables.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Tuple
 
 
 class ConfigVariable(str, Enum):
@@ -18,3 +19,8 @@ class ConfigVariable(str, Enum):
     QUERY_BATCH_WORKER_MEMORY = 'query/batch_worker_memory'
     QUERY_NAME_PREFIX = 'query/name_prefix'
     QUERY_DISABLE_PROGRESS_BAR = 'query/disable_progress_bar'
+
+    def to_section_option(self) -> Tuple[str, str]:
+        if '/' in self.value:
+            return tuple(self.value.split('/'))
+        return ('global', self.value)

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -1,18 +1,20 @@
 import orjson
 import os
 from shlex import quote as shq
+
 from hailtop import pip_version
+from hailtop.config import config_option_environment_variable_name
+from hailtop.config.variables import ConfigVariable
 
 
 async def submit(name, image_name, files, output, script, arguments):
     import hailtop.batch as hb  # pylint: disable=import-outside-toplevel
     import hailtop.batch_client.client as bc  # pylint: disable=import-outside-toplevel
     from hailtop.aiotools.copy import copy_from_dict  # pylint: disable=import-outside-toplevel
-    from hailtop.config import get_remote_tmpdir, get_user_config_path, get_deploy_config  # pylint: disable=import-outside-toplevel
+    from hailtop.config import get_remote_tmpdir, get_deploy_config, configuration_of  # pylint: disable=import-outside-toplevel
     from hailtop.utils import secret_alnum_string, unpack_comma_delimited_inputs  # pylint: disable=import-outside-toplevel
 
     files = unpack_comma_delimited_inputs(files)
-    user_config = get_user_config_path()
     quiet = output != 'text'
 
     remote_tmpdir = get_remote_tmpdir('hailctl batch submit')
@@ -31,7 +33,6 @@ async def submit(name, image_name, files, output, script, arguments):
     await copy_from_dict(
         files=[
             {'from': script, 'to': cloud_prefix(script)},
-            {'from': str(user_config), 'to': cloud_prefix(user_config)},
             *local_files_to_cloud_files,
         ]
     )
@@ -42,8 +43,12 @@ async def submit(name, image_name, files, output, script, arguments):
         j.command(f'ln -s {in_file} {local_file}')
 
     script_file = b.read_input(cloud_prefix(script))
-    config_file = b.read_input(cloud_prefix(user_config))
-    j.command(f'mkdir -p $HOME/.config/hail && ln -s {config_file} $HOME/.config/hail/config.ini')
+
+    for config_var in ConfigVariable:
+        config_val = configuration_of(config_var, None, None)
+        if config_val is not None:
+            config_ev_name = config_option_environment_variable_name(*config_var.to_section_option())
+            j.env(config_ev_name, config_val)
 
     j.env('HAIL_QUERY_BACKEND', 'batch')
 


### PR DESCRIPTION
CHANGELOG: `hailctl batch submit` now propagates configuration environment variables to the submitted job.



Copying the user's config file into the job feels hacky and rude. Now that everything is guaranteed to be using the `configuration_of` mechanism we can set the entire config through environment variables. Also, if the intention is that the job's environment should magically reflect what the user set up locally, we should use `configuration_of` so that `HAIL_BILLING_PROJECT=foo hailctl batch submit` actually works.