### PR TITLE
[query] Include traceback in code-generated asserts in debug builds

### DIFF
--- a/hail/build.sc
+++ b/hail/build.sc
@@ -59,6 +59,7 @@ def buildInfo: T[PathRef] = T {
        |revision=$revision
        |sparkVersion=${sparkVersion()}
        |hailPipVersion=${Settings.hailMajorMinorVersion}.${Settings.hailPatchVersion}
+       |hailBuildConfiguration=${debugOrRelease()}
        |""".stripMargin,
   )
   PathRef(T.dest)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -138,14 +138,14 @@ case class BlockMatrixNativeMetadataWriter(
     val metaHelper =
       BMMetadataHelper(path, typ.blockSize, typ.nRows, typ.nCols, typ.linearizedDefinedBlocks)
 
-    val pc = writeAnnotations.get(cb, "write annotations can't be missing!").asIndexable
+    val pc = writeAnnotations.getOrFatal(cb, "write annotations can't be missing!").asIndexable
     val partFiles = cb.newLocal[Array[String]]("partFiles")
     val n = cb.newLocal[Int]("n", pc.loadLength())
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partFiles, Code.newArray[String](n))
     cb.while_(
       i < n, {
-        val s = pc.loadElement(cb, i).get(cb, "file name can't be missing!").asString
+        val s = pc.loadElement(cb, i).getOrFatal(cb, "file name can't be missing!").asString
         cb += partFiles.update(i, s.loadString(cb))
         cb.assign(i, i + 1)
       },

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -263,7 +263,7 @@ object CompileIterator {
 
       cb.if_(
         !didSetup, {
-          optStream.toI(cb).get(cb) // handle missing, but bound stream producer above
+          optStream.toI(cb).getOrAssert(cb) // handle missing, but bound stream producer above
 
           cb.assign(producer.elementRegion, eltRegionField)
           producer.initialize(cb, outerRegion)
@@ -289,7 +289,7 @@ object CompileIterator {
       }
 
       stepF.implementLabel(producer.LproduceElementDone) { cb =>
-        val pc = producer.element.toI(cb).get(cb)
+        val pc = producer.element.toI(cb).getOrAssert(cb)
         cb.assign(elementAddress, returnType.store(cb, producer.elementRegion, pc, false))
         cb.assign(ret, true)
         cb.goto(Lreturn)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -451,12 +451,11 @@ case class IEmitCodeGen[+A](Lmissing: CodeLabel, Lpresent: CodeLabel, value: A, 
     value
   }
 
-  def get(
-    cb: EmitCodeBuilder,
-    errorMsg: Code[String] = s"expected non-missing",
-    errorID: Code[Int] = const(ErrorIDs.NO_ERROR),
-  ): A =
-    handle(cb, cb._assert(false, errorMsg))
+  def getOrFatal(cb: EmitCodeBuilder, errorMsg: Code[String], errorID: Code[Int] = const(ErrorIDs.NO_ERROR)): A =
+    handle(cb, cb._fatalWithError(errorID, errorMsg))
+
+  def getOrAssert(cb: EmitCodeBuilder, debugMsg: Code[String] = const("expected non-missing")): A =
+    handle(cb, cb._assert(false, debugMsg))
 
   def consume(cb: EmitCodeBuilder, ifMissing: => Unit, ifPresent: (A) => Unit): Unit = {
     val Lafter = CodeLabel()
@@ -623,7 +622,7 @@ class EmitSettable(
 
   def store(cb: EmitCodeBuilder, iec: IEmitCode): Unit =
     if (required)
-      cb.assign(vs, iec.get(cb, s"Required EmitSettable cannot be missing ${vs.st}"))
+      cb.assign(vs, iec.getOrFatal(cb, s"Required EmitSettable cannot be missing ${vs.st}"))
     else
       iec.consume(
         cb,
@@ -1674,14 +1673,14 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
             grpIdx < outerSize, {
               cb.assign(groupSize, coerce[Int](groupSizes(grpIdx)))
               cb.assign(withinGrpIdx, 0)
-              val firstStruct = sortedElts.loadFromIndex(cb, region, eltIdx).get(cb).asBaseStruct
+              val firstStruct = sortedElts.loadFromIndex(cb, region, eltIdx).getOrAssert(cb).asBaseStruct
               val key = EmitCode.fromI(mb)(cb => firstStruct.loadField(cb, 0))
               val group = EmitCode.fromI(mb) { cb =>
                 val (addElt, finishInner) = innerType
                   .constructFromFunctions(cb, region, groupSize, deepCopy = false)
                 cb.while_(
                   withinGrpIdx < groupSize, {
-                    val struct = sortedElts.loadFromIndex(cb, region, eltIdx).get(cb).asBaseStruct
+                    val struct = sortedElts.loadFromIndex(cb, region, eltIdx).getOrAssert(cb).asBaseStruct
                     addElt(cb, struct.loadField(cb, 1))
                     cb.assign(eltIdx, eltIdx + 1)
                     cb.assign(withinGrpIdx, withinGrpIdx + 1)
@@ -1703,15 +1702,15 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
         IEmitCode.present(cb, SRNGStateStaticSizeValue(cb))
 
       case RNGSplit(state, dynBitstring) =>
-        val stateValue = emitI(state).get(cb)
-        val tupleOrLong = emitI(dynBitstring).get(cb)
+        val stateValue = emitI(state).getOrAssert(cb)
+        val tupleOrLong = emitI(dynBitstring).getOrAssert(cb)
         val longs = if (tupleOrLong.isInstanceOf[SInt64Value]) {
           Array(tupleOrLong.asInt64.value)
         } else {
           val tuple = tupleOrLong.asBaseStruct
           Array.tabulate(tuple.st.size) { i =>
             tuple.loadField(cb, i)
-              .get(cb, "RNGSplit tuple components are required")
+              .getOrFatal(cb, "RNGSplit tuple components are required")
               .asInt64
               .value
           }
@@ -1787,7 +1786,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
                   val shapeValues = (0 until nDims).map { i =>
                     val shape = SingleCodeSCode.fromSCode(
                       cb,
-                      shapeTupleValue.loadField(cb, i).get(cb),
+                      shapeTupleValue.loadField(cb, i).getOrAssert(cb),
                       region,
                     )
                     cb.newLocal[Long](s"make_ndarray_shape_$i", coerce[Long](shape.code))
@@ -1837,7 +1836,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
                       val shapeValues = (0 until nDims).map { i =>
                         cb.newLocal[Long](
                           s"make_ndarray_shape_$i",
-                          shapeTupleValue.loadField(cb, i).get(cb).asLong.value,
+                          shapeTupleValue.loadField(cb, i).getOrAssert(cb).asLong.value,
                         )
                       }
 
@@ -2777,7 +2776,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
       case x @ ApplySeeded(_, args, rngState, staticUID, rt) =>
         val codeArgs = args.map(a => EmitCode.fromI(cb.emb)(emitInNewBuilder(_, a)))
         val codeArgsMem = codeArgs.map(_.memoize(cb, "ApplySeeded_arg"))
-        val state = emitI(rngState).get(cb)
+        val state = emitI(rngState).getOrAssert(cb)
         val impl = x.implementation
         assert(impl.unify(Array.empty[Type], x.argTypes, rt))
         val newState = EmitCode.present(mb, state.asRNGState.splitStatic(cb, staticUID))
@@ -3048,7 +3047,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
       case WriteValue(value, path, writer, stagingFile) =>
         emitI(path).flatMap(cb) { case pv: SStringValue =>
           emitI(value).map(cb) { v =>
-            val s = stagingFile.map(emitI(_).get(cb).asString)
+            val s = stagingFile.map(emitI(_).getOrAssert(cb).asString)
             val os = cb.memoize(mb.createUnbuffered(s.getOrElse(pv).loadString(cb)))
             writer.writeValue(cb, v, os)
             cb += os.invoke[Unit]("close")
@@ -3606,7 +3605,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
       }
 
       val iec = emitter.emitI(ir, cb, newEnv, None)
-      iec.get(cb, "Result of sorting function cannot be missing").asBoolean.value
+      iec.getOrFatal(cb, "Result of sorting function cannot be missing").asBoolean.value
     }
     (cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_]) =>
       cb.memoize(cb.invokeCode[Boolean](sort, cb.this_, region, l, r))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -451,7 +451,11 @@ case class IEmitCodeGen[+A](Lmissing: CodeLabel, Lpresent: CodeLabel, value: A, 
     value
   }
 
-  def getOrFatal(cb: EmitCodeBuilder, errorMsg: Code[String], errorID: Code[Int] = const(ErrorIDs.NO_ERROR)): A =
+  def getOrFatal(
+    cb: EmitCodeBuilder,
+    errorMsg: Code[String],
+    errorID: Code[Int] = const(ErrorIDs.NO_ERROR),
+  ): A =
     handle(cb, cb._fatalWithError(errorID, errorMsg))
 
   def getOrAssert(cb: EmitCodeBuilder, debugMsg: Code[String] = const("expected non-missing")): A =
@@ -1673,14 +1677,16 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
             grpIdx < outerSize, {
               cb.assign(groupSize, coerce[Int](groupSizes(grpIdx)))
               cb.assign(withinGrpIdx, 0)
-              val firstStruct = sortedElts.loadFromIndex(cb, region, eltIdx).getOrAssert(cb).asBaseStruct
+              val firstStruct =
+                sortedElts.loadFromIndex(cb, region, eltIdx).getOrAssert(cb).asBaseStruct
               val key = EmitCode.fromI(mb)(cb => firstStruct.loadField(cb, 0))
               val group = EmitCode.fromI(mb) { cb =>
                 val (addElt, finishInner) = innerType
                   .constructFromFunctions(cb, region, groupSize, deepCopy = false)
                 cb.while_(
                   withinGrpIdx < groupSize, {
-                    val struct = sortedElts.loadFromIndex(cb, region, eltIdx).getOrAssert(cb).asBaseStruct
+                    val struct =
+                      sortedElts.loadFromIndex(cb, region, eltIdx).getOrAssert(cb).asBaseStruct
                     addElt(cb, struct.loadField(cb, 1))
                     cb.assign(eltIdx, eltIdx + 1)
                     cb.assign(withinGrpIdx, withinGrpIdx + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -456,7 +456,7 @@ case class IEmitCodeGen[+A](Lmissing: CodeLabel, Lpresent: CodeLabel, value: A, 
     errorMsg: Code[String] = s"expected non-missing",
     errorID: Code[Int] = const(ErrorIDs.NO_ERROR),
   ): A =
-    handle(cb, cb._fatalWithError(errorID, errorMsg))
+    handle(cb, cb._assert(false, errorMsg))
 
   def consume(cb: EmitCodeBuilder, ifMissing: => Unit, ifPresent: (A) => Unit): Unit = {
     val Lafter = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -174,7 +174,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     if (iec.st.isRealizable) memoizeField(iec, name)
     else {
       assert(iec.st.isInstanceOf[SStream])
-      if (iec.required) EmitValue(None, iec.get(this, ""))
+      if (iec.required) EmitValue(None, iec.getOrFatal(this, s"'$name' cannot be missing."))
       else {
         val m = emb.genFieldThisRef[Boolean](name + "_missing")
         iec.consume(this, assign(m, true), _ => assign(m, false))
@@ -227,7 +227,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
           val castEc = (ec.required, et.required) match {
             case (true, false) => ec.setOptional
             case (false, true) =>
-              EmitCode.fromI(emb)(cb => IEmitCode.present(cb, ec.toI(cb).get(cb)))
+              EmitCode.fromI(emb)(cb => IEmitCode.present(cb, ec.toI(cb).getOrAssert(cb)))
             case _ => ec
           }
           val castEv = memoize(castEc, "_invoke")

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -279,7 +279,10 @@ object EmitStreamDistribute {
             shouldUseIdentityBuckets, {
               cb.assign(
                 currentFileToMapTo,
-                currentFileToMapTo + splitterWasDuplicated.loadElement(cb, bucketIdx / 2).getOrAssert(
+                currentFileToMapTo + splitterWasDuplicated.loadElement(
+                  cb,
+                  bucketIdx / 2,
+                ).getOrAssert(
                   cb
                 ).asBoolean.value.toI,
               )
@@ -392,7 +395,9 @@ object EmitStreamDistribute {
       )
 
       val fileToUse =
-        cb.memoize[Int](fileMapping.loadElement(cb, b - numberOfBuckets).getOrAssert(cb).asInt.value)
+        cb.memoize[Int](
+          fileMapping.loadElement(cb, b - numberOfBuckets).getOrAssert(cb).asInt.value
+        )
 
       val ob = cb.memoize[OutputBuffer](outputBuffers(fileToUse))
 
@@ -504,7 +509,9 @@ object EmitStreamDistribute {
               EmitCode.fromI(cb.emb)(cb => paddedSplitters.loadElement(cb, uniqueSplittersIdx)),
               false,
               cb.memoize(
-                !splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).getOrAssert(cb).asBoolean.value
+                !splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).getOrAssert(
+                  cb
+                ).asBoolean.value
               ),
             )
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -222,7 +222,7 @@ object EmitStreamDistribute {
               val elementLoaded = paddedSplitters.loadElement(
                 cb,
                 startingPoint + inner * (const(1) << (currentHeight + 1)),
-              ).get(cb)
+              ).getOrAssert(cb)
               keyPType.storeAtAddress(
                 cb,
                 treePType.loadElement(treeAddr, treeFillingIndex),
@@ -279,7 +279,7 @@ object EmitStreamDistribute {
             shouldUseIdentityBuckets, {
               cb.assign(
                 currentFileToMapTo,
-                currentFileToMapTo + splitterWasDuplicated.loadElement(cb, bucketIdx / 2).get(
+                currentFileToMapTo + splitterWasDuplicated.loadElement(cb, bucketIdx / 2).getOrAssert(
                   cb
                 ).asBoolean.value.toI,
               )
@@ -321,7 +321,7 @@ object EmitStreamDistribute {
       cb.assign(uniqueSplittersIdx, uniqueSplittersIdx + 1),
       cb.assign(
         numFilesToWrite,
-        numFilesToWrite + 1 + splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).get(
+        numFilesToWrite + 1 + splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).getOrAssert(
           cb
         ).asBoolean.value.toI,
       ),
@@ -392,7 +392,7 @@ object EmitStreamDistribute {
       )
 
       val fileToUse =
-        cb.memoize[Int](fileMapping.loadElement(cb, b - numberOfBuckets).get(cb).asInt.value)
+        cb.memoize[Int](fileMapping.loadElement(cb, b - numberOfBuckets).getOrAssert(cb).asInt.value)
 
       val ob = cb.memoize[OutputBuffer](outputBuffers(fileToUse))
 
@@ -442,7 +442,7 @@ object EmitStreamDistribute {
       cb,
       min,
       firstSplitter,
-    ) && splitterWasDuplicated.loadElement(cb, 0).get(cb).asBoolean.value)
+    ) && splitterWasDuplicated.loadElement(cb, 0).getOrAssert(cb).asBoolean.value)
     val skipMaxInterval = cb.memoize(equal(cb, max, lastSplitter))
 
     val (pushElement, finisher) = returnType.constructFromFunctions(
@@ -470,7 +470,7 @@ object EmitStreamDistribute {
           min,
           firstSplitter,
           true,
-          cb.memoize(!splitterWasDuplicated.loadElement(cb, 0).get(cb).asBoolean.value),
+          cb.memoize(!splitterWasDuplicated.loadElement(cb, 0).getOrAssert(cb).asBoolean.value),
         )
 
         pushElement(
@@ -504,7 +504,7 @@ object EmitStreamDistribute {
               EmitCode.fromI(cb.emb)(cb => paddedSplitters.loadElement(cb, uniqueSplittersIdx)),
               false,
               cb.memoize(
-                !splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).get(cb).asBoolean.value
+                !splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).getOrAssert(cb).asBoolean.value
               ),
             )
 
@@ -530,7 +530,7 @@ object EmitStreamDistribute {
 
         // Now, maybe have to make an identity bucket.
         cb.if_(
-          splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).get(cb).asBoolean.value, {
+          splitterWasDuplicated.loadElement(cb, uniqueSplittersIdx).getOrAssert(cb).asBoolean.value, {
             val identityInterval = intervalType.constructFromCodes(
               cb,
               region,

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -67,7 +67,7 @@ class PartitionIteratorLongReader(
     context.toI(cb).map(cb) { case _ctxStruct: SBaseStructValue =>
       val ctxStruct = cb.memoizeField(_ctxStruct, "ctxStruct")
       val partIdx =
-        cb.memoizeField(_ctxStruct.loadField(cb, "partitionIndex").get(cb).asInt.value.toL)
+        cb.memoizeField(_ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb).asInt.value.toL)
       val rowIdx = mb.genFieldThisRef[Long]("pnr_rowidx")
       val region = mb.genFieldThisRef[Region]("pilr_region")
       val it = mb.genFieldThisRef[Iterator[java.lang.Long]]("pilr_it")

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -529,7 +529,7 @@ case class SplitPartitionNativeWriter(
 
       val specs = FastSeq(spec1, spec2)
       stream.memoryManagedConsume(region, cb) { cb =>
-        val row = stream.element.toI(cb).get(cb, "row can't be missing").asBaseStruct
+        val row = stream.element.toI(cb).getOrFatal(cb, "row can't be missing").asBaseStruct
 
         writeIndexInfo.foreach { case (_, keyType, writer) =>
           writer.add(
@@ -706,16 +706,16 @@ case class MatrixSpecWriter(
     region: Value[Region],
   ): Unit = {
     cb += cb.emb.getFS.invoke[String, Unit]("mkDir", path)
-    val c = writeAnnotations.get(cb, "write annotations can't be missing!").asBaseStruct
+    val c = writeAnnotations.getOrFatal(cb, "write annotations can't be missing!").asBaseStruct
     val partCounts = cb.newLocal[Array[Long]]("partCounts")
-    val a = c.loadField(cb, "rows").get(cb).asIndexable
+    val a = c.loadField(cb, "rows").getOrAssert(cb).asIndexable
 
     val n = cb.newLocal[Int]("n", a.loadLength())
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partCounts, Code.newArray[Long](n))
     cb.while_(
       i < n, {
-        val count = a.loadElement(cb, i).get(cb, "part count can't be missing!")
+        val count = a.loadElement(cb, i).getOrFatal(cb, "part count can't be missing!")
         cb += partCounts.update(i, count.asInt64.value)
         cb.assign(i, i + 1)
       },
@@ -725,7 +725,7 @@ case class MatrixSpecWriter(
       .invoke[FS, Long, Array[Long], Unit](
         "write",
         cb.emb.getFS,
-        c.loadField(cb, "cols").get(cb).asInt64.value,
+        c.loadField(cb, "cols").getOrAssert(cb).asInt64.value,
         partCounts,
       )
   }
@@ -881,14 +881,14 @@ case class VCFPartitionWriter(
     context.toI(cb).map(cb) { case ctx: SBaseStructValue =>
       val formatFieldUTF8 = cb.memoize(const(formatFieldStr).invoke[Array[Byte]]("getBytes"))
       val filename =
-        ctx.loadField(cb, "partFile").get(cb, "partFile can't be missing").asString.loadString(cb)
+        ctx.loadField(cb, "partFile").getOrFatal(cb, "partFile can't be missing").asString.loadString(cb)
 
       val os = cb.memoize(cb.emb.create(filename))
       if (writeHeader) {
-        val sampleIds = ctx.loadField(cb, "cols").get(cb).asIndexable
+        val sampleIds = ctx.loadField(cb, "cols").getOrAssert(cb).asIndexable
         val stringSampleIds = cb.memoize(Code.newArray[String](sampleIds.loadLength()))
         sampleIds.forEachDefined(cb) { case (cb, i, colv: SBaseStructValue) =>
-          val s = colv.subset(typ.colKey: _*).loadField(cb, 0).get(cb).asString
+          val s = colv.subset(typ.colKey: _*).loadField(cb, 0).getOrAssert(cb).asString
           cb += (stringSampleIds(i) = s.loadString(cb))
         }
 
@@ -1083,8 +1083,8 @@ case class VCFPartitionWriter(
     def writeB(code: Code[Array[Byte]]) = _writeB(cb, code)
     def writeS(code: Code[String]) = _writeS(cb, code)
 
-    val elt = element.toI(cb).get(cb).asBaseStruct
-    val locus = elt.loadField(cb, locusIdx).get(cb).asLocus
+    val elt = element.toI(cb).getOrAssert(cb).asBaseStruct
+    val locus = elt.loadField(cb, locusIdx).getOrAssert(cb).asLocus
     // CHROM
     writeB(locus.contig(cb).toBytes(cb).loadBytes(cb))
     // POS
@@ -1106,8 +1106,8 @@ case class VCFPartitionWriter(
 
     // REF
     writeC('\t')
-    val alleles = elt.loadField(cb, allelesIdx).get(cb).asIndexable
-    writeB(alleles.loadElement(cb, 0).get(cb).asString.toBytes(cb).loadBytes(cb))
+    val alleles = elt.loadField(cb, allelesIdx).getOrAssert(cb).asIndexable
+    writeB(alleles.loadElement(cb, 0).getOrAssert(cb).asString.toBytes(cb).loadBytes(cb))
 
     // ALT
     writeC('\t')
@@ -1119,7 +1119,7 @@ case class VCFPartitionWriter(
           i < alleles.loadLength(),
           cb.assign(i, i + 1), {
             cb.if_(i.cne(1), writeC(','))
-            writeB(alleles.loadElement(cb, i).get(cb).asString.toBytes(cb).loadBytes(cb))
+            writeB(alleles.loadElement(cb, i).getOrAssert(cb).asString.toBytes(cb).loadBytes(cb))
           },
         )
       },
@@ -1214,7 +1214,7 @@ case class VCFPartitionWriter(
     }
 
     // FORMAT
-    val genotypes = elt.loadField(cb, entriesFieldName).get(cb).asIndexable
+    val genotypes = elt.loadField(cb, entriesFieldName).getOrAssert(cb).asIndexable
     cb.if_(
       genotypes.loadLength() > 0, {
         writeC('\t')
@@ -1248,10 +1248,10 @@ case class VCFExportFinalizer(
 
   private def header(cb: EmitCodeBuilder, annotations: SBaseStructValue): Code[String] = {
     val mb = cb.emb
-    val sampleIds = annotations.loadField(cb, "cols").get(cb).asIndexable
+    val sampleIds = annotations.loadField(cb, "cols").getOrAssert(cb).asIndexable
     val stringSampleIds = cb.memoize(Code.newArray[String](sampleIds.loadLength()))
     sampleIds.forEachDefined(cb) { case (cb, i, colv: SBaseStructValue) =>
-      val s = colv.subset(typ.colKey: _*).loadField(cb, 0).get(cb).asString
+      val s = colv.subset(typ.colKey: _*).loadField(cb, 0).getOrAssert(cb).asString
       cb += (stringSampleIds(i) = s.loadString(cb))
     }
     Code.invokeScalaObject6[
@@ -1279,9 +1279,9 @@ case class VCFExportFinalizer(
     val ctx: ExecuteContext = cb.emb.ctx
     val ext = ctx.fs.getCodecExtension(outputPath)
 
-    val annotations = writeAnnotations.get(cb).asBaseStruct
+    val annotations = writeAnnotations.getOrAssert(cb).asBaseStruct
 
-    val partPaths = annotations.loadField(cb, "partFiles").get(cb).asIndexable
+    val partPaths = annotations.loadField(cb, "partFiles").getOrAssert(cb).asIndexable
     val partFiles = partPaths.castTo(cb, region, SJavaArrayString(true), false).asInstanceOf[
       SJavaArrayStringValue
     ].array
@@ -1477,13 +1477,13 @@ final case class GenVariantWriter(typ: MatrixType, entriesFieldName: String, pre
       cb,
       cb._fatal("stream element cannot be missing!"),
       { case sv: SBaseStructValue =>
-        val locus = sv.loadField(cb, "locus").get(cb).asLocus
+        val locus = sv.loadField(cb, "locus").getOrAssert(cb).asLocus
         val contig = locus.contig(cb).loadString(cb)
-        val alleles = sv.loadField(cb, "alleles").get(cb).asIndexable
-        val rsid = sv.loadField(cb, "rsid").get(cb).asString.loadString(cb)
-        val varid = sv.loadField(cb, "varid").get(cb).asString.loadString(cb)
-        val a0 = alleles.loadElement(cb, 0).get(cb).asString.loadString(cb)
-        val a1 = alleles.loadElement(cb, 1).get(cb).asString.loadString(cb)
+        val alleles = sv.loadField(cb, "alleles").getOrAssert(cb).asIndexable
+        val rsid = sv.loadField(cb, "rsid").getOrAssert(cb).asString.loadString(cb)
+        val varid = sv.loadField(cb, "varid").getOrAssert(cb).asString.loadString(cb)
+        val a0 = alleles.loadElement(cb, 0).getOrAssert(cb).asString.loadString(cb)
+        val a1 = alleles.loadElement(cb, 1).getOrAssert(cb).asString.loadString(cb)
 
         cb += Code.invokeScalaObject6[String, Int, String, String, String, String, Unit](
           ExportGen.getClass,
@@ -1508,7 +1508,7 @@ final case class GenVariantWriter(typ: MatrixType, entriesFieldName: String, pre
         writeC(' ')
         writeS(a1)
 
-        sv.loadField(cb, entriesFieldName).get(cb).asIndexable.forEachDefinedOrMissing(cb)(
+        sv.loadField(cb, entriesFieldName).getOrAssert(cb).asIndexable.forEachDefinedOrMissing(cb)(
           (cb, i) => _writeS(cb, " 0 0 0"),
           { (cb, i, va) =>
             va.asBaseStruct.loadField(cb, "GP").consume(
@@ -1567,9 +1567,9 @@ final class GenSampleWriter extends SimplePartitionWriter {
       cb,
       cb._fatal("stream element cannot be missing!"),
       { case sv: SBaseStructValue =>
-        val id1 = sv.loadField(cb, 0).get(cb).asString.loadString(cb)
-        val id2 = sv.loadField(cb, 1).get(cb).asString.loadString(cb)
-        val missing = sv.loadField(cb, 2).get(cb).asDouble.value
+        val id1 = sv.loadField(cb, 0).getOrAssert(cb).asString.loadString(cb)
+        val id2 = sv.loadField(cb, 1).getOrAssert(cb).asString.loadString(cb)
+        val missing = sv.loadField(cb, 2).getOrAssert(cb).asDouble.value
 
         cb += Code.invokeScalaObject3[String, String, Double, Unit](
           ExportGen.getClass,
@@ -1700,19 +1700,19 @@ case class BGENPartitionWriter(
 
     context.toI(cb).map(cb) { case ctx: SBaseStructValue =>
       val filename =
-        ctx.loadField(cb, "partFile").get(cb, "partFile can't be missing").asString.loadString(cb)
+        ctx.loadField(cb, "partFile").getOrFatal(cb, "partFile can't be missing").asString.loadString(cb)
 
       val os = cb.memoize(cb.emb.create(filename))
-      val colValues = ctx.loadField(cb, "cols").get(cb).asIndexable
+      val colValues = ctx.loadField(cb, "cols").getOrAssert(cb).asIndexable
       val nSamples = colValues.loadLength()
 
       if (writeHeader) {
         val sampleIds = cb.memoize(Code.newArray[String](colValues.loadLength()))
         colValues.forEachDefined(cb) { case (cb, i, colv: SBaseStructValue) =>
-          val s = colv.subset(typ.colKey: _*).loadField(cb, 0).get(cb).asString
+          val s = colv.subset(typ.colKey: _*).loadField(cb, 0).getOrAssert(cb).asString
           cb += (sampleIds(i) = s.loadString(cb))
         }
-        val numVariants = ctx.loadField(cb, "numVariants").get(cb).asInt64.value
+        val numVariants = ctx.loadField(cb, "numVariants").getOrAssert(cb).asInt64.value
         val header = Code.invokeScalaObject3[Array[String], Long, Int, Array[Byte]](
           BgenWriter.getClass,
           "headerBlock",
@@ -1729,7 +1729,7 @@ case class BGENPartitionWriter(
 
       val slowCount = if (writeHeader || stream.length.isDefined) None
       else Some(cb.newLocal[Long]("num_variants", 0))
-      val fastCount = if (writeHeader) Some(ctx.loadField(cb, "numVariants").get(cb).asInt64.value)
+      val fastCount = if (writeHeader) Some(ctx.loadField(cb, "numVariants").getOrAssert(cb).asInt64.value)
       else stream.length.map(len => cb.memoize(len(cb).toL))
       stream.memoryManagedConsume(region, cb) { cb =>
         slowCount.foreach(nv => cb.assign(nv, nv + 1L))
@@ -1824,13 +1824,13 @@ case class BGENPartitionWriter(
     def add(cb: EmitCodeBuilder, bb: Value[ByteArrayBuilder], i: Value[Int]) =
       cb += bb.invoke[Byte, Unit]("add", i.toB)
 
-    val elt = element.toI(cb).get(cb).asBaseStruct
-    val locus = elt.loadField(cb, "locus").get(cb).asLocus
+    val elt = element.toI(cb).getOrAssert(cb).asBaseStruct
+    val locus = elt.loadField(cb, "locus").getOrAssert(cb).asLocus
     val chr = locus.contig(cb).loadString(cb)
     val pos = locus.position(cb)
-    val varid = elt.loadField(cb, "varid").get(cb).asString.loadString(cb)
-    val rsid = elt.loadField(cb, "rsid").get(cb).asString.loadString(cb)
-    val alleles = elt.loadField(cb, "alleles").get(cb).asIndexable
+    val varid = elt.loadField(cb, "varid").getOrAssert(cb).asString.loadString(cb)
+    val rsid = elt.loadField(cb, "rsid").getOrAssert(cb).asString.loadString(cb)
+    val alleles = elt.loadField(cb, "alleles").getOrAssert(cb).asIndexable
 
     cb.if_(
       alleles.loadLength() >= 0xffff,
@@ -1879,7 +1879,7 @@ case class BGENPartitionWriter(
     def emitNullGP(cb: EmitCodeBuilder): Unit =
       cb.for_(cb.assign(i, 0), i < nGenotypes - 1, cb.assign(i, i + 1), add(cb, uncompBuf, 0))
 
-    val entries = elt.loadField(cb, entriesFieldName).get(cb).asIndexable
+    val entries = elt.loadField(cb, entriesFieldName).getOrAssert(cb).asIndexable
     entries.forEachDefinedOrMissing(cb)(
       (cb, j) => emitNullGP(cb),
       { case (cb, j, entry: SBaseStructValue) =>
@@ -1975,15 +1975,15 @@ case class BGENExportFinalizer(typ: MatrixType, path: String, exportType: String
 
   def writeMetadata(writeAnnotations: => IEmitCode, cb: EmitCodeBuilder, region: Value[Region])
     : Unit = {
-    val annotations = writeAnnotations.get(cb).asBaseStruct
-    val colValues = annotations.loadField(cb, "cols").get(cb).asIndexable
+    val annotations = writeAnnotations.getOrAssert(cb).asBaseStruct
+    val colValues = annotations.loadField(cb, "cols").getOrAssert(cb).asIndexable
     val sampleIds = cb.memoize(Code.newArray[String](colValues.loadLength()))
     colValues.forEachDefined(cb) { case (cb, i, colv: SBaseStructValue) =>
-      val s = colv.subset(typ.colKey: _*).loadField(cb, 0).get(cb).asString
+      val s = colv.subset(typ.colKey: _*).loadField(cb, 0).getOrAssert(cb).asString
       cb += (sampleIds(i) = s.loadString(cb))
     }
 
-    val results = annotations.loadField(cb, "results").get(cb).asIndexable
+    val results = annotations.loadField(cb, "results").getOrAssert(cb).asIndexable
     val dropped = cb.newLocal[Long]("dropped", 0L)
     results.forEachDefined(cb) { (cb, i, res) =>
       res.asBaseStruct.loadField(cb, "dropped").consume(
@@ -2019,7 +2019,7 @@ case class BGENExportFinalizer(typ: MatrixType, path: String, exportType: String
       results.forEachDefined(cb) { (cb, i, res) =>
         cb += files.update(
           i,
-          res.asBaseStruct.loadField(cb, "partFile").get(cb).asString.loadString(cb),
+          res.asBaseStruct.loadField(cb, "partFile").getOrAssert(cb).asString.loadString(cb),
         )
       }
 
@@ -2066,7 +2066,7 @@ case class BGENExportFinalizer(typ: MatrixType, path: String, exportType: String
       )
       cb += os.invoke[Array[Byte], Unit]("write", header)
 
-      annotations.loadField(cb, "results").get(cb).asIndexable.forEachDefined(cb) { (cb, i, res) =>
+      annotations.loadField(cb, "results").getOrAssert(cb).asIndexable.forEachDefined(cb) { (cb, i, res) =>
         res.asBaseStruct.loadField(cb, "partFile").consume(
           cb,
           { /* do nothing */ },
@@ -2179,8 +2179,8 @@ case class PLINKPartitionWriter(typ: MatrixType, entriesFieldName: String) exten
     region: Value[Region],
   ): IEmitCode = {
     context.toI(cb).map(cb) { case context: SBaseStructValue =>
-      val bedFile = context.loadField(cb, "bedFile").get(cb).asString.loadString(cb)
-      val bimFile = context.loadField(cb, "bimFile").get(cb).asString.loadString(cb)
+      val bedFile = context.loadField(cb, "bedFile").getOrAssert(cb).asString.loadString(cb)
+      val bimFile = context.loadField(cb, "bimFile").getOrAssert(cb).asString.loadString(cb)
 
       val bedOs = cb.memoize(cb.emb.create(bedFile))
       val bimOs = cb.memoize(cb.emb.create(bimFile))
@@ -2215,21 +2215,21 @@ case class PLINKPartitionWriter(typ: MatrixType, entriesFieldName: String) exten
     def writeC(code: Code[Int]) = _writeC(cb, code)
     def writeS(code: Code[String]) = _writeS(cb, code)
 
-    val elt = element.toI(cb).get(cb).asBaseStruct
+    val elt = element.toI(cb).getOrAssert(cb).asBaseStruct
 
-    val (contig, position) = elt.loadField(cb, locusIdx).get(cb) match {
+    val (contig, position) = elt.loadField(cb, locusIdx).getOrAssert(cb) match {
       case locus: SLocusValue =>
         locus.contig(cb).loadString(cb) -> locus.position(cb)
       case locus: SBaseStructValue =>
-        locus.loadField(cb, 0).get(cb).asString.loadString(cb) -> locus.loadField(cb, 1).get(
+        locus.loadField(cb, 0).getOrAssert(cb).asString.loadString(cb) -> locus.loadField(cb, 1).getOrAssert(
           cb
         ).asInt.value
     }
-    val cmPosition = elt.loadField(cb, cmPosIdx).get(cb).asDouble
-    val varid = elt.loadField(cb, varidIdx).get(cb).asString.loadString(cb)
-    val alleles = elt.loadField(cb, allelesIdx).get(cb).asIndexable
-    val a0 = alleles.loadElement(cb, 0).get(cb).asString.loadString(cb)
-    val a1 = alleles.loadElement(cb, 1).get(cb).asString.loadString(cb)
+    val cmPosition = elt.loadField(cb, cmPosIdx).getOrAssert(cb).asDouble
+    val varid = elt.loadField(cb, varidIdx).getOrAssert(cb).asString.loadString(cb)
+    val alleles = elt.loadField(cb, allelesIdx).getOrAssert(cb).asIndexable
+    val a0 = alleles.loadElement(cb, 0).getOrAssert(cb).asString.loadString(cb)
+    val a1 = alleles.loadElement(cb, 1).getOrAssert(cb).asString.loadString(cb)
 
     cb += Code.invokeScalaObject5[String, String, Int, String, String, Unit](
       ExportPlink.getClass,
@@ -2253,7 +2253,7 @@ case class PLINKPartitionWriter(typ: MatrixType, entriesFieldName: String) exten
     writeS(a0)
     writeC('\n')
 
-    elt.loadField(cb, entriesFieldName).get(cb).asIndexable.forEachDefinedOrMissing(cb)(
+    elt.loadField(cb, entriesFieldName).getOrAssert(cb).asIndexable.forEachDefinedOrMissing(cb)(
       (cb, i) => cb += bp.invoke[Int, Unit]("add", 1),
       { (cb, i, va) =>
         va.asBaseStruct.loadField(cb, "GT").consume(
@@ -2296,12 +2296,12 @@ case class PLINKExportFinalizer(typ: MatrixType, path: String, headerPath: Strin
 
   def writeMetadata(writeAnnotations: => IEmitCode, cb: EmitCodeBuilder, region: Value[Region])
     : Unit = {
-    val paths = writeAnnotations.get(cb).asIndexable
+    val paths = writeAnnotations.getOrAssert(cb).asIndexable
     val bedFiles = cb.memoize(Code.newArray[String](paths.loadLength() + 1)) // room for header
     val bimFiles = cb.memoize(Code.newArray[String](paths.loadLength()))
     paths.forEachDefined(cb) { case (cb, i, elt: SBaseStructValue) =>
-      val bed = elt.loadField(cb, "bedFile").get(cb).asString.loadString(cb)
-      val bim = elt.loadField(cb, "bimFile").get(cb).asString.loadString(cb)
+      val bed = elt.loadField(cb, "bedFile").getOrAssert(cb).asString.loadString(cb)
+      val bim = elt.loadField(cb, "bimFile").getOrAssert(cb).asString.loadString(cb)
       cb += (bedFiles(cb.memoize(i + 1)) = bed)
       cb += (bimFiles(i) = bim)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -86,11 +86,11 @@ case class StringTablePartitionReader(lines: GenericLines, uidFieldName: String)
 
           cb.assign(
             fileName,
-            partitionContext.loadField(cb, "file").get(cb).asString.loadString(cb),
+            partitionContext.loadField(cb, "file").getOrAssert(cb).asString.loadString(cb),
           )
           cb.assign(
             partIdx,
-            partitionContext.loadField(cb, "partitionIndex").get(cb).asInt.value.toL,
+            partitionContext.loadField(cb, "partitionIndex").getOrAssert(cb).asInt.value.toL,
           )
           cb.assign(rowIdx, -1L)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -915,10 +915,13 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec, uidFieldName: Str
       concreteSType
 
     context.toI(cb).map(cb) { case ctxStruct: SBaseStructValue =>
-      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
+      val partIdx =
+        cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
       val rowIdx = mb.genFieldThisRef[Long]("pnr_rowidx")
       val pathString =
-        cb.memoizeField(ctxStruct.loadField(cb, "partitionPath").getOrAssert(cb).asString.loadString(cb))
+        cb.memoizeField(
+          ctxStruct.loadField(cb, "partitionPath").getOrAssert(cb).asString.loadString(cb)
+        )
       val xRowBuf = mb.genFieldThisRef[InputBuffer]("pnr_xrowbuf")
       val next = mb.newPSettable(mb.fieldBuilder, elementSType, "pnr_next")
       val region = mb.genFieldThisRef[Region]("pnr_region")
@@ -1153,9 +1156,10 @@ case class PartitionNativeIntervalReader(
                     cb.assign(indexInitialized, true),
                   )
                   cb.assign(indexCachedIndex, currPartitionIdx)
-                  val partPath = partitionPathsRuntime.loadElement(cb, currPartitionIdx).getOrAssert(
-                    cb
-                  ).asString.loadString(cb)
+                  val partPath =
+                    partitionPathsRuntime.loadElement(cb, currPartitionIdx).getOrAssert(
+                      cb
+                    ).asString.loadString(cb)
                   val idxPath = indexPathsRuntime.loadElement(cb, currPartitionIdx).getOrAssert(
                     cb
                   ).asString.loadString(cb)
@@ -1206,7 +1210,11 @@ case class PartitionNativeIntervalReader(
                       // read from start of partition to the end interval
 
                       val indexResult =
-                        index.queryBound(cb, ctx.loadEnd(cb).getOrAssert(cb).asBaseStruct, ctx.includesEnd)
+                        index.queryBound(
+                          cb,
+                          ctx.loadEnd(cb).getOrAssert(cb).asBaseStruct,
+                          ctx.includesEnd,
+                        )
                       val startIdx = indexResult.loadField(cb, 0).getOrAssert(cb).asInt64.value
                       cb.assign(currIdxInPartition, 0L)
                       cb.assign(stopIdxInPartition, startIdx)
@@ -1228,8 +1236,9 @@ case class PartitionNativeIntervalReader(
                       cb.assign(stopIdxInPartition, index.nKeys(cb))
                       cb.if_(
                         currIdxInPartition < stopIdxInPartition, {
-                          val firstOffset = indexResult.loadField(cb, 1).getOrAssert(cb).asBaseStruct
-                            .loadField(cb, "offset").getOrAssert(cb).asInt64.value
+                          val firstOffset =
+                            indexResult.loadField(cb, 1).getOrAssert(cb).asBaseStruct
+                              .loadField(cb, "offset").getOrAssert(cb).asInt64.value
 
                           cb += ib.seek(firstOffset)
                         },
@@ -1331,7 +1340,8 @@ case class PartitionNativeReaderIndexed(
     val index = new StagedIndexReader(cb.emb, indexSpec.leafCodec, indexSpec.internalNodeCodec)
 
     context.toI(cb).map(cb) { case ctxStruct: SBaseStructValue =>
-      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
+      val partIdx =
+        cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
       val curIdx = mb.genFieldThisRef[Long]("cur_index")
       val endIdx = mb.genFieldThisRef[Long]("end_index")
       val ib = mb.genFieldThisRef[InputBuffer]("buffer")
@@ -1672,7 +1682,10 @@ case class PartitionZippedIndexedNativeReader(
           cb.assign(curIdx, startIndex)
           cb.assign(endIdx, endIndex)
 
-          cb.assign(partIdx, ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb).asInt64.value)
+          cb.assign(
+            partIdx,
+            ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb).asInt64.value,
+          )
           cb.assign(
             leftBuffer,
             specLeft.buildCodeInputBuffer(

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -915,10 +915,10 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec, uidFieldName: Str
       concreteSType
 
     context.toI(cb).map(cb) { case ctxStruct: SBaseStructValue =>
-      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").get(cb), "partIdx")
+      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
       val rowIdx = mb.genFieldThisRef[Long]("pnr_rowidx")
       val pathString =
-        cb.memoizeField(ctxStruct.loadField(cb, "partitionPath").get(cb).asString.loadString(cb))
+        cb.memoizeField(ctxStruct.loadField(cb, "partitionPath").getOrAssert(cb).asString.loadString(cb))
       val xRowBuf = mb.genFieldThisRef[InputBuffer]("pnr_xrowbuf")
       val next = mb.newPSettable(mb.fieldBuilder, elementSType, "pnr_next")
       val region = mb.genFieldThisRef[Region]("pnr_region")
@@ -1075,9 +1075,9 @@ case class PartitionNativeIntervalReader(
 
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
 
-          val startBound = ctx.loadStart(cb).get(cb)
+          val startBound = ctx.loadStart(cb).getOrAssert(cb)
           val includesStart = ctx.includesStart
-          val endBound = ctx.loadEnd(cb).get(cb)
+          val endBound = ctx.loadEnd(cb).getOrAssert(cb)
           val includesEnd = ctx.includesEnd
 
           val (startPart, endPart) = IntervalFunctions.partitionerFindIntervalRange(
@@ -1153,10 +1153,10 @@ case class PartitionNativeIntervalReader(
                     cb.assign(indexInitialized, true),
                   )
                   cb.assign(indexCachedIndex, currPartitionIdx)
-                  val partPath = partitionPathsRuntime.loadElement(cb, currPartitionIdx).get(
+                  val partPath = partitionPathsRuntime.loadElement(cb, currPartitionIdx).getOrAssert(
                     cb
                   ).asString.loadString(cb)
-                  val idxPath = indexPathsRuntime.loadElement(cb, currPartitionIdx).get(
+                  val idxPath = indexPathsRuntime.loadElement(cb, currPartitionIdx).getOrAssert(
                     cb
                   ).asString.loadString(cb)
                   index.initialize(cb, idxPath)
@@ -1180,22 +1180,22 @@ case class PartitionNativeIntervalReader(
                       // query the full interval
                       val indexResult = index.queryInterval(cb, ctx)
                       val startIdx = indexResult.loadField(cb, 0)
-                        .get(cb)
+                        .getOrAssert(cb)
                         .asInt64
                         .value
                       cb.assign(currIdxInPartition, startIdx)
                       val endIdx = indexResult.loadField(cb, 1)
-                        .get(cb)
+                        .getOrAssert(cb)
                         .asInt64
                         .value
                       cb.assign(stopIdxInPartition, endIdx)
                       cb.if_(
                         endIdx > startIdx, {
                           val firstOffset = indexResult.loadField(cb, 2)
-                            .get(cb)
+                            .getOrAssert(cb)
                             .asBaseStruct
                             .loadField(cb, "offset")
-                            .get(cb)
+                            .getOrAssert(cb)
                             .asInt64
                             .value
 
@@ -1206,8 +1206,8 @@ case class PartitionNativeIntervalReader(
                       // read from start of partition to the end interval
 
                       val indexResult =
-                        index.queryBound(cb, ctx.loadEnd(cb).get(cb).asBaseStruct, ctx.includesEnd)
-                      val startIdx = indexResult.loadField(cb, 0).get(cb).asInt64.value
+                        index.queryBound(cb, ctx.loadEnd(cb).getOrAssert(cb).asBaseStruct, ctx.includesEnd)
+                      val startIdx = indexResult.loadField(cb, 0).getOrAssert(cb).asInt64.value
                       cb.assign(currIdxInPartition, 0L)
                       cb.assign(stopIdxInPartition, startIdx)
                       // no need to seek, starting at beginning of partition
@@ -1219,17 +1219,17 @@ case class PartitionNativeIntervalReader(
                       // read from left endpoint until end of partition
                       val indexResult = index.queryBound(
                         cb,
-                        ctx.loadStart(cb).get(cb).asBaseStruct,
+                        ctx.loadStart(cb).getOrAssert(cb).asBaseStruct,
                         cb.memoize(!ctx.includesStart),
                       )
-                      val startIdx = indexResult.loadField(cb, 0).get(cb).asInt64.value
+                      val startIdx = indexResult.loadField(cb, 0).getOrAssert(cb).asInt64.value
 
                       cb.assign(currIdxInPartition, startIdx)
                       cb.assign(stopIdxInPartition, index.nKeys(cb))
                       cb.if_(
                         currIdxInPartition < stopIdxInPartition, {
-                          val firstOffset = indexResult.loadField(cb, 1).get(cb).asBaseStruct
-                            .loadField(cb, "offset").get(cb).asInt64.value
+                          val firstOffset = indexResult.loadField(cb, 1).getOrAssert(cb).asBaseStruct
+                            .loadField(cb, "offset").getOrAssert(cb).asInt64.value
 
                           cb += ib.seek(firstOffset)
                         },
@@ -1331,7 +1331,7 @@ case class PartitionNativeReaderIndexed(
     val index = new StagedIndexReader(cb.emb, indexSpec.leafCodec, indexSpec.internalNodeCodec)
 
     context.toI(cb).map(cb) { case ctxStruct: SBaseStructValue =>
-      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").get(cb), "partIdx")
+      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
       val curIdx = mb.genFieldThisRef[Long]("cur_index")
       val endIdx = mb.genFieldThisRef[Long]("end_index")
       val ib = mb.genFieldThisRef[InputBuffer]("buffer")
@@ -1347,27 +1347,27 @@ case class PartitionNativeReaderIndexed(
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
           val indexPath = ctxStruct
             .loadField(cb, "indexPath")
-            .get(cb)
+            .getOrAssert(cb)
             .asString
             .loadString(cb)
           val partitionPath = ctxStruct
             .loadField(cb, "partitionPath")
-            .get(cb)
+            .getOrAssert(cb)
             .asString
             .loadString(cb)
           val interval = ctxStruct
             .loadField(cb, "interval")
-            .get(cb)
+            .getOrAssert(cb)
             .asInterval
           index.initialize(cb, indexPath)
 
           val indexResult = index.queryInterval(cb, interval)
           val startIndex = indexResult.loadField(cb, 0)
-            .get(cb)
+            .getOrAssert(cb)
             .asInt64
             .value
           val endIndex = indexResult.loadField(cb, 1)
-            .get(cb)
+            .getOrAssert(cb)
             .asInt64
             .value
           cb.assign(curIdx, startIndex)
@@ -1384,10 +1384,10 @@ case class PartitionNativeReaderIndexed(
           cb.if_(
             endIndex > startIndex, {
               val firstOffset = indexResult.loadField(cb, 2)
-                .get(cb)
+                .getOrAssert(cb)
                 .asBaseStruct
                 .loadField(cb, "offset")
-                .get(cb)
+                .getOrAssert(cb)
                 .asInt64
                 .value
 
@@ -1651,35 +1651,35 @@ case class PartitionZippedIndexedNativeReader(
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
           val indexPath = ctxStruct
             .loadField(cb, "indexPath")
-            .get(cb)
+            .getOrAssert(cb)
             .asString
             .loadString(cb)
           val interval = ctxStruct
             .loadField(cb, "interval")
-            .get(cb)
+            .getOrAssert(cb)
             .asInterval
           index.initialize(cb, indexPath)
 
           val indexResult = index.queryInterval(cb, interval)
           val startIndex = indexResult.loadField(cb, 0)
-            .get(cb)
+            .getOrAssert(cb)
             .asInt64
             .value
           val endIndex = indexResult.loadField(cb, 1)
-            .get(cb)
+            .getOrAssert(cb)
             .asInt64
             .value
           cb.assign(curIdx, startIndex)
           cb.assign(endIdx, endIndex)
 
-          cb.assign(partIdx, ctxStruct.loadField(cb, "partitionIndex").get(cb).asInt64.value)
+          cb.assign(partIdx, ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb).asInt64.value)
           cb.assign(
             leftBuffer,
             specLeft.buildCodeInputBuffer(
               Code.newInstance[ByteTrackingInputStream, InputStream](
                 mb.openUnbuffered(
                   ctxStruct.loadField(cb, "leftPartitionPath")
-                    .get(cb)
+                    .getOrAssert(cb)
                     .asString
                     .loadString(cb),
                   true,
@@ -1693,7 +1693,7 @@ case class PartitionZippedIndexedNativeReader(
               Code.newInstance[ByteTrackingInputStream, InputStream](
                 mb.openUnbuffered(
                   ctxStruct.loadField(cb, "rightPartitionPath")
-                    .get(cb)
+                    .getOrAssert(cb)
                     .asString
                     .loadString(cb),
                   true,
@@ -1705,21 +1705,21 @@ case class PartitionZippedIndexedNativeReader(
           cb.if_(
             endIndex > startIndex, {
               val leafNode = indexResult.loadField(cb, 2)
-                .get(cb)
+                .getOrAssert(cb)
                 .asBaseStruct
 
               val leftSeekAddr = leftOffsetFieldIndex match {
                 case Some(offsetIdx) =>
                   leafNode
                     .loadField(cb, "annotation")
-                    .get(cb)
+                    .getOrAssert(cb)
                     .asBaseStruct
                     .loadField(cb, offsetIdx)
-                    .get(cb)
+                    .getOrAssert(cb)
                 case None =>
                   leafNode
                     .loadField(cb, "offset")
-                    .get(cb)
+                    .getOrAssert(cb)
               }
               cb += leftBuffer.seek(leftSeekAddr.asInt64.value)
 
@@ -1727,14 +1727,14 @@ case class PartitionZippedIndexedNativeReader(
                 case Some(offsetIdx) =>
                   leafNode
                     .loadField(cb, "annotation")
-                    .get(cb)
+                    .getOrAssert(cb)
                     .asBaseStruct
                     .loadField(cb, offsetIdx)
-                    .get(cb)
+                    .getOrAssert(cb)
                 case None =>
                   leafNode
                     .loadField(cb, "offset")
-                    .get(cb)
+                    .getOrAssert(cb)
               }
               cb += rightBuffer.seek(rightSeekAddr.asInt64.value)
             },

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -391,11 +391,11 @@ case class PartitionNativeWriter(
     context: EmitCode,
     region: Value[Region],
   ): IEmitCode = {
-    val ctx = context.toI(cb).get(cb)
+    val ctx = context.toI(cb).getOrAssert(cb)
     val consumer = new StreamConsumer(ctx, cb, region)
     consumer.setup()
     stream.memoryManagedConsume(region, cb) { cb =>
-      val element = stream.element.toI(cb).get(cb, "row can't be missing")
+      val element = stream.element.toI(cb).getOrFatal(cb, "row can't be missing")
       consumer.consumeElement(cb, element, stream.elementRegion)
     }
     IEmitCode.present(cb, consumer.result())
@@ -411,14 +411,14 @@ case class RVDSpecWriter(path: String, spec: RVDSpecMaker) extends MetadataWrite
     region: Value[Region],
   ): Unit = {
     cb += cb.emb.getFS.invoke[String, Unit]("mkDir", path)
-    val a = writeAnnotations.get(cb, "write annotations can't be missing!").asIndexable
+    val a = writeAnnotations.getOrFatal(cb, "write annotations can't be missing!").asIndexable
     val partFiles = cb.newLocal[Array[String]]("partFiles")
     val n = cb.newLocal[Int]("n", a.loadLength())
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partFiles, Code.newArray[String](n))
     cb.while_(
       i < n, {
-        val s = a.loadElement(cb, i).get(cb, "file name can't be missing!").asString
+        val s = a.loadElement(cb, i).getOrFatal(cb, "file name can't be missing!").asString
         cb += partFiles.update(i, s.loadString(cb))
         cb.assign(i, i + 1)
       },
@@ -486,7 +486,7 @@ case class TableSpecWriter(
 
     val hasKey = !this.typ.keyType.fields.isEmpty
 
-    val a = writeAnnotations.get(cb, "write annotations can't be missing!").asIndexable
+    val a = writeAnnotations.getOrFatal(cb, "write annotations can't be missing!").asIndexable
     val partCounts = cb.newLocal[Array[Long]]("partCounts")
 
     val idxOfFirstKeyField =
@@ -503,20 +503,14 @@ case class TableSpecWriter(
     cb.while_(
       i < n, {
         val curElement =
-          a.loadElement(cb, i).get(cb, "writeMetadata annotation can't be missing").asBaseStruct
-        val count = curElement.asBaseStruct.loadField(cb, "partitionCounts").get(
-          cb,
-          "part count can't be missing!",
-        ).asLong.value
+          a.loadElement(cb, i).getOrFatal(cb, "writeMetadata annotation can't be missing").asBaseStruct
+        val count = curElement.asBaseStruct.loadField(cb, "partitionCounts").getOrFatal(cb, "part count can't be missing!").asLong.value
 
         if (hasKey) {
           // Only nonempty partitions affect first, last, and distinctlyKeyed.
           cb.if_(
             count cne 0L, {
-              val curFirst = curElement.loadField(cb, "firstKey").get(
-                cb,
-                const("firstKey of curElement can't be missing, part size was ") concat count.toS,
-              )
+              val curFirst = curElement.loadField(cb, "firstKey").getOrFatal(cb, const("firstKey of curElement can't be missing, part size was ") concat count.toS)
 
               val comparator = NEQ(lastSeenSettable.emitType.virtualType).codeOrdering(
                 cb.emb.ecb,
@@ -530,7 +524,7 @@ case class TableSpecWriter(
               ).asInstanceOf[Value[Boolean]]
 
               val partWasDistinctlyKeyed =
-                curElement.loadField(cb, "distinctlyKeyed").get(cb).asBoolean.value
+                curElement.loadField(cb, "distinctlyKeyed").getOrAssert(cb).asBoolean.value
               cb.assign(
                 distinctlyKeyed,
                 distinctlyKeyed && partWasDistinctlyKeyed && notEqualToLast,
@@ -812,7 +806,7 @@ case class TableTextFinalizer(
     : Unit = {
     val ctx: ExecuteContext = cb.emb.ctx
     val ext = ctx.fs.getCodecExtension(outputPath)
-    val partPaths = writeAnnotations.get(cb, "write annotations cannot be missing!")
+    val partPaths = writeAnnotations.getOrFatal(cb, "write annotations cannot be missing!")
     val files = partPaths.castTo(cb, region, SJavaArrayString(true), false).asInstanceOf[
       SJavaArrayStringValue
     ].array
@@ -1069,12 +1063,12 @@ class PartitionNativeFanoutWriter(
     context: EmitCode,
     region: Value[Region],
   ): IEmitCode = {
-    val ctx = context.toI(cb).get(cb)
+    val ctx = context.toI(cb).getOrAssert(cb)
     val consumers = targets.map(target => new target.rowWriter.StreamConsumer(ctx, cb, region))
 
     consumers.foreach(_.setup())
     stream.memoryManagedConsume(region, cb) { cb =>
-      val row = stream.element.toI(cb).get(cb, "row can't be missing")
+      val row = stream.element.toI(cb).getOrFatal(cb, "row can't be missing")
 
       (consumers zip targets).foreach { case (consumer, target) =>
         consumer.consumeElement(

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -503,14 +503,23 @@ case class TableSpecWriter(
     cb.while_(
       i < n, {
         val curElement =
-          a.loadElement(cb, i).getOrFatal(cb, "writeMetadata annotation can't be missing").asBaseStruct
-        val count = curElement.asBaseStruct.loadField(cb, "partitionCounts").getOrFatal(cb, "part count can't be missing!").asLong.value
+          a.loadElement(cb, i).getOrFatal(
+            cb,
+            "writeMetadata annotation can't be missing",
+          ).asBaseStruct
+        val count = curElement.asBaseStruct.loadField(cb, "partitionCounts").getOrFatal(
+          cb,
+          "part count can't be missing!",
+        ).asLong.value
 
         if (hasKey) {
           // Only nonempty partitions affect first, last, and distinctlyKeyed.
           cb.if_(
             count cne 0L, {
-              val curFirst = curElement.loadField(cb, "firstKey").getOrFatal(cb, const("firstKey of curElement can't be missing, part size was ") concat count.toS)
+              val curFirst = curElement.loadField(cb, "firstKey").getOrFatal(
+                cb,
+                const("firstKey of curElement can't be missing, part size was ") concat count.toS,
+              )
 
               val comparator = NEQ(lastSeenSettable.emitType.virtualType).codeOrdering(
                 cb.emb.ecb,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -464,8 +464,8 @@ class DownsampleState(
               cb,
               {},
               { case point: SBaseStructValue =>
-                val x = point.loadField(cb, "x").get(cb).asFloat64.value
-                val y = point.loadField(cb, "y").get(cb).asFloat64.value
+                val x = point.loadField(cb, "x").getOrAssert(cb).asFloat64.value
+                val y = point.loadField(cb, "y").getOrAssert(cb).asFloat64.value
                 val pointc = coerce[Long](SingleCodeSCode.fromSCode(cb, point, region).code)
                 insertIntoTree(
                   cb,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -216,7 +216,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
               i < k, {
                 cb += Region.storeDouble(
                   sptr,
-                  Region.loadDouble(sptr) + x.loadElement(cb, i).get(cb).asDouble.value * y,
+                  Region.loadDouble(sptr) + x.loadElement(cb, i).getOrAssert(cb).asDouble.value * y,
                 )
                 cb.assign(i, i + 1)
                 cb.assign(sptr, sptr + scalar.byteSize)
@@ -235,7 +235,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
                     cb += Region.storeDouble(
                       sptr,
                       Region.loadDouble(sptr) +
-                        (x.loadElement(cb, i).get(cb).asDouble.value * x.loadElement(cb, j).get(
+                        (x.loadElement(cb, i).getOrAssert(cb).asDouble.value * x.loadElement(cb, j).getOrAssert(
                           cb
                         ).asDouble.value),
                     )

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -235,7 +235,10 @@ class LinearRegressionAggregator() extends StagedAggregator {
                     cb += Region.storeDouble(
                       sptr,
                       Region.loadDouble(sptr) +
-                        (x.loadElement(cb, i).getOrAssert(cb).asDouble.value * x.loadElement(cb, j).getOrAssert(
+                        (x.loadElement(cb, i).getOrAssert(cb).asDouble.value * x.loadElement(
+                          cb,
+                          j,
+                        ).getOrAssert(
                           cb
                         ).asDouble.value),
                     )

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -542,7 +542,11 @@ object ArrayFunctions extends RegistryFunctions {
             val laGIndexer = cb.newLocal[Int]("g_indexer", 0)
             cb.while_(
               i < laLen, {
-                val lai = localAlleles.loadElement(cb, i).getOrFatal(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
+                val lai = localAlleles.loadElement(cb, i).getOrFatal(
+                  cb,
+                  "local_to_global: local alleles elements cannot be missing",
+                  err,
+                ).asInt32.value
                 cb.if_(
                   lai >= nTotalAlleles,
                   cb._fatalWithError(
@@ -557,7 +561,11 @@ object ArrayFunctions extends RegistryFunctions {
                 val j = cb.newLocal[Int]("la_j", 0)
                 cb.while_(
                   j <= i, {
-                    val laj = localAlleles.loadElement(cb, j).getOrFatal(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
+                    val laj = localAlleles.loadElement(cb, j).getOrFatal(
+                      cb,
+                      "local_to_global: local alleles elements cannot be missing",
+                      err,
+                    ).asInt32.value
 
                     val dest = cb.newLocal[Int]("dest")
                     cb.if_(
@@ -669,7 +677,11 @@ object ArrayFunctions extends RegistryFunctions {
             val i = cb.newLocal[Int]("la_i", 0)
             cb.while_(
               i < localLen, {
-                val lai = localAlleles.loadElement(cb, i + idxAdjustmentForOmitFirst).getOrFatal(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
+                val lai = localAlleles.loadElement(cb, i + idxAdjustmentForOmitFirst).getOrFatal(
+                  cb,
+                  "local_to_global: local alleles elements cannot be missing",
+                  err,
+                ).asInt32.value
                 cb.if_(
                   lai >= nTotalAlleles,
                   cb._fatalWithError(

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -542,11 +542,7 @@ object ArrayFunctions extends RegistryFunctions {
             val laGIndexer = cb.newLocal[Int]("g_indexer", 0)
             cb.while_(
               i < laLen, {
-                val lai = localAlleles.loadElement(cb, i).get(
-                  cb,
-                  "local_to_global: local alleles elements cannot be missing",
-                  err,
-                ).asInt32.value
+                val lai = localAlleles.loadElement(cb, i).getOrFatal(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
                 cb.if_(
                   lai >= nTotalAlleles,
                   cb._fatalWithError(
@@ -561,11 +557,7 @@ object ArrayFunctions extends RegistryFunctions {
                 val j = cb.newLocal[Int]("la_j", 0)
                 cb.while_(
                   j <= i, {
-                    val laj = localAlleles.loadElement(cb, j).get(
-                      cb,
-                      "local_to_global: local alleles elements cannot be missing",
-                      err,
-                    ).asInt32.value
+                    val laj = localAlleles.loadElement(cb, j).getOrFatal(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
 
                     val dest = cb.newLocal[Int]("dest")
                     cb.if_(
@@ -677,11 +669,7 @@ object ArrayFunctions extends RegistryFunctions {
             val i = cb.newLocal[Int]("la_i", 0)
             cb.while_(
               i < localLen, {
-                val lai = localAlleles.loadElement(cb, i + idxAdjustmentForOmitFirst).get(
-                  cb,
-                  "local_to_global: local alleles elements cannot be missing",
-                  err,
-                ).asInt32.value
+                val lai = localAlleles.loadElement(cb, i + idxAdjustmentForOmitFirst).getOrFatal(cb, "local_to_global: local alleles elements cannot be missing", err).asInt32.value
                 cb.if_(
                   lai >= nTotalAlleles,
                   cb._fatalWithError(

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -18,7 +18,8 @@ object GenotypeFunctions extends RegistryFunctions {
 
         cb.while_(
           i < pl.loadLength(), {
-            val value = pl.loadElement(cb, i).getOrFatal(cb, "PL cannot have missing elements.", errorID)
+            val value =
+              pl.loadElement(cb, i).getOrFatal(cb, "PL cannot have missing elements.", errorID)
             val pli = cb.newLocal[Int]("pli", value.asInt.value)
             cb.if_(
               pli < m, {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -18,7 +18,7 @@ object GenotypeFunctions extends RegistryFunctions {
 
         cb.while_(
           i < pl.loadLength(), {
-            val value = pl.loadElement(cb, i).get(cb, "PL cannot have missing elements.", errorID)
+            val value = pl.loadElement(cb, i).getOrFatal(cb, "PL cannot have missing elements.", errorID)
             val pli = cb.newLocal[Int]("pli", value.asInt.value)
             cb.if_(
               pli < m, {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -164,10 +164,10 @@ object IntervalFunctions extends RegistryFunctions {
     rhs: SBaseStructValue,
     rSign: Value[Int],
   ): Value[Int] = {
-    val lStruct = lhs.loadField(cb, 0).get(cb).asBaseStruct
-    val lLength = lhs.loadField(cb, 1).get(cb).asInt.value
-    val rStruct = rhs.loadField(cb, 0).get(cb).asBaseStruct
-    val rLength = rhs.loadField(cb, 1).get(cb).asInt.value
+    val lStruct = lhs.loadField(cb, 0).getOrAssert(cb).asBaseStruct
+    val lLength = lhs.loadField(cb, 1).getOrAssert(cb).asInt.value
+    val rStruct = rhs.loadField(cb, 0).getOrAssert(cb).asBaseStruct
+    val rLength = rhs.loadField(cb, 1).getOrAssert(cb).asInt.value
     _partitionIntervalEndpointCompare(cb, lStruct, lLength, lSign, rStruct, rLength, rSign)
   }
 
@@ -177,8 +177,8 @@ object IntervalFunctions extends RegistryFunctions {
     intervalEndpoint: SBaseStructValue,
     leansRight: Code[Boolean],
   ): Value[Int] = {
-    val endpoint = intervalEndpoint.loadField(cb, 0).get(cb).asBaseStruct
-    val endpointLength = intervalEndpoint.loadField(cb, 1).get(cb).asInt.value
+    val endpoint = intervalEndpoint.loadField(cb, 0).getOrAssert(cb).asBaseStruct
+    val endpointLength = intervalEndpoint.loadField(cb, 1).getOrAssert(cb).asInt.value
     val sign = cb.memoize((leansRight.toI << 1) - 1)
     _partitionIntervalEndpointCompare(cb, point, point.st.size, 0, endpoint, endpointLength, sign)
   }
@@ -189,13 +189,13 @@ object IntervalFunctions extends RegistryFunctions {
     interval: SIntervalValue,
   ): Value[Int] = {
     val start = interval.loadStart(cb)
-      .get(cb, "partition intervals cannot have missing endpoints")
+      .getOrFatal(cb, "partition intervals cannot have missing endpoints")
       .asBaseStruct
     cb.if_(
       compareStructWithPartitionIntervalEndpoint(cb, point, start, !interval.includesStart) < 0,
       primitive(const(-1)), {
         val end = interval.loadEnd(cb)
-          .get(cb, "partition intervals cannot have missing endpoints")
+          .getOrFatal(cb, "partition intervals cannot have missing endpoints")
           .asBaseStruct
         cb.if_(
           compareStructWithPartitionIntervalEndpoint(cb, point, end, interval.includesEnd) < 0,
@@ -213,18 +213,18 @@ object IntervalFunctions extends RegistryFunctions {
     errorID: Value[Int],
   ): (Value[Int], Value[Int]) = {
     val needleStart = query.loadStart(cb)
-      .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+      .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
       .asBaseStruct
     val needleEnd = query.loadEnd(cb)
-      .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+      .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
       .asBaseStruct
 
     def ltNeedle(interval: IEmitCode): Code[Boolean] = {
       val intervalVal = interval
-        .get(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+        .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
         .asInterval
       val intervalEnd = intervalVal.loadEnd(cb)
-        .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+        .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
         .asBaseStruct
       val c = partitionIntervalEndpointCompare(
         cb,
@@ -238,10 +238,10 @@ object IntervalFunctions extends RegistryFunctions {
 
     def gtNeedle(interval: IEmitCode): Code[Boolean] = {
       val intervalVal = interval
-        .get(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+        .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
         .asInterval
       val intervalStart = intervalVal.loadStart(cb)
-        .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+        .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
         .asBaseStruct
       val c = partitionIntervalEndpointCompare(
         cb,
@@ -431,14 +431,10 @@ object IntervalFunctions extends RegistryFunctions {
     ) { case (_, cb, _, intervals, point, errorID) =>
       val compare = BinarySearch.Comparator.fromCompare { intervalEC =>
         val interval = intervalEC
-          .get(cb, "sortedNonOverlappingIntervalsContain assumes non-missing intervals", errorID)
+          .getOrFatal(cb, "sortedNonOverlappingIntervalsContain assumes non-missing intervals", errorID)
           .asInterval
         intervalPointCompare(cb, interval, point)
-          .get(
-            cb,
-            "sortedNonOverlappingIntervalsContain assumes non-missing interval endpoints",
-            errorID,
-          )
+          .getOrFatal(cb, "sortedNonOverlappingIntervalsContain assumes non-missing interval endpoints", errorID)
           .asInt.value
       }
 
@@ -456,10 +452,10 @@ object IntervalFunctions extends RegistryFunctions {
     ) { case (_, cb, _, intervals: SIndexableValue, point: SBaseStructValue, errorID) =>
       def ltNeedle(interval: IEmitCode): Code[Boolean] = {
         val intervalVal = interval
-          .get(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+          .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
           .asInterval
         val intervalEnd = intervalVal.loadEnd(cb)
-          .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+          .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
           .asBaseStruct
         val c = compareStructWithPartitionIntervalEndpoint(
           cb,
@@ -471,10 +467,10 @@ object IntervalFunctions extends RegistryFunctions {
       }
       def gtNeedle(interval: IEmitCode): Code[Boolean] = {
         val intervalVal = interval
-          .get(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+          .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
           .asInterval
         val intervalStart = intervalVal.loadStart(cb)
-          .get(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+          .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
           .asBaseStruct
         val c = compareStructWithPartitionIntervalEndpoint(
           cb,
@@ -572,7 +568,7 @@ object IntervalFunctions extends RegistryFunctions {
       (_, _, _) => SBoolean,
     ) {
       case (_, cb, _, interval: SIntervalValue, point: SBaseStructValue, _) =>
-        val leftTuple = interval.loadStart(cb).get(cb).asBaseStruct
+        val leftTuple = interval.loadStart(cb).getOrAssert(cb).asBaseStruct
 
         val includesLeft = interval.includesStart
         val pointGTLeft =
@@ -583,7 +579,7 @@ object IntervalFunctions extends RegistryFunctions {
         cb.if_(
           isContained, {
             // check right endpoint
-            val rightTuple = interval.loadEnd(cb).get(cb).asBaseStruct
+            val rightTuple = interval.loadEnd(cb).getOrAssert(cb).asBaseStruct
 
             val includesRight = interval.includesEnd
             val pointLTRight =

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -213,18 +213,34 @@ object IntervalFunctions extends RegistryFunctions {
     errorID: Value[Int],
   ): (Value[Int], Value[Int]) = {
     val needleStart = query.loadStart(cb)
-      .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+      .getOrFatal(
+        cb,
+        "partitionerFindIntervalRange assumes non-missing interval endpoints",
+        errorID,
+      )
       .asBaseStruct
     val needleEnd = query.loadEnd(cb)
-      .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+      .getOrFatal(
+        cb,
+        "partitionerFindIntervalRange assumes non-missing interval endpoints",
+        errorID,
+      )
       .asBaseStruct
 
     def ltNeedle(interval: IEmitCode): Code[Boolean] = {
       val intervalVal = interval
-        .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+        .getOrFatal(
+          cb,
+          "partitionerFindIntervalRange: partition intervals cannot be missing",
+          errorID,
+        )
         .asInterval
       val intervalEnd = intervalVal.loadEnd(cb)
-        .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+        .getOrFatal(
+          cb,
+          "partitionerFindIntervalRange assumes non-missing interval endpoints",
+          errorID,
+        )
         .asBaseStruct
       val c = partitionIntervalEndpointCompare(
         cb,
@@ -238,10 +254,18 @@ object IntervalFunctions extends RegistryFunctions {
 
     def gtNeedle(interval: IEmitCode): Code[Boolean] = {
       val intervalVal = interval
-        .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+        .getOrFatal(
+          cb,
+          "partitionerFindIntervalRange: partition intervals cannot be missing",
+          errorID,
+        )
         .asInterval
       val intervalStart = intervalVal.loadStart(cb)
-        .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+        .getOrFatal(
+          cb,
+          "partitionerFindIntervalRange assumes non-missing interval endpoints",
+          errorID,
+        )
         .asBaseStruct
       val c = partitionIntervalEndpointCompare(
         cb,
@@ -431,10 +455,18 @@ object IntervalFunctions extends RegistryFunctions {
     ) { case (_, cb, _, intervals, point, errorID) =>
       val compare = BinarySearch.Comparator.fromCompare { intervalEC =>
         val interval = intervalEC
-          .getOrFatal(cb, "sortedNonOverlappingIntervalsContain assumes non-missing intervals", errorID)
+          .getOrFatal(
+            cb,
+            "sortedNonOverlappingIntervalsContain assumes non-missing intervals",
+            errorID,
+          )
           .asInterval
         intervalPointCompare(cb, interval, point)
-          .getOrFatal(cb, "sortedNonOverlappingIntervalsContain assumes non-missing interval endpoints", errorID)
+          .getOrFatal(
+            cb,
+            "sortedNonOverlappingIntervalsContain assumes non-missing interval endpoints",
+            errorID,
+          )
           .asInt.value
       }
 
@@ -452,10 +484,18 @@ object IntervalFunctions extends RegistryFunctions {
     ) { case (_, cb, _, intervals: SIndexableValue, point: SBaseStructValue, errorID) =>
       def ltNeedle(interval: IEmitCode): Code[Boolean] = {
         val intervalVal = interval
-          .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+          .getOrFatal(
+            cb,
+            "partitionerFindIntervalRange: partition intervals cannot be missing",
+            errorID,
+          )
           .asInterval
         val intervalEnd = intervalVal.loadEnd(cb)
-          .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+          .getOrFatal(
+            cb,
+            "partitionerFindIntervalRange assumes non-missing interval endpoints",
+            errorID,
+          )
           .asBaseStruct
         val c = compareStructWithPartitionIntervalEndpoint(
           cb,
@@ -467,10 +507,18 @@ object IntervalFunctions extends RegistryFunctions {
       }
       def gtNeedle(interval: IEmitCode): Code[Boolean] = {
         val intervalVal = interval
-          .getOrFatal(cb, "partitionerFindIntervalRange: partition intervals cannot be missing", errorID)
+          .getOrFatal(
+            cb,
+            "partitionerFindIntervalRange: partition intervals cannot be missing",
+            errorID,
+          )
           .asInterval
         val intervalStart = intervalVal.loadStart(cb)
-          .getOrFatal(cb, "partitionerFindIntervalRange assumes non-missing interval endpoints", errorID)
+          .getOrFatal(
+            cb,
+            "partitionerFindIntervalRange assumes non-missing interval endpoints",
+            errorID,
+          )
           .asBaseStruct
         val c = compareStructWithPartitionIntervalEndpoint(
           cb,

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -254,7 +254,10 @@ object LocusFunctions extends RegistryFunctions {
           cb.while_(
             iContig < ncontigs, {
               val coordPerContig =
-                grouped.loadElement(cb, iContig).getOrFatal(cb, "locus_windows group cannot be missing")
+                grouped.loadElement(cb, iContig).getOrFatal(
+                  cb,
+                  "locus_windows group cannot be missing",
+                )
                   .asIndexable
               f(cb, iContig, coordPerContig)
               cb.assign(iContig, iContig + 1)
@@ -287,7 +290,10 @@ object LocusFunctions extends RegistryFunctions {
               cb.assign(lastCoord, 0.0),
               cb.assign(
                 lastCoord,
-                coords.loadElement(cb, 0).getOrFatal(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value,
+                coords.loadElement(cb, 0).getOrFatal(
+                  cb,
+                  "locus_windows: missing value for 'coord_expr'",
+                ).asDouble.value,
               ),
             )
             cb.while_(
@@ -351,7 +357,10 @@ object LocusFunctions extends RegistryFunctions {
                 coords.loadElement(cb, i)
                   .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'")
                   .asDouble.value > (coords.loadElement(cb, idx)
-                  .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value + radius)
+                    .getOrFatal(
+                      cb,
+                      "locus_windows: missing value for 'coord_expr'",
+                    ).asDouble.value + radius)
               }
             ),
             EmitCode.fromI(cb.emb)(cb =>
@@ -359,7 +368,10 @@ object LocusFunctions extends RegistryFunctions {
                 coords.loadElement(cb, i)
                   .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'")
                   .asDouble.value >= (coords.loadElement(cb, idx)
-                  .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value - radius)
+                    .getOrFatal(
+                      cb,
+                      "locus_windows: missing value for 'coord_expr'",
+                    ).asDouble.value - radius)
               }
             ),
           ),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -254,7 +254,7 @@ object LocusFunctions extends RegistryFunctions {
           cb.while_(
             iContig < ncontigs, {
               val coordPerContig =
-                grouped.loadElement(cb, iContig).get(cb, "locus_windows group cannot be missing")
+                grouped.loadElement(cb, iContig).getOrFatal(cb, "locus_windows group cannot be missing")
                   .asIndexable
               f(cb, iContig, coordPerContig)
               cb.assign(iContig, iContig + 1)
@@ -287,10 +287,7 @@ object LocusFunctions extends RegistryFunctions {
               cb.assign(lastCoord, 0.0),
               cb.assign(
                 lastCoord,
-                coords.loadElement(cb, 0).get(
-                  cb,
-                  "locus_windows: missing value for 'coord_expr'",
-                ).asDouble.value,
+                coords.loadElement(cb, 0).getOrFatal(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value,
               ),
             )
             cb.while_(
@@ -352,23 +349,17 @@ object LocusFunctions extends RegistryFunctions {
             EmitCode.fromI(cb.emb)(cb =>
               addIdxWithCondition(cb) { case (cb, i, idx, coords) =>
                 coords.loadElement(cb, i)
-                  .get(cb, "locus_windows: missing value for 'coord_expr'")
+                  .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'")
                   .asDouble.value > (coords.loadElement(cb, idx)
-                    .get(
-                      cb,
-                      "locus_windows: missing value for 'coord_expr'",
-                    ).asDouble.value + radius)
+                  .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value + radius)
               }
             ),
             EmitCode.fromI(cb.emb)(cb =>
               addIdxWithCondition(cb) { case (cb, i, idx, coords) =>
                 coords.loadElement(cb, i)
-                  .get(cb, "locus_windows: missing value for 'coord_expr'")
+                  .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'")
                   .asDouble.value >= (coords.loadElement(cb, idx)
-                    .get(
-                      cb,
-                      "locus_windows: missing value for 'coord_expr'",
-                    ).asDouble.value - radius)
+                  .getOrFatal(cb, "locus_windows: missing value for 'coord_expr'").asDouble.value - radius)
               }
             ),
           ),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -418,8 +418,8 @@ object NDArrayFunctions extends RegistryFunctions {
           cb.assign(row, 0L),
           row < nRows.get,
           cb.assign(row, row + 1L), {
-            val start = starts.loadElement(cb, row.toI).get(cb).asInt64.value
-            val stop = stops.loadElement(cb, row.toI).get(cb).asInt64.value
+            val start = starts.loadElement(cb, row.toI).getOrAssert(cb).asInt64.value
+            val stop = stops.loadElement(cb, row.toI).getOrAssert(cb).asInt64.value
             newBlock.slice(cb, row, (null, start)).coiterateMutate(cb, er.region) { _ =>
               primitive(0.0d)
             }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -405,10 +405,7 @@ object RandomSeededFunctions extends RegistryFunctions {
         i < len, {
           cb.assign(
             s,
-            s + weights.loadElement(cb, i).get(
-              cb,
-              "rand_cat requires all elements of input array to be present",
-            ).asFloat64.value,
+            s + weights.loadElement(cb, i).getOrFatal(cb, "rand_cat requires all elements of input array to be present").asFloat64.value,
           )
           cb.assign(i, i + 1)
         },
@@ -419,10 +416,7 @@ object RandomSeededFunctions extends RegistryFunctions {
       cb.loop { start =>
         cb.assign(
           elt,
-          weights.loadElement(cb, i).get(
-            cb,
-            "rand_cat requires all elements of input array to be present",
-          ).asFloat64.value,
+          weights.loadElement(cb, i).getOrFatal(cb, "rand_cat requires all elements of input array to be present").asFloat64.value,
         )
         cb.if_(
           r > elt && i < len, {
@@ -464,7 +458,7 @@ object RandomSeededFunctions extends RegistryFunctions {
           cb.assign(i, i + 1),
           cb.assign(
             totalNumberOfRecords,
-            totalNumberOfRecords + partitionCounts.loadElement(cb, i).get(cb).asInt32.value,
+            totalNumberOfRecords + partitionCounts.loadElement(cb, i).getOrAssert(cb).asInt32.value,
           ),
         )
 
@@ -500,12 +494,12 @@ object RandomSeededFunctions extends RegistryFunctions {
               "rhyper",
               successStatesRemaining.toD,
               failureStatesRemaining.toD,
-              partitionCounts.loadElement(cb, i).get(cb).asInt32.value.toD,
+              partitionCounts.loadElement(cb, i).getOrAssert(cb).asInt32.value.toD,
             ).toI)
             cb.assign(successStatesRemaining, successStatesRemaining - numSuccesses)
             cb.assign(
               failureStatesRemaining,
-              failureStatesRemaining - (partitionCounts.loadElement(cb, i).get(
+              failureStatesRemaining - (partitionCounts.loadElement(cb, i).getOrAssert(
                 cb
               ).asInt32.value - numSuccesses),
             )

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -405,7 +405,10 @@ object RandomSeededFunctions extends RegistryFunctions {
         i < len, {
           cb.assign(
             s,
-            s + weights.loadElement(cb, i).getOrFatal(cb, "rand_cat requires all elements of input array to be present").asFloat64.value,
+            s + weights.loadElement(cb, i).getOrFatal(
+              cb,
+              "rand_cat requires all elements of input array to be present",
+            ).asFloat64.value,
           )
           cb.assign(i, i + 1)
         },
@@ -416,7 +419,10 @@ object RandomSeededFunctions extends RegistryFunctions {
       cb.loop { start =>
         cb.assign(
           elt,
-          weights.loadElement(cb, i).getOrFatal(cb, "rand_cat requires all elements of input array to be present").asFloat64.value,
+          weights.loadElement(cb, i).getOrFatal(
+            cb,
+            "rand_cat requires all elements of input array to be present",
+          ).asFloat64.value,
         )
         cb.if_(
           r > elt && i < len, {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -537,8 +537,8 @@ object UtilFunctions extends RegistryFunctions {
         if (l.required && r.required) {
           val result = cb.newLocal[Boolean]("land_result")
           cb.if_(
-            l.toI(cb).get(cb).asBoolean.value,
-            cb.assign(result, r.toI(cb).get(cb).asBoolean.value),
+            l.toI(cb).getOrAssert(cb).asBoolean.value,
+            cb.assign(result, r.toI(cb).getOrAssert(cb).asBoolean.value),
             cb.assign(result, const(false)),
           )
 
@@ -581,9 +581,9 @@ object UtilFunctions extends RegistryFunctions {
         if (l.required && r.required) {
           val result = cb.newLocal[Boolean]("land_result")
           cb.if_(
-            l.toI(cb).get(cb).asBoolean.value,
+            l.toI(cb).getOrAssert(cb).asBoolean.value,
             cb.assign(result, const(true)),
-            cb.assign(result, r.toI(cb).get(cb).asBoolean.value),
+            cb.assign(result, r.toI(cb).getOrAssert(cb).asBoolean.value),
           )
 
           IEmitCode.present(cb, primitive(result))

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -284,7 +284,11 @@ object EmitNDArray {
                 (0 until outputNDims).foreach { i =>
                   cb.assign(
                     tempShapeElement,
-                    tupleValue.loadField(cb, i).getOrFatal(cb, "Can't reshape if elements of reshape tuple are missing.", errorID).asLong.value,
+                    tupleValue.loadField(cb, i).getOrFatal(
+                      cb,
+                      "Can't reshape if elements of reshape tuple are missing.",
+                      errorID,
+                    ).asLong.value,
                   )
                   cb.if_(
                     tempShapeElement < 0L, {
@@ -326,7 +330,11 @@ object EmitNDArray {
                 (0 until outputNDims).foreach { i =>
                   cb.assign(
                     tempShapeElement,
-                    tupleValue.loadField(cb, i).getOrFatal(cb, "Can't reshape if elements of reshape tuple are missing.", errorID).asLong.value,
+                    tupleValue.loadField(cb, i).getOrFatal(
+                      cb,
+                      "Can't reshape if elements of reshape tuple are missing.",
+                      errorID,
+                    ).asLong.value,
                   )
                   cb.assign(
                     requestedShapeValues(i),
@@ -382,7 +390,9 @@ object EmitNDArray {
                   // compute index of first input which has non-zero concat axis size
                   val firstNonEmpty = cb.newLocal[Int]("ndarray_concat_first_nonempty", 0)
                   cb.while_(
-                    stagedArrayOfSizes.loadElement(cb, firstNonEmpty).getOrAssert(cb).asInt64.value.ceq(0L),
+                    stagedArrayOfSizes.loadElement(cb, firstNonEmpty).getOrAssert(
+                      cb
+                    ).asInt64.value.ceq(0L),
                     cb.assign(firstNonEmpty, firstNonEmpty + 1),
                   )
 
@@ -653,7 +663,10 @@ object EmitNDArray {
                         }, {
                           val startPoint = cb.newLocal[Long](
                             "ndarray_producer_filter_init_axis",
-                            filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(cb, s"NDArrayFilter: can't filter on missing index (axis=$idx)").asLong.value,
+                            filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(
+                              cb,
+                              s"NDArrayFilter: can't filter on missing index (axis=$idx)",
+                            ).asLong.value,
                           )
                           childProducer.stepAxis(idx)(cb, startPoint)
                         },
@@ -668,9 +681,17 @@ object EmitNDArray {
                           childProducer.stepAxis(idx)(cb, step)
                           cb.assign(idxVars(idx), idxVars(idx) + step)
                         }, {
-                          val currentPos = filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(cb, s"NDArrayFilter: can't filter on missing index (axis=$idx)").asLong.value
+                          val currentPos =
+                            filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(
+                              cb,
+                              s"NDArrayFilter: can't filter on missing index (axis=$idx)",
+                            ).asLong.value
                           cb.assign(idxVars(idx), idxVars(idx) + step)
-                          val newPos = filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(cb, s"NDArrayFilter: can't filter on missing index (axis=$idx)").asLong.value
+                          val newPos =
+                            filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(
+                              cb,
+                              s"NDArrayFilter: can't filter on missing index (axis=$idx)",
+                            ).asLong.value
                           val stepSize = cb.newLocal[Long](
                             "ndarray_producer_filter_step_size",
                             newPos - currentPos,

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -173,7 +173,7 @@ object EmitNDArray {
                     elemRef,
                     EmitCode.present(cb.emb, childProducer.loadElementAtCurrentAddr(cb)),
                   )
-                  bodyEC.toI(cb).get(cb, "NDArray map body cannot be missing")
+                  bodyEC.toI(cb).getOrFatal(cb, "NDArray map body cannot be missing")
                 }
               }
             }
@@ -227,7 +227,7 @@ object EmitNDArray {
                       EmitCode.present(cb.emb, rightBroadcasted.loadElementAtCurrentAddr(cb)),
                     )
 
-                    bodyEC.toI(cb).get(cb, "NDArrayMap2 body cannot be missing", errorID)
+                    bodyEC.toI(cb).getOrFatal(cb, "NDArrayMap2 body cannot be missing", errorID)
                   }
                 }
               }
@@ -284,11 +284,7 @@ object EmitNDArray {
                 (0 until outputNDims).foreach { i =>
                   cb.assign(
                     tempShapeElement,
-                    tupleValue.loadField(cb, i).get(
-                      cb,
-                      "Can't reshape if elements of reshape tuple are missing.",
-                      errorID,
-                    ).asLong.value,
+                    tupleValue.loadField(cb, i).getOrFatal(cb, "Can't reshape if elements of reshape tuple are missing.", errorID).asLong.value,
                   )
                   cb.if_(
                     tempShapeElement < 0L, {
@@ -330,11 +326,7 @@ object EmitNDArray {
                 (0 until outputNDims).foreach { i =>
                   cb.assign(
                     tempShapeElement,
-                    tupleValue.loadField(cb, i).get(
-                      cb,
-                      "Can't reshape if elements of reshape tuple are missing.",
-                      errorID,
-                    ).asLong.value,
+                    tupleValue.loadField(cb, i).getOrFatal(cb, "Can't reshape if elements of reshape tuple are missing.", errorID).asLong.value,
                   )
                   cb.assign(
                     requestedShapeValues(i),
@@ -371,7 +363,7 @@ object EmitNDArray {
               IEmitCode(
                 cb,
                 ndsArraySValue.hasMissingValues(cb), {
-                  val firstND = ndsArraySValue.loadElement(cb, 0).get(cb).asNDArray
+                  val firstND = ndsArraySValue.loadElement(cb, 0).getOrAssert(cb).asNDArray
 
                   // compute array of sizes along concat axis, and total size of concat axis
                   val arrayLongPType = PCanonicalArray(PInt64(), true)
@@ -390,7 +382,7 @@ object EmitNDArray {
                   // compute index of first input which has non-zero concat axis size
                   val firstNonEmpty = cb.newLocal[Int]("ndarray_concat_first_nonempty", 0)
                   cb.while_(
-                    stagedArrayOfSizes.loadElement(cb, firstNonEmpty).get(cb).asInt64.value.ceq(0L),
+                    stagedArrayOfSizes.loadElement(cb, firstNonEmpty).getOrAssert(cb).asInt64.value.ceq(0L),
                     cb.assign(firstNonEmpty, firstNonEmpty + 1),
                   )
 
@@ -466,7 +458,7 @@ object EmitNDArray {
                               curIdxVar >= stagedArrayOfSizes.loadElement(
                                 cb,
                                 currentNDArrayIdx,
-                              ).get(cb).asInt64.value,
+                              ).getOrAssert(cb).asInt64.value,
                             )
                             cb.while_(
                               shouldLoop, {
@@ -475,7 +467,7 @@ object EmitNDArray {
                                   curIdxVar - stagedArrayOfSizes.loadElement(
                                     cb,
                                     currentNDArrayIdx,
-                                  ).get(cb).asInt64.value,
+                                  ).getOrAssert(cb).asInt64.value,
                                 )
                                 cb.assign(currentNDArrayIdx, currentNDArrayIdx + 1)
                                 cb.if_(
@@ -485,7 +477,7 @@ object EmitNDArray {
                                     curIdxVar >= stagedArrayOfSizes.loadElement(
                                       cb,
                                       currentNDArrayIdx,
-                                    ).get(cb).asInt64.value,
+                                    ).getOrAssert(cb).asInt64.value,
                                   ),
                                   cb.assign(shouldLoop, false),
                                 )
@@ -498,7 +490,7 @@ object EmitNDArray {
 
                     override def loadElementAtCurrentAddr(cb: EmitCodeBuilder): SValue = {
                       val currentNDArray =
-                        ndsArraySValue.loadElement(cb, currentNDArrayIdx).get(cb).asNDArray
+                        ndsArraySValue.loadElement(cb, currentNDArrayIdx).getOrAssert(cb).asNDArray
                       currentNDArray.loadElement(idxVars, cb)
                     }
                   }
@@ -661,10 +653,7 @@ object EmitNDArray {
                         }, {
                           val startPoint = cb.newLocal[Long](
                             "ndarray_producer_filter_init_axis",
-                            filtPValues(idx).loadElement(cb, idxVars(idx).toI).get(
-                              cb,
-                              s"NDArrayFilter: can't filter on missing index (axis=$idx)",
-                            ).asLong.value,
+                            filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(cb, s"NDArrayFilter: can't filter on missing index (axis=$idx)").asLong.value,
                           )
                           childProducer.stepAxis(idx)(cb, startPoint)
                         },
@@ -679,15 +668,9 @@ object EmitNDArray {
                           childProducer.stepAxis(idx)(cb, step)
                           cb.assign(idxVars(idx), idxVars(idx) + step)
                         }, {
-                          val currentPos = filtPValues(idx).loadElement(cb, idxVars(idx).toI).get(
-                            cb,
-                            s"NDArrayFilter: can't filter on missing index (axis=$idx)",
-                          ).asLong.value
+                          val currentPos = filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(cb, s"NDArrayFilter: can't filter on missing index (axis=$idx)").asLong.value
                           cb.assign(idxVars(idx), idxVars(idx) + step)
-                          val newPos = filtPValues(idx).loadElement(cb, idxVars(idx).toI).get(
-                            cb,
-                            s"NDArrayFilter: can't filter on missing index (axis=$idx)",
-                          ).asLong.value
+                          val newPos = filtPValues(idx).loadElement(cb, idxVars(idx).toI).getOrFatal(cb, s"NDArrayFilter: can't filter on missing index (axis=$idx)").asLong.value
                           val stepSize = cb.newLocal[Long](
                             "ndarray_producer_filter_step_size",
                             newPos - currentPos,

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -1536,14 +1536,14 @@ object EmitStream {
               cb.goto(blocksProducer.LproduceElement)
               cb.define(blocksProducer.LproduceElementDone)
               val row =
-                blocksProducer.element.toI(cb).get(cb, "StreamWhiten: missing tuple").asBaseStruct
+                blocksProducer.element.toI(cb).getOrFatal(cb, "StreamWhiten: missing tuple").asBaseStruct
               row.loadField(cb, prevWindowName).consume(
                 cb,
                 {},
                 prevWindow => state.initializeWindow(cb, prevWindow.asNDArray),
               )
               val block =
-                row.loadField(cb, newChunkName).get(cb, "StreamWhiten: missing chunk").asNDArray
+                row.loadField(cb, newChunkName).getOrFatal(cb, "StreamWhiten: missing chunk").asNDArray
               val whitenedBlock =
                 LinalgCodeUtils.checkColMajorAndCopyIfNeeded(block, cb, elementRegion)
               state.whitenBlock(cb, whitenedBlock)
@@ -1727,7 +1727,7 @@ object EmitStream {
               SBaseStructPointer(rProd.element.st.storageType().asInstanceOf[PBaseStruct])
 
             def loadInterval(cb: EmitCodeBuilder, rElem: SValue): SIntervalValue =
-              rElem.asBaseStruct.loadField(cb, rIntrvlName).get(cb).asInterval
+              rElem.asBaseStruct.loadField(cb, rIntrvlName).getOrAssert(cb).asInterval
 
             val q: StagedMinHeap =
               StagedMinHeap(mb.emodb, rElemSTy) {
@@ -1736,9 +1736,9 @@ object EmitStream {
                   val r = loadInterval(cb, b)
                   IntervalFunctions.intervalEndpointCompare(
                     cb,
-                    l.loadEnd(cb).get(cb),
+                    l.loadEnd(cb).getOrAssert(cb),
                     l.includesEnd,
-                    r.loadEnd(cb).get(cb),
+                    r.loadEnd(cb).getOrAssert(cb),
                     r.includesEnd,
                   )
               }(mb.ecb)
@@ -1798,8 +1798,8 @@ object EmitStream {
                     cb.goto(lProd.LproduceElement)
                     cb.define(lProd.LproduceElementDone)
 
-                    cb.assign(lElement, lProd.element.toI(cb).get(cb).asBaseStruct)
-                    val point = lElement.loadField(cb, lKeyField).get(cb)
+                    cb.assign(lElement, lProd.element.toI(cb).getOrAssert(cb).asBaseStruct)
+                    val point = lElement.loadField(cb, lKeyField).getOrAssert(cb)
 
                     /* Drop rows from the priority queue if their interval's right endpoint is
                      * before the current key. */
@@ -1807,7 +1807,7 @@ object EmitStream {
                       cb.if_(
                         q.nonEmpty(cb), {
                           val interval = loadInterval(cb, q.peek(cb))
-                          val end = interval.loadEnd(cb).get(cb)
+                          val end = interval.loadEnd(cb).getOrAssert(cb)
                           cb.if_(
                             pointGTIntervalEndpoint(cb, point, end, interval.includesEnd), {
                               q.pop(cb)
@@ -1830,20 +1830,20 @@ object EmitStream {
                       val rElement = rElemSTy.coerceOrCopy(
                         cb,
                         elementRegion,
-                        rProd.element.toI(cb).get(cb),
+                        rProd.element.toI(cb).getOrAssert(cb),
                         deepCopy = false,
                       )
                       val interval = loadInterval(cb, rElement)
 
                       // Drop intervals whose right endpoint is before the key
-                      val end = interval.loadEnd(cb).get(cb)
+                      val end = interval.loadEnd(cb).getOrAssert(cb)
                       cb.if_(
                         pointGTIntervalEndpoint(cb, point, end, interval.includesEnd),
                         cb.goto(LproduceRightElement),
                       )
 
                       // Stop consuming intervals if the left endpoint is after the key
-                      val start = interval.loadStart(cb).get(cb)
+                      val start = interval.loadStart(cb).getOrAssert(cb)
                       cb.if_(
                         pointLTIntervalEndpoint(
                           cb,
@@ -2673,7 +2673,7 @@ object EmitStream {
           }
 
           mb.implementLabel(childProducer.LproduceElementDone) { cb =>
-            cb.assign(xCurElt, childProducer.element.toI(cb).get(cb))
+            cb.assign(xCurElt, childProducer.element.toI(cb).getOrAssert(cb))
             cb.assign(curKey, subsetCode)
             cb.if_(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
           }
@@ -3314,7 +3314,7 @@ object EmitStream {
 
                   cb.define(p.LproduceElementDone)
                   val storedElt =
-                    eltType.store(cb, p.elementRegion, p.element.toI(cb).get(cb), false)
+                    eltType.store(cb, p.elementRegion, p.element.toI(cb).getOrAssert(cb), false)
                   cb += (heads(idx) = storedElt)
                   cb.assign(matchIdx, (idx + k) >>> 1)
                   cb.goto(LrunMatch)
@@ -3366,7 +3366,7 @@ object EmitStream {
                 cb,
                 env.bind(ctxName, cb.memoize(contextsArray.loadElement(cb, idx))),
               )
-                .get(cb, "streams in zipJoinProducers cannot be missing")
+                .getOrFatal(cb, "streams in zipJoinProducers cannot be missing")
                 .asInstanceOf[SStreamConcrete]
               streamRequiresMemoryManagement = iter.st.requiresMemoryManagement
               cb += iterArray.update(idx, iter.it)
@@ -3759,7 +3759,7 @@ object EmitStream {
 
                     cb.define(p.LproduceElementDone)
                     cb += (heads(idx) =
-                      unifiedType.store(cb, p.elementRegion, p.element.toI(cb).get(cb), false)
+                      unifiedType.store(cb, p.elementRegion, p.element.toI(cb).getOrAssert(cb), false)
                     )
                     cb.assign(matchIdx, (const(idx) + k) >>> 1)
                     cb.goto(LrunMatch)
@@ -3801,14 +3801,14 @@ object EmitStream {
                 childProducer.requiresMemoryManagementPerElement
 
               def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                cb.assign(queueSize, emit(maxQueueSize, cb).get(cb).asInt32.value)
+                cb.assign(queueSize, emit(maxQueueSize, cb).getOrAssert(cb).asInt32.value)
                 cb.assign(queue, Code.newInstance[util.ArrayDeque[BitPackedVector], Int](queueSize))
-                cb.assign(threshold, emit(r2Threshold, cb).get(cb).asFloat64.value)
-                cb.assign(windowSize, emit(winSize, cb).get(cb).asInt32.value)
+                cb.assign(threshold, emit(r2Threshold, cb).getOrAssert(cb).asFloat64.value)
+                cb.assign(windowSize, emit(winSize, cb).getOrAssert(cb).asInt32.value)
                 cb.assign(
                   builder,
                   Code.newInstance[BitPackedVectorBuilder, Int](
-                    emit(nSamples, cb).get(cb).asInt32.value
+                    emit(nSamples, cb).getOrAssert(cb).asInt32.value
                   ),
                 )
                 childProducer.initialize(cb, outerRegion)
@@ -3824,9 +3824,9 @@ object EmitStream {
                   cb,
                   cb.goto(Lpruned),
                   { case sc: SBaseStructValue =>
-                    val locus = sc.loadField(cb, "locus").get(cb).asLocus
+                    val locus = sc.loadField(cb, "locus").getOrAssert(cb).asLocus
                     val locusObj = locus.getLocusObj(cb)
-                    val genotypes = sc.loadField(cb, "genotypes").get(cb).asIndexable
+                    val genotypes = sc.loadField(cb, "genotypes").getOrAssert(cb).asIndexable
                     cb += builder.invoke[Unit]("reset")
                     genotypes.forEachDefinedOrMissing(cb)(
                       (cb, _) => cb += builder.invoke[Unit]("addMissing"),

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -1536,14 +1536,20 @@ object EmitStream {
               cb.goto(blocksProducer.LproduceElement)
               cb.define(blocksProducer.LproduceElementDone)
               val row =
-                blocksProducer.element.toI(cb).getOrFatal(cb, "StreamWhiten: missing tuple").asBaseStruct
+                blocksProducer.element.toI(cb).getOrFatal(
+                  cb,
+                  "StreamWhiten: missing tuple",
+                ).asBaseStruct
               row.loadField(cb, prevWindowName).consume(
                 cb,
                 {},
                 prevWindow => state.initializeWindow(cb, prevWindow.asNDArray),
               )
               val block =
-                row.loadField(cb, newChunkName).getOrFatal(cb, "StreamWhiten: missing chunk").asNDArray
+                row.loadField(cb, newChunkName).getOrFatal(
+                  cb,
+                  "StreamWhiten: missing chunk",
+                ).asNDArray
               val whitenedBlock =
                 LinalgCodeUtils.checkColMajorAndCopyIfNeeded(block, cb, elementRegion)
               state.whitenBlock(cb, whitenedBlock)
@@ -3759,7 +3765,12 @@ object EmitStream {
 
                     cb.define(p.LproduceElementDone)
                     cb += (heads(idx) =
-                      unifiedType.store(cb, p.elementRegion, p.element.toI(cb).getOrAssert(cb), false)
+                      unifiedType.store(
+                        cb,
+                        p.elementRegion,
+                        p.element.toI(cb).getOrAssert(cb),
+                        false,
+                      )
                     )
                     cb.assign(matchIdx, (const(idx) + k) >>> 1)
                     cb.goto(LrunMatch)

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StagedMinHeap.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StagedMinHeap.scala
@@ -65,7 +65,7 @@ object StagedMinHeap {
       classBuilder.defineEmitMethod("load", FastSeq(IntInfo), elemParamType) { mb =>
         mb.emitSCode { cb =>
           val idx = mb.getCodeParam[Int](1)
-          heap.loadElement(cb, idx).toI(cb).get(cb, errorMsg = idx.toS)
+          heap.loadElement(cb, idx).toI(cb).getOrAssert(cb, debugMsg = idx.toS)
         }
       }
 

--- a/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
@@ -57,8 +57,10 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
     requestedType: TStruct,
   ): IEmitCode = {
     context.toI(cb).map(cb) { case ctxStruct: SBaseStructValue =>
-      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
-      val pathString = ctxStruct.loadField(cb, "partitionPath").getOrAssert(cb).asString.loadString(cb)
+      val partIdx =
+        cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
+      val pathString =
+        ctxStruct.loadField(cb, "partitionPath").getOrAssert(cb).asString.loadString(cb)
 
       val makeUID = requestedType.hasField(uidFieldName)
       val concreteRequestedType = if (makeUID)

--- a/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
@@ -57,8 +57,8 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
     requestedType: TStruct,
   ): IEmitCode = {
     context.toI(cb).map(cb) { case ctxStruct: SBaseStructValue =>
-      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").get(cb), "partIdx")
-      val pathString = ctxStruct.loadField(cb, "partitionPath").get(cb).asString.loadString(cb)
+      val partIdx = cb.memoizeField(ctxStruct.loadField(cb, "partitionIndex").getOrAssert(cb), "partIdx")
+      val pathString = ctxStruct.loadField(cb, "partitionPath").getOrAssert(cb).asString.loadString(cb)
 
       val makeUID = requestedType.hasField(uidFieldName)
       val concreteRequestedType = if (makeUID)

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -878,7 +878,9 @@ case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option
         override def method: EmitMethodBuilder[_] = mb
 
         override val length: Option[EmitCodeBuilder => Code[Int]] =
-          Some(cb => ctxField.asBaseStruct.loadField(cb, "n_variants").getOrAssert(cb).asLong.value.toI)
+          Some(cb =>
+            ctxField.asBaseStruct.loadField(cb, "n_variants").getOrAssert(cb).asLong.value.toI
+          )
 
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
 

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -713,7 +713,7 @@ case class BgenPartitionReaderWithVariantFilter(
             override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
               vs.initialize(cb, outerRegion)
 
-              cb.assign(fileIdx, context.loadField(cb, "file_index").get(cb).asInt.value)
+              cb.assign(fileIdx, context.loadField(cb, "file_index").getOrAssert(cb).asInt.value)
               val metadata =
                 cb.memoize(mb.getObject[IndexedSeq[BgenFileMetadata]](fileMetadata.toFastSeq)
                   .invoke[Int, BgenFileMetadata]("apply", fileIdx))
@@ -744,7 +744,7 @@ case class BgenPartitionReaderWithVariantFilter(
                 currVariantIndex < stopVariantIndex, {
                   val addr = index.queryIndex(cb, vs.elementRegion, currVariantIndex)
                     .loadField(cb, "offset")
-                    .get(cb).asLong.value
+                    .getOrAssert(cb).asLong.value
                   cb += cbfis.invoke[Long, Unit]("seek", addr)
 
                   val reqTypeNoUID = if (requestedType.hasField(uidFieldName))
@@ -752,7 +752,7 @@ case class BgenPartitionReaderWithVariantFilter(
                   else requestedType
                   val sc = StagedBGENReader.decodeRow(cb, elementRegion, cbfis, nSamples, fileIdx,
                     compression, skipInvalidLoci, contigRecoding, reqTypeNoUID, rg)
-                    .toI(cb).get(cb)
+                    .toI(cb).getOrAssert(cb)
                   val scUID = if (requestedType.hasField(uidFieldName))
                     sc.asBaseStruct.insert(
                       cb,
@@ -782,7 +782,7 @@ case class BgenPartitionReaderWithVariantFilter(
               cb.goto(vs.LproduceElement)
               cb.define(vs.LproduceElementDone)
 
-              val nextVariant = vs.element.toI(cb).get(cb).asBaseStruct
+              val nextVariant = vs.element.toI(cb).getOrAssert(cb).asBaseStruct
               val bound = SStackStruct.constructFromArgs(
                 cb,
                 vs.elementRegion,
@@ -804,11 +804,11 @@ case class BgenPartitionReaderWithVariantFilter(
 
               cb.assign(
                 currVariantIndex,
-                index.queryBound(cb, bound, false).loadField(cb, 0).get(cb).asLong.value,
+                index.queryBound(cb, bound, false).loadField(cb, 0).getOrAssert(cb).asLong.value,
               )
               cb.assign(
                 stopVariantIndex,
-                index.queryBound(cb, bound, true).loadField(cb, 0).get(cb).asLong.value,
+                index.queryBound(cb, bound, true).loadField(cb, 0).getOrAssert(cb).asLong.value,
               )
               cb.goto(Lstart)
 
@@ -878,11 +878,11 @@ case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option
         override def method: EmitMethodBuilder[_] = mb
 
         override val length: Option[EmitCodeBuilder => Code[Int]] =
-          Some(cb => ctxField.asBaseStruct.loadField(cb, "n_variants").get(cb).asLong.value.toI)
+          Some(cb => ctxField.asBaseStruct.loadField(cb, "n_variants").getOrAssert(cb).asLong.value.toI)
 
         override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
 
-          cb.assign(fileIdx, context.loadField(cb, "file_index").get(cb).asInt.value)
+          cb.assign(fileIdx, context.loadField(cb, "file_index").getOrAssert(cb).asInt.value)
           val metadata =
             cb.memoize(mb.getObject[IndexedSeq[BgenFileMetadata]](fileMetadata.toFastSeq)
               .invoke[Int, BgenFileMetadata]("apply", fileIdx))
@@ -903,11 +903,11 @@ case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option
 
           cb.assign(
             currVariantIndex,
-            context.loadField(cb, "first_variant_index").get(cb).asLong.value,
+            context.loadField(cb, "first_variant_index").getOrAssert(cb).asLong.value,
           )
           cb.assign(
             endVariantIndex,
-            currVariantIndex + context.loadField(cb, "n_variants").get(cb).asLong.value,
+            currVariantIndex + context.loadField(cb, "n_variants").getOrAssert(cb).asLong.value,
           )
         }
 
@@ -920,7 +920,7 @@ case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option
 
           val addr = index.queryIndex(cb, eltRegion, currVariantIndex)
             .loadField(cb, "offset")
-            .get(cb).asLong.value
+            .getOrAssert(cb).asLong.value
           cb += cbfis.invoke[Long, Unit]("seek", addr)
 
           val reqTypeNoUID = if (requestedType.hasField(uidFieldName))

--- a/hail/src/main/scala/is/hail/io/bgen/StagedBGENReader.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/StagedBGENReader.scala
@@ -582,7 +582,7 @@ object StagedBGENReader {
           val r = index.queryIndex(cb, mb.partitionRegion, cb.memoize(indices(i))).loadField(
             cb,
             "key",
-          ).get(cb)
+          ).getOrAssert(cb)
           cb += boxed.update(
             i,
             StringFunctions.svalueToJavaValue(cb, mb.partitionRegion, r, safe = true),
@@ -905,9 +905,9 @@ object BGENFunctions extends RegistryFunctions {
 
         val nAdded = cb.newLocal[Long]("nAdded", 0)
         mergedStream.memoryManagedConsume(er.region, cb) { cb =>
-          val row = mergedStream.element.toI(cb).get(cb).asBaseStruct
+          val row = mergedStream.element.toI(cb).getOrAssert(cb).asBaseStruct
           val key = row.subset("locus", "alleles")
-          val offset = row.loadField(cb, "offset").get(cb).asInt64.value
+          val offset = row.loadField(cb, "offset").getOrAssert(cb).asInt64.value
           cb.assign(nAdded, nAdded + 1)
           iw.add(
             cb,

--- a/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -73,7 +73,7 @@ class StagedInternalNodeBuilder(
   def loadFrom(cb: EmitCodeBuilder, ib: StagedIndexWriterUtils, idx: Value[Int]): Unit = {
     cb.assign(region, ib.getRegion(idx))
     cb.assign(node.a, ib.getArrayOffset(idx))
-    val aoff = node.loadField(cb, 0).get(cb).asInstanceOf[SIndexablePointerValue].a
+    val aoff = node.loadField(cb, 0).getOrAssert(cb).asInstanceOf[SIndexablePointerValue].a
     ab.loadFrom(cb, aoff, ib.getLength(idx))
   }
 

--- a/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/StagedIndexReader.scala
@@ -333,7 +333,9 @@ class StagedIndexReader(
       val keyFieldName = if (isInternalNode) "first_key" else "key"
       if (isPointQuery) {
         def ltNeedle(child: IEmitCode): Code[Boolean] = {
-          val key = child.getOrAssert(cb).asBaseStruct.loadField(cb, keyFieldName).getOrAssert(cb).asBaseStruct
+          val key = child.getOrAssert(cb).asBaseStruct.loadField(cb, keyFieldName).getOrAssert(
+            cb
+          ).asBaseStruct
           val c = compareStructWithPartitionIntervalEndpoint(cb, key, startKey, startLeansRight)
           c < 0
         }
@@ -377,7 +379,10 @@ class StagedIndexReader(
       cb.if_(
         idx < children.loadLength(), {
           val successorChild = children.loadElement(cb, idx).getOrAssert(cb).asBaseStruct
-          cb.assign(successorIndex, successorChild.loadField(cb, "first_idx").getOrAssert(cb).asLong.value)
+          cb.assign(
+            successorIndex,
+            successorChild.loadField(cb, "first_idx").getOrAssert(cb).asLong.value,
+          )
           cb.assign(successorLeaf, getFirstLeaf(cb, successorChild))
         },
       )
@@ -594,11 +599,16 @@ class StagedIndexReader(
             level ceq 0, {
               val leafNode = readLeafNode(cb, offset)
               val localIdx = cb.memoize(
-                (absIndex - leafNode.loadField(cb, "first_idx").getOrAssert(cb).asInt64.value.toL).toI
+                (absIndex - leafNode.loadField(cb, "first_idx").getOrAssert(
+                  cb
+                ).asInt64.value.toL).toI
               )
               cb.assign(
                 result,
-                leafNode.loadField(cb, "keys").getOrAssert(cb).asIndexable.loadElement(cb, localIdx).getOrAssert(cb),
+                leafNode.loadField(cb, "keys").getOrAssert(cb).asIndexable.loadElement(
+                  cb,
+                  localIdx,
+                ).getOrAssert(cb),
               )
             }, {
               val internalNode = readInternalNode(cb, offset)

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -2211,8 +2211,10 @@ case class GVCFPartitionReader(
   ): IEmitCode = {
     context.toI(cb).map(cb) { case ctxValue: SBaseStructValue =>
       val fileNum = cb.memoizeField(ctxValue.loadField(cb, "fileNum").getOrAssert(cb).asInt32.value)
-      val filePath = cb.memoizeField(ctxValue.loadField(cb, "path").getOrAssert(cb).asString.loadString(cb))
-      val contig = cb.memoizeField(ctxValue.loadField(cb, "contig").getOrAssert(cb).asString.loadString(cb))
+      val filePath =
+        cb.memoizeField(ctxValue.loadField(cb, "path").getOrAssert(cb).asString.loadString(cb))
+      val contig =
+        cb.memoizeField(ctxValue.loadField(cb, "contig").getOrAssert(cb).asString.loadString(cb))
       val start = cb.memoizeField(ctxValue.loadField(cb, "start").getOrAssert(cb).asInt32.value)
       val end = cb.memoizeField(ctxValue.loadField(cb, "end").getOrAssert(cb).asInt32.value)
 

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -2210,11 +2210,11 @@ case class GVCFPartitionReader(
     requestedType: TStruct,
   ): IEmitCode = {
     context.toI(cb).map(cb) { case ctxValue: SBaseStructValue =>
-      val fileNum = cb.memoizeField(ctxValue.loadField(cb, "fileNum").get(cb).asInt32.value)
-      val filePath = cb.memoizeField(ctxValue.loadField(cb, "path").get(cb).asString.loadString(cb))
-      val contig = cb.memoizeField(ctxValue.loadField(cb, "contig").get(cb).asString.loadString(cb))
-      val start = cb.memoizeField(ctxValue.loadField(cb, "start").get(cb).asInt32.value)
-      val end = cb.memoizeField(ctxValue.loadField(cb, "end").get(cb).asInt32.value)
+      val fileNum = cb.memoizeField(ctxValue.loadField(cb, "fileNum").getOrAssert(cb).asInt32.value)
+      val filePath = cb.memoizeField(ctxValue.loadField(cb, "path").getOrAssert(cb).asString.loadString(cb))
+      val contig = cb.memoizeField(ctxValue.loadField(cb, "contig").getOrAssert(cb).asString.loadString(cb))
+      val start = cb.memoizeField(ctxValue.loadField(cb, "start").getOrAssert(cb).asInt32.value)
+      val end = cb.memoizeField(ctxValue.loadField(cb, "end").getOrAssert(cb).asInt32.value)
 
       val requestedPType = fullRowPType.subsetTo(requestedType).asInstanceOf[PStruct]
       val eltRegion = mb.genFieldThisRef[Region]("gvcf_elt_region")

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -265,7 +265,10 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
                 cb,
                 result.firstDataAddress + (loopCtr * elementType.byteSize),
                 region,
-                dataValue.loadElement(cb, loopCtr.toI).getOrFatal(cb, "NDArray elements cannot be missing"),
+                dataValue.loadElement(cb, loopCtr.toI).getOrFatal(
+                  cb,
+                  "NDArray elements cannot be missing",
+                ),
                 true,
               ),
             )
@@ -466,7 +469,9 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     val a = cb.memoize(addr)
     val shapeTuple = shapeType.loadCheapSCode(cb, representation.loadField(a, "shape"))
     val shape =
-      Array.tabulate(nDims)(i => SizeValueDyn(shapeTuple.loadField(cb, i).getOrAssert(cb).asLong.value))
+      Array.tabulate(nDims)(i =>
+        SizeValueDyn(shapeTuple.loadField(cb, i).getOrAssert(cb).asLong.value)
+      )
     val strideTuple = strideType.loadCheapSCode(cb, representation.loadField(a, "strides"))
     val strides = Array.tabulate(nDims)(strideTuple.loadField(cb, _).getOrAssert(cb).asLong.value)
     val firstDataAddress = cb.memoize(dataFirstElementPointer(a))

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -54,7 +54,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     assert(settables.length == nDims, s"got ${settables.length} settables, expect $nDims dims")
     val shapeTuple = shapeType.loadCheapSCode(cb, representation.loadField(addr, "shape"))
     (0 until nDims).foreach { dimIdx =>
-      cb.assign(settables(dimIdx), shapeTuple.loadField(cb, dimIdx).get(cb).asLong.value)
+      cb.assign(settables(dimIdx), shapeTuple.loadField(cb, dimIdx).getOrAssert(cb).asLong.value)
     }
   }
 
@@ -63,7 +63,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     assert(settables.length == nDims)
     val strideTuple = strideType.loadCheapSCode(cb, representation.loadField(addr, "strides"))
     (0 until nDims).foreach { dimIdx =>
-      cb.assign(settables(dimIdx), strideTuple.loadField(cb, dimIdx).get(cb).asLong.value)
+      cb.assign(settables(dimIdx), strideTuple.loadField(cb, dimIdx).getOrAssert(cb).asLong.value)
     }
   }
 
@@ -265,10 +265,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
                 cb,
                 result.firstDataAddress + (loopCtr * elementType.byteSize),
                 region,
-                dataValue.loadElement(cb, loopCtr.toI).get(
-                  cb,
-                  "NDArray elements cannot be missing",
-                ),
+                dataValue.loadElement(cb, loopCtr.toI).getOrFatal(cb, "NDArray elements cannot be missing"),
                 true,
               ),
             )
@@ -469,9 +466,9 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     val a = cb.memoize(addr)
     val shapeTuple = shapeType.loadCheapSCode(cb, representation.loadField(a, "shape"))
     val shape =
-      Array.tabulate(nDims)(i => SizeValueDyn(shapeTuple.loadField(cb, i).get(cb).asLong.value))
+      Array.tabulate(nDims)(i => SizeValueDyn(shapeTuple.loadField(cb, i).getOrAssert(cb).asLong.value))
     val strideTuple = strideType.loadCheapSCode(cb, representation.loadField(a, "strides"))
-    val strides = Array.tabulate(nDims)(strideTuple.loadField(cb, _).get(cb).asLong.value)
+    val strides = Array.tabulate(nDims)(strideTuple.loadField(cb, _).getOrAssert(cb).asLong.value)
     val firstDataAddress = cb.memoize(dataFirstElementPointer(a))
     new SNDArrayPointerValue(sType, a, shape, strides, firstDataAddress)
   }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -139,7 +139,11 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
           " local alleles",
         ),
       )
-      localAlleles.loadElement(cb, av).getOrFatal(cb, const("lgt_to_gt: found missing value in local alleles at index ").concat(av.toS), errorID = errorID)
+      localAlleles.loadElement(cb, av).getOrFatal(
+        cb,
+        const("lgt_to_gt: found missing value in local alleles at index ").concat(av.toS),
+        errorID = errorID,
+      )
         .asInt.value
     }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -139,11 +139,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
           " local alleles",
         ),
       )
-      localAlleles.loadElement(cb, av).get(
-        cb,
-        const("lgt_to_gt: found missing value in local alleles at index ").concat(av.toS),
-        errorID = errorID,
-      )
+      localAlleles.loadElement(cb, av).getOrFatal(cb, const("lgt_to_gt: found missing value in local alleles at index ").concat(av.toS), errorID = errorID)
         .asInt.value
     }
 


### PR DESCRIPTION
Include the call-stack of the compiler when we emit assertions into generated code. This is useful for showing us the trace of the code that emitted a `.get` on `IEmitCode`, for example.

To do this, add a `hailBuildConfiguration` enum {`release`|`debug`} into `build-info.properties`, parsed as `HAIL_BUILD_CONFIGURATION`.