### PR TITLE
[query] fix ndarray concat with size 0 dims

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1171,6 +1171,14 @@ def test_hstack():
     assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([a, b]))), np.hstack((a, b))))
     assert_table(a, b)
 
+    empty = np.array([], np.int64).reshape((3, 0))
+    assert(np.array_equal(hl.eval(hl.nd.hstack((a, empty))), np.hstack((a, empty))))
+    assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([a, empty]))), np.hstack((a, empty))))
+    assert(np.array_equal(hl.eval(hl.nd.hstack((empty, a))), np.hstack((empty, a))))
+    assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([empty, a]))), np.hstack((empty, a))))
+    assert_table(a, empty)
+    assert_table(empty, a)
+
 
 def test_eye():
     for i in range(13):

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1142,10 +1142,15 @@ def test_vstack_2():
 
     a = np.array([[1], [2], [3]])
     b = np.array([[2], [3], [4]])
-    seq = (a, b)
-    seq2 = hl.array([a, b])
-    assert(np.array_equal(hl.eval(hl.nd.vstack(seq)), np.vstack(seq)))
-    assert(np.array_equal(hl.eval(hl.nd.vstack(seq2)), np.vstack(seq)))
+    empty = np.array([], np.int64).reshape((0, 1))
+
+    assert(np.array_equal(hl.eval(hl.nd.vstack((a, b))), np.vstack((a, b))))
+    assert(np.array_equal(hl.eval(hl.nd.vstack(hl.array([a, b]))), np.vstack((a, b))))
+    assert(np.array_equal(hl.eval(hl.nd.vstack((a, empty, b))), np.vstack((a, empty, b))))
+    assert(np.array_equal(hl.eval(hl.nd.vstack(hl.array([a, empty, b]))), np.vstack((a, empty, b))))
+    assert(np.array_equal(hl.eval(hl.nd.vstack((empty, a, b))), np.vstack((empty, a, b))))
+    assert(np.array_equal(hl.eval(hl.nd.vstack(hl.array([empty, a, b]))), np.vstack((empty, a, b))))
+
     ht2 = ht.annotate(x=hl.nd.array(a), y=hl.nd.array(b))
     ht2 = ht2.annotate(stacked=hl.nd.vstack([ht2.x, ht2.y]))
     assert np.array_equal(ht2.collect()[0].stacked, np.vstack([a, b]))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1123,40 +1123,66 @@ def test_concatenate_differing_shapes():
         ])
 
 
-def test_vstack_1():
-    ht = hl.utils.range_table(10)
-
-    a = np.array([1, 2, 3])
-    b = np.array([2, 3, 4])
-
-    seq = (a, b)
-    seq2 = hl.array([a, b])
-    assert(np.array_equal(hl.eval(hl.nd.vstack(seq)), np.vstack(seq)))
-    assert(np.array_equal(hl.eval(hl.nd.vstack(seq2)), np.vstack(seq)))
-    ht2 = ht.annotate(x=hl.nd.array(a), y=hl.nd.array(b))
-    ht2 = ht2.annotate(stacked=hl.nd.vstack([ht2.x, ht2.y]))
-    assert np.array_equal(ht2.collect()[0].stacked, np.vstack([a, b]))
-
-def test_vstack_2():
-    ht = hl.utils.range_table(10)
-
+def make_test_vstack_data():
     a = np.array([[1], [2], [3]])
     b = np.array([[2], [3], [4]])
     empty = np.array([], np.int64).reshape((0, 1))
 
-    assert(np.array_equal(hl.eval(hl.nd.vstack((a, b))), np.vstack((a, b))))
-    assert(np.array_equal(hl.eval(hl.nd.vstack(hl.array([a, b]))), np.vstack((a, b))))
-    assert(np.array_equal(hl.eval(hl.nd.vstack((a, empty, b))), np.vstack((a, empty, b))))
-    assert(np.array_equal(hl.eval(hl.nd.vstack(hl.array([a, empty, b]))), np.vstack((a, empty, b))))
-    assert(np.array_equal(hl.eval(hl.nd.vstack((empty, a, b))), np.vstack((empty, a, b))))
-    assert(np.array_equal(hl.eval(hl.nd.vstack(hl.array([empty, a, b]))), np.vstack((empty, a, b))))
+    yield a, b
+    yield a, empty, b
+    yield empty, a, b
+
+
+    a = np.array([1, 2, 3])
+    b = np.array([2, 3, 4])
+    yield a, b
+
+
+@pytest.mark.parametrize("data", make_test_vstack_data())
+def test_vstack(data):
+    assert(np.array_equal(hl.eval(hl.nd.vstack(data)), np.vstack(data)))
+    assert(np.array_equal(hl.eval(hl.nd.vstack(hl.array(list(data)))), np.vstack(data)))
+
+
+def make_test_vstack_2_data():
+    a = np.array([[1], [2], [3]])
+    b = np.array([[2], [3], [4]])
+    empty = np.array([], np.int64).reshape((0, 1))
+
+    yield (a, b)
+    yield (a, empty)
+    yield (empty, a)
+
+    a = np.array([1, 2, 3])
+    b = np.array([2, 3, 4])
+    yield (a, b)
+
+
+@pytest.mark.parametrize("a,b", make_test_vstack_2_data())
+def test_vstack_2(a, b):
+    ht = hl.utils.range_table(10)
 
     ht2 = ht.annotate(x=hl.nd.array(a), y=hl.nd.array(b))
     ht2 = ht2.annotate(stacked=hl.nd.vstack([ht2.x, ht2.y]))
     assert np.array_equal(ht2.collect()[0].stacked, np.vstack([a, b]))
 
 
-def test_hstack():
+def make_test_hstack_data():
+    a = np.array([1, 2, 3])
+    b = np.array([2, 3, 4])
+    yield a, b
+
+    a = np.array([[1], [2], [3]])
+    b = np.array([[2], [3], [4]])
+    yield a, b
+
+    empty = np.array([], np.int64).reshape((3, 0))
+    yield a, empty
+    yield empty, a
+
+
+@pytest.mark.parametrize("a,b", make_test_hstack_data())
+def test_hstack(a, b):
     ht = hl.utils.range_table(10)
 
     def assert_table(a, b):
@@ -1164,25 +1190,9 @@ def test_hstack():
         ht2 = ht2.annotate(stacked=hl.nd.hstack([ht2.x, ht2.y]))
         assert np.array_equal(ht2.collect()[0].stacked, np.hstack([a, b]))
 
-    a = np.array([1, 2, 3])
-    b = np.array([2, 3, 4])
     assert(np.array_equal(hl.eval(hl.nd.hstack((a, b))), np.hstack((a, b))))
     assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([a, b]))), np.hstack((a, b))))
     assert_table(a, b)
-
-    a = np.array([[1], [2], [3]])
-    b = np.array([[2], [3], [4]])
-    assert(np.array_equal(hl.eval(hl.nd.hstack((a, b))), np.hstack((a, b))))
-    assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([a, b]))), np.hstack((a, b))))
-    assert_table(a, b)
-
-    empty = np.array([], np.int64).reshape((3, 0))
-    assert(np.array_equal(hl.eval(hl.nd.hstack((a, empty))), np.hstack((a, empty))))
-    assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([a, empty]))), np.hstack((a, empty))))
-    assert(np.array_equal(hl.eval(hl.nd.hstack((empty, a))), np.hstack((empty, a))))
-    assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([empty, a]))), np.hstack((empty, a))))
-    assert_table(a, empty)
-    assert_table(empty, a)
 
 
 def test_eye():

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -275,56 +275,51 @@ object EmitNDArray {
                 cb._fatal("need at least one ndarray to concatenate")
               })
 
-              val missing: Code[Boolean] = {
-                if (ndsArraySValue.st.elementEmitType.required)
-                  const(false)
-                else {
-                  val missing = cb.newLocal[Boolean]("ndarray_concat_result_missing")
-                  cb.assign(missing, false)
-                  // Need to check if the any of the ndarrays are missing.
-                  val missingCheckLoopIdx = cb.newLocal[Int]("ndarray_concat_missing_check_idx")
-                  cb.forLoop(cb.assign(missingCheckLoopIdx, 0), missingCheckLoopIdx < arrLength, cb.assign(missingCheckLoopIdx, missingCheckLoopIdx + 1),
-                    cb.assign(missing, missing | ndsArraySValue.isElementMissing(cb, missingCheckLoopIdx))
-                  )
-                  missing
+              IEmitCode(cb, ndsArraySValue.hasMissingValues(cb), {
+                val firstND = ndsArraySValue.loadElement(cb, 0).get(cb).asNDArray
+
+                // compute array of sizes along concat axis, and total size of concat axis
+                val arrayLongPType = PCanonicalArray(PInt64(), true)
+                val (pushSize, finishSizes) = arrayLongPType.constructFromFunctions(cb, region, arrLength, false)
+
+                val concatAxisSize = cb.newLocal[Long](s"ndarray_concat_axis_size", 0L)
+
+                ndsArraySValue.forEachDefined(cb) { (cb, i, nd) =>
+                  val dimLength = nd.asNDArray.shapes(axis)
+                  pushSize(cb, EmitCode(Code._empty, false, primitive(dimLength)).toI(cb))
+                  cb.assign(concatAxisSize, concatAxisSize + dimLength)
                 }
-              }
+                val stagedArrayOfSizes = finishSizes(cb)
 
-              IEmitCode(cb, missing, {
-                val loopIdx = cb.newLocal[Int]("ndarray_concat_shape_check_idx")
-                val firstND = ndsArraySValue.loadElement(cb, 0).map(cb) { sCode => sCode.asNDArray }.get(cb)
+                // compute index of first input which has non-zero concat axis size
+                val firstNonEmpty = cb.newLocal[Int]("ndarray_concat_first_nonempty", 0)
+                cb.whileLoop(stagedArrayOfSizes.loadElement(cb, firstNonEmpty).get(cb).asInt64.value.ceq(0L), {
+                  cb.assign(firstNonEmpty, firstNonEmpty + 1)
+                })
 
-                val stagedArrayOfSizesPType = PCanonicalArray(PInt64(), true)
-                val (pushElement, finish) = stagedArrayOfSizesPType.constructFromFunctions(cb, region, arrLength, false)
-
-                val newShape = (0 until x.typ.nDims).map { dimIdx =>
-                  val localDim = cb.newLocal[Long](s"ndarray_concat_output_shape_element_${dimIdx}")
-                  val ndShape = firstND.shapes
-                  cb.assign(localDim, ndShape(dimIdx))
-                  if (dimIdx == axis) {
-                    pushElement(cb, EmitCode(Code._empty, false, primitive(localDim)).toI(cb))
+                // check that all sizes along other axes are consistent
+                ndsArraySValue.forEachDefined(cb) { case (cb, _, nd: SNDArrayValue) =>
+                  val mismatchedDim = cb.newLocal[Int]("ndarray_concat_mismatched_dim", -1)
+                  val expected = cb.newLocal[Long]("ndarray_concat_expected_size")
+                  val found = cb.newLocal[Long]("ndarray_concat_found_size")
+                  for (i <- (0 until firstND.st.nDims).reverse if i != axis) {
+                    cb.ifx(firstND.shapes(i).cne(nd.shapes(i)), {
+                      cb.assign(mismatchedDim, i)
+                      cb.assign(expected, firstND.shapes(i))
+                      cb.assign(found, nd.shapes(i))
+                    })
                   }
-
-                  cb.forLoop(cb.assign(loopIdx, 1), loopIdx < arrLength, cb.assign(loopIdx, loopIdx + 1), {
-                    val shapeOfNDAtIdx = ndsArraySValue.loadElement(cb, loopIdx).map(cb) { sCode => sCode.asNDArray }.get(cb).shapeStruct(cb)
-                    val dimLength = cb.newLocal[Long]("dimLength", shapeOfNDAtIdx.loadField(cb, dimIdx).get(cb).asInt64.value)
-
-                    if (dimIdx == axis) {
-                      pushElement(cb, EmitCode(Code._empty, false, primitive(dimLength)).toI(cb))
-                      cb.assign(localDim, localDim + dimLength)
-                    }
-                    else {
-                      cb.ifx(dimLength.cne(localDim),
-                        cb._fatal(const(s"NDArrayConcat: mismatched dimensions of input NDArrays along axis ").concat(loopIdx.toS).concat(": expected ")
-                          .concat(localDim.toS).concat(", got ")
-                          .concat(dimLength.toS))
-                      )
-                    }
-                  })
-                  localDim
+                  cb.ifx(mismatchedDim.cne(-1),
+                    cb._fatal(const(s"NDArrayConcat: mismatched dimensions of input NDArrays along axis ")
+                                .concat(mismatchedDim.toS)
+                                .concat(": expected ").concat(expected.toS)
+                                .concat(", got ").concat(found.toS)))
                 }
 
-                val stagedArrayOfSizes = finish(cb)
+                // compute shape of result
+                val newShape = (0 until x.typ.nDims).map { i =>
+                  if (i == axis) concatAxisSize else firstND.shapes(i)
+                }
 
                 new NDArrayProducer {
                   override def elementType: PType = firstND.st.elementPType
@@ -337,13 +332,13 @@ object EmitNDArray {
 
                   override val initAll: EmitCodeBuilder => Unit = { cb =>
                     idxVars.foreach(idxVar => cb.assign(idxVar, 0L))
-                    cb.assign(currentNDArrayIdx, 0)
+                    cb.assign(currentNDArrayIdx, firstNonEmpty)
                   }
                   override val initAxis: IndexedSeq[EmitCodeBuilder => Unit] =
                     shape.indices.map(i => (cb: EmitCodeBuilder) => {
                       cb.assign(idxVars(i), 0L)
                       if (i == axis) {
-                        cb.assign(currentNDArrayIdx, 0)
+                        cb.assign(currentNDArrayIdx, firstNonEmpty)
                       }
                     })
                   override val stepAxis: IndexedSeq[(EmitCodeBuilder, Value[Long]) => Unit] = {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1747,10 +1747,14 @@ class IRSuite extends HailSuite {
     assertNDEvals(NDArrayConcat(nds(nd1, rowwise), 0), rowwiseExpected)
     assertNDEvals(NDArrayConcat(nds(nd1, rowwise, emptyRowwise), 0), rowwiseExpected)
     assertNDEvals(NDArrayConcat(nds(nd1, emptyRowwise, rowwise), 0), rowwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(emptyRowwise, nd1, rowwise), 0), rowwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(emptyRowwise), 0), FastSeq())
 
     assertNDEvals(NDArrayConcat(nds(nd1, colwise), 1), colwiseExpected)
     assertNDEvals(NDArrayConcat(nds(nd1, colwise, emptyColwise), 1), colwiseExpected)
     assertNDEvals(NDArrayConcat(nds(nd1, emptyColwise, colwise), 1), colwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(emptyColwise, nd1, colwise), 1), colwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(emptyColwise), 1), FastSeq(FastSeq(), FastSeq()))
 
     assertNDEvals(NDArrayConcat(nds(nd1, na), 1), null)
     assertNDEvals(NDArrayConcat(nds(na, na), 1), null)


### PR DESCRIPTION
ndarray concat was broken when the first input has size 0 along the concat axis. For example
```
In [3]: hl.eval(hl.nd.hstack([hl.nd.zeros((2, 0)), hl.nd.array([[1.0, 2.0], [3.0, 4.0]])]))
Out[3]:
array([[0., 2.],
       [0., 4.]])
```
The zeros matrix is 2 by 0, so horizontal concatenation should just return the other matrix.
(I once saw the first column filled with random numbers, presumably from a buffer overflow)

I did some cleaning up in the concat implementation, but the functional change is to record the index of the first input which is non-empty along the concat axis, and when resetting to the start of the axis, reset to that non-empty index. Other size 0 inputs are correctly handled when incrementing the index, the problem was that the first read happens before an increment.