### PR TITLE
[infra] Use https instead of hail-az in service configs

### DIFF
--- a/infra/azure/modules/batch/outputs.tf
+++ b/infra/azure/modules/batch/outputs.tf
@@ -1,9 +1,9 @@
 output batch_logs_storage_uri {
-  value = "hail-az://${azurerm_storage_account.batch.name}/${azurerm_storage_container.batch_logs.name}"
+  value = "https://${azurerm_storage_account.batch.name}.blob.core.windows.net/${azurerm_storage_container.batch_logs.name}"
 }
 
 output query_storage_uri {
-  value = "hail-az://${azurerm_storage_account.batch.name}/${azurerm_storage_container.query.name}"
+  value = "https://${azurerm_storage_account.batch.name}.blob.core.windows.net/${azurerm_storage_container.query.name}"
 }
 
 output test_storage_container {
@@ -11,7 +11,7 @@ output test_storage_container {
 }
 
 output test_storage_uri {
-  value = "hail-az://${azurerm_storage_account.test.name}/${azurerm_storage_container.test.name}"
+  value = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}"
 }
 
 output ci_principal_id {

--- a/infra/azure/modules/ci/main.tf
+++ b/infra/azure/modules/ci/main.tf
@@ -49,7 +49,7 @@ resource "azurerm_role_assignment" "ci_test_container_contributor" {
 module "k8s_resources" {
   source = "../../../k8s/ci"
 
-  storage_uri                             = "hail-az://${azurerm_storage_account.ci.name}/${azurerm_storage_container.ci_artifacts.name}"
+  storage_uri                             = "https://${azurerm_storage_account.ci.name}.blob.core.windows.net/${azurerm_storage_container.ci_artifacts.name}"
   deploy_steps                            = var.deploy_steps
   watched_branches                        = var.watched_branches
   github_context                          = var.github_context


### PR DESCRIPTION
If this looks good I will apply it before merging. Once this is in we can fully drop support for `hail-az`.