### PR TITLE
[compiler] Flatten Emitting `Let`s

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -238,11 +238,10 @@ object CompileIterator {
       val emitContext = EmitContext.analyze(ctx, ir)
       val emitter = new Emit(emitContext, stepFECB)
 
-      val env = EmitEnv(
-        Env.empty,
+      val env = new EmitEnv(
         argTypeInfo.indices.filter(i => argTypeInfo(i).isInstanceOf[EmitParamType]).map(i =>
           stepF.getEmitParam(cb, i + 1)
-        ),
+        )
       )
       val optStream = EmitCode.fromI(stepF)(cb =>
         EmitStream.produce(emitter, ir, cb, cb.emb, outerRegion, env, None)

--- a/hail/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Env.scala
@@ -150,7 +150,7 @@ class Env[V] private (val m: Map[Env.K, V]) {
   def apply(name: String): V = m(name)
 
   def lookup(name: String): V =
-    m.get(name).getOrElse(throw new RuntimeException(s"Cannot find $name in $m"))
+    m.getOrElse(name, throw new RuntimeException(s"Cannot find $name in $m"))
 
   def lookupOption(name: String): Option[V] = m.get(name)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/FoldAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/FoldAggregator.scala
@@ -42,9 +42,6 @@ class FoldAggregator(
     other: TypedRegionBackedAggState,
   ): Unit = {
 
-    val stateEV = state.get(cb).memoizeField(cb, "fold_agg_comb_op_state")
-    val otherEV = other.get(cb).memoizeField(cb, "fold_agg_comb_op_other")
-    val env = EmitEnv(Env.apply((accumName, stateEV), (otherAccumName, otherEV)), IndexedSeq())
     val pEnv = Env.apply(
       (accumName, resultEmitType.storageType),
       (otherAccumName, resultEmitType.storageType),
@@ -52,7 +49,12 @@ class FoldAggregator(
 
     val emitCtx = EmitContext.analyze(ctx, combOpIR, pEnv)
     val emit = new Emit[Any](emitCtx, cb.emb.ecb.asInstanceOf[EmitClassBuilder[Any]])
-    val ec = emit.emit(combOpIR, cb.emb.asInstanceOf[EmitMethodBuilder[Any]], env, None)
+
+    val stateEV = state.get(cb).memoizeField(cb, "fold_agg_comb_op_state")
+    val otherEV = other.get(cb).memoizeField(cb, "fold_agg_comb_op_other")
+    val emitEnv = new EmitEnv().bind(accumName -> stateEV, otherAccumName -> otherEV)
+
+    val ec = emit.emit(combOpIR, cb.emb.asInstanceOf[EmitMethodBuilder[Any]], emitEnv, None)
     ec.toI(cb).consume(cb, state.storeMissing(cb), sv => state.storeNonmissing(cb, sv))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -89,7 +89,7 @@ class EmitStreamSuite extends HailSuite {
         cb,
         cb.emb,
         region,
-        EmitEnv(Env.empty, inputTypes.indices.map(i => mb.storeEmitParamAsField(cb, i + 2))),
+        new EmitEnv(inputTypes.indices.map(i => mb.storeEmitParamAsField(cb, i + 2))),
         None,
       )
         .consumeCode[Long](
@@ -184,7 +184,7 @@ class EmitStreamSuite extends HailSuite {
         cb,
         cb.emb,
         region,
-        EmitEnv(Env.empty, FastSeq()),
+        new EmitEnv(),
         None,
       )
         .consume(


### PR DESCRIPTION
By the time we get to `Emit(?:Stream)?$`, all bindings of type TStream should have been:
 - inlined (if it has exactly one use), or
 - eliminated (if it has no uses)

Note streams cannot have more than one use.

Previously `Emit(?:Stream)?$` was written without this assumption and had to emit stream bindings recursively. This can lead to stack overflows for large numbers of let-bindings (eg benchmark `matrix-multi-write-nothing`).

This change emits bindings iteratively with the assertion emit bindings may not be of type TStream.