### PR TITLE
[query] remove unneeded deps from memory module

### DIFF
--- a/hail/build.sc
+++ b/hail/build.sc
@@ -197,13 +197,11 @@ object main extends RootModule with HailScalaModule { outer =>
     Deps.Breeze.natives.excludeOrg("org.apache.commons.math3"),
     Deps.Commons.io,
     Deps.Commons.lang3,
-    //    ivy"org.apache.commons:commons-math3:3.6.1",
     Deps.Commons.codec,
     Deps.lz4,
     Deps.netlib,
     Deps.avro.excludeOrg("com.fasterxml.jackson.core"),
     Deps.junixsocket,
-//    Deps.zstd
   )
 
   override def compileIvyDeps: T[Agg[Dep]] = Agg(
@@ -212,7 +210,6 @@ object main extends RootModule with HailScalaModule { outer =>
     Deps.Spark.core(),
     Deps.Spark.mllib(),
     Deps.Breeze.core,
-    //      ivy"org.scalanlp::breeze-natives:1.1",
   )
 
   override def assemblyRules: Seq[Rule] = super.assemblyRules ++ Seq(
@@ -257,11 +254,6 @@ object main extends RootModule with HailScalaModule { outer =>
     override def sources: T[Seq[PathRef]] = T.sources {
       Seq(PathRef(this.millSourcePath / os.up / "src" / debugOrRelease() / "java"))
     }
-
-    override def compileIvyDeps: T[Agg[Dep]] = Agg(
-      Deps.hadoopClient,
-      Deps.samtools.excludeOrg("*"),
-    )
   }
 
   object test extends HailTests {
@@ -269,7 +261,6 @@ object main extends RootModule with HailScalaModule { outer =>
 
     override def assemblyRules: Seq[Rule] = outer.assemblyRules ++ Seq(
       Rule.Relocate("org.codehaus.jackson.**", "is.hail.relocated.@0")
-//      Rule.Relocate("org.codehaus.stax2.**", "is.hail.relocated.@0"),
     )
 
     override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Seq(


### PR DESCRIPTION
This fixes an issue which caused tests run through IntelliJ to fail due to version conflicts between dependencies.