### PR TITLE
[batch] Drop redunant port mapping on worker container run

### DIFF
--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -284,7 +284,6 @@ docker run \
 -v /sys/fs/cgroup:/sys/fs/cgroup \
 --mount type=bind,source=/mnt/disks/$WORKER_DATA_DISK_NAME,target=/host \
 --mount type=bind,source=/dev,target=/dev,bind-propagation=rshared \
--p 5000:5000 \
 --device /dev/fuse \
 --device $XFS_DEVICE \
 --device /dev \

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -329,7 +329,6 @@ docker run \
 -v /sys/fs/cgroup:/sys/fs/cgroup \
 --mount type=bind,source=/mnt/disks/$WORKER_DATA_DISK_NAME,target=/host \
 --mount type=bind,source=/dev,target=/dev,bind-propagation=rshared \
--p 5000:5000 \
 --device /dev/fuse \
 --device $XFS_DEVICE \
 --device /dev \


### PR DESCRIPTION
Fixes #14262

Ever since starting to control job network namespaces ourselves, we run the worker container with `--network host`. But running with the host's network namespace means there's no need (nor meaning) to use port forwarding rules with `-p`. Docker safely ignores this redundant setting but emit some log messages like:

```
WARNING: Published ports are discarded when using host network mode
```

The solution here is to just remove the old port publishing settings.