### PR TITLE
[batch] Ignore client_job attribute in test_callback test

### DIFF
--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -162,6 +162,7 @@ async def test_callback(client):
         callback_body.pop('duration')
         callback_body.pop('duration_ms')
         callback_body.pop('cost_breakdown')
+        callback_body['attributes'].pop('client_job')
         assert callback_body == {
             'id': b.id,
             'user': 'test',


### PR DESCRIPTION
I think the `client_job` attribute is doing its intended job but we need to ignore uncontrollable attributes in this test in particular.