### PR TITLE
[hailtop] Add subpath to deploy config

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1160,7 +1160,7 @@ python3 -c \'{script}\'''',
             'HAIL_DOMAIN': DOMAIN,
             'HAIL_DEFAULT_NAMESPACE': 'default',
             'HAIL_LOCATION': 'external',
-            'HAIL_SUBPATH': '',
+            'HAIL_BASE_PATH': '',
         },
     )
     b.submit()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1135,7 +1135,7 @@ backend.close()
 
 
 def test_cant_submit_to_default_with_other_ns_creds(client: BatchClient, remote_tmpdir: str):
-    DOMAIN = os.environ['HAIL_DOMAIN']
+    DOMAIN = os.environ['HAIL_PRODUCTION_DOMAIN']
     NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
 
     script = f'''import hailtop.batch as hb
@@ -1156,7 +1156,12 @@ backend.close()
             f'''
 python3 -c \'{script}\'''',
         ],
-        env={'HAIL_DOMAIN': DOMAIN, 'HAIL_DEFAULT_NAMESPACE': 'default', 'HAIL_LOCATION': 'external'},
+        env={
+            'HAIL_DOMAIN': DOMAIN,
+            'HAIL_DEFAULT_NAMESPACE': 'default',
+            'HAIL_LOCATION': 'external',
+            'HAIL_SUBPATH': '',
+        },
     )
     b.submit()
     status = j.wait()

--- a/build.yaml
+++ b/build.yaml
@@ -478,7 +478,7 @@ steps:
       EOF
       {% else %}
       cat > deploy-config.json <<EOF
-      {"location":"k8s","default_namespace":"{{ default_ns.name }}","domain":"internal.{{ global.domain }}","subpath":"/{{ default_ns.name }}"}
+      {"location":"k8s","default_namespace":"{{ default_ns.name }}","domain":"internal.{{ global.domain }}","base_path":"/{{ default_ns.name }}"}
       EOF
       {% endif %}
       kubectl -n {{ default_ns.name }} create secret generic deploy-config \

--- a/build.yaml
+++ b/build.yaml
@@ -472,9 +472,15 @@ steps:
       set -ex
 
       # k8s deploy config
+      {% if default_ns.name == "default" %}
       cat > deploy-config.json <<EOF
       {"location":"k8s","default_namespace":"{{ default_ns.name }}","domain":"{{ global.domain }}"}
       EOF
+      {% else %}
+      cat > deploy-config.json <<EOF
+      {"location":"k8s","default_namespace":"{{ default_ns.name }}","domain":"internal.{{ global.domain }}","subpath":"/{{ default_ns.name }}"}
+      EOF
+      {% endif %}
       kubectl -n {{ default_ns.name }} create secret generic deploy-config \
               --from-file=./deploy-config.json \
               --save-config --dry-run=client -o yaml \
@@ -2717,7 +2723,7 @@ steps:
       export HAIL_GENETICS_HAIL_IMAGE="{{ hailgenetics_hail_image.image }}"
       export HAIL_TOKEN="{{ token }}"
       export HAIL_CLOUD="{{ global.cloud }}"
-      export HAIL_DOMAIN="{{ global.domain }}"
+      export HAIL_PRODUCTION_DOMAIN="{{ global.domain }}"
       export HAIL_GPU_IMAGE="{{ gpu_image.image }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/test_batch/{{ token }}/
 

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional, TypeVar, Union
 import os
 import json
 import logging
@@ -8,22 +8,33 @@ from .user_config import get_user_config
 
 log = logging.getLogger('deploy_config')
 
+T = TypeVar("T")
 
-def env_var_or_default(name: str, defaults: Dict[str, str]) -> str:
-    return os.environ.get(f'HAIL_{name.upper()}') or defaults[name]
+
+def env_var_or_default(name: str, default: T) -> Union[str, T]:
+    return os.environ.get(f'HAIL_{name.upper()}', default)
 
 
 class DeployConfig:
     @staticmethod
     def from_config(config: Dict[str, str]) -> 'DeployConfig':
-        return DeployConfig(
-            env_var_or_default('location', config),
-            env_var_or_default('default_namespace', config),
-            env_var_or_default('domain', config),
-        )
+        location = env_var_or_default('location', config['location'])
+        domain = env_var_or_default('domain', config['domain'])
+        ns = env_var_or_default('default_namespace', config['default_namespace'])
+        subpath = env_var_or_default('subpath', config.get('subpath')) or None
+        if subpath is None and ns != 'default':
+            domain = f'internal.{config["domain"]}'
+            subpath = f'/{ns}'
 
-    def get_config(self) -> Dict[str, str]:
-        return {'location': self._location, 'default_namespace': self._default_namespace, 'domain': self._domain}
+        return DeployConfig(location, ns, domain, subpath)
+
+    def get_config(self) -> Dict[str, Optional[str]]:
+        return {
+            'location': self._location,
+            'default_namespace': self._default_namespace,
+            'domain': self._domain,
+            'subpath': self._subpath,
+        }
 
     @staticmethod
     def from_config_file(config_file=None) -> 'DeployConfig':
@@ -47,19 +58,20 @@ class DeployConfig:
             }
         return DeployConfig.from_config(config)
 
-    def __init__(self, location, default_namespace, domain):
+    def __init__(self, location: str, default_namespace: str, domain: str, subpath: Optional[str]):
         assert location in ('external', 'k8s', 'gce')
         self._location = location
         self._default_namespace = default_namespace
         self._domain = domain
+        self._subpath = subpath
 
     def with_default_namespace(self, default_namespace):
-        return DeployConfig(self._location, default_namespace, self._domain)
+        return DeployConfig(self._location, default_namespace, self._domain, self._subpath)
 
     def with_location(self, location):
-        return DeployConfig(location, self._default_namespace, self._domain)
+        return DeployConfig(location, self._default_namespace, self._domain, self._subpath)
 
-    def default_namespace(self) -> str:
+    def default_namespace(self):
         return self._default_namespace
 
     def location(self):
@@ -74,19 +86,18 @@ class DeployConfig:
         if self._location == 'k8s':
             return f'{service}.{ns}'
         if self._location == 'gce':
-            if ns == 'default':
+            if self._subpath is None:
                 return f'{service}.hail'
             return 'internal.hail'
         assert self._location == 'external'
-        if ns == 'default':
+        if self._subpath is None:
             return f'{service}.{self._domain}'
-        return f'internal.{self._domain}'
+        return self._domain
 
     def base_path(self, service):
-        ns = self._default_namespace
-        if ns == 'default':
+        if self._subpath is None:
             return ''
-        return f'/{ns}/{service}'
+        return f'{self._subpath}/{service}'
 
     def base_url(self, service, base_scheme='http'):
         return f'{self.scheme(base_scheme)}://{self.domain(service)}{self.base_path(service)}'
@@ -100,12 +111,11 @@ class DeployConfig:
         return 'sesh'
 
     def external_url(self, service, path, base_scheme='http'):
-        ns = self._default_namespace
-        if ns == 'default':
+        if self._subpath is None:
             if service == 'www':
                 return f'{base_scheme}s://{self._domain}{path}'
             return f'{base_scheme}s://{service}.{self._domain}{path}'
-        return f'{base_scheme}s://internal.{self._domain}/{ns}/{service}{path}'
+        return f'{base_scheme}s://{self._domain}{self._subpath}/{service}{path}'
 
     def prefix_application(self, app, service, **kwargs):
         from aiohttp import web  # pylint: disable=import-outside-toplevel

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -4,7 +4,7 @@ from hailtop.config.deploy_config import DeployConfig
 
 class Test(unittest.TestCase):
     def test_deploy_external_default(self):
-        deploy_config = DeployConfig('external', 'default', 'organization.tld')
+        deploy_config = DeployConfig('external', 'default', 'organization.tld', None)
 
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.default_namespace(), 'default')
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.organization.tld/moo')
 
     def test_deploy_external_bar(self):
-        deploy_config = DeployConfig('external', 'bar', 'organization.tld')
+        deploy_config = DeployConfig('external', 'bar', 'internal.organization.tld', '/bar')
 
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.default_namespace(), 'bar')
@@ -31,7 +31,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.external_url('foo', '/moo'), 'https://internal.organization.tld/bar/foo/moo')
 
     def test_deploy_k8s_default(self):
-        deploy_config = DeployConfig('k8s', 'default', 'organization.tld')
+        deploy_config = DeployConfig('k8s', 'default', 'organization.tld', None)
 
         self.assertEqual(deploy_config.location(), 'k8s')
         self.assertEqual(deploy_config.default_namespace(), 'default')
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.organization.tld/moo')
 
     def test_deploy_k8s_bar(self):
-        deploy_config = DeployConfig('k8s', 'bar', 'organization.tld')
+        deploy_config = DeployConfig('k8s', 'bar', 'internal.organization.tld', '/bar')
 
         self.assertEqual(deploy_config.location(), 'k8s')
         self.assertEqual(deploy_config.default_namespace(), 'bar')
@@ -58,7 +58,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.external_url('foo', '/moo'), 'https://internal.organization.tld/bar/foo/moo')
 
     def test_deploy_batch_job_default(self):
-        deploy_config = DeployConfig('gce', 'default', 'organization.tld')
+        deploy_config = DeployConfig('gce', 'default', 'organization.tld', None)
 
         self.assertEqual(deploy_config.location(), 'gce')
         self.assertEqual(deploy_config.default_namespace(), 'default')
@@ -72,7 +72,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.organization.tld/moo')
 
     def test_deploy_batch_job_bar(self):
-        deploy_config = DeployConfig('gce', 'bar', 'organization.tld')
+        deploy_config = DeployConfig('gce', 'bar', 'internal.organization.tld', '/bar')
 
         self.assertEqual(deploy_config.location(), 'gce')
         self.assertEqual(deploy_config.default_namespace(), 'bar')


### PR DESCRIPTION
Currently, the k8s namespace field is used both for routing internal requests inside kubernetes but also external requests over the internet. It also has special logic based on whether the namespace indicates a production or dev environment. For example, if `namespace == 'default'`, then we route external `batch` requests to `batch.<domain>/path`, but if `namespace == foo_dev`, we route external `batch` requests to `internal.<domain>/foo_dev/path`.

This PR decouples the namespace field from routing. Aside from being overall more straightforward in my opinion, this is necessary for batch on azure terra where batch is served out of a subpath it does not control and is unrelated to whatever namespace it might reside in. The guiding principle for routing is then as follows: If the config has no subpath, use a subdomain, otherwise put everything under domain + subpath.

For example:
- `{'domain': 'hail.is', 'subpath': null}` => `batch.hail.is`
- `{'domain': 'internal.hail.is', 'subpath': '/foo_dev'}` => `internal.hail.is/foo_dev/batch`

Since the CI pipeline runs on current production instances, there is a minor need to stay compatible with old deploy configs (or else hack up the CI build.yaml). It's quite a simple translation though, because if there is no subpath provided we can infer one based on the `default_namespace`.