### PR TITLE
[ci] Clean up temporary config for OAuth changes

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1604,22 +1604,6 @@ steps:
       - default_ns
       - create_certs
       - copy_third_party_images
-  - kind: runImage
-    name: create_dummy_oauth2_client_secret
-    resources:
-      memory: standard
-      cpu: '0.25'
-    image:
-      valueFrom: ci_utils_image.image
-    script: |
-      set -ex
-      kubectl -n {{ default_ns.name }} create secret generic auth-oauth2-client-secret || true
-    scopes:
-      - test
-      - dev
-    dependsOn:
-      - default_ns
-      - ci_utils_image
   - kind: deploy
     name: deploy_auth
     namespace:
@@ -1638,7 +1622,6 @@ steps:
       - create_session_key
       - auth_database
       - auth_image
-      - create_dummy_oauth2_client_secret
       - create_certs
       - create_accounts
   - kind: runImage
@@ -2387,25 +2370,12 @@ steps:
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
 
-      {% if global.cloud == "gcp" %}
       export GCS_REQUESTER_PAYS_PROJECT=broad-ctsa
-      {% elif global.cloud == "azure" %}
-      export HAIL_AZURE_SUBSCRIPTION_ID={{ global.azure_subscription_id }}
-      export HAIL_AZURE_RESOURCE_GROUP={{ global.azure_resource_group }}
-      export HAIL_AZURE_OAUTH_SCOPE=$(cat /oauth-secret/sp_oauth_scope)
-      {% endif %}
 
       export HAIL_SHUFFLE_MAX_BRANCH=4
       export HAIL_SHUFFLE_CUTOFF=1000000
       export HAIL_QUERY_BACKEND=batch
-      {% if global.cloud == "azure" %}
-      export HAIL_BATCH_REGIONS={{ global.azure_location }}
-      {% elif global.cloud == "gcp" %}
       export HAIL_BATCH_REGIONS={{ global.gcp_region }}
-      {% else %}
-      echo "unknown cloud {{ global.cloud }}"
-      exit 1
-      {% endif %}
       export HAIL_BATCH_BILLING_PROJECT=test
       export HAIL_BATCH_REMOTE_TMPDIR={{ global.test_storage_uri }}
 
@@ -2468,24 +2438,13 @@ steps:
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
 
-      {% if global.cloud == "gcp" %}
-      export GCS_REQUESTER_PAYS_PROJECT=broad-ctsa
-      {% elif global.cloud == "azure" %}
       export HAIL_AZURE_SUBSCRIPTION_ID={{ global.azure_subscription_id }}
       export HAIL_AZURE_RESOURCE_GROUP={{ global.azure_resource_group }}
-      {% endif %}
 
       export HAIL_SHUFFLE_MAX_BRANCH=4
       export HAIL_SHUFFLE_CUTOFF=1000000
       export HAIL_QUERY_BACKEND=batch
-      {% if global.cloud == "azure" %}
       export HAIL_BATCH_REGIONS={{ global.azure_location }}
-      {% elif global.cloud == "gcp" %}
-      export HAIL_BATCH_REGIONS={{ global.gcp_region }}
-      {% else %}
-      echo "unknown cloud {{ global.cloud }}"
-      exit 1
-      {% endif %}
       export HAIL_BATCH_BILLING_PROJECT=test
       export HAIL_BATCH_REMOTE_TMPDIR={{ global.test_storage_uri }}
 
@@ -2511,10 +2470,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
-      - name: auth-oauth2-client-secret
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /oauth-secret
     dependsOn:
       - default_ns
       - merge_code
@@ -2940,11 +2895,8 @@ steps:
       export HAIL_GENETICS_HAIL_IMAGE="{{ hailgenetics_hail_image.image }}"
 
       {% if global.cloud == "gcp" %}
-      export HAIL_IDENTITY_PROVIDER_JSON='{"idp": "Google"}'
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       {% elif global.cloud == "azure" %}
-      export HAIL_IDENTITY_PROVIDER_JSON='{"idp": "Microsoft"}'
-      export HAIL_AZURE_OAUTH_SCOPE=$(cat /oauth-secret/sp_oauth_scope)
       export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       {% else %}
       echo "unknown cloud {{ global.cloud }}"
@@ -3039,10 +2991,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
-      - name: auth-oauth2-client-secret
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /oauth-secret
     dependsOn:
       - hailgenetics_hail_image
       - upload_query_jar
@@ -3548,9 +3496,6 @@ steps:
 
       export HAIL_CLOUD={{ global.cloud }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
-      {% if global.cloud == "azure" %}
-      export HAIL_AZURE_OAUTH_SCOPE=$(cat /oauth-secret/sp_oauth_scope)
-      {% endif %}
 
       cd /io
       mkdir -p src/test
@@ -3572,10 +3517,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
-      - name: auth-oauth2-client-secret
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /oauth-secret
     timeout: 1200
     dependsOn:
       - default_ns


### PR DESCRIPTION
All this `HAIL_AZURE_OAUTH_SCOPE` and `HAIL_IDENTITY_PROVIDER_JSON` are now injected by batch workers by default so we don't need to specify them explicitly in `build.yaml`.

Unrelatedly, I don't think `create_dummy_oauth2_client_secret` does anything as `auth-oauth2-client-secret` already exists inside new namespaces.