### PR TITLE
[aiocloud] refresh access tokens after transient errors

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/credentials.py
+++ b/hail/python/hailtop/aiocloud/aioazure/credentials.py
@@ -4,7 +4,7 @@ import json
 import time
 import logging
 
-from types import TracebackType
+from types import TracebackType, Tuple
 from typing import Any, List, Optional, Type, Union
 from azure.identity.aio import DefaultAzureCredential, ClientSecretCredential
 from azure.core.credentials import AccessToken
@@ -110,17 +110,17 @@ class AzureCredentials(CloudCredentials):
             scopes = ['https://management.azure.com/.default']
         self.scopes = scopes
 
-    async def auth_headers(self):
-        access_token = await self.access_token()
-        return {'Authorization': f'Bearer {access_token}'}
+    async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
+        access_token, expiration = await self.access_token_with_expiration()
+        return {'Authorization': f'Bearer {access_token}'}, expiration
 
-    async def access_token(self) -> str:
+    async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
         now = time.time()
         if self._access_token is None or (self._expires_at is not None and now > self._expires_at):
             self._access_token = await self.get_access_token()
             self._expires_at = now + (self._access_token.expires_on - now) // 2   # type: ignore
         assert self._access_token
-        return self._access_token.token
+        return self._access_token.token, self._expires_at
 
     async def get_access_token(self):
         return await self.credential.get_token(*self.scopes)

--- a/hail/python/hailtop/aiocloud/aioazure/credentials.py
+++ b/hail/python/hailtop/aiocloud/aioazure/credentials.py
@@ -4,8 +4,8 @@ import json
 import time
 import logging
 
-from types import TracebackType, Tuple
-from typing import Any, List, Optional, Type, Union
+from types import TracebackType
+from typing import Any, List, Optional, Type, Union, Tuple, Dict
 from azure.identity.aio import DefaultAzureCredential, ClientSecretCredential
 from azure.core.credentials import AccessToken
 from azure.core.credentials_async import AsyncTokenCredential

--- a/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union, List, Literal, ClassVar, overload
+from typing import Dict, Optional, Union, List, Literal, ClassVar, overload, Tuple
 import os
 import json
 import time
@@ -102,13 +102,14 @@ class GoogleCredentials(CloudCredentials):
                     'run `gcloud auth application-default login` first to log in.')
         return AnonymousCloudCredentials()
 
-    async def auth_headers(self) -> Dict[str, str]:
-        return {'Authorization': f'Bearer {await self.access_token()}'}
+    async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
+        token, expiration = await self.access_token_with_expiration()
+        return {'Authorization': f'Bearer {token}'}, expiration
 
-    async def access_token(self) -> str:
+    async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
         if self._access_token is None or self._access_token.expired():
             self._access_token = await self._get_access_token()
-        return self._access_token.token
+        return self._access_token.token, self._access_token._expiry_time
 
     async def _get_access_token(self) -> GoogleExpiringAccessToken:
         raise NotImplementedError

--- a/hail/python/hailtop/aiocloud/common/credentials.py
+++ b/hail/python/hailtop/aiocloud/common/credentials.py
@@ -1,15 +1,29 @@
 import abc
-from typing import Dict
+from typing import Dict, Tuple, Optional
 
 
 class CloudCredentials(abc.ABC):
     @abc.abstractmethod
-    async def auth_headers(self) -> Dict[str, str]:
+    async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
+        """Return HTTP authentication headers and the time of expiration in seconds since the epoch (Unix time).
+
+        None indicates a non-expiring credentials."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    async def access_token(self) -> str:
+    async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
+        """Return an access token and the time of expiration in seconds since the epoch (Unix time).
+
+        None indicates a non-expiring credentials."""
         raise NotImplementedError
+
+    async def auth_headers(self) -> Dict[str, str]:
+        headers, _ = await self.auth_headers_with_expiration()
+        return headers
+
+    async def access_token(self) -> str:
+        access_token, _ = await self.access_token_with_expiration()
+        return access_token
 
     @abc.abstractmethod
     async def close(self):
@@ -17,6 +31,9 @@ class CloudCredentials(abc.ABC):
 
 
 class AnonymousCloudCredentials:
+    async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
+        return {}, None
+
     async def auth_headers(self) -> Dict[str, str]:
         return {}
 

--- a/hail/python/hailtop/aiocloud/common/session.py
+++ b/hail/python/hailtop/aiocloud/common/session.py
@@ -116,9 +116,8 @@ class Session(BaseSession):
                 if err.status != 401:
                     raise
                 if expiration is None or time.time() <= expiration:
-                    log.exception(f'The server at {url} rejected credentials valid until {expiration}', err)
                     raise err
-                log.info(f'Credentials expired while waiting for request to {url}. We will retry.', err)
+                log.info(f'Credentials expired while waiting for request to {url}. We will retry. {err}.')
 
     async def close(self) -> None:
         async with AsyncExitStack() as stack:

--- a/hail/python/hailtop/aiocloud/common/session.py
+++ b/hail/python/hailtop/aiocloud/common/session.py
@@ -1,5 +1,5 @@
 from contextlib import AsyncExitStack
-from types import TracebackType, Dict, Any
+from types import TracebackType
 from typing import Optional, Type, TypeVar, Mapping, Union
 import time
 import aiohttp

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -40,32 +40,38 @@ class HailCredentials(CloudCredentials):
         self._namespace = namespace
         self._authorize_target = authorize_target
 
-    async def auth_headers(self) -> Dict[str, str]:
+    async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
         headers = {}
+        expiration = None
         if self._authorize_target:
-            token = await self._get_idp_access_token_or_hail_token(self._namespace)
+            token, expiration = await self._get_idp_access_token_or_hail_token(self._namespace)
             headers['Authorization'] = f'Bearer {token}'
         if get_deploy_config().location() == 'external' and self._namespace != 'default':
             # We prefer an extant hail token to an access token for the internal auth token
             # during development of the idp access token feature because the production auth
             # is not yet configured to accept access tokens. This can be changed to always prefer
             # an idp access token when this change is in production.
-            token = await self._get_hail_token_or_idp_access_token('default')
+            token, internal_expiration = await self._get_hail_token_or_idp_access_token('default')
+            if internal_expiration:
+                if not expiration:
+                    expiration = internal_expiration
+                else:
+                    expiration = min(expiration, internal_expiration)
             headers['X-Hail-Internal-Authorization'] = f'Bearer {token}'
-        return headers
+        return headers, expiration
 
-    async def access_token(self) -> str:
+    async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
         return await self._get_idp_access_token_or_hail_token(self._namespace)
 
-    async def _get_idp_access_token_or_hail_token(self, namespace: str) -> str:
+    async def _get_idp_access_token_or_hail_token(self, namespace: str) -> Tuple[str, Optional[float]]:
         if self._cloud_credentials is not None:
-            return await self._cloud_credentials.access_token()
-        return self._tokens.namespace_token_or_error(namespace)
+            return await self._cloud_credentials.access_token_with_expiration()
+        return self._tokens.namespace_token_with_expiration_or_error(namespace)
 
-    async def _get_hail_token_or_idp_access_token(self, namespace: str) -> str:
+    async def _get_hail_token_or_idp_access_token(self, namespace: str) -> Tuple[str, Optional[float]]:
         if self._cloud_credentials is None:
-            return self._tokens.namespace_token_or_error(namespace)
-        return self._tokens.namespace_token(namespace) or await self._cloud_credentials.access_token()
+            return self._tokens.namespace_token_with_expiration_or_error(namespace)
+        return self._tokens.namespace_token_with_expiration(namespace) or await self._cloud_credentials.access_token_with_expiration()
 
     async def close(self):
         if self._cloud_credentials:

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
 import base64
 import collections.abc
 import os
@@ -71,6 +71,11 @@ class Tokens(collections.abc.MutableMapping):
     def namespace_token(self, ns: str) -> Optional[str]:
         return self._tokens.get(ns)
 
+    def namespace_token_with_expiration(self, ns: str) -> Optional[Tuple[str, Optional[float]]]:
+        if token := self._tokens.get(ns):
+            return token, None
+        return None
+
     def namespace_token_or_error(self, ns: str) -> str:
         if ns in self._tokens:
             return self._tokens[ns]
@@ -79,6 +84,9 @@ class Tokens(collections.abc.MutableMapping):
         default_ns = deploy_config.default_namespace()
         ns_arg = '' if ns == default_ns else f'-n {ns}'
         raise NotLoggedInError(ns_arg)
+
+    def namespace_token_with_expiration_or_error(self, ns: str) -> Tuple[str, Optional[float]]:
+        return self.namespace_token_or_error(ns), None
 
     def __delitem__(self, key: str):
         del self._tokens[key]

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -14,6 +14,7 @@ from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.aiocloud.common import Session
 from hailtop.aiocloud.common.credentials import CloudCredentials
 from hailtop.auth import hail_credentials
+from hailtop.auth.tokens import Tokens
 from hailtop.utils import bounded_gather, sleep_before_try
 from hailtop.utils.rich_progress_bar import BatchProgressBar, BatchProgressBarTask
 from hailtop import httpx
@@ -854,11 +855,11 @@ class HailExplicitTokenCredentials(CloudCredentials):
     def __init__(self, token: str):
         self._token = token
 
-    async def auth_headers(self) -> Dict[str, str]:
-        return {'Authorization': f'Bearer {self._token}'}
+    async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
+        return {'Authorization': f'Bearer {self._token}'}, None
 
-    async def access_token(self) -> str:
-        return self._token
+    async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
+        return self._token, None
 
     async def close(self):
         pass

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -14,7 +14,6 @@ from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.aiocloud.common import Session
 from hailtop.aiocloud.common.credentials import CloudCredentials
 from hailtop.auth import hail_credentials
-from hailtop.auth.tokens import Tokens
 from hailtop.utils import bounded_gather, sleep_before_try
 from hailtop.utils.rich_progress_bar import BatchProgressBar, BatchProgressBarTask
 from hailtop import httpx


### PR DESCRIPTION
We need to retry 401s until we get a 401 from credentials we know to be invalid.