### PR TITLE
[compiler] fix ndarray broadcasting with 0 sizes

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -425,6 +425,7 @@ def test_ndarray_map2():
                        [11, 12]],
                       [[13, 14],
                        [15, 16]]])
+    empty = np.array([], np.int32).reshape((0, 2, 2))
 
     na = hl.nd.array(a)
     nx = hl.nd.array(x)
@@ -432,6 +433,7 @@ def test_ndarray_map2():
     nrow_vec = hl.nd.array(row_vec)
     ncube1 = hl.nd.array(cube1)
     ncube2 = hl.nd.array(cube2)
+    nempty = hl.nd.array(empty)
 
     assert_ndarrays_eq(
         # with lists/numerics
@@ -447,10 +449,13 @@ def test_ndarray_map2():
         # Broadcasting
         (ncube1 + na, cube1 + a),
         (na + ncube1, a + cube1),
+        (na + nempty, a + empty),
         (ncube1 + ny, cube1 + y),
         (ny + ncube1, y + cube1),
+        (ny + nempty, y + empty),
         (nrow_vec + ncube1, row_vec + cube1),
         (ncube1 + nrow_vec, cube1 + row_vec),
+        (nrow_vec + nempty, row_vec + empty),
         (ncube1.map2(na, lambda c, d: c+d), cube1 + a),
         (nrow_vec.map2(ncube1, lambda c, d: c+d), row_vec + cube1),
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2842,7 +2842,7 @@ object NDArrayEmitter {
               .concat("] vs [ ")
           )((accum, v) => accum.concat(v.toS).concat(" "))
             .concat("]"), errorID),
-          (left > right).mux(left, right)))
+          (right ceq 1L).mux(left, right)))
     }
 
     shape

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1850,12 +1850,29 @@ class IRSuite extends HailSuite {
     assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, FastSeq(0, 0)), 2.0)
     assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, FastSeq(0, 1)), 3.0)
     assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, FastSeq(1, 0)), 2.0)
+
+    val vectorWithEmpty = NDArrayMap2(
+      NDArrayReindex(vectorRowMajor, FastSeq(1, 0)),
+      makeNDArray(FastSeq(), FastSeq(0, 2), True()),
+      "v", "m",
+      ApplyBinaryPrimOp(Add(), Ref("v", TFloat64), Ref("m", TFloat64)), ErrorIDs.NO_ERROR)
+    assertEvalsTo(NDArrayShape(vectorWithEmpty), Row(0L, 2L))
+
+    val colVectorWithEmpty = NDArrayMap2(
+      colVector,
+      makeNDArray(FastSeq(), FastSeq(2, 0), True()),
+      "v", "m",
+      ApplyBinaryPrimOp(Add(), Ref("v", TFloat64), Ref("m", TFloat64)), ErrorIDs.NO_ERROR)
+    assertEvalsTo(NDArrayShape(colVectorWithEmpty), Row(2L, 0L))
   }
 
-  @Test(enabled = false) def testNDArrayAgg() {
+  @Test def testNDArrayAgg() {
     implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
 
-    val three = makeNDArrayRef(NDArrayAgg(scalarRowMajor, IndexedSeq.empty), IndexedSeq.empty)
+    val empty = makeNDArrayRef(NDArrayAgg(makeNDArray(IndexedSeq(), IndexedSeq(0, 5), true), IndexedSeq(0, 1)), IndexedSeq())
+    assertEvalsTo(empty, 0.0)
+
+    val three = makeNDArrayRef(NDArrayAgg(scalarRowMajor, IndexedSeq.empty), IndexedSeq())
     assertEvalsTo(three, 3.0)
 
     val zero = makeNDArrayRef(NDArrayAgg(vectorRowMajor, IndexedSeq(0)), IndexedSeq.empty)


### PR DESCRIPTION
Really bad example:
```python
In [2]: a = hl.nd.array(2)

In [3]: empty = np.array([], np.int32).reshape((0, 2, 2))

In [4]: empty = hl.nd.array(empty)

In [5]: hl.eval(empty)
Out[5]: array([], shape=(0, 2, 2), dtype=int32)

In [6]: hl.eval(a + empty)
Out[6]:
array([[[       2, 55622722],
        [       2,        3]]], dtype=int32)
```

Result of sum of shape `()` with shape `(0, 2, 2)` should be shape `(0, 2, 2)` by standard numpy broadcasting rules. Instead, we try to produce a result with shape `(1, 2, 2)`, which contains garbage data.