### PR TITLE
[gear] Set SameSite=Lax on the session cookie

### DIFF
--- a/gear/gear/session.py
+++ b/gear/gear/session.py
@@ -20,6 +20,7 @@ def setup_aiohttp_session(app):
                 cookie_name=cookie_name,
                 secure=True,
                 httponly=True,
+                samesite='Lax',
                 domain=os.environ['HAIL_DOMAIN'],
                 # 2592000s = 30d
                 max_age=2592000,


### PR DESCRIPTION
Typically, a CSRF attack can occur when `evil.com` tricks a user into requesting a state-changing URL at `batch.hail.is`. We use CSRF tokens to protect against such attacks, but there is an additional defense-in-depth cookie attribute that we can use called [SameSite](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#samesite-cookie-attribute). The possible values for this attribute are:

- None => browser always sends this cookie in cross-site requests
- Strict => browser never sends this cookie in cross-site requests
- Lax => browser only sends this cookie in cross-site requests that use "safe" HTTP methods (GET, HEAD, OPTIONS)

Both Lax and Strict protect against the most primitive forms of CSRF (a form on evil.com submitting a POST to batch.hail.is). Lax seems very reasonable, and still allows linking to, say, linking to jobs from Zulip's web app without the user needing to log in once they get there. Worth noting that this does not protect against [all forms of CSRF](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-02#section-5.3.7.1) attacks, so this does not replace CSRF tokens, just provides additional defense-in-depth.