### PR TITLE
[ci] Remove unnecessary GSA activation for GAR policy step

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3945,7 +3945,6 @@ steps:
     scopes:
       - deploy
     script: |
-      gcloud auth activate-service-account --key-file=/gsa-key/key.json
       gcloud artifacts repositories set-cleanup-policies hail \
         --project={{ global.gcp_project }} \
         --location=us \


### PR DESCRIPTION
Since recently adding metadata server support for batch jobs in GCP, `gcloud` should now "Just Work" using the CI service account in CI jobs without explicitly configuring it with a key file, so we no longer need this line. I tested that this succeeds with a dev deploy.