### PR TITLE
[hailtop] remove dead code in test

### DIFF
--- a/hail/python/test/hailtop/inter_cloud/test_copy.py
+++ b/hail/python/test/hailtop/inter_cloud/test_copy.py
@@ -472,10 +472,6 @@ async def test_file_and_directory_error_with_slash_empty_file(
     for transfer_type in (Transfer.DEST_IS_TARGET, Transfer.DEST_DIR, Transfer.INFER_DEST):
         dest_base = await fresh_dir(fs, bases, cloud_scheme)
 
-        await Copier.copy(fs, sema, Transfer(f'{src_base}', dest_base.rstrip('/'), treat_dest_as=transfer_type))
-
-        dest_base = await fresh_dir(fs, bases, cloud_scheme)
-
         await Copier.copy(fs, sema, Transfer(f'{src_base}empty/', dest_base.rstrip('/'), treat_dest_as=transfer_type))
 
         await collect_files(await fs.listfiles(f'{dest_base}'))


### PR DESCRIPTION
AFAICT, this does a copy that has no effect. We blow away dest_dir so we can't possibly verify that this copy was correct. Unless there's some side effect that I'm misunderstanding?