### PR TITLE
[hailtop] allow configuration of default HTTP timeout

### DIFF
--- a/hail/python/hailtop/config/variables.py
+++ b/hail/python/hailtop/config/variables.py
@@ -19,3 +19,4 @@ class ConfigVariable(str, Enum):
     QUERY_BATCH_WORKER_MEMORY = 'query/batch_worker_memory'
     QUERY_NAME_PREFIX = 'query/name_prefix'
     QUERY_DISABLE_PROGRESS_BAR = 'query/disable_progress_bar'
+    HTTP_TIMEOUT_IN_SECONDS = 'http/timeout_in_seconds'

--- a/hail/python/hailtop/hailctl/config/config_variables.py
+++ b/hail/python/hailtop/hailctl/config/config_variables.py
@@ -9,6 +9,14 @@ _config_variables = None
 ConfigVariableInfo = namedtuple('ConfigVariableInfo', ['help_msg', 'validation'])
 
 
+def _is_float_str(x: str) -> bool:
+    try:
+        float(x)
+        return True
+    except ValueError:
+        return False
+
+
 def config_variables():
     from hailtop.batch_client.parse import CPU_REGEXPAT, MEMORY_REGEXPAT  # pylint: disable=import-outside-toplevel
     from hailtop.aiotools.router_fs import RouterAsyncFS  # pylint: disable=import-outside-toplevel
@@ -123,6 +131,10 @@ def config_variables():
             ConfigVariable.QUERY_DISABLE_PROGRESS_BAR: ConfigVariableInfo(
                 help_msg='Disable the progress bar with a value of 1. Enable the progress bar with a value of 0',
                 validation=(lambda x: x in ('0', '1'), 'should be a value of 0 or 1'),
+            ),
+            ConfigVariable.TIMEOUT_IN_SECONDS: ConfigVariableInfo(
+                help_msg='The default timeout for HTTP requests in seconds.',
+                validation=(_is_float_str, 'should be a float or an int like 42.42 or 42'),
             ),
         }
 

--- a/hail/python/hailtop/hailctl/config/config_variables.py
+++ b/hail/python/hailtop/hailctl/config/config_variables.py
@@ -132,7 +132,7 @@ def config_variables():
                 help_msg='Disable the progress bar with a value of 1. Enable the progress bar with a value of 0',
                 validation=(lambda x: x in ('0', '1'), 'should be a value of 0 or 1'),
             ),
-            ConfigVariable.TIMEOUT_IN_SECONDS: ConfigVariableInfo(
+            ConfigVariable.HTTP_TIMEOUT_IN_SECONDS: ConfigVariableInfo(
                 help_msg='The default timeout for HTTP requests in seconds.',
                 validation=(_is_float_str, 'should be a float or an int like 42.42 or 42'),
             ),

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -8,6 +8,7 @@ import aiohttp.typedefs
 
 from .tls import internal_client_ssl_context, external_client_ssl_context
 from .config.deploy_config import get_deploy_config
+from .config import ConfigVariable, configuration_of
 
 
 class ClientResponseError(aiohttp.ClientResponseError):
@@ -101,8 +102,9 @@ class ClientSession:
 
         assert 'connector' not in kwargs
 
-        if timeout is None:
-            timeout = aiohttp.ClientTimeout(total=5)
+        timeout = configuration_of(ConfigVariable.HTTP_TIMEOUT_IN_SECONDS, timeout, 5)
+        if isinstance(timeout, str):
+            timeout = float(timeout)
         if isinstance(timeout, (float, int)):
             timeout = aiohttp.ClientTimeout(total=timeout)
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -102,16 +102,23 @@ class ClientSession:
 
         assert 'connector' not in kwargs
 
-        timeout = configuration_of(ConfigVariable.HTTP_TIMEOUT_IN_SECONDS, timeout, 5)
-        if isinstance(timeout, str):
-            timeout = float(timeout)
-        if isinstance(timeout, (float, int)):
-            timeout = aiohttp.ClientTimeout(total=timeout)
+        configuration_of_timeout = configuration_of(ConfigVariable.HTTP_TIMEOUT_IN_SECONDS, timeout, 5)
+        del timeout
+
+        if isinstance(configuration_of_timeout, str):
+            configuration_of_timeout = float(configuration_of_timeout)
+        if isinstance(configuration_of_timeout, (float, int)):
+            configuration_of_timeout = aiohttp.ClientTimeout(total=configuration_of_timeout)
+        assert isinstance(configuration_of_timeout, aiohttp.ClientTimeout)
 
         self.loop = asyncio.get_running_loop()
         self.raise_for_status = raise_for_status
         self.client_session = aiohttp.ClientSession(
-            *args, timeout=timeout, raise_for_status=False, connector=aiohttp.TCPConnector(ssl=tls), **kwargs
+            *args,
+            timeout=configuration_of_timeout,
+            raise_for_status=False,
+            connector=aiohttp.TCPConnector(ssl=tls),
+            **kwargs,
         )
 
     def request(


### PR DESCRIPTION
Until we have a mechanism to infer the correct timeout based on network conditions, this provides an escape hatch for users on flaky network connections such as wifi.