### PR TITLE
[query] add less biased unsmoothed pdf to ggplot

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -165,7 +165,10 @@ def _error_from_cdf_python(cdf, failure_prob, all_quantiles=False):
     def compute_single_error(s, failure_prob=failure_prob):
         return math.sqrt(math.log(2 / failure_prob) * s / 2)
 
-    if all_quantiles:
+    if s == 0:
+        # no compactions ergo no error
+        return 0
+    elif all_quantiles:
         p = compute_grid_size(s)
         return 1 / p + compute_single_error(s, failure_prob / p)
     else:

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -128,6 +128,50 @@ def _error_from_cdf(cdf, failure_prob, all_quantiles=False):
         return hl.rbind(cdf, lambda cdf: hl.rbind(compute_sum(cdf), compute_single_error))
 
 
+def _error_from_cdf_python(cdf, failure_prob, all_quantiles=False):
+    """Estimates error of approx_cdf aggregator, using Hoeffding's inequality.
+
+    Parameters
+    ----------
+    cdf : :obj:`dict`
+        Result of :func:`.approx_cdf` aggregator, evaluated to a python dict
+    failure_prob: :obj:`float`
+        Upper bound on probability of true error being greater than estimated error.
+    all_quantiles: :obj:`bool`
+        If ``True``, with probability 1 - `failure_prob`, error estimate applies
+        to all quantiles simultaneously.
+
+    Returns
+    -------
+    :obj:`float`
+        Upper bound on error of quantile estimates.
+    """
+    import math
+
+    s = 0
+    for i in builtins.range(builtins.len(cdf._compaction_counts)):
+        s += cdf._compaction_counts[i] << (2 * i)
+    s = s / (cdf.ranks[-1] ** 2)
+
+    def update_grid_size(p):
+        return 4 * math.sqrt(math.log(2 * p / failure_prob) / (2 * s))
+
+    def compute_grid_size(s):
+        p = 1 / failure_prob
+        for _ in builtins.range(5):
+            p = update_grid_size(p)
+        return p
+
+    def compute_single_error(s, failure_prob=failure_prob):
+        return math.sqrt(math.log(2 / failure_prob) * s / 2)
+
+    if all_quantiles:
+        p = compute_grid_size(s)
+        return 1 / p + compute_single_error(s, failure_prob / p)
+    else:
+        return compute_single_error(s, failure_prob)
+
+
 @typecheck(t=hail_type)
 def missing(t: Union[HailType, str]):
     """Creates an expression representing a missing value of a specified type.

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -514,14 +514,16 @@ def geom_histogram(mapping=aes(), *, min_val=None, max_val=None, bins=None, fill
 # new_y is an array the same length as x. For each i in keep, new_y[i] is the
 # y coordinate of the point on the max-ent cdf.
 def _max_entropy_cdf(min_x, max_x, x, y, e):
+    # equivalent to compare(x1 / y1, x2 / y2)
     def compare(x1, y1, x2, y2):
         return x1 * y2 - x2 * y1
 
     new_y = np.full_like(x, 0.0, dtype=np.float64)
     keep = np.full_like(x, False, dtype=np.bool_)
 
-    fx = min_x  # fixed x
-    fy = 0  # fixed y
+    # (fx, fy) is most recently fixed point on max-ent cdf
+    fx = min_x
+    fy = 0
     li = 0  # index of lower slope
     ui = 0  # index of upper slope
     ldx = x[li] - fx

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -546,8 +546,8 @@ def _max_entropy_cdf(min_x, max_x, x, y, e):
 
     def fix_point_on_result(i, upper):
         nonlocal fx, fy, new_y, keep
-        yi = point_on_bound(i, upper)
-        fx, fy = x[i], yi
+        xi, yi = point_on_bound(i, upper)
+        fx, fy = xi, yi
         new_y[i] = fy
         keep[i] = True
 

--- a/hail/python/hail/ggplot/geoms.py
+++ b/hail/python/hail/ggplot/geoms.py
@@ -1,6 +1,5 @@
 from typing import Dict, Any, Optional
 import abc
-import math
 import numpy as np
 import plotly.graph_objects as go
 
@@ -718,7 +717,7 @@ def geom_density(mapping=aes(), *, k=1000, smoothing=0.5, fill=None, color=None,
         If false, uses a custom method do generate a variable width histogram
         directly from the approx_cdf results.
 
-   Returns
+    Returns
     -------
     :class:`FigureAttribute`
         The geom to be applied.

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -5,7 +5,6 @@ import abc
 from pandas import DataFrame
 
 import pandas as pd
-import numpy as np
 
 import hail as hl
 from hail.utils.java import warning

--- a/hail/python/hail/ggplot/stats.py
+++ b/hail/python/hail/ggplot/stats.py
@@ -150,14 +150,9 @@ class StatCDF(Stat):
         result = []
 
         for grouped_struct, data in agg_result.items():
-            n = data['ranks'][-1]
-            weights = np.diff(data['ranks'][1:-1])
-            min = data['values'][0]
-            max = data['values'][-1]
-            values = np.array(data['values'][1:-1])
-            df = pd.DataFrame({'value': values, 'weight': weights})
+            df = pd.DataFrame()
             df.attrs.update(**grouped_struct)
-            df.attrs.update({'min': min, 'max': max, 'n': n})
+            df.attrs.update({"data": data})
 
             result.append(df)
         return result

--- a/hail/python/hail/plot/plots.py
+++ b/hail/python/hail/plot/plots.py
@@ -223,7 +223,7 @@ def _max_entropy_cdf(min_x, max_x, x, y, e):
     def compare(x1, y1, x2, y2):
         return x1 * y2 - x2 * y1
 
-    new_y = np.full_like(x, 0)
+    new_y = np.full_like(x, 0.0, dtype=np.float64)
     keep = np.full_like(x, False, dtype=np.bool_)
 
     fx = min_x  # fixed x


### PR DESCRIPTION
… and make the default

Examples
Histogram without setting min/max. Requires two passes over data, has low resolution over interesting part of the distribution:
<img width="1178" alt="Screenshot 2023-09-12 at 8 26 54 AM" src="https://github.com/hail-is/hail/assets/3430459/90e9317c-7fb3-49d2-8291-ceb19563bafe">

Histogram with manual min/max. Most accurate, but different choices of number of bins cause different artifacts. Requires knowledge of distribution beforehand.
<img width="1177" alt="Screenshot 2023-09-12 at 8 28 19 AM" src="https://github.com/hail-is/hail/assets/3430459/48da720d-ac83-42b3-b886-37a7889398d5">

Smoothed `approx_cdf` based pdf (old default). Smoothing causes large distortion.
<img width="1172" alt="Screenshot 2023-09-12 at 8 30 16 AM" src="https://github.com/hail-is/hail/assets/3430459/53a5ab62-a983-4b93-8d05-96348d333e1e">

New unsmoothed `approx_cdf_ based pdf. Single pass, works well for any distribution, needs no tuning or foreknowledge of distribution.
<img width="1175" alt="Screenshot 2023-09-12 at 8 31 20 AM" src="https://github.com/hail-is/hail/assets/3430459/d69c78cd-d52f-4089-9f89-f67b09dc0859">
