### PR TITLE
[infra] Make CI an admin of the artifact registry

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3937,6 +3937,7 @@ steps:
     scopes:
       - deploy
     script: |
+      gcloud auth activate-service-account --key-file=/gsa-key/key.json
       gcloud artifacts repositories set-cleanup-policies hail \
         --project={{ global.gcp_project }} \
         --location=us \

--- a/infra/gcp-broad/ci/main.tf
+++ b/infra/gcp-broad/ci/main.tf
@@ -41,7 +41,7 @@ resource "google_storage_bucket" "bucket" {
 
 resource "google_storage_bucket_iam_member" "ci_bucket_admin" {
   bucket = google_storage_bucket.bucket.name
-  role = "roles/storage.legacyBucketWriter"
+  role = "roles/storage.objectAdmin"
   member = "serviceAccount:${var.ci_email}"
 }
 

--- a/infra/gcp-broad/ci/main.tf
+++ b/infra/gcp-broad/ci/main.tf
@@ -16,6 +16,7 @@ resource "google_storage_bucket" "bucket" {
   location = var.bucket_location
   force_destroy = false
   storage_class = var.bucket_storage_class
+  uniform_bucket_level_access = true
   labels = {
     "name" = "hail-ci-${random_string.hail_ci_bucket_suffix.result}"
   }

--- a/infra/gcp-broad/gcs_bucket/main.tf
+++ b/infra/gcp-broad/gcs_bucket/main.tf
@@ -7,4 +7,5 @@ resource "google_storage_bucket" "bucket" {
   location = var.location
   force_destroy = true
   storage_class = var.storage_class
+  uniform_bucket_level_access = true
 }

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -853,7 +853,7 @@ resource "kubernetes_cluster_role_binding" "batch" {
   }
 }
 
-resource "kubernetes_pod_disruption_budget" "kube_dns_pdb" {
+resource "kubernetes_pod_disruption_budget_v1" "kube_dns_pdb" {
   metadata {
     name = "kube-dns"
     namespace = "kube-system"
@@ -868,7 +868,7 @@ resource "kubernetes_pod_disruption_budget" "kube_dns_pdb" {
   }
 }
 
-resource "kubernetes_pod_disruption_budget" "kube_dns_autoscaler_pdb" {
+resource "kubernetes_pod_disruption_budget_v1" "kube_dns_autoscaler_pdb" {
   metadata {
     name = "kube-dns-autoscaler"
     namespace = "kube-system"
@@ -883,7 +883,7 @@ resource "kubernetes_pod_disruption_budget" "kube_dns_autoscaler_pdb" {
   }
 }
 
-resource "kubernetes_pod_disruption_budget" "event_exporter_pdb" {
+resource "kubernetes_pod_disruption_budget_v1" "event_exporter_pdb" {
   metadata {
     name = "event-exporter"
     namespace = "kube-system"

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -438,15 +438,6 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_bat
   member = "serviceAccount:${google_service_account.batch_agent.email}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_repo_admin" {
-  provider = google-beta
-  project = var.gcp_project
-  repository = google_artifact_registry_repository.repository.name
-  location = var.artifact_registry_location
-  role = "roles/artifactregistry.repoAdmin"
-  member = "serviceAccount:${module.ci_gsa_secret.email}"
-}
-
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_admin" {
   provider = google-beta
   project = var.gcp_project

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -438,12 +438,21 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_bat
   member = "serviceAccount:${google_service_account.batch_agent.email}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_admin" {
+resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_repo_admin" {
   provider = google-beta
   project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.artifact_registry_location
   role = "roles/artifactregistry.repoAdmin"
+  member = "serviceAccount:${module.ci_gsa_secret.email}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_admin" {
+  provider = google-beta
+  project = var.gcp_project
+  repository = google_artifact_registry_repository.repository.name
+  location = var.artifact_registry_location
+  role = "roles/artifactregistry.admin"
   member = "serviceAccount:${module.ci_gsa_secret.email}"
 }
 

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "4.32.0"
+      version = "5.15.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -438,12 +438,12 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_bat
   member = "serviceAccount:${google_service_account.batch_agent.email}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_viewer" {
+resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_admin" {
   provider = google-beta
   project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.artifact_registry_location
-  role = "roles/artifactregistry.reader"
+  role = "roles/artifactregistry.repoAdmin"
   member = "serviceAccount:${module.ci_gsa_secret.email}"
 }
 
@@ -525,15 +525,6 @@ module "ci_gsa_secret" {
   iam_roles = [
     "cloudprofiler.agent",
   ]
-}
-
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_viewer" {
-  provider = google-beta
-  project = var.gcp_project
-  repository = google_artifact_registry_repository.repository.name
-  location = var.artifact_registry_location
-  role = "roles/artifactregistry.reader"
-  member = "serviceAccount:${module.ci_gsa_secret.email}"
 }
 
 module "testns_ci_gsa_secret" {
@@ -811,7 +802,7 @@ resource "google_storage_bucket" "hail_test_requester_pays_bucket" {
 }
 
 resource "google_dns_managed_zone" "dns_zone" {
-  description = ""
+  description = "hail managed dns zone"
   name = "hail"
   dns_name = "hail."
   visibility = "private"


### PR DESCRIPTION
If CI jobs are to apply cleanup policies to the Artifact Registry, CI needs to have the permissions on the AR to do so. Prior to this change, CI only had viewer on the AR and used a different service account named `gcr-push` to push images to the registry. I don't see the point in having this second service account and think that CI should have these permissions (because it basically does already if it can submit jobs with the `gcr-push` service account). So the main point of this PR is to give CI admin on the AR, and then we can follow up by deleting the `gcr-push` service account.

Separately:

Not sure how this ever worked, but I needed to update the google terraform provider to get `cleanup_policy_dry_run = false`. That upgrade now made the DNS zone description mandatory so I added one. I thin the DNS zone is no longer used, but removing it is for another time. There was also for some reason a duplicate resource for CI's viewer role on the AR repo, so I changed one to admin and deleted the other.

cc @ehigham 