### PR TITLE
[query] faster array decoder

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -42,7 +42,7 @@ class RegionValueBuilder(sm: HailStateManager, var region: Region) {
         case t: PCanonicalBaseStruct =>
           offsetstk.top + t.byteOffsets(i)
         case t: PArray =>
-          elementsOffsetstk.top + i * t.elementByteSize
+          t.incrementElementOffset(elementsOffsetstk.top, i)
       }
     }
   }

--- a/hail/src/main/scala/is/hail/annotations/UnsafeUtils.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeUtils.scala
@@ -18,6 +18,30 @@ object UnsafeUtils {
     (offset + (alignment - 1)) & ~(alignment - 1)
   }
 
+  def roundDownAlignment(offset: Long, alignment: Long): Long = {
+    assert(alignment > 0)
+    assert((alignment & (alignment - 1)) == 0) // power of 2
+    offset & -alignment
+  }
+
+  def roundDownAlignment(offset: Code[Long], alignment: Long): Code[Long] = {
+    assert(alignment > 0)
+    assert((alignment & (alignment - 1)) == 0) // power of 2
+    offset & -alignment
+  }
+
+  def roundDownAlignment(offset: Int, alignment: Int): Int = {
+    assert(alignment > 0)
+    assert((alignment & (alignment - 1)) == 0) // power of 2
+    offset & -alignment
+  }
+
+  def roundDownAlignment(offset: Code[Int], alignment: Int): Code[Int] = {
+    assert(alignment > 0)
+    assert((alignment & (alignment - 1)) == 0) // power of 2
+    offset & -alignment
+  }
+
   def packBitsToBytes(nBits: Int): Int =
     (nBits + 7) >>> 3
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1018,11 +1018,7 @@ class Emit[C](
       case ArrayZeros(length) =>
         emitI(length).map(cb) { case n: SInt32Value =>
           val outputPType = PCanonicalArray(PInt32Required)
-          val elementSize = outputPType.elementByteSize
-          val numElements = n.value
-          val arrayAddress = cb.newLocal[Long]("array_addr", outputPType.allocate(region, numElements))
-          outputPType.stagedInitialize(cb, arrayAddress, numElements)
-          cb += Region.setMemory(outputPType.firstElementOffset(arrayAddress), numElements.toL * elementSize, 0.toByte)
+          val arrayAddress = outputPType.zeroes(cb, region, n.value)
           outputPType.loadCheapSCode(cb, arrayAddress)
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -132,13 +132,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
     cb.ifx(size.ceq(capacity),
       {
         cb.assign(capacity, capacity * 2)
-        cb.assign(newDataOffset, eltArray.allocate(region, capacity))
-        eltArray.stagedInitialize(cb, newDataOffset, capacity, setMissing = true)
-        cb += Region.copyFrom(data + eltArray.lengthHeaderBytes, newDataOffset + eltArray.lengthHeaderBytes, eltArray.nMissingBytes(size).toL)
-        cb += Region.copyFrom(data + eltArray.elementsOffset(size),
-          newDataOffset + eltArray.elementsOffset(capacity.load()),
-          size.toL * const(eltArray.elementByteSize))
-        cb.assign(data, newDataOffset)
+        cb.assign(data, eltArray.padWithMissing(cb, region, size, capacity, data))
       })
   }
 }

--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -109,12 +109,21 @@ final case class EArray(val elementType: EType, override val required: Boolean =
       val elemOff = cb.newLocal[Long]("elemOff", arrayType.firstElementOffset(array, len))
       if (arrayType.trivialElements) {
         // elements have 0 size, so all elements have the same address
-        // still need to read `len` elements from the input stream
+        // still need to read `len` elements from the input stream, as they may have non-zero size
         val i = cb.newLocal[Int]("i", 0)
-        cb.forLoop({}, i < len, cb.assign(i, i+1), readElemF(cb, region, elemOff, in))
+        cb.forLoop({}, i < (len & -8), cb.assign(i, i + 8), {
+          for (k <- 0 until 8)
+            readElemF(cb, region, cb.memoize(arrayType.incrementElementOffset(elemOff, k)), in)
+        })
+        cb.forLoop({}, i < len, cb.assign(i, i + 1), readElemF(cb, region, elemOff, in))
       } else {
+        val lastBlockAddr = cb.memoize(arrayType.elementOffset(array, len, len & -8))
+        cb.forLoop({}, elemOff < lastBlockAddr, cb.assign(elemOff, arrayType.incrementElementOffset(elemOff, 8)), {
+          for (i <- 0 until 8)
+            readElemF(cb, region, cb.memoize(arrayType.incrementElementOffset(elemOff, i)), in)
+        })
         cb.forLoop({}, elemOff < pastLastOff, cb.assign(elemOff, arrayType.nextElementAddress(elemOff)), {
-            readElemF(cb, region, elemOff, in)
+          readElemF(cb, region, elemOff, in)
         })
       }
     } else {

--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -98,8 +98,8 @@ final case class EArray(val elementType: EType, override val required: Boolean =
       case t: PCanonicalDict => t.arrayRep
     }
 
-    val len = cb.memoize(in.readInt())
-    val array = cb.memoize(arrayType.allocate(region, len))
+    val len = cb.memoize(in.readInt(), "len")
+    val array = cb.memoize(arrayType.allocate(region, len), "array")
     arrayType.storeLength(cb, array, len)
 
     val readElemF = elementType.buildInplaceDecoder(arrayType.elementType, cb.emb.ecb)

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -10,12 +10,6 @@ import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePoin
 trait PArrayBackedContainer extends PContainer {
   val arrayRep: PArray
 
-  override lazy val elementByteSize = arrayRep.elementByteSize
-
-  override lazy val contentsAlignment = arrayRep.contentsAlignment
-
-  override lazy val lengthHeaderBytes: Long = arrayRep.lengthHeaderBytes
-
   override lazy val byteSize: Long = arrayRep.byteSize
 
   override def loadLength(aoff: Long): Int =
@@ -26,9 +20,6 @@ trait PArrayBackedContainer extends PContainer {
 
   override def storeLength(cb: EmitCodeBuilder, aoff: Code[Long], length: Code[Int]): Unit =
     arrayRep.storeLength(cb, aoff, length)
-
-  override def nMissingBytes(len: Code[Int]): Code[Int] =
-    arrayRep.nMissingBytes(len)
 
   override def elementsOffset(length: Int): Long =
     arrayRep.elementsOffset(length)
@@ -106,6 +97,12 @@ trait PArrayBackedContainer extends PContainer {
   override def clearMissingBits(aoff: Long, length: Int) =
     arrayRep.clearMissingBits(aoff, length)
 
+  def contentsByteSize(length: Int): Long =
+    arrayRep.contentsByteSize(length)
+
+  def contentsByteSize(length: Code[Int]): Code[Long] =
+    arrayRep.contentsByteSize(length)
+
   override def initialize(aoff: Long, length: Int, setMissing: Boolean = false) =
     arrayRep.initialize(aoff, length, setMissing)
 
@@ -135,6 +132,18 @@ trait PArrayBackedContainer extends PContainer {
 
   override def nextElementAddress(currentOffset: Code[Long]): Code[Long] =
     arrayRep.nextElementAddress(currentOffset)
+
+  override def incrementElementOffset(currentOffset: Long, increment: Int): Long =
+    arrayRep.incrementElementOffset(currentOffset, increment)
+
+  override def incrementElementOffset(currentOffset: Code[Long], increment: Code[Int]): Code[Long] =
+    arrayRep.incrementElementOffset(currentOffset, increment)
+
+  override def pastLastElementOffset(aoff: Long, length: Int): Long =
+    arrayRep.pastLastElementOffset(aoff, length)
+
+  override def pastLastElementOffset(aoff: Code[Long], length: Value[Int]): Code[Long] =
+    arrayRep.pastLastElementOffset(aoff, length)
 
   override def unstagedStoreAtAddress(sm: HailStateManager, addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
     arrayRep.unstagedStoreAtAddress(sm, addr, region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -37,7 +37,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   private val elementByteSize: Long = UnsafeUtils.arrayElementSize(elementType)
 
-  def trivialElements: Boolean = elementByteSize == 0
+  def zeroSizeElements: Boolean = elementByteSize == 0
 
   private val contentsAlignment: Long = 8
 
@@ -101,7 +101,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   def missingBytesOffset: Long = lengthHeaderBytes
 
-  def pastLastMissingByteAddr(aoff: Code[Long], len: Code[Int]): Code[Long] =
+  def pastLastMissingByteOff(aoff: Code[Long], len: Code[Int]): Code[Long] =
     aoff + lengthHeaderBytes + nMissingBytes(len).toL
 
   def isElementDefined(aoff: Long, i: Int): Boolean =

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -23,11 +23,11 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   }
 
 
-  val elementByteSize: Long = UnsafeUtils.arrayElementSize(elementType)
+  private val elementByteSize: Long = UnsafeUtils.arrayElementSize(elementType)
 
-  val contentsAlignment: Long = elementType.alignment.max(4)
+  private val contentsAlignment: Long = elementType.alignment.max(4)
 
-  val lengthHeaderBytes: Long = 4
+  private val lengthHeaderBytes: Long = 4
 
   override val byteSize: Long = 8
 
@@ -84,6 +84,8 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   def elementsOffset(length: Code[Int]): Code[Long] = {
     _elementsOffset(length)
   }
+
+  def missingBytesOffset: Long = lengthHeaderBytes
 
   def isElementDefined(aoff: Long, i: Int): Boolean =
     elementRequired || !Region.loadBit(aoff + lengthHeaderBytes, i)
@@ -149,6 +151,18 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     }
 
   private def elementOffsetFromFirst(firstElementAddr: Code[Long], i: Code[Int]): Code[Long] = firstElementAddr + i.toL * const(elementByteSize)
+
+  override def incrementElementOffset(currentOffset: Long, increment: Int): Long =
+    currentOffset + increment * elementByteSize
+
+  override def incrementElementOffset(currentOffset: Code[Long], increment: Code[Int]): Code[Long] =
+    currentOffset + increment.toL * elementByteSize
+
+  override def pastLastElementOffset(aoff: Long, length: Int): Long =
+    firstElementOffset(aoff, length) + length * elementByteSize
+
+  override def pastLastElementOffset(aoff: Code[Long], length: Value[Int]): Code[Long] =
+    firstElementOffset(aoff, length) + length.toL * elementByteSize
 
   def nextElementAddress(currentOffset: Long) =
     currentOffset + elementByteSize
@@ -240,8 +254,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   def zeroes(cb: EmitCodeBuilder, region: Value[Region], length: Code[Int]): Code[Long] = {
     require(elementType.isNumeric)
     val lengthMem = cb.memoize(length)
-    val aoff = cb.newLocal[Long]("pcanonical_array_zeroes_aoff")
-    cb.assign(aoff, allocate(region, lengthMem))
+    val aoff = cb.memoize[Long](allocate(region, lengthMem))
     stagedInitialize(cb, aoff, lengthMem)
     cb += Region.setMemory(aoff + elementsOffset(lengthMem), lengthMem.toL * elementByteSize, 0.toByte)
     aoff
@@ -431,6 +444,17 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   private def deepRenameArray(t: TArray): PArray =
     PCanonicalArray(this.elementType.deepRename(t.elementType), this.required)
 
+  def padWithMissing(cb: EmitCodeBuilder, region: Value[Region], oldLength: Value[Int], newLength: Value[Int], srcAddress: Value[Long]): Value[Long] = {
+    val dstAddress = cb.memoize(allocate(region, newLength))
+    stagedInitialize(cb, dstAddress, newLength, setMissing = true)
+    cb += Region.copyFrom(srcAddress + lengthHeaderBytes, dstAddress + lengthHeaderBytes, nMissingBytes(oldLength).toL)
+    cb += Region.copyFrom(
+      srcAddress + elementsOffset(oldLength),
+      dstAddress + elementsOffset(newLength),
+      oldLength.toL * elementByteSize)
+    dstAddress
+  }
+
   def constructFromElements(cb: EmitCodeBuilder, region: Value[Region], length: Value[Int], deepCopy: Boolean)
     (f: (EmitCodeBuilder, Value[Int]) => IEmitCode): SIndexablePointerValue = {
 
@@ -541,5 +565,25 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       this
     else
       PCanonicalArray(copiedElement, required)
+  }
+
+
+
+  def forEachDefined(cb: EmitCodeBuilder, aoff: Value[Long])(f: (EmitCodeBuilder, Value[Int], SValue) => Unit) {
+    val length = cb.memoize(loadLength(aoff))
+    val elementsAddress = cb.memoize(firstElementOffset(aoff))
+    val idx = cb.newLocal[Int]("foreach_pca_idx", 0)
+    val elementPtr = cb.newLocal[Long]("foreach_pca_elt_ptr", elementsAddress)
+    val et = elementType
+    cb.whileLoop(idx < length, {
+      cb.ifx(isElementMissing(aoff, idx),
+        {}, // do nothing,
+        {
+          val elt = et.loadCheapSCode(cb, et.loadFromNested(elementPtr))
+          f(cb, idx, elt)
+        })
+      cb.assign(idx, idx + 1)
+      cb.assign(elementPtr, elementPtr + elementByteSize)
+    })
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -37,9 +37,9 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   private val elementByteSize: Long = UnsafeUtils.arrayElementSize(elementType)
 
-  private val contentsAlignment: Long = 8
+  private val contentsAlignment: Long = elementType.alignment.max(4)
 
-  private val lengthHeaderBytes: Long = 8
+  private val lengthHeaderBytes: Long = 4
 
   override val byteSize: Long = 8
 

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -7,19 +7,11 @@ import is.hail.expr.ir.EmitCodeBuilder
 abstract class PContainer extends PIterable {
   override def containsPointers: Boolean = true
 
-  def elementByteSize: Long
-
-  def contentsAlignment: Long
-
   def loadLength(aoff: Long): Int
 
   def loadLength(aoff: Code[Long]): Code[Int]
 
   def storeLength(cb: EmitCodeBuilder, aoff: Code[Long], length: Code[Int]): Unit
-
-  def nMissingBytes(len: Code[Int]): Code[Int]
-
-  def lengthHeaderBytes: Long
 
   def elementsOffset(length: Int): Long
 
@@ -63,6 +55,10 @@ abstract class PContainer extends PIterable {
 
   def loadElement(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long]
 
+  def contentsByteSize(length: Int): Long
+
+  def contentsByteSize(length: Code[Int]): Code[Long]
+
   def allocate(region: Region, length: Int): Long
 
   def allocate(region: Code[Region], length: Code[Int]): Code[Long]
@@ -84,4 +80,12 @@ abstract class PContainer extends PIterable {
   def nextElementAddress(currentOffset: Long): Long
 
   def nextElementAddress(currentOffset: Code[Long]): Code[Long]
+
+  def incrementElementOffset(currentOffset: Long, increment: Int): Long
+
+  def incrementElementOffset(currentOffset: Code[Long], increment: Code[Int]): Code[Long]
+
+  def pastLastElementOffset(aoff: Long, length: Int): Long
+
+  def pastLastElementOffset(aoff: Code[Long], length: Value[Int]): Code[Long]
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -88,20 +88,7 @@ class SIndexablePointerValue(
 
   override def forEachDefined(cb: EmitCodeBuilder)(f: (EmitCodeBuilder, Value[Int], SValue) => Unit) {
     st.pType match {
-      case pca: PCanonicalArray =>
-        val idx = cb.newLocal[Int]("foreach_pca_idx", 0)
-        val elementPtr = cb.newLocal[Long]("foreach_pca_elt_ptr", elementsAddress)
-        val et = pca.elementType
-        cb.whileLoop(idx < length, {
-          cb.ifx(isElementMissing(cb, idx),
-            {}, // do nothing,
-            {
-              val elt = et.loadCheapSCode(cb, et.loadFromNested(elementPtr))
-              f(cb, idx, elt)
-            })
-          cb.assign(idx, idx + 1)
-          cb.assign(elementPtr, elementPtr + pca.elementByteSize)
-        })
+      case pca: PCanonicalArray => pca.forEachDefined(cb, a)(f)
       case _ => super.forEachDefined(cb)(f)
     }
   }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -81,10 +81,9 @@ trait SIndexableValue extends SValue {
   override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val storageType = this.st.storageType().asInstanceOf[PContainer]
     val length = this.loadLength()
-    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes")
+    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.elementsOffset(length).toL)
     if (this.st.elementType.containsPointers) {
       this.forEachDefined(cb) { (cb, _, element) =>
-        cb.assign(totalSize, storageType.elementsOffset(length).toL)
         cb.assign(totalSize, totalSize + element.sizeToStoreInBytes(cb).value)
       }
     } else {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -81,13 +81,14 @@ trait SIndexableValue extends SValue {
   override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value = {
     val storageType = this.st.storageType().asInstanceOf[PContainer]
     val length = this.loadLength()
-    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes", storageType.elementsOffset(length).toL)
+    val totalSize = cb.newLocal[Long]("sindexableptr_size_in_bytes")
     if (this.st.elementType.containsPointers) {
       this.forEachDefined(cb) { (cb, _, element) =>
+        cb.assign(totalSize, storageType.elementsOffset(length).toL)
         cb.assign(totalSize, totalSize + element.sizeToStoreInBytes(cb).value)
       }
     } else {
-      cb.assign(totalSize, totalSize + (length.toL * storageType.elementByteSize))
+      cb.assign(totalSize, storageType.contentsByteSize(length))
     }
 
     new SInt64Value(totalSize)

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -61,7 +61,7 @@ class CodeSuite extends HailSuite {
       }
       sarray.sizeToStoreInBytes(cb).value
     })
-    assert(fb.result(ctx)(theHailClassLoader)(ctx.r) == 28L) // 2 missing bytes 4 byte aligned + 4 header bytes + 5 elements * 4 bytes for ints.
+    assert(fb.result(ctx)(theHailClassLoader)(ctx.r) == 36L) // 2 missing bytes 8 byte aligned + 8 header bytes + 5 elements * 4 bytes for ints.
   }
 
   @Test def testIntervalSizeInBytes(): Unit = {

--- a/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
@@ -16,17 +16,17 @@ class PContainerTest extends PhysicalTestUtils {
     })
   }
 
-  def testContainsNonZeroBits(sourceType: PArray, data: IndexedSeq[Any]) = {
+  def testContainsNonZeroBits(sourceType: PCanonicalArray, data: IndexedSeq[Any]) = {
     val srcRegion = Region(pool=pool)
     val src = ScalaToRegionValue(ctx.stateManager, srcRegion, sourceType, data)
 
     log.info(s"Testing $data")
 
-    val res = Region.containsNonZeroBits(src + sourceType.lengthHeaderBytes, sourceType.loadLength(src))
+    val res = Region.containsNonZeroBits(src + sourceType.missingBytesOffset, sourceType.loadLength(src))
     res
   }
 
-  def testContainsNonZeroBitsStaged(sourceType: PArray, data: IndexedSeq[Any]) = {
+  def testContainsNonZeroBitsStaged(sourceType: PCanonicalArray, data: IndexedSeq[Any]) = {
     val srcRegion = Region(pool=pool)
     val src = ScalaToRegionValue(ctx.stateManager, srcRegion, sourceType, data)
 
@@ -35,7 +35,7 @@ class PContainerTest extends PhysicalTestUtils {
     val fb = EmitFunctionBuilder[Long, Boolean](ctx, "not_empty")
     val value = fb.getCodeParam[Long](1)
 
-    fb.emit(Region.containsNonZeroBits(value + sourceType.lengthHeaderBytes, sourceType.loadLength(value).toL))
+    fb.emit(Region.containsNonZeroBits(value + sourceType.missingBytesOffset, sourceType.loadLength(value).toL))
 
     val res = fb.result(ctx)(theHailClassLoader)(src)
     res


### PR DESCRIPTION
Picking up where #13776 left off.

CHANGELOG: improved speed of reading hail format datasets from disk

This PR speeds up decoding arrays in two main ways:
* instead of calling `arrayType.isElementDefined(array, i)` on every single array element, which expands to
  ```scala
  val b = aoff + lengthHeaderBytes + (i >> 3)
  !((Memory.loadByte(b) & (1 << (i & 7).toInt)) != 0)
  ```
  process elements in groups of 64, and load the corresponding long of missing bits once
* once we have a whole long of missing bits, we can be smarter than branching on each bit. After flipping to get `presentBits`, we use the following psuedocode to extract the positions of the set bits, with time proportional to the number of set bits:
  ```
  while (presentBits != 0) {
    val idx = java.lang.Long.numberOfTrailingZeroes(presentBits)
    // do something with idx
    presentBits = presentBits & (presentBits - 1) // unsets the rightmost set bit
  }
  ```

To avoid needing to handle the last block of 64 elements differently, this PR changes the layout of `PCanonicalArray` to ensure the missing bits are always padded out to a multiple of 64 bits. They were already padded to a multiple of 32, and I don't expect this change to have much of an effect. But if needed, blocking by 32 elements instead had very similar performance in my benchmarks.

I also experimented with unrolling loops. In the non-missing case, this is easy. In the missing case, I tried using `if (presentBits.bitCount >= 8)` to guard an unrolled inner loop. In both cases, unrolling was if anything slower.

Dan observed benefit from unrolling, but that was combined with the first optimization above (not loading a bit from memory every element), which I beleive was the real source of improvement.