### PR TITLE
[ci] Remove dead code from CI configs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -37,7 +37,6 @@ steps:
   - kind: createNamespace
     name: default_ns
     namespaceName: default
-    public: true
     secrets:
       - name: auth-oauth2-client-secret
       - name: registry-push-credentials

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -70,26 +70,11 @@ spec:
                secretKeyRef:
                  name: ci-config
                  key: storage_uri
-           - name: HAIL_DOCKER_PREFIX
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: docker_prefix
-           - name: HAIL_DOCKER_ROOT_IMAGE
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: docker_root_image
            - name: HAIL_DOMAIN
              valueFrom:
                secretKeyRef:
                  name: global-config
                  key: domain
-           - name: KUBERNETES_SERVER_URL
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: kubernetes_server_url
            - name: CLOUD
              valueFrom:
                secretKeyRef:

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -2,7 +2,6 @@ steps:
   - kind: createNamespace
     name: default_ns
     namespaceName: default
-    public: true
     secrets:
       - name: doesnotexist
         optional: true


### PR DESCRIPTION
- `CreateNamespaceStep.public` was entirely unused
- `adminServiceAccount` is not used in `build.yaml` so `CreateNamespaceStep.admin_service_account` is always `None` meaning it has no effect.
- The three environment variables that I deleted from the `deployment.yaml` are as far as I can tell entirely unused (they are now grabbed from the global config)