### PR TITLE
[fs] rate limit our use of parallelism in copy

### DIFF
--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict
+from typing import List, Dict, AsyncContextManager, Optional, Tuple
 import argparse
 import asyncio
 import json
@@ -6,7 +6,9 @@ import logging
 import sys
 
 from concurrent.futures import ThreadPoolExecutor
+from rich.progress import Progress, TaskID
 
+from ..utils.utils import sleep_before_try
 from ..utils.rich_progress_bar import RichProgressBar, make_listener
 from . import Transfer, Copier
 from .router_fs import RouterAsyncFS
@@ -20,6 +22,48 @@ except ImportError as e:
 
     def uvloop_install():
         pass
+
+
+class GrowingSempahore(AsyncContextManager[asyncio.Semaphore]):
+    def __init__(self, start_max: int, target_max: int, progress_and_tid: Optional[Tuple[Progress, TaskID]]):
+        self.task: Optional[asyncio.Task] = None
+        self.target_max = target_max
+        self.current_max = start_max
+        self.sema = asyncio.Semaphore(self.current_max)
+        self.progress_and_tid = progress_and_tid
+
+    async def _grow(self):
+        growths = 0
+        while self.current_max < self.target_max:
+            await sleep_before_try(
+                growths,
+                base_delay_ms=15_000,
+                max_delay_ms=5 * 60_000,
+            )
+            new_max = min(int(self.current_max * 1.5), self.target_max)
+            diff = new_max - self.current_max
+            self.sema._value += diff
+            self.sema._wake_up_next()
+            self.current_max = new_max
+            if self.progress_and_tid:
+                progress, tid = self.progress_and_tid
+                progress.update(tid, advance=diff)
+
+    async def __aenter__(self) -> asyncio.Semaphore:
+        self.task = asyncio.create_task(self._grow())
+        await self.sema.__aenter__()
+        return self.sema
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            await self.sema.__aexit__(exc_type, exc, tb)
+        finally:
+            if self.task is not None:
+                if self.task.done() and not self.task.cancelled():
+                    if exc := self.task.exception():
+                        raise exc
+                else:
+                    self.task.cancel()
 
 
 async def copy(*,
@@ -50,9 +94,15 @@ async def copy(*,
                                  gcs_kwargs=gcs_kwargs,
                                  azure_kwargs=azure_kwargs,
                                  s3_kwargs=s3_kwargs) as fs:
-            sema = asyncio.Semaphore(max_simultaneous_transfers)
-            async with sema:
-                with RichProgressBar(transient=True, disable=not verbose) as progress:
+            with RichProgressBar(transient=True, disable=not verbose) as progress:
+                initial_simultaneous_transfers = 10
+                parallelism_tid = progress.add_task(description='parallelism',
+                                                    completed=initial_simultaneous_transfers,
+                                                    total=max_simultaneous_transfers,
+                                                    visible=verbose)
+                async with GrowingSempahore(initial_simultaneous_transfers,
+                                            max_simultaneous_transfers,
+                                            (progress, parallelism_tid)) as sema:
                     file_tid = progress.add_task(description='files', total=0, visible=verbose)
                     bytes_tid = progress.add_task(description='bytes', total=0, visible=verbose)
                     copy_report = await Copier.copy(


### PR DESCRIPTION
This is the result of some experimentation. With ten-way parallelism, the copier very rarely gets rate-limited. With 75-way parallelism (the default), we almost always experience a tens of transient errors. If we start at ten and back off as in this PR, I can get to 75 with just a handful of transient errors.

cc: @jigold 