### PR TITLE
[hailctl] Fix uploading files from parent directories of cwd

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1042,6 +1042,7 @@ steps:
               --durations=50 \
               --ignore=test/hailtop/batch/ \
               --ignore=test/hailtop/inter_cloud \
+              --ignore=test/hailtop/hailctl/batch/ \
               --timeout=120 \
               test
     inputs:
@@ -3005,7 +3006,8 @@ steps:
               --instafail \
               --durations=50 \
               --timeout=360 \
-              /io/test/hailtop/batch/
+              /io/test/hailtop/batch/ \
+              /io/test/hailtop/hailctl/batch/
     inputs:
       - from: /repo/hail/python/test
         to: /io/test

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -501,6 +501,8 @@ class AzureAsyncFS(AsyncFS):
     async def create(
         self, url: str, *, retry_writes: bool = True
     ) -> AsyncContextManager[WritableStream]:  # pylint: disable=unused-argument
+        print(url)
+        logger.info(url)
         return AzureCreateManager(self.get_blob_client(self.parse_url(url)))
 
     async def multi_part_create(self, sema: asyncio.Semaphore, url: str, num_parts: int) -> MultiPartCreate:

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -501,8 +501,6 @@ class AzureAsyncFS(AsyncFS):
     async def create(
         self, url: str, *, retry_writes: bool = True
     ) -> AsyncContextManager[WritableStream]:  # pylint: disable=unused-argument
-        print(url)
-        logger.info(url)
         return AzureCreateManager(self.get_blob_client(self.parse_url(url)))
 
     async def multi_part_create(self, sema: asyncio.Semaphore, url: str, num_parts: int) -> MultiPartCreate:

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -4,7 +4,7 @@ import typer
 from typer import Option as Opt, Argument as Arg
 import json
 
-from typing import Optional, List, Annotated as Ann, cast, Dict, Any, Tuple
+from typing import Optional, List, Annotated as Ann, cast, Dict, Any
 
 from . import list_batches
 from . import billing

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -165,9 +165,6 @@ def submit(
     files: Ann[
         Optional[List[str]], Opt(help='Files or directories to add to the working directory of the job.')
     ] = None,
-    mounts: Ann[
-        Optional[List[str]], Opt(help='Files or directories to add to a specific mount location in the job. Equivalent to -v src:dest in Docker.')
-    ] = None,
     name: Ann[str, Opt(help='The name of the batch.')] = '',
     image_name: Ann[Optional[str], Opt(help='Name of Docker image for the job (default: hailgenetics/hail)')] = None,
     output: StructuredFormatPlusTextOption = StructuredFormatPlusText.TEXT,
@@ -180,7 +177,7 @@ def submit(
 
     $ hailctl batch submit --image-name docker.io/image my_script.py -- some-argument --animal dog
     '''
-    asyncio.run(_submit.submit(name, image_name, files or [], mounts or [], output, script, [*(arguments or []), *ctx.args]))
+    asyncio.run(_submit.submit(name, image_name, files or [], output, script, [*(arguments or []), *ctx.args]))
 
 
 @app.command('init', help='Initialize a Hail Batch environment.')

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -4,7 +4,7 @@ import typer
 from typer import Option as Opt, Argument as Arg
 import json
 
-from typing import Optional, List, Annotated as Ann, cast, Dict, Any
+from typing import Optional, List, Annotated as Ann, cast, Dict, Any, Tuple
 
 from . import list_batches
 from . import billing
@@ -165,6 +165,9 @@ def submit(
     files: Ann[
         Optional[List[str]], Opt(help='Files or directories to add to the working directory of the job.')
     ] = None,
+    mounts: Ann[
+        Optional[List[str]], Opt(help='Files or directories to add to a specific mount location in the job. Equivalent to -v src:dest in Docker.')
+    ] = None,
     name: Ann[str, Opt(help='The name of the batch.')] = '',
     image_name: Ann[Optional[str], Opt(help='Name of Docker image for the job (default: hailgenetics/hail)')] = None,
     output: StructuredFormatPlusTextOption = StructuredFormatPlusText.TEXT,
@@ -177,7 +180,7 @@ def submit(
 
     $ hailctl batch submit --image-name docker.io/image my_script.py -- some-argument --animal dog
     '''
-    asyncio.run(_submit.submit(name, image_name, files or [], output, script, [*(arguments or []), *ctx.args]))
+    asyncio.run(_submit.submit(name, image_name, files or [], mounts or [], output, script, [*(arguments or []), *ctx.args]))
 
 
 @app.command('init', help='Initialize a Hail Batch environment.')

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -47,6 +47,7 @@ async def submit(name, image_name, files, output, script, arguments):
         if src is None:
             raise ValueError(f'invalid file specification {file}. Must have a "src" defined.')
         src = os.path.abspath(os.path.expanduser(src))
+        src = src.rstrip('/')
 
         dest = result.get('dest')
         if dest is not None:

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -31,6 +31,7 @@ async def submit(name, image_name, files, output, script, arguments):
     tmpdir_path_prefix = secret_alnum_string()
 
     def cloud_prefix(path):
+        path = path.lstrip('/')
         return f'{remote_tmpdir}/{tmpdir_path_prefix}/{path}'
 
     def file_input_to_src_dest(file: str) -> Tuple[str, str, str]:

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -75,11 +75,11 @@ async def submit(name, image_name, files, output, script, arguments):
     script_src, _, script_cloud_file = file_input_to_src_dest(script)
     user_config_src, _, user_config_cloud_file = file_input_to_src_dest(user_config)
 
+    await copy_from_dict(files=local_files_to_cloud_files)
     await copy_from_dict(
         files=[
             {'from': script_src, 'to': script_cloud_file},
             {'from': user_config_src, 'to': user_config_cloud_file},
-            *local_files_to_cloud_files,
         ]
     )
 

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -75,10 +75,13 @@ async def submit(name, image_name, files, output, script, arguments):
 
     assert False, str(local_files_to_cloud_files)
 
-    await copy_from_dict(files=[
-        {'from': script_src, 'to': script_cloud_file},
-        {'from': user_config_src, 'to': user_config_cloud_file},
-        *local_files_to_cloud_files])
+    await copy_from_dict(
+        files=[
+            {'from': script_src, 'to': script_cloud_file},
+            {'from': user_config_src, 'to': user_config_cloud_file},
+            *local_files_to_cloud_files,
+        ]
+    )
 
     script_file = b.read_input(script_cloud_file)
     config_file = b.read_input(user_config_cloud_file)

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -1,10 +1,15 @@
 import orjson
 import os
+import re
 from shlex import quote as shq
 from hailtop import pip_version
+from typing import Tuple
 
 
-async def submit(name, image_name, files, mounts, output, script, arguments):
+FILE_REGEX = re.compile(r'(?P<src>[^:]+)(:(?P<dest>.+))?')
+
+
+async def submit(name, image_name, files, output, script, arguments):
     import hailtop.batch as hb  # pylint: disable=import-outside-toplevel
     from hailtop.aiotools.copy import copy_from_dict  # pylint: disable=import-outside-toplevel
     from hailtop.config import (  # pylint: disable=import-outside-toplevel
@@ -17,9 +22,9 @@ async def submit(name, image_name, files, mounts, output, script, arguments):
         unpack_comma_delimited_inputs,
     )
 
-    script = os.path.expanduser(script)
     files = unpack_comma_delimited_inputs(files)
-    user_config = get_user_config_path()
+    user_config = str(get_user_config_path())
+
     quiet = output != 'text'
 
     remote_tmpdir = get_remote_tmpdir('hailctl batch submit')
@@ -28,71 +33,62 @@ async def submit(name, image_name, files, mounts, output, script, arguments):
     def cloud_prefix(path):
         return f'{remote_tmpdir}/{tmpdir_path_prefix}/{path}'
 
+    def file_input_to_src_dest(file: str) -> Tuple[str, str, str]:
+        if file.startswith('file://'):
+            file = file[7:]
+
+        match = FILE_REGEX.match(file)
+        if match is None:
+            raise ValueError(f'invalid file specification {file}. Must have the form "src" or "src:dest"')
+
+        result = match.groupdict()
+
+        src = result.get('src')
+        if src is None:
+            raise ValueError(f'invalid file specification {file}. Must have a "src" defined.')
+        src = os.path.abspath(os.path.expanduser(src))
+
+        dest = result.get('dest')
+        if dest is not None:
+            dest = os.path.abspath(os.path.expanduser(dest))
+        else:
+            dest = os.getcwd()
+
+        cloud_file = cloud_prefix(dest)
+
+        return (src, dest, cloud_file)
+
     backend = hb.ServiceBackend()
     b = hb.Batch(name=name, backend=backend)
     j = b.new_bash_job()
     j.image(image_name or os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{pip_version()}'))
 
-    rel_file_paths = []
+    local_files_to_cloud_files = []
+
     for file in files:
-        rel_path = os.path.relpath(file)
-        if rel_path.startswith('..'):
-            raise ValueError(f'File {file} is located in a parent of the current directory. Use the --mounts option with a mount point specified instead.')
-        rel_file_paths.append(rel_path)
-
-    local_files_to_cloud_files = [{'from': local, 'to': cloud_prefix(local)} for local in rel_file_paths]
-
-    await copy_from_dict(
-        files=[
-            {'from': script, 'to': cloud_prefix(script)},
-            {'from': str(user_config), 'to': cloud_prefix(user_config)},
-            *local_files_to_cloud_files,
-        ]
-    )
-    for file in local_files_to_cloud_files:
-        local_file = file['from']
-        cloud_file = file['to']
-        in_file = b.read_input(cloud_file)
-        j.command(f'ln -s {in_file} {local_file}')
-
-    mount_files_to_cloud_files = []
-    for _input in mounts:
-        if _input.startswith('file://'):
-            input = _input[7:]
-        else:
-            input = _input
-        if ':' not in input:
-            raise ValueError('Must specify mount point separated by a colon (ex: foo.py:/foo/)')
-
-        source, mount = input.split(':')
-        source = os.path.expanduser(source)
-
-        if not mount.startswith('/'):
-            raise ValueError(f'Mount point must start with a "/". Found {mount} for source {source}.')
-
-        if os.path.isfile(source):
-            mount = mount.rstrip('/') + '/'
-            dest = mount + os.path.basename(source)
-        else:
-            dest = mount
-
-        cloud_file = cloud_prefix(dest.lstrip('/'))
-
-        mount_files_to_cloud_files.append({'from': source, 'to': cloud_file})
-
+        src, dest, cloud_file = file_input_to_src_dest(file)
+        local_files_to_cloud_files.append({'from': src, 'to': cloud_file})
         in_file = b.read_input(cloud_file)
         j.command(f'mkdir -p {os.path.dirname(dest)}; ln -s {in_file} {dest}')
 
-    await copy_from_dict(files=[*mount_files_to_cloud_files])
+    script_src, script_dest, script_cloud_file = file_input_to_src_dest(script)
+    user_config_src, user_config_dest, user_config_cloud_file = file_input_to_src_dest(user_config)
 
-    script_file = b.read_input(cloud_prefix(script))
-    config_file = b.read_input(cloud_prefix(user_config))
-    j.command(f'mkdir -p $HOME/.config/hail && ln -s {config_file} $HOME/.config/hail/config.ini')
+    await copy_from_dict(files=[
+        {'from': script_src, 'to': script_cloud_file},
+        {'from': user_config_src, 'to': user_config_cloud_file},
+        *local_files_to_cloud_files])
+
+    script_file = b.read_input(script_cloud_file)
+    config_file = b.read_input(user_config_cloud_file)
 
     j.env('HAIL_QUERY_BACKEND', 'batch')
 
     command = 'python3' if script.endswith('.py') else 'bash'
     script_arguments = " ".join(shq(x) for x in arguments)
+
+    j.command(f'mkdir -p $HOME/.config/hail && ln -s {config_file} $HOME/.config/hail/config.ini')
+    j.command(f'cd {os.getcwd()}')
     j.command(f'{command} {script_file} {script_arguments}')
     batch_handle = await b._async_run(wait=False, disable_progress_bar=quiet)
     assert batch_handle

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -54,7 +54,7 @@ async def submit(name, image_name, files, output, script, arguments):
         else:
             dest = os.getcwd()
 
-        cloud_file = cloud_prefix(dest)
+        cloud_file = cloud_prefix(src)
 
         return (src, dest, cloud_file)
 
@@ -71,8 +71,8 @@ async def submit(name, image_name, files, output, script, arguments):
         in_file = b.read_input(cloud_file)
         j.command(f'mkdir -p {os.path.dirname(dest)}; ln -s {in_file} {dest}')
 
-    script_src, script_dest, script_cloud_file = file_input_to_src_dest(script)
-    user_config_src, user_config_dest, user_config_cloud_file = file_input_to_src_dest(user_config)
+    script_src, _, script_cloud_file = file_input_to_src_dest(script)
+    user_config_src, _, user_config_cloud_file = file_input_to_src_dest(user_config)
 
     await copy_from_dict(files=[
         {'from': script_src, 'to': script_cloud_file},

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -56,11 +56,13 @@ async def submit(name, image_name, files, mounts, output, script, arguments):
         j.command(f'ln -s {in_file} {local_file}')
 
     mount_files_to_cloud_files = []
-    for input in mounts:
-        if input.startswith('file://'):
-            input = input[7:]
+    for _input in mounts:
+        if _input.startswith('file://'):
+            input = _input[7:]
+        else:
+            input = _input
         if ':' not in input:
-            raise ValueError(f'Must specify mount point separated by a colon (ex: foo.py:/foo/)')
+            raise ValueError('Must specify mount point separated by a colon (ex: foo.py:/foo/)')
 
         source, mount = input.split(':')
         source = os.path.expanduser(source)

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -28,6 +28,8 @@ async def submit(name, image_name, files, output, script, arguments):
     quiet = output != 'text'
 
     remote_tmpdir = get_remote_tmpdir('hailctl batch submit')
+    remote_tmpdir = remote_tmpdir.rstrip('/')
+
     tmpdir_path_prefix = secret_alnum_string()
 
     def cloud_prefix(path):
@@ -72,8 +74,6 @@ async def submit(name, image_name, files, output, script, arguments):
 
     script_src, _, script_cloud_file = file_input_to_src_dest(script)
     user_config_src, _, user_config_cloud_file = file_input_to_src_dest(user_config)
-
-    assert False, str(local_files_to_cloud_files)
 
     await copy_from_dict(
         files=[

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -35,9 +35,6 @@ async def submit(name, image_name, files, output, script, arguments):
         return f'{remote_tmpdir}/{tmpdir_path_prefix}/{path}'
 
     def file_input_to_src_dest(file: str) -> Tuple[str, str, str]:
-        if file.startswith('file://'):
-            file = file[7:]
-
         match = FILE_REGEX.match(file)
         if match is None:
             raise ValueError(f'invalid file specification {file}. Must have the form "src" or "src:dest"')
@@ -75,6 +72,8 @@ async def submit(name, image_name, files, output, script, arguments):
 
     script_src, _, script_cloud_file = file_input_to_src_dest(script)
     user_config_src, _, user_config_cloud_file = file_input_to_src_dest(user_config)
+
+    assert False, str(local_files_to_cloud_files)
 
     await copy_from_dict(files=[
         {'from': script_src, 'to': script_cloud_file},

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -109,12 +109,3 @@ def test_dir_outside_curdir(runner: CliRunner):
         write_script(dir, '/hello1.txt')
         res = runner.invoke(cli.app, ['submit', '--files', f'{dir}/:/', '../test_job.py'])
         assert res.exit_code == 0
-
-
-def test_file_prefixed_with_file(runner: CliRunner):
-    with tempfile.TemporaryDirectory() as dir:
-        os.chdir(dir)
-        write_hello(f'{dir}/hello.txt')
-        write_script(dir, '/hello.txt')
-        res = runner.invoke(cli.app, ['submit', '--files', f'file://{dir}/hello.txt:/', 'test_job.py'])
-        assert res.exit_code == 0

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -108,4 +108,5 @@ def test_dir_outside_curdir(runner: CliRunner):
         write_hello(f'{dir}/hello2.txt')
         write_script(dir, '/hello1.txt')
         res = runner.invoke(cli.app, ['submit', '--files', f'{dir}/:/', '../test_job.py'])
+        print(res.stdout)
         assert res.exit_code == 0, (res.exit_code, res.stdout, res.stderr)

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -108,5 +108,5 @@ def test_dir_outside_curdir(runner: CliRunner):
         write_hello(f'{dir}/hello2.txt')
         write_script(dir, '/hello1.txt')
         res = runner.invoke(cli.app, ['submit', '--files', f'{dir}/:/', '../test_job.py'])
-        print(res.stdout)
+        assert 'foo' in res.stdout, res.stdout
         assert res.exit_code == 0, (res.exit_code, res.stdout, res.stderr)

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -39,7 +39,6 @@ def test_file_with_no_dest(runner: CliRunner):
         assert res.exit_code == 0
 
 
-# failed
 def test_file_in_current_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
@@ -58,7 +57,6 @@ def test_file_mount_in_child_dir(runner: CliRunner):
         assert res.exit_code == 0
 
 
-# failed
 def test_file_mount_in_child_dir_to_root_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
@@ -88,7 +86,6 @@ def test_dir_mount_in_child_dir_to_child_dir(runner: CliRunner):
         assert res.exit_code == 0
 
 
-# failed
 def test_file_outside_curdir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.mkdir(f'{dir}/working_dir')
@@ -110,7 +107,6 @@ def test_dir_outside_curdir(runner: CliRunner):
         assert res.exit_code == 0
 
 
-# failed
 def test_file_prefixed_with_file(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -33,7 +33,7 @@ def write_hello(filename: str):
 def test_file_in_current_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
-        write_hello('hello.txt')
+        write_hello(f'{dir}/hello.txt')
         write_script(dir, '/hello.txt')
         res = runner.invoke(cli.app, ['submit', '--mounts', 'hello.txt:/', 'test_job.py'])
         assert res.exit_code == 0
@@ -42,7 +42,7 @@ def test_file_in_current_dir(runner: CliRunner):
 def test_file_mount_in_child_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
-        write_hello('hello.txt')
+        write_hello(f'{dir}/hello.txt')
         write_script(dir, '/child/hello.txt')
         res = runner.invoke(cli.app, ['submit', '--mounts', 'hello.txt:/child/', 'test_job.py'])
         assert res.exit_code == 0
@@ -51,7 +51,7 @@ def test_file_mount_in_child_dir(runner: CliRunner):
 def test_file_mount_in_child_dir_to_root_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
-        write_hello('child/hello.txt')
+        write_hello(f'{dir}/child/hello.txt')
         write_script(dir, '/hello.txt')
         res = runner.invoke(cli.app, ['submit', '--mounts', 'child/hello.txt:/', 'test_job.py'])
         assert res.exit_code == 0
@@ -60,8 +60,8 @@ def test_file_mount_in_child_dir_to_root_dir(runner: CliRunner):
 def test_dir_mount_in_child_dir_to_child_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
-        write_hello('child/hello1.txt')
-        write_hello('child/hello2.txt')
+        write_hello(f'{dir}/child/hello1.txt')
+        write_hello(f'{dir}/child/hello2.txt')
         write_script(dir, '/child/hello1.txt')
         res = runner.invoke(cli.app, ['submit', '--mounts', 'child/:/child/', 'test_job.py'])
         assert res.exit_code == 0
@@ -73,7 +73,7 @@ def test_file_outside_curdir(runner: CliRunner):
         os.chdir(f'{dir}/working_dir')
         write_hello(f'{dir}/hello.txt')
         write_script(dir, '/hello.txt')
-        res = runner.invoke(cli.app, ['submit', '--mounts', f'{dir}/hello.txt:/', 'test_job.py'])
+        res = runner.invoke(cli.app, ['submit', '--mounts', f'{dir}/hello.txt:/', '../test_job.py'])
         assert res.exit_code == 0
 
 
@@ -84,7 +84,7 @@ def test_dir_outside_curdir(runner: CliRunner):
         write_hello(f'{dir}/hello1.txt')
         write_hello(f'{dir}/hello2.txt')
         write_script(dir, '/hello1.txt')
-        res = runner.invoke(cli.app, ['submit', '--mounts', f'{dir}/:/', 'test_job.py'])
+        res = runner.invoke(cli.app, ['submit', '--mounts', f'{dir}/:/', '../test_job.py'])
         assert res.exit_code == 0
 
 
@@ -95,5 +95,5 @@ def test_dir_outside_curdir_fails_with_files(runner: CliRunner):
         write_hello(f'{dir}/hello1.txt')
         write_hello(f'{dir}/hello2.txt')
         write_script(dir, '/hello1.txt')
-        res = runner.invoke(cli.app, ['submit', '--files', dir, 'test_job.py'])
+        res = runner.invoke(cli.app, ['submit', '--files', dir, '../test_job.py'])
         assert res.exit_code == 1

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -39,6 +39,7 @@ def test_file_with_no_dest(runner: CliRunner):
         assert res.exit_code == 0
 
 
+# failed
 def test_file_in_current_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
@@ -57,6 +58,7 @@ def test_file_mount_in_child_dir(runner: CliRunner):
         assert res.exit_code == 0
 
 
+# failed
 def test_file_mount_in_child_dir_to_root_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
@@ -72,7 +74,7 @@ def test_mount_multiple_files(runner: CliRunner):
         write_hello(f'{dir}/child/hello1.txt')
         write_hello(f'{dir}/child/hello2.txt')
         write_script(dir, '/hello1.txt')
-        res = runner.invoke(cli.app, ['submit', '--files', 'child/hello1.txt:/', '--mounts', 'child/hello2.txt:/', 'test_job.py'])
+        res = runner.invoke(cli.app, ['submit', '--files', 'child/hello1.txt:/', '--files', 'child/hello2.txt:/', 'test_job.py'])
         assert res.exit_code == 0
 
 
@@ -86,6 +88,7 @@ def test_dir_mount_in_child_dir_to_child_dir(runner: CliRunner):
         assert res.exit_code == 0
 
 
+# failed
 def test_file_outside_curdir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.mkdir(f'{dir}/working_dir')
@@ -107,17 +110,7 @@ def test_dir_outside_curdir(runner: CliRunner):
         assert res.exit_code == 0
 
 
-def test_dir_outside_curdir_fails_with_files(runner: CliRunner):
-    with tempfile.TemporaryDirectory() as dir:
-        os.mkdir(f'{dir}/working_dir')
-        os.chdir(f'{dir}/working_dir')
-        write_hello(f'{dir}/hello1.txt')
-        write_hello(f'{dir}/hello2.txt')
-        write_script(dir, '/hello1.txt')
-        res = runner.invoke(cli.app, ['submit', '--files', dir, '../test_job.py'])
-        assert res.exit_code == 1
-
-
+# failed
 def test_file_prefixed_with_file(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -25,7 +25,7 @@ backend.close()
 
 
 def write_hello(filename: str):
-    os.makedirs(filename, exist_ok=True)
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
     with open(filename, 'w') as f:
         f.write('hello\n')
 

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -1,0 +1,99 @@
+import os
+import pytest
+import tempfile
+
+from typer.testing import CliRunner
+
+from hailtop.hailctl.batch import cli
+
+
+@pytest.fixture
+def runner():
+    yield CliRunner(mix_stderr=False)
+
+
+def write_script(dir: str, filename: str):
+    with open(f'{dir}/test_job.py', 'w') as f:
+        f.write(f'''
+import hailtop.batch as hb
+b = hb.Batch()
+j = b.new_job()
+j.command('cat {filename}')
+b.run(wait=False)
+backend.close()
+''')
+
+
+def write_hello(filename: str):
+    os.makedirs(filename, exist_ok=True)
+    with open(filename, 'w') as f:
+        f.write('hello\n')
+
+
+def test_file_in_current_dir(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.chdir(dir)
+        write_hello('hello.txt')
+        write_script(dir, '/hello.txt')
+        res = runner.invoke(cli.app, ['submit', '--mounts', 'hello.txt:/', 'test_job.py'])
+        assert res.exit_code == 0
+
+
+def test_file_mount_in_child_dir(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.chdir(dir)
+        write_hello('hello.txt')
+        write_script(dir, '/child/hello.txt')
+        res = runner.invoke(cli.app, ['submit', '--mounts', 'hello.txt:/child/', 'test_job.py'])
+        assert res.exit_code == 0
+
+
+def test_file_mount_in_child_dir_to_root_dir(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.chdir(dir)
+        write_hello('child/hello.txt')
+        write_script(dir, '/hello.txt')
+        res = runner.invoke(cli.app, ['submit', '--mounts', 'child/hello.txt:/', 'test_job.py'])
+        assert res.exit_code == 0
+
+
+def test_dir_mount_in_child_dir_to_child_dir(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.chdir(dir)
+        write_hello('child/hello1.txt')
+        write_hello('child/hello2.txt')
+        write_script(dir, '/child/hello1.txt')
+        res = runner.invoke(cli.app, ['submit', '--mounts', 'child/:/child/', 'test_job.py'])
+        assert res.exit_code == 0
+
+
+def test_file_outside_curdir(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.mkdir(f'{dir}/working_dir')
+        os.chdir(f'{dir}/working_dir')
+        write_hello(f'{dir}/hello.txt')
+        write_script(dir, '/hello.txt')
+        res = runner.invoke(cli.app, ['submit', '--mounts', f'{dir}/hello.txt:/', 'test_job.py'])
+        assert res.exit_code == 0
+
+
+def test_dir_outside_curdir(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.mkdir(f'{dir}/working_dir')
+        os.chdir(f'{dir}/working_dir')
+        write_hello(f'{dir}/hello1.txt')
+        write_hello(f'{dir}/hello2.txt')
+        write_script(dir, '/hello1.txt')
+        res = runner.invoke(cli.app, ['submit', '--mounts', f'{dir}/:/', 'test_job.py'])
+        assert res.exit_code == 0
+
+
+def test_dir_outside_curdir_fails_with_files(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.mkdir(f'{dir}/working_dir')
+        os.chdir(f'{dir}/working_dir')
+        write_hello(f'{dir}/hello1.txt')
+        write_hello(f'{dir}/hello2.txt')
+        write_script(dir, '/hello1.txt')
+        res = runner.invoke(cli.app, ['submit', '--files', dir, 'test_job.py'])
+        assert res.exit_code == 1

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -57,6 +57,16 @@ def test_file_mount_in_child_dir_to_root_dir(runner: CliRunner):
         assert res.exit_code == 0
 
 
+def test_mount_multiple_files(runner: CliRunner):
+    with tempfile.TemporaryDirectory() as dir:
+        os.chdir(dir)
+        write_hello(f'{dir}/child/hello1.txt')
+        write_hello(f'{dir}/child/hello2.txt')
+        write_script(dir, '/hello1.txt')
+        res = runner.invoke(cli.app, ['submit', '--mounts', 'child/hello1.txt:/', '--mounts', 'child/hello2.txt:/', 'test_job.py'])
+        assert res.exit_code == 0
+
+
 def test_dir_mount_in_child_dir_to_child_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -108,5 +108,4 @@ def test_dir_outside_curdir(runner: CliRunner):
         write_hello(f'{dir}/hello2.txt')
         write_script(dir, '/hello1.txt')
         res = runner.invoke(cli.app, ['submit', '--files', f'{dir}/:/', '../test_job.py'])
-        assert 'foo' in res.stdout, res.stdout
         assert res.exit_code == 0, (res.exit_code, res.stdout, res.stderr)

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -108,4 +108,4 @@ def test_dir_outside_curdir(runner: CliRunner):
         write_hello(f'{dir}/hello2.txt')
         write_script(dir, '/hello1.txt')
         res = runner.invoke(cli.app, ['submit', '--files', f'{dir}/:/', '../test_job.py'])
-        assert res.exit_code == 0
+        assert res.exit_code == 0, (res.exit_code, res.stdout, res.stderr)

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -14,14 +14,16 @@ def runner():
 
 def write_script(dir: str, filename: str):
     with open(f'{dir}/test_job.py', 'w') as f:
-        f.write(f'''
+        f.write(
+            f'''
 import hailtop.batch as hb
 b = hb.Batch()
 j = b.new_job()
 j.command('cat {filename}')
 b.run(wait=False)
 backend.close()
-''')
+'''
+        )
 
 
 def write_hello(filename: str):
@@ -72,7 +74,9 @@ def test_mount_multiple_files(runner: CliRunner):
         write_hello(f'{dir}/child/hello1.txt')
         write_hello(f'{dir}/child/hello2.txt')
         write_script(dir, '/hello1.txt')
-        res = runner.invoke(cli.app, ['submit', '--files', 'child/hello1.txt:/', '--files', 'child/hello2.txt:/', 'test_job.py'])
+        res = runner.invoke(
+            cli.app, ['submit', '--files', 'child/hello1.txt:/', '--files', 'child/hello2.txt:/', 'test_job.py']
+        )
         assert res.exit_code == 0
 
 


### PR DESCRIPTION
The bug in #13785 was that we used a `relpath`, but the files that were to be included was the parent directory of the current working directory of the script. To solve this, I added a new option `--mounts` that uses the Docker syntax for `-v src:dest` to specify where the contents of the source should be mounted into the container.


Fixes #13785 