### PR TITLE
[ci] Use CI's credentials for image pushing instead of gcr-push

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -39,7 +39,6 @@ steps:
     namespaceName: default
     secrets:
       - name: auth-oauth2-client-secret
-      - name: registry-push-credentials
       - name: hail-ci-0-1-github-oauth-token
       - name: testns-test-gsa-key
       - name: testns-test-dev-gsa-key
@@ -79,11 +78,11 @@ steps:
       REGISTRY={{ global.docker_prefix.split('/')[0] }}
 
       {% if global.cloud == "gcp" %}
-      cat /registry-push-credentials/credentials.json | base64 -w 0 | skopeo login -u _json_key_base64 --password-stdin $REGISTRY
+      cat $GOOGLE_APPLICATION_CREDENTIALS | base64 -w 0 | skopeo login -u _json_key_base64 --password-stdin $REGISTRY
       {% elif global.cloud == "azure" %}
       dnf install -y jq
-      USERNAME=$(cat /registry-push-credentials/credentials.json | jq -jr '.appId')
-      cat /registry-push-credentials/credentials.json | jq -jr '.password' | skopeo login -u $USERNAME --password-stdin $REGISTRY
+      USERNAME=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -jr '.appId')
+      cat $AZURE_APPLICATION_CREDENTIALS | jq -jr '.password' | skopeo login -u $USERNAME --password-stdin $REGISTRY
       {% else %}
       echo "unknown cloud {{ global.cloud }}"
       exit 1
@@ -94,11 +93,6 @@ steps:
     inputs:
       - from: /repo/docker
         to: /io/docker
-    secrets:
-      - name: registry-push-credentials
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /registry-push-credentials
     scopes:
       - deploy
     dependsOn:
@@ -3437,11 +3431,11 @@ steps:
 
       set +x
       {% if global.cloud == "gcp" %}
-      cat /registry-push-credentials/credentials.json | base64 -w 0 | skopeo login -u _json_key_base64 --password-stdin $REGISTRY
+      cat $GOOGLE_APPLICATION_CREDENTIALS | base64 -w 0 | skopeo login -u _json_key_base64 --password-stdin $REGISTRY
       {% elif global.cloud == "azure" %}
       dnf install -y jq
-      USERNAME=$(cat /registry-push-credentials/credentials.json | jq -jr '.appId')
-      cat /registry-push-credentials/credentials.json | jq -jr '.password' | skopeo login -u $USERNAME --password-stdin $REGISTRY
+      USERNAME=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -jr '.appId')
+      cat $AZURE_APPLICATION_CREDENTIALS | jq -jr '.password' | skopeo login -u $USERNAME --password-stdin $REGISTRY
       {% else %}
       echo "unknown cloud {{ global.cloud }}"
       exit 1
@@ -3459,11 +3453,6 @@ steps:
         to: /io/docker/hailgenetics/mirror_images.sh
       - from: /repo/docker/copy_image.sh
         to: /io/docker/copy_image.sh
-    secrets:
-      - name: registry-push-credentials
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /registry-push-credentials
     scopes:
       - deploy
       - dev

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -539,12 +539,12 @@ resource "google_storage_bucket_iam_member" "testns_ci_bucket_admin" {
   member = "serviceAccount:${module.testns_ci_gsa_secret.email}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_testns_ci_viewer" {
+resource "google_artifact_registry_repository_iam_member" "artifact_registry_testns_ci_repo_admin" {
   provider = google-beta
   project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.artifact_registry_location
-  role = "roles/artifactregistry.reader"
+  role = "roles/artifactregistry.repoAdmin"
   member = "serviceAccount:${module.testns_ci_gsa_secret.email}"
 }
 

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -512,12 +512,12 @@ resource "google_storage_bucket_iam_member" "testns_ci_bucket_admin" {
   member = "serviceAccount:${module.testns_ci_gsa_secret.email}"
 }
 
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_testns_ci_viewer" {
+resource "google_artifact_registry_repository_iam_member" "artifact_registry_testns_ci_repo_admin" {
   provider = google-beta
   project = var.gcp_project
   repository = google_artifact_registry_repository.repository.name
   location = var.gcp_location
-  role = "roles/artifactregistry.reader"
+  role = "roles/artifactregistry.repoAdmin"
   member = "serviceAccount:${module.testns_ci_gsa_secret.email}"
 }
 


### PR DESCRIPTION
CI owns the internal container registry, so there's no reason to have an additional service account that CI impersonates in order to push images. This removes uses of `registry-push-credentials` in favor of using the CI identity that already exists in the batch jobs that interact with the container registry. I've marked this as `full-deploy` because you want to roll out this change before a subsequent PR that I will make to delete the `gcr-push` identity.