### PR TITLE
[pytest] Stop and reinitialize hail between QoB tests

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -230,6 +230,7 @@ class ServiceBackend(Backend):
         jar_url = configuration_of(ConfigVariable.QUERY_JAR_URL, jar_url, None)
         jar_spec = GitRevision(revision()) if jar_url is None else JarUrl(jar_url)
 
+        name_prefix = configuration_of(ConfigVariable.QUERY_NAME_PREFIX, name_prefix, '')
         batch_attributes: Dict[str, str] = {
             'hail-version': version(),
         }
@@ -240,7 +241,6 @@ class ServiceBackend(Backend):
         driver_memory = configuration_of(ConfigVariable.QUERY_BATCH_DRIVER_MEMORY, driver_memory, None)
         worker_cores = configuration_of(ConfigVariable.QUERY_BATCH_WORKER_CORES, worker_cores, None)
         worker_memory = configuration_of(ConfigVariable.QUERY_BATCH_WORKER_MEMORY, worker_memory, None)
-        name_prefix = configuration_of(ConfigVariable.QUERY_NAME_PREFIX, name_prefix, '')
 
         if regions is None:
             regions_from_conf = configuration_of(ConfigVariable.BATCH_REGIONS, regions, None)
@@ -287,7 +287,6 @@ class ServiceBackend(Backend):
             driver_memory=driver_memory,
             worker_cores=worker_cores,
             worker_memory=worker_memory,
-            name_prefix=name_prefix or '',
             regions=regions
         )
         sb._initialize_flags(flags)
@@ -307,7 +306,6 @@ class ServiceBackend(Backend):
                  driver_memory: Optional[str],
                  worker_cores: Optional[Union[int, str]],
                  worker_memory: Optional[str],
-                 name_prefix: str,
                  regions: List[str]):
         super(ServiceBackend, self).__init__()
         self.billing_project = billing_project
@@ -327,7 +325,6 @@ class ServiceBackend(Backend):
         self.driver_memory = driver_memory
         self.worker_cores = worker_cores
         self.worker_memory = worker_memory
-        self.name_prefix = name_prefix
         self.regions = regions
 
         self._batch: aiohb.Batch = self._create_batch()

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -140,6 +140,7 @@ class HailContext(object):
         return self._default_ref
 
     def stop(self):
+        assert self._backend
         self._backend.stop()
         self._backend = None
         Env._hc = None

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -65,21 +65,16 @@ def pytest_runtest_makereport(item, call):
 
 
 @pytest.fixture(autouse=True)
-def set_query_name(init_hail, request):
+def reinitialize_hail_for_each_qob_test(init_hail, request):
     backend = current_backend()
     if isinstance(backend, ServiceBackend):
-        backend.batch_attributes = dict(name=request.node.name)
+        hl_stop_for_test()
+        hl_init_for_test(app_name=request.node.name)
         yield
-        backend.batch_attributes = dict()
-        references = list(backend._references.keys())
-        for rg in references:
-            backend.remove_reference(rg)
-        backend.initialize_references()
-        if backend._batch:
+        if backend._batch_was_submitted:
             report: Dict[str, CollectReport] = request.node.stash[test_results_key]
             if any(r.failed for r in report.values()):
                 log.info(f'cancelling failed test batch {backend._batch.id}')
                 asyncio.get_event_loop().run_until_complete(backend._batch.cancel())
-            backend._batch = backend._create_batch()
     else:
         yield


### PR DESCRIPTION
Stopping and re-initing is cheap and easy with QoB (compared to spark) and is a cleaner way to reset service backend state. Also note that we pass in the test name as `app_name` in init so batches are guaranteed to be created with the name of the test.