### PR TITLE
[query] do not store function return values in variables

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -1275,12 +1275,10 @@ class Invokeable[T, S](tcls: Class[T],
         lir.methodStmt(invokeOp, Type.getInternalName(tcls), name, descriptor, isInterface, sti, argvs))
       new VCode(start, end, null)
     } else {
-      val t = new lir.Local(null, s"invoke_$name", sti)
       var r = lir.methodInsn(invokeOp, Type.getInternalName(tcls), name, descriptor, isInterface, sti, argvs)
       if (concreteReturnType != sct.runtimeClass)
         r = lir.checkcast(Type.getInternalName(sct.runtimeClass), r)
-      end.append(lir.store(t, r))
-      new VCode(start, end, lir.load(t))
+      new VCode(start, end, r)
     }
   }
 }


### PR DESCRIPTION
I do not know why we do this, but we return a `Code` here, not a `Value`, so it seems silly to store in a variable. In practice, the LIR is littered with invocations that store their value in a local which is then read and stored in a different local beause we `memoize` the function call.