### PR TITLE
[fs] improve copy tool progress bars

### DIFF
--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -7,7 +7,7 @@ import sys
 
 from concurrent.futures import ThreadPoolExecutor
 
-from ..utils.rich_progress_bar import RichProgressBar, make_listener
+from ..utils.rich_progress_bar import CopyToolProgressBar, make_listener
 from . import Transfer, Copier
 from .router_fs import RouterAsyncFS
 
@@ -52,7 +52,7 @@ async def copy(*,
                                  s3_kwargs=s3_kwargs) as fs:
             sema = asyncio.Semaphore(max_simultaneous_transfers)
             async with sema:
-                with RichProgressBar(transient=True, disable=not verbose) as progress:
+                with CopyToolProgressBar(transient=True, disable=not verbose) as progress:
                     file_tid = progress.add_task(description='files', total=0, visible=verbose)
                     bytes_tid = progress.add_task(description='bytes', total=0, visible=verbose)
                     copy_report = await Copier.copy(

--- a/hail/python/hailtop/aiotools/delete.py
+++ b/hail/python/hailtop/aiotools/delete.py
@@ -5,7 +5,7 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor
 
 from .router_fs import RouterAsyncFS
-from ..utils.rich_progress_bar import SimpleRichProgressBar
+from ..utils.rich_progress_bar import SimpleCopyToolProgressBar
 
 
 async def delete(paths: List[str]) -> None:
@@ -14,7 +14,7 @@ async def delete(paths: List[str]) -> None:
         async with RouterAsyncFS(local_kwargs=kwargs, s3_kwargs=kwargs) as fs:
             sema = asyncio.Semaphore(50)
             async with sema:
-                with SimpleRichProgressBar(
+                with SimpleCopyToolProgressBar(
                         description='files',
                         transient=True,
                         total=0) as file_pbar:

--- a/hail/python/hailtop/aiotools/diff.py
+++ b/hail/python/hailtop/aiotools/diff.py
@@ -7,7 +7,7 @@ import sys
 
 from concurrent.futures import ThreadPoolExecutor
 
-from ..utils.rich_progress_bar import SimpleRichProgressBar, SimpleRichProgressBarTask
+from ..utils.rich_progress_bar import SimpleCopyToolProgressBar, SimpleCopyToolProgressBarTask
 from .router_fs import RouterAsyncFS
 from .fs import AsyncFS, FileStatus
 
@@ -51,7 +51,7 @@ async def diff(*,
                                  gcs_kwargs=gcs_kwargs,
                                  azure_kwargs=azure_kwargs,
                                  s3_kwargs=s3_kwargs) as fs:
-            with SimpleRichProgressBar(
+            with SimpleCopyToolProgressBar(
                     description='files',
                     transient=True,
                     total=0,
@@ -68,7 +68,7 @@ class DiffException(ValueError):
     pass
 
 
-async def do_diff(top_source: str, top_target: str, fs: AsyncFS, max_simultaneous: int, pbar: SimpleRichProgressBarTask) -> List[dict]:
+async def do_diff(top_source: str, top_target: str, fs: AsyncFS, max_simultaneous: int, pbar: SimpleCopyToolProgressBarTask) -> List[dict]:
     if await fs.isfile(top_source):
         result = await diff_one(top_source, top_target, fs)
         if result is None:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -16,7 +16,7 @@ from rich.progress import track
 
 from hailtop import pip_version
 from hailtop.config import ConfigVariable, configuration_of, get_deploy_config, get_remote_tmpdir
-from hailtop.utils.rich_progress_bar import SimpleRichProgressBar
+from hailtop.utils.rich_progress_bar import SimpleCopyToolProgressBar
 from hailtop.utils import parse_docker_image_reference, async_to_blocking, bounded_gather, url_scheme
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES, hailgenetics_hail_image_for_current_python_version
 
@@ -688,9 +688,9 @@ class ServiceBackend(Backend[bc.Batch]):
         )
 
         disable_setup_steps_progress_bar = disable_progress_bar or len(unsubmitted_jobs) < 10_000
-        with SimpleRichProgressBar(total=len(unsubmitted_jobs),
-                                   description='upload code',
-                                   disable=disable_setup_steps_progress_bar) as pbar:
+        with SimpleCopyToolProgressBar(total=len(unsubmitted_jobs),
+                                       description='upload code',
+                                       disable=disable_setup_steps_progress_bar) as pbar:
             async def compile_job(job):
                 used_remote_tmpdir = await job._compile(local_tmpdir, batch_remote_tmpdir, dry_run=dry_run)
                 pbar.update(1)


### PR DESCRIPTION
I renamed RichProgressBar and SimpleRichProgressBar to ...CopyToolProgressBar because that is more accurate. I enhanced both to now include a count and a rate with the right units based on the description. It is a bit flaky because I need the descriptions to be exactly "files" or exactly "bytes" to pick the right units, but this seems fine for the specific case of th CopyToolProgressBar.

There is probably a better way to build these UIs. I am sure we will start to figure that out as we use rich more.


Before:
<img width="830" alt="Screenshot 2023-10-16 at 18 28 14" src="https://github.com/hail-is/hail/assets/106194/95f8828e-beb3-46d2-9403-18ff7aa60256">

After:
<img width="830" alt="Screenshot 2023-10-16 at 18 27 53" src="https://github.com/hail-is/hail/assets/106194/01186b7c-d59f-4a0e-a1f6-9279fb50ae7e">
