### PR TITLE
[query] substantially reduce single core latency for force-count

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -1011,6 +1011,8 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
 
   def numberOfTrailingZeros: Code[Int] = Code.invokeStatic1[java.lang.Long, Long, Int]("numberOfTrailingZeros", lhs)
 
+  def reverseBytes: Code[Long] = Code.invokeStatic1[java.lang.Long, Long, Long]("reverseBytes", lhs)
+
   def bitCount: Code[Int] = Code.invokeStatic1[java.lang.Long, Long, Int]("bitCount", lhs)
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -61,6 +61,9 @@ trait PArrayBackedContainer extends PContainer {
   override def setElementPresent(cb: EmitCodeBuilder, aoff: Code[Long], i: Code[Int]): Unit =
     arrayRep.setElementPresent(cb, aoff, i)
 
+  override def firstElementOffset(aoff: Long): Long =
+    arrayRep.firstElementOffset(aoff)
+
   override def firstElementOffset(aoff: Long, length: Int): Long =
     arrayRep.firstElementOffset(aoff, length)
 
@@ -81,6 +84,18 @@ trait PArrayBackedContainer extends PContainer {
 
   override def elementOffset(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] =
     arrayRep.elementOffset(aoff, length, i)
+
+  override def incrementElementOffset(currentOffset: Long, increment: Int): Long =
+    arrayRep.incrementElementOffset(currentOffset, increment)
+
+  override def incrementElementOffset(currentOffset: Code[Long], increment: Code[Int]): Code[Long] =
+    arrayRep.incrementElementOffset(currentOffset, increment)
+
+  override def pastLastElementOffset(aoff: Long, length: Int): Long =
+    arrayRep.pastLastElementOffset(aoff, length)
+
+  override def pastLastElementOffset(aoff: Code[Long], length: Code[Int]): Code[Long] =
+    arrayRep.pastLastElementOffset(aoff, length)
 
   override def loadElement(aoff: Long, length: Int, i: Int): Long =
     arrayRep.loadElement(aoff, length, i)
@@ -129,12 +144,6 @@ trait PArrayBackedContainer extends PContainer {
 
   override def _copyFromAddress(sm: HailStateManager, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
     arrayRep.copyFromAddress(sm, region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)
-
-  override def nextElementAddress(currentOffset: Long): Long =
-    arrayRep.nextElementAddress(currentOffset)
-
-  override def nextElementAddress(currentOffset: Code[Long]): Code[Long] =
-    arrayRep.nextElementAddress(currentOffset)
 
   override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
     arrayRep.unstagedStoreAtAddress(sm, addr, region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -148,13 +148,19 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       firstElementOffset(aoff, loadLength(aoff)) + i.toL * const(elementByteSize)
     }
 
+  def incrementElementOffset(currentOffset: Long, increment: Int): Long =
+    currentOffset + increment * elementByteSize
+
+  def incrementElementOffset(currentOffset: Code[Long], increment: Code[Int]): Code[Long] =
+    currentOffset + increment.toL * elementByteSize
+
+  def pastLastElementOffset(aoff: Long, length: Int): Long =
+    firstElementOffset(aoff, length) + length * elementByteSize
+
+  def pastLastElementOffset(aoff: Code[Long], length: Code[Int]): Code[Long] =
+    firstElementOffset(aoff, length) + length.toL * elementByteSize
+
   private def elementOffsetFromFirst(firstElementAddr: Code[Long], i: Code[Int]): Code[Long] = firstElementAddr + i.toL * const(elementByteSize)
-
-  def nextElementAddress(currentOffset: Long) =
-    currentOffset + elementByteSize
-
-  def nextElementAddress(currentOffset: Code[Long]) =
-    currentOffset + elementByteSize
 
   def loadElement(aoff: Long, length: Int, i: Int): Long = {
     val off = elementOffset(aoff, length, i)
@@ -521,7 +527,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       else {
         elementType.unstagedStoreJavaObjectAtAddress(sm, curElementAddress, is(i), region)
       }
-      curElementAddress = nextElementAddress(curElementAddress)
+      curElementAddress = nextElementOffset(curElementAddress)
       i += 1
     }
 

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -43,6 +43,12 @@ abstract class PContainer extends PIterable {
 
   def firstElementOffset(aoff: Long, length: Int): Long
 
+  def firstElementOffset(aoff: Long): Long
+
+  def firstElementOffset(aoff: Code[Long], length: Code[Int]): Code[Long]
+
+  def firstElementOffset(aoff: Code[Long]): Code[Long]
+
   def elementOffset(aoff: Long, length: Int, i: Int): Long
 
   def elementOffset(aoff: Long, i: Int): Long
@@ -51,9 +57,17 @@ abstract class PContainer extends PIterable {
 
   def elementOffset(aoff: Code[Long], i: Code[Int]): Code[Long]
 
-  def firstElementOffset(aoff: Code[Long], length: Code[Int]): Code[Long]
+  def nextElementOffset(currentOffset: Long): Long = incrementElementOffset(currentOffset, 1)
 
-  def firstElementOffset(aoff: Code[Long]): Code[Long]
+  def nextElementOffset(currentOffset: Code[Long]): Code[Long] = incrementElementOffset(currentOffset, 1)
+
+  def incrementElementOffset(currentOffset: Long, increment: Int): Long
+
+  def incrementElementOffset(currentOffset: Code[Long], increment: Code[Int]): Code[Long]
+
+  def pastLastElementOffset(aoff: Long, length: Int): Long
+
+  def pastLastElementOffset(aoff: Code[Long], length: Code[Int]): Code[Long]
 
   def loadElement(aoff: Long, length: Int, i: Int): Long
 
@@ -80,8 +94,4 @@ abstract class PContainer extends PIterable {
   def zeroes(cb: EmitCodeBuilder, region: Value[Region], length: Code[Int]): Code[Long]
 
   def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean]
-
-  def nextElementAddress(currentOffset: Long): Long
-
-  def nextElementAddress(currentOffset: Code[Long]): Code[Long]
 }


### PR DESCRIPTION
CHANGELOG: Reduce latency on simple pipelines by as much as 50% by reducing decoding time.

Force count essentially tests decoding because it forces decoding but then just increments a counter by one. Analysis of profile results indicates that the array inplace decoder was perhaps 50% of time, but exactly what part of decoding was unclear.

I attempted many different things. I eventually settled on loop unrolling as the primary benefit. After team meeting, I applied @patrick-schultz 's advice to use bit twiddling to further improve the speed.

---

I assessed the latency using `time python3` on this file:

```python
import hail as hl
hl.init(master='local[1]')
hl._set_flags(write_ir_files='1')
hl.read_matrix_table('/Users/dking/projects/hail-data/foo.mt')._force_count_rows()
```

`foo.mt` is a subset of the `variant_data` from a VDS with ~80k samples, ~300k variants, stored in ~1.6GiB.

1. This PR: 34s, 33s
2. no twiddling: 43s, 43s https://github.com/hail-is/hail/compare/main...danking:hail:unroll-64
3. no twiddling & 8 element blocks: 37s, 38s https://github.com/hail-is/hail/compare/main...danking:hail:unroll-8
4. `main` (`481cfc201b [query] fix backoff code (#13713)`): 68s, 69s

In YourKit, I observe that (1) reads 50-70MB/s with one core whereas (4) reads 15-35MB/s.

I also assessed the 10-core latency and JIT effects:

- (1) starts at ~12s, warms to ~6s (+- 0.5s). Peak bandwidth 490MB/s.
- (4) starts at ~17s and warms up to ~11s (+- 2s). Peak bandwidth ~250MB/s.

I suspect, with this PR, the multi-core speed is fast enough to saturate any of our file stores (including my laptop, which I think taps out just around ~500MB/s).

Big thanks to everyone who contributed, particularly @patrick-schultz, whose suggestion to use bit-twiddling, squeezeed another 10% off the 8 element blocks.