### PR TITLE
[auth] hd is not present for iam.gserviceaccount.com

### DIFF
--- a/hail/python/hailtop/auth/flow.py
+++ b/hail/python/hailtop/auth/flow.py
@@ -152,8 +152,8 @@ class GoogleFlow(Flow):
             if not (is_human_with_hail_audience or is_service_account):
                 return None
 
-            domain = userinfo.get('hd')
-            if domain == 'iam.gserviceaccount.com':
+            email = userinfo['email']
+            if email.endswith('iam.gserviceaccount.com'):
                 return userinfo['sub']
             # We don't currently track user's unique GCP IAM ID (sub) in the database, just their email,
             # but we should eventually use the sub as that is guaranteed to be unique to the user.


### PR DESCRIPTION
This would seem to violate this [statement about `hd`](https://developers.google.com/identity/openid-connect/openid-connect#id_token-hd):
> The absence of this claim indicates that the account does not belong to a Google hosted domain.

but alas, that's the truth. They elide `hd` for iam.gserviceaccount.com accounts.