### PR TITLE
[qob] update GCS client lib to 2.27.1 to fix #13721

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -157,7 +157,7 @@ dependencies {
         throw new UnsupportedOperationException("Couldn't pick a valid elasticsearch.")
     }
 
-    implementation(group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.26.1') {
+    implementation(group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.27.1') {
         exclude group: 'com.fasterxml.jackson.core'
     }
 


### PR DESCRIPTION
CHANGELOG: Fix #13721 which manifested with the message "Missing Range header in response". The root cause was a bug in the Google Cloud Storage SDK on which we rely. The fix is to update to a version without this bug. The buggy version of GCS SDK was introduced in 0.2.123.

The details are not particularly important, but the GCS client library was unable to parse a certain kind of exceptional server condition. This updates us to the latest GCS version.