### PR TITLE
[deploy] Fix deploy script to correctly push 3.11 image and hailtop image

### DIFF
--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -92,8 +92,11 @@ retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE docker://us-docker.pkg.dev/hail-vdc/
 retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE_PY_3_10 docker://docker.io/hailgenetics/hail:$HAIL_PIP_VERSION-py3.10
 retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE_PY_3_10 docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hail:$HAIL_PIP_VERSION-py3.10
 
-retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE_PY_3_11 docker://docker.io/hailgenetics/hailtop:$HAIL_PIP_VERSION-py3.11
-retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE_PY_3_11 docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hailtop:$HAIL_PIP_VERSION-py3.11
+retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE_PY_3_11 docker://docker.io/hailgenetics/hail:$HAIL_PIP_VERSION-py3.11
+retry skopeo copy $HAIL_GENETICS_HAIL_IMAGE_PY_3_11 docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hail:$HAIL_PIP_VERSION-py3.11
+
+retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE docker://docker.io/hailgenetics/hailtop:$HAIL_PIP_VERSION
+retry skopeo copy $HAIL_GENETICS_HAILTOP_IMAGE docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/hailtop:$HAIL_PIP_VERSION
 
 retry skopeo copy $HAIL_GENETICS_VEP_GRCH37_85_IMAGE docker://docker.io/hailgenetics/vep-grch37-85:$HAIL_PIP_VERSION
 retry skopeo copy $HAIL_GENETICS_VEP_GRCH37_85_IMAGE docker://us-docker.pkg.dev/hail-vdc/hail/hailgenetics/vep-grch37-85:$HAIL_PIP_VERSION


### PR DESCRIPTION
#13643 just totally mixed up the hailtop and hail 3.11 images. `$HAIL_GENETICS_HAILTOP_IMAGE_PY_3_11` does not exist.