### PR TITLE
[hailtop] in WithoutSemaphore, optionally do not acquire the semaphore when raising

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -65,7 +65,7 @@ U = TypeVar('U')  # pylint: disable=invalid-name
 P = ParamSpec("P")
 
 
-async def the_empty_async_generator() -> AsyncGenerator[T, None]:
+async def the_empty_async_generator() -> AsyncGenerator[Any, None]:
     if False:  # pylint: disable=using-constant-test
         yield  # The appearance of the keyword `yield` forces Python to make this function into a generator
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -65,7 +65,7 @@ U = TypeVar('U')  # pylint: disable=invalid-name
 P = ParamSpec("P")
 
 
-async def the_empty_async_generator() -> AsyncGenerator[Any, None]:
+async def the_empty_async_generator() -> AsyncGenerator[T, None]:
     if False:  # pylint: disable=using-constant-test
         yield  # The appearance of the keyword `yield` forces Python to make this function into a generator
 
@@ -283,8 +283,9 @@ class WaitableSharedPool:
 
 
 class WithoutSemaphore:
-    def __init__(self, sema):
+    def __init__(self, sema, *, acquire_on_error: bool = False):
         self._sema = sema
+        self._acquire_on_error = acquire_on_error
 
     async def __aenter__(self) -> 'WithoutSemaphore':
         self._sema.release()
@@ -293,7 +294,8 @@ class WithoutSemaphore:
     async def __aexit__(
         self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
     ) -> None:
-        await self._sema.acquire()
+        if exc_val is None or self._acquire_on_error:
+            await self._sema.acquire()
 
 
 class PoolShutdownError(Exception):


### PR DESCRIPTION
Suppose there are 10,000 tasks competing for the semaphore. If any one of them rasises an exception while the `WithoutSempahore` context manager is active, then the probability that the `WithoutSemaphore.__aexit__` wins the semaphore is 1/10,000 aka unlikely. In practice, this means we need to process through most of the tasks to get the first exception. If, for a real world example, there is a permission issue, you will wait many minutes for all 10,000 tasks to fail, all with the same exception, and then you will finally receive the first exception plus a *litany* of log messages about other tasks which were not properly cleaned up (due to the implementation of `bounded_gather2_raise_exceptions`).