### PR TITLE
[vds/combiner] Better calculation of ref_block_max_length

### DIFF
--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -428,19 +428,11 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
             self._job_id += 1
 
     def _write_final(self, vds):
-        fd = VariantDataset.ref_block_max_length_field
-
-        if fd not in vds.reference_data.globals:
-            info("VDS combiner: computing reference block max length...")
-            max_len = vds.reference_data.aggregate_entries(
-                hl.agg.max(vds.reference_data.END + 1 - vds.reference_data.locus.position)
-            )
-            info(f"VDS combiner: max reference block length is {max_len}")
-            vds = VariantDataset(
-                reference_data=vds.reference_data.annotate_globals(**{fd: max_len}), variant_data=vds.variant_data
-            )
-
         vds.write(self._output_path)
+
+        if VariantDataset.ref_block_max_length_field not in vds.reference_data.globals:
+            info("VDS combiner: computing reference block max length...")
+            hl.vds.store_ref_block_max_length(self._output_path)
 
     def _step_vdses(self):
         current_bin = original_bin = min(self._vdses)

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -83,7 +83,7 @@ def store_ref_block_max_length(vds_path):
     ----------
     vds_path : :obj:`str`
     """
-    vds = hl.vds.read_vds(vds_path)
+    vds = read_vds(vds_path, _warn_no_ref_block_max_length=False)
 
     if VariantDataset.ref_block_max_length_field in vds.reference_data.globals:
         warning(f"VDS at {vds_path} already contains a global annotation with the max reference block length")


### PR DESCRIPTION
Use the patch in place function of `store_ref_block_max_length` to compute `ref_block_max_length` rather than computing it on a zip join pipeline, causing that zip join pipeline to be executed twice.