### PR TITLE
[query] update past a broken google cloud storage java library

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -168,7 +168,7 @@ dependencies {
         throw new UnsupportedOperationException("Couldn't pick a valid elasticsearch.")
     }
 
-    implementation(group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.29.1') {
+    implementation(group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.30.1') {
         exclude group: 'com.fasterxml.jackson.core'
     }
 


### PR DESCRIPTION
CHANGELOG: Fix #13979, affecting Query-on-Batch and manifesting most frequently as "com.github.luben.zstd.ZstdException: Corrupted block detected".

This PR upgrades google-cloud-storage from 2.29.1 to 2.30.1. The google-cloud-storage java library has a bug present at least since 2.29.0 in which simply incorrect data was returned. https://github.com/googleapis/java-storage/issues/2301 . The issue seems related to their use of multiple intremediate ByteBuffers. As far as I can tell, this is what could happen:

1. If there's no channel, open a new channel with the current position.
2. Read *some* data from the input ByteChannel into an intermediate ByteBuffer.
3. While attempting to read more data into a subsequent intermediate ByteBuffer, an retryable exception occurs.
4. The exception bubbles to google-cloud-storage's error handling, which frees the channel and loops back to (1)

The key bug is that the intermediate buffers have data but the `position` hasn't been updated. When we recreate the channel we will jump to the wrong position and re-read some data. Lucky for us, between Zstd and our assertions, this usually crashes the program instead of silently returning bad data.

This is the third bug we have found in Google's cloud storage java library. The previous two:

1. https://github.com/hail-is/hail/issues/13721
2. https://github.com/hail-is/hail/issues/13937

Be forewarned: the next time we see bizarre networking or data corruption issues, check if updating google-cloud-storage fixes the problem.