### PR TITLE
[hailtop] types, new exceptions, better task exception handling

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -17,7 +17,6 @@ import asyncio
 import aiohttp
 import urllib.parse
 import urllib3.exceptions
-import google.api_core.exceptions
 import secrets
 import socket
 import requests
@@ -730,10 +729,6 @@ def is_transient_error(e: BaseException) -> bool:
     if isinstance(e, socket.gaierror) and e.errno in (socket.EAI_AGAIN, socket.EAI_NONAME):
         # socket.EAI_AGAIN: [Errno -3] Temporary failure in name resolution
         # socket.EAI_NONAME: [Errno 8] nodename nor servname provided, or not known
-        return True
-    if isinstance(e, google.api_core.exceptions.GatewayTimeout):
-        return True
-    if isinstance(e, google.api_core.exceptions.ServiceUnavailable):
         return True
     if isinstance(e, botocore.exceptions.ConnectionClosedError):
         return True

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -907,7 +907,7 @@ def retry_response_returning_functions(fun, *args, **kwargs):
     return response
 
 
-def external_requests_client_session(headers: Dict[str, Any] = None, timeout: int = 5) -> requests.Session:
+def external_requests_client_session(headers: Optional[Dict[str, Any]] = None, timeout: int = 5) -> requests.Session:
     session = requests.Session()
     adapter = TimeoutHTTPAdapter(max_retries=1, timeout=timeout)
     session.mount('http://', adapter)

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -695,14 +695,6 @@ def is_transient_error(e: BaseException) -> bool:
     if (isinstance(e, aiohttp.ClientConnectorError)
             and is_transient_error(e.os_error)):
         return True
-    if (isinstance(e, aiohttp.ClientOSError)
-            and len(e.args) >= 2
-            and e.args[0] == 1
-            and 'sslv3 alert bad record mac' in e.args[1]):
-        # aiohttp.client_exceptions.ClientOSError: [Errno 1] [SSL: SSLV3_ALERT_BAD_RECORD_MAC] sslv3 alert bad record mac (_ssl.c:2548)
-        #
-        # This appears to be a symptom of Google rate-limiting as of 2023-10-15
-        return True
     # appears to happen when the connection is lost prematurely, see:
     # https://github.com/aio-libs/aiohttp/issues/4581
     # https://github.com/aio-libs/aiohttp/blob/v3.7.4/aiohttp/client_proto.py#L85


### PR DESCRIPTION
Besides the types and some transient exceptions, I think I fixed our task exception handling in several spots. Two things:

1. We do not need to wait on a cancelled task. If it was not done, then it could not possibly have an exception to retrieve. Moreover, now that it is cancelled, there is nothing else to do. Cancellation is immediate.

2. If a task is done, we *must* always retrieve the exception, otherwise we might not see an exception.