### PR TITLE
[batch] back off gpu timeout to 10 minutes

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1434,6 +1434,7 @@ def test_pool_standard_instance_cheapest(client: BatchClient):
 
 
 @skip_in_azure
+@pytest.mark.timeout(10 * 60)
 def test_gpu_accesibility_g2(client: BatchClient):
     b = create_batch(client)
     resources = {'machine_type': "g2-standard-4", 'storage': '100Gi'}


### PR DESCRIPTION
It definitely looks like "ZONE_RESOURCE_POOL_EXHAUSTED" is the cause of these GPU test failures. In this case it looks like it took ~4 minutes to successfully get a VM (after two exhaustion errors) & schedule the job. By then, our uniform 6 minute timeout per test left us with just two minutes. It looks like the job actually did succeed in the worker (seems to have taken ~2 minutes, seems long, does testing for CUDA do some kind of initialization work?). Looks like backing that off to 10 minutes might be just enough to eventually get us a GPU. Might be worth pulling that into its own build.yaml test job so that it does not block the queue of other tests.