### PR TITLE
[qob] minor fixes to service backend

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -495,7 +495,7 @@ class ServiceBackend(Backend):
             raise FatalError('Hail internal error. Please contact the Hail team and provide the following information.\n\n' + yamlx.dump({
                 'service_backend_debug_info': self.debug_info(),
                 'batch_debug_info': await self._batch.debug_info(
-                    _jobs_query_string='failed',
+                    _jobs_query_string='bad',
                     _max_jobs=10
                 ),
                 'input_uri': await self._async_fs.read(input_uri),
@@ -519,7 +519,7 @@ class ServiceBackend(Backend):
             raise FatalError('Hail internal error. Please contact the Hail team and provide the following information.\n\n' + yamlx.dump({
                 'service_backend_debug_info': self.debug_info(),
                 'batch_debug_info': await self._batch.debug_info(
-                    _jobs_query_string='failed',
+                    _jobs_query_string='bad',
                     _max_jobs=10
                 ),
                 'in': await self._async_fs.read(input_uri),

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -66,15 +66,17 @@ def pytest_runtest_makereport(item, call):
 
 @pytest.fixture(autouse=True)
 def reinitialize_hail_for_each_qob_test(init_hail, request):
-    backend = current_backend()
-    if isinstance(backend, ServiceBackend):
+    if isinstance(current_backend(), ServiceBackend):
         hl_stop_for_test()
         hl_init_for_test(app_name=request.node.name)
+        new_backend = current_backend()
+        assert isinstance(new_backend, ServiceBackend)
         yield
-        if backend._batch_was_submitted:
+        if new_backend._batch_was_submitted:
+            batch = new_backend._batch
             report: Dict[str, CollectReport] = request.node.stash[test_results_key]
             if any(r.failed for r in report.values()):
-                log.info(f'cancelling failed test batch {backend._batch.id}')
-                asyncio.get_event_loop().run_until_complete(backend._batch.cancel())
+                log.info(f'cancelling failed test batch {batch.id}')
+                asyncio.get_event_loop().run_until_complete(batch.cancel())
     else:
         yield


### PR DESCRIPTION
1. If a job errors rather than fails, we still want to see its logs in the debug info.

2. The backend from before `hl_stop_for_test` is broken. In particular, it does not have an open ClientSession, so it cannot make HTTP requests.