### PR TITLE
[batch] substantially reduce PR test costs

### DIFF
--- a/batch/sql/set-test-pools-to-known-parameters.py
+++ b/batch/sql/set-test-pools-to-known-parameters.py
@@ -33,7 +33,7 @@ SET
   max_new_instances_per_autoscaler_loop = %s,
   autoscaler_loop_period_secs = %s,
   worker_max_idle_time_secs = %s
-WHERE name == %s
+WHERE name = %s
             ''',
             (
                 max_instances,
@@ -54,7 +54,7 @@ SET
   standing_worker_max_idle_time_secs = %s,
   job_queue_scheduling_window_secs = %s,
   min_instances = %s
-WHERE name == %s
+WHERE name = %s
             ''',
             (
                 worker_cores,

--- a/batch/sql/set-test-pools-to-known-parameters.py
+++ b/batch/sql/set-test-pools-to-known-parameters.py
@@ -1,0 +1,103 @@
+import os
+import asyncio
+from gear import Database
+
+
+async def main():
+    if os.environ['HAIL_SCOPE'] in ('deploy', 'dev'):
+        return
+
+    db = Database()
+    await db.async_init()
+
+    async def set_pool(
+        name,
+        max_instances = 16,
+        max_live_instances = 16,
+        max_new_instances_per_autoscaler_loop = 10,
+        autoscaler_loop_period_secs = 15,
+        worker_max_idle_time_secs = 120,
+        worker_cores = 16,
+        enable_standing_worker = False,
+        standing_worker_cores = 16,
+        standing_worker_max_idle_time_secs = 5 * 60,
+        job_queue_scheduling_window_secs = 150,
+        min_instances = 1,
+    ):
+        await db.execute_update(
+            '''
+UPDATE inst_colls
+SET
+  max_instances = %s,
+  max_live_instances = %s,
+  max_new_instances_per_autoscaler_loop = %s,
+  autoscaler_loop_period_secs = %s,
+  worker_max_idle_time_secs = %s
+WHERE name == %s
+            ''',
+            (
+                max_instances,
+                max_live_instances,
+                max_new_instances_per_autoscaler_loop,
+                autoscaler_loop_period_secs,
+                worker_max_idle_time_secs,
+                name,
+            )
+        )
+        await db.execute_update(
+            '''
+UPDATE pools
+SET
+  worker_cores = %s,
+  enable_standing_worker = %s,
+  standing_worker_cores = %s,
+  standing_worker_max_idle_time_secs = %s,
+  job_queue_scheduling_window_secs = %s,
+  min_instances = %s
+WHERE name == %s
+            ''',
+            (
+                worker_cores,
+                enable_standing_worker,
+                standing_worker_cores,
+                standing_worker_max_idle_time_secs,
+                job_queue_scheduling_window_secs,
+                min_instances,
+                name,
+            )
+        )
+
+    await set_pool(
+        'highcpu',
+        min_instances=0,
+        enable_standing_worker=False,
+    )
+    await set_pool(
+        'highcpu-np',
+        min_instances=0,
+        enable_standing_worker=False,
+    )
+    await set_pool(
+        'highmem',
+        min_instances=0,
+        enable_standing_worker=False,
+    )
+    await set_pool(
+        'highmem-np',
+        min_instances=0,
+        enable_standing_worker=False,
+    )
+    await set_pool(
+        'standard',
+        min_instances=0,
+        enable_standing_worker=True,
+    )
+    await set_pool(
+        'standard-np',
+        min_instances=0,
+        enable_standing_worker=True,
+    )
+    await db.async_close()
+
+
+asyncio.run(main())

--- a/batch/sql/set-test-pools-to-known-parameters.py
+++ b/batch/sql/set-test-pools-to-known-parameters.py
@@ -22,8 +22,10 @@ async def main():
         standing_worker_cores = 16,
         standing_worker_max_idle_time_secs = 5 * 60,
         job_queue_scheduling_window_secs = 150,
-        min_instances = 1,
+        min_instances = 0,
     ):
+        assert not enable_standing_worker, 'use min_instances'
+
         await db.execute_update(
             '''
 UPDATE inst_colls
@@ -69,33 +71,27 @@ WHERE name = %s
 
     await set_pool(
         'highcpu',
-        min_instances=0,
-        enable_standing_worker=False,
+        min_instances=0,  # min_instances means n_standing_workers
     )
     await set_pool(
         'highcpu-np',
-        min_instances=0,
-        enable_standing_worker=False,
+        min_instances=0,  # min_instances means n_standing_workers
     )
     await set_pool(
         'highmem',
-        min_instances=0,
-        enable_standing_worker=False,
+        min_instances=0,  # min_instances means n_standing_workers
     )
     await set_pool(
         'highmem-np',
-        min_instances=0,
-        enable_standing_worker=False,
+        min_instances=0,  # min_instances means n_standing_workers
     )
     await set_pool(
         'standard',
-        min_instances=0,
-        enable_standing_worker=True,
+        min_instances=1,  # min_instances means n_standing_workers
     )
     await set_pool(
         'standard-np',
-        min_instances=0,
-        enable_standing_worker=True,
+        min_instances=1,  # min_instances means n_standing_workers
     )
     await db.async_close()
 

--- a/build.yaml
+++ b/build.yaml
@@ -2295,6 +2295,9 @@ steps:
       - name: cleanup-deprecated-functions
         script: /io/sql/cleanup-deprecated-functions.sql
         online: true
+      - name: set-test-pools-to-known-parameters
+        script: /io/sql/set-test-pools-to-known-parameters.py
+        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
The biggest benefit of this PR is that I declare most of the pool state in one file so that we have one place to look to figure out what the tests are doing.

We pay about 2 USD per PR test, which is not very high but still higher than I would like. I investigated why and looked at eight recent PR tests (all after Daniel's QoB test reduction):

1. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1695065243258&to=1695070128973&var-namespace=pr-13643-default-w484n4ke6oeg&orgId=1
2. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1694628837271&to=1694632585473&var-namespace=pr-12468-default-y8okmle5k65x&orgId=1
3. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1695078157872&to=1695080578446&var-namespace=pr-13644-default-phtb7scq3qln&orgId=1
4. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1694729270680&to=1694730449193&var-namespace=pr-13376-default-biulo4i0wohp&orgId=1
5. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1694628896138&to=1694632029521&var-namespace=pr-12468-default-y8okmle5k65x&orgId=1
6. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1695077856969&to=1695080563275&var-namespace=pr-13644-default-phtb7scq3qln&orgId=1
7. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1694625081745&to=1694626754800&var-namespace=pr-13430-default-hf2v0q29kgqy&orgId=1
8. https://grafana.hail.is/d/8Kldmmynk/job-analytics?from=1694729252321&to=1694730683820&var-namespace=pr-13376-default-biulo4i0wohp&orgId=1

In every case, we spin up 32 cores of highcpu VMs but, apparently, never use them. They are live for 20-40 minutes depending on the tests. For the non-preemptible VM, thats about 0.40 USD for 30 minutes. We use 16 highmem cores once for about two minutes but we otherwise let them run idle the whole time. This PR accepts that we will wait 2-3min for a highmem to start when we need it. In exchange, we save about a dollar per PR (50%). I am also investigating why we seem to keep 80 cores alive for about 10 minutes despite being unused. My best guess is fragmentation, probably not much to do about that.

cc: @daniel-goldstein, @jigold.