### PR TITLE
[hailtop] Apply nest_asyncio on hailtop import

### DIFF
--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -117,10 +117,6 @@ def test_cancel_left_after_tail(client):
 
 
 async def test_callback(client):
-    import nest_asyncio  # pylint: disable=import-outside-toplevel
-
-    nest_asyncio.apply()
-
     app = web.Application()
     callback_bodies = []
     callback_event = asyncio.Event()

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -335,8 +335,6 @@ def init(sc=None,
         backend = 'batch'
 
     if backend == 'batch':
-        import nest_asyncio
-        nest_asyncio.apply()
         import asyncio
         return asyncio.get_event_loop().run_until_complete(init_batch(
             log=log,

--- a/hail/python/hailtop/__init__.py
+++ b/hail/python/hailtop/__init__.py
@@ -1,3 +1,6 @@
+import nest_asyncio
+nest_asyncio.apply()
+
 _VERSION = None
 
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -53,8 +53,6 @@ class Backend(abc.ABC, Generic[RunningBatchType]):
 
     def __init__(self):
         self._requester_pays_fses: Dict[GCSRequesterPaysConfiguration, RouterAsyncFS] = {}
-        import nest_asyncio  # pylint: disable=import-outside-toplevel
-        nest_asyncio.apply()
 
     def requester_pays_fs(self, requester_pays_config: GCSRequesterPaysConfiguration) -> RouterAsyncFS:
         try:

--- a/hail/python/hailtop/fs/router_fs.py
+++ b/hail/python/hailtop/fs/router_fs.py
@@ -1,7 +1,6 @@
 from typing import List, AsyncContextManager, BinaryIO, Optional, Tuple, Dict, Any
 import asyncio
 import io
-import nest_asyncio
 import os
 import functools
 import glob
@@ -175,7 +174,6 @@ class RouterFS(FS):
                  gcs_kwargs: Optional[Dict[str, Any]] = None,
                  azure_kwargs: Optional[Dict[str, Any]] = None,
                  s3_kwargs: Optional[Dict[str, Any]] = None):
-        nest_asyncio.apply()
         if afs and (local_kwargs or gcs_kwargs or azure_kwargs or s3_kwargs):
             raise ValueError(
                 f'If afs is specified, no other arguments may be specified: {afs=}, {local_kwargs=}, {gcs_kwargs=}, {azure_kwargs=}, {s3_kwargs=}'


### PR DESCRIPTION
Currently on `main`, Hail Query calls that check for cold storage use `asyncio.run_until_complete` which fails in a jupyter notebook without the application of `nest_asyncio.apply()` (because you are already running inside jupyter's event loop). This is a blanket solution that just always applies `nest_asyncio.apply()` on hailtop import to avoid these edge cases.

I don't think there is any downside to applying nest_asyncio, but something that I'm unsure about is whether I should delete the application from all these other callsites? There's now an implicit requirement that for our codebase to work as expected you must import `hailtop` before you do anything meaningful. Perhaps we should instead alter our call sites that use `run_until_complete` and apply there if we haven't already?