### PR TITLE
[infra] Remove unused registry-push-credentials secret

### DIFF
--- a/devbin/rotate_keys.py
+++ b/devbin/rotate_keys.py
@@ -91,8 +91,7 @@ class KubeSecretManager:
                 GSAKeySecret(s, 'test-dataproc-service-account-key.json')
                 for s in secrets
                 if s.metadata.name == 'test-dataproc-service-account-key'
-            ]
-            + [GSAKeySecret(s, 'credentials.json') for s in secrets if s.metadata.name == 'registry-push-credentials'],
+            ],
         )
 
     async def update_gsa_key_secret(self, secret: GSAKeySecret, key_data: str) -> GSAKeySecret:

--- a/infra/azure/modules/batch/main.tf
+++ b/infra/azure/modules/batch/main.tf
@@ -319,16 +319,6 @@ resource "azurerm_role_assignment" "ci_acr_role" {
   principal_id         = module.ci_sp.principal_id
 }
 
-resource "kubernetes_secret" "registry_push_credentials" {
-  metadata {
-    name = "registry-push-credentials"
-  }
-
-  data = {
-    "credentials.json" = jsonencode(module.ci_sp.credentials)
-  }
-}
-
 resource "azuread_application" "testns_ci" {
   display_name = "${var.resource_group.name}-testns-ci"
 }

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -412,19 +412,6 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_pus
   member = "serviceAccount:${google_service_account.gcr_push.email}"
 }
 
-# This is intended to match the secret name also used for azure credentials
-# This should ultimately be replaced by using CI's own batch-managed credentials
-# in BuildImage jobs
-resource "kubernetes_secret" "registry_push_credentials" {
-  metadata {
-    name = "registry-push-credentials"
-  }
-
-  data = {
-    "credentials.json" = base64decode(google_service_account_key.gcr_push_key.private_key)
-  }
-}
-
 module "ukbb" {
   count = var.deploy_ukbb ? 1 : 0
   source = "../k8s/ukbb"


### PR DESCRIPTION
#14301 Switched image building steps in the CI pipeline over to just using CI's own credentials instead of this special `registry-push-credentials` secret. `registry-push-credentials` is now unused in the codebase and can be removed. Will run this when the PR is approved, then merge.