### PR TITLE
[hailctl] fix hailctl describe requester pays argument handling

### DIFF
--- a/hail/python/hailtop/hailctl/describe.py
+++ b/hail/python/hailtop/hailctl/describe.py
@@ -113,7 +113,7 @@ async def async_describe(
 
     gcs_kwargs = {}
     if requester_pays_project_id:
-        gcs_kwargs['project'] = requester_pays_project_id
+        gcs_kwargs['gcs_requester_pays_configuration'] = requester_pays_project_id
 
     async with aio_contextlib.closing(RouterAsyncFS(gcs_kwargs=gcs_kwargs)) as fs:
         j = orjson.loads(decompress(await fs.read(path.join(file, 'metadata.json.gz')), 16 + MAX_WBITS))


### PR DESCRIPTION
Fix the overriding of the gcs_requester_pays/project config variable through using 'hailctl describe -u'.

Closes #13793