### PR TITLE
[aiotools.fs] tighter type on AsyncFS.__aenter__

### DIFF
--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
     Tuple,
 )
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, Self
 from types import TracebackType
 import abc
 import asyncio
@@ -426,7 +426,7 @@ class AsyncFS(abc.ABC):
     async def close(self) -> None:
         pass
 
-    async def __aenter__(self) -> "AsyncFS":
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(


### PR DESCRIPTION
In particular, this allows `async with RouterAsyncFS(...) as fs` to give a tight type to `fs`.