### PR TITLE
[ci] Use the public networks where possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CHECK_SERVICES_MODULES := $(patsubst %, check-%, $(SERVICES_MODULES))
 SPECIAL_IMAGES := hail-ubuntu batch-worker letsencrypt
 
 HAILGENETICS_IMAGES = $(foreach img,hail vep-grch37-85 vep-grch38-95,hailgenetics-$(img))
-CI_IMAGES = ci-utils ci-buildkit base hail-run
+CI_IMAGES = ci-utils hail-buildkit base hail-run
 PRIVATE_REGISTRY_IMAGES = $(patsubst %, pushed-private-%-image, $(SPECIAL_IMAGES) $(SERVICES_PLUS_ADMIN_POD) $(CI_IMAGES) $(HAILGENETICS_IMAGES))
 
 HAILTOP_VERSION := hail/python/hailtop/hail_version

--- a/build.yaml
+++ b/build.yaml
@@ -412,6 +412,7 @@ steps:
       name: admin
       namespace:
         valueFrom: default_ns.name
+    network: private
     runIfRequested: true
     scopes:
       - dev
@@ -584,6 +585,7 @@ steps:
       name: admin
       namespace:
         valueFrom: default_ns.name
+    network: private
     secrets:
       - name:
           valueFrom: auth_database.user_secret_name
@@ -1762,6 +1764,7 @@ steps:
       name: admin
       namespace:
         valueFrom: default_ns.name
+    network: private
     runIfRequested: true
     scopes:
       - dev
@@ -1986,6 +1989,7 @@ steps:
       name: admin
       namespace:
         valueFrom: default_ns.name
+    network: private
     runIfRequested: true
     scopes:
       - dev
@@ -2014,6 +2018,7 @@ steps:
       name: admin
       namespace:
         valueFrom: default_ns.name
+    network: private
     runIfRequested: true
     scopes:
       - dev

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -427,7 +427,6 @@ cat /home/user/trace
             resources=self.resources,
             input_files=input_files,
             parents=self.deps_parents(),
-            network='private',
             unconfined=True,
             regions=[REGION],
         )
@@ -494,7 +493,6 @@ true
             resources={'cpu': '0.25'},
             parents=parents,
             always_run=True,
-            network='private',
             timeout=5 * 60,
             regions=[REGION],
         )
@@ -515,6 +513,7 @@ class RunImageStep(Step):
         always_run,
         timeout,
         num_splits,
+        network,
     ):  # pylint: disable=unused-argument
         super().__init__(params)
         self.image = expand_value_from(image, self.input_config(params.code, params.scope))
@@ -536,6 +535,7 @@ class RunImageStep(Step):
         self.timeout = timeout
         self.jobs = []
         self.num_splits = num_splits
+        self.network = network
 
     def wrapped_job(self):
         return self.jobs
@@ -556,6 +556,7 @@ class RunImageStep(Step):
             json.get('alwaysRun', False),
             json.get('timeout', 3600),
             json.get('numSplits', 1),
+            json.get('network', 'public'),
         )
 
     def config(self, scope):  # pylint: disable=unused-argument
@@ -619,7 +620,7 @@ class RunImageStep(Step):
             parents=self.deps_parents(),
             always_run=self.always_run,
             timeout=self.timeout,
-            network='private',
+            network=self.network,
             env=env,
             regions=[REGION],
         )
@@ -629,11 +630,12 @@ class RunImageStep(Step):
 
 
 class CreateNamespaceStep(Step):
-    def __init__(self, params, namespace_name, secrets):
+    def __init__(self, params, namespace_name, secrets, network):
         super().__init__(params)
         self.namespace_name = namespace_name
         self.secrets = secrets
         self.job = None
+        self.network = network
 
         if is_test_deployment:
             assert self.namespace_name == 'default'
@@ -661,6 +663,7 @@ class CreateNamespaceStep(Step):
             params,
             json['namespaceName'],
             json.get('secrets'),
+            json.get('network', 'private'),
         )
 
     def config(self, scope):  # pylint: disable=unused-argument
@@ -765,7 +768,7 @@ date
             # FIXME configuration
             service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
             parents=self.deps_parents(),
-            network='private',
+            network=self.network,
             regions=[REGION],
         )
 
@@ -794,7 +797,7 @@ true
             service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
             parents=parents,
             always_run=True,
-            network='private',
+            network=self.network,
             regions=[REGION],
         )
 
@@ -927,7 +930,6 @@ date
             service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
             resources={'cpu': '0.25'},
             parents=self.deps_parents(),
-            network='private',
             regions=[REGION],
         )
 
@@ -954,7 +956,6 @@ date
                 resources={'cpu': '0.25'},
                 parents=parents,
                 always_run=True,
-                network='private',
                 regions=[REGION],
             )
 

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -290,6 +290,7 @@ steps:
       name: admin
       namespace:
         valueFrom: default_ns.name
+    network: private
     dependsOn:
       - default_ns
       - hello_database


### PR DESCRIPTION
`network=private` is an escape hatch for CI so certain jobs can talk to internal endpoints on our network that we do not permit user jobs to reach. In `main`, all CI jobs are hard-coded to use `private` in `build.py`, but few jobs in the CI pipeline actually require these heightened privileges. The steps in the CI pipeline are of the following types:

- `BuildImageStep`: These do not need to use the private network and have now all been made to use the public network namespaces
- `CreateDatabaseStep`: These *do* need to use `network='private'` because all our DBs only have private IPs on our internal network
- `RunImageStep`: Those steps that contact the DB need the private network. This PR makes the network configurable for these steps but default to public, so steps that need DB access explicitly do `network: private`
- `DeployStep`: These do not need to use the private network because they use the public K8s API server endpoint. Whether they should is perhaps a different question. I'm open to keeping these on the private networks and creating an issue to use the internal API server endpoint instead. We definitely have a static internal IP in GKE but I don't believe we have one for AKS and that would involve some research.
- `CreateNamespaceStep`: I don't believe that this needs the private network because it is functionally the same as a `DeployStep` in that it just talks to K8s, but I am unable to test this step in `test_ci` so I am reluctant to make a change that could brick CI. I instead made it configurable and default to its current value ('private'). We could then make a follow-up PR that tries turning it public.