### PR TITLE
[qob] In GCS, recreate the ReadChannel if a transient error occurs

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -190,9 +190,6 @@ abstract class FSSeekableInputStream extends InputStream with Seekable {
     } else {
       bb.clear()
       bb.limit(0)
-      if (bb.remaining() != 0) {
-        assert(false, bb.remaining().toString())
-      }
       physicalSeek(newPos)
     }
     pos = newPos


### PR DESCRIPTION
CHANGELOG: Fix #13356 and fix #13409. In QoB pipelines with 10K or more partitions, transient "Corrupted block detected" errors were common. This was caused by incorrect retry logic. That logic has been fixed.

I now assume we cannot reuse a ReadChannel after any exception occurs during read. We also do not assume that the ReadChannel "atomically", in some sense, modifies the ByteBuffer. In particular, if we encounter any error, we blow away the ByteBuffer and restart our read entirely.

As I described in [this comment to #13409](https://github.com/hail-is/hail/issues/13409#issuecomment-1737926184), I have a 10K partition pipeline which was reliably producing this error but now reliably *does not* produce this error (it produces another one, #13721, fix forthcoming for that too).