### PR TITLE
[query] add hl.utils.table_iterator to iterate through values of a table

### DIFF
--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -14,6 +14,7 @@ from .tutorial import get_1kg, get_hgdp, get_movie_lens
 from .deduplicate import deduplicate
 from .jsonx import JSONEncoder
 from .genomic_range_table import genomic_range_table
+from .table_iterator import table_iterator
 
 __all__ = ['hadoop_open',
            'hadoop_copy',
@@ -57,4 +58,5 @@ __all__ = ['hadoop_open',
            'JSONEncoder',
            'genomic_range_table',
            'ANY_REGION',
+           'table_iterator',
            ]

--- a/hail/python/hail/utils/table_iterator.py
+++ b/hail/python/hail/utils/table_iterator.py
@@ -1,0 +1,38 @@
+from typing import Optional
+import hail as hl
+from concurrent.futures import ProcessPoolExecutor
+
+
+ht: Optional[hl.Table] = None
+
+
+def init_process(path):
+    global ht
+    assert ht is None
+    hl.init()
+    ht = hl.read_table(path)
+
+
+def read_partition(i):
+    assert ht is not None
+    return ht._filter_partitions([i]).collect()
+
+
+def n_partitions():
+    assert ht is not None
+    return ht.n_partitions()
+
+
+def table_iterator(path):
+    with ProcessPoolExecutor(max_workers=1, initializer=init_process, initargs=(path,)) as pool:
+        n_parts = pool.submit(n_partitions).result()
+        if n_parts == 0:
+            return
+
+        fut = pool.submit(read_partition, 0)
+        for i in range(0, n_parts):
+            part = fut.result()
+            if i + 1 < n_parts:
+                fut = pool.submit(read_partition, i + 1)
+            for row in part:
+                yield row

--- a/hail/python/test/hail/utils/test_table_iterator.py
+++ b/hail/python/test/hail/utils/test_table_iterator.py
@@ -1,0 +1,9 @@
+import hail as hl
+
+from ..helpers import resource
+
+
+def test_table_iterator_list_same_as_collecting_whole_table():
+    actual = list(hl.utils.table_iterator(resource('backward_compatability/1.1.0/table/0.ht')))
+    expected = hl.read_table(resource('backward_compatability/1.1.0/table/0.ht')).collect()
+    assert actual == expected


### PR DESCRIPTION
Not the fastest thing, but it makes the impossible possible.