### PR TITLE
[hailtop] Remove service_ns method in DeployConfig

### DIFF
--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -195,7 +195,7 @@ async def async_logout():
     deploy_config = get_deploy_config()
 
     # Logout any legacy auth tokens that might still exist
-    auth_ns = deploy_config.service_ns('auth')
+    auth_ns = deploy_config.default_namespace()
     tokens = get_tokens()
     if auth_ns in tokens:
         await logout_deprecated_token_credentials(deploy_config, tokens[auth_ns])

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -76,8 +76,8 @@ class Tokens(collections.abc.MutableMapping):
             return self._tokens[ns]
 
         deploy_config = get_deploy_config()
-        auth_ns = deploy_config.service_ns('auth')
-        ns_arg = '' if ns == auth_ns else f'-n {ns}'
+        default_ns = deploy_config.default_namespace()
+        ns_arg = '' if ns == default_ns else f'-n {ns}'
         raise NotLoggedInError(ns_arg)
 
     def __delitem__(self, key: str):

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -68,15 +68,12 @@ class DeployConfig:
     def location(self):
         return self._location
 
-    def service_ns(self, service):  # pylint: disable=unused-argument
-        return self._default_namespace
-
     def scheme(self, base_scheme='http'):
         # FIXME: should depend on ssl context
         return (base_scheme + 's') if self._location in ('external', 'k8s') else base_scheme
 
     def domain(self, service):
-        ns = self.service_ns(service)
+        ns = self._default_namespace
         if self._location == 'k8s':
             return f'{service}.{ns}'
         if self._location == 'gce':
@@ -89,7 +86,7 @@ class DeployConfig:
         return f'internal.{self._domain}'
 
     def base_path(self, service):
-        ns = self.service_ns(service)
+        ns = self._default_namespace
         if ns == 'default':
             return ''
         return f'/{ns}/{service}'
@@ -101,13 +98,12 @@ class DeployConfig:
         return f'{self.base_url(service, base_scheme=base_scheme)}{path}'
 
     def auth_session_cookie_name(self):
-        auth_ns = self.service_ns('auth')
-        if auth_ns == 'default':
+        if self._default_namespace == 'default':
             return 'session'
         return 'sesh'
 
     def external_url(self, service, path, base_scheme='http'):
-        ns = self.service_ns(service)
+        ns = self._default_namespace
         if ns == 'default':
             if service == 'www':
                 return f'{base_scheme}s://{self._domain}{path}'

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -55,10 +55,9 @@ def list():
     from hailtop.auth import get_tokens  # pylint: disable=import-outside-toplevel
 
     deploy_config = get_deploy_config()
-    auth_ns = deploy_config.service_ns('auth')
     tokens = get_tokens()
     for ns in tokens:
-        if ns == auth_ns:
+        if ns == deploy_config.default_namespace():
             s = '*'
         else:
             s = ' '

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -6,8 +6,7 @@ class Test(unittest.TestCase):
         deploy_config = DeployConfig('external', 'default', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'external')
-        self.assertEqual(deploy_config.service_ns('quam'), 'default')
-        self.assertEqual(deploy_config.service_ns('foo'), 'default')
+        self.assertEqual(deploy_config.default_namespace(), 'default')
         self.assertEqual(deploy_config.scheme(), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
@@ -21,8 +20,7 @@ class Test(unittest.TestCase):
         deploy_config = DeployConfig('external', 'bar', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'external')
-        self.assertEqual(deploy_config.service_ns('quam'), 'bar')
-        self.assertEqual(deploy_config.service_ns('foo'), 'bar')
+        self.assertEqual(deploy_config.default_namespace(), 'bar')
         self.assertEqual(deploy_config.scheme(), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'sesh')
 
@@ -35,8 +33,7 @@ class Test(unittest.TestCase):
         deploy_config = DeployConfig('k8s', 'default', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'k8s')
-        self.assertEqual(deploy_config.service_ns('quam'), 'default')
-        self.assertEqual(deploy_config.service_ns('foo'), 'default')
+        self.assertEqual(deploy_config.default_namespace(), 'default')
         self.assertEqual(deploy_config.scheme(), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
@@ -50,8 +47,7 @@ class Test(unittest.TestCase):
         deploy_config = DeployConfig('k8s', 'bar', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'k8s')
-        self.assertEqual(deploy_config.service_ns('quam'), 'bar')
-        self.assertEqual(deploy_config.service_ns('foo'), 'bar')
+        self.assertEqual(deploy_config.default_namespace(), 'bar')
         self.assertEqual(deploy_config.scheme(), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'sesh')
 
@@ -64,8 +60,7 @@ class Test(unittest.TestCase):
         deploy_config = DeployConfig('gce', 'default', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'gce')
-        self.assertEqual(deploy_config.service_ns('quam'), 'default')
-        self.assertEqual(deploy_config.service_ns('foo'), 'default')
+        self.assertEqual(deploy_config.default_namespace(), 'default')
         self.assertEqual(deploy_config.scheme(), 'http')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
@@ -79,8 +74,7 @@ class Test(unittest.TestCase):
         deploy_config = DeployConfig('gce', 'bar', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'gce')
-        self.assertEqual(deploy_config.service_ns('quam'), 'bar')
-        self.assertEqual(deploy_config.service_ns('foo'), 'bar')
+        self.assertEqual(deploy_config.default_namespace(), 'bar')
         self.assertEqual(deploy_config.scheme(), 'http')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'sesh')
 


### PR DESCRIPTION
The `DeployConfig.service_ns` doesn't really do anything, we always use the `_default_namespace`. This is maybe from an earlier age where some services might live in different namespaces.