### PR TITLE
[security] update scipy pin to 1.11.1

### DIFF
--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -395,7 +395,7 @@ pyzmq==25.1.1
     #   jupyter-console
     #   jupyter-server
     #   qtconsole
-qtconsole==5.4.3
+qtconsole==5.4.4
     # via jupyter
 qtpy==2.4.0
     # via qtconsole
@@ -421,7 +421,7 @@ rpds-py==0.10.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.0.286
+ruff==0.0.287
     # via -r hail/hail/python/dev/requirements.txt
 send2trash==1.8.2
     # via jupyter-server

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -322,7 +322,7 @@ s3transfer==0.6.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   boto3
-scipy==1.9.3
+scipy==1.11.2
     # via -r hail/hail/python/requirements.txt
 six==1.16.0
     # via

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -14,4 +14,4 @@ plotly>=5.5.0,<6
 protobuf==3.20.2
 pyspark>=3.3.0,<3.4
 requests>=2.25.1,<3
-scipy>1.2,<1.10
+scipy>1.2,<1.12


### PR DESCRIPTION
Supersedes https://github.com/hail-is/hail/pull/13228 . Resolves [CVE-2023-25399](https://nvd.nist.gov/vuln/detail/CVE-2023-25399).