### PR TITLE
[ci] Use appkeys instead of strings for application storage.

### DIFF
--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -6,8 +6,7 @@ from typing import Dict, Optional
 
 import aiohttp
 
-from gear import Database, transaction
-from hailtop import httpx
+from gear import CommonAiohttpAppKeys, Database, transaction
 from hailtop.humanizex import naturaldelta_msec
 from hailtop.utils import retry_transient_errors, time_msecs, time_msecs_str
 
@@ -133,7 +132,7 @@ VALUES (%s, %s);
         instance_config: InstanceConfig,
     ):
         self.db: Database = app['db']
-        self.client_session: httpx.ClientSession = app['client_session']
+        self.client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
         self.inst_coll = inst_coll
         # pending, active, inactive, deleted
         self._state = state

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, List
 
 import aiohttp
 
-from gear import Database, K8sCache
+from gear import CommonAiohttpAppKeys, Database, K8sCache
 from hailtop import httpx
 from hailtop.aiotools import BackgroundTaskManager
 from hailtop.utils import Notice, retry_transient_errors, time_msecs
@@ -140,7 +140,7 @@ async def mark_job_complete(
     scheduler_state_changed: Notice = app['scheduler_state_changed']
     cancel_ready_state_changed: asyncio.Event = app['cancel_ready_state_changed']
     db: Database = app['db']
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
 
     inst_coll_manager: 'InstanceCollectionManager' = app['driver'].inst_coll_manager
     task_manager: BackgroundTaskManager = app['task_manager']
@@ -268,7 +268,7 @@ async def unschedule_job(app, record):
     cancel_ready_state_changed: asyncio.Event = app['cancel_ready_state_changed']
     scheduler_state_changed: Notice = app['scheduler_state_changed']
     db: Database = app['db']
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
     inst_coll_manager = app['driver'].inst_coll_manager
 
     batch_id = record['batch_id']
@@ -471,7 +471,7 @@ async def schedule_job(app, record, instance):
     assert instance.state == 'active'
 
     db: Database = app['db']
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
 
     batch_id = record['batch_id']
     job_id = record['job_id']

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -26,6 +26,7 @@ from prometheus_async.aio.web import server_stats
 
 from gear import (
     AuthServiceAuthenticator,
+    CommonAiohttpAppKeys,
     Database,
     K8sCache,
     Transaction,
@@ -1611,8 +1612,8 @@ SELECT instance_id, frozen FROM globals;
 
     inst_coll_configs = await InstanceCollectionConfigs.create(db)
 
-    app['client_session'] = httpx.client_session()
-    exit_stack.push_async_callback(app['client_session'].close)
+    app[CommonAiohttpAppKeys.CLIENT_SESSION] = httpx.client_session()
+    exit_stack.push_async_callback(app[CommonAiohttpAppKeys.CLIENT_SESSION].close)
 
     app['driver'] = await get_cloud_driver(app, db, MACHINE_NAME_PREFIX, DEFAULT_NAMESPACE, inst_coll_configs)
     exit_stack.push_async_callback(app['driver'].shutdown)

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -31,6 +31,7 @@ from typing_extensions import ParamSpec
 
 from gear import (
     AuthServiceAuthenticator,
+    CommonAiohttpAppKeys,
     Database,
     Transaction,
     UserData,
@@ -405,7 +406,7 @@ async def _get_job_container_log(app, batch_id, job_id, container, job_record) -
     state = job_record['state']
     if state == 'Running':
         return await _get_job_container_log_from_worker(
-            app['client_session'], batch_id, job_id, container, job_record['ip_address']
+            app[CommonAiohttpAppKeys.CLIENT_SESSION], batch_id, job_id, container, job_record['ip_address']
         )
 
     attempt_id = attempt_id_from_spec(job_record)
@@ -430,7 +431,7 @@ async def _get_job_log(app, batch_id, job_id) -> Dict[str, Optional[bytes]]:
 async def _get_job_resource_usage(app, batch_id, job_id) -> Optional[Dict[str, Optional[pd.DataFrame]]]:
     record = await _get_job_record(app, batch_id, job_id)
 
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
     file_store: FileStore = app['file_store']
     batch_format_version = BatchFormatVersion(record['format_version'])
 
@@ -540,7 +541,7 @@ async def _get_full_job_spec(app, record):
 
 
 async def _get_full_job_status(app, record):
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
     file_store: FileStore = app['file_store']
 
     batch_id = record['batch_id']
@@ -1639,7 +1640,7 @@ WHERE user = %s AND batches.id = %s AND batch_updates.update_id = %s AND NOT del
 
 
 async def _commit_update(app: web.Application, batch_id: int, update_id: int, user: str, db: Database):
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
 
     try:
         now = time_msecs()
@@ -2553,7 +2554,7 @@ async def _add_user_to_billing_project(request: web.Request, db: Database, billi
         session_id = await get_session_id(request)
         assert session_id is not None
         url = deploy_config.url('auth', f'/api/v1alpha/users/{user}')
-        await impersonate_user(session_id, request.app['client_session'], url)
+        await impersonate_user(session_id, request.app[CommonAiohttpAppKeys.CLIENT_SESSION], url)
     except aiohttp.ClientResponseError as e:
         if e.status == 404:
             raise NonExistentUserError(user) from e
@@ -2846,7 +2847,7 @@ async def index(request: web.Request, _) -> NoReturn:
 
 
 async def cancel_batch_loop_body(app):
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
     await retry_transient_errors(
         client_session.post,
         deploy_config.url('batch-driver', '/api/v1alpha/batches/cancel'),
@@ -2858,7 +2859,7 @@ async def cancel_batch_loop_body(app):
 
 
 async def delete_batch_loop_body(app):
-    client_session: httpx.ClientSession = app['client_session']
+    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
     await retry_transient_errors(
         client_session.post,
         deploy_config.url('batch-driver', '/api/v1alpha/batches/delete'),
@@ -2896,8 +2897,8 @@ async def on_startup(app):
     exit_stack = AsyncExitStack()
     app['exit_stack'] = exit_stack
 
-    app['client_session'] = httpx.client_session()
-    exit_stack.push_async_callback(app['client_session'].close)
+    app[CommonAiohttpAppKeys.CLIENT_SESSION] = httpx.client_session()
+    exit_stack.push_async_callback(app[CommonAiohttpAppKeys.CLIENT_SESSION].close)
 
     db = Database()
     await db.async_init()

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -21,6 +21,7 @@ from prometheus_async.aio.web import server_stats  # type: ignore
 
 from gear import (
     AuthServiceAuthenticator,
+    CommonAiohttpAppKeys,
     Database,
     UserData,
     check_csrf_token,
@@ -78,7 +79,7 @@ class PRConfig(TypedDict):
 
 async def pr_config(app, pr: PR) -> PRConfig:
     batch_id = pr.batch.id if pr.batch and isinstance(pr.batch, Batch) else None
-    build_state = pr.build_state if await pr.authorized(app['db']) else 'unauthorized'
+    build_state = pr.build_state if await pr.authorized(app[AppKeys.DB]) else 'unauthorized'
     if build_state is None and batch_id is not None:
         build_state = 'building'
     return {
@@ -136,7 +137,10 @@ async def watched_branch_config(app, wb: WatchedBranch, index: int) -> WatchedBr
 @auth.authenticated_developers_only()
 async def index(request: web.Request, userdata: UserData) -> web.Response:
     wb_configs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
-    page_context = {'watched_branches': wb_configs, 'frozen_merge_deploy': request.app['frozen_merge_deploy']}
+    page_context = {
+        'watched_branches': wb_configs,
+        'frozen_merge_deploy': request.app[AppKeys.FROZEN_MERGE_DEPLOY],
+    }
     return await render_template('ci', request, userdata, 'index.html', page_context)
 
 
@@ -201,7 +205,7 @@ async def get_pr(request: web.Request, userdata: UserData) -> web.Response:
                 traceback.format_exception(None, batch.exception, batch.exception.__traceback__)
             )
 
-    batch_client = request.app['batch_client']
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
     target_branch = wb.branch.short_str()
     batches = batch_client.list_batches(f'test=1 ' f'pr={pr.number} ' f'target_branch={target_branch} ' f'user:ci')
     batches = sorted([b async for b in batches], key=lambda b: b.id, reverse=True)
@@ -227,7 +231,7 @@ async def retry_pr(wb, pr, request):
         return
 
     batch_id = pr.batch.id
-    db: Database = app['db']
+    db = app[AppKeys.DB]
     await db.execute_insertone('INSERT INTO invalidated_batches (batch_id) VALUES (%s);', batch_id)
     await wb.notify_batch_changed(app)
 
@@ -247,7 +251,7 @@ async def post_retry_pr(request: web.Request, _) -> NoReturn:
 @routes.get('/batches')
 @auth.authenticated_developers_only()
 async def get_batches(request, userdata):
-    batch_client = request.app['batch_client']
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
     batches = [b async for b in batch_client.list_batches()]
     statuses = [await b.last_known_status() for b in batches]
     page_context = {'batches': statuses}
@@ -258,7 +262,7 @@ async def get_batches(request, userdata):
 @auth.authenticated_developers_only()
 async def get_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
-    batch_client = request.app['batch_client']
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
     b = await batch_client.get_batch(batch_id)
     status = await b.last_known_status()
     jobs = await collect_aiter(b.jobs())
@@ -319,7 +323,7 @@ async def get_user(request: web.Request, userdata: UserData) -> web.Response:
     review_wbs = filter_wbs(wbs, lambda pr: is_pr_reviewer(user.gh_username, pr))
     actionable_wbs = filter_wbs(wbs, lambda pr: pr_requires_action(user.gh_username, pr))
 
-    batch_client = request.app['batch_client']
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
     dev_deploys = batch_client.list_batches(f'user={user.hail_username} dev_deploy=1', limit=10)
     dev_deploys = sorted([b async for b in dev_deploys], key=lambda b: b.id, reverse=True)
 
@@ -341,7 +345,7 @@ async def get_user(request: web.Request, userdata: UserData) -> web.Response:
 @auth.authenticated_developers_only(redirect=False)
 async def post_authorized_source_sha(request: web.Request, _) -> NoReturn:
     app = request.app
-    db: Database = app['db']
+    db = app[AppKeys.DB]
     post = await request.post()
     sha = str(post['sha']).strip()
     await db.execute_insertone('INSERT INTO authorized_shas (sha) VALUES (%s);', sha)
@@ -366,7 +370,10 @@ async def pull_request_callback(event):
     target_branch = FQBranch.from_gh_json(gh_pr['base'])
     for wb in watched_branches:
         if (wb.prs and number in wb.prs) or (wb.branch == target_branch):
-            await wb.notify_github_changed(event.app)
+            app: web.Application = event.app
+            await wb.notify_github_changed(
+                app[AppKeys.DB], app[AppKeys.BATCH_CLIENT], app[AppKeys.GH_CLIENT], app[AppKeys.FROZEN_MERGE_DEPLOY]
+            )
 
 
 @gh_router.register('push')
@@ -378,7 +385,10 @@ async def push_callback(event):
         branch = FQBranch(Repo.from_gh_json(data['repository']), branch_name)
         for wb in watched_branches:
             if wb.branch == branch:
-                await wb.notify_github_changed(event.app)
+                app: web.Application = event.app
+                await wb.notify_github_changed(
+                    app[AppKeys.DB], app[AppKeys.BATCH_CLIENT], app[AppKeys.GH_CLIENT], app[AppKeys.FROZEN_MERGE_DEPLOY]
+                )
 
 
 @gh_router.register('pull_request_review')
@@ -387,7 +397,10 @@ async def pull_request_review_callback(event):
     number = gh_pr['number']
     for wb in watched_branches:
         if number in wb.prs:
-            await wb.notify_github_changed(event.app)
+            app: web.Application = event.app
+            await wb.notify_github_changed(
+                app[AppKeys.DB], app[AppKeys.BATCH_CLIENT], app[AppKeys.GH_CLIENT], app[AppKeys.FROZEN_MERGE_DEPLOY]
+            )
 
 
 async def github_callback_handler(request):
@@ -410,9 +423,9 @@ async def remove_namespace_from_db(db: Database, namespace: str):
     )
 
 
-async def batch_callback_handler(request):
+async def batch_callback_handler(request: web.Request):
     app = request.app
-    db: Database = app['db']
+    db = app[AppKeys.DB]
     params = await json_request(request)
     log.info(f'batch callback {params}')
     attrs = params.get('attributes')
@@ -430,13 +443,15 @@ async def batch_callback_handler(request):
                         if DEFAULT_NAMESPACE == 'default':
                             await remove_namespace_from_db(db, namespace)
 
-                    await wb.notify_batch_changed(app)
+                    await wb.notify_batch_changed(
+                        db, app[AppKeys.BATCH_CLIENT], app[AppKeys.GH_CLIENT], app[AppKeys.FROZEN_MERGE_DEPLOY]
+                    )
 
 
 @routes.get('/api/v1alpha/deploy_status')
 @auth.authenticated_developers_only()
 async def deploy_status(request: web.Request, _) -> web.Response:
-    batch_client = request.app['batch_client']
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
 
     async def get_failure_information(batch):
         if isinstance(batch, MergeFailureBatch):
@@ -447,7 +462,8 @@ async def deploy_status(request: web.Request, _) -> web.Response:
         async def fetch_job_and_log(j):
             full_job = await batch_client.get_job(j['batch_id'], j['job_id'])
             log = await full_job.log()
-            return {**full_job._status, 'log': log}
+            status = await full_job.status()
+            return {**status, 'log': log}
 
         return await asyncio.gather(*[fetch_job_and_log(j) for j in jobs if j['state'] in ('Error', 'Failed')])
 
@@ -471,12 +487,16 @@ async def deploy_status(request: web.Request, _) -> web.Response:
 @auth.authenticated_developers_only()
 async def post_update(request: web.Request, _) -> web.Response:
     log.info('developer triggered update')
+    db = request.app[AppKeys.DB]
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
+    gh_client = request.app[AppKeys.GH_CLIENT]
+    frozen = request.app[AppKeys.FROZEN_MERGE_DEPLOY]
 
     async def update_all():
         for wb in watched_branches:
-            await wb.update(request.app)
+            await wb.update(db, batch_client, gh_client, frozen)
 
-    request.app['task_manager'].ensure_future(update_all())
+    request.app[AppKeys.TASK_MANAGER].ensure_future(update_all())
     return web.Response(status=200)
 
 
@@ -505,7 +525,7 @@ async def dev_deploy_branch(request: web.Request, userdata: UserData) -> web.Res
         log.info('dev deploy failed: ' + message, exc_info=True)
         raise web.HTTPBadRequest(text=message) from e
 
-    gh = app['github_client']
+    gh = app[AppKeys.GH_CLIENT]
     request_string = f'/repos/{branch.repo.owner}/{branch.repo.name}/git/refs/heads/{branch.name}'
 
     try:
@@ -518,12 +538,12 @@ async def dev_deploy_branch(request: web.Request, userdata: UserData) -> web.Res
         log.info('dev deploy failed: ' + message, exc_info=True)
         raise web.HTTPBadRequest(text=message) from e
 
-    unwatched_branch = UnwatchedBranch(branch, sha, userdata, app['developers'], extra_config=extra_config)
+    unwatched_branch = UnwatchedBranch(branch, sha, userdata, app[AppKeys.DEVELOPERS], extra_config=extra_config)
 
-    batch_client = app['batch_client']
+    batch_client = app[AppKeys.BATCH_CLIENT]
 
     try:
-        batch_id = await unwatched_branch.deploy(app['db'], batch_client, steps, excluded_steps=excluded_steps)
+        batch_id = await unwatched_branch.deploy(app[AppKeys.DB], batch_client, steps, excluded_steps=excluded_steps)
     except asyncio.CancelledError:
         raise
     except Exception as e:  # pylint: disable=broad-except
@@ -542,10 +562,10 @@ async def batch_callback(request):
 @auth.authenticated_developers_only()
 async def freeze_deploys(request: web.Request, _) -> NoReturn:
     app = request.app
-    db: Database = app['db']
+    db = app[AppKeys.DB]
     session = await aiohttp_session.get_session(request)
 
-    if app['frozen_merge_deploy']:
+    if app[AppKeys.FROZEN_MERGE_DEPLOY]:
         set_message(session, 'CI is already frozen.', 'info')
         raise web.HTTPFound(deploy_config.external_url('ci', '/'))
 
@@ -555,7 +575,7 @@ UPDATE globals SET frozen_merge_deploy = 1;
 """
     )
 
-    app['frozen_merge_deploy'] = True
+    app[AppKeys.FROZEN_MERGE_DEPLOY] = True
 
     set_message(session, 'Froze all merges and deploys.', 'info')
 
@@ -566,10 +586,10 @@ UPDATE globals SET frozen_merge_deploy = 1;
 @auth.authenticated_developers_only()
 async def unfreeze_deploys(request: web.Request, _) -> NoReturn:
     app = request.app
-    db: Database = app['db']
+    db = app[AppKeys.DB]
     session = await aiohttp_session.get_session(request)
 
-    if not app['frozen_merge_deploy']:
+    if not app[AppKeys.FROZEN_MERGE_DEPLOY]:
         set_message(session, 'CI is already unfrozen.', 'info')
         raise web.HTTPFound(deploy_config.external_url('ci', '/'))
 
@@ -579,7 +599,7 @@ UPDATE globals SET frozen_merge_deploy = 0;
 """
     )
 
-    app['frozen_merge_deploy'] = False
+    app[AppKeys.FROZEN_MERGE_DEPLOY] = False
 
     set_message(session, 'Unfroze all merges and deploys.', 'info')
 
@@ -589,7 +609,7 @@ UPDATE globals SET frozen_merge_deploy = 0;
 @routes.get('/namespaces')
 @auth.authenticated_developers_only()
 async def get_active_namespaces(request: web.Request, userdata: UserData) -> web.Response:
-    db: Database = request.app['db']
+    db = request.app[AppKeys.DB]
     namespaces = [
         r
         async for r in db.execute_and_fetchall(
@@ -612,7 +632,7 @@ GROUP BY active_namespaces.namespace"""
 @routes.post('/namespaces/{namespace}/services/add')
 @auth.authenticated_developers_only()
 async def add_namespaced_service(request: web.Request, _) -> NoReturn:
-    db: Database = request.app['db']
+    db = request.app[AppKeys.DB]
     post = await request.post()
     service = post['service']
     namespace = request.match_info['namespace']
@@ -640,7 +660,7 @@ WHERE namespace = %s AND service = %s
 @routes.post('/namespaces/add')
 @auth.authenticated_developers_only()
 async def add_namespace(request: web.Request, _) -> NoReturn:
-    db: Database = request.app['db']
+    db = request.app[AppKeys.DB]
     post = await request.post()
     namespace = post['namespace']
 
@@ -716,13 +736,15 @@ GROUP BY active_namespaces.namespace""",
         )
 
 
-async def update_loop(app):
+async def update_loop(app: web.Application):
     wb: Optional[WatchedBranch] = None
     while True:
         try:
             for wb in watched_branches:
                 log.info(f'updating {wb.branch.short_str()}')
-                await wb.update(app)
+                await wb.update(
+                    app[AppKeys.DB], app[AppKeys.BATCH_CLIENT], app[AppKeys.GH_CLIENT], app[AppKeys.FROZEN_MERGE_DEPLOY]
+                )
         except concurrent.futures.CancelledError:
             raise
         except Exception:  # pylint: disable=broad-except
@@ -731,30 +753,41 @@ async def update_loop(app):
         await asyncio.sleep(300)
 
 
-async def on_startup(app):
+class AppKeys(CommonAiohttpAppKeys):
+    DB = web.AppKey('db', Database)
+    GH_CLIENT = web.AppKey('github_client', gh_aiohttp.GitHubAPI)
+    BATCH_CLIENT = web.AppKey('batch_client', BatchClient)
+    FROZEN_MERGE_DEPLOY = web.AppKey('frozen_merge_deploy', bool)
+    TASK_MANAGER = web.AppKey('task_manager', aiotools.BackgroundTaskManager)
+    DEVELOPERS = web.AppKey('developers', List[UserData])
+
+
+async def on_startup(app: web.Application):
     client_session = httpx.client_session()
-    app['client_session'] = client_session
-    app['github_client'] = gh_aiohttp.GitHubAPI(app['client_session'], 'ci', oauth_token=oauth_token)
-    app['batch_client'] = await BatchClient.create('ci')
 
-    app['db'] = Database()
-    await app['db'].async_init()
+    app[AppKeys.CLIENT_SESSION] = client_session
+    app[AppKeys.GH_CLIENT] = gh_aiohttp.GitHubAPI(client_session.client_session, 'ci', oauth_token=oauth_token)
+    app[AppKeys.BATCH_CLIENT] = await BatchClient.create('ci')
 
-    row = await app['db'].select_and_fetchone(
+    app[AppKeys.DB] = Database()
+    await app[AppKeys.DB].async_init()
+
+    row = await app[AppKeys.DB].select_and_fetchone(
         """
 SELECT frozen_merge_deploy FROM globals;
 """
     )
 
-    app['frozen_merge_deploy'] = row['frozen_merge_deploy']
-
-    app['task_manager'] = aiotools.BackgroundTaskManager()
+    app[AppKeys.FROZEN_MERGE_DEPLOY] = row['frozen_merge_deploy']
+    app[AppKeys.TASK_MANAGER] = aiotools.BackgroundTaskManager()
 
     if DEFAULT_NAMESPACE == 'default':
         kubernetes_asyncio.config.load_incluster_config()
         k8s_client = kubernetes_asyncio.client.CoreV1Api()
-        app['task_manager'].ensure_future(periodically_call(10, update_envoy_configs, app['db'], k8s_client))
-        app['task_manager'].ensure_future(periodically_call(10, cleanup_expired_namespaces, app['db']))
+        app[AppKeys.TASK_MANAGER].ensure_future(
+            periodically_call(10, update_envoy_configs, app[AppKeys.DB], k8s_client)
+        )
+        app[AppKeys.TASK_MANAGER].ensure_future(periodically_call(10, cleanup_expired_namespaces, app[AppKeys.DB]))
 
     async with hail_credentials() as creds:
         headers = await creds.auth_headers()
@@ -763,25 +796,25 @@ SELECT frozen_merge_deploy FROM globals;
         deploy_config.url('auth', '/api/v1alpha/users'),
         headers=headers,
     )
-    app['developers'] = [u for u in users if u['is_developer'] == 1 and u['state'] == 'active']
+    app[AppKeys.DEVELOPERS] = [u for u in users if u['is_developer'] == 1 and u['state'] == 'active']
 
     global watched_branches
     watched_branches = [
-        WatchedBranch(index, FQBranch.from_short_str(bss), deployable, mergeable, app['developers'])
+        WatchedBranch(index, FQBranch.from_short_str(bss), deployable, mergeable, app[AppKeys.DEVELOPERS])
         for (index, [bss, deployable, mergeable]) in enumerate(
             json.loads(os.environ.get('HAIL_WATCHED_BRANCHES', '[]'))
         )
     ]
 
-    app['task_manager'].ensure_future(update_loop(app))
+    app[AppKeys.TASK_MANAGER].ensure_future(update_loop(app))
 
 
 async def on_cleanup(app):
     async with AsyncExitStack() as cleanup:
-        cleanup.push_async_callback(app['db'].async_close)
-        cleanup.push_async_callback(app['client_session'].close)
-        cleanup.push_async_callback(app['batch_client'].close)
-        cleanup.callback(app['task_manager'].shutdown)
+        cleanup.push_async_callback(app[AppKeys.DB].async_close)
+        cleanup.push_async_callback(app[AppKeys.CLIENT_SESSION].close)
+        cleanup.push_async_callback(app[AppKeys.BATCH_CLIENT].close)
+        cleanup.callback(app[AppKeys.TASK_MANAGER].shutdown)
 
 
 def run():

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -1,4 +1,4 @@
-from .auth import Authenticator, AuthServiceAuthenticator, UserData, maybe_parse_bearer_header
+from .auth import Authenticator, AuthServiceAuthenticator, CommonAiohttpAppKeys, UserData, maybe_parse_bearer_header
 from .auth_utils import create_session, insert_user
 from .csrf import check_csrf_token, new_csrf_token
 from .database import Database, Transaction, create_database_pool, resolve_test_db_endpoint, transaction
@@ -20,6 +20,7 @@ __all__ = [
     'maybe_parse_bearer_header',
     'Authenticator',
     'AuthServiceAuthenticator',
+    'CommonAiohttpAppKeys',
     'UserData',
     'monitor_endpoints_middleware',
     'json_request',

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -24,6 +24,10 @@ BEARER = 'Bearer '
 TEN_SECONDS_IN_NANOSECONDS = int(1e10)
 
 
+class CommonAiohttpAppKeys:
+    CLIENT_SESSION = web.AppKey('client_session', httpx.ClientSession)
+
+
 class UserData(TypedDict):
     id: int
     state: str
@@ -102,7 +106,7 @@ class AuthServiceAuthenticator(Authenticator):
         if session_id is None:
             return None
 
-        return await self._userdata_cache.lookup((session_id, request.app['client_session']))
+        return await self._userdata_cache.lookup((session_id, request.app[CommonAiohttpAppKeys.CLIENT_SESSION]))
 
     @staticmethod
     async def _fetch_userdata_from_auth_service(session_id_and_session: Tuple[str, httpx.ClientSession]):

--- a/website/website/website.py
+++ b/website/website/website.py
@@ -8,7 +8,7 @@ import jinja2
 from aiohttp import web
 from prometheus_async.aio.web import server_stats  # type: ignore
 
-from gear import AuthServiceAuthenticator, monitor_endpoints_middleware, setup_aiohttp_session
+from gear import AuthServiceAuthenticator, CommonAiohttpAppKeys, monitor_endpoints_middleware, setup_aiohttp_session
 from hailtop import httpx
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
@@ -103,11 +103,11 @@ for fname in os.listdir(f'{MODULE_PATH}/pages'):
 
 
 async def on_startup(app):
-    app['client_session'] = httpx.client_session()
+    app[CommonAiohttpAppKeys.CLIENT_SESSION] = httpx.client_session()
 
 
 async def on_cleanup(app):
-    await app['client_session'].close()
+    await app[CommonAiohttpAppKeys.CLIENT_SESSION].close()
 
 
 def run(local_mode):


### PR DESCRIPTION
Uses aiohttp [AppKeys](https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.AppKey) to statically type `Application` storage. Also more explicitly pass additional parameters to methods in the `github.py` module instead of using `app` to ship around state.