### PR TITLE
[query] avoid signed integer overlow in partition function

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -2504,3 +2504,12 @@ def test_query_table_interval_key():
 def test_large_number_of_partitions():
     ht = hl.utils.range_table(1500, n_partitions=1500)
     ht.collect()
+
+
+def test_range_table_biggest_int():
+    biggest_int32 = (1 << 31) - 1
+    ht = hl.utils.range_table(biggest_int32)
+
+    n = biggest_int32 - 1  # NB: range table is [0, ..., n - 1]
+    expected_sum = n * (n + 1) // 2
+    assert expected_sum == ht.aggregate(hl.agg.sum(hl.int64(ht.idx)))

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -690,7 +690,7 @@ package object utils extends Logging
 
     assert(n >= 0)
     assert(k > 0)
-    val parts = Array.tabulate(k)(i => (n - i + k - 1) / k)
+    val parts = Array.tabulate(k)(i => n / k + (i < (n % k)).toInt)
     assert(parts.sum == n)
     assert(parts.max - parts.min <= 1)
     parts
@@ -704,7 +704,7 @@ package object utils extends Logging
 
     assert(n >= 0)
     assert(k > 0)
-    val parts = Array.tabulate(k)(i => (n - i + k - 1) / k)
+    val parts = Array.tabulate(k)(i => n / k + (i < (n % k)).toLong)
     assert(parts.sum == n)
     assert(parts.max - parts.min <= 1)
     parts


### PR DESCRIPTION
Not a correctness bug because we raise an assertion error in the partition function.