### PR TITLE
[batch] Stream job logs from the worker to cloud storage

### DIFF
--- a/batch/batch/file_store.py
+++ b/batch/batch/file_store.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import pandas as pd
 
-from hailtop.aiotools.fs import AsyncFS
+from hailtop.aiotools.fs import AsyncFS, ReadableStream
 
 from .batch_format_version import BatchFormatVersion
 from .globals import BATCH_FORMAT_VERSION
@@ -48,9 +48,13 @@ class FileStore:
         url = self.log_path(format_version, batch_id, job_id, attempt_id, task)
         return await self.fs.read(url)
 
-    async def write_log_file(self, format_version, batch_id, job_id, attempt_id, task, data: bytes):
+    async def write_log_file(self, format_version, batch_id, job_id, attempt_id, task, data: ReadableStream):
         url = self.log_path(format_version, batch_id, job_id, attempt_id, task)
-        await self.fs.write(url, data)
+        log.info(f'Starting to write {url}')
+        async with await self.fs.create(url, retry_writes=False) as f:
+            while b := await data.read(1024):
+                log.info(f'Writing chunk of {url}')
+                await f.write(b)
 
     async def write_jvm_profile(self, format_version, batch_id, job_id, attempt_id, task, data):
         url = self.jvm_profile_path(format_version, batch_id, job_id, attempt_id, task)


### PR DESCRIPTION
This allows the writing of job logs greater than the max size of a python `bytes`, and probably more stable memory usage on the worker.