### PR TITLE
[letsencrypt] Update make targets to be compatible with new docker-build.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SERVICES_IMAGES := $(patsubst %, %-image, $(SERVICES_PLUS_ADMIN_POD))
 SERVICES_DATABASES := $(patsubst %, %-db, $(SERVICES))
 SERVICES_MODULES := $(SERVICES) gear web_common
 CHECK_SERVICES_MODULES := $(patsubst %, check-%, $(SERVICES_MODULES))
-SPECIAL_IMAGES := hail-ubuntu batch-worker
+SPECIAL_IMAGES := hail-ubuntu batch-worker letsencrypt
 
 HAILGENETICS_IMAGES = $(foreach img,hail vep-grch37-85 vep-grch38-95,hailgenetics-$(img))
 CI_IMAGES = ci-utils ci-buildkit base hail-run
@@ -215,6 +215,10 @@ hailgenetics-vep-grch37-85-image: hail-ubuntu-image
 hailgenetics-vep-grch38-95-image: hail-ubuntu-image
 	./docker-build.sh docker/vep docker/vep/grch38/95/Dockerfile $(IMAGE_NAME) \
 		--build-arg BASE_IMAGE=$(shell cat hail-ubuntu-image)
+	echo $(IMAGE_NAME) > $@
+
+letsencrypt-image:
+	./docker-build.sh letsencrypt Dockerfile $(IMAGE_NAME)
 	echo $(IMAGE_NAME) > $@
 
 $(PRIVATE_REGISTRY_IMAGES): pushed-private-%-image: %-image

--- a/letsencrypt/Makefile
+++ b/letsencrypt/Makefile
@@ -1,23 +1,21 @@
 include ../config.mk
 
-LETSENCRYPT_IMAGE := $(DOCKER_PREFIX)/letsencrypt:$(TOKEN)
-
 .PHONY: build start-service run clean
 
 build:
-	../docker-build.sh . Dockerfile $(LETSENCRYPT_IMAGE)
+	$(MAKE) -C .. pushed-private-letsencrypt-image
 
 DRY_RUN ?= false
 run: build
 	echo $(DOMAIN) > domains.txt.out
 	echo internal.$(DOMAIN) >> domains.txt.out
 	sed 's/$$/.$(DOMAIN)/g' subdomains.txt >> domains.txt.out
-	python3 ../ci/jinja2_render.py '{"letsencrypt_image":{"image":"$(LETSENCRYPT_IMAGE)"},"domain":"$(DOMAIN)","domains":"'$$(paste -s -d, domains.txt.out)'","dry_run":$(DRY_RUN)}' letsencrypt-pod.yaml letsencrypt-pod.yaml.out
+	python3 ../ci/jinja2_render.py '{"letsencrypt_image":{"image":"$(shell cat ../pushed-private-letsencrypt-image)"},"domain":"$(DOMAIN)","domains":"'$$(paste -s -d, domains.txt.out)'","dry_run":$(DRY_RUN)}' letsencrypt-pod.yaml letsencrypt-pod.yaml.out
 	/bin/bash run-letsencrypt.sh letsencrypt-pod.yaml.out
 
 revoke: build
 	! [ -z "$(CERT_IDS_TO_REVOKE)" ]  # call this like: make deploy CERT_IDS_TO_REVOKE='abc123 def567'
-	python3 ../ci/jinja2_render.py '{"letsencrypt_image":{"image":"$(LETSENCRYPT_IMAGE)"},"cert_ids_to_revoke":"$(CERT_IDS_TO_REVOKE)"}' revoke-certs-pod.yaml revoke-certs-pod.yaml.out
+	python3 ../ci/jinja2_render.py '{"letsencrypt_image":{"image":"$(shell cat ../pushed-private-letsencrypt-image)"},"cert_ids_to_revoke":"$(CERT_IDS_TO_REVOKE)"}' revoke-certs-pod.yaml revoke-certs-pod.yaml.out
 	/bin/bash run-letsencrypt.sh revoke-certs-pod.yaml.out
 
 .PHONY: clean

--- a/letsencrypt/subdomains.txt
+++ b/letsencrypt/subdomains.txt
@@ -3,7 +3,6 @@ www
 batch
 batch-driver
 blog
-memory
 monitoring
 auth
 ukbb-rg


### PR DESCRIPTION
This wasn't updated when I separated out building and pushing so the `build` target wasn't pushing the image. When I fixed that the cert generation failed because `memory` is no longer available. These changes got everything working again.