### PR TITLE
[aiotools] add basename to FileStatus; rename name in FileListEntry

### DIFF
--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -74,8 +74,15 @@ class PageIterator:
 
 
 class S3HeadObjectFileStatus(FileStatus):
-    def __init__(self, head_object_resp):
+    def __init__(self, head_object_resp, url: str):
         self.head_object_resp = head_object_resp
+        self._url = url
+
+    def basename(self) -> str:
+        return os.path.basename(self._url.rstrip('/'))
+
+    def url(self) -> str:
+        return self._url
 
     async def size(self) -> int:
         return self.head_object_resp['ContentLength']
@@ -95,8 +102,15 @@ class S3HeadObjectFileStatus(FileStatus):
 
 
 class S3ListFilesFileStatus(FileStatus):
-    def __init__(self, item: Dict[str, Any]):
+    def __init__(self, item: Dict[str, Any], url: str):
         self._item = item
+        self._url = url
+
+    def basename(self) -> str:
+        return os.path.basename(self._url.rstrip('/'))
+
+    def url(self) -> str:
+        return self._url
 
     async def size(self) -> int:
         return self._item['Size']
@@ -166,8 +180,8 @@ class S3FileListEntry(FileListEntry):
         self._item = item
         self._status: Optional[S3ListFilesFileStatus] = None
 
-    def name(self) -> str:
-        return os.path.basename(self._key)
+    def basename(self) -> str:
+        return os.path.basename(self._key.rstrip('/'))
 
     async def url(self) -> str:
         return f's3://{self._bucket}/{self._key}'
@@ -182,7 +196,7 @@ class S3FileListEntry(FileListEntry):
         if self._status is None:
             if self._item is None:
                 raise IsADirectoryError(f's3://{self._bucket}/{self._key}')
-            self._status = S3ListFilesFileStatus(self._item)
+            self._status = S3ListFilesFileStatus(self._item, await self.url())
         return self._status
 
 
@@ -462,7 +476,7 @@ class S3AsyncFS(AsyncFS):
         bucket, name = self.get_bucket_and_name(url)
         try:
             resp = await blocking_to_async(self._thread_pool, self._s3.head_object, Bucket=bucket, Key=name)
-            return S3HeadObjectFileStatus(resp)
+            return S3HeadObjectFileStatus(resp, url)
         except botocore.exceptions.ClientError as e:
             if e.response['ResponseMetadata']['HTTPStatusCode'] == 404:
                 raise FileNotFoundError(url) from e

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -546,8 +546,9 @@ class AzureAsyncFS(AsyncFS):
     @handle_public_access_error
     async def statfile(self, url: str) -> FileStatus:
         try:
-            blob_props = await self.get_blob_client(self.parse_url(url)).get_blob_properties()
-            return AzureFileStatus(blob_props)
+            parsed_url = self.parse_url(url)
+            blob_props = await self.get_blob_client(parsed_url).get_blob_properties()
+            return AzureFileStatus(blob_props, parsed_url)
         except azure.core.exceptions.ResourceNotFoundError as e:
             raise FileNotFoundError(url) from e
 

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -266,7 +266,7 @@ class AzureFileStatus(FileStatus):
         self._url = url
 
     def basename(self) -> str:
-        return os.path.basename(self.url().rstrip('/'))
+        return os.path.basename(self._url.base.rstrip('/'))
 
     def url(self) -> str:
         return str(self._url)

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -150,7 +150,7 @@ class FileListEntry(abc.ABC):
         Examples
         --------
 
-        The only interesting case are signed URLs in Azure. These are called shared signature tokens or SAS tokens.
+        The only interesting case is for signed URLs in Azure. These are called shared signature tokens or SAS tokens.
         For example, the following URL
 
             https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -52,7 +52,6 @@ class FileStatus(abc.ABC):
         - https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
         - /folder/file
         '''
-        pass
 
     @abc.abstractmethod
     def url(self) -> str:
@@ -75,7 +74,6 @@ class FileStatus(abc.ABC):
             https://account.blob.core.windows.net/container/folder/file
 
         '''
-        pass
 
     @abc.abstractmethod
     async def size(self) -> int:
@@ -120,7 +118,6 @@ class FileListEntry(abc.ABC):
         - https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
         - /folder/file
         '''
-        pass
 
     @abc.abstractmethod
     async def url(self) -> str:
@@ -143,7 +140,6 @@ class FileListEntry(abc.ABC):
             https://account.blob.core.windows.net/container/folder/file
 
         '''
-        pass
 
     async def url_maybe_trailing_slash(self) -> str:
         return await self.url()

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -39,7 +39,7 @@ async def with_exception(
 class FileStatus(abc.ABC):
     @abc.abstractmethod
     def basename(self) -> str:
-        '''The basename of the object.
+        """The basename of the object.
 
         Examples
         --------
@@ -51,11 +51,11 @@ class FileStatus(abc.ABC):
         - https://account.blob.core.windows.net/container/folder/file
         - https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
         - /folder/file
-        '''
+        """
 
     @abc.abstractmethod
     def url(self) -> str:
-        '''The URL of the object without any query parameters.
+        """The URL of the object without any query parameters.
 
         Examples
         --------
@@ -73,7 +73,7 @@ class FileStatus(abc.ABC):
 
             https://account.blob.core.windows.net/container/folder/file
 
-        '''
+        """
 
     @abc.abstractmethod
     async def size(self) -> int:
@@ -81,21 +81,21 @@ class FileStatus(abc.ABC):
 
     @abc.abstractmethod
     def time_created(self) -> datetime.datetime:
-        '''The time the object was created in seconds since the epcoh, UTC.
+        """The time the object was created in seconds since the epcoh, UTC.
 
         Some filesystems do not support creation time. In that case, an error is raised.
 
-        '''
+        """
 
     @abc.abstractmethod
     def time_modified(self) -> datetime.datetime:
-        '''The time the object was last modified in seconds since the epoch, UTC.
+        """The time the object was last modified in seconds since the epoch, UTC.
 
         The meaning of modification time is cloud-defined. In some clouds, it is the creation
         time. In some clouds, it is the more recent of the creation time or the time of the most
         recent metadata modification.
 
-        '''
+        """
 
     @abc.abstractmethod
     async def __getitem__(self, key: str) -> Any:
@@ -105,7 +105,7 @@ class FileStatus(abc.ABC):
 class FileListEntry(abc.ABC):
     @abc.abstractmethod
     def basename(self) -> str:
-        '''The basename of the object.
+        """The basename of the object.
 
         Examples
         --------
@@ -117,11 +117,11 @@ class FileListEntry(abc.ABC):
         - https://account.blob.core.windows.net/container/folder/file
         - https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
         - /folder/file
-        '''
+        """
 
     @abc.abstractmethod
     async def url(self) -> str:
-        '''The URL of the object without any query parameters.
+        """The URL of the object without any query parameters.
 
         Examples
         --------
@@ -139,13 +139,13 @@ class FileListEntry(abc.ABC):
 
             https://account.blob.core.windows.net/container/folder/file
 
-        '''
+        """
 
     async def url_maybe_trailing_slash(self) -> str:
         return await self.url()
 
     async def url_full(self) -> str:
-        '''The URL of the object with any query parameters.
+        """The URL of the object with any query parameters.
 
         Examples
         --------
@@ -159,7 +159,7 @@ class FileListEntry(abc.ABC):
 
             https://account.blob.core.windows.net/container/folder/file
 
-        '''
+        """
         return await self.url()
 
     @abc.abstractmethod
@@ -183,7 +183,7 @@ class MultiPartCreate(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def __aenter__(self) -> 'MultiPartCreate':
+    async def __aenter__(self) -> "MultiPartCreate":
         pass
 
     @abc.abstractmethod
@@ -215,12 +215,12 @@ class AsyncFSURL(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def with_path(self, path) -> 'AsyncFSURL':
+    def with_path(self, path) -> "AsyncFSURL":
         pass
 
-    def with_new_path_component(self, new_path_component) -> 'AsyncFSURL':
-        prefix = self.path if self.path.endswith('/') else self.path + '/'
-        suffix = new_path_component[1:] if new_path_component.startswith('/') else new_path_component
+    def with_new_path_component(self, new_path_component) -> "AsyncFSURL":
+        prefix = self.path if self.path.endswith("/") else self.path + "/"
+        suffix = new_path_component[1:] if new_path_component.startswith("/") else new_path_component
         return self.with_path(prefix + suffix)
 
     @abc.abstractmethod
@@ -229,8 +229,8 @@ class AsyncFSURL(abc.ABC):
 
 
 class AsyncFS(abc.ABC):
-    FILE = 'file'
-    DIR = 'dir'
+    FILE = "file"
+    DIR = "dir"
 
     @staticmethod
     @abc.abstractmethod
@@ -239,8 +239,8 @@ class AsyncFS(abc.ABC):
 
     @staticmethod
     def copy_part_size(url: str) -> int:  # pylint: disable=unused-argument
-        '''Part size when copying using multi-part uploads.  The part size of
-        the destination filesystem is used.'''
+        """Part size when copying using multi-part uploads.  The part size of
+        the destination filesystem is used."""
         return 128 * 1024 * 1024
 
     @staticmethod
@@ -260,12 +260,12 @@ class AsyncFS(abc.ABC):
     async def open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         if length == 0:
             fs_url = self.parse_url(url)
-            if fs_url.path.endswith('/'):
-                file_url = str(fs_url.with_path(fs_url.path.rstrip('/')))
+            if fs_url.path.endswith("/"):
+                file_url = str(fs_url.with_path(fs_url.path.rstrip("/")))
                 dir_url = str(fs_url)
             else:
                 file_url = str(fs_url)
-                dir_url = str(fs_url.with_path(fs_url.path + '/'))
+                dir_url = str(fs_url.with_path(fs_url.path + "/"))
             isfile, isdir = await asyncio.gather(self.isfile(file_url), self.isdir(dir_url))
             if isfile:
                 if isdir:
@@ -311,10 +311,10 @@ class AsyncFS(abc.ABC):
         pass
 
     async def _staturl_parallel_isfile_isdir(self, url: str) -> str:
-        assert not url.endswith('/')
+        assert not url.endswith("/")
 
         [(is_file, isfile_exc), (is_dir, isdir_exc)] = await asyncio.gather(
-            with_exception(self.isfile, url), with_exception(self.isdir, url + '/')
+            with_exception(self.isfile, url), with_exception(self.isdir, url + "/")
         )
         # raise exception deterministically
         if isfile_exc:
@@ -408,7 +408,7 @@ class AsyncFS(abc.ABC):
     async def close(self) -> None:
         pass
 
-    async def __aenter__(self) -> 'AsyncFS':
+    async def __aenter__(self) -> "AsyncFS":
         return self
 
     async def __aexit__(
@@ -417,7 +417,7 @@ class AsyncFS(abc.ABC):
         await self.close()
 
 
-T = TypeVar('T', bound=AsyncFS)
+T = TypeVar("T", bound=AsyncFS)
 
 
 class AsyncFSFactory(abc.ABC, Generic[T]):

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -38,6 +38,46 @@ async def with_exception(
 
 class FileStatus(abc.ABC):
     @abc.abstractmethod
+    def basename(self) -> str:
+        '''The basename of the object.
+
+        Examples
+        --------
+
+        The basename of all of these objects is "file":
+
+        - s3://bucket/folder/file
+        - gs://bucket/folder/file
+        - https://account.blob.core.windows.net/container/folder/file
+        - https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
+        - /folder/file
+        '''
+        pass
+
+    @abc.abstractmethod
+    def url(self) -> str:
+        '''The URL of the object without any query parameters.
+
+        Examples
+        --------
+
+        - s3://bucket/folder/file
+        - gs://bucket/folder/file
+        - https://account.blob.core.windows.net/container/folder/file
+        - /folder/file
+
+        Note that the following URL
+
+            https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
+
+        becomes
+
+            https://account.blob.core.windows.net/container/folder/file
+
+        '''
+        pass
+
+    @abc.abstractmethod
     async def size(self) -> int:
         pass
 
@@ -66,17 +106,64 @@ class FileStatus(abc.ABC):
 
 class FileListEntry(abc.ABC):
     @abc.abstractmethod
-    def name(self) -> str:
+    def basename(self) -> str:
+        '''The basename of the object.
+
+        Examples
+        --------
+
+        The basename of all of these objects is "file":
+
+        - s3://bucket/folder/file
+        - gs://bucket/folder/file
+        - https://account.blob.core.windows.net/container/folder/file
+        - https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
+        - /folder/file
+        '''
         pass
 
     @abc.abstractmethod
     async def url(self) -> str:
+        '''The URL of the object without any query parameters.
+
+        Examples
+        --------
+
+        - s3://bucket/folder/file
+        - gs://bucket/folder/file
+        - https://account.blob.core.windows.net/container/folder/file
+        - /folder/file
+
+        Note that the following URL
+
+            https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
+
+        becomes
+
+            https://account.blob.core.windows.net/container/folder/file
+
+        '''
         pass
 
     async def url_maybe_trailing_slash(self) -> str:
         return await self.url()
 
     async def url_full(self) -> str:
+        '''The URL of the object with any query parameters.
+
+        Examples
+        --------
+
+        The only interesting case are signed URLs in Azure. These are called shared signature tokens or SAS tokens.
+        For example, the following URL
+
+            https://account.blob.core.windows.net/container/folder/file?sv=2023-01-01&sr=bv&sig=abc123&sp=rcw
+
+        is a signed version of this URL
+
+            https://account.blob.core.windows.net/container/folder/file
+
+        '''
         return await self.url()
 
     @abc.abstractmethod

--- a/hail/python/hailtop/aiotools/local_fs.py
+++ b/hail/python/hailtop/aiotools/local_fs.py
@@ -25,9 +25,16 @@ from .fs import (
 
 
 class LocalStatFileStatus(FileStatus):
-    def __init__(self, stat_result: os.stat_result):
+    def __init__(self, stat_result: os.stat_result, url: str):
         self._stat_result = stat_result
         self._items = None
+        self._url = url
+
+    def basename(self) -> str:
+        return os.path.basename(self._url)
+
+    def url(self) -> str:
+        return self._url
 
     async def size(self) -> int:
         return self._stat_result.st_size
@@ -52,7 +59,7 @@ class LocalFileListEntry(FileListEntry):
         self._entry = entry
         self._status = None
 
-    def name(self) -> str:
+    def basename(self) -> str:
         return self._entry.name
 
     async def url(self) -> str:
@@ -72,7 +79,9 @@ class LocalFileListEntry(FileListEntry):
         if self._status is None:
             if await self.is_dir():
                 raise IsADirectoryError()
-            self._status = LocalStatFileStatus(await blocking_to_async(self._thread_pool, self._entry.stat))
+            self._status = LocalStatFileStatus(
+                await blocking_to_async(self._thread_pool, self._entry.stat), await self.url()
+            )
         return self._status
 
 
@@ -289,7 +298,7 @@ class LocalAsyncFS(AsyncFS):
         stat_result = await blocking_to_async(self._thread_pool, os.stat, path)
         if stat.S_ISDIR(stat_result.st_mode):
             raise FileNotFoundError(f'is directory: {url}')
-        return LocalStatFileStatus(stat_result)
+        return LocalStatFileStatus(stat_result, path)
 
     # entries has no type hint because the return type of os.scandir
     # appears to be a private type, posix.ScandirIterator.

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -530,7 +530,8 @@ async def test_file_can_contain_url_query_delimiter(filesystem: Tuple[asyncio.Se
 async def test_basename_is_not_path(filesystem: Tuple[asyncio.Semaphore, AsyncFS, AsyncFSURL]):
     _, fs, base = filesystem
 
-    assert base.with_new_path_component('abc123').basename() == 'abc123'
+    await fs.write(str(base.with_new_path_component('abc123')), b'foo')
+    assert (await fs.statfile(str(base.with_new_path_component('abc123')))).basename() == 'abc123'
 
 
 async def test_listfiles(filesystem: Tuple[asyncio.Semaphore, AsyncFS, AsyncFSURL]):

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -521,10 +521,16 @@ async def test_file_can_contain_url_query_delimiter(filesystem: Tuple[asyncio.Se
     await fs.write(file, secrets.token_bytes(10))
     assert await fs.exists(file)
     async for f in await fs.listfiles(str(base)):
-        if 'bar?baz' in f.name():
+        if 'bar?baz' in f.basename():
             break
     else:
         assert False, 'File bar?baz not found'
+
+
+async def test_basename_is_not_path(filesystem: Tuple[asyncio.Semaphore, AsyncFS, AsyncFSURL]):
+    _, fs, base = filesystem
+
+    assert base.with_new_path_component('abc123').basename() == 'abc123'
 
 
 async def test_listfiles(filesystem: Tuple[asyncio.Semaphore, AsyncFS, AsyncFSURL]):


### PR DESCRIPTION
The term `name` has long been ambiguous and, indeed, our Azure implementation differed from S3 and Google. Now both FileStatus and FileListEntry use the term `basename`. Azure has been changed to have the same semantics as S3 and Google.