### PR TITLE
[compiler] allow relational IR in ExtractIntervals

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -866,7 +866,10 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
     }
 
     res = if (res == null) {
-      val children = x.children.map(child => recur(child.asInstanceOf[IR])).toFastSeq
+      val children = x.children.map {
+        case child: IR => recur(child)
+        case _ => AbstractLattice.top
+      }.toFastSeq
       val keyOrConstVal = computeKeyOrConst(x, children)
       if (x.typ == TBoolean) {
         if (keyOrConstVal == AbstractLattice.top)

--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -757,6 +757,19 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
     )
   }
 
+  @Test def testRelationalChildren(): Unit = {
+    val testRows = FastSeq(
+      Row(0, 0, true),
+      Row(0, 10, true),
+      Row(0, 20, true),
+      Row(0, null, true))
+
+    val count = TableAggregate(TableRange(10, 1), ApplyAggOp(FastSeq(), FastSeq(), AggSignature(Count(), FastSeq(), FastSeq())))
+    print(count.typ)
+    val filter = gt(count, Cast(k1, TInt64))
+    check(filter, ref1, k1Full, testRows, filter, FastSeq(Interval(Row(), Row(), true, true)))
+  }
+
   @Test def testIntegration() {
     hc // force initialization
     val tab1 = TableRange(10, 5)


### PR DESCRIPTION
Fix bug where relational IR inside the condition of a TableFilter or MatrixFilter causes a ClassCastException. This can happen if, for example, there's a TableAggregate inside the condition.