### PR TITLE
[query] relax tolerance in local whitening test

### DIFF
--- a/hail/python/test/hail/experimental/test_local_whitening.py
+++ b/hail/python/test/hail/experimental/test_local_whitening.py
@@ -24,7 +24,7 @@ def run_local_whitening_test(vec_size, num_rows, chunk_size, window_size, partit
     ht = tsm.block_table
     whitened_hail = np.vstack(ht.aggregate(hl.agg.collect(tsm.block_expr)))
     whitened_naive = naive_whiten(data.T, window_size)
-    np.testing.assert_allclose(whitened_hail, whitened_naive, rtol=5e-05)
+    np.testing.assert_allclose(whitened_hail, whitened_naive, rtol=1e-04)
 
 @test_timeout(local=5 * 60, batch=12 * 60)
 def test_local_whitening():


### PR DESCRIPTION
It’s a random test, and it seems the current tolerance still allows rare sporadic failures.