### PR TITLE
[services] Fix domain configuration in dev namespaces

### DIFF
--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -45,11 +45,6 @@ spec:
             value: "{{ default_ns.name }}"
           - name: HAIL_DEPLOY_CONFIG_FILE
             value: /deploy-config/deploy-config.json
-          - name: HAIL_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: global-config
-                key: domain
           - name: CLOUD
             valueFrom:
               secretKeyRef:
@@ -179,11 +174,6 @@ spec:
             value: "{{ default_ns.name }}"
           - name: HAIL_DEPLOY_CONFIG_FILE
             value: /deploy-config/deploy-config.json
-          - name: HAIL_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: global-config
-                key: domain
           - name: HAIL_ORGANIZATION_DOMAIN
             valueFrom:
               secretKeyRef:

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -177,11 +177,6 @@ spec:
            value: "5000"
          - name: GOOGLE_APPLICATION_CREDENTIALS
            value: /gsa-key/key.json
-         - name: HAIL_DOMAIN
-           valueFrom:
-             secretKeyRef:
-               name: global-config
-               key: domain
          - name: HAIL_DEPLOY_CONFIG_FILE
            value: /deploy-config/deploy-config.json
          - name: HAIL_BATCH_WORKER_IMAGE
@@ -371,7 +366,7 @@ spec:
         env:
          - name: PORT
            value: "443"
-         - name: HAIL_DOMAIN
+         - name: HAIL_PRODUCTION_DOMAIN
            valueFrom:
              secretKeyRef:
                name: global-config

--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 import yaml
 
-DOMAIN = os.environ['HAIL_DOMAIN']
+DOMAIN = os.environ['HAIL_PRODUCTION_DOMAIN']
 
 
 def create_rds_response(

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -70,7 +70,7 @@ spec:
                secretKeyRef:
                  name: ci-config
                  key: storage_uri
-           - name: HAIL_DOMAIN
+           - name: HAIL_PRODUCTION_DOMAIN
              valueFrom:
                secretKeyRef:
                  name: global-config

--- a/ci/test/resources/deployment.yaml
+++ b/ci/test/resources/deployment.yaml
@@ -66,11 +66,6 @@ spec:
                secretKeyRef:
                  name: global-config
                  key: ip
-           - name: HAIL_DOMAIN
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: domain
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
            - name: HAIL_SHA

--- a/ci/test/resources/statefulset.yaml
+++ b/ci/test/resources/statefulset.yaml
@@ -65,11 +65,6 @@ spec:
                secretKeyRef:
                  name: global-config
                  key: ip
-           - name: HAIL_DOMAIN
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: domain
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
            - name: HAIL_SHA

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -6,7 +6,7 @@ IP := $(shell kubectl get secret global-config --template={{.data.ip}} | base64 
 SHA := $(shell git rev-parse --short=12 HEAD)
 
 envoy-xds-config:
-	HAIL_DOMAIN=$(DOMAIN) python3 ../ci/ci/envoy.py gateway ${HAIL}/letsencrypt/subdomains.txt ${HAIL}/gateway/cds.yaml.out ${HAIL}/gateway/rds.yaml.out
+	HAIL_PRODUCTION_DOMAIN=$(DOMAIN) python3 ../ci/ci/envoy.py gateway ${HAIL}/letsencrypt/subdomains.txt ${HAIL}/gateway/cds.yaml.out ${HAIL}/gateway/rds.yaml.out
 	kubectl -n default create configmap gateway-xds-config \
 		--from-file=cds.yaml=cds.yaml.out \
 		--from-file=rds.yaml=rds.yaml.out \

--- a/gear/gear/session.py
+++ b/gear/gear/session.py
@@ -1,5 +1,3 @@
-import os
-
 import aiohttp_session
 import aiohttp_session.cookie_storage
 
@@ -21,7 +19,8 @@ def setup_aiohttp_session(app):
                 secure=True,
                 httponly=True,
                 samesite='Lax',
-                domain=os.environ['HAIL_DOMAIN'],
+                domain=deploy_config._domain,
+                path=deploy_config._base_path or '/',
                 # 2592000s = 30d
                 max_age=2592000,
             ),

--- a/monitoring/deployment.yaml
+++ b/monitoring/deployment.yaml
@@ -39,11 +39,6 @@ spec:
             value: /deploy-config/deploy-config.json
           - name: HAIL_SHA
             value: "{{ code.sha }}"
-          - name: HAIL_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: global-config
-                key: domain
           - name: PROJECT
             valueFrom:
               secretKeyRef:

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -98,6 +98,6 @@ async def render_template(
     context['csrf_token'] = csrf_token
 
     response = aiohttp_jinja2.render_template(file, request, context)
-    domain = cookie_domain or os.environ['HAIL_DOMAIN']
+    domain = cookie_domain or deploy_config._domain
     response.set_cookie('_csrf', csrf_token, domain=domain, secure=True, httponly=True)
     return response


### PR DESCRIPTION
As of #14056, there is ambiguity when referring to the configuration value `domain`.

- In the `global-config`, this is the root domain of the entire hail system. This is the same across all namespaces.
- In the `deploy-config` of a namespace N, this refers to the root domain served by applications of that namespace. In production (namespace `default`), this is `hail.is`, the same as the root domain of the entire system. In other namespaces, this is `internal.hail.is`.

Setting the `HAIL_DOMAIN` environment variable in the k8s deployments from the `global-config` overrides what should be `internal.hail.is` to `hail.is`, breaking any form of redirection. There's really no need to set this environment variable at all, as its value can be derived from the `deploy-config`. This PR removes that environment variable. I tested this in my development namespace.