### PR TITLE
[batch] disable bunch submission progress bar when fewer than 100

### DIFF
--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -832,10 +832,10 @@ class Batch:
         assert max_bunch_size > 0
 
         if progress:
-            start_job_id = await self._submit(max_bunch_bytesize, max_bunch_size, disable_progress_bar, None, progress)
+            start_job_id = await self._submit(max_bunch_bytesize, max_bunch_size, disable_progress_bar, progress)
         else:
             with BatchProgressBar(disable=disable_progress_bar) as progress2:
-                start_job_id = await self._submit(max_bunch_bytesize, max_bunch_size, disable_progress_bar, 100, progress2)
+                start_job_id = await self._submit(max_bunch_bytesize, max_bunch_size, disable_progress_bar, progress2)
 
         assert self.is_created
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -782,16 +782,12 @@ class Batch:
                       max_bunch_bytesize: int,
                       max_bunch_size: int,
                       disable_progress_bar: bool,
-                      min_bunches_for_progress_bar: Optional[int],
                       progress: BatchProgressBar) -> Optional[int]:
         n_jobs = len(self._jobs)
         byte_job_specs_bunches, job_bunch_sizes = self._create_bunches(self._job_specs, max_bunch_bytesize, max_bunch_size)
         n_job_bunches = len(byte_job_specs_bunches)
 
-        if min_bunches_for_progress_bar is not None and n_job_bunches < 100:
-            progress.progress.disable = True
-
-        with progress.with_task('submit job bunches', total=n_jobs, disable=disable_progress_bar) as job_progress_task:
+        with progress.with_task('submit job bunches', total=n_jobs, disable=(disable_progress_bar or n_job_bunches < 100)) as job_progress_task:
             if not self.is_created:
                 if n_job_bunches == 0:
                     await self._open_batch()

--- a/hail/python/hailtop/utils/rich_progress_bar.py
+++ b/hail/python/hailtop/utils/rich_progress_bar.py
@@ -4,18 +4,18 @@ from rich.progress import MofNCompleteColumn, BarColumn, TextColumn, TimeRemaini
 
 class SimpleRichProgressBarTask:
     def __init__(self, progress: Progress, tid):
-        self.progress = progress
+        self._progress = progress
         self.tid = tid
 
     def total(self) -> int:
-        assert len(self.progress.tasks) == 1
-        return int(self.progress.tasks[0].total or 0)
+        assert len(self._progress.tasks) == 1
+        return int(self._progress.tasks[0].total or 0)
 
     def update(self, delta_n: int, *, total: Optional[int] = None):
-        self.progress.update(self.tid, advance=delta_n, total=total)
+        self._progress.update(self.tid, advance=delta_n, total=total)
 
     def make_listener(self) -> Callable[[int], None]:
-        return make_listener(self.progress, self.tid)
+        return make_listener(self._progress, self.tid)
 
 
 class SimpleRichProgressBar:
@@ -25,21 +25,21 @@ class SimpleRichProgressBar:
         self.visible = visible
         if len(args) == 0:
             args = RichProgressBar.get_default_columns()
-        self.progress = Progress(*args, **kwargs)
+        self._progress = Progress(*args, **kwargs)
 
     def __enter__(self) -> SimpleRichProgressBarTask:
-        self.progress.start()
-        tid = self.progress.add_task(self.description or '', total=self.total, visible=self.visible)
-        return SimpleRichProgressBarTask(self.progress, tid)
+        self._progress.start()
+        tid = self._progress.add_task(self.description or '', total=self.total, visible=self.visible)
+        return SimpleRichProgressBarTask(self._progress, tid)
 
     def __exit__(self, exc_type, exc_value, traceback):
         del exc_type
         del exc_value
         del traceback
         try:
-            self.progress.refresh()
+            self._progress.refresh()
         finally:
-            self.progress.stop()
+            self._progress.stop()
 
 
 def make_listener(progress: Progress, tid) -> Callable[[int], None]:
@@ -59,7 +59,7 @@ class RichProgressBar:
     def __init__(self, *args, **kwargs):
         if len(args) == 0:
             args = RichProgressBar.get_default_columns()
-        self.progress = Progress(*args, **kwargs)
+        self._progress = Progress(*args, **kwargs)
 
     @staticmethod
     def get_default_columns() -> Tuple[ProgressColumn, ...]:
@@ -72,24 +72,24 @@ class RichProgressBar:
         )
 
     def __enter__(self) -> Progress:
-        self.progress.start()
-        return self.progress
+        self._progress.start()
+        return self._progress
 
     def __exit__(self, exc_type, exc_value, traceback):
         del exc_type
         del exc_value
         del traceback
         try:
-            self.progress.refresh()
+            self._progress.refresh()
         finally:
-            self.progress.stop()
+            self._progress.stop()
 
 
 class BatchProgressBar:
     def __init__(self, *args, **kwargs):
         if len(args) == 0:
             args = BatchProgressBar.get_default_columns()
-        self.progress = Progress(*args, **kwargs)
+        self._progress = Progress(*args, **kwargs)
 
     @staticmethod
     def get_default_columns() -> Tuple[ProgressColumn, ...]:
@@ -103,7 +103,7 @@ class BatchProgressBar:
         )
 
     def __enter__(self) -> 'BatchProgressBar':
-        self.progress.start()
+        self._progress.start()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -111,24 +111,24 @@ class BatchProgressBar:
         del exc_value
         del traceback
         try:
-            self.progress.refresh()
+            self._progress.refresh()
         finally:
-            self.progress.stop()
+            self._progress.stop()
 
     def with_task(self, description: str, *, total: int = 0, disable: bool = False, transient: bool = False) -> 'BatchProgressBarTask':
-        tid = self.progress.add_task(description, total=total, disable=disable)
-        return BatchProgressBarTask(self.progress, tid, transient)
+        tid = self._progress.add_task(description, total=total, disable=disable)
+        return BatchProgressBarTask(self._progress, tid, transient)
 
 
 class BatchProgressBarTask:
     def __init__(self, progress: Progress, tid, transient: bool):
-        self.progress = progress
+        self._progress = progress
         self.tid = tid
         self.transient = transient
 
     def total(self) -> int:
-        assert len(self.progress.tasks) == 1
-        return int(self.progress.tasks[0].total or 0)
+        assert len(self._progress.tasks) == 1
+        return int(self._progress.tasks[0].total or 0)
 
     def __enter__(self) -> 'BatchProgressBarTask':
         return self
@@ -138,7 +138,7 @@ class BatchProgressBarTask:
         del exc_value
         del traceback
         if self.transient:
-            self.progress.remove_task(self.tid)
+            self._progress.remove_task(self.tid)
 
     def update(self, advance: Optional[int] = None, **kwargs):
-        self.progress.update(self.tid, advance=advance, **kwargs)
+        self._progress.update(self.tid, advance=advance, **kwargs)


### PR DESCRIPTION
I think this was inadvertantly broken. The `Progress.disable` property needs to be set *before* you start the progress bar, otherwise it has no effect. Clients of all these progress bars should not touch their `Progress` instance, that is an implementation detail. I have changed rich_progress_bar.py to use `_progress` to clearly communicate this.