### PR TITLE
[query] unswap print_(ir / inputs)_on_worker flags

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2441,9 +2441,9 @@ class Emit[C](
               (gname, decodedGlobal)), FastIndexedSeq())
 
             if (ctx.executeContext.getFlag("print_ir_on_worker") != null)
-              cb.consoleInfo(cb.strValue(decodedContext))
-            if (ctx.executeContext.getFlag("print_inputs_on_worker") != null)
               cb.consoleInfo(Pretty(ctx.executeContext, body, elideLiterals = true))
+            if (ctx.executeContext.getFlag("print_inputs_on_worker") != null)
+              cb.consoleInfo(cb.strValue(decodedContext))
 
             val bodyResult = wrapInTuple(cb,
               region,


### PR DESCRIPTION
Implementations were swapped