### PR TITLE
[docker] Build hailgenetics/hail images with all supported python versions

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -120,6 +120,42 @@ steps:
     dependsOn:
       - merge_code
       - copy_third_party_images
+  - kind: buildImage2
+    name: hail_ubuntu_image_python_3_10
+    dockerFile: /io/hail-ubuntu/Dockerfile
+    contextPath: /io/hail-ubuntu
+    publishAs: hail-ubuntu-python-3-10
+    buildArgs:
+      - name: PYTHON_VERSION
+        value: "3.10"
+    resources:
+      storage: 10Gi
+      cpu: "2"
+      memory: standard
+    inputs:
+      - from: /repo/docker/hail-ubuntu
+        to: /io/hail-ubuntu
+    dependsOn:
+      - merge_code
+      - copy_third_party_images
+  - kind: buildImage2
+    name: hail_ubuntu_image_python_3_11
+    dockerFile: /io/hail-ubuntu/Dockerfile
+    contextPath: /io/hail-ubuntu
+    publishAs: hail-ubuntu-python-3-11
+    buildArgs:
+      - name: PYTHON_VERSION
+        value: "3.11"
+    resources:
+      storage: 10Gi
+      cpu: "2"
+      memory: standard
+    inputs:
+      - from: /repo/docker/hail-ubuntu
+        to: /io/hail-ubuntu
+    dependsOn:
+      - merge_code
+      - copy_third_party_images
   - kind: deploy
     name: deploy_batch_sa
     namespace:
@@ -1330,16 +1366,79 @@ steps:
       - merge_code
       - build_hail_jar_and_wheel
       - hail_ubuntu_image
+  - kind: buildImage2
+    name: hailgenetics_hail_image_python_3_10
+    dockerFile: /io/repo/docker/hailgenetics/hail/Dockerfile
+    contextPath: /io/repo
+    publishAs: hailgenetics/hail
+    buildArgs:
+      - name: BASE_IMAGE
+        value:
+          valueFrom: hail_ubuntu_image_python_3_10.image
+    inputs:
+      - from: /repo/docker/hailgenetics/hail
+        to: /io/repo/docker/hailgenetics/hail
+      - from: /repo/hail/python/pinned-requirements.txt
+        to: /io/repo/hail/python/pinned-requirements.txt
+      - from: /wheel-container.tar
+        to: /io/repo/wheel-container.tar
+    dependsOn:
+      - merge_code
+      - build_hail_jar_and_wheel
+      - hail_ubuntu_image_python_3_10
+  - kind: buildImage2
+    name: hailgenetics_hail_image_python_3_11
+    dockerFile: /io/repo/docker/hailgenetics/hail/Dockerfile
+    contextPath: /io/repo
+    publishAs: hailgenetics/hail
+    buildArgs:
+      - name: BASE_IMAGE
+        value:
+          valueFrom: hail_ubuntu_image_python_3_11.image
+    inputs:
+      - from: /repo/docker/hailgenetics/hail
+        to: /io/repo/docker/hailgenetics/hail
+      - from: /repo/hail/python/pinned-requirements.txt
+        to: /io/repo/hail/python/pinned-requirements.txt
+      - from: /wheel-container.tar
+        to: /io/repo/wheel-container.tar
+    dependsOn:
+      - merge_code
+      - build_hail_jar_and_wheel
+      - hail_ubuntu_image_python_3_11
   - kind: runImage
     name: test_hailgenetics_hail_image
     image:
       valueFrom: hailgenetics_hail_image.image
     script: |
       set -ex
+      python3 --version | grep '3.9'
       python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
       python3 -c 'import numpy; import pandas; import sklearn; import scipy'
     dependsOn:
       - hailgenetics_hail_image
+  - kind: runImage
+    name: test_hailgenetics_hail_image_python_3_10
+    image:
+      valueFrom: hailgenetics_hail_image_python_3_10.image
+    script: |
+      set -ex
+      python3 --version | grep '3.10'
+      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
+      python3 -c 'import numpy; import pandas; import sklearn; import scipy'
+    dependsOn:
+      - hailgenetics_hail_image_python_3_10
+  - kind: runImage
+    name: test_hailgenetics_hail_image_python_3_11
+    image:
+      valueFrom: hailgenetics_hail_image_python_3_11.image
+    script: |
+      set -ex
+      python3 --version | grep '3.11'
+      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
+      python3 -c 'import numpy; import pandas; import sklearn; import scipy'
+    dependsOn:
+      - hailgenetics_hail_image_python_3_11
   - kind: buildImage2
     name: hail_dev_image
     dockerFile: /io/repo/docker/Dockerfile.hail-dev
@@ -3185,6 +3284,8 @@ steps:
                              /io/github-oauth \
                              docker://{{ hailgenetics_hail_image.image }} \
                              docker://{{ hailgenetics_hailtop_image.image }} \
+                             docker://{{ hailgenetics_hail_image_python_3_10.image }} \
+                             docker://{{ hailgenetics_hail_image_python_3_11.image }} \
                              docker://{{ hailgenetics_vep_grch37_85_image.image }} \
                              docker://{{ hailgenetics_vep_grch38_95_image.image }} \
                              /io/wheel-for-azure/hail-*-py3-none-any.whl \
@@ -3229,6 +3330,8 @@ steps:
       - ci_utils_image
       - merge_code
       - hailgenetics_hail_image
+      - hailgenetics_hail_image_python_3_10
+      - hailgenetics_hail_image_python_3_11
       - hailgenetics_hailtop_image
       - hailgenetics_vep_grch37_85_image
       - hailgenetics_vep_grch38_95_image

--- a/build.yaml
+++ b/build.yaml
@@ -1355,6 +1355,10 @@ steps:
     dockerFile: /io/repo/docker/hailgenetics/hail/Dockerfile
     contextPath: /io/repo
     publishAs: hailgenetics/hail
+    buildArgs:
+      - name: BASE_IMAGE
+        value:
+          valueFrom: hail_ubuntu_image.image
     inputs:
       - from: /repo/docker/hailgenetics/hail
         to: /io/repo/docker/hailgenetics/hail

--- a/docker/hailgenetics/hail/Dockerfile
+++ b/docker/hailgenetics/hail/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
+ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 RUN hail-apt-get-install \

--- a/docker/hailgenetics/hail/Dockerfile
+++ b/docker/hailgenetics/hail/Dockerfile
@@ -1,13 +1,10 @@
-FROM {{ hail_ubuntu_image.image }}
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 
 RUN hail-apt-get-install \
-    curl \
     git \
-    jq \
     liblapack3 \
-    openjdk-8-jre-headless \
-    rsync \
-    vim
+    openjdk-8-jre-headless
 
 COPY hail/python/pinned-requirements.txt requirements.txt
 RUN hail-pip-install -r requirements.txt scikit-learn ipython

--- a/docker/hailgenetics/hail/Dockerfile
+++ b/docker/hailgenetics/hail/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
 FROM $BASE_IMAGE
 
 RUN hail-apt-get-install \

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -18,7 +18,7 @@ from hailtop import pip_version
 from hailtop.config import ConfigVariable, configuration_of, get_deploy_config, get_remote_tmpdir
 from hailtop.utils.rich_progress_bar import SimpleRichProgressBar
 from hailtop.utils import parse_docker_image_reference, async_to_blocking, bounded_gather, url_scheme
-from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES, hailgenetics_python_dill_image_for_current_python_version
+from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES, hailgenetics_hail_image_for_current_python_version
 
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 import hailtop.batch_client.client as bc
@@ -681,7 +681,7 @@ class ServiceBackend(Backend[bc.Batch]):
         pyjobs = [j for j in unsubmitted_jobs if isinstance(j, _job.PythonJob)]
         for pyjob in pyjobs:
             if pyjob._image is None:
-                pyjob._image = hailgenetics_python_dill_image_for_current_python_version()
+                pyjob._image = hailgenetics_hail_image_for_current_python_version()
         await batch._serialize_python_functions_to_input_files(
             batch_remote_tmpdir, dry_run=dry_run
         )

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -82,10 +82,10 @@ class Batch:
         timeout.
     default_python_image:
         Default image to use for all Python jobs. This must be the full name of the image including
-        any repository prefix and tags if desired (default tag is `latest`).  The image must have
+        any repository prefix and tags if desired (default tag is `latest`). The image must have
         the `dill` Python package installed and have the same version of Python installed that is
-        currently running. If `None`, a compatible Python image with `dill` pre-installed will
-        automatically be used if the current Python version is 3.9, or 3.10.
+        currently running. If `None`, a tag of the `hailgenetics/hail` image will be chosen
+        according to the current Hail and Python version.
     default_spot:
         If unspecified or ``True``, jobs will run by default on spot instances. If ``False``, jobs
         will run by default on non-spot instances. Each job can override this setting with

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -8,7 +8,7 @@ import dill
 import functools
 
 from hailtop.utils import secret_alnum_string, partition
-from hailtop.batch.hail_genetics_images import hailgenetics_python_dill_image_for_current_python_version
+from hailtop.batch.hail_genetics_images import hailgenetics_hail_image_for_current_python_version
 import hailtop.batch_client.aioclient as low_level_batch_client
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 from hailtop.aiotools.router_fs import RouterAsyncFS
@@ -136,7 +136,7 @@ class BatchPoolExecutor:
         self.finished_future_count = 0
         self._shutdown = False
         if image is None:
-            self.image = hailgenetics_python_dill_image_for_current_python_version()
+            self.image = hailgenetics_hail_image_for_current_python_version()
         else:
             self.image = image
         self.cpus_per_job = cpus_per_job

--- a/hail/python/hailtop/batch/hail_genetics_images.py
+++ b/hail/python/hailtop/batch/hail_genetics_images.py
@@ -1,5 +1,7 @@
 import sys
 
+from hailtop import pip_version
+
 
 HAIL_GENETICS = 'hailgenetics/'
 HAIL_GENETICS_IMAGES = [
@@ -7,11 +9,11 @@ HAIL_GENETICS_IMAGES = [
     for name in ('hail', 'hailtop', 'genetics', 'python-dill', 'vep-grch37-85', 'vep-grch38-95')]
 
 
-def hailgenetics_python_dill_image_for_current_python_version():
+def hailgenetics_hail_image_for_current_python_version():
     version = sys.version_info
     if version.major != 3 or version.minor not in (9, 10, 11):
         raise ValueError(
             f'You must specify an "image" for Python jobs and the BatchPoolExecutor if you are '
             f'using a Python version other than 3.9, 3.10, or 3.11 (you are using {version})'
         )
-    return f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
+    return f'hailgenetics/hail:{pip_version()}-py{version.major}.{version.minor}'

--- a/hail/python/hailtop/batch/hail_genetics_images.py
+++ b/hail/python/hailtop/batch/hail_genetics_images.py
@@ -16,4 +16,6 @@ def hailgenetics_hail_image_for_current_python_version():
             f'You must specify an "image" for Python jobs and the BatchPoolExecutor if you are '
             f'using a Python version other than 3.9, 3.10, or 3.11 (you are using {version})'
         )
+    if version.minor == 9:
+        return f'hailgenetics/hail:{pip_version()}'
     return f'hailgenetics/hail:{pip_version()}-py{version.major}.{version.minor}'

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -19,13 +19,17 @@ REMOTE=$4
 WHEEL=$5
 GITHUB_OAUTH_HEADER_FILE=$6
 HAIL_GENETICS_HAIL_IMAGE=$7
-HAIL_GENETICS_HAILTOP_IMAGE=$8
-HAIL_GENETICS_VEP_GRCH37_85_IMAGE=$9
-HAIL_GENETICS_VEP_GRCH37_85_IMAGE=${10}
-WHEEL_FOR_AZURE=${11}
-WEBSITE_TAR=${12}
+HAIL_GENETICS_HAIL_IMAGE_PY_3_10=$8
+HAIL_GENETICS_HAIL_IMAGE_PY_3_11=$9
+HAIL_GENETICS_HAILTOP_IMAGE=${10}
+HAIL_GENETICS_VEP_GRCH37_85_IMAGE=${11}
+HAIL_GENETICS_VEP_GRCH37_85_IMAGE=${12}
+WHEEL_FOR_AZURE=${13}
+WEBSITE_TAR=${14}
 
 retry skopeo inspect $HAIL_GENETICS_HAIL_IMAGE || (echo "could not pull $HAIL_GENETICS_HAIL_IMAGE" ; exit 1)
+retry skopeo inspect $HAIL_GENETICS_HAIL_IMAGE_PY_3_10 || (echo "could not pull $HAIL_GENETICS_HAIL_IMAGE_PY_3_10" ; exit 1)
+retry skopeo inspect $HAIL_GENETICS_HAIL_IMAGE_PY_3_11 || (echo "could not pull $HAIL_GENETICS_HAIL_IMAGE_PY_3_11" ; exit 1)
 retry skopeo inspect $HAIL_GENETICS_HAILTOP_IMAGE || (echo "could not pull $HAIL_GENETICS_HAILTOP_IMAGE" ; exit 1)
 retry skopeo inspect $HAIL_GENETICS_VEP_GRCH37_85_IMAGE || (echo "could not pull $HAIL_GENETICS_VEP_GRCH37_85_IMAGE" ; exit 1)
 retry skopeo inspect $HAIL_GENETICS_VEP_GRCH38_95_IMAGE || (echo "could not pull $HAIL_GENETICS_VEP_GRCH38_95_IMAGE" ; exit 1)
@@ -81,11 +85,19 @@ curl -XPOST -H @$GITHUB_OAUTH_HEADER_FILE https://api.github.com/repos/hail-is/h
 }'
 
 retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://docker.io/hailgenetics/hail:$HAIL_PIP_VERSION
+retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://docker.io/hailgenetics/hail:$HAIL_PIP_VERSION-py3.9
 retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hail:$HAIL_PIP_VERSION
-retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE docker://docker.io/hailgenetics/hailtop:$HAIL_PIP_VERSION
-retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hailtop:$HAIL_PIP_VERSION
+retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hail:$HAIL_PIP_VERSION-py3.9
+
+retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE_PY_3_10 docker://docker.io/hailgenetics/hail:$HAIL_PIP_VERSION-py3.10
+retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE_PY_3_10 docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hail:$HAIL_PIP_VERSION-py3.10
+
+retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE_PY_3_11 docker://docker.io/hailgenetics/hailtop:$HAIL_PIP_VERSION-py3.11
+retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE_PY_3_11 docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hailtop:$HAIL_PIP_VERSION-py3.11
+
 retry skopeo copy $HAIL_GENETICS_VEP_GRCH37_85_IMAGE docker://docker.io/hailgenetics/vep-grch37-85:$HAIL_PIP_VERSION
 retry skopeo copy $HAIL_GENETICS_VEP_GRCH37_85_IMAGE docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/vep-grch37-85:$HAIL_PIP_VERSION
+
 retry skopeo copy $HAIL_GENETICS_VEP_GRCH38_95_IMAGE docker://docker.io/hailgenetics/vep-grch38-95:$HAIL_PIP_VERSION
 retry skopeo copy $HAIL_GENETICS_VEP_GRCH38_95_IMAGE docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/vep/grch38-95:$HAIL_PIP_VERSION
 

--- a/infra/gcp-broad/gcp-ar-cleanup-policy.txt
+++ b/infra/gcp-broad/gcp-ar-cleanup-policy.txt
@@ -119,6 +119,8 @@
                 "hail-run",
                 "hail-ubuntu",
                 "hail-ubuntu-py-3-10",
+                "hail-ubuntu-python-3-10",
+                "hail-ubuntu-python-3-11",
                 "hailgenetics/hail",
                 "hailgenetics/hailtop",
                 "hailgenetics/vep-grch37-85",


### PR DESCRIPTION
CHANGELOG: Python jobs in Hail Batch that use the default image now support all supported python versions and include the `hail` python package.

The `-py3.X` tag suffix is copied from dask's DockerHub images. Resolves #13558