### PR TITLE
[aiotools] pervasively retrieve exceptions when cancelling tasks

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -43,8 +43,8 @@ class EventHandler:
         self.min_delay_secs = min_delay_secs
         self.task_manager = aiotools.BackgroundTaskManager()
 
-    def shutdown(self):
-        self.task_manager.shutdown()
+    async def shutdown(self):
+        await self.task_manager.shutdown()
 
     async def main_loop(self):
         delay_secs = self.min_delay_secs
@@ -598,7 +598,7 @@ async def async_main():
             finally:
                 try:
                     if user_creation_loop is not None:
-                        user_creation_loop.shutdown()
+                        await user_creation_loop.shutdown()
                 finally:
                     try:
                         await app['identity_client'].close()

--- a/batch/batch/driver/canceller.py
+++ b/batch/batch/driver/canceller.py
@@ -67,9 +67,9 @@ class Canceller:
 
         self.task_manager = aiotools.BackgroundTaskManager()
 
-    def shutdown(self):
+    async def shutdown(self):
         try:
-            self.task_manager.shutdown()
+            await self.task_manager.shutdown()
         finally:
             self.async_worker_pool.shutdown()
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1615,8 +1615,8 @@ SELECT instance_id, frozen FROM globals;
 async def on_cleanup(app):
     try:
         async with AsyncExitStack() as cleanup:
-            cleanup.callback(app['canceller'].shutdown)
-            cleanup.callback(app['task_manager'].shutdown)
+            cleanup.push_async_callback(app['canceller'].shutdown)
+            cleanup.push_async_callback(app['task_manager'].shutdown)
             cleanup.push_async_callback(app['driver'].shutdown)
             cleanup.push_async_callback(app['file_store'].shutdown)
             cleanup.push_async_callback(app['client_session'].close)

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2946,7 +2946,7 @@ SELECT instance_id, n_tokens, frozen FROM globals;
 
 async def on_cleanup(app):
     async with AsyncExitStack() as stack:
-        stack.callback(app['task_manager'].shutdown)
+        stack.push_async_callback(app['task_manager'].shutdown)
         stack.push_async_callback(app['hail_credentials'].close)
         stack.push_async_callback(app['client_session'].close)
         stack.push_async_callback(app['file_store'].close)

--- a/batch/batch/resource_usage.py
+++ b/batch/batch/resource_usage.py
@@ -94,7 +94,7 @@ class ResourceUsageMonitor:
 
         self.out: Optional[io.BufferedWriter] = None
 
-        self.task: Optional[asyncio.Future] = None
+        self.task: Optional[asyncio.Task] = None
 
     def write_header(self):
         assert self.out
@@ -270,12 +270,12 @@ iptables -t mangle -L -v -n -x -w | grep "{self.veth_host}" | awk '{{ if ($6 == 
         self.out = open(self.output_file_path, 'wb')  # pylint: disable=consider-using-with
         self.write_header()
 
-        self.task = asyncio.ensure_future(periodically_measure())
+        self.task = asyncio.create_task(periodically_measure())
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.task is not None:
-            cancel_and_retrieve_all_exceptions([self.task])
+            await cancel_and_retrieve_all_exceptions([self.task])
             self.task = None
 
         if self.out is not None:

--- a/batch/batch/resource_usage.py
+++ b/batch/batch/resource_usage.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 from hailtop.aiotools.fs import AsyncFS
-from hailtop.utils import check_shell_output, sleep_before_try, time_msecs, time_ns
+from hailtop.utils import cancel_and_retrieve_all_exceptions, check_shell_output, sleep_before_try, time_msecs, time_ns
 
 log = logging.getLogger('resource_usage')
 
@@ -275,7 +275,7 @@ iptables -t mangle -L -v -n -x -w | grep "{self.veth_host}" | awk '{{ if ($6 == 
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.task is not None:
-            cancel_and_retrieve_all_exceptions(self.task)
+            cancel_and_retrieve_all_exceptions([self.task])
             self.task = None
 
         if self.out is not None:

--- a/batch/batch/resource_usage.py
+++ b/batch/batch/resource_usage.py
@@ -275,7 +275,7 @@ iptables -t mangle -L -v -n -x -w | grep "{self.veth_host}" | awk '{{ if ($6 == 
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.task is not None:
-            self.task.cancel()
+            cancel_and_retrieve_all_exceptions(self.task)
             self.task = None
 
         if self.out is not None:

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -825,7 +825,7 @@ class Container:
         # regarding no-member: https://github.com/PyCQA/pylint/issues/4223
         self.process: Optional[asyncio.subprocess.Process] = None  # pylint: disable=no-member
 
-        self._run_fut: Optional[asyncio.Future] = None
+        self._run_fut: Optional[asyncio.Task] = None
         self._cleanup_lock = asyncio.Lock()
 
         self._killed = False
@@ -962,8 +962,9 @@ class Container:
                         finally:
                             self.process = None
             finally:
-                await cancel_and_retrieve_all_exceptions([self._run_fut])
-                self._run_fut = None
+                if self._run_fut is not None:
+                    await cancel_and_retrieve_all_exceptions([self._run_fut])
+                    self._run_fut = None
                 self._killed = True
 
     async def _cleanup(self):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -55,6 +55,7 @@ from hailtop.utils import (
     CalledProcessError,
     Timings,
     blocking_to_async,
+    cancel_and_retrieve_all_exceptions,
     check_exec_output,
     check_shell,
     check_shell_output,
@@ -68,7 +69,6 @@ from hailtop.utils import (
     retry_transient_errors_with_delayed_warnings,
     time_msecs,
     time_msecs_str,
-    cancel_and_retrieve_all_exceptions,
 )
 
 from ..batch_format_version import BatchFormatVersion

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -779,7 +779,7 @@ async def on_cleanup(app):
         cleanup.push_async_callback(app['db'].async_close)
         cleanup.push_async_callback(app['client_session'].close)
         cleanup.push_async_callback(app['batch_client'].close)
-        cleanup.callback(app['task_manager'].shutdown)
+        cleanup.push_async_callback(app['task_manager'].shutdown)
 
 
 def run():

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -362,7 +362,7 @@ class Database:
     async def async_close(self):
         assert self.pool
         assert self.connection_release_task_manager
-        self.connection_release_task_manager.shutdown()
+        await self.connection_release_task_manager.shutdown()
         self.pool.close()
         await self.pool.wait_closed()
         await self.async_exit_stack.aclose()

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -3,7 +3,6 @@ from typing import (Tuple, Any, Set, Optional, MutableMapping, Dict, AsyncIterat
                     List, Coroutine, ClassVar)
 from types import TracebackType
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import
-import sys
 import logging
 import asyncio
 import urllib.parse

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -10,14 +10,12 @@ import urllib.parse
 import aiohttp
 import datetime
 from hailtop import timex
-from hailtop.utils import (
-    secret_alnum_string, OnlineBoundedGather2,
-    TransientError, retry_transient_errors)
+from hailtop.utils import (secret_alnum_string, OnlineBoundedGather2, TransientError,
+                           retry_transient_errors, cancel_and_retrieve_all_exceptions)
 from hailtop.aiotools.fs import (FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
                                  AsyncFSURL, AsyncFSFactory, FileAndDirectoryError, MultiPartCreate,
                                  UnexpectedEOFError)
 from hailtop.aiotools import FeedableAsyncIterable, WriteBuffer
-from hailtop.aiotools.tasks import cancel_and_retrieve_all_exceptions
 
 from .base_client import GoogleBaseClient
 from ..session import GoogleSession

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -3,7 +3,7 @@ from .fs import (FileStatus, FileListEntry, AsyncFS, Transfer, MultiPartCreate,
                  WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async)
 from .local_fs import LocalAsyncFS
 from .utils import FeedableAsyncIterable, WriteBuffer
-from .tasks import BackgroundTaskManager, TaskManagerClosedError
+from .tasks import BackgroundTaskManager, TaskManagerClosedError, cancel_and_retrieve_all_exceptions
 from .weighted_semaphore import WeightedSemaphore
 
 __all__ = [
@@ -25,4 +25,5 @@ __all__ = [
     'WeightedSemaphore',
     'WriteBuffer',
     'Copier',
+    'cancel_and_retrieve_all_exceptions',
 ]

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -3,7 +3,7 @@ from .fs import (FileStatus, FileListEntry, AsyncFS, Transfer, MultiPartCreate,
                  WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async)
 from .local_fs import LocalAsyncFS
 from .utils import FeedableAsyncIterable, WriteBuffer
-from .tasks import BackgroundTaskManager, TaskManagerClosedError, cancel_and_retrieve_all_exceptions
+from .tasks import BackgroundTaskManager, TaskManagerClosedError
 from .weighted_semaphore import WeightedSemaphore
 
 __all__ = [
@@ -25,5 +25,4 @@ __all__ = [
     'WeightedSemaphore',
     'WriteBuffer',
     'Copier',
-    'cancel_and_retrieve_all_exceptions',
 ]

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -12,6 +12,7 @@ from ..utils.utils import sleep_before_try
 from ..utils.rich_progress_bar import RichProgressBar, make_listener
 from . import Transfer, Copier
 from .router_fs import RouterAsyncFS
+from .tasks import cancel_and_retrieve_all_exceptions
 
 try:
     import uvloop
@@ -58,12 +59,7 @@ class GrowingSempahore(AsyncContextManager[asyncio.Semaphore]):
         try:
             await self.sema.__aexit__(exc_type, exc, tb)
         finally:
-            if self.task is not None:
-                if self.task.done() and not self.task.cancelled():
-                    if exc := self.task.exception():
-                        raise exc
-                else:
-                    self.task.cancel()
+            await cancel_and_retrieve_all_exceptions([self.task])
 
 
 async def copy(*,

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -58,7 +58,8 @@ class GrowingSempahore(AsyncContextManager[asyncio.Semaphore]):
         try:
             await self.sema.__aexit__(exc_type, exc, tb)
         finally:
-            await cancel_and_retrieve_all_exceptions([self.task])
+            if self.task is not None:
+                await cancel_and_retrieve_all_exceptions([self.task])
 
 
 async def copy(*,

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -8,11 +8,10 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from rich.progress import Progress, TaskID
 
-from ..utils.utils import sleep_before_try
+from ..utils.utils import sleep_before_try, cancel_and_retrieve_all_exceptions
 from ..utils.rich_progress_bar import RichProgressBar, make_listener
 from . import Transfer, Copier
 from .router_fs import RouterAsyncFS
-from .tasks import cancel_and_retrieve_all_exceptions
 
 try:
     import uvloop

--- a/hail/python/hailtop/aiotools/diff.py
+++ b/hail/python/hailtop/aiotools/diff.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from ..utils.rich_progress_bar import SimpleRichProgressBar, SimpleRichProgressBarTask
 from .router_fs import RouterAsyncFS
 from .fs import AsyncFS, FileStatus
-from ..tasks import cancel_and_retrieve_all_exceptions
+from ..utils import cancel_and_retrieve_all_exceptions
 
 try:
     import uvloop

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Set
+from typing import Set
 import asyncio
 import logging
 from ..utils import cancel_and_retrieve_all_exceptions

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -1,23 +1,10 @@
 from typing import Iterable, Set
 import asyncio
 import logging
-from contextlib import ExitStack
+from ..utils import cancel_and_retrieve_all_exceptions
 
 
 log = logging.getLogger('aiotools.tasks')
-
-
-async def cancel_and_retrieve_all_exceptions(tasks: Iterable[asyncio.Task]):
-    for task in tasks:
-        if not task.cancelled():
-            task.cancel()
-    await asyncio.wait(tasks)
-    with ExitStack() as retrieve_all_exceptions:
-        # NB: only the first exception is raised
-        for task in tasks:
-            assert task.done()
-            if not task.cancelled():
-                retrieve_all_exceptions.callback(task.result)
 
 
 class TaskManagerClosedError(Exception):

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -7,11 +7,10 @@ import concurrent.futures
 import dill
 import functools
 
-from hailtop.utils import secret_alnum_string, partition
+from hailtop.utils import secret_alnum_string, partition, cancel_and_retrieve_all_exceptions
 import hailtop.batch_client.aioclient as low_level_batch_client
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.aiotools.tasks import cancel_and_retrieve_all_exceptions
 
 from .batch import Batch
 from .backend import ServiceBackend, HAIL_GENETICS_HAIL_IMAGE

--- a/hail/python/hailtop/cleanup_gcr/__main__.py
+++ b/hail/python/hailtop/cleanup_gcr/__main__.py
@@ -18,8 +18,8 @@ class AsyncIOExecutor:
         self._semaphore = asyncio.Semaphore(parallelism)
         self.task_manager = aiotools.BackgroundTaskManager()
 
-    def shutdown(self):
-        self.task_manager.shutdown()
+    async def shutdown(self):
+        await self.task_manager.shutdown()
 
     async def _run(self, fut, aw):
         async with self._semaphore:
@@ -45,8 +45,8 @@ class CleanupImages:
         self._executor = AsyncIOExecutor(8)
         self._client = client
 
-    def shutdown(self):
-        self._executor.shutdown()
+    async def shutdown(self):
+        await self._executor.shutdown()
 
     async def cleanup_digest(self, image, digest, tags):
         log.info(f'cleaning up digest {image}@{digest}')
@@ -115,7 +115,7 @@ async def main():
         try:
             await cleanup_images.run()
         finally:
-            cleanup_images.shutdown()
+            await cleanup_images.shutdown()
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -15,7 +15,8 @@ from .utils import (unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool
                     unpack_comma_delimited_inputs, unpack_key_value_inputs,
                     retry_all_errors_n_times, Timings, is_limited_retries_error, am_i_interactive,
                     is_delayed_warning_error, retry_transient_errors_with_delayed_warnings,
-                    periodically_call_with_dynamic_sleep, delay_ms_for_try, ait_to_blocking)
+                    periodically_call_with_dynamic_sleep, delay_ms_for_try, ait_to_blocking,
+                    cancel_and_retrieve_all_exceptions)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output, sync_check_exec)
@@ -98,4 +99,5 @@ __all__ = [
     'rich_progress_bar',
     'time_ns',
     'am_i_interactive',
+    'cancel_and_retrieve_all_exceptions',
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1150,6 +1150,9 @@ def am_i_interactive() -> bool:
 
 
 async def cancel_and_retrieve_all_exceptions(tasks: Iterable[asyncio.Task]):
+    if not tasks:
+        return
+
     for task in tasks:
         if not task.cancelled():
             task.cancel()

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1148,3 +1148,16 @@ def am_i_interactive() -> bool:
     """
     # https://stackoverflow.com/questions/2356399/tell-if-python-is-in-interactive-mode
     return bool(getattr(sys, 'ps1', sys.flags.interactive))
+
+
+async def cancel_and_retrieve_all_exceptions(tasks: Iterable[asyncio.Task]):
+    for task in tasks:
+        if not task.cancelled():
+            task.cancel()
+    await asyncio.wait(tasks)
+    with contextlib.ExitStack() as retrieve_all_exceptions:
+        # NB: only the first exception is raised
+        for task in tasks:
+            assert task.done()
+            if not task.cancelled():
+                retrieve_all_exceptions.callback(task.result)

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -27,7 +27,6 @@ from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 
 from .time import time_msecs
-from ..aiotools.tasks import cancel_and_retrieve_all_exceptions
 
 
 try:

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -358,7 +358,7 @@ async def on_cleanup(app):
     async with AsyncExitStack() as cleanup:
         cleanup.push_async_callback(app['db'].async_close)
         cleanup.push_async_callback(app['client_session'].close)
-        cleanup.callback(app['task_manager'].shutdown)
+        cleanup.push_async_callback(app['task_manager'].shutdown)
 
 
 def run():


### PR DESCRIPTION
cc: @daniel-goldstein 

I think I now understand the states of an asyncio.Task well enough to ensure we always retrieve exceptions.

---

I searched for all the uses of `cancel` and made sure they check for exceptions. One thing I might have got wrong: this code might add duplicate exception logs. This happens if one of the tasks sent to `cancel_and_retrieve_all_exceptions` already had its exception retrieved and logged.

These are my experiments that convinced me we need to cancel, wait, and then retrieve exceptions.

1. When you cancel a never-run task it immediately enters the "cancelling" state; however, it will not become done or cancelled until the event loop has a chance to process it. The running coroutine must `await` to allow that.

```ipython
In [3]: import asyncio
   ...:
   ...: async def foo():
   ...:     t = asyncio.create_task(asyncio.sleep(100))
   ...:     t.cancel()
   ...:     print((t, t.done(), t.cancelled()))
   ...:
   ...: asyncio.run(foo())
   ...:
(<Task cancelling name='Task-502' coro=<sleep() running at /Users/dking/miniconda3/lib/python3.10/asyncio/tasks.py:593>>, False, False)
```

2. If you let a task start running before you cancel it, it will be "pending". In this case, I believe the `CancelledError` needs to bubble up the entire coroutine task before the task can become cancelling or cancelled or done.

```ipython
In [4]: async def foo():
   ...:     t = asyncio.create_task(asyncio.sleep(100))
   ...:     await asyncio.sleep(0)  # let the other task run for a moment
   ...:     t.cancel()
   ...:     print((t, t.done(), t.cancelled()))
   ...:
   ...: asyncio.run(foo())
   ...:
(<Task pending name='Task-522' coro=<sleep() running at /Users/dking/miniconda3/lib/python3.10/asyncio/tasks.py:605> wait_for=<Future cancelled>>, False, False)
```

3. If you yield to the task, it will encounter a `CancelledError`. That bubbles up, running any `finally` blocks, until it reaches the top of the coroutine's stack. At this point the task can become done and cancelled.

```ipython
In [5]: async def foo():
   ...:     t = asyncio.create_task(asyncio.sleep(100))
   ...:     await asyncio.sleep(0)  # let the other task run for a moment
   ...:     t.cancel()
   ...:     await asyncio.wait([t])
   ...:     print((t, t.done(), t.cancelled()))
   ...:
   ...: asyncio.run(foo())
   ...:
(<Task cancelled name='Task-542' coro=<sleep() done, defined at /Users/dking/miniconda3/lib/python3.10/asyncio/tasks.py:593>>, True, True)
```

4. Here's an example of a finally block that raises an exception. That exception takes priority over the CancelledError. Notice that the task is done but *not cancelled*. This exception is not retrieved, which asyncio reports.

```
In [7]: async def foo():
   ...:     async def raises(message):
   ...:         try:
   ...:             await asyncio.sleep(100)
   ...:         finally:
   ...:             raise ValueError(message)
   ...:
   ...:     unretrieved = asyncio.create_task(raises('unretrieved case'))
   ...:     await asyncio.sleep(0)  # let the other task run for a moment
   ...:     unretrieved.cancel()
   ...:     await asyncio.wait([unretrieved])
   ...:     print((unretrieved, unretrieved.done(), unretrieved.cancelled()))
   ...:
   ...: asyncio.run(foo())
   ...:
(<Task finished name='Task-579' coro=<foo.<locals>.raises() done, defined at <ipython-input-7-ccfd397235b8>:2> exception=ValueError('unretrieved case')>, True, False)
Task exception was never retrieved
future: <Task finished name='Task-579' coro=<foo.<locals>.raises() done, defined at <ipython-input-7-ccfd397235b8>:2> exception=ValueError('unretrieved case')>
Traceback (most recent call last):
  File "<ipython-input-7-ccfd397235b8>", line 4, in raises
    await asyncio.sleep(100)
  File "/Users/dking/miniconda3/lib/python3.10/asyncio/tasks.py", line 605, in sleep
    return await future
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<ipython-input-7-ccfd397235b8>", line 6, in raises
    raise ValueError(message)
ValueError: unretrieved case
```

5. And here is an example of "retrieving" the exception (by calling `Task.exception`). Notice we do not get the "Task exception was never retrieved" message.

```
In [8]: async def foo():
   ...:     async def raises(message):
   ...:         try:
   ...:             await asyncio.sleep(100)
   ...:         finally:
   ...:             raise ValueError(message)
   ...:
   ...:     t = asyncio.create_task(raises('retrieved case'))
   ...:     await asyncio.sleep(0)  # let the other task run for a moment
   ...:     t.cancel()
   ...:     await asyncio.wait([t])
   ...:     print((t, t.done(), t.cancelled(), t.exception()))
   ...:
   ...: asyncio.run(foo())
   ...:
(<Task finished name='Task-599' coro=<foo.<locals>.raises() done, defined at <ipython-input-8-5fa396151822>:2> exception=ValueError('retrieved case')>, True, False, ValueError('retrieved case'))
```

---

One more thing of interest, I confirmed that the ExitStack throws the first exception it encountered *after* performing all callbacks.

```ipython
In [6]: with ExitStack() as exit:
   ...:     def foo(i):
   ...:         print(str(i))
   ...:         raise ValueError(i)
   ...:     exit.callback(foo, 1)
   ...:     exit.callback(foo, 2)
2
1
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[6], line 1
----> 1 with ExitStack() as exit:
      2     def foo(i):
      3         print(str(i))

File ~/miniconda3/lib/python3.10/contextlib.py:576, in ExitStack.__exit__(self, *exc_details)
    572 try:
    573     # bare "raise exc_details[1]" replaces our carefully
    574     # set-up context
    575     fixed_ctx = exc_details[1].__context__
--> 576     raise exc_details[1]
    577 except BaseException:
    578     exc_details[1].__context__ = fixed_ctx

File ~/miniconda3/lib/python3.10/contextlib.py:561, in ExitStack.__exit__(self, *exc_details)
    559 assert is_sync
    560 try:
--> 561     if cb(*exc_details):
    562         suppressed_exc = True
    563         pending_raise = False

File ~/miniconda3/lib/python3.10/contextlib.py:449, in _BaseExitStack._create_cb_wrapper.<locals>._exit_wrapper(exc_type, exc, tb)
    448 def _exit_wrapper(exc_type, exc, tb):
--> 449     callback(*args, **kwds)

Cell In[6], line 4, in foo(i)
      2 def foo(i):
      3     print(str(i))
----> 4     raise ValueError(i)

ValueError: 1
```