### PR TITLE
[batch] Add resource_usage endpoint for jobs

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -436,7 +436,6 @@ async def _get_job_resource_usage(app, batch_id: int, job_id: int) -> Optional[D
 async def _get_job_resource_usage_from_record(
     app, record, batch_id: int, job_id: int
 ) -> Optional[Dict[str, Optional[pd.DataFrame]]]:
-
     client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
     file_store: FileStore = app['file_store']
     batch_format_version = BatchFormatVersion(record['format_version'])

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1928,19 +1928,15 @@ async def get_job_resource_usage(request: web.Request, _, batch_id: int) -> web.
 
     job_record = await _get_job_record(request.app, batch_id, job_id)
 
-    # effectively the auth check
-    if not job_record:
-        raise web.HTTPNotFound()
-
     resources: Optional[Dict[str, Optional[pd.DataFrame]]] = await _get_job_resource_usage_from_record(
         app=request.app, record=job_record, batch_id=batch_id, job_id=job_id
     )
 
     if not resources:
         # empty response if not available yet
-        return web.json_response({})
+        return json_response({})
 
-    return web.json_response({
+    return json_response({
         stage: stage_resource.to_dict(orient='split')
         for stage, stage_resource in resources.items()
         if stage_resource is not None

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -936,6 +936,7 @@ def test_authorized_users_only():
         (session.post, '/api/v1alpha/billing_limits/foo/edit', 401),
         (session.get, '/api/v1alpha/batches/0/jobs/0', 401),
         (session.get, '/api/v1alpha/batches/0/jobs/0/log', 401),
+        (session.get, '/api/v1alpha/batches/0/jobs/0/resource_usage', 401),
         (session.get, '/api/v1alpha/batches', 401),
         (session.post, '/api/v1alpha/batches/create', 401),
         (session.post, '/api/v1alpha/batches/0/jobs/create', 401),

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -45,6 +45,19 @@ def test_job(client: BatchClient):
     assert job_log['main'] == 'test\n', str((job_log, b.debug_info()))
 
 
+def test_job_resource_usage(client: BatchClient):
+    b = create_batch(client)
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['echo', 'test'])
+    b.submit()
+
+    status = j.wait()
+    assert status['state'] == 'Success', str((status, b.debug_info()))
+
+    resource_usage = j.resource_usage()
+    if resource_usage is None:
+        assert resource_usage['main'] is not None, str((resource_usage, b.debug_info()))
+
+
 def test_job_running_logs(client: BatchClient):
     b = create_batch(client)
     j = b.create_job(DOCKER_ROOT_IMAGE, ['bash', '-c', 'echo test && sleep 300'])

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -304,6 +304,25 @@ class Job:
         resp = await self._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/attempts')
         return await resp.json()
 
+    async def resource_usage(self):
+        """
+        Get resource usage for a job, one key for each section of the task.
+        This doesn't return a dictionary of dataframes, but could be converted with:
+
+            dataframes = {
+                key: pd.DataFrame(data=values['data'], columns=values['columns'])
+                for key, values in job.resource_usage.items()
+            }
+
+        Returns:
+            dict[str, dict]: values are convertible to dataframe
+        """
+        self._raise_if_not_submitted()
+        resp = await self._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/resource_usage')
+        # note, not a dataframe, but easy to get with:
+
+        return await resp.json()
+
 
 class BatchSubmissionInfo:
     def __init__(self, used_fast_path: Optional[bool] = None):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -95,6 +95,21 @@ class Job:
     def attempts(self):
         return async_to_blocking(self._async_job.attempts())
 
+    def resource_usage(self):
+        """
+        Get resource usage for a job, one key for each section of the task.
+        This doesn't return a dictionary of dataframes, but could be converted with:
+
+            dataframes = {
+                key: pd.DataFrame(data=values['data'], columns=values['columns'])
+                for key, values in job.resource_usage.items()
+            }
+
+        Returns:
+            dict[str, dict]: values are convertible to dataframe
+        """
+        return async_to_blocking(self._async_job.resource_usage())
+
 
 class Batch:
     @staticmethod


### PR DESCRIPTION
Hi! 

I know this is out of the blue, but we would like the ability to fetch resource_usage data from an endpoint programmatically to evaluate our job performance. I thought it might be worth suggesting this upstream to see if it's something you'd like too :)

This PR:
1. Use the internal method to fetch the dataframes for a job
2. Transform the data frame to dictionary with `orient='split'`

And FWIW, here's how to convert it back into a dataframe:

```python
import pandas as pd

response = {} # response from Hail Batch
dataframes = {
    key: pd.DataFrame(data=values['data'], columns=values['columns'])
    for key, values in response.items()
}
```

I tested this in on a dev deploy and it worked pretty well, but happy to add testing if you can direct me to a place to add it.