### PR TITLE
[query] eliminate optimization that can blow RAM

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -337,11 +337,10 @@ object Simplify {
     case ToArray(ToStream(a, _)) if a.typ.isInstanceOf[TSet] || a.typ.isInstanceOf[TDict] =>
       CastToArray(a)
 
-    // // These rules need to a way to preserve the memory management semantics of the given ToStream
-    // case ToStream(ToArray(s), _) if s.typ.isInstanceOf[TStream] => s
-    //
-    // case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
-    //   Let(name, value, x)
+    case ToStream(ToArray(s), false) if s.typ.isInstanceOf[TStream] => s
+
+    case ToStream(Let(name, value, ToArray(x)), false) if x.typ.isInstanceOf[TStream] =>
+      Let(name, value, x)
 
     case MakeNDArray(ToArray(someStream), shape, rowMajor, errorId) => MakeNDArray(someStream, shape, rowMajor, errorId)
     case MakeNDArray(ToStream(someArray, _), shape, rowMajor, errorId) => MakeNDArray(someArray, shape, rowMajor, errorId)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -337,10 +337,11 @@ object Simplify {
     case ToArray(ToStream(a, _)) if a.typ.isInstanceOf[TSet] || a.typ.isInstanceOf[TDict] =>
       CastToArray(a)
 
-    case ToStream(ToArray(s), _) if s.typ.isInstanceOf[TStream] => s
-
-    case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
-      Let(name, value, x)
+    // // These rules need to a way to preserve the memory management semantics of the given ToStream
+    // case ToStream(ToArray(s), _) if s.typ.isInstanceOf[TStream] => s
+    //
+    // case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
+    //   Let(name, value, x)
 
     case MakeNDArray(ToArray(someStream), shape, rowMajor, errorId) => MakeNDArray(someStream, shape, rowMajor, errorId)
     case MakeNDArray(ToStream(someArray, _), shape, rowMajor, errorId) => MakeNDArray(someArray, shape, rowMajor, errorId)


### PR DESCRIPTION
CHANGELOG: On some pipelines, since at least 0.2.58 (commit 23813afd5b), Hail could use essentially unbounded amounts of memory. This change removes "optimization" rules that accidentally caused that.

Closes #13606