### PR TITLE
[query] fix pickling of hl.Struct

### DIFF
--- a/hail/python/hail/utils/struct.py
+++ b/hail/python/hail/utils/struct.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any
 from collections import OrderedDict
 from collections.abc import Mapping
 import pprint
@@ -49,6 +50,12 @@ class Struct(Mapping):
 
     def __contains__(self, item):
         return item in self._fields
+
+    def __getstate__(self) -> Dict[str, Any]:
+        return self._fields
+
+    def __setstate__(self, state: Dict[str, Any]):
+        self.__dict__["_fields"] = state
 
     def _get_field(self, item):
         if item in self._fields:

--- a/hail/python/test/hail/utils/test_pickle.py
+++ b/hail/python/test/hail/utils/test_pickle.py
@@ -1,0 +1,33 @@
+import pickle
+import dill
+import hail as hl
+
+
+def test_simple_struct_pickle():
+    x = hl.Struct(key='group', value='adj')
+    assert x == pickle.loads(pickle.dumps(x))
+
+
+def test_simple_struct_dill():
+    x = hl.Struct(key='group', value='adj')
+    assert x == dill.loads(dill.dumps(x))
+
+
+def test_frozendict_pickle():
+    x = {hl.utils.frozendict({'abc': 123, 'def': 'hello'}): 10}
+    assert x == pickle.loads(pickle.dumps(x))
+
+
+def test_frozendict_dill():
+    x = {hl.utils.frozendict({'abc': 123, 'def': 'hello'}): 10}
+    assert x == dill.loads(dill.dumps(x))
+
+
+def test_locus_pickle():
+    x = hl.Locus('1', 123)
+    assert x == pickle.loads(pickle.dumps(x))
+
+
+def test_locus_dill():
+    x = hl.Locus('1', 123)
+    assert x == dill.loads(dill.dumps(x))


### PR DESCRIPTION
CHANGELOG: `hl.Struct` is now pickle-able.