### PR TITLE
[build.yaml] Give delete_gcp_batch_instances job the proper service account

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3674,7 +3674,7 @@ steps:
     alwaysRun: true
     script: |
       set -ex
-      gcloud -q auth activate-service-account --key-file=/test-gsa-key/key.json
+      gcloud -q auth activate-service-account --key-file=/batch-gsa-key/key.json
       set +e
       kubectl -n {{ default_ns.name }} scale deployment batch-driver --replicas=0
       gcloud -q compute instances list \
@@ -3688,10 +3688,10 @@ steps:
           --project {{ global.gcp_project }} \
         | xargs -P8 -n2 -r sh -c 'gcloud -q compute disks delete --zone "$1" --project {{ global.gcp_project }} "$2" || true' argv0
     secrets:
-      - name: test-gsa-key
+      - name: batch-gsa-key
         namespace:
           valueFrom: default_ns.name
-        mountPath: /test-gsa-key
+        mountPath: /batch-gsa-key
     scopes:
       - dev
       - test


### PR DESCRIPTION
See #13554. This is the first fix that needs to happen such that the service account has permissions to delete VMs and disks. Note that the correct service account was already being used in Azure.