### PR TITLE
[batch] no logs on container deleted

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1888,6 +1888,8 @@ class DockerJob(Job):
             await container.run(on_completion)
         except asyncio.CancelledError:
             raise
+        except ContainerDeletedError as exc:
+            log.info(f'Container {container} was deleted while running.', exc)
         except Exception:
             log.exception(f'While running container: {container}')
 


### PR DESCRIPTION
Containers get deleted when a job is cancelled. This is not exceptional behavior.

Example: https://cloudlogging.app.goo.gl/punCSPauoM1ZEqZ27