### PR TITLE
[batch] Use default credentials for the Azure SAS token test

### DIFF
--- a/hail/python/test/hail/fs/test_worker_driver_fs.py
+++ b/hail/python/test/hail/fs/test_worker_driver_fs.py
@@ -141,8 +141,7 @@ def test_qob_can_use_sas_tokens():
 
     sub_id = os.environ['HAIL_AZURE_SUBSCRIPTION_ID']
     rg = os.environ['HAIL_AZURE_RESOURCE_GROUP']
-    creds_file = os.environ['AZURE_APPLICATION_CREDENTIALS']
-    sas_token = asyncio.run(AzureAsyncFS(credential_file=creds_file).generate_sas_token(sub_id, rg, account, "rl"))
+    sas_token = asyncio.run(AzureAsyncFS().generate_sas_token(sub_id, rg, account, "rl"))
 
     mt = hl.import_vcf(f'{vcf}?{sas_token}', min_partitions=4)
     mt._force_count_rows()


### PR DESCRIPTION
A very small PR but here's the background and context behind this change. When talking to either GCP or Azure, hail chooses credentials in the following order from highest priority to lowest priority:

1. An explicit `credential_file` argument passed to the relevant credentials class
2. An environment variable containing the path to the credentials (`GOOGLE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS`) (from this you can see why the code that was here is totally redundant)
3. The latent credentials present on the machine. This might be `gcloud` or `az` credentials, or the metadata server if you're on a cloud VM.

I'm trying to rid the codebase of most explicit providing of credentials file paths, for two reasons:
- Quality of life. I'm already signed into the cloud with `gcloud` and `az`. I shouldn't need to download some file and provide `AZURE_APPLICATION_CREDENTIALS` to run this test. It should just use the latent credentials.
- We are trying to phase out credentials files altogether for security reasons. These files are long-lived secrets that you really don't want to leak and are currently exposed to users in Batch jobs, so they can be easily exfiltrated. Using the latent credentials on a cloud VM (the metadata server) has the benefit of only issuing short-lived access tokens which last for hours not months, so it's basically always better to use the latent credentials when possible.