### PR TITLE
[qob] prevent race to write to log file

### DIFF
--- a/batch/jvm-entryway/src/main/java/is/hail/JVMEntryway.java
+++ b/batch/jvm-entryway/src/main/java/is/hail/JVMEntryway.java
@@ -149,13 +149,6 @@ class JVMEntryway {
           completedThread = gather.take();
         } catch (Throwable t) {
           entrywayException = t;
-        } finally {
-          QoBOutputStreamManager.flushAllAppenders();
-          LoggerContext context = (LoggerContext) LogManager.getContext(false);
-          ClassLoader loader = JVMEntryway.class.getClassLoader();
-          URL url = loader.getResource("log4j2.properties");
-          System.err.println("reconfiguring logging " + url.toString());
-          context.setConfigLocation(url.toURI()); // this will force a reconfiguration
         }
 
         if (entrywayException != null) {
@@ -199,6 +192,13 @@ class JVMEntryway {
                           mainThread);
           }
         }
+      } finally {
+        QoBOutputStreamManager.flushAllAppenders();
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        ClassLoader loader = JVMEntryway.class.getClassLoader();
+        URL url = loader.getResource("log4j2.properties");
+        System.err.println("reconfiguring logging " + url.toString());
+        context.setConfigLocation(url.toURI()); // this will force a reconfiguration
       }
       System.err.println("waiting for next connection");
       System.err.flush();


### PR DESCRIPTION
Fixes #13716

This finally block is currently located after `gather.take()` but *before* we cancel (aka shutdown) all threads. As a result, it is possible for us to shudown the logging (thus flushing, closing, and destorying old appenders) then restart logging (thus opening the file in overwrite mode) and blow away whatever was there.

I have verified in my namespace across 10s of thosuands of JVM Jobs that this never blows away the log.