### PR TITLE
[query] fix backoff code

### DIFF
--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -42,10 +42,10 @@ package object services {
     // Based on AWS' recommendations:
     // - https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
     // - https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedBackoffStrategies.java
-    val multiplier = 1 << math.min(tries, LOG_2_MAX_MULTIPLIER)
-    val ceilingForDelayMs = baseDelayMs * multiplier
+    val multiplier = 1L << math.min(tries, LOG_2_MAX_MULTIPLIER)
+    val ceilingForDelayMs = math.min(baseDelayMs * multiplier, maxDelayMs).toInt
     val proposedDelayMs = ceilingForDelayMs / 2 + Random.nextInt(ceilingForDelayMs / 2 + 1)
-    return math.min(proposedDelayMs, maxDelayMs)
+    return proposedDelayMs
   }
 
   def sleepBeforTry(


### PR DESCRIPTION
CHANGELOG: Fixes #13704, in which Hail could encounter an IllegalArgumentException if there are too many transient errors.

I need to do the multiplication in 64-bits so that it does not wrap around to a large negative value. Then I can use `math.min` with the maxDelayMs to get us back into 32-bits.

I'm just pushing through a bunch of bugs to get Wenhan unblocked today.