### PR TITLE
[query] avoid orjson-caused segfault in py4j_backend.py

### DIFF
--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -98,7 +98,7 @@ multidict==6.0.4
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   yarl
-orjson==3.9.12
+orjson==3.9.11
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt

--- a/gear/requirements.txt
+++ b/gear/requirements.txt
@@ -14,4 +14,5 @@ prometheus_async>=19.2.0,<20
 prometheus_client>=0.11.0,<1
 PyMySQL>=1,<2
 sortedcontainers>=2.4.0,<3
-orjson>=3.6.4,<4
+# <3.9.12: https://github.com/hail-is/hail/issues/14299
+orjson>=3.6.4,<3.9.12

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -106,7 +106,7 @@ nest-asyncio==1.6.0
     # via -r hail/hail/python/hailtop/requirements.txt
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.9.12
+orjson==3.9.11
     # via -r hail/hail/python/hailtop/requirements.txt
 packaging==23.2
     # via msal-extensions

--- a/hail/python/hailtop/requirements.txt
+++ b/hail/python/hailtop/requirements.txt
@@ -12,7 +12,8 @@ google-auth-oauthlib>=0.5.2,<1
 humanize>=1.0.0,<2
 janus>=0.6,<1.1
 nest_asyncio>=1.5.8,<2
-orjson>=3.6.4,<4
+# <3.9.12: https://github.com/hail-is/hail/issues/14299
+orjson>=3.6.4,<3.9.12
 protobuf==3.20.2
 rich>=12.6.0,<13
 typer>=0.9.0,<1

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -187,7 +187,7 @@ oauthlib==3.2.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   requests-oauthlib
-orjson==3.9.12
+orjson==3.9.11
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt


### PR DESCRIPTION
CHANGELOG: Require `orjson<3.9.12` to avoid a segfault introduced in orjson 3.9.12.

See https://github.com/hail-is/hail/issues/14299 for details.