### PR TITLE
[query] fix #13937 which manifests as Google throwing an NPE

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -166,7 +166,7 @@ dependencies {
         throw new UnsupportedOperationException("Couldn't pick a valid elasticsearch.")
     }
 
-    implementation(group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.27.1') {
+    implementation(group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.29.1') {
         exclude group: 'com.fasterxml.jackson.core'
     }
 


### PR DESCRIPTION
CHANGELOG: Fix #13937 caused by faulty library code in the Google Cloud Storage API Java client library.