### PR TITLE
[internal-gateway] Greatly reduce rate limit for batch-driver requests from workers

### DIFF
--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -173,7 +173,7 @@ def auth_check_exemption() -> dict:
 
 
 def rate_limit_config(service: str) -> dict:
-    max_rps = 60 if service == 'batch-driver' else 200
+    max_rps = 10 if service == 'batch-driver' else 200
 
     return {
         '@type': 'type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit',


### PR DESCRIPTION
This might be an overcorrection, but as it is we are not scheduling more than 30j/s with the database at max capacity. With 3 replicas of internal-gateway this will let 30rps reach the batch driver. This should give us a clear indication of whether rate limiting more aggressively will help with the database currently being overloaded. See [this thread](https://hail.zulipchat.com/#narrow/stream/300487-Hail-Batch-Dev/topic/trying.20to.20mark.20batch.200.20complete/near/423839864) for more details.