### PR TITLE
[auth] Dont load session_id in the UserData dict

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -468,8 +468,8 @@ async def get_copy_paste_token(request: web.Request, userdata: UserData) -> web.
 
 @routes.post('/api/v1alpha/copy-paste-token')
 @authenticated_users_only
-async def get_copy_paste_token_api(request: web.Request, userdata: UserData) -> web.Response:
-    session_id = userdata['session_id']
+async def get_copy_paste_token_api(request: web.Request, _) -> web.Response:
+    session_id = await get_session_id(request)
     db = request.app['db']
     copy_paste_token = await create_copy_paste_token(db, session_id)
     return web.Response(body=copy_paste_token)
@@ -483,7 +483,7 @@ async def logout(request: web.Request, userdata: Optional[UserData]) -> NoReturn
         raise web.HTTPFound(deploy_config.external_url('auth', ''))
 
     db = request.app['db']
-    session_id = userdata['session_id']
+    session_id = await get_session_id(request)
     await db.just_execute('DELETE FROM sessions WHERE session_id = %s;', session_id)
 
     session = await aiohttp_session.get_session(request)
@@ -730,8 +730,8 @@ WHERE copy_paste_tokens.id = %s
 
 @routes.post('/api/v1alpha/logout')
 @authenticated_users_only
-async def rest_logout(request: web.Request, userdata: UserData) -> web.Response:
-    session_id = userdata['session_id']
+async def rest_logout(request: web.Request, _) -> web.Response:
+    session_id = await get_session_id(request)
     db = request.app['db']
     await db.just_execute('DELETE FROM sessions WHERE session_id = %s;', session_id)
 
@@ -789,9 +789,10 @@ async def get_userinfo_from_hail_session_id(request: web.Request, session_id: st
         x
         async for x in db.select_and_fetchall(
             '''
-SELECT users.*, sessions.session_id FROM users
+SELECT users.*
+FROM users
 INNER JOIN sessions ON users.id = sessions.user_id
-WHERE users.state = 'active' AND (sessions.session_id = %s) AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
+WHERE users.state = 'active' AND sessions.session_id = %s AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
 ''',
             session_id,
             'get_userinfo',

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -731,8 +731,7 @@ async def _create_jobs(
     file_store: FileStore = app['file_store']
     user = userdata['username']
 
-    # restrict to what's necessary; in particular, drop the session
-    # which is sensitive
+    # restrict to what's necessary
     userdata = {
         'username': user,
         'hail_credentials_secret_name': userdata['hail_credentials_secret_name'],

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -33,7 +33,6 @@ class UserData(TypedDict):
     is_service_account: bool
     hail_credentials_secret_name: str
     tokens_secret_name: str
-    session_id: str
 
 
 def maybe_parse_bearer_header(value: str) -> Optional[str]:


### PR DESCRIPTION
The `UserData` dict is loaded from the `auth` database and passed around to different services, but mostly to look at the current user's username or some other metadata. Because it's in so many places I'm a little worried about it getting logged, which we can't do because it contains the user's `session_id`. But `userdata["session_id"]` is used in so few places that I removed `session_id` from the dict and retrieve it explicitly where it's needed.