### PR TITLE
[ci] Remove unused arguments to release script

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3380,9 +3380,7 @@ steps:
                               docker://{{ hailgenetics_vep_grch37_85_image.image }} \
                               docker://{{ hailgenetics_vep_grch38_95_image.image }} \
                               /io/wheel-for-azure/hail-*-py3-none-any.whl \
-                              /io/www.tar.gz \
-                              {{ global.gcp_project }} \
-                              /io/repo/infra/gcp-broad/gcp-ar-cleanup-policy.txt
+                              /io/www.tar.gz
     inputs:
       - from: /hail_version
         to: /io/hail_version

--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -55,7 +55,7 @@ critically depend on experimental functionality.**
 
 ## Version 0.2.128
 
-Released 2024-02-15
+Released 2024-02-16
 
 In GCP, the Hail Annotation DB and Datasets API have moved from multi-regional US and EU buckets to
 regional US-CENTRAL1 and EUROPE-WEST1 buckets. These buckets are requester pays which means unless


### PR DESCRIPTION
#14198 removed the GAR-related parameters to release.sh but they were still passed in in build.yaml so it refused to run.