### PR TITLE
[compiler] Don't append StmtX after ControlX

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -778,10 +778,6 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
     case _ => !lhs.toCCode
   }
 
-  def muxAny(cthen: Code[_], celse: Code[_]): Code[_] = {
-    mux[Any](coerce[Any](cthen), coerce[Any](celse))
-  }
-
   def branch(csq: CodeLabel, alt: CodeLabel): Code[Unit] = {
     val cond = toCCode
     cond.Ltrue.append(lir.goto(csq.start))

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -777,7 +777,7 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
     assert(csq.v.ti.desc == alt.v.ti.desc, s"${csq.v.ti.desc} == ${alt.v.ti.desc}")
     CodeBuilder.scopedCode(null) { cb =>
       val t = Code.newLocal[T]("mux")(csq.v.ti.asInstanceOf[TypeInfo[T]])
-      cb.ifx(lhs, cb.assign(t, csq), cb.assign(t, alt))
+      cb.if_(lhs, cb.assign(t, csq), cb.assign(t, alt))
       t
     }
   }
@@ -1267,7 +1267,7 @@ class ThisLazyFieldRef[T: TypeInfo](cb: ClassBuilder[_], name: String, setup: Co
 
   override def get: Code[T] =
     CodeBuilder.scopedCode(null) { cb =>
-      cb.ifx(!present, cb += setm.invoke(cb) )
+      cb.if_(!present, cb += setm.invoke(cb) )
       value
     }
 }

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -2,7 +2,7 @@ package is.hail.asm4s
 
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.lir
-import is.hail.lir.{Block, ControlX, StmtX, ValueX}
+import is.hail.lir.{Block, ControlX, ValueX}
 import is.hail.utils._
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -15,14 +15,6 @@ abstract class Thrower[T] {
   def apply[U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U]
 }
 
-@scala.annotation.implicitAmbiguous("${A} must not be equal to ${B}")
-sealed abstract class =!=[A, B] extends Serializable
-object =!= {
-  implicit def refl[A, B]: A =!= B = new=!=[A, B] {}
-  implicit def ambig1[A]: A =!= A = ???
-  implicit def ambig2[A]: A =!= A = ???
-}
-
 object Code {
   def void[T](v: lir.StmtX): Code[T] = {
     val L = new lir.Block()

--- a/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
@@ -113,7 +113,6 @@ trait CodeBuilderLike {
   def whileLoop[A](cond: Code[Boolean], emitBody: CodeLabel => A)
                   (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = 
     loop { Lstart =>
-      emitBody(Lstart)
       ifx(cond, {
         emitBody(Lstart)
         goto(Lstart)

--- a/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
@@ -51,7 +51,7 @@ trait CodeBuilderLike {
     append(array.update(index, value))
 
   def memoize[T: TypeInfo](v: Code[T], optionalName: String = "")
-                          (implicit ev: T =!= Unit /* See note EVIDENCE_IS_NOT_UNIT */)
+                          (implicit ev: T =!= Unit)
   : Value[T] =
     v match {
       case b: ConstCodeBoolean => coerce[T](b.b)
@@ -67,12 +67,45 @@ trait CodeBuilderLike {
   def assignAny[T](s: Settable[T], v: Code[_]): Unit =
     append(s := coerce[T](v))
 
+  /*
+  Note [Evidence Is Unit]
+  -----------------------
+  Here's an example of a common `CodeBuilderLike` foot-gun:
+
+    // previously:
+    //   def ifx(cond: Code[Bool], csq: => Unit): Unit
+
+    cb.ifx(cond, a := expr)
+
+  What's wrong?
+   -> It doesn't generate the right code despite passing the type-checker!
+   -> `a := expr` is never emitted because `ifx` evaluates its parameters for effects only;
+   -> their values are discarded by a conversion to `Unit`. [1]
+
+  How do we fix this? We could write a test and catch this at runtime, but some errors will
+  slip through. Better to use the type system to prevent these kind of foot-guns.
+
+  The key observation is that the compiler inserts conversions to Unit. We can prevent it
+  from doing this if we parameterise the type of `csq`:
+
+  // def ifx[A](code: Code[Bool], csq: => A)(implicit ev: A =:= Unit): Unit
+
+  The compiler now infers the type `A` from `csq`; no conversions to `Unit` are made.
+  We can use an implicit constraint on `A` to fail compilation if `A` is inferred to
+  anything other than `Unit`, thus catching and preventing this foot-gun!
+
+  It's worth bearing in mind that while this handles simple cases, it won't prevent the
+  dedicated hacker from working around it.
+
+  [1]: https://github.com/scala/scala/blob/2.13.x/spec/06-expressions.md#value-discarding
+  */
+
   def ifx[A](c: Code[Boolean], emitThen: => A)
-            (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = 
+            (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = 
     ifx(c, emitThen, ().asInstanceOf[A])
 
   def ifx[A](cond: Code[Boolean], emitThen: => A, emitElse: => A)
-            (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = {
+            (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = {
     val Ltrue = CodeLabel()
     val Lfalse = CodeLabel()
     val Lexit = CodeLabel()
@@ -86,14 +119,14 @@ trait CodeBuilderLike {
     define(Lexit)
   }
 
-  def switch[A](discriminant: Code[Int], emitDefault: => A, _cases: IndexedSeq[() => A])
-               (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = {
+  def switch[A](discriminant: Code[Int], emitDefault: => A, cases: IndexedSeq[() => A])
+               (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = {
     val Lexit = CodeLabel()
-    val Lcases = IndexedSeq.fill(_cases.length)(CodeLabel())
+    val Lcases = IndexedSeq.fill(cases.length)(CodeLabel())
     val Ldefault = CodeLabel()
 
     append(discriminant.switch(Ldefault, Lcases))
-    (Lcases, _cases).zipped.foreach { case (label, emitCase) =>
+    (Lcases, cases).zipped.foreach { case (label, emitCase) =>
       define(label)
       emitCase()
       if (isOpenEnded) append(Lexit.goto)
@@ -104,14 +137,14 @@ trait CodeBuilderLike {
   }
 
   def loop[A](emitBody: CodeLabel => A)
-             (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = {
+             (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = {
     val Lstart = CodeLabel()
     define(Lstart)
     emitBody(Lstart)
   }
 
   def while_[A](cond: Code[Boolean], emitBody: CodeLabel => A)
-               (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit =
+               (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit =
     loop { Lstart =>
       ifx(cond, {
         emitBody(Lstart)
@@ -120,11 +153,11 @@ trait CodeBuilderLike {
     }
 
   def while_[A](c: Code[Boolean], emitBody: => A)
-               (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit =
+               (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit =
     while_(c, (_: CodeLabel) => emitBody)
 
   def for_[A](setup: => A, cond: Code[Boolean], incr: => A, emitBody: CodeLabel => A)
-             (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = {
+             (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = {
     setup
     while_(cond, {
       val Lincr = CodeLabel()
@@ -135,16 +168,14 @@ trait CodeBuilderLike {
   }
 
   def for_[A](setup: => A, cond: Code[Boolean], incr: => A, body: => A)
-             (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit =
+             (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit =
     for_(setup, cond, incr, (_: CodeLabel) => body)
 
-  def newLocal[T: TypeInfo](name: String)
-                           (implicit ev: T =!= Unit /* See note EVIDENCE_IS_NOT_UNIT */)
+  def newLocal[T: TypeInfo](name: String)(implicit ev: T =!= Unit)
   : LocalRef[T] =
     mb.newLocal[T](name)
 
-  def newLocal[T: TypeInfo](name: String, c: Code[T])
-                           (implicit ev: T =!= Unit /* See note EVIDENCE_IS_NOT_UNIT */)
+  def newLocal[T: TypeInfo](name: String, c: Code[T])(implicit ev: T =!= Unit)
   : LocalRef[T] = {
     val l = newLocal[T](name)
     append(l := c)
@@ -160,13 +191,11 @@ trait CodeBuilderLike {
     ref
   }
 
-  def newField[T: TypeInfo](name: String)
-                           (implicit ev: T =!= Unit /* See note EVIDENCE_IS_NOT_UNIT */)
+  def newField[T: TypeInfo](name: String)(implicit ev: T =!= Unit)
   : ThisFieldRef[T] =
     mb.genFieldThisRef[T](name)
 
-  def newField[T: TypeInfo](name: String, c: Code[T])
-                           (implicit ev: T =!= Unit /* See note EVIDENCE_IS_NOT_UNIT */)
+  def newField[T: TypeInfo](name: String, c: Code[T])(implicit ev: T =!= Unit)
   : ThisFieldRef[T] = {
     val f = newField[T](name)
     append(f := c)

--- a/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
@@ -100,11 +100,11 @@ trait CodeBuilderLike {
   [1]: https://github.com/scala/scala/blob/2.13.x/spec/06-expressions.md#value-discarding
   */
 
-  def ifx[A](c: Code[Boolean], emitThen: => A)
-            (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = 
-    ifx(c, emitThen, ().asInstanceOf[A])
+  def if_[A](c: => Code[Boolean], emitThen: => A)
+            (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit =
+    if_(c, emitThen, ().asInstanceOf[A])
 
-  def ifx[A](cond: Code[Boolean], emitThen: => A, emitElse: => A)
+  def if_[A](cond: => Code[Boolean], emitThen: => A, emitElse: => A)
             (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = {
     val Ltrue = CodeLabel()
     val Lfalse = CodeLabel()
@@ -119,7 +119,7 @@ trait CodeBuilderLike {
     define(Lexit)
   }
 
-  def switch[A](discriminant: Code[Int], emitDefault: => A, cases: IndexedSeq[() => A])
+  def switch[A](discriminant: => Code[Int], emitDefault: => A, cases: IndexedSeq[() => A])
                (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = {
     val Lexit = CodeLabel()
     val Lcases = IndexedSeq.fill(cases.length)(CodeLabel())
@@ -143,20 +143,20 @@ trait CodeBuilderLike {
     emitBody(Lstart)
   }
 
-  def while_[A](cond: Code[Boolean], emitBody: CodeLabel => A)
+  def while_[A](cond: => Code[Boolean], emitBody: CodeLabel => A)
                (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit =
     loop { Lstart =>
-      ifx(cond, {
+      if_(cond, {
         emitBody(Lstart)
         goto(Lstart)
       })
     }
 
-  def while_[A](c: Code[Boolean], emitBody: => A)
+  def while_[A](c: => Code[Boolean], emitBody: => A)
                (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit =
     while_(c, (_: CodeLabel) => emitBody)
 
-  def for_[A](setup: => A, cond: Code[Boolean], incr: => A, emitBody: CodeLabel => A)
+  def for_[A](setup: => A, cond: => Code[Boolean], incr: => A, emitBody: CodeLabel => A)
              (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit = {
     setup
     while_(cond, {
@@ -167,7 +167,7 @@ trait CodeBuilderLike {
     })
   }
 
-  def for_[A](setup: => A, cond: Code[Boolean], incr: => A, body: => A)
+  def for_[A](setup: => A, cond: => Code[Boolean], incr: => A, body: => A)
              (implicit ev: A =:= Unit /* Note [Evidence Is Unit] */): Unit =
     for_(setup, cond, incr, (_: CodeLabel) => body)
 

--- a/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
@@ -110,8 +110,8 @@ trait CodeBuilderLike {
     emitBody(Lstart)
   }
 
-  def whileLoop[A](cond: Code[Boolean], emitBody: CodeLabel => A)
-                  (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = 
+  def while_[A](cond: Code[Boolean], emitBody: CodeLabel => A)
+               (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit =
     loop { Lstart =>
       ifx(cond, {
         emitBody(Lstart)
@@ -119,14 +119,14 @@ trait CodeBuilderLike {
       })
     }
 
-  def whileLoop[A](c: Code[Boolean], emitBody: => A)
-                  (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = 
-    whileLoop(c, (_: CodeLabel) => emitBody)
+  def while_[A](c: Code[Boolean], emitBody: => A)
+               (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit =
+    while_(c, (_: CodeLabel) => emitBody)
 
-  def forLoop[A](setup: => A, cond: Code[Boolean], incr: => A, emitBody: CodeLabel => A)
-                (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = {
+  def for_[A](setup: => A, cond: Code[Boolean], incr: => A, emitBody: CodeLabel => A)
+             (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit = {
     setup
-    whileLoop(cond, {
+    while_(cond, {
       val Lincr = CodeLabel()
       emitBody(Lincr)
       define(Lincr)
@@ -134,9 +134,9 @@ trait CodeBuilderLike {
     })
   }
 
-  def forLoop[A](setup: => A, cond: Code[Boolean], incr: => A, body: => A)
-                (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit =
-    forLoop(setup, cond, incr, (_: CodeLabel) => body)
+  def for_[A](setup: => A, cond: Code[Boolean], incr: => A, body: => A)
+             (implicit ev: A =:= Unit /* See note EVIDENCE_IS_UNIT */): Unit =
+    for_(setup, cond, incr, (_: CodeLabel) => body)
 
   def newLocal[T: TypeInfo](name: String)
                            (implicit ev: T =!= Unit /* See note EVIDENCE_IS_NOT_UNIT */)

--- a/hail/src/main/scala/is/hail/asm4s/GenericTypeInfo.scala
+++ b/hail/src/main/scala/is/hail/asm4s/GenericTypeInfo.scala
@@ -36,9 +36,9 @@ final case class GenericTypeInfo[T : TypeInfo]() extends MaybeGenericTypeInfo[T]
       case _: UnitInfo.type =>
         coerce[T](Code._empty)
       case cti: ClassInfo[_] =>
-        cb.memoize(Code.checkcast[T](x)(cti))(cti)
+        cb.memoize(Code.checkcast[T](x)(cti))
       case ati: ArrayInfo[_] =>
-        cb.memoize(Code.checkcast[T](x)(ati))(ati)
+        cb.memoize(Code.checkcast[T](x)(ati))
     }
   }
 

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -7,6 +7,16 @@ import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 package asm4s {
+
+  // lifted from https://github.com/milessabin/shapeless
+  @scala.annotation.implicitAmbiguous("${A} must not be equal to ${B}")
+  sealed abstract class =!=[A, B] extends Serializable
+  object =!= {
+    implicit def refl[A, B]: A =!= B = new=!=[A, B] {}
+    implicit def ambig1[A]: A =!= A = ???
+    implicit def ambig2[A]: A =!= A = ???
+  }
+
   trait TypeInfo[T] {
     val desc: String
     val iname: String = desc

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -32,8 +32,8 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       val size = cb.newLocal[Int]("size", array.size)
 
       cb.while_(i < size, {
-        cb.ifx(!array.isMissing(i), {
-          cb.ifx(newEnd.cne(i), cb += array.update(newEnd, array.apply(i)))
+        cb.if_(!array.isMissing(i), {
+          cb.if_(newEnd.cne(i), cb += array.update(newEnd, array.apply(i)))
           cb.assign(newEnd, newEnd + 1)
         })
         cb.assign(i, i + 1)
@@ -68,9 +68,9 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
           val LtakeFromRight = CodeLabel()
           val Ldone = CodeLabel()
 
-          cb.ifx(j < end, {
-            cb.ifx(i >= mid, cb.goto(LtakeFromRight))
-            cb.ifx(comparesLessThan(cb, r, arrayA.index(cb, j), arrayA.index(cb, i)), cb.goto(LtakeFromRight), cb.goto(LtakeFromLeft))
+          cb.if_(j < end, {
+            cb.if_(i >= mid, cb.goto(LtakeFromRight))
+            cb.if_(comparesLessThan(cb, r, arrayA.index(cb, j), arrayA.index(cb, i)), cb.goto(LtakeFromRight), cb.goto(LtakeFromLeft))
           }, cb.goto(LtakeFromLeft))
 
           cb.define(LtakeFromLeft)
@@ -97,7 +97,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
         val arrayB = splitMergeMB.getCodeParam(4)(workingArrayInfo)
         val arrayA = splitMergeMB.getCodeParam(5)(workingArrayInfo)
 
-        cb.ifx(end - begin > 1, {
+        cb.if_(end - begin > 1, {
           val mid = cb.newLocal[Int]("splitMerge_mid", (begin + end) / 2)
 
           cb.invokeVoid(splitMergeMB, r, begin, mid, arrayA, arrayB)
@@ -109,7 +109,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       }
 
       // these arrays should be allocated once and reused
-      cb.ifx(workingArray1.isNull || arrayRef(workingArray1).length() < newEnd, {
+      cb.if_(workingArray1.isNull || arrayRef(workingArray1).length() < newEnd, {
         cb.assignAny(workingArray1, Code.newArray(newEnd)(array.ti))
         cb.assignAny(workingArray2, Code.newArray(newEnd)(array.ti))
       })
@@ -160,8 +160,8 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
     val n = cb.newLocal[Int]("n", 0)
     val size = cb.newLocal[Int]("size", array.size)
     cb.while_(i < size, {
-      cb.ifx(!array.isMissing(i), {
-        cb.ifx(i.cne(n),
+      cb.if_(!array.isMissing(i), {
+        cb.if_(i.cne(n),
           cb += array.update(n, array(i)))
         cb.assign(n, n + 1)
       })
@@ -184,8 +184,8 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
         val LskipLoopBegin = CodeLabel()
         val LskipLoopEnd = CodeLabel()
         cb.define(LskipLoopBegin)
-        cb.ifx(i >= size, cb.goto(LskipLoopEnd))
-        cb.ifx(!discardNext(cb, region,
+        cb.if_(i >= size, cb.goto(LskipLoopEnd))
+        cb.if_(!discardNext(cb, region,
           EmitCode.fromI(distinctMB)(cb => array.loadFromIndex(cb, region, n)),
           EmitCode.fromI(distinctMB)(cb => array.loadFromIndex(cb, region, i))),
           cb.goto(LskipLoopEnd))
@@ -196,9 +196,9 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
 
         cb.assign(n, n + 1)
 
-        cb.ifx(i < size && i.cne(n), {
+        cb.if_(i < size && i.cne(n), {
           cb += array.setMissing(n, array.isMissing(i))
-          cb.ifx(!array.isMissing(n), cb += array.update(n, array(i)))
+          cb.if_(!array.isMissing(n), cb += array.update(n, array(i)))
         })
 
       })

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -31,7 +31,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       val i = cb.newLocal[Int]("i", 0)
       val size = cb.newLocal[Int]("size", array.size)
 
-      cb.whileLoop(i < size, {
+      cb.while_(i < size, {
         cb.ifx(!array.isMissing(i), {
           cb.ifx(newEnd.cne(i), cb += array.update(newEnd, array.apply(i)))
           cb.assign(newEnd, newEnd + 1)
@@ -39,7 +39,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
         cb.assign(i, i + 1)
       })
       cb.assign(i, newEnd)
-      cb.whileLoop(i < size, {
+      cb.while_(i < size, {
         cb += array.setMissing(i, true)
         cb.assign(i, i + 1)
       })
@@ -62,7 +62,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
         val j = cb.newLocal[Int]("mergemb_j", mid)
 
         val k = cb.newLocal[Int]("mergemb_k", i)
-        cb.whileLoop(k < end, {
+        cb.while_(k < end, {
 
           val LtakeFromLeft = CodeLabel()
           val LtakeFromRight = CodeLabel()
@@ -115,7 +115,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       })
 
       cb.assign(i, 0)
-      cb.whileLoop(i < newEnd, {
+      cb.while_(i < newEnd, {
         cb += arrayRef(workingArray1).update(i, array(i))
         cb += arrayRef(workingArray2).update(i, array(i))
         cb.assign(i, i + 1)
@@ -125,7 +125,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       cb.invokeVoid(splitMergeMB, sortMB.getCodeParam[Region](1), const(0), newEnd, workingArray1, workingArray2)
 
       cb.assign(i, 0)
-      cb.whileLoop(i < newEnd, {
+      cb.while_(i < newEnd, {
         cb += array.update(i, arrayRef(workingArray2)(i))
         cb.assign(i, i + 1)
       })
@@ -159,7 +159,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
     val i = cb.newLocal[Int]("i", 0)
     val n = cb.newLocal[Int]("n", 0)
     val size = cb.newLocal[Int]("size", array.size)
-    cb.whileLoop(i < size, {
+    cb.while_(i < size, {
       cb.ifx(!array.isMissing(i), {
         cb.ifx(i.cne(n),
           cb += array.update(n, array(i)))
@@ -178,7 +178,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       val i = cb.newLocal[Int]("i", 0)
       val n = cb.newLocal[Int]("n", 0)
       val size = cb.newLocal[Int]("size", array.size)
-      cb.whileLoop(i < size, {
+      cb.while_(i < size, {
         cb.assign(i, i + 1)
 
         val LskipLoopBegin = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -16,9 +16,9 @@ object BinarySearch {
     ): Comparator = new Comparator {
       def apply(cb: EmitCodeBuilder, elt: IEmitCode, ifLtNeedle: => Unit, ifGtNeedle: => Unit, ifNeither: => Unit): Unit = {
         val eltVal = cb.memoize(elt)
-        cb.ifx(ltNeedle(eltVal.loadI(cb)),
+        cb.if_(ltNeedle(eltVal.loadI(cb)),
           ifLtNeedle,
-          cb.ifx(gtNeedle(eltVal.loadI(cb)),
+          cb.if_(gtNeedle(eltVal.loadI(cb)),
             ifGtNeedle,
             ifNeither))
       }
@@ -27,9 +27,9 @@ object BinarySearch {
     def fromCompare(compare: IEmitCode => Value[Int]): Comparator = new Comparator {
       def apply(cb: EmitCodeBuilder, elt: IEmitCode, ifLtNeedle: => Unit, ifGtNeedle: => Unit, ifNeither: => Unit): Unit = {
         val c = cb.memoize(compare(elt))
-        cb.ifx(c < 0,
+        cb.if_(c < 0,
           ifLtNeedle,
-          cb.ifx(c > 0,
+          cb.if_(c > 0,
             ifGtNeedle,
             ifNeither))
       }
@@ -37,7 +37,7 @@ object BinarySearch {
 
     def fromPred(pred: IEmitCode => Code[Boolean]): Comparator = new Comparator {
       def apply(cb: EmitCodeBuilder, elt: IEmitCode, ifLtNeedle: => Unit, ifGtNeedle: => Unit, ifNeither: => Unit): Unit = {
-        cb.ifx(pred(elt), ifGtNeedle, ifLtNeedle)
+        cb.if_(pred(elt), ifGtNeedle, ifLtNeedle)
       }
     }
   }
@@ -228,7 +228,7 @@ object BinarySearch {
     // - left <= right
     // terminates b/c (right - left) strictly decreases each iteration
     cb.loop { recur =>
-      cb.ifx(left < right, {
+      cb.if_(left < right, {
         val mid = cb.memoize((left + right) >>> 1) // works even when sum overflows
         compare(cb, haystack.loadElement(cb, mid), {
           // range [start, mid] is < needle

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -99,7 +99,7 @@ case class BlockMatrixNativeMetadataWriter(path: String, stageLocally: Boolean, 
     val n = cb.newLocal[Int]("n", pc.loadLength())
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partFiles, Code.newArray[String](n))
-    cb.whileLoop(i < n, {
+    cb.while_(i < n, {
       val s = pc.loadElement(cb, i).get(cb, "file name can't be missing!").asString
       cb += partFiles.update(i, s.loadString(cb))
       cb.assign(i, i + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -210,7 +210,7 @@ object CompileIterator {
       val ret = cb.newLocal[Boolean]("stepf_ret")
       val Lreturn = CodeLabel()
 
-      cb.ifx(!didSetup, {
+      cb.if_(!didSetup, {
         optStream.toI(cb).get(cb) // handle missing, but bound stream producer above
 
         cb.assign(producer.elementRegion, eltRegionField)
@@ -219,7 +219,7 @@ object CompileIterator {
         cb.assign(eosField, false)
       })
 
-      cb.ifx(eosField, {
+      cb.if_(eosField, {
         cb.assign(ret, false)
         cb.goto(Lreturn)
       })

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1176,7 +1176,7 @@ class Emit[C](
               val rawSet = cb.memoize(ms)
               val maxSet = cb.memoize(Code.newArray[String](rawSet.invoke[Int]("length")))
               val i = cb.newLocal[Int]("mis_str_iseq_to_arr_i")
-              cb.forLoop(cb.assign(i, 0), i < maxSet.length(), cb.assign(i, i + 1), {
+              cb.for_(cb.assign(i, 0), i < maxSet.length(), cb.assign(i, i + 1), {
                 cb += maxSet.update(i, Code.checkcast[String](rawSet.invoke[Int, java.lang.Object]("apply", i)))
               })
 
@@ -1303,7 +1303,7 @@ class Emit[C](
               .equiv(cb, lk, rk, missingEqual = true)
           }
 
-          cb.whileLoop(eltIdx < sortedElts.size, {
+          cb.while_(eltIdx < sortedElts.size, {
             val bottomOfLoop = CodeLabel()
             val newGroup = CodeLabel()
 
@@ -1336,7 +1336,7 @@ class Emit[C](
           cb.assign(eltIdx, 0)
           cb.assign(grpIdx, 0)
 
-          cb.whileLoop(grpIdx < outerSize, {
+          cb.while_(grpIdx < outerSize, {
             cb.assign(groupSize, coerce[Int](groupSizes(grpIdx)))
             cb.assign(withinGrpIdx, 0)
             val firstStruct = sortedElts.loadFromIndex(cb, region, eltIdx).get(cb).asBaseStruct
@@ -1344,7 +1344,7 @@ class Emit[C](
             val group = EmitCode.fromI(mb) { cb =>
               val (addElt, finishInner) = innerType
                 .constructFromFunctions(cb, region, groupSize, deepCopy = false)
-              cb.whileLoop(withinGrpIdx < groupSize, {
+              cb.while_(withinGrpIdx < groupSize, {
                 val struct = sortedElts.loadFromIndex(cb, region, eltIdx).get(cb).asBaseStruct
                 addElt(cb, struct.loadField(cb, 1))
                 cb.assign(eltIdx, eltIdx + 1)
@@ -1695,7 +1695,7 @@ class Emit[C](
 
                   val kLen = lShape(lSType.nDims - 1)
                   cb.assignAny(element, numericElementType.zero)
-                  cb.forLoop(cb.assign(k, 0L), k < kLen, cb.assign(k, k + 1L), {
+                  cb.for_(cb.assign(k, 0L), k < kLen, cb.assign(k, k + 1L), {
                     val lElem = leftPVal.loadElement(lIndices, cb)
                     val rElem = rightPVal.loadElement(rIndices, cb)
                     cb.assignAny(element, numericElementType.add(multiply(lElem, rElem), element))
@@ -2036,12 +2036,12 @@ class Emit[C](
             val curWriteAddress = cb.newLocal[Long]("ndarray_qr_curr_write_addr", rDataAddress)
 
             // I think this just copies out the upper triangle into new ndarray in column major order
-            cb.forLoop({
+            cb.for_({
               cb.assign(currCol, 0L)
             }, currCol < rCols, {
               cb.assign(currCol, currCol + 1L)
             }, {
-              cb.forLoop({
+              cb.for_({
                 cb.assign(currRow, 0L)
               }, currRow < rRows, {
                 cb.assign(currRow, currRow + 1L)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2035,16 +2035,8 @@ class Emit[C](
             val curWriteAddress = cb.newLocal[Long]("ndarray_qr_curr_write_addr", rDataAddress)
 
             // I think this just copies out the upper triangle into new ndarray in column major order
-            cb.for_({
-              cb.assign(currCol, 0L)
-            }, currCol < rCols, {
-              cb.assign(currCol, currCol + 1L)
-            }, {
-              cb.for_({
-                cb.assign(currRow, 0L)
-              }, currRow < rRows, {
-                cb.assign(currRow, currRow + 1L)
-              }, {
+            cb.for_(cb.assign(currCol, 0L), currCol < rCols, cb.assign(currCol, currCol + 1L), {
+              cb.for_(cb.assign(currRow, 0L), currRow < rRows, cb.assign(currRow, currRow + 1L), {
                 cb.append(Region.storeDouble(
                   curWriteAddress,
                   (currCol >= currRow).mux(

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2323,10 +2323,10 @@ class Emit[C](
         val msg = cb.newLocal[String]("die_msg")
         cm.consume(cb,
           cb.assign(msg, "<exception message missing>"),
-          { sc => cb.assign(msg, sc.asString.loadString(cb)) })
+          { sc => cb.assign(msg, sc.asString.loadString(cb)) }
+        )
         cb._throw[HailException](Code.newInstance[HailException, String, Int](msg, errorId))
-
-        IEmitCode.present(cb, SUnreachable.fromVirtualType(typ).defaultValue)
+        IEmitCode(CodeLabel(), CodeLabel(), SUnreachable.fromVirtualType(typ).defaultValue, true)
 
       case ConsoleLog(message, result) =>
         val cm = emitI(message)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -92,8 +92,7 @@ object Emit {
 
         val env = EmitEnv(Env.empty, (0 until nParams).map(i => mb.storeEmitParamAsField(cb, i + 2)))  // this, region, ...
         val sc = emitter.emitI(ir, cb, region, env, container, None).handle(cb, {
-          cb._throw[RuntimeException](
-            Code.newInstance[RuntimeException, String]("cannot return empty"))
+          cb._throw(Code.newInstance[RuntimeException, String]("cannot return empty"))
         })
 
         val scp = SingleCodeSCode.fromSCode(cb, sc, region)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1438,7 +1438,7 @@ class Emit[C](
 
                   val shapeValues = (0 until nDims).map { i =>
                     val shape = SingleCodeSCode.fromSCode(cb, shapeTupleValue.loadField(cb, i).get(cb), region)
-                    cb.newLocalAny[Long](s"make_ndarray_shape_${ i }", shape.code)
+                    cb.newLocal[Long](s"make_ndarray_shape_${ i }", coerce[Long](shape.code))
                   }
 
                   cb.ifx(isRowMajorCode.asBoolean.value, {
@@ -1662,7 +1662,7 @@ class Emit[C](
 
               val emitter = new NDArrayEmitter(unifiedShape, leftPVal.st.elementType) {
                 override def outputElement(cb: EmitCodeBuilder, idxVars: IndexedSeq[Value[Long]]): SValue = {
-                  val element = coerce[Any](cb.newField("matmul_element")(eVti))
+                  val element = cb.newFieldAny("matmul_element", eVti)
                   val k = cb.newField[Long]("ndarray_matmul_k")
 
                   val (lIndices: IndexedSeq[Value[Long]], rIndices: IndexedSeq[Value[Long]]) = (lSType.nDims, rSType.nDims, idxVars) match {
@@ -1694,11 +1694,11 @@ class Emit[C](
 
 
                   val kLen = lShape(lSType.nDims - 1)
-                  cb.assign(element, numericElementType.zero)
+                  cb.assignAny(element, numericElementType.zero)
                   cb.forLoop(cb.assign(k, 0L), k < kLen, cb.assign(k, k + 1L), {
                     val lElem = leftPVal.loadElement(lIndices, cb)
                     val rElem = rightPVal.loadElement(rIndices, cb)
-                    cb.assign(element, numericElementType.add(multiply(lElem, rElem), element))
+                    cb.assignAny(element, numericElementType.add(multiply(lElem, rElem), element))
                   })
 
                   primitive(outputPType.elementType.virtualType, element)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -675,7 +675,7 @@ class EmitClassBuilder[C](
     mb.voidWithBuilder { cb =>
       val rgFields = emodb.referenceGenomeFields()
       val rgs = mb.getCodeParam[Array[ReferenceGenome]](1)
-      cb.ifx(rgs.length().cne(const(rgFields.length)), cb._fatal("Invalid number of references, expected ", rgFields.length.toString, " got ", rgs.length().toS))
+      cb.if_(rgs.length().cne(const(rgFields.length)), cb._fatal("Invalid number of references, expected ", rgFields.length.toString, " got ", rgs.length().toS))
       for ((fld, i) <- rgFields.zipWithIndex) {
         cb += rgs(i).invoke[String, FS, Unit]("heal", ctx.localTmpdir, getFS)
         cb += fld.put(rgs(i))
@@ -695,7 +695,7 @@ class EmitClassBuilder[C](
     val rngFields = rngs.result()
 
     mb.voidWithBuilder { cb =>
-      cb.ifx(!initialized, {
+      cb.if_(!initialized, {
         rngFields.foreach { case (field, init) =>
           cb.assign(field, init)
         }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -161,10 +161,8 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def fieldBuilder: SettableBuilder = cb.fieldBuilder
 
-  def result(
-    ctx: ExecuteContext,
-    print: Option[PrintWriter] = None
-  ): (HailClassLoader) => C = cb.result(ctx.shouldWriteIRFiles(), print)
+  def result(print: Option[PrintWriter] = None): HailClassLoader => C =
+    cb.result(ctx.shouldWriteIRFiles(), print)
 
   def getHailClassLoader: Code[HailClassLoader] = ecb.getHailClassLoader
 
@@ -216,7 +214,9 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def getThreefryRNG(): Value[ThreefryRandomEngine] = ecb.getThreefryRNG()
 
-  def resultWithIndex(writeIRs: Boolean = ctx.shouldWriteIRFiles(), print: Option[PrintWriter] = None): (HailClassLoader, FS, HailTaskContext, Region) => C = ecb.resultWithIndex(writeIRs, print)
+  def resultWithIndex(print: Option[PrintWriter] = None)
+  : (HailClassLoader, FS, HailTaskContext, Region) => C =
+    ecb.resultWithIndex(print)
 
   def getOrGenEmitMethod(
     baseName: String, key: Any, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType
@@ -550,7 +550,7 @@ class EmitClassBuilder[C](
         case CodeOrdering.Gteq(missingEqual) => ord.gteq(cb, v1, v2, missingEqual)
         case CodeOrdering.Neq(missingEqual) => !ord.equiv(cb, v1, v2, missingEqual)
       }
-      cb.memoize[op.ReturnType](coerce[op.ReturnType](r))(op.rtti)
+      cb.memoize[op.ReturnType](coerce[op.ReturnType](r))(op.rtti, implicitly[op.ReturnType =!= Unit])
     }
   }
 
@@ -569,7 +569,7 @@ class EmitClassBuilder[C](
         case CodeOrdering.StructGt(missingEqual) => ord.gt(cb, v1, v2, missingEqual)
         case CodeOrdering.StructCompare(missingEqual) => ord.compare(cb, v1, v2, missingEqual)
       }
-      cb.memoize[op.ReturnType](coerce[op.ReturnType](r))(op.rtti)
+      cb.memoize[op.ReturnType](coerce[op.ReturnType](r))(op.rtti, implicitly[op.ReturnType =!= Unit])
     }
   }
 
@@ -730,10 +730,8 @@ class EmitClassBuilder[C](
     }
   }
 
-  def resultWithIndex(
-    writeIRs: Boolean,
-    print: Option[PrintWriter] = None
-  ): (HailClassLoader, FS, HailTaskContext, Region) => C = {
+  def resultWithIndex(print: Option[PrintWriter] = None)
+  : (HailClassLoader, FS, HailTaskContext, Region) => C = {
     makeRNGs()
     makeAddPartitionRegion()
     makeAddHailClassLoader()
@@ -768,7 +766,7 @@ class EmitClassBuilder[C](
       "FunctionBuilder emission should happen on master, but happened on worker")
 
     val n = cb.className.replace("/", ".")
-    val classesBytes = modb.classesBytes(writeIRs, print)
+    val classesBytes = modb.classesBytes(ctx.shouldWriteIRFiles(), print)
 
     new ((HailClassLoader, FS, HailTaskContext, Region) => C) with java.io.Serializable {
       @transient @volatile private var theClass: Class[_] = null

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -58,7 +58,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     tmp
   }
 
-  def ifx(c: Code[Boolean], emitThen: => SValue, emitElse: => SValue): SValue = {
+  def if_(c: => Code[Boolean], emitThen: => SValue, emitElse: => SValue): SValue = {
     val Ltrue = CodeLabel()
     val Lfalse = CodeLabel()
     val Lafter = CodeLabel()
@@ -74,7 +74,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     value
   }
 
-  def ifx(c: Code[Boolean], emitThen: => IEmitCode, emitElse: => IEmitCode): IEmitCode = {
+  def if_(c: => Code[Boolean], emitThen: => IEmitCode, emitElse: => IEmitCode): IEmitCode = {
     val Lmissing = CodeLabel()
     val Lpresent = CodeLabel()
     val Ltrue = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -142,12 +142,6 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     memoizeField[T](v, "memoize")
   }
 
-  def memoizeFieldAny(v: Code[_], name: String, ti: TypeInfo[_]): Value[_] = {
-    val l = newField(name)(ti)
-    append(l.storeAny(v))
-    l
-  }
-
   def memoize(v: EmitCode): EmitValue =
     memoize(v, "memoize")
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -2,7 +2,6 @@ package is.hail.expr.ir
 
 import is.hail.asm4s.{coerce => _, _}
 import is.hail.expr.ir.functions.StringFunctions
-import is.hail.lir
 import is.hail.types.physical.stypes.interfaces.{SStream, SStreamValue}
 import is.hail.types.physical.stypes.{SSettable, SType, SValue}
 import is.hail.utils._
@@ -57,14 +56,6 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     val tmp = code
     code = Code._empty
     tmp
-  }
-
-  def mux[T: TypeInfo](c: Code[Boolean], emitThen: Code[T], emitElse: Code[T])
-                      (implicit ev: T =!= Unit): Value[T] = {
-    val expr = c.mux(emitThen, emitElse)
-    val loc = newLocal[T]("ifx_value")
-    assign(loc, expr)
-    loc
   }
 
   def ifx(c: Code[Boolean], emitThen: => SValue, emitElse: => SValue): SValue = {

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -87,7 +87,7 @@ class PartitionIteratorLongReader(
         override val elementRegion: Settable[Region] = region
         override val requiresMemoryManagementPerElement: Boolean = true
         override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-          cb.ifx(!it.get.hasNext,
+          cb.if_(!it.get.hasNext,
             cb.goto(LendOfStream))
           cb.assign(rv, Code.longValue(it.get.next()))
           cb.assign(rowIdx, rowIdx + 1L)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -1417,7 +1417,7 @@ case class PLINKPartitionWriter(typ: MatrixType, entriesFieldName: String) exten
         cb += bp.invoke[Int, Unit]("add", 1)
       }, { case call: SCallValue =>
         val gtIx = cb.memoize(Code.invokeScalaObject1[Call, Int](Call.getClass, "unphasedDiploidGtIndex", call.canonicalCall(cb)))
-        val gt = cb.mux(gtIx.ceq(0), 3, cb.mux(gtIx.ceq(1), 2, 0))
+        val gt = (gtIx ceq 0).mux(3, (gtIx ceq 1).mux(2, 0))
         cb += bp.invoke[Int, Unit]("add", gt)
       })
     })

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -1417,7 +1417,7 @@ case class PLINKPartitionWriter(typ: MatrixType, entriesFieldName: String) exten
         cb += bp.invoke[Int, Unit]("add", 1)
       }, { case call: SCallValue =>
         val gtIx = cb.memoize(Code.invokeScalaObject1[Call, Int](Call.getClass, "unphasedDiploidGtIndex", call.canonicalCall(cb)))
-        val gt = cb.ifx(gtIx.ceq(0), 3, cb.ifx(gtIx.ceq(1), 2, 0))
+        val gt = cb.mux(gtIx.ceq(0), 3, cb.mux(gtIx.ceq(1), 2, 0))
         cb += bp.invoke[Int, Unit]("add", gt)
       })
     })

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -93,7 +93,7 @@ case class StringTablePartitionReader(lines: GenericLines, uidFieldName: String)
 
         override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
           val hasNext = iter.invoke[Boolean]("hasNext")
-          cb.ifx(hasNext, {
+          cb.if_(hasNext, {
             val gLine = iter.invoke[GenericLine]("next")
             cb.assign(line, gLine.invoke[String]("toString"))
             cb.assign(rowIdx, rowIdx + 1L)

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -315,7 +315,7 @@ case class RVDSpecWriter(path: String, spec: RVDSpecMaker) extends MetadataWrite
     val n = cb.newLocal[Int]("n", a.loadLength())
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partFiles, Code.newArray[String](n))
-    cb.whileLoop(i < n, {
+    cb.while_(i < n, {
       val s = a.loadElement(cb, i).get(cb, "file name can't be missing!").asString
       cb += partFiles.update(i, s.loadString(cb))
       cb.assign(i, i + 1)
@@ -374,7 +374,7 @@ case class TableSpecWriter(path: String, typ: TableType, rowRelPath: String, glo
     val n = cb.newLocal[Int]("n", a.loadLength())
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partCounts, Code.newArray[Long](n))
-    cb.whileLoop(i < n, {
+    cb.while_(i < n, {
       val curElement =  a.loadElement(cb, i).get(cb, "writeMetadata annotation can't be missing").asBaseStruct
       val count = curElement.asBaseStruct.loadField(cb, "partitionCounts").get(cb, "part count can't be missing!").asLong.value
 
@@ -597,7 +597,7 @@ case class TableTextFinalizer(outputPath: String, rowType: TStruct, delimiter: S
         cb += cb.emb.getFS.invoke[Array[String], String, Unit]("concatenateFiles", jFiles, const(outputPath))
 
         val i = cb.newLocal[Int]("i")
-        cb.forLoop(cb.assign(i, 0), i < jFiles.length, cb.assign(i, i + 1), {
+        cb.for_(cb.assign(i, 0), i < jFiles.length, cb.assign(i, i + 1), {
           cb += cb.emb.getFS.invoke[String, Boolean, Unit]("delete", jFiles(i), const(false))
         })
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -255,7 +255,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         })
       }
 
-      cb.whileLoop(cmp.cne(0), { Lcont =>
+      cb.whileLoop(cmp.cne(0), { (Lcont: CodeLabel)  =>
         (0 until maxElements).foreach { i =>
           cb.ifx(hasKey(cb, node, i), {
             cb.assign(keyV, loadKey(cb, node, i))
@@ -301,7 +301,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     }
 
     stackPush(root)
-    cb.whileLoop(stackI >= 0, { (Lstart) =>
+    cb.whileLoop(stackI >= 0, { (Lstart: CodeLabel) =>
       val node = cb.newLocal("btree_foreach_node", nodeStack(stackI))
       val idx = cb.newLocal("btree_foreach_idx", idxStack(stackI))
       val Lend = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -117,7 +117,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       def makeUninitialized(cb: EmitCodeBuilder, idx: Int): Value[Long] = {
         setKeyPresent(cb, node, idx)
         key.initializeEmpty(cb, keyOffset(node, idx))
-        cb.ifx(!isLeaf(cb, node), {
+        cb.if_(!isLeaf(cb, node), {
           setChild(cb, node, idx, child, "makeUninitialized setChild")
         })
         loadKey(cb, node, idx)
@@ -128,7 +128,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         val srcNode = cb.newLocal("aobt_copy_from_srcnode", srcNodeC)
         setKeyPresent(cb, destNode, destIdx)
         key.copy(cb, keyOffset(srcNode, srcIdx), keyOffset(destNode, destIdx))
-        cb.ifx(!isLeaf(cb, srcNode),
+        cb.if_(!isLeaf(cb, srcNode),
           {
             setChild(cb, destNode, destIdx, loadChild(cb, srcNode, srcIdx), "insert copyFrom")
           })
@@ -146,15 +146,15 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
         (0 until maxElements).foreach { i =>
           val b = cb.newLocal[Boolean]("btree_insertkey_b", !hasKey(cb, parent(cb), i))
-          cb.ifx(!b, cb.assign(b, key.compWithKey(cb, loadKey(cb, parent(cb), i), ev) >= 0))
-          cb.ifx(b, {
+          cb.if_(!b, cb.assign(b, key.compWithKey(cb, loadKey(cb, parent(cb), i), ev) >= 0))
+          cb.if_(b, {
             cb.assign(upperBound, i)
             cb.goto(Lfound)
           })
         }
 
         cb.define(Lfound)
-        cb.ifx(!isLeaf(cb, node), {
+        cb.if_(!isLeaf(cb, node), {
           setChild(cb, newNode, -1, c, "insertKey !isLeaf")
         })
         cb.invokeCode(insertAt, parent(cb), upperBound, ev, newNode)
@@ -164,7 +164,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       def promote(cb: EmitCodeBuilder, idx: Int): Unit = {
         val nikey = cb.newLocal("aobt_insert_nikey", loadKey(cb, node, idx))
 
-        cb.ifx(!isLeaf(cb, node), {
+        cb.if_(!isLeaf(cb, node), {
           setChild(cb, newNode, -1, loadChild(cb, node, idx), "promote")
         })
 
@@ -173,8 +173,8 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
         (0 until maxElements).foreach { i =>
           val b = cb.newLocal[Boolean]("btree_insert_promote_b", !hasKey(cb, parent(cb), i))
-          cb.ifx(!b, cb.assign(b, key.compSame(cb, loadKey(cb, parent(cb), i), nikey) >= 0))
-          cb.ifx(b, {
+          cb.if_(!b, cb.assign(b, key.compSame(cb, loadKey(cb, parent(cb), i), nikey) >= 0))
+          cb.if_(b, {
             cb.assign(upperBound, i)
             cb.goto(Lfound)
           })
@@ -186,19 +186,19 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       }
 
       def splitAndInsert(cb: EmitCodeBuilder): Code[Long] = {
-        cb.ifx(isRoot(cb, node), {
+        cb.if_(isRoot(cb, node), {
           createNode(cb, root)
           setChild(cb, root, -1, node, "splitAndInsert")
         })
         createNode(cb, newNode)
         val out = cb.newLocal[Long]("split_and_insert_out")
-        cb.ifx(insertIdx > splitIdx, {
+        cb.if_(insertIdx > splitIdx, {
           copyToNew(cb, splitIdx + 1)
           promote(cb, splitIdx)
           cb.assign(out, cb.invokeCode(insertAt, newNode, cb.memoize(insertIdx - splitIdx - 1), k, child))
         }, {
           copyToNew(cb, splitIdx)
-          cb.ifx(insertIdx.ceq(splitIdx), {
+          cb.if_(insertIdx.ceq(splitIdx), {
             cb.assign(out, insertKey(cb, k, child))
           }, {
             promote(cb, splitIdx - 1)
@@ -212,10 +212,10 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         val ret = cb.newLocal[Long]("shift_and_insert")
         val Lout = CodeLabel()
         (1 until maxElements).reverse.foreach { destIdx =>
-          cb.ifx(hasKey(cb, node, destIdx - 1), {
+          cb.if_(hasKey(cb, node, destIdx - 1), {
             copyFrom(cb, node, destIdx, node, destIdx - 1)
           })
-          cb.ifx(insertIdx.ceq(destIdx), {
+          cb.if_(insertIdx.ceq(destIdx), {
             cb.assign(ret, makeUninitialized(cb, destIdx))
             cb.goto(Lout)
           })
@@ -227,7 +227,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
       insertAt.emitWithBuilder { cb =>
         val ret = cb.newLocal[Long]("btree_insert_result")
-        cb.ifx(isFull(cb, node),
+        cb.if_(isFull(cb, node),
           cb.assign(ret, splitAndInsert(cb)),
           cb.assign(ret, shiftAndInsert(cb)))
         ret
@@ -247,7 +247,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       val keyV = cb.newLocal("btree_get_keyV", 0L)
 
       def insertOrGetAt(i: Int) = {
-        cb.ifx(isLeaf(cb, node), {
+        cb.if_(isLeaf(cb, node), {
           cb.assign(keyV, insert(cb, node, const(i), k, const(0L)))
           cb.assign(cmp, 0)
         }, {
@@ -257,11 +257,11 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
       cb.while_(cmp.cne(0), { (Lcont: CodeLabel)  =>
         (0 until maxElements).foreach { i =>
-          cb.ifx(hasKey(cb, node, i), {
+          cb.if_(hasKey(cb, node, i), {
             cb.assign(keyV, loadKey(cb, node, i))
             cb.assign(cmp, key.compWithKey(cb, keyV, k))
-            cb.ifx(cmp.ceq(0), cb.goto(Lcont))
-            cb.ifx(cmp > 0, {
+            cb.if_(cmp.ceq(0), cb.goto(Lcont))
+            cb.if_(cmp > 0, {
               insertOrGetAt(i)
               cb.goto(Lcont)
             })
@@ -310,23 +310,23 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       // this should probably be a switch, don't know how to make it one though
       // furthermore, we should be able to do the lookups at runtime
       // FIXME, clean this up once we have fixed arrays
-      cb.ifx(idx.ceq(-1), cb.goto(Lminus1))
+      cb.if_(idx.ceq(-1), cb.goto(Lminus1))
       (0 until maxElements).zip(labels).foreach { case (i, l) =>
-        cb.ifx(idx.ceq(i), cb.goto(l))
+        cb.if_(idx.ceq(i), cb.goto(l))
       }
       cb.goto(Lend)
 
       cb.define(Lminus1)
-      cb.ifx(!isLeaf(cb, node), {
+      cb.if_(!isLeaf(cb, node), {
         stackUpdateIdx(0)
         stackPush(loadChild(cb, node, -1))
         cb.goto(Lstart)
       })
       (0 until maxElements).foreach { i =>
         cb.define(labels(i))
-        cb.ifx(hasKey(cb, node, i), {
+        cb.if_(hasKey(cb, node, i), {
           visitor(cb, loadKey(cb, node, i))
-          cb.ifx(!isLeaf(cb, node), {
+          cb.if_(!isLeaf(cb, node), {
             stackUpdateIdx(i + 1)
             stackPush(loadChild(cb, node, i))
             cb.goto(Lstart)
@@ -355,15 +355,15 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         cb.invokeVoid(cb.emb, newNode, loadChild(cb, srcNode, i))
       }
 
-      cb.ifx(!isLeaf(cb, srcNode), {
+      cb.if_(!isLeaf(cb, srcNode), {
         copyChild(-1)
         setChild(cb, destNode, -1, newNode, "deepcopy1")
       })
 
       (0 until maxElements).foreach { i =>
-        cb.ifx(hasKey(cb, srcNode, i), {
+        cb.if_(hasKey(cb, srcNode, i), {
           key.deepCopy(cb, er, destNode, srcNode)
-          cb.ifx(!isLeaf(cb, srcNode), {
+          cb.if_(!isLeaf(cb, srcNode), {
             copyChild(i)
             setChild(cb, destNode, i, newNode, "deepcopy2")
           })
@@ -383,15 +383,15 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
     f.voidWithBuilder { cb =>
       cb += ob.writeBoolean(!isLeaf(cb, node))
-      cb.ifx(!isLeaf(cb, node), {
+      cb.if_(!isLeaf(cb, node), {
         cb.invokeVoid(f, loadChild(cb, node, -1), ob)
       })
       val Lexit = CodeLabel()
       (0 until maxElements).foreach { i =>
-        cb.ifx(hasKey(cb, node, i), {
+        cb.if_(hasKey(cb, node, i), {
           cb += ob.writeBoolean(true)
           keyStore(cb, ob, loadKey(cb, node, i))
-          cb.ifx(!isLeaf(cb, node), {
+          cb.if_(!isLeaf(cb, node), {
             cb.invokeVoid(f, loadChild(cb, node, i), ob)
           })
         }, {
@@ -415,17 +415,17 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
     f.voidWithBuilder { cb =>
       cb.assign(isInternalNode, ib.readBoolean())
-      cb.ifx(isInternalNode, {
+      cb.if_(isInternalNode, {
         createNode(cb, newNode)
         setChild(cb, node, -1, newNode, "bulkLoad1")
         cb.invokeVoid(f, newNode, ib)
       })
       val Lexit = CodeLabel()
       (0 until maxElements).foreach { i =>
-        cb.ifx(ib.readBoolean(), {
+        cb.if_(ib.readBoolean(), {
           setKeyPresent(cb, node, i)
           keyLoad(cb, ib, keyOffset(node, i))
-          cb.ifx(isInternalNode, {
+          cb.if_(isInternalNode, {
             createNode(cb, newNode)
             setChild(cb, node, i, newNode, "bulkLoad2")
             cb.invokeVoid(f, newNode, ib)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -255,7 +255,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         })
       }
 
-      cb.whileLoop(cmp.cne(0), { (Lcont: CodeLabel)  =>
+      cb.while_(cmp.cne(0), { (Lcont: CodeLabel)  =>
         (0 until maxElements).foreach { i =>
           cb.ifx(hasKey(cb, node, i), {
             cb.assign(keyV, loadKey(cb, node, i))
@@ -301,7 +301,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     }
 
     stackPush(root)
-    cb.whileLoop(stackI >= 0, { (Lstart: CodeLabel) =>
+    cb.while_(stackI >= 0, { (Lstart: CodeLabel) =>
       val node = cb.newLocal("btree_foreach_node", nodeStack(stackI))
       val idx = cb.newLocal("btree_foreach_idx", idxStack(stackI))
       val Lend = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -77,26 +77,22 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
 
   override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     (cb, ob: Value[OutputBuffer]) =>
-      cb += Code(
-        ob.writeBoolean(initialized),
-        ob.writeInt(k),
-        initialized.orEmpty(
-          aggr.invoke[OutputBuffer, Unit]("serializeTo", ob)
-        ))
+      cb += ob.writeBoolean(initialized)
+      cb += ob.writeInt(k)
+      cb.ifx(initialized, cb += aggr.invoke[OutputBuffer, Unit]("serializeTo", ob))
   }
 
   override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     (cb, ib: Value[InputBuffer]) =>
-      cb += Code(
-        initialized := ib.readBoolean(),
-        k := ib.readInt(),
-        initialized.orEmpty(
-          Code(
-            aggr := Code.invokeScalaObject2[Int, InputBuffer, ApproxCDFStateManager](
-              ApproxCDFStateManager.getClass, "deserializeFrom", k, ib),
-            id := region.storeJavaObject(aggr)
-          )
-        ))
+      cb.assign(initialized, ib.readBoolean())
+      cb.assign(k, ib.readInt())
+      cb.ifx(initialized, {
+        cb.assign(aggr, Code.invokeScalaObject2[Int, InputBuffer, ApproxCDFStateManager](
+          ApproxCDFStateManager.getClass, "deserializeFrom", k, ib)
+        )
+
+        cb.assign(id, region.storeJavaObject(aggr))
+      })
   }
 
   override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -51,13 +51,13 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
+    cb.if_(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
 
   override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Value[Long]): Unit = {
     regionLoader(cb, r)
     cb.assign(id, Region.loadInt(idOffset(src)))
     cb.assign(initialized, Region.loadBoolean(initializedOffset(src)))
-    cb.ifx(initialized,
+    cb.if_(initialized,
       {
         cb.assign(aggr, Code.checkcast[ApproxCDFStateManager](region.lookupJavaObject(id)))
         cb.assign(k, Region.loadInt(kOffset(src)))
@@ -65,7 +65,7 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   }
 
   override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Value[Long]): Unit = {
-    cb.ifx(region.isValid,
+    cb.if_(region.isValid,
       {
         regionStorer(cb, region)
         cb += region.invalidate()
@@ -79,14 +79,14 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
     (cb, ob: Value[OutputBuffer]) =>
       cb += ob.writeBoolean(initialized)
       cb += ob.writeInt(k)
-      cb.ifx(initialized, cb += aggr.invoke[OutputBuffer, Unit]("serializeTo", ob))
+      cb.if_(initialized, cb += aggr.invoke[OutputBuffer, Unit]("serializeTo", ob))
   }
 
   override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     (cb, ib: Value[InputBuffer]) =>
       cb.assign(initialized, ib.readBoolean())
       cb.assign(k, ib.readInt())
-      cb.ifx(initialized, {
+      cb.if_(initialized, {
         cb.assign(aggr, Code.invokeScalaObject2[Int, InputBuffer, ApproxCDFStateManager](
           ApproxCDFStateManager.getClass, "deserializeFrom", k, ib)
         )

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -63,7 +63,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
   def seq(cb: EmitCodeBuilder, init: => Unit, initPerElt: => Unit, seqOp: => Unit): Unit = {
     init
     cb.assign(idx, 0)
-    cb.whileLoop(idx < lenRef, {
+    cb.while_(idx < lenRef, {
       initPerElt
       seqOp
       store(cb)
@@ -113,7 +113,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
         })
       cb += ob.writeInt(lenRef)
       cb.assign(idx, 0)
-      cb.whileLoop(idx < lenRef, {
+      cb.while_(idx < lenRef, {
         load(cb)
         nested.toCodeWithArgs(cb,
           { case (cb, i, _) =>
@@ -232,7 +232,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
       resultPType.stagedInitialize(cb, resultAddr, len, setMissing = false)
       val i = cb.newLocal[Int]("arrayagg_result_i", 0)
 
-      cb.whileLoop(i < len, {
+      cb.while_(i < len, {
         val addrAtI = cb.newLocal[Long]("arrayagg_result_addr_at_i", resultPType.elementOffset(resultAddr, len, i))
         resultEltType.stagedInitialize(cb, addrAtI, setMissing = false)
         cb.assign(state.idx, i)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -47,7 +47,7 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
   def dump(cb: CodeBuilderLike, tag: String): Unit = {
     val i = cb.newLocal[Int]("i")
     cb += Code._println(s"at tag $tag")
-    cb.forLoop(
+    cb.for_(
       setup = cb.assign(i, 0),
       cond = i < nAlleles,
       incr = cb.assign(i, i + 1),
@@ -136,7 +136,7 @@ class CallStatsAggregator extends StagedAggregator {
           CallStatsState.callStatsInternalArrayType.stagedInitialize(cb, addr, n)
           cb += Region.storeAddress(state.homCountsOffset, addr)
           cb.assign(i, 0)
-          cb.whileLoop(i < n,
+          cb.while_(i < n,
             {
               state.updateAlleleCountAtIndex(cb, i, n, _ => 0)
               state.updateHomCountAtIndex(cb, i, n, _ => 0)
@@ -176,7 +176,7 @@ class CallStatsAggregator extends StagedAggregator {
       cb += Code._fatal[Unit]("hl.agg.call_stats: length mismatch"),
       {
         cb.assign(i, 0)
-        cb.whileLoop(i < state.nAlleles,
+        cb.while_(i < state.nAlleles,
           {
             state.updateAlleleCountAtIndex(cb, i, state.nAlleles, _ + other.alleleCountAtIndex(i, state.nAlleles))
             state.updateHomCountAtIndex(cb, i, state.nAlleles, _ + other.homCountAtIndex(i, state.nAlleles))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -47,18 +47,13 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
   def dump(cb: CodeBuilderLike, tag: String): Unit = {
     val i = cb.newLocal[Int]("i")
     cb += Code._println(s"at tag $tag")
-    cb.for_(
-      setup = cb.assign(i, 0),
-      cond = i < nAlleles,
-      incr = cb.assign(i, i + 1),
-      body = {
-        cb += Code._println(
-          const("at i=") + i.toS +
-            ", AC=" + alleleCountAtIndex(i, nAlleles).toS +
-            ", HOM=" + homCountAtIndex(i, nAlleles).toS
-        )
-      }
-    )
+    cb.for_(cb.assign(i, 0), i < nAlleles, cb.assign(i, i + 1), {
+      cb += Code._println(
+        const("at i=") + i.toS +
+          ", AC=" + alleleCountAtIndex(i, nAlleles).toS +
+          ", HOM=" + homCountAtIndex(i, nAlleles).toS
+      )
+    })
   }
 
   override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Value[Long]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -150,16 +150,16 @@ class CallStatsAggregator extends StagedAggregator {
       val lastAllele = cb.newLocal[Int]("lastAllele", -1)
       val i = cb.newLocal[Int]("i", 0)
       call.forEachAllele(cb) { allele: Value[Int] =>
-        cb.ifx(allele > state.nAlleles,
+        cb.if_(allele > state.nAlleles,
           cb._fatal(const("hl.agg.call_stats: found allele outside of expected range [0, ")
             .concat(state.nAlleles.toS).concat("]: ").concat(allele.toS)))
         state.updateAlleleCountAtIndex(cb, allele, state.nAlleles, _ + 1)
-        cb.ifx(i > 0, cb.assign(hom, hom && allele.ceq(lastAllele)))
+        cb.if_(i > 0, cb.assign(hom, hom && allele.ceq(lastAllele)))
         cb.assign(lastAllele, allele)
         cb.assign(i, i + 1)
       }
 
-      cb.ifx((i > 1) && hom, {
+      cb.if_((i > 1) && hom, {
         state.updateHomCountAtIndex(cb, lastAllele, state.nAlleles, _ + 1)
       })
     })
@@ -167,7 +167,7 @@ class CallStatsAggregator extends StagedAggregator {
 
   protected def _combOp(ctx: ExecuteContext, cb: EmitCodeBuilder, state: CallStatsState, other: CallStatsState): Unit = {
     val i = state.kb.genFieldThisRef[Int]()
-    cb.ifx(other.nAlleles.cne(state.nAlleles),
+    cb.if_(other.nAlleles.cne(state.nAlleles),
       cb += Code._fatal[Unit]("hl.agg.call_stats: length mismatch"),
       {
         cb.assign(i, 0)
@@ -198,7 +198,7 @@ class CallStatsAggregator extends StagedAggregator {
 
     acType.storeAtAddress(cb, rt.fieldOffset(addr, "AC"), region, ac, deepCopy = false)
 
-    cb.ifx(alleleNumber.ceq(0),
+    cb.if_(alleleNumber.ceq(0),
       rt.setFieldMissing(cb, addr, "AF"),
       {
         val afType = resultStorageType.fieldType("AF").asInstanceOf[PCanonicalArray]

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -44,14 +44,20 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
   }
 
   // unused but extremely useful for debugging if something goes wrong
-  def dump(tag: String): Code[Unit] = {
-    val i = kb.genFieldThisRef[Int]()
-    Code(
-      Code._println(s"at tag $tag"),
-      i := 0,
-      Code.whileLoop(i < nAlleles,
-        Code._println(const("at i=").concat(i.toS).concat(", AC=").concat(alleleCountAtIndex(i, nAlleles).toS).concat(", HOM=").concat(homCountAtIndex(i, nAlleles).toS)),
-        i := i + 1)
+  def dump(cb: CodeBuilderLike, tag: String): Unit = {
+    val i = cb.newLocal[Int]("i")
+    cb += Code._println(s"at tag $tag")
+    cb.forLoop(
+      setup = cb.assign(i, 0),
+      cond = i < nAlleles,
+      incr = cb.assign(i, i + 1),
+      body = {
+        cb += Code._println(
+          const("at i=") + i.toS +
+            ", AC=" + alleleCountAtIndex(i, nAlleles).toS +
+            ", HOM=" + homCountAtIndex(i, nAlleles).toS
+        )
+      }
     )
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -24,7 +24,7 @@ class CollectAggState(val elemVType: VirtualTypeWithReq, val kb: EmitClassBuilde
   override def regionSize: Region.Size = Region.REGULAR
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, {
+    cb.if_(region.isNull, {
       cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
       cb += region.invalidate()
     })
@@ -37,7 +37,7 @@ class CollectAggState(val elemVType: VirtualTypeWithReq, val kb: EmitClassBuilde
   }
 
   override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Value[Long]): Unit = {
-    cb.ifx(region.isValid,
+    cb.if_(region.isValid,
       {
         regionStorer(cb, region)
         bll.store(cb, dest)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -76,7 +76,7 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], vt: VirtualTypeWithReq) ex
 
   override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Value[Long]): Unit = {
     super.load(cb, regionLoader, src)
-    cb.ifx(off.cne(0L),
+    cb.if_(off.cne(0L),
       {
         cb.assign(size, Region.loadInt(typ.loadField(off, 0)))
         cb.assign(root, Region.loadAddress(typ.loadField(off, 1)))
@@ -100,7 +100,7 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], vt: VirtualTypeWithReq) ex
   def insert(cb: EmitCodeBuilder, v: EmitCode): Unit = {
     val _v = cb.memoize(v, "collect_as_set_insert_value")
     cb.assign(_elt, tree.getOrElseInitialize(cb, _v))
-    cb.ifx(key.isEmpty(cb, _elt), {
+    cb.if_(key.isEmpty(cb, _elt), {
       cb.assign(size, size + 1)
       key.store(cb, _elt, _v)
     })
@@ -125,7 +125,7 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], vt: VirtualTypeWithReq) ex
       tree.bulkStore(cb, ob) { (cb, ob, srcCode) =>
         val src = cb.newLocal("aoss_ser_src", srcCode)
         cb += ob.writeBoolean(key.isKeyMissing(cb, src))
-        cb.ifx(!key.isKeyMissing(cb, src), {
+        cb.if_(!key.isKeyMissing(cb, src), {
           val k = key.loadKey(cb, src)
           et.buildEncoder(k.st, kb)
               .apply(cb, k, ob)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -39,7 +39,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
   }
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, {
+    cb.if_(region.isNull, {
       cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
     })
 
@@ -76,7 +76,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
 
       cb.assign(arrayAddr, arrayStorageType.store(cb, region, decValue, deepCopy = false))
       cb.assign(length, arrayStorageType.loadLength(arrayAddr))
-      cb.ifx(ib.readInt().cne(const(DensifyAggregator.END_SERIALIZATION)),
+      cb.if_(ib.readInt().cne(const(DensifyAggregator.END_SERIALIZATION)),
         cb += Code._fatal[Unit](s"densify serialization failed"))
     }
   }
@@ -88,7 +88,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
   }
 
   private def gc(cb: EmitCodeBuilder): Unit = {
-    cb.ifx(region.totalManagedBytes() > maxRegionSize, {
+    cb.if_(region.totalManagedBytes() > maxRegionSize, {
       val newRegion = cb.newLocal[Region]("densify_gc", Region.stagedCreate(regionSize, kb.pool()))
       cb.assign(arrayAddr, arrayStorageType.store(cb, newRegion, arrayStorageType.loadCheapSCode(cb, arrayAddr), deepCopy = true))
       cb += region.invalidate()

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -212,7 +212,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         cb += ob.writeInt(treeSize)
         tree.bulkStore(cb, ob) { (cb, ob, srcCode) =>
           val src = cb.newLocal("downsample_state_ser_src", srcCode)
-          cb += Region.loadBoolean(key.storageType.loadField(src, "empty")).orEmpty(Code._fatal[Unit]("bad"))
+          cb.ifx(Region.loadBoolean(key.storageType.loadField(src, "empty")), cb._fatal("bad"))
           val binCode = binType.loadCheapSCode(cb, key.storageType.loadField(src, "bin"))
           binET.buildEncoder(binCode.st, kb).apply(cb, binCode, ob)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -360,7 +360,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         tree.init(cb)
         copyFromTree(cb, oldRootBTree)
         cb.assign(i, 0)
-        cb.whileLoop(i < buffer.size,
+        cb.while_(i < buffer.size,
           {
             buffer.loadElement(cb, i).toI(cb).consume(cb, {}, { case point: SBaseStructValue =>
               val x = point.loadField(cb, "x").get(cb).asFloat64.value
@@ -509,7 +509,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
     val i = mb.newLocal[Int]("i")
     mb.emitWithBuilder { cb =>
       cb.assign(i, 0)
-      cb.whileLoop(i < other.buffer.size, {
+      cb.while_(i < other.buffer.size, {
         val point = SingleCodeSCode.fromSCode(cb, other.buffer.loadElement(cb, i).pv, region)
         deepCopyAndInsertPoint(cb, coerce[Long](point.code))
         cb.assign(i, i + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -34,7 +34,7 @@ class DownsampleBTreeKey(binType: PBaseStruct, pointType: PBaseStruct, kb: EmitC
 
   override def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, srcc: Code[Long], dest: Code[Long]): Unit = {
     val src = cb.newLocal[Long]("dsa_deep_copy_src", srcc)
-    cb.ifx(Region.loadBoolean(storageType.loadField(src, "empty")),
+    cb.if_(Region.loadBoolean(storageType.loadField(src, "empty")),
       cb += Code._fatal[Unit]("key empty!"))
     storageType.storeAtAddress(cb, dest, er.region, storageType.loadCheapSCode(cb, src), deepCopy = true)
   }
@@ -61,7 +61,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
   def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
+    cb.if_(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
 
   val binType = PCanonicalStruct(required = true, "x" -> PInt32Required, "y" -> PInt32Required)
   val pointType = PCanonicalStruct(required = true, "x" -> PFloat64Required, "y" -> PFloat64Required, "label" -> labelPType)
@@ -117,7 +117,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
       allocateSpace(cb)
       cb.assign(this.nDivisions, mb.getCodeParam[Int](1).load())
 
-      cb.ifx(this.nDivisions < 4, cb += Code._fatal[Unit](const("downsample: require n_divisions >= 4, found ").concat(this.nDivisions.toS)))
+      cb.if_(this.nDivisions < 4, cb += Code._fatal[Unit](const("downsample: require n_divisions >= 4, found ").concat(this.nDivisions.toS)))
 
       cb.assign(left, 0d)
       cb.assign(right, 0d)
@@ -171,7 +171,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
 
     cb.assign(off, dest)
     cb.invokeVoid(mb)
-    cb.ifx(region.isValid,
+    cb.if_(region.isValid,
       {
         regionStorer(cb, region)
         cb += region.invalidate()
@@ -212,7 +212,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         cb += ob.writeInt(treeSize)
         tree.bulkStore(cb, ob) { (cb, ob, srcCode) =>
           val src = cb.newLocal("downsample_state_ser_src", srcCode)
-          cb.ifx(Region.loadBoolean(key.storageType.loadField(src, "empty")), cb._fatal("bad"))
+          cb.if_(Region.loadBoolean(key.storageType.loadField(src, "empty")), cb._fatal("bad"))
           val binCode = binType.loadCheapSCode(cb, key.storageType.loadField(src, "bin"))
           binET.buildEncoder(binCode.st, kb).apply(cb, binCode, ob)
 
@@ -257,7 +257,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         }
         buffer.initialize(cb)
         cb.assign(serializationEndTag, ib.readInt())
-        cb.ifx(serializationEndTag.cne(DownsampleState.serializationEndMarker), {
+        cb.if_(serializationEndTag.cne(DownsampleState.serializationEndMarker), {
           cb._fatal("downsample aggregator failed to serialize!")
         })
         Code._empty
@@ -297,7 +297,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         cb += Region.storeInt(binType.fieldOffset(binStaging, "y"), binY)
         cb.assign(insertOffset,
           tree.getOrElseInitialize(cb, EmitCode.present(cb.emb, storageType.fieldType("binStaging").loadCheapSCode(cb, binStaging))))
-        cb.ifx(key.isEmpty(cb, insertOffset), {
+        cb.if_(key.isEmpty(cb, insertOffset), {
           cb.assign(binOffset, key.storageType.loadField(insertOffset, "bin"))
           cb += Region.storeInt(binType.loadField(binOffset, "x"), binX)
           cb += Region.storeInt(binType.loadField(binOffset, "y"), binY)
@@ -348,7 +348,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
     val mb = kb.getOrGenEmitMethod(name, (this, name), FastSeq[ParamType](), UnitInfo) { mb =>
       val i = mb.newLocal[Int]("i")
       mb.voidWithBuilder { cb =>
-        cb.ifx(buffer.size.ceq(0), cb += Code._return[Unit](Code._empty))
+        cb.if_(buffer.size.ceq(0), cb += Code._return[Unit](Code._empty))
         cb.assign(left, min(left, bufferLeft))
         cb.assign(right, max(right, bufferRight))
         cb.assign(bottom, min(bottom, bufferBottom))
@@ -392,7 +392,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         cb.assign(bufferBottom, min(bufferBottom, y))
         cb.assign(bufferTop, max(bufferTop, y))
         buffer.append(cb, pointType.loadCheapSCode(cb, point))
-        cb.ifx(buffer.size >= maxBufferSize, dumpBuffer(cb))
+        cb.if_(buffer.size >= maxBufferSize, dumpBuffer(cb))
       }
     }
 
@@ -430,7 +430,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
       mb.voidWithBuilder { cb =>
         cb.assign(binX, xBinCoordinate(cb, x))
         cb.assign(binY, yBinCoordinate(cb, y))
-        cb.ifx(checkBounds(cb, binX, binY),
+        cb.if_(checkBounds(cb, binX, binY),
           insertPointIntoBuffer(cb, x, y, point, deepCopy = deepCopy),
           insertIntoTree(cb, binX, binY, point, deepCopy = deepCopy)
         )
@@ -453,7 +453,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
 
         def yy = y.asDouble.value
 
-        cb.ifx((!(isFinite(xx) && isFinite(yy))), cb += Code._return[Unit](Code._empty))
+        cb.if_((!(isFinite(xx) && isFinite(yy))), cb += Code._return[Unit](Code._empty))
         cb.assign(pointStaging, storageType.loadField(off, "pointStaging"))
         pointType.fieldType("x").storeAtAddress(cb, pointType.fieldOffset(pointStaging, "x"), region, x, deepCopy = true)
         pointType.fieldType("y").storeAtAddress(cb, pointType.fieldOffset(pointStaging, "y"), region, y, deepCopy = true)
@@ -527,7 +527,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
     dumpBuffer(cb)
 
     val (pushElement, finish) = resType.constructFromFunctions(cb, region, treeSize, deepCopy = true)
-    cb.ifx(treeSize > 0, {
+    cb.if_(treeSize > 0, {
       tree.foreach(cb) { (cb, tv) =>
         val pointCode = pointType.loadCheapSCode(cb, key.storageType.loadField(tv, "point"))
         pushElement(cb, IEmitCode.present(cb, pointCode))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -139,7 +139,7 @@ class DictState(val kb: EmitClassBuilder[_], val keyVType: VirtualTypeWithReq, v
   def loadContainer(cb: EmitCodeBuilder, kec: EmitCode): Unit = {
     val kev = cb.memoize(kec, "ga_load_cont_k")
     cb.assign(_elt, tree.getOrElseInitialize(cb, kev))
-    cb.ifx(keyed.isEmpty(cb, _elt), {
+    cb.if_(keyed.isEmpty(cb, _elt), {
       initElement(cb, _elt, kev)
       keyed.copyStatesFrom(cb, initStatesOffset)
     }, {
@@ -160,7 +160,7 @@ class DictState(val kb: EmitClassBuilder[_], val keyVType: VirtualTypeWithReq, v
 
   override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Value[Long]): Unit = {
     super.load(cb, regionLoader, src)
-    cb.ifx(off.cne(0L),
+    cb.if_(off.cne(0L),
       {
         cb.assign(size, Region.loadInt(typ.loadField(off, 1)))
         cb.assign(root, Region.loadAddress(typ.loadField(off, 2)))
@@ -214,7 +214,7 @@ class DictState(val kb: EmitClassBuilder[_], val keyVType: VirtualTypeWithReq, v
         cb.assign(_elt, kvOff)
         val km = keyed.isKeyMissing(cb, _elt)
         cb += (ob.writeBoolean(km))
-        cb.ifx(!km, {
+        cb.if_(!km, {
           val k = keyed.loadKey(cb, _elt)
           keyEType.buildEncoder(k.st, kb)
             .apply(cb, k, ob)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -234,7 +234,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
     val oxty = cb.newLocal[Long]("oxty")
     val oxtx = cb.newLocal[Long]("oxtx")
 
-    cb += Code(FastSeq(
+    cb += Code(
       xty := stateType.loadField(state.off, 0),
       xtx := stateType.loadField(state.off, 1),
       oxty := stateType.loadField(other.off, 0),
@@ -242,22 +242,32 @@ class LinearRegressionAggregator() extends StagedAggregator {
       n := vector.loadLength(xty),
       i := 0,
       sptr := vector.firstElementOffset(xty, n),
-      optr := vector.firstElementOffset(oxty, n),
-      Code.whileLoop(i < n, Code(
+      optr := vector.firstElementOffset(oxty, n)
+    )
+
+    cb.whileLoop(i < n, {
+      cb += Code(
         Region.storeDouble(sptr, Region.loadDouble(sptr) + Region.loadDouble(optr)),
         i := i + 1,
         sptr := sptr + scalar.byteSize,
-        optr := optr + scalar.byteSize)),
+        optr := optr + scalar.byteSize
+      )
+    })
 
+    cb += Code(
       n := vector.loadLength(xtx),
       i := 0,
       sptr := vector.firstElementOffset(xtx, n),
-      optr := vector.firstElementOffset(oxtx, n),
-      Code.whileLoop(i < n, Code(
+      optr := vector.firstElementOffset(oxtx, n)
+    )
+
+    cb.whileLoop(i < n, {
+      cb += Code(
         Region.storeDouble(sptr, Region.loadDouble(sptr) + Region.loadDouble(optr)),
         i := i + 1,
         sptr := sptr + scalar.byteSize,
-        optr := optr + scalar.byteSize))))
+        optr := optr + scalar.byteSize)
+    })
   }
 
   protected def _combOp(ctx: ExecuteContext, cb: EmitCodeBuilder, state: AbstractTypedRegionBackedAggState, other: AbstractTypedRegionBackedAggState): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -102,7 +102,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
   def initOpF(state: State)(cb: EmitCodeBuilder, kc: Code[Int], k0c: Code[Int]): Unit = {
     val k = cb.newLocal[Int]("lra_init_k", kc)
     val k0 = cb.newLocal[Int]("lra_init_k0", k0c)
-    cb.ifx((k0 < 0) || (k0 > k),
+    cb.if_((k0 < 0) || (k0 > k),
       cb += Code._fatal[Unit](const("linreg: `nested_dim` must be between 0 and the number (")
         .concat(k.toS)
         .concat(") of covariates, inclusive"))
@@ -139,7 +139,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
     val xty = cb.newLocal[Long]("linreg_agg_seqop_xty")
     val xtx = cb.newLocal[Long]("linreg_agg_seqop_xtx")
 
-    cb.ifx(!x.hasMissingValues(cb),
+    cb.if_(!x.hasMissingValues(cb),
       {
         cb.assign(xty, stateType.loadField(state.off, 0))
         cb.assign(xtx, stateType.loadField(state.off, 1))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -154,7 +154,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
             val xptr = cb.newLocal[Long]("linreg_agg_seqop_xptr")
             val xptr2 = cb.newLocal[Long]("linreg_agg_seqop_xptr2")
             cb.assign(xptr, pt.firstElementOffset(xAddr, k))
-            cb.whileLoop(i < k,
+            cb.while_(i < k,
               {
                 cb += Region.storeDouble(sptr, Region.loadDouble(sptr) + (Region.loadDouble(xptr) * y))
                 cb.assign(i, i + 1)
@@ -166,11 +166,11 @@ class LinearRegressionAggregator() extends StagedAggregator {
             cb.assign(sptr, vector.firstElementOffset(xtx, k))
             cb.assign(xptr, pt.firstElementOffset(xAddr, k))
 
-            cb.whileLoop(i < k,
+            cb.while_(i < k,
               {
                 cb.assign(j, 0)
                 cb.assign(xptr2, pt.firstElementOffset(xAddr, k))
-                cb.whileLoop(j < k,
+                cb.while_(j < k,
                   {
                     // add x[i] * x[j] to the value at sptr
                     cb += Region.storeDouble(sptr, Region.loadDouble(sptr) + (Region.loadDouble(xptr) * Region.loadDouble(xptr2)))
@@ -183,7 +183,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
               })
 
           case _ =>
-            cb.whileLoop(i < k,
+            cb.while_(i < k,
               {
                 cb += Region.storeDouble(sptr, Region.loadDouble(sptr) + x.loadElement(cb, i).get(cb).asDouble.value * y)
                 cb.assign(i, i + 1)
@@ -193,10 +193,10 @@ class LinearRegressionAggregator() extends StagedAggregator {
             cb.assign(i, 0)
             cb.assign(sptr, vector.firstElementOffset(xtx, k))
 
-            cb.whileLoop(i < k,
+            cb.while_(i < k,
               {
                 cb.assign(j, 0)
-                cb.whileLoop(j < k,
+                cb.while_(j < k,
                   {
                     // add x[i] * x[j] to the value at sptr
                     cb += Region.storeDouble(sptr, Region.loadDouble(sptr) +
@@ -245,7 +245,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
       optr := vector.firstElementOffset(oxty, n)
     )
 
-    cb.whileLoop(i < n, {
+    cb.while_(i < n, {
       cb += Code(
         Region.storeDouble(sptr, Region.loadDouble(sptr) + Region.loadDouble(optr)),
         i := i + 1,
@@ -261,7 +261,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
       optr := vector.firstElementOffset(oxtx, n)
     )
 
-    cb.whileLoop(i < n, {
+    cb.while_(i < n, {
       cb += Code(
         Region.storeDouble(sptr, Region.loadDouble(sptr) + Region.loadDouble(optr)),
         i := i + 1,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -65,9 +65,9 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     ev2: EmitValue
   ): Unit = {
     val combined = primitive(monoid.typ, monoid(cb, ev1.pv.asPrimitive.primitiveValue, ev2.pv.asPrimitive.primitiveValue))
-    cb.ifx(ev1.m,
-      cb.ifx(!ev2.m, cb.assign(ev1, ev2)),
-      cb.ifx(!ev2.m,
+    cb.if_(ev1.m,
+      cb.if_(!ev2.m, cb.assign(ev1, ev2)),
+      cb.if_(!ev2.m,
         cb.assign(ev1, EmitCode.present(cb.emb, combined))))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -86,7 +86,7 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
 object NDArraySumAggregator {
 
   def addValues(cb: EmitCodeBuilder, region: Value[Region], leftNdValue: SNDArrayValue, rightNdValue: SNDArrayValue): Unit = {
-    cb.ifx(!leftNdValue.sameShape(cb, rightNdValue),
+    cb.if_(!leftNdValue.sameShape(cb, rightNdValue),
       cb += Code._fatal[Unit]("Can't sum ndarrays of different shapes."))
 
     leftNdValue.coiterateMutate(cb, region, (rightNdValue, "right")) {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ReservoirSampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ReservoirSampleAggregator.scala
@@ -35,7 +35,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
 
   def createState(cb: EmitCodeBuilder): Unit = {
     cb.assign(rand, Code.newInstance[java.util.Random])
-    cb.ifx(region.isNull, {
+    cb.if_(region.isNull, {
       cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
     })
   }
@@ -49,7 +49,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
   }
 
   override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Value[Long]): Unit = {
-    cb.ifx(region.isValid,
+    cb.if_(region.isValid,
       {
         regionStorer(cb, region)
         cb += region.invalidate()
@@ -88,7 +88,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
     cb.invokeVoid(cb.emb.ecb.getOrGenEmitMethod("reservoir_sample_gc",
       (this, "gc"), FastSeq(), UnitInfo) { mb =>
       mb.voidWithBuilder { cb =>
-        cb.ifx(garbage > (maxSize.toL * 2L + 1024L), {
+        cb.if_(garbage > (maxSize.toL * 2L + 1024L), {
           val oldRegion = mb.newLocal[Region]("old_region")
           cb.assign(oldRegion, region)
           cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
@@ -103,7 +103,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
   def seqOp(cb: EmitCodeBuilder, elt: EmitCode): Unit = {
     val eltVal = cb.memoize(elt)
     cb.assign(seenSoFar, seenSoFar + 1)
-    cb.ifx(builder.size < maxSize,
+    cb.if_(builder.size < maxSize,
       eltVal.toI(cb)
         .consume(cb,
           builder.setMissing(cb),
@@ -111,7 +111,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
     {
       // swaps the next element into the reservoir with probability (k / n), where
       // k is the reservoir size and n is the number of elements seen so far (including current)
-      cb.ifx(rand.invoke[Double]("nextDouble") * seenSoFar.toD <= maxSize.toD, {
+      cb.if_(rand.invoke[Double]("nextDouble") * seenSoFar.toD <= maxSize.toD, {
         val idxToSwap = cb.memoize(rand.invoke[Int, Int]("nextInt", maxSize))
         builder.overwrite(cb, eltVal, idxToSwap)
         cb.assign(garbage, garbage + 1L)
@@ -132,7 +132,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
 
   def combine(cb: EmitCodeBuilder, other: ReservoirSampleRVAS): Unit = {
     val j = cb.newLocal[Int]("j")
-    cb.ifx(other.builder.size < maxSize, {
+    cb.if_(other.builder.size < maxSize, {
 
       cb.assign(j, 0)
       cb.while_(j < other.builder.size, {
@@ -140,7 +140,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
         cb.assign(j, j + 1)
       })
     }, {
-      cb.ifx(builder.size < maxSize, {
+      cb.if_(builder.size < maxSize, {
         cb.assign(j, 0)
         cb.while_(j < builder.size, {
           other.seqOp(cb, cb.memoize(builder.loadElement(cb, j)))
@@ -168,7 +168,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
         cb.assign(j, 0)
         cb.while_(j < maxSize, {
           val x = cb.memoize(rand.invoke[Double]("nextDouble"))
-          cb.ifx(x * (totalWeightLeft + totalWeightRight) <= totalWeightLeft, {
+          cb.if_(x * (totalWeightLeft + totalWeightRight) <= totalWeightLeft, {
 
             val idxToSample = cb.memoize(rand.invoke[Int, Int]("nextInt", leftSize))
             builder.loadElement(cb, idxToSample).toI(cb).consume(cb,
@@ -176,7 +176,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
               newBuilder.append(cb, _, false))
             cb.assign(leftSize, leftSize - 1)
             cb.assign(totalWeightLeft, totalWeightLeft - 1)
-            cb.ifx(idxToSample < leftSize, {
+            cb.if_(idxToSample < leftSize, {
               builder.overwrite(cb, cb.memoize(builder.loadElement(cb, leftSize)), idxToSample, false)
             })
           }, {
@@ -186,7 +186,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
               newBuilder.append(cb, _, true))
             cb.assign(rightSize, rightSize - 1)
             cb.assign(totalWeightRight, totalWeightRight - 1)
-            cb.ifx(idxToSample < rightSize, {
+            cb.if_(idxToSample < rightSize, {
               other.builder.overwrite(cb, cb.memoize(other.builder.loadElement(cb, rightSize)), idxToSample, false)
             })
           })

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ReservoirSampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ReservoirSampleAggregator.scala
@@ -123,7 +123,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
   def dump(cb: EmitCodeBuilder, prefix: String): Unit = {
     cb.println(s"> dumping reservoir: $prefix with size=", maxSize.toS,", seen=", seenSoFar.toS)
     val j = cb.newLocal[Int]("j", 0)
-    cb.whileLoop(j < builder.size, {
+    cb.while_(j < builder.size, {
       cb.println("    j=", j.toS, ", elt=", cb.strValue(builder.loadElement(cb, j)))
       cb.assign(j, j + 1)
     })
@@ -135,14 +135,14 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
     cb.ifx(other.builder.size < maxSize, {
 
       cb.assign(j, 0)
-      cb.whileLoop(j < other.builder.size, {
+      cb.while_(j < other.builder.size, {
         seqOp(cb, cb.memoize(other.builder.loadElement(cb, j)))
         cb.assign(j, j + 1)
       })
     }, {
       cb.ifx(builder.size < maxSize, {
         cb.assign(j, 0)
-        cb.whileLoop(j < builder.size, {
+        cb.while_(j < builder.size, {
           other.seqOp(cb, cb.memoize(builder.loadElement(cb, j)))
           cb.assign(j, j + 1)
         })
@@ -166,7 +166,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
         val rightSize = cb.newLocal[Int]("rightSize", other.builder.size)
 
         cb.assign(j, 0)
-        cb.whileLoop(j < maxSize, {
+        cb.while_(j < maxSize, {
           val x = cb.memoize(rand.invoke[Double]("nextDouble"))
           cb.ifx(x * (totalWeightLeft + totalWeightRight) <= totalWeightLeft, {
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -81,9 +81,9 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
         .apply(cb, region, ib)
       cb.assign(data, eltArray.store(cb, region, decValue, deepCopy = false))
 
-      cb += ib.readInt()
-        .cne(const(StagedArrayBuilder.END_SERIALIZATION))
-        .orEmpty(Code._fatal[Unit](s"StagedArrayBuilder serialization failed"))
+      cb.ifx(ib.readInt() cne StagedArrayBuilder.END_SERIALIZATION,
+        cb._fatal(s"StagedArrayBuilder serialization failed")
+      )
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -81,7 +81,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
         .apply(cb, region, ib)
       cb.assign(data, eltArray.store(cb, region, decValue, deepCopy = false))
 
-      cb.ifx(ib.readInt() cne StagedArrayBuilder.END_SERIALIZATION,
+      cb.if_(ib.readInt() cne StagedArrayBuilder.END_SERIALIZATION,
         cb._fatal(s"StagedArrayBuilder serialization failed")
       )
     }
@@ -129,7 +129,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
 
   private def resize(cb: EmitCodeBuilder): Unit = {
     val newDataOffset = kb.genFieldThisRef[Long]("new_data_offset")
-    cb.ifx(size.ceq(capacity),
+    cb.if_(size.ceq(capacity),
       {
         cb.assign(capacity, capacity * 2)
         cb.assign(data, eltArray.padWithMissing(cb, region, size, capacity, data))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -103,7 +103,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
 
   def overwrite(cb: EmitCodeBuilder, elt: EmitValue, idx: Value[Int], deepCopy: Boolean = true): Unit = {
     elt.toI(cb).consume(cb,
-      eltArray.setElementMissing(cb, data, idx),
+      PContainer.unsafeSetElementMissing(cb, eltArray, data, idx),
       value => eltType.storeAtAddress(cb, eltArray.elementOffset(data, capacity, idx), region, value, deepCopy))
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -254,7 +254,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
       other.foreach(cb) { (cb, elt) =>
         elt.toI(cb)
           .consume(cb,
-            bufferType.setElementMissing(cb, buf, i),
+            PContainer.unsafeSetElementMissing(cb, bufferType, buf, i),
             { sc =>
               bufferType.setElementPresent(cb, buf, i)
               elemType.storeAtAddress(cb, bufferType.elementOffset(buf, i), r, sc, deepCopy = true)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -91,7 +91,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
 
   private def pushMissing(cb: EmitCodeBuilder, n: Node): Unit =
     if (elemType.required)
-      cb._fatal(s"Cannot insert missing element of ptype '${elemType.asIdent}' after index ", count(n).toS, ".")
+      cb._fatal(s"Cannot insert missing element of ptype '${elemType.asIdent}' at index ", count(n).toS, ".")
     else {
       bufferType.setElementMissing(cb, buffer(n), count(n))
       incrCount(cb, n)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -121,7 +121,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     val present = cb.newLocal[Boolean]("bll_foreachnode_present")
     cb.assign(tmpNode, firstNode)
     cb.assign(present, true)
-    cb.whileLoop(present,
+    cb.while_(present,
       {
         body(cb)
         cb.assign(present, hasNext(tmpNode))
@@ -134,7 +134,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     foreachNode(cb, n) { cb =>
       val i = cb.newLocal[Int]("bll_foreach_i")
       cb.assign(i, 0)
-      cb.whileLoop(i < count(n),
+      cb.while_(i < count(n),
         {
           val elt = EmitCode.fromI(cb.emb) { cb =>
             IEmitCode(cb,
@@ -223,7 +223,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     val ib = desF.getCodeParam[InputBuffer](2)
     val dec = bufferEType.buildDecoder(bufferType.virtualType, desF.ecb)
     desF.voidWithBuilder { cb =>
-      cb.whileLoop(ib.readBoolean(), {
+      cb.while_(ib.readBoolean(), {
         appendShallow(cb, r, dec(cb, r, ib))
       })
     }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -141,7 +141,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
   }
 
   private def pushImpl(cb: EmitCodeBuilder, r: Value[Region], v: EmitCode): Unit = {
-    cb.ifx(count(lastNode) >= capacity(lastNode),
+    cb.if_(count(lastNode) >= capacity(lastNode),
       pushNewBlockNode(cb, r, defaultBlockCap))
     v.toI(cb)
       .consume(cb,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -27,7 +27,7 @@ class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) ext
   def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, {
+    cb.if_(region.isNull, {
       cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
     })
 
@@ -38,7 +38,7 @@ class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) ext
   }
 
   override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Value[Long]): Unit = {
-    cb.ifx(region.isValid,
+    cb.if_(region.isValid,
       {
         regionStorer(cb, region)
         cb += region.invalidate()
@@ -67,7 +67,7 @@ class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) ext
   }
 
   def seqOp(cb: EmitCodeBuilder, elt: EmitCode): Unit = {
-    cb.ifx(builder.size < maxSize,
+    cb.if_(builder.size < maxSize,
       elt.toI(cb)
         .consume(cb,
           builder.setMissing(cb),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -77,7 +77,7 @@ class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) ext
   def combine(cb: EmitCodeBuilder, other: TakeRVAS): Unit = {
     val j = kb.genFieldThisRef[Int]()
     cb.assign(j, 0)
-    cb.whileLoop((builder.size < maxSize) && (j < other.builder.size),
+    cb.while_((builder.size < maxSize) && (j < other.builder.size),
       {
         other.builder.loadElement(cb, j).toI(cb)
           .consume(cb,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -184,9 +184,9 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           cb.assign(maxSize, ib.readInt())
           ab.deserialize(codec)(cb, ib)
           initStaging(cb)
-          cb += ib.readInt()
-            .cne(const(TakeByRVAS.END_SERIALIZATION))
-            .orEmpty(Code._fatal[Unit](s"StagedSizedKeyValuePriorityQueue serialization failed"))
+          cb.ifx(ib.readInt() cne TakeByRVAS.END_SERIALIZATION,
+            cb._fatal(s"StagedSizedKeyValuePriorityQueue serialization failed")
+          )
         }
       )({ cb =>
         cb.assign(maxGarbage, ib.readInt())

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -506,8 +506,8 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       mb.voidWithBuilder { cb =>
         cb.ifx(low < high, {
           cb.assign(pivotIndex, partition(cb, indices, low, high))
-          mb.invokeCode(cb, indices, low, pivotIndex)
-          mb.invokeCode(cb, indices, cb.memoize(pivotIndex + 1), high)
+          cb.invokeVoid(mb, indices, low, pivotIndex)
+          cb.invokeVoid(mb, indices, cb.memoize(pivotIndex + 1), high)
         })
       }
       mb.invokeCode(_, _, _, _)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -399,7 +399,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
 
     mb.voidWithBuilder { cb =>
       val i = cb.newLocal[Int]("combine_i")
-      cb.forLoop(cb.assign(i, 0), i < other.ab.size, cb.assign(i, i + 1), {
+      cb.for_(cb.assign(i, 0), i < other.ab.size, cb.assign(i, i + 1), {
         val offset = other.elementOffset(cb, i)
         val indexOffset = cb.memoize(indexedKeyType.fieldOffset(eltTuple.loadField(offset, 0), 1))
         cb += Region.storeLong(indexOffset, Region.loadLong(indexOffset) + maxIndex)
@@ -477,14 +477,14 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           cb.assign(pivotIndex, (low + high) / 2)
           cb.assign(pivotOffset, elementOffset(cb, indexAt(cb, pivotIndex)))
           cb.assign(continue, true)
-          cb.whileLoop(continue, {
-            cb.whileLoop({
+          cb.while_(continue, {
+            cb.while_({
               cb.assign(tmpOffset, elementOffset(cb, indexAt(cb, low)))
               compareElt(cb, tmpOffset, pivotOffset) < 0
             }, {
               cb.assign(low, low + 1)
             })
-            cb.whileLoop({
+            cb.while_({
               cb.assign(tmpOffset, elementOffset(cb, indexAt(cb, high)))
               compareElt(cb, tmpOffset, pivotOffset) > 0
             }, {
@@ -523,7 +523,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
 
       def indexOffset(idx: Code[Int]): Code[Long] = indicesToSort + idx.toL * 4L
 
-      cb.whileLoop(i < ab.size, {
+      cb.while_(i < ab.size, {
         cb += Region.storeInt(indexOffset(i), i)
         cb.assign(i, i + 1)
       })

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -77,7 +77,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
   def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, {
+    cb.if_(region.isNull, {
       cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
       cb += region.invalidate()
     })
@@ -88,7 +88,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
   }
 
   override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Value[Long]): Unit = {
-    cb.ifx(region.isValid,
+    cb.if_(region.isValid,
       {
         regionStorer(cb, region)
         cb += region.invalidate()
@@ -106,7 +106,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       { cb =>
         cb.assign(maxIndex, 0L)
         cb.assign(maxSize, _maxSize)
-        cb.ifx(maxSize < 0,
+        cb.if_(maxSize < 0,
           cb += Code._fatal[Unit](const("'take': 'n' cannot be negative, found '").concat(maxSize.toS)))
         initStaging(cb)
         ab.initialize(cb)
@@ -184,7 +184,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           cb.assign(maxSize, ib.readInt())
           ab.deserialize(codec)(cb, ib)
           initStaging(cb)
-          cb.ifx(ib.readInt() cne TakeByRVAS.END_SERIALIZATION,
+          cb.if_(ib.readInt() cne TakeByRVAS.END_SERIALIZATION,
             cb._fatal(s"StagedSizedKeyValuePriorityQueue serialization failed")
           )
         }
@@ -239,12 +239,12 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     val idx = mb.getCodeParam[Int](1)
 
     mb.voidWithBuilder { cb =>
-      cb.ifx(idx > 0,
+      cb.if_(idx > 0,
         {
           val parent = cb.memoize((idx + 1) / 2 - 1)
           val ii = elementOffset(cb, idx)
           val jj = elementOffset(cb, parent)
-          cb.ifx(compareElt(cb, ii, jj) > 0, {
+          cb.if_(compareElt(cb, ii, jj) > 0, {
             swap(cb, ii, jj)
             cb.invokeVoid(mb, parent)
           })
@@ -267,12 +267,12 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     mb.voidWithBuilder { cb =>
       cb.assign(child1, (idx + 1) * 2 - 1)
       cb.assign(child2, child1 + 1)
-      cb.ifx(child1 < ab.size,
+      cb.if_(child1 < ab.size,
         {
-          cb.ifx(child2 >= ab.size, {
+          cb.if_(child2 >= ab.size, {
             cb.assign(minChild, child1)
           }, {
-            cb.ifx(compareElt(cb, elementOffset(cb, child1), elementOffset(cb, child2)) > 0, {
+            cb.if_(compareElt(cb, elementOffset(cb, child1), elementOffset(cb, child2)) > 0, {
               cb.assign(minChild, child1)
             }, {
               cb.assign(minChild, child2)
@@ -280,7 +280,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           })
           cb.assign(ii, elementOffset(cb, minChild))
           cb.assign(jj, elementOffset(cb, idx))
-          cb.ifx(compareElt(cb, ii, jj) > 0,
+          cb.if_(compareElt(cb, ii, jj) > 0,
             {
               swap(cb, ii, jj)
               cb.invokeVoid(mb, minChild)
@@ -296,7 +296,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       val oldRegion = mb.newLocal[Region]("old_region")
       mb.voidWithBuilder { cb =>
         cb.assign(garbage, garbage + 1)
-        cb.ifx(garbage >= maxGarbage,
+        cb.if_(garbage >= maxGarbage,
           {
             cb.assign(oldRegion, region)
             cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
@@ -330,7 +330,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
   private def copyElementToStaging(cb: EmitCodeBuilder, o: Code[Long]): Unit = cb += Region.copyFrom(o, staging, eltTuple.byteSize)
 
   private def copyToStaging(cb: EmitCodeBuilder, value: EmitCode, indexedKey: Code[Long]): Unit = {
-    cb.ifx(staging.ceq(0L), cb += Code._fatal[Unit]("staging is 0"))
+    cb.if_(staging.ceq(0L), cb += Code._fatal[Unit]("staging is 0"))
     indexedKeyType.storeAtAddress(cb,
       eltTuple.fieldOffset(staging, 0),
       region,
@@ -366,14 +366,14 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       val value = mb.getEmitParam(cb, 1)
       val key = mb.getEmitParam(cb, 2)
 
-      cb.ifx(maxSize > 0, {
-        cb.ifx(ab.size < maxSize, {
+      cb.if_(maxSize > 0, {
+        cb.if_(ab.size < maxSize, {
           stageAndIndexKey(cb, key)
           copyToStaging(cb, value, keyStage)
           enqueueStaging(cb)
         }, {
           cb.assign(tempPtr, eltTuple.loadField(elementOffset(cb, 0), 0))
-          cb.ifx(compareKey(cb, key, loadKey(cb, tempPtr)) < 0, {
+          cb.if_(compareKey(cb, key, loadKey(cb, tempPtr)) < 0, {
             stageAndIndexKey(cb, key)
             copyToStaging(cb, value, keyStage)
             swapStaging(cb)
@@ -403,15 +403,15 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
         val offset = other.elementOffset(cb, i)
         val indexOffset = cb.memoize(indexedKeyType.fieldOffset(eltTuple.loadField(offset, 0), 1))
         cb += Region.storeLong(indexOffset, Region.loadLong(indexOffset) + maxIndex)
-        cb.ifx(maxSize > 0,
-          cb.ifx(ab.size < maxSize,
+        cb.if_(maxSize > 0,
+          cb.if_(ab.size < maxSize,
             {
               copyElementToStaging(cb, offset)
               enqueueStaging(cb)
             },
             {
               cb.assign(tempPtr, elementOffset(cb, 0))
-              cb.ifx(compareElt(cb, offset, tempPtr) < 0,
+              cb.if_(compareElt(cb, offset, tempPtr) < 0,
                 {
                   copyElementToStaging(cb, offset)
                   swapStaging(cb)
@@ -472,14 +472,14 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           cb.memoize(Region.loadInt(indexOffset(cb, idx)))
 
         mb.emitWithBuilder { cb =>
-          cb.ifx(low.ceq(high), cb.append(Code._return(low)))
+          cb.if_(low.ceq(high), cb.append(Code._return(low)))
           cb.assign(pivotIndex, (low + high) / 2)
           cb.assign(pivotOffset, elementOffset(cb, indexAt(cb, pivotIndex)))
 
           cb.loop { Lrecur =>
             cb.loop { Linner =>
               cb.assign(tmpOffset, elementOffset(cb, indexAt(cb, low)))
-              cb.ifx(compareElt(cb, tmpOffset, pivotOffset) < 0, {
+              cb.if_(compareElt(cb, tmpOffset, pivotOffset) < 0, {
                 cb.assign(low, low + 1)
                 cb.goto(Linner)
               })
@@ -487,13 +487,13 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
 
             cb.loop { Linner =>
               cb.assign(tmpOffset, elementOffset(cb, indexAt(cb, high)))
-              cb.ifx(compareElt(cb, tmpOffset, pivotOffset) > 0, {
+              cb.if_(compareElt(cb, tmpOffset, pivotOffset) > 0, {
                 cb.assign(high, high - 1)
                 cb.goto(Linner)
               })
             }
 
-            cb.ifx(high > low, {
+            cb.if_(high > low, {
               swap(cb, indexOffset(cb, low), indexOffset(cb, high))
               cb.assign(low, low + 1)
               cb.assign(high, high - 1)
@@ -507,7 +507,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       }
 
       mb.voidWithBuilder { cb =>
-        cb.ifx(low < high, {
+        cb.if_(low < high, {
           cb.assign(pivotIndex, partition(cb, indices, low, high))
           cb.invokeVoid(mb, indices, low, pivotIndex)
           cb.invokeVoid(mb, indices, cb.memoize(pivotIndex + 1), high)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -282,7 +282,7 @@ object ArrayFunctions extends RegistryFunctions {
         ec2.toI(cb).flatMap(cb) { case pv2: SIndexableValue =>
           val l1 = cb.newLocal("len1", pv1.loadLength())
           val l2 = cb.newLocal("len2", pv2.loadLength())
-          cb.ifx(l1.cne(l2), {
+          cb.if_(l1.cne(l2), {
             cb._fatalWithError(errorID,
               "'corr': cannot compute correlation between arrays of different lengths: ",
                 l1.toS,
@@ -331,17 +331,17 @@ object ArrayFunctions extends RegistryFunctions {
             val nTotalAlleles =_nTotalAlleles.value
             val nGenotypes = cb.memoize(triangle(nTotalAlleles))
             val pt = rt.pType.asInstanceOf[PCanonicalArray]
-            cb.ifx(nTotalAlleles < 0, cb._fatalWithError(err, "local_to_global: n_total_alleles less than 0: ", nGenotypes.toS))
+            cb.if_(nTotalAlleles < 0, cb._fatalWithError(err, "local_to_global: n_total_alleles less than 0: ", nGenotypes.toS))
             val localLen = array.loadLength()
             val laLen = localAlleles.loadLength()
-            cb.ifx(localLen cne triangle(laLen), cb._fatalWithError(err, "local_to_global: array should be the triangle number of local alleles: found: ", localLen.toS, " elements, and", laLen.toS, " alleles"))
+            cb.if_(localLen cne triangle(laLen), cb._fatalWithError(err, "local_to_global: array should be the triangle number of local alleles: found: ", localLen.toS, " elements, and", laLen.toS, " alleles"))
 
             val fillIn = cb.memoize(fillInValue)
 
             val (push, finish) = pt.constructFromIndicesUnsafe(cb, region, nGenotypes, false)
 
             // fill in if necessary
-            cb.ifx(localLen cne nGenotypes, {
+            cb.if_(localLen cne nGenotypes, {
               val i = cb.newLocal[Int]("i", 0)
               cb.while_(i < nGenotypes, {
                 push(cb, i, fillIn.toI(cb))
@@ -354,14 +354,14 @@ object ArrayFunctions extends RegistryFunctions {
             val laGIndexer = cb.newLocal[Int]("g_indexer", 0)
             cb.while_(i < laLen, {
               val lai = localAlleles.loadElement(cb, i).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
-              cb.ifx(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
+              cb.if_(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
 
               val j = cb.newLocal[Int]("la_j", 0)
               cb.while_(j <= i, {
                 val laj = localAlleles.loadElement(cb, j).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
 
                 val dest = cb.newLocal[Int]("dest")
-                cb.ifx(lai >= laj, {
+                cb.if_(lai >= laj, {
                   cb.assign(dest, triangle(lai) + laj)
                 }, {
                   cb.assign(dest, triangle(laj) + lai)
@@ -387,14 +387,14 @@ object ArrayFunctions extends RegistryFunctions {
           case IndexedSeq(array: SIndexableValue, localAlleles: SIndexableValue, _nTotalAlleles: SInt32Value, omitFirst: SBooleanValue) =>
             val nTotalAlleles = _nTotalAlleles.value
             val pt = rt.pType.asInstanceOf[PCanonicalArray]
-            cb.ifx(nTotalAlleles < 0, cb._fatalWithError(err, "local_to_global: n_total_alleles less than 0: ", nTotalAlleles.toS))
+            cb.if_(nTotalAlleles < 0, cb._fatalWithError(err, "local_to_global: n_total_alleles less than 0: ", nTotalAlleles.toS))
             val localLen = array.loadLength()
-            cb.ifx(localLen cne localAlleles.loadLength(), cb._fatalWithError(err,"local_to_global: array and local alleles lengths differ: ", localLen.toS, ", ", localAlleles.loadLength().toS))
+            cb.if_(localLen cne localAlleles.loadLength(), cb._fatalWithError(err,"local_to_global: array and local alleles lengths differ: ", localLen.toS, ", ", localAlleles.loadLength().toS))
 
             val fillIn = cb.memoize(fillInValue)
 
             val idxAdjustmentForOmitFirst = cb.newLocal[Int]("idxAdj")
-            cb.ifx(omitFirst.value,
+            cb.if_(omitFirst.value,
               cb.assign(idxAdjustmentForOmitFirst, 1),
               cb.assign(idxAdjustmentForOmitFirst, 0))
 
@@ -403,7 +403,7 @@ object ArrayFunctions extends RegistryFunctions {
             val (push, finish) = pt.constructFromIndicesUnsafe(cb, region, globalLen, false)
 
             // fill in if necessary
-            cb.ifx(localLen cne globalLen, {
+            cb.if_(localLen cne globalLen, {
               val i = cb.newLocal[Int]("i", 0)
               cb.while_(i < globalLen, {
                 push(cb, i, fillIn.toI(cb))
@@ -414,7 +414,7 @@ object ArrayFunctions extends RegistryFunctions {
             val i = cb.newLocal[Int]("la_i", 0)
             cb.while_(i < localLen, {
               val lai = localAlleles.loadElement(cb, i + idxAdjustmentForOmitFirst).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
-              cb.ifx(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
+              cb.if_(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
               push(cb, cb.memoize(lai - idxAdjustmentForOmitFirst), array.loadElement(cb, i))
 
               cb.assign(i, i + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -297,7 +297,7 @@ object ArrayFunctions extends RegistryFunctions {
             val xySum = cb.newLocal[Double]("xySum", 0d)
             val i = cb.newLocal[Int]("i")
             val n = cb.newLocal[Int]("n", 0)
-            cb.forLoop(cb.assign(i, 0), i < l1, cb.assign(i, i + 1), {
+            cb.for_(cb.assign(i, 0), i < l1, cb.assign(i, i + 1), {
               pv1.loadElement(cb, i).consume(cb, {}, { xc =>
                 pv2.loadElement(cb, i).consume(cb, {}, { yc =>
                   val x = cb.newLocal[Double]("x", xc.asDouble.value)
@@ -343,7 +343,7 @@ object ArrayFunctions extends RegistryFunctions {
             // fill in if necessary
             cb.ifx(localLen cne nGenotypes, {
               val i = cb.newLocal[Int]("i", 0)
-              cb.whileLoop(i < nGenotypes, {
+              cb.while_(i < nGenotypes, {
                 push(cb, i, fillIn.toI(cb))
                 cb.assign(i, i + 1)
               })
@@ -352,12 +352,12 @@ object ArrayFunctions extends RegistryFunctions {
 
             val i = cb.newLocal[Int]("la_i", 0)
             val laGIndexer = cb.newLocal[Int]("g_indexer", 0)
-            cb.whileLoop(i < laLen, {
+            cb.while_(i < laLen, {
               val lai = localAlleles.loadElement(cb, i).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
               cb.ifx(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
 
               val j = cb.newLocal[Int]("la_j", 0)
-              cb.whileLoop(j <= i, {
+              cb.while_(j <= i, {
                 val laj = localAlleles.loadElement(cb, j).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
 
                 val dest = cb.newLocal[Int]("dest")
@@ -405,14 +405,14 @@ object ArrayFunctions extends RegistryFunctions {
             // fill in if necessary
             cb.ifx(localLen cne globalLen, {
               val i = cb.newLocal[Int]("i", 0)
-              cb.whileLoop(i < globalLen, {
+              cb.while_(i < globalLen, {
                 push(cb, i, fillIn.toI(cb))
                 cb.assign(i, i + 1)
               })
             })
 
             val i = cb.newLocal[Int]("la_i", 0)
-            cb.whileLoop(i < localLen, {
+            cb.while_(i < localLen, {
               val lai = localAlleles.loadElement(cb, i + idxAdjustmentForOmitFirst).get(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
               cb.ifx(lai >= nTotalAlleles, cb._fatalWithError(err, "local_to_global: local allele of ", lai.toS, " out of bounds given n_total_alleles of ", nTotalAlleles.toS))
               push(cb, cb.memoize(lai - idxAdjustmentForOmitFirst), array.loadElement(cb, i))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -19,11 +19,11 @@ object GenotypeFunctions extends RegistryFunctions {
       cb.while_(i < pl.loadLength(), {
         val value = pl.loadElement(cb, i).get(cb, "PL cannot have missing elements.", errorID)
         val pli = cb.newLocal[Int]("pli", value.asInt.value)
-        cb.ifx(pli < m, {
+        cb.if_(pli < m, {
           cb.assign(m2, m)
           cb.assign(m, pli)
         }, {
-          cb.ifx(pli < m2,
+          cb.if_(pli < m2,
             cb.assign(m2, pli))
         })
         cb.assign(i, i + 1)
@@ -36,7 +36,7 @@ object GenotypeFunctions extends RegistryFunctions {
       (_: Type, arrayType: EmitType) => EmitType(SFloat64, arrayType.required && arrayType.st.asInstanceOf[SContainer].elementEmitType.required)
     ) { case (cb, r, rt, errorID, gp) =>
       gp.toI(cb).flatMap(cb) { case gpv: SIndexableValue =>
-        cb.ifx(gpv.loadLength().cne(3),
+        cb.if_(gpv.loadLength().cne(3),
           cb._fatalWithError(errorID, const("length of gp array must be 3, got ").concat(gpv.loadLength().toS)))
 
         gpv.loadElement(cb, 1).flatMap(cb) { _1 =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -16,7 +16,7 @@ object GenotypeFunctions extends RegistryFunctions {
       val m2 = cb.newLocal[Int]("m2", 99)
       val i = cb.newLocal[Int]("i", 0)
 
-      cb.whileLoop(i < pl.loadLength(), {
+      cb.while_(i < pl.loadLength(), {
         val value = pl.loadElement(cb, i).get(cb, "PL cannot have missing elements.", errorID)
         val pli = cb.newLocal[Int]("pli", value.asInt.value)
         cb.ifx(pli < m, {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -126,8 +126,8 @@ object IntervalFunctions extends RegistryFunctions {
 
     cb.define(Leq)
     val c = cb.memoize(lLength - rLength)
-    val ls = cb.ifx(c <= 0, lSign, 0)
-    val rs = cb.ifx(c >= 0, rSign, 0)
+    val ls = cb.mux(c <= 0, lSign, 0)
+    val rs = cb.mux(c >= 0, rSign, 0)
     cb.assign(result, ls - rs)
 
     cb.define(Lafter)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -126,8 +126,8 @@ object IntervalFunctions extends RegistryFunctions {
 
     cb.define(Leq)
     val c = cb.memoize(lLength - rLength)
-    val ls = cb.mux(c <= 0, lSign, 0)
-    val rs = cb.mux(c >= 0, rSign, 0)
+    val ls = (c <= 0).mux(lSign, 0)
+    val rs = (c >= 0).mux(rSign, 0)
     cb.assign(result, ls - rs)
 
     cb.define(Lafter)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -43,7 +43,7 @@ object LocusFunctions extends RegistryFunctions {
       val ss = SStringPointer(ps)
       val (push, finish) = pAlleles.constructFromFunctions(cb, r, len, deepCopy = false)
       val i = cb.newLocal[Int]("locus_alleles_i", 0)
-      cb.whileLoop(i < len, {
+      cb.while_(i < len, {
         push(cb, IEmitCode.present(cb, ss.constructFromString(cb, r, all.invoke[Int, String]("apply", i))))
         cb.assign(i, i + 1)
       })
@@ -146,7 +146,7 @@ object LocusFunctions extends RegistryFunctions {
 
         def forAllContigs(cb: EmitCodeBuilder)(f: (EmitCodeBuilder, Value[Int], SIndexableValue) => Unit): Unit = {
           val iContig = cb.newLocal[Int]("locuswindows_icontig", 0)
-          cb.whileLoop(iContig < ncontigs, {
+          cb.while_(iContig < ncontigs, {
             val coordPerContig = grouped.loadElement(cb, iContig).get(cb, "locus_windows group cannot be missing")
               .asIndexable
             f(cb, iContig, coordPerContig)
@@ -172,7 +172,7 @@ object LocusFunctions extends RegistryFunctions {
             cb.ifx(len.ceq(0),
               cb.assign(lastCoord, 0.0),
               cb.assign(lastCoord, coords.loadElement(cb, 0).get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value))
-            cb.whileLoop(i < len, {
+            cb.while_(i < len, {
 
               coords.loadElement(cb, i).consume(cb,
                 cb._fatalWithError(errorID, const("locus_windows: missing value for 'coord_expr' at row ")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -113,7 +113,7 @@ object LocusFunctions extends RegistryFunctions {
         val basePos = inputLocus.position(cb)
         val bps = basePairsToAdd.value
         val newPos = cb.newLocal[Int]("newPos")
-        cb.ifx(bps <= 0,
+        cb.if_(bps <= 0,
           cb.assign(newPos, (basePos + bps).max(1)),
           cb.assign(newPos, (basePos + bps).min(cb.emb.getReferenceGenome(rt.rg).invoke[String, Int]("contigLength", contig)))
         )
@@ -169,7 +169,7 @@ object LocusFunctions extends RegistryFunctions {
             val i = cb.newLocal[Int]("locuswindows_i", 0)
             val idx = cb.newLocal[Int]("locuswindows_idx", 0)
             val len = coords.loadLength()
-            cb.ifx(len.ceq(0),
+            cb.if_(len.ceq(0),
               cb.assign(lastCoord, 0.0),
               cb.assign(lastCoord, coords.loadElement(cb, 0).get(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value))
             cb.while_(i < len, {
@@ -179,7 +179,7 @@ object LocusFunctions extends RegistryFunctions {
                     .concat((offset + i).toS)),
                 { sc =>
                   val currentCoord = cb.newLocal[Double]("locuswindows_coord_i", sc.asDouble.value)
-                  cb.ifx(lastCoord > currentCoord,
+                  cb.if_(lastCoord > currentCoord,
                     cb._fatalWithError(errorID, "locus_windows: 'coord_expr' must be in ascending order within each contig."),
                     cb.assign(lastCoord, currentCoord)
                   )
@@ -189,10 +189,10 @@ object LocusFunctions extends RegistryFunctions {
               val Lbreak = CodeLabel()
 
               cb.define(Lstart)
-              cb.ifx(idx >= len,
+              cb.if_(idx >= len,
                 cb.goto(Lbreak)
               )
-              cb.ifx(cond(cb, i, idx, coords),
+              cb.if_(cond(cb, i, idx, coords),
                 {
                   cb.assign(idx, idx + 1)
                   cb.goto(Lstart)
@@ -286,7 +286,7 @@ object LocusFunctions extends RegistryFunctions {
               rgCode(cb.emb, plocus.rg),
               invalidMissing.asBoolean.value))
 
-          cb.ifx(interval.isNull, cb.goto(Lmissing))
+          cb.if_(interval.isNull, cb.goto(Lmissing))
 
           val intervalCode = emitLocusInterval(cb, r, interval, rt)
           cb.goto(Ldefined)
@@ -333,7 +333,7 @@ object LocusFunctions extends RegistryFunctions {
                         rgCode(cb.emb, plocus.rg),
                         invalidMissing.asBoolean.value))
 
-                    cb.ifx(interval.isNull, cb.goto(Lmissing))
+                    cb.if_(interval.isNull, cb.goto(Lmissing))
 
                     val intervalCode = emitLocusInterval(cb, r, interval, rt)
                     cb.goto(Ldefined)
@@ -385,7 +385,7 @@ object LocusFunctions extends RegistryFunctions {
               rgCode(cb.emb, srcRG).invoke[String, Locus, Double, (Locus, Boolean)]("liftoverLocus",
                 destRG, locusObj, minMatch.asDouble.value))
 
-            cb.ifx(lifted.isNull, cb.goto(Lmissing))
+            cb.if_(lifted.isNull, cb.goto(Lmissing))
 
             val locType = rt.types(0).asInstanceOf[PCanonicalLocus]
             val locusCode = EmitCode.present(cb.emb, emitLocus(cb, r, Code.checkcast[Locus](lifted.getField[java.lang.Object]("_1")), locType))
@@ -426,7 +426,7 @@ object LocusFunctions extends RegistryFunctions {
                 destRG, intervalObj, minMatch.asDouble.value))
 
 
-            cb.ifx(lifted.isNull, cb.goto(Lmissing))
+            cb.if_(lifted.isNull, cb.goto(Lmissing))
 
             val iType = rt.types(0).asInstanceOf[PCanonicalInterval]
             val intervalCode = EmitCode.present(cb.emb, emitLocusInterval(cb, r, Code.checkcast[Interval](lifted.getField[java.lang.Object]("_1")), iType))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -178,7 +178,7 @@ object  NDArrayFunctions extends RegistryFunctions {
           cb.assign(iLeft, (-lower.value).max(0L))
           cb.assign(iRight, (nCols.get - lower.value).min(nRows.get))
 
-          cb.forLoop({
+          cb.for_({
             cb.assign(i, iLeft)
             cb.assign(j, lower.value.max(0L))
           }, i < iRight, {
@@ -206,7 +206,7 @@ object  NDArrayFunctions extends RegistryFunctions {
             primitive(0.0d)
           }
 
-          cb.forLoop({
+          cb.for_({
             cb.assign(i, iLeft)
             cb.assign(j, upper.value.max(0L) + 1)
           }, i < iRight, {
@@ -229,7 +229,7 @@ object  NDArrayFunctions extends RegistryFunctions {
         val newBlock = rst.coerceOrCopy(cb, er.region, block, deepCopy = false).asInstanceOf[SNDArrayPointerValue]
         val row = cb.newLocal[Long]("rowIdx")
         val IndexedSeq(nRows, nCols) = newBlock.shapes
-        cb.forLoop(cb.assign(row, 0L), row < nRows.get, cb.assign(row, row + 1L), {
+        cb.for_(cb.assign(row, 0L), row < nRows.get, cb.assign(row, row + 1L), {
           val start = starts.loadElement(cb, row.toI).get(cb).asInt64.value
           val stop = stops.loadElement(cb, row.toI).get(cb).asInt64.value
           newBlock.slice(cb, row, (null, start)).coiterateMutate(cb, er.region) { _ =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -43,13 +43,13 @@ object  NDArrayFunctions extends RegistryFunctions {
       val ndDepColMajor = LinalgCodeUtils.checkColMajorAndCopyIfNeeded(ndDep, cb, region)
 
       val IndexedSeq(ndCoefRow, ndCoefCol) = ndCoefColMajor.shapes
-      cb.ifx(ndCoefRow cne ndCoefCol, cb._fatalWithError(errorID, "hail.nd.solve_triangular: matrix a must be square."))
+      cb.if_(ndCoefRow cne ndCoefCol, cb._fatalWithError(errorID, "hail.nd.solve_triangular: matrix a must be square."))
 
       val IndexedSeq(ndDepRow, ndDepCol) = ndDepColMajor.shapes
-      cb.ifx(ndCoefRow  cne ndDepRow, cb._fatalWithError(errorID,"hail.nd.solve_triangular: Solve dimensions incompatible"))
+      cb.if_(ndCoefRow  cne ndDepRow, cb._fatalWithError(errorID,"hail.nd.solve_triangular: Solve dimensions incompatible"))
 
       val uplo = cb.newLocal[String]("dtrtrs_uplo")
-      cb.ifx(lower.value, cb.assign(uplo, const("L")), cb.assign(uplo, const("U")))
+      cb.if_(lower.value, cb.assign(uplo, const("L")), cb.assign(uplo, const("U")))
 
       val infoDTRTRSResult = cb.newLocal[Int]("dtrtrs_result")
 
@@ -77,11 +77,11 @@ object  NDArrayFunctions extends RegistryFunctions {
 
       val IndexedSeq(n0, n1) = aColMajor.shapes
 
-      cb.ifx(n0 cne n1, cb._fatalWithError(errorID, "hail.nd.solve: matrix a must be square."))
+      cb.if_(n0 cne n1, cb._fatalWithError(errorID, "hail.nd.solve: matrix a must be square."))
 
       val IndexedSeq(n, nrhs) = bColMajor.shapes
 
-      cb.ifx(n0 cne n, cb._fatalWithError(errorID, "hail.nd.solve: Solve dimensions incompatible"))
+      cb.if_(n0 cne n, cb._fatalWithError(errorID, "hail.nd.solve: Solve dimensions incompatible"))
 
       val infoDGESVResult = cb.newLocal[Int]("dgesv_result")
       val ipiv = cb.newLocal[Long]("dgesv_ipiv")
@@ -135,7 +135,7 @@ object  NDArrayFunctions extends RegistryFunctions {
       { (t, p1, p2) => PCanonicalNDArray(PFloat64Required, 2, true).sType }) {
       case (er, cb, SNDArrayPointer(pt), apc, bpc, errorID) =>
         val (resPCode, info) = linear_solve(apc.asNDArray, bpc.asNDArray, pt, cb, er.region, errorID)
-        cb.ifx(info cne 0, cb._fatalWithError(errorID,s"hl.nd.solve: Could not solve, matrix was singular. dgesv error code ", info.toS))
+        cb.if_(info cne 0, cb._fatalWithError(errorID,s"hl.nd.solve: Could not solve, matrix was singular. dgesv error code ", info.toS))
         resPCode
     }
 
@@ -158,7 +158,7 @@ object  NDArrayFunctions extends RegistryFunctions {
       { (t, p1, p2, p3) => PCanonicalNDArray(PFloat64Required, 2, true).sType }) {
       case (er, cb, SNDArrayPointer(pt), apc, bpc, lower, errorID) =>
         val (resPCode, info) = linear_triangular_solve(apc.asNDArray, bpc.asNDArray, lower.asBoolean, pt, cb, er.region, errorID)
-        cb.ifx(info cne 0, cb._fatalWithError(errorID,s"hl.nd.solve: Could not solve, matrix was singular. dtrtrs error code ", info.toS))
+        cb.if_(info cne 0, cb._fatalWithError(errorID,s"hl.nd.solve: Could not solve, matrix was singular. dtrtrs error code ", info.toS))
         resPCode
     }
 
@@ -174,7 +174,7 @@ object  NDArrayFunctions extends RegistryFunctions {
         val i = cb.newLocal[Long]("i")
         val j = cb.newLocal[Long]("j")
 
-        cb.ifx(lower.value > lowestDiagIndex, {
+        cb.if_(lower.value > lowestDiagIndex, {
           cb.assign(iLeft, (-lower.value).max(0L))
           cb.assign(iRight, (nCols.get - lower.value).min(nRows.get))
 
@@ -197,7 +197,7 @@ object  NDArrayFunctions extends RegistryFunctions {
           }
         })
 
-        cb.ifx(upper.value < highestDiagIndex, {
+        cb.if_(upper.value < highestDiagIndex, {
           cb.assign(iLeft, (-upper.value).max(0L))
           cb.assign(iRight, (nCols.get - upper.value).min(nRows.get))
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -206,7 +206,7 @@ object RandomSeededFunctions extends RegistryFunctions {
       val rng = cb.emb.getThreefryRNG()
       rngState.copyIntoEngine(cb, rng)
       val value = cb.newLocal[Double]("value", rng.invoke[Double, Double, Double]("rbeta", a.value, b.value))
-      cb.whileLoop(value < min.value || value > max.value, {
+      cb.while_(value < min.value || value > max.value, {
         cb.assign(value, rng.invoke[Double, Double, Double]("rbeta", a.value, b.value))
       })
       primitive(value)
@@ -226,7 +226,7 @@ object RandomSeededFunctions extends RegistryFunctions {
       val len = weights.loadLength()
       val i = cb.newLocal[Int]("i", 0)
       val s = cb.newLocal[Double]("sum", 0.0)
-      cb.whileLoop(i < len, {
+      cb.while_(i < len, {
         cb.assign(s, s + weights.loadElement(cb, i).get(cb, "rand_cat requires all elements of input array to be present").asFloat64.value)
         cb.assign(i, i + 1)
       })
@@ -253,7 +253,7 @@ object RandomSeededFunctions extends RegistryFunctions {
       val totalNumberOfRecords = cb.newLocal[Int]("scnspp_total_number_of_records", 0)
       val resultSize: Value[Int] = partitionCounts.loadLength()
       val i = cb.newLocal[Int]("scnspp_index", 0)
-      cb.forLoop(cb.assign(i, 0), i < resultSize, cb.assign(i, i + 1), {
+      cb.for_(cb.assign(i, 0), i < resultSize, cb.assign(i, i + 1), {
         cb.assign(totalNumberOfRecords, totalNumberOfRecords + partitionCounts.loadElement(cb, i).get(cb).asInt32.value)
       })
 
@@ -266,7 +266,7 @@ object RandomSeededFunctions extends RegistryFunctions {
       val arrayRt = rt.asInstanceOf[SIndexablePointer]
       val (push, finish) = arrayRt.pType.asInstanceOf[PCanonicalArray].constructFromFunctions(cb, r.region, resultSize, false)
 
-      cb.forLoop(cb.assign(i, 0), i < resultSize, cb.assign(i, i + 1), {
+      cb.for_(cb.assign(i, 0), i < resultSize, cb.assign(i, i + 1), {
         val numSuccesses = cb.memoize(rng.invoke[Double, Double, Double, Double]("rhyper",
           successStatesRemaining.toD, failureStatesRemaining.toD, partitionCounts.loadElement(cb, i).get(cb).asInt32.value.toD).toI)
         cb.assign(successStatesRemaining, successStatesRemaining - numSuccesses)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -235,7 +235,7 @@ object RandomSeededFunctions extends RegistryFunctions {
       val elt = cb.newLocal[Double]("elt")
       cb.loop { start =>
         cb.assign(elt, weights.loadElement(cb, i).get(cb, "rand_cat requires all elements of input array to be present").asFloat64.value)
-        cb.ifx(r > elt && i < len, {
+        cb.if_(r > elt && i < len, {
           cb.assign(r, r - elt)
           cb.assign(i, i + 1)
           cb.goto(start)
@@ -257,7 +257,7 @@ object RandomSeededFunctions extends RegistryFunctions {
         cb.assign(totalNumberOfRecords, totalNumberOfRecords + partitionCounts.loadElement(cb, i).get(cb).asInt32.value)
       })
 
-      cb.ifx(initalNumSamplesToSelect.value > totalNumberOfRecords, cb._fatal("Requested selection of ", initalNumSamplesToSelect.value.toS,
+      cb.if_(initalNumSamplesToSelect.value > totalNumberOfRecords, cb._fatal("Requested selection of ", initalNumSamplesToSelect.value.toS,
         " samples from ", totalNumberOfRecords.toS, " records"))
 
       val successStatesRemaining = cb.newLocal[Int]("scnspp_success", initalNumSamplesToSelect.value)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -164,7 +164,7 @@ object StringFunctions extends RegistryFunctions {
 
     val LreturnWithoutAppending = CodeLabel()
 
-    cb.whileLoop(i < string.length(), {
+    cb.while_(i < string.length(), {
       val c = cb.newLocal[Char]("c", string(i))
 
       val l = getPatternMatch(i, c)
@@ -181,7 +181,7 @@ object StringFunctions extends RegistryFunctions {
               cb.assign(i, i + 1) // skip quote
               cb.assign(lastFieldStart, i)
 
-              cb.whileLoop(i < string.length() && string(i).cne(qc), {
+              cb.while_(i < string.length() && string(i).cne(qc), {
                 cb.assign(i, i + 1)
               })
 
@@ -457,7 +457,7 @@ object StringFunctions extends RegistryFunctions {
             val m = l1.cne(l2)
 
             IEmitCode(cb, m, {
-              cb.whileLoop(i < l1, {
+              cb.while_(i < l1, {
                 cb.ifx(v1.invoke[Int, Char]("charAt", i).toI.cne(v2.invoke[Int, Char]("charAt", i).toI),
                   cb.assign(n, n + 1))
                 cb.assign(i, i + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -282,7 +282,7 @@ object StringFunctions extends RegistryFunctions {
     registerIEmitCode1("showStr", tv("T"), TString, {
       (_: Type, _: EmitType) => EmitType(SJavaString, true)
     }) { case (cb, r, st: SJavaString.type, _, a) =>
-      val jObj = cb.newLocal("showstr_java_obj")(boxedTypeInfo(a.st.virtualType))
+      val jObj = cb.newLocalAny("showstr_java_obj", boxedTypeInfo(a.st.virtualType))
       a.toI(cb).consume(cb,
         cb.assignAny(jObj, Code._null(boxedTypeInfo(a.st.virtualType))),
         sc => cb.assignAny(jObj, svalueToJavaValue(cb, r, sc)))
@@ -295,7 +295,7 @@ object StringFunctions extends RegistryFunctions {
     registerIEmitCode2("showStr", tv("T"), TInt32, TString, {
       (_: Type, _: EmitType, truncType: EmitType) => EmitType(SJavaString, truncType.required)
     }) { case (cb, r, st: SJavaString.type, _, a, trunc) =>
-      val jObj = cb.newLocal("showstr_java_obj")(boxedTypeInfo(a.st.virtualType))
+      val jObj = cb.newLocalAny("showstr_java_obj", boxedTypeInfo(a.st.virtualType))
       trunc.toI(cb).map(cb) { trunc =>
 
         a.toI(cb).consume(cb,
@@ -310,7 +310,7 @@ object StringFunctions extends RegistryFunctions {
     registerIEmitCode1("json", tv("T"), TString, (_: Type, _: EmitType) => EmitType(SJavaString, true)) {
       case (cb, r, st: SJavaString.type, _, a) =>
         val ti = boxedTypeInfo(a.st.virtualType)
-        val inputJavaValue = cb.newLocal("json_func_input_jv")(ti)
+        val inputJavaValue = cb.newLocalAny("json_func_input_jv", ti)
         a.toI(cb).consume(cb,
           cb.assignAny(inputJavaValue, Code._null(ti)),
           { sc =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -139,7 +139,7 @@ object StringFunctions extends RegistryFunctions {
       separator match {
         case Left(sepChar) =>
           (_: Value[Int], char: Value[Char]) => {
-            cb.ifx(char.ceq(sepChar), cb.assign(x, 1), cb.assign(x, -1));
+            cb.if_(char.ceq(sepChar), cb.assign(x, 1), cb.assign(x, -1));
             x
           }
         case Right(regex) =>
@@ -168,15 +168,15 @@ object StringFunctions extends RegistryFunctions {
       val c = cb.newLocal[Char]("c", string(i))
 
       val l = getPatternMatch(i, c)
-      cb.ifx(l.cne(-1), {
+      cb.if_(l.cne(-1), {
         addValueOrNA(cb, i)
         cb.assign(i, i + l) // skip delim
         cb.assign(lastFieldStart, i)
       }, {
         quoteChar match {
           case Some(qc) =>
-            cb.ifx(c.ceq(qc), {
-              cb.ifx(i.cne(lastFieldStart),
+            cb.if_(c.ceq(qc), {
+              cb.if_(i.cne(lastFieldStart),
                 cb._fatalWithError(errorID, "opening quote character '", qc.toS, "' not at start of field"))
               cb.assign(i, i + 1) // skip quote
               cb.assign(lastFieldStart, i)
@@ -187,14 +187,14 @@ object StringFunctions extends RegistryFunctions {
 
               addValueOrNA(cb, i)
 
-              cb.ifx(i.ceq(string.length()),
+              cb.if_(i.ceq(string.length()),
                 cb._fatalWithError(errorID, "missing terminating quote character '", qc.toS, "'"))
               cb.assign(i, i + 1) // skip quote
 
-              cb.ifx(i < string.length, {
+              cb.if_(i < string.length, {
                 cb.assign(c, string(i))
                 val l = getPatternMatch(i, c)
-                cb.ifx(l.ceq(-1), {
+                cb.if_(l.ceq(-1), {
                   cb._fatalWithError(errorID, "terminating quote character '", qc.toS, "' not at end of field")
                 })
                 cb.assign(i, i + l) // skip delim
@@ -372,7 +372,7 @@ object StringFunctions extends RegistryFunctions {
     }) { case (r, cb, st: SJavaArrayString, s, separator, missing, quote, errorID) =>
       val quoteStr = cb.newLocal[String]("quoteStr", quote.asString.loadString(cb))
       val quoteChar = cb.newLocal[Char]("quoteChar")
-      cb.ifx(quoteStr.length().cne(1), cb._fatalWithError(errorID, "quote must be a single character"))
+      cb.if_(quoteStr.length().cne(1), cb._fatalWithError(errorID, "quote must be a single character"))
       cb.assign(quoteChar, quoteStr(0))
 
       val string = cb.newLocal[String]("string", s.asString.loadString(cb))
@@ -387,13 +387,13 @@ object StringFunctions extends RegistryFunctions {
     }) { case (r, cb, st: SJavaArrayString, s, separator, missing, quote, errorID) =>
       val quoteStr = cb.newLocal[String]("quoteStr", quote.asString.loadString(cb))
       val quoteChar = cb.newLocal[Char]("quoteChar")
-      cb.ifx(quoteStr.length().cne(1), cb._fatalWithError(errorID, "quote must be a single character"))
+      cb.if_(quoteStr.length().cne(1), cb._fatalWithError(errorID, "quote must be a single character"))
       cb.assign(quoteChar, quoteStr(0))
 
       val string = cb.newLocal[String]("string", s.asString.loadString(cb))
       val sep = cb.newLocal[String]("sep", separator.asString.loadString(cb))
       val sepChar = cb.newLocal[Char]("sepChar")
-      cb.ifx(sep.length().cne(1), cb._fatalWithError(errorID, "splitQuotedChar expected a single character for separator"))
+      cb.if_(sep.length().cne(1), cb._fatalWithError(errorID, "splitQuotedChar expected a single character for separator"))
       cb.assign(sepChar, sep(0))
       val mv = missing.asIndexable
 
@@ -415,7 +415,7 @@ object StringFunctions extends RegistryFunctions {
       val string = cb.newLocal[String]("string", s.asString.loadString(cb))
       val sep = cb.newLocal[String]("sep", separator.asString.loadString(cb))
       val sepChar = cb.newLocal[Char]("sepChar")
-      cb.ifx(sep.length().cne(1), cb._fatalWithError(errorID, "splitChar expected a single character for separator"))
+      cb.if_(sep.length().cne(1), cb._fatalWithError(errorID, "splitChar expected a single character for separator"))
       cb.assign(sepChar, sep(0))
       val mv = missing.asIndexable
 
@@ -458,7 +458,7 @@ object StringFunctions extends RegistryFunctions {
 
             IEmitCode(cb, m, {
               cb.while_(i < l1, {
-                cb.ifx(v1.invoke[Int, Char]("charAt", i).toI.cne(v2.invoke[Int, Char]("charAt", i).toI),
+                cb.if_(v1.invoke[Int, Char]("charAt", i).toI.cne(v2.invoke[Int, Char]("charAt", i).toI),
                   cb.assign(n, n + 1))
                 cb.assign(i, i + 1)
               })
@@ -482,7 +482,7 @@ object StringFunctions extends RegistryFunctions {
     ) { case (er, cb, _, resultType, Array(s: SStringValue), _) =>
 
       val warnCtx = cb.emb.genFieldThisRef[mutable.HashSet[String]]("parse_json_context")
-      cb.ifx(warnCtx.load().isNull, cb.assign(warnCtx, Code.newInstance[mutable.HashSet[String]]()))
+      cb.if_(warnCtx.load().isNull, cb.assign(warnCtx, Code.newInstance[mutable.HashSet[String]]()))
 
       val row = Code.invokeScalaObject3[String, Type, mutable.HashSet[String], Row](JSONAnnotationImpex.getClass, "irImportAnnotation",
         s.loadString(cb), er.mb.ecb.getType(resultType.virtualType.asInstanceOf[TTuple].types(0)), warnCtx)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -330,7 +330,7 @@ object UtilFunctions extends RegistryFunctions {
       case (cb, _, rt,_ , l, r) =>
         if (l.required && r.required) {
           val result = cb.newLocal[Boolean]("land_result")
-          cb.ifx(l.toI(cb).get(cb).asBoolean.value, {
+          cb.if_(l.toI(cb).get(cb).asBoolean.value, {
             cb.assign(result, r.toI(cb).get(cb).asBoolean.value)
           }, {
             cb.assign(result, const(false))
@@ -350,7 +350,7 @@ object UtilFunctions extends RegistryFunctions {
               b1 => cb.assign(w, b1.asBoolean.value.mux(const(2), const(0)))
             )
 
-          cb.ifx(w.cne(0),
+          cb.if_(w.cne(0),
             {
               r.toI(cb).consume(cb,
                 cb.assign(w, w | const(4)),
@@ -368,7 +368,7 @@ object UtilFunctions extends RegistryFunctions {
       case (cb, _, rt,_, l, r) =>
         if (l.required && r.required) {
           val result = cb.newLocal[Boolean]("land_result")
-          cb.ifx(l.toI(cb).get(cb).asBoolean.value, {
+          cb.if_(l.toI(cb).get(cb).asBoolean.value, {
             cb.assign(result, const(true))
           }, {
             cb.assign(result, r.toI(cb).get(cb).asBoolean.value)
@@ -388,7 +388,7 @@ object UtilFunctions extends RegistryFunctions {
               b1 => cb.assign(w, b1.asBoolean.value.mux(const(2), const(0)))
             )
 
-          cb.ifx(w.cne(2),
+          cb.if_(w.cne(2),
             {
               r.toI(cb).consume(cb,
                 cb.assign(w, w | const(4)),

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -283,7 +283,7 @@ object EmitNDArray {
                   cb.assign(missing, false)
                   // Need to check if the any of the ndarrays are missing.
                   val missingCheckLoopIdx = cb.newLocal[Int]("ndarray_concat_missing_check_idx")
-                  cb.forLoop(cb.assign(missingCheckLoopIdx, 0), missingCheckLoopIdx < arrLength, cb.assign(missingCheckLoopIdx, missingCheckLoopIdx + 1),
+                  cb.for_(cb.assign(missingCheckLoopIdx, 0), missingCheckLoopIdx < arrLength, cb.assign(missingCheckLoopIdx, missingCheckLoopIdx + 1),
                     cb.assign(missing, missing | ndsArraySValue.isElementMissing(cb, missingCheckLoopIdx))
                   )
                   missing
@@ -305,7 +305,7 @@ object EmitNDArray {
                     pushElement(cb, EmitCode(Code._empty, false, primitive(localDim)).toI(cb))
                   }
 
-                  cb.forLoop(cb.assign(loopIdx, 1), loopIdx < arrLength, cb.assign(loopIdx, loopIdx + 1), {
+                  cb.for_(cb.assign(loopIdx, 1), loopIdx < arrLength, cb.assign(loopIdx, loopIdx + 1), {
                     val shapeOfNDAtIdx = ndsArraySValue.loadElement(cb, loopIdx).map(cb) { sCode => sCode.asNDArray }.get(cb).shapeStruct(cb)
                     val dimLength = cb.newLocal[Long]("dimLength", shapeOfNDAtIdx.loadField(cb, dimIdx).get(cb).asInt64.value)
 
@@ -356,7 +356,7 @@ object EmitNDArray {
                       if (idx == axis) {
                         // If bigger than current ndarray, then we need to subtract out the size of this ndarray, increment to the next ndarray, and see if we are happy yet.
                         val shouldLoop = cb.newLocal[Boolean]("should_loop", curIdxVar >= stagedArrayOfSizes.loadElement(cb, currentNDArrayIdx).get(cb).asInt64.value)
-                        cb.whileLoop(shouldLoop,
+                        cb.while_(shouldLoop,
                           {
                             cb.assign(curIdxVar, curIdxVar - stagedArrayOfSizes.loadElement(cb, currentNDArrayIdx).get(cb).asInt64.value)
                             cb.assign(currentNDArrayIdx, currentNDArrayIdx + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/BinaryOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/BinaryOrdering.scala
@@ -28,11 +28,11 @@ object BinaryOrdering {
             Code.invokeStatic1[java.lang.Byte, Byte, Int]("toUnsignedInt", xv.loadByte(cb, i)),
             Code.invokeStatic1[java.lang.Byte, Byte, Int]("toUnsignedInt", yv.loadByte(cb, i)))
           cb.assign(cmp, compval)
-          cb.ifx(cmp.cne(0), cb.goto(Lbreak))
+          cb.if_(cmp.cne(0), cb.goto(Lbreak))
         })
 
         cb.define(Lbreak)
-        cb.ifx(cmp.ceq(0), {
+        cb.if_(cmp.ceq(0), {
           cb.assign(cmp, Code.invokeStatic2[java.lang.Integer, Int, Int, Int]("compare", xlen, ylen))
         })
 

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/BinaryOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/BinaryOrdering.scala
@@ -19,11 +19,11 @@ object BinaryOrdering {
         val xlen = xv.loadLength(cb)
         val ylen = yv.loadLength(cb)
         val lim = cb.memoize[Int]((xlen < ylen).mux(xlen, ylen))
-        val i = cb.newLocal[Int]("i", 0)
+        val i = cb.newLocal[Int]("i")
         val cmp = cb.newLocal[Int]("cmp", 0)
         val Lbreak = CodeLabel()
 
-        cb.for_({}, i < lim, cb.assign(i, i + 1), {
+        cb.for_(cb.assign(i, 0), i < lim, cb.assign(i, i + 1), {
           val compval = Code.invokeStatic2[java.lang.Integer, Int, Int, Int]("compare",
             Code.invokeStatic1[java.lang.Byte, Byte, Int]("toUnsignedInt", xv.loadByte(cb, i)),
             Code.invokeStatic1[java.lang.Byte, Byte, Int]("toUnsignedInt", yv.loadByte(cb, i)))

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/BinaryOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/BinaryOrdering.scala
@@ -23,7 +23,7 @@ object BinaryOrdering {
         val cmp = cb.newLocal[Int]("cmp", 0)
         val Lbreak = CodeLabel()
 
-        cb.forLoop({}, i < lim, cb.assign(i, i + 1), {
+        cb.for_({}, i < lim, cb.assign(i, i + 1), {
           val compval = Code.invokeStatic2[java.lang.Integer, Int, Int, Int]("compare",
             Code.invokeStatic1[java.lang.Byte, Byte, Int]("toUnsignedInt", xv.loadByte(cb, i)),
             Code.invokeStatic1[java.lang.Byte, Byte, Int]("toUnsignedInt", yv.loadByte(cb, i)))

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
@@ -188,24 +188,24 @@ abstract class CodeOrdering {
 
   def _compare(cb: EmitCodeBuilder, x: EmitValue, y: EmitValue, missingEqual: Boolean = true): Value[Int] = {
     val cmp = cb.newLocal[Int]("cmp")
-    cb.ifx(x.m,
-      cb.ifx(y.m, cb.assign(cmp, if (missingEqual) 0 else -1), cb.assign(cmp, 1)),
-      cb.ifx(y.m, cb.assign(cmp, -1), cb.assign(cmp, compareNonnull(cb, x.v, y.v))))
+    cb.if_(x.m,
+      cb.if_(y.m, cb.assign(cmp, if (missingEqual) 0 else -1), cb.assign(cmp, 1)),
+      cb.if_(y.m, cb.assign(cmp, -1), cb.assign(cmp, compareNonnull(cb, x.v, y.v))))
     cmp
   }
 
   def _lt(cb: EmitCodeBuilder, x: EmitValue, y: EmitValue, missingEqual: Boolean): Value[Boolean] = {
     val ret = cb.newLocal[Boolean]("lt")
     if (missingEqual) {
-      cb.ifx(x.m,
+      cb.if_(x.m,
         cb.assign(ret, false),
-        cb.ifx(y.m,
+        cb.if_(y.m,
           cb.assign(ret, true),
           cb.assign(ret, ltNonnull(cb, x.v, y.v))))
     } else {
-      cb.ifx(y.m,
+      cb.if_(y.m,
         cb.assign(ret, true),
-        cb.ifx(x.m,
+        cb.if_(x.m,
           cb.assign(ret, false),
           cb.assign(ret, ltNonnull(cb, x.v, y.v))))
     }
@@ -214,9 +214,9 @@ abstract class CodeOrdering {
 
   def _lteq(cb: EmitCodeBuilder, x: EmitValue, y: EmitValue, missingEqual: Boolean): Value[Boolean] = {
     val ret = cb.newLocal[Boolean]("lteq")
-    cb.ifx(y.m,
+    cb.if_(y.m,
       cb.assign(ret, true),
-      cb.ifx(x.m,
+      cb.if_(x.m,
         cb.assign(ret, false),
         cb.assign(ret, lteqNonnull(cb, x.v, y.v))))
     ret
@@ -224,9 +224,9 @@ abstract class CodeOrdering {
 
   def _gt(cb: EmitCodeBuilder, x: EmitValue, y: EmitValue, missingEqual: Boolean): Value[Boolean] = {
     val ret = cb.newLocal[Boolean]("gt")
-    cb.ifx(y.m,
+    cb.if_(y.m,
       cb.assign(ret, false),
-      cb.ifx(x.m,
+      cb.if_(x.m,
         cb.assign(ret, true),
         cb.assign(ret, gtNonnull(cb, x.v, y.v))))
     ret
@@ -235,15 +235,15 @@ abstract class CodeOrdering {
   def _gteq(cb: EmitCodeBuilder, x: EmitValue, y: EmitValue, missingEqual: Boolean): Value[Boolean] = {
     val ret = cb.newLocal[Boolean]("gteq")
     if (missingEqual) {
-      cb.ifx(x.m,
+      cb.if_(x.m,
         cb.assign(ret, true),
-        cb.ifx(y.m,
+        cb.if_(y.m,
           cb.assign(ret, false),
           cb.assign(ret, gteqNonnull(cb, x.v, y.v))))
     } else {
-      cb.ifx(y.m,
+      cb.if_(y.m,
         cb.assign(ret, false),
-        cb.ifx(x.m,
+        cb.if_(x.m,
           cb.assign(ret, true),
           cb.assign(ret, gteqNonnull(cb, x.v, y.v))))
     }
@@ -253,13 +253,13 @@ abstract class CodeOrdering {
   def _equiv(cb: EmitCodeBuilder, x: EmitValue, y: EmitValue, missingEqual: Boolean): Value[Boolean] = {
     val ret = cb.newLocal[Boolean]("eq")
     if (missingEqual) {
-      cb.ifx(x.m && y.m,
+      cb.if_(x.m && y.m,
         cb.assign(ret, true),
-        cb.ifx(!x.m && !y.m,
+        cb.if_(!x.m && !y.m,
           cb.assign(ret, equivNonnull(cb, x.v, y.v)),
           cb.assign(ret, false)))
     } else {
-      cb.ifx(!x.m && !y.m, cb.assign(ret, equivNonnull(cb, x.v, y.v)), cb.assign(ret, false))
+      cb.if_(!x.m && !y.m, cb.assign(ret, equivNonnull(cb, x.v, y.v)), cb.assign(ret, false))
     }
     ret
   }

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/IntervalOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/IntervalOrdering.scala
@@ -21,15 +21,15 @@ object IntervalOrdering {
       val lstart = cb.memoize(lhs.loadStart(cb))
       val rstart = cb.memoize(rhs.loadStart(cb))
       cb.assign(cmp, pointCompare(cb, lstart, rstart))
-      cb.ifx(cmp.ceq(0), {
-        cb.ifx(lhs.includesStart.cne(rhs.includesStart), {
+      cb.if_(cmp.ceq(0), {
+        cb.if_(lhs.includesStart.cne(rhs.includesStart), {
           cb.assign(cmp, lhs.includesStart.mux(-1, 1))
         }, {
           val lend = cb.memoize(lhs.loadEnd(cb))
           val rend = cb.memoize(rhs.loadEnd(cb))
           cb.assign(cmp, pointCompare(cb, lend, rend))
-          cb.ifx(cmp.ceq(0), {
-            cb.ifx(lhs.includesEnd.cne(rhs.includesEnd), {
+          cb.if_(cmp.ceq(0), {
+            cb.if_(lhs.includesEnd.cne(rhs.includesEnd), {
               cb.assign(cmp, lhs.includesEnd.mux(1, -1))
             })
           })
@@ -52,18 +52,18 @@ object IntervalOrdering {
       val lhs = x.asInterval
       val rhs = y.asInterval
 
-      cb.ifx(lhs.includesStart.cne(rhs.includesStart) ||
+      cb.if_(lhs.includesStart.cne(rhs.includesStart) ||
         lhs.includesEnd.cne(rhs.includesEnd), {
         exitWith(false)
       })
 
       val lstart = cb.memoize(lhs.loadStart(cb))
       val rstart = cb.memoize(rhs.loadStart(cb))
-      cb.ifx(!pointEq(cb, lstart, rstart), exitWith(false))
+      cb.if_(!pointEq(cb, lstart, rstart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
-      cb.ifx(!pointEq(cb, lend, rend), exitWith(false))
+      cb.if_(!pointEq(cb, lend, rend), exitWith(false))
 
       cb.define(Lout)
       ret
@@ -85,15 +85,15 @@ object IntervalOrdering {
       val lstart = cb.memoize(lhs.loadStart(cb))
       val rstart = cb.memoize(rhs.loadStart(cb))
 
-      cb.ifx(pointLt(cb, lstart, rstart), exitWith(true))
-      cb.ifx(!pointEq(cb, lstart, rstart), exitWith(false))
-      cb.ifx(lhs.includesStart && !rhs.includesStart, exitWith(true))
-      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
+      cb.if_(pointLt(cb, lstart, rstart), exitWith(true))
+      cb.if_(!pointEq(cb, lstart, rstart), exitWith(false))
+      cb.if_(lhs.includesStart && !rhs.includesStart, exitWith(true))
+      cb.if_(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
 
-      cb.ifx(pointLt(cb, lend, rend), exitWith(true))
+      cb.if_(pointLt(cb, lend, rend), exitWith(true))
       cb.assign(ret, pointEq(cb, lend, rend) && !lhs.includesEnd && rhs.includesEnd)
 
       cb.define(Lout)
@@ -116,14 +116,14 @@ object IntervalOrdering {
       val lstart = cb.memoize(lhs.loadStart(cb))
       val rstart = cb.memoize(rhs.loadStart(cb))
 
-      cb.ifx(!pointLtEq(cb, lstart, rstart), exitWith(false))
-      cb.ifx(!pointEq(cb, lstart, rstart), exitWith(true))
-      cb.ifx(lhs.includesStart && !rhs.includesStart, exitWith(true))
-      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
+      cb.if_(!pointLtEq(cb, lstart, rstart), exitWith(false))
+      cb.if_(!pointEq(cb, lstart, rstart), exitWith(true))
+      cb.if_(lhs.includesStart && !rhs.includesStart, exitWith(true))
+      cb.if_(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
-      cb.ifx(!pointLtEq(cb, lend, rend), exitWith(false))
+      cb.if_(!pointLtEq(cb, lend, rend), exitWith(false))
       cb.assign(ret, !pointEq(cb, lend, rend) || !lhs.includesEnd || rhs.includesEnd)
 
       cb.define(Lout)
@@ -146,15 +146,15 @@ object IntervalOrdering {
       val lstart = cb.memoize(lhs.loadStart(cb))
       val rstart = cb.memoize(rhs.loadStart(cb))
 
-      cb.ifx(pointGt(cb, lstart, rstart), exitWith(true))
-      cb.ifx(!pointEq(cb, lstart, rstart), exitWith(false))
-      cb.ifx(!lhs.includesStart && rhs.includesStart, exitWith(true))
-      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
+      cb.if_(pointGt(cb, lstart, rstart), exitWith(true))
+      cb.if_(!pointEq(cb, lstart, rstart), exitWith(false))
+      cb.if_(!lhs.includesStart && rhs.includesStart, exitWith(true))
+      cb.if_(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
 
-      cb.ifx(pointGt(cb, lend, rend), exitWith(true))
+      cb.if_(pointGt(cb, lend, rend), exitWith(true))
       cb.assign(ret, pointEq(cb, lend, rend) && lhs.includesEnd && !rhs.includesEnd)
 
       cb.define(Lout)
@@ -177,14 +177,14 @@ object IntervalOrdering {
       val lstart = cb.memoize(lhs.loadStart(cb))
       val rstart = cb.memoize(rhs.loadStart(cb))
 
-      cb.ifx(!pointGtEq(cb, lstart, rstart), exitWith(false))
-      cb.ifx(!pointEq(cb, lstart, rstart), exitWith(true))
-      cb.ifx(!lhs.includesStart && rhs.includesStart, exitWith(true))
-      cb.ifx(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
+      cb.if_(!pointGtEq(cb, lstart, rstart), exitWith(false))
+      cb.if_(!pointEq(cb, lstart, rstart), exitWith(true))
+      cb.if_(!lhs.includesStart && rhs.includesStart, exitWith(true))
+      cb.if_(lhs.includesStart.cne(rhs.includesStart), exitWith(false))
 
       val lend = cb.memoize(lhs.loadEnd(cb))
       val rend = cb.memoize(rhs.loadEnd(cb))
-      cb.ifx(!pointGtEq(cb, lend, rend), exitWith(false))
+      cb.if_(!pointGtEq(cb, lend, rend), exitWith(false))
       cb.assign(ret, !pointEq(cb, lend, rend) || lhs.includesEnd || !rhs.includesEnd)
 
       cb.define(Lout)

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/IterableOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/IterableOrdering.scala
@@ -17,7 +17,7 @@ object IterableOrdering {
     ): Unit = {
       val i = cb.newLocal[Int]("i")
       val lim = cb.newLocal("lim", lhs.loadLength().min(rhs.loadLength()))
-      cb.forLoop(cb.assign(i, 0), i < lim, cb.assign(i, i + 1), {
+      cb.for_(cb.assign(i, 0), i < lim, cb.assign(i, i + 1), {
         val left = cb.memoize(lhs.loadElement(cb, i))
         val right = cb.memoize(rhs.loadElement(cb, i))
         f(left, right)

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/IterableOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/IterableOrdering.scala
@@ -34,7 +34,7 @@ object IterableOrdering {
       val rhs = y.asIndexable
       loop(cb, lhs, rhs) { (lhs, rhs) =>
         cb.assign(cmp, elemCmp(cb, lhs, rhs))
-        cb.ifx(cmp.cne(0), cb.goto(Lout))
+        cb.if_(cmp.cne(0), cb.goto(Lout))
       }
 
       // if we get here, cmp is 0
@@ -59,7 +59,7 @@ object IterableOrdering {
         val lt = elemLt(cb, lhs, rhs)
         val eq = !lt && elemEq(cb, lhs, rhs)
 
-        cb.ifx(!eq, {
+        cb.if_(!eq, {
           cb.assign(ret, lt)
           cb.goto(Lout)
         })
@@ -84,7 +84,7 @@ object IterableOrdering {
         val lteq = elemLtEq(cb, lhs, rhs)
         val eq = elemEq(cb, lhs, rhs)
 
-        cb.ifx(!eq, {
+        cb.if_(!eq, {
           cb.assign(ret, lteq)
           cb.goto(Lout)
         })
@@ -111,7 +111,7 @@ object IterableOrdering {
         val gt = elemGt(cb, lhs, rhs)
         val eq = !gt && elemEq(cb, lhs, rhs)
 
-        cb.ifx(!eq, {
+        cb.if_(!eq, {
           cb.assign(ret, gt)
           cb.goto(Lout)
         })
@@ -136,7 +136,7 @@ object IterableOrdering {
         val gteq = elemGtEq(cb, lhs, rhs)
         val eq = elemEq(cb, lhs, rhs)
 
-        cb.ifx(!eq, {
+        cb.if_(!eq, {
           cb.assign(ret, gteq)
           cb.goto(Lout)
         })
@@ -158,10 +158,10 @@ object IterableOrdering {
 
       val lhs = x.asIndexable
       val rhs = y.asIndexable
-      cb.ifx(lhs.loadLength().cne(rhs.loadLength()), exitWith(false))
+      cb.if_(lhs.loadLength().cne(rhs.loadLength()), exitWith(false))
       loop(cb, lhs, rhs) { (lhs, rhs) =>
         cb.assign(ret, elemEq(cb, lhs, rhs))
-        cb.ifx(!ret, cb.goto(Lout))
+        cb.if_(!ret, cb.goto(Lout))
       }
 
       cb.define(Lout)

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/LocusOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/LocusOrdering.scala
@@ -30,7 +30,7 @@ object LocusOrdering {
             val strcmp = CodeOrdering.makeOrdering(lhsContigType, rhsContigType, ecb)
 
             val ret = cb.newLocal[Int]("locus_cmp_ret", 0)
-            cb.ifx(strcmp.compareNonnull(cb, lhsContig, rhsContig).ceq(0), {
+            cb.if_(strcmp.compareNonnull(cb, lhsContig, rhsContig).ceq(0), {
               cb.assign(ret, Code.invokeStatic2[java.lang.Integer, Int, Int, Int](
                 "compare", lhs.position(cb), rhs.position(cb)))
             }, {

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/StructOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/StructOrdering.scala
@@ -36,7 +36,7 @@ object StructOrdering {
         val l = cb.memoize(lhs.loadField(cb, i))
         val r = cb.memoize(rhs.loadField(cb, i))
         cb.assign(cmp, fldCmp(cb, l, r))
-        cb.ifx(cmp.cne(0), cb.goto(Lout))
+        cb.if_(cmp.cne(0), cb.goto(Lout))
         i += 1
       }
 
@@ -59,7 +59,7 @@ object StructOrdering {
         val r = cb.memoize(rhs.loadField(cb, i))
         cb.assign(lt, fldLt(cb, l, r))
         val eq = !lt && fldEq(cb, l, r)
-        cb.ifx(!eq, cb.goto(Lout))
+        cb.if_(!eq, cb.goto(Lout))
         i += 1
       }
 
@@ -82,7 +82,7 @@ object StructOrdering {
         val r = cb.memoize(rhs.loadField(cb, i))
         cb.assign(lteq, fldLtEq(cb, l, r))
         val eq = fldEq(cb, l, r)
-        cb.ifx(!eq, cb.goto(Lout))
+        cb.if_(!eq, cb.goto(Lout))
         i += 1
       }
 
@@ -105,7 +105,7 @@ object StructOrdering {
         val r = cb.memoize(rhs.loadField(cb, i))
         cb.assign(gt, fldGt(cb, l, r))
         val eq = !gt && fldEq(cb, l, r)
-        cb.ifx(!eq, cb.goto(Lout))
+        cb.if_(!eq, cb.goto(Lout))
         i += 1
       }
 
@@ -128,7 +128,7 @@ object StructOrdering {
         val r = cb.memoize(rhs.loadField(cb, i))
         cb.assign(gteq, fldGtEq(cb, l, r))
         val eq = fldEq(cb, l, r)
-        cb.ifx(!eq, cb.goto(Lout))
+        cb.if_(!eq, cb.goto(Lout))
         i += 1
       }
 
@@ -148,7 +148,7 @@ object StructOrdering {
         val l = cb.memoize(lhs.loadField(cb, i))
         val r = cb.memoize(rhs.loadField(cb, i))
         cb.assign(eq, fldEq(cb, l, r))
-        cb.ifx(!eq, cb.goto(Lout))
+        cb.if_(!eq, cb.goto(Lout))
         i += 1
       }
 

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -815,7 +815,7 @@ object EmitStream {
                 val u = cb.newLocal[Double]("seq_sample_rand_unif", Code.invokeStatic0[Math, Double]("random"))
                 val fC = cb.newLocal[Double]("seq_sample_Fc", (totalSizeVal.value - candidate - nRemaining).toD / (totalSizeVal.value - candidate).toD)
 
-                cb.whileLoop(fC > u, {
+                cb.while_(fC > u, {
                   cb.assign(candidate, candidate + 1)
                   cb.assign(fC, fC * (const(1.0) - (nRemaining.toD / (totalSizeVal.value - candidate).toD)))
                 })
@@ -2590,7 +2590,7 @@ object EmitStream {
               initMemoryManagementPerElementArray(cb)
               cb.assign(bracket, Code.newArray[Int](k))
               cb.assign(heads, Code.newArray[Long](k))
-              cb.forLoop(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
+              cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
                 cb += (bracket(i) = -1)
               })
               cb.assign(result, Code._null)
@@ -2625,7 +2625,7 @@ object EmitStream {
               cb.goto(LproduceElementDone)
 
               cb.define(LstartNewKey)
-              cb.forLoop(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
+              cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
                 cb += (result(i) = 0L)
               })
               cb.assign(curKey, eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
@@ -2752,7 +2752,7 @@ object EmitStream {
             .asInstanceOf[PCanonicalStruct]
             .setRequired(false)
           var streamRequiresMemoryManagement = false
-          cb.whileLoop(idx < nStreams, {
+          cb.while_(idx < nStreams, {
             val iter = produceIterator(makeProducer,
               eltType,
               cb,
@@ -2823,7 +2823,7 @@ object EmitStream {
                 cb.assign(regionArray, Code.newArray[Region](nStreams))
               cb.assign(bracket, Code.newArray[Int](k))
               cb.assign(heads, Code.newArray[Long](k))
-              cb.forLoop(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
+              cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
                 cb.updateArray(bracket, i, -1)
                 val eltRegion: Value[Region] = if (streamRequiresMemoryManagement) {
                   val r = cb.memoize(Region.stagedCreate(Region.REGULAR, outerRegion.getPool()))
@@ -2864,7 +2864,7 @@ object EmitStream {
               cb.goto(LproduceElementDone)
 
               cb.define(LstartNewKey)
-              cb.forLoop(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
+              cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
                 cb.updateArray(result, i, 0L)
               })
               cb.assign(curKey, eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
@@ -2959,7 +2959,7 @@ object EmitStream {
 
             override def close(cb: EmitCodeBuilder): Unit = {
               cb.assign(i, 0)
-              cb.whileLoop(i < nStreams, {
+              cb.while_(i < nStreams, {
                 cb += iterArray(i).invoke[Unit]("close")
                 if (requiresMemoryManagementPerElement)
                   cb += regionArray(i).invoke[Unit]("invalidate")

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -340,7 +340,7 @@ object EmitStream {
 
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
                 cb.assign(idx, idx + 1)
-                cb.ifx(idx >= container.loadLength(), cb.goto(LendOfStream))
+                cb.if_(idx >= container.loadLength(), cb.goto(LendOfStream))
                 cb.goto(LproduceElementDone)
               }
 
@@ -408,7 +408,7 @@ object EmitStream {
                 val startLabel = CodeLabel()
 
                 cb.define(startLabel)
-                cb.ifx(produceElementMode, {
+                cb.if_(produceElementMode, {
                   cb.goto(elementProduceLabel)
                 })
 
@@ -435,11 +435,11 @@ object EmitStream {
                 dictState.withContainer(cb, resultKeyValue, { cb =>
                   emitVoid(seqOps, cb, container = Some(keyedContainer), env = env.bind(name, eltField))
                 })
-                cb.ifx(dictState.size >= maxSize,{
+                cb.if_(dictState.size >= maxSize,{
                   cb.assign(produceElementMode, true)
                 })
 
-                cb.ifx(produceElementMode, {
+                cb.if_(produceElementMode, {
                   cb.goto(elementProduceLabel)},
                   {
                   cb.goto(getElemLabel)
@@ -451,18 +451,18 @@ object EmitStream {
                 cb.assign(produceElementMode, true)
 
                 cb.define(elementProduceLabel)
-                cb.ifx(numElemInArray ceq 0, {
+                cb.if_(numElemInArray ceq 0, {
                   dictState.tree.foreach(cb) { (cb, elementOff) =>
                     cb += nodeArray.update(numElemInArray, elementOff)
                     cb.assign(numElemInArray, numElemInArray + 1)
                   }
                 })
 
-                cb.ifx(numElemInArray <= idx, {
+                cb.if_(numElemInArray <= idx, {
                   cb.assign(idx, 0)
                   cb.assign(numElemInArray, 0)
                   cb.assign(produceElementMode, false)
-                  cb.ifx(childStreamEnded , {
+                  cb.if_(childStreamEnded , {
                     cb.goto(LendOfStream)
                   }, {
                     cb.goto(startLabel)
@@ -563,7 +563,7 @@ object EmitStream {
           val xElt = mb.newEmitField(unifiedElementType)
 
           val region = mb.genFieldThisRef[Region]("streamif_region")
-          cb.ifx(xCond,
+          cb.if_(xCond,
             leftEC.toI(cb).consume(cb, cb.goto(Lmissing), _ => cb.goto(Lpresent)),
             rightEC.toI(cb).consume(cb, cb.goto(Lmissing), _ => cb.goto(Lpresent)))
 
@@ -573,13 +573,13 @@ object EmitStream {
               .liftedZip(rightProducer.length).map { case (computeL1, computeL2) =>
               cb: EmitCodeBuilder => {
                 val len = cb.newLocal[Int]("if_len")
-                cb.ifx(xCond, cb.assign(len, computeL1(cb)), cb.assign(len, computeL2(cb)))
+                cb.if_(xCond, cb.assign(len, computeL1(cb)), cb.assign(len, computeL2(cb)))
                 len.get
               }
             }
 
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-              cb.ifx(xCond, {
+              cb.if_(xCond, {
                 cb.assign(leftProducer.elementRegion, region)
                 leftProducer.initialize(cb, outerRegion)
               }, {
@@ -591,7 +591,7 @@ object EmitStream {
             override val elementRegion: Settable[Region] = region
             override val requiresMemoryManagementPerElement: Boolean = leftProducer.requiresMemoryManagementPerElement || rightProducer.requiresMemoryManagementPerElement
             override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              cb.ifx(xCond, cb.goto(leftProducer.LproduceElement), cb.goto(rightProducer.LproduceElement))
+              cb.if_(xCond, cb.goto(leftProducer.LproduceElement), cb.goto(rightProducer.LproduceElement))
 
               cb.define(leftProducer.LproduceElementDone)
               cb.assign(xElt, leftProducer.element.toI(cb).map(cb)(_.castTo(cb, region, xElt.st)))
@@ -611,7 +611,7 @@ object EmitStream {
             override val element: EmitCode = xElt.load
 
             override def close(cb: EmitCodeBuilder): Unit = {
-              cb.ifx(xCond, leftProducer.close(cb), rightProducer.close(cb))
+              cb.if_(xCond, leftProducer.close(cb), rightProducer.close(cb))
             }
           }
 
@@ -669,11 +669,11 @@ object EmitStream {
               override val length: Option[EmitCodeBuilder => Code[Int]] = Some({ cb =>
                 val len = cb.newLocal[Int]("streamrange_len")
                 if (step > 0)
-                  cb.ifx(startVar >= stopVar,
+                  cb.if_(startVar >= stopVar,
                     cb.assign(len, 0),
                     cb.assign(len, ((stopVar.toL - startVar.toL - 1L) / step.toLong + 1L).toI))
                 else
-                  cb.ifx(startVar <= stopVar,
+                  cb.if_(startVar <= stopVar,
                     cb.assign(len, 0),
                     cb.assign(len, ((startVar.toL - stopVar.toL - 1L) / (-step.toLong) + 1L).toI))
                 len
@@ -684,7 +684,7 @@ object EmitStream {
                   case I32(x) if step < 0 && ((x.toLong - Int.MinValue.toLong) / step.toLong + 1) < Int.MaxValue =>
                   case I32(x) if step > 0 && ((Int.MaxValue.toLong - x.toLong) / step.toLong + 1) < Int.MaxValue =>
                   case _ =>
-                    cb.ifx((stopVar.toL - startVar.toL) / step.toLong > const(Int.MaxValue.toLong),
+                    cb.if_((stopVar.toL - startVar.toL) / step.toLong > const(Int.MaxValue.toLong),
                       cb._fatalWithError(errorID, "Array range cannot have more than MAXINT elements."))
                 }
                 cb.assign(curr, startVar - step)
@@ -697,9 +697,9 @@ object EmitStream {
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
                 cb.assign(curr, curr + step)
                 if (step > 0)
-                  cb.ifx(curr >= stopVar, cb.goto(LendOfStream))
+                  cb.if_(curr >= stopVar, cb.goto(LendOfStream))
                 else
-                  cb.ifx(curr <= stopVar, cb.goto(LendOfStream))
+                  cb.if_(curr <= stopVar, cb.goto(LendOfStream))
                 cb.goto(LproduceElementDone)
               }
 
@@ -738,21 +738,21 @@ object EmitStream {
                 override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
                   val llen = cb.newLocal[Long]("streamrange_llen")
 
-                  cb.ifx(step ceq const(0), cb._fatalWithError(errorID, "Array range cannot have step size 0."))
-                  cb.ifx(step < const(0), {
-                    cb.ifx(start.toL <= stop.toL, {
+                  cb.if_(step ceq const(0), cb._fatalWithError(errorID, "Array range cannot have step size 0."))
+                  cb.if_(step < const(0), {
+                    cb.if_(start.toL <= stop.toL, {
                       cb.assign(llen, 0L)
                     }, {
                       cb.assign(llen, (start.toL - stop.toL - 1L) / (-step.toL) + 1L)
                     })
                   }, {
-                    cb.ifx(start.toL >= stop.toL, {
+                    cb.if_(start.toL >= stop.toL, {
                       cb.assign(llen, 0L)
                     }, {
                       cb.assign(llen, (stop.toL - start.toL - 1L) / step.toL + 1L)
                     })
                   })
-                  cb.ifx(llen > const(Int.MaxValue.toLong), {
+                  cb.if_(llen > const(Int.MaxValue.toLong), {
                     cb._fatalWithError(errorID, "Array range cannot have more than MAXINT elements.")
                   })
                   cb.assign(len, llen.toI)
@@ -766,7 +766,7 @@ object EmitStream {
                 override val requiresMemoryManagementPerElement: Boolean = _requiresMemoryManagementPerElement
 
                 override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                  cb.ifx(idx >= len, cb.goto(LendOfStream))
+                  cb.if_(idx >= len, cb.goto(LendOfStream))
                   cb.assign(curr, curr + step)
                   cb.assign(idx, idx + 1)
                   cb.goto(LproduceElementDone)
@@ -810,7 +810,7 @@ object EmitStream {
               override val requiresMemoryManagementPerElement: Boolean = _requiresMemoryManagementPerElement
 
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.ifx(nRemaining <= 0, cb.goto(LendOfStream))
+                cb.if_(nRemaining <= 0, cb.goto(LendOfStream))
 
                 val u = cb.newLocal[Double]("seq_sample_rand_unif", Code.invokeStatic0[Math, Double]("random"))
                 val fC = cb.newLocal[Double]("seq_sample_Fc", (totalSizeVal.value - candidate - nRemaining).toD / (totalSizeVal.value - candidate).toD)
@@ -870,7 +870,7 @@ object EmitStream {
                   .consume(cb,
                     cb.goto(Lfiltered),
                     { sc =>
-                      cb.ifx(!sc.asBoolean.value, cb.goto(Lfiltered))
+                      cb.if_(!sc.asBoolean.value, cb.goto(Lfiltered))
                     })
 
                 if (requiresMemoryManagementPerElement)
@@ -913,7 +913,7 @@ object EmitStream {
 
                 override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
                   cb.assign(n, num.value)
-                  cb.ifx(n < 0, cb._fatal(s"stream take: negative number of elements to take: ", n.toS))
+                  cb.if_(n < 0, cb._fatal(s"stream take: negative number of elements to take: ", n.toS))
                   cb.assign(idx, 0)
                   childProducer.initialize(cb, outerRegion)
                 }
@@ -921,7 +921,7 @@ object EmitStream {
                 override val elementRegion: Settable[Region] = childProducer.elementRegion
                 override val requiresMemoryManagementPerElement: Boolean = childProducer.requiresMemoryManagementPerElement
                 override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                  cb.ifx(idx >= n, cb.goto(LendOfStream))
+                  cb.if_(idx >= n, cb.goto(LendOfStream))
                   cb.assign(idx, idx + 1)
                   cb.goto(childProducer.LproduceElement)
 
@@ -958,7 +958,7 @@ object EmitStream {
 
                 override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
                   cb.assign(n, num.value)
-                  cb.ifx(n < 0, cb._fatal(s"stream drop: negative number of elements to drop: ", n.toS))
+                  cb.if_(n < 0, cb._fatal(s"stream drop: negative number of elements to drop: ", n.toS))
                   cb.assign(idx, 0)
                   childProducer.initialize(cb, outerRegion)
                 }
@@ -969,7 +969,7 @@ object EmitStream {
                   cb.goto(childProducer.LproduceElement)
                   cb.define(childProducer.LproduceElementDone)
                   cb.assign(idx, idx + 1)
-                  cb.ifx(idx <= n, {
+                  cb.if_(idx <= n, {
                     if (childProducer.requiresMemoryManagementPerElement)
                       cb += childProducer.elementRegion.clearRegion()
                     cb.goto(childProducer.LproduceElement)
@@ -1015,7 +1015,7 @@ object EmitStream {
                 emit(condIR, cb, region = childProducer.elementRegion, env = env.bind(elt, eltSettable))
                   .consume(cb,
                     cb.goto(LendOfStream),
-                    code => cb.ifx(code.asBoolean.value,
+                    code => cb.if_(code.asBoolean.value,
                       cb.goto(LproduceElementDone),
                       cb.goto(LendOfStream)))
 
@@ -1057,14 +1057,14 @@ object EmitStream {
                 cb.define(childProducer.LproduceElementDone)
                 cb.assign(eltSettable, childProducer.element)
 
-                cb.ifx(doneComparisons, cb.goto(LproduceElementDone))
+                cb.if_(doneComparisons, cb.goto(LproduceElementDone))
 
                 val LdropThis = CodeLabel()
                 val LdoneDropping = CodeLabel()
                 emit(condIR, cb, region = childProducer.elementRegion, env = env.bind(elt, eltSettable))
                   .consume(cb,
                     cb.goto(LdoneDropping),
-                    code => cb.ifx(code.asBoolean.value,
+                    code => cb.if_(code.asBoolean.value,
                       cb.goto(LdropThis),
                       cb.goto(LdoneDropping)))
 
@@ -1169,7 +1169,7 @@ object EmitStream {
 
               val LcopyAndReturn = CodeLabel()
 
-              cb.ifx(first, {
+              cb.if_(first, {
 
                 cb.assign(first, false)
                 cb.assign(accValueEltRegion, emit(zeroIR, cb, region = elementRegion).map(cb)(sc => sc.castTo(cb, elementRegion, accValueAccRegion.st)))
@@ -1366,7 +1366,7 @@ object EmitStream {
             override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
               val LnextOuter = CodeLabel()
               val LnextInner = CodeLabel()
-              cb.ifx(first, {
+              cb.if_(first, {
                 cb.assign(first, false)
 
                 cb.define(LnextOuter)
@@ -1376,7 +1376,7 @@ object EmitStream {
                   cb += outerProducer.elementRegion.clearRegion()
 
 
-                cb.ifx(innerUnclosed, {
+                cb.if_(innerUnclosed, {
                   cb.assign(innerUnclosed, false)
                   innerProducer.close(cb)
                   if (innerProducer.requiresMemoryManagementPerElement) {
@@ -1425,7 +1425,7 @@ object EmitStream {
             val element: EmitCode = innerProducer.element
 
             def close(cb: EmitCodeBuilder): Unit = {
-              cb.ifx(innerUnclosed, {
+              cb.if_(innerUnclosed, {
                 cb.assign(innerUnclosed, false)
                 if (innerProducer.requiresMemoryManagementPerElement) {
                   cb += innerProducer.elementRegion.invalidate()
@@ -1561,12 +1561,12 @@ object EmitStream {
                     cb.assign(lx, leftProducer.element)
 
                     // if right stream is exhausted, return immediately
-                    cb.ifx(rightEOS, cb.goto(LproduceElementDone))
+                    cb.if_(rightEOS, cb.goto(LproduceElementDone))
 
                     val Lpush = CodeLabel()
 
                     val LpullRight = CodeLabel()
-                    cb.ifx(!pulledRight, {
+                    cb.if_(!pulledRight, {
                       cb.assign(pulledRight, true)
                       cb.goto(LpullRight)
                     })
@@ -1574,9 +1574,9 @@ object EmitStream {
                     val Lcompare = CodeLabel()
                     cb.define(Lcompare)
                     val c = cb.newLocal[Int]("left_join_right_distinct_c", compare(cb, lx, rx))
-                    cb.ifx(c > 0, cb.goto(LpullRight))
+                    cb.if_(c > 0, cb.goto(LpullRight))
 
-                    cb.ifx(c < 0, {
+                    cb.if_(c < 0, {
                       cb.assign(rxOut, EmitCode.missing(mb, rxOut.st))
                     }, {
                       // c == 0
@@ -1650,21 +1650,21 @@ object EmitStream {
                     val Lcompare = CodeLabel()
                     val LmaybePullRight = CodeLabel()
 
-                    cb.ifx(leftEOS, cb.goto(Lcompare))
-                    cb.ifx(c <= 0, cb.goto(LpullLeft), cb.goto(LpullRight))
+                    cb.if_(leftEOS, cb.goto(Lcompare))
+                    cb.if_(c <= 0, cb.goto(LpullLeft), cb.goto(LpullRight))
 
                     cb.define(Lcompare)
-                    cb.ifx(leftEOS, {
-                      cb.ifx(pushedRight,
+                    cb.if_(leftEOS, {
+                      cb.if_(pushedRight,
                         cb.goto(LpullRight),
                         cb.goto(Lpush))
                     })
                     cb.assign(c, compare(cb, lx, rx))
 
-                    cb.ifx(c < 0, cb.goto(LpullLeft))
+                    cb.if_(c < 0, cb.goto(LpullLeft))
 
-                    cb.ifx(c > 0, {
-                      cb.ifx(pushedRight, cb.goto(LpullRight))
+                    cb.if_(c > 0, {
+                      cb.if_(pushedRight, cb.goto(LpullRight))
                       cb.assign(lxOut, EmitCode.missing(mb, lxOut.st))
                     }, {
                       // c == 0
@@ -1676,7 +1676,7 @@ object EmitStream {
                     cb.goto(Lpush)
 
                     mb.implementLabel(LmaybePullRight) { cb =>
-                      cb.ifx(!pulledRight, {
+                      cb.if_(!pulledRight, {
                         cb.assign(pulledRight, true)
                         cb.goto(LpullRight)
                       },
@@ -1752,7 +1752,7 @@ object EmitStream {
                     cb.assign(lx, leftProducer.element)
 
                     val LpullRight = CodeLabel()
-                    cb.ifx(!pulledRight, {
+                    cb.if_(!pulledRight, {
                       cb.assign(pulledRight, true)
                       cb.goto(LpullRight)
                     })
@@ -1760,9 +1760,9 @@ object EmitStream {
                     val Lcompare = CodeLabel()
                     cb.define(Lcompare)
                     val c = cb.newLocal[Int]("left_join_right_distinct_c", compare(cb, lx, rx))
-                    cb.ifx(c > 0, cb.goto(LpullRight))
+                    cb.if_(c > 0, cb.goto(LpullRight))
 
-                    cb.ifx(c < 0, {
+                    cb.if_(c < 0, {
                       if (leftProducer.requiresMemoryManagementPerElement)
                         cb += leftProducer.elementRegion.clearRegion()
                       cb.goto(leftProducer.LproduceElement)
@@ -1824,11 +1824,11 @@ object EmitStream {
                     val LpullLeft = CodeLabel()
                     val Lpush = CodeLabel()
 
-                    cb.ifx(leftEOS,
+                    cb.if_(leftEOS,
                       cb.goto(LpullRight),
-                      cb.ifx(rightEOS,
+                      cb.if_(rightEOS,
                         cb.goto(LpullLeft),
-                        cb.ifx(c <= 0,
+                        cb.if_(c <= 0,
                           cb.goto(LpullLeft),
                           cb.goto(LpullRight))))
 
@@ -1848,9 +1848,9 @@ object EmitStream {
                       cb.assign(c, compare(cb, lx, rx))
                       cb.assign(lOutMissing, false)
                       cb.assign(rOutMissing, false)
-                      cb.ifx(c > 0,
+                      cb.if_(c > 0,
                         {
-                          cb.ifx(pulledRight && !pushedRight, {
+                          cb.if_(pulledRight && !pushedRight, {
                             cb.assign(lOutMissing, true)
                             if (rightProducer.requiresMemoryManagementPerElement) {
                               cb += elementRegion.trackAndIncrementReferenceCountOf(rightProducer.elementRegion)
@@ -1861,7 +1861,7 @@ object EmitStream {
                           )
                         },
                         {
-                          cb.ifx(c < 0,
+                          cb.if_(c < 0,
                             {
                               cb.assign(rOutMissing, true)
                               if (leftProducer.requiresMemoryManagementPerElement) {
@@ -1883,11 +1883,11 @@ object EmitStream {
                     }
 
                     mb.implementLabel(Lpush) { cb =>
-                      cb.ifx(lOutMissing,
+                      cb.if_(lOutMissing,
                         cb.assign(lxOut, EmitCode.missing(mb, lxOut.st)),
                         cb.assign(lxOut, lx)
                       )
-                      cb.ifx(rOutMissing,
+                      cb.if_(rOutMissing,
                         cb.assign(rxOut, EmitCode.missing(mb, rxOut.st)),
                         {
                           cb.assign(rxOut, rx)
@@ -1900,13 +1900,13 @@ object EmitStream {
                     mb.implementLabel(rightProducer.LproduceElementDone) { cb =>
                       cb.assign(rx, rightProducer.element)
                       cb.assign(pushedRight, false)
-                      cb.ifx(leftEOS, cb.goto(Lpush), cb.goto(Lcompare))
+                      cb.if_(leftEOS, cb.goto(Lpush), cb.goto(Lcompare))
                     }
 
                     mb.implementLabel(leftProducer.LproduceElementDone) { cb =>
                       cb.assign(lx, leftProducer.element)
-                      cb.ifx(pulledRight,
-                        cb.ifx(rightEOS,
+                      cb.if_(pulledRight,
+                        cb.if_(rightEOS,
                           {
                             if (leftProducer.requiresMemoryManagementPerElement) {
                               cb += elementRegion.trackAndIncrementReferenceCountOf(leftProducer.elementRegion)
@@ -1922,13 +1922,13 @@ object EmitStream {
                     }
 
                     mb.implementLabel(leftProducer.LendOfStream) { cb =>
-                      cb.ifx(rightEOS,
+                      cb.if_(rightEOS,
                         cb.goto(LendOfStream),
                         {
                           cb.assign(leftEOS, true)
                           cb.assign(lOutMissing, true)
                           cb.assign(rOutMissing, false)
-                          cb.ifx(pulledRight && !pushedRight,
+                          cb.if_(pulledRight && !pushedRight,
                             {
                               if (rightProducer.requiresMemoryManagementPerElement) {
                                 cb += elementRegion.trackAndIncrementReferenceCountOf(rightProducer.elementRegion)
@@ -1945,7 +1945,7 @@ object EmitStream {
                     }
 
                     mb.implementLabel(rightProducer.LendOfStream) { cb =>
-                      cb.ifx(leftEOS, cb.goto(LendOfStream))
+                      cb.if_(leftEOS, cb.goto(LendOfStream))
                       cb.assign(rightEOS, true)
                       cb.assign(lOutMissing, false)
                       cb.assign(rOutMissing, true)
@@ -2014,7 +2014,7 @@ object EmitStream {
               val LelementReady = CodeLabel()
 
               // the first pull from the inner stream has the next record ready to go from the outer stream
-              cb.ifx(inOuter, {
+              cb.if_(inOuter, {
                 cb.assign(inOuter, false)
                 cb.goto(LelementReady)
               })
@@ -2026,7 +2026,7 @@ object EmitStream {
               cb.define(LchildProduceDoneInner)
 
               // if not equivalent, end inner stream and prepare for next outer iteration
-              cb.ifx(!equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
+              cb.if_(!equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
                 if (requiresMemoryManagementPerElement)
                   cb += keyRegion.clearRegion()
 
@@ -2073,13 +2073,13 @@ object EmitStream {
             override val elementRegion: Settable[Region] = outerElementRegion
             override val requiresMemoryManagementPerElement: Boolean = childProducer.requiresMemoryManagementPerElement
             override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              cb.ifx(eos, {
+              cb.if_(eos, {
                 cb.goto(LendOfStream)
               })
 
               val LinnerStreamReady = CodeLabel()
 
-              cb.ifx(nextGroupReady, cb.goto(LinnerStreamReady))
+              cb.if_(nextGroupReady, cb.goto(LinnerStreamReady))
 
               cb.assign(inOuter, true)
 
@@ -2091,13 +2091,13 @@ object EmitStream {
 
               val LdifferentKey = CodeLabel()
 
-              cb.ifx(first, {
+              cb.if_(first, {
                 cb.assign(first, false)
                 cb.goto(LdifferentKey)
               })
 
               // if equiv, go to next element. Otherwise, fall through to next group
-              cb.ifx(equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
+              cb.if_(equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
                 if (childProducer.requiresMemoryManagementPerElement)
                   cb += childProducer.elementRegion.clearRegion()
                 cb.goto(childProducer.LproduceElement)
@@ -2127,7 +2127,7 @@ object EmitStream {
 
           mb.implementLabel(childProducer.LendOfStream) { cb =>
             cb.assign(eos, true)
-            cb.ifx(inOuter,
+            cb.if_(inOuter,
               cb.goto(outerProducer.LendOfStream),
               cb.goto(innerProducer.LendOfStream)
             )
@@ -2136,7 +2136,7 @@ object EmitStream {
           mb.implementLabel(childProducer.LproduceElementDone) { cb =>
             cb.assign(xCurElt, childProducer.element.toI(cb).get(cb))
             cb.assign(curKey, subsetCode)
-            cb.ifx(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
+            cb.if_(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
           }
 
           SStreamValue(outerProducer)
@@ -2174,12 +2174,12 @@ object EmitStream {
               override val elementRegion: Settable[Region] = innerResultRegion
               override val requiresMemoryManagementPerElement: Boolean = childProducer.requiresMemoryManagementPerElement
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.ifx(inOuter, {
+                cb.if_(inOuter, {
                   cb.assign(inOuter, false)
-                  cb.ifx(xCounter.cne(1), cb._fatal(s"streamgrouped inner producer error, xCounter=", xCounter.toS))
+                  cb.if_(xCounter.cne(1), cb._fatal(s"streamgrouped inner producer error, xCounter=", xCounter.toS))
                   cb.goto(LchildProduceDoneInner)
                 })
-                cb.ifx(xCounter >= n, {
+                cb.if_(xCounter >= n, {
                   cb.assign(inOuter, true)
                   cb.goto(LendOfStream)
                 })
@@ -2207,7 +2207,7 @@ object EmitStream {
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
                 cb.assign(n, groupSize.value)
-                cb.ifx(n <= 0, cb._fatal(s"stream grouped: non-positive size: ", n.toS))
+                cb.if_(n <= 0, cb._fatal(s"stream grouped: non-positive size: ", n.toS))
                 cb.assign(eos, false)
                 cb.assign(xCounter, n)
 
@@ -2223,7 +2223,7 @@ object EmitStream {
               override val elementRegion: Settable[Region] = outerElementRegion
               override val requiresMemoryManagementPerElement: Boolean = childProducer.requiresMemoryManagementPerElement
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.ifx(eos, {
+                cb.if_(eos, {
                   cb.goto(LendOfStream)
                 })
 
@@ -2231,7 +2231,7 @@ object EmitStream {
                 cb.define(LchildProduceDoneOuter)
 
 
-                cb.ifx(xCounter <= n,
+                cb.if_(xCounter <= n,
                   {
                     if (childProducer.requiresMemoryManagementPerElement)
                       cb += childProducer.elementRegion.clearRegion()
@@ -2251,7 +2251,7 @@ object EmitStream {
 
             mb.implementLabel(childProducer.LendOfStream) { cb =>
               cb.assign(eos, true)
-              cb.ifx(inOuter,
+              cb.if_(inOuter,
                 cb.goto(outerProducer.LendOfStream),
                 cb.goto(innerProducer.LendOfStream)
               )
@@ -2259,7 +2259,7 @@ object EmitStream {
 
             mb.implementLabel(childProducer.LproduceElementDone) { cb =>
               cb.assign(xCounter, xCounter + 1)
-              cb.ifx(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
+              cb.if_(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
             }
 
             SStreamValue(outerProducer)
@@ -2360,7 +2360,7 @@ object EmitStream {
                       val len = cb.newLocal[Int]("zip_len", ls.head(cb))
                         ls.tail.foreach { compL =>
                           val lenTemp = cb.newLocal[Int]("lenTemp", compL(cb))
-                          cb.ifx(len.cne(lenTemp), cb._fatalWithError(errorID, "zip: length mismatch: ", len.toS, ", ", lenTemp.toS))
+                          cb.if_(len.cne(lenTemp), cb._fatalWithError(errorID, "zip: length mismatch: ", len.toS, ", ", lenTemp.toS))
                         }
                       len
                     })
@@ -2402,8 +2402,8 @@ object EmitStream {
                     cb.define(fallThrough)
                   }
 
-                  cb.ifx(anyEOS,
-                    cb.ifx(allEOS,
+                  cb.if_(anyEOS,
+                    cb.if_(allEOS,
                       cb.goto(LendOfStream),
                       cb._fatalWithError(errorID, "zip: length mismatch"))
                   )
@@ -2464,7 +2464,7 @@ object EmitStream {
                     // label at the end of processing this element
                     val endProduce = CodeLabel()
 
-                    cb.ifx(eosPerStream(i), cb.goto(endProduce))
+                    cb.if_(eosPerStream(i), cb.goto(endProduce))
 
                     cb.goto(p.LproduceElement)
 
@@ -2472,7 +2472,7 @@ object EmitStream {
                     cb.define(p.LendOfStream)
                     cb.assign(nEOS, nEOS + 1)
 
-                    cb.ifx(nEOS.ceq(const(producers.length)), cb.goto(LendOfStream))
+                    cb.if_(nEOS.ceq(const(producers.length)), cb.goto(LendOfStream))
 
                     // this stream has ended before each other, so we set the eos flag and the element EmitSettable
                     cb.assign(eosPerStream(i), true)
@@ -2610,11 +2610,11 @@ object EmitStream {
 
               def inSetup: Code[Boolean] = result.isNull
 
-              cb.ifx(inSetup, {
+              cb.if_(inSetup, {
                 cb.assign(i, 0)
                 cb.goto(LpullChild)
               }, {
-                cb.ifx(winner.ceq(k), cb.goto(LendOfStream), cb.goto(LstartNewKey))
+                cb.if_(winner.ceq(k), cb.goto(LendOfStream), cb.goto(LstartNewKey))
               })
 
               cb.define(Lpush)
@@ -2634,7 +2634,7 @@ object EmitStream {
 
               cb.define(LaddToResult)
               cb += (result(winner) = heads(winner))
-              cb.ifx(lookupMemoryManagementByIndex(cb, winner), {
+              cb.if_(lookupMemoryManagementByIndex(cb, winner), {
                 val r = cb.newLocal[Region]("tzj_winner_region", regionArray(winner))
                 cb += elementRegion.trackAndIncrementReferenceCountOf(r)
                 cb += r.clearRegion()
@@ -2650,19 +2650,19 @@ object EmitStream {
 
               cb.define(LrunMatch)
               cb.assign(challenger, bracket(matchIdx))
-              cb.ifx(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
+              cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
 
               val LafterChallenge = CodeLabel()
 
-              cb.ifx(challenger.cne(k), {
+              cb.if_(challenger.cne(k), {
                 val LchallengerWins = CodeLabel()
 
-                cb.ifx(winner.ceq(k), cb.goto(LchallengerWins))
+                cb.if_(winner.ceq(k), cb.goto(LchallengerWins))
 
                 val left = eltType.loadCheapSCode(cb, heads(challenger)).subset(key: _*)
                 val right = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
                 val ord = StructOrdering.make(left.st, right.st, cb.emb.ecb, missingFieldsEqual = false)
-                cb.ifx(ord.lteqNonnull(cb, left, right),
+                cb.if_(ord.lteqNonnull(cb, left, right),
                   cb.goto(LchallengerWins),
                   cb.goto(LafterChallenge))
 
@@ -2675,24 +2675,24 @@ object EmitStream {
               cb.goto(LrunMatch)
 
               cb.define(LloopEnd)
-              cb.ifx(matchIdx.ceq(0), {
+              cb.if_(matchIdx.ceq(0), {
                 // 'winner' is smallest of all k heads. If 'winner' = k, all heads
                 // must be k, and all streams are exhausted.
 
-                cb.ifx(inSetup, {
-                  cb.ifx(winner.ceq(k),
+                cb.if_(inSetup, {
+                  cb.if_(winner.ceq(k),
                     cb.goto(LendOfStream),
                     {
                       cb.assign(result, Code.newArray[Long](k))
                       cb.goto(LstartNewKey)
                     })
                 }, {
-                  cb.ifx(!winner.cne(k), cb.goto(Lpush))
+                  cb.if_(!winner.cne(k), cb.goto(Lpush))
                   val left = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
                   val right = curKey
                   val ord = StructOrdering.make(left.st, right.st.asInstanceOf[SBaseStruct],
                     cb.emb.ecb, missingFieldsEqual = false)
-                  cb.ifx(ord.equivNonnull(cb, left, right), cb.goto(LaddToResult), cb.goto(Lpush))
+                  cb.if_(ord.equivNonnull(cb, left, right), cb.goto(LaddToResult), cb.goto(Lpush))
                 })
               }, {
                 // We're still in the setup phase
@@ -2849,11 +2849,11 @@ object EmitStream {
 
               def inSetup: Code[Boolean] = result.isNull
 
-              cb.ifx(inSetup, {
+              cb.if_(inSetup, {
                 cb.assign(i, 0)
                 cb.goto(LpullChild)
               }, {
-                cb.ifx(winner.ceq(k), cb.goto(LendOfStream), cb.goto(LstartNewKey))
+                cb.if_(winner.ceq(k), cb.goto(LendOfStream), cb.goto(LstartNewKey))
               })
 
               cb.define(Lpush)
@@ -2889,19 +2889,19 @@ object EmitStream {
 
               cb.define(LrunMatch)
               cb.assign(challenger, bracket(matchIdx))
-              cb.ifx(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
+              cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
 
               val LafterChallenge = CodeLabel()
 
-              cb.ifx(challenger.cne(k), {
+              cb.if_(challenger.cne(k), {
                 val LchallengerWins = CodeLabel()
 
-                cb.ifx(winner.ceq(k), cb.goto(LchallengerWins))
+                cb.if_(winner.ceq(k), cb.goto(LchallengerWins))
 
                 val left = eltType.loadCheapSCode(cb, heads(challenger)).subset(key: _*)
                 val right = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
                 val ord = StructOrdering.make(left.st, right.st, cb.emb.ecb, missingFieldsEqual = false)
-                cb.ifx(ord.lteqNonnull(cb, left, right),
+                cb.if_(ord.lteqNonnull(cb, left, right),
                   cb.goto(LchallengerWins),
                   cb.goto(LafterChallenge))
 
@@ -2914,24 +2914,24 @@ object EmitStream {
               cb.goto(LrunMatch)
 
               cb.define(LloopEnd)
-              cb.ifx(matchIdx.ceq(0), {
+              cb.if_(matchIdx.ceq(0), {
                 // 'winner' is smallest of all k heads. If 'winner' = k, all heads
                 // must be k, and all streams are exhausted.
 
-                cb.ifx(inSetup, {
-                  cb.ifx(winner.ceq(k),
+                cb.if_(inSetup, {
+                  cb.if_(winner.ceq(k),
                     cb.goto(LendOfStream),
                     {
                       cb.assign(result, Code.newArray[Long](k))
                       cb.goto(LstartNewKey)
                     })
                 }, {
-                  cb.ifx(!winner.cne(k), cb.goto(Lpush))
+                  cb.if_(!winner.cne(k), cb.goto(Lpush))
                   val left = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
                   val right = curKey
                   val ord = StructOrdering.make(left.st, right.st.asInstanceOf[SBaseStruct],
                     cb.emb.ecb, missingFieldsEqual = false)
-                  cb.ifx(ord.equivNonnull(cb, left, right), cb.goto(LaddToResult), cb.goto(Lpush))
+                  cb.if_(ord.equivNonnull(cb, left, right), cb.goto(LaddToResult), cb.goto(Lpush))
                 })
               }, {
                 // We're still in the setup phase
@@ -2942,10 +2942,10 @@ object EmitStream {
               })
 
               cb.define(LpullChild)
-              cb.ifx(winner >= nStreams, cb.goto(LendOfStream)) // can only happen if k=0
+              cb.if_(winner >= nStreams, cb.goto(LendOfStream)) // can only happen if k=0
               val winnerIter = cb.memoize(iterArray(winner))
               val winnerNextElt = cb.memoize(winnerIter.invoke[Long]("next"))
-              cb.ifx(winnerIter.invoke[Boolean]("eos"), {
+              cb.if_(winnerIter.invoke[Boolean]("eos"), {
                 cb.assign(matchIdx, (winner + k) >>> 1)
                 cb.assign(winner, k)
               }, {
@@ -3048,13 +3048,13 @@ object EmitStream {
 
               cb.define(LrunMatch)
               cb.assign(challenger, bracket(matchIdx))
-              cb.ifx(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
+              cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
 
               val LafterChallenge = CodeLabel()
-              cb.ifx(challenger.cne(k), {
+              cb.if_(challenger.cne(k), {
                 val Lwon = CodeLabel()
-                cb.ifx(winner.ceq(k), cb.goto(Lwon))
-                cb.ifx(comp(cb, challenger, heads(challenger), winner, heads(winner)), cb.goto(Lwon), cb.goto(LafterChallenge))
+                cb.if_(winner.ceq(k), cb.goto(Lwon))
+                cb.if_(comp(cb, challenger, heads(challenger), winner, heads(winner)), cb.goto(Lwon), cb.goto(LafterChallenge))
 
                 cb.define(Lwon)
                 cb += (bracket(matchIdx) = winner)
@@ -3067,14 +3067,14 @@ object EmitStream {
 
               cb.define(LloopEnd)
 
-              cb.ifx(matchIdx.ceq(0), {
+              cb.if_(matchIdx.ceq(0), {
                 // 'winner' is smallest of all k heads. If 'winner' = k, all heads
                 // must be k, and all streams are exhausted.
-                cb.ifx(winner.ceq(k),
+                cb.if_(winner.ceq(k),
                   cb.goto(LendOfStream),
                   {
                     // we have a winner
-                    cb.ifx(lookupMemoryManagementByIndex(cb, winner), {
+                    cb.if_(lookupMemoryManagementByIndex(cb, winner), {
                       val winnerRegion = cb.newLocal[Region]("smm_winner_region", regionArray(winner))
                       cb += elementRegion.trackAndIncrementReferenceCountOf(winnerRegion)
                       cb += winnerRegion.clearRegion()
@@ -3164,10 +3164,10 @@ object EmitStream {
                       cb += builder.invoke[Int, Unit]("addGT", gt.asCall.canonicalCall(cb))
                     })
                     val bpv = cb.memoize(builder.invoke[Locus, Array[String], BitPackedVector]("finish", locusObj, Code._null[Array[String]]))
-                    cb.ifx(bpv.isNull, cb.goto(Lpruned))
+                    cb.if_(bpv.isNull, cb.goto(Lpruned))
                     val keepVariant = Code.invokeScalaObject5[util.ArrayDeque[BitPackedVector], BitPackedVector, Double, Int, Int, Boolean](LocalLDPrune.getClass, "pruneLocal",
                       queue, bpv, threshold, windowSize, queueSize)
-                    cb.ifx(!keepVariant, cb.goto(Lpruned))
+                    cb.if_(!keepVariant, cb.goto(Lpruned))
 
                     val mean = SFloat64Value(cb.memoize(bpv.invoke[Double]("mean")))
                     val centeredLengthRec = SFloat64Value(cb.memoize(bpv.invoke[Double]("centeredLengthRec")))

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -210,7 +210,7 @@ object StreamUtils {
       implInit(cb, outerRegion)
       cb.assign(bracket, Code.newArray[Int](k))
       cb.assign(heads, Code.newArray[Long](k))
-      cb.forLoop(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
+      cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
         cb += (bracket(i) = -1)
       })
       cb.assign(i, 0)
@@ -259,7 +259,7 @@ object StreamUtils {
 
       def forEachIterator(cb: EmitCodeBuilder)(f: (EmitCodeBuilder, Value[Int], Value[NoBoxLongIterator]) => Unit) = {
         val idx = cb.newLocal[Int]("idx", 0)
-        cb.whileLoop(idx < k, {
+        cb.while_(idx < k, {
           val iter = cb.memoize(iterators(idx))
           f(cb, idx, iter)
           cb.assign(idx, idx + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -199,7 +199,7 @@ object StreamUtils {
       val ord1 = StructOrdering.make(l.asBaseStruct.st, r.asBaseStruct.st, cb.emb.ecb, missingFieldsEqual = false)
       val ord2 = StructOrdering.make(r.asBaseStruct.st, l.asBaseStruct.st, cb.emb.ecb, missingFieldsEqual = false)
       val b = cb.newLocal[Boolean]("stream_merge_comp_result")
-      cb.ifx(li < ri,
+      cb.if_(li < ri,
         cb.assign(b, ord1.compareNonnull(cb, l, r) <= 0),
         cb.assign(b, ord2.compareNonnull(cb, r, l) > 0))
       b
@@ -275,7 +275,7 @@ object StreamUtils {
         forEachIterator(cb) { case (cb, idx, iter) =>
           val reqMM = lookupMemoryManagementByIndex(cb, idx)
           val eltRegion = cb.newLocal[Region]("eltRegion")
-          cb.ifx(reqMM,
+          cb.if_(reqMM,
             cb.assign(eltRegion, Region.stagedCreate(Region.REGULAR, outerRegion.getPool())),
             cb.assign(eltRegion, outerRegion))
           cb += iter.invoke[Region, Region, Unit]("init", outerRegion, eltRegion)
@@ -296,29 +296,29 @@ object StreamUtils {
 
         cb.define(LpullChild)
 
-        cb.ifx(winner >= k, cb.goto(LendOfStream))
+        cb.if_(winner >= k, cb.goto(LendOfStream))
         val winnerIter = cb.memoize(iterators(winner))
         val next = cb.memoize(winnerIter.invoke[Long]("next"))
-        cb.ifx(winnerIter.invoke[Boolean]("eos"), {
+        cb.if_(winnerIter.invoke[Boolean]("eos"), {
           cb.assign(matchIdx, (winner + k) >>> 1)
           cb.assign(winner, k)
           cb.goto(LrunMatch)
         })
 
-        cb.ifx(next ceq 0L, cb._fatal("stream multi merge: elements cannot be missing"))
+        cb.if_(next ceq 0L, cb._fatal("stream multi merge: elements cannot be missing"))
         cb += heads.update(winner, next)
         cb.assign(matchIdx, (winner + k) >>> 1)
         cb.goto(LrunMatch)
 
         cb.define(LrunMatch)
         cb.assign(challenger, bracket(matchIdx))
-        cb.ifx(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
+        cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
 
         val LafterChallenge = CodeLabel()
-        cb.ifx(challenger.cne(k), {
+        cb.if_(challenger.cne(k), {
           val Lwon = CodeLabel()
-          cb.ifx(winner.ceq(k), cb.goto(Lwon))
-          cb.ifx(comp(cb, challenger, heads(challenger), winner, heads(winner)), cb.goto(Lwon), cb.goto(LafterChallenge))
+          cb.if_(winner.ceq(k), cb.goto(Lwon))
+          cb.if_(comp(cb, challenger, heads(challenger), winner, heads(winner)), cb.goto(Lwon), cb.goto(LafterChallenge))
 
           cb.define(Lwon)
           cb += (bracket(matchIdx) = winner)
@@ -331,14 +331,14 @@ object StreamUtils {
 
         cb.define(LloopEnd)
 
-        cb.ifx(matchIdx.ceq(0), {
+        cb.if_(matchIdx.ceq(0), {
           // 'winner' is smallest of all k heads. If 'winner' = k, all heads
           // must be k, and all streams are exhausted.
-          cb.ifx(winner.ceq(k),
+          cb.if_(winner.ceq(k),
             cb.goto(LendOfStream),
             {
               // we have a winner
-              cb.ifx(lookupMemoryManagementByIndex(cb, winner), {
+              cb.if_(lookupMemoryManagementByIndex(cb, winner), {
                 val winnerRegion = cb.newLocal[Region]("smm_winner_region", regionArray(winner))
                 cb += elementRegion.trackAndIncrementReferenceCountOf(winnerRegion)
                 cb += winnerRegion.clearRegion()
@@ -355,7 +355,7 @@ object StreamUtils {
 
       override def implClose(cb: EmitCodeBuilder): Unit = {
         forEachIterator(cb) { case (cb, idx, iter) =>
-          cb.ifx(lookupMemoryManagementByIndex(cb, idx), cb += regionArray(idx).invalidate())
+          cb.if_(lookupMemoryManagementByIndex(cb, idx), cb += regionArray(idx).invalidate())
           cb += iter.invoke[Unit]("close")
         }
       }

--- a/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
@@ -88,7 +88,7 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
         val elementRegion: Settable[Region] = region
         val requiresMemoryManagementPerElement: Boolean = true
         val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-          cb.ifx(!it.invoke[Boolean]("hasNext"), cb.goto(LendOfStream))
+          cb.if_(!it.invoke[Boolean]("hasNext"), cb.goto(LendOfStream))
           cb.assign(record, it.invoke[AnyRef, GenericRecord]("next", record))
           cb.assign(rowIdx, rowIdx + 1L)
           cb.goto(LproduceElementDone)

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -646,7 +646,7 @@ case class BgenPartitionReaderWithVariantFilter(fileMetadata: Array[BgenFileMeta
             override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
               val Lstart = CodeLabel()
               cb.define(Lstart)
-              cb.ifx(currVariantIndex < stopVariantIndex, {
+              cb.if_(currVariantIndex < stopVariantIndex, {
                 val addr = index.queryIndex(cb, vs.elementRegion, currVariantIndex)
                   .loadField(cb, "offset")
                   .get(cb).asLong.value
@@ -777,7 +777,7 @@ case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option
         override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
           val Lstart = CodeLabel()
           cb.define(Lstart)
-          cb.ifx(currVariantIndex ceq endVariantIndex, cb.goto(LendOfStream))
+          cb.if_(currVariantIndex ceq endVariantIndex, cb.goto(LendOfStream))
 
           val addr = index.queryIndex(cb, eltRegion, currVariantIndex)
             .loadField(cb, "offset")

--- a/hail/src/main/scala/is/hail/io/bgen/StagedBGENReader.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/StagedBGENReader.scala
@@ -131,7 +131,7 @@ object StagedBGENReader {
             {
               cb.assign(nAlleles, cbfis.invoke[Int]("readShort"))
               cb.assign(i, 0)
-              cb.whileLoop(i < nAlleles,
+              cb.while_(i < nAlleles,
                 {
                   cb += cbfis.invoke[Int, Unit]("readLengthAndSkipString", 4)
                   cb.assign(i, i + 1)
@@ -174,7 +174,7 @@ object StagedBGENReader {
         val allelesType = SJavaArrayString(true)
 
         val a = cb.newLocal[Array[String]]("alleles", Code.newArray[String](nAlleles))
-        cb.whileLoop(i < nAlleles, {
+        cb.while_(i < nAlleles, {
           cb += a.update(i, cbfis.invoke[Int, String]("readLengthAndString", 4))
           cb.assign(i, i + 1)
         })
@@ -221,9 +221,9 @@ object StagedBGENReader {
             val (push, finish) = memoTyp.constructFromFunctions(cb, partRegion, 1 << 16, false)
 
             val d0 = cb.newLocal[Int]("memoize_entries_d0", 0)
-            cb.whileLoop(d0 < 256, {
+            cb.while_(d0 < 256, {
               val d1 = cb.newLocal[Int]("memoize_entries_d1", 0)
-              cb.whileLoop(d1 < 256, {
+              cb.while_(d1 < 256, {
                 val d2 = cb.newLocal[Int]("memoize_entries_d2", const(255) - d0 - d1)
 
                 val entryFieldCodes = new BoxedArrayBuilder[EmitCode]()
@@ -350,7 +350,7 @@ object StagedBGENReader {
               .concat("'.")))
 
           cb.assign(i, 0)
-          cb.whileLoop(i < nSamples, {
+          cb.while_(i < nSamples, {
             cb.assign(ploidy, reader.invoke[Int]("read"))
             cb.ifx((ploidy & 0x3f).cne(2),
               cb._fatal(const("Ploidy value must equal to 2. Found ")
@@ -390,7 +390,7 @@ object StagedBGENReader {
           val (pushElement, finish) = entriesArrayType.constructFromFunctions(cb, region, nSamples, deepCopy = false)
 
           cb.assign(i, 0)
-          cb.whileLoop(i < nSamples, {
+          cb.while_(i < nSamples, {
 
             val Lmissing = CodeLabel()
             val Lpresent = CodeLabel()
@@ -441,7 +441,7 @@ object StagedBGENReader {
       val len = cb.memoize(indices.length())
       val boxed = cb.memoize(Code.newArray[AnyRef](len))
       val i = cb.newLocal[Int]("i", 0)
-      cb.whileLoop(i < len, {
+      cb.while_(i < len, {
 
         val r = index.queryIndex(cb, mb.partitionRegion, cb.memoize(indices(i))).loadField(cb, "key").get(cb)
         cb += boxed.update(i, StringFunctions.svalueToJavaValue(cb, mb.partitionRegion, r, safe = true))
@@ -543,7 +543,7 @@ object BGENFunctions extends RegistryFunctions {
           val ob = cb.newLocal[OutputBuffer]("currFile", spec.buildCodeOutputBuffer(mb.create(path)))
 
           val i = cb.newLocal[Int]("i", 0)
-          cb.whileLoop(i < currSize, {
+          cb.while_(i < currSize, {
             val k = bufferSct.loadToSValue(cb, cb.memoizeAny(buffer.apply(i), buffer.ti))
             spec.encodedType.buildEncoder(k.st, mb.ecb).apply(cb, k, ob)
             cb.assign(i, i + 1)
@@ -561,7 +561,7 @@ object BGENFunctions extends RegistryFunctions {
 
         val nRead = cb.newLocal[Long]("nRead", 0L)
         val nWritten = cb.newLocal[Long]("nWritten", 0L)
-        cb.whileLoop(nRead < nVariants, {
+        cb.while_(nRead < nVariants, {
           StagedBGENReader.decodeRow(cb, er.region, cbfis, nSamples, fileIdx, compression, skipInvalidLoci, recoding,
             TStruct("locus" -> locType, "alleles" -> TArray(TString), "offset" -> TInt64), rg).toI(cb).consume(cb, {
             // do nothing if missing (invalid locus)
@@ -638,7 +638,7 @@ object BGENFunctions extends RegistryFunctions {
         val iters = mb.genFieldThisRef[Array[NoBoxLongIterator]]("iters")
         cb.assign(iters, Code.newArray[NoBoxLongIterator](groupIndex))
         val i = cb.newLocal[Int]("i")
-        cb.whileLoop(i < groupIndex, {
+        cb.while_(i < groupIndex, {
           cb += iters.update(i, coerce[NoBoxLongIterator](Code.newInstance(ecb.cb, ctor.mb, FastSeq(paths(i), fileSizes(i)))))
           cb.assign(i, i + 1)
         })

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -357,7 +357,7 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
       val level = m.newLocal[Int]("level")
       cb.ifx(leafBuilder.ab.length > 0, cb.invokeVoid(writeLeafNode))
       cb.assign(level, const(0))
-      cb.whileLoop(level < utils.size - 1, {
+      cb.while_(level < utils.size - 1, {
         cb.ifx(utils.getLength(level) > 0,
           cb.invokeVoid(writeInternalNode, CodeParam(level), CodeParam(false))
         )

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -306,10 +306,10 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
 
       val next = m.newLocal[Int]("next")
       cb.assign(next, level + 1)
-      cb.ifx(!isRoot, {
-        cb.ifx(utils.size.ceq(next),
+      cb.if_(!isRoot, {
+        cb.if_(utils.size.ceq(next),
           parentBuilder.create(cb), {
-            cb.ifx(utils.getLength(next).ceq(branchingFactor),
+            cb.if_(utils.getLength(next).ceq(branchingFactor),
               cb.invokeVoid(m, CodeParam(next), CodeParam(false))
             )
             parentBuilder.loadFrom(cb, utils, next)
@@ -337,7 +337,7 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
       leafBuilder.encode(cb, ob)
       cb += ob.flush()
 
-      cb.ifx(utils.getLength(0).ceq(branchingFactor),
+      cb.if_(utils.getLength(0).ceq(branchingFactor),
         cb.invokeVoid(writeInternalNode, CodeParam(0), CodeParam(false))
       )
       parentBuilder.loadFrom(cb, utils, 0)
@@ -355,10 +355,10 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
     m.emitWithBuilder { cb =>
       val idxOff = cb.newLocal[Long]("indexOff")
       val level = m.newLocal[Int]("level")
-      cb.ifx(leafBuilder.ab.length > 0, cb.invokeVoid(writeLeafNode))
+      cb.if_(leafBuilder.ab.length > 0, cb.invokeVoid(writeLeafNode))
       cb.assign(level, const(0))
       cb.while_(level < utils.size - 1, {
-        cb.ifx(utils.getLength(level) > 0,
+        cb.if_(utils.getLength(level) > 0,
           cb.invokeVoid(writeInternalNode, CodeParam(level), CodeParam(false))
         )
         cb.assign(level, level + 1)
@@ -371,7 +371,7 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
   }
 
   def add(cb: EmitCodeBuilder, key: => IEmitCode, offset: Code[Long], annotation: => IEmitCode) {
-    cb.ifx(leafBuilder.ab.length.ceq(branchingFactor), cb.invokeVoid(writeLeafNode))
+    cb.if_(leafBuilder.ab.length.ceq(branchingFactor), cb.invokeVoid(writeLeafNode))
     leafBuilder.add(cb, key, offset, annotation)
     cb.assign(elementIdx, elementIdx + 1L)
   }

--- a/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -45,7 +45,7 @@ class StagedLeafNodeBuilder(maxSize: Int, keyType: PType, annotationType: PType,
   private[this] val idxType = pType.fieldType("first_idx").asInstanceOf[PInt64]
   private[this] val node = new SBaseStructPointerSettable(SBaseStructPointer(pType), sb.newSettable[Long]("lef_node_addr"))
 
-  def close(cb: EmitCodeBuilder): Unit = cb.ifx(!region.isNull, cb += region.invalidate())
+  def close(cb: EmitCodeBuilder): Unit = cb.if_(!region.isNull, cb += region.invalidate())
 
   def reset(cb: EmitCodeBuilder, firstIdx: Code[Long]): Unit = {
     cb += region.invoke[Unit]("clear")

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -2044,7 +2044,7 @@ case class GVCFPartitionReader(header: VCFHeaderInfo,
         override val requiresMemoryManagementPerElement: Boolean = true
         override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
           cb.assign(currentElt, iter.invoke[Region, Long]("next", eltRegion))
-          cb.ifx(currentElt ceq 0L, cb.goto(LendOfStream), cb.goto(LproduceElementDone))
+          cb.if_(currentElt ceq 0L, cb.goto(LendOfStream), cb.goto(LproduceElementDone))
         }
         override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, requestedPType.loadCheapSCode(cb, currentElt)))
         override def close(cb: EmitCodeBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -60,7 +60,7 @@ object LinalgCodeUtils {
   def checkColMajorAndCopyIfNeeded(aInput: SNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): SNDArrayValue = {
     val aIsColumnMajor = LinalgCodeUtils.checkColumnMajor(aInput, cb)
     val aColMajor = cb.emb.newPField("ndarray_output_column_major", aInput.st).asInstanceOf[SNDArraySettable]
-    cb.ifx(aIsColumnMajor, {cb.assign(aColMajor, aInput)},
+    cb.if_(aIsColumnMajor, {cb.assign(aColMajor, aInput)},
       {
         cb.assign(aColMajor, LinalgCodeUtils.createColumnMajorCode(aInput, cb, region))
       })
@@ -73,9 +73,9 @@ object LinalgCodeUtils {
 
     val aIsColumnMajor = LinalgCodeUtils.checkColumnMajor(aInput, cb)
     val a = cb.emb.newPField("ndarray_output_standardized", aInput.st).asInstanceOf[SNDArraySettable]
-    cb.ifx(aIsColumnMajor, {cb.assign(a, aInput)}, {
+    cb.if_(aIsColumnMajor, {cb.assign(a, aInput)}, {
       val isRowMajor = LinalgCodeUtils.checkRowMajor(aInput, cb)
-      cb.ifx(isRowMajor, {cb.assign(a, aInput)}, {
+      cb.if_(isRowMajor, {cb.assign(a, aInput)}, {
         cb.assign(a, LinalgCodeUtils.createColumnMajorCode(aInput, cb, region))
       })
     })

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -1,13 +1,11 @@
 package is.hail.lir
 
-import java.io.PrintWriter
-
-import is.hail.HailContext
-
-import scala.collection.mutable
 import is.hail.asm4s._
 import is.hail.utils._
 import org.objectweb.asm.Opcodes._
+
+import java.io.PrintWriter
+import scala.collection.mutable
 
 // FIXME move typeinfo stuff lir
 
@@ -356,13 +354,7 @@ class Block {
 
     last match {
       case ctrl: ControlX =>
-        var i = 0
-        while (i < ctrl.targetArity()) {
-          if (ctrl.target(i) == null)
-            return false
-          i += 1
-        }
-        true
+        (0 until ctrl.targetArity()).forall(ctrl.target(_) != null)
       case _ => false
     }
   }
@@ -411,9 +403,8 @@ class Block {
 
   def append(x: StmtX): Unit = {
     assert(x.parent == null)
-    if (last.isInstanceOf[ControlX])
-      // if last is a ControlX, x is dead code, so just drop it
-      return
+    assert(!last.isInstanceOf[ControlX], s"StmtX '$x' is redundant after ControlX '$last'.")
+
     if (last == null) {
       first = x
       last = x

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -702,29 +702,15 @@ class SwitchX(var lineNumber: Int = 0) extends ControlX {
   def Lcases: IndexedSeq[Block] = _Lcases
 
   def setLcases(newLcases: IndexedSeq[Block]): Unit = {
-    var i = 0
-    while (i < _Lcases.length) {
-      val L = _Lcases(i)
-      if (L != null)
-        L.removeUse(this, i + 1)
-      _Lcases(i) = null
-      i += 1
+    for ((block, i) <- _Lcases.zipWithIndex) {
+      if (block != null) block.removeUse(this, i + 1)
     }
 
     // don't allow sharing
-    _Lcases = new Array[Block](newLcases.length)
-    i = 0
-    while (i < _Lcases.length) {
-      _Lcases(i) = newLcases(i)
-      i += 1
-    }
+    _Lcases = Array(newLcases: _*)
 
-    i = 0
-    while (i < _Lcases.length) {
-      val L = _Lcases(i)
-      if (L != null)
-        L.addUse(this, i + 1)
-      i += 1
+    for ((block, i) <- _Lcases.zipWithIndex) {
+      if (block != null) block.addUse(this, i + 1)
     }
   }
 

--- a/hail/src/main/scala/is/hail/methods/LocalWhitening.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalWhitening.scala
@@ -68,9 +68,9 @@ class LocalWhitening(cb: EmitCodeBuilder, vecSize: SizeValue, _w: Value[Long], c
 
     // set work1 to I
     work1.setToZero(cb)
-    cb.forLoop(cb.assign(i, 0L), i.toL < w + n, cb.assign(i, i+1), work1.setElement(FastSeq(i, i), primitive(1.0), cb))
+    cb.for_(cb.assign(i, 0L), i.toL < w + n, cb.assign(i, i+1), work1.setElement(FastSeq(i, i), primitive(1.0), cb))
 
-    cb.forLoop(cb.assign(i, 0L), i < n, cb.assign(i, i+1), {
+    cb.for_(cb.assign(i, 0L), i < n, cb.assign(i, i+1), {
       // Loop invariant:
       // * ([Q1 Q2] work1[:, i:w+n]) R[i:w+n, i:w+n] = [A1 A2][i:w+n] is qr fact
       // * ([Q1 Q2] work2[:, 0:i]) is locally whitened A2[:, 0:i]
@@ -126,7 +126,7 @@ class LocalWhitening(cb: EmitCodeBuilder, vecSize: SizeValue, _w: Value[Long], c
 
     // Set lower trapezoid of R[r12, r1] to zero
     val j = cb.mb.newLocal[Long]("j")
-    cb.forLoop(cb.assign(j, p0), j < p1, cb.assign(j, j+1), {
+    cb.for_(cb.assign(j, p0), j < p1, cb.assign(j, j+1), {
       R.slice(cb, (j+1, null), j).setToZero(cb)
     })
 
@@ -282,7 +282,7 @@ class LocalWhitening(cb: EmitCodeBuilder, vecSize: SizeValue, _w: Value[Long], c
 
       // Copy whitened A back to A
       val j = cb.newLocal[Long]("j")
-      cb.forLoop(cb.assign(j, 0L), j < b, cb.assign(j, j+1), {
+      cb.for_(cb.assign(j, 0L), j < b, cb.assign(j, j+1), {
         val Acol = A.slice(cb, Colon, j)
         SNDArray.copyVector(cb, Qslice2.slice(cb, Colon, j), Acol)
         SNDArray.scale(cb, Rslice2.loadElement(FastSeq(j, j), cb), Acol)

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -151,7 +151,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
           if (!rf.typ.required)
             structType.setFieldPresent(cb, addr, rf.index)
         } else {
-          cb.ifx(Region.loadBit(mbytes, const(missingIdx(f.index).toLong)), {
+          cb.if_(Region.loadBit(mbytes, const(missingIdx(f.index).toLong)), {
             structType.setFieldMissing(cb, addr, rf.index)
           }, {
             structType.setFieldPresent(cb, addr, rf.index)
@@ -163,7 +163,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
         if (f.typ.required)
           skip(cb, region, in)
         else
-          cb.ifx(!Region.loadBit(mbytes, const(missingIdx(f.index).toLong)), skip(cb, region, in))
+          cb.if_(!Region.loadBit(mbytes, const(missingIdx(f.index).toLong)), skip(cb, region, in))
       }
     }
   }
@@ -176,7 +176,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       if (f.typ.required)
         skip(cb, r, in)
       else
-        cb.ifx(!Region.loadBit(mbytes, missingIdx(f.index).toLong), skip(cb, r, in))
+        cb.if_(!Region.loadBit(mbytes, missingIdx(f.index).toLong), skip(cb, r, in))
     }
   }
 

--- a/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
@@ -34,14 +34,14 @@ final case class EBlockMatrixNDArray(elementType: EType, encodeRowMajor: Boolean
     cb += out.writeInt(c.toI)
     cb += out.writeBoolean(encodeRowMajor)
     if (encodeRowMajor) {
-      cb.forLoop(cb.assign(i, 0L), i < r, cb.assign(i, i + 1L), {
-        cb.forLoop(cb.assign(j, 0L), j < c, cb.assign(j, j + 1L), {
+      cb.for_(cb.assign(i, 0L), i < r, cb.assign(i, i + 1L), {
+        cb.for_(cb.assign(j, 0L), j < c, cb.assign(j, j + 1L), {
           writeElemF(cb, ndarray.loadElement(FastSeq(i, j), cb), out)
         })
       })
     } else {
-      cb.forLoop(cb.assign(j, 0L), j < c, cb.assign(j, j + 1L), {
-        cb.forLoop(cb.assign(i, 0L), i < r, cb.assign(i, i + 1L), {
+      cb.for_(cb.assign(j, 0L), j < c, cb.assign(j, j + 1L), {
+        cb.for_(cb.assign(i, 0L), i < r, cb.assign(i, i + 1L), {
           writeElemF(cb, ndarray.loadElement(FastSeq(i, j), cb), out)
         })
       })
@@ -66,7 +66,7 @@ final case class EBlockMatrixNDArray(elementType: EType, encodeRowMajor: Boolean
     val currElementAddress = cb.newLocal[Long]("eblockmatrix_ndarray_currElementAddress", tFirstElementAddress)
 
     val i = cb.newLocal[Int]("i")
-    cb.forLoop(cb.assign(i, 0), i < n, cb.assign(i, i + 1), {
+    cb.for_(cb.assign(i, 0), i < n, cb.assign(i, i + 1), {
       readElemF(cb, region, currElementAddress, in)
       cb.assign(currElementAddress, currElementAddress + pt.elementType.byteSize)
     })
@@ -80,7 +80,7 @@ final case class EBlockMatrixNDArray(elementType: EType, encodeRowMajor: Boolean
     val len = cb.newLocal[Int]("len", in.readInt() * in.readInt())
     val i = cb.newLocal[Int]("i")
     cb += in.skipBoolean()
-    cb.forLoop(cb.assign(i, 0), i < len, cb.assign(i, i + 1), skip(cb, r, in))
+    cb.for_(cb.assign(i, 0), i < len, cb.assign(i, i + 1), skip(cb, r, in))
   }
 
   def _asIdent = s"ndarray_of_${ elementType.asIdent }"

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -43,7 +43,7 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     val currElementAddress = cb.newLocal[Long]("eblockmatrix_ndarray_currElementAddress", pndFirstElementAddress)
 
     val dataIdx = cb.newLocal[Int]("ndarray_decoder_data_idx")
-    cb.forLoop(cb.assign(dataIdx, 0), dataIdx < totalNumElements.toI, cb.assign(dataIdx, dataIdx + 1), {
+    cb.for_(cb.assign(dataIdx, 0), dataIdx < totalNumElements.toI, cb.assign(dataIdx, dataIdx + 1), {
       readElemF(cb, region, currElementAddress, in)
       cb.assign(currElementAddress, currElementAddress + pnd.elementType.byteSize)
     })
@@ -57,7 +57,7 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     val numElements = cb.newLocal[Long]("ndarray_skipper_total_num_elements",
       (0 until nDims).foldLeft(const(1L).get) { (p, i) => p * in.readLong() })
     val i = cb.newLocal[Long]("ndarray_skipper_data_idx")
-    cb.forLoop(cb.assign(i, 0L), i < numElements, cb.assign(i, i + 1L), skip(cb, r, in))
+    cb.for_(cb.assign(i, 0L), i < numElements, cb.assign(i, i + 1L), skip(cb, r, in))
   }
 
   def _decodedSType(requestedType: Type): SType = {

--- a/hail/src/main/scala/is/hail/types/encoded/ENumpyBinaryNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENumpyBinaryNDArray.scala
@@ -31,8 +31,8 @@ final case class ENumpyBinaryNDArray(nRows: Long, nCols: Long, required: Boolean
     val j = cb.newLocal[Long]("j")
     val writeElemF = elementType.buildEncoder(ndarray.st.elementType, cb.emb.ecb)
 
-    cb.forLoop(cb.assign(i, 0L), i < nRows, cb.assign(i, i + 1L), {
-      cb.forLoop(cb.assign(j, 0L), j < nCols, cb.assign(j, j + 1L), {
+    cb.for_(cb.assign(i, 0L), i < nRows, cb.assign(i, i + 1L), {
+      cb.for_(cb.assign(j, 0L), j < nCols, cb.assign(j, j + 1L), {
         writeElemF(cb, ndarray.loadElement(FastSeq(i, j), cb), out)
       })
     })
@@ -53,7 +53,7 @@ final case class ENumpyBinaryNDArray(nRows: Long, nCols: Long, required: Boolean
     val currElementAddress = cb.newLocal[Long]("eblockmatrix_ndarray_currElementAddress", tFirstElementAddress)
 
     val i = cb.newLocal[Long]("i")
-    cb.forLoop(cb.assign(i, 0L), i < n, cb.assign(i, i + 1L), {
+    cb.for_(cb.assign(i, 0L), i < n, cb.assign(i, i + 1L), {
       readElemF(cb, region, currElementAddress, in)
       cb.assign(currElementAddress, currElementAddress + pt.elementType.byteSize)
     })

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -212,7 +212,7 @@ object EType {
         val f = et.buildEncoder(pc.st, mb.ecb)
         f(cb, pc, out)
       }
-      val func = fb.result(ctx)
+      val func = fb.result()
       encoderCache.put(k, func)
       func
     }
@@ -249,7 +249,7 @@ object EType {
         pt.store(cb, region, pc, false)
       }
 
-      val r = (pt, fb.result(ctx))
+      val r = (pt, fb.result())
       decoderCache.put(k, r)
       r
     }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -299,7 +299,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     cb.assign(dstAddress, dstAddressCode)
     val currentIdx = cb.newLocal[Int]("pcarray_deep_pointer_copy_current_idx")
     val currentElementAddress = cb.newLocal[Long]("pcarray_deep_pointer_copy_current_element_addr")
-    cb.forLoop(
+    cb.for_(
       cb.assign(currentIdx, 0),
       currentIdx < len,
       cb.assign(currentIdx, currentIdx + 1),
@@ -390,7 +390,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
         stagedInitialize(cb, addr, length, setMissing = false)
 
         val idx = cb.newLocal[Int]("pcarray_store_at_addr_idx", 0)
-        cb.whileLoop(idx < length, {
+        cb.while_(idx < length, {
           indexable
             .loadElement(cb, idx)
             .consume(
@@ -439,7 +439,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     val i = cb.newLocal[Int]("pcarray_construct1_i", 0)
 
     val firstElementAddr = cb.newLocal[Long]("pcarray_construct1_firstelementaddr", firstElementOffset(addr, length))
-    cb.whileLoop(i < length, {
+    cb.while_(i < length, {
       f(cb, i).consume(cb,
         setElementMissing(cb, addr, i),
         { sc =>

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -329,7 +329,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     val currentIdx = cb.newLocal[Int]("pcarray_deep_pointer_copy_current_idx")
     val currentElementAddress = cb.newLocal[Long]("pcarray_deep_pointer_copy_current_element_addr")
     cb.for_(cb.assign(currentIdx, 0), currentIdx < len, cb.assign(currentIdx, currentIdx + 1),
-      cb.ifx(isElementDefined(dstAddress, currentIdx),
+      cb.if_(isElementDefined(dstAddress, currentIdx),
         {
           cb.assign(currentElementAddress, elementOffset(dstAddress, len, currentIdx))
           elementType.storeAtAddress(cb, currentElementAddress, region,
@@ -408,7 +408,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       case SIndexablePointer(otherType@PCanonicalArray(otherElementType, _)) if otherElementType.equalModuloRequired(elementType) =>
         // other is optional, constructing required
         if (elementType.required) {
-          cb.ifx(indexable.hasMissingValues(cb),
+          cb.if_(indexable.hasMissingValues(cb),
             cb._fatal("tried to copy array with missing values to array of required elements"))
         }
         stagedInitialize(cb, addr, indexable.loadLength(), setMissing = false)
@@ -509,7 +509,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     }
 
     def finish(cb: EmitCodeBuilder): SIndexablePointerValue = {
-      cb.ifx(currentElementIndex cne length,
+      cb.if_(currentElementIndex cne length,
         cb._fatal("PCanonicalArray.constructFromFunctions push was called the wrong number of times",
           ": len=", length.toS,
           ", calls=", currentElementIndex.toS
@@ -592,7 +592,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     val elementPtr = cb.newLocal[Long]("foreach_pca_elt_ptr", elementsAddress)
     val et = elementType
     cb.while_(idx < length, {
-      cb.ifx(isElementMissing(aoff, idx),
+      cb.if_(isElementMissing(aoff, idx),
         {}, // do nothing,
         {
           val elt = et.loadCheapSCode(cb, et.loadFromNested(elementPtr))

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -98,7 +98,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
     fields.foreach { f =>
       val dstFieldType = f.typ
       if (dstFieldType.containsPointers) {
-        cb.ifx(isFieldDefined(cb, dstAddr, f.index),
+        cb.if_(isFieldDefined(cb, dstAddr, f.index),
           {
             val fieldAddr = cb.newLocal[Long]("pcbs_dpcopy_field", fieldOffset(dstAddr, f.index))
             dstFieldType.storeAtAddress(cb, fieldAddr, region, dstFieldType.loadCheapSCode(cb, dstFieldType.loadFromNested(fieldAddr)), deepCopy = true)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -205,7 +205,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
             cb += Region.copyFrom(dataValue.asInstanceOf[SIndexablePointerValue].elementsAddress, result.firstDataAddress, dataValue.loadLength().toL * elementType.byteSize)
           case _ =>
             val loopCtr = cb.newLocal[Long]("pcanonical_ndarray_construct_by_copying_loop_idx")
-            cb.forLoop(cb.assign(loopCtr, 0L), loopCtr < dataValue.loadLength().toL, cb.assign(loopCtr, loopCtr + 1L), {
+            cb.for_(cb.assign(loopCtr, 0L), loopCtr < dataValue.loadLength().toL, cb.assign(loopCtr, loopCtr + 1L), {
               elementType.storeAtAddress(cb, result.firstDataAddress + (loopCtr * elementType.byteSize), region, dataValue.loadElement(cb, loopCtr.toI).get(cb, "NDArray elements cannot be missing"), true)
             })
         }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -268,7 +268,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   ): SNDArrayValue = {
     val oldDataAddr = toBeCopied.firstDataAddress
     val numDataBytes = cb.newLocal("constructByActuallyCopyingData_numDataBytes", Region.getSharedChunkByteSize(oldDataAddr))
-    cb.ifx(numDataBytes < 0L, cb._fatal("numDataBytes was ", numDataBytes.toS))
+    cb.if_(numDataBytes < 0L, cb._fatal("numDataBytes was ", numDataBytes.toS))
     val newDataAddr = cb.newLocal("constructByActuallyCopyingData_newDataAddr", region.allocateSharedChunk(numDataBytes))
     cb += Region.copyFrom(oldDataAddr, newDataAddr, numDataBytes)
     constructByCopyingDataPointer(

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -85,3 +85,12 @@ abstract class PContainer extends PIterable {
 
   def nextElementAddress(currentOffset: Code[Long]): Code[Long]
 }
+
+object PContainer {
+  def unsafeSetElementMissing(cb: EmitCodeBuilder, p: PContainer, aoff: Code[Long], i: Code[Int]): Unit = {
+    if (p.elementType.required)
+      cb._fatal("Missing element at index ", i.toS, s" of ptype ${p.elementType.asIdent}'.")
+    else
+      p.setElementMissing(cb, aoff, i)
+  }
+}

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -333,7 +333,7 @@ object PType {
         val srcAddr = fb.apply_method.getCodeParam[Long](2)
         cpt.store(cb, region, t.loadCheapSCode(cb, srcAddr), deepCopy = false)
       }
-      Some(fb.result(ctx))
+      Some(fb.result())
     }
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
@@ -80,7 +80,7 @@ class StoredCodeTuple(tis: Array[TypeInfo[_]]) {
         case DoubleInfo => Region.loadDouble(offset)
         case BooleanInfo => Region.loadBoolean(offset)
       }
-      cb.memoize(code)(ti.asInstanceOf[TypeInfo[AnyVal]])
+      cb.memoizeAny(code, ti)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -52,7 +52,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
 
   override def unphase(cb: EmitCodeBuilder): SCanonicalCallValue = {
     val repr = cb.newLocal[Int]("unphase_call", call)
-    cb.ifx(isPhased(cb),
+    cb.if_(isPhased(cb),
       cb.assign(repr, Code.invokeScalaObject1[Int, Int](Call.getClass, "unphase", call)),
       cb.assign(repr, call))
     new SCanonicalCallValue(repr)
@@ -81,8 +81,8 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
     val j = cb.newLocal[Int]("fea_j")
     val k = cb.newLocal[Int]("fea_k")
 
-    cb.ifx(p.ceq(2), {
-      cb.ifx(call2 < Genotype.nCachedAllelePairs, {
+    cb.if_(p.ceq(2), {
+      cb.if_(call2 < Genotype.nCachedAllelePairs, {
         cb.assign(j, Code.invokeScalaObject1[Int, Int](Genotype.getClass, "cachedAlleleJ", call2))
         cb.assign(k, Code.invokeScalaObject1[Int, Int](Genotype.getClass, "cachedAlleleK", call2))
       }, {
@@ -90,12 +90,12 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
         cb.assign(j, call2 - (k * (k + 1) / 2))
       })
       alleleCode(j)
-      cb.ifx(isPhased(cb), cb.assign(k, k - j))
+      cb.if_(isPhased(cb), cb.assign(k, k - j))
       alleleCode(k)
     }, {
-      cb.ifx(p.ceq(1),
+      cb.if_(p.ceq(1),
         alleleCode(call2),
-        cb.ifx(p.cne(0),
+        cb.if_(p.cne(0),
           cb.append(Code._fatal[Unit](const("invalid ploidy: ").concat(p.toS)))))
     })
   }
@@ -104,7 +104,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
 
     def checkAndTranslate(cb: EmitCodeBuilder, allele: Code[Int]): Code[Int] = {
       val av = cb.newLocal[Int](s"allele", allele)
-      cb.ifx(av >= localAlleles.loadLength(),
+      cb.if_(av >= localAlleles.loadLength(),
         cb._fatalWithError(errorID,
           s"lgt_to_gt: found allele ", av.toS, ", but there are only ", localAlleles.loadLength().toS, " local alleles"))
       localAlleles.loadElement(cb, av).get(cb, const("lgt_to_gt: found missing value in local alleles at index ").concat(av.toS), errorID = errorID)
@@ -128,7 +128,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
           val j = cb.newLocal[Int]("allele_j", Code.invokeScalaObject1[Int, Int](AllelePair.getClass, "j", allelePair))
           val k = cb.newLocal[Int]("allele_k", Code.invokeScalaObject1[Int, Int](AllelePair.getClass, "k", allelePair))
 
-          cb.ifx(j >= localAlleles.loadLength(), cb._fatalWithError(errorID, "invalid lgt_to_gt: allele "))
+          cb.if_(j >= localAlleles.loadLength(), cb._fatalWithError(errorID, "invalid lgt_to_gt: allele "))
 
           cb.assign(repr, Code.invokeScalaObject4[Int, Int, Boolean, Int, Int](Call2.getClass, "withErrorID",
             checkAndTranslate(cb, j),

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -112,17 +112,18 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
     }
 
     val repr = cb.newLocal[Int]("lgt_to_gt_repr")
-    cb += Code.switch(ploidy(cb),
-      EmitCodeBuilder.scopedVoid(cb.emb)(cb => cb._fatalWithError(errorID, s"ploidy above 2 is not currently supported")),
+    cb.switch(ploidy(cb),
+      cb._fatalWithError(errorID, s"ploidy above 2 is not currently supported"),
       FastSeq(
-        EmitCodeBuilder.scopedVoid(cb.emb)(cb => cb.assign(repr, call)), // ploidy 0
-        EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
+        { () => cb.assign(repr, call) }, // ploidy 0
+        { () =>
           val allele = Code.invokeScalaObject1[Int, Int](Call.getClass, "alleleRepr", call)
           val newCall = Code.invokeScalaObject2[Int, Boolean, Int](Call1.getClass, "apply",
-            checkAndTranslate(cb, allele), isPhased(cb))
+            checkAndTranslate(cb, allele), isPhased(cb)
+          )
           cb.assign(repr, newCall)
         }, // ploidy 1
-        EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
+        { () =>
           val allelePair = cb.newLocal[Int]("allelePair", Code.invokeScalaObject1[Int, Int](Call.getClass, "allelePairUnchecked", call))
           val j = cb.newLocal[Int]("allele_j", Code.invokeScalaObject1[Int, Int](AllelePair.getClass, "j", allelePair))
           val k = cb.newLocal[Int]("allele_k", Code.invokeScalaObject1[Int, Int](AllelePair.getClass, "k", allelePair))
@@ -133,7 +134,8 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
             checkAndTranslate(cb, j),
             checkAndTranslate(cb, k),
             isPhased(cb),
-            errorID))
+            errorID)
+          )
         } // ploidy 2
       )
     )

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -92,7 +92,7 @@ class SIndexablePointerValue(
         val idx = cb.newLocal[Int]("foreach_pca_idx", 0)
         val elementPtr = cb.newLocal[Long]("foreach_pca_elt_ptr", elementsAddress)
         val et = pca.elementType
-        cb.whileLoop(idx < length, {
+        cb.while_(idx < length, {
           cb.ifx(isElementMissing(cb, idx),
             {}, // do nothing,
             {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -83,7 +83,7 @@ class SNDArrayPointerValue(
   }
 
   override def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue = {
-    cb.ifx(!hasShape(cb, otherShape), cb._fatal("incompatible shapes"))
+    cb.if_(!hasShape(cb, otherShape), cb._fatal("incompatible shapes"))
     new SNDArrayPointerValue(st, a, otherShape, strides, firstDataAddress)
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
@@ -78,7 +78,7 @@ class SNDArraySliceValue(
     pt.elementType.loadCheapSCode(cb, loadElementAddress(indices, cb))
 
   def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue = {
-    cb.ifx(!hasShape(cb, otherShape), cb._fatal("incompatible shapes"))
+    cb.if_(!hasShape(cb, otherShape), cb._fatal("incompatible shapes"))
     new SNDArraySliceValue(st, otherShape, strides, firstDataAddress)
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
@@ -156,7 +156,7 @@ class SCanonicalRNGStateValue(
     cb.ifx(!hasStaticSplit, cb._fatal("RNGState never received static split"))
     val x = Array.tabulate[Settable[Long]](4)(i => cb.newLocal[Long](s"rand_x$i", runningSum(i)))
     val key = Threefry.defaultKey
-    val finalTweak = cb.ifx(numWordsInLastBlock.ceq(4), Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
+    val finalTweak = cb.mux(numWordsInLastBlock.ceq(4), Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
     for (i <- 0 until 4) cb.assign(x(i), x(i) ^ lastDynBlock(i))
     cb += Code.switch(
       numWordsInLastBlock,
@@ -174,7 +174,7 @@ class SCanonicalRNGStateValue(
   def copyIntoEngine(cb: EmitCodeBuilder, tf: Value[ThreefryRandomEngine]): Unit = {
     cb.ifx(!hasStaticSplit, cb._fatal("RNGState never received static split"))
     val x = Array.tabulate[Settable[Long]](4)(i => cb.newLocal[Long](s"cie_x$i", runningSum(i)))
-    val finalTweak = cb.ifx(numWordsInLastBlock.ceq(4), Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
+    val finalTweak = cb.mux(numWordsInLastBlock.ceq(4), Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
     for (i <- 0 until 4) cb.assign(x(i), x(i) ^ lastDynBlock(i))
     cb += Code.switch(
       numWordsInLastBlock,

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
@@ -131,9 +131,8 @@ class SCanonicalRNGStateValue(
 
     cb.ifx(numWordsInLastBlock < 4, {
       cb.switch(numWordsInLastBlock,
-        cb._fatal("invalid numWordsInLastBlock"),
-        for {i <- 0 until 4}
-          yield () => cb.assign(newLastDynBlock(i), idx)
+        cb._fatal("invalid numWordsInLastBlock: ", numWordsInLastBlock.toS),
+        for {i <- 0 until 4} yield () => cb.assign(newLastDynBlock(i), idx)
       )
       cb.assign(newNumWordsInLastBlock, newNumWordsInLastBlock + 1)
     }, {
@@ -156,9 +155,14 @@ class SCanonicalRNGStateValue(
     val finalTweak = cb.memoize((numWordsInLastBlock ceq 4).mux(Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak))
     for (i <- 0 until 4) cb.assign(x(i), x(i) ^ lastDynBlock(i))
     cb.switch(numWordsInLastBlock,
-      cb._fatal("invalid numWordsInLastBlock"),
-      for {i <- 0 until 4}
-        yield () => cb.assign(x(i), x(i) ^ 1L)
+      cb._fatal("invalid numWordsInLastBlock: ", numWordsInLastBlock.toS),
+      FastSeq(
+        () => cb += (x(0) := x(0) ^ 1L),
+        () => cb += (x(1) := x(1) ^ 1L),
+        () => cb += (x(2) := x(2) ^ 1L),
+        () => cb += (x(3) := x(3) ^ 1L),
+        () => {}
+      )
     )
     Threefry.encrypt(cb, key, Array(finalTweak, const(0L)), x)
     x
@@ -170,9 +174,14 @@ class SCanonicalRNGStateValue(
     val finalTweak = (numWordsInLastBlock ceq 4).mux(Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
     for (i <- 0 until 4) cb.assign(x(i), x(i) ^ lastDynBlock(i))
     cb.switch(numWordsInLastBlock,
-      cb._fatal("invalid numWordsInLastBlock"),
-      for {i <- 0 until 4}
-        yield () => cb.assign(x(i), x(i) ^ 1L)
+      cb._fatal("invalid numWordsInLastBlock: ", numWordsInLastBlock.toS),
+      FastSeq(
+        () => cb += (x(0) := x(0) ^ 1L),
+        () => cb += (x(1) := x(1) ^ 1L),
+        () => cb += (x(2) := x(2) ^ 1L),
+        () => cb += (x(3) := x(3) ^ 1L),
+        () => {}
+      )
     )
     cb += tf.invoke[Long, Long, Long, Long, Long, Unit]("resetState", x(0), x(1), x(2), x(3), finalTweak)
   }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SRNGState.scala
@@ -153,7 +153,7 @@ class SCanonicalRNGStateValue(
     cb.ifx(!hasStaticSplit, cb._fatal("RNGState never received static split"))
     val x = Array.tabulate[Settable[Long]](4)(i => cb.newLocal[Long](s"rand_x$i", runningSum(i)))
     val key = Threefry.defaultKey
-    val finalTweak = cb.mux(numWordsInLastBlock.ceq(4), Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
+    val finalTweak = cb.memoize((numWordsInLastBlock ceq 4).mux(Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak))
     for (i <- 0 until 4) cb.assign(x(i), x(i) ^ lastDynBlock(i))
     cb.switch(numWordsInLastBlock,
       cb._fatal("invalid numWordsInLastBlock"),
@@ -167,7 +167,7 @@ class SCanonicalRNGStateValue(
   def copyIntoEngine(cb: EmitCodeBuilder, tf: Value[ThreefryRandomEngine]): Unit = {
     cb.ifx(!hasStaticSplit, cb._fatal("RNGState never received static split"))
     val x = Array.tabulate[Settable[Long]](4)(i => cb.newLocal[Long](s"cie_x$i", runningSum(i)))
-    val finalTweak = cb.mux(numWordsInLastBlock.ceq(4), Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
+    val finalTweak = (numWordsInLastBlock ceq 4).mux(Threefry.finalBlockNoPadTweak, Threefry.finalBlockPaddedTweak)
     for (i <- 0 until 4) cb.assign(x(i), x(i) ^ lastDynBlock(i))
     cb.switch(numWordsInLastBlock,
       cb._fatal("invalid numWordsInLastBlock"),

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -33,7 +33,7 @@ trait SIndexableValue extends SValue {
   def forEachDefined(cb: EmitCodeBuilder)(f: (EmitCodeBuilder, Value[Int], SValue) => Unit): Unit = {
     val length = loadLength()
     val idx = cb.newLocal[Int]("foreach_idx", 0)
-    cb.whileLoop(idx < length, {
+    cb.while_(idx < length, {
 
       loadElement(cb, idx).consume(cb,
         {}, /*do nothing if missing*/
@@ -47,7 +47,7 @@ trait SIndexableValue extends SValue {
   def forEachDefinedOrMissing(cb: EmitCodeBuilder)(missingF: (EmitCodeBuilder, Value[Int]) => Unit, presentF: (EmitCodeBuilder, Value[Int], SValue) => Unit): Unit = {
     val length = loadLength()
     val idx = cb.newLocal[Int]("foreach_idx", 0)
-    cb.whileLoop(idx < length, {
+    cb.while_(idx < length, {
 
       loadElement(cb, idx).consume(cb,
         { /*do function if missing*/

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -54,7 +54,7 @@ trait SIntervalValue extends SValue {
     val start = cb.memoize(loadStart(cb), "start")
     val end = cb.memoize(loadEnd(cb), "end")
     val empty = cb.newLocal[Boolean]("is_empty")
-    cb.ifx(includesStart && includesEnd,
+    cb.if_(includesStart && includesEnd,
       cb.assign(empty, gt(cb, start, end)),
       cb.assign(empty, gteq(cb, start, end)))
     empty

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -116,7 +116,7 @@ object SNDArray {
           }
         }
 
-        cb.forLoop(init(), coord < indexSizes(idx), increment(), recurLoopBuilder(idx - 1))
+        cb.for_(init(), coord < indexSizes(idx), increment(), recurLoopBuilder(idx - 1))
       }
     }
 
@@ -142,7 +142,7 @@ object SNDArray {
 
         recurLoopBuilder(dimIdx + 1,
           () => {
-            cb.forLoop({
+            cb.for_({
               inits(dimIdx)(cb)
               cb.assign(dimVar, 0L)
             }, dimVar < shape(dimIdx), {
@@ -183,7 +183,7 @@ object SNDArray {
 
         recurLoopBuilder(dimIdx - 1,
           () => {
-            cb.forLoop({
+            cb.for_({
               inits(dimIdx)(cb)
               cb.assign(dimVar, 0L)
             }, dimVar < shape(dimIdx), {
@@ -423,7 +423,7 @@ object SNDArray {
     // Set Q to I
     Q.setToZero(cb)
     val i = cb.mb.newLocal[Long]("i")
-    cb.forLoop(cb.assign(i, 0L), i < n, cb.assign(i, i+1), {
+    cb.for_(cb.assign(i, 0L), i < n, cb.assign(i, i+1), {
       Q.setElement(FastSeq(i, i), primitive(1.0), cb)
     })
     SNDArray.gemqrt("L", "N", A, T, Q, work, blocksize, cb)
@@ -506,7 +506,7 @@ object SNDArray {
     // Set Q to I
     Q.setToZero(cb)
     val i = cb.mb.newLocal[Long]("i")
-    cb.forLoop(cb.assign(i, 0L), i < n, cb.assign(i, i+1), {
+    cb.for_(cb.assign(i, 0L), i < n, cb.assign(i, i+1), {
       Q.setElement(FastSeq(i, i), primitive(1.0), cb)
     })
     SNDArray.gemqr(cb, "L", "N", A, T, Q, work)
@@ -873,7 +873,7 @@ trait SNDArrayValue extends SValue {
           val end = cb.mb.newLocal[Long](s"NDArray_setToZero_end_$dim")
           cb.assign(ptr, startPtr)
           cb.assign(end, ptr + strides(dim-1) * shapes(dim-1))
-          cb.forLoop({}, ptr < end, cb.assign(ptr, ptr + strides(dim-1)), recur(ptr, dim - 1, contiguousDims))
+          cb.for_({}, ptr < end, cb.assign(ptr, ptr + strides(dim-1)), recur(ptr, dim - 1, contiguousDims))
         }
       } else {
         eltType.storePrimitiveAtAddress(cb, startPtr, primitive(eltType.virtualType, eltType.zero))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -871,14 +871,9 @@ trait SNDArrayValue extends SValue {
         else {
           val ptr = cb.mb.newLocal[Long](s"NDArray_setToZero_ptr_$dim")
           val end = cb.mb.newLocal[Long](s"NDArray_setToZero_end_$dim")
-
+          cb.assign(ptr, startPtr)
           cb.assign(end, ptr + strides(dim-1) * shapes(dim-1))
-          cb.for_(
-            cb.assign(ptr, startPtr),
-            ptr < end,
-            cb.assign(ptr, ptr + strides(dim-1)),
-            recur(ptr, dim - 1, contiguousDims)
-          )
+          cb.for_({}, ptr < end, cb.assign(ptr, ptr + strides(dim-1)), recur(ptr, dim - 1, contiguousDims))
         }
       } else {
         eltType.storePrimitiveAtAddress(cb, startPtr, primitive(eltType.virtualType, eltType.zero))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -871,9 +871,14 @@ trait SNDArrayValue extends SValue {
         else {
           val ptr = cb.mb.newLocal[Long](s"NDArray_setToZero_ptr_$dim")
           val end = cb.mb.newLocal[Long](s"NDArray_setToZero_end_$dim")
-          cb.assign(ptr, startPtr)
+
           cb.assign(end, ptr + strides(dim-1) * shapes(dim-1))
-          cb.for_({}, ptr < end, cb.assign(ptr, ptr + strides(dim-1)), recur(ptr, dim - 1, contiguousDims))
+          cb.for_(
+            cb.assign(ptr, startPtr),
+            ptr < end,
+            cb.assign(ptr, ptr + strides(dim-1)),
+            recur(ptr, dim - 1, contiguousDims)
+          )
         }
       } else {
         eltType.storePrimitiveAtAddress(cb, startPtr, primitive(eltType.virtualType, eltType.zero))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -104,7 +104,7 @@ class SStreamConcrete(val st: SStreamIteratorLong, val it: Value[NoBoxLongIterat
       override val requiresMemoryManagementPerElement: Boolean = st.requiresMemoryManagement
       override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
         cb.assign(next, it.invoke[Long]("next"))
-        cb.ifx(it.invoke[Boolean]("eos"), cb.goto(LendOfStream))
+        cb.if_(it.invoke[Boolean]("eos"), cb.goto(LendOfStream))
         cb.goto(LproduceElementDone)
       }
       override val element: EmitCode = {

--- a/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
@@ -33,7 +33,7 @@ class StagedConstructorSuite extends HailSuite {
 
     val region = Region(pool=pool)
     val rv = RegionValue(region)
-    rv.setOffset(fb.result(ctx)(theHailClassLoader)(region, input))
+    rv.setOffset(fb.result()(theHailClassLoader)(region, input))
 
     if (showRVInfo) {
       printRegion(region, "string")
@@ -70,7 +70,7 @@ class StagedConstructorSuite extends HailSuite {
 
     val region = Region(pool=pool)
     val rv = RegionValue(region)
-    rv.setOffset(fb.result(ctx)(theHailClassLoader)(region, input))
+    rv.setOffset(fb.result()(theHailClassLoader)(region, input))
 
     if (showRVInfo) {
       printRegion(region, "int")
@@ -107,7 +107,7 @@ class StagedConstructorSuite extends HailSuite {
 
     val region = Region(pool=pool)
     val rv = RegionValue(region)
-    rv.setOffset(fb.result(ctx)(theHailClassLoader)(region, input))
+    rv.setOffset(fb.result()(theHailClassLoader)(region, input))
 
     if (showRVInfo) {
       printRegion(region, "array")
@@ -151,7 +151,7 @@ class StagedConstructorSuite extends HailSuite {
 
     val region = Region(pool=pool)
     val rv = RegionValue(region)
-    rv.setOffset(fb.result(ctx)(theHailClassLoader)(region, input))
+    rv.setOffset(fb.result()(theHailClassLoader)(region, input))
 
     if (showRVInfo) {
       printRegion(region, "struct")
@@ -195,7 +195,7 @@ class StagedConstructorSuite extends HailSuite {
 
     val region = Region(pool=pool)
     val rv = RegionValue(region)
-    rv.setOffset(fb.result(ctx)(theHailClassLoader)(region, input))
+    rv.setOffset(fb.result()(theHailClassLoader)(region, input))
 
     if (showRVInfo) {
       printRegion(region, "array of struct")
@@ -328,7 +328,7 @@ class StagedConstructorSuite extends HailSuite {
 
     val region = Region(pool=pool)
     val rv = RegionValue(region)
-    rv.setOffset(fb.result(ctx)(theHailClassLoader)(region, input))
+    rv.setOffset(fb.result()(theHailClassLoader)(region, input))
 
     if (showRVInfo) {
       printRegion(region, "struct with array")
@@ -376,7 +376,7 @@ class StagedConstructorSuite extends HailSuite {
 
     val region = Region(pool=pool)
     val rv = RegionValue(region)
-    rv.setOffset(fb.result(ctx)(theHailClassLoader)(region, input))
+    rv.setOffset(fb.result()(theHailClassLoader)(region, input))
 
     if (showRVInfo) {
       printRegion(region, "missing array")
@@ -417,7 +417,7 @@ class StagedConstructorSuite extends HailSuite {
     }
 
     val region = Region(pool=pool)
-    val f = fb.result(ctx)(theHailClassLoader)
+    val f = fb.result()(theHailClassLoader)
     def run(i: Int, b: Boolean, d: Double): (Int, Boolean, Double) = {
       val off = f(region, i, b, d)
       (Region.loadInt(t.loadField(off, 0)),

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -446,6 +446,19 @@ class ASM4SSuite extends HailSuite {
     assert(test() == 1)
   }
 
+  @Test def testIf(): Unit = {
+    val Main = FunctionBuilder[Int, Int]("If")
+    Main.emitWithBuilder[Int] { cb =>
+      val a = cb.mb.getArg[Int](1)
+      val t = cb.newLocal[Int]("t")
+      cb.ifx(a > 0, cb.assign(t, a), cb.assign(t, -a))
+      t
+    }
+
+    val abs = Main.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
+    Prop.forAll { (x: Int) => abs(x) == x.abs }.check()
+  }
+
   @Test def testWhile(): Unit = {
     val Main = FunctionBuilder[Int, Int, Int]("While")
     Main.emitWithBuilder[Int] { cb =>
@@ -463,9 +476,9 @@ class ASM4SSuite extends HailSuite {
       b
     }
 
-    val f = Main.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
+    val add = Main.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
     Prop.forAll(Gen.choose(-10, 10), Gen.choose(-10, 10))
-      { (x, y) => f(x, y) == x + y }
+      { (x, y) => add(x, y) == x + y }
       .check()
   }
 
@@ -487,8 +500,8 @@ class ASM4SSuite extends HailSuite {
       b
     }
 
-    val f = Main.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
-    Prop.forAll(Gen.choose(-10, 10), Gen.choose(-10, 10)) { (x, y) => f(x, y) == x + y }
+    val add = Main.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
+    Prop.forAll(Gen.choose(-10, 10), Gen.choose(-10, 10)) { (x, y) => add(x, y) == x + y }
       .check()
   }
 

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -191,7 +191,7 @@ class ASM4SSuite extends HailSuite {
     val i = fb.getArg[Int](1)
     fb.emitWithBuilder[Int] { cb =>
       val n = cb.newLocal[Int]("n")
-      cb.ifx(i < 3, cb.assign(n, 1), {
+      cb.if_(i < 3, cb.assign(n, 1), {
         val vn_1 = cb.newLocal[Int]("vn_1")
         val vn_2 = cb.newLocal[Int]("vn_2")
         cb.assign(vn_1, 1)
@@ -314,10 +314,10 @@ class ASM4SSuite extends HailSuite {
       val b = fb.getArg[Int](2)
       val c = fb.getArg[Int](3)
       val res = cb.newLocal[Int]("res")
-      cb.ifx(a.ceq(0), {
+      cb.if_(a.ceq(0), {
         cb.assign(res, add.invoke(cb, b, c))
       }, {
-        cb.ifx(a.ceq(1),
+        cb.if_(a.ceq(1),
           cb.assign(res, sub.invoke(cb, b, c)),
           cb.assign(res, mul.invoke(cb, b, c)))
       })
@@ -418,7 +418,7 @@ class ASM4SSuite extends HailSuite {
     val fb = FunctionBuilder[Boolean, Int]("F")
     fb.emitWithBuilder { cb =>
       val a = cb.newLocal[Int]("a")
-      cb.ifx(!fb.getArg[Boolean](1), cb.assign(a, 5))
+      cb.if_(!fb.getArg[Boolean](1), cb.assign(a, 5))
       a
     }
     val f = fb.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
@@ -451,7 +451,7 @@ class ASM4SSuite extends HailSuite {
     Main.emitWithBuilder[Int] { cb =>
       val a = cb.mb.getArg[Int](1)
       val t = cb.newLocal[Int]("t")
-      cb.ifx(a > 0, cb.assign(t, a), cb.assign(t, -a))
+      cb.if_(a > 0, cb.assign(t, a), cb.assign(t, -a))
       t
     }
 
@@ -466,7 +466,7 @@ class ASM4SSuite extends HailSuite {
       val b = cb.mb.getArg[Int](2)
 
       val acc = cb.newLocal[Int]("signum")
-      cb.ifx(a > 0, cb.assign(acc, 1), cb.assign(acc, -1))
+      cb.if_(a > 0, cb.assign(acc, 1), cb.assign(acc, -1))
 
       cb.while_(a cne 0, {
         cb.assign(a, a - acc)
@@ -491,7 +491,7 @@ class ASM4SSuite extends HailSuite {
       val acc = cb.newLocal[Int]("signum")
 
       cb.for_(
-        setup = cb.ifx(a > 0, cb.assign(acc, 1), cb.assign(acc, -1)),
+        setup = cb.if_(a > 0, cb.assign(acc, 1), cb.assign(acc, -1)),
         cond = a cne 0,
         incr = cb.assign(a, a - acc),
         body = cb.assign(b, b + acc)

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -1,16 +1,17 @@
 package is.hail.asm4s
 
 import java.io.PrintWriter
-
 import is.hail.HailSuite
 import is.hail.asm4s.Code._
 import is.hail.asm4s.FunctionBuilder._
 import is.hail.check.{Gen, Prop}
+import is.hail.utils.HailException
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 import scala.collection.mutable
 import scala.language.postfixOps
+import scala.util.Random
 
 trait Z2Z { def apply(z:Boolean): Boolean }
 
@@ -139,17 +140,17 @@ class ASM4SSuite extends HailSuite {
   @Test def fact(): Unit = {
     val fb = FunctionBuilder[Int, Int]("Fact")
     val i = fb.getArg[Int](1)
-    val r = fb.newLocal[Int]()
-    fb.emit(Code(
-      r.store(1),
-      whileLoop(
-        fb.getArg[Int](1) > 1,
-        Code(
-          r.store(r * i),
-          i.store(i - 1))),
-      r))
-    val f = fb.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
+    fb.emitWithBuilder[Int] { cb =>
+      val r = cb.newLocal[Int]("r")
+      cb.assign(r, 1)
+      cb.whileLoop(i > 1, {
+        cb.assign(r, r * i)
+        cb.assign(i, i - 1)
+      })
+      r
+    }
 
+    val f = fb.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
     assert(f(3) == 6)
     assert(f(4) == 24)
   }
@@ -186,25 +187,25 @@ class ASM4SSuite extends HailSuite {
 
   @Test def fibonacci(): Unit = {
     val fb = FunctionBuilder[Int, Int]("Fib")
+
     val i = fb.getArg[Int](1)
-    val n = fb.newLocal[Int]()
-    val vn_2 = fb.newLocal[Int]()
-    val vn_1 = fb.newLocal[Int]()
-    val temp = fb.newLocal[Int]()
-    fb.emit(
-      (i < 3).mux(1, Code(
-        vn_2.store(1),
-        vn_1.store(1),
-        whileLoop(
-          i > 3,
-          Code(
-            temp.store(vn_2 + vn_1),
-            vn_2.store(vn_2),
-            vn_1.store(temp),
-            i.store(i - 1)
-          )
-        ),
-        vn_2 + vn_1)))
+    fb.emitWithBuilder[Int] { cb =>
+      val n = cb.newLocal[Int]("n")
+      cb.ifx(i < 3, cb.assign(n, 1), {
+        val vn_1 = cb.newLocal[Int]("vn_1")
+        val vn_2 = cb.newLocal[Int]("vn_2")
+        cb.assign(vn_1, 1)
+        cb.assign(vn_2, 1)
+        cb.whileLoop(i > 3, {
+          val temp = fb.newLocal[Int]()
+          cb.assign(temp, vn_2 + vn_1)
+          cb.assign(vn_1, temp)
+          cb.assign(i, i - 1)
+        })
+        cb.assign(n, vn_2 + vn_1)
+      })
+      n
+    }
     val f = fb.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
 
     Prop.forAll(Gen.choose(0, 100)) { i =>
@@ -328,7 +329,6 @@ class ASM4SSuite extends HailSuite {
     assert(f(2, 2, 8) == 16)
   }
 
-
   @Test def checkLocalVarsOnMethods(): Unit = {
     val fb = FunctionBuilder[Int, Int, Int]("F")
     val add = fb.genMethod[Int, Int, Int]("add")
@@ -399,25 +399,28 @@ class ASM4SSuite extends HailSuite {
   }
 
   @Test def lazyFieldEvaluatesOnce(): Unit = {
-    val fb = FunctionBuilder[Int]("F")
-    val v2 = fb.genFieldThisRef[Int]()
-    val v1 = fb.genLazyFieldThisRef(v2 + 1)
+    val F = FunctionBuilder[Int]("LazyField")
+    val a = F.genFieldThisRef[Int]("a")
+    val lzy = F.genLazyFieldThisRef(a + 1, "lzy")
 
-    fb.emit(Code(
-      v2 := 0,
-      v2 := v1,
-      v2 := v1,
-      v1))
+    F.emit(Code(
+      a := 0,
+      a := lzy,
+      a := lzy,
+      lzy
+    ))
 
-    assert(fb.result(ctx.shouldWriteIRFiles())(theHailClassLoader)() == 1)
+    val f = F.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
+    assert(f() == 1)
   }
 
   @Test def testInitialize(): Unit = {
     val fb = FunctionBuilder[Boolean, Int]("F")
-    val l = fb.newLocal[Int]()
-    fb.emit(Code(
-      fb.getArg[Boolean](1).mux(Code._empty, l := 5),
-      l))
+    fb.emitWithBuilder { cb =>
+      val a = cb.newLocal[Int]("a")
+      cb.ifx(!fb.getArg[Boolean](1), cb.assign(a, 5))
+      a
+    }
     val f = fb.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
     assert(f(true) == 0)
     assert(f(false) == 5)

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -143,7 +143,7 @@ class ASM4SSuite extends HailSuite {
     fb.emitWithBuilder[Int] { cb =>
       val r = cb.newLocal[Int]("r")
       cb.assign(r, 1)
-      cb.whileLoop(i > 1, {
+      cb.while_(i > 1, {
         cb.assign(r, r * i)
         cb.assign(i, i - 1)
       })
@@ -196,7 +196,7 @@ class ASM4SSuite extends HailSuite {
         val vn_2 = cb.newLocal[Int]("vn_2")
         cb.assign(vn_1, 1)
         cb.assign(vn_2, 1)
-        cb.whileLoop(i > 3, {
+        cb.while_(i > 3, {
           val temp = fb.newLocal[Int]()
           cb.assign(temp, vn_2 + vn_1)
           cb.assign(vn_1, temp)
@@ -455,7 +455,7 @@ class ASM4SSuite extends HailSuite {
       val acc = cb.newLocal[Int]("signum")
       cb.ifx(a > 0, cb.assign(acc, 1), cb.assign(acc, -1))
 
-      cb.whileLoop(a cne 0, {
+      cb.while_(a cne 0, {
         cb.assign(a, a - acc)
         cb.assign(b, b + acc)
       })
@@ -477,7 +477,7 @@ class ASM4SSuite extends HailSuite {
 
       val acc = cb.newLocal[Int]("signum")
 
-      cb.forLoop(
+      cb.for_(
         setup = cb.ifx(a > 0, cb.assign(acc, 1), cb.assign(acc, -1)),
         cond = a cne 0,
         incr = cb.assign(a, a - acc),

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -19,7 +19,7 @@ class CodeSuite extends HailSuite {
       val i = cb.newLocal[Int]("i")
       val sum = cb.newLocal[Int]("sum", 0)
       cb.assign(sum, 0)
-      cb.forLoop(
+      cb.for_(
         cb.assign(i, 0),
         i < 5,
         cb.assign(i, i + 1),

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -44,7 +44,7 @@ class CodeSuite extends HailSuite {
       mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
         v.sizeToStoreInBytes(cb).value
       })
-      fb.result(ctx)(theHailClassLoader)()
+      fb.result()(theHailClassLoader)()
     }
 
     assert(testSizeHelper(int64) == 8L)
@@ -65,7 +65,7 @@ class CodeSuite extends HailSuite {
       }
       sarray.sizeToStoreInBytes(cb).value
     })
-    assert(fb.result(ctx)(theHailClassLoader)(ctx.r) == 28L) // 2 missing bytes 4 byte aligned + 4 header bytes + 5 elements * 4 bytes for ints.
+    assert(fb.result()(theHailClassLoader)(ctx.r) == 28L) // 2 missing bytes 4 byte aligned + 4 header bytes + 5 elements * 4 bytes for ints.
   }
 
   @Test def testIntervalSizeInBytes(): Unit = {
@@ -90,7 +90,7 @@ class CodeSuite extends HailSuite {
         true, true)
       sval.sizeToStoreInBytes(cb).value
     })
-    assert(fb.result(ctx)(theHailClassLoader)(ctx.r) == 72L) // 2 28 byte structs, plus 2 1 byte booleans that get 8 byte for an extra 8 bytes, plus missing bytes.
+    assert(fb.result()(theHailClassLoader)(ctx.r) == 72L) // 2 28 byte structs, plus 2 1 byte booleans that get 8 byte for an extra 8 bytes, plus missing bytes.
   }
 
   @Test def testHash() {
@@ -113,7 +113,7 @@ class CodeSuite extends HailSuite {
       val hash = v.hash(cb)
       hash.value
     })
-    fb.result(ctx)(theHailClassLoader)()
+    fb.result()(theHailClassLoader)()
   }
 
   def hashTestStringHelper(toHash: String): Int = {
@@ -129,7 +129,7 @@ class CodeSuite extends HailSuite {
       hash.value
     })
     val region = Region(pool=pool)
-    fb.result(ctx)(theHailClassLoader)(region)
+    fb.result()(theHailClassLoader)(region)
   }
 
   def hashTestArrayHelper(toHash: IndexedSeq[Int]): Int = {
@@ -144,7 +144,7 @@ class CodeSuite extends HailSuite {
     })
     val region = Region(pool=pool)
     val arrayPointer = pArray.unstagedStoreJavaObject(ctx.stateManager, toHash, region)
-    fb.result(ctx)(theHailClassLoader)(arrayPointer)
+    fb.result()(theHailClassLoader)(arrayPointer)
   }
 
   def hashTestStructHelper(toHash: Row, fields : IndexedSeq[PField]): Int = {
@@ -159,6 +159,6 @@ class CodeSuite extends HailSuite {
     })
     val region = Region(pool=pool)
     val structPointer = pStruct.unstagedStoreJavaObject(ctx.stateManager, toHash, region)
-    fb.result(ctx)(theHailClassLoader)(structPointer)
+    fb.result()(theHailClassLoader)(structPointer)
   }
 }

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -19,12 +19,7 @@ class CodeSuite extends HailSuite {
       val i = cb.newLocal[Int]("i")
       val sum = cb.newLocal[Int]("sum", 0)
       cb.assign(sum, 0)
-      cb.for_(
-        cb.assign(i, 0),
-        i < 5,
-        cb.assign(i, i + 1),
-        cb.assign(sum, sum + i)
-      )
+      cb.for_(cb.assign(i, 0), i < 5, cb.assign(i, i + 1), cb.assign(sum, sum + i))
       sum
     }
 

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -56,7 +56,7 @@ class CodeSuite extends HailSuite {
     mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
       val region = fb.emb.getCodeParam[Region](1)
       val sarray = ptype.constructFromElements(cb, region, 5, true) { (cb, idx) =>
-        cb.ifx(idx ceq 2, { IEmitCode.missing(cb, stype.elementType.defaultValue)}, { IEmitCode.present(cb, new SInt32Value(idx))})
+        cb.if_(idx ceq 2, { IEmitCode.missing(cb, stype.elementType.defaultValue)}, { IEmitCode.present(cb, new SInt32Value(idx))})
       }
       sarray.sizeToStoreInBytes(cb).value
     })

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -15,15 +15,19 @@ class CodeSuite extends HailSuite {
 
   @Test def testForLoop() {
     val fb = EmitFunctionBuilder[Int](ctx, "foo")
-    val mb = fb.apply_method
-    val i = mb.newLocal[Int]()
-    val sum = mb.newLocal[Int]()
-    val code = Code(
-      sum := 0,
-      Code.forLoop(i := 0, i < 5, i := i + 1, sum :=  sum + i),
-      sum.load()
-    )
-    fb.emit(code)
+    fb.emitWithBuilder[Int] { cb =>
+      val i = cb.newLocal[Int]("i")
+      val sum = cb.newLocal[Int]("sum", 0)
+      cb.assign(sum, 0)
+      cb.forLoop(
+        cb.assign(i, 0),
+        i < 5,
+        cb.assign(i, i + 1),
+        cb.assign(sum, sum + i)
+      )
+      sum
+    }
+
     val result = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, ctx.r)()
     assert(result == 10)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
@@ -64,14 +64,14 @@ class ArrayFunctionsSuite extends HailSuite {
 
   @Test def median() {
     assertEvalsTo(invoke("median", TInt32, IRArray(5)), 5)
-//    assertEvalsTo(invoke("median", TInt32, IRArray(5, null, null)), 5)
-//    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7)), 5)
-//    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 7, 1, null)), 3)
-//    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7, 1)), 3)
-//    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 9, 6, 1, null)), 4)
-//    assertEvalsTo(invoke("median", TInt32, IRArray()), null)
-//    assertEvalsTo(invoke("median", TInt32, IRArray(null)), null)
-//    assertEvalsTo(invoke("median", TInt32, naa), null)
+    assertEvalsTo(invoke("median", TInt32, IRArray(5, null, null)), 5)
+    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7)), 5)
+    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 7, 1, null)), 3)
+    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7, 1)), 3)
+    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 9, 6, 1, null)), 4)
+    assertEvalsTo(invoke("median", TInt32, IRArray()), null)
+    assertEvalsTo(invoke("median", TInt32, IRArray(null)), null)
+    assertEvalsTo(invoke("median", TInt32, naa), null)
   }
   
   @Test(dataProvider = "basicPairs")

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
@@ -64,14 +64,14 @@ class ArrayFunctionsSuite extends HailSuite {
 
   @Test def median() {
     assertEvalsTo(invoke("median", TInt32, IRArray(5)), 5)
-    assertEvalsTo(invoke("median", TInt32, IRArray(5, null, null)), 5)
-    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7)), 5)
-    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 7, 1, null)), 3)
-    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7, 1)), 3)
-    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 9, 6, 1, null)), 4)
-    assertEvalsTo(invoke("median", TInt32, IRArray()), null)
-    assertEvalsTo(invoke("median", TInt32, IRArray(null)), null)
-    assertEvalsTo(invoke("median", TInt32, naa), null)
+//    assertEvalsTo(invoke("median", TInt32, IRArray(5, null, null)), 5)
+//    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7)), 5)
+//    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 7, 1, null)), 3)
+//    assertEvalsTo(invoke("median", TInt32, IRArray(3, 7, 1)), 3)
+//    assertEvalsTo(invoke("median", TInt32, IRArray(3, null, 9, 6, 1, null)), 4)
+//    assertEvalsTo(invoke("median", TInt32, IRArray()), null)
+//    assertEvalsTo(invoke("median", TInt32, IRArray(null)), null)
+//    assertEvalsTo(invoke("median", TInt32, naa), null)
   }
   
   @Test(dataProvider = "basicPairs")

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -148,7 +148,7 @@ class EmitStreamSuite extends HailSuite {
               cb.assign(len, len + 1)
             }
           })
-      cb.ifx(len2.cne(-1) && (len2.cne(len)),
+      cb.if_(len2.cne(-1) && (len2.cne(len)),
         cb._fatal(s"length mismatch between computed and iteration length: computed=", len2.toS, ", iter=", len.toS))
 
       len2

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -26,7 +26,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = EmitFunctionBuilder[T, R](ctx, "stream_test")
     val mb = fb.apply_method
     mb.emit(f(mb, mb.getCodeParam[T](1)))
-    val asmFn = fb.result(ctx)(theHailClassLoader)
+    val asmFn = fb.result()(theHailClassLoader)
     asmFn.apply
   }
 
@@ -34,7 +34,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = EmitFunctionBuilder[T, U, R](ctx, "F")
     val mb = fb.apply_method
     mb.emit(f(mb, mb.getCodeParam[T](1), mb.getCodeParam[U](2)))
-    val asmFn = fb.result(ctx)(theHailClassLoader)
+    val asmFn = fb.result()(theHailClassLoader)
     asmFn.apply
   }
 
@@ -42,7 +42,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = EmitFunctionBuilder[T, U, V, R](ctx, "F")
     val mb = fb.apply_method
     mb.emit(f(mb, mb.getCodeParam[T](1), mb.getCodeParam[U](2), mb.getCodeParam[V](3)))
-    val asmFn = fb.result(ctx)(theHailClassLoader)
+    val asmFn = fb.result()(theHailClassLoader)
     asmFn.apply
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/RandomSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomSuite.scala
@@ -64,7 +64,7 @@ class RandomSuite extends HailSuite {
 
       resArray
     }
-    f.result(ctx)(new HailClassLoader(getClass.getClassLoader))
+    f.result()(new HailClassLoader(getClass.getClassLoader))
   }
 
   def pmacEngineStagedStaticSize(staticID: Long, size: Int): AsmFunction1[Array[Long], ThreefryRandomEngine] = {
@@ -82,7 +82,7 @@ class RandomSuite extends HailSuite {
       state.copyIntoEngine(cb, engine)
       engine
     }
-    f.result(ctx)(new HailClassLoader(getClass.getClassLoader))
+    f.result()(new HailClassLoader(getClass.getClassLoader))
   }
 
   def pmacStagedDynSize(staticID: Long): AsmFunction1[Array[Long], Array[Long]] = {
@@ -107,7 +107,7 @@ class RandomSuite extends HailSuite {
 
       resArray
     }
-    f.result(ctx)(new HailClassLoader(getClass.getClassLoader))
+    f.result()(new HailClassLoader(getClass.getClassLoader))
   }
 
   def pmacEngineStagedDynSize(staticID: Long): AsmFunction1[Array[Long], ThreefryRandomEngine] = {
@@ -128,7 +128,7 @@ class RandomSuite extends HailSuite {
       state.copyIntoEngine(cb, engine)
       engine
     }
-    f.result(ctx)(new HailClassLoader(getClass.getClassLoader))
+    f.result()(new HailClassLoader(getClass.getClassLoader))
   }
 
   val pmacTestCases = FastSeq(

--- a/hail/src/test/scala/is/hail/expr/ir/RandomSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomSuite.scala
@@ -93,7 +93,7 @@ class RandomSuite extends HailSuite {
       cb.assign(state, SCanonicalRNGStateValue(cb))
       val i = cb.newLocal[Int]("i", 0)
       val len = cb.memoize(message.length())
-      cb.forLoop({}, i < len, cb.assign(i, i + 1), {
+      cb.for_({}, i < len, cb.assign(i, i + 1), {
         cb.assign(state, state.splitDyn(cb, cb.memoize(message(i))))
       })
       cb.assign(state, state.splitStatic(cb, staticID))
@@ -118,7 +118,7 @@ class RandomSuite extends HailSuite {
       cb.assign(state, SCanonicalRNGStateValue(cb))
       val i = cb.newLocal[Int]("i", 0)
       val len = cb.memoize(message.length())
-      cb.forLoop({}, i < len, cb.assign(i, i + 1), {
+      cb.for_({}, i < len, cb.assign(i, i + 1), {
         cb.assign(state, state.splitDyn(cb, cb.memoize(message(i))))
       })
       cb.assign(state, state.splitStatic(cb, staticID))

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -152,12 +152,14 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
           cb += sab.add(ec.pv.asInt64.value))
       }
       cb += (returnArray := Code.newArray[java.lang.Long](sab.size))
-      cb += (idx := 0)
-      cb += Code.whileLoop(idx < sab.size,
-        returnArray.update(idx, sab.isMissing(idx).mux(
+      cb.forLoop(
+        cb.assign(idx, 0),
+        idx < sab.size,
+        cb.assign(idx, idx + 1),
+        cb += returnArray.update(idx, sab.isMissing(idx).mux(
           Code._null[java.lang.Long],
-          Code.boxLong(coerce[Long](sab(idx))))),
-        idx := idx + 1
+          Code.boxLong(coerce[Long](sab(idx)))
+        ))
       )
       returnArray
     }

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -152,7 +152,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
           cb += sab.add(ec.pv.asInt64.value))
       }
       cb += (returnArray := Code.newArray[java.lang.Long](sab.size))
-      cb.forLoop(
+      cb.for_(
         cb.assign(idx, 0),
         idx < sab.size,
         cb.assign(idx, idx + 1),

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -29,7 +29,7 @@ class TestBTreeKey(mb: EmitMethodBuilder[_]) extends BTreeKey {
   def storeKey(cb: EmitCodeBuilder, _off: Code[Long], m: Code[Boolean], v: Code[Long]): Unit = {
     val off = cb.memoize[Long](_off)
     storageType.stagedInitialize(cb, off)
-    cb.ifx(m,
+    cb.if_(m,
       storageType.setFieldMissing(cb, off, 0),
       cb += Region.storeLong(storageType.fieldOffset(off, 0), v)
     )
@@ -119,7 +119,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       cb.assign(r, fb.getCodeParam[Region](1))
       cb.assign(root, fb.getCodeParam[Long](2))
       cb.assign(elt, btree.getOrElseInitialize(cb, ec))
-      cb.ifx(key.isEmpty(cb, elt), {
+      cb.if_(key.isEmpty(cb, elt), {
         key.storeKey(cb, elt, m, v)
       })
       root
@@ -147,7 +147,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       btree.foreach(cb) { (cb, _koff) =>
         val koff = cb.memoize(_koff)
         val ec = key.loadCompKey(cb, koff)
-        cb.ifx(ec.m,
+        cb.if_(ec.m,
           cb += sab.addMissing(),
           cb += sab.add(ec.pv.asInt64.value))
       }
@@ -185,7 +185,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
         val off = cb.newLocal("off", offc)
         val ev = cb.memoize(key.loadCompKey(cb, off), "ev")
         cb += ob.writeBoolean(ev.m)
-        cb.ifx(!ev.m, {
+        cb.if_(!ev.m, {
           cb += ob.writeLong(ev.pv.asInt64.value)
         })
       }

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -107,7 +107,7 @@ class TakeByAggregatorSuite extends HailSuite {
             ab.append(cb, new SInt32Value(random))
             cb += (i := i + 1)
           })
-          cb.ifx(ab.size cne n, cb._fatal("bad size!"))
+          cb.if_(ab.size cne n, cb._fatal("bad size!"))
           cb += (resultOff := argR.allocate(8L, 16L))
           cb += Region.storeAddress(resultOff, tba.result(cb, argR, rt).a)
           cb += Region.storeAddress(resultOff + 8L, ab.data)

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -28,7 +28,7 @@ class TakeByAggregatorSuite extends HailSuite {
           tba.newState(cb, 0L)
           tba.initialize(cb, size)
           cb += (i := 0L)
-          cb.whileLoop(i < n.toLong, {
+          cb.while_(i < n.toLong, {
             cb += argR.invoke[Unit]("clear")
             cb.assign(off, stringPT.allocateAndStoreString(cb, argR, const("str").concat(i.toS)))
             tba.seqOp(cb, false, off, false, cb.memoize(-i))
@@ -101,7 +101,7 @@ class TakeByAggregatorSuite extends HailSuite {
           tba.initialize(cb, nToTake)
           ab.initialize(cb)
           cb += (i := 0)
-          cb.whileLoop(i < n, {
+          cb.while_(i < n, {
             cb += (random := rng.invoke[Double, Double, Double]("runif", -10000d, 10000d).toI)
             tba.seqOp(cb, false, random, false, random)
             ab.append(cb, new SInt32Value(random))

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -107,7 +107,7 @@ class TakeByAggregatorSuite extends HailSuite {
             ab.append(cb, new SInt32Value(random))
             cb += (i := i + 1)
           })
-          cb += ab.size.cne(n).orEmpty(Code._fatal[Unit]("bad size!"))
+          cb.ifx(ab.size cne n, cb._fatal("bad size!"))
           cb += (resultOff := argR.allocate(8L, 16L))
           cb += Region.storeAddress(resultOff, tba.result(cb, argR, rt).a)
           cb += Region.storeAddress(resultOff + 8L, ab.data)

--- a/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
@@ -34,7 +34,7 @@ class DownsampleSuite extends HailSuite {
       cb.assign(i, 0)
       ds1.init(cb, 100)
       ds2.init(cb, 100)
-      cb.whileLoop(i < 10000000, {
+      cb.while_(i < 10000000, {
           cb.assign(x, rng.invoke[Double, Double, Double]("runif", 0d, 1d))
           cb.assign(y, rng.invoke[Double, Double, Double]("runif", 0d, 1d))
 

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -31,7 +31,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
         ptr
       }
 
-      fb.result(ctx)(theHailClassLoader)(_)
+      fb.result()(theHailClassLoader)(_)
     }
 
     private val pushF: (Region, Long, E) => Unit = {
@@ -52,7 +52,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
         Code._empty
       }
 
-      val f = fb.result(ctx)(theHailClassLoader)
+      val f = fb.result()(theHailClassLoader)
       ({ (r, ptr, elt) =>
         f(r, ptr, if(elt == null) 0L else ScalaToRegionValue(ctx.stateManager, r, elemPType, elt))
       })
@@ -75,7 +75,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
         Code._empty
       }
 
-      val f = fb.result(ctx)(theHailClassLoader)
+      val f = fb.result()(theHailClassLoader)
       ({ (r, ptr, other) =>
         assert(other.elemPType.required == elemPType.required)
         f(r, ptr, other.ptr)
@@ -96,7 +96,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
         sbll.resultArray(cb, rArg, arrayPType).a
       }
 
-      val f = fb.result(ctx)(theHailClassLoader)
+      val f = fb.result()(theHailClassLoader)
       ({ (r, ptr) =>
         SafeRow.read(arrayPType, f(r, ptr))
           .asInstanceOf[IndexedSeq[E]]
@@ -119,7 +119,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
         dstPtr
       }
 
-      val f = fb.result(ctx)(theHailClassLoader)
+      val f = fb.result()(theHailClassLoader)
       ({ (r, other) => f(r, other.ptr) })
      }
 

--- a/hail/src/test/scala/is/hail/lir/LIRSplitSuite.scala
+++ b/hail/src/test/scala/is/hail/lir/LIRSplitSuite.scala
@@ -16,7 +16,7 @@ class LIRSplitSuite extends HailSuite {
 
         cb.assign(arg, 1000L)
         (0 until 1000).foreach { i =>
-          cb.ifx(arg.cne(1000L), cb._fatal(s"bad split at $i!"))
+          cb.if_(arg.cne(1000L), cb._fatal(s"bad split at $i!"))
         }
       }
       cb.invokeVoid(mb, const(1L))

--- a/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
@@ -37,7 +37,7 @@ class PContainerTest extends PhysicalTestUtils {
 
     fb.emit(Region.containsNonZeroBits(value + sourceType.lengthHeaderBytes, sourceType.loadLength(value).toL))
 
-    val res = fb.result(ctx)(theHailClassLoader)(src)
+    val res = fb.result()(theHailClassLoader)(src)
     res
   }
 
@@ -52,7 +52,7 @@ class PContainerTest extends PhysicalTestUtils {
 
     fb.emit(sourceType.hasMissingValues(value))
 
-    val res = fb.result(ctx)(theHailClassLoader)(src)
+    val res = fb.result()(theHailClassLoader)(src)
     res
   }
 

--- a/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
@@ -331,7 +331,7 @@ class PNDArraySuite extends PhysicalTestUtils {
         throw e
     }
 
-    val f = fb.result(ctx)(theHailClassLoader)
+    val f = fb.result()(theHailClassLoader)
     val result1 = f(region1, region2, region3)
     val result1Data = nd.unstagedDataFirstElementPointer(result1)
 

--- a/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
@@ -146,7 +146,7 @@ class PNDArraySuite extends PhysicalTestUtils {
     val T = vecType.constructUninitialized(FastSeq(btn), cb, region)
 
     val j = cb.newLocal[Long]("j")
-    cb.forLoop(cb.assign(j, 0L), j < n, cb.assign(j, j+1), {
+    cb.for_(cb.assign(j, 0L), j < n, cb.assign(j, j+1), {
       val windowStart = cb.memoize((j-w).max(0))
       val windowSize = cb.memoize(j - windowStart)
       val window = curWindow.slice(cb, Colon, (null, windowSize))
@@ -259,7 +259,7 @@ class PNDArraySuite extends PhysicalTestUtils {
 
         val state = new LocalWhitening(cb, m, w, b, blocksize, region, false)
         val i = cb.newLocal[Long]("i", 0)
-        cb.whileLoop(i < n, {
+        cb.while_(i < n, {
           state.whitenBlock(cb, A.slice(cb, Colon, (i, (i+b).min(n))))
           cb.assign(i, i+b)
         })

--- a/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
@@ -204,7 +204,7 @@ class PNDArraySuite extends PhysicalTestUtils {
         }
 
         var relError: Value[Double] = cb.memoize(Code.invokeStatic1[java.lang.Math, Double, Double]("sqrt", normDiff / normA))
-        cb.ifx(relError > 1e-14, {
+        cb.if_(relError > 1e-14, {
           cb._fatal("backwards error too large: ", relError.toS)
         })
 
@@ -224,7 +224,7 @@ class PNDArraySuite extends PhysicalTestUtils {
 
         relError = cb.memoize(Code.invokeStatic1[java.lang.Math, Double, Double]("sqrt", normDiff / normW2))
         cb.println(relError.toS)
-        cb.ifx(!(relError < 1e-14), {
+        cb.if_(!(relError < 1e-14), {
           cb._fatal("relative error vs naive too large: ", relError.toS)
         })
 
@@ -280,7 +280,7 @@ class PNDArraySuite extends PhysicalTestUtils {
         }
 
         val relError = cb.memoize(Code.invokeStatic1[java.lang.Math, Double, Double]("sqrt", normDiff / normW2))
-        cb.ifx(!(relError < 1e-14), {
+        cb.if_(!(relError < 1e-14), {
           cb._fatal("relative error vs naive too large: ", relError.toS)
         })
 

--- a/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
@@ -76,7 +76,7 @@ abstract class PhysicalTestUtils extends HailSuite {
     }
 
     val copy = try {
-      val f = fb.result(ctx)(theHailClassLoader)
+      val f = fb.result()(theHailClassLoader)
       val copyOff = f(region, srcAddress)
       UnsafeRow.read(destType, region, copyOff)
     } catch {


### PR DESCRIPTION
This change grew out of https://github.com/hail-is/hail/pull/13674.
The idea is simple - we shouldn't be appending code after control statements as such statements are redundant. That idea opened pandora's box, but now we're not generating and dropping dead code anymore.

Main changes that rose form fixing fallout from adding assert in `Block.append`:
- Implement basic control-flow structures (if, while, for, switch) in `CodeBuilderLike` and remove the older implementations from `Code`.
  - main difference is these are built from sequencing `Code` operations rather than being defined from LIR
  - allows for a higher-level implementation that I think is simpler to read.
- Use the type-system to prevent foot-guns like `cb.ifx(cond, label.goto)`.

Other changes:
- rename `ifx`, `forLoop` and `whileLoop` to just `if_`, `for_` and `while_`, respectively.
- Implement loops in-terms of one-another to remove code duplication.
- Fix logic for when to write IRs as some default value behaviour was broken when `HAIL_WRITE_IR_FILES` was set in tests