### PR TITLE
[monitoring] Use aiohttp.AppKey to add static typing to Application storage

### DIFF
--- a/devbin/dev_proxy.py
+++ b/devbin/dev_proxy.py
@@ -31,7 +31,7 @@ async def default_proxied_web_route(request: web.Request):
 
 
 async def proxy(request: web.Request):
-    backend_client: Session = request.app['backend_client']
+    backend_client = request.app[BC]
     backend_route = deploy_config.external_url(SERVICE, request.raw_path)
     headers = {'x-hail-return-jinja-context': '1'}
     try:
@@ -50,12 +50,15 @@ async def render_html(request: web.Request, context: dict):
     return await render_template(SERVICE, request, **context, cookie_domain='localhost:8000')
 
 
+BC = web.AppKey('backend_client', Session)
+
+
 async def on_startup(app: web.Application):
-    app['backend_client'] = Session(credentials=hail_credentials())
+    app[BC] = Session(credentials=hail_credentials())
 
 
 async def on_cleanup(app: web.Application):
-    await app['backend_client'].close()
+    await app[AppKeys.BC].close()
 
 
 app = web.Application()

--- a/devbin/dev_proxy.py
+++ b/devbin/dev_proxy.py
@@ -18,6 +18,7 @@ deploy_config = get_deploy_config()
 
 SERVICE = os.environ['SERVICE']
 MODULES = {'batch': 'batch.front_end', 'batch-driver': 'batch.driver'}
+BC = web.AppKey('backend_client', Session)
 
 
 @routes.get('/api/{route:.*}')
@@ -50,15 +51,12 @@ async def render_html(request: web.Request, context: dict):
     return await render_template(SERVICE, request, **context, cookie_domain='localhost:8000')
 
 
-BC = web.AppKey('backend_client', Session)
-
-
 async def on_startup(app: web.Application):
     app[BC] = Session(credentials=hail_credentials())
 
 
 async def on_cleanup(app: web.Application):
-    await app[AppKeys.BC].close()
+    await app[BC].close()
 
 
 app = web.Application()

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -131,7 +131,7 @@ async def _billing(request: web.Request):
         set_message(session, msg, 'error')
         return ([], [], [], time_period_query)
 
-    db = app['db']
+    db = app[AppKeys.DB]
     records = db.execute_and_fetchall(
         'SELECT * FROM monitoring_billing_data WHERE year = %s AND month = %s;', (time_period.year, time_period.month)
     )
@@ -169,8 +169,8 @@ async def billing(request: web.Request, userdata) -> web.Response:  # pylint: di
 
 
 async def query_billing_body(app):
-    db = app['db']
-    bigquery_client = app['bigquery_client']
+    db = app[AppKeys.DB]
+    bigquery_client = app[AppKeys.BQ_CLIENT]
 
     async def _query(dt):
         month = dt.month
@@ -257,22 +257,22 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
 
 
 async def polling_loop(app):
-    db = app['db']
+    db = app[AppKeys.DB]
     while True:
         now = datetime.datetime.now()
         row = await db.select_and_fetchone('SELECT mark FROM monitoring_billing_mark;')
         if not row['mark'] or now > datetime.datetime.fromtimestamp(row['mark'] / 1000) + datetime.timedelta(days=1):
-            app['query_billing_event'].set()
+            app[AppKeys.QUERY_BILLING_EVENT].set()
         await asyncio.sleep(60)
 
 
 async def monitor_disks(app):
     log.info('monitoring disks')
-    compute_client: aiogoogle.GoogleComputeClient = app['compute_client']
+    compute_client = app[AppKeys.COMPUTE_CLIENT]
 
     disk_counts = defaultdict(list)
 
-    for zone in app['zones']:
+    for zone in app[AppKeys.ZONES]:
         async for disk in await compute_client.list(f'/zones/{zone}/disks', params={'filter': '(labels.batch = 1)'}):
             namespace = disk['labels']['namespace']
             size_gb = int(disk['sizeGb'])
@@ -304,11 +304,11 @@ async def monitor_disks(app):
 
 async def monitor_instances(app):
     log.info('monitoring instances')
-    compute_client: aiogoogle.GoogleComputeClient = app['compute_client']
+    compute_client = app[AppKeys.COMPUTE_CLIENT]
 
     instance_counts: Dict[InstanceLabels, int] = defaultdict(int)
 
-    for zone in app['zones']:
+    for zone in app[AppKeys.ZONES]:
         async for instance in await compute_client.list(
             f'/zones/{zone}/instances', params={'filter': '(labels.role = batch2-agent)'}
         ):
@@ -327,49 +327,54 @@ async def monitor_instances(app):
 
 
 class AppKeys(CommonAiohttpAppKeys):
-    pass
+    DB = web.AppKey('db', Database)
+    BQ_CLIENT = web.AppKey('bigquery_client', aiogoogle.GoogleBigQueryClient)
+    COMPUTE_CLIENT = web.AppKey('compute_client', aiogoogle.GoogleComputeClient)
+    QUERY_BILLING_EVENT = web.AppKey('query_billing_event', asyncio.Event)
+    ZONES = web.AppKey('zones', List[str])
+    TASK_MANAGER = web.AppKey('task_manager', aiotools.BackgroundTaskManager)
 
 
 async def on_startup(app):
     db = Database()
     await db.async_init()
-    app['db'] = db
+    app[AppKeys.DB] = db
     app[AppKeys.CLIENT_SESSION] = httpx.client_session()
 
     aiogoogle_credentials = aiogoogle.GoogleCredentials.from_file('/billing-monitoring-gsa-key/key.json')
 
-    bigquery_client = aiogoogle.GoogleBigQueryClient('broad-ctsa', credentials=aiogoogle_credentials)
-    app['bigquery_client'] = bigquery_client
+    app[AppKeys.BQ_CLIENT] = aiogoogle.GoogleBigQueryClient('broad-ctsa', credentials=aiogoogle_credentials)
 
     compute_client = aiogoogle.GoogleComputeClient(PROJECT, credentials=aiogoogle_credentials)
-    app['compute_client'] = compute_client
+    app[AppKeys.COMPUTE_CLIENT] = compute_client
 
     query_billing_event = asyncio.Event()
-    app['query_billing_event'] = query_billing_event
+    app[AppKeys.QUERY_BILLING_EVENT] = query_billing_event
 
     region_info = {name: await compute_client.get(f'/regions/{name}') for name in BATCH_GCP_REGIONS}
     zones = [url_basename(z) for r in region_info.values() for z in r['zones']]
-    app['zones'] = zones
+    app[AppKeys.ZONES] = zones
 
-    app['task_manager'] = aiotools.BackgroundTaskManager()
+    task_manager = aiotools.BackgroundTaskManager()
+    app[AppKeys.TASK_MANAGER] = task_manager
 
-    app['task_manager'].ensure_future(retry_long_running('polling_loop', polling_loop, app))
+    task_manager.ensure_future(retry_long_running('polling_loop', polling_loop, app))
 
-    app['task_manager'].ensure_future(
+    task_manager.ensure_future(
         retry_long_running(
             'query_billing_loop', run_if_changed_idempotent, query_billing_event, query_billing_body, app
         )
     )
 
-    app['task_manager'].ensure_future(periodically_call(60, monitor_disks, app))
-    app['task_manager'].ensure_future(periodically_call(60, monitor_instances, app))
+    task_manager.ensure_future(periodically_call(60, monitor_disks, app))
+    task_manager.ensure_future(periodically_call(60, monitor_instances, app))
 
 
 async def on_cleanup(app):
     async with AsyncExitStack() as cleanup:
-        cleanup.push_async_callback(app['db'].async_close)
+        cleanup.push_async_callback(app[AppKeys.DB].async_close)
         cleanup.push_async_callback(app[AppKeys.CLIENT_SESSION].close)
-        cleanup.callback(app['task_manager'].shutdown)
+        cleanup.callback(app[AppKeys.TASK_MANAGER].shutdown)
 
 
 def run():


### PR DESCRIPTION
Forgive my throwing the dev proxy change in here too, but this gets us static typechecking on stuff stored in `app` across the codebase except for `batch`. That's a beast that will be a lot of changes to port to `AppKey`s and I don't want to mess with the current in flight PRs.