### PR TITLE
[query/ggplot] makes plotting setup lazy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ wheel-container.tar
 *-image
 hail/python/hail/backend/extra_classpath
 hail/python/hail/backend/hail.jar
+hail/install-editable

--- a/hail/python/hail/ggplot/__init__.py
+++ b/hail/python/hail/ggplot/__init__.py
@@ -1,6 +1,6 @@
-from hailtop import IS_NOTEBOOK
+from hailtop import is_notebook
 
-if IS_NOTEBOOK:
+if is_notebook():
     from plotly.io import renderers
     renderers.default='iframe'
 

--- a/hail/python/hail/plot/__init__.py
+++ b/hail/python/hail/plot/__init__.py
@@ -1,6 +1,6 @@
-from hailtop import IS_NOTEBOOK
+from hailtop import is_notebook
 
-if IS_NOTEBOOK:
+if is_notebook():
     from bokeh.io import output_notebook
     output_notebook()
 

--- a/hail/python/hailtop/__init__.py
+++ b/hail/python/hailtop/__init__.py
@@ -13,8 +13,15 @@ def pip_version() -> str:
     return version().split('-')[0]
 
 
-try:
-    from IPython.core.getipython import get_ipython
-    IS_NOTEBOOK = get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
-except (NameError, ModuleNotFoundError):
-    IS_NOTEBOOK = False
+IS_NOTEBOOK = None
+
+
+def is_notebook() -> bool:
+    global IS_NOTEBOOK
+    if IS_NOTEBOOK is None:
+        try:
+            from IPython.core.getipython import get_ipython  # pylint: disable=import-outside-toplevel
+            IS_NOTEBOOK = get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
+        except (NameError, ModuleNotFoundError):
+            IS_NOTEBOOK = False
+    return IS_NOTEBOOK

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -9,7 +9,7 @@ import aiohttp
 import orjson
 import secrets
 
-from hailtop import IS_NOTEBOOK
+from hailtop import is_notebook
 from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.aiocloud.common import Session
 from hailtop.aiocloud.common.credentials import CloudCredentials
@@ -446,7 +446,7 @@ class Batch:
         url = deploy_config.external_url('batch', f'/batches/{self.id}')
         i = 0
         status = await self.status()
-        if IS_NOTEBOOK:
+        if is_notebook():
             description += f'[link={url}]{self.id}[/link]'
         else:
             description += url


### PR DESCRIPTION
https://github.com/hail-is/hail/pull/13610 added the setup for bokeh and plotly into `hailtop/__init__.py`, which causes `IPython` to be imported when invoking `hailctl`, adding unnecessary startup time to it (observed between 0.210s and 0.400s). This change moves the setup into the `__init__.py` files for the plotting modules, with the resulting state stored in a global variable in `hailtop/__init__.py`. The plotting setup is still run upon invoking `import hail`, as this imports all submodules of hail as well, but the `IPython` import no longer happens when invoking `hailctl`.