### PR TITLE
[ci] Bump number of cores to 16 for db deployment jobs

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1328,7 +1328,7 @@ EOF
                 regions=[REGION],
             )
 
-        n_cores = 4 if scope == 'deploy' and not is_test_deployment else 1
+        n_cores = 16 if scope == 'deploy' and not is_test_deployment else 1
 
         self.create_database_job = batch.create_job(
             self.image,


### PR DESCRIPTION
I wanted to be safe rather than sorry for #13487 to make sure we have enough memory to fit all of the 100 row chunk endpoints in memory. We can switch it back to 4 cores after that PR is merged.