### PR TITLE
[batch] yank populate job groups migration

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2341,9 +2341,6 @@ steps:
       - name: dedup-job-resources
         script: /io/sql/dedup_job_resources.py
         online: true
-      - name: populate-job-groups
-        script: /io/sql/populate_job_groups.py
-        online: true
     inputs:
       - from: /repo/batch/sql
         to: /io/sql


### PR DESCRIPTION
#13487 is broken due to incompatible ENUM states between job groups and batches. Yanking the migration until we figure out what we want to do.