### PR TITLE
[ci] Retry more for auth copy paste logins

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1870,7 +1870,7 @@ steps:
       COPY_PASTE_TOKEN=$(hailctl curl {{ default_ns.name }} \
                          auth /api/v1alpha/copy-paste-token \
                          -fsSL \
-                         --retry 3 \
+                         --retry 10 \
                          --retry-delay 5 \
                          -XPOST)
       hailctl auth copy-paste-login "$COPY_PASTE_TOKEN"
@@ -1932,7 +1932,7 @@ steps:
       COPY_PASTE_TOKEN=$(hailctl curl {{ default_ns.name }} \
                          auth /api/v1alpha/copy-paste-token \
                          -fsSL \
-                         --retry 3 \
+                         --retry 10 \
                          --retry-delay 5 \
                          -XPOST)
       sleep $(( 5 * 60 + 1))


### PR DESCRIPTION
I don't have great evidence but 15 seconds might not be very much if we get big preemptions in k8s and our auth pods need to be redeployed on new nodes. I've been seeing more timeouts in Azure CI in this step and thought we should retry a little longer. If this issue persists I'll devote some time to digging deeper on it.