### PR TITLE
[batch] Add client job id to test batch attributes for debugging

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1735,6 +1735,8 @@ class DockerJob(Job):
         hail_extra_env = [
             {'name': 'HAIL_REGION', 'value': REGION},
             {'name': 'HAIL_BATCH_ID', 'value': str(batch_id)},
+            {'name': 'HAIL_JOB_ID', 'value': str(self.job_id)},
+            {'name': 'HAIL_ATTEMPT_ID', 'value': str(self.attempt_id)},
             {'name': 'HAIL_IDENTITY_PROVIDER_JSON', 'value': json.dumps(self.credentials.identity_provider_json)},
         ]
         self.env += hail_extra_env

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -23,7 +23,12 @@ def create_batch(client: aiobc.BatchClient, **kwargs) -> aiobc.Batch:
 def create_batch(client: Union[bc.BatchClient, aiobc.BatchClient], **kwargs) -> Union[bc.Batch, aiobc.Batch]:
     name_of_test_method = inspect.stack()[1][3]
     attrs = kwargs.pop('attributes', {})  # Tests should be able to override the name
-    return client.create_batch(attributes={'name': name_of_test_method, **attrs}, **kwargs)
+    attributes = {'name': name_of_test_method, **attrs}
+    this_batch_id = os.environ.get('HAIL_BATCH_ID')
+    this_job_id = os.environ.get('HAIL_JOB_ID')
+    if this_batch_id and this_job_id:
+        attributes['parent_job'] = f'{this_batch_id}-{this_job_id}'
+    return client.create_batch(attributes, **kwargs)
 
 
 def batch_status_job_counter(batch_status, job_state):

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -27,7 +27,7 @@ def create_batch(client: Union[bc.BatchClient, aiobc.BatchClient], **kwargs) -> 
     this_batch_id = os.environ.get('HAIL_BATCH_ID')
     this_job_id = os.environ.get('HAIL_JOB_ID')
     if this_batch_id and this_job_id:
-        attributes['parent_job'] = f'{this_batch_id}-{this_job_id}'
+        attributes['client_job'] = f'{this_batch_id}-{this_job_id}'
     return client.create_batch(attributes, **kwargs)
 
 


### PR DESCRIPTION
I started to debug #13599 and found this feature of knowing which job spun off the test batch would have been helpful for debugging purposes. 