### PR TITLE
[batch] Tokenize batches_n_complete_states

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -33,12 +33,13 @@ async def mark_batch_complete(db: Database, client_session: httpx.ClientSession,
         '''
 UPDATE batches
 LEFT JOIN LATERAL (
-  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed
+  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed,
+    CAST(MAX(time_completed) AS SIGNED) AS time_completed
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id
 ) AS states ON TRUE
-SET state = 'complete'
+SET state = 'complete', time_completed = time_completed
 WHERE id = %s AND state != 'complete' AND n_jobs = n_completed;
 ''',
         (batch_id,),

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -33,7 +33,7 @@ async def mark_batch_complete(db: Database, client_session: httpx.ClientSession,
         '''
 UPDATE batches
 LEFT JOIN LATERAL (
-  SELECT COALESCE(SUM(n_completed), 0) AS n_completed
+  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id
@@ -54,8 +54,10 @@ WHERE id = %s AND state != 'complete' AND n_jobs = n_completed;
 SELECT batches.*, cost_t.*, batches_cancelled.id IS NOT NULL AS cancelled, states.*
 FROM batches
 LEFT JOIN LATERAL (
-  SELECT COALESCE(SUM(n_completed), 0) AS n_completed, COALESCE(SUM(n_succeeded), 0) AS n_succeeded,
-    COALESCE(SUM(n_failed), 0) AS n_failed, COALESCE(SUM(n_cancelled), 0) AS n_cancelled
+  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed,
+    CAST(COALESCE(SUM(n_succeeded), 0) AS SIGNED) AS n_succeeded,
+    CAST(COALESCE(SUM(n_failed), 0) AS SIGNED) AS n_failed,
+    CAST(COALESCE(SUM(n_cancelled), 0) AS SIGNED) AS n_cancelled
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -80,6 +80,9 @@ WHERE batches.id = %s AND NOT deleted AND callback IS NOT NULL AND
         'notify_batch_job_complete',
     )
 
+    if record is None:
+        return
+
     callback = record['callback']
 
     log.info(f'making callback for batch {batch_id}: {callback}')

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1254,7 +1254,7 @@ async def monitor_for_missed_complete_batches(app):
 SELECT id
 FROM batches
 LEFT JOIN LATERAL (
-  SELECT COALESCE(SUM(n_completed), 0) AS n_completed
+  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id
@@ -1297,7 +1297,7 @@ async def cancel_fast_failing_batches(app):
 SELECT batches.id
 FROM batches
 LEFT JOIN LATERAL (
-  SELECT id, COALESCE(SUM(n_failed), 0) AS n_failed
+  SELECT id, CAST(COALESCE(SUM(n_failed), 0) AS SIGNED) AS n_failed
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1259,7 +1259,7 @@ LEFT JOIN LATERAL (
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id
 ) AS states ON TRUE
-WHERE state != 'complete' AND n_jobs = n_completed
+WHERE state = "running" AND n_jobs = n_completed
 LIMIT 1000;
 ''',
         query_name='get_missed_complete_batches',

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1470,10 +1470,10 @@ async def _get_batch(app, batch_id):
 SELECT batches.*, batches_cancelled.id IS NOT NULL AS cancelled, states.*, cost_t.*
 FROM batches
 LEFT JOIN LATERAL (
-  SELECT COALESCE(SUM(n_completed), 0) AS n_completed,
-    COALESCE(SUM(n_succeeded), 0) AS n_succeeded,
-    COALESCE(SUM(n_failed), 0) AS n_failed,
-    COALESCE(SUM(n_cancelled), 0) AS n_cancelled
+  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed,
+    CAST(COALESCE(SUM(n_succeeded), 0) AS SIGNED) AS n_succeeded,
+    CAST(COALESCE(SUM(n_failed), 0) AS SIGNED) AS n_failed,
+    CAST(COALESCE(SUM(n_cancelled), 0) AS SIGNED) AS n_cancelled
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id
@@ -1497,13 +1497,6 @@ WHERE batches.id = %s AND NOT deleted;
     )
     if not record:
         raise web.HTTPNotFound()
-
-    try:
-        batch_record_to_dict(record)
-    except asyncio.CancelledError:
-        raise
-    except Exception:
-        log.exception(f'batch_id {batch_id}: record {record}')
 
     return batch_record_to_dict(record)
 

--- a/batch/batch/front_end/query/query_v1.py
+++ b/batch/batch/front_end/query/query_v1.py
@@ -88,8 +88,10 @@ SELECT batches.*, batches_cancelled.id IS NOT NULL AS cancelled, states.*, cost_
 FROM batches
 LEFT JOIN billing_projects ON batches.billing_project = billing_projects.name
 LEFT JOIN LATERAL (
-  SELECT COALESCE(SUM(n_completed), 0) AS n_completed, COALESCE(SUM(n_succeeded), 0) AS n_succeeded,
-    COALESCE(SUM(n_failed), 0) AS n_failed, COALESCE(SUM(n_cancelled), 0) AS n_cancelled
+  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed,
+    CAST(COALESCE(SUM(n_succeeded), 0) AS SIGNED) AS n_succeeded,
+    CAST(COALESCE(SUM(n_failed), 0) AS SIGNED) AS n_failed,
+    CAST(COALESCE(SUM(n_cancelled), 0) AS SIGNED) AS n_cancelled
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id

--- a/batch/batch/front_end/query/query_v1.py
+++ b/batch/batch/front_end/query/query_v1.py
@@ -85,16 +85,16 @@ def parse_list_batches_query_v1(user: str, q: str, last_batch_id: Optional[int])
 
     sql = f'''
 WITH base_t AS (
-  SELECT batches.*,
-    batches_cancelled.id IS NOT NULL AS cancelled,
-    batches_n_jobs_in_complete_states.n_completed,
-    batches_n_jobs_in_complete_states.n_succeeded,
-    batches_n_jobs_in_complete_states.n_failed,
-    batches_n_jobs_in_complete_states.n_cancelled
+  SELECT batches.*, batches_cancelled.id IS NOT NULL AS cancelled, states.*
   FROM batches
   LEFT JOIN billing_projects ON batches.billing_project = billing_projects.name
-  LEFT JOIN batches_n_jobs_in_complete_states
-    ON batches.id = batches_n_jobs_in_complete_states.id
+  LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(n_completed), 0) AS n_completed, COALESCE(SUM(n_succeeded), 0) AS n_succeeded,
+      COALESCE(SUM(n_failed), 0) AS n_failed, COALESCE(SUM(n_cancelled), 0) AS n_cancelled
+    FROM batches_n_jobs_in_complete_states
+    WHERE batches.id = batches_n_jobs_in_complete_states.id
+    GROUP BY id
+  ) AS states ON TRUE
   LEFT JOIN batches_cancelled
     ON batches.id = batches_cancelled.id
   STRAIGHT_JOIN billing_project_users ON batches.billing_project = billing_project_users.billing_project

--- a/batch/batch/front_end/query/query_v2.py
+++ b/batch/batch/front_end/query/query_v2.py
@@ -131,8 +131,10 @@ SELECT batches.*, batches_cancelled.id IS NOT NULL AS cancelled, states.*, cost_
 FROM batches
 LEFT JOIN billing_projects ON batches.billing_project = billing_projects.name
 LEFT JOIN LATERAL (
-  SELECT COALESCE(SUM(n_completed), 0) AS n_completed, COALESCE(SUM(n_succeeded), 0) AS n_succeeded,
-    COALESCE(SUM(n_failed), 0) AS n_failed, COALESCE(SUM(n_cancelled), 0) AS n_cancelled
+  SELECT CAST(COALESCE(SUM(n_completed), 0) AS SIGNED) AS n_completed,
+    CAST(COALESCE(SUM(n_succeeded), 0) AS SIGNED) AS n_succeeded,
+    CAST(COALESCE(SUM(n_failed), 0) AS SIGNED) AS n_failed,
+    CAST(COALESCE(SUM(n_cancelled), 0) AS SIGNED) AS n_cancelled
   FROM batches_n_jobs_in_complete_states
   WHERE batches.id = batches_n_jobs_in_complete_states.id
   GROUP BY id

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1503,15 +1503,10 @@ BEGIN
   DECLARE delta_cores_mcpu INT DEFAULT 0;
   DECLARE total_jobs_in_batch INT;
   DECLARE expected_attempt_id VARCHAR(40);
-  DECLARE cur_n_tokens INT;
-  DECLARE rand_token INT;
 
   START TRANSACTION;
 
   SELECT n_jobs INTO total_jobs_in_batch FROM batches WHERE id = in_batch_id;
-
-  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
-  SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
   SELECT state, cores_mcpu
   INTO cur_job_state, cur_cores_mcpu
@@ -1553,8 +1548,9 @@ BEGIN
     SET state = new_state, status = new_status, attempt_id = in_attempt_id
     WHERE batch_id = in_batch_id AND job_id = in_job_id;
 
+    # We insert at token = 0 for backwards compatibility until server is updated
     INSERT INTO batches_n_jobs_in_complete_states (id, token, n_completed, n_succeeded, n_failed, n_cancelled, time_completed)
-    VALUES (in_batch_id, rand_token,
+    VALUES (in_batch_id, 0,
             1,
             (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed'),
             (new_state = 'Error' OR new_state = 'Failed'),

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1502,10 +1502,15 @@ BEGIN
   DECLARE delta_cores_mcpu INT DEFAULT 0;
   DECLARE total_jobs_in_batch INT;
   DECLARE expected_attempt_id VARCHAR(40);
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
 
   START TRANSACTION;
 
   SELECT n_jobs INTO total_jobs_in_batch FROM batches WHERE id = in_batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
   SELECT state, cores_mcpu
   INTO cur_job_state, cur_cores_mcpu

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1560,7 +1560,7 @@ BEGIN
       n_completed = n_completed + 1,
       n_succeeded = n_succeeded + (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed'),
       n_failed    = n_failed + (new_state = 'Error' OR new_state = 'Failed'),
-      n_cancelled = n_cancelled + (new_state = 'Cancelled')
+      n_cancelled = n_cancelled + (new_state = 'Cancelled'),
       time_completed = GREATEST(time_completed, new_timestamp);
 
     UPDATE jobs

--- a/batch/sql/tokenize-job-complete-states.sql
+++ b/batch/sql/tokenize-job-complete-states.sql
@@ -82,7 +82,7 @@ BEGIN
       n_completed = n_completed + 1,
       n_succeeded = n_succeeded + (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed'),
       n_failed    = n_failed + (new_state = 'Error' OR new_state = 'Failed'),
-      n_cancelled = n_cancelled + (new_state = 'Cancelled')
+      n_cancelled = n_cancelled + (new_state = 'Cancelled'),
       time_completed = GREATEST(time_completed, new_timestamp);
 
     UPDATE jobs

--- a/batch/sql/tokenize-job-complete-states.sql
+++ b/batch/sql/tokenize-job-complete-states.sql
@@ -1,6 +1,7 @@
 DELIMITER $$
 
 ALTER TABLE batches_n_jobs_in_complete_states ADD COLUMN token INT NOT NULL DEFAULT 0, ALGORITHM=INSTANT;
+ALTER TABLE batches_n_jobs_in_complete_states ADD COLUMN time_completed BIGINT, ALGORITHM=INSTANT;
 ALTER TABLE batches_n_jobs_in_complete_states DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `token`), ALGORITHM=INPLACE, LOCK=NONE;
 
 DROP PROCEDURE IF EXISTS mark_job_complete $$
@@ -74,17 +75,19 @@ BEGIN
     SET state = new_state, status = new_status, attempt_id = in_attempt_id
     WHERE batch_id = in_batch_id AND job_id = in_job_id;
 
-    INSERT INTO batches_n_jobs_in_complete_states (id, token, n_completed, n_succeeded, n_failed, n_cancelled)
+    INSERT INTO batches_n_jobs_in_complete_states (id, token, n_completed, n_succeeded, n_failed, n_cancelled, time_completed)
     VALUES (in_batch_id, rand_token,
             1,
             (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed'),
             (new_state = 'Error' OR new_state = 'Failed'),
-            (new_state = 'Cancelled'))
+            (new_state = 'Cancelled'),
+            new_timestamp)
     ON DUPLICATE KEY UPDATE
       n_completed = n_completed + 1,
       n_succeeded = n_succeeded + (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed'),
       n_failed    = n_failed + (new_state = 'Error' OR new_state = 'Failed'),
-      n_cancelled = n_cancelled + (new_state = 'Cancelled');
+      n_cancelled = n_cancelled + (new_state = 'Cancelled')
+      time_completed = GREATEST(time_completed, new_timestamp);
 
     UPDATE jobs
       LEFT JOIN `jobs_telemetry` ON `jobs_telemetry`.batch_id = jobs.batch_id AND `jobs_telemetry`.job_id = jobs.job_id

--- a/batch/sql/tokenize-job-complete-states.sql
+++ b/batch/sql/tokenize-job-complete-states.sql
@@ -1,0 +1,116 @@
+DELIMITER $$
+
+ALTER TABLE batches_n_jobs_in_complete_states ADD COLUMN token INT NOT NULL DEFAULT 0, ALGORITHM=INSTANT;
+ALTER TABLE batches_n_jobs_in_complete_states DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `token`), ALGORITHM=INPLACE, LOCK=NONE;
+
+DROP PROCEDURE IF EXISTS mark_job_complete $$
+CREATE PROCEDURE mark_job_complete(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_state VARCHAR(40),
+  IN new_status TEXT,
+  IN new_start_time BIGINT,
+  IN new_end_time BIGINT,
+  IN new_reason VARCHAR(40),
+  IN new_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE delta_cores_mcpu INT DEFAULT 0;
+  DECLARE total_jobs_in_batch INT;
+  DECLARE expected_attempt_id VARCHAR(40);
+
+  START TRANSACTION;
+
+  SELECT n_jobs INTO total_jobs_in_batch FROM batches WHERE id = in_batch_id;
+
+  SELECT state, cores_mcpu
+  INTO cur_job_state, cur_cores_mcpu
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  SELECT end_time INTO cur_end_time FROM attempts
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id
+  FOR UPDATE;
+
+  UPDATE attempts
+  SET start_time = new_start_time, rollup_time = new_end_time, end_time = new_end_time, reason = new_reason
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+  IF cur_instance_state = 'active' AND cur_end_time IS NULL THEN
+    UPDATE instances_free_cores_mcpu
+    SET free_cores_mcpu = free_cores_mcpu + cur_cores_mcpu
+    WHERE instances_free_cores_mcpu.name = in_instance_name;
+
+    SET delta_cores_mcpu = delta_cores_mcpu + cur_cores_mcpu;
+  END IF;
+
+  SELECT attempt_id INTO expected_attempt_id FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  IF expected_attempt_id IS NOT NULL AND expected_attempt_id != in_attempt_id THEN
+    COMMIT;
+    SELECT 2 as rc,
+      expected_attempt_id,
+      delta_cores_mcpu,
+      'input attempt id does not match expected attempt id' as message;
+  ELSEIF cur_job_state = 'Ready' OR cur_job_state = 'Creating' OR cur_job_state = 'Running' THEN
+    UPDATE jobs
+    SET state = new_state, status = new_status, attempt_id = in_attempt_id
+    WHERE batch_id = in_batch_id AND job_id = in_job_id;
+
+    INSERT INTO batches_n_jobs_in_complete_states (id, token, n_completed, n_succeeded, n_failed, n_cancelled)
+    VALUES (in_batch_id, rand_token,
+            1,
+            (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed'),
+            (new_state = 'Error' OR new_state = 'Failed'),
+            (new_state = 'Cancelled'))
+    ON DUPLICATE KEY UPDATE
+      n_completed = n_completed + 1,
+      n_succeeded = n_succeeded + (new_state != 'Cancelled' AND new_state != 'Error' AND new_state != 'Failed'),
+      n_failed    = n_failed + (new_state = 'Error' OR new_state = 'Failed'),
+      n_cancelled = n_cancelled + (new_state = 'Cancelled');
+
+    UPDATE jobs
+      LEFT JOIN `jobs_telemetry` ON `jobs_telemetry`.batch_id = jobs.batch_id AND `jobs_telemetry`.job_id = jobs.job_id
+      INNER JOIN `job_parents`
+        ON jobs.batch_id = `job_parents`.batch_id AND
+           jobs.job_id = `job_parents`.job_id
+      SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
+          jobs.n_pending_parents = jobs.n_pending_parents - 1,
+          jobs.cancelled = IF(new_state = 'Success', jobs.cancelled, 1),
+          jobs_telemetry.time_ready = IF(jobs.n_pending_parents = 1, new_timestamp, jobs_telemetry.time_ready)
+      WHERE jobs.batch_id = in_batch_id AND
+            `job_parents`.batch_id = in_batch_id AND
+            `job_parents`.parent_id = in_job_id;
+
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSEIF cur_job_state = 'Cancelled' OR cur_job_state = 'Error' OR
+         cur_job_state = 'Failed' OR cur_job_state = 'Success' THEN
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc,
+      cur_job_state,
+      delta_cores_mcpu,
+      'job state not Ready, Creating, Running or complete' as message;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/batch/sql/tokenize-job-complete-states.sql
+++ b/batch/sql/tokenize-job-complete-states.sql
@@ -24,10 +24,15 @@ BEGIN
   DECLARE delta_cores_mcpu INT DEFAULT 0;
   DECLARE total_jobs_in_batch INT;
   DECLARE expected_attempt_id VARCHAR(40);
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
 
   START TRANSACTION;
 
   SELECT n_jobs INTO total_jobs_in_batch FROM batches WHERE id = in_batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
   SELECT state, cores_mcpu
   INTO cur_job_state, cur_cores_mcpu

--- a/build.yaml
+++ b/build.yaml
@@ -2244,6 +2244,9 @@ steps:
       - name: cleanup-deprecated-functions
         script: /io/sql/cleanup-deprecated-functions.sql
         online: true
+      - name: tokenize-job-complete-states
+        script: /io/sql/tokenize-job-complete-states.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
This PR adds a new token and time_completed column to the `batches_n_jobs_in_complete_states` table. The reason for doing this is twofold:

1. This will get rid of the serialization in MJC where every job needs to update the same row in the `batches_n_jobs_in_complete_states` table.
2. We also push marking the batch complete to outside of the MJC stored procedure as a separate database query. The current code for marking a batch complete won't work for job groups (or at least not without a complicated query I don't know how to easily write) because the job group completion state check needs to be vectorized up the ancestors tree.

The mechanism for how this works is there is a new `mark_batch_complete` function in Python that is executed after every MJC. There's also a periodic loop that looks for batches that are complete (n_jobs == n_completed), but have not had state = "complete". This makes sure we eventually update the batch state when complete even if MJC is interrupted. The new `mark_batch_complete` function optimistically tries to update the batch state and time_completed if `n_jobs == n_complete AND state != "complete"`. If an update occurs, then the function issues a callback if specified; otherwise, it just returns. `time_completed` is tracked as a new column on the `batches_n_jobs_in_complete_states` table where we take the GREATEST timepoint when updating a row on duplicate key. Then the time_completed is just equal to the MAX of all entries in the table for that batch.

I'm still proving backwards compatibility to myself without manually copying time_completed to the `batches_n_jobs_in_complete_states` table from the `batches` table. I believe that if we have a running batch:

(A) MJC in SQL uses the new token column when inserting into `batches_n_jobs_in_complete_states`, but all new entries are always inserted at token=0 so the original SQL queries currently running on the server execute the same. However, we no longer mark the batch as complete or set the time_completed.
(B) The original server code will show the batch as not complete for batches that were running during and after the migration. So there is a delay, but it's not incorrect.
(C) The new server code deploys with the new `mark_batch_complete` code that runs periodically. Eventually the newly completed batches since the migration will get set to "complete".

Follow up: Have MJC insert rows at the random token (not hard coded to 0) to get the desired parallelism.