### PR TITLE
[fs] expose hl.fast_stat and hl.hadoop_fast_stat to users

### DIFF
--- a/hail/python/hail/docs/fs_api.rst
+++ b/hail/python/hail/docs/fs_api.rst
@@ -26,6 +26,7 @@ Top-Level Functions
     remove
     rmtree
     stat
+    fast_stat
 
 .. autofunction:: copy
 .. autofunction:: exists
@@ -37,3 +38,4 @@ Top-Level Functions
 .. autofunction:: remove
 .. autofunction:: rmtree
 .. autofunction:: stat
+.. autofunction:: fast_stat

--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -179,6 +179,12 @@ def hadoop_is_dir(path: str) -> bool:
 def hadoop_stat(path: str) -> Dict[str, Any]:
     """Returns information about the file or directory at a given path.
 
+    Warning
+    -------
+
+    This function requires the use of more expensive cloud object storage operations than
+    :func:`.hadoop_fast_stat`. See :func:`.hadoop_fast_stat` for details.
+
     Notes
     -----
     Raises an error if `path` does not exist.
@@ -199,8 +205,44 @@ def hadoop_stat(path: str) -> Dict[str, Any]:
     Returns
     -------
     :obj:`dict`
+
     """
     return Env.fs().stat(path).to_legacy_dict()
+
+
+def hadoop_fast_stat(path: str) -> Dict[str, Any]:
+    """Returns information about the file or directory at a given path.
+
+    Notes
+    -----
+
+    In cloud object stores, `path` could be a file (aka object), a directory (aka prefix), or
+    both. Determining if a path is or is not a directory is typically more expensive than retrieving
+    file metadata such as the size or creation time. For example, Google Cloud Storage charges a
+    list-by-prefix operation as a "Class A Operation" and an object-metadata operation as a "Class B
+    Operation".
+
+    This function does not determine if `path` is a directory, it only returns metadata about the
+    file at `path`, if a file exists.
+
+    The resulting dictionary contains the following data:
+
+    - size_bytes (:obj:`int`) -- Size in bytes.
+    - size (:class:`str`) -- Size as a readable string.
+    - modification_time (:class:`str`) -- Time of last file modification.
+    - owner (:class:`str`) -- Owner.
+    - path (:class:`str`) -- Path.
+
+    Parameters
+    ----------
+    path : :class:`str`
+
+    Returns
+    -------
+    :obj:`dict`
+
+    """
+    return Env.fs().fast_stat(path).to_legacy_dict()
 
 
 def hadoop_ls(path: str) -> List[Dict[str, Any]]:

--- a/hail/python/hailtop/fs/fs.py
+++ b/hail/python/hailtop/fs/fs.py
@@ -1,7 +1,7 @@
 import abc
 from typing import IO, List
 
-from .stat_result import FileListEntry
+from .stat_result import FileListEntry, FileStatus
 
 
 class FS(abc.ABC):
@@ -27,6 +27,10 @@ class FS(abc.ABC):
 
     @abc.abstractmethod
     def stat(self, path: str) -> FileListEntry:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def fast_stat(self, path: str) -> FileStatus:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/hail/python/hailtop/fs/fs_utils.py
+++ b/hail/python/hailtop/fs/fs_utils.py
@@ -2,7 +2,7 @@ import io
 from typing import List
 
 from .router_fs import RouterFS
-from .stat_result import FileListEntry
+from .stat_result import FileListEntry, FileStatus
 
 _router_fs = None
 
@@ -153,6 +153,12 @@ def is_dir(path: str) -> bool:
 def stat(path: str) -> FileListEntry:
     """Returns information about the file or directory at a given path.
 
+    Warning
+    -------
+
+    This function requires the use of more expensive cloud object storage operations than
+    :func:`.fast_stat`. See :func:`.fast_stat` for details.
+
     Notes
     -----
     Raises an error if `path` does not exist.
@@ -175,6 +181,41 @@ def stat(path: str) -> FileListEntry:
     :obj:`dict`
     """
     return _fs().stat(path)
+
+
+def fast_stat(path: str) -> FileStatus:
+    """Returns information about the file or directory at a given path.
+
+    Notes
+    -----
+    In cloud object stores, `path` could be a file (aka object), a directory (aka prefix), or
+    both. Determining if a path is or is not a directory is typically more expensive than retrieving
+    file metadata such as the size or creation time. For example, Google Cloud Storage charges a
+    list-by-prefix operation as a "Class A Operation" and an object-metadata operation as a "Class B
+    Operation".
+
+    This function does not determine if `path` is a directory, it only returns metadata about the
+    file at `path`, if a file exists.
+
+    If no file exists at `path`, this function raises an error.
+
+    The resulting dictionary contains the following data:
+
+    - size_bytes (:obj:`int`) -- Size in bytes.
+    - size (:class:`str`) -- Size as a readable string.
+    - modification_time (:class:`str`) -- Time of last file modification.
+    - owner (:class:`str`) -- Owner.
+    - path (:class:`str`) -- Path.
+
+    Parameters
+    ----------
+    path : :class:`str`
+
+    Returns
+    -------
+    :obj:`dict`
+    """
+    return _fs().fast_stat(path)
 
 
 def ls(path: str) -> List[FileListEntry]:

--- a/hail/python/hailtop/fs/stat_result.py
+++ b/hail/python/hailtop/fs/stat_result.py
@@ -10,6 +10,23 @@ class FileType(Enum):
     SYMLINK = auto()
 
 
+class FileStatus(NamedTuple):
+    path: str
+    owner: Union[None, str, int]
+    size: int
+    # common point between unix, google, and hadoop filesystems, represented as a unix timestamp
+    modification_time: Optional[float]
+
+    def to_legacy_dict(self) -> Dict[str, Any]:
+        return {
+            'path': self.path,
+            'owner': self.owner,
+            'size_bytes': self.size,
+            'size': filesize(self.size),
+            'modification_time': self.modification_time,
+        }
+
+
 class FileListEntry(NamedTuple):
     path: str
     owner: Union[None, str, int]

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1410,14 +1410,14 @@ class BGENTests(unittest.TestCase):
 
         with hl.TemporaryFilename() as f:
             hl.current_backend().fs.copy(bgen_file, f)
-            with pytest.raises(FatalError, match='have no .idx2 index file'):
+            with pytest.raises(FatalError, match=f'The following BGEN .idx2 index files do not exist.*{f}.idx2.*'):
                 hl.import_bgen(f, ['GT', 'GP'], sample_file, n_partitions=3)
 
             try:
                 with hl.current_backend().fs.open(f + '.idx', 'wb') as fobj:
                     fobj.write(b'')
 
-                with pytest.raises(FatalError, match='have no .idx2 index file'):
+                with pytest.raises(FatalError, match=f'The following BGEN .idx2 index files do not exist.*{f}.idx2.*'):
                     hl.import_bgen(f, ['GT', 'GP'], sample_file)
             finally:
                 hl.current_backend().fs.remove(f + '.idx')

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.backend.spark.SparkBackend
 import is.hail.io.compress.BGzipInputStream
-import is.hail.io.fs.{FS, FileListEntry, Positioned, PositionedInputStream, BGZipCompressionCodec}
+import is.hail.io.fs.{FS, FileListEntry, FileStatus, Positioned, PositionedInputStream, BGZipCompressionCodec}
 import is.hail.io.tabix.{TabixReader, TabixLineIterator}
 import is.hail.types.virtual.{TBoolean, TInt32, TInt64, TString, TStruct, Type}
 import is.hail.utils._
@@ -252,7 +252,7 @@ object GenericLines {
 
   def read(
     fs: FS,
-    fileListEntries0: IndexedSeq[FileListEntry],
+    fileListEntries0: IndexedSeq[_ <: FileStatus],
     nPartitions: Option[Int],
     blockSizeInMB: Option[Int],
     minPartitions: Option[Int],

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -13,7 +13,7 @@ import is.hail.types.physical.stypes.concrete.{SJavaString, SStackStruct, SStack
 import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SStreamValue}
 import is.hail.types.physical.stypes.primitives.{SInt64, SInt64Value}
 import is.hail.types.virtual._
-import is.hail.types.{BaseTypeWithRequiredness, RStruct, TableType, VirtualTypeWithReq}
+import is.hail.types.{BaseTypeWithRequiredness, RStruct, TableType, TypeWithRequiredness, VirtualTypeWithReq}
 import is.hail.utils.{FastSeq, fatal, checkGzipOfGlobbedFiles}
 import org.json4s.{Extraction, Formats, JValue}
 

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -241,7 +241,7 @@ object LoadBgen {
 
   def getIndexFiles(fs: FS, files: Array[FileListEntry], indexFileMap: Map[String, String]): Array[String] = {
     val indexFiles = getIndexFileNames(fs, files, indexFileMap)
-    val missingIdxFiles = files.zip(indexFiles).filterNot { case (f, index) => fs.exists(index) && index.endsWith("idx2") }.map(_._1)
+    val missingIdxFiles = files.zip(indexFiles).filterNot { case (f, index) => fs.exists(index) && index.endsWith("idx2") }.map(_._1.getPath)
     if (missingIdxFiles.nonEmpty)
       fatal(
         s"""The following BGEN .idx2 index files do not exist. Use 'index_bgen' to create the index file once before calling 'import_bgen':

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -464,7 +464,7 @@ class GoogleStorageFS(
     if (url.path == "")
       return GoogleStorageFileListEntry.dir(url)
 
-    val blob = getBlob(urL)
+    val blob = getBlob(url)
 
     if (blob == null) {
       throw new FileNotFoundException(url.toString)
@@ -496,7 +496,7 @@ class GoogleStorageFS(
     val exactFileMatch = getBlob(url)
     if (exactFileMatch != null) {
       val exactFileMatchFLE = GoogleStorageFileListEntry(exactFileMatch)
-      FS.fileListEntryFromIterator(url, it ++ FastSeq(exactFileMatch).iterator)
+      FS.fileListEntryFromIterator(url, it ++ FastSeq(exactFileMatchFLE).iterator)
     } else {
       FS.fileListEntryFromIterator(url, it)
     }

--- a/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/RouterFS.scala
@@ -53,6 +53,8 @@ class RouterFS(fss: IndexedSeq[FS]) extends FS {
 
   def glob(url: URL): Array[FileListEntry] = url.fs.glob(url.url)
 
+  def fileStatus(url: URL): FileStatus = url.fs.fileStatus(url.url)
+
   def fileListEntry(url: URL): FileListEntry = url.fs.fileListEntry(url.url)
 
   override def eTag(url: URL): Option[String] = url.fs.eTag(url.url)

--- a/hail/src/test/scala/is/hail/expr/ir/analyses/SemanticHashSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/analyses/SemanticHashSuite.scala
@@ -291,6 +291,7 @@ class SemanticHashSuite extends HailSuite {
       override def glob(url: FakeURL): Array[FileListEntry] =
         Array(new FileListEntry {
           override def getPath: String = url.getPath
+          override def getActualUrl(): String = url.getPath
           override def getModificationTime: lang.Long = ???
           override def getLen: Long = ???
           override def isDirectory: Boolean = ???

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -88,7 +88,8 @@ class IndexSuite extends HailSuite {
         TStruct("a" -> TBoolean),
         branchingFactor,
         attributes)
-      assert(fs.getFileSize(file) != 0)
+      assert(fs.getFileSize(file + "/index") != 0)
+      assert(fs.getFileSize(file + "/metadata.json.gz") != 0)
 
       val index = indexReader(file, TStruct("a" -> TBoolean))
 
@@ -108,7 +109,8 @@ class IndexSuite extends HailSuite {
   @Test def testEmptyKeys() {
     val file = ctx.createTmpPath("empty", "idx")
     writeIndex(file, Array.empty[String], Array.empty[Annotation], TStruct("a" -> TBoolean), 2)
-    assert(fs.getFileSize(file) != 0)
+    assert(fs.getFileSize(file + "/index") != 0)
+    assert(fs.getFileSize(file + "/metadata.json.gz") != 0)
     val index = indexReader(file, TStruct("a" -> TBoolean))
     intercept[IllegalArgumentException](index.queryByIndex(0L))
     assert(index.queryByKey("moo").isEmpty)

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -75,7 +75,7 @@ class BGzipCodecSuite extends HailSuite {
   @Test def testGenericLinesSimpleUncompressed() {
     val lines = Source.fromFile(uncompPath).getLines().toFastSeq
 
-    val uncompStatus = fs.fileListEntry(uncompPath)
+    val uncompStatus = fs.fileStatus(uncompPath)
     var i = 0
     while (i < 16) {
       val lines2 = GenericLines.collect(
@@ -89,7 +89,7 @@ class BGzipCodecSuite extends HailSuite {
   @Test def testGenericLinesSimpleBGZ() {
     val lines = Source.fromFile(uncompPath).getLines().toFastSeq
 
-    val compStatus = fs.fileListEntry(compPath)
+    val compStatus = fs.fileStatus(compPath)
     var i = 0
     while (i < 16) {
       val lines2 = GenericLines.collect(
@@ -104,7 +104,7 @@ class BGzipCodecSuite extends HailSuite {
     val lines = Source.fromFile(uncompPath).getLines().toFastSeq
 
     // won't split, just run once
-    val gzStatus = fs.fileListEntry(gzPath)
+    val gzStatus = fs.fileStatus(gzPath)
     val lines2 = GenericLines.collect(
       fs,
       GenericLines.read(fs, Array(gzStatus), Some(7), None, None, false, true))
@@ -113,7 +113,7 @@ class BGzipCodecSuite extends HailSuite {
 
   @Test def testGenericLinesRefuseGZ() {
     interceptFatal("Cowardly refusing") {
-      val gzStatus = fs.fileListEntry(gzPath)
+      val gzStatus = fs.fileStatus(gzPath)
       GenericLines.read(fs, Array(gzStatus), Some(7), None, None, false, false)
     }
   }

--- a/hail/src/test/scala/is/hail/io/fs/AzureStorageFSSuite.scala
+++ b/hail/src/test/scala/is/hail/io/fs/AzureStorageFSSuite.scala
@@ -8,7 +8,7 @@ import org.testng.annotations.{BeforeClass, Test}
 import java.io.FileInputStream
 
 
-class AzureStorageFSSuite extends TestNGSuite with FSSuite {
+class AzureStorageFSSuite extends FSSuite {
   @BeforeClass
   def beforeclass(): Unit = {
     if (System.getenv("HAIL_CLOUD") != "azure") {
@@ -43,10 +43,5 @@ class AzureStorageFSSuite extends TestNGSuite with FSSuite {
         return
     }
     assert(false)
-  }
-
-  @Test def testETag(): Unit = {
-    val etag = fs.eTag(s"$fsResourcesRoot/a")
-    assert(etag.nonEmpty)
   }
 }

--- a/hail/src/test/scala/is/hail/io/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/io/fs/FSSuite.scala
@@ -463,8 +463,8 @@ trait FSSuite extends TestNGSuite {
   @Test def fileAndDirectoryIsError(): Unit = {
     val d = t()
     fs.mkDir(d)
-    fs.touch(s"$d/x")
     fs.touch(s"$d/x/file")
+    fs.touch(s"$d/x")
 
     TestUtils.interceptException[FileAndDirectoryException](s"$d/x")(
       fs.fileListEntry(s"$d/x")

--- a/hail/src/test/scala/is/hail/io/fs/FakeFS.scala
+++ b/hail/src/test/scala/is/hail/io/fs/FakeFS.scala
@@ -3,6 +3,7 @@ package is.hail.io.fs
 
 case class FakeURL(path: String) extends FSURL {
   def getPath(): String = path
+  def getActualUrl(): String = path
 }
 
 abstract class FakeFS extends FS {
@@ -14,6 +15,7 @@ abstract class FakeFS extends FS {
   override def createNoCompression(url: FakeURL): PositionedDataOutputStream = ???
   override def delete(url: FakeURL,recursive: Boolean): Unit = ???
   override def eTag(url: FakeURL): Option[String] = ???
+  override def fileStatus(url: FakeURL): FileStatus = ???
   override def fileListEntry(url: FakeURL): FileListEntry = ???
   override def glob(url: FakeURL): Array[FileListEntry] = ???
   override def listDirectory(url: FakeURL): Array[FileListEntry] = ???

--- a/hail/src/test/scala/is/hail/io/fs/GoogleStorageFSSuite.scala
+++ b/hail/src/test/scala/is/hail/io/fs/GoogleStorageFSSuite.scala
@@ -42,10 +42,4 @@ class GoogleStorageFSSuite extends TestNGSuite with FSSuite {
     }
     assert(false)
   }
-
-  @Test def testETag(): Unit = {
-    val etag = fs.eTag(s"$fsResourcesRoot/a")
-    assert(etag.nonEmpty)
-  }
-
 }

--- a/hail/src/test/scala/is/hail/utils/RichRDDSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/RichRDDSuite.scala
@@ -34,7 +34,7 @@ class RichRDDSuite extends HailSuite {
     val merged = ctx.createTmpPath("merged", ".gz")
     val mergeList = Array(separateHeader + "/header.gz",
       separateHeader + "/part-00000.gz",
-      separateHeader + "/part-00001.gz").flatMap((x: String) => fs.glob(x))
+      separateHeader + "/part-00001.gz").map(x => fs.fileStatus(x))
     fs.copyMergeList(mergeList, merged, deleteSource = false)
 
     assert(read(merged) sameElements read(concatenated))

--- a/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -90,11 +90,9 @@ class UtilsSuite extends HailSuite {
     val fs = new HadoopFS(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
 
     val partFileNames = fs.glob("src/test/resources/part-*")
-      .map { fileListEntry =>
-        (fileListEntry, new hadoop.fs.Path(fileListEntry.getPath))
-      }.sortBy { case (fileListEntry, path) =>
-        getPartNumber(path.getName)
-      }.map(_._2.getName)
+      .sortBy { fileListEntry =>
+        getPartNumber(fileListEntry.getPath)
+      }.map(_.getPath.split("/").last)
 
     assert(partFileNames(0) == "part-40001" && partFileNames(1) == "part-100001")
   }


### PR DESCRIPTION
CHANGELOG: Introduce `hl.fs.fast_stat` and `hl.hadoop_fast_stat` which use cheaper Class B Operations in Google Cloud Storage rather than Class A Operations. Users of `hl.hadoop_stat` and `hl.fs.stat` should consider switching.

This PR extends https://github.com/hail-is/hail/pull/13885 into the public API.