### PR TITLE
[query/vds combiner] Change sanity checks on combiner construction

### DIFF
--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -223,8 +223,6 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
                  gvcf_info_to_keep: Optional[Collection[str]] = None,
                  gvcf_reference_entry_fields_to_keep: Optional[Collection[str]] = None,
                  ):
-        if not (vdses or gvcfs):
-            raise ValueError("one of 'vdses' or 'gvcfs' must be nonempty")
         if gvcf_import_intervals:
             interval = gvcf_import_intervals[0]
             if not isinstance(interval.point_type, hl.tlocus):
@@ -654,8 +652,9 @@ def new_combiner(*,
                 combiner._target_records = target_records
                 combiner._gvcf_batch_size = gvcf_batch_size
                 return combiner
-            except (ValueError, TypeError, OSError, KeyError):
-                warning(f'file exists at {save_path}, but it is not a valid combiner plan, overwriting')
+            except (ValueError, TypeError, OSError, KeyError) as e:
+                warning(f'file exists at {save_path}, but it is not a valid combiner plan, overwriting\n'
+                        f'    caused by: {e}')
         return None
 
     # We do the first save_path check now after validating the arguments

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -12,10 +12,10 @@ import hail as hl
 from hail.expr import HailType, tmatrix
 from hail.utils import FatalError, Interval
 from hail.utils.java import info, warning
-from hail.vds import VariantDataset
 from .combine import combine_variant_datasets, transform_gvcf, defined_entry_fields, make_variant_stream, \
     make_reference_stream, combine_r, calculate_even_genome_partitioning, \
     calculate_new_intervals, combine
+from ..variant_dataset import VariantDataset
 
 
 class VDSMetadata(NamedTuple):


### PR DESCRIPTION
* Add assertion to `load_combiner` and `new_combiner` to fail if the output vds exists
* Remove assertion that disallows empty `gvcfs` and `vdses` in `VariantDatasetCombiner.__init__`

Resolves #14079 