### PR TITLE
[ci] Start update loop after watched branches are initialized

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -742,6 +742,8 @@ SELECT frozen_merge_deploy FROM globals;
 
     app['frozen_merge_deploy'] = row['frozen_merge_deploy']
 
+    app['task_manager'] = aiotools.BackgroundTaskManager()
+
     if DEFAULT_NAMESPACE == 'default':
         kubernetes_asyncio.config.load_incluster_config()
         k8s_client = kubernetes_asyncio.client.CoreV1Api()
@@ -764,7 +766,6 @@ SELECT frozen_merge_deploy FROM globals;
         )
     ]
 
-    app['task_manager'] = aiotools.BackgroundTaskManager()
     app['task_manager'].ensure_future(update_loop(app))
 
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -742,9 +742,6 @@ SELECT frozen_merge_deploy FROM globals;
 
     app['frozen_merge_deploy'] = row['frozen_merge_deploy']
 
-    app['task_manager'] = aiotools.BackgroundTaskManager()
-    app['task_manager'].ensure_future(update_loop(app))
-
     if DEFAULT_NAMESPACE == 'default':
         kubernetes_asyncio.config.load_incluster_config()
         k8s_client = kubernetes_asyncio.client.CoreV1Api()
@@ -766,6 +763,9 @@ SELECT frozen_merge_deploy FROM globals;
             json.loads(os.environ.get('HAIL_WATCHED_BRANCHES', '[]'))
         )
     ]
+
+    app['task_manager'] = aiotools.BackgroundTaskManager()
+    app['task_manager'].ensure_future(update_loop(app))
 
 
 async def on_cleanup(app):


### PR DESCRIPTION
#13331 moved the initialization of the `WatchedBranch`s out of the top level in `ci.py` and into the end of `on_startup`. Notice that this new location is both after `app['task_manager'].ensure_future(update_loop(app))` is run *and* after an `await`-point. It's quite likely that the first time `update_loop` is run is *before* there are any watched branches. This loop then sleeps for five minutes before it runs again. I believe this is why sometimes on startup it can take multiple minutes before CI loads PR information.