### PR TITLE
[query] Don't error on VCF export when haploid call is unphased

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -432,6 +432,12 @@ class VCFTests(unittest.TestCase):
 """
         assert msg in str(exp.value)
 
+    def test_export_vcf_haploid(self):
+        ds = hl.import_vcf(resource("sample.vcf"))
+        ds = ds.select_entries(GT=hl.call(0))
+        with TemporaryFilename(suffix='.vcf') as export_path:
+            hl.export_vcf(ds, export_path)
+
     def import_gvcfs_sample_vcf(self, path):
         parts_type = hl.tarray(hl.tinterval(hl.tstruct(locus=hl.tlocus('GRCh37'))))
         parts = [

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -1012,7 +1012,10 @@ case class VCFPartitionWriter(
       case v: SCallValue =>
         val ploidy = v.ploidy(cb)
         cb.if_(ploidy.ceq(0), cb._fatal("VCF spec does not support 0-ploid calls."))
-        cb.if_(ploidy.ceq(1), cb._fatal("VCF spec does not support phased haploid calls."))
+        cb.if_(
+          ploidy.ceq(1) && v.isPhased(cb),
+          cb._fatal("VCF spec does not support phased haploid calls."),
+        )
         val c = v.canonicalCall(cb)
         _writeB(cb, Code.invokeScalaObject1[Int, Array[Byte]](Call.getClass, "toUTF8", c))
     }


### PR DESCRIPTION
resolves #14330 