### PR TITLE
[query] retry Tag mismatch a limited number of times

### DIFF
--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -83,6 +83,10 @@ package object services {
 	//   at sun.nio.ch.IOUtil.read(IOUtil.java:192) ~[?:1.8.0_362]
 	//   at sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:379) ~[?:1.8.0_362]
         true
+      case e: SSLException
+          if e.getMessage != null && e.getMessage.contains("Tag mismatch!") =>
+        // https://github.com/googleapis/java-storage/issues/2337
+        true
       case e =>
         val cause = e.getCause
         cause != null && isLimitedRetriesError(cause)


### PR DESCRIPTION
Wenhan observed this error after I gave her a branch using google cloud storage 2.30.1. I've reported this new transient error to the client API repo, but I doubt it will be fixed. https://github.com/googleapis/java-storage/issues/2337

SSL errors seem like the kind of thing we should not retry forever since they could indicate a bad actor.