### PR TITLE
[make] Separate image building from image pushing

### DIFF
--- a/auth/Makefile
+++ b/auth/Makefile
@@ -2,15 +2,15 @@ include ../config.mk
 
 .PHONY: build
 build:
-	$(MAKE) -C .. auth-image
+	$(MAKE) -C .. push-private-auth-image
 
 .PHONY: deploy
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	kubectl -n $(NAMESPACE) apply -f auth-driver-service-account.yaml
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"global":{"cloud":"$(CLOUD)"},"deploy":$(DEPLOY),"scope":"$(SCOPE)","default_ns":{"name":"$(NAMESPACE)"},"auth_image":{"image":"'$$(cat ../auth-image)'"},"auth_database":{"user_secret_name":"sql-auth-user-config"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"global":{"cloud":"$(CLOUD)"},"deploy":$(DEPLOY),"scope":"$(SCOPE)","default_ns":{"name":"$(NAMESPACE)"},"auth_image":{"image":"$(shell cat ../auth-image)"},"auth_database":{"user_secret_name":"sql-auth-user-config"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out
 
 .PHONY:
 clean:
-	rm -f Dockerfile.out deployment.yaml.out
+	rm -f deployment.yaml.out

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -2,7 +2,7 @@ include ../config.mk
 
 .PHONY: build
 build:
-	$(MAKE) -C .. batch-image batch-worker-image
+	$(MAKE) -C .. push-private-batch-image push-private-batch-worker-image
 
 JINJA_ENVIRONMENT = '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"batch_image":{"image":"$(shell cat ../batch-image)"},"batch_worker_image":{"image":"$(shell cat ../batch-worker-image)"},"default_ns":{"name":"$(NAMESPACE)"},"batch_database":{"user_secret_name":"sql-batch-user-config"},"scope":"$(SCOPE)","global":{"docker_prefix":"$(DOCKER_PREFIX)","cloud":"$(CLOUD)"}}'
 

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,15 +1,11 @@
 include ../config.mk
 
-.PHONY: blacken
-blacken:
-	$(BLACK)
-
 .PHONY: build
 build:
-	$(MAKE) -C .. ci-image ci-utils-image hail-buildkit-image
+	$(MAKE) -C .. push-private-ci-image push-private-ci-utils-image push-private-hail-buildkit-image
 
 .PHONY: deploy
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	python3 jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"global":{"cloud":"$(CLOUD)"},"deploy":$(DEPLOY),"scope":"$(SCOPE)","default_ns":{"name":"$(NAMESPACE)"},"ci_image":{"image":"'$$(cat ../ci-image)'"},"ci_utils_image":{"image":"'$$(cat ../ci-utils-image)'"},"ci_database":{"user_secret_name":"sql-ci-user-config"},"hail_buildkit_image":{"image":"'$$(cat ../hail-buildkit-image)'"}}' deployment.yaml deployment.yaml.out
+	python3 jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"global":{"cloud":"$(CLOUD)"},"deploy":$(DEPLOY),"scope":"$(SCOPE)","default_ns":{"name":"$(NAMESPACE)"},"ci_image":{"image":"$(shell cat ../ci-image)"},"ci_utils_image":{"image":"'$$(cat ../ci-utils-image)'"},"ci_database":{"user_secret_name":"sql-ci-user-config"},"hail_buildkit_image":{"image":"'$$(cat ../hail-buildkit-image)'"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,13 @@
 # These values should be lazy so you don't need kubectl for targets that don't
 # require it but also only evaluated at most once every make invocation
 # https://make.mad-scientist.net/deferred-simple-variable-expansion/
+
+ifdef NAMESPACE
 DOCKER_PREFIX = $(eval DOCKER_PREFIX := $$(shell kubectl -n $(NAMESPACE) get secret global-config --template={{.data.docker_prefix}} | base64 --decode))$(DOCKER_PREFIX)
+else
+DOCKER_PREFIX = docker.io
+endif
+
 DOMAIN = $(eval DOMAIN := $$(shell kubectl -n $(NAMESPACE) get secret global-config --template={{.data.domain}} | base64 --decode))$(DOMAIN)
 CLOUD = $(eval CLOUD := $$(shell kubectl -n $(NAMESPACE) get secret global-config --template={{.data.cloud}} | base64 --decode))$(CLOUD)
 
@@ -13,4 +19,4 @@ SCOPE = dev
 DEPLOY = false
 endif
 
-TOKEN = $(SCOPE)-$(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
+TOKEN := $(SCOPE)-$(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -2,20 +2,14 @@
 
 set -ex
 
-if [ -z "${NAMESPACE}" ]; then
-    echo "Must specify a NAMESPACE environment variable"
-    exit 1;
-fi
-
 CONTEXT="$(cd $1 && pwd)"
 DOCKERFILE="$CONTEXT/$2"
-REMOTE_IMAGE_NAME=$3
-EXTRA_CACHE=$4
+IMAGE_NAME=$3
 
-WITHOUT_TAG=$(echo $REMOTE_IMAGE_NAME | sed -E 's/(:[^:]+)(@[^@]+)?$//')
+WITHOUT_TAG=$(echo $IMAGE_NAME | sed -E 's/(:[^:]+)(@[^@]+)?$//')
 MAIN_CACHE=${WITHOUT_TAG}:cache
 
-if [ "${NAMESPACE}" == "default" ]; then
+if [ "${NAMESPACE:-default}" == "default" ]; then
     CACHE_IMAGE_NAME=${MAIN_CACHE}
 else
     DEV_CACHE=${WITHOUT_TAG}:cache-${NAMESPACE}
@@ -27,12 +21,8 @@ DOCKER_BUILDKIT=1 docker build \
        --file ${DOCKERFILE} \
        --cache-from ${MAIN_CACHE} \
        ${DEV_CACHE:+--cache-from ${DEV_CACHE}} \
-       ${EXTRA_CACHE:+--cache-from ${EXTRA_CACHE}} \
        --build-arg BUILDKIT_INLINE_CACHE=1 \
        ${DOCKER_BUILD_ARGS} \
-       --tag ${REMOTE_IMAGE_NAME} \
+       --tag ${IMAGE_NAME} \
        --tag ${CACHE_IMAGE_NAME} \
        ${CONTEXT}
-
-time DOCKER_BUILDKIT=1 docker push ${REMOTE_IMAGE_NAME}
-time DOCKER_BUILDKIT=1 docker push ${CACHE_IMAGE_NAME}

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -54,8 +54,8 @@ deploy_unmanaged() {
 
     export NAMESPACE=default
     kubectl -n default apply -f $HAIL/ci/bootstrap.yaml
-    make -C $HAIL ci-utils-image hail-buildkit-image
-    make -C $HAIL batch-worker-image
+    make -C $HAIL push-private-ci-utils-image push-private-hail-buildkit-image
+    make -C $HAIL push-private-batch-worker-image
     make -C $HAIL/internal-gateway envoy-xds-config deploy
     make -C $HAIL/bootstrap-gateway deploy
     make -C $HAIL/letsencrypt run

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -2,7 +2,7 @@ include ../config.mk
 
 .PHONY: build
 build:
-	$(MAKE) -C .. monitoring-image
+	$(MAKE) -C .. push-private-monitoring-image
 
 .PHONY: deploy
 deploy: build

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,6 +1,6 @@
 include ../config.mk
 
-.PHONY: build run run-docker deploy clean
+.PHONY: build push run run-docker deploy clean
 
 build:
 	$(MAKE) -C .. website-image
@@ -12,7 +12,10 @@ run:
 run-docker: build
 	docker run -e HAIL_DOMAIN=localhost:5555 -e PORT=5555 -p 5555:5555 $(shell cat ../website-image) python3 -m website local
 
-deploy: build
+push:
+	$(MAKE) -C .. push-private-website-image
+
+deploy: push
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	python3 ../ci/jinja2_render.py '{"default_ns":{"name":"$(NAMESPACE)"},"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"scope":"$(SCOPE)","website_image":{"image":"'$$(cat ../website-image)'"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out


### PR DESCRIPTION
This came to mind yesterday during our pairing. This PR introduces the following properties that our image building targets do not currently have:
1. If your intention is only to build images, you shouldn't need `kubectl`. When `DOCKER_PREFIX` is used as a docker build arg it is because we mirror some dockerhub images inside our registry (for reliability/rate limiting reasons). But for local building there's no reason you can't use the dockerhub image. Also, other people should be able to build the hail image if they want to!
2. One should *only* need to use `kubectl` if they are intending to use an image in a kubernetes deployment. In other words, you should only need the private registry `DOCKER_PREFIX` for pushing images.
3. One should not need to endure image pushing if the only goal is to build the image locally
4. No intermediate tags should end up in the private registry. If we push on every image build, the private docker registry will accumulate a lot of `hail-ubuntu:dev-xxxxxx` tags that are never used again because `hail-ubuntu` is just an intermediate used to build other images. This does *not* change the number of layers that end up in the registry, but reduces a bit of the work that the registry cleanup job needs to do to untag and delete images and just seems cleaner.