### PR TITLE
[query] Dont compile code cache function three times

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -124,8 +124,8 @@ trait BackendWithCodeCache {
       case Some(v) => v.asInstanceOf[CompiledFunction[T]]
       case None =>
         val compiledFunction = f
-        codeCache += ((k, f))
-        f
+        codeCache += ((k, compiledFunction))
+        compiledFunction
     }
   }
 }


### PR DESCRIPTION
`f` is a thunk so it is currently being evaluated thrice before inserted into the code cache. The `compiledFunction` variable was unused so I think this is what was originally intended.