### PR TITLE
[batch] Prevent user jobs from causing the worker to be killed

### DIFF
--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -293,6 +293,8 @@ docker run \
 --security-opt apparmor:unconfined \
 --network host \
 --cgroupns host \
+--oom-score-adj 0 \
+--oom-kill-disable \
 $BATCH_WORKER_IMAGE \
 python3 -u -m batch.worker.worker >worker.log 2>&1
 

--- a/batch/batch/cloud/azure/instance_config.py
+++ b/batch/batch/cloud/azure/instance_config.py
@@ -4,7 +4,7 @@ from hailtop.utils import filter_none
 
 from ...driver.billing_manager import ProductVersions
 from ...instance_config import InstanceConfig
-from .resource_utils import azure_machine_type_to_worker_type_and_cores
+from .resource_utils import azure_machine_type_to_worker_type_and_cores, azure_worker_memory_per_core_mib
 from .resources import (
     AzureDynamicSizedDiskResource,
     AzureIPFeeResource,
@@ -79,6 +79,9 @@ class AzureSlimInstanceConfig(InstanceConfig):
 
         self._worker_type = worker_type
         self.cores = cores
+
+    def total_memory_mib(self) -> int:
+        return azure_worker_memory_per_core_mib(self._worker_type) * self.cores
 
     def worker_type(self) -> str:
         return self._worker_type

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -370,6 +370,7 @@ docker run \
 --security-opt apparmor:unconfined \
 --network host \
 --cgroupns host \
+--oom-score-adj 0 \
 {docker_run_gpu_args} \
 $BATCH_WORKER_IMAGE \
 python3 -u -m batch.worker.worker >worker.log 2>&1

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -371,6 +371,7 @@ docker run \
 --network host \
 --cgroupns host \
 --oom-score-adj 0 \
+--oom-kill-disable \
 {docker_run_gpu_args} \
 $BATCH_WORKER_IMAGE \
 python3 -u -m batch.worker.worker >worker.log 2>&1

--- a/batch/batch/cloud/gcp/instance_config.py
+++ b/batch/batch/cloud/gcp/instance_config.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 from ...driver.billing_manager import ProductVersions
 from ...instance_config import InstanceConfig
-from .resource_utils import gcp_machine_type_to_parts, machine_family_to_gpu
+from .resource_utils import gcp_machine_type_to_parts, gcp_worker_memory_per_core_mib, machine_family_to_gpu
 from .resources import (
     GCPAcceleratorResource,
     GCPComputeResource,
@@ -100,6 +100,9 @@ class GCPSlimInstanceConfig(InstanceConfig):
         self._worker_type = machine_type_parts.worker_type
         self.cores = machine_type_parts.cores
         self.resources = resources
+
+    def total_memory_mib(self) -> int:
+        return gcp_worker_memory_per_core_mib(self._worker_type) * self.cores
 
     def worker_type(self) -> str:
         return self._worker_type

--- a/batch/batch/instance_config.py
+++ b/batch/batch/instance_config.py
@@ -31,6 +31,10 @@ class InstanceConfig(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def total_memory_mib(self) -> int:
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def worker_type(self) -> str:
         raise NotImplementedError
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1206,10 +1206,9 @@ class Container:
                         'limit': self.memory_in_bytes,
                         'reservation': self.memory_in_bytes,
                         'swap': self.memory_in_bytes,  # https://docs.docker.com/config/containers/resource_constraints/#prevent-a-container-from-using-swap
-                        'kernel': -1,  # https://docs.docker.com/config/containers/resource_constraints/#--kernel-memory-details
-                        'kernelTCP': -1,  # https://github.com/opencontainers/runtime-spec/blob/main/config.md
                         'swappiness': 0,
                         'disableOOMKiller': False,
+                        'oom_group': 1,
                     },
                     # 'blockIO': {'weight': min(weight, 1000)}, FIXME blkio.weight not supported
                 },


### PR DESCRIPTION
Fixes #13902. I'm pretty sure the kernel was randomly choosing the worker process to be killed when another process caused the kernel memory to be exhausted on OOM causing the non-responsiveness of the worker. It was strongly discourage from setting an explicit kernel memory limit on containers in the documentation. However, it might be fine to set it to the same memory limit as the other 3 memory settings from reading this [documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt) on memory settings.

