### PR TITLE
[fs] Refresh blob client on every range read

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -273,12 +273,9 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
   }
 
   def openNoCompression(url: URL): SeekableDataInputStream = handlePublicAccessError(url) {
-    val blobClient: BlobClient = getBlobClient(url)
-    val blobSize = blobClient.getProperties.getBlobSize
+    val blobSize = getBlobClient(url).getProperties.getBlobSize
 
     val is: SeekableInputStream = new FSSeekableInputStream {
-      private[this] val client: BlobClient = blobClient
-
       val bbOS = new OutputStream {
         override def write(b: Array[Byte]): Unit = bb.put(b)
         override def write(b: Int): Unit = bb.put(b.toByte)
@@ -296,7 +293,7 @@ class AzureStorageFS(val credentialsJSON: Option[String] = None) extends FS {
 
         val response = retryTransientErrors {
           bb.clear()
-          client.downloadStreamWithResponse(
+          getBlobClient(url).downloadStreamWithResponse(
             bbOS,
             new BlobRange(pos, count),
             null,


### PR DESCRIPTION
In anticipation of terra where we will need to refresh SAS tokens with WSM, this change grabs a blob client on every range read instead of stashing one from the first read. This gives the opportunity for `get_blob_client` to refresh expired credentials and create a new blob client in circumstances where we are streaming through large data.