### PR TITLE
[query] if worker or driver raise an exception, fail the Batch job

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -231,7 +231,7 @@ class ServiceBackend(
               val shortMessage = readString(is)
               val expandedMessage = readString(is)
               val errorId = is.readInt()
-              throw new HailWorkerException(shortMessage, expandedMessage, errorId)
+              throw new HailWorkerException(i, shortMessage, expandedMessage, errorId)
             }
           },
           i
@@ -838,6 +838,8 @@ class ServiceBackendSocketAPI2(
             output.writeInt(exc.errorId)
           }
         }
+        log.error("A worker failed. The exception was written for Python but we will also throw an exception to fail this driver job.")
+        throw exc
       case t: Throwable =>
         val (shortMessage, expandedMessage, errorId) = handleForPython(t)
         retryTransientErrors {
@@ -849,6 +851,8 @@ class ServiceBackendSocketAPI2(
             output.writeInt(errorId)
           }
         }
+        log.error("An exception occurred in the driver. The exception was written for Python but we will re-throw to fail this driver job.")
+        throw t
     }
   }
 }

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -193,7 +193,7 @@ object Worker {
     timer.end(s"Job $i")
     log.info(s"finished job $i at root $root")
 
-    if (throwableWhileExecutingUserCode != null) {
+    result.left.map { throwableWhileExecutingUserCode =>
       log.info("throwing the exception so that this Worker job is marked as failed.")
       throw throwableWhileExecutingUserCode
     }

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -8,10 +8,11 @@ class HailException(val msg: String, val logMsg: Option[String], cause: Throwabl
 }
 
 class HailWorkerException(
+  val partitionId: Int,
   val shortMessage: String,
   val expandedMessage: String,
   val errorId: Int
-) extends RuntimeException(shortMessage)
+) extends RuntimeException(s"[partitionId=$partitionId] " + shortMessage)
 
 trait ErrorHandling {
   def fatal(msg: String): Nothing = throw new HailException(msg)
@@ -58,8 +59,6 @@ trait ErrorHandling {
     val short = deepestMessage(e)
     val expanded = expandException(e, false)
     val logExpanded = expandException(e, true)
-
-    log.error(s"$short\nFrom $logExpanded")
 
     def searchForErrorCode(exception: Throwable): Int = {
       if (exception.isInstanceOf[HailException]) {


### PR DESCRIPTION
CHANGELOG: Fixes #13697, a long standing issue with QoB, in which a failing partition job or driver job is not failed in the Batch UI.

I am not sure why we did not do this this way in the first place. If a JVMJob raises an exception, Batch will mark the job as failed. Ergo, we should raise an exception when a driver or a worker fails!

Here's an example: I used a simple pipeline that write to a bucket to which I have read-only access. You can see an example Batch (where every partition fails): https://batch.hail.is/batches/8046901. [1]

```python3
import hail as hl
hl.utils.range_table(3, n_partitions=3).write('gs://neale-bge/foo.ht')
```

NB: I removed the `log.error` in `handleForPython` because that log is never necessary. That function converts a stack of exceptions into a triplet of the short message, the full exception with stack trace, and a Hail error id (if present). That triplet is always passed along to someone else who logs the exception.

(FWIW, the error id indicates a Python source location that is associated with the error. On the Python-side, we can look up that error id and provide a better stack trace.)

[1] You'll notice the logs are missing. I noticed this as well, it's a new bug. I fixed it in https://github.com/hail-is/hail/pull/13729.