### PR TITLE
[qob] only try to cancel a test batch if it was submitted

### DIFF
--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -75,7 +75,7 @@ def set_query_name(init_hail, request):
         for rg in references:
             backend.remove_reference(rg)
         backend.initialize_references()
-        if backend._batch:
+        if backend._batch_was_submitted:
             report: Dict[str, CollectReport] = request.node.stash[test_results_key]
             if any(r.failed for r in report.values()):
                 log.info(f'cancelling failed test batch {backend._batch.id}')


### PR DESCRIPTION
#13564 forgot to change this condition (which was based on the old `None` means not-submitted logic).