### PR TITLE
[query] Support `!=` contig comparisons in filter intervals

### DIFF
--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -497,6 +497,10 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
 
     checkAll(ir1, ref, ref, testRows, trueIntervals, falseIntervals, naIntervals)
     checkAll(ir2, ref, ref, testRows, trueIntervals, falseIntervals, naIntervals)
+
+    val ir3 = neq(Str("chr2"), invoke("contig", TString, k))
+    checkAll(ir3, ref, ref, testRows, falseIntervals, trueIntervals, naIntervals)
+    checkAll(not(ir1), ref, ref, testRows, falseIntervals, trueIntervals, naIntervals)
   }
 
   @Test def testLocusPositionComparison(): Unit = {


### PR DESCRIPTION
Fixes: 14288
All other unsupported comparisons now return top