### PR TITLE
[query] fixes hail jar for dataproc notebooks

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -85,6 +85,8 @@ compileScala {
 }
 
 configurations {
+    justSpark
+
     all {
         resolutionStrategy {
             eachDependency { DependencyResolveDetails details ->
@@ -92,14 +94,20 @@ configurations {
                     details.useVersion(sparkVersion)
                 }
             }
-	}
+        }
+    }
+
+    hailJar.extendsFrom implementation
+    hailJar {
+        exclude group: 'org.scala-lang', module: 'scala-library'
+        exclude group: 'org.apache.spark'
     }
 
     testImplementation.extendsFrom shadow
 }
 
 dependencies {
-    shadow ('org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion) {
+    justSpark('org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion) {
         exclude group: 'org.scalanlp'
     }
 
@@ -330,12 +338,13 @@ tasks.withType(ShadowJar) {
 
 shadowJar {
     archiveClassifier = 'spark'
+    from project.sourceSets.main.output
+    configurations = [project.configurations.hailJar]
 }
 
 task shadowTestJar(type: ShadowJar) {
     archiveClassifier = 'spark-test'
-    from sourceSets.test.output
-    from sourceSets.main.output
+    from project.sourceSets.main.output, project.sourceSets.test.output
     configurations = [project.configurations.testRuntimeClasspath]
 }
 


### PR DESCRIPTION
closes https://github.com/hail-is/hail/issues/13690.

to test that this works, i've been running these commands from the root of my clone of the hail repo:

```bash
make -C hail install-editable
make -C hail install-hailctl
hailctl dataproc start notebook-slowdown-repro --region us-central1
hailctl dataproc connect notebook-slowdown-repro notebook
```

and then running this minimal example in the notebook:

```python
import hail
hail.utils.range_table(10).show()
```

and making sure it outputs a visual of the table, instead of getting stuck displaying `Stage 0:> (0+X)/Y` and not progressing.