### PR TITLE
[rich_progress_bar] show two sigfigs when rate <1

### DIFF
--- a/hail/python/hailtop/utils/rich_progress_bar.py
+++ b/hail/python/hailtop/utils/rich_progress_bar.py
@@ -104,9 +104,8 @@ class RateColumn(ProgressColumn):
         if speed is None:
             return Text("?", style="progress.data.speed")
 
-        speed = int(speed)
-        unit, suffix = filesize.pick_unit_and_suffix(speed, *units(task))
-        precision = 0 if unit == 1 else 1
+        unit, suffix = filesize.pick_unit_and_suffix(int(speed), *units(task))
+        precision = 2 if unit == 1 else 1
         return Text(f"{speed / unit:,.{precision}f} {suffix}/s", style="progress.data.speed")
 
 


### PR DESCRIPTION
Calling `int` truncates the value, rates below 1 units/second, appear as "0". This preserves the floating point value and displays it with two precision digits. This does mean that numbers like "123.45" are now displayed like that rather than as "123" :shrug:.