### PR TITLE
[query] ruff the tests up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ check-all: check-hail check-services
 check-hail-fast:
 	ruff check hail/python/hail
 	ruff check hail/python/hailtop
+	ruff check hail/python/test
 	ruff format hail --check
 	$(PYTHON) -m pyright hail/python/hailtop
 

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -182,6 +182,7 @@ class AzureReadableStream(ReadableStream):
                 raise FileNotFoundError(self._url) from e
             data = await downloader.readall()
             self._eof = True
+            assert isinstance(data, bytes)
             return data
 
         if self._downloader is None:

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -1,9 +1,9 @@
 import os
 
 import hail as hl
-
-from ..helpers import skip_unless_service_backend, test_timeout, qobtest
 from hail.backend.service_backend import ServiceBackend
+
+from ..helpers import qobtest, skip_unless_service_backend, test_timeout
 
 
 @qobtest

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -1,19 +1,17 @@
-from typing import Dict
 import asyncio
 import hashlib
-import os
 import logging
+import os
+from typing import Dict
 
 import pytest
-from pytest import StashKey, CollectReport
+from pytest import CollectReport, StashKey
 
-
-from hail import current_backend, init, reset_global_randomness
+from hail import current_backend, reset_global_randomness
 from hail.backend.service_backend import ServiceBackend
 from hailtop.hail_event_loop import hail_event_loop
-from hailtop.utils import secret_alnum_string
-from .helpers import hl_init_for_test, hl_stop_for_test
 
+from .helpers import hl_init_for_test, hl_stop_for_test
 
 log = logging.getLogger(__name__)
 

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -1,9 +1,20 @@
-import numpy as np
-import hail as hl
 import unittest
+
+import numpy as np
 import pytest
-from ..helpers import *
+
+import hail as hl
 from hail.utils import new_temp_file
+
+from ..helpers import (
+    assert_evals_to,
+    doctest_resource,
+    fails_local_backend,
+    fails_service_backend,
+    qobtest,
+    resource,
+    test_timeout,
+)
 
 
 class Tests(unittest.TestCase):
@@ -339,7 +350,6 @@ class Tests(unittest.TestCase):
     @fails_local_backend()
     def test_block_matrices_tofiles(self):
         data = [np.random.rand(11 * 12), np.random.rand(5 * 17)]
-        arrs = [data[0].reshape((11, 12)), data[1].reshape((5, 17))]
         bms = [
             hl.linalg.BlockMatrix._create(11, 12, data[0].tolist(), block_size=4),
             hl.linalg.BlockMatrix._create(5, 17, data[1].tolist(), block_size=8),
@@ -432,7 +442,7 @@ class Tests(unittest.TestCase):
         with pytest.raises(
             TypeError, match="requested type ndarray<int32, 2> does not match inferred type ndarray<float64, 2>"
         ):
-            result = hl.experimental.loop(
+            hl.experimental.loop(
                 lambda f, my_nd: hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
                 hl.tndarray(hl.tint32, 2),
                 hl.nd.zeros((20, 10), hl.tfloat64),

--- a/hail/python/test/hail/experimental/test_local_whitening.py
+++ b/hail/python/test/hail/experimental/test_local_whitening.py
@@ -1,8 +1,10 @@
 import numpy as np
 from numpy.random import default_rng
-from hail.methods.pca import _make_tsm
+
 import hail as hl
-from ..helpers import *
+from hail.methods.pca import _make_tsm
+
+from ..helpers import test_timeout
 
 
 def naive_whiten(X, w):

--- a/hail/python/test/hail/experimental/test_time.py
+++ b/hail/python/test/hail/experimental/test_time.py
@@ -1,6 +1,4 @@
-import pytest
-from ..helpers import *
-
+import hail as hl
 import hail.experimental.time as htime
 
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1,15 +1,17 @@
 import math
-import pytest
 import random
-from scipy.stats import pearsonr
+import unittest
+
 import numpy as np
+import pytest
+from scipy.stats import pearsonr
 
 import hail as hl
 import hail.expr.aggregators as agg
-from hail.expr.types import *
-from hail.expr.functions import _error_from_cdf, _cdf_combine, _result_from_raw_cdf
-import hail.ir as ir
-from ..helpers import *
+from hail import ir
+from hail.expr.functions import _cdf_combine, _error_from_cdf, _result_from_raw_cdf
+
+from ..helpers import assert_evals_to, convert_struct_to_dict, qobtest, resource, test_timeout, with_flags
 
 
 def _test_many_equal(test_cases):
@@ -108,7 +110,9 @@ class Tests(unittest.TestCase):
         self.assertEqual(ht.order_by(ht.x).take(5), expected)
 
     def test_operators(self):
-        schema = hl.tstruct(a=hl.tint32, b=hl.tint32, c=hl.tint32, d=hl.tint32, e=hl.tstr, f=hl.tarray(hl.tint32))
+        schema = hl.hl.hl.tstruct(
+            a=hl.hl.tint32, b=hl.hl.tint32, c=hl.hl.tint32, d=hl.hl.tint32, e=hl.hl.tstr, f=hl.hl.tarray(hl.hl.tint32)
+        )
 
         rows = [
             {'a': 4, 'b': 1, 'c': 3, 'd': 5, 'e': "hello", 'f': [1, 2, 3]},
@@ -247,7 +251,7 @@ class Tests(unittest.TestCase):
                 self.assertEqual(v, result[k], msg=k)
 
     def test_array_slicing(self):
-        schema = hl.tstruct(a=hl.tarray(hl.tint32))
+        schema = hl.hl.hl.tstruct(a=hl.hl.tarray(hl.hl.tint32))
         rows = [{'a': [1, 2, 3, 4, 5]}]
         kt = hl.Table.parallelize(rows, schema)
         ha = hl.array(hl.range(100))
@@ -299,7 +303,7 @@ class Tests(unittest.TestCase):
             hl.eval(ha[::0])
 
     def test_dict_methods(self):
-        schema = hl.tstruct(x=hl.tfloat64)
+        schema = hl.hl.hl.tstruct(x=hl.hl.tfloat64)
         rows = [{'x': 2.0}]
         kt = hl.Table.parallelize(rows, schema)
 
@@ -340,10 +344,10 @@ class Tests(unittest.TestCase):
     def test_dict_missing_error(self):
         d = hl.dict({'a': 2, 'b': 3})
         with pytest.raises(hl.utils.HailUserError, match='Key NA not found in dictionary'):
-            hl.eval(d[hl.missing(hl.tstr)])
+            hl.eval(d[hl.missing(hl.hl.tstr)])
 
     def test_numeric_conversion(self):
-        schema = hl.tstruct(a=hl.tfloat64, b=hl.tfloat64, c=hl.tint32, d=hl.tint32)
+        schema = hl.hl.hl.tstruct(a=hl.hl.tfloat64, b=hl.hl.tfloat64, c=hl.hl.tint32, d=hl.hl.tint32)
         rows = [{'a': 2.0, 'b': 4.0, 'c': 1, 'd': 5}]
         kt = hl.Table.parallelize(rows, schema)
         kt = kt.annotate(d=hl.int64(kt.d))
@@ -351,15 +355,15 @@ class Tests(unittest.TestCase):
         kt = kt.annotate(x1=[1.0, kt.a, 1], x2=[1, 1.0], x3=[kt.a, kt.c], x4=[kt.c, kt.d], x5=[1, kt.c])
 
         expected_schema = {
-            'a': hl.tfloat64,
-            'b': hl.tfloat64,
-            'c': hl.tint32,
-            'd': hl.tint64,
-            'x1': hl.tarray(hl.tfloat64),
-            'x2': hl.tarray(hl.tfloat64),
-            'x3': hl.tarray(hl.tfloat64),
-            'x4': hl.tarray(hl.tint64),
-            'x5': hl.tarray(hl.tint32),
+            'a': hl.hl.tfloat64,
+            'b': hl.hl.tfloat64,
+            'c': hl.hl.tint32,
+            'd': hl.hl.tint64,
+            'x1': hl.hl.tarray(hl.hl.tfloat64),
+            'x2': hl.hl.tarray(hl.hl.tfloat64),
+            'x3': hl.hl.tarray(hl.hl.tfloat64),
+            'x4': hl.hl.tarray(hl.hl.tint64),
+            'x5': hl.hl.tarray(hl.hl.tint32),
         }
 
         for f, t in kt.row.dtype.items():
@@ -368,7 +372,7 @@ class Tests(unittest.TestCase):
     def test_genetics_constructors(self):
         rg = hl.ReferenceGenome("foo", ["1"], {"1": 100})
 
-        schema = hl.tstruct(a=hl.tfloat64, b=hl.tfloat64, c=hl.tint32, d=hl.tint32)
+        schema = hl.hl.hl.tstruct(a=hl.hl.tfloat64, b=hl.hl.tfloat64, c=hl.hl.tint32, d=hl.hl.tint32)
         rows = [{'a': 2.0, 'b': 4.0, 'c': 1, 'd': 5}]
         kt = hl.Table.parallelize(rows, schema)
         kt = kt.annotate(d=hl.int64(kt.d))
@@ -381,10 +385,10 @@ class Tests(unittest.TestCase):
         )
 
         expected_schema = {
-            'a': hl.tfloat64,
-            'b': hl.tfloat64,
-            'c': hl.tint32,
-            'd': hl.tint64,
+            'a': hl.hl.tfloat64,
+            'b': hl.hl.tfloat64,
+            'c': hl.hl.tint32,
+            'd': hl.hl.tint64,
             'l1': hl.tlocus(),
             'l2': hl.tlocus(rg),
             'i1': hl.tinterval(hl.tlocus(rg)),
@@ -456,7 +460,7 @@ class Tests(unittest.TestCase):
 
     def test_string_join(self):
         self.assertEqual(hl.eval(hl.str(":").join(["foo", "bar", "baz"])), "foo:bar:baz")
-        self.assertEqual(hl.eval(hl.str(",").join(hl.empty_array(hl.tstr))), "")
+        self.assertEqual(hl.eval(hl.str(",").join(hl.empty_array(hl.hl.tstr))), "")
 
         with pytest.raises(TypeError, match="Expected str collection, int32 found"):
             hl.eval(hl.str(",").join([1, 2, 3]))
@@ -472,16 +476,16 @@ class Tests(unittest.TestCase):
     def test_cond(self):
         self.assertEqual(hl.eval('A' + hl.if_else(True, 'A', 'B')), 'AA')
 
-        self.assertEqual(hl.eval(hl.if_else(True, hl.struct(), hl.missing(hl.tstruct()))), hl.utils.Struct())
-        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.tbool), 1, 2)), None)
-        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.tbool), 1, 2, missing_false=True)), 2)
+        self.assertEqual(hl.eval(hl.if_else(True, hl.struct(), hl.missing(hl.hl.hl.tstruct()))), hl.utils.Struct())
+        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.hl.tbool), 1, 2)), None)
+        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.hl.tbool), 1, 2, missing_false=True)), 2)
 
     def test_if_else(self):
         self.assertEqual(hl.eval('A' + hl.if_else(True, 'A', 'B')), 'AA')
 
-        self.assertEqual(hl.eval(hl.if_else(True, hl.struct(), hl.missing(hl.tstruct()))), hl.utils.Struct())
-        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.tbool), 1, 2)), None)
-        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.tbool), 1, 2, missing_false=True)), 2)
+        self.assertEqual(hl.eval(hl.if_else(True, hl.struct(), hl.missing(hl.hl.hl.tstruct()))), hl.utils.Struct())
+        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.hl.tbool), 1, 2)), None)
+        self.assertEqual(hl.eval(hl.if_else(hl.missing(hl.hl.tbool), 1, 2, missing_false=True)), 2)
 
     @qobtest
     def test_aggregators(self):
@@ -491,10 +495,10 @@ class Tests(unittest.TestCase):
                 x=hl.agg.count(),
                 y=hl.agg.count_where(table.idx % 2 == 0),
                 z=hl.agg.filter(table.idx % 2 == 0, hl.agg.count()),
-                arr_sum=hl.agg.array_sum([1, 2, hl.missing(tint32)]),
+                arr_sum=hl.agg.array_sum([1, 2, hl.missing(hl.tint32)]),
                 bind_agg=hl.agg.count_where(hl.bind(lambda x: x % 2 == 0, table.idx)),
                 mean=hl.agg.mean(table.idx),
-                mean2=hl.agg.mean(hl.if_else(table.idx == 9, table.idx, hl.missing(tint32))),
+                mean2=hl.agg.mean(hl.if_else(table.idx == 9, table.idx, hl.missing(hl.tint32))),
                 foo=hl.min(3, hl.agg.sum(table.idx)),
             )
         )
@@ -508,7 +512,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(r.bind_agg, 5)
         self.assertEqual(r.foo, 3)
 
-        a = hl.literal([1, 2], tarray(tint32))
+        a = hl.literal([1, 2], hl.tarray(hl.tint32))
         self.assertEqual(table.aggregate(hl.agg.filter(True, hl.agg.array_sum(a))), [10, 20])
 
         r = table.aggregate(
@@ -579,7 +583,7 @@ class Tests(unittest.TestCase):
         )
         self.assertEqual(sum_and_product, hl.Struct(x=4950, y=9.332621544394414e157))
 
-        ht = ht.annotate(maybe=hl.if_else(ht.idx % 2 == 0, ht.idx, hl.missing(hl.tint32)))
+        ht = ht.annotate(maybe=hl.if_else(ht.idx % 2 == 0, ht.idx, hl.missing(hl.hl.tint32)))
         sum_evens_missing = ht.aggregate(hl.agg.fold(0, lambda x: x + ht.maybe, lambda a, b: a + b))
         assert sum_evens_missing is None
         sum_evens_only = ht.aggregate(
@@ -714,7 +718,7 @@ class Tests(unittest.TestCase):
 
     def test_agg_array_empty(self):
         ht = hl.utils.range_table(1).annotate(a=[0]).filter(False)
-        assert ht.aggregate(hl.agg.array_agg(lambda x: hl.agg.sum(x), ht.a)) == None
+        assert ht.aggregate(hl.agg.array_agg(lambda x: hl.agg.sum(x), ht.a)) is None
 
     def test_agg_array_non_trivial_post_op(self):
         ht = hl.utils.range_table(10)
@@ -836,55 +840,55 @@ class Tests(unittest.TestCase):
             (
                 hl.agg.explode(
                     lambda elt: hl.agg.collect(elt + 1).append(0),
-                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                 ),
                 [9, 10, 10, 11, 0],
             ),
             (
                 hl.agg.explode(
                     lambda elt: hl.agg.explode(lambda elt2: hl.agg.collect(elt2 + 1).append(0), [elt, elt + 1]),
-                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                 ),
                 [9, 10, 10, 11, 10, 11, 11, 12, 0],
             ),
             (
                 hl.agg.explode(
                     lambda elt: hl.agg.filter(elt > 8, hl.agg.collect(elt + 1).append(0)),
-                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                 ),
                 [10, 10, 11, 0],
             ),
             (
                 hl.agg.explode(
                     lambda elt: hl.agg.group_by(elt % 3, hl.agg.collect(elt + 1).append(0)),
-                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                 ),
                 {0: [10, 10, 0], 1: [11, 0], 2: [9, 0]},
             ),
             (
                 hl.agg.explode(
-                    lambda elt: hl.agg.count(), hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))
+                    lambda elt: hl.agg.count(), hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32))
                 ),
                 4,
             ),
             (
                 hl.agg.explode(
                     lambda elt: hl.agg.explode(lambda elt2: hl.agg.count(), [elt, elt + 1]),
-                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                 ),
                 8,
             ),
             (
                 hl.agg.explode(
                     lambda elt: hl.agg.filter(elt > 8, hl.agg.count()),
-                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                 ),
                 3,
             ),
             (
                 hl.agg.explode(
                     lambda elt: hl.agg.group_by(elt % 3, hl.agg.count()),
-                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                    hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                 ),
                 {0: 2, 1: 1, 2: 1},
             ),
@@ -910,7 +914,7 @@ class Tests(unittest.TestCase):
                     t.idx % 3,
                     hl.agg.explode(
                         lambda elt: hl.agg.collect(elt + 1).append(0),
-                        hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32)),
+                        hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                     ),
                 ),
                 {0: [10, 11, 0], 1: [0], 2: [9, 10, 0]},
@@ -921,7 +925,8 @@ class Tests(unittest.TestCase):
                 hl.agg.group_by(
                     t.idx % 3,
                     hl.agg.explode(
-                        lambda elt: hl.agg.count(), hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))
+                        lambda elt: hl.agg.count(),
+                        hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.hl.tint32)),
                     ),
                 ),
                 {0: 2, 1: 0, 2: 2},
@@ -947,7 +952,7 @@ class Tests(unittest.TestCase):
                 {"cohort": "IBD", "pop": "EUR", "GT": hl.Call([0, 0])},
                 {"cohort": "IBD", "pop": None, "GT": hl.Call([0, 1])},
             ],
-            hl.tstruct(cohort=hl.tstr, pop=hl.tstr, GT=hl.tcall),
+            hl.hl.hl.tstruct(cohort=hl.hl.tstr, pop=hl.hl.tstr, GT=hl.hl.tcall),
             n_partitions=3,
         )
 
@@ -1085,7 +1090,7 @@ class Tests(unittest.TestCase):
             scan_count=hl.scan.count(),
             scan_count_where=hl.scan.count_where(table.idx % 2 == 0),
             scan_count_where2=hl.scan.filter(table.idx % 2 == 0, hl.scan.count()),
-            arr_sum=hl.scan.array_sum([1, 2, hl.missing(tint32)]),
+            arr_sum=hl.scan.array_sum([1, 2, hl.missing(hl.tint32)]),
             bind_agg=hl.scan.count_where(hl.bind(lambda x: x % 2 == 0, table.idx)),
             mean=hl.scan.mean(table.idx),
             foo=hl.min(3, hl.scan.sum(table.idx)),
@@ -1212,10 +1217,10 @@ class Tests(unittest.TestCase):
         table = hl.utils.range_table(10)
         # FIXME: add boolean when function registry is removed
         for f, typ in [
-            (lambda x: hl.int32(x), tint32),
-            (lambda x: hl.int64(x), tint64),
-            (lambda x: hl.float32(x), tfloat32),
-            (lambda x: hl.float64(x), tfloat64),
+            (lambda x: hl.int32(x), hl.tint32),
+            (lambda x: hl.int64(x), hl.tint64),
+            (lambda x: hl.float32(x), hl.tfloat32),
+            (lambda x: hl.float64(x), hl.tfloat64),
         ]:
             t = table.annotate(x=-1 * f(table.idx) - 5, y=hl.missing(typ))
             r = t.aggregate(
@@ -1228,10 +1233,10 @@ class Tests(unittest.TestCase):
     def test_aggregators_sum_product(self):
         table = hl.utils.range_table(5)
         for f, typ in [
-            (lambda x: hl.int32(x), tint32),
-            (lambda x: hl.int64(x), tint64),
-            (lambda x: hl.float32(x), tfloat32),
-            (lambda x: hl.float64(x), tfloat64),
+            (lambda x: hl.int32(x), hl.tint32),
+            (lambda x: hl.int64(x), hl.tint64),
+            (lambda x: hl.float32(x), hl.tfloat32),
+            (lambda x: hl.float64(x), hl.tfloat64),
         ]:
             t = table.annotate(x=-1 * f(table.idx) - 1, y=f(table.idx), z=hl.missing(typ))
             r = t.aggregate(
@@ -1313,7 +1318,7 @@ class Tests(unittest.TestCase):
                 {"y": -0.99106171, "x": -1.1688806},
                 {"y": 2.12823289, "x": 0.5587043},
             ],
-            hl.tstruct(y=hl.tfloat64, x=hl.tfloat64),
+            hl.hl.hl.tstruct(y=hl.hl.tfloat64, x=hl.hl.tfloat64),
             n_partitions=3,
         )
         r = t.aggregate(hl.struct(linreg=hl.agg.linreg(t.y, [1, t.x]))).linreg
@@ -1455,7 +1460,7 @@ class Tests(unittest.TestCase):
                 {"group": "m", "x": 4},
                 {"group": "m", "x": 5},
             ],
-            hl.tstruct(group=hl.tstr, x=hl.tint32),
+            hl.hl.hl.tstruct(group=hl.hl.tstr, x=hl.hl.tint32),
             n_partitions=1,
         )
 
@@ -1467,8 +1472,8 @@ class Tests(unittest.TestCase):
         ht = ht.annotate(
             tests=hl.range(0, 10).map(
                 lambda i: hl.struct(
-                    x=hl.if_else(hl.rand_bool(0.1), hl.missing(hl.tfloat64), hl.rand_unif(-10, 10)),
-                    y=hl.if_else(hl.rand_bool(0.1), hl.missing(hl.tfloat64), hl.rand_unif(-10, 10)),
+                    x=hl.if_else(hl.rand_bool(0.1), hl.missing(hl.hl.tfloat64), hl.rand_unif(-10, 10)),
+                    y=hl.if_else(hl.rand_bool(0.1), hl.missing(hl.hl.tfloat64), hl.rand_unif(-10, 10)),
                 )
             )
         )
@@ -1489,7 +1494,7 @@ class Tests(unittest.TestCase):
 
     def test_switch(self):
         x = hl.literal('1')
-        na = hl.missing(tint32)
+        na = hl.missing(hl.tint32)
 
         expr1 = hl.switch(x).when('123', 5).when('1', 6).when('0', 2).or_missing()
         self.assertEqual(hl.eval(expr1), 6)
@@ -1500,7 +1505,7 @@ class Tests(unittest.TestCase):
         expr3 = hl.switch(x).when('123', 5).when('0', 2).default(100)
         self.assertEqual(hl.eval(expr3), 100)
 
-        expr4 = hl.switch(na).when(5, 0).when(6, 1).when(0, 2).when(hl.missing(tint32), 3).default(4)  # NA != NA
+        expr4 = hl.switch(na).when(5, 0).when(6, 1).when(0, 2).when(hl.missing(hl.tint32), 3).default(4)  # NA != NA
         self.assertEqual(hl.eval(expr4), None)
 
         expr5 = (
@@ -1508,7 +1513,7 @@ class Tests(unittest.TestCase):
             .when(5, 0)
             .when(6, 1)
             .when(0, 2)
-            .when(hl.missing(tint32), 3)  # NA != NA
+            .when(hl.missing(hl.tint32), 3)  # NA != NA
             .when_missing(-1)
             .default(4)
         )
@@ -1529,8 +1534,8 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(make_case(-1)), 'D')
         self.assertEqual(hl.eval(make_case(2)), None)
 
-        self.assertEqual(hl.eval(hl.case().when(hl.missing(hl.tbool), 1).default(2)), None)
-        self.assertEqual(hl.eval(hl.case(missing_false=True).when(hl.missing(hl.tbool), 1).default(2)), 2)
+        self.assertEqual(hl.eval(hl.case().when(hl.missing(hl.hl.tbool), 1).default(2)), None)
+        self.assertEqual(hl.eval(hl.case(missing_false=True).when(hl.missing(hl.hl.tbool), 1).default(2)), 2)
 
         error_case = hl.case().when(False, 1).or_error("foo")
         with pytest.raises(hl.utils.java.HailUserError) as exc:
@@ -1546,31 +1551,33 @@ class Tests(unittest.TestCase):
             self.assertEqual(t, dtype)
             self.assertEqual(result, r)
 
-        assert_typed(s.drop('f3'), hl.Struct(f1=1, f2=2), tstruct(f1=tint32, f2=tint32))
+        assert_typed(s.drop('f3'), hl.Struct(f1=1, f2=2), hl.hl.tstruct(f1=hl.tint32, f2=hl.tint32))
 
-        assert_typed(s.drop('f1'), hl.Struct(f2=2, f3=3), tstruct(f2=tint32, f3=tint32))
+        assert_typed(s.drop('f1'), hl.Struct(f2=2, f3=3), hl.hl.tstruct(f2=hl.tint32, f3=hl.tint32))
 
-        assert_typed(s.drop(), hl.Struct(f1=1, f2=2, f3=3), tstruct(f1=tint32, f2=tint32, f3=tint32))
+        assert_typed(s.drop(), hl.Struct(f1=1, f2=2, f3=3), hl.hl.tstruct(f1=hl.tint32, f2=hl.tint32, f3=hl.tint32))
 
-        assert_typed(s.select('f1', 'f2'), hl.Struct(f1=1, f2=2), tstruct(f1=tint32, f2=tint32))
+        assert_typed(s.select('f1', 'f2'), hl.Struct(f1=1, f2=2), hl.hl.tstruct(f1=hl.tint32, f2=hl.tint32))
 
         assert_typed(
             s.select('f2', 'f1', f4=5, f5=6),
             hl.Struct(f2=2, f1=1, f4=5, f5=6),
-            tstruct(f2=tint32, f1=tint32, f4=tint32, f5=tint32),
+            hl.hl.tstruct(f2=hl.tint32, f1=hl.tint32, f4=hl.tint32, f5=hl.tint32),
         )
 
-        assert_typed(s.select(), hl.Struct(), tstruct())
+        assert_typed(s.select(), hl.Struct(), hl.hl.tstruct())
 
         assert_typed(
             s.annotate(f1=5, f2=10, f4=15),
             hl.Struct(f1=5, f2=10, f3=3, f4=15),
-            tstruct(f1=tint32, f2=tint32, f3=tint32, f4=tint32),
+            hl.hl.tstruct(f1=hl.tint32, f2=hl.tint32, f3=hl.tint32, f4=hl.tint32),
         )
 
-        assert_typed(s.annotate(f1=5), hl.Struct(f1=5, f2=2, f3=3), tstruct(f1=tint32, f2=tint32, f3=tint32))
+        assert_typed(
+            s.annotate(f1=5), hl.Struct(f1=5, f2=2, f3=3), hl.hl.tstruct(f1=hl.tint32, f2=hl.tint32, f3=hl.tint32)
+        )
 
-        assert_typed(s.annotate(), hl.Struct(f1=1, f2=2, f3=3), tstruct(f1=tint32, f2=tint32, f3=tint32))
+        assert_typed(s.annotate(), hl.Struct(f1=1, f2=2, f3=3), hl.hl.tstruct(f1=hl.tint32, f2=hl.tint32, f3=hl.tint32))
 
     def test_shadowed_struct_fields(self):
         from typing import Callable
@@ -1611,20 +1618,20 @@ class Tests(unittest.TestCase):
         self.assertRaises(hl.expr.ExpressionException, lambda: hl.eval(list(a)))
 
     def test_dict_get(self):
-        d = hl.dict({'a': 1, 'b': 2, 'missing_value': hl.missing(hl.tint32), hl.missing(hl.tstr): 5})
+        d = hl.dict({'a': 1, 'b': 2, 'missing_value': hl.missing(hl.hl.tint32), hl.missing(hl.hl.tstr): 5})
         self.assertEqual(hl.eval(d.get('a')), 1)
         self.assertEqual(hl.eval(d['a']), 1)
         self.assertEqual(hl.eval(d.get('b')), 2)
         self.assertEqual(hl.eval(d['b']), 2)
         self.assertEqual(hl.eval(d.get('c')), None)
-        self.assertEqual(hl.eval(d.get(hl.missing(hl.tstr))), 5)
-        self.assertEqual(hl.eval(d[hl.missing(hl.tstr)]), 5)
+        self.assertEqual(hl.eval(d.get(hl.missing(hl.hl.tstr))), 5)
+        self.assertEqual(hl.eval(d[hl.missing(hl.hl.tstr)]), 5)
 
         self.assertEqual(hl.eval(d.get('c', 5)), 5)
         self.assertEqual(hl.eval(d.get('a', 5)), 1)
 
         self.assertEqual(hl.eval(d.get('missing_values')), None)
-        self.assertEqual(hl.eval(d.get('missing_values', hl.missing(hl.tint32))), None)
+        self.assertEqual(hl.eval(d.get('missing_values', hl.missing(hl.hl.tint32))), None)
         self.assertEqual(hl.eval(d.get('missing_values', 5)), 5)
 
     def test_functions_any_and_all(self):
@@ -1662,9 +1669,9 @@ class Tests(unittest.TestCase):
         df = df.annotate(
             all_true=True,
             all_false=False,
-            true_or_missing=hl.if_else(df.idx % 2 == 0, True, hl.missing(tbool)),
-            false_or_missing=hl.if_else(df.idx % 2 == 0, False, hl.missing(tbool)),
-            all_missing=hl.missing(tbool),
+            true_or_missing=hl.if_else(df.idx % 2 == 0, True, hl.missing(hl.tbool)),
+            false_or_missing=hl.if_else(df.idx % 2 == 0, False, hl.missing(hl.tbool)),
+            all_missing=hl.missing(hl.tbool),
             mixed_true_false=hl.if_else(df.idx % 2 == 0, True, False),
             mixed_all=hl.switch(df.idx % 3).when(0, True).when(1, False).or_missing(),
         ).cache()
@@ -1695,7 +1702,7 @@ class Tests(unittest.TestCase):
                 hl._values_similar(
                     t.prev.idx,
                     hl.case()
-                    .when(t.idx < 2, hl.missing(hl.tint32))
+                    .when(t.idx < 2, hl.missing(hl.hl.tint32))
                     .when(((t.idx - 1) % 3) == 0, t.idx - 2)
                     .default(t.idx - 1),
                 )
@@ -1728,7 +1735,7 @@ class Tests(unittest.TestCase):
 
     def test_agg_minmax(self):
         nan = float('nan')
-        na = hl.missing(hl.tfloat32)
+        na = hl.missing(hl.hl.tfloat32)
         size = 200
         for aggfunc in (agg.min, agg.max):
             array_with_nan = hl.array([0.0 if i == 1 else nan for i in range(size)])
@@ -1805,18 +1812,18 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(hl.str(hl.missing('int32'))), None)
 
     def test_missing_with_field_starting_with_number(self):
-        assert hl.eval(hl.missing(hl.tstruct(**{"1kg": hl.tint32}))) is None
+        assert hl.eval(hl.missing(hl.hl.hl.tstruct(**{"1kg": hl.hl.tint32}))) is None
 
     def check_expr(self, expr, expected, expected_type):
         self.assertEqual(expected_type, expr.dtype)
         self.assertEqual((expected, expected_type), hl.eval_typed(expr))
 
     def test_division(self):
-        a_int32 = hl.array([2, 4, 8, 16, hl.missing(tint32)])
+        a_int32 = hl.array([2, 4, 8, 16, hl.missing(hl.tint32)])
         a_int64 = a_int32.map(lambda x: hl.int64(x))
         a_float32 = a_int32.map(lambda x: hl.float32(x))
         a_float64 = a_int32.map(lambda x: hl.float64(x))
-        int32_4s = hl.array([4, 4, 4, 4, hl.missing(tint32)])
+        int32_4s = hl.array([4, 4, 4, 4, hl.missing(hl.tint32)])
         int64_4 = hl.int64(4)
         int64_4s = int32_4s.map(lambda x: hl.int64(x))
         float32_4 = hl.float32(4)
@@ -1828,63 +1835,62 @@ class Tests(unittest.TestCase):
         expected_inv = [2.0, 1.0, 0.5, 0.25, None]
 
         _test_many_equal_typed([
-            (a_int32 / 4, expected, tarray(tfloat64)),
-            (a_int64 / 4, expected, tarray(tfloat64)),
-            (a_float32 / 4, expected, tarray(tfloat32)),
-            (a_float64 / 4, expected, tarray(tfloat64)),
-            (int32_4s / a_int32, expected_inv, tarray(tfloat64)),
-            (int32_4s / a_int64, expected_inv, tarray(tfloat64)),
-            (int32_4s / a_float32, expected_inv, tarray(tfloat32)),
-            (int32_4s / a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 / int32_4s, expected, tarray(tfloat64)),
-            (a_int64 / int32_4s, expected, tarray(tfloat64)),
-            (a_float32 / int32_4s, expected, tarray(tfloat32)),
-            (a_float64 / int32_4s, expected, tarray(tfloat64)),
-            (a_int32 / int64_4, expected, tarray(tfloat64)),
-            (a_int64 / int64_4, expected, tarray(tfloat64)),
-            (a_float32 / int64_4, expected, tarray(tfloat32)),
-            (a_float64 / int64_4, expected, tarray(tfloat64)),
-            (int64_4 / a_int32, expected_inv, tarray(tfloat64)),
-            (int64_4 / a_int64, expected_inv, tarray(tfloat64)),
-            (int64_4 / a_float32, expected_inv, tarray(tfloat32)),
-            (int64_4 / a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 / int64_4s, expected, tarray(tfloat64)),
-            (a_int64 / int64_4s, expected, tarray(tfloat64)),
-            (a_float32 / int64_4s, expected, tarray(tfloat32)),
-            (a_float64 / int64_4s, expected, tarray(tfloat64)),
-            (a_int32 / float32_4, expected, tarray(tfloat32)),
-            (a_int64 / float32_4, expected, tarray(tfloat32)),
-            (a_float32 / float32_4, expected, tarray(tfloat32)),
-            (a_float64 / float32_4, expected, tarray(tfloat64)),
-            (float32_4 / a_int32, expected_inv, tarray(tfloat32)),
-            (float32_4 / a_int64, expected_inv, tarray(tfloat32)),
-            (float32_4 / a_float32, expected_inv, tarray(tfloat32)),
-            (float32_4 / a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 / float32_4s, expected, tarray(tfloat32)),
-            (a_int64 / float32_4s, expected, tarray(tfloat32)),
-            (a_float32 / float32_4s, expected, tarray(tfloat32)),
-            (a_float64 / float32_4s, expected, tarray(tfloat64)),
-            (a_int32 / float64_4, expected, tarray(tfloat64)),
-            (a_int64 / float64_4, expected, tarray(tfloat64)),
-            (a_float32 / float64_4, expected, tarray(tfloat64)),
-            (a_float64 / float64_4, expected, tarray(tfloat64)),
-            (float64_4 / a_int32, expected_inv, tarray(tfloat64)),
-            (float64_4 / a_int64, expected_inv, tarray(tfloat64)),
-            (float64_4 / a_float32, expected_inv, tarray(tfloat64)),
-            (float64_4 / a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 / float64_4s, expected, tarray(tfloat64)),
-            (a_int64 / float64_4s, expected, tarray(tfloat64)),
-            (a_float32 / float64_4s, expected, tarray(tfloat64)),
-            (a_float64 / float64_4s, expected, tarray(tfloat64)),
+            (a_int32 / 4, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 / 4, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 / 4, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 / 4, expected, hl.tarray(hl.tfloat64)),
+            (int32_4s / a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (int32_4s / a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (int32_4s / a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (int32_4s / a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 / int32_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 / int32_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 / int32_4s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 / int32_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 / int64_4, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 / int64_4, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 / int64_4, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 / int64_4, expected, hl.tarray(hl.tfloat64)),
+            (int64_4 / a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (int64_4 / a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (int64_4 / a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (int64_4 / a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 / int64_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 / int64_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 / int64_4s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 / int64_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 / float32_4, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 / float32_4, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 / float32_4, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 / float32_4, expected, hl.tarray(hl.tfloat64)),
+            (float32_4 / a_int32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_4 / a_int64, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_4 / a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_4 / a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 / float32_4s, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 / float32_4s, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 / float32_4s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 / float32_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 / float64_4, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 / float64_4, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 / float64_4, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 / float64_4, expected, hl.tarray(hl.tfloat64)),
+            (float64_4 / a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_4 / a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_4 / a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_4 / a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 / float64_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 / float64_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 / float64_4s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 / float64_4s, expected, hl.tarray(hl.tfloat64)),
         ])
 
     def test_floor_division(self):
-        a_int32 = hl.array([2, 4, 8, 16, hl.missing(tint32)])
+        a_int32 = hl.array([2, 4, 8, 16, hl.missing(hl.tint32)])
         a_int64 = a_int32.map(lambda x: hl.int64(x))
         a_float32 = a_int32.map(lambda x: hl.float32(x))
         a_float64 = a_int32.map(lambda x: hl.float64(x))
-        int32_4s = hl.array([4, 4, 4, 4, hl.missing(tint32)])
-        int32_3s = hl.array([3, 3, 3, 3, hl.missing(tint32)])
+        int32_3s = hl.array([3, 3, 3, 3, hl.missing(hl.tint32)])
         int64_3 = hl.int64(3)
         int64_3s = int32_3s.map(lambda x: hl.int64(x))
         float32_3 = hl.float32(3)
@@ -1896,63 +1902,62 @@ class Tests(unittest.TestCase):
         expected_inv = [1, 0, 0, 0, None]
 
         _test_many_equal_typed([
-            (a_int32 // 3, expected, tarray(tint32)),
-            (a_int64 // 3, expected, tarray(tint64)),
-            (a_float32 // 3, expected, tarray(tfloat32)),
-            (a_float64 // 3, expected, tarray(tfloat64)),
-            (3 // a_int32, expected_inv, tarray(tint32)),
-            (3 // a_int64, expected_inv, tarray(tint64)),
-            (3 // a_float32, expected_inv, tarray(tfloat32)),
-            (3 // a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 // int32_3s, expected, tarray(tint32)),
-            (a_int64 // int32_3s, expected, tarray(tint64)),
-            (a_float32 // int32_3s, expected, tarray(tfloat32)),
-            (a_float64 // int32_3s, expected, tarray(tfloat64)),
-            (a_int32 // int64_3, expected, tarray(tint64)),
-            (a_int64 // int64_3, expected, tarray(tint64)),
-            (a_float32 // int64_3, expected, tarray(tfloat32)),
-            (a_float64 // int64_3, expected, tarray(tfloat64)),
-            (int64_3 // a_int32, expected_inv, tarray(tint64)),
-            (int64_3 // a_int64, expected_inv, tarray(tint64)),
-            (int64_3 // a_float32, expected_inv, tarray(tfloat32)),
-            (int64_3 // a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 // int64_3s, expected, tarray(tint64)),
-            (a_int64 // int64_3s, expected, tarray(tint64)),
-            (a_float32 // int64_3s, expected, tarray(tfloat32)),
-            (a_float64 // int64_3s, expected, tarray(tfloat64)),
-            (a_int32 // float32_3, expected, tarray(tfloat32)),
-            (a_int64 // float32_3, expected, tarray(tfloat32)),
-            (a_float32 // float32_3, expected, tarray(tfloat32)),
-            (a_float64 // float32_3, expected, tarray(tfloat64)),
-            (float32_3 // a_int32, expected_inv, tarray(tfloat32)),
-            (float32_3 // a_int64, expected_inv, tarray(tfloat32)),
-            (float32_3 // a_float32, expected_inv, tarray(tfloat32)),
-            (float32_3 // a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 // float32_3s, expected, tarray(tfloat32)),
-            (a_int64 // float32_3s, expected, tarray(tfloat32)),
-            (a_float32 // float32_3s, expected, tarray(tfloat32)),
-            (a_float64 // float32_3s, expected, tarray(tfloat64)),
-            (a_int32 // float64_3, expected, tarray(tfloat64)),
-            (a_int64 // float64_3, expected, tarray(tfloat64)),
-            (a_float32 // float64_3, expected, tarray(tfloat64)),
-            (a_float64 // float64_3, expected, tarray(tfloat64)),
-            (float64_3 // a_int32, expected_inv, tarray(tfloat64)),
-            (float64_3 // a_int64, expected_inv, tarray(tfloat64)),
-            (float64_3 // a_float32, expected_inv, tarray(tfloat64)),
-            (float64_3 // a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 // float64_3s, expected, tarray(tfloat64)),
-            (a_int64 // float64_3s, expected, tarray(tfloat64)),
-            (a_float32 // float64_3s, expected, tarray(tfloat64)),
-            (a_float64 // float64_3s, expected, tarray(tfloat64)),
+            (a_int32 // 3, expected, hl.tarray(hl.tint32)),
+            (a_int64 // 3, expected, hl.tarray(hl.tint64)),
+            (a_float32 // 3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 // 3, expected, hl.tarray(hl.tfloat64)),
+            (3 // a_int32, expected_inv, hl.tarray(hl.tint32)),
+            (3 // a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (3 // a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (3 // a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 // int32_3s, expected, hl.tarray(hl.tint32)),
+            (a_int64 // int32_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 // int32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 // int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 // int64_3, expected, hl.tarray(hl.tint64)),
+            (a_int64 // int64_3, expected, hl.tarray(hl.tint64)),
+            (a_float32 // int64_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 // int64_3, expected, hl.tarray(hl.tfloat64)),
+            (int64_3 // a_int32, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 // a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 // a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (int64_3 // a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 // int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_int64 // int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 // int64_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 // int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 // float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 // float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 // float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 // float32_3, expected, hl.tarray(hl.tfloat64)),
+            (float32_3 // a_int32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 // a_int64, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 // a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 // a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 // float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 // float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 // float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 // float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 // float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 // float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 // float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 // float64_3, expected, hl.tarray(hl.tfloat64)),
+            (float64_3 // a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 // a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 // a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 // a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 // float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 // float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 // float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 // float64_3s, expected, hl.tarray(hl.tfloat64)),
         ])
 
     def test_addition(self):
-        a_int32 = hl.array([2, 4, 8, 16, hl.missing(tint32)])
+        a_int32 = hl.array([2, 4, 8, 16, hl.missing(hl.tint32)])
         a_int64 = a_int32.map(lambda x: hl.int64(x))
         a_float32 = a_int32.map(lambda x: hl.float32(x))
         a_float64 = a_int32.map(lambda x: hl.float64(x))
-        int32_4s = hl.array([4, 4, 4, 4, hl.missing(tint32)])
-        int32_3s = hl.array([3, 3, 3, 3, hl.missing(tint32)])
+        int32_3s = hl.array([3, 3, 3, 3, hl.missing(hl.tint32)])
         int64_3 = hl.int64(3)
         int64_3s = int32_3s.map(lambda x: hl.int64(x))
         float32_3 = hl.float32(3)
@@ -1964,63 +1969,62 @@ class Tests(unittest.TestCase):
         expected_inv = expected
 
         _test_many_equal_typed([
-            (a_int32 + 3, expected, tarray(tint32)),
-            (a_int64 + 3, expected, tarray(tint64)),
-            (a_float32 + 3, expected, tarray(tfloat32)),
-            (a_float64 + 3, expected, tarray(tfloat64)),
-            (3 + a_int32, expected_inv, tarray(tint32)),
-            (3 + a_int64, expected_inv, tarray(tint64)),
-            (3 + a_float32, expected_inv, tarray(tfloat32)),
-            (3 + a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 + int32_3s, expected, tarray(tint32)),
-            (a_int64 + int32_3s, expected, tarray(tint64)),
-            (a_float32 + int32_3s, expected, tarray(tfloat32)),
-            (a_float64 + int32_3s, expected, tarray(tfloat64)),
-            (a_int32 + int64_3, expected, tarray(tint64)),
-            (a_int64 + int64_3, expected, tarray(tint64)),
-            (a_float32 + int64_3, expected, tarray(tfloat32)),
-            (a_float64 + int64_3, expected, tarray(tfloat64)),
-            (int64_3 + a_int32, expected_inv, tarray(tint64)),
-            (int64_3 + a_int64, expected_inv, tarray(tint64)),
-            (int64_3 + a_float32, expected_inv, tarray(tfloat32)),
-            (int64_3 + a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 + int64_3s, expected, tarray(tint64)),
-            (a_int64 + int64_3s, expected, tarray(tint64)),
-            (a_float32 + int64_3s, expected, tarray(tfloat32)),
-            (a_float64 + int64_3s, expected, tarray(tfloat64)),
-            (a_int32 + float32_3, expected, tarray(tfloat32)),
-            (a_int64 + float32_3, expected, tarray(tfloat32)),
-            (a_float32 + float32_3, expected, tarray(tfloat32)),
-            (a_float64 + float32_3, expected, tarray(tfloat64)),
-            (float32_3 + a_int32, expected_inv, tarray(tfloat32)),
-            (float32_3 + a_int64, expected_inv, tarray(tfloat32)),
-            (float32_3 + a_float32, expected_inv, tarray(tfloat32)),
-            (float32_3 + a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 + float32_3s, expected, tarray(tfloat32)),
-            (a_int64 + float32_3s, expected, tarray(tfloat32)),
-            (a_float32 + float32_3s, expected, tarray(tfloat32)),
-            (a_float64 + float32_3s, expected, tarray(tfloat64)),
-            (a_int32 + float64_3, expected, tarray(tfloat64)),
-            (a_int64 + float64_3, expected, tarray(tfloat64)),
-            (a_float32 + float64_3, expected, tarray(tfloat64)),
-            (a_float64 + float64_3, expected, tarray(tfloat64)),
-            (float64_3 + a_int32, expected_inv, tarray(tfloat64)),
-            (float64_3 + a_int64, expected_inv, tarray(tfloat64)),
-            (float64_3 + a_float32, expected_inv, tarray(tfloat64)),
-            (float64_3 + a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 + float64_3s, expected, tarray(tfloat64)),
-            (a_int64 + float64_3s, expected, tarray(tfloat64)),
-            (a_float32 + float64_3s, expected, tarray(tfloat64)),
-            (a_float64 + float64_3s, expected, tarray(tfloat64)),
+            (a_int32 + 3, expected, hl.tarray(hl.tint32)),
+            (a_int64 + 3, expected, hl.tarray(hl.tint64)),
+            (a_float32 + 3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 + 3, expected, hl.tarray(hl.tfloat64)),
+            (3 + a_int32, expected_inv, hl.tarray(hl.tint32)),
+            (3 + a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (3 + a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (3 + a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 + int32_3s, expected, hl.tarray(hl.tint32)),
+            (a_int64 + int32_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 + int32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 + int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 + int64_3, expected, hl.tarray(hl.tint64)),
+            (a_int64 + int64_3, expected, hl.tarray(hl.tint64)),
+            (a_float32 + int64_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 + int64_3, expected, hl.tarray(hl.tfloat64)),
+            (int64_3 + a_int32, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 + a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 + a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (int64_3 + a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 + int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_int64 + int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 + int64_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 + int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 + float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 + float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 + float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 + float32_3, expected, hl.tarray(hl.tfloat64)),
+            (float32_3 + a_int32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 + a_int64, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 + a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 + a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 + float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 + float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 + float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 + float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 + float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 + float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 + float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 + float64_3, expected, hl.tarray(hl.tfloat64)),
+            (float64_3 + a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 + a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 + a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 + a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 + float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 + float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 + float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 + float64_3s, expected, hl.tarray(hl.tfloat64)),
         ])
 
     def test_subtraction(self):
-        a_int32 = hl.array([2, 4, 8, 16, hl.missing(tint32)])
+        a_int32 = hl.array([2, 4, 8, 16, hl.missing(hl.tint32)])
         a_int64 = a_int32.map(lambda x: hl.int64(x))
         a_float32 = a_int32.map(lambda x: hl.float32(x))
         a_float64 = a_int32.map(lambda x: hl.float64(x))
-        int32_4s = hl.array([4, 4, 4, 4, hl.missing(tint32)])
-        int32_3s = hl.array([3, 3, 3, 3, hl.missing(tint32)])
+        int32_3s = hl.array([3, 3, 3, 3, hl.missing(hl.tint32)])
         int64_3 = hl.int64(3)
         int64_3s = int32_3s.map(lambda x: hl.int64(x))
         float32_3 = hl.float32(3)
@@ -2032,63 +2036,62 @@ class Tests(unittest.TestCase):
         expected_inv = [1, -1, -5, -13, None]
 
         _test_many_equal_typed([
-            (a_int32 - 3, expected, tarray(tint32)),
-            (a_int64 - 3, expected, tarray(tint64)),
-            (a_float32 - 3, expected, tarray(tfloat32)),
-            (a_float64 - 3, expected, tarray(tfloat64)),
-            (3 - a_int32, expected_inv, tarray(tint32)),
-            (3 - a_int64, expected_inv, tarray(tint64)),
-            (3 - a_float32, expected_inv, tarray(tfloat32)),
-            (3 - a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 - int32_3s, expected, tarray(tint32)),
-            (a_int64 - int32_3s, expected, tarray(tint64)),
-            (a_float32 - int32_3s, expected, tarray(tfloat32)),
-            (a_float64 - int32_3s, expected, tarray(tfloat64)),
-            (a_int32 - int64_3, expected, tarray(tint64)),
-            (a_int64 - int64_3, expected, tarray(tint64)),
-            (a_float32 - int64_3, expected, tarray(tfloat32)),
-            (a_float64 - int64_3, expected, tarray(tfloat64)),
-            (int64_3 - a_int32, expected_inv, tarray(tint64)),
-            (int64_3 - a_int64, expected_inv, tarray(tint64)),
-            (int64_3 - a_float32, expected_inv, tarray(tfloat32)),
-            (int64_3 - a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 - int64_3s, expected, tarray(tint64)),
-            (a_int64 - int64_3s, expected, tarray(tint64)),
-            (a_float32 - int64_3s, expected, tarray(tfloat32)),
-            (a_float64 - int64_3s, expected, tarray(tfloat64)),
-            (a_int32 - float32_3, expected, tarray(tfloat32)),
-            (a_int64 - float32_3, expected, tarray(tfloat32)),
-            (a_float32 - float32_3, expected, tarray(tfloat32)),
-            (a_float64 - float32_3, expected, tarray(tfloat64)),
-            (float32_3 - a_int32, expected_inv, tarray(tfloat32)),
-            (float32_3 - a_int64, expected_inv, tarray(tfloat32)),
-            (float32_3 - a_float32, expected_inv, tarray(tfloat32)),
-            (float32_3 - a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 - float32_3s, expected, tarray(tfloat32)),
-            (a_int64 - float32_3s, expected, tarray(tfloat32)),
-            (a_float32 - float32_3s, expected, tarray(tfloat32)),
-            (a_float64 - float32_3s, expected, tarray(tfloat64)),
-            (a_int32 - float64_3, expected, tarray(tfloat64)),
-            (a_int64 - float64_3, expected, tarray(tfloat64)),
-            (a_float32 - float64_3, expected, tarray(tfloat64)),
-            (a_float64 - float64_3, expected, tarray(tfloat64)),
-            (float64_3 - a_int32, expected_inv, tarray(tfloat64)),
-            (float64_3 - a_int64, expected_inv, tarray(tfloat64)),
-            (float64_3 - a_float32, expected_inv, tarray(tfloat64)),
-            (float64_3 - a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 - float64_3s, expected, tarray(tfloat64)),
-            (a_int64 - float64_3s, expected, tarray(tfloat64)),
-            (a_float32 - float64_3s, expected, tarray(tfloat64)),
-            (a_float64 - float64_3s, expected, tarray(tfloat64)),
+            (a_int32 - 3, expected, hl.tarray(hl.tint32)),
+            (a_int64 - 3, expected, hl.tarray(hl.tint64)),
+            (a_float32 - 3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 - 3, expected, hl.tarray(hl.tfloat64)),
+            (3 - a_int32, expected_inv, hl.tarray(hl.tint32)),
+            (3 - a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (3 - a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (3 - a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 - int32_3s, expected, hl.tarray(hl.tint32)),
+            (a_int64 - int32_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 - int32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 - int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 - int64_3, expected, hl.tarray(hl.tint64)),
+            (a_int64 - int64_3, expected, hl.tarray(hl.tint64)),
+            (a_float32 - int64_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 - int64_3, expected, hl.tarray(hl.tfloat64)),
+            (int64_3 - a_int32, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 - a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 - a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (int64_3 - a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 - int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_int64 - int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 - int64_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 - int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 - float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 - float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 - float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 - float32_3, expected, hl.tarray(hl.tfloat64)),
+            (float32_3 - a_int32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 - a_int64, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 - a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 - a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 - float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 - float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 - float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 - float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 - float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 - float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 - float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 - float64_3, expected, hl.tarray(hl.tfloat64)),
+            (float64_3 - a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 - a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 - a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 - a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 - float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 - float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 - float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 - float64_3s, expected, hl.tarray(hl.tfloat64)),
         ])
 
     def test_multiplication(self):
-        a_int32 = hl.array([2, 4, 8, 16, hl.missing(tint32)])
+        a_int32 = hl.array([2, 4, 8, 16, hl.missing(hl.tint32)])
         a_int64 = a_int32.map(lambda x: hl.int64(x))
         a_float32 = a_int32.map(lambda x: hl.float32(x))
         a_float64 = a_int32.map(lambda x: hl.float64(x))
-        int32_4s = hl.array([4, 4, 4, 4, hl.missing(tint32)])
-        int32_3s = hl.array([3, 3, 3, 3, hl.missing(tint32)])
+        int32_3s = hl.array([3, 3, 3, 3, hl.missing(hl.tint32)])
         int64_3 = hl.int64(3)
         int64_3s = int32_3s.map(lambda x: hl.int64(x))
         float32_3 = hl.float32(3)
@@ -2100,63 +2103,62 @@ class Tests(unittest.TestCase):
         expected_inv = expected
 
         _test_many_equal_typed([
-            (a_int32 * 3, expected, tarray(tint32)),
-            (a_int64 * 3, expected, tarray(tint64)),
-            (a_float32 * 3, expected, tarray(tfloat32)),
-            (a_float64 * 3, expected, tarray(tfloat64)),
-            (3 * a_int32, expected_inv, tarray(tint32)),
-            (3 * a_int64, expected_inv, tarray(tint64)),
-            (3 * a_float32, expected_inv, tarray(tfloat32)),
-            (3 * a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 * int32_3s, expected, tarray(tint32)),
-            (a_int64 * int32_3s, expected, tarray(tint64)),
-            (a_float32 * int32_3s, expected, tarray(tfloat32)),
-            (a_float64 * int32_3s, expected, tarray(tfloat64)),
-            (a_int32 * int64_3, expected, tarray(tint64)),
-            (a_int64 * int64_3, expected, tarray(tint64)),
-            (a_float32 * int64_3, expected, tarray(tfloat32)),
-            (a_float64 * int64_3, expected, tarray(tfloat64)),
-            (int64_3 * a_int32, expected_inv, tarray(tint64)),
-            (int64_3 * a_int64, expected_inv, tarray(tint64)),
-            (int64_3 * a_float32, expected_inv, tarray(tfloat32)),
-            (int64_3 * a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 * int64_3s, expected, tarray(tint64)),
-            (a_int64 * int64_3s, expected, tarray(tint64)),
-            (a_float32 * int64_3s, expected, tarray(tfloat32)),
-            (a_float64 * int64_3s, expected, tarray(tfloat64)),
-            (a_int32 * float32_3, expected, tarray(tfloat32)),
-            (a_int64 * float32_3, expected, tarray(tfloat32)),
-            (a_float32 * float32_3, expected, tarray(tfloat32)),
-            (a_float64 * float32_3, expected, tarray(tfloat64)),
-            (float32_3 * a_int32, expected_inv, tarray(tfloat32)),
-            (float32_3 * a_int64, expected_inv, tarray(tfloat32)),
-            (float32_3 * a_float32, expected_inv, tarray(tfloat32)),
-            (float32_3 * a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 * float32_3s, expected, tarray(tfloat32)),
-            (a_int64 * float32_3s, expected, tarray(tfloat32)),
-            (a_float32 * float32_3s, expected, tarray(tfloat32)),
-            (a_float64 * float32_3s, expected, tarray(tfloat64)),
-            (a_int32 * float64_3, expected, tarray(tfloat64)),
-            (a_int64 * float64_3, expected, tarray(tfloat64)),
-            (a_float32 * float64_3, expected, tarray(tfloat64)),
-            (a_float64 * float64_3, expected, tarray(tfloat64)),
-            (float64_3 * a_int32, expected_inv, tarray(tfloat64)),
-            (float64_3 * a_int64, expected_inv, tarray(tfloat64)),
-            (float64_3 * a_float32, expected_inv, tarray(tfloat64)),
-            (float64_3 * a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 * float64_3s, expected, tarray(tfloat64)),
-            (a_int64 * float64_3s, expected, tarray(tfloat64)),
-            (a_float32 * float64_3s, expected, tarray(tfloat64)),
-            (a_float64 * float64_3s, expected, tarray(tfloat64)),
+            (a_int32 * 3, expected, hl.tarray(hl.tint32)),
+            (a_int64 * 3, expected, hl.tarray(hl.tint64)),
+            (a_float32 * 3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 * 3, expected, hl.tarray(hl.tfloat64)),
+            (3 * a_int32, expected_inv, hl.tarray(hl.tint32)),
+            (3 * a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (3 * a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (3 * a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 * int32_3s, expected, hl.tarray(hl.tint32)),
+            (a_int64 * int32_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 * int32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 * int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 * int64_3, expected, hl.tarray(hl.tint64)),
+            (a_int64 * int64_3, expected, hl.tarray(hl.tint64)),
+            (a_float32 * int64_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 * int64_3, expected, hl.tarray(hl.tfloat64)),
+            (int64_3 * a_int32, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 * a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 * a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (int64_3 * a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 * int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_int64 * int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 * int64_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 * int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 * float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 * float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 * float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 * float32_3, expected, hl.tarray(hl.tfloat64)),
+            (float32_3 * a_int32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 * a_int64, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 * a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 * a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 * float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 * float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 * float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 * float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 * float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 * float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 * float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 * float64_3, expected, hl.tarray(hl.tfloat64)),
+            (float64_3 * a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 * a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 * a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 * a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 * float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 * float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 * float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 * float64_3s, expected, hl.tarray(hl.tfloat64)),
         ])
 
     def test_exponentiation(self):
-        a_int32 = hl.array([2, 4, 8, 16, hl.missing(tint32)])
+        a_int32 = hl.array([2, 4, 8, 16, hl.missing(hl.tint32)])
         a_int64 = a_int32.map(lambda x: hl.int64(x))
         a_float32 = a_int32.map(lambda x: hl.float32(x))
         a_float64 = a_int32.map(lambda x: hl.float64(x))
-        int32_4s = hl.array([4, 4, 4, 4, hl.missing(tint32)])
-        int32_3s = hl.array([3, 3, 3, 3, hl.missing(tint32)])
+        int32_3s = hl.array([3, 3, 3, 3, hl.missing(hl.tint32)])
         int64_3 = hl.int64(3)
         int64_3s = int32_3s.map(lambda x: hl.int64(x))
         float32_3 = hl.float32(3)
@@ -2168,63 +2170,62 @@ class Tests(unittest.TestCase):
         expected_inv = [9.0, 81.0, 6561.0, 43046721.0, None]
 
         _test_many_equal_typed([
-            (a_int32**3, expected, tarray(tfloat64)),
-            (a_int64**3, expected, tarray(tfloat64)),
-            (a_float32**3, expected, tarray(tfloat64)),
-            (a_float64**3, expected, tarray(tfloat64)),
-            (3**a_int32, expected_inv, tarray(tfloat64)),
-            (3**a_int64, expected_inv, tarray(tfloat64)),
-            (3**a_float32, expected_inv, tarray(tfloat64)),
-            (3**a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32**int32_3s, expected, tarray(tfloat64)),
-            (a_int64**int32_3s, expected, tarray(tfloat64)),
-            (a_float32**int32_3s, expected, tarray(tfloat64)),
-            (a_float64**int32_3s, expected, tarray(tfloat64)),
-            (a_int32**int64_3, expected, tarray(tfloat64)),
-            (a_int64**int64_3, expected, tarray(tfloat64)),
-            (a_float32**int64_3, expected, tarray(tfloat64)),
-            (a_float64**int64_3, expected, tarray(tfloat64)),
-            (int64_3**a_int32, expected_inv, tarray(tfloat64)),
-            (int64_3**a_int64, expected_inv, tarray(tfloat64)),
-            (int64_3**a_float32, expected_inv, tarray(tfloat64)),
-            (int64_3**a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32**int64_3s, expected, tarray(tfloat64)),
-            (a_int64**int64_3s, expected, tarray(tfloat64)),
-            (a_float32**int64_3s, expected, tarray(tfloat64)),
-            (a_float64**int64_3s, expected, tarray(tfloat64)),
-            (a_int32**float32_3, expected, tarray(tfloat64)),
-            (a_int64**float32_3, expected, tarray(tfloat64)),
-            (a_float32**float32_3, expected, tarray(tfloat64)),
-            (a_float64**float32_3, expected, tarray(tfloat64)),
-            (float32_3**a_int32, expected_inv, tarray(tfloat64)),
-            (float32_3**a_int64, expected_inv, tarray(tfloat64)),
-            (float32_3**a_float32, expected_inv, tarray(tfloat64)),
-            (float32_3**a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32**float32_3s, expected, tarray(tfloat64)),
-            (a_int64**float32_3s, expected, tarray(tfloat64)),
-            (a_float32**float32_3s, expected, tarray(tfloat64)),
-            (a_float64**float32_3s, expected, tarray(tfloat64)),
-            (a_int32**float64_3, expected, tarray(tfloat64)),
-            (a_int64**float64_3, expected, tarray(tfloat64)),
-            (a_float32**float64_3, expected, tarray(tfloat64)),
-            (a_float64**float64_3, expected, tarray(tfloat64)),
-            (float64_3**a_int32, expected_inv, tarray(tfloat64)),
-            (float64_3**a_int64, expected_inv, tarray(tfloat64)),
-            (float64_3**a_float32, expected_inv, tarray(tfloat64)),
-            (float64_3**a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32**float64_3s, expected, tarray(tfloat64)),
-            (a_int64**float64_3s, expected, tarray(tfloat64)),
-            (a_float32**float64_3s, expected, tarray(tfloat64)),
-            (a_float64**float64_3s, expected, tarray(tfloat64)),
+            (a_int32**3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**3, expected, hl.tarray(hl.tfloat64)),
+            (3**a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (3**a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (3**a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (3**a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32**int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32**int64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**int64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**int64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**int64_3, expected, hl.tarray(hl.tfloat64)),
+            (int64_3**a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (int64_3**a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (int64_3**a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (int64_3**a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32**int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32**float32_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**float32_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**float32_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**float32_3, expected, hl.tarray(hl.tfloat64)),
+            (float32_3**a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float32_3**a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float32_3**a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float32_3**a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32**float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32**float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**float64_3, expected, hl.tarray(hl.tfloat64)),
+            (float64_3**a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3**a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3**a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3**a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32**float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64**float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32**float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64**float64_3s, expected, hl.tarray(hl.tfloat64)),
         ])
 
     def test_modulus(self):
-        a_int32 = hl.array([2, 4, 8, 16, hl.missing(tint32)])
+        a_int32 = hl.array([2, 4, 8, 16, hl.missing(hl.tint32)])
         a_int64 = a_int32.map(lambda x: hl.int64(x))
         a_float32 = a_int32.map(lambda x: hl.float32(x))
         a_float64 = a_int32.map(lambda x: hl.float64(x))
-        int32_4s = hl.array([4, 4, 4, 4, hl.missing(tint32)])
-        int32_3s = hl.array([3, 3, 3, 3, hl.missing(tint32)])
+        int32_3s = hl.array([3, 3, 3, 3, hl.missing(hl.tint32)])
         int64_3 = hl.int64(3)
         int64_3s = int32_3s.map(lambda x: hl.int64(x))
         float32_3 = hl.float32(3)
@@ -2236,73 +2237,73 @@ class Tests(unittest.TestCase):
         expected_inv = [1, 3, 3, 3, None]
 
         _test_many_equal_typed([
-            (a_int32 % 3, expected, tarray(tint32)),
-            (a_int64 % 3, expected, tarray(tint64)),
-            (a_float32 % 3, expected, tarray(tfloat32)),
-            (a_float64 % 3, expected, tarray(tfloat64)),
-            (3 % a_int32, expected_inv, tarray(tint32)),
-            (3 % a_int64, expected_inv, tarray(tint64)),
-            (3 % a_float32, expected_inv, tarray(tfloat32)),
-            (3 % a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 % int32_3s, expected, tarray(tint32)),
-            (a_int64 % int32_3s, expected, tarray(tint64)),
-            (a_float32 % int32_3s, expected, tarray(tfloat32)),
-            (a_float64 % int32_3s, expected, tarray(tfloat64)),
-            (a_int32 % int64_3, expected, tarray(tint64)),
-            (a_int64 % int64_3, expected, tarray(tint64)),
-            (a_float32 % int64_3, expected, tarray(tfloat32)),
-            (a_float64 % int64_3, expected, tarray(tfloat64)),
-            (int64_3 % a_int32, expected_inv, tarray(tint64)),
-            (int64_3 % a_int64, expected_inv, tarray(tint64)),
-            (int64_3 % a_float32, expected_inv, tarray(tfloat32)),
-            (int64_3 % a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 % int64_3s, expected, tarray(tint64)),
-            (a_int64 % int64_3s, expected, tarray(tint64)),
-            (a_float32 % int64_3s, expected, tarray(tfloat32)),
-            (a_float64 % int64_3s, expected, tarray(tfloat64)),
-            (a_int32 % float32_3, expected, tarray(tfloat32)),
-            (a_int64 % float32_3, expected, tarray(tfloat32)),
-            (a_float32 % float32_3, expected, tarray(tfloat32)),
-            (a_float64 % float32_3, expected, tarray(tfloat64)),
-            (float32_3 % a_int32, expected_inv, tarray(tfloat32)),
-            (float32_3 % a_int64, expected_inv, tarray(tfloat32)),
-            (float32_3 % a_float32, expected_inv, tarray(tfloat32)),
-            (float32_3 % a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 % float32_3s, expected, tarray(tfloat32)),
-            (a_int64 % float32_3s, expected, tarray(tfloat32)),
-            (a_float32 % float32_3s, expected, tarray(tfloat32)),
-            (a_float64 % float32_3s, expected, tarray(tfloat64)),
-            (a_int32 % float64_3, expected, tarray(tfloat64)),
-            (a_int64 % float64_3, expected, tarray(tfloat64)),
-            (a_float32 % float64_3, expected, tarray(tfloat64)),
-            (a_float64 % float64_3, expected, tarray(tfloat64)),
-            (float64_3 % a_int32, expected_inv, tarray(tfloat64)),
-            (float64_3 % a_int64, expected_inv, tarray(tfloat64)),
-            (float64_3 % a_float32, expected_inv, tarray(tfloat64)),
-            (float64_3 % a_float64, expected_inv, tarray(tfloat64)),
-            (a_int32 % float64_3s, expected, tarray(tfloat64)),
-            (a_int64 % float64_3s, expected, tarray(tfloat64)),
-            (a_float32 % float64_3s, expected, tarray(tfloat64)),
-            (a_float64 % float64_3s, expected, tarray(tfloat64)),
+            (a_int32 % 3, expected, hl.tarray(hl.tint32)),
+            (a_int64 % 3, expected, hl.tarray(hl.tint64)),
+            (a_float32 % 3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 % 3, expected, hl.tarray(hl.tfloat64)),
+            (3 % a_int32, expected_inv, hl.tarray(hl.tint32)),
+            (3 % a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (3 % a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (3 % a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 % int32_3s, expected, hl.tarray(hl.tint32)),
+            (a_int64 % int32_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 % int32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 % int32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 % int64_3, expected, hl.tarray(hl.tint64)),
+            (a_int64 % int64_3, expected, hl.tarray(hl.tint64)),
+            (a_float32 % int64_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 % int64_3, expected, hl.tarray(hl.tfloat64)),
+            (int64_3 % a_int32, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 % a_int64, expected_inv, hl.tarray(hl.tint64)),
+            (int64_3 % a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (int64_3 % a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 % int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_int64 % int64_3s, expected, hl.tarray(hl.tint64)),
+            (a_float32 % int64_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 % int64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 % float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 % float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 % float32_3, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 % float32_3, expected, hl.tarray(hl.tfloat64)),
+            (float32_3 % a_int32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 % a_int64, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 % a_float32, expected_inv, hl.tarray(hl.tfloat32)),
+            (float32_3 % a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 % float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_int64 % float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float32 % float32_3s, expected, hl.tarray(hl.tfloat32)),
+            (a_float64 % float32_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int32 % float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 % float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 % float64_3, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 % float64_3, expected, hl.tarray(hl.tfloat64)),
+            (float64_3 % a_int32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 % a_int64, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 % a_float32, expected_inv, hl.tarray(hl.tfloat64)),
+            (float64_3 % a_float64, expected_inv, hl.tarray(hl.tfloat64)),
+            (a_int32 % float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_int64 % float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float32 % float64_3s, expected, hl.tarray(hl.tfloat64)),
+            (a_float64 % float64_3s, expected, hl.tarray(hl.tfloat64)),
         ])
 
     def test_comparisons(self):
         f0 = hl.float(0.0)
-        fnull = hl.missing(tfloat)
+        fnull = hl.missing(hl.tfloat)
         finf = hl.float(float('inf'))
         fnan = hl.float(float('nan'))
 
         _test_many_equal_typed([
-            (f0 == fnull, None, tbool),
-            (f0 < fnull, None, tbool),
-            (f0 != fnull, None, tbool),
-            (fnan == fnan, False, tbool),
-            (f0 == f0, True, tbool),
-            (finf == finf, True, tbool),
-            (f0 < finf, True, tbool),
-            (f0 > finf, False, tbool),
-            (fnan <= finf, False, tbool),
-            (fnan >= finf, False, tbool),
+            (f0 == fnull, None, hl.tbool),
+            (f0 < fnull, None, hl.tbool),
+            (f0 != fnull, None, hl.tbool),
+            (fnan == fnan, False, hl.tbool),  # noqa: PLR0124
+            (f0 == f0, True, hl.tbool),  # noqa: PLR0124
+            (finf == finf, True, hl.tbool),  # noqa: PLR0124
+            (f0 < finf, True, hl.tbool),
+            (f0 > finf, False, hl.tbool),
+            (fnan <= finf, False, hl.tbool),
+            (fnan >= finf, False, hl.tbool),
         ])
 
     def test_bools_can_math(self):
@@ -2456,7 +2457,7 @@ class Tests(unittest.TestCase):
         c2_hetvar = hl.call(2, 1, phased=True)
         c1 = hl.call(1)
         c0 = hl.call()
-        cNull = hl.missing(tcall)
+        cNull = hl.missing(hl.tcall)
         call_expr_1 = hl.call(1, 2, phased=True)
         a0 = hl.literal(1)
         a1 = 2
@@ -2466,51 +2467,51 @@ class Tests(unittest.TestCase):
         call_expr_4 = hl.unphased_diploid_gt_index_call(2)
 
         _test_many_equal_typed([
-            (c2_homref.ploidy, 2, tint32),
-            (c2_homref[0], 0, tint32),
-            (c2_homref[1], 0, tint32),
-            (c2_homref.phased, False, tbool),
-            (c2_homref.is_hom_ref(), True, tbool),
-            (c2_het.ploidy, 2, tint32),
-            (c2_het[0], 1, tint32),
-            (c2_het[1], 0, tint32),
-            (c2_het.phased, True, tbool),
-            (c2_het.is_het(), True, tbool),
-            (c2_homvar.ploidy, 2, tint32),
-            (c2_homvar[0], 1, tint32),
-            (c2_homvar[1], 1, tint32),
-            (c2_homvar.phased, False, tbool),
-            (c2_homvar.is_hom_var(), True, tbool),
-            (c2_homvar.unphased_diploid_gt_index(), 2, tint32),
-            (c2_hetvar.ploidy, 2, tint32),
-            (c2_hetvar[0], 2, tint32),
-            (c2_hetvar[1], 1, tint32),
-            (c2_hetvar.phased, True, tbool),
-            (c2_hetvar.is_hom_var(), False, tbool),
-            (c2_hetvar.is_het_non_ref(), True, tbool),
-            (c1.ploidy, 1, tint32),
-            (c1[0], 1, tint32),
-            (c1.phased, False, tbool),
-            (c1.is_hom_var(), True, tbool),
-            (c0.ploidy, 0, tint32),
-            (c0.phased, False, tbool),
-            (c0.is_hom_var(), False, tbool),
-            (cNull.ploidy, None, tint32),
-            (cNull[0], None, tint32),
-            (cNull.phased, None, tbool),
-            (cNull.is_hom_var(), None, tbool),
-            (call_expr_1[0], 1, tint32),
-            (call_expr_1[1], 2, tint32),
-            (call_expr_1.ploidy, 2, tint32),
-            (call_expr_2[0], 1, tint32),
-            (call_expr_2[1], 2, tint32),
-            (call_expr_2.ploidy, 2, tint32),
-            (call_expr_3[0], 1, tint32),
-            (call_expr_3[1], 2, tint32),
-            (call_expr_3.ploidy, 2, tint32),
-            (call_expr_4[0], 1, tint32),
-            (call_expr_4[1], 1, tint32),
-            (call_expr_4.ploidy, 2, tint32),
+            (c2_homref.ploidy, 2, hl.tint32),
+            (c2_homref[0], 0, hl.tint32),
+            (c2_homref[1], 0, hl.tint32),
+            (c2_homref.phased, False, hl.tbool),
+            (c2_homref.is_hom_ref(), True, hl.tbool),
+            (c2_het.ploidy, 2, hl.tint32),
+            (c2_het[0], 1, hl.tint32),
+            (c2_het[1], 0, hl.tint32),
+            (c2_het.phased, True, hl.tbool),
+            (c2_het.is_het(), True, hl.tbool),
+            (c2_homvar.ploidy, 2, hl.tint32),
+            (c2_homvar[0], 1, hl.tint32),
+            (c2_homvar[1], 1, hl.tint32),
+            (c2_homvar.phased, False, hl.tbool),
+            (c2_homvar.is_hom_var(), True, hl.tbool),
+            (c2_homvar.unphased_diploid_gt_index(), 2, hl.tint32),
+            (c2_hetvar.ploidy, 2, hl.tint32),
+            (c2_hetvar[0], 2, hl.tint32),
+            (c2_hetvar[1], 1, hl.tint32),
+            (c2_hetvar.phased, True, hl.tbool),
+            (c2_hetvar.is_hom_var(), False, hl.tbool),
+            (c2_hetvar.is_het_non_ref(), True, hl.tbool),
+            (c1.ploidy, 1, hl.tint32),
+            (c1[0], 1, hl.tint32),
+            (c1.phased, False, hl.tbool),
+            (c1.is_hom_var(), True, hl.tbool),
+            (c0.ploidy, 0, hl.tint32),
+            (c0.phased, False, hl.tbool),
+            (c0.is_hom_var(), False, hl.tbool),
+            (cNull.ploidy, None, hl.tint32),
+            (cNull[0], None, hl.tint32),
+            (cNull.phased, None, hl.tbool),
+            (cNull.is_hom_var(), None, hl.tbool),
+            (call_expr_1[0], 1, hl.tint32),
+            (call_expr_1[1], 2, hl.tint32),
+            (call_expr_1.ploidy, 2, hl.tint32),
+            (call_expr_2[0], 1, hl.tint32),
+            (call_expr_2[1], 2, hl.tint32),
+            (call_expr_2.ploidy, 2, hl.tint32),
+            (call_expr_3[0], 1, hl.tint32),
+            (call_expr_3[1], 2, hl.tint32),
+            (call_expr_3.ploidy, 2, hl.tint32),
+            (call_expr_4[0], 1, hl.tint32),
+            (call_expr_4[1], 1, hl.tint32),
+            (call_expr_4.ploidy, 2, hl.tint32),
         ])
 
     def test_call_unphase(self):
@@ -2623,8 +2624,8 @@ class Tests(unittest.TestCase):
 
         self.assertEqual(hl.eval(hl.dict([('1', 2), ('2', 3)])), {'1': 2, '2': 3})
         self.assertEqual(hl.eval(hl.dict({('1', 2), ('2', 3)})), {'1': 2, '2': 3})
-        self.assertEqual(hl.eval(hl.dict([('1', 2), (hl.missing(tstr), 3)])), {'1': 2, None: 3})
-        self.assertEqual(hl.eval(hl.dict({('1', 2), (hl.missing(tstr), 3)})), {'1': 2, None: 3})
+        self.assertEqual(hl.eval(hl.dict([('1', 2), (hl.missing(hl.tstr), 3)])), {'1': 2, None: 3})
+        self.assertEqual(hl.eval(hl.dict({('1', 2), (hl.missing(hl.tstr), 3)})), {'1': 2, None: 3})
 
     def test_zip(self):
         a1 = [1, 2, 3]
@@ -2662,7 +2663,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(hl.all(False, False)), False)
 
     def test_any_form_2(self):
-        self.assertEqual(hl.eval(hl.any(hl.empty_array(hl.tbool))), False)
+        self.assertEqual(hl.eval(hl.any(hl.empty_array(hl.hl.tbool))), False)
 
         self.assertEqual(hl.eval(hl.any([True])), True)
         self.assertEqual(hl.eval(hl.any([False])), False)
@@ -2673,7 +2674,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(hl.any([False, False])), False)
 
     def test_all_form_2(self):
-        self.assertEqual(hl.eval(hl.all(hl.empty_array(hl.tbool))), True)
+        self.assertEqual(hl.eval(hl.all(hl.empty_array(hl.hl.tbool))), True)
 
         self.assertEqual(hl.eval(hl.all([True])), True)
         self.assertEqual(hl.eval(hl.all([False])), False)
@@ -2697,7 +2698,7 @@ class Tests(unittest.TestCase):
                 (hl.map(lambda x: x % 2 == 0, [0, 1, 4, 6]), [True, False, True, True]),
                 (hl.len([0, 1, 4, 6]), 4),
                 (math.isnan(hl.eval(hl.mean(hl.empty_array(hl.tint)))), True),
-                (hl.mean([0, 1, 4, 6, hl.missing(tint32)]), 2.75),
+                (hl.mean([0, 1, 4, 6, hl.missing(hl.tint32)]), 2.75),
                 (hl.median(hl.empty_array(hl.tint)), None),
                 (1 <= hl.eval(hl.median([0, 1, 4, 6])) <= 4, True),
             ]
@@ -2745,14 +2746,14 @@ class Tests(unittest.TestCase):
         assert hl.eval(x.grouped(100)) == [[0, 1, 2, 3, 4]]
 
     def test_array_find(self):
-        self.assertEqual(hl.eval(hl.find(lambda x: x < 0, hl.missing(hl.tarray(hl.tint32)))), None)
-        self.assertEqual(hl.eval(hl.find(lambda x: hl.missing(hl.tbool), [1, 0, -4, 6])), None)
+        self.assertEqual(hl.eval(hl.find(lambda x: x < 0, hl.missing(hl.hl.tarray(hl.hl.tint32)))), None)
+        self.assertEqual(hl.eval(hl.find(lambda x: hl.missing(hl.hl.tbool), [1, 0, -4, 6])), None)
         self.assertEqual(hl.eval(hl.find(lambda x: x < 0, [1, 0, -4, 6])), -4)
         self.assertEqual(hl.eval(hl.find(lambda x: x < 0, [1, 0, 4, 6])), None)
 
     def test_set_find(self):
-        self.assertEqual(hl.eval(hl.find(lambda x: x < 0, hl.missing(hl.tset(hl.tint32)))), None)
-        self.assertEqual(hl.eval(hl.find(lambda x: hl.missing(hl.tbool), hl.set([1, 0, -4, 6]))), None)
+        self.assertEqual(hl.eval(hl.find(lambda x: x < 0, hl.missing(hl.tset(hl.hl.tint32)))), None)
+        self.assertEqual(hl.eval(hl.find(lambda x: hl.missing(hl.hl.tbool), hl.set([1, 0, -4, 6]))), None)
         self.assertEqual(hl.eval(hl.find(lambda x: x < 0, hl.set([1, 0, -4, 6]))), -4)
         self.assertEqual(hl.eval(hl.find(lambda x: x < 0, hl.set([1, 0, 4, 6]))), None)
 
@@ -2760,12 +2761,13 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(hl.sorted([0, 1, 4, 3, 2], lambda x: x % 2)), [0, 4, 2, 1, 3])
         self.assertEqual(hl.eval(hl.sorted([0, 1, 4, 3, 2], lambda x: x % 2, reverse=True)), [1, 3, 0, 4, 2])
 
-        self.assertEqual(hl.eval(hl.sorted([0, 1, 4, hl.missing(tint), 3, 2], lambda x: x)), [0, 1, 2, 3, 4, None])
+        self.assertEqual(hl.eval(hl.sorted([0, 1, 4, hl.missing(hl.tint), 3, 2], lambda x: x)), [0, 1, 2, 3, 4, None])
         self.assertEqual(
-            hl.sorted([0, 1, 4, hl.missing(tint), 3, 2], lambda x: x, reverse=True).collect()[0], [4, 3, 2, 1, 0, None]
+            hl.sorted([0, 1, 4, hl.missing(hl.tint), 3, 2], lambda x: x, reverse=True).collect()[0],
+            [4, 3, 2, 1, 0, None],
         )
         self.assertEqual(
-            hl.eval(hl.sorted([0, 1, 4, hl.missing(tint), 3, 2], lambda x: x, reverse=True)), [4, 3, 2, 1, 0, None]
+            hl.eval(hl.sorted([0, 1, 4, hl.missing(hl.tint), 3, 2], lambda x: x, reverse=True)), [4, 3, 2, 1, 0, None]
         )
 
         self.assertEqual(hl.eval(hl.sorted({0, 1, 4, 3, 2})), [0, 1, 2, 3, 4])
@@ -2774,7 +2776,7 @@ class Tests(unittest.TestCase):
 
     def test_sort_by(self):
         self.assertEqual(
-            hl.eval(hl._sort_by(["c", "aaa", "bb", hl.missing(hl.tstr)], lambda l, r: hl.len(l) < hl.len(r))),
+            hl.eval(hl._sort_by(["c", "aaa", "bb", hl.missing(hl.hl.tstr)], lambda l, r: hl.len(l) < hl.len(r))),
             ["c", "bb", "aaa", None],
         )
         self.assertEqual(
@@ -2785,7 +2787,7 @@ class Tests(unittest.TestCase):
             self.assertEqual(
                 hl.eval(
                     hl._sort_by(
-                        [hl.Struct(x=i, y="foo", z=5.5) for i in [5, 3, 8, 2, 5, hl.missing(hl.tint32)]],
+                        [hl.Struct(x=i, y="foo", z=5.5) for i in [5, 3, 8, 2, 5, hl.missing(hl.hl.tint32)]],
                         lambda l, r: l.x < r.x,
                     )
                 ),
@@ -2845,8 +2847,8 @@ class Tests(unittest.TestCase):
                 10,
             ),
             (hl.max(0, 10, 2, 3, 4, 5, 6), 10),
-            (hl.max([-5, -4, hl.missing(tint32), -3, -2, hl.missing(tint32)]), -2),
-            (hl.max([float('nan'), -4, float('nan'), -3, -2, hl.missing(tint32)]), float('nan')),
+            (hl.max([-5, -4, hl.missing(hl.tint32), -3, -2, hl.missing(hl.tint32)]), -2),
+            (hl.max([float('nan'), -4, float('nan'), -3, -2, hl.missing(hl.tint32)]), float('nan')),
             (hl.max(0.1, hl.missing('float'), 0.0), 0.1),
             (hl.max(0.1, hl.missing('float'), float('nan')), float('nan')),
             (hl.max(hl.missing('float'), float('nan')), float('nan')),
@@ -2890,8 +2892,8 @@ class Tests(unittest.TestCase):
             (hl.min(0, 1, 2), 0),
             (hl.min([10, 10, 2, 3, 4, 5, 6]), 2),
             (hl.min(0, 10, 2, 3, 4, 5, 6), 0),
-            (hl.min([-5, -4, hl.missing(tint32), -3, -2, hl.missing(tint32)]), -5),
-            (hl.min([float('nan'), -4, float('nan'), -3, -2, hl.missing(tint32)]), float('nan')),
+            (hl.min([-5, -4, hl.missing(hl.tint32), -3, -2, hl.missing(hl.tint32)]), -5),
+            (hl.min([float('nan'), -4, float('nan'), -3, -2, hl.missing(hl.tint32)]), float('nan')),
             (hl.min(-0.1, hl.missing('float'), 0.0), -0.1),
             (hl.min(0.1, hl.missing('float'), float('nan')), float('nan')),
             (hl.min(hl.missing('float'), float('nan')), float('nan')),
@@ -2944,10 +2946,10 @@ class Tests(unittest.TestCase):
         a = hl.array([2, 1, 1, 4, 4, 3])
         self.assertEqual(hl.eval(hl.argmax(a)), 3)
         self.assertEqual(hl.eval(hl.argmax(a, unique=True)), None)
-        self.assertEqual(hl.eval(hl.argmax(hl.empty_array(tint32))), None)
+        self.assertEqual(hl.eval(hl.argmax(hl.empty_array(hl.tint32))), None)
         self.assertEqual(hl.eval(hl.argmin(a)), 1)
         self.assertEqual(hl.eval(hl.argmin(a, unique=True)), None)
-        self.assertEqual(hl.eval(hl.argmin(hl.empty_array(tint32))), None)
+        self.assertEqual(hl.eval(hl.argmin(hl.empty_array(hl.tint32))), None)
 
     def test_show_row_key_regression(self):
         ds = hl.utils.range_matrix_table(3, 3)
@@ -2977,7 +2979,10 @@ class Tests(unittest.TestCase):
         with hl.TemporaryFilename() as f:
             mt.GT.export(f)
             actual = hl.import_matrix_table(
-                f, row_fields={'locus': hl.tstr, 'alleles': hl.tstr}, row_key=['locus', 'alleles'], entry_type=hl.tstr
+                f,
+                row_fields={'locus': hl.hl.tstr, 'alleles': hl.hl.tstr},
+                row_key=['locus', 'alleles'],
+                entry_type=hl.hl.tstr,
             )
             actual = actual.rename({'col_id': 's'})
             actual = actual.key_rows_by(
@@ -3028,10 +3033,10 @@ class Tests(unittest.TestCase):
         interval = hl.interval(3, 6)
         self.assertTrue(hl.eval_typed(interval.start) == (3, hl.tint))
         self.assertTrue(hl.eval_typed(interval.end) == (6, hl.tint))
-        self.assertTrue(hl.eval_typed(interval.includes_start) == (True, hl.tbool))
-        self.assertTrue(hl.eval_typed(interval.includes_end) == (False, hl.tbool))
-        self.assertTrue(hl.eval_typed(interval.contains(5)) == (True, hl.tbool))
-        self.assertTrue(hl.eval_typed(interval.overlaps(hl.interval(5, 9))) == (True, hl.tbool))
+        self.assertTrue(hl.eval_typed(interval.includes_start) == (True, hl.hl.tbool))
+        self.assertTrue(hl.eval_typed(interval.includes_end) == (False, hl.hl.tbool))
+        self.assertTrue(hl.eval_typed(interval.contains(5)) == (True, hl.hl.tbool))
+        self.assertTrue(hl.eval_typed(interval.overlaps(hl.interval(5, 9))) == (True, hl.hl.tbool))
 
         li = hl.parse_locus_interval('1:100-110')
         self.assertEqual(hl.eval(li), hl.utils.Interval(hl.genetics.Locus("1", 100), hl.genetics.Locus("1", 110)))
@@ -3363,14 +3368,12 @@ class Tests(unittest.TestCase):
             (locus_auto, True, hv, het, het): None,
             (locus_auto, True, het, hr, het): None,
             (locus_auto, True, hv, hr, het): None,
-            (locus_auto, True, hv, hr, het): None,
             (locus_x_nonpar, True, hv, hr, het): None,
             (locus_x_nonpar, False, hv, hr, hr): None,
             (locus_x_nonpar, None, hv, hr, hr): None,
             (locus_x_nonpar, False, het, hr, hr): None,
             (locus_y_nonpar, True, het, hr, het): None,
             (locus_y_nonpar, True, het, hr, hr): None,
-            (locus_y_nonpar, True, het, hr, het): None,
             (locus_y_nonpar, True, het, het, het): None,
             (locus_y_nonpar, True, hr, hr, hr): None,
             (locus_y_nonpar, None, hr, hr, hr): None,
@@ -3380,13 +3383,14 @@ class Tests(unittest.TestCase):
         }
 
         arg_list = hl.literal(
-            list(expected.keys()), hl.tarray(hl.ttuple(hl.tlocus(), hl.tbool, hl.tcall, hl.tcall, hl.tcall))
+            list(expected.keys()),
+            hl.hl.tarray(hl.ttuple(hl.tlocus(), hl.hl.tbool, hl.hl.tcall, hl.hl.tcall, hl.hl.tcall)),
         )
         values = arg_list.map(lambda args: hl.mendel_error_code(*args))
         expr = hl.dict(hl.zip(arg_list, values))
         results = hl.eval(expr)
         for args, result in results.items():
-            self.assertEqual(result, expected[args], msg=f'expected {expected[args]}, found {result} at {str(args)}')
+            self.assertEqual(result, expected[args], msg=f'expected {expected[args]}, found {result} at {args!s}')
 
     def test_min_rep(self):
         def assert_min_reps_to(old, new, pos_change=0):
@@ -3439,7 +3443,7 @@ class Tests(unittest.TestCase):
         self.assert_evals_to(s.union(t), set([1, 3, 7, 8]))
 
     def test_set_numeric_functions(self):
-        s = hl.set([1, 3, 5, hl.missing(tint32)])
+        s = hl.set([1, 3, 5, hl.missing(hl.tint32)])
         self.assert_evals_to(hl.min(s), 1)
         self.assert_evals_to(hl.max(s), 5)
         self.assert_evals_to(hl.mean(s), 3)
@@ -3757,17 +3761,17 @@ class Tests(unittest.TestCase):
 
     def test_format(self):
         self.assertEqual(hl.eval(hl.format("%.4f %s %.3e", 0.25, 'hello', 0.114)), '0.2500 hello 1.140e-01')
-        self.assertEqual(hl.eval(hl.format("%.4f %d", hl.missing(hl.tint32), hl.missing(hl.tint32))), 'null null')
+        self.assertEqual(hl.eval(hl.format("%.4f %d", hl.missing(hl.hl.tint32), hl.missing(hl.hl.tint32))), 'null null')
         self.assertEqual(
             hl.eval(hl.format("%s", hl.struct(foo=5, bar=True, baz=hl.array([4, 5])))),
             '{foo: 5, bar: true, baz: [4,5]}',
         )
         self.assertEqual(
-            hl.eval(hl.format("%s %s", hl.locus("1", 356), hl.tuple([9, True, hl.missing(hl.tstr)]))),
+            hl.eval(hl.format("%s %s", hl.locus("1", 356), hl.tuple([9, True, hl.missing(hl.hl.tstr)]))),
             '1:356 (9, true, null)',
         )
         self.assertEqual(
-            hl.eval(hl.format("%b %B %b %b", hl.missing(hl.tint), hl.missing(hl.tstr), True, "hello")),
+            hl.eval(hl.format("%b %B %b %b", hl.missing(hl.tint), hl.missing(hl.hl.tstr), True, "hello")),
             "false FALSE true true",
         )
 
@@ -3812,7 +3816,7 @@ class Tests(unittest.TestCase):
 
     def test_approx_equal(self):
         self.assertTrue(hl.eval(hl.approx_equal(0.25, 0.25000001)))
-        self.assertTrue(hl.eval(hl.approx_equal(hl.missing(hl.tint64), 5)) is None)
+        self.assertTrue(hl.eval(hl.approx_equal(hl.missing(hl.hl.tint64), 5)) is None)
         self.assertFalse(hl.eval(hl.approx_equal(0.25, 0.251, absolute=True, tolerance=1e-3)))
 
     def test_issue3729(self):
@@ -3825,19 +3829,21 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(expr), value)
 
     def test_array_fold_and_scan(self):
-        self.assertValueEqual(hl.fold(lambda x, y: x + y, 0, [1, 2, 3]), 6, tint32)
-        self.assertValueEqual(hl.array_scan(lambda x, y: x + y, 0, [1, 2, 3]), [0, 1, 3, 6], tarray(tint32))
+        self.assertValueEqual(hl.fold(lambda x, y: x + y, 0, [1, 2, 3]), 6, hl.tint32)
+        self.assertValueEqual(hl.array_scan(lambda x, y: x + y, 0, [1, 2, 3]), [0, 1, 3, 6], hl.tarray(hl.tint32))
 
-        self.assertValueEqual(hl.fold(lambda x, y: x + y, 0.0, [1, 2, 3]), 6.0, tfloat64)
-        self.assertValueEqual(hl.fold(lambda x, y: x + y, 0, [1.0, 2.0, 3.0]), 6.0, tfloat64)
-        self.assertValueEqual(hl.array_scan(lambda x, y: x + y, 0.0, [1, 2, 3]), [0.0, 1.0, 3.0, 6.0], tarray(tfloat64))
+        self.assertValueEqual(hl.fold(lambda x, y: x + y, 0.0, [1, 2, 3]), 6.0, hl.tfloat64)
+        self.assertValueEqual(hl.fold(lambda x, y: x + y, 0, [1.0, 2.0, 3.0]), 6.0, hl.tfloat64)
         self.assertValueEqual(
-            hl.array_scan(lambda x, y: x + y, 0, [1.0, 2.0, 3.0]), [0.0, 1.0, 3.0, 6.0], tarray(tfloat64)
+            hl.array_scan(lambda x, y: x + y, 0.0, [1, 2, 3]), [0.0, 1.0, 3.0, 6.0], hl.tarray(hl.tfloat64)
+        )
+        self.assertValueEqual(
+            hl.array_scan(lambda x, y: x + y, 0, [1.0, 2.0, 3.0]), [0.0, 1.0, 3.0, 6.0], hl.tarray(hl.tfloat64)
         )
 
     def test_cumulative_sum(self):
-        self.assertValueEqual(hl.cumulative_sum([1, 2, 3, 4]), [1, 3, 6, 10], tarray(tint32))
-        self.assertValueEqual(hl.cumulative_sum([1.0, 2.0, 3.0, 4.0]), [1.0, 3.0, 6.0, 10.0], tarray(tfloat64))
+        self.assertValueEqual(hl.cumulative_sum([1, 2, 3, 4]), [1, 3, 6, 10], hl.tarray(hl.tint32))
+        self.assertValueEqual(hl.cumulative_sum([1.0, 2.0, 3.0, 4.0]), [1.0, 3.0, 6.0, 10.0], hl.tarray(hl.tfloat64))
 
     def test_nan_inf_checks(self):
         finite = 0
@@ -3845,20 +3851,20 @@ class Tests(unittest.TestCase):
         nan = math.nan
         na = hl.missing('float64')
 
-        assert hl.eval(hl.is_finite(finite)) == True
-        assert hl.eval(hl.is_finite(infinite)) == False
-        assert hl.eval(hl.is_finite(nan)) == False
-        assert hl.eval(hl.is_finite(na)) == None
+        assert hl.eval(hl.is_finite(finite)) is True
+        assert hl.eval(hl.is_finite(infinite)) is False
+        assert hl.eval(hl.is_finite(nan)) is False
+        assert hl.eval(hl.is_finite(na)) is None
 
-        assert hl.eval(hl.is_infinite(finite)) == False
-        assert hl.eval(hl.is_infinite(infinite)) == True
-        assert hl.eval(hl.is_infinite(nan)) == False
-        assert hl.eval(hl.is_infinite(na)) == None
+        assert hl.eval(hl.is_infinite(finite)) is False
+        assert hl.eval(hl.is_infinite(infinite)) is True
+        assert hl.eval(hl.is_infinite(nan)) is False
+        assert hl.eval(hl.is_infinite(na)) is None
 
-        assert hl.eval(hl.is_nan(finite)) == False
-        assert hl.eval(hl.is_nan(infinite)) == False
-        assert hl.eval(hl.is_nan(nan)) == True
-        assert hl.eval(hl.is_nan(na)) == None
+        assert hl.eval(hl.is_nan(finite)) is False
+        assert hl.eval(hl.is_nan(infinite)) is False
+        assert hl.eval(hl.is_nan(nan)) is True
+        assert hl.eval(hl.is_nan(na)) is None
 
     def test_array_and_if_requiredness(self):
         mt = hl.import_vcf(resource('sample.vcf'), array_elements_required=True)
@@ -3872,7 +3878,7 @@ class Tests(unittest.TestCase):
     def test_reversed(self):
         a = hl.array(['a', 'b', 'c'])
         ea = hl.empty_array(hl.tint)
-        na = hl.missing(hl.tarray(hl.tbool))
+        na = hl.missing(hl.hl.tarray(hl.hl.tbool))
 
         assert hl.eval(hl.reversed(a)) == ['c', 'b', 'a']
         assert hl.eval(hl.reversed(ea)) == []
@@ -3880,33 +3886,33 @@ class Tests(unittest.TestCase):
 
         s = hl.str('abc')
         es = ''
-        ns = hl.missing(hl.tstr)
+        ns = hl.missing(hl.hl.tstr)
 
         assert hl.eval(hl.reversed(s)) == 'cba'
         assert hl.eval(hl.reversed(es)) == ''
         assert hl.eval(hl.reversed(ns)) is None
 
     def test_bit_ops_types(self):
-        assert hl.bit_and(1, 1).dtype == hl.tint32
-        assert hl.bit_and(hl.int64(1), 1).dtype == hl.tint64
+        assert hl.bit_and(1, 1).dtype == hl.hl.tint32
+        assert hl.bit_and(hl.int64(1), 1).dtype == hl.hl.tint64
 
-        assert hl.bit_or(1, 1).dtype == hl.tint32
-        assert hl.bit_or(hl.int64(1), 1).dtype == hl.tint64
+        assert hl.bit_or(1, 1).dtype == hl.hl.tint32
+        assert hl.bit_or(hl.int64(1), 1).dtype == hl.hl.tint64
 
-        assert hl.bit_xor(1, 1).dtype == hl.tint32
-        assert hl.bit_xor(hl.int64(1), 1).dtype == hl.tint64
+        assert hl.bit_xor(1, 1).dtype == hl.hl.tint32
+        assert hl.bit_xor(hl.int64(1), 1).dtype == hl.hl.tint64
 
-        assert hl.bit_lshift(1, 1).dtype == hl.tint32
-        assert hl.bit_lshift(hl.int64(1), 1).dtype == hl.tint64
+        assert hl.bit_lshift(1, 1).dtype == hl.hl.tint32
+        assert hl.bit_lshift(hl.int64(1), 1).dtype == hl.hl.tint64
 
-        assert hl.bit_rshift(1, 1).dtype == hl.tint32
-        assert hl.bit_rshift(hl.int64(1), 1).dtype == hl.tint64
+        assert hl.bit_rshift(1, 1).dtype == hl.hl.tint32
+        assert hl.bit_rshift(hl.int64(1), 1).dtype == hl.hl.tint64
 
-        assert hl.bit_not(1).dtype == hl.tint32
-        assert hl.bit_not(hl.int64(1)).dtype == hl.tint64
+        assert hl.bit_not(1).dtype == hl.hl.tint32
+        assert hl.bit_not(hl.int64(1)).dtype == hl.hl.tint64
 
-        assert hl.bit_count(1).dtype == hl.tint32
-        assert hl.bit_count(hl.int64(1)).dtype == hl.tint32
+        assert hl.bit_count(1).dtype == hl.hl.tint32
+        assert hl.bit_count(hl.int64(1)).dtype == hl.hl.tint32
 
     def test_bit_shifts(self):
         assert hl.eval(hl.bit_lshift(hl.int(8), 2)) == 32
@@ -4002,8 +4008,8 @@ class Tests(unittest.TestCase):
         for htyp in collection_types:
             a = htyp([hl.struct(x='foo'), hl.struct(x='bar')])
 
-            assert hasattr(a, 'x') == True
-            assert hasattr(a, 'y') == False
+            assert hasattr(a, 'x') is True
+            assert hasattr(a, 'y') is False
 
             with pytest.raises(AttributeError, match="has no field"):
                 getattr(a, 'y')
@@ -4190,7 +4196,7 @@ def test_approx_cdf_accuracy(cdf_test_data):
 
 
 def test_approx_cdf_all_missing():
-    table = hl.utils.range_table(10).annotate(foo=hl.missing(tint))
+    table = hl.utils.range_table(10).annotate(foo=hl.missing(hl.tint))
     table.aggregate(hl.agg.approx_quantiles(table.foo, qs=[0.5]))
 
 
@@ -4249,11 +4255,11 @@ def test_export_entry(delimiter, missing, header):
         mt.x.export(f, delimiter=delimiter, header=header, missing=missing)
         if header:
             actual = hl.import_matrix_table(
-                f, row_fields={'row_idx': hl.tint32}, row_key=['row_idx'], sep=delimiter, missing=missing
+                f, row_fields={'row_idx': hl.hl.tint32}, row_key=['row_idx'], sep=delimiter, missing=missing
             )
         else:
             actual = hl.import_matrix_table(
-                f, row_fields={'f0': hl.tint32}, row_key=['f0'], sep=delimiter, no_header=True, missing=missing
+                f, row_fields={'f0': hl.hl.tint32}, row_key=['f0'], sep=delimiter, no_header=True, missing=missing
             )
             actual = actual.rename({'f0': 'row_idx'})
         actual = actual.key_cols_by(col_idx=hl.int(actual.col_id))
@@ -4279,7 +4285,7 @@ def test_stream_randomness():
     a = hl.missing('array<int32>')
     a = a.map(lambda x: x + hl.rand_int32(10))
     assert_contains_node(a, ir.NA)
-    assert hl.eval(a) == None
+    assert hl.eval(a) is None
 
     # test If
     a1 = hl._stream_range(0, 5)
@@ -4327,13 +4333,13 @@ def test_stream_randomness():
 
     # test StreamFold
     a = hl._stream_range(10)
-    a = a.fold(lambda acc, x: acc.append(hl.rand_int64()), hl.empty_array(hl.tint64))
+    a = a.fold(lambda acc, x: acc.append(hl.rand_int64()), hl.empty_array(hl.hl.tint64))
     assert_contains_node(a, ir.StreamFold)
     assert len(set(hl.eval(a))) == 10
 
     # test StreamScan
     a = hl._stream_range(5)
-    a = a.scan(lambda acc, x: acc.append(hl.rand_int64()), hl.empty_array(hl.tint64))
+    a = a.scan(lambda acc, x: acc.append(hl.rand_int64()), hl.empty_array(hl.hl.tint64))
     assert_contains_node(a, ir.StreamScan)
     assert len(set(hl.eval(a.to_array())[-1])) == 5
 
@@ -4432,15 +4438,19 @@ def test_to_relational_row_and_col_refs():
     mt = mt.annotate_cols(y=1)
     mt = mt.annotate_entries(z=1)
 
-    assert mt.row._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.tstruct(
-        row_idx=hl.tint32, x=hl.tint32
+    assert mt.row._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.hl.hl.tstruct(
+        row_idx=hl.hl.tint32, x=hl.hl.tint32
     )
-    assert mt.row_key._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.tstruct(row_idx=hl.tint32)
+    assert mt.row_key._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.hl.hl.tstruct(
+        row_idx=hl.hl.tint32
+    )
 
-    assert mt.col._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.tstruct(
-        col_idx=hl.tint32, y=hl.tint32
+    assert mt.col._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.hl.hl.tstruct(
+        col_idx=hl.hl.tint32, y=hl.hl.tint32
     )
-    assert mt.col_key._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.tstruct(col_idx=hl.tint32)
+    assert mt.col_key._to_relational_preserving_rows_and_cols('x')[1].row.dtype == hl.hl.hl.tstruct(
+        col_idx=hl.hl.tint32
+    )
 
 
 def test_locus_addition():
@@ -4478,7 +4488,6 @@ def test_reservoir_sampling():
         mean = np.mean(sample)
         expected_stdev = math.sqrt(sample_variance / sample_size)
         assert abs(mean - sample_mean) / expected_stdev < 4, (
-            iteration,
             sample_size,
             abs(mean - sample_mean) / expected_stdev,
         )

--- a/hail/python/test/hail/expr/test_freezing.py
+++ b/hail/python/test/hail/expr/test_freezing.py
@@ -1,4 +1,5 @@
 from typing import Dict
+
 import hail as hl
 from hailtop.frozendict import frozendict
 from hailtop.hail_frozenlist import frozenlist

--- a/hail/python/test/hail/expr/test_functions.py
+++ b/hail/python/test/hail/expr/test_functions.py
@@ -1,6 +1,8 @@
-import hail as hl
-import scipy.stats as spst
 import pytest
+import scipy.stats as spst
+
+import hail as hl
+
 from ..helpers import resource
 
 
@@ -57,7 +59,7 @@ def test_pgenchisq():
     for test in tests:
         assert abs(test.genchisq_result.value - test.expected) < 0.0000005, str(test)
         assert test.genchisq_result.fault == 0, str(test)
-        assert test.genchisq_result.converged == True, str(test)
+        assert test.genchisq_result.converged is True, str(test)
         assert test.genchisq_result.n_iterations == test.expected_n_iterations, str(test)
 
 

--- a/hail/python/test/hail/expr/test_math.py
+++ b/hail/python/test/hail/expr/test_math.py
@@ -1,6 +1,6 @@
-import hail as hl
 import scipy.special as scsp
-import pytest
+
+import hail as hl
 
 
 def test_logit():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1,10 +1,13 @@
 import math
-import numpy as np
 import re
-from ..helpers import *
+
+import numpy as np
 import pytest
 
+import hail as hl
 from hail.utils.java import FatalError, HailUserError
+
+from ..helpers import assert_all_eval_to, assert_evals_to
 
 
 def assert_ndarrays(asserter, exprs_and_expecteds):
@@ -889,7 +892,6 @@ def test_svd():
             assert h.shape == n.shape
 
         k = min(np_array.shape)
-        rank = np.linalg.matrix_rank(np_array)
 
         if compute_uv:
             hu, hs, hv = evaled

--- a/hail/python/test/hail/expr/test_show.py
+++ b/hail/python/test/hail/expr/test_show.py
@@ -1,7 +1,5 @@
 import hail as hl
 
-from ..helpers import test_timeout
-
 
 def test_show_1():
     mt = hl.balding_nichols_model(3, 10, 10)

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -1,50 +1,50 @@
-from typing import Optional
 import unittest
+from typing import Optional
 
-from hail.expr import coercer_from_dtype
-from hail.expr.types import *
-from hail.genetics import reference_genome
-from ..helpers import *
+import hail as hl
+from hail.expr import coercer_from_dtype, dtype
 from hail.utils.java import Env
+
+from ..helpers import fails_local_backend, resource, skip_unless_spark_backend, skip_when_service_backend
 
 
 class Tests(unittest.TestCase):
     def types_to_test(self):
         return [
-            tint32,
-            tint64,
-            tfloat32,
-            tfloat64,
-            tstr,
-            tbool,
-            tcall,
-            tinterval(tint32),
-            tdict(tstr, tint32),
-            tarray(tstr),
-            tndarray(tstr, 1),
-            tndarray(tfloat64, 2),
-            tset(tint64),
-            tlocus('GRCh37'),
-            tlocus('GRCh38'),
-            tstruct(),
-            tstruct(x=tint32, y=tint64, z=tarray(tset(tstr))),
-            tstruct(**{
-                'weird field name 1': tint32,
-                r"""this one ' has "" quotes and `` backticks```""": tint64,
-                '!@#$%^&({[': tarray(tset(tstr)),
+            hl.tint32,
+            hl.tint64,
+            hl.tfloat32,
+            hl.tfloat64,
+            hl.tstr,
+            hl.tbool,
+            hl.tcall,
+            hl.tinterval(hl.tint32),
+            hl.tdict(hl.tstr, hl.tint32),
+            hl.tarray(hl.tstr),
+            hl.tndarray(hl.tstr, 1),
+            hl.tndarray(hl.tfloat64, 2),
+            hl.tset(hl.tint64),
+            hl.tlocus('GRCh37'),
+            hl.tlocus('GRCh38'),
+            hl.tstruct(),
+            hl.tstruct(x=hl.tint32, y=hl.tint64, z=hl.tarray(hl.tset(hl.tstr))),
+            hl.tstruct(**{
+                'weird field name 1': hl.tint32,
+                r"""this one ' has "" quotes and `` backticks```""": hl.tint64,
+                '!@#$%^&({[': hl.tarray(hl.tset(hl.tstr)),
             }),
-            tinterval(tlocus()),
-            tset(tinterval(tlocus())),
-            tstruct(a=tint32, b=tint32, c=tarray(tstr)),
-            tstruct(a=tfloat64, bb=tint32, c=tbool),
-            tstruct(a=tint32, b=tint32),
-            tstruct(**{'___': tint32, '_ . _': tint32}),
-            tunion(),
-            tunion(a=tint32, b=tstr),
-            tunion(**{'!@#$%^&({[': tstr}),
-            ttuple(tstr, tint32),
-            ttuple(tarray(tint32), tstr, tstr, tint32, tbool),
-            ttuple(),
+            hl.tinterval(hl.tlocus()),
+            hl.tset(hl.tinterval(hl.tlocus())),
+            hl.tstruct(a=hl.tint32, b=hl.tint32, c=hl.tarray(hl.tstr)),
+            hl.tstruct(a=hl.tfloat64, bb=hl.tint32, c=hl.tbool),
+            hl.tstruct(a=hl.tint32, b=hl.tint32),
+            hl.tstruct(**{'___': hl.tint32, '_ . _': hl.tint32}),
+            hl.tunion(),
+            hl.tunion(a=hl.tint32, b=hl.tstr),
+            hl.tunion(**{'!@#$%^&({[': hl.tstr}),
+            hl.ttuple(hl.tstr, hl.tint32),
+            hl.ttuple(hl.tarray(hl.tint32), hl.tstr, hl.tstr, hl.tint32, hl.tbool),
+            hl.ttuple(),
         ]
 
     def test_parser_roundtrip(self):
@@ -103,49 +103,49 @@ class Tests(unittest.TestCase):
             hl.tstruct(a=hl.tbool, b=hl.tint32)._rename({'b': 'a'})
 
     def test_get_context(self):
-        tl1 = tlocus('GRCh37')
-        tl2 = tlocus('GRCh38')
+        tl1 = hl.tlocus('GRCh37')
+        tl2 = hl.tlocus('GRCh38')
 
         types_and_rgs = [
             (
                 [
-                    tint32,
-                    tint64,
-                    tfloat32,
-                    tfloat64,
-                    tstr,
-                    tbool,
-                    tcall,
-                    tinterval(tset(tint32)),
-                    tdict(tstr, tarray(tint32)),
-                    tndarray(tstr, 1),
-                    tstruct(),
-                    tstruct(x=tint32, y=tint64, z=tarray(tset(tstr))),
-                    tunion(),
-                    tunion(a=tint32, b=tstr),
-                    ttuple(tstr, tint32),
-                    ttuple(),
+                    hl.tint32,
+                    hl.tint64,
+                    hl.tfloat32,
+                    hl.tfloat64,
+                    hl.tstr,
+                    hl.tbool,
+                    hl.tcall,
+                    hl.tinterval(hl.tset(hl.tint32)),
+                    hl.tdict(hl.tstr, hl.tarray(hl.tint32)),
+                    hl.tndarray(hl.tstr, 1),
+                    hl.tstruct(),
+                    hl.tstruct(x=hl.tint32, y=hl.tint64, z=hl.tarray(hl.tset(hl.tstr))),
+                    hl.tunion(),
+                    hl.tunion(a=hl.tint32, b=hl.tstr),
+                    hl.ttuple(hl.tstr, hl.tint32),
+                    hl.ttuple(),
                 ],
                 set(),
             ),
             (
                 [
                     tl1,
-                    tinterval(tl1),
-                    tdict(tstr, tl1),
-                    tndarray(tl1, 2),
-                    tinterval(tl1),
-                    tset(tinterval(tl1)),
-                    tstruct(a=tint32, b=tint32, c=tarray(tl1)),
-                    tunion(a=tint32, b=tl1),
-                    ttuple(tarray(tint32), tl1, tstr, tint32, tbool),
+                    hl.tinterval(tl1),
+                    hl.tdict(hl.tstr, tl1),
+                    hl.tndarray(tl1, 2),
+                    hl.tinterval(tl1),
+                    hl.tset(hl.tinterval(tl1)),
+                    hl.tstruct(a=hl.tint32, b=hl.tint32, c=hl.tarray(tl1)),
+                    hl.tunion(a=hl.tint32, b=tl1),
+                    hl.ttuple(hl.tarray(hl.tint32), tl1, hl.tstr, hl.tint32, hl.tbool),
                 ],
                 {"GRCh37"},
             ),
             (
                 [
-                    tdict(tl1, tl2),
-                    ttuple(tarray(tl2), tl1, tstr, tint32, tbool),
+                    hl.tdict(tl1, tl2),
+                    hl.ttuple(hl.tarray(tl2), tl1, hl.tstr, hl.tint32, hl.tbool),
                 ],
                 {"GRCh37", "GRCh38"},
             ),
@@ -156,12 +156,12 @@ class Tests(unittest.TestCase):
                 self.assertEqual(t.get_context().references, rgs)
 
     def test_tlocus_schema_from_rg_matches_scala(self):
-        def locus_from_import_vcf(rg: Optional[str]) -> HailType:
+        def locus_from_import_vcf(rg: Optional[str]) -> hl.HailType:
             return hl.import_vcf(resource('sample2.vcf'), reference_genome=rg).locus.dtype
 
-        assert tlocus._schema_from_rg(None) == locus_from_import_vcf(None)
-        assert tlocus._schema_from_rg('GRCh37') == locus_from_import_vcf('GRCh37')
-        assert tlocus._schema_from_rg('GRCh38') == locus_from_import_vcf('GRCh38')
-        assert tlocus._schema_from_rg('GRCm38') == locus_from_import_vcf('GRCm38')
-        assert tlocus._schema_from_rg('CanFam3') == locus_from_import_vcf('CanFam3')
-        assert tlocus._schema_from_rg('default') == locus_from_import_vcf('default')
+        assert hl.tlocus._schema_from_rg(None) == locus_from_import_vcf(None)
+        assert hl.tlocus._schema_from_rg('GRCh37') == locus_from_import_vcf('GRCh37')
+        assert hl.tlocus._schema_from_rg('GRCh38') == locus_from_import_vcf('GRCh38')
+        assert hl.tlocus._schema_from_rg('GRCm38') == locus_from_import_vcf('GRCm38')
+        assert hl.tlocus._schema_from_rg('CanFam3') == locus_from_import_vcf('CanFam3')
+        assert hl.tlocus._schema_from_rg('default') == locus_from_import_vcf('default')

--- a/hail/python/test/hail/extract_intervals/conftest.py
+++ b/hail/python/test/hail/extract_intervals/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import hail as hl
 
 from ..helpers import resource

--- a/hail/python/test/hail/fs/test_worker_driver_fs.py
+++ b/hail/python/test/hail/fs/test_worker_driver_fs.py
@@ -1,13 +1,12 @@
 import asyncio
 import os
-import pytest
 
 import hail as hl
-from hailtop.utils import secret_alnum_string
-from hailtop.test_utils import skip_in_azure, run_if_azure
 from hailtop.aiocloud.aioazure import AzureAsyncFS
+from hailtop.test_utils import run_if_azure, skip_in_azure
+from hailtop.utils import secret_alnum_string
 
-from ..helpers import fails_local_backend, hl_stop_for_test, hl_init_for_test, test_timeout, resource
+from ..helpers import fails_local_backend, hl_init_for_test, hl_stop_for_test, resource, test_timeout
 
 
 @skip_in_azure

--- a/hail/python/test/hail/genetics/test_call.py
+++ b/hail/python/test/hail/genetics/test_call.py
@@ -1,12 +1,11 @@
 import unittest
 
-from hail.genetics import *
-from ..helpers import *
+import hail as hl
 
 
 class Tests(unittest.TestCase):
     def test_hom_ref(self):
-        c_hom_ref = Call([0, 0])
+        c_hom_ref = hl.Call([0, 0])
         self.assertEqual(c_hom_ref.alleles, [0, 0])
         self.assertEqual(c_hom_ref.ploidy, 2)
         self.assertFalse(c_hom_ref.phased)
@@ -23,7 +22,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(c_hom_ref.unphased_diploid_gt_index() == 0)
 
     def test_het(self):
-        c_het_phased = Call([1, 0], phased=True)
+        c_het_phased = hl.Call([1, 0], phased=True)
         self.assertEqual(c_het_phased.alleles, [1, 0])
         self.assertEqual(c_het_phased.ploidy, 2)
         self.assertTrue(c_het_phased.phased)
@@ -39,7 +38,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(c_het_phased.is_het_ref())
 
     def test_hom_var(self):
-        c_hom_var = Call([1, 1])
+        c_hom_var = hl.Call([1, 1])
         self.assertEqual(c_hom_var.alleles, [1, 1])
         self.assertEqual(c_hom_var.ploidy, 2)
         self.assertFalse(c_hom_var.phased)
@@ -56,7 +55,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(c_hom_var.unphased_diploid_gt_index() == 2)
 
     def test_haploid(self):
-        c_haploid = Call([2], phased=True)
+        c_haploid = hl.Call([2], phased=True)
         self.assertEqual(c_haploid.alleles, [2])
         self.assertEqual(c_haploid.ploidy, 1)
         self.assertTrue(c_haploid.phased)
@@ -72,7 +71,7 @@ class Tests(unittest.TestCase):
         self.assertFalse(c_haploid.is_het_ref())
 
     def test_zeroploid(self):
-        c_zeroploid = Call([])
+        c_zeroploid = hl.Call([])
         self.assertEqual(c_zeroploid.alleles, [])
         self.assertEqual(c_zeroploid.ploidy, 0)
         self.assertFalse(c_zeroploid.phased)
@@ -88,12 +87,12 @@ class Tests(unittest.TestCase):
         self.assertFalse(c_zeroploid.is_het_ref())
 
         self.assertRaisesRegex(
-            NotImplementedError, "Calls with greater than 2 alleles are not supported.", Call, [1, 1, 1, 1]
+            NotImplementedError, "Calls with greater than 2 alleles are not supported.", hl.Call, [1, 1, 1, 1]
         )
 
 
 def test_call_rich_comparison():
-    val = Call([0, 0])
+    val = hl.Call([0, 0])
     expr = hl.call(0, 0)
 
     assert hl.eval(val == expr)

--- a/hail/python/test/hail/genetics/test_locus.py
+++ b/hail/python/test/hail/genetics/test_locus.py
@@ -1,5 +1,5 @@
-from hail.genetics import Locus
 import hail as hl
+from hail.genetics import Locus
 
 
 def test_constructor():

--- a/hail/python/test/hail/genetics/test_pedigree.py
+++ b/hail/python/test/hail/genetics/test_pedigree.py
@@ -1,8 +1,9 @@
 import unittest
 
-from hail.genetics import Trio, Pedigree
-from ..helpers import *
+from hail.genetics import Pedigree, Trio
 from hail.utils.java import FatalError
+
+from ..helpers import resource
 
 
 class Tests(unittest.TestCase):

--- a/hail/python/test/hail/genetics/test_reference_genome.py
+++ b/hail/python/test/hail/genetics/test_reference_genome.py
@@ -1,10 +1,11 @@
-import pytest
 from random import randint
 
+import pytest
+
 import hail as hl
-from hail.genetics import *
-from ..helpers import *
 from hail.utils import FatalError
+
+from ..helpers import qobtest, resource
 
 
 @qobtest
@@ -26,7 +27,7 @@ def test_reference_genome():
     mt_contigs = ["MT"]
     par = [("X", 5, 1000)]
 
-    gr2 = ReferenceGenome(name, contigs, lengths, x_contigs, y_contigs, mt_contigs, par)
+    gr2 = hl.ReferenceGenome(name, contigs, lengths, x_contigs, y_contigs, mt_contigs, par)
     assert gr2.name == name
     assert gr2.contigs == contigs
     assert gr2.x_contigs == x_contigs
@@ -42,11 +43,11 @@ def test_reference_genome():
 
 @qobtest
 def test_reference_genome_sequence():
-    gr3 = ReferenceGenome.read(resource("fake_ref_genome.json"))
+    gr3 = hl.ReferenceGenome.read(resource("fake_ref_genome.json"))
     assert gr3.name == "my_reference_genome"
     assert not gr3.has_sequence()
 
-    gr4 = ReferenceGenome.from_fasta_file(
+    gr4 = hl.ReferenceGenome.from_fasta_file(
         "test_rg",
         resource("fake_reference.fasta"),
         resource("fake_reference.fasta.fai"),

--- a/hail/python/test/hail/ggplot/test_ggplot.py
+++ b/hail/python/test/hail/ggplot/test_ggplot.py
@@ -1,7 +1,27 @@
-import hail as hl
-from hail.ggplot import *
-import numpy as np
 import math
+
+import numpy as np
+
+import hail as hl
+from hail.ggplot import (
+    aes,
+    coord_cartesian,
+    facet_wrap,
+    geom_area,
+    geom_bar,
+    geom_col,
+    geom_histogram,
+    geom_hline,
+    geom_line,
+    geom_point,
+    geom_ribbon,
+    geom_text,
+    ggplot,
+    ggtitle,
+    scale_color_manual,
+    xlab,
+    ylab,
+)
 
 
 def test_geom_point_line_text_col_area():

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -1,14 +1,14 @@
-from typing import Callable, TypeVar
-from typing_extensions import ParamSpec
 import os
-from timeit import default_timer as timer
 import unittest
+from timeit import default_timer as timer
+from typing import Callable, TypeVar
+
 import pytest
-from hailtop.hail_decorator import decorator
+from typing_extensions import ParamSpec
 
-from hail.utils.java import choose_backend
 import hail as hl
-
+from hail.utils.java import choose_backend
+from hailtop.hail_decorator import decorator
 
 GCS_REQUESTER_PAYS_PROJECT = os.environ.get('GCS_REQUESTER_PAYS_PROJECT')
 HAIL_QUERY_N_CORES = os.environ.get('HAIL_QUERY_N_CORES', '2')

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1,14 +1,15 @@
-import pytest
 import math
-import numpy as np
-import hail as hl
-
 from contextlib import contextmanager
 
+import numpy as np
+import pytest
+
+import hail as hl
 from hail.expr.expressions import ExpressionException
 from hail.linalg import BlockMatrix
 from hail.utils import FatalError, HailUserError
-from ..helpers import *
+
+from ..helpers import fails_local_backend, fails_service_backend, fails_spark_backend, test_timeout
 
 
 def sparsify_numpy(np_mat, block_size, blocks_to_sparsify):

--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -1,12 +1,18 @@
 import asyncio
-import pytest
-import os
 from typing import List, Tuple
-from pathlib import Path
+
+import pytest
 
 import hail as hl
 from hail.utils.java import Env, scala_object
-from ..helpers import *
+
+from ..helpers import (
+    create_all_values_datasets,
+    create_all_values_matrix_table,
+    create_all_values_table,
+    resource,
+    resource_dir,
+)
 
 
 def create_backward_compatibility_files():

--- a/hail/python/test/hail/matrixtable/test_grouped_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_grouped_matrix_table.py
@@ -1,7 +1,8 @@
 import unittest
 
 import hail as hl
-from ..helpers import *
+
+from ..helpers import qobtest, test_timeout
 
 
 class Tests(unittest.TestCase):

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1,14 +1,27 @@
 import math
 import operator
 import random
+import unittest
+
 import pytest
 
 import hail as hl
-import hail.ir as ir
 import hail.expr.aggregators as agg
+from hail import ir
 from hail.utils.java import Env
 from hail.utils.misc import new_temp_file
-from ..helpers import *
+
+from ..helpers import (
+    convert_struct_to_dict,
+    create_all_values_matrix_table,
+    fails_local_backend,
+    fails_service_backend,
+    get_dataset,
+    qobtest,
+    resource,
+    schema_eq,
+    test_timeout,
+)
 
 
 class Tests(unittest.TestCase):

--- a/hail/python/test/hail/matrixtable/test_matrix_table_from_parts.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table_from_parts.py
@@ -1,4 +1,5 @@
 import pytest
+
 import hail as hl
 
 
@@ -6,100 +7,97 @@ def unless(test: bool, kvs):
     return {} if test else kvs
 
 
-class TestData:
-    globals = {'hello': 'world'}
-    rows = {'foo': ['a', 'b']}
-    cols = {'bar': ['c', 'd']}
-    entries = {'baz': [[1, 2], [3, 4]]}
+globals = {'hello': 'world'}
+rows = {'foo': ['a', 'b']}
+cols = {'bar': ['c', 'd']}
+entries = {'baz': [[1, 2], [3, 4]]}
 
-    @staticmethod
-    def assert_matches_globals(mt: 'hl.MatrixTable', no_props=False):
-        assert hl.eval(mt.globals) == hl.Struct(**unless(no_props, TestData.globals))
 
-    @staticmethod
-    def assert_no_globals(mt: 'hl.MatrixTable'):
-        TestData.assert_matches_globals(mt, no_props=True)
+def assert_matches_globals(mt: 'hl.MatrixTable', no_props=False):
+    assert hl.eval(mt.globals) == hl.Struct(**unless(no_props, globals))
 
-    @staticmethod
-    def assert_matches_rows(mt: 'hl.MatrixTable', no_props=False):
-        assert mt.rows().collect() == [
-            hl.Struct(row_idx=0, **unless(no_props, {'foo': 'a'})),
-            hl.Struct(row_idx=1, **unless(no_props, {'foo': 'b'})),
-        ]
 
-    @staticmethod
-    def assert_matches_cols(mt: 'hl.MatrixTable', no_props=False):
-        assert mt.cols().collect() == [
-            hl.Struct(col_idx=0, **unless(no_props, {'bar': 'c'})),
-            hl.Struct(col_idx=1, **unless(no_props, {'bar': 'd'})),
-        ]
+def assert_no_globals(mt: 'hl.MatrixTable'):
+    assert_matches_globals(mt, no_props=True)
 
-    @staticmethod
-    def assert_matches_entries(mt: 'hl.MatrixTable', no_props=False):
-        assert mt.select_rows().select_cols().entries().collect() == [
-            hl.Struct(row_idx=0, col_idx=0, **unless(no_props, {'baz': 1})),
-            hl.Struct(row_idx=0, col_idx=1, **unless(no_props, {'baz': 2})),
-            hl.Struct(row_idx=1, col_idx=0, **unless(no_props, {'baz': 3})),
-            hl.Struct(row_idx=1, col_idx=1, **unless(no_props, {'baz': 4})),
-        ]
+
+def assert_matches_rows(mt: 'hl.MatrixTable', no_props=False):
+    assert mt.rows().collect() == [
+        hl.Struct(row_idx=0, **unless(no_props, {'foo': 'a'})),
+        hl.Struct(row_idx=1, **unless(no_props, {'foo': 'b'})),
+    ]
+
+
+def assert_matches_cols(mt: 'hl.MatrixTable', no_props=False):
+    assert mt.cols().collect() == [
+        hl.Struct(col_idx=0, **unless(no_props, {'bar': 'c'})),
+        hl.Struct(col_idx=1, **unless(no_props, {'bar': 'd'})),
+    ]
+
+
+def assert_matches_entries(mt: 'hl.MatrixTable', no_props=False):
+    assert mt.select_rows().select_cols().entries().collect() == [
+        hl.Struct(row_idx=0, col_idx=0, **unless(no_props, {'baz': 1})),
+        hl.Struct(row_idx=0, col_idx=1, **unless(no_props, {'baz': 2})),
+        hl.Struct(row_idx=1, col_idx=0, **unless(no_props, {'baz': 3})),
+        hl.Struct(row_idx=1, col_idx=1, **unless(no_props, {'baz': 4})),
+    ]
 
 
 def test_from_parts():
-    mt = hl.MatrixTable.from_parts(
-        globals=TestData.globals, rows=TestData.rows, cols=TestData.cols, entries=TestData.entries
-    )
-    TestData.assert_matches_globals(mt)
-    TestData.assert_matches_rows(mt)
-    TestData.assert_matches_cols(mt)
-    TestData.assert_matches_entries(mt)
+    mt = hl.MatrixTable.from_parts(globals=globals, rows=rows, cols=cols, entries=entries)
+    assert_matches_globals(mt)
+    assert_matches_rows(mt)
+    assert_matches_cols(mt)
+    assert_matches_entries(mt)
 
 
 def test_optional_globals():
-    mt = hl.MatrixTable.from_parts(rows=TestData.rows, cols=TestData.cols, entries=TestData.entries)
-    TestData.assert_no_globals(mt)
-    TestData.assert_matches_rows(mt)
-    TestData.assert_matches_cols(mt)
-    TestData.assert_matches_entries(mt)
+    mt = hl.MatrixTable.from_parts(rows=rows, cols=cols, entries=entries)
+    assert_no_globals(mt)
+    assert_matches_rows(mt)
+    assert_matches_cols(mt)
+    assert_matches_entries(mt)
 
 
 def test_optional_rows():
-    mt = hl.MatrixTable.from_parts(globals=TestData.globals, cols=TestData.cols, entries=TestData.entries)
-    TestData.assert_matches_globals(mt)
-    TestData.assert_matches_rows(mt, no_props=True)
-    TestData.assert_matches_cols(mt)
-    TestData.assert_matches_entries(mt)
+    mt = hl.MatrixTable.from_parts(globals=globals, cols=cols, entries=entries)
+    assert_matches_globals(mt)
+    assert_matches_rows(mt, no_props=True)
+    assert_matches_cols(mt)
+    assert_matches_entries(mt)
 
 
 def test_optional_cols():
-    mt = hl.MatrixTable.from_parts(globals=TestData.globals, rows=TestData.rows, entries=TestData.entries)
-    TestData.assert_matches_globals(mt)
-    TestData.assert_matches_rows(mt)
-    TestData.assert_matches_cols(mt, no_props=True)
-    TestData.assert_matches_entries(mt)
+    mt = hl.MatrixTable.from_parts(globals=globals, rows=rows, entries=entries)
+    assert_matches_globals(mt)
+    assert_matches_rows(mt)
+    assert_matches_cols(mt, no_props=True)
+    assert_matches_entries(mt)
 
 
 def test_optional_globals_and_cols():
-    mt = hl.MatrixTable.from_parts(rows=TestData.rows, entries=TestData.entries)
-    TestData.assert_no_globals(mt)
-    TestData.assert_matches_rows(mt)
-    TestData.assert_matches_cols(mt, no_props=True)
-    TestData.assert_matches_entries(mt)
+    mt = hl.MatrixTable.from_parts(rows=rows, entries=entries)
+    assert_no_globals(mt)
+    assert_matches_rows(mt)
+    assert_matches_cols(mt, no_props=True)
+    assert_matches_entries(mt)
 
 
 def test_optional_globals_and_rows_and_cols():
-    mt = hl.MatrixTable.from_parts(entries=TestData.entries)
-    TestData.assert_no_globals(mt)
-    TestData.assert_matches_rows(mt, no_props=True)
-    TestData.assert_matches_cols(mt, no_props=True)
-    TestData.assert_matches_entries(mt)
+    mt = hl.MatrixTable.from_parts(entries=entries)
+    assert_no_globals(mt)
+    assert_matches_rows(mt, no_props=True)
+    assert_matches_cols(mt, no_props=True)
+    assert_matches_entries(mt)
 
 
 def test_optional_entries():
-    mt = hl.MatrixTable.from_parts(rows=TestData.rows, cols=TestData.cols)
-    TestData.assert_no_globals(mt)
-    TestData.assert_matches_rows(mt)
-    TestData.assert_matches_cols(mt)
-    TestData.assert_matches_entries(mt, no_props=True)
+    mt = hl.MatrixTable.from_parts(rows=rows, cols=cols)
+    assert_no_globals(mt)
+    assert_matches_rows(mt)
+    assert_matches_cols(mt)
+    assert_matches_entries(mt, no_props=True)
 
 
 def test_rectangular_matrices():
@@ -112,22 +110,22 @@ def test_rectangular_matrices():
 
 def test_raises_when_no_rows_and_entries():
     with pytest.raises(AssertionError):
-        hl.MatrixTable.from_parts(cols=TestData.cols)
+        hl.MatrixTable.from_parts(cols=cols)
 
 
 def test_raises_when_no_cols_and_entries():
     with pytest.raises(AssertionError):
-        hl.MatrixTable.from_parts(rows=TestData.rows)
+        hl.MatrixTable.from_parts(rows=rows)
 
 
 def test_raises_when_mismatched_row_property_dimensions():
     with pytest.raises(ValueError):
-        hl.MatrixTable.from_parts(rows={'foo': [1], 'bar': [1, 2]}, entries=TestData.entries)
+        hl.MatrixTable.from_parts(rows={'foo': [1], 'bar': [1, 2]}, entries=entries)
 
 
 def test_raises_when_mismatched_col_property_dimensions():
     with pytest.raises(ValueError):
-        hl.MatrixTable.from_parts(cols={'foo': [1], 'bar': [1, 2]}, entries=TestData.entries)
+        hl.MatrixTable.from_parts(cols={'foo': [1], 'bar': [1, 2]}, entries=entries)
 
 
 def test_raises_when_mismatched_entry_property_dimensions():

--- a/hail/python/test/hail/methods/relatedness/test_identity_by_descent.py
+++ b/hail/python/test/hail/methods/relatedness/test_identity_by_descent.py
@@ -1,11 +1,13 @@
 import os
-import pytest
 import subprocess as sp
 import unittest
 
+import pytest
+
 import hail as hl
-import hail.utils as utils
-from ...helpers import test_timeout, qobtest
+from hail import utils
+
+from ...helpers import qobtest, test_timeout
 
 
 @pytest.fixture(scope='module')

--- a/hail/python/test/hail/methods/relatedness/test_pc_relate.py
+++ b/hail/python/test/hail/methods/relatedness/test_pc_relate.py
@@ -1,6 +1,6 @@
 import hail as hl
 
-from ...helpers import resource, skip_when_service_backend, test_timeout, skip_when_service_backend_in_azure, qobtest
+from ...helpers import qobtest, resource, skip_when_service_backend, skip_when_service_backend_in_azure, test_timeout
 
 
 @test_timeout(local=6 * 60, batch=14 * 60)

--- a/hail/python/test/hail/methods/test_family_methods.py
+++ b/hail/python/test/hail/methods/test_family_methods.py
@@ -1,7 +1,12 @@
 import unittest
 
 import hail as hl
-from ..helpers import *
+
+from ..helpers import (
+    qobtest,
+    resource,
+    test_timeout,
+)
 
 
 class Tests(unittest.TestCase):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1,21 +1,29 @@
 import json
-import re
 import os
-import pytest
+import re
 import shutil
 import unittest
-
 from unittest import mock
 
+import pytest
 from avro.datafile import DataFileReader
 from avro.io import DatumReader
-from hail.context import TemporaryFilename
 
-import pytest
 import hail as hl
-from ..helpers import *
 from hail import ir
-from hail.utils import new_temp_file, new_local_temp_file, FatalError, run_command, uri_path, HailUserError
+from hail.context import TemporaryFilename
+from hail.utils import FatalError, HailUserError, new_local_temp_file, new_temp_file, run_command, uri_path
+
+from ..helpers import (
+    doctest_resource,
+    fails_local_backend,
+    fails_service_backend,
+    get_dataset,
+    qobtest,
+    resource,
+    test_timeout,
+    with_flags,
+)
 
 _FLOAT_INFO_FIELDS = [
     'BaseQRankSum',
@@ -332,13 +340,13 @@ class VCFTests(unittest.TestCase):
 
     def test_import_vcf_invalid_float_type(self):
         with self.assertRaises(TypeError):
-            mt = hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tstr)
+            hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tstr)
         with self.assertRaises(TypeError):
-            mt = hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tint)
+            hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tint)
         with self.assertRaises(TypeError):
-            mt = hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tint32)
+            hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tint32)
         with self.assertRaises(TypeError):
-            mt = hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tint64)
+            hl.import_vcf(resource('small-ds.vcf'), entry_float_type=hl.tint64)
 
     def test_export_vcf(self):
         dataset = hl.import_vcf(resource('sample.vcf.bgz'))
@@ -536,7 +544,7 @@ class VCFTests(unittest.TestCase):
         self.assertTrue(mt._same(vcf))
 
     def test_combiner_works(self):
-        from hail.vds.combiner.combine import transform_gvcf, combine_variant_datasets
+        from hail.vds.combiner.combine import combine_variant_datasets, transform_gvcf
 
         _paths = ['gvcfs/HG00096.g.vcf.gz', 'gvcfs/HG00268.g.vcf.gz']
         paths = [resource(p) for p in _paths]
@@ -1077,7 +1085,6 @@ class PLINKTests(unittest.TestCase):
     def test_export_plink_quantitative_phenotype(self):
         ds = get_dataset()
         fam_mapping = {'f0': 'fam_id', 'f1': 'ind_id', 'f2': 'pat_id', 'f3': 'mat_id', 'f4': 'is_female', 'f5': 'pheno'}
-        bim_mapping = {'f0': 'contig', 'f1': 'varid', 'f2': 'cm_position', 'f3': 'position', 'f4': 'a1', 'f5': 'a2'}
         out3 = new_temp_file()
         hl.export_plink(ds, out3, ind_id=ds.s, pheno=hl.float64(hl.len(ds.s)))
         fam3 = hl.import_table(out3 + '.fam', no_header=True, impute=False, missing="").rename(fam_mapping)
@@ -1136,9 +1143,7 @@ class PLINKTests(unittest.TestCase):
             reference_genome='GRCh38',
         )
 
-        rg_random = hl.ReferenceGenome(
-            "random", ['1', '23', '24', '25', '26'], {'1': 10, '23': 10, '24': 10, '25': 10, '26': 10}
-        )
+        hl.ReferenceGenome("random", ['1', '23', '24', '25', '26'], {'1': 10, '23': 10, '24': 10, '25': 10, '26': 10})
 
         hl.import_plink(
             resource('sex_mt_contigs.bed'),
@@ -1271,8 +1276,6 @@ class BGENTests(unittest.TestCase):
         self.assertEqual(mt.count(), (16, 10))
 
     def test_import_bgen_dosage_and_gp_dosage_function_agree(self):
-        recoding = {'0{}'.format(i): str(i) for i in range(1, 10)}
-
         sample_file = resource('example.sample')
         bgen_file = resource('example.8bits.bgen')
 
@@ -1987,7 +1990,7 @@ class ImportMatrixTableTests(unittest.TestCase):
                 resource("samplenonintentries.txt"), row_fields={'f0': hl.tstr}, row_key=['f0']
             )._force_count_rows()
 
-    def test_key_by_after_empty_key_import(self):
+    def test_key_by_after_empty_key_import1(self):
         fields = {'Chromosome': hl.tstr, 'Position': hl.tint32, 'Ref': hl.tstr, 'Alt': hl.tstr}
         mt = hl.import_matrix_table(
             resource('sample2_va_nomulti.tsv'), row_fields=fields, row_key=[], entry_type=hl.tfloat
@@ -1995,7 +1998,7 @@ class ImportMatrixTableTests(unittest.TestCase):
         mt = mt.key_rows_by('Chromosome', 'Position')
         assert 0.001 < abs(0.50965 - mt.aggregate_entries(hl.agg.mean(mt.x)))
 
-    def test_key_by_after_empty_key_import(self):
+    def test_key_by_after_empty_key_import2(self):
         fields = {'Chromosome': hl.tstr, 'Position': hl.tint32, 'Ref': hl.tstr, 'Alt': hl.tstr}
         mt = hl.import_matrix_table(
             resource('sample2_va_nomulti.tsv'), row_fields=fields, row_key=[], entry_type=hl.tfloat
@@ -2095,7 +2098,6 @@ def test_import_matrix_table_round_trip(missing, delimiter, header, entry_fun):
     actual = actual.rename({'col_id': 'col_idx'})
 
     row_key = mt.row_key
-    col_key = mt.col_key
     mt = mt.key_rows_by()
     mt = mt.annotate_entries(x=hl.if_else(hl.str(mt.x) == missing, hl.missing(entry_type), mt.x))
     mt = mt.annotate_rows(**{f: hl.if_else(hl.str(mt[f]) == missing, hl.missing(mt[f].dtype), mt[f]) for f in mt.row})

--- a/hail/python/test/hail/methods/test_king.py
+++ b/hail/python/test/hail/methods/test_king.py
@@ -1,7 +1,8 @@
 import pytest
 
 import hail as hl
-from ..helpers import resource, fails_local_backend, fails_service_backend
+
+from ..helpers import fails_local_backend, fails_service_backend, resource
 
 
 def assert_c_king_same_as_hail_king(c_king_path, hail_king_mt):

--- a/hail/python/test/hail/methods/test_misc.py
+++ b/hail/python/test/hail/methods/test_misc.py
@@ -1,7 +1,12 @@
 import unittest
 
 import hail as hl
-from ..helpers import *
+
+from ..helpers import (
+    get_dataset,
+    resource,
+    test_timeout,
+)
 
 
 class Tests(unittest.TestCase):

--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -1,10 +1,12 @@
 import math
-import pytest
+
 import numpy as np
+import pytest
 
 import hail as hl
 from hail.methods.pca import _make_tsm
-from ..helpers import resource, fails_local_backend, skip_when_service_backend, test_timeout
+
+from ..helpers import fails_local_backend, resource, skip_when_service_backend, test_timeout
 
 
 @fails_local_backend()
@@ -174,7 +176,7 @@ def test_blanczos_flags(compute_loadings, compute_scores, transpose):
     # compare absolute values to account for +-1 indeterminacy factor in singular vectors
     U = np.abs(U[:, :k])
     V = np.abs(V[:, :k])
-    Usigma = U * sigma[:k]
+    # Usigma = U * sigma[:k]
     Vsigma = V * sigma[:k]
 
     mt = mt_A_T if transpose else mt_A

--- a/hail/python/test/hail/methods/test_simulation.py
+++ b/hail/python/test/hail/methods/test_simulation.py
@@ -1,6 +1,8 @@
 import hail as hl
 
-from ..helpers import *
+from ..helpers import (
+    get_dataset,
+)
 
 
 def test_mating_simulation():

--- a/hail/python/test/hail/methods/test_skat.py
+++ b/hail/python/test/hail/methods/test_skat.py
@@ -1,9 +1,9 @@
-import hail as hl
 import pytest
 
+import hail as hl
 from hail.utils import FatalError, HailUserError
 
-from ..helpers import resource, test_timeout, qobtest
+from ..helpers import qobtest, resource, test_timeout
 
 
 @pytest.mark.parametrize("skat_model", [('hl._linear_skat', hl._linear_skat), ('hl._logistic_skat', hl._logistic_skat)])

--- a/hail/python/test/hail/plot/test_plot.py
+++ b/hail/python/test/hail/plot/test_plot.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 import hail as hl
 
@@ -31,12 +32,12 @@ def test_cumulative_histogram():
     hl.plot.cumulative_histogram(ht.idx)
 
 
-def test_histogram2d():
+def test_histogram2d_1():
     ht = hl.utils.range_matrix_table(100)
     hl.plot.histogram2d(ht.idx, ht.col_idx)
 
 
-def test_histogram2d():
+def test_histogram2d_2():
     ht = hl.utils.range_table(100)
     hl.plot.histogram2d(ht.idx, ht.idx * ht.idx)
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1,18 +1,28 @@
+import os
 import unittest
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pyspark.sql
 import pytest
 
 import hail as hl
 import hail.expr.aggregators as agg
+from hail import ExpressionException, ir
 from hail.utils import new_temp_file
 from hail.utils.java import Env
-import hail.ir as ir
 
-from hail import ExpressionException
-from ..helpers import *
+from ..helpers import (
+    assert_time,
+    convert_struct_to_dict,
+    create_all_values_datasets,
+    create_all_values_table,
+    lower_only,
+    qobtest,
+    resource,
+    skip_unless_spark_backend,
+    test_timeout,
+)
 
 
 class Tests(unittest.TestCase):
@@ -1842,7 +1852,6 @@ def create_width_scale_files():
     def write_file(n, n_rows=5):
         assert n % 4 == 0
         n2 = n // 4
-        d = {}
         header = []
         for i in range(n2):
             header.append(f'i{i}')
@@ -1864,6 +1873,7 @@ def create_width_scale_files():
                     out.write('\t')
                     out.write(str(i % 2 == 0))
 
+    widths = [1 << k for k in range(8, 14)]
     for w in widths:
         write_file(w)
 
@@ -2489,7 +2499,6 @@ def test_table_randomness_matrix_cols_table():
 
 
 def test_table_randomness_parallelize_with_body_randomness():
-    rt = hl.utils.range_table(20, 3)
     t = hl.Table.parallelize(hl.array([1, 2, 3]).map(lambda x: hl.struct(x=x, r=hl.rand_int64())))
     assert_contains_node(t, ir.TableParallelize)
     t._force_count()  # test with no consumer randomness
@@ -2497,7 +2506,6 @@ def test_table_randomness_parallelize_with_body_randomness():
 
 
 def test_table_randomness_parallelize_without_body_randomness():
-    rt = hl.utils.range_table(20, 3)
     t = hl.Table.parallelize(hl.array([1, 2, 3]).map(lambda x: hl.struct(x=x)))
     assert_contains_node(t, ir.TableParallelize)
     assert_unique_uids(t)

--- a/hail/python/test/hail/test_call_caching.py
+++ b/hail/python/test/hail/test_call_caching.py
@@ -1,6 +1,6 @@
 import hail as hl
-
 from hail.utils.misc import new_temp_file
+
 from .helpers import with_flags
 
 

--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -1,10 +1,10 @@
-from typing import Tuple, Dict, Optional
+from test.hail.helpers import hl_init_for_test, hl_stop_for_test, qobtest, skip_unless_spark_backend, with_flags
+from typing import Dict, Optional, Tuple
 
 import hail as hl
-from hail.utils.java import Env
 from hail.backend.backend import Backend
 from hail.backend.spark_backend import SparkBackend
-from test.hail.helpers import skip_unless_spark_backend, hl_init_for_test, hl_stop_for_test, qobtest, with_flags
+from hail.utils.java import Env
 
 
 def _scala_map_str_to_tuple_str_str_to_dict(scala) -> Dict[str, Tuple[Optional[str], Optional[str]]]:

--- a/hail/python/test/hail/test_exceptions_from_workers_have_stack_traces.py
+++ b/hail/python/test/hail/test_exceptions_from_workers_have_stack_traces.py
@@ -1,8 +1,10 @@
-import hail as hl
-import pytest
 import re
 
+import pytest
+
+import hail as hl
 from hail.utils.java import FatalError
+
 from .helpers import qobtest
 
 

--- a/hail/python/test/hail/test_hail_in_notebook.py
+++ b/hail/python/test/hail/test_hail_in_notebook.py
@@ -1,6 +1,8 @@
-from hailtop.utils.process import sync_check_exec
 import os
 import pathlib
+
+from hailtop.utils.process import sync_check_exec
+
 from .helpers import skip_when_local_backend
 
 

--- a/hail/python/test/hail/test_no_context.py
+++ b/hail/python/test/hail/test_no_context.py
@@ -1,6 +1,6 @@
 import unittest
+
 import hail as hl
-from .helpers import *
 
 
 class Tests(unittest.TestCase):

--- a/hail/python/test/hail/typecheck/test_typecheck.py
+++ b/hail/python/test/hail/typecheck/test_typecheck.py
@@ -1,6 +1,20 @@
 import unittest
 
-from hail.typecheck.check import *
+from hail.typecheck.check import (
+    anytype,
+    dictof,
+    func_spec,
+    lazy,
+    nullable,
+    numeric,
+    oneof,
+    sequenceof,
+    sized_tupleof,
+    transformed,
+    tupleof,
+    typecheck,
+    typecheck_method,
+)
 
 
 class Tests(unittest.TestCase):

--- a/hail/python/test/hail/utils/test_hl_hadoop_and_hail_fs.py
+++ b/hail/python/test/hail/utils/test_hl_hadoop_and_hail_fs.py
@@ -1,14 +1,15 @@
-from typing import Generator
-import pytest
-import secrets
 import os
+import secrets
+from typing import Generator
+
+import pytest
 
 import hail as hl
-import hailtop.fs as fs
 from hail.context import _get_local_tmpdir
-from hail.utils import hadoop_open, hadoop_copy, hadoop_ls
-from hailtop.utils import secret_alnum_string
+from hail.utils import hadoop_copy, hadoop_ls, hadoop_open
 from hail.utils.java import FatalError
+from hailtop import fs
+from hailtop.utils import secret_alnum_string
 
 from ..helpers import qobtest
 
@@ -133,7 +134,7 @@ def test_hadoop_stat(tmpdir: str):
             f.write('\n')
 
     stat1 = hl.hadoop_stat(f'{tmpdir}')
-    assert stat1['is_dir'] == True
+    assert stat1['is_dir'] is True
 
     hadoop_copy(f'{tmpdir}/test_hadoop_stat.txt.gz', f'{tmpdir}/test_hadoop_stat.copy.txt.gz')
 
@@ -142,7 +143,7 @@ def test_hadoop_stat(tmpdir: str):
     # practice, Hadoop creates a 175 byte file and gzip.GzipFile creates a 202 byte file. The 27
     # extra bytes appear to include at least the filename (20 bytes) and a modification timestamp.
     assert stat2['size_bytes'] == 175 or stat2['size_bytes'] == 202
-    assert stat2['is_dir'] == False
+    assert stat2['is_dir'] is False
     assert 'path' in stat2
 
 

--- a/hail/python/test/hail/utils/test_pickle.py
+++ b/hail/python/test/hail/utils/test_pickle.py
@@ -1,5 +1,7 @@
 import pickle
+
 import dill
+
 import hail as hl
 
 

--- a/hail/python/test/hail/utils/test_placement_tree.py
+++ b/hail/python/test/hail/utils/test_placement_tree.py
@@ -1,7 +1,6 @@
 import unittest
 
 import hail as hl
-
 from hail.utils.placement_tree import PlacementTree
 
 

--- a/hail/python/test/hail/utils/test_struct_repr_pprint.py
+++ b/hail/python/test/hail/utils/test_struct_repr_pprint.py
@@ -1,5 +1,6 @@
-import hail as hl
 from pprint import pformat
+
+import hail as hl
 
 
 def test_repr_empty_struct():
@@ -69,18 +70,6 @@ Struct(a0=0,
        a3=3,
        a4=4,
        a5=Struct(b0='', b1='na', b2='nana', b3='nanana'))
-""".strip()
-    assert pformat(x) == expected
-
-
-def test_pformat_big_struct_in_small_struct():
-    x = hl.Struct(a5=hl.Struct(b0='', b1='na', b2='nana', b3='nanana', b5='ndasdfhjwafdhjskfdshjkfhdjksfhdsjk'))
-    expected = """
-Struct(a5=Struct(b0='',
-                 b1='na',
-                 b2='nana',
-                 b3='nanana',
-                 b5='ndasdfhjwafdhjskfdshjkfhdjksfhdsjk'))
 """.strip()
     assert pformat(x) == expected
 

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -7,9 +7,9 @@ import pytest
 import hail as hl
 from hail.utils.java import FatalError
 from hail.utils.linkedlist import LinkedList
-from hail.utils.misc import escape_id, escape_str
+from hail.utils.misc import escape_id, escape_str, with_local_temp_file
 
-from ..helpers import fails_local_backend, fails_service_backend, qobtest, resource, with_local_temp_file
+from ..helpers import fails_local_backend, fails_service_backend, qobtest, resource
 
 
 def normalize_path(path: str) -> str:

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -1,13 +1,11 @@
 import os
-import pytest
 
 import hail as hl
-
 from hail.utils.java import Env
 from hail.utils.misc import new_temp_file
-from hail.vds.combiner import combine_variant_datasets, new_combiner, load_combiner, transform_gvcf
-from hail.vds.combiner.combine import defined_entry_fields
-from ..helpers import resource, skip_when_service_backend, test_timeout, qobtest
+from hail.vds.combiner import load_combiner, new_combiner
+
+from ..helpers import qobtest, resource, skip_when_service_backend, test_timeout
 
 all_samples = [
     'HG00308',

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -1,10 +1,12 @@
 import os
+
 import pytest
 
 import hail as hl
 from hail.utils import new_temp_file
 from hail.vds.combiner.combine import defined_entry_fields
-from ..helpers import resource, test_timeout, qobtest
+
+from ..helpers import qobtest, resource, test_timeout
 
 
 # run this method to regenerate the combined VDS from 5 samples
@@ -628,7 +630,7 @@ def test_to_dense_mt():
         hl.dict(hl.zip(hl.agg.collect((hl.str(dense.locus), dense.s)), hl.agg.collect(dense.entry)))
     )
 
-    assert as_dict.get(('chr22:10514784', 'NA12891')) == None
+    assert as_dict.get(('chr22:10514784', 'NA12891')) is None
     assert as_dict.get(('chr22:10514784', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=23, DP=4)
 
     assert as_dict.get(('chr22:10516102', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=12, DP=7)
@@ -638,7 +640,7 @@ def test_to_dense_mt():
     assert as_dict.get(('chr22:10516150', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=99, DP=10)
 
     assert as_dict.get(('chr22:10519088', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=99, DP=21)
-    assert as_dict.get(('chr22:10519088', 'NA12878')) == None
+    assert as_dict.get(('chr22:10519088', 'NA12878')) is None
 
     assert as_dict.get(('chr22:10557694', 'NA12891')) == hl.Struct(LGT=hl.Call([0, 1]), LA=[0, 1], GQ=28, DP=19)
     assert as_dict.get(('chr22:10557694', 'NA12878')) == hl.Struct(LGT=hl.Call([0, 0]), LA=None, GQ=13, DP=16)

--- a/hail/python/test/hail/vds/test_vds_functions.py
+++ b/hail/python/test/hail/vds/test_vds_functions.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import hail as hl
@@ -30,9 +32,16 @@ def test_lgt_to_gt_invalid():
     c1 = hl.call(1, 1)
     c2 = hl.call(1, 1, phased=True)
     assert hl.eval(hl.vds.lgt_to_gt(c1, [0, 17495])) == hl.Call([17495, 17495])
-    # the below fails because phasing uses the sum of j and k for its second allele.
-    # we cannot represent this allele index in 28 bits
-    # assert hl.eval(hl.vds.lgt_to_gt(c2, [0, 17495])) == hl.Call([17495, 17495], phased=True)
+    with pytest.raises(
+        hl.utils.HailUserError,
+        match=re.compile(
+            r'Error summary: HailException: invalid allele representation: 612185040. Max value is 2\^29 - 1.*',
+            re.DOTALL,
+        ),
+    ):
+        # the below fails because phasing uses the sum of j and k for its second allele.
+        # we cannot represent this allele index in 28 bits
+        hl.eval(hl.vds.lgt_to_gt(c2, [0, 17495])) == hl.Call([17495, 17495], phased=True)
 
 
 def test_local_to_global():

--- a/hail/python/test/hailtop/batch/test_batch_local_backend.py
+++ b/hail/python/test/hailtop/batch/test_batch_local_backend.py
@@ -1,14 +1,14 @@
-from typing import AsyncIterator
 import os
-import pytest
 import subprocess as sp
 import tempfile
+from typing import AsyncIterator
+
+import pytest
 
 from hailtop import pip_version
 from hailtop.batch import Batch, LocalBackend, ResourceGroup
 from hailtop.batch.resource import JobResourceFile
 from hailtop.batch.utils import concatenate
-
 
 DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:22.04')
 PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.9-slim'
@@ -110,13 +110,13 @@ def test_single_job_with_nonsense_shell(batch):
     b = batch
     j = b.new_job(shell='/bin/ajdsfoijasidojf')
     j.image(DOCKER_ROOT_IMAGE)
-    j.command(f'printf "hello"')
+    j.command('printf "hello"')
     with pytest.raises(Exception):
         b.run()
 
     b = batch
     j = b.new_job(shell='/bin/nonexistent')
-    j.command(f'printf "hello"')
+    j.command('printf "hello"')
     with pytest.raises(Exception):
         b.run()
 
@@ -124,9 +124,9 @@ def test_single_job_with_nonsense_shell(batch):
 def test_single_job_with_intermediate_failure(batch):
     b = batch
     j = b.new_job()
-    j.command(f'echoddd "hello"')
+    j.command('echoddd "hello"')
     j2 = b.new_job()
-    j2.command(f'echo "world"')
+    j2.command('echo "world"')
 
     with pytest.raises(Exception):
         b.run()
@@ -216,7 +216,7 @@ def test_resource_group_get_all_mentioned_dependent_jobs(batch):
     b = batch
     j = b.new_job()
     j.declare_resource_group(foo={'bed': '{root}.bed', 'bim': '{root}.bim'})
-    j.command(f"cat")
+    j.command("cat")
     j2 = b.new_job()
     j2.command(f"cat {j.foo}")
 

--- a/hail/python/test/hailtop/batch/test_batch_pool_executor.py
+++ b/hail/python/test/hailtop/batch/test_batch_pool_executor.py
@@ -4,9 +4,8 @@ import time
 import pytest
 
 from hailtop.batch import BatchPoolExecutor, ServiceBackend
-from hailtop.config import get_user_config
-from hailtop.utils import sync_sleep_before_try
 from hailtop.batch_client.client import BatchClient
+from hailtop.utils import sync_sleep_before_try
 
 PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.9'
 

--- a/hail/python/test/hailtop/batch/test_batch_service_backend.py
+++ b/hail/python/test/hailtop/batch/test_batch_service_backend.py
@@ -1,31 +1,25 @@
-from typing import AsyncIterator, List, Tuple
 import asyncio
 import inspect
-import secrets
-
-import pytest
 import os
+import secrets
+from configparser import ConfigParser
 from shlex import quote as shq
-import uuid
-import re
-import orjson
+from typing import AsyncIterator, Tuple
 
-import hailtop.fs as hfs
+import orjson
+import pytest
+
 import hailtop.batch_client.client as bc
 from hailtop import pip_version
-from hailtop.batch import Batch, ServiceBackend, ResourceGroup
+from hailtop.aiotools.router_fs import RouterAsyncFS
+from hailtop.batch import Batch, ResourceGroup, ServiceBackend
 from hailtop.batch.exceptions import BatchException
 from hailtop.batch.globals import arg_max
-from hailtop.utils import grouped, async_to_blocking, secret_alnum_string
-from hailtop.config import get_remote_tmpdir, configuration_of
-from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.test_utils import skip_in_azure
-from hailtop.httpx import ClientResponseError
-
-from configparser import ConfigParser
-from hailtop.config import get_user_config, user_config
+from hailtop.config import configuration_of, get_remote_tmpdir, get_user_config, user_config
 from hailtop.config.variables import ConfigVariable
-
+from hailtop.httpx import ClientResponseError
+from hailtop.test_utils import skip_in_azure
+from hailtop.utils import grouped, secret_alnum_string
 
 DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:22.04')
 PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.9-slim'
@@ -312,7 +306,7 @@ def test_cloudfuse_fails_with_io_mount_point(fs: RouterAsyncFS, backend: Service
     b = batch(backend)
     j = b.new_job()
     j.command(f'mkdir -p {path}; echo head > {path}/cloudfuse_test_1')
-    j.cloudfuse(bucket, f'/io', read_only=True)
+    j.cloudfuse(bucket, '/io', read_only=True)
 
     try:
         b.run()
@@ -344,8 +338,8 @@ def test_cloudfuse_implicit_dirs(fs: RouterAsyncFS, backend: ServiceBackend, upl
 
     b = batch(backend)
     j = b.new_job()
-    j.command(f'cat ' + os.path.join('/cloudfuse', object_name))
-    j.cloudfuse(bucket_name, f'/cloudfuse', read_only=True)
+    j.command('cat ' + os.path.join('/cloudfuse', object_name))
+    j.cloudfuse(bucket_name, '/cloudfuse', read_only=True)
 
     res = b.run()
     assert res
@@ -376,7 +370,7 @@ async def test_cloudfuse_submount_in_io_doesnt_rm_bucket(
     b = batch(backend)
     j = b.new_job()
     j.cloudfuse(bucket, '/io/cloudfuse')
-    j.command(f'ls /io/cloudfuse/')
+    j.command('ls /io/cloudfuse/')
     res = b.run()
     assert res
     res_status = res.status()
@@ -406,8 +400,8 @@ def test_fuse_non_requester_pays_bucket_when_requester_pays_project_specified(
 
     b = batch(backend, requester_pays_project=REQUESTER_PAYS_PROJECT)
     j = b.new_job()
-    j.command(f'ls /fuse-bucket')
-    j.cloudfuse(bucket, f'/fuse-bucket', read_only=True)
+    j.command('ls /fuse-bucket')
+    j.cloudfuse(bucket, '/fuse-bucket', read_only=True)
 
     res = b.run()
     assert res
@@ -444,7 +438,7 @@ def test_benchmark_lookalike_workflow(backend: ServiceBackend, output_tmpdir):
         j.command(f'echo "bar" >> {j.ofile}')
         jobs.append(j)
 
-    combine = b.new_job(f'combine_output').cpu(0.25)
+    combine = b.new_job('combine_output').cpu(0.25)
     for _ in grouped(arg_max(), jobs):
         combine.command(f'cat {" ".join(shq(j.ofile) for j in jobs)} >> {combine.ofile}')
     b.write_output(combine.ofile, os.path.join(output_tmpdir, 'pipeline_benchmark_test.txt'))
@@ -477,7 +471,7 @@ def test_single_job_with_shell(backend: ServiceBackend):
 def test_single_job_with_nonsense_shell(backend: ServiceBackend):
     b = batch(backend)
     j = b.new_job(shell='/bin/ajdsfoijasidojf')
-    j.command(f'echo "hello"')
+    j.command('echo "hello"')
     res = b.run()
     assert res
     res_status = res.status()
@@ -487,9 +481,9 @@ def test_single_job_with_nonsense_shell(backend: ServiceBackend):
 def test_single_job_with_intermediate_failure(backend: ServiceBackend):
     b = batch(backend)
     j = b.new_job()
-    j.command(f'echoddd "hello"')
+    j.command('echoddd "hello"')
     j2 = b.new_job()
-    j2.command(f'echo "world"')
+    j2.command('echo "world"')
 
     res = b.run()
     assert res
@@ -1059,7 +1053,7 @@ def test_non_spot_job(backend: ServiceBackend):
     j.command('echo hello')
     res = b.run()
     assert res
-    assert res.get_job(1).status()['spec']['resources']['preemptible'] == False
+    assert res.get_job(1).status()['spec']['resources']['preemptible'] is False
 
 
 def test_spot_unspecified_job(backend: ServiceBackend):
@@ -1068,7 +1062,7 @@ def test_spot_unspecified_job(backend: ServiceBackend):
     j.command('echo hello')
     res = b.run()
     assert res
-    assert res.get_job(1).status()['spec']['resources']['preemptible'] == True
+    assert res.get_job(1).status()['spec']['resources']['preemptible'] is True
 
 
 def test_spot_true_job(backend: ServiceBackend):
@@ -1078,7 +1072,7 @@ def test_spot_true_job(backend: ServiceBackend):
     j.command('echo hello')
     res = b.run()
     assert res
-    assert res.get_job(1).status()['spec']['resources']['preemptible'] == True
+    assert res.get_job(1).status()['spec']['resources']['preemptible'] is True
 
 
 def test_non_spot_batch(backend: ServiceBackend):
@@ -1092,9 +1086,9 @@ def test_non_spot_batch(backend: ServiceBackend):
     j3.command('echo hello')
     res = b.run()
     assert res
-    assert res.get_job(1).status()['spec']['resources']['preemptible'] == False
-    assert res.get_job(2).status()['spec']['resources']['preemptible'] == False
-    assert res.get_job(3).status()['spec']['resources']['preemptible'] == True
+    assert res.get_job(1).status()['spec']['resources']['preemptible'] is False
+    assert res.get_job(2).status()['spec']['resources']['preemptible'] is False
+    assert res.get_job(3).status()['spec']['resources']['preemptible'] is True
 
 
 def test_local_file_paths_error(backend: ServiceBackend):

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -1,4 +1,5 @@
 import unittest
+
 from hailtop.config.deploy_config import DeployConfig
 
 

--- a/hail/python/test/hailtop/conftest.py
+++ b/hail/python/test/hailtop/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import os
+
 import pytest
 
 

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -1,7 +1,7 @@
 import os
-import pytest
 import tempfile
 
+import pytest
 from typer.testing import CliRunner
 
 from hailtop.hailctl.batch import cli
@@ -45,7 +45,7 @@ def test_file_in_current_dir(runner: CliRunner):
     with tempfile.TemporaryDirectory() as dir:
         os.chdir(dir)
         write_hello(f'{dir}/hello.txt')
-        write_script(dir, f'/hello.txt')
+        write_script(dir, '/hello.txt')
         res = runner.invoke(cli.app, ['submit', '--files', 'hello.txt:/', 'test_job.py'], catch_exceptions=False)
         assert res.exit_code == 0, repr((res.output, res.stdout, res.stderr, res.exception))
 

--- a/hail/python/test/hailtop/hailctl/config/conftest.py
+++ b/hail/python/test/hailtop/hailctl/config/conftest.py
@@ -1,6 +1,6 @@
-import pytest
 import tempfile
 
+import pytest
 from typer.testing import CliRunner
 
 

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -1,10 +1,10 @@
 import os
-import pytest
 
+import pytest
 from typer.testing import CliRunner
 
-from hailtop.config.variables import ConfigVariable
 from hailtop.config.user_config import get_user_config_path
+from hailtop.config.variables import ConfigVariable
 from hailtop.hailctl.config import cli, config_variables
 
 
@@ -67,7 +67,7 @@ def test_config_get_unknown_names(runner: CliRunner, config_dir: str):
     os.makedirs(os.path.dirname(config_path))
     with open(config_path, 'w', encoding='utf-8') as config:
         config.write(
-            f"""
+            """
 [global]
 email = johndoe@gmail.com
 

--- a/hail/python/test/hailtop/hailctl/dataproc/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_cli.py
@@ -1,8 +1,8 @@
 from unittest.mock import Mock
+
 from typer.testing import CliRunner
 
 from hailtop.hailctl.dataproc import cli
-
 
 runner = CliRunner(mix_stderr=False)
 

--- a/hail/python/test/hailtop/hailctl/dataproc/test_connect.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_connect.py
@@ -1,10 +1,9 @@
 from unittest.mock import Mock
-from typer.testing import CliRunner
 
 import pytest
+from typer.testing import CliRunner
 
 from hailtop.hailctl.dataproc import cli
-
 
 runner = CliRunner(mix_stderr=False)
 

--- a/hail/python/test/hailtop/hailctl/dataproc/test_list_clusters.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_list_clusters.py
@@ -2,7 +2,6 @@ from typer.testing import CliRunner
 
 from hailtop.hailctl.dataproc import cli
 
-
 runner = CliRunner(mix_stderr=False)
 
 

--- a/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
@@ -3,7 +3,6 @@ from typer.testing import CliRunner
 
 from hailtop.hailctl.dataproc import cli
 
-
 runner = CliRunner(mix_stderr=False)
 
 

--- a/hail/python/test/hailtop/hailctl/dataproc/test_start.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_start.py
@@ -3,7 +3,6 @@ from typer.testing import CliRunner
 
 from hailtop.hailctl.dataproc import cli
 
-
 runner = CliRunner(mix_stderr=False)
 
 
@@ -126,7 +125,7 @@ def test_requester_pays_mode_configuration(gcloud_run, requester_pays_arg, expec
 def test_requester_pays_buckets_configuration(gcloud_run):
     runner.invoke(cli.app, ['start', 'test-cluster', '--requester-pays-allow-buckets=foo,bar'])
     properties = next(arg for arg in gcloud_run.call_args[0][0] if arg.startswith("--properties="))
-    assert f"spark:spark.hadoop.fs.gs.requester.pays.buckets=foo,bar" in properties
+    assert "spark:spark.hadoop.fs.gs.requester.pays.buckets=foo,bar" in properties
 
 
 @pytest.mark.parametrize(

--- a/hail/python/test/hailtop/hailctl/dataproc/test_stop.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_stop.py
@@ -2,7 +2,6 @@ from typer.testing import CliRunner
 
 from hailtop.hailctl.dataproc import cli
 
-
 runner = CliRunner(mix_stderr=False)
 
 

--- a/hail/python/test/hailtop/hailctl/dataproc/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_submit.py
@@ -2,7 +2,6 @@ from typer.testing import CliRunner
 
 from hailtop.hailctl.dataproc import cli
 
-
 runner = CliRunner(mix_stderr=False)
 
 

--- a/hail/python/test/hailtop/inter_cloud/generate_copy_test_specs.py
+++ b/hail/python/test/hailtop/inter_cloud/generate_copy_test_specs.py
@@ -1,8 +1,9 @@
+import asyncio
+import pprint
 import secrets
 from concurrent.futures import ThreadPoolExecutor
-import pprint
-import asyncio
-from hailtop.aiotools import LocalAsyncFS, Transfer, Copier
+
+from hailtop.aiotools import Copier, Transfer
 from hailtop.aiotools.router_fs import RouterAsyncFS
 
 
@@ -152,7 +153,7 @@ async def copy_test_specs():
 async def main():
     test_specs = await copy_test_specs()
     with open('test/hailtop/aiotools/copy_test_specs.py', 'w') as f:
-        f.write(f'COPY_TEST_SPECS = ')
+        f.write('COPY_TEST_SPECS = ')
         pprint.pprint(test_specs, stream=f)
 
 

--- a/hail/python/test/hailtop/inter_cloud/test_diff.py
+++ b/hail/python/test/hailtop/inter_cloud/test_diff.py
@@ -1,15 +1,16 @@
-from typing import Tuple, AsyncIterator, Dict
-import secrets
-import os
 import asyncio
-import pytest
 import functools
+import os
+import secrets
+from typing import AsyncIterator, Dict, Tuple
 
+import pytest
+
+from hailtop.aiotools.diff import DiffException, diff
 from hailtop.aiotools.fs import AsyncFS
-from hailtop.frozendict import frozendict
-from hailtop.aiotools.diff import diff, DiffException
-from hailtop.utils import bounded_gather2
 from hailtop.aiotools.router_fs import RouterAsyncFS
+from hailtop.frozendict import frozendict
+from hailtop.utils import bounded_gather2
 
 
 @pytest.fixture(scope='module')

--- a/hail/python/test/hailtop/inter_cloud/test_fs.py
+++ b/hail/python/test/hailtop/inter_cloud/test_fs.py
@@ -1,19 +1,21 @@
-from typing import Tuple, AsyncIterator
+import asyncio
 import datetime
-import random
 import functools
 import os
+import random
 import secrets
 from concurrent.futures import ThreadPoolExecutor
-import asyncio
-from hailtop.aiotools.fs.fs import AsyncFSURL
+from typing import AsyncIterator, Tuple
+
 import pytest
-from hailtop.utils import secret_alnum_string, retry_transient_errors, bounded_gather2
-from hailtop.aiotools import LocalAsyncFS, UnexpectedEOFError, AsyncFS
-from hailtop.aiotools.router_fs import RouterAsyncFS
+
 from hailtop.aiocloud.aioaws import S3AsyncFS
 from hailtop.aiocloud.aioazure import AzureAsyncFS
 from hailtop.aiocloud.aiogoogle import GoogleStorageAsyncFS
+from hailtop.aiotools import AsyncFS, LocalAsyncFS, UnexpectedEOFError
+from hailtop.aiotools.fs.fs import AsyncFSURL
+from hailtop.aiotools.router_fs import RouterAsyncFS
+from hailtop.utils import bounded_gather2, retry_transient_errors, secret_alnum_string
 
 
 @pytest.fixture(

--- a/hail/python/test/hailtop/inter_cloud/test_into_copy.py
+++ b/hail/python/test/hailtop/inter_cloud/test_into_copy.py
@@ -1,7 +1,7 @@
-import pytest
 import os.path
-from hailtop.aiotools.copy import copy_from_dict
 import tempfile
+
+from hailtop.aiotools.copy import copy_from_dict
 
 
 def write_file(path, data):

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -1,14 +1,15 @@
+import asyncio
+import concurrent.futures
+import functools
 import os
 import secrets
 from concurrent.futures import ThreadPoolExecutor
-import asyncio
+
 import pytest
-import concurrent.futures
-import functools
-from hailtop.utils import secret_alnum_string, bounded_gather2, retry_transient_errors
-from hailtop.aiotools import LocalAsyncFS
+
+from hailtop.aiocloud.aiogoogle import GoogleStorageAsyncFS, GoogleStorageClient
 from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.aiocloud.aiogoogle import GoogleStorageClient, GoogleStorageAsyncFS
+from hailtop.utils import bounded_gather2, retry_transient_errors, secret_alnum_string
 
 
 @pytest.fixture(params=['gs', 'router/gs'])

--- a/hail/python/test/hailtop/test_timex.py
+++ b/hail/python/test/hailtop/test_timex.py
@@ -1,5 +1,6 @@
-from hailtop import timex
 import datetime
+
+from hailtop import timex
 
 
 def test_google_cloud_storage_example():

--- a/hail/python/test/hailtop/utils/test_filesize.py
+++ b/hail/python/test/hailtop/utils/test_filesize.py
@@ -1,4 +1,5 @@
 from pytest import raises
+
 from hailtop.utils.filesize import filesize
 
 

--- a/hail/python/test/hailtop/utils/test_gcs_requester_pays.py
+++ b/hail/python/test/hailtop/utils/test_gcs_requester_pays.py
@@ -2,7 +2,6 @@ import pytest
 
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.fs.router_fs import RouterFS
-from hailtop.utils import async_to_blocking
 from hailtop.utils.gcs_requester_pays import GCSRequesterPaysFSCache
 
 
@@ -11,7 +10,6 @@ def test_get_fs_by_requester_pays_config(cls):
     config_1 = "foo"
     config_2 = ("foo", ["bar", "baz", "bat"])
     kwargs_1 = {"gcs_requester_pays_configuration": config_1}
-    kwargs_2 = {"gcs_requester_pays_configuration": config_2}
     fses = GCSRequesterPaysFSCache(cls)
     assert fses[None]._gcs_kwargs == {}
     assert fses[config_1]._gcs_kwargs == kwargs_1

--- a/hail/python/test/hailtop/utils/test_utils.py
+++ b/hail/python/test/hailtop/utils/test_utils.py
@@ -1,13 +1,13 @@
 from hailtop.utils import (
+    grouped,
+    parse_docker_image_reference,
     partition,
+    url_and_params,
     url_basename,
     url_join,
     url_scheme,
-    url_and_params,
-    parse_docker_image_reference,
-    grouped,
 )
-from hailtop.utils.utils import digits_needed, unzip, filter_none, flatten
+from hailtop.utils.utils import digits_needed, filter_none, flatten, unzip
 
 
 def test_partition_zero_empty():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ known-first-party = ["auth", "batch", "ci", "gear", "hailtop", "monitoring", "we
 [tool.ruff.per-file-ignores]
 "hail/python/hail/**/*" = ["I", "PL", "RUF"]
 "hail/python/hailtop/**/*" = ["I"]
-"hail/python/test/**/*" = ["ALL"]
 "hail/python/cluster-tests/**/*" = ["ALL"]
 "hail/python/setup-hailtop.py" = ["ALL"]
 "hail/python/setup.py" = ["ALL"]


### PR DESCRIPTION
Ruff linting the tests is not too hard, so I did it. I also looked at pyright/pylint, but the Hail package has way too many errors to make that feasible on a Friday night.