### PR TITLE
[batch] More debugging information for network namespace errors

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -228,6 +228,16 @@ read_from_head true
 tag worker.log
 </source>
 
+<filter worker.log>
+@type record_transformer
+enable_ruby
+<record>
+    severity \${{ record["levelname"] }}
+    timestamp \${{ record["asctime"] }}
+</record>
+</filter>
+EOF
+
 sudo tee /etc/google-fluentd/config.d/syslog.conf <<EOF
 <source>
 @type tail
@@ -237,16 +247,6 @@ pos_file /var/lib/google-fluentd/pos/syslog.pos
 read_from_head true
 tag syslog
 </source>
-EOF
-
-<filter worker.log>
-@type record_transformer
-enable_ruby
-<record>
-    severity \${{ record["levelname"] }}
-    timestamp \${{ record["asctime"] }}
-</record>
-</filter>
 EOF
 
 sudo tee /etc/google-fluentd/config.d/run-log.conf <<EOF

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -228,6 +228,17 @@ read_from_head true
 tag worker.log
 </source>
 
+sudo tee /etc/google-fluentd/config.d/syslog.conf <<EOF
+<source>
+@type tail
+format syslog
+path /var/log/syslog
+pos_file /var/lib/google-fluentd/pos/syslog.pos
+read_from_head true
+tag syslog
+</source>
+EOF
+
 <filter worker.log>
 @type record_transformer
 enable_ruby

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1847,7 +1847,7 @@ class DockerJob(Job):
         except asyncio.CancelledError:
             raise
         except Exception:
-            pass
+            log.exception('While running container')
 
     async def run(self):
         async with self.worker.cpu_sem(self.cpu_in_mcpu):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1035,7 +1035,7 @@ class Container:
                 else:
                     assert self.network is None or self.network == 'public'
                     self.netns = await network_allocator.allocate_public()
-        except asyncio.CancelledError:
+        except asyncio.TimeoutError:
             log.exception(network_allocator.task_manager.tasks)
             raise
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -965,6 +965,7 @@ class Container:
                 self._killed = True
 
     async def _cleanup(self):
+        log.info(f'Cleaning up {self}')
         if self._cleaned_up:
             return
 
@@ -987,6 +988,7 @@ class Container:
             if self.netns:
                 assert network_allocator
                 network_allocator.free(self.netns)
+                log.info(f'Freed the network namespace for {self}')
                 self.netns = None
         finally:
             try:
@@ -1026,12 +1028,16 @@ class Container:
     async def _setup_network_namespace(self):
         assert network_allocator
         assert port_allocator
-        async with async_timeout.timeout(60):
-            if self.network == 'private':
-                self.netns = await network_allocator.allocate_private()
-            else:
-                assert self.network is None or self.network == 'public'
-                self.netns = await network_allocator.allocate_public()
+        try:
+            async with async_timeout.timeout(60):
+                if self.network == 'private':
+                    self.netns = await network_allocator.allocate_private()
+                else:
+                    assert self.network is None or self.network == 'public'
+                    self.netns = await network_allocator.allocate_public()
+        except asyncio.CancelledError:
+            log.exception(network_allocator.task_manager.tasks)
+            raise
 
         if self.port is not None:
             self.host_port = await port_allocator.allocate()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1853,7 +1853,7 @@ class DockerJob(Job):
         except asyncio.CancelledError:
             raise
         except Exception:
-            log.exception('While running container')
+            log.exception(f'While running container: {container}')
 
     async def run(self):
         async with self.worker.cpu_sem(self.cpu_in_mcpu):


### PR DESCRIPTION
In a previous PR we added exception logging when tasks on a `BackgroundTaskManager` fail. I'm not seeing any of those messages in the worker logs, suggesting that for some reason the Tasks to free a network namespace when a job is finished are not getting created in the first place. I don't see how in the code we could somehow *not* free the network namespace, but I'm hoping that some of these diagnostics shed some light. Also open to suggestions for where else might be a good spot to add more logging.