### PR TITLE
[ci] Fix namespace used for logging queries on PR page

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -191,7 +191,7 @@ async def get_pr(request: web.Request, userdata: UserData) -> web.Response:
                 start_time = status['time_created']
                 end_time = status['time_completed']
                 assert start_time is not None
-                page_context['logging_queries'] = gcp_logging_queries(start_time, end_time)
+                page_context['logging_queries'] = gcp_logging_queries(batch.attributes['namespace'], start_time, end_time)
             else:
                 page_context['logging_queries'] = None
         else:

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -191,7 +191,9 @@ async def get_pr(request: web.Request, userdata: UserData) -> web.Response:
                 start_time = status['time_created']
                 end_time = status['time_completed']
                 assert start_time is not None
-                page_context['logging_queries'] = gcp_logging_queries(batch.attributes['namespace'], start_time, end_time)
+                page_context['logging_queries'] = gcp_logging_queries(
+                    batch.attributes['namespace'], start_time, end_time
+                )
             else:
                 page_context['logging_queries'] = None
         else:

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -7,8 +7,6 @@ from typing import List, Optional
 from gear import Database
 from gear.cloud_config import get_gcp_config
 
-from .environment import DEFAULT_NAMESPACE
-
 
 def generate_token(size=12):
     assert size > 0

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -105,9 +105,8 @@ labels.namespace="{namespace}"
     return f'https://console.cloud.google.com/logs/query;query={urllib.parse.quote(query)};{urllib.parse.quote(timestamp_query)}?project={project}'
 
 
-def gcp_logging_queries(start_time: str, end_time: Optional[str]):
+def gcp_logging_queries(namespace: str, start_time: str, end_time: Optional[str]):
     project = get_gcp_config().project
-    namespace = DEFAULT_NAMESPACE
     return {
         'batch-k8s-error-warning': gcp_service_logging_url(
             project,


### PR DESCRIPTION
DEFAULT_NAMESPACE will always point to `default` for the production CI deployment.