### PR TITLE
[query] refactor approx_cdf to support manual combining

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -12,7 +12,7 @@ from hail.expr import (ExpressionException, Expression, ArrayExpression,
 from hail.expr.types import (hail_type, tint32, tint64, tfloat32, tfloat64,
                              tbool, tcall, tset, tarray, tstruct, tdict, ttuple, tstr)
 from hail.expr.expressions.typed_expressions import construct_variable
-from hail.expr.functions import rbind, float32, _quantile_from_cdf, _result_from_raw_cdf, _func
+from hail.expr.functions import rbind, float32, _quantile_from_cdf, _result_from_raw_cdf
 import hail.ir as ir
 from hail.typecheck import (TypeChecker, typecheck_method, typecheck,
                             sequenceof, func_spec, identity, nullable, oneof)

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -339,10 +339,10 @@ def approx_cdf(expr, k=100, *, _raw=False):
         tfloat32: lambda x: x.map(hl.float32),
         tfloat64: identity
     }
-    raw_res = raw_res.annotate(items=conv[expr.dtype](raw_res['items']))
     if _raw:
         return raw_res
     else:
+        raw_res = raw_res.annotate(items=conv[expr.dtype](raw_res['items']))
         return _result_from_raw_cdf(raw_res)
 
 

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -12,7 +12,7 @@ from hail.expr import (ExpressionException, Expression, ArrayExpression,
 from hail.expr.types import (hail_type, tint32, tint64, tfloat32, tfloat64,
                              tbool, tcall, tset, tarray, tstruct, tdict, ttuple, tstr)
 from hail.expr.expressions.typed_expressions import construct_variable
-from hail.expr.functions import rbind, float32, _quantile_from_cdf, _func
+from hail.expr.functions import rbind, float32, _quantile_from_cdf, _result_from_raw_cdf, _func
 import hail.ir as ir
 from hail.typecheck import (TypeChecker, typecheck_method, typecheck,
                             sequenceof, func_spec, identity, nullable, oneof)
@@ -287,8 +287,8 @@ def _check_agg_bindings(expr, bindings):
         raise ExpressionException("dynamic variables created by 'hl.bind' or lambda methods like 'hl.map' may not be aggregated")
 
 
-@typecheck(expr=expr_numeric, k=int, raw=bool)
-def approx_cdf(expr, k=100, *, raw=False):
+@typecheck(expr=expr_numeric, k=int, _raw=bool)
+def approx_cdf(expr, k=100, *, _raw=False):
     """Produce a summary of the distribution of values.
 
     Notes
@@ -330,7 +330,7 @@ def approx_cdf(expr, k=100, *, raw=False):
     :class:`.StructExpression`
         Struct containing `values` and `ranks` arrays.
     """
-    res = _agg_func('ApproxCDF', [hl.float64(expr)],
+    raw_res = _agg_func('ApproxCDF', [hl.float64(expr)],
                     tstruct(levels=tarray(tint32), items=tarray(tfloat64), _compaction_counts=tarray(tint32)),
                     init_op_args=[k])
     conv = {
@@ -339,19 +339,11 @@ def approx_cdf(expr, k=100, *, raw=False):
         tfloat32: lambda x: x.map(hl.float32),
         tfloat64: identity
     }
-    if raw:
-        return res.annotate(items=conv[expr.dtype](res['items']))
+    raw_res = raw_res.annotate(items=conv[expr.dtype](raw_res['items']))
+    if _raw:
+        return raw_res
     else:
-        res = _func('approxCDFResult',
-                    tstruct(values=tarray(tfloat64), ranks=tarray(tint64), _compaction_counts=tarray(tint32)),
-                    res)
-        conv = {
-            tint32: lambda x: x.map(hl.int),
-            tint64: lambda x: x.map(hl.int64),
-            tfloat32: lambda x: x.map(hl.float32),
-            tfloat64: identity
-        }
-        return res.annotate(values=conv[expr.dtype](res['values']))
+        return _result_from_raw_cdf(raw_res)
 
 
 @typecheck(expr=expr_numeric, qs=expr_oneof(expr_numeric, expr_array(expr_numeric)), k=int)

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -12,7 +12,7 @@ from hail.expr import (ExpressionException, Expression, ArrayExpression,
 from hail.expr.types import (hail_type, tint32, tint64, tfloat32, tfloat64,
                              tbool, tcall, tset, tarray, tstruct, tdict, ttuple, tstr)
 from hail.expr.expressions.typed_expressions import construct_variable
-from hail.expr.functions import rbind, float32, _quantile_from_cdf
+from hail.expr.functions import rbind, float32, _quantile_from_cdf, _func
 import hail.ir as ir
 from hail.typecheck import (TypeChecker, typecheck_method, typecheck,
                             sequenceof, func_spec, identity, nullable, oneof)
@@ -331,8 +331,11 @@ def approx_cdf(expr, k=100):
         Struct containing `values` and `ranks` arrays.
     """
     res = _agg_func('ApproxCDF', [hl.float64(expr)],
-                    tstruct(values=tarray(tfloat64), ranks=tarray(tint64), _compaction_counts=tarray(tint32)),
+                    tstruct(levels=tarray(tint32), items=tarray(tfloat64), _compaction_counts=tarray(tint32)),
                     init_op_args=[k])
+    res = _func('approxCDFResult',
+                tstruct(values=tarray(tfloat64), ranks=tarray(tint64), _compaction_counts=tarray(tint32)),
+                res)
     conv = {
         tint32: lambda x: x.map(hl.int),
         tint64: lambda x: x.map(hl.int64),

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -89,11 +89,21 @@ def _quantile_from_cdf(cdf, q):
 
 @typecheck(raw_cdf=expr_struct())
 def _result_from_raw_cdf(raw_cdf):
-    item_weights = hl.range(hl.len(raw_cdf['items'])).aggregate(lambda i: hl.agg.group_by(raw_cdf['items'][i], hl.agg.sum(2 ** raw_cdf.levels[i])))
+    levels = raw_cdf.levels
+    item_weights = hl._stream_range(hl.len(levels) - 1) \
+        .flatmap(lambda l: hl._stream_range(levels[l], levels[l+1])
+                 .map(lambda i: hl.struct(level=l, value=raw_cdf['items'][i]))) \
+        .aggregate(lambda x: hl.agg.group_by(x.value, hl.agg.sum(hl.bit_lshift(1, x.level))))
     weights = item_weights.values()
-    ranks = weights.scan(lambda acc, weight: acc + weight, 0).append(hl.sum(weights))
+    ranks = weights.scan(lambda acc, weight: acc + weight, 0)
     values = item_weights.keys()
     return hl.struct(values=values, ranks=ranks, _compaction_counts=raw_cdf._compaction_counts)
+
+
+@typecheck(k=expr_int32, left=expr_struct(), right=expr_struct())
+def _cdf_combine(k, left, right):
+    t = tstruct(levels=tarray(tint32), items=tarray(tfloat64), _compaction_counts=tarray(tint32))
+    return _func('approxCDFCombine', t, k, left, right)
 
 
 @typecheck(cdf=expr_struct(), failure_prob=expr_oneof(expr_float32, expr_float64), all_quantiles=bool)

--- a/hail/python/hail/ir/register_aggregators.py
+++ b/hail/python/hail/ir/register_aggregators.py
@@ -5,13 +5,13 @@ def register_aggregators():
     from hail.expr.types import dtype
 
     register_aggregator('ApproxCDF', (dtype('int32'),), (dtype('int32'),),
-                        dtype('struct{values:array<int32>,ranks:array<int64>,_compaction_counts:array<int32>}'))
+                        dtype('struct{levels:array<int32>,items:array<int32>,_compaction_counts:array<int32>}'))
     register_aggregator('ApproxCDF', (dtype('int32'),), (dtype('int64'),),
-                        dtype('struct{values:array<int64>,ranks:array<int64>,_compaction_counts:array<int32>}'))
+                        dtype('struct{levels:array<int32>,items:array<int64>,_compaction_counts:array<int32>}'))
     register_aggregator('ApproxCDF', (dtype('int32'),), (dtype('float32'),),
-                        dtype('struct{values:array<float32>,ranks:array<int64>,_compaction_counts:array<int32>}'))
+                        dtype('struct{levels:array<int32>,items:array<float32>,_compaction_counts:array<int32>}'))
     register_aggregator('ApproxCDF', (dtype('int32'),), (dtype('float64'),),
-                        dtype('struct{values:array<float64>,ranks:array<int64>,_compaction_counts:array<int32>}'))
+                        dtype('struct{levels:array<int32>,items:array<float64>,_compaction_counts:array<int32>}'))
 
     register_aggregator('Collect', (), (dtype("?in"),), dtype('array<?in>'))
     register_aggregator('Densify', (dtype('int32'),), (dtype("?in"),), dtype('?in'))

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -396,6 +396,9 @@ object LowerMatrixIR {
             builder += ((uid, aggIR))
             aggs.foldLeft[IR](liftedBody) { case (acc, (name, _)) => Let(name, GetField(Ref(uid, structResult.typ), name), acc) }
 
+          case x: StreamAgg => x
+          case x: StreamAggScan => x
+
           case _ =>
             MapIR(lift(_, scanBindings, aggBindings))(ir)
         }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -29,8 +29,6 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   private val k = kb.genFieldThisRef[Int]("k")
   private val kOffset: Code[Long] => Code[Long] = storageType.loadField(_, "k")
 
-  IndexedSeq().toArray
-
   def init(cb: EmitCodeBuilder, k: Code[Int]): Unit = {
       cb.assign(this.k, k)
       cb.assign(aggr, Code.invokeScalaObject1[Int, ApproxCDFStateManager](ApproxCDFStateManager.getClass, "apply", this.k))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -100,12 +100,10 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   }
 
   override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
-    cb += Code(
-      k := Region.loadInt(kOffset(src)),
-      aggr := Code.newInstance[ApproxCDFStateManager, Int](k),
-      id := region.storeJavaObject(aggr),
-      this.initialized := true
-    )
+    cb.assign(k, Region.loadInt(kOffset(src)))
+    cb.assign(aggr, Code.invokeScalaObject1[Int, ApproxCDFStateManager](ApproxCDFStateManager.getClass, "apply", this.k))
+    cb.assign(id, region.storeJavaObject(aggr))
+    cb.assign(this.initialized, true)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -29,9 +29,11 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   private val k = kb.genFieldThisRef[Int]("k")
   private val kOffset: Code[Long] => Code[Long] = storageType.loadField(_, "k")
 
+  IndexedSeq().toArray
+
   def init(cb: EmitCodeBuilder, k: Code[Int]): Unit = {
       cb.assign(this.k, k)
-      cb.assign(aggr, Code.newInstance[ApproxCDFStateManager, Int](this.k))
+      cb.assign(aggr, Code.invokeScalaObject1[Int, ApproxCDFStateManager](ApproxCDFStateManager.getClass, "apply", this.k))
       cb.assign(id, region.storeJavaObject(aggr))
       cb.assign(this.initialized, true)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
@@ -1,0 +1,59 @@
+package is.hail.expr.ir.functions
+
+import is.hail.annotations.Region
+import is.hail.asm4s.{Code, TypeInfo, Value, toCodeObject, valueToCodeObject}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
+import is.hail.expr.ir.agg.{ApproxCDFCombiner, QuantilesAggregator}
+import is.hail.types.physical.{PCanonicalArray, PCanonicalStruct, PFloat64, PInt32, PInt64}
+import is.hail.types.physical.stypes.concrete.SBaseStructPointer
+import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SIndexableValue, primitive}
+import is.hail.utils.FastIndexedSeq
+
+import scala.reflect.ClassTag
+
+object ApproxCDFFunctions extends RegistryFunctions {
+  val stateType = QuantilesAggregator.resultPType.virtualType
+  val resultPType: PCanonicalStruct =
+    PCanonicalStruct(required = false,
+      "values" -> PCanonicalArray(PFloat64(true), required = true),
+      "ranks" -> PCanonicalArray(PInt64(true), required = true),
+      "_compaction_counts" -> PCanonicalArray(PInt32(true), required = true))
+  val resultSType = SBaseStructPointer(resultPType)
+
+  def sIndexableFromJava[A: ClassTag: TypeInfo](cb: EmitCodeBuilder, r: Value[Region], array: Value[IndexedSeq[A]], pt: PCanonicalArray): SIndexableValue = {
+    pt.constructFromElements(cb, r, cb.memoize(array.invoke[Int]("length")), true) { (cb, i) =>
+      IEmitCode.present(cb, primitive(pt.elementType.virtualType, cb.memoize(array.invoke[Int, A]("apply", i))))
+    }
+  }
+
+  def indexedSeqToArrayInt(seq: IndexedSeq[Int]): Array[Int] = seq.toArray
+  def indexedSeqToArrayDouble(seq: IndexedSeq[Double]): Array[Double] = seq.toArray
+
+  def registerAll(): Unit = {
+    registerSCode1("approxCDFResult", stateType, resultPType.virtualType, (_, _) => resultSType) {
+      case (r, cb, rt, state: SBaseStructValue, errorID) =>
+        val levels = state.loadField(cb, "levels").get(cb).asIndexable
+        val items = state.loadField(cb, "items").get(cb).asIndexable
+        val counts = state.loadField(cb, "_compaction_counts").get(cb).asIndexable
+        val javaLevels = cb.memoize(Code.invokeScalaObject1[IndexedSeq[Int], Array[Int]](ApproxCDFFunctions.getClass, "indexedSeqToArrayInt",
+          Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, levels))))
+        val javaItems = cb.memoize(Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r.region, items)).invoke[Array[Double]]("toArray"))
+        val javaCounts = cb.memoize(Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, counts)).invoke[Array[Int]]("toArray"))
+        val combiner = cb.memoize(Code.newInstance[ApproxCDFCombiner, Array[Int], Array[Double], Array[Int], Int, java.util.Random](
+          javaLevels,
+          javaItems,
+          javaCounts,
+          levels.loadLength() - 1,
+          Code.newInstance[java.util.Random]()))
+        val javaCDF = cb.memoize(combiner.invoke[(Array[Double], Array[Long])]("computeCDF"))
+        val javaValues = cb.memoize(Code.checkcast[IndexedSeq[Double]](javaCDF.invoke[Array[Double]]("_1")))
+        val javaRanks = cb.memoize(Code.checkcast[IndexedSeq[Long]](javaCDF.invoke[Array[Long]]("_2")))
+        val valuesPType = resultPType.field("values").typ.asInstanceOf[PCanonicalArray]
+        val ranksPType = resultPType.field("ranks").typ.asInstanceOf[PCanonicalArray]
+        val values = sIndexableFromJava(cb, r.region, javaValues, valuesPType)
+        val ranks = sIndexableFromJava(cb, r.region, javaRanks, ranksPType)
+
+        resultPType.constructFromFields(cb, r.region, FastIndexedSeq(EmitCode.present(cb.emb, values), EmitCode.present(cb.emb, ranks), EmitCode.present(cb.emb, counts)), false)
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
@@ -15,12 +15,6 @@ import org.apache.spark.sql.Row
 object ApproxCDFFunctions extends RegistryFunctions {
   val statePType = QuantilesAggregator.resultPType
   val stateType = statePType.virtualType
-  val resultPType: PCanonicalStruct =
-    PCanonicalStruct(required = false,
-      "values" -> PCanonicalArray(PFloat64(true), required = true),
-      "ranks" -> PCanonicalArray(PInt64(true), required = true),
-      "_compaction_counts" -> PCanonicalArray(PInt32(true), required = true))
-  val resultSType = SBaseStructPointer(resultPType)
 
   def rowToStateManager(k: Int, row: Row): ApproxCDFStateManager = {
     val levels = row.getAs[IndexedSeq[Int]](0).toArray
@@ -53,7 +47,7 @@ object ApproxCDFFunctions extends RegistryFunctions {
         val leftState = makeStateManager(cb, r.region, k.value, left)
         val rightState = makeStateManager(cb, r.region, k.value, right)
 
-        leftState.invoke[ApproxCDFStateManager, Unit]("combOp", rightState)
+        cb += leftState.invoke[ApproxCDFStateManager, Unit]("combOp", rightState)
 
         fromStateManager(cb, r.region, leftState)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
@@ -1,18 +1,20 @@
 package is.hail.expr.ir.functions
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Code, TypeInfo, Value, toCodeObject, valueToCodeObject}
-import is.hail.expr.ir.agg.{ApproxCDFCombiner, QuantilesAggregator}
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.stypes.concrete.SBaseStructPointer
-import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SIndexableValue, primitive}
+import is.hail.asm4s.{Code, Value, valueToCodeObject}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.expr.ir.agg.{ApproxCDFStateManager, QuantilesAggregator}
 import is.hail.types.physical._
-import is.hail.utils.FastSeq
-
-import scala.reflect.ClassTag
+import is.hail.types.physical.stypes.concrete.SBaseStructPointer
+import is.hail.types.physical.stypes.interfaces.SBaseStructValue
+import is.hail.types.physical.stypes.primitives.SInt32Value
+import is.hail.types.virtual.TInt32
+import is.hail.utils.toRichIterable
+import org.apache.spark.sql.Row
 
 object ApproxCDFFunctions extends RegistryFunctions {
-  val stateType = QuantilesAggregator.resultPType.virtualType
+  val statePType = QuantilesAggregator.resultPType
+  val stateType = statePType.virtualType
   val resultPType: PCanonicalStruct =
     PCanonicalStruct(required = false,
       "values" -> PCanonicalArray(PFloat64(true), required = true),
@@ -20,42 +22,40 @@ object ApproxCDFFunctions extends RegistryFunctions {
       "_compaction_counts" -> PCanonicalArray(PInt32(true), required = true))
   val resultSType = SBaseStructPointer(resultPType)
 
-  def sIndexableFromArray[A: ClassTag: TypeInfo](cb: EmitCodeBuilder, r: Value[Region], array: Value[Array[A]], pt: PCanonicalArray): SIndexableValue = {
-    pt.constructFromElements(cb, r, cb.memoize(array.length()), true) { (cb, i) =>
-      IEmitCode.present(cb, primitive(pt.elementType.virtualType, cb.memoize(array(i))))
-    }
+  def rowToStateManager(k: Int, row: Row): ApproxCDFStateManager = {
+    val levels = row.getAs[IndexedSeq[Int]](0).toArray
+    val items = row.getAs[IndexedSeq[Double]](1).toArray
+    val counts = row.getAs[IndexedSeq[Int]](2).toArray
+    ApproxCDFStateManager.fromData(k, levels, items, counts)
   }
 
-  def indexedSeqToArrayInt(seq: IndexedSeq[Int]): Array[Int] = seq.toArray
-  def indexedSeqToArrayDouble(seq: IndexedSeq[Double]): Array[Double] = seq.toArray
+  def makeStateManager(cb: EmitCodeBuilder, r: Value[Region], k: Value[Int], state: SBaseStructValue): Value[ApproxCDFStateManager] = {
+    val row = svalueToJavaValue(cb, r, state)
+    cb.memoize(Code.invokeScalaObject2[Int, Row, ApproxCDFStateManager](
+      ApproxCDFFunctions.getClass, "rowToStateManager",
+      k, Code.checkcast[Row](row)))
+  }
+
+  def stateManagerToRow(state: ApproxCDFStateManager): Row = {
+    Row(state.levels.toFastSeq, state.items.toFastSeq, state.compactionCounts.toFastSeq)
+  }
+
+  def fromStateManager(cb: EmitCodeBuilder, r: Value[Region], state: Value[ApproxCDFStateManager]): SBaseStructValue = {
+    val row = cb.memoize(Code.invokeScalaObject1[ApproxCDFStateManager, Row](
+      ApproxCDFFunctions.getClass, "stateManagerToRow",
+      state))
+    unwrapReturn(cb, r, SBaseStructPointer(statePType), row).asBaseStruct
+  }
 
   def registerAll(): Unit = {
-    registerSCode1("approxCDFResult", stateType, resultPType.virtualType, (_, _) => resultSType) {
-      case (r, cb, rt, state: SBaseStructValue, errorID) =>
-        val levels = state.loadField(cb, "levels").get(cb).asIndexable
-        val items = state.loadField(cb, "items").get(cb).asIndexable
-        val counts = state.loadField(cb, "_compaction_counts").get(cb).asIndexable
-        val javaLevels = cb.memoize(Code.invokeScalaObject1[IndexedSeq[Int], Array[Int]](ApproxCDFFunctions.getClass, "indexedSeqToArrayInt",
-          Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, levels))))
-        val javaItems = cb.memoize(Code.invokeScalaObject1[IndexedSeq[Double], Array[Double]](ApproxCDFFunctions.getClass, "indexedSeqToArrayDouble",
-          Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r.region, items))))
-        val javaCounts = cb.memoize(Code.invokeScalaObject1[IndexedSeq[Int], Array[Int]](ApproxCDFFunctions.getClass, "indexedSeqToArrayInt",
-          Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, counts))))
-        val combiner = cb.memoize(Code.newInstance[ApproxCDFCombiner, Array[Int], Array[Double], Array[Int], Int, java.util.Random](
-          javaLevels,
-          javaItems,
-          javaCounts,
-          levels.loadLength() - 1,
-          Code.newInstance[java.util.Random]()))
-        val javaCDF = cb.memoize(combiner.invoke[(Array[Double], Array[Long])]("computeCDF"))
-        val javaValues = cb.memoize(javaCDF.invoke[Array[Double]]("_1"))
-        val javaRanks = cb.memoize(javaCDF.invoke[Array[Long]]("_2"))
-        val valuesPType = resultPType.field("values").typ.asInstanceOf[PCanonicalArray]
-        val ranksPType = resultPType.field("ranks").typ.asInstanceOf[PCanonicalArray]
-        val values = sIndexableFromArray(cb, r.region, javaValues, valuesPType)
-        val ranks = sIndexableFromArray(cb, r.region, javaRanks, ranksPType)
+    registerSCode3("approxCDFCombine", TInt32, stateType, stateType, stateType, (_, _, _, _) => SBaseStructPointer(statePType)) {
+      case (r, cb, rt, k: SInt32Value, left: SBaseStructValue, right: SBaseStructValue, errorID) =>
+        val leftState = makeStateManager(cb, r.region, k.value, left)
+        val rightState = makeStateManager(cb, r.region, k.value, right)
 
-        resultPType.constructFromFields(cb, r.region, FastSeq(EmitCode.present(cb.emb, values), EmitCode.present(cb.emb, ranks), EmitCode.present(cb.emb, counts)), false)
+        leftState.invoke[ApproxCDFStateManager, Unit]("combOp", rightState)
+
+        fromStateManager(cb, r.region, leftState)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
@@ -2,12 +2,12 @@ package is.hail.expr.ir.functions
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, TypeInfo, Value, toCodeObject, valueToCodeObject}
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.expr.ir.agg.{ApproxCDFCombiner, QuantilesAggregator}
-import is.hail.types.physical.{PCanonicalArray, PCanonicalStruct, PFloat64, PInt32, PInt64}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.stypes.concrete.SBaseStructPointer
 import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SIndexableValue, primitive}
-import is.hail.utils.FastIndexedSeq
+import is.hail.types.physical._
+import is.hail.utils.FastSeq
 
 import scala.reflect.ClassTag
 
@@ -20,9 +20,9 @@ object ApproxCDFFunctions extends RegistryFunctions {
       "_compaction_counts" -> PCanonicalArray(PInt32(true), required = true))
   val resultSType = SBaseStructPointer(resultPType)
 
-  def sIndexableFromJava[A: ClassTag: TypeInfo](cb: EmitCodeBuilder, r: Value[Region], array: Value[IndexedSeq[A]], pt: PCanonicalArray): SIndexableValue = {
-    pt.constructFromElements(cb, r, cb.memoize(array.invoke[Int]("length")), true) { (cb, i) =>
-      IEmitCode.present(cb, primitive(pt.elementType.virtualType, cb.memoize(array.invoke[Int, A]("apply", i))))
+  def sIndexableFromArray[A: ClassTag: TypeInfo](cb: EmitCodeBuilder, r: Value[Region], array: Value[Array[A]], pt: PCanonicalArray): SIndexableValue = {
+    pt.constructFromElements(cb, r, cb.memoize(array.length()), true) { (cb, i) =>
+      IEmitCode.present(cb, primitive(pt.elementType.virtualType, cb.memoize(array(i))))
     }
   }
 
@@ -37,8 +37,10 @@ object ApproxCDFFunctions extends RegistryFunctions {
         val counts = state.loadField(cb, "_compaction_counts").get(cb).asIndexable
         val javaLevels = cb.memoize(Code.invokeScalaObject1[IndexedSeq[Int], Array[Int]](ApproxCDFFunctions.getClass, "indexedSeqToArrayInt",
           Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, levels))))
-        val javaItems = cb.memoize(Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r.region, items)).invoke[Array[Double]]("toArray"))
-        val javaCounts = cb.memoize(Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, counts)).invoke[Array[Int]]("toArray"))
+        val javaItems = cb.memoize(Code.invokeScalaObject1[IndexedSeq[Double], Array[Double]](ApproxCDFFunctions.getClass, "indexedSeqToArrayDouble",
+          Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r.region, items))))
+        val javaCounts = cb.memoize(Code.invokeScalaObject1[IndexedSeq[Int], Array[Int]](ApproxCDFFunctions.getClass, "indexedSeqToArrayInt",
+          Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, counts))))
         val combiner = cb.memoize(Code.newInstance[ApproxCDFCombiner, Array[Int], Array[Double], Array[Int], Int, java.util.Random](
           javaLevels,
           javaItems,
@@ -46,14 +48,14 @@ object ApproxCDFFunctions extends RegistryFunctions {
           levels.loadLength() - 1,
           Code.newInstance[java.util.Random]()))
         val javaCDF = cb.memoize(combiner.invoke[(Array[Double], Array[Long])]("computeCDF"))
-        val javaValues = cb.memoize(Code.checkcast[IndexedSeq[Double]](javaCDF.invoke[Array[Double]]("_1")))
-        val javaRanks = cb.memoize(Code.checkcast[IndexedSeq[Long]](javaCDF.invoke[Array[Long]]("_2")))
+        val javaValues = cb.memoize(javaCDF.invoke[Array[Double]]("_1"))
+        val javaRanks = cb.memoize(javaCDF.invoke[Array[Long]]("_2"))
         val valuesPType = resultPType.field("values").typ.asInstanceOf[PCanonicalArray]
         val ranksPType = resultPType.field("ranks").typ.asInstanceOf[PCanonicalArray]
-        val values = sIndexableFromJava(cb, r.region, javaValues, valuesPType)
-        val ranks = sIndexableFromJava(cb, r.region, javaRanks, ranksPType)
+        val values = sIndexableFromArray(cb, r.region, javaValues, valuesPType)
+        val ranks = sIndexableFromArray(cb, r.region, javaRanks, ranksPType)
 
-        resultPType.constructFromFields(cb, r.region, FastIndexedSeq(EmitCode.present(cb.emb, values), EmitCode.present(cb.emb, ranks), EmitCode.present(cb.emb, counts)), false)
+        resultPType.constructFromFields(cb, r.region, FastSeq(EmitCode.present(cb.emb, values), EmitCode.present(cb.emb, ranks), EmitCode.present(cb.emb, counts)), false)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -237,7 +237,8 @@ object IRFunctionRegistry {
     UtilFunctions,
     ExperimentalFunctions,
     ReferenceGenomeFunctions,
-    BGENFunctions
+    BGENFunctions,
+    ApproxCDFFunctions
   ).foreach(_.registerAll())
 
   def dumpFunctions(): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -39,6 +39,10 @@ case object SInt64 extends SPrimitive {
   override def storageType(): PType = PInt64()
 }
 
+object SInt64Value {
+  def apply(value: Value[Long]): SInt64Value = new SInt64Value(value)
+}
+
 class SInt64Value(val value: Value[Long]) extends SPrimitiveValue {
   val pt: PInt64 = PInt64(false)
 

--- a/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
@@ -18,7 +18,7 @@ class ApproxCDFAggregatorSuite extends TestNGSuite {
     val levels: Array[Int] = Array(0,4,7,10)
     val items: Array[Double] = Array(7,2,6,4, 1,3,8, 0,5,9)
     val compactionCounts: Array[Int] = Array(0, 0, 0)
-    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, Double.NaN, rand)
+    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, rand)
     combiner.compactLevel(0)
     assert(items.view(1,10) sameElements Array(2,7, 1,3,6,8, 0,5,9))
   }
@@ -29,19 +29,8 @@ class ApproxCDFAggregatorSuite extends TestNGSuite {
     val levels: Array[Int] = Array(0,3,6,9)
     val items: Array[Double] = Array(7,2,4, 1,3,8, 0,5,9)
     val compactionCounts: Array[Int] = Array(0, 0, 0)
-    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, Double.NaN, rand)
+    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, rand)
     combiner.compactLevel(1)
     assert(items.view(1,9) sameElements Array(7,2,4, 1, 0,5,8,9))
-  }
-
-  @Test
-  def testCompactLevelKeep() {
-    val rand = new java.util.Random(1) // first Boolean is `true`
-    val levels: Array[Int] = Array(0,3,7,10)
-    val items: Array[Double] = Array(7,2,4, 1,3,6,8, 0,5,9)
-    val compactionCounts: Array[Int] = Array(0, 0, 0)
-    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, .01, rand)
-    combiner.compactLevel(1)
-    assert(items.view(1,10) sameElements Array(7,2,4, 1,8, 0,5,6,9))
   }
 }


### PR DESCRIPTION
This PR enables users to combine results from multiple independent approx_cdf aggregators, for instance to allow updating quantile summaries when adding new samples.

In more detail:
* Change the result type of the internal aggregator to be a lossless representation of the internal state.
* Add a registered function which expose the CombOp of the aggregator.
* Move the function which computes the old result type from the internal state to python.
* Add a flag `_raw` to `approx_cdf` which produces the internal result type, which supports combining; otherwise convert to the old result type.