### PR TITLE
[batch] Report duration ms in batch and job records

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -40,8 +40,10 @@ def batch_record_to_dict(record: Dict[str, Any]) -> Dict[str, Any]:
     time_completed = _time_msecs_str(record['time_completed'])
 
     if record['time_created'] and record['time_completed']:
-        duration = humanize_timedelta_msecs(record['time_completed'] - record['time_created'])
+        duration_ms = record['time_completed'] - record['time_created']
+        duration = humanize_timedelta_msecs(duration_ms)
     else:
+        duration_ms = None
         duration = None
 
     if record['cost_breakdown'] is not None:
@@ -63,6 +65,7 @@ def batch_record_to_dict(record: Dict[str, Any]) -> Dict[str, Any]:
         'time_created': time_created,
         'time_closed': time_closed,
         'time_completed': time_completed,
+        'duration_ms': duration_ms,
         'duration': duration,
         'msec_mcpu': record['msec_mcpu'],
         'cost': coalesce(record['cost'], 0),

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1827,6 +1827,7 @@ WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
                 end_time = time_msecs()
             duration_msecs = max(end_time - start_time, 0)
             attempt['duration'] = humanize_timedelta_msecs(duration_msecs)
+            attempt['duration_ms'] = duration_msecs
 
     return attempts
 

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -160,6 +160,7 @@ async def test_callback(client):
         callback_body.pop('time_closed')
         callback_body.pop('time_completed')
         callback_body.pop('duration')
+        callback_body.pop('duration_ms')
         callback_body.pop('cost_breakdown')
         assert callback_body == {
             'id': b.id,


### PR DESCRIPTION
Having a numerical value is helpful in the API if I'm trying to do any analytics with the the result of fetching batches.