### PR TITLE
[batch] Remove GOOGLE_APPLICATION_CREDENTIALS from the batch docs

### DIFF
--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -91,15 +91,6 @@ has the following prefix `us-docker.pkg.dev/<MY_PROJECT>`:
     gcloud artifacts repositories add-iam-policy-binding <REPO> \
            --member=<SERVICE_ACCOUNT_NAME> --role=roles/artifactregistry.repoAdmin
 
-If you want to run gcloud commands within your Batch jobs, the service account file is available in
-the main container with its path specified in the `$GOOGLE_APPLICATION_CREDENTIALS` environment
-variable. You can authenticate using the service account by adding
-the following line to your user code and using a Docker image that has gcloud installed.
-
-.. code-block:: sh
-
-    gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-
 
 Billing
 -------


### PR DESCRIPTION
With the introduction of the metadata server, users no longer need to explicitly activate a service account with `gcloud` and this line of code will stop working when we remove key files.