### PR TITLE
[website] add docs/latest/ (which currently redirects to 0.2)

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -489,6 +489,7 @@ hail-docs: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	@echo Built Hail docs: build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
 
 .PHONY: hail-docs-no-test
+hail-docs-no-test: install-editable
 hail-docs-no-test: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs \
 	        BUILDDIR=$(HAIL_HAIL_DIR)/build/docs/hail \

--- a/website/website/website.py
+++ b/website/website/website.py
@@ -71,7 +71,14 @@ docs_pages = set(
 @routes.get('/docs/{tail:.*}')
 @auth.maybe_authenticated_user
 async def serve_docs(request, userdata):
-    tail = request.match_info['tail']
+    tail: str = request.match_info['tail']
+
+    splits = tail.split('/', maxsplit=1)
+    if len(splits) == 2:
+        folder, tailtail = splits
+        if folder == 'latest':
+            raise web.HTTPFound('/docs/0.2/' + tailtail)
+
     if tail in docs_pages:
         if tail.endswith('.html'):
             return await render_template('www', request, userdata, tail, {})


### PR DESCRIPTION
I also fixed local/dev docs building. You need Hail installed for the docs build to work because it tries to `import` the classes for which you're building docs.