### PR TITLE
[batch] Add json parsing and severity to GCP Ops Agent config

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -230,6 +230,8 @@ logging:
       - /batch/jvm-container-logs/jvm-*.log
       record_log_file_path: true
   processors:
+    parse_message:
+      type: parse_json
     labels:
       type: modify_fields
       fields:
@@ -237,11 +239,13 @@ logging:
           static_value: $NAMESPACE
         labels.instance_id:
           static_value: $INSTANCE_ID
+        severity:
+          move_from: jsonPayload.severity
   service:
     log_level: error
     pipelines:
       default_pipeline:
-        processors: [labels]
+        processors: [parse_message, labels]
         receivers: [runlog, workerlog, jvmlog]
 
 metrics:


### PR DESCRIPTION
Currently the Ops Agent does not do any parsing of the log message, so the log entry in Google Logging looks like:

```
jsonPayload: {
  message: "{"severity":"INFO","levelname":"INFO","asctime":"2024-01-22 16:10:45,748","filename":"worker.py","funcNameAndLine":"<module>:3461","message":"closed","hail_log":1}"
}
```

The `parse_json` processor extracts the json fields from the message into fields on the `jsonPayload` so it looks like this

```
jsonPayload: {
asctime: "2024-01-22 16:14:06,098"
filename: "worker.py"
funcNameAndLine: "<module>:180"
hail_log: 1
levelname: "INFO"
message: "CLOUD gcp"
}
```

and only the new `message` field is displayed in the Google Logging row instead of the whole json.

This also adds a `severity` field on the log entry so filters such as `SEVERITY!=INFO` work as expected.