### PR TITLE
[query] avoid hanging the JVM in Dataproc

### DIFF
--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -54,7 +54,7 @@ critically depend on experimental functionality.**
 
 ## Version 0.2.125
 
-Released 2023-10-25
+Released 2023-10-26
 
 ### New Features
 
@@ -100,6 +100,7 @@ Released 2023-10-25
 
 - (hail#13894) Fix #13837 in which Hail could break a Spark installation if the Hail JAR appears on the classpath before the Scala JARs.
 
+- (hail#13919) Fix #13915 which prevented using a glob pattern in `hl.import_vcf`.
 
 ## Version 0.2.124
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -638,8 +638,7 @@ def is_transient_error(e: BaseException) -> bool:
             and e.args[0] == "Response payload is not completed"):
         return True
     if (isinstance(e, aiohttp.ClientOSError)
-            and len(e.args) >= 2
-            and 'sslv3 alert bad record mac' in e.args[1]):
+            and 'sslv3 alert bad record mac' in e.strerror):
         # aiohttp.client_exceptions.ClientOSError: [Errno 1] [SSL: SSLV3_ALERT_BAD_RECORD_MAC] sslv3 alert bad record mac (_ssl.c:2548)
         #
         # This appears to be a symptom of Google rate-limiting as of 2023-10-15

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -9,6 +9,7 @@ from pytest import StashKey, CollectReport
 
 from hail import current_backend, init, reset_global_randomness
 from hail.backend.service_backend import ServiceBackend
+from hailtop.hail_event_loop import hail_event_loop
 from hailtop.utils import secret_alnum_string
 from .helpers import hl_init_for_test, hl_stop_for_test
 


### PR DESCRIPTION
Non-daemon threads [keep a JVM alive](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html):

> When a Java Virtual Machine starts up, there is usually a single non-daemon thread (which typically calls the method named main of some designated class). The Java Virtual Machine continues to execute threads until either of the following occurs:
>
> The exit method of class Runtime has been called and the security manager has permitted the exit operation to take place.
>
> All threads that are not daemon threads have died, either by returning from the call to the run method or by throwing an exception that propagates beyond the run method.

Spark appears to wait for the JVM to terminate before it considers a job complete.