### PR TITLE
[batch|qob] Dont request hail tokens in the batch client

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1128,7 +1128,6 @@ backend.close()
     j = b.create_job(
         HAIL_GENETICS_HAILTOP_IMAGE,
         ['/bin/bash', '-c', f'''python3 -c \'{script}\''''],
-        mount_tokens=True,
     )
     b.submit()
     status = j.wait()
@@ -1158,7 +1157,6 @@ backend.close()
 python3 -c \'{script}\'''',
         ],
         env={'HAIL_DOMAIN': DOMAIN, 'HAIL_DEFAULT_NAMESPACE': 'default', 'HAIL_LOCATION': 'external'},
-        mount_tokens=True,
     )
     b.submit()
     status = j.wait()

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -406,7 +406,6 @@ class ServiceBackend(Backend):
                         iodir + '/in',
                         iodir + '/out',
                     ],
-                    mount_tokens=True,
                     resources=resources,
                     attributes={'name': name + '_driver'},
                     regions=self.regions,

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -801,7 +801,6 @@ class ServiceBackend(Backend[bc.Batch]):
                 cloudfuse=job._cloudfuse if len(job._cloudfuse) > 0 else None,
                 env=env,
                 requester_pays_project=batch.requester_pays_project,
-                mount_tokens=True,
                 user_code=user_code,
                 regions=job._regions,
                 always_copy_output=job._always_copy_output


### PR DESCRIPTION
Jobs that are configured with `mount_tokens=True` will have their Hail tokens mounted into the main container. However, now that we are using access tokens from cloud identities, the tokens are no longer used. This removes the default behavior of mounting the `tokens.json` files since they aren't used by our codebase anyway.