### PR TITLE
[batch] fix misnamed resources

### DIFF
--- a/batch/batch/cloud/gcp/instance_config.py
+++ b/batch/batch/cloud/gcp/instance_config.py
@@ -149,8 +149,8 @@ class GCPSlimInstanceConfig(InstanceConfig):
                 GCPStaticSizedDiskResource('disk/pd-ssd/1', boot_disk_size_gb),
                 data_disk_resource,
                 GCPDynamicSizedDiskResource('disk/pd-ssd/1'),
-                GCPIPFeeResource('service-fee/1'),
-                GCPServiceFeeResource('ip-fee/1024/1'),
+                GCPServiceFeeResource('service-fee/1'),
+                GCPIPFeeResource('ip-fee/1024/1'),
             ]
         else:
             resources = [gcp_resource_from_dict(data) for data in resources]


### PR DESCRIPTION
I am having trouble determining the effect of this mistake, but it seems like we would be substantially undercharging for the serivce fee if it was really being charged by worker_fraction_in_1024ths instead of core-hours.