### PR TITLE
[batch] Only write logs and resource usage for started containers

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1856,6 +1856,9 @@ class DockerJob(Job):
 
     async def run_container(self, container: Container, task_name: str):
         async def on_completion():
+            if container.state in ('pending', 'creating'):
+                return
+
             with container._step('uploading_log'):
                 assert self.worker.file_store
                 await self.worker.file_store.write_log_file(


### PR DESCRIPTION
I'm not sure this is the only reason why we're getting worker log errors when a user deletes jobs, but this code is definitely wrong in the case a container hasn't been started. I'm conflicted on whether we should do nothing or write empty files though.