### PR TITLE
[query] emit LIR instructions in order (instead of reverse order)

### DIFF
--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -226,12 +226,12 @@ class Method private[lir] (
 
         assert(L.first != null)
         val x = L.last.asInstanceOf[ControlX]
-        var i = 0
-        while (i < x.targetArity()) {
+        var i = x.targetArity() - 1
+        while (i >= 0) {
           val target = x.target(i)
           assert(target != null)
           s.push(target)
-          i += 1
+          i -= 1
         }
         visited += L
       }


### PR DESCRIPTION
This has no discernable effect on latency but it makes the LIR much easier to read because, for example, `IfX IFNE L1 L2 ...` will have `L1` (in printed LIR and JVM bytecode) immediately after it rather than `L2`. The labels also tend to appear in sequential order, which I find helps me navigate the LIR.