### PR TITLE
[query] Avoid py4j for python-backend interactions

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -99,6 +99,7 @@ class IRTypePayload(ActionPayload):
 class ExecutePayload(ActionPayload):
     ir: str
     stream_codec: str
+    timed: bool
 
 @dataclass
 class LoadReferencesFromDatasetPayload(ActionPayload):
@@ -172,7 +173,7 @@ class Backend(abc.ABC):
         pass
 
     def execute(self, ir: BaseIR, timed: bool = False) -> Any:
-        payload = ExecutePayload(self._render_ir(ir), '{"name":"StreamBufferSpec"}')
+        payload = ExecutePayload(self._render_ir(ir), '{"name":"StreamBufferSpec"}', timed)
         try:
             result, timings = self._rpc(ActionTag.EXECUTE, payload)
         except FatalError as e:

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -1,116 +1,19 @@
-from typing import Optional, Union, Tuple, List, Set
+from typing import Optional, Union, Tuple, List
 import os
-import socket
-import socketserver
 import sys
-from threading import Thread
 
-import orjson
-import py4j
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 
-from hail.utils.java import scala_package_object
 from hail.ir.renderer import CSERenderer
 from hail.ir import finalize_randomness
-from .py4j_backend import Py4JBackend, handle_java_exception, action_routes
-from .backend import local_jar_information, fatal_error_from_java_error_triplet
-from ..hail_logging import Logger
+from .py4j_backend import Py4JBackend, uninstall_exception_handler
+from .backend import local_jar_information
 from ..expr import Expression
 from ..expr.types import HailType
 
 from hailtop.utils import find_spark_home
 from hailtop.fs.router_fs import RouterFS
 from hailtop.aiotools.validators import validate_file
-
-
-_installed = False
-_original = None
-
-
-def install_exception_handler():
-    global _installed
-    global _original
-    if not _installed:
-        _original = py4j.protocol.get_return_value
-        _installed = True
-        # The original `get_return_value` is not patched, it's idempotent.
-        patched = handle_java_exception(_original)
-        # only patch the one used in py4j.java_gateway (call Java API)
-        py4j.java_gateway.get_return_value = patched
-
-
-def uninstall_exception_handler():
-    global _installed
-    global _original
-    if _installed:
-        _installed = False
-        py4j.protocol.get_return_value = _original
-
-
-class LoggingTCPHandler(socketserver.StreamRequestHandler):
-    def handle(self):
-        for line in self.rfile:
-            sys.stderr.write(line.decode("ISO-8859-1"))
-
-
-class SimpleServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
-    daemon_threads = True
-    allow_reuse_address = True
-
-    def __init__(self, server_address, handler_class):
-        socketserver.TCPServer.__init__(self, server_address, handler_class)
-
-
-def connect_logger(utils_package_object, host, port):
-    """
-    This method starts a simple server which listens on a port for a
-    client to connect and start writing messages. Whenever a message
-    is received, it is written to sys.stderr. The server is run in
-    a daemon thread from the caller, which is killed when the caller
-    thread dies.
-
-    If the socket is in use, then the server tries to listen on the
-    next port (port + 1). After 25 tries, it gives up.
-
-    :param str host: Hostname for server.
-    :param int port: Port to listen on.
-    """
-    server = None
-    tries = 0
-    max_tries = 25
-    while not server:
-        try:
-            server = SimpleServer((host, port), LoggingTCPHandler)
-        except socket.error:
-            port += 1
-            tries += 1
-
-            if tries >= max_tries:
-                sys.stderr.write(
-                    'WARNING: Could not find a free port for logger, maximum retries {} exceeded.'.format(max_tries))
-                return
-
-    t = Thread(target=server.serve_forever, args=())
-
-    # The thread should be a daemon so that it shuts down when the parent thread is killed
-    t.daemon = True
-
-    t.start()
-    utils_package_object.addSocketAppender(host, port)
-
-
-class Log4jLogger(Logger):
-    def __init__(self, log_pkg):
-        self._log_pkg = log_pkg
-
-    def error(self, msg):
-        self._log_pkg.error(msg)
-
-    def warning(self, msg):
-        self._log_pkg.warn(msg)
-
-    def info(self, msg):
-        self._log_pkg.info(msg)
 
 
 class LocalBackend(Py4JBackend):
@@ -121,7 +24,6 @@ class LocalBackend(Py4JBackend):
                  gcs_requester_pays_project: Optional[str] = None,
                  gcs_requester_pays_buckets: Optional[str] = None
                  ):
-        super(LocalBackend, self).__init__()
         assert gcs_requester_pays_project is not None or gcs_requester_pays_buckets is None
 
         spark_home = find_spark_home()
@@ -150,14 +52,10 @@ class LocalBackend(Py4JBackend):
             die_on_exit=True)
         self._gateway = JavaGateway(
             gateway_parameters=GatewayParameters(port=port, auto_convert=True))
-        self._jvm = self._gateway.jvm
 
-        hail_package = getattr(self._jvm, 'is').hail
+        hail_package = getattr(self._gateway.jvm, 'is').hail
 
-        self._hail_package = hail_package
-        self._utils_package_object = scala_package_object(hail_package.utils)
-
-        self._jbackend = hail_package.backend.local.LocalBackend.apply(
+        jbackend = hail_package.backend.local.LocalBackend.apply(
             tmpdir,
             gcs_requester_pays_project,
             gcs_requester_pays_buckets,
@@ -166,26 +64,14 @@ class LocalBackend(Py4JBackend):
             append,
             skip_logging_configuration
         )
-        self._jhc = hail_package.HailContext.apply(
-            self._jbackend, branching_factor, optimizer_iterations, True)
+        jhc = hail_package.HailContext.apply(
+            jbackend,
+            branching_factor,
+            optimizer_iterations,
+            True
+        )
 
-        self._backend_server = hail_package.backend.BackendServer.apply(self._jbackend)
-        self._backend_server_port: int = self._backend_server.port()
-        self._backend_server.start()
-        self._registered_ir_function_names: Set[str] = set()
-
-        # This has to go after creating the SparkSession. Unclear why.
-        # Maybe it does its own patch?
-        install_exception_handler()
-
-        from hail.context import version
-
-        py_version = version()
-        jar_version = self._jhc.version()
-        if jar_version != py_version:
-            raise RuntimeError(f"Hail version mismatch between JAR and Python library\n"
-                               f"  JAR:    {jar_version}\n"
-                               f"  Python: {py_version}")
+        super(LocalBackend, self).__init__(self._gateway.jvm, jbackend, jhc)
 
         self._fs = RouterFS()
         self._logger = None
@@ -194,15 +80,6 @@ class LocalBackend(Py4JBackend):
 
     def validate_file(self, uri: str) -> None:
         validate_file(uri, self._fs.afs)
-
-    def jvm(self):
-        return self._jvm
-
-    def hail_package(self):
-        return self._hail_package
-
-    def utils_package_object(self):
-        return self._utils_package_object
 
     def register_ir_function(self,
                              name: str,
@@ -224,19 +101,6 @@ class LocalBackend(Py4JBackend):
             return_type._parsable_string(),
             jbody)
 
-    def _is_registered_ir_function_name(self, name: str) -> bool:
-        return name in self._registered_ir_function_names
-
-    def _rpc(self, action, payload) -> Tuple[bytes, str]:
-        data = orjson.dumps(payload)
-        path = action_routes[action]
-        port = self._backend_server_port
-        resp = self._requests_session.post(f'http://localhost:{port}{path}', data=data)
-        if resp.status_code >= 400:
-            error_json = orjson.loads(resp.content)
-            raise fatal_error_from_java_error_triplet(error_json['short'], error_json['expanded'], error_json['error_id'])
-        return resp.content, resp.headers.get('X-Hail-Timings', '')
-
     def stop(self):
         self._backend_server.stop()
         self._jhc.stop()
@@ -244,12 +108,6 @@ class LocalBackend(Py4JBackend):
         self._gateway.shutdown()
         self._registered_ir_function_names = set()
         uninstall_exception_handler()
-
-    @property
-    def logger(self):
-        if self._logger is None:
-            self._logger = Log4jLogger(self._utils_package_object)
-        return self._logger
 
     @property
     def fs(self):

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -167,7 +167,7 @@ class LocalBackend(Py4JBackend):
             skip_logging_configuration
         )
         self._jhc = hail_package.HailContext.apply(
-            self._jbackend, branching_factor, optimizer_iterations)
+            self._jbackend, branching_factor, optimizer_iterations, True)
 
         self._backend_server = hail_package.backend.BackendServer.apply(self._jbackend)
         self._backend_server_port: int = self._backend_server.port()

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -67,8 +67,7 @@ class LocalBackend(Py4JBackend):
         jhc = hail_package.HailContext.apply(
             jbackend,
             branching_factor,
-            optimizer_iterations,
-            True
+            optimizer_iterations
         )
 
         super(LocalBackend, self).__init__(self._gateway.jvm, jbackend, jhc)
@@ -102,11 +101,8 @@ class LocalBackend(Py4JBackend):
             jbody)
 
     def stop(self):
-        self._backend_server.stop()
-        self._jhc.stop()
-        self._jhc = None
+        super().stop()
         self._gateway.shutdown()
-        self._registered_ir_function_names = set()
         uninstall_exception_handler()
 
     @property

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -14,6 +14,9 @@ from hail.utils.java import FatalError, Env
 
 from .backend import ActionTag, Backend, fatal_error_from_java_error_triplet
 
+import http.client
+http.client._MAXLINE = 2 ** 20
+
 
 def handle_java_exception(f):
     def deco(*args, **kwargs):

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -287,3 +287,10 @@ class Py4JBackend(Backend):
 
     def _to_java_blockmatrix_ir(self, ir):
         return self._to_java_ir(ir, self._parse_blockmatrix_ir)
+
+    def stop(self):
+        self._backend_server.stop()
+        self._jhc.stop()
+        self._jhc = None
+        self._registered_ir_function_names = set()
+        uninstall_exception_handler()

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -20,6 +20,8 @@ from .backend import ActionTag, Backend, fatal_error_from_java_error_triplet
 from ..hail_logging import Logger
 
 import http.client
+# This defaults to 65536 and fails if a header is longer than _MAXLINE
+# The timing json that we output can exceed 65536 bytes so we raise the limit
 http.client._MAXLINE = 2 ** 20
 
 

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -417,7 +417,7 @@ class ServiceBackend(Backend):
                     raise
 
             with timings.step("read output"):
-                result_bytes = await retry_transient_errors(self._read_output, None, iodir + '/out', iodir + '/in')
+                result_bytes = await retry_transient_errors(self._read_output, iodir + '/out', iodir + '/in')
                 return result_bytes, str(timings.to_dict())
 
     async def _read_output(self, output_uri: str, input_uri: str) -> bytes:

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -1,6 +1,7 @@
-from typing import Dict, Optional, Callable, Awaitable, Mapping, Any, List, Union, Tuple, TypeVar, Set
+from typing import Dict, Optional, Awaitable, Mapping, Any, List, Union, Tuple, TypeVar, Set
 import abc
 import asyncio
+from dataclasses import dataclass
 import math
 import struct
 from hail.expr.expressions.base_expression import Expression
@@ -8,19 +9,16 @@ import orjson
 import logging
 import warnings
 
-from hail.context import TemporaryDirectory, tmp_dir, TemporaryFilename, revision, version
+from hail.context import TemporaryDirectory, TemporaryFilename, tmp_dir, revision, version
 from hail.utils import FatalError
-from hail.expr.types import HailType, dtype, ttuple, tvoid
-from hail.expr.table_type import ttable
-from hail.expr.matrix_type import tmatrix
-from hail.expr.blockmatrix_type import tblockmatrix
-from hail.experimental import write_expression, read_expression
+from hail.expr.types import HailType
+from hail.experimental import read_expression, write_expression
 from hail.ir import finalize_randomness
 from hail.ir.renderer import CSERenderer
 
 from hailtop import yamlx
 from hailtop.config import (ConfigVariable, configuration_of, get_remote_tmpdir)
-from hailtop.utils import async_to_blocking, TransientError, Timings, am_i_interactive, retry_transient_errors
+from hailtop.utils import async_to_blocking, Timings, am_i_interactive, retry_transient_errors
 from hailtop.utils.rich_progress_bar import BatchProgressBar
 from hailtop.batch_client import client as hb
 from hailtop.batch_client import aioclient as aiohb
@@ -31,7 +29,7 @@ from hailtop.fs.fs import FS
 from hailtop.fs.router_fs import RouterFS
 from hailtop.aiotools.fs.exceptions import UnexpectedEOFError
 
-from .backend import Backend, fatal_error_from_java_error_triplet
+from .backend import Backend, fatal_error_from_java_error_triplet, ActionTag, ActionPayload, ExecutePayload
 from ..builtin_references import BUILTIN_REFERENCES
 from ..ir import BaseIR
 from ..utils import ANY_REGION
@@ -47,41 +45,6 @@ T = TypeVar("T")
 log = logging.getLogger('backend.service_backend')
 
 
-async def write_bool(strm: afs.WritableStream, v: bool):
-    if v:
-        await strm.write(b'\x01')
-    else:
-        await strm.write(b'\x00')
-
-
-async def write_int(strm: afs.WritableStream, v: int):
-    await strm.write(struct.pack('<i', v))
-
-
-async def write_long(strm: afs.WritableStream, v: int):
-    await strm.write(struct.pack('<q', v))
-
-
-async def write_bytes(strm: afs.WritableStream, b: bytes):
-    n = len(b)
-    await write_int(strm, n)
-    await strm.write(b)
-
-
-async def write_str(strm: afs.WritableStream, s: str):
-    await write_bytes(strm, s.encode('utf-8'))
-
-
-async def write_str_array(strm: afs.WritableStream, los: List[str]):
-    await write_int(strm, len(los))
-    for s in los:
-        await write_str(strm, s)
-
-
-class EndOfStream(TransientError):
-    pass
-
-
 async def read_byte(strm: afs.ReadableStream) -> int:
     return (await strm.readexactly(1))[0]
 
@@ -93,11 +56,6 @@ async def read_bool(strm: afs.ReadableStream) -> bool:
 async def read_int(strm: afs.ReadableStream) -> int:
     b = await strm.readexactly(4)
     return struct.unpack('<i', b)[0]
-
-
-async def read_long(strm: afs.ReadableStream) -> int:
-    b = await strm.readexactly(8)
-    return struct.unpack('<q', b)[0]
 
 
 async def read_bytes(strm: afs.ReadableStream) -> bytes:
@@ -138,6 +96,16 @@ class GitRevision(JarSpec):
         return f'GitRevision({self.revision})'
 
 
+@dataclass
+class SerializedIRFunction:
+    name: str
+    type_parameters: List[str]
+    value_parameter_names: List[str]
+    value_parameter_types: List[str]
+    return_type: str
+    rendered_body: str
+
+
 class IRFunction:
     def __init__(self,
                  name: str,
@@ -147,7 +115,7 @@ class IRFunction:
                  return_type: HailType,
                  body: Expression):
         assert len(value_parameter_names) == len(value_parameter_types)
-        render = CSERenderer(stop_at_jir=True)
+        render = CSERenderer()
         self._name = name
         self._type_parameters = type_parameters
         self._value_parameter_names = value_parameter_names
@@ -155,23 +123,38 @@ class IRFunction:
         self._return_type = return_type
         self._rendered_body = render(finalize_randomness(body._ir))
 
-    async def serialize(self, writer: afs.WritableStream):
-        await write_str(writer, self._name)
+    def to_dataclass(self):
+        return SerializedIRFunction(
+            name=self._name,
+            type_parameters=[tp._parsable_string() for tp in self._type_parameters],
+            value_parameter_names=list(self._value_parameter_names),
+            value_parameter_types=[vpt._parsable_string() for vpt in self._value_parameter_types],
+            return_type=self._return_type._parsable_string(),
+            rendered_body=self._rendered_body,
+        )
 
-        await write_int(writer, len(self._type_parameters))
-        for type_parameter in self._type_parameters:
-            await write_str(writer, type_parameter._parsable_string())
 
-        await write_int(writer, len(self._value_parameter_names))
-        for value_parameter_name in self._value_parameter_names:
-            await write_str(writer, value_parameter_name)
+@dataclass
+class ServiceBackendExecutePayload(ActionPayload):
+    functions: List[SerializedIRFunction]
+    payload: ExecutePayload
 
-        await write_int(writer, len(self._value_parameter_types))
-        for value_parameter_type in self._value_parameter_types:
-            await write_str(writer, value_parameter_type._parsable_string())
 
-        await write_str(writer, self._return_type._parsable_string())
-        await write_str(writer, self._rendered_body)
+@dataclass
+class ServiceBackendRPCConfig:
+    tmp_dir: str
+    remote_tmpdir: str
+    billing_project: str
+    worker_cores: str
+    worker_memory: str
+    storage: str
+    cloudfuse_configs: List[Tuple[str, str, bool]]
+    regions: List[str]
+    idempotency_token: str
+    flags: Dict[str, str]
+    custom_references: List[str]
+    liftovers: Dict[str, Dict[str, str]]
+    sequences: Dict[str, Tuple[str, str]]
 
 
 class ServiceBackend(Backend):
@@ -365,74 +348,28 @@ class ServiceBackend(Backend):
 
     def render(self, ir):
         r = CSERenderer()
-        assert len(r.jirs) == 0
         return r(finalize_randomness(ir))
 
-    async def _rpc(self,
-                   name: str,
-                   inputs: Callable[[afs.WritableStream, str], Awaitable[None]],
-                   *,
-                   ir: Optional[BaseIR] = None,
-                   progress: Optional[BatchProgressBar] = None,
-                   driver_cores: Optional[Union[int, str]] = None,
-                   driver_memory: Optional[str] = None,
-                   worker_cores: Optional[Union[int, str]] = None,
-                   worker_memory: Optional[str] = None,
-                   ):
+    async def _run_on_batch(
+        self,
+        name: str,
+        service_backend_config: ServiceBackendRPCConfig,
+        action: ActionTag,
+        payload: ActionPayload,
+        *,
+        progress: Optional[BatchProgressBar] = None,
+        driver_cores: Optional[Union[int, str]] = None,
+        driver_memory: Optional[str] = None,
+    ) -> Tuple[bytes, str]:
         timings = Timings()
         with TemporaryDirectory(ensure_exists=False) as iodir:
-            readonly_fuse_buckets = set()
-            storage_requirement_bytes = 0
-
             with timings.step("write input"):
                 async with await self._async_fs.create(iodir + '/in') as infile:
-                    nonnull_flag_count = sum(v is not None for v in self.flags.values())
-                    await write_int(infile, nonnull_flag_count)
-                    for k, v in self.flags.items():
-                        if v is not None:
-                            await write_str(infile, k)
-                            await write_str(infile, v)
-                    custom_references = [rg for rg in self._references.values() if rg.name not in BUILTIN_REFERENCES]
-                    await write_int(infile, len(custom_references))
-                    for reference_config in custom_references:
-                        await write_str(infile, orjson.dumps(reference_config._config).decode('utf-8'))
-                    non_empty_liftovers = {rg.name: rg._liftovers for rg in self._references.values() if len(rg._liftovers) > 0}
-                    await write_int(infile, len(non_empty_liftovers))
-                    for source_genome_name, liftovers in non_empty_liftovers.items():
-                        await write_str(infile, source_genome_name)
-                        await write_int(infile, len(liftovers))
-                        for dest_reference_genome, chain_file in liftovers.items():
-                            await write_str(infile, dest_reference_genome)
-                            await write_str(infile, chain_file)
-                    added_sequences = {rg.name: rg._sequence_files for rg in self._references.values() if rg._sequence_files is not None}
-                    await write_int(infile, len(added_sequences))
-                    for rg_name, (fasta_file, index_file) in added_sequences.items():
-                        await write_str(infile, rg_name)
-                        for blob in (fasta_file, index_file):
-                            bucket, path = self._get_bucket_and_path(blob)
-                            readonly_fuse_buckets.add(bucket)
-                            storage_requirement_bytes += await (await self._async_fs.statfile(blob)).size()
-                            await write_str(infile, f'/cloudfuse/{bucket}/{path}')
-                    if worker_cores is not None:
-                        await write_str(infile, str(worker_cores))
-                    else:
-                        await write_str(infile, str(self.worker_cores))
-                    if worker_memory is not None:
-                        await write_str(infile, str(worker_memory))
-                    else:
-                        await write_str(infile, str(self.worker_memory))
-                    await write_int(infile, len(self.regions))
-                    for region in self.regions:
-                        await write_str(infile, region)
-                    storage_gib_str = f'{math.ceil(storage_requirement_bytes / 1024 / 1024 / 1024)}Gi'
-                    await write_str(infile, storage_gib_str)
-                    cloudfuse_config = [(bucket, f'/cloudfuse/{bucket}', True) for bucket in readonly_fuse_buckets]
-                    await write_int(infile, len(cloudfuse_config))
-                    for bucket, mount_point, readonly in cloudfuse_config:
-                        await write_str(infile, bucket)
-                        await write_str(infile, mount_point)
-                        await write_bool(infile, readonly)
-                    await inputs(infile, self._batch.token)
+                    await infile.write(orjson.dumps({
+                        'config': service_backend_config,
+                        'action': action.value,
+                        'payload': payload,
+                    }))
 
             with timings.step("submit batch"):
                 resources: Dict[str, Union[str, bool]] = {'preemptible': False}
@@ -446,8 +383,8 @@ class ServiceBackend(Backend):
                 elif self.driver_memory is not None:
                     resources['memory'] = str(self.driver_memory)
 
-                if storage_requirement_bytes != 0:
-                    resources['storage'] = storage_gib_str
+                if service_backend_config.storage != '0Gi':
+                    resources['storage'] = service_backend_config.storage
 
                 j = self._batch.create_jvm_job(
                     jar_spec=self.jar_spec.to_dict(),
@@ -461,7 +398,7 @@ class ServiceBackend(Backend):
                     resources=resources,
                     attributes={'name': name + '_driver'},
                     regions=self.regions,
-                    cloudfuse=cloudfuse_config,
+                    cloudfuse=[],
                     profile=self.flags['profile'] is not None,
                 )
                 await self._batch.submit(disable_progress_bar=True)
@@ -485,7 +422,7 @@ class ServiceBackend(Backend):
                     raise
 
             with timings.step("read output"):
-                result_bytes = await retry_transient_errors(self._read_output, ir, iodir + '/out', iodir + '/in')
+                result_bytes = await retry_transient_errors(self._read_output, None, iodir + '/out', iodir + '/in')
                 return result_bytes, timings
 
     async def _read_output(self, ir: Optional[BaseIR], output_uri: str, input_uri: str) -> bytes:
@@ -537,127 +474,44 @@ class ServiceBackend(Backend):
                 self._batch_was_submitted = False
             raise
 
-    def execute(self, ir: BaseIR, timed: bool = False, **kwargs):
-        return self._cancel_on_ctrl_c(self._async_execute(ir, timed=timed, **kwargs))
+    def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, str]:
+        return self._cancel_on_ctrl_c(self._async_rpc(action, payload))
 
-    async def _async_execute(self,
-                             ir: BaseIR,
-                             *,
-                             timed: bool = False,
-                             progress: Optional[BatchProgressBar] = None,
-                             **kwargs):
-        async def inputs(infile, token):
-            await write_int(infile, ServiceBackend.EXECUTE)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, self.render(ir))
-            await write_str(infile, token)
-            await write_int(infile, len(self.functions))
-            for fun in self.functions:
-                await fun.serialize(infile)
-            await write_str(infile, '{"name":"StreamBufferSpec"}')
+    async def _async_rpc(self, action: ActionTag, payload: ActionPayload):
+        if action == ActionTag.EXECUTE:
+            assert isinstance(payload, ExecutePayload)
+            payload = ServiceBackendExecutePayload([f.to_dataclass() for f in self.functions], payload)
 
-        resp, timings = await self._rpc(
-            'execute(...)',
-            inputs,
-            ir=ir,
-            progress=progress,
-            **kwargs
+        storage_requirement_bytes = 0
+        readonly_fuse_buckets = set()
+
+        added_sequences = {rg.name: rg._sequence_files for rg in self._references.values() if rg._sequence_files is not None}
+        sequence_file_mounts = {}
+        for rg_name, (fasta_file, index_file) in added_sequences.items():
+            fasta_bucket, fasta_path = self._get_bucket_and_path(fasta_file)
+            index_bucket, index_path = self._get_bucket_and_path(index_file)
+            for bucket, blob in [(fasta_bucket, fasta_file), (index_bucket, index_file)]:
+                readonly_fuse_buckets.add(bucket)
+                storage_requirement_bytes += await (await self._async_fs.statfile(blob)).size()
+            sequence_file_mounts[rg_name] = (f'/cloudfuse/{fasta_bucket}/{fasta_path}', f'/cloudfuse/{index_bucket}/{index_path}')
+
+        storage_gib_str = f'{math.ceil(storage_requirement_bytes / 1024 / 1024 / 1024)}Gi'
+        qob_config = ServiceBackendRPCConfig(
+            tmp_dir=tmp_dir(),
+            remote_tmpdir=self.remote_tmpdir,
+            billing_project=self.billing_project,
+            worker_cores=str(self.worker_cores),
+            worker_memory=str(self.worker_memory),
+            storage=storage_gib_str,
+            cloudfuse_configs=[(bucket, f'/cloudfuse/{bucket}', True) for bucket in readonly_fuse_buckets],
+            regions=self.regions,
+            idempotency_token=self._batch.token,
+            flags=self.flags,
+            custom_references=[orjson.dumps(rg._config).decode('utf-8') for rg in self._references.values() if rg.name not in BUILTIN_REFERENCES],
+            liftovers={rg.name: rg._liftovers for rg in self._references.values() if len(rg._liftovers) > 0},
+            sequences=sequence_file_mounts,
         )
-        typ: HailType = ir.typ
-        if typ == tvoid:
-            assert resp == b'', (typ, resp)
-            converted_value = None
-        else:
-            converted_value = ttuple(typ)._from_encoding(resp)[0]
-        if timed:
-            return converted_value, timings
-        return converted_value
-
-    def value_type(self, ir):
-        return self._cancel_on_ctrl_c(self._async_value_type(ir))
-
-    async def _async_value_type(self, ir, *, progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.VALUE_TYPE)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, self.render(ir))
-        resp, _ = await self._rpc('value_type(...)', inputs, progress=progress)
-        return dtype(orjson.loads(resp))
-
-    def table_type(self, tir):
-        return self._cancel_on_ctrl_c(self._async_table_type(tir))
-
-    async def _async_table_type(self, tir, *, progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.TABLE_TYPE)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, self.render(tir))
-        resp, _ = await self._rpc('table_type(...)', inputs, progress=progress)
-        return ttable._from_json(orjson.loads(resp))
-
-    def matrix_type(self, mir):
-        return self._cancel_on_ctrl_c(self._async_matrix_type(mir))
-
-    async def _async_matrix_type(self, mir, *, progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.MATRIX_TABLE_TYPE)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, self.render(mir))
-        resp, _ = await self._rpc('matrix_type(...)', inputs, progress=progress)
-        return tmatrix._from_json(orjson.loads(resp))
-
-    def blockmatrix_type(self, bmir):
-        return self._cancel_on_ctrl_c(self._async_blockmatrix_type(bmir))
-
-    async def _async_blockmatrix_type(self, bmir, *, progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.BLOCK_MATRIX_TYPE)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, self.render(bmir))
-        resp, _ = await self._rpc('blockmatrix_type(...)', inputs, progress=progress)
-        return tblockmatrix._from_json(orjson.loads(resp))
-
-    def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
-        return async_to_blocking(self._from_fasta_file(name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par))
-
-    async def _from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par, *, progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.FROM_FASTA_FILE)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, name)
-            await write_str(infile, fasta_file)
-            await write_str(infile, index_file)
-            await write_str_array(infile, x_contigs)
-            await write_str_array(infile, y_contigs)
-            await write_str_array(infile, mt_contigs)
-            await write_str_array(infile, par)
-        resp, _ = await self._rpc('from_fasta_file(...)', inputs, progress=progress)
-        return orjson.loads(resp)
-
-    def load_references_from_dataset(self, path):
-        return self._cancel_on_ctrl_c(self._async_load_references_from_dataset(path))
-
-    async def _async_load_references_from_dataset(self, path, *, progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.LOAD_REFERENCES_FROM_DATASET)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, path)
-        resp, _ = await self._rpc('load_references_from_dataset(...)', inputs, progress=progress)
-        return orjson.loads(resp)
+        return await self._run_on_batch(f'{action.name.lower()}(...)', qob_config, action, payload)
 
     # Sequence and liftover information is stored on the ReferenceGenome
     # and there is no persistent backend to keep in sync.
@@ -679,41 +533,6 @@ class ServiceBackend(Backend):
 
     def remove_liftover(self, name, dest_reference_genome):  # pylint: disable=unused-argument
         pass
-
-    def parse_vcf_metadata(self, path):
-        return self._cancel_on_ctrl_c(self._async_parse_vcf_metadata(path))
-
-    async def _async_parse_vcf_metadata(self, path, *, progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.PARSE_VCF_METADATA)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, path)
-        resp, _ = await self._rpc('parse_vcf_metadata(...)', inputs, progress=progress)
-        return orjson.loads(resp)
-
-    def import_fam(self, path: str, quant_pheno: bool, delimiter: str, missing: str):
-        return self._cancel_on_ctrl_c(self._async_import_fam(path, quant_pheno, delimiter, missing))
-
-    async def _async_import_fam(self,
-                                path: str,
-                                quant_pheno: bool,
-                                delimiter: str,
-                                missing: str,
-                                *,
-                                progress: Optional[BatchProgressBar] = None):
-        async def inputs(infile, _):
-            await write_int(infile, ServiceBackend.IMPORT_FAM)
-            await write_str(infile, tmp_dir())
-            await write_str(infile, self.billing_project)
-            await write_str(infile, self.remote_tmpdir)
-            await write_str(infile, path)
-            await write_bool(infile, quant_pheno)
-            await write_str(infile, delimiter)
-            await write_str(infile, missing)
-        resp, _ = await self._rpc('import_fam(...)', inputs, progress=progress)
-        return orjson.loads(resp)
 
     def register_ir_function(self,
                              name: str,

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -483,8 +483,7 @@ class ServiceBackend(Backend):
         return self._cancel_on_ctrl_c(self._async_rpc(action, payload))
 
     async def _async_rpc(self, action: ActionTag, payload: ActionPayload):
-        if action == ActionTag.EXECUTE:
-            assert isinstance(payload, ExecutePayload)
+        if isinstance(payload, ExecutePayload):
             payload = ServiceBackendExecutePayload([f.to_dataclass() for f in self.functions], self._batch.token, payload)
 
         storage_requirement_bytes = 0

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -1,18 +1,15 @@
 import sys
 import os
-import json
 import pyspark
 import pyspark.sql
 
 import orjson
-from typing import List, Optional
+from typing import Optional
 
-import hail as hl
 from hail.expr.table_type import ttable
 from hail.fs.hadoop_fs import HadoopFS
 from hail.ir.renderer import CSERenderer
 from hail.table import Table
-from hail.matrixtable import MatrixTable
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
 
@@ -187,16 +184,6 @@ class SparkBackend(Py4JBackend):
             argument_names, [pt._parsable_string() for pt in argument_types],
             return_type._parsable_string(),
             jbody)
-
-    def read_multiple_matrix_tables(self, paths: 'List[str]', intervals: 'List[hl.Interval]', intervals_type):
-        json_repr = {
-            'paths': paths,
-            'intervals': intervals_type._convert_to_json(intervals),
-            'intervalPointType': intervals_type.element_type.point_type._parsable_string(),
-        }
-
-        results = self._jbackend.pyReadMultipleMatrixTables(json.dumps(json_repr))
-        return [MatrixTable._from_java(jm) for jm in results]
 
     @property
     def requires_lowering(self):

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -218,7 +218,7 @@ class SparkBackend(Py4JBackend):
                 jsc, app_name, master, local, log, True, append, skip_logging_configuration, min_block_size, tmpdir, local_tmpdir,
                 gcs_requester_pays_project, gcs_requester_pays_buckets)
             self._jhc = hail_package.HailContext.apply(
-                self._jbackend, branching_factor, optimizer_iterations)
+                self._jbackend, branching_factor, optimizer_iterations, True)
 
         self._backend_server = hail_package.backend.BackendServer.apply(self._jbackend)
         self._backend_server_port: int = self._backend_server.port()

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -13,7 +13,7 @@ from hail.table import Table
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
 
-from .py4j_backend import Py4JBackend, uninstall_exception_handler
+from .py4j_backend import Py4JBackend
 from .backend import local_jar_information
 
 
@@ -114,7 +114,7 @@ class SparkBackend(Py4JBackend):
                 jsc, app_name, master, local, log, True, append, skip_logging_configuration, min_block_size, tmpdir, local_tmpdir,
                 gcs_requester_pays_project, gcs_requester_pays_buckets)
             jhc = hail_package.HailContext.apply(
-                jbackend, branching_factor, optimizer_iterations, True)
+                jbackend, branching_factor, optimizer_iterations)
 
         self._jsc = jbackend.sc()
         if sc:
@@ -146,13 +146,10 @@ class SparkBackend(Py4JBackend):
         validate_file(uri, self._router_async_fs)
 
     def stop(self):
+        super().stop()
         self._jbackend.close()
-        self._jhc.stop()
-        self._jhc = None
         self.sc.stop()
         self.sc = None
-        self._registered_ir_function_names = set()
-        uninstall_exception_handler()
 
     @property
     def fs(self):

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -147,7 +147,6 @@ class SparkBackend(Py4JBackend):
 
     def stop(self):
         super().stop()
-        self._jbackend.close()
         self.sc.stop()
         self.sc = None
 

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -427,7 +427,8 @@ def init_spark(sc=None,
                _optimizer_iterations=None,
                gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None
                ):
-    from hail.backend.spark_backend import SparkBackend, connect_logger
+    from hail.backend.py4j_backend import connect_logger
+    from hail.backend.spark_backend import SparkBackend
 
     log = _get_log(log)
     tmpdir = _get_tmpdir(tmp_dir)
@@ -554,7 +555,8 @@ def init_local(
         _optimizer_iterations=None,
         gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None
 ):
-    from hail.backend.local_backend import LocalBackend, connect_logger
+    from hail.backend.py4j_backend import connect_logger
+    from hail.backend.local_backend import LocalBackend
 
     log = _get_log(log)
     tmpdir = _get_tmpdir(tmpdir)

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -1,5 +1,5 @@
 from typing import Set, Dict
-from hail.typecheck import typecheck, setof, nullable
+from hail.typecheck import typecheck, setof
 
 from .indices import Indices, Aggregation
 from ..expressions import Expression, ExpressionException, expr_any
@@ -130,8 +130,8 @@ def analyze(caller: str,
         raise errors[0]
 
 
-@typecheck(expression=expr_any, _execute_kwargs=nullable(dict))
-def eval_timed(expression, *, _execute_kwargs=None):
+@typecheck(expression=expr_any)
+def eval_timed(expression):
     """Evaluate a Hail expression, returning the result and the times taken for
     each stage in the evaluation process.
 
@@ -158,12 +158,11 @@ def eval_timed(expression, *, _execute_kwargs=None):
         uid = Env.get_uid()
         ir = expression._indices.source.select_globals(**{uid: expression}).index_globals()[uid]._ir
 
-    _execute_kwargs = _execute_kwargs or {}
-    return Env.backend().execute(MakeTuple([ir]), timed=True, **_execute_kwargs)[0]
+    return Env.backend().execute(MakeTuple([ir]), timed=True)[0]
 
 
-@typecheck(expression=expr_any, _execute_kwargs=nullable(dict))
-def eval(expression, *, _execute_kwargs=None):
+@typecheck(expression=expr_any)
+def eval(expression):
     """Evaluate a Hail expression, returning the result.
 
     This method is extremely useful for learning about Hail expressions and
@@ -189,7 +188,7 @@ def eval(expression, *, _execute_kwargs=None):
     -------
     Any
     """
-    return eval_timed(expression, _execute_kwargs=_execute_kwargs)[0]
+    return eval_timed(expression)[0]
 
 
 @typecheck(expression=expr_any)

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -36,7 +36,7 @@ from .matrix_ir import MatrixAggregateRowsByKey, MatrixRead, MatrixFilterRows, \
     MatrixRowsHead, MatrixColsHead, MatrixRowsTail, MatrixColsTail, \
     MatrixExplodeCols, CastTableToMatrix, MatrixAnnotateRowsTable, \
     MatrixAnnotateColsTable, MatrixToMatrixApply, MatrixRename, \
-    MatrixFilterIntervals, JavaMatrix
+    MatrixFilterIntervals
 from .blockmatrix_ir import BlockMatrixRead, BlockMatrixMap, BlockMatrixMap2, \
     BlockMatrixDot, BlockMatrixBroadcast, BlockMatrixAgg, BlockMatrixFilter, \
     BlockMatrixDensify, BlockMatrixSparsifier, BandSparsifier, \
@@ -259,7 +259,6 @@ __all__ = [
     'MatrixToMatrixApply',
     'MatrixRename',
     'MatrixFilterIntervals',
-    'JavaMatrix',
     'MatrixReader',
     'MatrixNativeReader',
     'MatrixRangeReader',

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -34,7 +34,7 @@ class BaseIR(Renderable):
         self._stack_trace = None
 
     def __str__(self):
-        r = PlainRenderer(stop_at_jir=False)
+        r = PlainRenderer()
         return r(self)
 
     def render_head(self, r: Renderer):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -408,21 +408,6 @@ class BlockMatrixRandom(BlockMatrixIR):
         return tblockmatrix(hl.tfloat64, tensor_shape, is_row_vector, self.block_size)
 
 
-class JavaBlockMatrix(BlockMatrixIR):
-    def __init__(self, jir):
-        super().__init__()
-        self._jir = jir
-
-    def render_head(self, r):
-        return f'(JavaBlockMatrix {r.add_jir(self._jir)}'
-
-    def _compute_type(self, deep_typecheck):
-        if self._type is None:
-            return hl.tblockmatrix._from_java(self._jir.typ())
-        else:
-            return self._type
-
-
 def tensor_shape_to_matrix_shape(bmir):
     shape = bmir.typ.shape
     is_row_vector = bmir.typ.is_row_vector

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -3721,7 +3721,7 @@ class JavaIR(IR):
     def __init__(self, hail_type, ir_id, ref: Optional[JavaIRSharedReference] = None):
         super(JavaIR, self).__init__()
         self._type: HailType = hail_type
-        self._id: str = ir_id
+        self._id: int = ir_id
         self._ref = ref or JavaIRSharedReference(ir_id)
 
     def copy(self):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -3718,10 +3718,10 @@ class JavaIRSharedReference:
 
 
 class JavaIR(IR):
-    def __init__(self, hail_type, ir_id, ref: Optional[JavaIRSharedReference] = None):
+    def __init__(self, hail_type: HailType, ir_id: int, ref: Optional[JavaIRSharedReference] = None):
         super(JavaIR, self).__init__()
-        self._type: HailType = hail_type
-        self._id: int = ir_id
+        self._type = hail_type
+        self._id = ir_id
         self._ref = ref or JavaIRSharedReference(ir_id)
 
     def copy(self):

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -4,7 +4,6 @@ from hail.expr.types import HailType, tint64
 from hail.ir.base_ir import BaseIR, MatrixIR
 from hail.ir.utils import modify_deep_field, zip_with_index, zip_with_index_field, default_row_uid, default_col_uid, unpack_row_uid, unpack_col_uid
 import hail.ir.ir as ir
-from hail.utils import FatalError
 from hail.utils.misc import escape_str, parsable_strings, escape_id
 from hail.utils.jsonx import dump_json
 from hail.utils.java import Env
@@ -1192,22 +1191,3 @@ class MatrixFilterIntervals(MatrixIR):
     def _compute_type(self, deep_typecheck):
         self.child.compute_type(deep_typecheck)
         return self.child.typ
-
-
-class JavaMatrix(MatrixIR):
-    def __init__(self, jir):
-        super().__init__()
-        self._jir = jir
-
-    def _handle_randomness(self, row_uid_field_name, col_uid_field_name):
-        raise FatalError('JavaMatrix does not support randomness in consumers')
-
-    def render_head(self, r):
-        return f'(JavaMatrix {r.add_jir(self._jir)}'
-
-    def _compute_type(self, deep_typecheck):
-        if self._type is None:
-            return hl.tmatrix._from_java(self._jir.typ())
-        else:
-            return self._type
-

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -1210,15 +1210,23 @@ class TableGen(TableIR):
 
 
 class JavaTable(TableIR):
-    def __init__(self, jir):
+    def __init__(self, table_type, tir_id: str):
         super().__init__()
-        self._jir = jir
+        self._type = table_type
+        self._id = tir_id
 
     def _handle_randomness(self, uid_field_name):
         raise FatalError('JavaTable does not support randomness in consumers')
 
     def render_head(self, r):
-        return f'(JavaTable {r.add_jir(self._jir)}'
+        return f'(JavaTable {self._id}'
 
     def _compute_type(self, deep_typecheck):
-        return hl.ttable._from_java(self._jir.typ())
+        return self._type
+
+    def __del__(self):
+        from hail.backend.py4j_backend import Py4JBackend
+        if Env._hc:
+            backend = Env.backend()
+            assert isinstance(backend, Py4JBackend)
+            backend._jbackend.removeJavaIR(self._id)

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -1210,7 +1210,7 @@ class TableGen(TableIR):
 
 
 class JavaTable(TableIR):
-    def __init__(self, table_type, tir_id: str):
+    def __init__(self, table_type, tir_id: int):
         super().__init__()
         self._type = table_type
         self._id = tir_id

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -537,10 +537,6 @@ class MatrixTable(ExprContainer):
     """
 
     @staticmethod
-    def _from_java(jmir):
-        return MatrixTable(ir.JavaMatrix(jmir))
-
-    @staticmethod
     @typecheck(
         globals=nullable(dictof(str, anytype)),
         rows=nullable(dictof(str, sequenceof(anytype))),

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -337,8 +337,8 @@ class Table(ExprContainer):
     """
 
     @staticmethod
-    def _from_java(jtir):
-        return Table(ir.JavaTable(jtir))
+    def _from_java(table_type, ir_id):
+        return Table(ir.JavaTable(table_type, ir_id))
 
     def __init__(self, tir):
         super(Table, self).__init__()

--- a/hail/python/test/hail/genetics/test_reference_genome.py
+++ b/hail/python/test/hail/genetics/test_reference_genome.py
@@ -128,6 +128,7 @@ def test_reference_genome_liftover():
     grch38.remove_liftover("GRCh37")
 
 
+@qobtest
 def test_liftover_strand():
     grch37 = hl.get_reference('GRCh37')
     grch37.add_liftover(resource('grch37_to_grch38_chr20.over.chain.gz'), 'GRCh38')
@@ -184,6 +185,7 @@ def test_read_custom_reference_genome():
     assert_rg_loaded_correctly('test_rg_2')
 
 
+@qobtest
 def test_custom_reference_read_write():
     hl.ReferenceGenome("dk", ['hello'], {"hello": 123})
     ht = hl.utils.range_table(5)

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -107,8 +107,7 @@ object HailContext {
 
   def apply(backend: Backend,
     branchingFactor: Int = 50,
-    optimizerIterations: Int = 3,
-    addDefaultReferences: Boolean = true): HailContext = synchronized {
+    optimizerIterations: Int = 3): HailContext = synchronized {
     require(theContext == null)
     checkJavaVersion()
 
@@ -123,11 +122,6 @@ object HailContext {
     theContext = new HailContext(backend, branchingFactor, optimizerIterations)
 
     info(s"Running Hail version ${ theContext.version }")
-
-    // needs to be after `theContext` is set, since this creates broadcasts
-    if (addDefaultReferences) {
-      backend.addDefaultReferences()
-    }
 
     theContext
   }

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -107,7 +107,8 @@ object HailContext {
 
   def apply(backend: Backend,
     branchingFactor: Int = 50,
-    optimizerIterations: Int = 3): HailContext = synchronized {
+    optimizerIterations: Int = 3,
+    addDefaultReferences: Boolean = true): HailContext = synchronized {
     require(theContext == null)
     checkJavaVersion()
 
@@ -124,7 +125,9 @@ object HailContext {
     info(s"Running Hail version ${ theContext.version }")
 
     // needs to be after `theContext` is set, since this creates broadcasts
-    backend.addDefaultReferences()
+    if (addDefaultReferences) {
+      backend.addDefaultReferences()
+    }
 
     theContext
   }

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -47,7 +47,7 @@ object HailFeatureFlags {
       )
     )
 
-  def fromMap(m: mutable.Map[String, String]): HailFeatureFlags =
+  def fromMap(m: Map[String, String]): HailFeatureFlags =
     new HailFeatureFlags(
       mutable.Map(
         HailFeatureFlags.defaults.map {

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -35,6 +35,12 @@ object Backend {
     id += 1
     s"hail_query_$id"
   }
+
+  private var irID: Int = 0
+  def nextIRID(): Int = {
+    irID += 1
+    irID
+  }
 }
 
 abstract class BroadcastValue[T] { def value: T }
@@ -44,9 +50,15 @@ trait BackendContext {
 }
 
 abstract class Backend {
-  val persistedIR: mutable.Map[String, BaseIR] = mutable.Map()
+  val persistedIR: mutable.Map[Int, BaseIR] = mutable.Map()
 
-  def removeJavaIR(id: String): Unit = persistedIR.remove(id)
+  protected[this] def addJavaIR(ir: BaseIR): Int = {
+    val id = Backend.nextIRID()
+    persistedIR += (id -> ir)
+    id
+  }
+
+  def removeJavaIR(id: Int): Unit = persistedIR.remove(id)
 
   def defaultParallelism: Int
 

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -1,16 +1,120 @@
 package is.hail.backend
 
+import com.sun.net.httpserver.{HttpContext, HttpExchange, HttpHandler, HttpServer}
+import java.io._
+import java.net._
+import java.nio.charset.StandardCharsets
+
+import org.json4s._
+import org.json4s.jackson.{JsonMethods, Serialization}
+
 import is.hail.asm4s._
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.expr.ir.{CodeCacheKey, CompiledFunction, LoweringAnalyses, SortField, TableIR, TableReader}
+import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.io.fs._
+import is.hail.io.plink.LoadPlink
+import is.hail.io.vcf.LoadVCF
+import is.hail.expr.ir.{IRParser, BaseIR}
 import is.hail.linalg.BlockMatrix
 import is.hail.types._
+import is.hail.types.encoded.EType
+import is.hail.types.virtual.TFloat64
+import is.hail.types.physical.PTuple
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
+import is.hail.expr.ir.IRParserEnvironment
+
+
+case class IRTypePayload(ir: String)
+case class LoadReferencesFromDatasetPayload(path: String)
+case class FromFASTAFilePayload(name: String, fasta_file: String, index_file: String,
+    x_contigs: Array[String], y_contigs: Array[String], mt_contigs: Array[String],
+    par: Array[String])
+case class ParseVCFMetadataPayload(path: String)
+case class ImportFamPayload(path: String, quant_pheno: Boolean, delimiter: String, missing: String)
+case class ExecutePayload(ir: String, stream_codec: String)
+
+object BackendServer {
+  def apply(backend: Backend) = new BackendServer(backend)
+}
+
+class BackendServer(backend: Backend) {
+  // 0 => let the OS pick an available port
+  private val httpServer = HttpServer.create(new InetSocketAddress(0), 10)
+  private val handler = new BackendHttpHandler(backend)
+
+  def port = httpServer.getAddress.getPort
+
+  def start(): Unit = {
+    httpServer.createContext("/", handler)
+    httpServer.setExecutor(null)
+    httpServer.start()
+  }
+
+  def stop(): Unit = {
+    httpServer.stop(10)
+  }
+}
+
+class BackendHttpHandler(backend: Backend) extends HttpHandler {
+  def handle(exchange: HttpExchange): Unit = {
+    implicit val formats: Formats = DefaultFormats
+
+    try {
+      val body = using(exchange.getRequestBody)(JsonMethods.parse(_))
+      if (exchange.getRequestURI.getPath == "/execute") {
+          val config = body.extract[ExecutePayload]
+          backend.execute(config.ir, false) { (ctx, res, timings) =>
+            exchange.getResponseHeaders().add("X-Hail-Timings", timings)
+            res match {
+              case Left(_) => exchange.sendResponseHeaders(200, -1L)
+              case Right((t, off)) =>
+                exchange.sendResponseHeaders(200, 0L)  // 0 => an arbitrarily long response body
+                using(exchange.getResponseBody()) { os =>
+                  backend.encodeToOutputStream(ctx, t, off, config.stream_codec, os)
+                }
+            }
+          }
+          return
+      }
+      val response: Array[Byte] = exchange.getRequestURI.getPath match {
+        case "/value/type" => backend.valueType(body.extract[IRTypePayload].ir)
+        case "/table/type" => backend.tableType(body.extract[IRTypePayload].ir)
+        case "/matrixtable/type" => backend.matrixTableType(body.extract[IRTypePayload].ir)
+        case "/blockmatrix/type" => backend.blockMatrixType(body.extract[IRTypePayload].ir)
+        case "/references/load" => backend.loadReferencesFromDataset(body.extract[LoadReferencesFromDatasetPayload].path)
+        case "/references/from_fasta" =>
+          val config = body.extract[FromFASTAFilePayload]
+          backend.fromFASTAFile(config.name, config.fasta_file, config.index_file,
+            config.x_contigs, config.y_contigs, config.mt_contigs, config.par)
+        case "/vcf/metadata/parse" => backend.parseVCFMetadata(body.extract[ParseVCFMetadataPayload].path)
+        case "/fam/import" =>
+          val config = body.extract[ImportFamPayload]
+          backend.importFam(config.path, config.quant_pheno, config.delimiter, config.missing)
+      }
+
+      exchange.sendResponseHeaders(200, response.length)
+      using(exchange.getResponseBody())(_.write(response))
+    } catch {
+      case t: Throwable =>
+        error(t.getMessage)
+        val (shortMessage, expandedMessage, errorId) = handleForPython(t)
+        val errorJson = JObject(
+          "short" -> JString(shortMessage),
+          "expanded" -> JString(expandedMessage),
+          "error_id" -> JInt(errorId)
+        )
+        val errorBytes = JsonMethods.compact(errorJson).getBytes(StandardCharsets.UTF_8)
+        exchange.sendResponseHeaders(500, errorBytes.length)
+        using(exchange.getResponseBody())(_.write(errorBytes))
+    }
+  }
+}
 
 object Backend {
 
@@ -28,6 +132,10 @@ trait BackendContext {
 }
 
 abstract class Backend {
+  val persistedIR: mutable.Map[String, BaseIR] = mutable.Map()
+
+  def removeJavaIR(id: String): Unit = persistedIR.remove(id)
+
   def defaultParallelism: Int
 
   def canExecuteParallelTasksOnDriver: Boolean = true
@@ -115,6 +223,91 @@ abstract class Backend {
     inputIR: TableIR,
     analyses: LoweringAnalyses
   ): TableStage
+
+  def withExecuteContext[T](methodName: String): (ExecuteContext => T) => T
+
+  final def valueType(s: String): Array[Byte] = {
+    withExecuteContext("tableType") { ctx =>
+      val v = IRParser.parse_value_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
+      v.typ.toString.getBytes(StandardCharsets.UTF_8)
+    }
+  }
+
+  private[this] def jsonToBytes(f: => JValue): Array[Byte] = {
+    JsonMethods.compact(f).getBytes(StandardCharsets.UTF_8)
+  }
+
+  final def tableType(s: String): Array[Byte] = jsonToBytes {
+    withExecuteContext("tableType") { ctx =>
+      val x = IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
+      x.typ.toJSON
+    }
+  }
+
+  final def matrixTableType(s: String): Array[Byte] = jsonToBytes {
+    withExecuteContext("matrixTableType") { ctx =>
+      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap)).typ.pyJson
+    }
+  }
+
+  final def blockMatrixType(s: String): Array[Byte] = jsonToBytes {
+    withExecuteContext("blockMatrixType") { ctx =>
+      val x = IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
+      val t = x.typ
+      JObject(
+        "element_type" -> JString(t.elementType.toString),
+        "shape" -> JArray(t.shape.map(s => JInt(s)).toList),
+        "is_row_vector" -> JBool(t.isRowVector),
+        "block_size" -> JInt(t.blockSize)
+      )
+    }
+  }
+
+  def loadReferencesFromDataset(path: String): Array[Byte] = {
+    withExecuteContext("loadReferencesFromDataset") { ctx =>
+      val rgs = ReferenceGenome.fromHailDataset(ctx.fs, path)
+      rgs.foreach(addReference)
+
+      implicit val formats: Formats = defaultJSONFormats
+      Serialization.write(rgs.map(_.toJSON).toFastSeq).getBytes(StandardCharsets.UTF_8)
+    }
+  }
+
+  def fromFASTAFile(name: String, fastaFile: String, indexFile: String,
+    xContigs: Array[String], yContigs: Array[String], mtContigs: Array[String],
+    parInput: Array[String]): Array[Byte] = {
+    withExecuteContext("fromFASTAFile") { ctx =>
+      val rg = ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
+        xContigs, yContigs, mtContigs, parInput)
+      rg.toJSONString.getBytes(StandardCharsets.UTF_8)
+    }
+  }
+
+  def parseVCFMetadata(path: String): Array[Byte] = jsonToBytes {
+    withExecuteContext("parseVCFMetadata") { ctx =>
+      val metadata = LoadVCF.parseHeaderMetadata(ctx.fs, Set.empty, TFloat64, path)
+      implicit val formats = defaultJSONFormats
+      Extraction.decompose(metadata)
+    }
+  }
+
+  def importFam(path: String, isQuantPheno: Boolean, delimiter: String, missingValue: String): Array[Byte] = {
+    withExecuteContext("importFam") { ctx =>
+      LoadPlink.importFamJSON(ctx.fs, path, isQuantPheno, delimiter, missingValue).getBytes(StandardCharsets.UTF_8)
+    }
+  }
+
+  def execute(ir: String, timed: Boolean)(consume: (ExecuteContext, Either[Unit, (PTuple, Long)], String) => Unit): Unit = ()
+
+  def encodeToOutputStream(ctx: ExecuteContext, t: PTuple, off: Long, bufferSpecString: String, os: OutputStream): Unit = {
+    val bs = BufferSpec.parseOrDefault(bufferSpecString)
+    assert(t.size == 1)
+    val elementType = t.fields(0).typ
+    val codec = TypedCodecSpec(
+      EType.fromTypeAllOptional(elementType.virtualType), elementType.virtualType, bs)
+    assert(t.isFieldDefined(off, 0))
+    codec.encode(ctx, elementType, t.loadField(off, 0), os)
+  }
 }
 
 trait BackendWithCodeCache {

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -37,7 +37,7 @@ case class FromFASTAFilePayload(name: String, fasta_file: String, index_file: St
     par: Array[String])
 case class ParseVCFMetadataPayload(path: String)
 case class ImportFamPayload(path: String, quant_pheno: Boolean, delimiter: String, missing: String)
-case class ExecutePayload(ir: String, stream_codec: String)
+case class ExecutePayload(ir: String, stream_codec: String, timed: Boolean)
 
 object BackendServer {
   def apply(backend: Backend) = new BackendServer(backend)
@@ -69,7 +69,7 @@ class BackendHttpHandler(backend: Backend) extends HttpHandler {
       val body = using(exchange.getRequestBody)(JsonMethods.parse(_))
       if (exchange.getRequestURI.getPath == "/execute") {
           val config = body.extract[ExecutePayload]
-          backend.execute(config.ir, false) { (ctx, res, timings) =>
+          backend.execute(config.ir, config.timed) { (ctx, res, timings) =>
             exchange.getResponseHeaders().add("X-Hail-Timings", timings)
             res match {
               case Left(_) => exchange.sendResponseHeaders(200, -1L)

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -1,8 +1,6 @@
 package is.hail.backend
 
-import com.sun.net.httpserver.{HttpContext, HttpExchange, HttpHandler, HttpServer}
 import java.io._
-import java.net._
 import java.nio.charset.StandardCharsets
 
 import org.json4s._
@@ -29,92 +27,6 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 import is.hail.expr.ir.IRParserEnvironment
 
-
-case class IRTypePayload(ir: String)
-case class LoadReferencesFromDatasetPayload(path: String)
-case class FromFASTAFilePayload(name: String, fasta_file: String, index_file: String,
-    x_contigs: Array[String], y_contigs: Array[String], mt_contigs: Array[String],
-    par: Array[String])
-case class ParseVCFMetadataPayload(path: String)
-case class ImportFamPayload(path: String, quant_pheno: Boolean, delimiter: String, missing: String)
-case class ExecutePayload(ir: String, stream_codec: String, timed: Boolean)
-
-object BackendServer {
-  def apply(backend: Backend) = new BackendServer(backend)
-}
-
-class BackendServer(backend: Backend) {
-  // 0 => let the OS pick an available port
-  private val httpServer = HttpServer.create(new InetSocketAddress(0), 10)
-  private val handler = new BackendHttpHandler(backend)
-
-  def port = httpServer.getAddress.getPort
-
-  def start(): Unit = {
-    httpServer.createContext("/", handler)
-    httpServer.setExecutor(null)
-    httpServer.start()
-  }
-
-  def stop(): Unit = {
-    httpServer.stop(10)
-  }
-}
-
-class BackendHttpHandler(backend: Backend) extends HttpHandler {
-  def handle(exchange: HttpExchange): Unit = {
-    implicit val formats: Formats = DefaultFormats
-
-    try {
-      val body = using(exchange.getRequestBody)(JsonMethods.parse(_))
-      if (exchange.getRequestURI.getPath == "/execute") {
-          val config = body.extract[ExecutePayload]
-          backend.execute(config.ir, config.timed) { (ctx, res, timings) =>
-            exchange.getResponseHeaders().add("X-Hail-Timings", timings)
-            res match {
-              case Left(_) => exchange.sendResponseHeaders(200, -1L)
-              case Right((t, off)) =>
-                exchange.sendResponseHeaders(200, 0L)  // 0 => an arbitrarily long response body
-                using(exchange.getResponseBody()) { os =>
-                  backend.encodeToOutputStream(ctx, t, off, config.stream_codec, os)
-                }
-            }
-          }
-          return
-      }
-      val response: Array[Byte] = exchange.getRequestURI.getPath match {
-        case "/value/type" => backend.valueType(body.extract[IRTypePayload].ir)
-        case "/table/type" => backend.tableType(body.extract[IRTypePayload].ir)
-        case "/matrixtable/type" => backend.matrixTableType(body.extract[IRTypePayload].ir)
-        case "/blockmatrix/type" => backend.blockMatrixType(body.extract[IRTypePayload].ir)
-        case "/references/load" => backend.loadReferencesFromDataset(body.extract[LoadReferencesFromDatasetPayload].path)
-        case "/references/from_fasta" =>
-          val config = body.extract[FromFASTAFilePayload]
-          backend.fromFASTAFile(config.name, config.fasta_file, config.index_file,
-            config.x_contigs, config.y_contigs, config.mt_contigs, config.par)
-        case "/vcf/metadata/parse" => backend.parseVCFMetadata(body.extract[ParseVCFMetadataPayload].path)
-        case "/fam/import" =>
-          val config = body.extract[ImportFamPayload]
-          backend.importFam(config.path, config.quant_pheno, config.delimiter, config.missing)
-      }
-
-      exchange.sendResponseHeaders(200, response.length)
-      using(exchange.getResponseBody())(_.write(response))
-    } catch {
-      case t: Throwable =>
-        error(t.getMessage)
-        val (shortMessage, expandedMessage, errorId) = handleForPython(t)
-        val errorJson = JObject(
-          "short" -> JString(shortMessage),
-          "expanded" -> JString(expandedMessage),
-          "error_id" -> JInt(errorId)
-        )
-        val errorBytes = JsonMethods.compact(errorJson).getBytes(StandardCharsets.UTF_8)
-        exchange.sendResponseHeaders(500, errorBytes.length)
-        using(exchange.getResponseBody())(_.write(errorBytes))
-    }
-  }
-}
 
 object Backend {
 

--- a/hail/src/main/scala/is/hail/backend/BackendServer.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendServer.scala
@@ -1,0 +1,95 @@
+package is.hail.backend
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import com.sun.net.httpserver.{HttpContext, HttpExchange, HttpHandler, HttpServer}
+
+import org.json4s._
+import org.json4s.jackson.{JsonMethods, Serialization}
+
+import is.hail.utils._
+
+case class IRTypePayload(ir: String)
+case class LoadReferencesFromDatasetPayload(path: String)
+case class FromFASTAFilePayload(name: String, fasta_file: String, index_file: String,
+    x_contigs: Array[String], y_contigs: Array[String], mt_contigs: Array[String],
+    par: Array[String])
+case class ParseVCFMetadataPayload(path: String)
+case class ImportFamPayload(path: String, quant_pheno: Boolean, delimiter: String, missing: String)
+case class ExecutePayload(ir: String, stream_codec: String, timed: Boolean)
+
+object BackendServer {
+  def apply(backend: Backend) = new BackendServer(backend)
+}
+
+class BackendServer(backend: Backend) {
+  // 0 => let the OS pick an available port
+  private[this] val httpServer = HttpServer.create(new InetSocketAddress(0), 10)
+  private[this] val handler = new BackendHttpHandler(backend)
+
+  def port = httpServer.getAddress.getPort
+
+  def start(): Unit = {
+    httpServer.createContext("/", handler)
+    httpServer.setExecutor(null)
+    httpServer.start()
+  }
+
+  def stop(): Unit = {
+    httpServer.stop(10)
+  }
+}
+
+class BackendHttpHandler(backend: Backend) extends HttpHandler {
+  def handle(exchange: HttpExchange): Unit = {
+    implicit val formats: Formats = DefaultFormats
+
+    try {
+      val body = using(exchange.getRequestBody)(JsonMethods.parse(_))
+      if (exchange.getRequestURI.getPath == "/execute") {
+          val config = body.extract[ExecutePayload]
+          backend.execute(config.ir, config.timed) { (ctx, res, timings) =>
+            exchange.getResponseHeaders().add("X-Hail-Timings", timings)
+            res match {
+              case Left(_) => exchange.sendResponseHeaders(200, -1L)
+              case Right((t, off)) =>
+                exchange.sendResponseHeaders(200, 0L)  // 0 => an arbitrarily long response body
+                using(exchange.getResponseBody()) { os =>
+                  backend.encodeToOutputStream(ctx, t, off, config.stream_codec, os)
+                }
+            }
+          }
+          return
+      }
+      val response: Array[Byte] = exchange.getRequestURI.getPath match {
+        case "/value/type" => backend.valueType(body.extract[IRTypePayload].ir)
+        case "/table/type" => backend.tableType(body.extract[IRTypePayload].ir)
+        case "/matrixtable/type" => backend.matrixTableType(body.extract[IRTypePayload].ir)
+        case "/blockmatrix/type" => backend.blockMatrixType(body.extract[IRTypePayload].ir)
+        case "/references/load" => backend.loadReferencesFromDataset(body.extract[LoadReferencesFromDatasetPayload].path)
+        case "/references/from_fasta" =>
+          val config = body.extract[FromFASTAFilePayload]
+          backend.fromFASTAFile(config.name, config.fasta_file, config.index_file,
+            config.x_contigs, config.y_contigs, config.mt_contigs, config.par)
+        case "/vcf/metadata/parse" => backend.parseVCFMetadata(body.extract[ParseVCFMetadataPayload].path)
+        case "/fam/import" =>
+          val config = body.extract[ImportFamPayload]
+          backend.importFam(config.path, config.quant_pheno, config.delimiter, config.missing)
+      }
+
+      exchange.sendResponseHeaders(200, response.length)
+      using(exchange.getResponseBody())(_.write(response))
+    } catch {
+      case t: Throwable =>
+        val (shortMessage, expandedMessage, errorId) = handleForPython(t)
+        val errorJson = JObject(
+          "short" -> JString(shortMessage),
+          "expanded" -> JString(expandedMessage),
+          "error_id" -> JInt(errorId)
+        )
+        val errorBytes = JsonMethods.compact(errorJson).getBytes(StandardCharsets.UTF_8)
+        exchange.sendResponseHeaders(500, errorBytes.length)
+        using(exchange.getResponseBody())(_.write(errorBytes))
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -226,7 +226,7 @@ class LocalBackend(
       result
     }
 
-  def executeLiteral(irStr: String): String = {
+  def executeLiteral(irStr: String): Int = {
     ExecutionTimer.logTime("SparkBackend.executeLiteral") { timer =>
       withExecuteContext(timer) { ctx =>
         val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
@@ -240,9 +240,7 @@ class LocalBackend(
           case Right((pt, addr)) => GetFieldByIdx(EncodedLiteral.fromPTypeAndAddress(pt, addr, ctx), 0)
         }
         log.info(s"finished execution of query $queryID")
-        val id = UUID4().id
-        this.persistedIR += (id -> literalIR)
-        id
+        addJavaIR(literalIR)
       }
     }
   }

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -56,6 +56,7 @@ object LocalBackend {
       gcsRequesterPaysProject,
       gcsRequesterPaysBuckets
     )
+    theLocalBackend.addDefaultReferences()
     theLocalBackend
   }
 

--- a/hail/src/main/scala/is/hail/backend/service/Main.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Main.scala
@@ -12,7 +12,7 @@ object Main {
   def main(argv: Array[String]): Unit = {
     argv(3) match {
       case WORKER => Worker.main(argv)
-      case DRIVER => ServiceBackendSocketAPI2.main(argv)
+      case DRIVER => ServiceBackendAPI.main(argv)
       case kind => throw new RuntimeException(s"unknown kind: ${kind}")
     }
   }

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -367,35 +367,11 @@ class ServiceBackend(
 
   def getPersistedBlockMatrixType(backendContext: BackendContext, id: String): BlockMatrixType = ???
 
-  def importFam(
-    ctx: ExecuteContext,
-    path: String,
-    quantPheno: Boolean,
-    delimiter: String,
-    missing: String
-  ): String = {
-    LoadPlink.importFamJSON(ctx.fs, path, quantPheno, delimiter, missing)
-  }
-
   def tableToTableStage(ctx: ExecuteContext,
     inputIR: TableIR,
     analyses: LoweringAnalyses
   ): TableStage = {
     LowerTableIR.applyTable(inputIR, DArrayLowering.All, ctx, analyses)
-  }
-
-  def fromFASTAFile(
-    ctx: ExecuteContext,
-    name: String,
-    fastaFile: String,
-    indexFile: String,
-    xContigs: Array[String],
-    yContigs: Array[String],
-    mtContigs: Array[String],
-    parInput: Array[String]
-  ): String = {
-    val rg = ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile, xContigs, yContigs, mtContigs, parInput)
-    rg.toJSONString
   }
 
   def withExecuteContext[T](methodName: String): (ExecuteContext => T) => T = { f =>

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -336,6 +336,7 @@ class ServiceBackend(
         elementType.virtualType,
         BufferSpec.parseOrDefault(bufferSpecString)
       )
+      assert(pt.isFieldDefined(off, 0))
       codec.encode(ctx, elementType, pt.loadField(off, 0))
     }
   }
@@ -449,7 +450,7 @@ object ServiceBackendAPI {
       HailContext.get.backend = backend
       log.info("Default references added to already initialized HailContexet.")
     } else {
-      HailContext(backend, 50, 3, false)
+      HailContext(backend, 50, 3)
       log.info("HailContexet initialized.")
     }
 

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -90,6 +90,7 @@ object ServiceBackend {
       backendContext,
       scratchDir
     )
+    backend.addDefaultReferences()
 
     rpcConfig.custom_references.foreach { s =>
       backend.addReference(ReferenceGenome.fromJSON(s))
@@ -469,7 +470,6 @@ object ServiceBackendSocketAPI2 {
     log.info("ServiceBackend allocated.")
     if (HailContext.isInitialized) {
       HailContext.get.backend = backend
-      backend.addDefaultReferences()
       log.info("Default references added to already initialized HailContexet.")
     } else {
       HailContext(backend, 50, 3)

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -323,19 +323,20 @@ class ServiceBackend(
       ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))
       Array()
     } else {
-      val (Some(PTypeReferenceSingleCodeType(pt)), f) = Compile[AsmFunction1RegionLong](ctx,
+      val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) = Compile[AsmFunction1RegionLong](ctx,
         FastSeq(),
-        FastSeq[TypeInfo[_]](classInfo[Region]), LongInfo,
+        FastSeq(classInfo[Region]), LongInfo,
         MakeTuple.ordered(FastSeq(x)),
         optimize = true)
       val retPType = pt.asInstanceOf[PBaseStruct]
+      val elementType = pt.fields(0).typ
       val off = ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))
       val codec = TypedCodecSpec(
-        EType.fromTypeAllOptional(retPType.virtualType),
-        retPType.virtualType,
+        EType.fromTypeAllOptional(elementType.virtualType),
+        elementType.virtualType,
         BufferSpec.parseOrDefault(bufferSpecString)
       )
-      codec.encode(ctx, retPType, off)
+      codec.encode(ctx, elementType, pt.loadField(off, 0))
     }
   }
 

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -449,7 +449,7 @@ object ServiceBackendSocketAPI2 {
       HailContext.get.backend = backend
       log.info("Default references added to already initialized HailContexet.")
     } else {
-      HailContext(backend, 50, 3)
+      HailContext(backend, 50, 3, false)
       log.info("HailContexet initialized.")
     }
 

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -408,7 +408,7 @@ class ServiceBackend(
 class EndOfInputException extends RuntimeException
 class HailBatchFailure(message: String) extends RuntimeException(message)
 
-object ServiceBackendSocketAPI2 {
+object ServiceBackendAPI {
   private[this] val log = Logger.getLogger(getClass.getName())
 
   def main(argv: Array[String]): Unit = {
@@ -455,7 +455,7 @@ object ServiceBackendSocketAPI2 {
 
     val action = (input \ "action").extract[Int]
     val payload = (input \ "payload")
-    new ServiceBackendSocketAPI2(backend, fs, outputURL).executeOneCommand(action, payload)
+    new ServiceBackendAPI(backend, fs, outputURL).executeOneCommand(action, payload)
   }
 }
 
@@ -528,7 +528,7 @@ case class SerializedIRFunction(
   rendered_body: String,
 )
 
-class ServiceBackendSocketAPI2(
+class ServiceBackendAPI(
   private[this] val backend: ServiceBackend,
   private[this] val fs: FS,
   private[this] val outputURL: String,

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -158,11 +158,11 @@ object Worker {
     timer.start("executeFunction")
 
     if (HailContext.isInitialized) {
-      HailContext.get.backend = new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()), null, None)
+      HailContext.get.backend = new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()), null, None, null, null, null, null)
     } else {
       HailContext(
         // FIXME: workers should not have backends, but some things do need hail contexts
-        new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()), null, None))
+        new ServiceBackend(null, null, new HailClassLoader(getClass().getClassLoader()), null, None, null, null, null, null))
     }
 
     var result: Array[Byte] = null

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -247,6 +247,7 @@ object SparkBackend {
     sc1.uiWebUrl.foreach(ui => info(s"SparkUI: $ui"))
 
     theSparkBackend = new SparkBackend(tmpdir, localTmpdir, sc1, gcsRequesterPaysProject, gcsRequesterPaysBuckets)
+    theSparkBackend.addDefaultReferences()
     theSparkBackend
   }
 

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -32,7 +32,8 @@ import org.json4s
 import org.json4s.jackson.{JsonMethods, Serialization}
 import org.json4s.{DefaultFormats, Formats}
 
-import java.io.{Closeable, PrintWriter}
+import com.sun.net.httpserver.{HttpExchange}
+import java.io.{Closeable, PrintWriter, OutputStream}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -358,6 +359,16 @@ class SparkBackend(
       }
     )
 
+  def withExecuteContext[T](methodName: String): (ExecuteContext => T) => T = { f =>
+    ExecutionTimer.logTime(methodName) { timer =>
+      ExecuteContext.scoped(tmpdir, tmpdir, this, fs, timer, null, theHailClassLoader, this.references, flags, new BackendContext {
+        override val executionCache: ExecutionCache =
+          ExecutionCache.fromFlags(flags, fs, tmpdir)
+      })(f)
+    }
+  }
+
+
   def broadcast[T : ClassTag](value: T): BroadcastValue[T] = new SparkBroadcastValue[T](sc.broadcast(value))
 
   override def parallelizeAndComputeWithIndex(
@@ -506,11 +517,12 @@ class SparkBackend(
     }
   }
 
-  def executeLiteral(ir: IR): IR = {
-    val t = ir.typ
-    assert(t.isRealizable)
+  def executeLiteral(irStr: String): String = {
     ExecutionTimer.logTime("SparkBackend.executeLiteral") { timer =>
       withExecuteContext(timer) { ctx =>
+        val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
+        val t = ir.typ
+        assert(t.isRealizable)
         val queryID = Backend.nextID()
         log.info(s"starting execution of query $queryID} of initial size ${ IRSize(ir) }")
         val retVal = _execute(ctx, ir, true)
@@ -519,18 +531,25 @@ class SparkBackend(
           case Right((pt, addr)) => GetFieldByIdx(EncodedLiteral.fromPTypeAndAddress(pt, addr, ctx), 0)
         }
         log.info(s"finished execution of query $queryID")
-        literalIR
+        val id = UUID4().id
+        persistedIR += (id -> literalIR)
+        id
       }
     }
   }
 
-  def executeJSON(ir: IR): String = {
-    val (jsonValue, timer) = ExecutionTimer.time("SparkBackend.executeJSON") { timer =>
-      val t = ir.typ
-      val value = execute(timer, ir, optimize = true)
-      JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value, t))
+  override def execute(ir: String, timed: Boolean)(consume: (ExecuteContext, Either[Unit, (PTuple, Long)], String) => Unit): Unit = {
+    withExecuteContext("SparkBackend.execute") { ctx =>
+      val res = ctx.timer.time("execute") {
+        val irData = IRParser.parse_value_ir(ir, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
+        val queryID = Backend.nextID()
+        log.info(s"starting execution of query $queryID of initial size ${ IRSize(irData) }")
+        _execute(ctx, irData, true)
+      }
+      ctx.timer.finish()
+      val timings = if (timed) Serialization.write(Map("timings" -> ctx.timer.toMap))(new DefaultFormats {}) else ""
+      consume(ctx, res, timings)
     }
-    Serialization.write(Map("value" -> jsonValue, "timings" -> timer.toMap))(new DefaultFormats {})
   }
 
   def executeEncode(ir: IR, bufferSpecString: String, timed: Boolean): (Array[Byte], String) = {
@@ -574,19 +593,23 @@ class SparkBackend(
     }
   }
 
-  def pyFromDF(df: DataFrame, jKey: java.util.List[String]): TableIR = {
+  def pyFromDF(df: DataFrame, jKey: java.util.List[String]): (String, String) = {
     ExecutionTimer.logTime("SparkBackend.pyFromDF") { timer =>
       val key = jKey.asScala.toArray.toFastSeq
       val signature = SparkAnnotationImpex.importType(df.schema).setRequired(true).asInstanceOf[PStruct]
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        TableLiteral(TableValue(ctx, signature.virtualType.asInstanceOf[TStruct], key, df.rdd, Some(signature)), ctx.theHailClassLoader)
+        val tir = TableLiteral(TableValue(ctx, signature.virtualType.asInstanceOf[TStruct], key, df.rdd, Some(signature)), ctx.theHailClassLoader)
+        val id = UUID4().id
+        persistedIR += (id -> tir)
+        (id, JsonMethods.compact(tir.typ.toJSON))
       }
     }
   }
 
-  def pyToDF(tir: TableIR): DataFrame = {
+  def pyToDF(s: String): DataFrame = {
     ExecutionTimer.logTime("SparkBackend.pyToDF") { timer =>
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
+        val tir = IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
         Interpret(tir, ctx).toDF()
       }
     }
@@ -612,14 +635,6 @@ class SparkBackend(
     }
     log.info("pyReadMultipleMatrixTables: returning N matrix tables")
     matrixReaders.asJava
-  }
-
-  def pyLoadReferencesFromDataset(path: String): String = {
-    val rgs = ReferenceGenome.fromHailDataset(fs, path)
-    rgs.foreach(addReference)
-
-    implicit val formats: Formats = defaultJSONFormats
-    Serialization.write(rgs.map(_.toJSON).toFastSeq)
   }
 
   def pyAddReference(jsonConfig: String): Unit = addReference(ReferenceGenome.fromJSON(jsonConfig))
@@ -685,36 +700,34 @@ class SparkBackend(
     }
   }
 
-  def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
+  def parse_value_ir(s: String, refMap: java.util.Map[String, String]): IR = {
     ExecutionTimer.logTime("SparkBackend.parse_value_ir") { timer =>
       withExecuteContext(timer) { ctx =>
-        IRParser.parse_value_ir(s, IRParserEnvironment(ctx, BindingEnv.eval(refMap.asScala.toMap.mapValues(IRParser.parseType).toSeq: _*), irMap.asScala.toMap))
+        IRParser.parse_value_ir(s, IRParserEnvironment(ctx, BindingEnv.eval(refMap.asScala.toMap.mapValues(IRParser.parseType).toSeq: _*), irMap = persistedIR.toMap))
       }
     }
   }
 
-  def parse_table_ir(s: String, irMap: java.util.Map[String, BaseIR]): TableIR = {
+  def parse_table_ir(s: String): TableIR = {
     ExecutionTimer.logTime("SparkBackend.parse_table_ir") { timer =>
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
+        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
       }
     }
   }
 
-  def parse_matrix_ir(s: String, irMap: java.util.Map[String, BaseIR]): MatrixIR = {
+  def parse_matrix_ir(s: String): MatrixIR = {
     ExecutionTimer.logTime("SparkBackend.parse_matrix_ir") { timer =>
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
+        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
       }
     }
   }
 
-  def parse_blockmatrix_ir(
-    s: String, irMap: java.util.Map[String, BaseIR]
-  ): BlockMatrixIR = {
+  def parse_blockmatrix_ir(s: String): BlockMatrixIR = {
     ExecutionTimer.logTime("SparkBackend.parse_blockmatrix_ir") { timer =>
       withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = irMap.asScala.toMap))
+        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
       }
     }
   }
@@ -753,9 +766,6 @@ class SparkBackend(
     val (rowPType: PStruct, orderedCRDD) = codec.decodeRDD(ctx, rowType, rdd.map(_._2))
     RVDTableReader(RVD.unkeyed(rowPType, orderedCRDD), globalsLit, rt)
   }
-
-  def pyImportFam(path: String, isQuantPheno: Boolean, delimiter: String, missingValue: String): String =
-    LoadPlink.importFamJSON(fs, path, isQuantPheno, delimiter, missingValue)
 
   def close(): Unit = {
     longLifeTempFileManager.cleanup()

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -127,7 +127,7 @@ object IRLexer extends JavaTokenParsers {
 case class IRParserEnvironment(
   ctx: ExecuteContext,
   refMap: BindingEnv[Type] = BindingEnv.empty[Type],
-  irMap: Map[String, BaseIR] = Map.empty,
+  irMap: Map[Int, BaseIR] = Map.empty,
 ) {
 
   def promoteAgg: IRParserEnvironment = copy(refMap = refMap.promoteAgg)
@@ -1529,8 +1529,8 @@ object IRParser {
           dynamicID <- ir_value_expr(env)(it)
         } yield CollectDistributedArray(ctxs, globals, cname, gname, body, dynamicID, staticID)
       case "JavaIR" =>
-        val name = identifier(it)
-        done(env.irMap(name).asInstanceOf[IR])
+        val id = int32_literal(it)
+        done(env.irMap(id).asInstanceOf[IR])
       case "ReadPartition" =>
         val requestedTypeRaw = it.head match {
           case x: IdentifierToken if x.value == "None" || x.value == "DropRowUIDs" =>
@@ -1795,8 +1795,8 @@ object IRParser {
           body <- table_ir(env.onlyRelational.bindRelational(name, value.typ))(it)
         } yield RelationalLetTable(name, value, body)
       case "JavaTable" =>
-        val name = identifier(it)
-        done(env.irMap(name).asInstanceOf[TableIR])
+        val id = int32_literal(it)
+        done(env.irMap(id).asInstanceOf[TableIR])
     }
   }
 
@@ -2002,9 +2002,6 @@ object IRParser {
           value <- ir_value_expr(env.onlyRelational)(it)
           body <- matrix_ir(env.onlyRelational.bindRelational(name, value.typ))(it)
         } yield RelationalLetMatrixTable(name, value, body)
-      case "JavaMatrix" =>
-        val name = identifier(it)
-        done(env.irMap(name).asInstanceOf[MatrixIR])
     }
   }
 
@@ -2141,9 +2138,6 @@ object IRParser {
           value <- ir_value_expr(env.onlyRelational)(it)
           body <- blockmatrix_ir(env.onlyRelational.bindRelational(name, value.typ))(it)
         } yield RelationalLetBlockMatrix(name, value, body)
-      case "JavaBlockMatrix" =>
-        val name = identifier(it)
-        done(env.irMap(name).asInstanceOf[BlockMatrixIR])
     }
   }
 

--- a/hail/src/main/scala/is/hail/io/CodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/CodecSpec.scala
@@ -35,13 +35,17 @@ trait AbstractTypedCodecSpec extends Spec {
 
   def encode(ctx: ExecuteContext, t: PType, offset: Long): Array[Byte] = {
     val baos = new ByteArrayOutputStream()
-    using(buildEncoder(ctx, t)(baos, ctx.theHailClassLoader))(_.writeRegionValue(offset))
+    encode(ctx, t, offset, baos)
     baos.toByteArray
+  }
+
+  def encode(ctx: ExecuteContext, t: PType, offset: Long, os: OutputStream): Unit = {
+    using(buildEncoder(ctx, t)(os, ctx.theHailClassLoader))(_.writeRegionValue(offset))
   }
 
   def encodeArrays(ctx: ExecuteContext, t: PType, offset: Long): Array[Array[Byte]] = {
     val baos = new ArrayOfByteArrayOutputStream()
-    using(buildEncoder(ctx, t)(baos, ctx.theHailClassLoader))(_.writeRegionValue(offset))
+    encode(ctx, t, offset, baos)
     baos.toByteArrays()
   }
 

--- a/hail/src/main/scala/is/hail/types/TableType.scala
+++ b/hail/src/main/scala/is/hail/types/TableType.scala
@@ -5,6 +5,8 @@ import is.hail.types.physical.{PStruct, PType}
 import is.hail.types.virtual.{TStruct, Type}
 import is.hail.rvd.RVDType
 import is.hail.utils._
+
+import org.json4s._
 import org.json4s.CustomSerializer
 import org.json4s.JsonAST.JString
 
@@ -77,5 +79,13 @@ case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStr
     indent -= 4
     newline()
     sb += '}'
+  }
+
+  def toJSON: JObject = {
+    JObject(
+      "global_type" -> JString(globalType.toString),
+      "row_type" -> JString(rowType.toString),
+      "row_key" -> JArray(key.map(f => JString(f)).toList)
+    )
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3097,27 +3097,18 @@ class IRSuite extends HailSuite {
 
   @Test def testCachedIR() {
     val cached = Literal(TSet(TInt32), Set(1))
-    val s = s"(JavaIR __uid1)"
+    val s = s"(JavaIR 1)"
     val x2 = ExecuteContext.scoped() { ctx =>
-      IRParser.parse_value_ir(s, IRParserEnvironment(ctx, irMap = Map("__uid1" -> cached)))
+      IRParser.parse_value_ir(s, IRParserEnvironment(ctx, irMap = Map(1 -> cached)))
     }
     assert(x2 eq cached)
   }
 
   @Test def testCachedTableIR() {
     val cached = TableRange(1, 1)
-    val s = s"(JavaTable __uid1)"
+    val s = s"(JavaTable 1)"
     val x2 = ExecuteContext.scoped() { ctx =>
-      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = Map("__uid1" -> cached)))
-    }
-    assert(x2 eq cached)
-  }
-
-  @Test def testCachedMatrixIR() {
-    val cached = MatrixIR.range(3, 7, None)
-    val s = s"(JavaMatrix __uid1)"
-    val x2 = ExecuteContext.scoped() { ctx =>
-      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = Map("__uid1" -> cached)))
+      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = Map(1 -> cached)))
     }
     assert(x2 eq cached)
   }


### PR DESCRIPTION
CHANGELOG: Fixes #13756: operations that collect large results such as `to_pandas` may require up to 3x less memory.

This turns all "actions", i.e. backend methods supported by QoB into HTTP endpoints on the spark and local backends. This intentionally avoids py4j because py4j was really designed to pass function names and references around and does not handle large payloads well (such as results from a `collect`). Specifically, py4j uses a text-based protocol on top of TCP that substantially inflates the memory requirement for communicating large byte arrays. On the Java side, py4j serializes every binary payload as a Base64-encoded `java.lang.String`, which between the Base64 encoding and `String`'s use of UTF-16 results in a memory footprint of the `String` being `4/3 * 2 = 8/3` nearly three times the size of the byte array on either side of the py4j pipe. py4j also appears to do an entire copy of this payload, which means nearly a 6x memory requirement for sending back bytes. Using our own socket means we can directly send back the response bytes to python without any of this overhead, even going so far as to encode results directly into the TCP output stream. Formalizing the API between python and java also allows us to reuse the same payload schema across all three backends.