### PR TITLE
[batch] Use normal credentials instead of internal_token for communicating between batch and batch-driver

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -9,6 +9,7 @@ import random
 import re
 import signal
 import traceback
+from contextlib import AsyncExitStack
 from functools import wraps
 from numbers import Number
 from typing import Any, Awaitable, Callable, Dict, List, NoReturn, Optional, Tuple, TypeVar, Union, cast
@@ -44,6 +45,7 @@ from gear.clients import get_cloud_async_fs
 from gear.database import CallError
 from gear.profiling import install_profiler_if_requested
 from hailtop import aiotools, dictfix, httpx, version
+from hailtop.auth import hail_credentials
 from hailtop.batch_client.parse import parse_cpu_in_mcpu, parse_memory_in_bytes, parse_storage_in_bytes
 from hailtop.batch_client.types import GetJobResponseV1Alpha, GetJobsResponseV1Alpha, JobListEntryV1Alpha
 from hailtop.config import get_deploy_config
@@ -1618,7 +1620,7 @@ async def _commit_update(app: web.Application, batch_id: int, update_id: int, us
         retry_transient_errors(
             client_session.patch,
             deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/update'),
-            headers=app['batch_headers'],
+            headers=await app['hail_credentials'].auth_headers(),
         )
     )
 
@@ -2800,7 +2802,7 @@ async def cancel_batch_loop_body(app):
     await retry_transient_errors(
         client_session.post,
         deploy_config.url('batch-driver', '/api/v1alpha/batches/cancel'),
-        headers=app['batch_headers'],
+        headers=await app['hail_credentials'].auth_headers(),
     )
 
     should_wait = True
@@ -2812,7 +2814,7 @@ async def delete_batch_loop_body(app):
     await retry_transient_errors(
         client_session.post,
         deploy_config.url('batch-driver', '/api/v1alpha/batches/delete'),
-        headers=app['batch_headers'],
+        headers=await app['hail_credentials'].auth_headers(),
     )
 
     should_wait = True
@@ -2852,7 +2854,7 @@ async def on_startup(app):
 
     row = await db.select_and_fetchone(
         '''
-SELECT instance_id, internal_token, n_tokens, frozen FROM globals;
+SELECT instance_id, n_tokens, frozen FROM globals;
 '''
     )
 
@@ -2862,9 +2864,7 @@ SELECT instance_id, internal_token, n_tokens, frozen FROM globals;
     log.info(f'instance_id {instance_id}')
     app['instance_id'] = instance_id
 
-    app['internal_token'] = row['internal_token']
-
-    app['batch_headers'] = {'Authorization': f'Bearer {row["internal_token"]}'}
+    app['hail_credentials'] = hail_credentials()
 
     app['frozen'] = row['frozen']
 
@@ -2900,16 +2900,12 @@ SELECT instance_id, internal_token, n_tokens, frozen FROM globals;
 
 
 async def on_cleanup(app):
-    try:
-        app['task_manager'].shutdown()
-    finally:
-        try:
-            await app['client_session'].close()
-        finally:
-            try:
-                await app['file_store'].close()
-            finally:
-                await app['db'].async_close()
+    async with AsyncExitStack() as stack:
+        stack.callback(app['task_manager'].shutdown)
+        stack.push_async_callback(app['hail_credentials'].close)
+        stack.push_async_callback(app['client_session'].close)
+        stack.push_async_callback(app['file_store'].close)
+        stack.push_async_callback(app['db'].async_close)
 
 
 def run():

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import secrets
 from collections import deque
 from functools import wraps
 from typing import Any, Deque, Dict, List, Optional, Set, Tuple, overload
@@ -28,21 +27,6 @@ def authorization_token(request):
     if not session_id:
         return None
     return session_id
-
-
-def batch_only(fun):
-    @wraps(fun)
-    async def wrapped(request):
-        token = authorization_token(request)
-        if not token:
-            raise web.HTTPUnauthorized()
-
-        if not secrets.compare_digest(token, request.app['internal_token']):
-            raise web.HTTPUnauthorized()
-
-        return await fun(request)
-
-    return wrapped
 
 
 def add_metadata_to_request(fun):

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -175,22 +175,6 @@ spec:
         env:
          - name: PORT
            value: "5000"
-{% if global.cloud == "gcp" %}
-         - name: GOOGLE_APPLICATION_CREDENTIALS
-           value: /gsa-key/key.json
-         - name: HAIL_IDENTITY_PROVIDER_JSON
-           value: '{"idp": "Google"}'
-{% else %}
-         - name: AZURE_APPLICATION_CREDENTIALS
-           value: /gsa-key/key.json
-         - name: HAIL_IDENTITY_PROVIDER_JSON
-           value: '{"idp": "Microsoft"}'
-         - name: HAIL_AZURE_OAUTH_SCOPE
-           valueFrom:
-             secretKeyRef:
-               name: auth-oauth2-client-secret
-               key: sp_oauth_scope
-{% endif %}
          - name: HAIL_DOMAIN
            valueFrom:
              secretKeyRef:

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -175,8 +175,22 @@ spec:
         env:
          - name: PORT
            value: "5000"
+{% if global.cloud == "gcp" %}
          - name: GOOGLE_APPLICATION_CREDENTIALS
            value: /gsa-key/key.json
+         - name: HAIL_IDENTITY_PROVIDER_JSON
+           value: '{"idp": "Google"}'
+{% else %}
+         - name: AZURE_APPLICATION_CREDENTIALS
+           value: /gsa-key/key.json
+         - name: HAIL_IDENTITY_PROVIDER_JSON
+           value: '{"idp": "Microsoft"}'
+         - name: HAIL_AZURE_OAUTH_SCOPE
+           valueFrom:
+             secretKeyRef:
+               name: auth-oauth2-client-secret
+               key: sp_oauth_scope
+{% endif %}
          - name: HAIL_DOMAIN
            valueFrom:
              secretKeyRef:
@@ -405,8 +419,22 @@ spec:
              secretKeyRef:
                name: global-config
                key: internal_ip
+{% if global.cloud == "gcp" %}
          - name: GOOGLE_APPLICATION_CREDENTIALS
            value: /gsa-key/key.json
+         - name: HAIL_IDENTITY_PROVIDER_JSON
+           value: '{"idp": "Google"}'
+{% else %}
+         - name: AZURE_APPLICATION_CREDENTIALS
+           value: /gsa-key/key.json
+         - name: HAIL_IDENTITY_PROVIDER_JSON
+           value: '{"idp": "Microsoft"}'
+         - name: HAIL_AZURE_OAUTH_SCOPE
+           valueFrom:
+             secretKeyRef:
+               name: auth-oauth2-client-secret
+               key: sp_oauth_scope
+{% endif %}
          - name: HAIL_SHA
            value: "{{ code.sha }}"
 {% if scope != "test" %}

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -175,6 +175,8 @@ spec:
         env:
          - name: PORT
            value: "5000"
+         - name: GOOGLE_APPLICATION_CREDENTIALS
+           value: /gsa-key/key.json
          - name: HAIL_DOMAIN
            valueFrom:
              secretKeyRef:

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `globals` (
   `instance_id` VARCHAR(100) NOT NULL,
-  `internal_token` VARCHAR(100) NOT NULL,
+  `internal_token` VARCHAR(100) NOT NULL,  # deprecated
   `n_tokens` INT NOT NULL,
   `frozen` BOOLEAN NOT NULL DEFAULT FALSE
 ) ENGINE = InnoDB;

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -74,6 +74,7 @@ async def main():
     users = [
         # username, login_id, is_developer, is_service_account
         ('auth', None, 0, 1),
+        ('batch', None, 0, 1),
         ('ci', None, 0, 1),
         ('test', None, 0, 0),
         ('test-dev', None, 1, 0),


### PR DESCRIPTION
In the spirit of getting everyone talking with the same authentication mechanism. The communication between batch and batch-driver isn't really a big deal, but we are basically storing a password as plaintext with this `internal_token`.