### PR TITLE
[batch] ensure exactly one request creates each update

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1789,7 +1789,8 @@ async def _create_batch_update(
             """
 SELECT update_id, start_job_id, start_job_group_id
 FROM batch_updates
-WHERE batch_id = %s AND token = %s;
+WHERE batch_id = %s AND token = %s
+FOR UPDATE;
 """,
             (batch_id, update_token),
         )
@@ -1828,7 +1829,8 @@ SELECT update_id, start_job_id, n_jobs, start_job_group_id, n_job_groups
 FROM batch_updates
 WHERE batch_id = %s
 ORDER BY update_id DESC
-LIMIT 1;
+LIMIT 1
+FOR UPDATE;
 """,
             (batch_id,),
         )


### PR DESCRIPTION
As written there are at least two issues:

1. This function is not idempotent. If we retry the request while the first is still running, the second request will receive nothing from the first query and attempt to insert records into that empty space.

2. Intentionally concurrent updates will try to use the same update id because we do not take a FOR UPDATE lock on the gap after the last row. We should verify that what I have written here takes that gap lock.