### PR TITLE
[tooling] adds non-hailtop subdirs to pylint ignore

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -2,7 +2,7 @@
 
 # I also tried extension-pkg-allow-list, but it had no effect. https://stackoverflow.com/a/35259944/6823256
 generated-members=orjson
-ignore=sql
+ignore-paths=^.*.sql$,^.*hail/python/cluster-tests/.*$,^.*hail/python/dev/.*$,^.*hail/python/hail/.*$,^.*hail/python/hail.egg-info/.*$,^.*hail/python/test/.*$
 
 [MESSAGES CONTROL]
 # C0111 Missing docstring


### PR DESCRIPTION
We only have `make` commands for running `pylint` on subdirectories that have been kept up to date with its rules, but the `pylintrc` doesn't actually contain any indication of which subdirectories should be ignored when running `pylint`. This makes the use of language servers that run `pylint` on the file that's open frustrating, as files in the ignored subdirectories will often be full of `pylint` suggestions. This change adds the relevant subdirectories to the `pylintrc` file. Note that this does not necessarily enable us to run `pylint` directly on those subdirectories with the equivalent `make` commands to the ones that already exist, because there is no way that I've found to make `pylint` ignore the `__init__.py` file of whatever module it's being run on, so running it on `hail/python/hail`, for example, produces many errors.