### PR TITLE
[query] support importing empty JSON objects

### DIFF
--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -268,7 +268,7 @@ object JSONAnnotationImpex {
           } else if (jfields.size == 0) {
             0
           } else {
-            jfields.map { case (name, jv2) =>
+            jfields.map { case (name, _) =>
               t.selfField(name).map(_.index).getOrElse(-1)
             }.max + 1
           }

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -263,11 +263,15 @@ object JSONAnnotationImpex {
         if (t.size == 0)
           Annotation.empty
         else {
-          val annotationSize =
-            if (padNulls) t.size
-            else jfields.map { case (name, _) =>
+          val annotationSize = if (padNulls) {
+            t.size
+          } else if (jfields.size == 0) {
+            0
+          } else {
+            jfields.map { case (name, jv2) =>
               t.selfField(name).map(_.index).getOrElse(-1)
             }.max + 1
+          }
           val a = Array.fill[Any](annotationSize)(null)
 
           for ((name, jv2) <- jfields) {

--- a/hail/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -74,14 +74,13 @@ class ExprSuite extends HailSuite {
   @Test def testImportEmptyJSONObjectAsStruct(): Unit =
     assert(JSONAnnotationImpex.importAnnotation(parse("{}"), TStruct()) == Row())
 
-  @Test def testExportEmptyJSONObjectAsStruct(): Unit = {
+  @Test def testExportEmptyJSONObjectAsStruct(): Unit =
     assert(compact(render(JSONAnnotationImpex.exportAnnotation(Row(), TStruct()))) == "{}")
-  }
 
   @Test def testRoundTripEmptyJSONObject(): Unit = {
     val actual = JSONAnnotationImpex.exportAnnotation(
       JSONAnnotationImpex.importAnnotation(parse("{}"), TStruct()),
-      TStruct()
+      TStruct(),
     )
     assert(compact(render(actual)) == "{}")
   }
@@ -89,7 +88,7 @@ class ExprSuite extends HailSuite {
   @Test def testRoundTripEmptyStruct(): Unit = {
     val actual = JSONAnnotationImpex.importAnnotation(
       JSONAnnotationImpex.exportAnnotation(Row(), TStruct()),
-      TStruct()
+      TStruct(),
     )
     assert(actual == Row())
   }

--- a/hail/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -6,12 +6,13 @@ import is.hail.check.Prop._
 import is.hail.check.Properties
 import is.hail.expr._
 import is.hail.expr.ir.IRParser
-import is.hail.types.virtual.{TInt32, Type}
+import is.hail.types.virtual._
 import is.hail.utils.StringEscapeUtils._
 
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.testng.annotations.Test
+import org.apache.spark.sql.Row
 
 class ExprSuite extends HailSuite {
 
@@ -68,6 +69,29 @@ class ExprSuite extends HailSuite {
     }
 
     p.check()
+  }
+
+  @Test def testImportEmptyJSONObjectAsStruct(): Unit =
+    assert(JSONAnnotationImpex.importAnnotation(parse("{}"), TStruct()) == Row())
+
+  @Test def testExportEmptyJSONObjectAsStruct(): Unit = {
+    assert(compact(render(JSONAnnotationImpex.exportAnnotation(Row(), TStruct()))) == "{}")
+  }
+
+  @Test def testRoundTripEmptyJSONObject(): Unit = {
+    val actual = JSONAnnotationImpex.exportAnnotation(
+      JSONAnnotationImpex.importAnnotation(parse("{}"), TStruct()),
+      TStruct()
+    )
+    assert(compact(render(actual)) == "{}")
+  }
+
+  @Test def testRoundTripEmptyStruct(): Unit = {
+    val actual = JSONAnnotationImpex.importAnnotation(
+      JSONAnnotationImpex.exportAnnotation(Row(), TStruct()),
+      TStruct()
+    )
+    assert(actual == Row())
   }
 
   @Test def testImpexes(): Unit = {


### PR DESCRIPTION
@patrick-schultz I'm not sure if this makes sense or not, but I observed it while working on something else. It seems weird but acceptable to import an empty dictionary as any struct. Does this seem reasonable to you? How have we avoided this bug for so long?

I'm not familiar enough with this code to know how to simply reproduce the bug and add a corresponding test. Thoughts?