### PR TITLE
[copy] Expandvars in file path names

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1434,6 +1434,7 @@ def copy_container(
     scratch: str,
     requester_pays_project: Optional[str],
     client_session: httpx.ClientSession,
+    env: Optional[List[str]],
 ) -> Container:
     assert files
     assert job.worker.fs is not None
@@ -1459,6 +1460,7 @@ def copy_container(
         volume_mounts=volume_mounts,
         user_credentials=job.credentials,
         stdin=json.dumps(files),
+        env=env,
     )
 
 
@@ -1756,6 +1758,8 @@ class DockerJob(Job):
                     self.input_volume_mounts.append(volume_mount)
                     self.output_volume_mounts.append(volume_mount)
 
+        env = [f'{var["name"]}={var["value"]}' for var in self.env]
+
         # create containers
         containers: Dict[str, Container] = {}
 
@@ -1770,6 +1774,7 @@ class DockerJob(Job):
                 self.scratch,
                 requester_pays_project,
                 client_session,
+                env=env,
             )
 
         assert self.worker.fs
@@ -1788,7 +1793,7 @@ class DockerJob(Job):
             timeout=job_spec.get('timeout'),
             unconfined=job_spec.get('unconfined'),
             volume_mounts=self.main_volume_mounts,
-            env=[f'{var["name"]}={var["value"]}' for var in self.env],
+            env=env,
         )
 
         if output_files:
@@ -1802,6 +1807,7 @@ class DockerJob(Job):
                 self.scratch,
                 requester_pays_project,
                 client_session,
+                env=env,
             )
 
         self.containers = containers

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -123,9 +123,17 @@ async def copy(
 
 def make_transfer(json_object: Dict[str, str]) -> Transfer:
     if 'to' in json_object:
-        return Transfer(os.path.expandvars(json_object['from']), os.path.expandvars(json_object['to']), treat_dest_as=Transfer.DEST_IS_TARGET)
+        return Transfer(
+            os.path.expandvars(json_object['from']),
+            os.path.expandvars(json_object['to']),
+            treat_dest_as=Transfer.DEST_IS_TARGET,
+        )
     assert 'into' in json_object
-    return Transfer(os.path.expandvars(json_object['from']), os.path.expandvars(json_object['into']), treat_dest_as=Transfer.DEST_DIR)
+    return Transfer(
+        os.path.expandvars(json_object['from']),
+        os.path.expandvars(json_object['into']),
+        treat_dest_as=Transfer.DEST_DIR,
+    )
 
 
 async def copy_from_dict(

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -1,3 +1,5 @@
+import os.path
+
 from typing import List, Dict, AsyncContextManager, Optional, Tuple
 import argparse
 import asyncio
@@ -121,9 +123,9 @@ async def copy(
 
 def make_transfer(json_object: Dict[str, str]) -> Transfer:
     if 'to' in json_object:
-        return Transfer(json_object['from'], json_object['to'], treat_dest_as=Transfer.DEST_IS_TARGET)
+        return Transfer(os.path.expandvars(json_object['from']), os.path.expandvars(json_object['to']), treat_dest_as=Transfer.DEST_IS_TARGET)
     assert 'into' in json_object
-    return Transfer(json_object['from'], json_object['into'], treat_dest_as=Transfer.DEST_DIR)
+    return Transfer(os.path.expandvars(json_object['from']), os.path.expandvars(json_object['into']), treat_dest_as=Transfer.DEST_DIR)
 
 
 async def copy_from_dict(


### PR DESCRIPTION
For my SAIGE implementation, it would be nice to be able to use the `{BATCH_TMPDIR}` environment variable within a file name so that I can give user-specified file path names for output files to write that can be used downstream in globs when importing temporary files in Hail without having to localize all of the files (could be 4K+ files). I also thought this could solve Konrad's region bucket request where we copy data from a region-specific location.