### PR TITLE
[batch] Correct ordering of batch_id and job_group_id in mark_job_errored

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -571,7 +571,7 @@ async def schedule_job(app, record, instance):
         log.exception(f'while making job config for job {id} with attempt id {attempt_id}')
 
         await mark_job_errored(
-            app, job_group_id, batch_id, job_id, attempt_id, record['user'], format_version, traceback.format_exc()
+            app, batch_id, job_group_id, job_id, attempt_id, record['user'], format_version, traceback.format_exc()
         )
         raise
 


### PR DESCRIPTION
Surfaced because sometimes k8s secrets 404 for CI pipelines and we got FK constraint failures because there is no batch 0. No danger of bad data being written, just noise and unnecessary database load. Thank you foreign key checks!