### PR TITLE
Verify `logistic_regression_rows` `y` param is column-indexed

### DIFF
--- a/hail/python/hail/experimental/pca.py
+++ b/hail/python/hail/experimental/pca.py
@@ -1,7 +1,7 @@
 import hail as hl
 from hail.typecheck import typecheck
 from hail.expr.expressions import expr_call, expr_numeric, expr_array, \
-    check_entry_indexed, check_row_indexed
+    raise_unless_entry_indexed, raise_unless_row_indexed
 
 
 @typecheck(call_expr=expr_call,
@@ -37,9 +37,9 @@ def pc_project(call_expr, loadings_expr, af_expr):
     :class:`.Table`
         Table with scores calculated from loadings in column `scores`
     """
-    check_entry_indexed('pc_project', call_expr)
-    check_row_indexed('pc_project', loadings_expr)
-    check_row_indexed('pc_project', af_expr)
+    raise_unless_entry_indexed('pc_project', call_expr)
+    raise_unless_row_indexed('pc_project', loadings_expr)
+    raise_unless_row_indexed('pc_project', af_expr)
 
     gt_source = call_expr._indices.source
     loadings_source = loadings_expr._indices.source

--- a/hail/python/hail/experimental/table_ndarray_utils.py
+++ b/hail/python/hail/experimental/table_ndarray_utils.py
@@ -1,10 +1,10 @@
 import hail as hl
-from hail.expr import (check_entry_indexed, matrix_table_source)
+from hail.expr import (raise_unless_entry_indexed, matrix_table_source)
 from hail.utils.java import Env
 
 
 def mt_to_table_of_ndarray(entry_expr, block_size=16, *, partition_size=None, window_size=None, return_checkpointed_table_also=False):
-    check_entry_indexed('mt_to_table_of_ndarray/entry_expr', entry_expr)
+    raise_unless_entry_indexed('mt_to_table_of_ndarray/entry_expr', entry_expr)
     mt = matrix_table_source('mt_to_table_of_ndarray/entry_expr', entry_expr)
 
     if partition_size is None:

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -6,7 +6,7 @@ from .table_type import ttable
 from .matrix_type import tmatrix
 from .blockmatrix_type import tblockmatrix
 from .expressions import (analyze, eval, eval_typed, eval_timed, extract_refs_by_indices, get_refs,
-                          matrix_table_source, table_source, check_entry_indexed, check_row_indexed, Indices, Aggregation,
+                          matrix_table_source, table_source, raise_unless_entry_indexed, raise_unless_row_indexed, Indices, Aggregation,
                           apply_expr, construct_expr, construct_variable, construct_reference, impute_type, to_expr,
                           cast_expr, unify_all, unify_types_limited, unify_types, unify_exprs, Expression,
                           ExpressionException, ArrayExpression, ArrayNumericExpression, BooleanExpression, CallExpression,
@@ -15,7 +15,8 @@ from .expressions import (analyze, eval, eval_typed, eval_timed, extract_refs_by
                           StreamExpression, StringExpression, StructExpression, TupleExpression, NDArrayExpression,
                           NDArrayNumericExpression, expr_any, expr_int32, expr_int64, expr_float32, expr_float64,
                           expr_call, expr_bool, expr_str, expr_locus, expr_interval, expr_array, expr_ndarray, expr_set,
-                          expr_dict, expr_tuple, expr_struct, expr_oneof, expr_numeric, coercer_from_dtype)
+                          expr_dict, expr_tuple, expr_struct, expr_oneof, expr_numeric, coercer_from_dtype,
+                          raise_unless_column_indexed)
 from .functions import (literal, chi_squared_test, if_else, cond, switch, case, bind, rbind,
                         contingency_table_test, dbeta, dict, dpois, exp, entropy, fisher_exact_test, gp_dosage,
                         hardy_weinberg_test, parse_locus, parse_variant, variant_str, locus, locus_from_global_position,
@@ -78,8 +79,9 @@ __all__ = ['HailType',
            'get_refs',
            'matrix_table_source',
            'table_source',
-           'check_entry_indexed',
-           'check_row_indexed',
+           'raise_unless_entry_indexed',
+           'raise_unless_row_indexed',
+           'raise_unless_column_indexed',
            'literal',
            'chi_squared_test',
            'if_else',

--- a/hail/python/hail/expr/expressions/__init__.py
+++ b/hail/python/hail/expr/expressions/__init__.py
@@ -16,7 +16,7 @@ from .expression_typecheck import (expr_any, expr_int32, expr_int64,
                                    expr_struct, expr_oneof, expr_numeric, coercer_from_dtype)
 from .expression_utils import (analyze, eval_timed, eval, eval_typed,
                                extract_refs_by_indices, get_refs, matrix_table_source, table_source,
-                               check_entry_indexed, check_row_indexed)
+                               raise_unless_entry_indexed, raise_unless_row_indexed, raise_unless_column_indexed)
 
 __all__ = ['Indices',
            'Aggregation',
@@ -56,8 +56,9 @@ __all__ = ['Indices',
            'NDArrayExpression',
            'NDArrayNumericExpression',
            'analyze',
-           'check_entry_indexed',
-           'check_row_indexed',
+           'raise_unless_entry_indexed',
+           'raise_unless_row_indexed',
+           'raise_unless_column_indexed',
            'get_refs',
            'extract_refs_by_indices',
            'eval',

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -288,23 +288,37 @@ def table_source(caller, expr):
     return source
 
 
-@typecheck(caller=str,
-           expr=Expression)
-def check_entry_indexed(caller, expr):
+@typecheck(caller=str, expr=Expression)
+def raise_unless_entry_indexed(caller, expr):
     if expr._indices.source is None:
-        raise ExpressionException("{}: expression must be entry-indexed,"
-                                  " found no indices (no source)")
+        raise ExpressionException(f"{caller}: expression must be entry-indexed"
+                                  f", found no indices (no source)"
+                                  )
     if expr._indices != expr._indices.source._entry_indices:
-        raise ExpressionException("{}: expression must be entry-indexed,"
-                                  " found indices {}".format(caller, list(expr._indices.axes)))
+        raise ExpressionException(f"{caller}: expression must be entry-indexed"
+                                  f", found indices {list(expr._indices.axes)}."
+                                  )
 
 
-@typecheck(caller=str,
-           expr=Expression)
-def check_row_indexed(caller, expr):
+@typecheck(caller=str, expr=Expression)
+def raise_unless_row_indexed(caller, expr):
     if expr._indices.source is None:
-        raise ExpressionException("{}: expression must be row-indexed,"
-                                  " found no indices (no source)")
+        raise ExpressionException(f"{caller}: expression must be row-indexed"
+                                  f", found no indices (no source)."
+                                  )
     if expr._indices != expr._indices.source._row_indices:
-        raise ExpressionException("{}: expression must be row-indexed,"
-                                  " found indices {}".format(caller, list(expr._indices.axes)))
+        raise ExpressionException(f"{caller}: expression must be row-indexed"
+                                  f", found indices {list(expr._indices.axes)}."
+                                  )
+
+
+@typecheck(caller=str, expr=Expression)
+def raise_unless_column_indexed(caller, expr):
+    if expr._indices.source is None:
+        raise ExpressionException(f"{caller}: expression must be column-indexed"
+                                  f", found no indices (no source)."
+                                  )
+    if expr._indices != expr._indices.source._col_indices:
+        raise ExpressionException(f"{caller}: expression must be column-indexed"
+                                  f", found indices ({list(expr._indices.axes)})."
+                                  )

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -11,7 +11,7 @@ import hail.expr.aggregators as agg
 from hail.expr import construct_expr, construct_variable
 from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.expressions import (expr_float64, matrix_table_source, expr_ndarray,
-                                   check_entry_indexed, expr_tuple, expr_array, expr_int32, expr_int64)
+                                   raise_unless_entry_indexed, expr_tuple, expr_array, expr_int32, expr_int64)
 from hail.ir import (BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, F64,
                      BlockMatrixBroadcast, ValueToBlockMatrix, BlockMatrixRead,
                      BlockMatrixMap, ApplyUnaryPrimOp, BlockMatrixDot, BlockMatrixCollect,
@@ -734,7 +734,7 @@ class BlockMatrix(object):
         if not block_size:
             block_size = BlockMatrix.default_block_size()
 
-        check_entry_indexed('BlockMatrix.write_from_entry_expr', entry_expr)
+        raise_unless_entry_indexed('BlockMatrix.write_from_entry_expr', entry_expr)
         mt = matrix_table_source('BlockMatrix.write_from_entry_expr', entry_expr)
 
         if not (mean_impute or center or normalize):

--- a/hail/python/hail/linalg/utils/misc.py
+++ b/hail/python/hail/linalg/utils/misc.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import hail as hl
 from hail.typecheck import typecheck, oneof, nullable
-from hail.expr.expressions import expr_locus, expr_float64, check_row_indexed
+from hail.expr.expressions import expr_locus, expr_float64, raise_unless_row_indexed
 from hail.utils.java import Env
 
 
@@ -166,9 +166,9 @@ def locus_windows(locus_expr, radius, coord_expr=None, _localize=True):
     """
     if radius < 0:
         raise ValueError(f"locus_windows: 'radius' must be non-negative, found {radius}")
-    check_row_indexed('locus_windows', locus_expr)
+    raise_unless_row_indexed('locus_windows', locus_expr)
     if coord_expr is not None:
-        check_row_indexed('locus_windows', coord_expr)
+        raise_unless_row_indexed('locus_windows', coord_expr)
 
     src = locus_expr._indices.source
     if locus_expr not in src._fields_inverse:

--- a/hail/python/hail/methods/pca.py
+++ b/hail/python/hail/methods/pca.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 import hail as hl
 import hail.expr.aggregators as agg
 from hail.expr.expressions import construct_expr
-from hail.expr import (expr_float64, expr_call, check_entry_indexed,
+from hail.expr import (expr_float64, expr_call, raise_unless_entry_indexed,
                        matrix_table_source)
 from hail import ir
 from hail.table import Table
@@ -191,7 +191,7 @@ def pca(entry_expr, k=10, compute_loadings=False) -> Tuple[List[float], Table, T
     if isinstance(hl.current_backend(), ServiceBackend):
         return _blanczos_pca(entry_expr, k, compute_loadings)
 
-    check_entry_indexed('pca/entry_expr', entry_expr)
+    raise_unless_entry_indexed('pca/entry_expr', entry_expr)
 
     mt = matrix_table_source('pca/entry_expr', entry_expr)
 
@@ -414,7 +414,7 @@ def _reduced_svd(A: TallSkinnyMatrix, k=10, compute_U=False, iterations=2, itera
            block_size=int)
 def _spectral_moments(A, num_moments, p=None, moment_samples=500, block_size=128):
     if not isinstance(A, TallSkinnyMatrix):
-        check_entry_indexed('_spectral_moments/entry_expr', A)
+        raise_unless_entry_indexed('_spectral_moments/entry_expr', A)
         A = _make_tsm(A, block_size)
 
     n = A.ncols
@@ -444,7 +444,7 @@ def _spectral_moments(A, num_moments, p=None, moment_samples=500, block_size=128
            moment_samples=int)
 def _pca_and_moments(A, k=10, num_moments=5, compute_loadings=False, q_iterations=10, oversampling_param=None, block_size=128, moment_samples=100):
     if not isinstance(A, TallSkinnyMatrix):
-        check_entry_indexed('_spectral_moments/entry_expr', A)
+        raise_unless_entry_indexed('_spectral_moments/entry_expr', A)
         A = _make_tsm(A, block_size)
 
     if oversampling_param is None:
@@ -595,7 +595,7 @@ def _blanczos_pca(A, k=10, compute_loadings=False, q_iterations=10, oversampling
         List of eigenvalues, table with column scores, table with row loadings.
     """
     if not isinstance(A, TallSkinnyMatrix):
-        check_entry_indexed('_blanczos_pca/entry_expr', A)
+        raise_unless_entry_indexed('_blanczos_pca/entry_expr', A)
         A = _make_tsm(A, block_size)
 
     if oversampling_param is None:
@@ -676,7 +676,7 @@ def _hwe_normalized_blanczos(call_expr, k=10, compute_loadings=False, q_iteratio
     (:obj:`list` of :obj:`float`, :class:`.Table`, :class:`.Table`)
         List of eigenvalues, table with column scores, table with row loadings.
     """
-    check_entry_indexed('_blanczos_pca/entry_expr', call_expr)
+    raise_unless_entry_indexed('_blanczos_pca/entry_expr', call_expr)
     A = _make_tsm_from_call(call_expr, block_size, hwe_normalize=True)
 
     return _blanczos_pca(A, k, compute_loadings=compute_loadings, q_iterations=q_iterations,

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -339,8 +339,9 @@ def linear_regression_rows(y, x, covariates, block_size=16, pass_through=(), *, 
     if is_chained and any(len(lst) == 0 for lst in y):
         raise ValueError("'linear_regression_rows': found empty inner list for 'y'")
 
-    y = [raise_unless_column_indexed('linear_regression_rows/y', y) or y
-         for y in wrap_to_list(y)
+    y = [raise_unless_column_indexed('linear_regression_rows_nd/y', y) or ys
+         for ys in wrap_to_list(y)
+         for y in (ys if is_chained else [ys])
          ]
 
     for e in (itertools.chain.from_iterable(y) if is_chained else y):
@@ -408,8 +409,9 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, weights=None, pa
     if is_chained and any(len(lst) == 0 for lst in y):
         raise ValueError("'linear_regression_rows': found empty inner list for 'y'")
 
-    y = [raise_unless_column_indexed('linear_regression_rows_nd/y', y) or y
-         for y in wrap_to_list(y)
+    y = [raise_unless_column_indexed('linear_regression_rows_nd/y', y) or ys
+         for ys in wrap_to_list(y)
+         for y in (ys if is_chained else [ys])
          ]
 
     if weights is not None:

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -343,9 +343,6 @@ def linear_regression_rows(y, x, covariates, block_size=16, pass_through=(), *, 
          for y in wrap_to_list(y)
          ]
 
-    # for yi in y:
-    #     raise_unless_column_indexed('linear_regression_rows/y', yi)
-
     for e in (itertools.chain.from_iterable(y) if is_chained else y):
         analyze('linear_regression_rows/y', e, mt._col_indices)
 

--- a/hail/python/hail/plot/plots.py
+++ b/hail/python/hail/plot/plots.py
@@ -21,7 +21,7 @@ from hail.expr import aggregators
 from hail.expr.expressions import (
     Expression, NumericExpression, StringExpression, LocusExpression,
     Int32Expression, Int64Expression, Float32Expression, Float64Expression,
-    expr_numeric, expr_float64, expr_any, expr_locus, expr_str, check_row_indexed
+    expr_numeric, expr_float64, expr_any, expr_locus, expr_str, raise_unless_row_indexed
 )
 from hail.expr.functions import _error_from_cdf_python
 from hail.typecheck import typecheck, oneof, nullable, sized_tupleof, numeric, \
@@ -684,8 +684,8 @@ def _generate_hist2d_data(x, y, bins, range):
         raise ValueError("histogram_2d requires source to be Table, not MatrixTable")
     if source != y_source:
         raise ValueError(f"histogram_2d expects two expressions from the same 'Table', found {source} and {y_source}")
-    check_row_indexed('histogram_2d', x)
-    check_row_indexed('histogram_2d', y)
+    raise_unless_row_indexed('histogram_2d', x)
+    raise_unless_row_indexed('histogram_2d', y)
     if isinstance(bins, int):
         x_bins = y_bins = bins
     else:
@@ -1659,7 +1659,7 @@ def visualize_missingness(entry_field, row_field=None, column_field=None,
     if not (mt == row_source == column_source):
         raise ValueError(f"visualize_missingness expects expressions from the same 'MatrixTable', "
                          f"found {mt} and {row_source} and {column_source}")
-    # check_row_indexed('visualize_missingness', row_source)
+    # raise_unless_row_indexed('visualize_missingness', row_source)
     if window:
         row_field_is_locus = isinstance(row_field.dtype, hail.tlocus)
         row_field_is_numeric = row_field.dtype in (hail.tint32, hail.tint64, hail.tfloat32, hail.tfloat64)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1794,3 +1794,17 @@ def test_logistic_regression_epacts_firth(logistic_epacts_mt):
     assert actual[4].locus == hl.Locus("22", 16117953, 'GRCh37')
     assert actual[4].beta == pytest.approx(0.5258, rel=1e-4)
     assert actual[4].p_value == pytest.approx(0.22562, rel=1e-4)
+
+
+## issue 13788
+def test_logistic_regression_y_parameter_sanity():
+    mt = hl.utils.range_matrix_table(2,2)
+    mt = mt.annotate_entries(prod = mt.row_idx * mt.col_idx)
+
+    with pytest.raises(hl.ExpressionException):
+        hl.logistic_regression_rows(
+            test='wald',
+            x=mt.prod,
+            y=mt.row_idx,
+            covariates=[1.0]
+        ).describe()


### PR DESCRIPTION
Fixes #13788:
- Add `raise_unless_column_indexed` guard and apply to all column-indexed parameters in `statgen.py`.
- Rename `check_row_indexed` and `check_entry_indexed` as I'm allergic to functions called "check" - now it's clearer what they do.