### PR TITLE
[auth] Fix the auth rest API for developers

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -770,7 +770,7 @@ async def userinfo(_, userdata: UserData) -> web.Response:
 
 
 async def get_session_id(request: web.Request) -> Optional[str]:
-    if 'X-Hail-Internal-Authorization' in request.headers:
+    if 'X-Hail-Internal-Authorization' in request.headers and DEFAULT_NAMESPACE == 'default':
         return maybe_parse_bearer_header(request.headers['X-Hail-Internal-Authorization'])
 
     if 'Authorization' in request.headers:


### PR DESCRIPTION
I must have broken this during a recent refactor of the decorators. When making requests to an internal namespace, the default namespace's auth token is set in the `X-Hail-Internal-Authorization` header and the dev namespace's token is in the `Authorization` header. The dev namespace needs to know *not* to pick up the `X-Hail-Internal-Authorization` header.