### PR TITLE
[compiler] a couple bugfixes in ssa pretty-printer

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -652,6 +652,9 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
         case Ref(name, _) =>
           val body = blockBindings.lookupOption(name).getOrElse(uniqueify("%undefined_ref"))
           concat(openBlock, group(nest(2, concat(line, body, line)), "}"))
+        case RelationalRef(name, _) =>
+          val body = blockBindings.lookupOption(name).getOrElse(uniqueify("%undefined_relational_ref"))
+          concat(openBlock, group(nest(2, concat(line, body, line)), "}"))
         case _ =>
           val (pre, body) = pretty(ir, blockBindings)
           concat(openBlock, nest(2, vsep(pre, body)), line, "}")

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -644,35 +644,41 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
     def prettyBlock(ir: BaseIR, newBindings: IndexedSeq[(String, String)], bindings: Env[String]): Doc = {
       val args = newBindings.map { case (name, base) => name -> s"%${uniqueify(base)}" }
       val blockBindings = bindings.bindIterable(args)
-      val (pre, body) = pretty(ir, blockBindings)
       val openBlock = if (args.isEmpty)
         text("{")
       else
         concat("{", softline, args.map(_._2).mkString("(", ", ", ") =>"))
-      concat(openBlock, nest(2, vsep(pre, body)), line, "}")
+      ir match {
+        case Ref(name, _) =>
+          val body = blockBindings.lookupOption(name).getOrElse(uniqueify("%undefined_ref"))
+          concat(openBlock, group(nest(2, concat(line, body, line)), "}"))
+        case _ =>
+          val (pre, body) = pretty(ir, blockBindings)
+          concat(openBlock, nest(2, vsep(pre, body)), line, "}")
+      }
     }
 
     def pretty(ir: BaseIR, bindings: Env[String]): (Doc, Doc) = ir match {
       case Let(name, value, body) =>
         val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
         val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
-        (vsep(valueDoc, bodyPre), bodyHead)
+        (concat(valueDoc, bodyPre), bodyHead)
       case RelationalLet(name, value, body) =>
         val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
         val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
-        (vsep(valueDoc, bodyPre), bodyHead)
+        (concat(valueDoc, bodyPre), bodyHead)
       case RelationalLetTable(name, value, body) =>
         val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
         val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
-        (vsep(valueDoc, bodyPre), bodyHead)
+        (concat(valueDoc, bodyPre), bodyHead)
       case RelationalLetMatrixTable(name, value, body) =>
         val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
         val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
-        (vsep(valueDoc, bodyPre), bodyHead)
+        (concat(valueDoc, bodyPre), bodyHead)
       case RelationalLetBlockMatrix(name, value, body) =>
         val (valueDoc, valueIdent) = prettyWithIdent(value, bindings, "%")
         val (bodyPre, bodyHead) = pretty(body, bindings.bind(name, valueIdent))
-        (vsep(valueDoc, bodyPre), bodyHead)
+        (concat(valueDoc, bodyPre), bodyHead)
       case _ =>
         val strictChildBodies = mutable.ArrayBuilder.make[Doc]()
         val strictChildIdents = for {
@@ -725,7 +731,6 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
               text("else"),
               nestedBlocks(1))
           case _ =>
-            val args = strictChildIdents.mkString("(", ", ", ")")
             hsep(text(Pretty.prettyClass(ir) + standardArgs) +: (attributes ++ nestedBlocks))
         }
 


### PR DESCRIPTION
Blocks containing only a single `Ref` node weren't being handled correctly, and we were adding empty lines in some cases.

Examples:

sexpr:
```
(Let __iruid_2
  (I32 2)
  (Let __iruid_1
    (I32 1)
    (Let __iruid_0
      (True)
      (If
        (Ref __iruid_0)
        (ApplyUnaryPrimOp Negate (Ref __iruid_1))
        (Ref __iruid_2)))))
```
ssa before:
```
%c2 = I32 [2]

%c1 = I32 [1]

%true = True

If %true then {
  ApplyUnaryPrimOp(%c1) [Negate]
} else {
  Ref [__iruid_2]
}
```
ssa after:
```
%c2 = I32 [2]
%c1 = I32 [1]
%true = True
If %true then {
  ApplyUnaryPrimOp(%c1) [Negate]
} else { %c2 }
```

sexpr:
```
(StreamMap __iruid_3
  (StreamRange -1 False (I32 0) (I32 5) (I32 1))
  (Ref __iruid_3))
```
ssa before:
```
!c0 = I32 [0] 
!c5 = I32 [5] 
!c1 = I32 [1]
!s = StreamRange(!c0, !c5, !c1) [-1, False]
StreamMap(!s) { (%elt) =>
  Ref [__iruid_3]
}
```
ssa after:
```
!c0 = I32 [0] 
!c5 = I32 [5] 
!c1 = I32 [1]
!s = StreamRange(!c0, !c5, !c1) [-1, False]
StreamMap(!s) { (%elt) => %elt }
```