### PR TITLE
[compiler] Add `Switch` to `IR`

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -28,6 +28,12 @@ object Children {
     case Consume(value) => FastSeq(value)
     case If(cond, cnsq, altr) =>
       Array(cond, cnsq, altr)
+    case s@Switch(x, default, cases) =>
+      val children = Array.ofDim[BaseIR](s.size)
+      children(0) = x
+      children(1) = default
+      for (i <- cases.indices) children(2 + i) = cases(i)
+      children
     case Let(name, value, body) =>
       Array(value, body)
     case RelationalLet(name, value, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -31,6 +31,9 @@ object Copy {
       case If(_, _, _) =>
         assert(newChildren.length == 3)
         If(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
+      case s: Switch =>
+        assert(s.size == newChildren.size)
+        Switch(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren.drop(2).asInstanceOf[IndexedSeq[IR]])
       case Let(name, _, _) =>
         assert(newChildren.length == 2)
         Let(name, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -183,6 +183,22 @@ final case class Consume(value: IR) extends IR
 
 final case class If(cond: IR, cnsq: IR, altr: IR) extends IR
 
+final case class Switch(x: IR, default: IR, cases: IndexedSeq[IR]) extends IR {
+  override def typ: Type =
+    default.typ
+
+  override protected lazy val childrenSeq: IndexedSeq[BaseIR] =
+    FastSeq(x, default) ++ cases
+
+  override lazy val size: Int =
+    2 + cases.length
+
+  protected override def copy(newChildren: IndexedSeq[BaseIR]): IR = {
+    val x +: default +: cases = newChildren
+    Switch(x.asInstanceOf[IR], default.asInstanceOf[IR], cases.map(_.asInstanceOf[IR]))
+  }
+}
+
 final case class AggLet(name: String, value: IR, body: IR, isScan: Boolean) extends IR
 final case class Let(name: String, value: IR, body: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -184,19 +184,8 @@ final case class Consume(value: IR) extends IR
 final case class If(cond: IR, cnsq: IR, altr: IR) extends IR
 
 final case class Switch(x: IR, default: IR, cases: IndexedSeq[IR]) extends IR {
-  override def typ: Type =
-    default.typ
-
-  override protected lazy val childrenSeq: IndexedSeq[BaseIR] =
-    FastSeq(x, default) ++ cases
-
   override lazy val size: Int =
     2 + cases.length
-
-  protected override def copy(newChildren: IndexedSeq[BaseIR]): IR = {
-    val x +: default +: cases = newChildren
-    Switch(x.asInstanceOf[IR], default.asInstanceOf[IR], cases.map(_.asInstanceOf[IR]))
-  }
 }
 
 final case class AggLet(name: String, value: IR, body: IR, isScan: Boolean) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InTailPosition.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InTailPosition.scala
@@ -4,6 +4,7 @@ object InTailPosition {
   def apply(x: IR, i: Int): Boolean = x match {
     case Let(_, _, _) => i == 1
     case If(_, _, _) => i != 0
+    case _: Switch => i != 0
     case TailLoop(_, params, _) => i == params.length
     case _ => false
   }

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -60,6 +60,8 @@ object InferType {
         assert(cond.typ == TBoolean)
         assert(cnsq.typ == altr.typ)
         cnsq.typ
+      case Switch(_, default, _) =>
+        default.typ
       case Let(name, value, body) =>
         body.typ
       case AggLet(name, value, body, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -123,8 +123,12 @@ object Interpret {
         else
           interpret(altr, env, args)
       case Switch(x_, default, cases) =>
-        val x = interpret(x_, env, args).asInstanceOf[Int]
-        interpret(if (x >= 0 && x < cases.length) cases(x) else default, env, args)
+        interpret(x_, env, args) match {
+          case x: Int =>
+            interpret(if (x >= 0 && x < cases.length) cases(x) else default, env, args)
+          case null =>
+            null
+        }
       case Let(name, value, body) =>
         val valueValue = interpret(value, env, args)
         interpret(body, env.bind(name, valueValue), args)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -122,6 +122,9 @@ object Interpret {
           interpret(cnsq, env, args)
         else
           interpret(altr, env, args)
+      case Switch(x_, default, cases) =>
+        val x = interpret(x_, env, args).asInstanceOf[Int]
+        interpret(if (x >= 0 && x < cases.length) cases(x) else default, env, args)
       case Let(name, value, body) =>
         val valueValue = interpret(value, env, args)
         interpret(body, env.bind(name, valueValue), args)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -78,19 +78,20 @@ sealed trait MatrixWriterComponents {
 }
 
 object MatrixNativeWriter {
-  def generateComponentFunctions(colsFieldName: String,
-                                 entriesFieldName: String,
-                                 colKey: IndexedSeq[String],
-                                 ctx: ExecuteContext,
-                                 tablestage: TableStage,
-                                 r: RTable,
-                                 path: String,
-                                 overwrite: Boolean = false,
-                                 stageLocally: Boolean = false,
-                                 codecSpecJSONStr: String = null,
-                                 partitions: String = null,
-                                 partitionsTypeStr: String = null
-                                ): MatrixWriterComponents = {
+  def generateComponentFunctions(
+    colsFieldName: String,
+    entriesFieldName: String,
+    colKey: IndexedSeq[String],
+    ctx: ExecuteContext,
+    tablestage: TableStage,
+    r: RTable,
+    path: String,
+    overwrite: Boolean = false,
+    stageLocally: Boolean = false,
+    codecSpecJSONStr: String = null,
+    partitions: String = null,
+    partitionsTypeStr: String = null
+  ): MatrixWriterComponents = {
     val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
     val tm = MatrixType.fromTableType(tablestage.tableType, colsFieldName, entriesFieldName, colKey)
     val rm = r.asMatrixType(colsFieldName, entriesFieldName)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -69,27 +69,28 @@ abstract class MatrixWriter {
     ctx: ExecuteContext, ts: TableStage, r: RTable): IR
 }
 
-case class MatrixWriterComponents(
-  stage: TableStage,
-  setup: IR,
-  writePartition: (IR, Ref) => IR,
-  finalizeWrite: (IR, IR) => IR
-)
+sealed trait MatrixWriterComponents {
+  def stage: TableStage
+  def setup: IR
+  def writePartitionType: Type
+  def writePartition(rows: IR, ctx: Ref): IR
+  def finalizeWrite(parts: IR, globals: IR): IR
+}
 
 object MatrixNativeWriter {
   def generateComponentFunctions(colsFieldName: String,
-    entriesFieldName: String,
-    colKey: IndexedSeq[String],
-    ctx: ExecuteContext,
-    tablestage: TableStage,
-    r: RTable,
-    path: String,
-    overwrite: Boolean = false,
-    stageLocally: Boolean = false,
-    codecSpecJSONStr: String = null,
-    partitions: String = null,
-    partitionsTypeStr: String = null
-  ): MatrixWriterComponents = {
+                                 entriesFieldName: String,
+                                 colKey: IndexedSeq[String],
+                                 ctx: ExecuteContext,
+                                 tablestage: TableStage,
+                                 r: RTable,
+                                 path: String,
+                                 overwrite: Boolean = false,
+                                 stageLocally: Boolean = false,
+                                 codecSpecJSONStr: String = null,
+                                 partitions: String = null,
+                                 partitionsTypeStr: String = null
+                                ): MatrixWriterComponents = {
     val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
     val tm = MatrixType.fromTableType(tablestage.tableType, colsFieldName, entriesFieldName, colKey)
     val rm = r.asMatrixType(colsFieldName, entriesFieldName)
@@ -123,7 +124,7 @@ object MatrixNativeWriter {
       s"$path/entries/rows/parts/",
       pKey.virtualType.fieldNames,
       Some(s"$path/index/" -> pKey),
-      if (stageLocally) Some(FileSystems.getDefault.getPath(ctx.localTmpdir, s"hail_stage_tmp_${ UUID.randomUUID }")) else None
+      if (stageLocally) Some(FileSystems.getDefault.getPath(ctx.localTmpdir, s"hail_stage_tmp_${UUID.randomUUID}")) else None
     )
 
     val globalTableWriter = TableSpecWriter(s"$path/globals", TableType(tm.globalType, FastSeq(), TStruct.empty), "rows", "globals", "../references", log = false)
@@ -131,78 +132,85 @@ object MatrixNativeWriter {
     val rowTableWriter = TableSpecWriter(s"$path/rows", tm.rowsTableType, "rows", "../globals/rows", "../references", log = false)
     val entriesTableWriter = TableSpecWriter(s"$path/entries", TableType(tm.entriesRVType, FastSeq(), tm.globalType), "rows", "../globals/rows", "../references", log = false)
 
-    val loweredMapContexts = lowered.mapContexts { oldCtx =>
-      val d = digitsNeeded(lowered.numPartitions)
-      val partFiles = Array.tabulate(lowered.numPartitions)(i => s"${ partFile(d, i) }-")
+    new MatrixWriterComponents {
 
-      zip2(oldCtx, ToStream(Literal(TArray(TString), partFiles.toFastSeq)), ArrayZipBehavior.AssertSameLength) { (ctxElt, pf) =>
-        MakeStruct(FastSeq("oldCtx" -> ctxElt, "writeCtx" -> pf))
-      }
-    }(GetField(_, "oldCtx"))
+      override val stage: TableStage =
+        lowered.mapContexts { oldCtx =>
+          val d = digitsNeeded(lowered.numPartitions)
+          val partFiles = Array.tabulate(lowered.numPartitions)(i => s"${partFile(d, i)}-")
 
-    val setup = Begin(FastSeq(
-      WriteMetadata(MakeStruct(FastSeq()), RelationalSetup(path, overwrite = overwrite, Some(tablestage.tableType))),
-      WriteMetadata(MakeStruct(FastSeq()), RelationalSetup(s"$path/globals", overwrite = false, None)),
-      WriteMetadata(MakeStruct(FastSeq()), RelationalSetup(s"$path/cols", overwrite = false, None)),
-      WriteMetadata(MakeStruct(FastSeq()), RelationalSetup(s"$path/rows", overwrite = false, None)),
-      WriteMetadata(MakeStruct(FastSeq()), RelationalSetup(s"$path/entries", overwrite = false, None))
-    ))
+          zip2(oldCtx, ToStream(Literal(TArray(TString), partFiles.toFastSeq)), ArrayZipBehavior.AssertSameLength) { (ctxElt, pf) =>
+            MakeStruct(FastSeq("oldCtx" -> ctxElt, "writeCtx" -> pf))
+          }
+        }(GetField(_, "oldCtx"))
 
-    val writePartition: ((IR, Ref) => IR) = (rows, ctx) => WritePartition(rows, GetField(ctx, "writeCtx") + UUID4(), rowWriter)
+      override val setup: IR =
+        Begin(FastSeq(
+          WriteMetadata(Void(), RelationalSetup(path, overwrite = overwrite, Some(tablestage.tableType))),
+          WriteMetadata(Void(), RelationalSetup(s"$path/globals", overwrite = false, None)),
+          WriteMetadata(Void(), RelationalSetup(s"$path/cols", overwrite = false, None)),
+          WriteMetadata(Void(), RelationalSetup(s"$path/rows", overwrite = false, None)),
+          WriteMetadata(Void(), RelationalSetup(s"$path/entries", overwrite = false, None))
+        ))
 
-    val finalizeWrite: ((IR, IR) => IR) = { (parts, globals) =>
-      // parts is array<struct> of partition results
-      val writeEmpty = WritePartition(MakeStream(FastSeq(makestruct()), TStream(TStruct.empty)), Str(partFile(1, 0)), emptyWriter)
-      val writeCols = WritePartition(ToStream(GetField(globals, colsFieldName)), Str(partFile(1, 0)), colWriter)
-      val writeGlobals = WritePartition(MakeStream(FastSeq(SelectFields(globals, tm.globalType.fieldNames)), TStream(tm.globalType)),
-        Str(partFile(1, 0)), globalWriter)
+      override def writePartitionType: Type =
+        rowWriter.returnType
+
+      override def writePartition(rows: IR, ctx: Ref): IR =
+        WritePartition(rows, GetField(ctx, "writeCtx") + UUID4(), rowWriter)
+
+      override def finalizeWrite(parts: IR, globals: IR): IR = {
+        // parts is array<struct> of partition results
+        val writeEmpty = WritePartition(MakeStream(FastSeq(makestruct()), TStream(TStruct.empty)), Str(partFile(1, 0)), emptyWriter)
+        val writeCols = WritePartition(ToStream(GetField(globals, colsFieldName)), Str(partFile(1, 0)), colWriter)
+        val writeGlobals = WritePartition(MakeStream(FastSeq(SelectFields(globals, tm.globalType.fieldNames)), TStream(tm.globalType)),
+          Str(partFile(1, 0)), globalWriter)
 
 
-      val matrixWriter = MatrixSpecWriter(path, tm, "rows/rows", "globals/rows", "cols/rows", "entries/rows", "references", log = true)
+        val matrixWriter = MatrixSpecWriter(path, tm, "rows/rows", "globals/rows", "cols/rows", "entries/rows", "references", log = true)
 
-      val rowsIndexSpec = IndexSpec.defaultAnnotation("../../index", tcoerce[PStruct](pKey))
-      val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", tcoerce[PStruct](pKey), withOffsetField = true)
+        val rowsIndexSpec = IndexSpec.defaultAnnotation("../../index", tcoerce[PStruct](pKey))
+        val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", tcoerce[PStruct](pKey), withOffsetField = true)
 
-      bindIR(writeCols) { colInfo =>
-        bindIR(parts) { partInfo =>
-          Begin(FastSeq(
-            WriteMetadata(MakeArray(GetField(writeEmpty, "filePath")),
-              RVDSpecWriter(s"$path/globals/globals", RVDSpecMaker(emptySpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
-            WriteMetadata(MakeArray(GetField(writeGlobals, "filePath")),
-              RVDSpecWriter(s"$path/globals/rows", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
-            WriteMetadata(MakeArray(MakeStruct(FastSeq("partitionCounts" -> I64(1), "distinctlyKeyed" -> True(), "firstKey" -> MakeStruct(FastSeq()), "lastKey" -> MakeStruct(FastSeq())))), globalTableWriter),
-            WriteMetadata(MakeArray(GetField(colInfo, "filePath")),
-              RVDSpecWriter(s"$path/cols/rows", RVDSpecMaker(colSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
-            WriteMetadata(MakeArray(SelectFields(colInfo, IndexedSeq("partitionCounts", "distinctlyKeyed", "firstKey", "lastKey"))), colTableWriter),
-            bindIR(ToArray(mapIR(ToStream(partInfo)) { fc => GetField(fc, "filePath") })) { files =>
-              Begin(FastSeq(
-                WriteMetadata(files, RVDSpecWriter(s"$path/rows/rows", RVDSpecMaker(rowSpec, lowered.partitioner, rowsIndexSpec))),
-                WriteMetadata(files, RVDSpecWriter(s"$path/entries/rows", RVDSpecMaker(entrySpec, RVDPartitioner.unkeyed(ctx.stateManager, lowered.numPartitions), entriesIndexSpec)))))
-            },
-            bindIR(ToArray(mapIR(ToStream(partInfo)) { fc => SelectFields(fc, FastSeq("partitionCounts", "distinctlyKeyed", "firstKey", "lastKey")) })) { countsAndKeyInfo =>
-              Begin(FastSeq(
-                WriteMetadata(countsAndKeyInfo, rowTableWriter),
-                WriteMetadata(
-                  ToArray(mapIR(ToStream(countsAndKeyInfo)) { countAndKeyInfo =>
-                    InsertFields(SelectFields(countAndKeyInfo, IndexedSeq("partitionCounts", "distinctlyKeyed")), IndexedSeq("firstKey" -> MakeStruct(FastSeq()), "lastKey" -> MakeStruct(FastSeq())))
-                  }),
-                  entriesTableWriter),
-                WriteMetadata(
-                  makestruct(
-                    "cols" -> GetField(colInfo, "partitionCounts"),
-                    "rows" -> ToArray(mapIR(ToStream(countsAndKeyInfo)) { countAndKey => GetField(countAndKey, "partitionCounts") })),
-                  matrixWriter)))
-            },
-            WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(path)),
-            WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/globals")),
-            WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/cols")),
-            WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/rows")),
-            WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/entries"))))
+        bindIR(writeCols) { colInfo =>
+          bindIR(parts) { partInfo =>
+            Begin(FastSeq(
+              WriteMetadata(MakeArray(GetField(writeEmpty, "filePath")),
+                RVDSpecWriter(s"$path/globals/globals", RVDSpecMaker(emptySpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
+              WriteMetadata(MakeArray(GetField(writeGlobals, "filePath")),
+                RVDSpecWriter(s"$path/globals/rows", RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
+              WriteMetadata(MakeArray(MakeStruct(FastSeq("partitionCounts" -> I64(1), "distinctlyKeyed" -> True(), "firstKey" -> MakeStruct(FastSeq()), "lastKey" -> MakeStruct(FastSeq())))), globalTableWriter),
+              WriteMetadata(MakeArray(GetField(colInfo, "filePath")),
+                RVDSpecWriter(s"$path/cols/rows", RVDSpecMaker(colSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)))),
+              WriteMetadata(MakeArray(SelectFields(colInfo, IndexedSeq("partitionCounts", "distinctlyKeyed", "firstKey", "lastKey"))), colTableWriter),
+              bindIR(ToArray(mapIR(ToStream(partInfo)) { fc => GetField(fc, "filePath") })) { files =>
+                Begin(FastSeq(
+                  WriteMetadata(files, RVDSpecWriter(s"$path/rows/rows", RVDSpecMaker(rowSpec, lowered.partitioner, rowsIndexSpec))),
+                  WriteMetadata(files, RVDSpecWriter(s"$path/entries/rows", RVDSpecMaker(entrySpec, RVDPartitioner.unkeyed(ctx.stateManager, lowered.numPartitions), entriesIndexSpec)))))
+              },
+              bindIR(ToArray(mapIR(ToStream(partInfo)) { fc => SelectFields(fc, FastSeq("partitionCounts", "distinctlyKeyed", "firstKey", "lastKey")) })) { countsAndKeyInfo =>
+                Begin(FastSeq(
+                  WriteMetadata(countsAndKeyInfo, rowTableWriter),
+                  WriteMetadata(
+                    ToArray(mapIR(ToStream(countsAndKeyInfo)) { countAndKeyInfo =>
+                      InsertFields(SelectFields(countAndKeyInfo, IndexedSeq("partitionCounts", "distinctlyKeyed")), IndexedSeq("firstKey" -> MakeStruct(FastSeq()), "lastKey" -> MakeStruct(FastSeq())))
+                    }),
+                    entriesTableWriter),
+                  WriteMetadata(
+                    makestruct(
+                      "cols" -> GetField(colInfo, "partitionCounts"),
+                      "rows" -> ToArray(mapIR(ToStream(countsAndKeyInfo)) { countAndKey => GetField(countAndKey, "partitionCounts") })),
+                    matrixWriter)))
+              },
+              WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(path)),
+              WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/globals")),
+              WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/cols")),
+              WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/rows")),
+              WriteMetadata(MakeStruct(FastSeq()), RelationalCommit(s"$path/entries"))))
+          }
         }
       }
     }
-
-    MatrixWriterComponents(loweredMapContexts, setup, writePartition, finalizeWrite)
   }
 }
 
@@ -1587,7 +1595,8 @@ case class MatrixNativeMultiWriter(
 ) {
   val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
 
-  def apply(ctx: ExecuteContext, mvs: IndexedSeq[MatrixValue]): Unit = MatrixValue.writeMultiple(ctx, mvs, paths, overwrite, stageLocally, bufferSpec)
+  def apply(ctx: ExecuteContext, mvs: IndexedSeq[MatrixValue]): Unit =
+    MatrixValue.writeMultiple(ctx, mvs, paths, overwrite, stageLocally, bufferSpec)
 
   def lower(ctx: ExecuteContext, tables: IndexedSeq[(String, String, IndexedSeq[String], TableStage, RTable)]): IR = {
     val components = paths.zip(tables).map { case (path, (colsFieldName, entriesFieldName, colKey, ts, rt)) =>
@@ -1596,57 +1605,59 @@ case class MatrixNativeMultiWriter(
     }
 
     require(tables.map(_._4.tableType.keyType).distinct.length == 1)
-    val unionTuple = TTuple(components.map(c => TIterable.elementType(c.stage.contexts.typ)): _*)
-    val contextUnionType = TStruct(
-      "tag" -> TInt32,
-      "options" -> unionTuple)
+    val unionType = TTuple(components.map(c => TIterable.elementType(c.stage.contexts.typ)): _*)
 
-    def contextToTaggedUnion(ctx: IR, idx: Int): IR = {
-      MakeStruct(FastSeq(("tag", I32(idx)),
-        ("options", MakeTuple(
-          (0 until components.length)
-            .map { i => (i, if (i == idx) ctx else NA(unionTuple.types(i))) }))))
-    }
+    val contextUnionType = TStruct("matrixId" -> TInt32, "options" -> unionType)
 
-    val concatenatedContexts = flatMapIR(ToStream(MakeArray(components.zipWithIndex.map { case (c, matrixIdx) =>
-      ToArray(mapIR(c.stage.contexts)(contextToTaggedUnion(_, matrixIdx)))
-    }, TArray(TArray(contextUnionType)))))(ToStream(_))
+    val emptyUnionIRs: IndexedSeq[(Int, IR)] =
+      IndexedSeq.tabulate(unionType.size)(i => i -> NA(unionType.types(i)))
 
-    val partitionCounts = components.map(_.stage.numPartitions)
-    val partitionCountScan = partitionCounts.scanLeft(0)(_ + _)
+    val concatenatedContexts =
+      flatten(
+        MakeArray(
+          components.zipWithIndex.map { case (c, matrixId) =>
+            ToArray(mapIR(c.stage.contexts) { ctx =>
+              MakeStruct(FastSeq(
+                "matrixId" -> I32(matrixId),
+                "options" -> MakeTuple(emptyUnionIRs.updated(matrixId, matrixId -> ctx))
+              ))
+            })
+          },
+          TArray(TArray(contextUnionType))
+        )
+      )
 
-    val allBroadcastIdxSeq = components.flatMap(_.stage.broadcastVals)
-    val allBroadcasts = MakeStruct(allBroadcastIdxSeq)
-
+    val allBroadcasts = MakeStruct(components.flatMap(_.stage.broadcastVals))
 
     Begin(FastSeq(
       Begin(components.map(_.setup)),
       TableStage.wrapInBindings(
-        bindIR(cdaIR(concatenatedContexts, allBroadcasts, "matrix_multi_writer") { case (ctx, bcVals) =>
-          bindIR(GetField(ctx, "tag")) { tag =>
-            bindIR(GetField(ctx, "options")) { options =>
-              val writeEach = components.zipWithIndex.map { case (c, idx) =>
-                (idx, bindIR(GetTupleElement(options, idx)) { ctxRef =>
-                  c.writePartition(
-                    c.stage.partition(ctxRef), ctxRef)
-                })
-              }
+        bindIR(cdaIR(concatenatedContexts, allBroadcasts, "matrix_multi_writer") { case (ctx, globals) =>
+          bindIR(GetField(ctx, "options")) { options =>
+            Switch(GetField(ctx, "matrixId"),
+              default = Die("MatrixId exceeds matrix count", components.head.writePartitionType),
+              cases = components.zipWithIndex.map { case (component, i) =>
+                val writePartition =
+                  bindIR(GetTupleElement(options, i)) { ctxRef =>
+                    component.writePartition(component.stage.partition(ctxRef), ctxRef)
+                  }
 
-              val partitionIR = writeEach.init.foldRight[IR](writeEach.last._2) { case ((i, writer), acc) =>
-                If(tag ceq i, writer, acc)
+                component.stage.broadcastVals.foldRight(writePartition) { case ((name, _), ir) =>
+                  Let(name, GetField(globals, name), ir)
+                }
               }
-
-              allBroadcastIdxSeq.foldLeft(partitionIR) { case (accum, (name, _)) =>
-                Let(name, GetField(bcVals, name), accum)
-              }
-
-            }
+            )
           }
         }) { cdaResult =>
+          val partitionCountScan =
+            components.map(_.stage.numPartitions).scanLeft(0)(_ + _)
+
           Begin(components.zipWithIndex.map { case (c, i) =>
             c.finalizeWrite(ArraySlice(cdaResult, partitionCountScan(i), Some(partitionCountScan(i + 1))), c.stage.globals)
           })
-        }, components.flatMap(_.stage.letBindings))
+        },
+        components.flatMap(_.stage.letBindings)
+      )
     ))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -18,12 +18,11 @@ import org.apache.spark.sql.Row
 import org.json4s.jackson.{JsonMethods, Serialization}
 import org.json4s.{Formats, JObject}
 
+import java.util.Base64
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Positional
-
-import java.util.Base64
 
 abstract class Token extends Positional {
   def value: Any
@@ -872,6 +871,12 @@ object IRParser {
           consq <- ir_value_expr(env)(it)
           altr <- ir_value_expr(env)(it)
         } yield If(cond, consq, altr)
+      case "Switch" =>
+        for {
+          x <- ir_value_expr(env)(it)
+          default <- ir_value_expr(env)(it)
+          cases <- ir_value_children(env)(it)
+        } yield Switch(x, default, cases)
       case "Let" =>
         val name = identifier(it)
         for {

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -492,6 +492,8 @@ class Pretty(width: Int, ribbonWidth: Int, elideLiterals: Boolean, maxLen: Int, 
     def blockArgs(ir: BaseIR, i: Int): Option[IndexedSeq[(String, String)]] = ir match {
       case If(_, _, _) =>
         if (i > 0) Some(FastSeq()) else None
+      case _: Switch =>
+        if (i > 0) Some(FastSeq()) else None
       case TailLoop(name, args, body) => if (i == args.length)
         Some(args.map { case (name, ir) => name -> "loopvar" } :+
           name -> "loop") else None

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1018,11 +1018,12 @@ object PruneDeadFields {
           memoizeValueIR(ctx, alt, requestedType, memo)
         )
       case Switch(x, default, cases) =>
-        unifyEnvsSeq(
-          FastSeq(
-            memoizeValueIR(ctx, x, x.typ, memo),
-            memoizeValueIR(ctx, default, requestedType, memo)
-          ) ++ cases.map(case_ => memoizeValueIR(ctx, case_, requestedType, memo))
+        unifyEnvs(
+          memoizeValueIR(ctx, x, x.typ, memo),
+          memoizeValueIR(ctx, default, requestedType, memo),
+          unifyEnvsSeq(cases.map { case_ =>
+            memoizeValueIR(ctx, case_, requestedType, memo)
+          })
         )
       case Coalesce(values) => unifyEnvsSeq(values.map(memoizeValueIR(ctx, _, requestedType, memo)))
       case Consume(value) => memoizeValueIR(ctx, value, value.typ, memo)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1017,6 +1017,13 @@ object PruneDeadFields {
           memoizeValueIR(ctx, cnsq, requestedType, memo),
           memoizeValueIR(ctx, alt, requestedType, memo)
         )
+      case Switch(x, default, cases) =>
+        unifyEnvsSeq(
+          FastSeq(
+            memoizeValueIR(ctx, x, x.typ, memo),
+            memoizeValueIR(ctx, default, requestedType, memo)
+          ) ++ cases.map(case_ => memoizeValueIR(ctx, case_, requestedType, memo))
+        )
       case Coalesce(values) => unifyEnvsSeq(values.map(memoizeValueIR(ctx, _, requestedType, memo)))
       case Consume(value) => memoizeValueIR(ctx, value, value.typ, memo)
       case Let(name, value, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -533,7 +533,10 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.union(lookup(cond).required)
         requiredness.unionFrom(lookup(cnsq))
         requiredness.unionFrom(lookup(altr))
-
+      case Switch(x, default, cases) =>
+        requiredness.union(lookup(x).required)
+        requiredness.unionFrom(lookup(default))
+        requiredness.unionFrom(cases.map(lookup))
       case AggLet(name, value, body, isScan) =>
         requiredness.unionFrom(lookup(body))
       case Let(name, value, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -267,7 +267,7 @@ object Simplify {
 
     case Switch(I32(x), default, cases) =>
       if (x >= 0 && x < cases.length) cases(x) else default
-    case Switch(_, default, IndexedSeq()) =>
+    case Switch(x, default, IndexedSeq()) if isDefinitelyDefined(x) =>
       default
 
     case Cast(x, t) if x.typ == t => x

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -265,6 +265,9 @@ object Simplify {
 
     case If(c1, cnsq1, If(c2, _, altr2)) if c1 == c2 => If(c1, cnsq1, altr2)
 
+    case Switch(I32(x), default, cases) =>
+      if (x >= 0 && x < cases.length) cases(x) else default
+
     case Cast(x, t) if x.typ == t => x
     case Cast(Cast(x, _), t) if x.typ == t =>x
 

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -267,6 +267,8 @@ object Simplify {
 
     case Switch(I32(x), default, cases) =>
       if (x >= 0 && x < cases.length) cases(x) else default
+    case Switch(_, default, IndexedSeq()) =>
+      default
 
     case Cast(x, t) if x.typ == t => x
     case Cast(Cast(x, _), t) if x.typ == t =>x

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -408,9 +408,10 @@ object RelationalWriter {
 case class RelationalSetup(path: String, overwrite: Boolean, refs: Option[TableType]) extends MetadataWriter {
   lazy val maybeRefs = refs.map(typ => "references" -> (ReferenceGenome.getReferences(typ.rowType) ++ ReferenceGenome.getReferences(typ.globalType)))
 
-  def annotationType: Type = TStruct()
+  override def annotationType: Type =
+    TVoid
 
-  def writeMetadata(
+  override def writeMetadata(
     writeAnnotations: => IEmitCode,
     cb: EmitCodeBuilder,
     region: Value[Region]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -408,12 +408,9 @@ object RelationalWriter {
 case class RelationalSetup(path: String, overwrite: Boolean, refs: Option[TableType]) extends MetadataWriter {
   lazy val maybeRefs = refs.map(typ => "references" -> (ReferenceGenome.getReferences(typ.rowType) ++ ReferenceGenome.getReferences(typ.globalType)))
 
-  def annotationType: Type = TStruct()
+  def annotationType: Type = TVoid
 
-  def writeMetadata(
-    writeAnnotations: => IEmitCode,
-    cb: EmitCodeBuilder,
-    region: Value[Region]): Unit = {
+  def writeMetadata(ignored: => IEmitCode, cb: EmitCodeBuilder, region: Value[Region]): Unit = {
     if (overwrite)
       cb += cb.emb.getFS.invoke[String, Boolean, Unit]("delete", path, true)
     else

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -408,10 +408,9 @@ object RelationalWriter {
 case class RelationalSetup(path: String, overwrite: Boolean, refs: Option[TableType]) extends MetadataWriter {
   lazy val maybeRefs = refs.map(typ => "references" -> (ReferenceGenome.getReferences(typ.rowType) ++ ReferenceGenome.getReferences(typ.globalType)))
 
-  override def annotationType: Type =
-    TVoid
+  def annotationType: Type = TStruct()
 
-  override def writeMetadata(
+  def writeMetadata(
     writeAnnotations: => IEmitCode,
     cb: EmitCodeBuilder,
     region: Value[Region]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -148,8 +148,9 @@ object TypeCheck {
         }
       case x@MakeArray(args, typ) =>
         assert(typ != null)
-        args.map(_.typ).zipWithIndex.foreach { case (x, i) => assert(x == typ.elementType,
-          s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
+        args.map(_.typ).zipWithIndex.foreach { case (x, i) =>
+          assert(x == typ.elementType && x.isRealizable,
+            s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
         }
       case x@MakeStream(args, typ, _) =>
         assert(typ != null)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -94,6 +94,9 @@ object TypeCheck {
           case tstream: TStream => assert(tstream.elementType.isRealizable)
           case _ =>
         }
+      case Switch(x, default, cases) =>
+        assert(x.typ == TInt32)
+        assert(cases.forall(_.typ == default.typ))
       case x@Let(_, _, body) =>
         assert(x.typ == body.typ)
       case x@AggLet(_, _, body, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/add-ir-checklist.txt
+++ b/hail/src/main/scala/is/hail/expr/ir/add-ir-checklist.txt
@@ -41,6 +41,8 @@ This is the list of things you need to do to add a new IR node.
 
  - If it binds a variable, add support to Bindings
 
+ - [Optional] Add a case in ExtractIntervalFilters
+
 * MatrixIR
 
  - Define copy, partitionCounts, columnCount, typ, and execute

--- a/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -344,6 +344,7 @@ case object SemanticHash extends Logging {
            _: StreamRange |
            _: StreamTake |
            _: StreamTakeWhile |
+           _: Switch |
            _: TableGetGlobals |
            _: TableAggregate |
            _: TableAggregateByKey |

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
@@ -79,7 +79,7 @@ object CanLowerEfficiently {
         case x: BlockMatrixCollect => fail(s"BlockMatrixIR lowering not yet efficient/scalable")
         case x: BlockMatrixToValueApply => fail(s"BlockMatrixIR lowering not yet efficient/scalable")
 
-        case mmr: MatrixMultiWrite => fail(s"no lowering for MatrixMultiWrite")
+        case _: MatrixMultiWrite =>
 
         case TableCount(_) =>
         case TableToValueApply(_, ForceCountTable()) =>

--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -12,7 +12,6 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
 
   val ref1 = Ref("foo", TStruct("w" -> TInt32, "x" -> TInt32, "y" -> TBoolean))
   val unknownBool = GetField(ref1, "y")
-  val k0 = GetField(ref1, "w")
   val k1 = GetField(ref1, "x")
   val k1Full = SelectFields(ref1, FastSeq("x"))
   val ref1Key = FastSeq("x")
@@ -721,19 +720,41 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
       val testRows = FastSeq(
         Row(0, 0, true),
         Row(0, 5, true),
-        Row(0, 7, true),
-        Row(0, 10, true),
-        Row(0, 15, true),
-        Row(0, null, true))
+        Row(0, -5, true),
+        Row(0, null, true),
+        Row(1, 0, true),
+        Row(1, 5, true),
+        Row(1, -5, true),
+        Row(1, null, true),
+        Row(null, null, true),
+      )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals, trueResidual, falseResidual, naResidual)
     }
 
-    check(Switch(k1, False(), FastSeq(True(), False())),
-      FastSeq(Interval(Row(-5), Row(5), false, false)),
-      FastSeq(
-        Interval(Row(), Row(-5), true, true),
-        Interval(Row(5), Row(null), true, false)),
-      FastSeq(Interval(Row(null), Row(), true, true)))
+    check(
+      Switch(I32(0), gt(k1, I32(-5)), FastSeq(lt(k1, I32(5)))),
+      FastSeq(Interval(Row(), Row(5), true, false)),
+      FastSeq(Interval(Row(5), Row(null), true, false)),
+      FastSeq(Interval(Row(null), Row(), true, true))
+    )
+
+    check(
+      Switch(I32(-1), gt(k1, I32(-5)), FastSeq(lt(k1, I32(5)))),
+      FastSeq(Interval(Row(-5), Row(null), false, false)),
+      FastSeq(Interval(Row(), Row(-5), true, true)),
+      FastSeq(Interval(Row(null), Row(), true, true))
+    )
+
+    val filter = Switch(GetField(ref1, "w"), gt(k1, I32(-5)), FastSeq(lt(k1, I32(5))))
+    check(
+      filter,
+      FastSeq(Interval(Row(), Row(null), true, false)),
+      FastSeq(Interval(Row(), Row(-5), true, true), Interval(Row(5), Row(null), true, false)),
+      FastSeq(Interval(Row(), Row(), true, true)),
+      trueResidual = filter,
+      falseResidual = ApplyUnaryPrimOp(Bang, filter),
+      naResidual = IsNA(filter)
+    )
   }
 
   @Test def testIntegration() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -576,6 +576,22 @@ class IRSuite extends HailSuite {
     assertEvalsTo(If(True(), NA(TInt32), I32(7)), null)
   }
 
+  @DataProvider(name="SwitchEval")
+  def switchEvalRules: Array[Array[Any]] =
+    Array(
+      Array(I32(-1), I32(Int.MinValue), FastSeq(0, Int.MaxValue).map(I32), Int.MinValue),
+      Array(I32(0), I32(Int.MinValue), FastSeq(0, Int.MaxValue).map(I32), 0),
+      Array(I32(1), I32(Int.MinValue), FastSeq(0, Int.MaxValue).map(I32), Int.MaxValue),
+      Array(I32(2), I32(Int.MinValue), FastSeq(0, Int.MaxValue).map(I32), Int.MinValue),
+      Array(NA(TInt32), I32(Int.MinValue), FastSeq(0, Int.MaxValue).map(I32), null),
+      Array(I32(-1), NA(TInt32), FastSeq(0, Int.MaxValue).map(I32), null),
+      Array(I32(0), NA(TInt32), FastSeq(NA(TInt32), I32(0)), null),
+    )
+
+  @Test(dataProvider = "SwitchEval")
+  def testSwitch(x: IR, default: IR, cases: IndexedSeq[IR], result: Any): Unit =
+    assertEvalsTo(Switch(x, default, cases), result)
+
   @Test def testLet() {
     assertEvalsTo(Let("v", I32(5), Ref("v", TInt32)), 5)
     assertEvalsTo(Let("v", NA(TInt32), Ref("v", TInt32)), null)
@@ -2730,6 +2746,7 @@ class IRSuite extends HailSuite {
       CastRename(NA(TStruct("a" -> TInt32)), TStruct("b" -> TInt32)),
       NA(TInt32), IsNA(i),
       If(b, i, j),
+      Switch(i, j, 0 until 7 map I32),
       Coalesce(FastSeq(i, I32(1))),
       Let("v", i, v),
       AggLet("v", i, collect(v), false) -> (_.createAgg),

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -576,6 +576,13 @@ class PruneSuite extends HailSuite {
       Array(TBoolean, justA, justA))
   }
 
+  @Test def testSwitchMemo(): Unit =
+    checkMemo(
+      Switch(I32(0), ref, FastSeq(ref)),
+      justA,
+      Array(TInt32, justA, justA)
+    )
+
   @Test def testCoalesceMemo() {
     checkMemo(Coalesce(FastSeq(ref, ref)),
       justA,
@@ -1158,6 +1165,14 @@ class PruneSuite extends HailSuite {
         ir.cnsq.typ == subsetTS("b") && ir.altr.typ == subsetTS("b")
       })
   }
+
+  @Test def testSwitchRebuild(): Unit =
+    checkRebuild[IR](Switch(I32(0), NA(ts), FastSeq(NA(ts))), subsetTS("b"), {
+      case (_, Switch(_, default, cases)) =>
+        default.typ == subsetTS("b") &&
+          cases(0).typ == subsetTS("b")
+      }
+    )
 
   @Test def testCoalesceRebuild() {
     checkRebuild(Coalesce(FastSeq(NA(ts), NA(ts))), subsetTS("b"),

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -213,6 +213,15 @@ class RequirednessSuite extends HailSuite {
             array(optional, required),
             int(optional)), tnestedarray))))
     nodes += Array(loop, PCanonicalArray(PCanonicalArray(PInt32(optional), optional), optional))
+    // Switch
+    for ((x, d, cs, r) <- Array(
+      (required, required, FastSeq(required), required),
+      (optional, required, FastSeq(required), optional),
+      (required, optional, FastSeq(required), optional),
+      (required, required, FastSeq(optional), optional),
+    )) {
+      nodes += Array(Switch(int(x), int(d), cs.map(int)), PInt32(r))
+    }
     // ArrayZip
     val s1 = Ref(genUID(), TInt32)
     val s2 = Ref(genUID(), TInt32)

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -471,6 +471,21 @@ class SimplifySuite extends HailSuite {
   @Test(dataProvider = "blockMatrixRules")
   def testBlockMatrixSimplification(input: BlockMatrixIR, expected: BlockMatrixIR): Unit =
     assert(Simplify(ctx, input) == expected)
+
+  @DataProvider(name = "SwitchRules")
+  def switchRules: Array[Array[Any]] =
+    Array(
+      Array(I32(-1), I32(-1), IndexedSeq.tabulate(5)(I32), I32(-1)),
+      Array(I32(1), I32(-1), IndexedSeq.tabulate(5)(I32), I32(1)),
+      Array(ref(TInt32), I32(-1), IndexedSeq.tabulate(5)(I32), Switch(ref(TInt32), I32(-1), IndexedSeq.tabulate(5)(I32))),
+      Array(I32(256), I32(-1), IndexedSeq.empty[IR], I32(-1)),
+      Array(ref(TInt32), I32(-1), IndexedSeq.empty[IR], Switch(ref(TInt32), I32(-1), IndexedSeq.empty[IR])), // missingness
+    )
+
+  @Test(dataProvider = "SwitchRules")
+  def testTestSwitchSimplification(x: IR, default: IR, cases: IndexedSeq[IR], expected: Any): Unit =
+    assert(Simplify(ctx, Switch(x, default, cases)) == expected)
+
 }
 
 


### PR DESCRIPTION
We have no high-level IR analogue to `CodeBuilderLike.switch`. Such a node is useful for flattening the IR in deeply-nested `If` nodes, predicated on integer equality.
This partially addresses the stack-overflow error on the `matrix_muluti_write_nothing` benchmark, which currently has a stack-overflow error when computing the type of the CDA.