### PR TITLE
[batch] Name the batch worker container

### DIFF
--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -246,6 +246,7 @@ BATCH_WORKER_IMAGE_ID=$(docker inspect $BATCH_WORKER_IMAGE --format='{{{{.Id}}}}
 
 # So here I go it's my shot.
 docker run \
+--name worker \
 -e CLOUD=azure \
 -e CORES=$CORES \
 -e NAME=$NAME \

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -326,6 +326,7 @@ BATCH_WORKER_IMAGE_ID=$(docker inspect $BATCH_WORKER_IMAGE --format='{{{{.Id}}}}
 
 # So here I go it's my shot.
 docker run \
+--name worker \
 -e CLOUD=gcp \
 -e CORES=$CORES \
 -e NAME=$NAME \


### PR DESCRIPTION
Super tiny quality of life change, so one can `docker exec worker …` instead of copy/pasting the container id