### PR TITLE
[make] Building images should not depend on k8s deployment files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ docs:
 
 website-image: docs
 
-$(SERVICES_IMAGES): %-image: $(SERVICES_IMAGE_DEPS) $(shell git ls-files $$*)
+$(SERVICES_IMAGES): %-image: $(SERVICES_IMAGE_DEPS) $(shell git ls-files $$* -- . ':!:deployment.yaml')
 	$(eval IMAGE := $(DOCKER_PREFIX)/$*:$(TOKEN))
 	python3 ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat hail-ubuntu-image)'"}}' $*/Dockerfile $*/Dockerfile.out
 	./docker-build.sh . $*/Dockerfile.out $(IMAGE)


### PR DESCRIPTION
This way if I change something in `batch.deployment.yaml` and then make deploy it only takes a couple seconds because no images need rebuilding and it just retemplates the yaml and applies it.