### PR TITLE
[compiler, lir] don’t compute unused loop regions

### DIFF
--- a/hail/src/main/scala/is/hail/lir/SplitMethod.scala
+++ b/hail/src/main/scala/is/hail/lir/SplitMethod.scala
@@ -526,6 +526,7 @@ class SplitMethod(
         assert(r.start == r.end)
         regionSize(i) = blockSize(blockPartitions.find(r.start))
       }
+      // The PST no longer computes loop regions. See PR #13566 for the removed code.
       /*
       if (i != pst.root && pst.loopRegion.get(i)) {
         splitSlice(r.start, r.end)


### PR DESCRIPTION
Remove the code computing loop regions in lir. They aren't currently being used, and the recursive function is causing stack overflows.