### PR TITLE
[batch] Allow image Env to be None

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1353,9 +1353,11 @@ class Container:
     def _env(self):
         assert self.image.image_config
         assert CLOUD_WORKER_API
-        env = self.image.image_config['Config']['Env'] or []
-        env.extend(self.env)
-        env.extend(CLOUD_WORKER_API.cloud_specific_env_vars_for_user_jobs)
+        env = (
+            (self.image.image_config['Config']['Env'] or [])
+            + self.env
+            + CLOUD_WORKER_API.cloud_specific_env_vars_for_user_jobs
+        )
         machine_family = INSTANCE_CONFIG["machine_type"].split("-")[0]
         if is_gpu(machine_family):
             env += ["NVIDIA_VISIBLE_DEVICES=all"]

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1353,9 +1353,9 @@ class Container:
     def _env(self):
         assert self.image.image_config
         assert CLOUD_WORKER_API
-        env = (
-            self.image.image_config['Config']['Env'] + self.env + CLOUD_WORKER_API.cloud_specific_env_vars_for_user_jobs
-        )
+        env = self.image.image_config['Config']['Env'] or []
+        env.extend(self.env)
+        env.extend(CLOUD_WORKER_API.cloud_specific_env_vars_for_user_jobs)
         machine_family = INSTANCE_CONFIG["machine_type"].split("-")[0]
         if is_gpu(machine_family):
             env += ["NVIDIA_VISIBLE_DEVICES=all"]


### PR DESCRIPTION
Ben came across an image in the wild with a null `Env` field in the manifest, which caused the following error:
```
Error
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/batch/worker/worker.py", line 868, in _run
    timed_out = await self._run_until_done_or_deleted(self._run_container)
  File "/usr/local/lib/python3.9/dist-packages/batch/worker/worker.py", line 1010, in _run_until_done_or_deleted
    return await run_until_done_or_deleted(self.deleted_event, f, *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/batch/worker/worker.py", line 680, in run_until_done_or_deleted
    return step.result()
  File "/usr/local/lib/python3.9/dist-packages/batch/worker/worker.py", line 1066, in _run_container
    await self._write_container_config()
  File "/usr/local/lib/python3.9/dist-packages/batch/worker/worker.py", line 1106, in _write_container_config
    config = await self.container_config()
  File "/usr/local/lib/python3.9/dist-packages/batch/worker/worker.py", line 1166, in container_config
    'env': self._env(),
  File "/usr/local/lib/python3.9/dist-packages/batch/worker/worker.py", line 1354, in _env
    self.image.image_config['Config']['Env'] + self.env + CLOUD_WORKER_API.cloud_specific_env_vars_for_user_jobs
TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'
```

He fixed it by creating the following docker image:

```docker
FROM jargene/hapice:1.0
```

It could be that old  versions of docker allowed this to be empty but have since made it `[]`, which would mean this would be unfortunately very annoying to test but nonetheless pretty trivial to fix.