### PR TITLE
[hailctl] Dev config set should only change one property

### DIFF
--- a/hail/python/test/hailtop/hailctl/dev/conftest.py
+++ b/hail/python/test/hailtop/hailctl/dev/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+import tempfile
+
+from typer.testing import CliRunner
+
+
+@pytest.fixture()
+def deploy_config_file():
+    with tempfile.NamedTemporaryFile() as f:
+        yield f.name
+
+
+@pytest.fixture
+def runner(deploy_config_file):
+    yield CliRunner(mix_stderr=False, env={'HAIL_DEPLOY_CONFIG_FILE': deploy_config_file})

--- a/hail/python/test/hailtop/hailctl/dev/test_config.py
+++ b/hail/python/test/hailtop/hailctl/dev/test_config.py
@@ -1,0 +1,44 @@
+import orjson
+from typer.testing import CliRunner
+
+from hailtop.hailctl.dev import config as cli
+
+default_config = {
+    'domain': 'example.com',
+    'location': 'external',
+    'default_namespace': 'default',
+}
+
+
+def set_deploy_config(deploy_config_file: str, config: dict):
+    with open(deploy_config_file, 'w', encoding='utf-8') as f:
+        f.write(orjson.dumps(config).decode('utf-8'))
+
+
+def load_deploy_config_dict(deploy_config_file: str) -> dict:
+    with open(deploy_config_file, 'r', encoding='utf-8') as f:
+        return orjson.loads(f.read())
+
+
+def test_dev_config_set(runner: CliRunner, deploy_config_file: str):
+    set_deploy_config(deploy_config_file, default_config)
+
+    res = runner.invoke(cli.app, ['set', 'default_namespace', 'foo'])
+    assert res.exit_code == 0, res.stderr
+
+    expected = {'domain': 'example.com', 'location': 'external', 'default_namespace': 'foo'}
+    assert load_deploy_config_dict(deploy_config_file) == expected
+
+
+def test_dev_config_set_not_affected_by_env_vars(runner: CliRunner, deploy_config_file: str):
+    set_deploy_config(deploy_config_file, default_config)
+
+    res = runner.invoke(
+        cli.app,
+        ['set', 'default_namespace', 'foo'],
+        env={'HAIL_DOMAIN': 'foo.example.com'},
+    )
+    assert res.exit_code == 0
+
+    expected = {'domain': 'example.com', 'location': 'external', 'default_namespace': 'foo'}
+    assert load_deploy_config_dict(deploy_config_file) == expected


### PR DESCRIPTION
#14056 added a new optional field to the deploy config, `base_path` which is intended to phase out `default_namespace`. But for backwards compatibility reasons we cannot yet remove `default_namespace`. This should all work fine without breaking any workflows like switching back and forth between namespaces so long as `base_path` is not explicitly set in a developer's deploy config.

But `hailctl dev config set <property> <value>` does not just set a single property, it loads the deploy config, sets the property, and then writes the whole deploy config back. If the deploy config does anything with default values, which it now does with `base_path`, this round trip does not work.

Another simpler example is that currently in main, the following will make two changes to a deploy config not one:

```
# deploy config of {'location': 'external', 'domain': 'hail.is', 'default_namespace': 'default'}
HAIL_DOMAIN=foo hailctl dev config set location gce

# deploy config will now read {'location': 'gce', 'domain': 'foo', 'default_namespace': 'default'}
```

This PR should change `hailctl dev config set` so that the only changes that are made to the deploy config are the single property/value change described in the command.