### PR TITLE
[query] All non-spark task context use in using blocks

### DIFF
--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -128,10 +128,10 @@ class LocalBackend(
   ): Array[Array[Byte]] = {
     val stageId = nextStageId()
     collection.zipWithIndex.map { case (c, i) =>
-      val htc = new LocalTaskContext(i, stageId)
-      val bytes = f(c, htc, theHailClassLoader, fs)
-      htc.close()
-      bytes
+      using(new LocalTaskContext(i, stageId)) { htc =>
+        val bytes = f(c, htc, theHailClassLoader, fs)
+        bytes
+      }
     }
   }
 

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -160,17 +160,18 @@ object Worker {
         // FIXME: workers should not have backends, but some things do need hail contexts
         new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()), null, None))
     }
-    val htc = new ServiceTaskContext(i)
+
     var result: Array[Byte] = null
     var userError: HailException = null
-    try {
-      retryTransientErrors {
-        result = f(context, htc, theHailClassLoader, fs)
+    using(new ServiceTaskContext(i)) { htc =>
+      try {
+        retryTransientErrors {
+          result = f(context, htc, theHailClassLoader, fs)
+        }
+      } catch {
+        case err: HailException => userError = err
       }
-    } catch {
-      case err: HailException => userError = err
     }
-    htc.close()
 
     timer.end("executeFunction")
     timer.start("writeOutputs")


### PR DESCRIPTION
This will ensure proper freeing of resources, no matter what.