### PR TITLE
Gateway return 503 on failed auth check

### DIFF
--- a/gateway/envoy.yaml
+++ b/gateway/envoy.yaml
@@ -97,6 +97,8 @@ data:
                 - name: envoy.filters.http.ext_authz
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                    status_on_error:
+                      code: 503
                     http_service:
                       server_uri:
                         uri: https://auth:443

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -36,6 +36,8 @@ data:
                 - name: envoy.filters.http.ext_authz
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                    status_on_error:
+                      code: 503
                     http_service:
                       server_uri:
                         uri: https://auth:443

--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -36,6 +36,8 @@ data:
                 - name: envoy.filters.http.ext_authz
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                    status_on_error:
+                      code: 503
                     http_service:
                       server_uri:
                         uri: https://auth:443


### PR DESCRIPTION
Envoy by default responds with a 403 if it fails to make an authorization check. We should treat the failure to contact `auth` as a transient error, so that clients can know to retry whatever request they were trying to make instead of failing. In particular, in dev namespaces the current behavior can trigger a QoB client to cancel an ongoing pipeline while polling for completion.

I deployed this in Azure by running `make -C gateway deploy NAMESPACE=default`. I poked around to see that I could access my dev namespace and production pages through the browser but did not otherwise try to prove that this failure mode no longer exists.