### PR TITLE
[tutorials] fix broken link to joins tutorial

### DIFF
--- a/hail/python/hail/docs/tutorials/07-matrixtable.ipynb
+++ b/hail/python/hail/docs/tutorials/07-matrixtable.ipynb
@@ -26,7 +26,7 @@
     }
    },
    "source": [
-    "In the last example of the [Table Joins Tutorial](https://hail.is/docs/0.2/tutorials/08-joins.html), the ratings table had a compound key: `movie_id` and `user_id`.  The ratings were secretly a movie-by-user matrix!\n",
+    "In the last example of the [Table Joins Tutorial](https://hail.is/docs/0.2/tutorials/06-joins.html), the ratings table had a compound key: `movie_id` and `user_id`.  The ratings were secretly a movie-by-user matrix!\n",
     "\n",
     "However, since this matrix is very sparse, it is reasonably represented in a so-called \"coordinate form\" `Table`, where each row of the table is an entry of the sparse matrix. For large and dense matrices (like sequencing data), the per-row overhead of coordinate reresentations is untenable. That's why we built `MatrixTable`, a 2-dimensional generalization of `Table`."
    ]


### PR DESCRIPTION
This is hard to keep valid without automatically verifiying our tutorials do not have broken links.