### PR TITLE
[query] improve field names and output of _same

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3720,8 +3720,8 @@ class MatrixTable(ExprContainer):
                       absolute=bool,
                       reorder_fields=bool)
     def _same(self, other, tolerance=1e-6, absolute=False, reorder_fields=False) -> bool:
-        entries_name = Env.get_uid()
-        cols_name = Env.get_uid()
+        entries_name = Env.get_uid('entries_')
+        cols_name = Env.get_uid('columns_')
 
         fd_f = set if reorder_fields else list
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3671,14 +3671,14 @@ class Table(ExprContainer):
             pretty_str = pprint.pformat(obj, width=columns)
             return ''.join('        ' + line for line in pretty_str.splitlines(keepends=True))
 
-        is_failure = False
+        is_same = True
         if mismatched_globals is not None:
             print(f'''Table._same: globals differ:
     Left:
 {pretty(mismatched_globals.left_globals)}
     Right:
 {pretty(mismatched_globals.right_globals)}''')
-            is_failure = True
+            is_same = False
 
         if len(mismatched_rows) > 0:
             print('Table._same: rows differ:')
@@ -3688,9 +3688,9 @@ class Table(ExprContainer):
 {pretty(r.left_row)}
     Right:
 {pretty(r.right_row)}''')
-            is_failure = True
+            is_same = False
 
-        return is_failure
+        return is_same
 
     def collect_by_key(self, name: str = 'values') -> 'Table':
         """Collect values for each unique key into an array.

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -4,6 +4,7 @@ import pandas
 import numpy as np
 import pyspark
 import pprint
+import shutil
 from typing import Optional, Dict, Callable, Sequence, Union, List, overload
 
 from hail.expr.expressions import Expression, StructExpression, \
@@ -1515,7 +1516,6 @@ class Table(ExprContainer):
     class _Show:
         def __init__(self, table, n, width, truncate, types):
             if n is None or width is None:
-                import shutil
                 (columns, lines) = shutil.get_terminal_size((80, 10))
                 width = width or columns
                 n = n or min(max(10, (lines - 20)), 100)
@@ -3641,49 +3641,56 @@ class Table(ExprContainer):
             print(f'Table._same: types differ:\n  {self._type}\n  {other._type}')
             return False
 
-        left_global_value = Env.get_uid()
-        left_value = Env.get_uid()
         left = self
-        left = left.select_globals(**{left_global_value: left.globals})
-        left = left.group_by(_key=left.key).aggregate(**{left_value: hl.agg.collect(left.row_value)})
+        left = left.select_globals(left_globals = left.globals)
+        left = left.group_by(key=left.key).aggregate(left_row = hl.agg.collect(left.row_value))
 
-        right_global_value = Env.get_uid()
-        right_value = Env.get_uid()
         right = other
-        right = right.select_globals(**{right_global_value: right.globals})
-        right = right.group_by(_key=right.key).aggregate(**{right_value: hl.agg.collect(right.row_value)})
+        right = right.select_globals(right_globals = right.globals)
+        right = right.group_by(key=right.key).aggregate(right_row = hl.agg.collect(right.row_value))
 
         t = left.join(right, how='outer')
 
         mismatched_globals, mismatched_rows = t.aggregate(hl.tuple((
             hl.or_missing(
-                ~_values_similar(t[left_global_value], t[right_global_value], tolerance, absolute),
-                hl.struct(left=t[left_global_value], right=t[right_global_value])
+                ~_values_similar(t.left_globals, t.right_globals, tolerance, absolute),
+                t.globals
             ),
             hl.agg.filter(
                 ~hl.all(
-                    hl.is_defined(t[left_value]),
-                    hl.is_defined(t[right_value]),
-                    _values_similar(t[left_value], t[right_value], tolerance, absolute),
+                    hl.is_defined(t.left_row),
+                    hl.is_defined(t.right_row),
+                    _values_similar(t.left_row, t.right_row, tolerance, absolute),
                 ),
-                hl.agg.take(
-                    hl.struct(_key=t._key, left=t[left_value], right=t[right_value]),
-                    10
-                )
+                hl.agg.take(t.row, 10)
             )
         )))
 
+        columns, _ = shutil.get_terminal_size((80, 10))
+        def pretty(obj):
+            pretty_str = pprint.pformat(obj, width=columns)
+            return ''.join('        ' + line for line in pretty_str.splitlines(keepends=True))
+
+        is_failure = False
         if mismatched_globals is not None:
-            print(f'Table._same: globals differ:\n{pprint.pformat(mismatched_globals.left)}\n{pprint.pformat(mismatched_globals.right)}')
-            return False
+            print(f'''Table._same: globals differ:
+    Left:
+{pretty(mismatched_globals.left_globals)}
+    Right:
+{pretty(mismatched_globals.right_globals)}''')
+            is_failure = True
 
         if len(mismatched_rows) > 0:
             print('Table._same: rows differ:')
             for r in mismatched_rows:
-                print(f'  Row mismatch at key={r._key}:\n    Left:\n{pprint.pformat(r.left)}\n    Right:\n{pprint.pformat(r.right)}')
-            return False
+                print(f'''  Row mismatch at key={r.key}:
+    Left:
+{pretty(r.left_row)}
+    Right:
+{pretty(r.right_row)}''')
+            is_failure = True
 
-        return True
+        return is_failure
 
     def collect_by_key(self, name: str = 'values') -> 'Table':
         """Collect values for each unique key into an array.


### PR DESCRIPTION
Rori encountered some confusing output. _same is private, but this is good both for GVS/AoU and also for us.

Things are indented properly, it uses as much terminal width as is available, the names are slightly less confusing, and we see both globals & row failures if both fail.

```python3
Table._same: rows differ:
  Row mismatch at key=Struct(locus=Locus(contig=1, position=1, reference_genome=GRCh37), alleles=['A', 'C']):
    Left:
        [Struct(ancestral_af=0.381520365258488,
                af=[0.6482459117152142],
                __uid_entries_85=[Struct(GT=Call(alleles=[1, 1], phased=False)), Struct(GT=Call(alleles=[1, 1], phased=False))])]
    Right:
        [Struct(ancestral_af=0.381520365258488,
                af=[0.2510276144176496],
                __uid_entries_85=[Struct(GT=Call(alleles=[0, 0], phased=False)), Struct(GT=Call(alleles=[0, 1], phased=False))])]
  Row mismatch at key=Struct(locus=Locus(contig=1, position=2, reference_genome=GRCh37), alleles=['A', 'C']):
    Left:
        [Struct(ancestral_af=0.7058845354840656,
                af=[0.5224710728099119],
                __uid_entries_85=[Struct(GT=Call(alleles=[0, 0], phased=False)), Struct(GT=Call(alleles=[0, 0], phased=False))])]
    Right:
        [Struct(ancestral_af=0.7058845354840656,
                af=[0.5042641171983404],
                __uid_entries_85=[Struct(GT=Call(alleles=[1, 1], phased=False)), Struct(GT=Call(alleles=[1, 1], phased=False))])]
```

versus

```python3
Table._same: rows differ:
  Row mismatch at key=Struct(_key=Struct(locus=Locus(contig=1, position=1, reference_genome=GRCh37), alleles=['A', 'C'])):
    Left:
[Struct(ancestral_af=0.381520365258488,
        af=[0.08835032612615329],
        __uid_39=[Struct(GT=Call(alleles=[0, 0], phased=False)),
                  Struct(GT=Call(alleles=[0, 0], phased=False))])]
    Right:
[Struct(ancestral_af=0.381520365258488,
        af=[0.6631710694002383],
        __uid_39=[Struct(GT=Call(alleles=[0, 1], phased=False)),
                  Struct(GT=Call(alleles=[1, 1], phased=False))])]
  Row mismatch at key=Struct(_key=Struct(locus=Locus(contig=1, position=2, reference_genome=GRCh37), alleles=['A', 'C'])):
    Left:
[Struct(ancestral_af=0.7058845354840656,
        af=[0.7020078954798737],
        __uid_39=[Struct(GT=Call(alleles=[0, 1], phased=False)),
                  Struct(GT=Call(alleles=[0, 1], phased=False))])]
    Right:
[Struct(ancestral_af=0.7058845354840656,
        af=[0.6393831798848757],
        __uid_39=[Struct(GT=Call(alleles=[1, 1], phased=False)),
                  Struct(GT=Call(alleles=[0, 1], phased=False))])]
```