### PR TITLE
[ci] Upgrade buildkit to 0.12.3

### DIFF
--- a/ci/buildkit/Dockerfile
+++ b/ci/buildkit/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKER_PREFIX={{ global.docker_prefix }}
-FROM $DOCKER_PREFIX/moby/buildkit:v0.8.3-rootless
+FROM $DOCKER_PREFIX/moby/buildkit:v0.12.3-rootless
 USER root
 RUN apk add python3 py-pip jq && pip3 install jinja2
 USER user

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -5,7 +5,7 @@ ghost:3.0-alpine
 google/cloud-sdk:305.0.0-slim
 grafana/grafana:9.1.4
 jupyter/scipy-notebook:c094bb7219f9
-moby/buildkit:v0.8.3-rootless
+moby/buildkit:v0.12.3-rootless
 python:3.9
 python:3.9-slim
 python:3.10

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -10,6 +10,7 @@ fi
 source $HAIL/devbin/functions.sh
 
 copy_images() {
+    export NAMESPACE=default
     make -C $HAIL/docker/third-party copy
 
     make -C $HAIL/hail python/hail/hail_pip_version


### PR DESCRIPTION
also fixed the `copy-images` target which has been broken a while because without a namespace it can't get `DOCKER_PREFIX`.