### PR TITLE
[jvm-fs] rename listStatus to listDirectory

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -561,7 +561,7 @@ object TableTextFinalizer {
   }
 
   def cleanup(fs: FS, outputPath: String, files: Array[String]): Unit = {
-    val outputFiles = fs.listStatus(fs.makeQualified(outputPath)).map(_.getPath).toSet
+    val outputFiles = fs.listDirectory(fs.makeQualified(outputPath)).map(_.getPath).toSet
     val fileSet = files.map(fs.makeQualified(_)).toSet
     outputFiles.diff(fileSet).foreach(fs.delete(_, false))
   }

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -163,7 +163,7 @@ object LoadBgen {
           warn(s"input file does not have .bgen extension: $file")
 
         if (fs.isDir(file))
-          fs.listStatus(file)
+          fs.listDirectory(file)
             .filter(fileListEntry => ".*part-[0-9]+(-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?".r.matches(fileListEntry.getPath.toString))
         else
           Array(fileListEntry)

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -379,7 +379,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
     }
   }
 
-  def listStatus(filename: String): Array[FileListEntry] = handlePublicAccessError(filename) {
+  def listDirectory(filename: String): Array[FileListEntry] = handlePublicAccessError(filename) {
     val url = AzureStorageFS.parseUrl(filename)
 
     val blobContainerClient: BlobContainerClient = getContainerClient(url)

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -340,9 +340,9 @@ trait FS extends Serializable {
 
   def delete(filename: String, recursive: Boolean)
 
-  def listStatus(filename: String): Array[FileListEntry]
+  def listDirectory(filename: String): Array[FileListEntry]
 
-  def listStatus(url: URL): Array[FileListEntry] = listStatus(url.toString)
+  def listDirectory(url: URL): Array[FileListEntry] = listDirectory(url.toString)
 
   def glob(filename: String): Array[FileListEntry]
 
@@ -376,7 +376,7 @@ trait FS extends Serializable {
         val c = components(i)
         if (containsWildcard(c)) {
           val m = javaFS.getPathMatcher(s"glob:$c")
-          for (cfs <- listStatus(prefix)) {
+          for (cfs <- listDirectory(prefix)) {
             val p = dropTrailingSlash(cfs.getPath)
             val d = p.drop(prefix.toString.length + 1)
             if (m.matches(javaFS.getPath(d))) {

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -450,9 +450,9 @@ class GoogleStorageFS(
     globWithPrefix(url.withPath(""), path = dropTrailingSlash(url.path))
   }
 
-  def listStatus(filename: String): Array[FileListEntry] = listStatus(parseUrl(filename))
+  def listDirectory(filename: String): Array[FileListEntry] = listDirectory(parseUrl(filename))
 
-  override def listStatus(url: GoogleStorageFSURL): Array[FileListEntry] = retryTransientErrors {
+  override def listDirectory(url: GoogleStorageFSURL): Array[FileListEntry] = retryTransientErrors {
     val path = if (url.path.endsWith("/")) url.path else url.path + "/"
 
     val blobs = retryTransientErrors {

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -123,7 +123,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     new hadoop.fs.Path(filename).getFileSystem(conf.value)
   }
 
-  def listStatus(filename: String): Array[FileListEntry] = {
+  def listDirectory(filename: String): Array[FileListEntry] = {
     val fs = getFileSystem(filename)
     val hPath = new hadoop.fs.Path(filename)
     var statuses = fs.globStatus(hPath)

--- a/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
@@ -28,7 +28,7 @@ class RouterFS(fss: IndexedSeq[FS]) extends FS {
 
   def delete(filename: String, recursive: Boolean) = lookupFS(filename).delete(filename, recursive)
 
-  def listStatus(filename: String): Array[FileListEntry] = lookupFS(filename).listStatus(filename)
+  def listDirectory(filename: String): Array[FileListEntry] = lookupFS(filename).listDirectory(filename)
 
   def glob(filename: String): Array[FileListEntry] = lookupFS(filename).glob(filename)
 

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -51,7 +51,7 @@ trait Py4jUtils {
   def makeDouble(d: Double): Double = d
 
   def ls(fs: FS, path: String): String = {
-    val statuses = fs.listStatus(path)
+    val statuses = fs.listDirectory(path)
     JsonMethods.compact(JArray(statuses.map(fs => fileListEntryToJson(fs)).toList))
   }
 

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -592,7 +592,7 @@ object ReferenceGenome {
 
   def readReferences(fs: FS, path: String): Array[ReferenceGenome] = {
     if (fs.exists(path)) {
-      val refs = fs.listStatus(path)
+      val refs = fs.listDirectory(path)
       val rgs = mutable.Set[ReferenceGenome]()
       refs.foreach { fileSystem =>
         val rgPath = fileSystem.getPath.toString

--- a/hail/src/test/scala/is/hail/io/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/io/fs/FSSuite.scala
@@ -134,13 +134,13 @@ trait FSSuite extends TestNGSuite {
     fs.delete(s"$d/foo", recursive = true)
   }
 
-  @Test def testListStatusDir(): Unit = {
-    val statuses = fs.listStatus(r(""))
+  @Test def testListDirectory(): Unit = {
+    val statuses = fs.listDirectory(r(""))
     assert(pathsRelResourcesRoot(statuses) == Set("/a", "/adir", "/az", "/dir", "/zzz"))
   }
 
-  @Test def testListStatusDirWithSlash(): Unit = {
-    val statuses = fs.listStatus(r("/"))
+  @Test def testListDirectoryWithSlash(): Unit = {
+    val statuses = fs.listDirectory(r("/"))
     assert(pathsRelResourcesRoot(statuses) == Set("/a", "/adir", "/az", "/dir", "/zzz"))
   }
 
@@ -401,7 +401,7 @@ trait FSSuite extends TestNGSuite {
       fs.touch(s"$prefix/$i.suffix")
     }
 
-    assert(fs.listStatus(prefix).size == 2000)
+    assert(fs.listDirectory(prefix).size == 2000)
     assert(fs.glob(prefix + "/" + "*.suffix").size == 2000)
 
     assert(fs.exists(prefix))
@@ -410,7 +410,7 @@ trait FSSuite extends TestNGSuite {
       // NB: TestNGSuite.assert does not have a lazy message argument so we must use an if to protect this list
       //
       // see: https://www.scalatest.org/scaladoc/1.7.2/org/scalatest/testng/TestNGSuite.html
-      assert(false, s"files not deleted:\n${ fs.listStatus(prefix).map(_.getPath).mkString("\n") }")
+      assert(false, s"files not deleted:\n${ fs.listDirectory(prefix).map(_.getPath).mkString("\n") }")
     }
   }
 

--- a/hail/src/test/scala/is/hail/io/fs/FakeFS.scala
+++ b/hail/src/test/scala/is/hail/io/fs/FakeFS.scala
@@ -6,7 +6,7 @@ abstract class FakeFS extends FS {
   override def openNoCompression(filename: String): SeekableDataInputStream = ???
   override def createNoCompression(filename: String): PositionedDataOutputStream = ???
   override def delete(filename: String, recursive: Boolean): Unit = ???
-  override def listStatus(filename: String): Array[FileListEntry] = ???
+  override def listDirectory(filename: String): Array[FileListEntry] = ???
   override def glob(filename: String): Array[FileListEntry] = ???
   override def fileListEntry(filename: String): FileListEntry = ???
   override def eTag(filename: String): Option[String] = ???


### PR DESCRIPTION
The "status" in `listStatus` referred to `FileStatus`, a Hadoop abstraction of a Linux `stat` object. In my last PR, I split that concept into `FileStatus` and `FileListEntry` where the former is only for files and the latter is for the contents of a directory (in the latter case, cloud providers usually definitively tell you if a path is an object, an object and a prefix [aka directory], or a prefix).

This method is really about listing (a la `ls`) directories, so I have changed its name to reflect that.

I specifically choose not to name it `ls` or `list` because I do not want it confused with `ls` because `ls` typically supports "listing" a specific file. This method is only for listing the contents of a directory.