### PR TITLE
[ci] Fix errant line in environment variable spec

### DIFF
--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -107,7 +107,6 @@ spec:
              value: "{{ hail_buildkit_image.image }}"
            - name: HAIL_DEFAULT_NAMESPACE
              value: "{{ default_ns.name }}"
-           - name: HAIL_IDENTITY_PROVIDER_JSON
 {% if global.cloud == "gcp" %}
            - name: GOOGLE_APPLICATION_CREDENTIALS
              value: /gsa-key/key.json


### PR DESCRIPTION
I accidentally copy pasted the line. If you look a few lines down you can see the actual name/value pair for that environment variable.