### PR TITLE
[qob] fix QoBAppender for real this time

### DIFF
--- a/batch/jvm-entryway/src/main/scala/is/hail/QoBAppender.scala
+++ b/batch/jvm-entryway/src/main/scala/is/hail/QoBAppender.scala
@@ -14,7 +14,7 @@ object QoBOutputStreamManager {
   private[this] var _instances: mutable.Map[Layout[_], QoBOutputStreamManager] = mutable.Map()
   private[this] var _filename: String = null
 
-  private def getInstance(layout: Layout[_]): QoBOutputStreamManager = synchronized {
+  def getInstance(layout: Layout[_]): QoBOutputStreamManager = synchronized {
     _instances.getOrElseUpdate(layout, new QoBOutputStreamManager(layout, _filename))
   }
 

--- a/batch/jvm-entryway/src/main/scala/is/hail/QoBAppender.scala
+++ b/batch/jvm-entryway/src/main/scala/is/hail/QoBAppender.scala
@@ -27,7 +27,7 @@ object QoBOutputStreamManager {
     _instances.remove(layout)
   }
 
-  private def flushAllAppenders(): Unit = synchronized {
+  def flushAllAppenders(): Unit = synchronized {
     _instances.values.foreach(_.flush())
   }
 }


### PR DESCRIPTION
Recent log demonstrating the failure: https://cloudlogging.app.goo.gl/ayiTFRnkLdrSzY2j7

In retrospect this seems kind of obvious. Consider `JVMEntryway`. The first `log` statement occurs on line 98 (the line after we set the filename). I think, in my head, the Appender would be created when we initialized the Logger on line 17. That's apparently incorrect. The Appender is lazily created when some internal buffer fills and the logger flushes that buffer.

That internal buffer is most likely to fill on the `log.error` lines because they dump a (large) stack trace to the log. That's why we always see the error there.

The fix is simple: we track the currently desired output filename and, if we happen to create an appender *after* someone has called `changeFileInAllAppenders`, we initialize that new appender with the filename.

This change ensures that, except for a short period during start up, there is always a valid filename. That short period is just the time between the JVM starting, allocating a `JVMEntryway`, calling `main` and getting to line 97. During that time, we carefully use `System.err.println` (not a logger) if something goes wrong.