### PR TITLE
[query] update zstd-jni to 1.5.5-11

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -202,7 +202,7 @@ dependencies {
 
     implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.6.1'
 
-    implementation 'com.github.luben:zstd-jni:1.5.5-2'
+    implementation 'com.github.luben:zstd-jni:1.5.5-11'
 
     implementation project(path: ':shadedazure', configuration: 'shadow')
 }


### PR DESCRIPTION
The Zstandard version is not changing. The zstd-jni library, which wraps Zstandard and provides some interoperation with java.nio, has released 9 times since 1.5.5-2. They do not publish a changelog, but I scanned through their commits. There were some potentially relevant bug fixes:

1. When using array-backed ByteBuffers, zstd-jni reads the wrong data if the arrayOffset is not zero. https://github.com/luben/zstd-jni/commit/355b8511a2967d097a619047a579930cac2ccd9d

2. Perhaps a slightly faster path for array-backed ByteBuffers. https://github.com/luben/zstd-jni/commit/100c434dfcec17a865ca2c2b844afe1046ce1b10

3. Possibly faster buffer pool. https://github.com/luben/zstd-jni/commit/2b6c3b75012dec44f8fd2dd56dd97eea0d62f19c

4. Removed a double free during compression. https://github.com/luben/zstd-jni/commit/b2ad3834439375b12b0fd0c0b80788a2fe94f06b