### PR TITLE
[query] don’t drop poduct flag on TableIntervalJoin

### DIFF
--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -123,7 +123,7 @@ class TableIntervalJoin(TableIR):
     def _handle_randomness(self, uid_field_name):
         left = self.left.handle_randomness(uid_field_name)
         right = self.right.handle_randomness(None)
-        return TableIntervalJoin(left, right, self.root)
+        return TableIntervalJoin(left, right, self.root, self.product)
 
     def head_str(self):
         return f'{escape_id(self.root)} {self.product}'

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -2151,6 +2151,9 @@ def test_table_randomness_interval_join():
     t = t1.annotate(x=t2[t1.idx].idx)
     assert_contains_node(t, ir.TableIntervalJoin)
     assert_unique_uids(t)
+    t = t1.annotate(x=t2.index(t1.idx, all_matches=True).idx)
+    assert_contains_node(t, ir.TableIntervalJoin)
+    assert_unique_uids(t)
 
 
 def test_table_randomness_union():


### PR DESCRIPTION
fixes #13699
fixes #13693