### PR TITLE
[algolia] also update the search bar on the docs page

### DIFF
--- a/website/website/templates/nav-bottom.html
+++ b/website/website/templates/nav-bottom.html
@@ -59,7 +59,8 @@
     };
 
     docsearch({
-      apiKey: 'd2dee24912091336c40033044c9bac58',
+      appId: 'SWB3TKBY4S',
+      apiKey: '313905b758e55f2aed5d9fe2fd9d0807',
       indexName: 'hail_is',
       inputSelector: '#search',
       debug: false, // hide on blur


### PR DESCRIPTION
Apparently the last change I made only updated the search on the home page. Grep for `d2dee24912091336c40033044c9bac58` now returns no results on our repo.