### PR TITLE
[fs] basic sync tool

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -208,6 +208,8 @@ pytest-inter-cloud: upload-remote-test-resources install-editable
           HAIL_TEST_S3_BUCKET=hail-test-dy5rg \
           HAIL_TEST_AZURE_ACCOUNT=hailtest \
           HAIL_TEST_AZURE_CONTAINER=hail-test-4nxei \
+          HAIL_TEST_AZURE_RESGRP=hail-dev \
+          HAIL_TEST_AZURE_SUBID=22cd45fe-f996-4c51-af67-ef329d977519 \
           $(HAIL_PYTHON3) -m pytest \
             -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
             --log-cli-level=INFO \

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -92,8 +92,11 @@ class S3HeadObjectFileStatus(FileStatus):
         self.head_object_resp = head_object_resp
         self._url = url
 
+    def __repr__(self):
+        return f'S3HeadObjectFileStatus({self.head_object_resp}, {self._url})'
+
     def basename(self) -> str:
-        return os.path.basename(self._url.rstrip('/'))
+        return os.path.basename(self._url)
 
     def url(self) -> str:
         return self._url
@@ -120,8 +123,11 @@ class S3ListFilesFileStatus(FileStatus):
         self._item = item
         self._url = url
 
+    def __repr__(self):
+        return f'S3ListFilesFileStatus({self._item}, {self._url})'
+
     def basename(self) -> str:
-        return os.path.basename(self._url.rstrip('/'))
+        return os.path.basename(self._url)
 
     def url(self) -> str:
         return self._url
@@ -194,8 +200,15 @@ class S3FileListEntry(FileListEntry):
         self._item = item
         self._status: Optional[S3ListFilesFileStatus] = None
 
+    def __repr__(self):
+        return f'S3FileListEntry({self._bucket}, {self._key}, {self._item})'
+
     def basename(self) -> str:
-        return os.path.basename(self._key.rstrip('/'))
+        object_name = self._key
+        if self._is_dir():
+            assert object_name[-1] == '/'
+            object_name = object_name[:-1]
+        return os.path.basename(object_name)
 
     async def url(self) -> str:
         return f's3://{self._bucket}/{self._key}'
@@ -203,8 +216,11 @@ class S3FileListEntry(FileListEntry):
     async def is_file(self) -> bool:
         return self._item is not None
 
-    async def is_dir(self) -> bool:
+    def _is_dir(self) -> bool:
         return self._item is None
+
+    async def is_dir(self) -> bool:
+        return self._is_dir()
 
     async def status(self) -> FileStatus:
         if self._status is None:

--- a/hail/python/hailtop/aiotools/plan.py
+++ b/hail/python/hailtop/aiotools/plan.py
@@ -1,0 +1,331 @@
+from typing import List, Tuple, Optional
+import asyncio
+import os
+import sys
+from contextlib import AsyncExitStack
+from hailtop.aiotools import FileAndDirectoryError
+
+from .router_fs import RouterAsyncFS
+from .fs import FileListEntry, FileStatus, AsyncFS, WritableStream
+from ..utils.rich_progress_bar import CopyToolProgressBar, Progress
+
+try:
+    import uvloop
+
+    uvloop_install = uvloop.install
+except ImportError as e:
+    if not sys.platform.startswith('win32'):
+        raise e
+
+    def uvloop_install():
+        pass
+
+
+class PlanError(ValueError):
+    pass
+
+
+async def plan(
+    folder: str,
+    copy_to: List[Tuple[str, str]],
+    copy_into: List[Tuple[str, str]],
+    gcs_requester_pays_project: Optional[str],
+    verbose: bool,
+    max_parallelism: int,
+):
+    if gcs_requester_pays_project:
+        gcs_kwargs = {'gcs_requester_pays_configuration': gcs_requester_pays_project}
+    else:
+        gcs_kwargs = {}
+
+    total_n_files = 0
+    total_n_bytes = 0
+
+    async with AsyncExitStack() as cleanups:
+        fs = await cleanups.enter_async_context(RouterAsyncFS(gcs_kwargs=gcs_kwargs))
+        source_destination_pairs = [
+            *copy_to,
+            *((src, copied_into_path(fs, source_path=src, folder_path=dst)) for src, dst in copy_into),
+        ]
+
+        if any(await asyncio.gather(fs.isfile(folder), fs.isdir(folder.rstrip('/') + '/'))):
+            raise PlanError(f'plan folder already exists: {folder}', 1)
+
+        await fs.mkdir(folder)
+        matches = await cleanups.enter_async_context(await fs.create(os.path.join(folder, 'matches')))
+        differs = await cleanups.enter_async_context(await fs.create(os.path.join(folder, 'differs')))
+        srconly = await cleanups.enter_async_context(await fs.create(os.path.join(folder, 'srconly')))
+        dstonly = await cleanups.enter_async_context(await fs.create(os.path.join(folder, 'dstonly')))
+        plan = await cleanups.enter_async_context(await fs.create(os.path.join(folder, 'plan')))
+
+        progress = cleanups.enter_context(CopyToolProgressBar(transient=True, disable=not verbose))
+
+        for src, dst in source_destination_pairs:
+            n_files, n_bytes = await find_all_copy_pairs(
+                fs,
+                matches,
+                differs,
+                srconly,
+                dstonly,
+                plan,
+                src,
+                dst,
+                progress,
+                asyncio.Semaphore(max_parallelism),
+                source_must_exist=True,
+            )
+            total_n_files += n_files
+            total_n_bytes += n_bytes
+
+        summary = await cleanups.enter_async_context(await fs.create(os.path.join(folder, 'summary')))
+        await summary.write((f'{total_n_files}\t{total_n_bytes}\n').encode('utf-8'))
+
+
+def copied_into_path(fs: AsyncFS, *, source_path: str, folder_path: str) -> str:
+    src_url = fs.parse_url(source_path)
+    dest_url = fs.parse_url(folder_path)
+    src_basename = os.path.basename(src_url.path.rstrip('/'))
+    return str(dest_url.with_new_path_component(src_basename))
+
+
+class FileStat:
+    def __init__(self, basename, url, is_dir, size):
+        self.basename = basename
+        self.url = url
+        self.is_dir = is_dir
+        self.size = size
+
+    def __repr__(self) -> str:
+        return f'FileStat({self.basename}, {self.url}, {self.is_dir}, {self.size})'
+
+    @staticmethod
+    async def from_file_list_entry(x: FileListEntry) -> 'FileStat':
+        url, is_dir = await asyncio.gather(x.url(), x.is_dir())
+        if is_dir:
+            size = 0
+        else:
+            size = await (await x.status()).size()
+        return FileStat(x.basename(), url, is_dir, size)
+
+    @staticmethod
+    async def from_file_status(x: FileStatus) -> 'FileStat':
+        return FileStat(x.basename(), x.url(), False, await x.size())
+
+
+async def listfiles(fs: AsyncFS, x: str) -> List[FileStat]:
+    try:
+        it = await fs.listfiles(x)
+        return [await FileStat.from_file_list_entry(x) async for x in it]
+    except (FileNotFoundError, NotADirectoryError):
+        return []
+
+
+async def statfile(fs: AsyncFS, x: str) -> Optional[FileStat]:
+    try:
+        file_status = await fs.statfile(x)
+        return await FileStat.from_file_status(file_status)
+    except FileNotFoundError:
+        return None
+
+
+async def writeline(file: WritableStream, *columns: str):
+    await file.write(('\t'.join(columns) + '\n').encode('utf-8'))
+
+
+def relativize_url(folder: str, file: str) -> str:
+    if folder[-1] != '/':
+        folder = folder + '/'
+    relative_path = file.removeprefix(folder)
+    assert relative_path[0] != '/'
+    return relative_path
+
+
+async def find_all_copy_pairs(
+    fs: AsyncFS,
+    matches: WritableStream,
+    differs: WritableStream,
+    srconly: WritableStream,
+    dstonly: WritableStream,
+    plan: WritableStream,
+    src: str,
+    dst: str,
+    progress: Progress,
+    sema: asyncio.Semaphore,
+    source_must_exist: bool,
+) -> Tuple[int, int]:
+    async with sema:
+        srcstat, srcfiles, dststat, dstfiles = await asyncio.gather(
+            statfile(fs, src),
+            listfiles(fs, src),
+            statfile(fs, dst),
+            listfiles(fs, dst),
+        )
+
+        if srcstat:
+            if srcstat.url[-1] == '/':
+                if srcstat.size == 0:
+                    srcstat = None
+                    if srcfiles:
+                        print(f'Not copying size-zero source file which shares a name with a source directory. {src}')
+                    else:
+                        print(f'Not copying size-zero source file whose name looks like a directory. {src}')
+                else:
+                    raise PlanError(
+                        f'Source is a non-size-zero file whose name looks like a directory. This is not supported. {src} {srcstat}',
+                        1,
+                    )
+            elif srcfiles:
+                raise PlanError(
+                    f'Source is both a directory and a file (other than a size-zero file whose name ends in "/"). '
+                    f'This is not supported. {src} {srcstat}',
+                    1,
+                ) from FileAndDirectoryError(src)
+        if dststat:
+            if dststat.url[-1] == '/':
+                if dststat.size == 0:
+                    dststat = None
+                    if dstfiles:
+                        print(
+                            f'Ignoring size-zero destination file which shares a name with a destination directory. {dst}'
+                        )
+                    else:
+                        print(f'Ignoring size-zero destination file whose name looks like a directory. {dst}')
+                else:
+                    raise PlanError(
+                        f'Destination is a non-size-zero file whose name looks like a directory. This is not supported. {dst} {dststat}',
+                        1,
+                    )
+            elif dstfiles:
+                raise PlanError(
+                    f'Destination identifies both a directory and a file (other than a size-zero file whose name ends '
+                    f'in "/"). This is not supported. {dst} {dststat}',
+                    1,
+                ) from FileAndDirectoryError(dst)
+        if srcstat and dstfiles:
+            raise PlanError(
+                f'Source is a file but destination is a directory. This is not supported. {src} -> {dst}', 1
+            ) from IsADirectoryError(dst)
+        if srcfiles and dststat:
+            raise PlanError(
+                f'Source is a directory but destination is a file. This is not supported. {src} -> {dst}', 1
+            ) from IsADirectoryError(src)
+        if source_must_exist and not srcstat and not srcfiles:
+            raise PlanError(f'Source is neither a folder nor a file: {src}', 1) from FileNotFoundError(src)
+
+        if srcstat:
+            assert len(srcfiles) == 0
+            assert len(dstfiles) == 0
+
+            if dststat:
+                if srcstat.size == dststat.size:
+                    await writeline(matches, srcstat.url, dststat.url)
+                    return 0, 0
+                await writeline(differs, srcstat.url, dststat.url, str(srcstat.size), str(dststat.size))
+                return 0, 0
+            await writeline(srconly, srcstat.url)
+            await writeline(plan, srcstat.url, dst)
+            return 1, srcstat.size
+
+        srcfiles.sort(key=lambda x: x.basename)
+        dstfiles.sort(key=lambda x: x.basename)
+
+        tid = progress.add_task(description=src, total=len(srcfiles) + len(dstfiles))
+
+        srcidx = 0
+        dstidx = 0
+
+        n_files = 0
+        n_bytes = 0
+
+        async def process_child_directory(new_srcurl: str, new_dsturl: str) -> Tuple[int, int]:
+            return await find_all_copy_pairs(
+                fs,
+                matches,
+                differs,
+                srconly,
+                dstonly,
+                plan,
+                new_srcurl,
+                new_dsturl,
+                progress,
+                sema,
+                source_must_exist=False,
+            )
+
+        async def retrieve_child_directory_results(child_directory_task):
+            nonlocal n_files
+            nonlocal n_bytes
+            dir_n_files, dir_n_bytes = await child_directory_task
+            n_files += dir_n_files
+            n_bytes += dir_n_bytes
+
+        async with AsyncExitStack() as child_directory_callbacks:
+
+            def background_process_child_dir(new_srcurl: str, new_dsturl: str):
+                t = asyncio.create_task(process_child_directory(new_srcurl, new_dsturl))
+                child_directory_callbacks.push_async_callback(retrieve_child_directory_results, t)
+
+            while srcidx < len(srcfiles) and dstidx < len(dstfiles):
+                srcf = srcfiles[srcidx]
+                dstf = dstfiles[dstidx]
+                if srcf.basename == dstf.basename:
+                    if srcf.is_dir and dstf.is_dir:
+                        background_process_child_dir(srcf.url, dstf.url)
+                    elif srcf.is_dir and not dstf.is_dir:
+                        await writeline(differs, srcf.url, dstf.url, 'dir', 'file')
+                    elif not srcf.is_dir and dstf.is_dir:
+                        await writeline(differs, srcf.url, dstf.url, 'file', 'dir')
+                    elif srcf.size == dstf.size:
+                        await writeline(matches, srcf.url, dstf.url)
+                    else:
+                        await writeline(differs, srcf.url, dstf.url, str(srcf.size), str(dstf.size))
+                    dstidx += 1
+                    srcidx += 1
+                    progress.update(tid, advance=2)
+                elif srcf.basename < dstf.basename:
+                    if srcf.is_dir:
+                        background_process_child_dir(
+                            srcf.url,
+                            os.path.join(dst, relativize_url(folder=src, file=srcf.url)),
+                        )
+                    else:
+                        await writeline(srconly, srcf.url)
+                        await writeline(plan, srcf.url, os.path.join(dst, srcf.basename))
+                        n_files += 1
+                        n_bytes += srcf.size
+                    srcidx += 1
+                    progress.update(tid, advance=1)
+                else:
+                    assert srcf.basename >= dstf.basename
+                    dstidx += 1
+                    progress.update(tid, advance=1)
+                    await writeline(dstonly, dstf.url)
+
+            while srcidx < len(srcfiles):
+                srcf = srcfiles[srcidx]
+
+                if srcf.is_dir:
+                    background_process_child_dir(
+                        srcf.url,
+                        os.path.join(dst, relativize_url(folder=src, file=srcf.url)),
+                    )
+                else:
+                    await writeline(srconly, srcf.url)
+                    await writeline(plan, srcf.url, os.path.join(dst, srcf.basename))
+                    n_files += 1
+                    n_bytes += srcf.size
+                srcidx += 1
+                progress.update(tid, advance=1)
+
+            while dstidx < len(dstfiles):
+                dstf = dstfiles[dstidx]
+
+                await writeline(dstonly, dstf.url)
+                dstidx += 1
+                progress.update(tid, advance=1)
+
+        # a short sleep ensures the progress bar is visible for a moment to the user
+        await asyncio.sleep(0.150)
+        progress.remove_task(tid)
+
+    return n_files, n_bytes

--- a/hail/python/hailtop/aiotools/sync.py
+++ b/hail/python/hailtop/aiotools/sync.py
@@ -1,0 +1,71 @@
+from typing import Optional
+import asyncio
+import os
+import sys
+
+from .fs.copier import Transfer
+from .router_fs import RouterAsyncFS, AsyncFS
+from .copy import copy
+
+try:
+    import uvloop
+
+    uvloop_install = uvloop.install
+except ImportError as e:
+    if not sys.platform.startswith('win32'):
+        raise e
+
+    def uvloop_install():
+        pass
+
+
+class SyncError(ValueError):
+    pass
+
+
+async def sync(
+    plan_folder: str,
+    gcs_requester_pays_project: Optional[str],
+    verbose: bool,
+    max_parallelism: int,
+) -> None:
+    gcs_kwargs = {'gcs_requester_pays_configuration': gcs_requester_pays_project}
+    s3_kwargs = {'max_pool_connections': max_parallelism * 5, 'max_workers': max_parallelism}
+
+    async with RouterAsyncFS(gcs_kwargs=gcs_kwargs, s3_kwargs=s3_kwargs) as fs:
+        if not all(
+            await asyncio.gather(
+                *(
+                    fs.exists(os.path.join(plan_folder, x))
+                    for x in ('matches', 'differs', 'srconly', 'dstonly', 'plan', 'summary')
+                )
+            )
+        ):
+            raise SyncError('Run hailctl fs sync --make-plan first.', 1)
+        results = (await fs.read(os.path.join(plan_folder, 'summary'))).decode('utf-8')
+        n_files, n_bytes = (int(x) for x in results.split('\t'))
+        await copy(
+            max_simultaneous_transfers=max_parallelism,
+            local_kwargs=None,
+            gcs_kwargs=gcs_kwargs,
+            azure_kwargs={},
+            s3_kwargs=s3_kwargs,
+            transfers=[
+                Transfer(src, dst, treat_dest_as=Transfer.DEST_IS_TARGET)
+                async for src, dst in iterate_plan_file(plan_folder, fs)
+            ],
+            verbose=verbose,
+            totals=(n_files, n_bytes),
+        )
+
+
+async def iterate_plan_file(plan_folder: str, fs: AsyncFS):
+    lineno = 0
+    plan = (await fs.read(os.path.join(plan_folder, 'plan'))).decode('utf-8')
+    for line in plan.split('\n'):
+        if not line:
+            continue
+        parts = line.strip().split('\t')
+        if len(parts) != 2:
+            raise SyncError(f'Malformed plan line, {lineno}, must have exactly one tab: {line}', 1)
+        yield parts

--- a/hail/python/hailtop/hailctl/__main__.py
+++ b/hail/python/hailtop/hailctl/__main__.py
@@ -1,4 +1,6 @@
+from typing import cast
 import typer
+import click
 import os
 
 from .auth import cli as auth_cli
@@ -8,6 +10,7 @@ from .describe import describe
 from .dataproc import cli as dataproc_cli
 from .dev import cli as dev_cli
 from .hdinsight import cli as hdinsight_cli
+from .fs import cli as fs_cli
 
 
 app = typer.Typer(
@@ -69,4 +72,6 @@ app.command(help='Describe Hail Matrix Table and Table files.')(describe)
 
 
 def main():
-    app()
+    click_app = cast(click.Group, typer.main.get_command(app))
+    click_app.add_command(fs_cli.app)
+    click_app()

--- a/hail/python/hailtop/hailctl/fs/cli.py
+++ b/hail/python/hailtop/hailctl/fs/cli.py
@@ -1,0 +1,116 @@
+from typing import Optional, List, Tuple, cast
+import asyncio
+import click
+import sys
+import typer
+
+from hailtop.aiotools.plan import plan, PlanError
+from hailtop.aiotools.sync import sync as aiotools_sync, SyncError
+
+
+app_without_click = typer.Typer(
+    name='fs',
+    no_args_is_help=True,
+    help='Use cloud object stores and local filesystems.',
+    pretty_exceptions_show_locals=False,
+)
+
+
+@app_without_click.callback()
+def callback():
+    """
+    Typer app, including Click subapp
+    """
+
+
+@click.command()
+@click.option(
+    '--copy-to',
+    help='Pairs of source and destination URL. May be specified multiple times. The destination is always treated as a file. See --copy-into to copy into a directory',
+    type=(str, str),
+    required=False,
+    multiple=True,
+    default=(),
+)
+@click.option(
+    '--copy-into',
+    help='Copies the source path into the target path. The target must not be a file.',
+    type=(str, str),
+    required=False,
+    multiple=True,
+    default=(),
+)
+@click.option(
+    '-v',
+    '--verbose',
+    help='The Google project to which to charge egress costs.',
+    is_flag=True,
+    required=False,
+    default=False,
+)
+@click.option(
+    '--max-parallelism', help='The maximum number of concurrent requests.', type=int, required=False, default=75
+)
+@click.option(
+    '--make-plan',
+    help='The folder in which to create a new synchronization plan. Must not exist.',
+    type=str,
+    required=False,
+)
+@click.option('--use-plan', help='The plan to execute. Must exist.', type=str, required=False)
+@click.option(
+    '--gcs-requester-pays-project', help='The Google project to which to charge egress costs.', type=str, required=False
+)
+def sync(
+    copy_to: List[Tuple[str, str]],
+    copy_into: List[Tuple[str, str]],
+    verbose: bool,
+    max_parallelism: int,
+    make_plan: Optional[str] = None,
+    use_plan: Optional[str] = None,
+    gcs_requester_pays_project: Optional[str] = None,
+):
+    """Synchronize files between one or more pairs of locations.
+
+    If a corresponding file already exists at the destination with the same size in bytes, this
+    command will not copy it. If you want to replace files that have the exact same size in bytes,
+    delete the destination files first. THIS COMMAND DOES NOT CHECK MD5s OR SHAs!
+
+    First generate a plan with --make-plan, then use the plan with --use-plan.
+
+    Copy all the files under gs://gcs-bucket/a to s3://s3-bucket/b. For example,
+    gs://gcs-bucket/a/b/c will appear at s3://s3-bucket/b/b/c:
+
+
+
+    $ hailctl fs sync --make-plan plan1 --copy gs://gcs-bucket/a s3://s3-bucket/b
+
+
+
+    $ hailctl fs sync --use-plan plan1
+    """
+    if (make_plan is None and use_plan is None) or (make_plan is not None and use_plan is not None):
+        print('Must specify one of --make-plan or --use-plan. See hailctl fs sync --help.')
+        raise typer.Exit(1)
+
+    if make_plan:
+        try:
+            asyncio.run(plan(make_plan, copy_to, copy_into, gcs_requester_pays_project, verbose, max_parallelism))
+        except PlanError as err:
+            print('ERROR: ' + err.args[0])
+            sys.exit(err.args[1])
+    if use_plan:
+        if copy_to or copy_into:
+            print(
+                'Do not specify --copy-to or --copy-into with --use-plan. Create the plan with --make-plan then call --use-plan without any --copy-to and --copy-into.'
+            )
+            raise typer.Exit(1)
+        try:
+            asyncio.run(aiotools_sync(use_plan, gcs_requester_pays_project, verbose, max_parallelism))
+        except SyncError as err:
+            print('ERROR: ' + err.args[0])
+            sys.exit(err.args[1])
+
+
+app = cast(click.Group, typer.main.get_command(app_without_click))
+app.add_command(sync)

--- a/hail/python/test/hailtop/inter_cloud/test_hailctl_fs_sync.py
+++ b/hail/python/test/hailtop/inter_cloud/test_hailctl_fs_sync.py
@@ -1,0 +1,128 @@
+from typing import Tuple, Dict, AsyncIterator, List
+import pytest
+import os.path
+import tempfile
+import secrets
+import asyncio
+import pytest
+from hailtop.utils import url_scheme, check_exec_output
+from hailtop.aiotools import Transfer, FileAndDirectoryError, Copier, AsyncFS, FileListEntry
+
+
+from .generate_copy_test_specs import run_test_spec, create_test_file, create_test_dir
+from .test_copy import cloud_scheme, router_filesystem, fresh_dir
+
+
+@pytest.mark.asyncio
+async def test_cli_file_and_dir(router_filesystem, cloud_scheme):
+    sema, fs, bases = router_filesystem
+
+    test_dir = await fresh_dir(fs, bases, cloud_scheme)
+    plandir = await fresh_dir(fs, bases, cloud_scheme)
+    plandir2 = await fresh_dir(fs, bases, cloud_scheme)
+
+    await fs.write(f"{test_dir}file1", b"hello world\n")
+
+    await check_exec_output(
+        'hailctl',
+        'fs',
+        'sync',
+        '--make-plan',
+        plandir,
+        '--copy-to',
+        f'{test_dir}file1',
+        f'{test_dir}file2',
+        '--copy-into',
+        f'{test_dir}file1',
+        f'{test_dir}dir1',
+    )
+
+    await check_exec_output(
+        'hailctl',
+        'fs',
+        'sync',
+        '--use-plan',
+        plandir,
+    )
+
+    expected_files = [f"{test_dir}file1", f"{test_dir}file2", f"{test_dir}dir1/file1"]
+    for url in expected_files:
+        assert await fs.read(url) == b"hello world\n"
+
+    await check_exec_output(
+        'hailctl',
+        'fs',
+        'sync',
+        '--make-plan',
+        plandir2,
+        '--copy-to',
+        f'{test_dir}file1',
+        f'{test_dir}file2',
+        '--copy-into',
+        f'{test_dir}file1',
+        f'{test_dir}dir1',
+    )
+    assert await fs.read(plandir2 + 'differs') == b''
+    assert await fs.read(plandir2 + 'dstonly') == b''
+    assert await fs.read(plandir2 + 'srconly') == b''
+
+
+@pytest.mark.asyncio
+async def test_cli_subdir(router_filesystem, cloud_scheme):
+    sema, fs, bases = router_filesystem
+
+    test_dir = await fresh_dir(fs, bases, cloud_scheme)
+    plandir = await fresh_dir(fs, bases, cloud_scheme)
+    plandir2 = await fresh_dir(fs, bases, cloud_scheme)
+
+    await fs.makedirs(f"{test_dir}dir")
+    await fs.makedirs(f"{test_dir}dir/subdir")
+    await fs.write(f"{test_dir}dir/subdir/file1", b"hello world\n")
+
+    await check_exec_output(
+        'hailctl', 'fs', 'sync', '--make-plan', plandir, '--copy-to', f'{test_dir}dir', f'{test_dir}dir2'
+    )
+
+    await check_exec_output(
+        'hailctl',
+        'fs',
+        'sync',
+        '--use-plan',
+        plandir,
+    )
+
+    assert await fs.read(f"{test_dir}dir2/subdir/file1") == b"hello world\n"
+
+    await check_exec_output(
+        'hailctl', 'fs', 'sync', '--make-plan', plandir2, '--copy-to', f'{test_dir}dir', f'{test_dir}dir2'
+    )
+
+    assert await fs.read(plandir2 + 'plan') == b''
+    assert await fs.read(plandir2 + 'summary') == b'0\t0\n'
+    assert await fs.read(plandir2 + 'differs') == b''
+    assert await fs.read(plandir2 + 'dstonly') == b''
+    assert await fs.read(plandir2 + 'srconly') == b''
+    assert await fs.read(plandir2 + 'matches') == f'{test_dir}dir/subdir/file1\t{test_dir}dir2/subdir/file1\n'.encode()
+
+
+@pytest.mark.asyncio
+async def test_cli_already_synced(router_filesystem, cloud_scheme):
+    sema, fs, bases = router_filesystem
+
+    test_dir = await fresh_dir(fs, bases, cloud_scheme)
+    plandir = await fresh_dir(fs, bases, cloud_scheme)
+
+    await fs.makedirs(f"{test_dir}dir")
+    await fs.write(f"{test_dir}dir/foo", b"hello world\n")
+    await fs.write(f"{test_dir}bar", b"hello world\n")
+
+    await check_exec_output(
+        'hailctl', 'fs', 'sync', '--make-plan', plandir, '--copy-to', f'{test_dir}dir/foo', f'{test_dir}bar'
+    )
+
+    assert await fs.read(plandir + 'plan') == b''
+    assert await fs.read(plandir + 'summary') == b'0\t0\n'
+    assert await fs.read(plandir + 'differs') == b''
+    assert await fs.read(plandir + 'dstonly') == b''
+    assert await fs.read(plandir + 'srconly') == b''
+    assert await fs.read(plandir + 'matches') == f'{test_dir}dir/foo\t{test_dir}bar\n'.encode()


### PR DESCRIPTION
CHANGELOG: Introduce `hailctl fs sync` which robustly transfers one or more files between Amazon S3, Azure Blob Storage, and Google Cloud Storage.

There are really two distinct conceptual changes remaining here. Given my waning time available, I am not going to split them into two pull requests. The changes are:

1. `basename` always agrees with the the [`basename` UNIX utility](https://en.wikipedia.org/wiki/Basename). In particular, the folder `/foo/bar/baz/`'s basename is *not* `''` it is `'baz'`. The only folders or objects whose basename is `''` are objects whose name literally ends in a slash, e.g. an *object* named `gs://foo/bar/baz/`.

2. `hailctl fs sync`, a robust copying tool with a user-friendly CLI.

`hailctl fs sync` comprises two pieces: `plan.py` and `sync.py`. The latter, `sync.py` is simple: it delegates to our existing copy infrastructure. That copy infastructure has been lightly modified to support this use-case. The former, `plan.py`, is concurrent file system `diff`.

`plan.py` generates and `sync.py` consumes a "plan folder" containing these files:

1. `matches` files whose names and sizes match. Two columns: source URL, destination URL.

2. `differs` files or folders whose names match but either differ in size or differ in type. Four columns: source URL, destination URL, source state, destination state. The states are either: `file`, `dif`, or a size. If either state is a size, both states are sizes.

3. `srconly` files only present in the source. One column: source URL.

4. `dstonly` files only present in the destination. One column: destination URL.

5. `plan` a proposed set of object-to-object copies. Two columns: source URL, destination URL.

6. `sumary` a one-line file containing the total number of copies in plan and the total number of bytes which would be copied.

As described in the CLI documentation, the intended use of these commands is:

```
hailctl fs sync --make-plan plan1 --copy gs://gcs-bucket/a s3://s3-bucket/b
hailctl fs sync --use-plan plan1
```

The first command generates a plan folder and the second command executes the plan. Separating this process into two commands allows the user to verify what exactly will be copied including the exact destination URLs. Moreover, if `hailctl fs sync --use-plan` fails, the user can re-run `hailctl fs sync --make-plan` to generate a new plan which will avoid copying already successfully copied files. Moreover, the user can re-run `hailctl fs sync --make-plan` to verify that every file was indeed successfully copied.

Testing. This change has a few sync-specific tests but largely reuses the tests for `hailtop.aiotools.copy`.

Future Work. Propagating a consistent kind of hash across all clouds and using that for detecting differences is a better solution than the file-size based difference used here. If all the clouds always provided the same type of hash value, this would be trivial to add. Alas, at time of writing, S3 and Google both support CRC32C for every blob (though, in S3, you must explicitly request it at object creation time), but *Azure Blob Storage does not*. ABS only supports MD5 sums which Google does not support for multi-part uploads.