### PR TITLE
[batch] Fix enum column state in job groups table

### DIFF
--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -196,7 +196,7 @@ CREATE TABLE IF NOT EXISTS `job_groups` (
   `user` VARCHAR(100) NOT NULL,
   `attributes` TEXT,
   `cancel_after_n_failures` INT DEFAULT NULL,
-  `state` ENUM('running', 'complete', 'open') NOT NULL,
+  `state` ENUM('running', 'complete') NOT NULL,
   `n_jobs` INT NOT NULL,
   `time_created` BIGINT NOT NULL,
   `time_completed` BIGINT,
@@ -698,9 +698,13 @@ DROP TRIGGER IF EXISTS batches_after_update $$
 CREATE TRIGGER batches_after_update AFTER UPDATE ON batches
 FOR EACH ROW
 BEGIN
+  DECLARE jg_state VARCHAR(40);
+
+  SET jg_state = IF(NEW.state = "open", "complete", NEW.state);
+
   IF OLD.migrated_batch = 0 AND NEW.migrated_batch = 1 THEN
     INSERT INTO job_groups (batch_id, job_group_id, `user`, cancel_after_n_failures, `state`, n_jobs, time_created, time_completed, callback, attributes)
-    VALUES (NEW.id, 0, NEW.`user`, NEW.cancel_after_n_failures, NEW.state, NEW.n_jobs, NEW.time_created, NEW.time_completed, NEW.callback, NEW.attributes);
+    VALUES (NEW.id, 0, NEW.`user`, NEW.cancel_after_n_failures, jg_state, NEW.n_jobs, NEW.time_created, NEW.time_completed, NEW.callback, NEW.attributes);
 
     INSERT INTO job_group_self_and_ancestors (batch_id, job_group_id, ancestor_id, `level`)
     VALUES (NEW.id, 0, 0, 0);

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -196,7 +196,7 @@ CREATE TABLE IF NOT EXISTS `job_groups` (
   `user` VARCHAR(100) NOT NULL,
   `attributes` TEXT,
   `cancel_after_n_failures` INT DEFAULT NULL,
-  `state` ENUM('running', 'complete') NOT NULL,
+  `state` ENUM('running', 'complete', 'open') NOT NULL,
   `n_jobs` INT NOT NULL,
   `time_created` BIGINT NOT NULL,
   `time_completed` BIGINT,

--- a/batch/sql/fix-job-groups-state-enum.sql
+++ b/batch/sql/fix-job-groups-state-enum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_groups MODIFY COLUMN `state` ENUM('running', 'complete', 'open'), ALGORITHM=INSTANT;

--- a/batch/sql/fix-job-groups-state-enum.sql
+++ b/batch/sql/fix-job-groups-state-enum.sql
@@ -1,1 +1,20 @@
-ALTER TABLE job_groups MODIFY COLUMN `state` ENUM('running', 'complete', 'open'), ALGORITHM=INSTANT;
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS batches_after_update $$
+CREATE TRIGGER batches_after_update AFTER UPDATE ON batches
+FOR EACH ROW
+BEGIN
+  DECLARE jg_state VARCHAR(40);
+
+  SET jg_state = IF(NEW.state = "open", "complete", NEW.state);
+
+  IF OLD.migrated_batch = 0 AND NEW.migrated_batch = 1 THEN
+    INSERT INTO job_groups (batch_id, job_group_id, `user`, cancel_after_n_failures, `state`, n_jobs, time_created, time_completed, callback, attributes)
+    VALUES (NEW.id, 0, NEW.`user`, NEW.cancel_after_n_failures, jg_state, NEW.n_jobs, NEW.time_created, NEW.time_completed, NEW.callback, NEW.attributes);
+
+    INSERT INTO job_group_self_and_ancestors (batch_id, job_group_id, ancestor_id, `level`)
+    VALUES (NEW.id, 0, 0, 0);
+  END IF;
+END $$
+
+DELIMITER ;

--- a/build.yaml
+++ b/build.yaml
@@ -2341,6 +2341,9 @@ steps:
       - name: dedup-job-resources
         script: /io/sql/dedup_job_resources.py
         online: true
+      - name: fix-job-groups-state-enum
+        script: /io/sql/fix-job-groups-state-enum.sql
+        online: true
       - name: populate-job-groups
         script: /io/sql/populate_job_groups.py
         online: true


### PR DESCRIPTION
I forgot that "open" was a valid batches state when I created the job groups table state column as an enum. This should fix the failed migration from #13487 