### PR TITLE
[ci] Run the dataproc tests on release PRs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3225,9 +3225,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-dataproc-service-account-key
-    scopes:
-      - deploy
-      - dev
     clouds:
       - gcp
   - kind: runImage
@@ -3267,9 +3264,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-dataproc-service-account-key
-    scopes:
-      - deploy
-      - dev
     clouds:
       - gcp
   - kind: runImage


### PR DESCRIPTION
These should basically run as no-ops on every PR but then actually test dataproc if we dare to bump the pip version. Can read these CI tests as "every version of hail has passed tests on dataproc".