### PR TITLE
[query] Fix 13706: enable Java tests to work again

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -95,7 +95,7 @@ configurations {
 	}
     }
 
-    testCompileOnly.extendsFrom shadow
+    testImplementation.extendsFrom shadow
 }
 
 dependencies {


### PR DESCRIPTION
Fixes #13706. When I reworked `build.gradle` to be simpler and conform with modern gradle standards, I forgot to dump all of our dependencies into our test runtime classpath.

This PR ensures that the test runtime classpath is the same as our runtime classpath in QoB and in QoS.