### PR TITLE
[qob] don’t use unbounded threads reading results

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -67,9 +67,8 @@ class ServiceBackend(
   import ServiceBackend.log
 
   private[this] var stageCount = 0
-  private[this] val executor = Executors.newCachedThreadPool()
   private[this] val MAX_AVAILABLE_GCS_CONNECTIONS = 1000
-  private[this] val availableGCSConnections = new Semaphore(MAX_AVAILABLE_GCS_CONNECTIONS, true)
+  private[this] val executor = Executors.newFixedThreadPool(MAX_AVAILABLE_GCS_CONNECTIONS)
 
   override def shouldCacheQueryInfo: Boolean = false
 
@@ -231,21 +230,16 @@ class ServiceBackend(
       executor.invokeAll(IndexedSeq.range(0, n).map { i =>
         new Callable[Array[Byte]]() {
           def call(): Array[Byte] = {
-            availableGCSConnections.acquire()
-            try {
-              val bytes = fs.readNoCompression(s"$root/result.$i")
-              if (bytes(0) != 0) {
-                bytes.slice(1, bytes.length)
-              } else {
-                val errorInformationBytes = bytes.slice(1, bytes.length)
-                val is = new DataInputStream(new ByteArrayInputStream(errorInformationBytes))
-                val shortMessage = readString(is)
-                val expandedMessage = readString(is)
-                val errorId = is.readInt()
-                throw new HailWorkerException(shortMessage, expandedMessage, errorId)
-              }
-            } finally {
-              availableGCSConnections.release()
+            val bytes = fs.readNoCompression(s"$root/result.$i")
+            if (bytes(0) != 0) {
+              bytes.slice(1, bytes.length)
+            } else {
+              val errorInformationBytes = bytes.slice(1, bytes.length)
+              val is = new DataInputStream(new ByteArrayInputStream(errorInformationBytes))
+              val shortMessage = readString(is)
+              val expandedMessage = readString(is)
+              val errorId = is.readInt()
+              throw new HailWorkerException(shortMessage, expandedMessage, errorId)
             }
           }
         }
@@ -258,7 +252,7 @@ class ServiceBackend(
     val rate = results.length / resultsReadingSeconds
     val byterate = results.map(_.length).sum / resultsReadingSeconds / 1024 / 1024
     log.info(s"all results read. $resultsReadingSeconds s. $rate result/s. $byterate MiB/s.")
-    results.toArray[Array[Byte]]
+    results
   }
 
   def stop(): Unit = ()


### PR DESCRIPTION
CHANGELOG: fix a bug which caused jobs with a large number of partitions (close to 100k) to run out of memory on the driver after all partitions finish.

Cap number of threads allocated when reading results of a cda on the driver.

~Still waiting on a test to confirm this fixes the bad scaling with number of partitions.~

We were reading cda results with a threadpool containing one thread per partition, but kept all but 1000 threads blocked. This changes to use a threadpool of 1000 threads.

We still use a surprising amount of memory when reading results, but this change will likely allow jobs with ~100k partitions to complete.

fixes #13533