### PR TITLE
[query/ggplot] fixes math for continuous color scales

### DIFF
--- a/hail/python/hail/ggplot/utils.py
+++ b/hail/python/hail/ggplot/utils.py
@@ -36,7 +36,7 @@ def should_use_scale_for_grouping(scale):
 
 def continuous_nums_to_colors(min_color, max_color, continuous_color_scale):
     def adjust_color(input_color):
-        return (input_color - min_color) / max_color - min_color
+        return (input_color - min_color) / (max_color - min_color)
 
     def transform_color(input_color):
         return plotly.colors.sample_colorscale(continuous_color_scale, adjust_color(input_color))[0]


### PR DESCRIPTION
CHANGELOG: Fixed a bug in `hail.ggplot.scale_color_continuous` that sometimes caused errors by generating invalid colors.

For example, this code:

```python
import hail as hl
from hail.ggplot import ggplot, aes, geom_point
t = hl.utils.range_table(10)
t = t.annotate(x=hl.rand_unif(), y=hl.rand_unif(), z=hl.rand_unif(1, 10))
fig = ggplot(t, aes(x=t.x, y=t.y, color=t.z)) + geom_point()
fig.show()
```

Produces an error like this:

```
ValueError:
    Invalid element(s) received for the 'color' property of scatter.marker
        Invalid elements include: ['rgb(-84, -187, 123)', 'rgb(-116, -227, 131)', 'rgb(-29, -120, 109)', 'rgb(-33, -125, 110)', 'rgb(15, -65, 97)', 'rgb(10, -71, 99)', 'rgb(-112, -223, 130)', 'rgb(-63, -162, 117)', 'rgb(-81, -185, 122)', 'rgb(31, -45, 93)']
```

But after this change is applied, it produces a plot like this:

![newplot(2)](https://github.com/hail-is/hail/assets/84595986/0da82782-2409-46f6-b924-eea72eb6ce97)