### PR TITLE
[batch] Use select instead of execute for retryable billing project queries

### DIFF
--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -163,7 +163,7 @@ LOCK IN SHARE MODE;
 """
 
     billing_projects = []
-    async for record in db.execute_and_fetchall(sql, tuple(args)):
+    async for record in db.select_and_fetchall(sql, tuple(args)):
         record['users'] = json.loads(record['users']) if record['users'] is not None else []
         billing_projects.append(record)
 
@@ -206,7 +206,7 @@ LOCK IN SHARE MODE;
 """
 
     billing_projects = []
-    async for record in db.execute_and_fetchall(sql, tuple(args)):
+    async for record in db.select_and_fetchall(sql, tuple(args)):
         record['users'] = json.loads(record['users']) if record['users'] is not None else []
         billing_projects.append(record)
 


### PR DESCRIPTION
`monitor_billing_updates` occasionally fails due to deadlocks on this query, but as it's read-only it should be fine to retry. Changing to `select_and_fetchall` uses read-only transactions and retries those transient errors.