### PR TITLE
[query] Use apache commons lang3 instead of lang

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -5,7 +5,7 @@ import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.expr.ir.Literal
 import is.hail.types.virtual._
 import is.hail.utils._
-import org.apache.commons.lang.builder.HashCodeBuilder
+import org.apache.commons.lang3.builder.HashCodeBuilder
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.Row
 import org.apache.spark.{Partitioner, SparkContext}

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -464,7 +464,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
   @transient lazy val broadcast: BroadcastValue[ReferenceGenome] = HailContext.backend.broadcast(this)
 
   override def hashCode: Int = {
-    import org.apache.commons.lang.builder.HashCodeBuilder
+    import org.apache.commons.lang3.builder.HashCodeBuilder
 
     val b = new HashCodeBuilder()
       .append(name)


### PR DESCRIPTION
`org.apache.commons.lang` is from the `commons-lang` library, but in `build.gradle` we explicitly depend on `commons-lang3` which puts everything under the `lang3` package. We must be picking up `commons-lang` as some transitive dependency but we no longer get it in Spark 3.4. Regardless, better to use what we explicitly depend on.