### PR TITLE
[prometheus] 90 day retention

### DIFF
--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -296,7 +296,7 @@ spec:
           - "/bin/prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"
           - "--storage.tsdb.path=/prometheus"
-          - "--storage.tsdb.retention.time=15d"
+          - "--storage.tsdb.retention.time=90d"
           - "--web.console.libraries=/usr/share/prometheus/console_libraries"
           - "--web.console.templates=/usr/share/prometheus/consoles"
           - "--web.enable-lifecycle"


### PR DESCRIPTION
Open question: we're using ~20GiB on /prometheus for 15d. We request 150GiB (and get closer to 146GiB). Should we increase the storage to give ourselves more slack? Assuming linear scaling, 90d would use 120GiB (26GiB of slack).

https://hail.zulipchat.com/#narrow/stream/300487-Hail-Batch-Dev/topic/Grafana.20retention.20period