### PR TITLE
[ci] Use private base image for GPU testing image

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1440,7 +1440,7 @@ def test_gpu_accesibility_g2(client: BatchClient):
     resources = {'machine_type': "g2-standard-4", 'storage': '100Gi'}
     j = b.create_job(
         os.environ['HAIL_GPU_IMAGE'],
-        ['python', '-c', 'import torch; assert torch.cuda.is_available()'],
+        ['python3', '-c', 'import torch; assert torch.cuda.is_available()'],
         resources=resources,
     )
     b.submit()

--- a/build.yaml
+++ b/build.yaml
@@ -2615,7 +2615,7 @@ steps:
       inline: |
         ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
         FROM $BASE_IMAGE
-        RUN pip install torch torchvision -f https://download.pytorch.org/whl/cu113/torch_stable.html
+        RUN hail-pip-install torch torchvision -f https://download.pytorch.org/whl/cu113/torch_stable.html
     dependsOn:
       - hail_ubuntu_image
   - kind: buildImage2

--- a/build.yaml
+++ b/build.yaml
@@ -2613,8 +2613,11 @@ steps:
       storage: 10Gi
     dockerFile:
       inline: |
-        FROM python:3.9
+        ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
+        FROM $BASE_IMAGE
         RUN pip install torch torchvision -f https://download.pytorch.org/whl/cu113/torch_stable.html
+    dependsOn:
+      - hail_ubuntu_image
   - kind: buildImage2
     name: workdir_image
     publishAs: workdir


### PR DESCRIPTION
Trying to rely on our private registry instead of dockerhub where we can.