### PR TITLE
[ci] Set database creation jobs back to 4 cores

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1328,7 +1328,7 @@ EOF
                 regions=[REGION],
             )
 
-        n_cores = 16 if scope == 'deploy' and not is_test_deployment else 1
+        n_cores = 4 if scope == 'deploy' and not is_test_deployment else 1
 
         self.create_database_job = batch.create_job(
             self.image,


### PR DESCRIPTION
The largest migration took 6.2 GB of memory. I think we'll be fine for awhile with 15 GB of memory (4 cores).