### PR TITLE
[query] non-shadow-jar for pytest, doctest, and install-editable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ infra/.terraform.lock.hcl
 .cache/
 wheel-container.tar
 *-image
+hail/python/hail/backend/extra_classpath
+hail/python/hail/backend/hail.jar

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -69,10 +69,12 @@ PYTHON_VERSION_INFO += python/hail/docs/_static/hail_version.js
 SCALA_BUILD_INFO := src/main/resources/build-info.properties
 
 SHADOW_JAR := build/libs/hail-all-spark.jar
+NON_SHADOW_JAR := build/libs/hail.jar
 SHADOW_TEST_JAR := build/libs/hail-all-spark-test.jar
 PYTHON_JAR := python/hail/backend/hail-all-spark.jar
+FAST_PYTHON_JAR := python/hail/backend/hail.jar
+FAST_PYTHON_JAR_EXTRA_CLASSPATH := python/hail/backend/extra_classpath
 WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
-EGG := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3.6.egg
 
 GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION) -Delasticsearch.major-version=$(ELASTIC_MAJOR_VERSION)
 
@@ -94,6 +96,18 @@ $(SHADOW_JAR): $(SCALA_BUILD_INFO) $(JAR_SOURCES) env/HAIL_DEBUG_MODE env/ELASTI
 	./gradlew shadowJar $(GRADLE_ARGS)
 ifdef HAIL_DEBUG_MODE
 	$(JAR) -uf $(SHADOW_JAR) -C $(BUILD_DEBUG_PREFIX) is/hail/annotations/Memory.class
+endif
+
+ifdef HAIL_COMPILE_NATIVES
+$(NON_SHADOW_JAR): native-lib-prebuilt
+endif
+ifdef HAIL_DEBUG_MODE
+$(NON_SHADOW_JAR): $(JAR_DEBUG_CLASSES)
+endif
+$(NON_SHADOW_JAR): $(SCALA_BUILD_INFO) $(JAR_SOURCES) env/HAIL_DEBUG_MODE env/ELASTIC_MAJOR_VERSION
+	./gradlew jar $(GRADLE_ARGS)
+ifdef HAIL_DEBUG_MODE
+	$(JAR) -uf $(NON_SHADOW_JAR) -C $(BUILD_DEBUG_PREFIX) is/hail/annotations/Memory.class
 endif
 
 .PHONY: shadowTestJar
@@ -121,7 +135,7 @@ endif
 services-jvm-test: $(SCALA_BUILD_INFO) $(JAR_SOURCES) $(JAR_TEST_SOURCES)
 	./gradlew testServices $(GRADLE_ARGS) $(GRADLE_TEST_ARGS)
 
-.PHONY: services-jvm-test
+.PHONY: fs-jvm-test
 ifdef HAIL_COMPILE_NATIVES
 fs-jvm-test: native-lib-prebuilt
 endif
@@ -175,12 +189,18 @@ python/README.md: ../README.md
 $(PYTHON_JAR): $(SHADOW_JAR)
 	cp -f $(SHADOW_JAR) $@
 
+$(FAST_PYTHON_JAR): $(NON_SHADOW_JAR)
+	cp -f $(NON_SHADOW_JAR) $@
+
+$(FAST_PYTHON_JAR_EXTRA_CLASSPATH): build.gradle
+	./gradlew -q printClasspath > $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
+
 .PHONY: python-jar
 python-jar: $(PYTHON_JAR)
 
 .PHONY: pytest
 pytest: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
-pytest: python/README.md $(PYTHON_JAR)
+pytest: python/README.md $(FAST_PYTHON_JAR) $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
 	cd python && $(HAIL_PYTHON3) -m pytest \
             -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
             --log-cli-level=INFO \
@@ -222,7 +242,7 @@ pytest-qob: upload-qob-jar upload-qob-test-resources install-editable
 
 .PHONY: doctest
 doctest: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
-doctest: python/README.md $(PYTHON_JAR)
+doctest: python/README.md $(FAST_PYTHON_JAR) $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
 	cd python && $(HAIL_PYTHON3) -m pytest \
             -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
             --log-cli-level=INFO \
@@ -272,12 +292,6 @@ wheel: $(WHEEL)
 $(WHEEL): copy-py-files
 	# Clear the bdist build cache before building the wheel
 	cd build/deploy; rm -rf build; $(HAIL_PYTHON3) setup.py -q sdist bdist_wheel
-
-.PHONY: egg
-egg: $(EGG)
-
-$(EGG): copy-py-files
-	cd build/deploy; $(HAIL_PYTHON3) setup.py -q sdist bdist_egg
 
 # if the DEPLOY_REMOTE flag is not set, then deploy init scripts into a dev-username location
 ifndef DEPLOY_REMOTE
@@ -340,12 +354,18 @@ upload-qob-jar: $(SHADOW_JAR)
 	! [ -z $(NAMESPACE) ]  # call this like: make upload-qob-jar NAMESPACE=default
 	bash ./scripts/upload_qob_jar.sh $(NAMESPACE) $(REVISION) $(SHADOW_JAR) $@
 
-.PHONY: install-editable
+# if the installation of Hail has changed, i.e. you pip-installed a non-development version of Hail,
+# this file will be newer than "install-editable"
+install-editable: $(shell pip3 show hail | grep Location: | sed 's/Location: //')/hail/__init__.py
+install-editable: python/setup.py
+install-editable: python/requirements.txt
+install-editable: python/README.md
 install-editable: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
-install-editable: python/README.md $(PYTHON_JAR)
+install-editable: $(FAST_PYTHON_JAR) $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
 	-$(PIP) uninstall -y hail
 	cd python && $(PIP) install -e .
 	hailctl config set query/backend spark
+	touch install-editable
 
 .PHONY: install-for-qob
 install-for-qob: upload-qob-jar install-editable
@@ -500,6 +520,8 @@ clean: clean-env clean-libs native-lib-clean
 	./gradlew clean $(GRADLE_ARGS)
 	rm -rf build/
 	rm -rf $(PYTHON_JAR)
+	rm -rf $(FAST_PYTHON_JAR)
+	rm -rf $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
 	rm -rf python/README.md
 	rm -rf $(SCALA_BUILD_INFO)
 	rm -rf $(PYTHON_VERSION_INFO)

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -352,3 +352,7 @@ task shadowTestJar(type: ShadowJar) {
     from project.sourceSets.main.output, project.sourceSets.test.output
     configurations = [project.configurations.hailTestJar]
 }
+
+task printClasspath(type: Exec) {
+    commandLine = ['echo', "${sourceSets.main.runtimeClasspath.asPath}"]
+}

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -5,7 +5,6 @@ import socketserver
 import sys
 from threading import Thread
 
-import pkg_resources
 import py4j
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 
@@ -13,6 +12,7 @@ from hail.utils.java import scala_package_object
 from hail.ir.renderer import CSERenderer
 from hail.ir import finalize_randomness
 from .py4j_backend import Py4JBackend, handle_java_exception
+from .backend import local_jar_information
 from ..hail_logging import Logger
 from ..expr import Expression
 from ..expr.types import HailType
@@ -126,9 +126,9 @@ class LocalBackend(Py4JBackend):
         spark_home = find_spark_home()
         hail_jar_path = os.environ.get('HAIL_JAR')
         if hail_jar_path is None:
-            if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
-                hail_jar_path = pkg_resources.resource_filename(__name__, "hail-all-spark.jar")
-            else:
+            try:
+                hail_jar_path = local_jar_information().path
+            except ValueError:
                 raise RuntimeError('local backend requires a packaged jar or HAIL_JAR to be set')
 
         jvm_opts = []

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -1,5 +1,4 @@
 from typing import Set
-import pkg_resources
 import sys
 import os
 import json
@@ -23,6 +22,7 @@ from hailtop.aiotools.validators import validate_file
 
 from .py4j_backend import Py4JBackend, handle_java_exception
 from ..hail_logging import Logger
+from .backend import local_jar_information
 
 
 _installed = False
@@ -134,16 +134,20 @@ class SparkBackend(Py4JBackend):
         super(SparkBackend, self).__init__()
         assert gcs_requester_pays_project is not None or gcs_requester_pays_buckets is None
 
-        if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
-            hail_jar_path = pkg_resources.resource_filename(__name__, "hail-all-spark.jar")
-            assert os.path.exists(hail_jar_path), f'{hail_jar_path} does not exist'
+        try:
+            local_jar_info = local_jar_information()
+        except ValueError:
+            local_jar_info = None
+
+        if local_jar_info is not None:
             conf = pyspark.SparkConf()
 
             base_conf = spark_conf or {}
             for k, v in base_conf.items():
                 conf.set(k, v)
 
-            jars = [hail_jar_path]
+            jars = [local_jar_info.path]
+            extra_classpath = local_jar_info.extra_classpath
 
             if os.environ.get('HAIL_SPARK_MONITOR') or os.environ.get('AZURE_SPARK') == '1':
                 import sparkmonitor
@@ -168,11 +172,15 @@ class SparkBackend(Py4JBackend):
                 append_to_comma_separated_list(
                     conf,
                     'spark.driver.extraClassPath',
-                    *jars)
+                    *jars,
+                    *extra_classpath
+                )
                 append_to_comma_separated_list(
                     conf,
                     'spark.executor.extraClassPath',
-                    './hail-all-spark.jar')
+                    './hail-all-spark.jar',
+                    *extra_classpath
+                )
 
             if sc is None:
                 pyspark.SparkContext._ensure_initialized(conf=conf)

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -20,6 +20,7 @@ from hailtop.utils import secret_alnum_string
 from hailtop.fs.fs import FS
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration, get_gcs_requester_pays_configuration
 from .builtin_references import BUILTIN_REFERENCES
+from .backend.backend import local_jar_information
 
 
 def _get_tmpdir(tmpdir):
@@ -611,7 +612,7 @@ def revision() -> str:
 def _hail_cite_url():
     v = version()
     [tag, sha_prefix] = v.split("-")
-    if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
+    if not local_jar_information().development_mode:
         # pip installed
         return f"https://github.com/hail-is/hail/releases/tag/{tag}"
     return f"https://github.com/hail-is/hail/commit/{sha_prefix}"
@@ -879,14 +880,12 @@ def _with_flags(**flags):
 
 def debug_info():
     from hail.backend.spark_backend import SparkBackend
-    hail_jar_path = None
-    if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
-        hail_jar_path = pkg_resources.resource_filename(__name__, "hail-all-spark.jar")
+    from hail.backend.backend import local_jar_information
     spark_conf = None
     if isinstance(Env.backend(), SparkBackend):
         spark_conf = spark_context()._conf.getAll()
     return {
         'spark_conf': spark_conf,
-        'hail_jar_path': hail_jar_path,
+        'local_jar_information': local_jar_information(),
         'version': version()
     }

--- a/hail/python/hail/experimental/compile.py
+++ b/hail/python/hail/experimental/compile.py
@@ -7,6 +7,7 @@ import zipfile
 from ..utils.java import Env
 from .codec import encode
 from ..expr.functions import literal
+from ..backend.backend import local_jar_information
 
 __libhail_loaded = False
 
@@ -17,7 +18,7 @@ def load_libhail():
         return
     with zipfile.ZipFile(pkg_resources.resource_stream(
             'hail',
-            "hail-all-spark.jar")) as jar:
+            local_jar_information().path)) as jar:
         if platform.system() == 'Darwin':
             lib_path = 'darwin/libhail.dylib'
         else:

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -109,6 +109,9 @@ if role == 'Master':
         + '/hail/backend/hail-all-spark.jar'
     )
 
+    if not os.path.exists(hail_jar):
+        raise ValueError(f'{hail_jar} must exist')
+
     conf_to_set = [
         'spark.executorEnv.PYTHONHASHSEED=0',
         'spark.app.name=Hail',


### PR DESCRIPTION
Apparently, creating a zip file of all our dependencies and the Hail code takes ~30s. This change skips the shadow JAR for local development. We still need a shadow JAR to produce a shareable wheel file; however, when doing local development, we can simply tell Py4J (and the JVM) where to find our dependencies class files.

Also notice that I made install-editable non-PHONY. It need not be PHONY as long as we can reliably determine if `hail/python` is the pip-installed version. To do so, we simply check if the `__init__.py` at the root of the pip package is newer than when we last installed. If its newer, then either:
1. We edited `__init__.py`, or
2. The pip location of Hail has changed since we last ran install-editable

I also deleted eggs because nobody uses eggs.