### PR TITLE
[docker] copy even if the tag already exists

### DIFF
--- a/docker/hailgenetics/mirror_images.sh
+++ b/docker/hailgenetics/mirror_images.sh
@@ -11,7 +11,7 @@ copy_if_not_present() {
     then
         echo "$1 does not exist yet, doing nothing"
     else
-      echo "$2 does not exist, copying $1 to $2"
+      echo "copying $1 to $2"
       copy_image $1 $2
     fi
 }

--- a/docker/hailgenetics/mirror_images.sh
+++ b/docker/hailgenetics/mirror_images.sh
@@ -10,9 +10,6 @@ copy_if_not_present() {
     if ! skopeo inspect "docker://docker.io/$1";
     then
         echo "$1 does not exist yet, doing nothing"
-    elif skopeo inspect "docker://$2";
-    then
-      echo "$2 already exists, doing nothing"
     else
       echo "$2 does not exist, copying $1 to $2"
       copy_image $1 $2


### PR DESCRIPTION
This inspect command prevents us from updating a tag, for example, if we need to replace an image with a security problem or if there is a bug like the one fixed by https://github.com/hail-is/hail/pull/13536.