### PR TITLE
[precommit] ignore hail/python/(hail|test) from pyright

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
         language: system
         types: [python]
         require_serial: true
+        exclude: hail/python/(hail|test)
         stages:
           - pre-push
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
We do not yet have pyright running on the Hail python package nor the tests. Without this change, I get failures on push.