### PR TITLE
[query/ggplot] runs plotting notebook setup on import

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2965,7 +2965,6 @@ steps:
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
-      cd /io/hailtop/batch
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/test_batch_docs/{{ token }}/
       python3 -m pytest \
@@ -2980,7 +2979,8 @@ steps:
               --doctest-glob='*.rst' \
               --ignore=docs/cookbook/files/ \
               --timeout=120 \
-              --ignore=docs/conf.py
+              --ignore=docs/conf.py \
+              /io/hailtop/batch
     secrets:
       - name: test-gsa-key
         namespace:

--- a/hail/python/hail/docs/tutorials/08-plotting.ipynb
+++ b/hail/python/hail/docs/tutorials/08-plotting.ipynb
@@ -18,9 +18,8 @@
     "import hail as hl\n",
     "hl.init()\n",
     "\n",
-    "from bokeh.io import show, output_notebook\n",
-    "from bokeh.layouts import gridplot\n",
-    "output_notebook()"
+    "from bokeh.io import show\n",
+    "from bokeh.layouts import gridplot"
    ]
   },
   {
@@ -251,7 +250,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -265,9 +264,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/hail/python/hail/docs/tutorials/09-ggplot.ipynb
+++ b/hail/python/hail/docs/tutorials/09-ggplot.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3343aabc",
    "metadata": {},
    "source": [
     "## GGPlot Tutorial\n"
@@ -17,9 +18,7 @@
     "import hail as hl\n",
     "from hail.ggplot import *\n",
     "\n",
-    "import plotly\n",
-    "import plotly.io as pio\n",
-    "pio.renderers.default='iframe'"
+    "import plotly"
    ]
   },
   {
@@ -375,7 +374,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -389,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/hail/python/hail/ggplot/__init__.py
+++ b/hail/python/hail/ggplot/__init__.py
@@ -1,3 +1,9 @@
+from hailtop import IS_NOTEBOOK
+
+if IS_NOTEBOOK:
+    from plotly.io import renderers
+    renderers.default='iframe'
+
 from .coord_cartesian import coord_cartesian
 from .ggplot import ggplot, GGPlot # noqa F401
 from .aes import aes, Aesthetic # noqa F401

--- a/hail/python/hail/plot/__init__.py
+++ b/hail/python/hail/plot/__init__.py
@@ -1,3 +1,9 @@
+from hailtop import IS_NOTEBOOK
+
+if IS_NOTEBOOK:
+    from bokeh.io import output_notebook
+    output_notebook()
+
 from .plots import output_notebook, show, histogram, cumulative_histogram, histogram2d, scatter, joint_plot, qq, manhattan, smoothed_pdf, pdf, cdf, set_font_size, visualize_missingness
 
 __all__ = ['output_notebook',

--- a/hail/python/hailtop/__init__.py
+++ b/hail/python/hailtop/__init__.py
@@ -11,3 +11,10 @@ def version() -> str:
 
 def pip_version() -> str:
     return version().split('-')[0]
+
+
+try:
+    from IPython.core.getipython import get_ipython
+    IS_NOTEBOOK = get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
+except (NameError, ModuleNotFoundError):
+    IS_NOTEBOOK = False

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -9,12 +9,13 @@ import aiohttp
 import orjson
 import secrets
 
+from hailtop import IS_NOTEBOOK
 from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.aiocloud.common import Session
 from hailtop.aiocloud.common.credentials import CloudCredentials
 from hailtop.auth import hail_credentials
 from hailtop.utils import bounded_gather, sleep_before_try
-from hailtop.utils.rich_progress_bar import is_notebook, BatchProgressBar, BatchProgressBarTask
+from hailtop.utils.rich_progress_bar import BatchProgressBar, BatchProgressBarTask
 from hailtop import httpx
 
 from .types import GetJobsResponseV1Alpha, JobListEntryV1Alpha, GetJobResponseV1Alpha
@@ -445,7 +446,7 @@ class Batch:
         url = deploy_config.external_url('batch', f'/batches/{self.id}')
         i = 0
         status = await self.status()
-        if is_notebook():
+        if IS_NOTEBOOK:
             description += f'[link={url}]{self.id}[/link]'
         else:
             description += url

--- a/hail/python/hailtop/utils/rich_progress_bar.py
+++ b/hail/python/hailtop/utils/rich_progress_bar.py
@@ -142,11 +142,3 @@ class BatchProgressBarTask:
 
     def update(self, advance: Optional[int] = None, **kwargs):
         self.progress.update(self.tid, advance=advance, **kwargs)
-
-
-def is_notebook() -> bool:
-    try:
-        from IPython.core.getipython import get_ipython  # pylint: disable=import-error,import-outside-toplevel
-        return get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
-    except (NameError, ModuleNotFoundError):
-        return False


### PR DESCRIPTION
CHANGELOG: Additional setup is no longer required when using `hail.plot` or `hail.ggplot` in a Jupyter notebook (calling `bokeh.io.output_notebook` or `hail.plot.output_notebook` and/or setting `plotly.io.renderers.default = 'iframe'` is no longer necessary).

I double-checked locally that `import hail as hl` and `from hail.ggplot import ggplot` both cause the added code to run, and that running them in a notebook does the setup we expect it to, but running it in iPython or the Python interpreter does not.