### PR TITLE
[auth|batch|aiogoogle] Favor latent credentials over specifying /gsa-key/key.json in application code

### DIFF
--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -45,6 +45,8 @@ spec:
             value: "{{ default_ns.name }}"
           - name: HAIL_DEPLOY_CONFIG_FILE
             value: /deploy-config/deploy-config.json
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /gsa-key/key.json
           - name: HAIL_DOMAIN
             valueFrom:
               secretKeyRef:

--- a/batch/batch/cloud/azure/driver/driver.py
+++ b/batch/batch/cloud/azure/driver/driver.py
@@ -28,7 +28,6 @@ class AzureDriver(CloudDriver):
         machine_name_prefix: str,
         namespace: str,
         inst_coll_configs: InstanceCollectionConfigs,
-        credentials_file: str,
         task_manager: aiotools.BackgroundTaskManager,  # BORROWED
     ) -> 'AzureDriver':
         azure_config = get_azure_config()
@@ -56,12 +55,10 @@ ON DUPLICATE KEY UPDATE region = region;
         with open(os.environ['HAIL_SSH_PUBLIC_KEY'], encoding='utf-8') as f:
             ssh_public_key = f.read()
 
-        arm_client = aioazure.AzureResourceManagerClient(
-            subscription_id, resource_group, credentials_file=credentials_file
-        )
-        compute_client = aioazure.AzureComputeClient(subscription_id, resource_group, credentials_file=credentials_file)
-        resources_client = aioazure.AzureResourcesClient(subscription_id, credentials_file=credentials_file)
-        network_client = aioazure.AzureNetworkClient(subscription_id, resource_group, credentials_file=credentials_file)
+        arm_client = aioazure.AzureResourceManagerClient(subscription_id, resource_group)
+        compute_client = aioazure.AzureComputeClient(subscription_id, resource_group)
+        resources_client = aioazure.AzureResourcesClient(subscription_id)
+        network_client = aioazure.AzureNetworkClient(subscription_id, resource_group)
         pricing_client = aioazure.AzurePricingClient()
 
         region_monitor = await RegionMonitor.create(region)

--- a/batch/batch/cloud/driver.py
+++ b/batch/batch/cloud/driver.py
@@ -14,17 +14,12 @@ async def get_cloud_driver(
     machine_name_prefix: str,
     namespace: str,
     inst_coll_configs: InstanceCollectionConfigs,
-    credentials_file: str,
     task_manager: aiotools.BackgroundTaskManager,
 ) -> CloudDriver:
     cloud = get_global_config()['cloud']
 
     if cloud == 'azure':
-        return await AzureDriver.create(
-            app, db, machine_name_prefix, namespace, inst_coll_configs, credentials_file, task_manager
-        )
+        return await AzureDriver.create(app, db, machine_name_prefix, namespace, inst_coll_configs, task_manager)
 
     assert cloud == 'gcp', cloud
-    return await GCPDriver.create(
-        app, db, machine_name_prefix, namespace, inst_coll_configs, credentials_file, task_manager
-    )
+    return await GCPDriver.create(app, db, machine_name_prefix, namespace, inst_coll_configs, task_manager)

--- a/batch/batch/cloud/gcp/driver/billing_manager.py
+++ b/batch/batch/cloud/gcp/driver/billing_manager.py
@@ -12,8 +12,8 @@ log = logging.getLogger('billing_manager')
 
 class GCPBillingManager(CloudBillingManager):
     @staticmethod
-    async def create(db: Database, credentials_file: str, regions: List[str]):
-        billing_client = aiogoogle.GoogleBillingClient(credentials_file=credentials_file)
+    async def create(db: Database, regions: List[str]):
+        billing_client = aiogoogle.GoogleBillingClient()
         product_versions_dict = await refresh_product_versions_from_db(db)
         bm = GCPBillingManager(db, product_versions_dict, billing_client, regions)
         await bm.refresh_resources()

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -242,22 +242,6 @@ async def delete_batch(request):
     return web.Response()
 
 
-# deprecated
-async def get_gsa_key_1(instance):
-    log.info(f'returning gsa-key to activating instance {instance}')
-    with open('/gsa-key/key.json', 'r', encoding='utf-8') as f:
-        key = json.loads(f.read())
-    return json_response({'key': key})
-
-
-async def get_credentials_1(instance):
-    log.info(f'returning {instance.inst_coll.cloud} credentials to activating instance {instance}')
-    credentials_file = '/gsa-key/key.json'
-    with open(credentials_file, 'r', encoding='utf-8') as f:
-        key = json.loads(f.read())
-    return json_response({'key': key})
-
-
 async def activate_instance_1(request, instance):
     body = await json_request(request)
     ip_address = body['ip_address']
@@ -268,20 +252,6 @@ async def activate_instance_1(request, instance):
     await instance.mark_healthy()
 
     return json_response({'token': token})
-
-
-# deprecated
-@routes.get('/api/v1alpha/instances/gsa_key')
-@activating_instances_only
-async def get_gsa_key(_, instance: Instance) -> web.Response:
-    return await asyncio.shield(get_gsa_key_1(instance))
-
-
-# deprecated
-@routes.get('/api/v1alpha/instances/credentials')
-@activating_instances_only
-async def get_credentials(_, instance: Instance) -> web.Response:
-    return await asyncio.shield(get_credentials_1(instance))
 
 
 @routes.post('/api/v1alpha/instances/activate')
@@ -1624,9 +1594,8 @@ SELECT instance_id, internal_token, frozen FROM globals;
 
     inst_coll_configs = await InstanceCollectionConfigs.create(db)
 
-    credentials_file = '/gsa-key/key.json'
     app['driver'] = await get_cloud_driver(
-        app, db, MACHINE_NAME_PREFIX, DEFAULT_NAMESPACE, inst_coll_configs, credentials_file, task_manager
+        app, db, MACHINE_NAME_PREFIX, DEFAULT_NAMESPACE, inst_coll_configs, task_manager
     )
 
     app['canceller'] = await Canceller.create(app)

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -403,6 +403,8 @@ spec:
              secretKeyRef:
                name: global-config
                key: internal_ip
+         - name: GOOGLE_APPLICATION_CREDENTIALS
+           value: /gsa-key/key.json
          - name: HAIL_SHA
            value: "{{ code.sha }}"
 {% if scope != "test" %}

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -175,6 +175,8 @@ spec:
         env:
          - name: PORT
            value: "5000"
+         - name: GOOGLE_APPLICATION_CREDENTIALS
+           value: /gsa-key/key.json
          - name: HAIL_DOMAIN
            valueFrom:
              secretKeyRef:

--- a/build.yaml
+++ b/build.yaml
@@ -536,6 +536,8 @@ steps:
       set -ex
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_SCOPE={{ scope }}
+      export GOOGLE_APPLICATION_CREDENTIALS=/auth-gsa-key/key.json
+
       python3 /io/bootstrap_create_accounts.py
     serviceAccount:
       name: admin

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -96,7 +96,7 @@ async def main():
     try:
         app['k8s_client'] = k8s_client
 
-        app['identity_client'] = get_identity_client(credentials_file='/auth-gsa-key/key.json')
+        app['identity_client'] = get_identity_client()
 
         for username, login_id, is_developer, is_service_account in users:
             user_id = await insert_user_if_not_exists(app, username, login_id, is_developer, is_service_account)

--- a/datasets/extract/extract_CADD.py
+++ b/datasets/extract/extract_CADD.py
@@ -24,7 +24,7 @@ for build in ["GRCh37", "GRCh38"]:
 
     j = batch.new_job(name=f"{name}_{version}_{build}")
     j.image("gcr.io/broad-ctsa/datasets:050521")
-    j.command("gcloud -q auth activate-service-account --key-file=/gsa-key/key.json")
+    j.command("gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS")
     j.command(f"wget -c -O - {snvs_url} {indels_url} | "
               "zcat | "
               "grep -v '^#' | "

--- a/datasets/extract/extract_dbSNP.py
+++ b/datasets/extract/extract_dbSNP.py
@@ -20,7 +20,7 @@ for build in ["GRCh37", "GRCh38"]:
     version = builds[build]["version"]
     j = batch.new_job(name=f"{name}_{version}_{build}")
     j.image("gcr.io/broad-ctsa/datasets:050521")
-    j.command("gcloud -q auth activate-service-account --key-file=/gsa-key/key.json")
+    j.command("gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS")
     j.command(f"wget -c -O - {vcf} | "
               "zcat | "
               "bgzip -c | "

--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,35 +1,27 @@
-from typing import Optional
-
 from gear.cloud_config import get_gcp_config, get_global_config
 from hailtop.aiocloud import aioazure, aiogoogle
 from hailtop.aiotools.fs import AsyncFS, AsyncFSFactory
 
 
-def get_identity_client(credentials_file: Optional[str] = None):
-    if credentials_file is None:
-        credentials_file = '/gsa-key/key.json'
-
+def get_identity_client():
     cloud = get_global_config()['cloud']
 
     if cloud == 'azure':
-        return aioazure.AzureGraphClient(credentials_file=credentials_file)
+        return aioazure.AzureGraphClient()
 
     assert cloud == 'gcp', cloud
     project = get_gcp_config().project
-    return aiogoogle.GoogleIAmClient(project, credentials_file=credentials_file)
+    return aiogoogle.GoogleIAmClient(project)
 
 
-def get_cloud_async_fs(credentials_file: Optional[str] = None) -> AsyncFS:
-    if credentials_file is None:
-        credentials_file = '/gsa-key/key.json'
-
+def get_cloud_async_fs() -> AsyncFS:
     cloud = get_global_config()['cloud']
 
     if cloud == 'azure':
-        return aioazure.AzureAsyncFS(credential_file=credentials_file)
+        return aioazure.AzureAsyncFS()
 
     assert cloud == 'gcp', cloud
-    return aiogoogle.GoogleStorageAsyncFS(credentials_file=credentials_file)
+    return aiogoogle.GoogleStorageAsyncFS()
 
 
 def get_cloud_async_fs_factory() -> AsyncFSFactory:

--- a/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
@@ -7,7 +7,7 @@ import socket
 from urllib.parse import urlencode
 import jwt
 
-from hailtop.utils import retry_transient_errors
+from hailtop.utils import first_extant_file, retry_transient_errors
 from hailtop import httpx
 from ..common.credentials import AnonymousCloudCredentials, CloudCredentials
 
@@ -79,13 +79,10 @@ class GoogleCredentials(CloudCredentials):
 
     @staticmethod
     def default_credentials(scopes: Optional[List[str]] = None, *, anonymous_ok: bool = True) -> Union['GoogleCredentials', AnonymousCloudCredentials]:
-        credentials_file = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
-
-        if credentials_file is None:
-            if "HOME" in os.environ:
-                application_default_credentials_file = f'{os.environ["HOME"]}/.config/gcloud/application_default_credentials.json'
-                if os.path.exists(application_default_credentials_file):
-                    credentials_file = application_default_credentials_file
+        credentials_file = first_extant_file(
+            os.environ.get('GOOGLE_APPLICATION_CREDENTIALS'),
+            f'{os.environ["HOME"]}/.config/gcloud/application_default_credentials.json' if 'HOME' in os.environ else None,
+        )
 
         if credentials_file:
             creds = GoogleCredentials.from_file(credentials_file, scopes=scopes)

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -91,13 +91,14 @@ has the following prefix `us-docker.pkg.dev/<MY_PROJECT>`:
     gcloud artifacts repositories add-iam-policy-binding <REPO> \
            --member=<SERVICE_ACCOUNT_NAME> --role=roles/artifactregistry.repoAdmin
 
-If you want to run gcloud commands within your Batch jobs, the service account file is available at
-`/gsa-key/key.json` in the main container. You can authenticate using the service account by adding
+If you want to run gcloud commands within your Batch jobs, the service account file is available in
+the main container with its path specified in the `$GOOGLE_APPLICATION_CREDENTIALS` environment
+variable. You can authenticate using the service account by adding
 the following line to your user code and using a Docker image that has gcloud installed.
 
 .. code-block:: sh
 
-    gcloud -q auth activate-service-account --key-file=/gsa-key/key.json
+    gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
 
 Billing


### PR DESCRIPTION
This is mostly cleanup reducing the amount of the codebase that depends on GSA key files (which are not available in terra or a future keyless hail-vdc). The core bit is instead of threading `credentials_file="/gsa-key/key.json` through the batch and auth codebase we set `GOOGLE_APPLICATION_CREDENTIALS` in their deployments. I can't think of a scenario where `auth` or `batch` would need to use multiple identities so better to remove their ability to do so and always use the default credentials.

I also did a bit of tidying up, using `$GOOGLE_APPLICATION_CREDENTIALS` instead of the hard-coded path and removing the credentials endpoints on the batch-driver which have been unused by workers for many months now.