### PR TITLE
[query] cleave Backend paths into normal parallelize and parallelize returning errors

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -77,11 +77,22 @@ abstract class Backend {
   def parallelizeAndComputeWithIndex(
     backendContext: BackendContext,
     fs: FS,
+    collection: Array[Array[Byte]],
+    stageIdentifier: String,
+    dependency: Option[TableStageDependency] = None
+  )(
+    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): Array[Array[Byte]]
+
+  def parallelizeAndComputeWithIndexReturnAllErrors(
+    backendContext: BackendContext,
+    fs: FS,
     collection: IndexedSeq[(Array[Byte], Int)],
     stageIdentifier: String,
     dependency: Option[TableStageDependency] = None
-  )(f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte])
-  : (Option[Throwable], IndexedSeq[(Array[Byte], Int)])
+  )(
+    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)])
 
   def stop(): Unit
 

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -47,6 +47,9 @@ class BackendUtils(mods: Array[(String, (HailClassLoader, FS, HailTaskContext, R
     tsd: Option[TableStageDependency]
   ): Array[Array[Byte]] = lookupSemanticHashResults(backendContext, stageName, semhash) match {
     case None =>
+      if (contexts.isEmpty)
+        return Array()
+
       val backend = HailContext.backend
       val f = getModule(modID)
 

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -7,6 +7,7 @@ import is.hail.backend.local.LocalTaskContext
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.expr.ir.lowering.TableStageDependency
 import is.hail.io.fs._
+import is.hail.services._
 import is.hail.utils._
 
 import scala.util.Try
@@ -23,87 +24,123 @@ class BackendUtils(mods: Array[(String, (HailClassLoader, FS, HailTaskContext, R
 
   def getModule(id: String): (HailClassLoader, FS, HailTaskContext, Region) => F = loadedModules(id)
 
-  def collectDArray(backendContext: BackendContext,
-                    theDriverHailClassLoader: HailClassLoader,
-                    fs: FS,
-                    modID: String,
-                    contexts: Array[Array[Byte]],
-                    globals: Array[Byte],
-                    stageName: String,
-                    semhash: Option[SemanticHash.Type],
-                    tsd: Option[TableStageDependency]
-                   ): Array[Array[Byte]] = {
+  def collectDArray(
+    backendContext: BackendContext,
+    theDriverHailClassLoader: HailClassLoader,
+    fs: FS,
+    modID: String,
+    contexts: Array[Array[Byte]],
+    globals: Array[Byte],
+    stageName: String,
+    semhash: Option[SemanticHash.Type],
+    tsd: Option[TableStageDependency]
+  ): Array[Array[Byte]] = semhash match {
+    case None =>
+      val backend = HailContext.backend
+      val f = getModule(modID)
 
-    val cachedResults =
-      semhash
-        .map { s =>
-          log.info(s"[collectDArray|$stageName]: querying cache for $s")
-          val cachedResults = backendContext.executionCache.lookup(s)
-          log.info(s"[collectDArray|$stageName]: found ${cachedResults.length} entries for $s.")
-          cachedResults
+      log.info(
+        s"[collectDArray|$stageName]: executing ${contexts.length} tasks, " +
+          s"contexts size = ${formatSpace(contexts.map(_.length.toLong).sum)}, " +
+          s"globals size = ${formatSpace(globals.length)}"
+      )
+
+      val t = System.nanoTime()
+      val results = if (backend.canExecuteParallelTasksOnDriver && contexts.length == 1) {
+        val context = contexts(0)
+        using(new LocalTaskContext(0, 0)) { htc =>
+          using(htc.getRegionPool().getRegion()) { r =>
+            val run = f(theDriverHailClassLoader, fs, htc, r)
+            val result = retryTransientErrors {
+              run(r, context, globals)
+            }
+            Array(result)
+          }
         }
-        .getOrElse(IndexedSeq.empty)
+      } else {
+        val globalsBC = backend.broadcast(globals)
+        val fsConfigBC = backend.broadcast(fs.getConfiguration())
+        backend.parallelizeAndComputeWithIndex(backendContext, fs, contexts, stageName, tsd) {
+          (ctx, htc, theHailClassLoader, fs) =>
+          val fsConfig = fsConfigBC.value
+          val gs = globalsBC.value
+          fs.setConfiguration(fsConfig)
+          htc.getRegionPool().scopedRegion { region =>
+            f(theHailClassLoader, fs, htc, region)(region, ctx, gs)
+          }
+        }
+      }
 
-    val remainingContexts =
-      for {
-        c@(_, k) <- contexts.zipWithIndex
-        if !cachedResults.containsOrdered[Int](k, _ < _, _._2)
-      } yield c
+      log.info(s"[collectDArray|$stageName]: executed ${contexts.length} tasks " +
+        s"in ${formatTime(System.nanoTime() - t)}"
+      )
 
-    val results =
-      if (remainingContexts.isEmpty) cachedResults else {
-        val backend = HailContext.backend
-        val f = getModule(modID)
+      results
+    case Some(s) =>
+      log.info(s"[collectDArray|$stageName]: querying cache for $s")
+      val cachedResults = backendContext.executionCache.lookup(s)
+      log.info(s"[collectDArray|$stageName]: found ${cachedResults.length} entries for $s.")
+      val remainingContexts =
+        for {
+          c@(_, k) <- contexts.zipWithIndex
+          if !cachedResults.containsOrdered[Int](k, _ < _, _._2)
+        } yield c
+      val results =
+        if (remainingContexts.isEmpty) {
+          cachedResults
+        } else {
+          val backend = HailContext.backend
+          val f = getModule(modID)
 
-        log.info(
-          s"[collectDArray|$stageName]: executing ${remainingContexts.length} tasks, " +
-            s"contexts size = ${formatSpace(contexts.map(_.length.toLong).sum)}, " +
-            s"globals size = ${formatSpace(globals.length)}"
-        )
+          log.info(
+            s"[collectDArray|$stageName]: executing ${remainingContexts.length} tasks, " +
+              s"contexts size = ${formatSpace(contexts.map(_.length.toLong).sum)}, " +
+              s"globals size = ${formatSpace(globals.length)}"
+          )
 
-        val t = System.nanoTime()
-        val (failureOpt, successes) =
-          remainingContexts match {
-            case Array((context, k)) if backend.canExecuteParallelTasksOnDriver =>
-              Try {
-                using(new LocalTaskContext(k, 0)) { htc =>
-                  using(htc.getRegionPool().getRegion()) { r =>
-                    val run = f(theDriverHailClassLoader, fs, htc, r)
-                    val res = is.hail.services.retryTransientErrors {
-                      run(r, context, globals)
+          val t = System.nanoTime()
+          val (failureOpt, successes) =
+            remainingContexts match {
+              case Array((context, k)) if backend.canExecuteParallelTasksOnDriver =>
+                Try {
+                  using(new LocalTaskContext(k, 0)) { htc =>
+                    using(htc.getRegionPool().getRegion()) { r =>
+                      val run = f(theDriverHailClassLoader, fs, htc, r)
+                      val res = retryTransientErrors {
+                        run(r, context, globals)
+                      }
+                      FastSeq(res -> k)
                     }
-                    FastSeq(res -> k)
                   }
                 }
-              }
-                .fold(t => (Some(t), IndexedSeq.empty), (None, _))
+                  .fold(t => (Some(t), IndexedSeq.empty), (None, _))
 
-            case _ =>
-              val globalsBC = backend.broadcast(globals)
-              val fsConfigBC = backend.broadcast(fs.getConfiguration())
-              val (failureOpt, successes) =
-                backend.parallelizeAndComputeWithIndex(backendContext, fs, remainingContexts, stageName, tsd) {
-                  (ctx, htc, theHailClassLoader, fs) =>
+              case _ =>
+                val globalsBC = backend.broadcast(globals)
+                val fsConfigBC = backend.broadcast(fs.getConfiguration())
+                val (failureOpt, successes) =
+                  backend.parallelizeAndComputeWithIndexReturnAllErrors(backendContext, fs, remainingContexts, stageName, tsd) {
+                    (ctx, htc, theHailClassLoader, fs) =>
                     val fsConfig = fsConfigBC.value
                     val gs = globalsBC.value
                     fs.setConfiguration(fsConfig)
                     htc.getRegionPool().scopedRegion { region =>
                       f(theHailClassLoader, fs, htc, region)(region, ctx, gs)
                     }
-                }
-              (failureOpt, successes)
-          }
+                  }
+                (failureOpt, successes)
+            }
 
-        log.info(s"[collectDArray|$stageName]: executed ${remainingContexts.length} tasks " +
-          s"in ${formatTime(System.nanoTime() - t)}"
-        )
+          log.info(s"[collectDArray|$stageName]: executed ${remainingContexts.length} tasks " +
+            s"in ${formatTime(System.nanoTime() - t)}"
+          )
 
-        val results = merge[(Array[Byte], Int)](cachedResults, successes.sortBy(_._2), _._2 < _._2)
-        semhash.foreach(s => backendContext.executionCache.put(s, results))
-        failureOpt.foreach(throw _)
+          val results = merge[(Array[Byte], Int)](cachedResults, successes.sortBy(_._2), _._2 < _._2)
+          semhash.foreach(s => backendContext.executionCache.put(s, results))
+          failureOpt.foreach(throw _)
 
-        results
-      }
+          results
+        }
 
       results.map(_._1).toArray
   }

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -132,7 +132,24 @@ class LocalBackend(
     current
   }
 
-  override def parallelizeAndComputeWithIndex(
+  def parallelizeAndComputeWithIndex(
+    backendContext: BackendContext,
+    fs: FS,
+    collection: Array[Array[Byte]],
+    stageIdentifier: String,
+    dependency: Option[TableStageDependency] = None
+  )(
+    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): Array[Array[Byte]] = {
+    val stageId = nextStageId()
+    collection.zipWithIndex.map { case (c, i) =>
+      using(new LocalTaskContext(i, stageId)) { htc =>
+        f(c, htc, theHailClassLoader, fs)
+      }
+    }
+  }
+
+  override def parallelizeAndComputeWithIndexReturnAllErrors(
     backendContext: BackendContext,
     fs: FS,
     collection: IndexedSeq[(Array[Byte], Int)],

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -35,6 +35,7 @@ import scala.annotation.switch
 import scala.collection.mutable
 import scala.language.higherKinds
 import scala.reflect.ClassTag
+import scala.collection.JavaConverters._
 
 class ServiceBackendContext(
   val billingProject: String,
@@ -151,14 +152,14 @@ class ServiceBackend(
     new String(bytes, StandardCharsets.UTF_8)
   }
 
-  override def parallelizeAndComputeWithIndex(
+  private[this] def submitAndWaitForBatch(
     _backendContext: BackendContext,
     fs: FS,
-    collection: IndexedSeq[(Array[Byte], Int)],
+    collection: Array[Array[Byte]],
     stageIdentifier: String,
-    dependency: Option[TableStageDependency] = None
-  )(f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
-  ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) = {
+    dependency: Option[TableStageDependency] = None,
+    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): (String, String, Int) = {
     val backendContext = _backendContext.asInstanceOf[ServiceBackendContext]
     val n = collection.length
     val token = tokenUrlSafe(32)
@@ -179,17 +180,15 @@ class ServiceBackend(
       retryTransientErrors {
         fs.writePDOS(s"$root/contexts") { os =>
           var o = 12L * n
-
-          // write header of context offsets and lengths
-          for ((context, _) <- collection) {
-            val len = context.length
+          var i = 0
+          while (i < n) {
+            val len = collection(i).length
             os.writeLong(o)
             os.writeInt(len)
+            i += 1
             o += len
           }
-
-          // write context arrays themselves
-          for ((context, _) <- collection) {
+          collection.foreach { context =>
             os.write(context)
           }
         }
@@ -199,19 +198,20 @@ class ServiceBackend(
     uploadFunction.get()
     uploadContexts.get()
 
-    val jobs = collection.map { case (_, i) =>
+    val jobs = new Array[JObject](n)
+    var i = 0
+    while (i < n) {
       var resources = JObject("preemptible" -> JBool(true))
       if (backendContext.workerCores != "None") {
-        resources = resources.merge(JObject("cpu" -> JString(backendContext.workerCores)))
+        resources = resources.merge(JObject(("cpu" -> JString(backendContext.workerCores))))
       }
       if (backendContext.workerMemory != "None") {
-        resources = resources.merge(JObject("memory" -> JString(backendContext.workerMemory)))
+        resources = resources.merge(JObject(("memory" -> JString(backendContext.workerMemory))))
       }
       if (backendContext.storageRequirement != "0Gi") {
-        resources = resources.merge(JObject("storage" -> JString(backendContext.storageRequirement)))
+        resources = resources.merge(JObject(("storage" -> JString(backendContext.storageRequirement))))
       }
-
-      JObject(
+      jobs(i) = JObject(
         "always_run" -> JBool(false),
         "job_id" -> JInt(i + 1),
         "in_update_parent_ids" -> JArray(List()),
@@ -224,8 +224,7 @@ class ServiceBackend(
             JString(Main.WORKER),
             JString(root),
             JString(s"$i"),
-            JString(s"$n")
-          )),
+            JString(s"$n"))),
           "type" -> JString("jvm"),
           "profile" -> JBool(backendContext.profile),
         ),
@@ -243,6 +242,7 @@ class ServiceBackend(
           )
         }.toList)
       )
+      i += 1
     }
 
     log.info(s"parallelizeAndComputeWithIndex: $token: running job")
@@ -250,17 +250,14 @@ class ServiceBackend(
     val (batchId, updateId) = curBatchId match {
       case Some(id) =>
         (id, batchClient.update(id, token, jobs))
-
       case None =>
         val batchId = batchClient.create(
           JObject(
             "billing_project" -> JString(backendContext.billingProject),
             "n_jobs" -> JInt(n),
             "token" -> JString(token),
-            "attributes" -> JObject("name" -> JString(name + "_" + stageCount))
-          ),
-          jobs
-        )
+            "attributes" -> JObject("name" -> JString(name + "_" + stageCount))),
+          jobs)
         (batchId, 1L)
     }
 
@@ -273,31 +270,68 @@ class ServiceBackend(
       throw new HailBatchFailure(s"Update $updateId for batch $batchId failed")
     }
 
+    (token, root, n)
+  }
+
+  private[this] def readResult(root: String, i: Int): Array[Byte] = {
+    val bytes = fs.readNoCompression(s"$root/result.$i")
+    if (bytes(0) != 0) {
+      bytes.slice(1, bytes.length)
+    } else {
+      val errorInformationBytes = bytes.slice(1, bytes.length)
+      val is = new DataInputStream(new ByteArrayInputStream(errorInformationBytes))
+      val shortMessage = readString(is)
+      val expandedMessage = readString(is)
+      val errorId = is.readInt()
+      throw new HailWorkerException(i, shortMessage, expandedMessage, errorId)
+    }
+  }
+
+  override def parallelizeAndComputeWithIndex(
+    _backendContext: BackendContext,
+    fs: FS,
+    collection: Array[Array[Byte]],
+    stageIdentifier: String,
+    dependency: Option[TableStageDependency] = None
+  )(
+    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): Array[Array[Byte]] = {
+    val (token, root, n) = submitAndWaitForBatch(_backendContext, fs, collection, stageIdentifier, dependency, f)
+
     log.info(s"parallelizeAndComputeWithIndex: $token: reading results")
-
     val startTime = System.nanoTime()
+    val results = try {
+      executor.invokeAll[Array[Byte]](
+        IndexedSeq.range(0, n).map { i =>
+          (() => readResult(root, i)): Callable[Array[Byte]]
+        }.asJavaCollection
+      ).asScala.map(_.get).toArray
+    } catch {
+      case exc: ExecutionException if exc.getCause() != null => throw exc.getCause()
+    }
+    val resultsReadingSeconds = (System.nanoTime() - startTime) / 1000000000.0
+    val rate = results.length / resultsReadingSeconds
+    val byterate = results.map(_.length).sum / resultsReadingSeconds / 1024 / 1024
+    log.info(s"all results read. $resultsReadingSeconds s. $rate result/s. $byterate MiB/s.")
+    results
+  }
 
+  override def parallelizeAndComputeWithIndexReturnAllErrors(
+    _backendContext: BackendContext,
+    fs: FS,
+    collection: IndexedSeq[(Array[Byte], Int)],
+    stageIdentifier: String,
+    dependency: Option[TableStageDependency] = None
+  )(f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) = {
+    val (token, root, n) = submitAndWaitForBatch(_backendContext, fs, collection.map(_._1).toArray, stageIdentifier, dependency, f)
+    log.info(s"parallelizeAndComputeWithIndex: $token: reading results")
+    val startTime = System.nanoTime()
     val r@(_, results) = runAllKeepFirstError(executor) {
-      collection.map { case (_, i) =>
-        (
-          () => {
-            val bytes = fs.readNoCompression(s"$root/result.$i")
-            if (bytes(0) != 0) {
-              bytes.slice(1, bytes.length)
-            } else {
-              val errorInformationBytes = bytes.slice(1, bytes.length)
-              val is = new DataInputStream(new ByteArrayInputStream(errorInformationBytes))
-              val shortMessage = readString(is)
-              val expandedMessage = readString(is)
-              val errorId = is.readInt()
-              throw new HailWorkerException(i, shortMessage, expandedMessage, errorId)
-            }
-          },
-          i
-        )
+      collection.zipWithIndex.map { case ((_, i), jobIndex) =>
+        (() => readResult(root, jobIndex), i)
       }
     }
-
     val resultsReadingSeconds = (System.nanoTime() - startTime) / 1000000000.0
     val rate = results.length / resultsReadingSeconds
     val byterate = results.map(_._1.length).sum / resultsReadingSeconds / 1024 / 1024

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -180,12 +180,10 @@ class ServiceBackend(
       retryTransientErrors {
         fs.writePDOS(s"$root/contexts") { os =>
           var o = 12L * n
-          var i = 0
-          while (i < n) {
-            val len = collection(i).length
+          collection.foreach { context =>
+            val len = context.length
             os.writeLong(o)
             os.writeInt(len)
-            i += 1
             o += len
           }
           collection.foreach { context =>
@@ -203,13 +201,13 @@ class ServiceBackend(
     while (i < n) {
       var resources = JObject("preemptible" -> JBool(true))
       if (backendContext.workerCores != "None") {
-        resources = resources.merge(JObject(("cpu" -> JString(backendContext.workerCores))))
+        resources = resources.merge(JObject("cpu" -> JString(backendContext.workerCores)))
       }
       if (backendContext.workerMemory != "None") {
-        resources = resources.merge(JObject(("memory" -> JString(backendContext.workerMemory))))
+        resources = resources.merge(JObject("memory" -> JString(backendContext.workerMemory)))
       }
       if (backendContext.storageRequirement != "0Gi") {
-        resources = resources.merge(JObject(("storage" -> JString(backendContext.storageRequirement))))
+        resources = resources.merge(JObject("storage" -> JString(backendContext.storageRequirement)))
       }
       jobs(i) = JObject(
         "always_run" -> JBool(false),

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -207,7 +207,7 @@ class ServiceBackend(
       if (backendContext.storageRequirement != "0Gi") {
         resources = resources.merge(JObject("storage" -> JString(backendContext.storageRequirement)))
       }
-      jobs(i) = JObject(
+      JObject(
         "always_run" -> JBool(false),
         "job_id" -> JInt(i + 1),
         "in_update_parent_ids" -> JArray(List()),

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -196,9 +196,7 @@ class ServiceBackend(
     uploadFunction.get()
     uploadContexts.get()
 
-    val jobs = new Array[JObject](n)
-    var i = 0
-    while (i < n) {
+    val jobs = collection.zipWithIndex.map { case (_, i) =>
       var resources = JObject("preemptible" -> JBool(true))
       if (backendContext.workerCores != "None") {
         resources = resources.merge(JObject("cpu" -> JString(backendContext.workerCores)))
@@ -240,7 +238,6 @@ class ServiceBackend(
           )
         }.toList)
       )
-      i += 1
     }
 
     log.info(s"parallelizeAndComputeWithIndex: $token: running job")

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -369,18 +369,32 @@ class SparkBackend(
     }
   }
 
-
   def broadcast[T : ClassTag](value: T): BroadcastValue[T] = new SparkBroadcastValue[T](sc.broadcast(value))
 
   override def parallelizeAndComputeWithIndex(
     backendContext: BackendContext,
     fs: FS,
+    collection: Array[Array[Byte]],
+    stageIdentifier: String,
+    dependency: Option[TableStageDependency] = None
+  )(
+    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): Array[Array[Byte]] = {
+    val sparkDeps = dependency.toIndexedSeq
+      .flatMap(dep => dep.deps.map(rvdDep => new AnonymousDependency(rvdDep.asInstanceOf[RVDDependency].rvd.crdd.rdd)))
+
+    new SparkBackendComputeRDD(sc, collection, f, sparkDeps).collect()
+  }
+
+  override def parallelizeAndComputeWithIndexReturnAllErrors(
+    backendContext: BackendContext,
+    fs: FS,
     contexts: IndexedSeq[(Array[Byte], Int)],
     stageIdentifier: String,
     dependency: Option[TableStageDependency] = None
-  )(f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte])
-  : (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) = {
-
+  )(
+    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) = {
     val sparkDeps =
       for {rvdDep <- dependency.toIndexedSeq; dep <- rvdDep.deps}
         yield new AnonymousDependency(dep.asInstanceOf[RVDDependency].rvd.crdd.rdd)
@@ -409,6 +423,7 @@ class SparkBackend(
         override def compute(partition: Partition, context: TaskContext): Iterator[(Try[Array[Byte]], Int)] = {
           val sp = partition.asInstanceOf[TaggedRDDPartition]
           val fs = new HadoopFS(null)
+          // FIXME: this is broken: the partitionId of SparkTaskContext will be incorrect
           val result = Try(f(sp.data, SparkTaskContext.get(), theHailClassLoaderForSparkWorkers, fs))
           Iterator.single((result, sp.tag))
         }
@@ -749,5 +764,25 @@ class SparkBackend(
       case None =>
         LowerTableIR.applyTable(inputIR, DArrayLowering.All, ctx, analyses)
     }
+  }
+}
+
+case class SparkBackendComputeRDDPartition(data: Array[Byte], index: Int) extends Partition
+
+class SparkBackendComputeRDD(
+  sc: SparkContext,
+  @transient private val collection: Array[Array[Byte]],
+  f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte],
+  deps: Seq[Dependency[_]]
+) extends RDD[Array[Byte]](sc, deps) {
+
+  override def getPartitions: Array[Partition] = {
+    Array.tabulate(collection.length)(i => SparkBackendComputeRDDPartition(collection(i), i))
+  }
+
+  override def compute(partition: Partition, context: TaskContext): Iterator[Array[Byte]] = {
+    val sp = partition.asInstanceOf[SparkBackendComputeRDDPartition]
+    val fs = new HadoopFS(null)
+    Iterator.single(f(sp.data, SparkTaskContext.get(), theHailClassLoaderForSparkWorkers, fs))
   }
 }

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1693,7 +1693,7 @@ object MatrixVCFReader {
         val localFilterAndReplace = params.filterAndReplace
 
         val fsConfigBC = backend.broadcast(fs.getConfiguration())
-        val (err, _) = backend.parallelizeAndComputeWithIndex(ctx.backendContext, fs, files.tail.map(_.getBytes).zipWithIndex, "load_vcf_parse_header", None) { (bytes, htc, _, fs) =>
+        backend.parallelizeAndComputeWithIndex(ctx.backendContext, fs, files.tail.map(_.getBytes), "load_vcf_parse_header", None) { (bytes, htc, _, fs) =>
           val fsConfig = fsConfigBC.value
           fs.setConfiguration(fsConfig)
           val file = new String(bytes)
@@ -1735,8 +1735,6 @@ object MatrixVCFReader {
 
           bytes
         }
-
-        err.foreach(throw _)
       }
     }
 

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -20,7 +20,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
 
 package object services {
-  lazy val log: Logger = LogManager.getLogger("is.hail.services")
+  private lazy val log: Logger = LogManager.getLogger("is.hail.services")
 
   val RETRYABLE_HTTP_STATUS_CODES: Set[Int] = {
     val s = Set(408, 429, 500, 502, 503, 504)

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -1017,8 +1017,9 @@ package object utils extends Logging
     (err, buffer)
   }
 
-  def runAllKeepFirstError[A](executor: ExecutorService)
-  : IndexedSeq[(() => A, Int)] => (Option[Throwable], IndexedSeq[(A, Int)]) =
+  def runAllKeepFirstError[A](
+    executor: ExecutorService
+  ): IndexedSeq[(() => A, Int)] => (Option[Throwable], IndexedSeq[(A, Int)]) =
     runAll[Option, A](executor) { case (opt, (e, _)) => opt.orElse(Some(e)) } (None)
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/table/TableGenSuite.scala
@@ -9,6 +9,7 @@ import is.hail.rvd.RVDPartitioner
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, HailException, Interval}
 import is.hail.{ExecStrategy, HailSuite}
+import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
 import org.scalatest.Matchers._
 import org.testng.annotations.Test

--- a/hail/src/test/scala/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/table/TableGenSuite.scala
@@ -116,11 +116,11 @@ class TableGenSuite extends HailSuite {
       errorId = Some(errorId)
     ))
     val lowered = LowerTableIR(table, DArrayLowering.All, ctx, LoweringAnalyses(table, ctx))
-    val ex = intercept[HailException] {
+    val ex = intercept[SparkException] {
       ExecuteContext.scoped() { ctx =>
         loweredExecute(ctx, lowered, Env.empty, FastSeq(), None)
       }
-    }
+    }.getCause.asInstanceOf[HailException]
 
     ex.errorId shouldBe errorId
     ex.getMessage should include("TableGen: Unexpected key in partition")


### PR DESCRIPTION
The original goal of this PR was avoiding `Try` when we are not using the restartability provided by semantic hashing because I strongly suspect it is related to the loss of stacktraces in exceptions.

Unrelatedly, we realized the semantic hash PR changed the semantics of Query-on-Spark even when semantic hash is disabled: previously we would abort RDD writing on the first exception. In Hail 0.2.123 through 0.2.126, the semantics were changed to only crash *after* we already ran every other partition. Two bad scenarios of which I can think:

1. Suppose the first partition fails due to OOM. We now waste time/money on the rest of the partitions even though we cannot possibly get a valid output.

2. Suppose every partition hits a permission error. Users should get that feedback after paying for O(1) partitions run, not O(N).

I created two Backend paths: the normal `parallelizeAndComputeWithIndex` with its pre-0.2.123 semantics as well as `parallelizeAndComputeWithIndexReturnAllErrors` which, as the name says, returns errors instead of raising them.

While making this change, I think I found two other bugs in the "return all errors" path, only one of which I addressed in this PR:

1. I'm pretty sure semantic-hash-enabled QoB batch submission is broken because it uses the logical partition ids as job indices. Suppose there are 10,000 partitions, but we only need to compute 1, 100, and 1543. 0.2.126 would try to submit a batch of size 3 but whose job indices are 1, 100, and 1543.

2. Likewise, the Query-on-Spark path returns an invalid `SparkTaskContext.partitionId` which, at best, produces confusing partition filenames.

I only fixed the former because it was simple to fix. I wasn't exactly sure what to do about the latter. We should fix that separately because the changes in this PR need to urgently land in the next release to avoid unexpected cost when one partition fails.