### PR TITLE
[hailctl] fix parsing in hailctl hdinsight start

### DIFF
--- a/hail/python/hailtop/hailctl/hdinsight/start.py
+++ b/hail/python/hailtop/hailctl/hdinsight/start.py
@@ -69,7 +69,7 @@ def start(
         '--location',
         location,
         '--workernode-count',
-        num_workers,
+        str(num_workers),
         '--ssh-password',
         sshuser_password,
         '--ssh-user',


### PR DESCRIPTION
CHANGELOG: Fix `hailctl hdinsight start`, which has been broken since 0.2.118.

The shift to typer/click accidentally converted this parameter from a string to an int.