### PR TITLE
[hailctl] fs subcommand and utilities

### DIFF
--- a/hail/python/hailtop/hailctl/__main__.py
+++ b/hail/python/hailtop/hailctl/__main__.py
@@ -7,6 +7,7 @@ from .config import cli as config_cli
 from .describe import describe
 from .dataproc import cli as dataproc_cli
 from .dev import cli as dev_cli
+from .fs import cli as fs_cli
 from .hdinsight import cli as hdinsight_cli
 
 
@@ -22,6 +23,7 @@ for cli in (
     config_cli.app,
     dataproc_cli.app,
     dev_cli.app,
+    fs_cli.app,
     hdinsight_cli.app,
 ):
     app.add_typer(cli)

--- a/hail/python/hailtop/hailctl/fs/__init__.py
+++ b/hail/python/hailtop/hailctl/fs/__init__.py
@@ -1,0 +1,3 @@
+from . import cli
+
+__all__ = ['cli']

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -42,9 +42,9 @@ def du(
     ] = False,
     summarize: Ann[bool, Opt('-s', '--summarize', help='display only a total for each argument')] = False,
 ):
-    '''
+    """
     Display storage resourse usage
-    '''
+    """
     from hailtop.aiotools.router_fs import RouterAsyncFS  # pylint: disable=import-outside-toplevel
     from hailtop.utils import async_to_blocking  # pylint: disable=import-outside-toplevel
 
@@ -67,9 +67,9 @@ def ls(
     long: Ann[bool, Opt('-l', '--long', help='use long listing format')] = False,
     human_readable: Ann[bool, Opt('-h', '--human-readable', help='print human readable file sizes (base 10)')] = False,
 ):
-    '''
+    """
     List objects
-    '''
+    """
     import tabulate  # pylint: disable=import-outside-toplevel
     from hailtop.fs.router_fs import RouterFS  # pylint: disable=import-outside-toplevel
     from hailtop.utils import async_to_blocking  # pylint: disable=import-outside-toplevel

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -4,15 +4,9 @@ from datetime import datetime
 from typing import List, Optional, Annotated as Ann
 
 import humanize
-import tabulate
 import typer
 
 from typer import Option as Opt, Argument as Arg
-
-import hailtop.fs.fs_utils
-
-from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.utils import async_to_blocking
 
 app = typer.Typer(
     name='fs',
@@ -22,7 +16,7 @@ app = typer.Typer(
 )
 
 
-async def async_du(fs: RouterAsyncFS, path: str, human_readable: bool, summarize: bool) -> int:
+async def async_du(fs, path: str, human_readable: bool, summarize: bool) -> int:
     total_size = 0
     async for item in await fs.listfiles(path):
         url, is_dir = await asyncio.gather(item.url(), item.is_dir())
@@ -48,6 +42,9 @@ def du(paths: Ann[Optional[List[str]], Arg()] = None,
     '''
     Display storage resourse usage
     '''
+    from hailtop.aiotools.router_fs import RouterAsyncFS  # pylint: disable=import-outside-toplevel
+    from hailtop.utils import async_to_blocking  # pylint: disable=import-outside-toplevel
+
     if not paths:
         paths = ['.']
     fs = RouterAsyncFS()
@@ -69,6 +66,10 @@ def ls(paths: Ann[Optional[List[str]], Arg()] = None,
     '''
     List objects
     '''
+    import tabulate  # pylint: disable=import-outside-toplevel
+    import hailtop.fs.fs_utils  # pylint: disable=import-outside-toplevel
+    from hailtop.utils import async_to_blocking  # pylint: disable=import-outside-toplevel
+
     def display_bytes(size):
         if size is None or size <= 0:
             return None

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -1,0 +1,29 @@
+import pprint
+
+import typer
+import hailtop.fs
+
+from typing import List, Optional, Annotated as Ann
+
+from typer import Option as Opt, Argument as Arg
+
+app = typer.Typer(
+    name='fs',
+    no_args_is_help=True,
+    help='Object and File utilites',
+    pretty_exceptions_show_locals=False,
+)
+
+
+@app.command()
+def ls(ctx: typer.Context,
+       paths: Ann[Optional[List[str]], Arg()] = None,
+       ):
+    '''
+    List objects
+    '''
+    if not paths:
+        paths = ['.']
+    for path in paths:
+        listing = hailtop.fs.ls(path)
+        print(*(item.path for item in listing), sep='\n')

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -41,8 +41,7 @@ async def async_du(fs: RouterAsyncFS, path: str, human_readable: bool, summarize
 
 
 @app.command()
-def du(ctx: typer.Context,
-       paths: Ann[Optional[List[str]], Arg()] = None,
+def du(paths: Ann[Optional[List[str]], Arg()] = None,
        human_readable: Ann[bool, Opt('-h', '--human-readable', help='print sizes in human readable format (base 10)')] = False,
        summarize: Ann[bool, Opt('-s', '--summarize', help='display only a total for each argument')] = False,
        ):
@@ -63,8 +62,7 @@ def du(ctx: typer.Context,
 
 
 @app.command()
-def ls(ctx: typer.Context,
-       paths: Ann[Optional[List[str]], Arg()] = None,
+def ls(paths: Ann[Optional[List[str]], Arg()] = None,
        long: Ann[bool, Opt('-l', '--long', help='use long listing format')] = False,
        human_readable: Ann[bool, Opt('-h', '--human-readable', help='print human readable file sizes (base 10)')] = False,
        ):

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -35,10 +35,13 @@ async def async_du(fs, path: str, human_readable: bool, summarize: bool) -> int:
 
 
 @app.command()
-def du(paths: Ann[Optional[List[str]], Arg()] = None,
-       human_readable: Ann[bool, Opt('-h', '--human-readable', help='print sizes in human readable format (base 10)')] = False,
-       summarize: Ann[bool, Opt('-s', '--summarize', help='display only a total for each argument')] = False,
-       ):
+def du(
+    paths: Ann[Optional[List[str]], Arg()] = None,
+    human_readable: Ann[
+        bool, Opt('-h', '--human-readable', help='print sizes in human readable format (base 10)')
+    ] = False,
+    summarize: Ann[bool, Opt('-s', '--summarize', help='display only a total for each argument')] = False,
+):
     '''
     Display storage resourse usage
     '''
@@ -59,10 +62,11 @@ def du(paths: Ann[Optional[List[str]], Arg()] = None,
 
 
 @app.command()
-def ls(paths: Ann[Optional[List[str]], Arg()] = None,
-       long: Ann[bool, Opt('-l', '--long', help='use long listing format')] = False,
-       human_readable: Ann[bool, Opt('-h', '--human-readable', help='print human readable file sizes (base 10)')] = False,
-       ):
+def ls(
+    paths: Ann[Optional[List[str]], Arg()] = None,
+    long: Ann[bool, Opt('-l', '--long', help='use long listing format')] = False,
+    human_readable: Ann[bool, Opt('-h', '--human-readable', help='print human readable file sizes (base 10)')] = False,
+):
     '''
     List objects
     '''
@@ -85,13 +89,18 @@ def ls(paths: Ann[Optional[List[str]], Arg()] = None,
             listing = fs.ls(path)
             listing.sort(key=lambda item: item.path)
             if long:
-                listing = [(item.typ,
-                            display_bytes(item.size),
-                            datetime.utcfromtimestamp(item.modification_time)
-                            if item.modification_time is not None else None,
-                            item.path) for item in listing]
-                print(tabulate.tabulate(listing, tablefmt='plain',
-                                        colalign=('global', 'right', 'global', 'global')))
+                listing = [
+                    (
+                        item.typ,
+                        display_bytes(item.size),
+                        datetime.utcfromtimestamp(item.modification_time)
+                        if item.modification_time is not None
+                        else None,
+                        item.path,
+                    )
+                    for item in listing
+                ]
+                print(tabulate.tabulate(listing, tablefmt='plain', colalign=('global', 'right', 'global', 'global')))
             else:
                 print(*(item.path for item in listing), sep='\n')
     finally:

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -1,8 +1,8 @@
-import pprint
-
+import tabulate
 import typer
 import hailtop.fs
 
+from datetime import datetime
 from typing import List, Optional, Annotated as Ann
 
 from typer import Option as Opt, Argument as Arg
@@ -18,6 +18,7 @@ app = typer.Typer(
 @app.command()
 def ls(ctx: typer.Context,
        paths: Ann[Optional[List[str]], Arg()] = None,
+       long: Ann[bool, Opt('-l', '--long', help='use long listing format')] = False,
        ):
     '''
     List objects
@@ -26,4 +27,12 @@ def ls(ctx: typer.Context,
         paths = ['.']
     for path in paths:
         listing = hailtop.fs.ls(path)
-        print(*(item.path for item in listing), sep='\n')
+        if long:
+            listing = [(item.typ,
+                        item.size if item.size > 0 else None,
+                        datetime.utcfromtimestamp(item.modification_time)
+                        if item.modification_time is not None else None,
+                        item.path) for item in listing]
+            print(tabulate.tabulate(listing, tablefmt='plain'))
+        else:
+            print(*(item.path for item in listing), sep='\n')

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -1,8 +1,9 @@
-import tabulate
-import typer
-
 from datetime import datetime
 from typing import List, Optional, Annotated as Ann
+
+import humanize
+import tabulate
+import typer
 
 from typer import Option as Opt, Argument as Arg
 
@@ -17,13 +18,33 @@ app = typer.Typer(
 
 
 @app.command()
+def du(ctx: typer.Context,
+       paths: Ann[Optional[List[str]], Arg()] = None,
+       human_readable: Ann[bool, Opt('-h', '--human-readable', help='print sizes in human readable format')] = False,
+       ):
+    '''
+    Display storage resourse usage
+    '''
+    if not paths:
+        paths = ['.']
+    print(paths, human_readable)
+
+
+@app.command()
 def ls(ctx: typer.Context,
        paths: Ann[Optional[List[str]], Arg()] = None,
        long: Ann[bool, Opt('-l', '--long', help='use long listing format')] = False,
+       human_readable: Ann[bool, Opt('-h', '--human-readable', help='print human readable (base 10) file sizes')] = False,
        ):
     '''
     List objects
     '''
+    def display_bytes(size):
+        if size is None or size <= 0:
+            return None
+        if human_readable:
+            return humanize.naturalsize(size, gnu=True)
+        return size
     if not paths:
         paths = ['.']
     for path in paths:
@@ -31,10 +52,11 @@ def ls(ctx: typer.Context,
         listing.sort(key=lambda item: item.path)
         if long:
             listing = [(item.typ,
-                        item.size if item.size > 0 else None,
+                        display_bytes(item.size),
                         datetime.utcfromtimestamp(item.modification_time)
                         if item.modification_time is not None else None,
                         item.path) for item in listing]
-            print(tabulate.tabulate(listing, tablefmt='plain'))
+            print(tabulate.tabulate(listing, tablefmt='plain',
+                                    colalign=('global', 'right', 'global', 'global')))
         else:
             print(*(item.path for item in listing), sep='\n')

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -67,7 +67,7 @@ def ls(paths: Ann[Optional[List[str]], Arg()] = None,
     List objects
     '''
     import tabulate  # pylint: disable=import-outside-toplevel
-    import hailtop.fs.fs_utils  # pylint: disable=import-outside-toplevel
+    from hailtop.fs.router_fs import RouterFS  # pylint: disable=import-outside-toplevel
     from hailtop.utils import async_to_blocking  # pylint: disable=import-outside-toplevel
 
     def display_bytes(size):
@@ -76,11 +76,13 @@ def ls(paths: Ann[Optional[List[str]], Arg()] = None,
         if human_readable:
             return humanize.naturalsize(size, gnu=True)
         return size
+
+    fs = RouterFS()
     try:
         if not paths:
             paths = ['.']
         for path in paths:
-            listing = hailtop.fs.fs_utils.ls(path)
+            listing = fs.ls(path)
             listing.sort(key=lambda item: item.path)
             if long:
                 listing = [(item.typ,
@@ -93,5 +95,4 @@ def ls(paths: Ann[Optional[List[str]], Arg()] = None,
             else:
                 print(*(item.path for item in listing), sep='\n')
     finally:
-        afs = hailtop.fs.fs_utils._fs().afs
-        async_to_blocking(afs.close())
+        async_to_blocking(fs.afs.close())

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -1,11 +1,12 @@
 import tabulate
 import typer
-import hailtop.fs
 
 from datetime import datetime
 from typing import List, Optional, Annotated as Ann
 
 from typer import Option as Opt, Argument as Arg
+
+import hailtop.fs
 
 app = typer.Typer(
     name='fs',
@@ -27,6 +28,7 @@ def ls(ctx: typer.Context,
         paths = ['.']
     for path in paths:
         listing = hailtop.fs.ls(path)
+        listing.sort(key=lambda item: item.path)
         if long:
             listing = [(item.typ,
                         item.size if item.size > 0 else None,


### PR DESCRIPTION
Add hailctl fs as a cloud agnostic filesystem utility, along with two commands `ls` and `du`. Output is rudimentary at this point and is subject to change.

du:
```
 Usage: hailctl fs du [OPTIONS] [PATHS]...

 Display storage resourse usage

╭─ Arguments ──────────────────────────────────────────────────────────────────╮
│   paths      [PATHS]...  [default: None]                                     │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --human-readable  -h        print sizes in human readable format (base 10)   │
│ --summarize       -s        display only a total for each argument           │
│ --help                      Show this message and exit.                      │
╰──────────────────────────────────────────────────────────────────────────────╯
```

ls:
```
 Usage: hailctl fs ls [OPTIONS] [PATHS]...

 List objects

╭─ Arguments ──────────────────────────────────────────────────────────────────╮
│   paths      [PATHS]...  [default: None]                                     │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Options ────────────────────────────────────────────────────────────────────╮
│ --long            -l        use long listing format                          │
│ --human-readable  -h        print human readable file sizes (base 10)        │
│ --help                      Show this message and exit.                      │
╰──────────────────────────────────────────────────────────────────────────────╯
```