### PR TITLE
PC-AiR Algorithm for Partitioning

### DIFF
--- a/hail/python/hail/methods/relatedness/pc_air.py
+++ b/hail/python/hail/methods/relatedness/pc_air.py
@@ -1,0 +1,161 @@
+from typing import Union
+
+import pandas as pd
+
+import hail as hl
+from hail import CallExpression, expr_call, king, NumericExpression, MatrixTable, expr_numeric, Struct
+from hail.typecheck import typecheck
+
+
+def _partition_samples_pandas(
+    genotype: CallExpression, relatedness_threshold: float = 0.025, divergence_threshold: float = 0.025
+):
+    matrix_table = king(genotype)
+    pair_df = matrix_table.entries().to_pandas()
+    # Rename column "s_1" to "o"
+    pair_df.rename(columns={'s_1': 'o'}, inplace=True)
+    # Reorder columns
+    pair_df = pair_df[['s', 'o', 'phi']]
+    # Drop rows where "s" and "o" are the same
+    pair_df = pair_df[pair_df['s'] != pair_df['o']]
+    samples_index = pd.Index(pair_df['s'].unique(), name='s')
+
+    eta = pair_df[pair_df['phi'] > relatedness_threshold].groupby('s', sort=False)['phi'].count()
+    eta = eta.reindex(samples_index, fill_value=0)
+
+    delta = (
+        pair_df[(pair_df['phi'] < relatedness_threshold) & (pair_df['phi'] < -divergence_threshold)]
+        .groupby('s', sort=False)['phi']
+        .count()
+    )
+    delta.reindex(samples_index, fill_value=0)
+
+    gamma = pair_df[pair_df['phi'] > relatedness_threshold].groupby('s', sort=False)['phi'].sum()
+    gamma = gamma.reindex(samples_index, fill_value=0)
+
+    unrelated = set(pair_df['s'])
+    related = set()
+
+    while True:
+        max_eta = eta.max()
+
+        if max_eta == 0:
+            return unrelated, related
+
+        fraktur_T_star = eta[eta == max_eta].index
+
+        if len(fraktur_T_star) > 1:
+            min_delta = delta[delta.index.isin(fraktur_T_star)].min()
+            fraktur_T_star = delta[(delta.index.isin(fraktur_T_star)) & (delta == min_delta)].index
+
+            if len(fraktur_T_star) > 1:
+                min_gamma = gamma[gamma.index.isin(fraktur_T_star)].min()
+                fraktur_T_star = gamma[(gamma.index.isin(fraktur_T_star)) & (gamma == min_gamma)].index[0:1]
+
+        assert len(fraktur_T_star) == 1
+        unrelated -= set(fraktur_T_star)
+        related |= set(fraktur_T_star)
+
+        selected_sample = fraktur_T_star[0]
+        affected_samples = pd.Index(
+            pair_df[(pair_df['o'] == selected_sample) & (pair_df['phi'] > relatedness_threshold)]['s']
+        )
+        eta[affected_samples] -= 1
+        eta[selected_sample] = 0
+        pass
+
+
+@typecheck(genotypes=expr_call, relatedness_threshold=expr_numeric, divergence_threshold=expr_numeric)
+def _partition_samples(
+    genotypes: CallExpression,
+    relatedness_threshold: Union[int, float, NumericExpression] = 0.025,
+    divergence_threshold: Union[int, float, NumericExpression] = 0.025,
+):
+    # https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4836868/#APP2title
+    # Returns the KING-robust, between-family kinship estimates for all sample pairs
+    # TODO: The paper uses the within-family estimate for ancestral divergence
+    # TODO: The paper suggests using the within-family estimate for relatedness as well
+    pairs: MatrixTable = king(genotypes)
+    pairs = pairs.cache()
+
+    assert len(pairs.row_key) == len(pairs.col_key)
+    assert isinstance(pairs.row_key.dtype, hl.tstruct) and isinstance(pairs.col_key.dtype, hl.tstruct)
+    assert pairs.row_key.dtype.types == pairs.col_key.dtype.types
+
+    def keys_are_different():
+        return hl.any(
+            list(
+                pairs[left_field] != pairs[right_field]
+                for left_field, right_field in zip(pairs.row_key.dtype, pairs.col_key.dtype)
+            )
+        )
+
+    pairs = pairs.annotate_cols(eta=hl.agg.count_where(keys_are_different() & (pairs.phi > relatedness_threshold)))
+    pairs = pairs.annotate_cols(
+        delta=hl.agg.count_where(
+            keys_are_different() & (pairs.phi < relatedness_threshold) & (pairs.phi < -divergence_threshold)
+        )
+    )
+    pairs = pairs.annotate_cols(
+        gamma=hl.agg.sum(hl.if_else(keys_are_different() & (pairs.phi > relatedness_threshold), pairs.phi, 0))
+    )
+
+    unrelated = pairs.aggregate_cols(hl.agg.collect_as_set(pairs.col_key))
+    related = set()
+    samples = pairs.cols()
+    samples_key = samples.key
+
+    while True:
+        samples = samples.order_by(hl.desc(samples.eta), samples.delta, samples.gamma)
+        samples = samples.cache()
+        selected_sample = samples.head(1).collect()[0]
+
+        if selected_sample.eta <= 0:
+            return unrelated, related
+
+        selected_sample = Struct(**{field: selected_sample[field] for field in samples_key.dtype})
+        unrelated -= {selected_sample}
+        related |= {selected_sample}
+
+        # A sample is "affected" if the associated value of eta will change
+        # due to the removal of the selected sample from the unrelated set
+        assert len(pairs.row_key.dtype) == len(samples_key.dtype)
+        are_keys_equal = hl.all(
+            list(
+                pairs[left_field] == selected_sample[right_field]
+                for left_field, right_field in zip(pairs.row_key.dtype, samples_key.dtype)
+            )
+        )
+        affected_samples = pairs.filter_rows(are_keys_equal)
+        affected_samples = affected_samples.annotate_cols(
+            is_affected=hl.agg.any(affected_samples.phi > relatedness_threshold)
+        )
+        affected_samples = affected_samples.filter_cols(affected_samples.is_affected)
+        affected_samples = affected_samples.aggregate_cols(
+            hl.agg.collect_as_set(list(affected_samples[field] for field in affected_samples.col_key.dtype)),
+            _localize=False,
+        )
+        # Subtract 1 from eta for the affected samples
+        samples = samples.annotate(
+            eta=hl.if_else(
+                affected_samples.contains(list(samples[field] for field in samples_key.dtype)),
+                samples.eta - 1,
+                samples.eta,
+            )
+        )
+        # Set eta to 0 for the selected sample
+        are_keys_equal = hl.all(list(samples[field] == selected_sample[field] for field in samples_key.dtype))
+        samples = samples.annotate(eta=hl.if_else(are_keys_equal, 0, samples.eta))
+
+
+@typecheck(genotypes=expr_call)
+def pc_air(genotypes: CallExpression):
+    _unrelated, _related = _partition_samples(genotypes)
+    raise NotImplementedError
+
+
+if __name__ == '__main__':
+    mt = hl.read_matrix_table('../../docs/data/example.mt')
+    # mt = hl.read_matrix_table('../../../../../data/1kg.mt')
+    unrelated, related = _partition_samples(mt.GT)
+    pass

--- a/hail/python/hail/methods/relatedness/pc_air.py
+++ b/hail/python/hail/methods/relatedness/pc_air.py
@@ -11,10 +11,48 @@ def _partition_samples(
     relatedness_threshold: Union[int, float, NumericExpression] = 0.025,
     divergence_threshold: Union[int, float, NumericExpression] = 0.025,
 ):
-    # https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4836868/#APP2title
-    # Returns the KING-robust, between-family kinship estimates for all sample pairs
+    """
+    Identify a diverse subset of unrelated individuals that is representative
+    of all ancestries in the sample using the PC-AiR algorithm for partitioning.
+
+    Notes
+    -----
+    We say that two samples are **related** if their kinship coefficient is greater than the relatedness threshold.
+    Otherwise, they are **unrelated**.
+
+    This method estimates the kinship coefficient between all samples
+    using the `KING-robust, between-family kinship coefficient <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3025716/>`_
+    estimator.
+
+    This method returns an unrelated set and a related set.
+    The intersection of these sets is empty, and the union of these sets is the set of all samples.
+    Thus, the unrelated set and the related set are a **partition** of the set of all samples.
+
+    No two samples in the unrelated set are related.
+
+    The partitioning algorithm is documented in the
+    `PC-AiR paper <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4836868/#APP2title>`_.
+
+    Parameters
+    ----------
+    genotypes : :class:`.CallExpression`
+        A call expression representing the genotype calls.
+    relatedness_threshold : :obj:`int` or :obj:`float` or :class:`.NumericExpression`
+        The relatedness threshold. The default is 0.025.
+    divergence_threshold : :obj:`int` or :obj:`float` or :class:`.NumericExpression`
+        The divergence threshold. The default is 0.025.
+
+    Returns
+    -------
+    :obj:`set` of :class:`.Struct`
+        The keys of the samples in the unrelated set.
+    :obj:`set` of :class:`.Struct`
+        The keys of the samples in the related set.
+    """
+    # The variable names in this method are based on the notation in the PC-AiR paper.
     # TODO: The paper uses the within-family estimate for ancestral divergence
     # TODO: The paper suggests using the within-family estimate for relatedness as well
+    # king returns the KING-robust, between-family kinship estimates for all sample pairs
     pairs: MatrixTable = king(genotypes)
     pairs = pairs.cache()
 

--- a/hail/python/test/hail/methods/relatedness/test_pc_air.py
+++ b/hail/python/test/hail/methods/relatedness/test_pc_air.py
@@ -1,0 +1,47 @@
+import unittest
+
+import hail as hl
+from hail.methods.relatedness.pc_air import _partition_samples
+
+from test.hail.helpers import resource
+
+
+class Tests(unittest.TestCase):
+    def test_partition_samples(self):
+        plink_path = resource('fastlmmTest')
+        mt = hl.import_plink(
+            bed=f'{plink_path}.bed', bim=f'{plink_path}.bim', fam=f'{plink_path}.fam', reference_genome=None
+        )
+        unrelated, related = _partition_samples(mt.GT, 0.05)
+        unrelated = set(map(lambda x: x.s, unrelated))
+        related = set(map(lambda x: x.s, related))
+        expected_related = {
+            'cid93P0',
+            'cid389P1',
+            'cid392P1',
+            'cid104P0',
+            'cid490P1',
+            'cid47P0',
+            'cid16P0',
+            'cid96P0',
+            'cid8P0',
+            'cid62P0',
+            'cid462P1',
+            'cid381P1',
+            'cid110P0',
+            'cid396P1',
+            'cid5P0',
+            'cid390P1',
+            'cid382P1',
+            'cid448P1',
+            'cid391P1',
+            'cid467P1',
+            'cid73P0',
+            'cid121P0',
+            'cid466P1',
+            'cid32P0',
+        }
+        expected_unrelated = set(mt.col_key.s.collect()) - expected_related
+
+        self.assertEqual(expected_related, related)
+        self.assertEqual(expected_unrelated, unrelated)


### PR DESCRIPTION
### Description

This pull request implements the [PC-AiR algorithm for partitioning](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4836868/#APP2title).

I plan to use this algorithm to implement PC-AiR. I may need to make changes to the `_partition_samples` method when I implement PC-AiR. I wanted to go ahead and create this pull request in case others want to examine the code or comment on it.

### Testing

I added a unit test that serves as a basic regression test.

### Discussion

My original implementation of the partitioning algorithm followed the paper's description of the algorithm closely using Hail expressions. However, I found that this implementation was too slow. Each step of the algorithm (computing $\mathcal{T}_1$,  $\mathcal{T}_2$,  $\mathcal{T}_3$, and  $\mathcal{T}^*$) resulted in more and more IR. I found that Hail generated IR that was around 100,000 characters long (if I recall correctly) and timed-out while trying to execute it.

I then tried implementing the algorithm by sorting. This significantly improved the speed of the implementation presumably because the sort operation generates much less IR.