### PR TITLE
[hailtop] avoid errors on rare transient errors

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -638,8 +638,7 @@ def is_transient_error(e: BaseException) -> bool:
             and e.args[0] == "Response payload is not completed"):
         return True
     if (isinstance(e, aiohttp.ClientOSError)
-            and len(e.args) >= 2
-            and 'sslv3 alert bad record mac' in e.args[1]):
+            and 'sslv3 alert bad record mac' in e.strerror):
         # aiohttp.client_exceptions.ClientOSError: [Errno 1] [SSL: SSLV3_ALERT_BAD_RECORD_MAC] sslv3 alert bad record mac (_ssl.c:2548)
         #
         # This appears to be a symptom of Google rate-limiting as of 2023-10-15


### PR DESCRIPTION
`aiohttp.ClientOSError` inherits from `OSError`, so we can just use `errno` or `strerror` directly.

We should not directly use the `args` because one of the subclasses of `ClientOSError` sets them to *its* arguments after initializing its super classes with the expected arguments:

```python3
class ClientConnectorError(ClientOSError):
    """Client connector error.

    Raised in :class:`aiohttp.connector.TCPConnector` if
        a connection can not be established.
    """

    def __init__(self, connection_key: ConnectionKey, os_error: OSError) -> None:
        self._conn_key = connection_key
        self._os_error = os_error
        super().__init__(os_error.errno, os_error.strerror)
        self.args = (connection_key, os_error)
```

I also tried to remove `e.args` from the `ClientPayloadError` case (the one right above this, and the only one still using `e.args`), but neither that class nor any super class sets a field with the error message (in fact, no fields are ever set so we can only use `e.args`).