### PR TITLE
Fix an error in the MatrixTable tutorial

### DIFF
--- a/hail/python/hail/docs/tutorials/07-matrixtable.ipynb
+++ b/hail/python/hail/docs/tutorials/07-matrixtable.ipynb
@@ -287,7 +287,7 @@
     }
    },
    "source": [
-    "All homozygous reference, which is not surprising.  Let's look at the distribution of genotype calls:"
+    "Let's look at the distribution of genotype calls:"
    ]
   },
   {
@@ -443,7 +443,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -457,9 +457,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
### Description

In this pull request, I fix an error in the MatrixTable tutorial. The tutorial shows some genotype data and erroneously states that all the genotypes that are shown are homozygous reference (0/0). In fact, there are also some heterozygous (0/1) and homozygous alternate (1/1) genotypes in the displayed data. In this pull request, I remove the erroneous statement.

### Testing

I ran the notebook to confirm that the notebook displays a mix of genotypes, not just homozygous reference. You can view the erroneous version of the tutorial [here](https://hail.is/docs/0.2/tutorials/07-matrixtable.html#MatrixTable-operations).