### PR TITLE
[hailtop] Properly close HailCredentials

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -750,7 +750,8 @@ SELECT frozen_merge_deploy FROM globals;
         app['task_manager'].ensure_future(periodically_call(10, update_envoy_configs, app['db'], k8s_client))
         app['task_manager'].ensure_future(periodically_call(10, cleanup_expired_namespaces, app['db']))
 
-    headers = await hail_credentials().auth_headers()
+    async with hail_credentials() as creds:
+        headers = await creds.auth_headers()
     users = await retry_transient_errors(
         client_session.get_read_json,
         deploy_config.url('auth', '/api/v1alpha/users'),

--- a/hail/python/hailtop/hailctl/dev/ci_client.py
+++ b/hail/python/hailtop/hailctl/dev/ci_client.py
@@ -17,7 +17,8 @@ class CIClient:
         self._session: Optional[httpx.ClientSession] = None
 
     async def __aenter__(self):
-        headers = await hail_credentials().auth_headers()
+        async with hail_credentials() as credentials:
+            headers = await credentials.auth_headers()
         self._session = client_session(
             raise_for_status=False, timeout=aiohttp.ClientTimeout(total=60), headers=headers
         )  # type: ignore


### PR DESCRIPTION
If you dev deploy right now you'll likely see warnings like this:

```
(hail) dgoldste@wmce3-cb7 hail % hailctl dev deploy -b hail-is/hail:main -s merge_code
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fb64d58f1f0>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7fb64d5a1520>, 1.908669784)]']
connector: <aiohttp.connector.TCPConnector object at 0x7fb64d579040>
Created deploy batch, see https://ci.hail.is/batches/7992015
(hail) dgoldste@wmce3-cb7 hail %
```

`HailCredentials` recently changed such that now they contain resources (GCP or Azure credentials) that require closing, so `hail_credentials()` needs to be used as a context manager or you get those unclosed errors on exit.