### PR TITLE
[devbin] Add a script for running a database locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,16 @@ vep-grch38-image: hail-ubuntu-image
 		./docker-build.sh docker/vep docker/vep/grch38/95/Dockerfile $(VEP_GRCH38_IMAGE)
 	echo $(VEP_GRCH38_IMAGE) > $@
 
-.PHONY: $(SERVICES_DATABASES)
-$(SERVICES_DATABASES): %-db:
+.PHONY: local-mysql
+local-mysql:
 	cd docker/mysql && docker compose up -d
+
+.PHONY: $(SERVICES_DATABASES)
+$(SERVICES_DATABASES): %-db: local-mysql
+ifdef DROP
+$(SERVICES_DATABASES): %-db:
+	MYSQL_PWD=pw mysql -h 127.0.0.1 -u root -e 'DROP DATABASE `local-$*`'
+else
+$(SERVICES_DATABASES): %-db:
 	python3 ci/create_local_database.py $* local-$*
+endif

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ include config.mk
 SERVICES := auth batch ci monitoring website
 SERVICES_PLUS_ADMIN_POD := $(SERVICES) admin-pod
 SERVICES_IMAGES := $(patsubst %, %-image, $(SERVICES_PLUS_ADMIN_POD))
+SERVICES_DATABASES := $(patsubst %, %-db, $(SERVICES))
 SERVICES_MODULES := $(SERVICES) gear web_common
 CHECK_SERVICES_MODULES := $(patsubst %, check-%, $(SERVICES_MODULES))
 
@@ -219,3 +220,8 @@ vep-grch38-image: hail-ubuntu-image
 	DOCKER_BUILD_ARGS='--build-arg BASE_IMAGE='$$(cat hail-ubuntu-image) \
 		./docker-build.sh docker/vep docker/vep/grch38/95/Dockerfile $(VEP_GRCH38_IMAGE)
 	echo $(VEP_GRCH38_IMAGE) > $@
+
+.PHONY: $(SERVICES_DATABASES)
+$(SERVICES_DATABASES): %-db:
+	cd docker/mysql && docker compose up -d
+	python3 ci/create_local_database.py $* local-$*

--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -24,10 +24,10 @@ RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
 RUN curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && \
     curl -s -L https://nvidia.github.io/libnvidia-container/ubuntu22.04/libnvidia-container.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list 
+    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
 RUN apt-get update && \
-    hail-apt-get-install nvidia-container-toolkit 
+    hail-apt-get-install nvidia-container-toolkit
 
 {% elif global.cloud == "azure" %}
 RUN apt-get update && \

--- a/batch/build-batch-worker-image-startup-gcp.sh
+++ b/batch/build-batch-worker-image-startup-gcp.sh
@@ -7,7 +7,7 @@ bash add-logging-agent-repo.sh
 
 
 # The nvidia toolkit must be installed in this startup script to be able to configure docker with the command nvidia-ctk runtime configure --runtime=docker. This command cannot be run from Dockerfile.worker
-# The toolkit also has to be installed in Dockerfile.worker since to execute the nvidia hook, the toolkit needs to be installed in the container from which crun is invoked. 
+# The toolkit also has to be installed in Dockerfile.worker since to execute the nvidia hook, the toolkit needs to be installed in the container from which crun is invoked.
 
 # Get the latest GPG key as it might not always be up to date
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired

--- a/ci/create_local_database.py
+++ b/ci/create_local_database.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+import tempfile
+from typing import List
+
+import typer
+import yaml
+from create_database import create_migration_tables, migrate
+
+from gear import Database
+
+
+def main(service: str, database_name: str):
+    asyncio.run(async_main(service, database_name))
+
+
+async def async_main(service: str, database_name: str):
+    migrations = read_migrations_from_build_yaml(service)
+
+    db = Database()
+    await db.async_init()
+    await db.just_execute(f'CREATE DATABASE IF NOT EXISTS `{database_name}`;')
+
+    os.environ['HAIL_SQL_DATABASE'] = database_name
+    os.environ['HAIL_SCOPE'] = 'dev'
+    os.environ['HAIL_NAMESPACE'] = 'local'
+
+    if 'HAIL_CLOUD' not in os.environ:
+        os.environ['HAIL_CLOUD'] = 'gcp'
+
+    # Pick up the `HAIL_SQL_DATABASE` change
+    await db.async_close()
+    db = Database()
+    await db.async_init()
+
+    await create_migration_tables(db, database_name)
+    with tempfile.NamedTemporaryFile() as mysql_cnf:
+        mysql_cnf.write(
+            f'''
+[client]
+host = 127.0.0.1
+user = root
+password = pw
+database = {database_name}
+'''.encode()
+        )
+        mysql_cnf.flush()
+        for i, m in enumerate(migrations):
+            await migrate(database_name, db, mysql_cnf.name, i, m)
+
+
+def read_migrations_from_build_yaml(service: str) -> List[dict]:
+    with open('build.yaml', 'r', encoding='utf-8') as f:
+        build = yaml.safe_load(f)
+
+    for step in build['steps']:
+        if step['name'] == f'{service}_database':
+            return [
+                {**m, 'script': m['script'].replace('/io/', f'{service}/'), 'online': True} for m in step['migrations']
+            ]
+    raise ValueError(f'No database for service {service}')
+
+
+if __name__ == '__main__':
+    typer.run(main)

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -213,6 +213,15 @@ that Batch Workers are not running as pods in Kubernetes, and are immutable. So
 if you want to update code running on a Batch Worker, you will need to `make`
 deploy and then delete existing workers in your namespace.
 
+##### Migration testing
+
+If your change involves adding migrations, you can spin up a database locally
+and run those migrations by running `make batch-db` (or sub any service for `batch`)
+in the root of the repository. Multiple invocations of `make batch-db` will run
+any new migrations since the previous run. Note that migrations are immutable!
+So if you *alter* your migration, you need to first drop the database with
+`make batch-db DROP=1` before you run the migrations again.
+
 ## PR
 
 Once you have a branch that you are happy with, then you create a Pull Request

--- a/docker/mysql/compose.yaml
+++ b/docker/mysql/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  mysql:
+    image: mysql:8.0.28
+    volumes:
+      - mysql-data:/var/lib/mysql
+    ports:
+      - 127.0.0.1:3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: pw
+volumes:
+  mysql-data:

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -108,10 +108,11 @@ def get_sql_config(maybe_config_file: Optional[str] = None) -> SQLConfig:
     if config_file is not None:
         with open(config_file, 'r', encoding='utf-8') as f:
             sql_config = SQLConfig.from_json(f.read())
+        sql_config.check()
+        log.info('using tls and verifying server certificates for MySQL')
     else:
         sql_config = SQLConfig.local_insecure_config()
-    sql_config.check()
-    log.info('using tls and verifying server certificates for MySQL')
+        log.info('Using unencrypted config for database on localhost')
     return sql_config
 
 

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -16,7 +16,7 @@ from gear.metrics import DB_CONNECTION_QUEUE_SIZE, SQL_TRANSACTIONS, PrometheusS
 from hailtop.aiotools import BackgroundTaskManager
 from hailtop.auth.sql_config import SQLConfig
 from hailtop.config import get_deploy_config
-from hailtop.utils import sleep_before_try
+from hailtop.utils import first_extant_file, sleep_before_try
 
 log = logging.getLogger('gear.database')
 
@@ -100,20 +100,22 @@ async def resolve_test_db_endpoint(sql_config: SQLConfig) -> SQLConfig:
 
 
 def get_sql_config(maybe_config_file: Optional[str] = None) -> SQLConfig:
-    if maybe_config_file is None:
-        config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE', '/sql-config/sql-config.json')
+    config_file = first_extant_file(
+        maybe_config_file,
+        os.environ.get('HAIL_DATABASE_CONFIG_FILE'),
+        '/sql-config/sql-config.json',
+    )
+    if config_file is not None:
+        with open(config_file, 'r', encoding='utf-8') as f:
+            sql_config = SQLConfig.from_json(f.read())
     else:
-        config_file = maybe_config_file
-    with open(config_file, 'r', encoding='utf-8') as f:
-        sql_config = SQLConfig.from_json(f.read())
+        sql_config = SQLConfig.local_insecure_config()
     sql_config.check()
     log.info('using tls and verifying server certificates for MySQL')
     return sql_config
 
 
-def get_database_ssl_context(sql_config: Optional[SQLConfig] = None) -> ssl.SSLContext:
-    if sql_config is None:
-        sql_config = get_sql_config()
+def get_database_ssl_context(sql_config: SQLConfig) -> ssl.SSLContext:
     database_ssl_context = ssl.create_default_context(cafile=sql_config.ssl_ca)
     if sql_config.ssl_cert is not None and sql_config.ssl_key is not None:
         database_ssl_context.load_cert_chain(sql_config.ssl_cert, keyfile=sql_config.ssl_key, password=None)
@@ -129,8 +131,11 @@ async def create_database_pool(
     sql_config = get_sql_config(config_file)
     if get_deploy_config().location() != 'k8s' and sql_config.host.endswith('svc.cluster.local'):
         sql_config = await resolve_test_db_endpoint(sql_config)
-    ssl_context = get_database_ssl_context(sql_config)
-    assert ssl_context is not None
+    if sql_config.host == 'localhost':
+        ssl_context = None
+    else:
+        ssl_context = get_database_ssl_context(sql_config)
+        assert ssl_context is not None
     return await aiomysql.create_pool(
         maxsize=maxsize,
         # connection args

--- a/hail/python/hailtop/auth/sql_config.py
+++ b/hail/python/hailtop/auth/sql_config.py
@@ -56,6 +56,8 @@ ssl-mode={self.ssl_mode}
         assert self.port is not None
         assert self.user is not None
         assert self.password is not None
+        assert self.instance is not None
+        assert self.connection_name is not None
         if self.ssl_cert is not None:
             assert self.ssl_key is not None
             if not os.path.isfile(self.ssl_cert):
@@ -64,11 +66,9 @@ ssl-mode={self.ssl_mode}
                 raise ValueError(f'specified ssl-key, {self.ssl_key}, does not exist')
         else:
             assert self.ssl_key is None
-        if self.host != 'localhost':
-            assert self.ssl_ca is not None
-            assert self.ssl_mode is not None
-            if not os.path.isfile(self.ssl_ca):
-                raise ValueError(f'specified ssl-ca, {self.ssl_ca}, does not exist')
+        assert self.ssl_ca is not None
+        if not os.path.isfile(self.ssl_ca):
+            raise ValueError(f'specified ssl-ca, {self.ssl_ca}, does not exist')
 
     def using_mtls(self) -> bool:
         if self.ssl_cert is not None:


### PR DESCRIPTION
I picked this refactor off of my terra branch and took it the last ten yards such that now you can run `make batch-db` and get a full local instance of the batch database that you can access through `mysql -h 127.0.0.1 -u root -ppw` or

```ipython
(hail) dgoldste@wmce3-cb7 hail % HAIL_SQL_DATABASE=local-batch ipython
Python 3.9.17 (main, Jul  5 2023, 16:17:03)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from gear import Database
   ...: db = Database()
   ...: await db.async_init()
   ...: await db.select_and_fetchone('SELECT * FROM globals')
   ...:
   ...:
Out[1]:
{'instance_id': 'XXXXXXXX',
 'internal_token': 'XXXXXXX',
 'n_tokens': 200,
 'frozen': 0}
```

If you add a migration, just run `make batch-db` again.