### PR TITLE
[query] Deprecate `collect_all` in `hail.plots.*` (use `n_divisions` instead)

### DIFF
--- a/hail/python/hail/docs/tutorials/08-plotting.ipynb
+++ b/hail/python/hail/docs/tutorials/08-plotting.ipynb
@@ -156,9 +156,9 @@
    "metadata": {},
    "source": [
     "Hail's downsample aggregator is incorporated into the `scatter()`, `qq()`,\n",
-    "`join_plot` and `manhattan()` functions. The `n_divisions` parameter controls the factor \n",
-    "by which values are downsampled. Using `n_divisions=None` tells the plot function\n",
-    "whether to collect all values."
+    "`join_plot` and `manhattan()` functions. The `n_divisions` parameter controls\n",
+    "the factor by which values are downsampled. Using `n_divisions=None` tells the\n",
+    "plot function to collect all values."
    ]
   },
   {

--- a/hail/python/hail/docs/tutorials/08-plotting.ipynb
+++ b/hail/python/hail/docs/tutorials/08-plotting.ipynb
@@ -146,7 +146,8 @@
    "source": [
     "p = hl.plot.scatter(pca_scores.scores[0], pca_scores.scores[1],\n",
     "                    label=common_mt.cols()[pca_scores.s].SuperPopulation,\n",
-    "                    title='PCA', xlabel='PC1', ylabel='PC2', collect_all=True)\n",
+    "                    title='PCA', xlabel='PC1', ylabel='PC2',\n",
+    "                    n_divisions=None)\n",
     "show(p)"
    ]
   },
@@ -154,7 +155,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hail's downsample aggregator is incorporated into the `scatter()`, `qq()`, and `manhattan()` functions. The `collect_all` parameter tells the plot function whether to collect all values or downsample. Choosing not to set this parameter results in downsampling."
+    "Hail's downsample aggregator is incorporated into the `scatter()`, `qq()`,\n",
+    "`join_plot` and `manhattan()` functions. The `n_divisions` parameter controls the factor \n",
+    "by which values are downsampled. Using `n_divisions=None` tells the plot function\n",
+    "whether to collect all values."
    ]
   },
   {
@@ -165,8 +169,8 @@
    "source": [
     "p2 = hl.plot.scatter(pca_scores.scores[0], pca_scores.scores[1],\n",
     "                    label=common_mt.cols()[pca_scores.s].SuperPopulation,\n",
-    "                    title='PCA (downsampled)', xlabel='PC1', ylabel='PC2', collect_all=False, n_divisions=50)\n",
-    "\n",
+    "                    title='PCA (downsampled)', xlabel='PC1', ylabel='PC2',\n",
+    "                    n_divisions=50)\n",
     "show(gridplot([p, p2], ncols=2, width=400, height=400))"
    ]
   },
@@ -204,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = hl.plot.qq(gwas.p_value, collect_all=True)\n",
+    "p = hl.plot.qq(gwas.p_value, n_divisions=None)\n",
     "p2 = hl.plot.qq(gwas.p_value, n_divisions=75)\n",
     "\n",
     "show(gridplot([p, p2], ncols=2, width=400, height=400))"
@@ -243,7 +247,7 @@
    "outputs": [],
    "source": [
     "hover_fields = dict([('alleles', gwas.alleles)])\n",
-    "p = hl.plot.manhattan(gwas.p_value, hover_fields=hover_fields, collect_all=True)\n",
+    "p = hl.plot.manhattan(gwas.p_value, hover_fields=hover_fields, n_divisions=None)\n",
     "show(p)"
    ]
   }

--- a/hail/python/test/hail/plot/test_plot.py
+++ b/hail/python/test/hail/plot/test_plot.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import patch
 
 import hail as hl
@@ -57,13 +58,24 @@ def test_qq():
 def test_manhattan():
     ht = hl.balding_nichols_model(1, n_variants=100, n_samples=1).rows()
     ht = ht.add_index('idx')
+    hl.plot.manhattan(ht.idx / 100)
+
+def test_manhatten_deprecated_collect_all():
+    ht = hl.balding_nichols_model(1, n_variants=100, n_samples=1).rows()
+    ht = ht.add_index('idx')
+
+    with pytest.raises(ValueError):
+        hl.plot.manhattan(ht.idx / 100, collect_all=True)
+
+    with pytest.raises(ValueError):
+        hl.plot.manhattan(ht.idx / 100, n_divisions=0)
 
     with patch('warnings.warn') as mock:
-        hl.plot.manhattan(ht.idx / 100)
+        hl.plot.manhattan(ht.idx / 100, n_divisions=None)
         mock.assert_not_called()
 
     with patch('warnings.warn') as mock:
-        hl.plot.manhattan(ht.idx / 100, collect_all=True)
+        hl.plot.manhattan(ht.idx / 100, n_divisions=None, collect_all=True)
         mock.assert_called()
 
 

--- a/hail/python/test/hail/plot/test_plot.py
+++ b/hail/python/test/hail/plot/test_plot.py
@@ -60,24 +60,33 @@ def test_manhattan():
     ht = ht.add_index('idx')
     hl.plot.manhattan(ht.idx / 100)
 
-def test_manhatten_deprecated_collect_all():
+
+@pytest.mark.parametrize(
+    'name, plot'
+    , [ ('manhattan', hl.plot.manhattan                                     )
+      , ('scatter',   lambda x, **kwargs: hl.plot.scatter(x, x, **kwargs)   )
+      , ('join_plot', lambda x, **kwargs: hl.plot.joint_plot(x, x,** kwargs))
+      , ('qq',        hl.plot.qq                                            )
+      ]
+    )
+def test_plots_deprecated_collect_all(name, plot):
     ht = hl.balding_nichols_model(1, n_variants=100, n_samples=1).rows()
     ht = ht.add_index('idx')
 
     with pytest.raises(ValueError):
-        hl.plot.manhattan(ht.idx / 100, collect_all=True)
+        plot(ht.idx, collect_all=True)
 
     with pytest.raises(ValueError):
-        hl.plot.manhattan(ht.idx / 100, n_divisions=0)
+        plot(ht.idx, n_divisions=0)
 
     with patch('warnings.warn') as mock:
-        hl.plot.manhattan(ht.idx / 100, n_divisions=None)
+        plot(ht.idx, n_divisions=None)
         mock.assert_not_called()
 
     with patch('warnings.warn') as mock:
-        hl.plot.manhattan(ht.idx / 100, n_divisions=None, collect_all=True)
+        plot(ht.idx, n_divisions=None, collect_all=True)
         mock.assert_called()
-
+        assert name in mock.call_args_list[0][0][0]
 
 
 def test_visualize_missingness():

--- a/hail/python/test/hail/plot/test_plot.py
+++ b/hail/python/test/hail/plot/test_plot.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import hail as hl
 
 
@@ -52,11 +54,18 @@ def test_qq():
     ht = hl.utils.range_table(100)
     hl.plot.qq(ht.idx / 100)
 
-
 def test_manhattan():
     ht = hl.balding_nichols_model(1, n_variants=100, n_samples=1).rows()
     ht = ht.add_index('idx')
-    hl.plot.manhattan(ht.idx / 100)
+
+    with patch('warnings.warn') as mock:
+        hl.plot.manhattan(ht.idx / 100)
+        mock.assert_not_called()
+
+    with patch('warnings.warn') as mock:
+        hl.plot.manhattan(ht.idx / 100, collect_all=True)
+        mock.assert_called()
+
 
 
 def test_visualize_missingness():


### PR DESCRIPTION
Fixes #13696.
`n_divisions` is a downsampling factor. It conflicts with `collect_all` when `collect_all=True` is specified.
Deprecate `collect_all` and issue warning when users supply a non-`None` `collect_all` argument.
Use `n_divisions=None` to not downsample (implies `collect_all=True`).
Throw when `collect_all=True` and `n_divisions` is not `None` - this is a conflict.
