### PR TITLE
[batch] Do not log user errors as exceptions

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1877,8 +1877,9 @@ class DockerJob(Job):
             raise
         except ContainerDeletedError as exc:
             log.info(f'Container {container} was deleted while running.', exc)
-        except Exception:
-            log.exception(f'While running container: {container}')
+        except Exception as e:
+            if not user_error(e):
+                log.exception(f'While running container: {container}')
 
     async def run(self):
         async with self.worker.cpu_sem(self.cpu_in_mcpu):


### PR DESCRIPTION
The current lack of this guard means we log exceptions when users submit jobs with images that don't exist or when users cancel their jobs (`ContainerDeletedError`). We do this check elsewhere but looks like this line slipped through.