### PR TITLE
[batch] Add SKU to latest_product_versions

### DIFF
--- a/batch/batch/cloud/azure/driver/billing_manager.py
+++ b/batch/batch/cloud/azure/driver/billing_manager.py
@@ -5,7 +5,12 @@ from typing import Dict, List
 from gear import Database
 from hailtop.aiocloud import aioazure
 
-from ....driver.billing_manager import CloudBillingManager, ProductVersions, refresh_product_versions_from_db
+from ....driver.billing_manager import (
+    CloudBillingManager,
+    ProductVersionInfo,
+    ProductVersions,
+    refresh_product_versions_from_db,
+)
 from .pricing import AzureVMPrice, fetch_prices
 
 log = logging.getLogger('billing_manager')
@@ -32,7 +37,7 @@ class AzureBillingManager(CloudBillingManager):
         db: Database,
         pricing_client: aioazure.AzurePricingClient,
         regions: List[str],
-        product_versions_dict: dict,
+        product_versions_dict: Dict[str, ProductVersionInfo],
     ):
         self.db = db
         self.product_versions = ProductVersions(product_versions_dict)

--- a/batch/batch/cloud/azure/driver/pricing.py
+++ b/batch/batch/cloud/azure/driver/pricing.py
@@ -26,13 +26,12 @@ class AzureVMPrice(Price):
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
+        super().__init__(
+            region=region, effective_start_date=effective_start_date, effective_end_date=effective_end_date, sku=sku
+        )
         self.machine_type = machine_type
         self.preemptible = preemptible
-        self.region = region
         self.cost_per_hour = cost_per_hour
-        self.sku = sku
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
 
     @property
     def product(self):
@@ -55,14 +54,13 @@ class AzureDiskPrice(Price):
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
+        super().__init__(
+            region=region, effective_start_date=effective_start_date, effective_end_date=effective_end_date, sku=sku
+        )
         self.disk_name = disk_name
         self.redundancy_type = redundancy_type
         self.size_gib = size_gib
-        self.region = region
         self.cost_per_month = cost_per_month
-        self.sku = sku
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
 
     @property
     def cost_per_gib_month(self):

--- a/batch/batch/cloud/gcp/driver/billing_manager.py
+++ b/batch/batch/cloud/gcp/driver/billing_manager.py
@@ -4,7 +4,12 @@ from typing import Dict, List
 from gear import Database
 from hailtop.aiocloud import aiogoogle
 
-from ....driver.billing_manager import CloudBillingManager, ProductVersions, refresh_product_versions_from_db
+from ....driver.billing_manager import (
+    CloudBillingManager,
+    ProductVersionInfo,
+    ProductVersions,
+    refresh_product_versions_from_db,
+)
 from .pricing import fetch_prices
 
 log = logging.getLogger('billing_manager')
@@ -23,7 +28,7 @@ class GCPBillingManager(CloudBillingManager):
     def __init__(
         self,
         db: Database,
-        product_versions_dict: Dict[str, str],
+        product_versions_dict: Dict[str, ProductVersionInfo],
         billing_client: aiogoogle.GoogleBillingClient,
         regions: List[str],
     ):

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -30,6 +30,7 @@ class GCPComputePrice(Price):
         preemptible: bool,
         region: str,
         cost_per_hour: float,
+        sku: str,
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
@@ -37,6 +38,7 @@ class GCPComputePrice(Price):
         self.preemptible = preemptible
         self.region = region
         self.cost_per_hour = cost_per_hour
+        self.sku = sku
         self.effective_start_date = effective_start_date
         self.effective_end_date = effective_end_date
 
@@ -82,6 +84,7 @@ class GCPMemoryPrice(Price):
         preemptible: bool,
         region: str,
         cost_per_hour: float,
+        sku: str,
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
@@ -89,6 +92,7 @@ class GCPMemoryPrice(Price):
         self.preemptible = preemptible
         self.region = region
         self.cost_per_hour = cost_per_hour
+        self.sku = sku
         self.effective_start_date = effective_start_date
         self.effective_end_date = effective_end_date
 
@@ -107,12 +111,14 @@ class GCPLocalSSDDiskPrice(Price):
         preemptible: bool,
         region: str,
         cost_per_month: float,
+        sku: str,
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
         self.preemptible = preemptible
         self.region = region
         self.cost_per_month = cost_per_month
+        self.sku = sku
         self.effective_start_date = effective_start_date
         self.effective_end_date = effective_end_date
 
@@ -135,12 +141,14 @@ class GCPDiskPrice(Price):
         disk_type: str,
         region: str,
         cost_per_month: float,
+        sku: str,
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
         self.disk_type = disk_type
         self.region = region
         self.cost_per_month = cost_per_month
+        self.sku = sku
         self.effective_start_date = effective_start_date
         self.effective_end_date = effective_end_date
 
@@ -225,7 +233,9 @@ def process_compute_sku(sku: dict, regions: List[str]) -> List[GCPComputePrice]:
     for service_region in service_regions:
         if service_region in regions:
             compute_prices.append(
-                GCPComputePrice(instance_family, preemptible, service_region, cost_per_hour, effective_start_date)
+                GCPComputePrice(
+                    instance_family, preemptible, service_region, cost_per_hour, sku['skuId'], effective_start_date
+                )
             )
     return compute_prices
 
@@ -289,7 +299,9 @@ def process_memory_sku(sku: dict, regions: List[str]) -> List[GCPMemoryPrice]:
     for service_region in service_regions:
         if service_region in regions:
             memory_prices.append(
-                GCPMemoryPrice(instance_family, preemptible, service_region, cost_per_hour, effective_start_date)
+                GCPMemoryPrice(
+                    instance_family, preemptible, service_region, cost_per_hour, sku['skuId'], effective_start_date
+                )
             )
     return memory_prices
 
@@ -316,7 +328,7 @@ def process_local_ssd_sku(sku: dict, regions: List[str]) -> List[GCPLocalSSDDisk
     for service_region in service_regions:
         if service_region in regions:
             local_ssd_prices.append(
-                GCPLocalSSDDiskPrice(preemptible, service_region, cost_per_month, effective_start_date)
+                GCPLocalSSDDiskPrice(preemptible, service_region, cost_per_month, sku['skuId'], effective_start_date)
             )
     return local_ssd_prices
 
@@ -340,7 +352,9 @@ def process_disk_sku(sku: dict, regions: List[str]) -> List[GCPDiskPrice]:
     service_regions = sku['serviceRegions']
     for service_region in service_regions:
         if service_region in regions:
-            disk_prices.append(GCPDiskPrice('pd-ssd', service_region, cost_per_month, effective_start_date))
+            disk_prices.append(
+                GCPDiskPrice('pd-ssd', service_region, cost_per_month, sku['skuId'], effective_start_date)
+            )
     return disk_prices
 
 

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -34,13 +34,12 @@ class GCPComputePrice(Price):
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
+        super().__init__(
+            region=region, effective_start_date=effective_start_date, effective_end_date=effective_end_date, sku=sku
+        )
         self.instance_family = instance_family
         self.preemptible = preemptible
-        self.region = region
         self.cost_per_hour = cost_per_hour
-        self.sku = sku
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
 
     @property
     def product(self):
@@ -62,13 +61,12 @@ class GCPAcceleratorPrice(Price):
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
+        super().__init__(
+            region=region, effective_start_date=effective_start_date, effective_end_date=effective_end_date, sku=sku
+        )
         self.accelerator_family = accelerator_family
         self.preemptible = preemptible
-        self.region = region
         self.cost_per_hour = cost_per_hour
-        self.sku = sku
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
 
     @property
     def product(self):
@@ -90,13 +88,12 @@ class GCPMemoryPrice(Price):
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
+        super().__init__(
+            region=region, effective_start_date=effective_start_date, effective_end_date=effective_end_date, sku=sku
+        )
         self.instance_family = instance_family
         self.preemptible = preemptible
-        self.region = region
         self.cost_per_hour = cost_per_hour
-        self.sku = sku
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
 
     @property
     def product(self):
@@ -117,12 +114,11 @@ class GCPLocalSSDDiskPrice(Price):
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
+        super().__init__(
+            region=region, effective_start_date=effective_start_date, effective_end_date=effective_end_date, sku=sku
+        )
         self.preemptible = preemptible
-        self.region = region
         self.cost_per_month = cost_per_month
-        self.sku = sku
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
 
     @property
     def cost_per_gib_month(self):
@@ -147,12 +143,11 @@ class GCPDiskPrice(Price):
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
+        super().__init__(
+            region=region, effective_start_date=effective_start_date, effective_end_date=effective_end_date, sku=sku
+        )
         self.disk_type = disk_type
-        self.region = region
         self.cost_per_month = cost_per_month
-        self.sku = sku
-        self.effective_start_date = effective_start_date
-        self.effective_end_date = effective_end_date
 
     @property
     def cost_per_gib_month(self):

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -58,6 +58,7 @@ class GCPAcceleratorPrice(Price):
         preemptible: bool,
         region: str,
         cost_per_hour: float,
+        sku: str,
         effective_start_date: int,
         effective_end_date: Optional[int] = None,
     ):
@@ -65,6 +66,7 @@ class GCPAcceleratorPrice(Price):
         self.preemptible = preemptible
         self.region = region
         self.cost_per_hour = cost_per_hour
+        self.sku = sku
         self.effective_start_date = effective_start_date
         self.effective_end_date = effective_end_date
 
@@ -269,7 +271,7 @@ def process_accelerator_sku(sku: dict, regions: List[str]) -> List[GCPAccelerato
         if service_region in regions:
             compute_prices.append(
                 GCPAcceleratorPrice(
-                    accelerator_family, preemptible, service_region, cost_per_hour, effective_start_date
+                    accelerator_family, preemptible, service_region, cost_per_hour, sku['skuId'], effective_start_date
                 )
             )
     return compute_prices

--- a/batch/batch/driver/billing_manager.py
+++ b/batch/batch/driver/billing_manager.py
@@ -66,7 +66,9 @@ class ProductVersions:
         for product, new_product_info in new_data.items():
             if product not in self._product_versions:
                 valid_updates[product] = new_product_info
-                log.info(f'added product {product} with version {new_product_info.latest_version} and sku {new_product_info.sku}')
+                log.info(
+                    f'added product {product} with version {new_product_info.latest_version} and sku {new_product_info.sku}'
+                )
 
         self._product_versions.update(valid_updates)
 

--- a/batch/batch/driver/billing_manager.py
+++ b/batch/batch/driver/billing_manager.py
@@ -1,5 +1,6 @@
 import abc
 import logging
+from collections import namedtuple
 from typing import Dict, List, Optional
 
 from gear import Database, transaction
@@ -9,40 +10,58 @@ from .pricing import Price
 log = logging.getLogger('billing_manager')
 
 
+ProductVersionInfo = namedtuple('ProductVersionInfo', ['latest_version', 'sku'])
+
+
 def product_version_to_resource(product: str, version: str) -> str:
     return f'{product}/{version}'
 
 
 class ProductVersions:
-    def __init__(self, data: Dict[str, str]):
-        self._product_versions = data
+    def __init__(self, data: Dict[str, ProductVersionInfo]):
+        self._data = data
 
     def latest_version(self, product: str) -> Optional[str]:
-        return self._product_versions.get(product)
+        info = self._data.get(product)
+        if info:
+            return info.latest_version
+        return None
+
+    def sku(self, product: str) -> Optional[str]:
+        info = self._data.get(product)
+        if info:
+            return info.sku
+        return None
 
     def resource_name(self, product: str) -> Optional[str]:
         version = self.latest_version(product)
-        assert version is not None, (product, str(self._product_versions))
+        assert version is not None, (product, str(self._data))
         return product_version_to_resource(product, version)
 
-    def update(self, data: Dict[str, str]):
-        for product, old_version in self._product_versions.items():
-            new_version = data.get(product)
-            if new_version is None:
+    def update(self, data: Dict[str, ProductVersionInfo]):
+        for product, (old_version, old_sku) in self._data.items():
+            product_info = data.get(product)
+
+            if product_info is None:
                 log.error(f'product {product} does not appear in new data; keeping in existing latest_product_versions')
+                continue
+
+            new_version, new_sku = product_info
+
+            if old_sku is not None and old_sku != new_sku:
+                log.error(
+                    f'product {product} does not have the same SKU as is currently in the database ({old_sku}, {new_sku})'
+                )
                 continue
 
             if new_version != old_version:
                 log.info(f'updated product version for {product} from {old_version} to {new_version}')
 
-        for product, new_version in data.items():
-            if product not in self._product_versions:
-                log.info(f'added product {product} with version {new_version}')
+        for product, (new_version, new_sku) in data.items():
+            if product not in self._data:
+                log.info(f'added product {product} with version {new_version} and sku {new_sku}')
 
-        self._product_versions.update(data)
-
-    def to_dict(self) -> Dict[str, str]:
-        return self._product_versions
+        self._data.update(data)
 
 
 class CloudBillingManager(abc.ABC):
@@ -59,17 +78,19 @@ class CloudBillingManager(abc.ABC):
             product = price.product
             latest_product_version = price.version
             latest_resource_rate = price.rate
+            latest_sku = price.sku
 
             current_product_version = self.product_versions.latest_version(product)
+            current_sku = self.product_versions.sku(product)
 
             is_new_product = current_product_version is None
 
             if is_new_product:
                 resource_name = product_version_to_resource(product, latest_product_version)
                 resource_updates.append((resource_name, latest_resource_rate))
-                product_version_updates.append((product, latest_product_version))
+                product_version_updates.append((product, latest_product_version, latest_sku))
                 log.info(
-                    f'adding new resource {resource_name} {latest_product_version} with rate change of {latest_resource_rate}'
+                    f'adding new resource {resource_name} {latest_product_version} with rate change of {latest_resource_rate} and sku {latest_sku}'
                 )
             else:
                 assert current_product_version
@@ -78,6 +99,14 @@ class CloudBillingManager(abc.ABC):
 
                 have_latest_version = current_product_version == latest_product_version
                 have_latest_rate = current_resource_rate == latest_resource_rate
+                have_latest_sku = current_sku is None or current_sku == latest_sku
+
+                if not have_latest_sku:
+                    log.error(
+                        f'the new sku for product {product} does not match the current sku in the database for '
+                        f'version {current_product_version}: {current_sku} vs {latest_sku}; '
+                        f'did the sku change without a product change?'
+                    )
 
                 if have_latest_version and not have_latest_rate:
                     log.error(
@@ -95,10 +124,10 @@ class CloudBillingManager(abc.ABC):
                     if price.is_current_price():
                         latest_resource_name = product_version_to_resource(product, latest_product_version)
                         resource_updates.append((latest_resource_name, latest_resource_rate))
-                        product_version_updates.append((product, latest_product_version))
+                        product_version_updates.append((product, latest_product_version, latest_sku))
                         log.info(
                             f'product {product} changed from {current_product_version} to {latest_product_version} with rate change of '
-                            f'({current_resource_rate}) => ({latest_resource_rate})'
+                            f'({current_resource_rate}) => ({latest_resource_rate}) and sku {latest_sku}'
                         )
                     else:
                         log.error(
@@ -107,8 +136,8 @@ class CloudBillingManager(abc.ABC):
                         )
                 else:
                     assert (
-                        have_latest_version and have_latest_rate
-                    ), f'{current_product_version} {latest_product_version} {current_resource_rate} {latest_resource_rate}'
+                        have_latest_version and have_latest_rate and have_latest_sku
+                    ), f'{current_product_version} {latest_product_version} {current_resource_rate} {latest_resource_rate} {latest_sku}'
 
         @transaction(self.db)
         async def insert_or_update(tx):
@@ -142,8 +171,8 @@ WHERE resource_id > %s AND deduped_resource_id IS NULL
             if product_version_updates:
                 await tx.execute_many(
                     '''
-INSERT INTO `latest_product_versions` (product, version)
-VALUES (%s, %s)
+INSERT INTO `latest_product_versions` (product, version, sku)
+VALUES (%s, %s, %s)
 ON DUPLICATE KEY UPDATE version = VALUES(version)
 ''',
                     product_version_updates,
@@ -167,9 +196,12 @@ ON DUPLICATE KEY UPDATE version = VALUES(version)
         await refresh()
 
 
-async def refresh_product_versions_from_db(db: Database) -> Dict[str, str]:
-    records = db.execute_and_fetchall('SELECT product, version FROM latest_product_versions')
-    return {record['product']: record['version'] async for record in records}
+async def refresh_product_versions_from_db(db: Database) -> Dict[str, ProductVersionInfo]:
+    records = db.execute_and_fetchall('SELECT product, version, sku FROM latest_product_versions')
+    return {
+        record['product']: ProductVersionInfo(latest_version=record['version'], sku=record['sku'])
+        async for record in records
+    }
 
 
 async def refresh_resource_rates_from_db(db: Database) -> Dict[str, float]:

--- a/batch/batch/driver/pricing.py
+++ b/batch/batch/driver/pricing.py
@@ -5,11 +5,11 @@ from hailtop.utils import time_msecs
 
 
 class Price(abc.ABC):
-    region: str
-    effective_start_date: int
-    effective_end_date: Optional[int]
-    time_updated: int
-    sku: str
+    def __init__(self, *, region: str, effective_start_date: int, effective_end_date: Optional[int], sku: str):
+        self.region = region
+        self.effective_start_date = effective_start_date
+        self.effective_end_date = effective_end_date
+        self.sku = sku
 
     def is_current_price(self):
         now = time_msecs()
@@ -20,9 +20,11 @@ class Price(abc.ABC):
         return str(self.effective_start_date)
 
     @property
-    def product(self):
-        raise NotImplementedError
+    @abc.abstractmethod
+    def product(self) -> str:
+        pass
 
     @property
-    def rate(self):
-        raise NotImplementedError
+    @abc.abstractmethod
+    def rate(self) -> float:
+        pass

--- a/batch/batch/driver/pricing.py
+++ b/batch/batch/driver/pricing.py
@@ -9,6 +9,7 @@ class Price(abc.ABC):
     effective_start_date: int
     effective_end_date: Optional[int]
     time_updated: int
+    sku: str
 
     def is_current_price(self):
         now = time_msecs()

--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -18,7 +18,7 @@ from .cloud.resource_utils import (
     valid_machine_types,
 )
 from .cloud.utils import possible_cloud_locations
-from .driver.billing_manager import ProductVersions
+from .driver.billing_manager import ProductVersionInfo, ProductVersions
 from .instance_config import InstanceConfig
 
 log = logging.getLogger('inst_coll_config')
@@ -291,9 +291,9 @@ LEFT JOIN pools ON inst_colls.name = pools.name;
         }
 
     @staticmethod
-    async def product_versions_from_db(db: Database) -> Dict[str, str]:
+    async def product_versions_from_db(db: Database) -> Dict[str, ProductVersionInfo]:
         return {
-            record['product']: record['version']
+            record['product']: ProductVersionInfo(latest_version=record['version'], sku=record['sku'])
             async for record in db.execute_and_fetchall('SELECT * FROM latest_product_versions;')
         }
 
@@ -302,7 +302,7 @@ LEFT JOIN pools ON inst_colls.name = pools.name;
         name_pool_config: Dict[str, PoolConfig],
         jpim_config: JobPrivateInstanceManagerConfig,
         resource_rates: Dict[str, float],
-        product_versions_data: Dict[str, str],
+        product_versions_data: Dict[str, ProductVersionInfo],
     ):
         self.name_pool_config = name_pool_config
         self.jpim_config = jpim_config

--- a/batch/sql/add-product-sku.sql
+++ b/batch/sql/add-product-sku.sql
@@ -1,0 +1,1 @@
+ALTER TABLE latest_product_versions ADD COLUMN sku VARCHAR(100), ALGORITHM=INSTANT;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -22,6 +22,7 @@ CREATE INDEX `resources_deduped_resource_id` ON `resources` (`deduped_resource_i
 CREATE TABLE IF NOT EXISTS `latest_product_versions` (
   `product` VARCHAR(100) NOT NULL,
   `version` VARCHAR(100) NOT NULL,
+  `sku` VARCHAR(100),
   `time_updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`product`)
 ) ENGINE = InnoDB;

--- a/build.yaml
+++ b/build.yaml
@@ -2295,6 +2295,9 @@ steps:
       - name: add-gcp-support-logs-specs-and-firewall-fees
         script: /io/sql/add-gcp-support-logs-specs-and-firewall-fees.py
         online: true
+      - name: add-product-sku
+        script: /io/sql/add-product-sku.sql
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
This change is to ensure that the SKU we think is associated with a product doesn't change in case the human readable name changes to a different SKU. This was raised as a good safety feature by #13430 