### PR TITLE
[query] restore Spark logs to the Hail log file

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -147,8 +147,6 @@ dependencies {
         transitive = false
     }
 
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
-
     def elasticMajorVersion = System.getProperty("elasticsearch.major-version", "7")
     if (elasticMajorVersion != "7" && elasticMajorVersion != "8") {
         throw new UnsupportedOperationException("elasticsearch.major-version must be 7 or 8")


### PR DESCRIPTION
Spark depends on a very old verison of SLF4J. We cannot upgrade. We added this dependency ages ago to fix some undocumented issue with logging and SLF4J. It seems reasonable to me that we should just accept whatever version of SLF4J that Spark provides.

This removes this message:
```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/usr/lib/spark/jars/log4j-slf4j-impl-2.17.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```

Which, IMO, really should be a stop-the-world error.