### PR TITLE
[query] Give test_ld_prune more time on the batch backend

### DIFF
--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1372,7 +1372,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(1, mt._force_count_rows())
 
     @qobtest
-    @test_timeout(batch=6 * 60)
+    @test_timeout(batch=9 * 60)
     def test_ld_prune(self):
         r2_threshold = 0.001
         window_size = 5


### PR DESCRIPTION
It's cutting it too close and sometimes timing out when jobs land on cold JVMs.