### PR TITLE
[httpx][Makefile][copier] add --timeout to copier; use in Makefile

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -349,13 +349,13 @@ upload-artifacts: $(WHEEL)
 # > rm upload-remote-test-resources
 upload-remote-test-resources: $(shell git ls-files src/test/resources)
 upload-remote-test-resources: $(shell git ls-files python/hail/docs/data)
-	gcloud storage cp -r src/test/resources/\* $(CLOUD_HAIL_TEST_RESOURCES_DIR)
-	gcloud storage cp -r python/hail/docs/data/\* $(CLOUD_HAIL_DOCTEST_DATA_DIR)
-	# # In Azure, use the following instead of gcloud storage cp
-	# python3 -m hailtop.aiotools.copy -vvv 'null' '[\
-        #      {"from":"src/test/resources","to":"$(CLOUD_HAIL_TEST_RESOURCES_DIR)"},\
-        #      {"from":"python/hail/docs/data","to":"$(CLOUD_HAIL_DOCTEST_DATA_DIR)"}\
-        # ]'
+	# # If hailtop.aiotools.copy gives you trouble:
+	# gcloud storage cp -r src/test/resources/\* $(CLOUD_HAIL_TEST_RESOURCES_DIR)
+	# gcloud storage cp -r python/hail/docs/data/\* $(CLOUD_HAIL_DOCTEST_DATA_DIR)
+	python3 -m hailtop.aiotools.copy -vvv 'null' '[\
+             {"from":"src/test/resources","to":"$(CLOUD_HAIL_TEST_RESOURCES_DIR)"},\
+             {"from":"python/hail/docs/data","to":"$(CLOUD_HAIL_DOCTEST_DATA_DIR)"}\
+        ]' --timeout 600
 	touch $@
 
 # NOTE: 1-day expiration of the test bucket means that this
@@ -505,13 +505,6 @@ hail-docs-do-not-render-notebooks: $(PYTHON_VERSION_INFO) python/hail/docs/chang
 	     -type f \
 	     -exec $(SED_INPLACE) -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
 	@echo Built docs: file://$(HAIL_HAIL_DIR)/build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
-
-.PHONY: upload-docs
-upload-docs: hail-docs batch-docs
-	cd build && tar czf www.tar.gz www
-	gcloud storage cp build/www.tar.gz $(docs_location)
-	gcloud storage objects update -r $(docs_location) --temporary-hold
-	gcloud storage objects update -r $(docs_location) --add-acl-grant=entity=AllUsers,role=READER
 
 .PHONY: test
 test: pytest jvm-test doctest

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -1,5 +1,4 @@
 .PHONY: jars clean
-.POSIX: # https://github.com/hail-is/hail/pull/14138#issuecomment-1894411324
 
 HAIL_HAIL_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -351,10 +350,14 @@ upload-remote-test-resources: $(shell git ls-files python/hail/docs/data)
 	# # If hailtop.aiotools.copy gives you trouble:
 	# gcloud storage cp -r src/test/resources/\* $(CLOUD_HAIL_TEST_RESOURCES_DIR)
 	# gcloud storage cp -r python/hail/docs/data/\* $(CLOUD_HAIL_DOCTEST_DATA_DIR)
-	python3 -m hailtop.aiotools.copy -vvv 'null' '[\
-             {"from":"src/test/resources","to":"$(CLOUD_HAIL_TEST_RESOURCES_DIR)"},\
-             {"from":"python/hail/docs/data","to":"$(CLOUD_HAIL_DOCTEST_DATA_DIR)"}\
-        ]' --timeout 600
+	python3 -m hailtop.aiotools.copy \
+            -vvv \
+            'null' \
+            "[\
+              {\"from\":\"src/test/resources\",\"to\":\"$(CLOUD_HAIL_TEST_RESOURCES_DIR)\"}, \
+              {\"from\":\"python/hail/docs/data\",\"to\":\"$(CLOUD_HAIL_DOCTEST_DATA_DIR)\"} \
+             ]" \
+            --timeout 600
 	touch $@
 
 # NOTE: 1-day expiration of the test bucket means that this

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -1,4 +1,5 @@
 .PHONY: jars clean
+.POSIX: # https://github.com/hail-is/hail/pull/14138#issuecomment-1894411324
 
 HAIL_HAIL_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -181,8 +181,7 @@ $(FAST_PYTHON_JAR_EXTRA_CLASSPATH): build.gradle
 python-jar: $(PYTHON_JAR)
 
 .PHONY: pytest
-pytest: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
-pytest: python/README.md $(FAST_PYTHON_JAR) $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
+pytest: install-editable
 	cd python && \
           $(HAIL_PYTHON3) -m pytest \
             -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
@@ -202,9 +201,7 @@ pytest: python/README.md $(FAST_PYTHON_JAR) $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
 
 # NOTE: Look at upload-remote-test-resources target if test resources are missing
 .PHONY: pytest-inter-cloud
-pytest-inter-cloud: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
-pytest-inter-cloud: python/README.md $(FAST_PYTHON_JAR) $(FAST_PYTHON_JAR_EXTRA_CLASSPATH)
-pytest-inter-cloud: upload-remote-test-resources
+pytest-inter-cloud: upload-remote-test-resources install-editable
 	cd python && \
           HAIL_TEST_STORAGE_URI=$(TEST_STORAGE_URI) \
           HAIL_TEST_GCS_BUCKET=$(HAIL_TEST_GCS_BUCKET) \
@@ -347,6 +344,7 @@ upload-artifacts: $(WHEEL)
 # NOTE: 1-day expiration of the test bucket means that this
 # target must be run at least once a day. To trigger this target to re-run,
 # > rm upload-remote-test-resources
+upload-remote-test-resources: install-editable
 upload-remote-test-resources: $(shell git ls-files src/test/resources)
 upload-remote-test-resources: $(shell git ls-files python/hail/docs/data)
 	# # If hailtop.aiotools.copy gives you trouble:

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -343,7 +343,7 @@ class S3AsyncFS(AsyncFS):
         max_workers: Optional[int] = None,
         *,
         max_pool_connections: int = 10,
-        timeout: Optional[Union[int, float, aiohttp.ClientTimeout]],
+        timeout: Optional[Union[int, float, aiohttp.ClientTimeout]] = None,
     ):
         if not thread_pool:
             thread_pool = ThreadPoolExecutor(max_workers=max_workers)

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -1,5 +1,19 @@
-from typing import Any, AsyncIterator, BinaryIO, cast, AsyncContextManager, Dict, List, Optional, Set, Tuple, Type
+from typing import (
+    Any,
+    AsyncIterator,
+    BinaryIO,
+    cast,
+    AsyncContextManager,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 from types import TracebackType
+import aiohttp
 import sys
 from concurrent.futures import ThreadPoolExecutor
 import os.path
@@ -329,12 +343,32 @@ class S3AsyncFS(AsyncFS):
         max_workers: Optional[int] = None,
         *,
         max_pool_connections: int = 10,
+        timeout: Optional[Union[int, float, aiohttp.ClientTimeout]],
     ):
         if not thread_pool:
             thread_pool = ThreadPoolExecutor(max_workers=max_workers)
         self._thread_pool = thread_pool
+
+        kwargs = {}
+        if isinstance(timeout, aiohttp.ClientTimeout):
+            if timeout.sock_read:
+                kwargs['read_timeout'] = timeout.sock_read
+            elif timeout.total:
+                kwargs['read_timeout'] = timeout.total
+
+            if timeout.sock_connect:
+                kwargs['connect_timeout'] = timeout.sock_connect
+            elif timeout.connect:
+                kwargs['connect_timeout'] = timeout.connect
+            elif timeout.total:
+                kwargs['connect_timeout'] = timeout.total
+        elif isinstance(timeout, (int, float)):
+            kwargs['read_timeout'] = timeout
+            kwargs['connect_timeout'] = timeout
+
         config = botocore.config.Config(
             max_pool_connections=max_pool_connections,
+            **kwargs,
         )
         self._s3 = boto3.client('s3', config=config)
 

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -370,7 +370,7 @@ class AzureAsyncFS(AsyncFS):
         *,
         credential_file: Optional[str] = None,
         credentials: Optional[AzureCredentials] = None,
-        timeout: Optional[Union[int, float, aiohttp.ClientTimeout]],
+        timeout: Optional[Union[int, float, aiohttp.ClientTimeout]] = None,
     ):
         if credentials is None:
             scopes = ['https://storage.azure.com/.default']

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -184,7 +184,6 @@ async def main() -> None:
     timeout = args.timeout
     if timeout:
         timeout = float(timeout)
-    print(timeout)
     gcs_kwargs = {
         'gcs_requester_pays_configuration': requester_pays_project,
         'timeout': timeout,

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -169,6 +169,7 @@ async def main() -> None:
     parser.add_argument(
         '-v', '--verbose', action='store_const', const=True, default=False, help='show logging information'
     )
+    parser.add_argument('--timeout', type=str, default=None, help='show logging information')
     args = parser.parse_args()
 
     if args.verbose:
@@ -179,11 +180,27 @@ async def main() -> None:
     if args.files is None or args.files == '-':
         args.files = sys.stdin.read()
     files = json.loads(args.files)
-    gcs_kwargs = {'gcs_requester_pays_configuration': requester_pays_project}
+
+    timeout = args.timeout
+    if timeout:
+        timeout = float(timeout)
+    print(timeout)
+    gcs_kwargs = {
+        'gcs_requester_pays_configuration': requester_pays_project,
+        'timeout': timeout,
+    }
+    azure_kwargs = {
+        'timeout': timeout,
+    }
+    s3_kwargs = {
+        'timeout': timeout,
+    }
 
     await copy_from_dict(
         max_simultaneous_transfers=args.max_simultaneous_transfers,
         gcs_kwargs=gcs_kwargs,
+        azure_kwargs=azure_kwargs,
+        s3_kwargs=s3_kwargs,
         files=files,
         verbose=args.verbose,
     )

--- a/hail/scripts/upload_qob_jar.sh
+++ b/hail/scripts/upload_qob_jar.sh
@@ -22,5 +22,9 @@ else
     JAR_LOCATION="${TEST_STORAGE_URI}/${NAMESPACE}/jars/${TOKEN}/${REVISION}.jar"
 fi
 
-python3 -m hailtop.aiotools.copy -vvv 'null' '[{"from":"'${SHADOW_JAR}'", "to":"'${JAR_LOCATION}'"}]'
+python3 -m hailtop.aiotools.copy \
+	-vvv \
+	'null' \
+	'[{"from":"'${SHADOW_JAR}'", "to":"'${JAR_LOCATION}'"}]' \
+	--timeout 600
 echo ${JAR_LOCATION} > ${PATH_FILE}


### PR DESCRIPTION
We have long had trouble with copying on flaky Internet connections. AFAIK, this is due to our very aggressive timeouts. This change permits the CLI to override the default timeout in `hailtop.aiotools.copy`. Setting this back to 600s should work on most flaky Internet connections. It works on my particularly bad home WiFi.

The upload-docs target was old and broken so I deleted it. I did not change the upload-artifacts target because that is Google Cloud specific anyway.

Main benefit is that these targets work in Azure now.