### PR TITLE
[guide-analysis] Host guide browser in hail-vdc

### DIFF
--- a/guide/Makefile
+++ b/guide/Makefile
@@ -1,0 +1,9 @@
+include ../config.mk
+
+.PHONY: deploy
+deploy:
+	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
+	python3 ../ci/jinja2_render.py \
+		'{"global":{"docker_prefix":"$(DOCKER_PREFIX)"},"default_ns":{"name":"$(NAMESPACE)"}}' \
+		deployment.yaml deployment.yaml.out
+	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/guide/deployment.yaml
+++ b/guide/deployment.yaml
@@ -1,0 +1,163 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: guide-sidecar-envoy-config
+data:
+  envoy.yaml: |
+    static_resources:
+      listeners:
+      - address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8443
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              codec_type: AUTO
+              stat_prefix: ingress_http
+              upgrade_configs:
+                - upgrade_type: websocket
+              route_config:
+                name: local_route
+                virtual_hosts:
+                  - name: guide-analysis
+                    domains: ["*"]
+                    routes:
+{% if default_ns.name != "default" %}
+                      - match:
+                          prefix: "/{{ default_ns.name }}/guide-analysis/"
+                        route:
+                          prefix_rewrite: "/"
+                          timeout: 0s
+                          cluster: guide-analysis
+{% endif %}
+                      - match:
+                          prefix: "/"
+                        route:
+                          timeout: 0s
+                          cluster: guide-analysis
+              http_filters:
+                - name: envoy.filters.http.router
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              common_tls_context:
+                tls_certificates:
+                - certificate_chain:
+                    filename: /ssl-config/guide-analysis-cert.pem
+                  private_key:
+                    filename: /ssl-config/guide-analysis-key.pem
+      clusters:
+      - name: guide-analysis
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: guide-analysis
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 8000
+    admin:
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8001
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guide-analysis
+  labels:
+    name: guide-analysis
+spec:
+  selector:
+    matchLabels:
+      app: guide-analysis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: guide-analysis
+    spec:
+      nodeSelector:
+        preemptible: "false"
+      containers:
+       - name: guide-analysis
+         image: gneak123/guide_browser:amd@sha256:d3801eb2ff08ac0b5e9587ee3780dfa491bc087c367bc8bf3d252b2e60fae5b6
+         imagePullPolicy: Always
+         resources:
+           requests:
+             cpu: "100m"
+             memory: "200M"
+           limits:
+             cpu: "1"
+             memory: "1G"
+         ports:
+          - containerPort: 8000
+            protocol: TCP
+       - name: envoy
+         image: "{{ global.docker_prefix }}/envoyproxy/envoy:v1.22.3"
+         command:
+           - /usr/local/bin/envoy
+           - --config-path
+           - /etc/envoy/envoy.yaml
+           - --concurrency
+           - "2"
+         resources:
+           requests:
+             cpu: "20m"
+             memory: "20M"
+           limits:
+             cpu: "1"
+             memory: "1G"
+         ports:
+          - containerPort: 8443
+         volumeMounts:
+          - name: ssl-config-guide-analysis
+            mountPath: /ssl-config
+            readOnly: true
+          - name: guide-sidecar-envoy-config
+            mountPath: /etc/envoy
+            readOnly: true
+         readinessProbe:
+           httpGet:
+{% if default_ns.name == "default" %}
+             path: /
+{% else %}
+             path: /{{ default_ns.name }}/guide-analysis/
+{% endif %}
+             port: 8443
+             scheme: HTTPS
+           initialDelaySeconds: 5
+           periodSeconds: 10
+           timeoutSeconds: 10
+      volumes:
+       - name: ssl-config-guide-analysis
+         secret:
+           optional: false
+           secretName: ssl-config-guide-analysis
+       - name: guide-sidecar-envoy-config
+         configMap:
+           name: guide-sidecar-envoy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: guide-analysis
+  labels:
+    app: guide-analysis
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: guide-analysis

--- a/letsencrypt/subdomains.txt
+++ b/letsencrypt/subdomains.txt
@@ -6,6 +6,7 @@ blog
 monitoring
 auth
 ukbb-rg
+guide-analysis
 grafana
 prometheus
 hello

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -62,3 +62,7 @@ principals:
   domains:
     - prometheus
   kind: nginx
+- name: guide-analysis
+  domains:
+    - guide-analysis
+  kind: nginx


### PR DESCRIPTION
This adds the k8s config necessary to host the [guide browser](https://hub.docker.com/r/gneak123/guide_browser/tags) in our k8s cluster. There's not much special here, a deployment with the browser app and an envoy sidecar to handle TLS. Once this merges and the `ssl-config-guide-analysis` is created in `default` I can `make -C guide deploy NAMESPACE=default` and then recreate the certs to pick up the new subdomain, after which it should be live.