### PR TITLE
[release] remove unused old stuff

### DIFF
--- a/hail/scripts/release.sh
+++ b/hail/scripts/release.sh
@@ -134,11 +134,6 @@ wheel_for_azure_url=gs://hail-common/azure-hdinsight-wheels/$(basename $WHEEL_FO
 gcloud storage cp $WHEEL_FOR_AZURE $wheel_for_azure_url
 gcloud storage objects update $wheel_for_azure_url --temporary-hold
 
-# update docs sha
-cloud_sha_location=gs://hail-common/builds/0.2/latest-hash/cloudtools-5-spark-2.4.0.txt
-printf "$GIT_VERSION" | gcloud storage cp  - $cloud_sha_location
-gcloud storage objects update -r $cloud_sha_location --add-acl-grant=entity=AllUsers,role=READER
-
 # deploy datasets (annotation db) json
 datasets_json_url=gs://hail-common/annotationdb/$HAIL_VERSION/datasets.json
 gcloud storage cp python/hail/experimental/datasets.json $datasets_json_url


### PR DESCRIPTION
cloudtools is an ancient name for hailctl dataproc. This is not the docs SHA. The docs are copied into a Docker image by the `website_image` build step. The only special file is gs://hail-common/builds/0.1/docs/hail-0.1-docs-5a6778710097.tar.gz which was the last 0.1 docs. It is the one that we host on the website for posterity.