### PR TITLE
[query] Fix #14303 - missing when sampling MatrixTable entries

### DIFF
--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -434,7 +434,10 @@ class TableIR(BaseIR):
         """
         if uid_field_name is None and not self.uses_randomness:
             return self
-        return self._handle_randomness(uid_field_name)
+
+        new_self = self._handle_randomness(uid_field_name)
+        assert uid_field_name is None or uid_field_name in new_self.typ.row_type.fields
+        return new_self
 
     def renderable_new_block(self, i: int) -> bool:
         return True

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -15,10 +15,8 @@ from hail.utils.jsonx import dump_json
 
 def unpack_uid(new_row_type, uid_field_name):
     new_row = ir.Ref('row', new_row_type)
-    if uid_field_name in new_row_type.fields:
-        uid = ir.GetField(new_row, uid_field_name)
-    else:
-        uid = ir.NA(tint64)
+    assert uid_field_name in new_row_type.fields
+    uid = ir.GetField(new_row, uid_field_name)
     return uid, ir.SelectFields(new_row, [field for field in new_row_type.fields if not field == uid_field_name])
 
 
@@ -463,7 +461,7 @@ class MatrixEntriesTable(TableIR):
                 ir.Ref('va', child.typ.row_type), [field for field in child.typ.row_type if field != temp_row_uid]
             ),
         )
-        return TableRename(MatrixEntriesTable(child), {'__entry_uid': default_row_uid}, {})
+        return TableRename(MatrixEntriesTable(child), {'__entry_uid': uid_field_name}, {})
 
     def _compute_type(self, deep_typecheck):
         self.child.compute_type(deep_typecheck)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -2339,3 +2339,10 @@ def test_upcast_tuples():
     t = t.annotate_cols(x=t.foo[1])
     t = t.drop('foo')
     t.cols().collect()
+
+
+def test_sample_entries():
+    mt = hl.utils.range_matrix_table(10, 10)
+    ht = mt.entries()
+    ht = ht.sample(0.5)
+    ht._force_count()


### PR DESCRIPTION
MatrixEntriesTable didn't define `uid_field_name` in `_handle_randomness`. Downstream operations failed to fetch the field and inserted a NA into `RNGSplit`. Assert that TableIRs define `uid_field_name` when provided to `handle_randomness`.

Fixes: #14303 