### PR TITLE
[batch] reduce runtime of listing batches and job groups

### DIFF
--- a/batch/batch/front_end/query/query_v1.py
+++ b/batch/batch/front_end/query/query_v1.py
@@ -113,7 +113,7 @@ WITH base_t AS (
   ) AS cancelled_t ON TRUE
   STRAIGHT_JOIN billing_project_users ON batches.billing_project = billing_project_users.billing_project
   WHERE {' AND '.join(where_conditions)}
-  ORDER BY job_groups.batch_id DESC, job_groups.job_group_id DESC
+  ORDER BY job_groups.batch_id DESC
   LIMIT 51
 )
 SELECT base_t.*, cost_t.cost, cost_t.cost_breakdown
@@ -128,7 +128,7 @@ LEFT JOIN LATERAL (
   ) AS usage_t
   LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
 ) AS cost_t ON TRUE
-ORDER BY batch_id DESC, job_group_id DESC
+ORDER BY batch_id DESC
 """
 
     return (sql, where_args)
@@ -188,7 +188,7 @@ LEFT JOIN LATERAL (
   LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
 ) AS cost_t ON TRUE
 WHERE {' AND '.join(where_conds)}
-ORDER BY job_group_id DESC
+ORDER BY job_group_id ASC
 LIMIT 51;
 """
 

--- a/batch/batch/front_end/query/query_v1.py
+++ b/batch/batch/front_end/query/query_v1.py
@@ -91,6 +91,7 @@ WITH base_t AS (
   SELECT
     batches.*,
     job_groups.batch_id as batch_id,
+    job_groups.job_group_id as job_group_id,
     cancelled_t.cancelled IS NOT NULL AS cancelled,
     job_groups_n_jobs_in_complete_states.n_completed,
     job_groups_n_jobs_in_complete_states.n_succeeded,

--- a/batch/batch/front_end/query/query_v1.py
+++ b/batch/batch/front_end/query/query_v1.py
@@ -91,7 +91,6 @@ WITH base_t AS (
   SELECT
     batches.*,
     job_groups.batch_id as batch_id,
-    job_groups.job_group_id as job_group_id,
     cancelled_t.cancelled IS NOT NULL AS cancelled,
     job_groups_n_jobs_in_complete_states.n_completed,
     job_groups_n_jobs_in_complete_states.n_succeeded,

--- a/batch/batch/front_end/query/query_v2.py
+++ b/batch/batch/front_end/query/query_v2.py
@@ -158,7 +158,7 @@ LEFT JOIN LATERAL (
   LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
 ) AS cost_t ON TRUE
 WHERE {' AND '.join(where_conditions)}
-ORDER BY job_groups.batch_id DESC, job_groups.job_group_id DESC
+ORDER BY job_groups.batch_id DESC
 LIMIT 51;
 """
 

--- a/batch/batch/front_end/query/query_v2.py
+++ b/batch/batch/front_end/query/query_v2.py
@@ -158,7 +158,7 @@ LEFT JOIN LATERAL (
   LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
 ) AS cost_t ON TRUE
 WHERE {' AND '.join(where_conditions)}
-ORDER BY batches.id DESC
+ORDER BY job_groups.batch_id DESC, job_groups.job_group_id DESC
 LIMIT 51;
 """
 


### PR DESCRIPTION
I started with a random slow query I observed in the database. I confirmed, by running it on the database, that it was longer than a few seconds. I never waiting long enough for it to complete.

Starting with `select * from job_groups limit 51;`, I iteratively added clauses until the query was slow. I got through every clause except the `ORDER BY batches.id DESC` with queries that took fractions of a second. Around the same time @jigold commented:

> Is the order by statement the issue. Would have thought that should be on job groups table

I think she's exactly right.

This is the query:

```
SELECT
  batches.*,
  cancelled_t.cancelled IS NOT NULL AS cancelled,
  job_groups_n_jobs_in_complete_states.n_completed,
  job_groups_n_jobs_in_complete_states.n_succeeded,
  job_groups_n_jobs_in_complete_states.n_failed,
  job_groups_n_jobs_in_complete_states.n_cancelled,
  cost_t.cost,
  cost_t.cost_breakdown
FROM job_groups
LEFT JOIN batches ON batches.id = job_groups.batch_id
LEFT JOIN billing_projects ON batches.billing_project = billing_projects.name
LEFT JOIN job_groups_n_jobs_in_complete_states ON job_groups.batch_id = job_groups_n_jobs_in_complete_states.id AND job_groups.job_group_id = job_groups_n_jobs_in_complete_states.job_group_id
LEFT JOIN LATERAL (
  SELECT 1 AS cancelled
  FROM job_group_self_and_ancestors
  INNER JOIN job_groups_cancelled
    ON job_group_self_and_ancestors.batch_id = job_groups_cancelled.id AND
      job_group_self_and_ancestors.ancestor_id = job_groups_cancelled.job_group_id
  WHERE job_groups.batch_id = job_group_self_and_ancestors.batch_id AND
    job_groups.job_group_id = job_group_self_and_ancestors.job_group_id
) AS cancelled_t ON TRUE
STRAIGHT_JOIN billing_project_users ON batches.billing_project = billing_project_users.billing_project
LEFT JOIN LATERAL (
  SELECT COALESCE(SUM(`usage` * rate), 0) AS cost, JSON_OBJECTAGG(resources.resource, COALESCE(`usage` * rate, 0)) AS cost_breakdown
  FROM (
    SELECT resource_id, CAST(COALESCE(SUM(`usage`), 0) AS SIGNED) AS `usage`
    FROM aggregated_job_group_resources_v3
    WHERE job_groups.batch_id = aggregated_job_group_resources_v3.batch_id AND job_groups.job_group_id = aggregated_job_group_resources_v3.job_group_id
    GROUP BY resource_id
  ) AS usage_t
  LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
) AS cost_t ON TRUE
WHERE (billing_project_users.`user` = 'test') AND NOT deleted AND job_groups.job_group_id = 0 AND (job_groups.batch_id < 8141193) AND ((batches.user = 'test'))
ORDER BY batches.id DESC
LIMIT 51;
```

And this is its explain. I've removed the possible_keys and ref for legibility. The important thing is the "Extra" column. Notice that we use a filesort. Filesorts are *extremely* slow.

| id | select_type       | table                                | partitions | type   | key         | key_len | rows    | filtered | Extra                                                                                 |
| -- | ----------------- | ------------------------------------ | ---------- | ------ | ----------- | ------- | ------- | -------- | ------------------------------------------------------------------------------------- |
|  1 | PRIMARY           | job_groups                           | NULL       | range  | PRIMARY     | 8       | 5420371 |    10.00 | Using where; Using index; Using temporary; Using filesort; Rematerialize (<derived3>) |
|  1 | PRIMARY           | batches                              | NULL       | eq_ref | PRIMARY     | 8       |       1 |    50.00 | Using where                                                                           |
|  1 | PRIMARY           | billing_projects                     | NULL       | eq_ref | PRIMARY     | 302     |       1 |   100.00 | Using index                                                                           |
|  1 | PRIMARY           | job_groups_n_jobs_in_complete_states | NULL       | eq_ref | PRIMARY     | 12      |       1 |   100.00 | NULL                                                                                  |
|  1 | PRIMARY           | job_groups_cancelled                 | NULL       | ref    | PRIMARY     | 8       |       1 |   100.00 | Using index                                                                           |
|  1 | PRIMARY           | job_group_self_and_ancestors         | NULL       | eq_ref | PRIMARY     | 16      |       1 |   100.00 | Using index                                                                           |
|  1 | PRIMARY           | billing_project_users                | NULL       | eq_ref | PRIMARY     | 604     |       1 |   100.00 | Using index                                                                           |
|  1 | PRIMARY           | <derived3>                           | NULL       | ALL    | NULL        | NULL    |       2 |   100.00 | Using where                                                                           |
|  3 | DEPENDENT DERIVED | <derived4>                           | NULL       | ALL    | NULL        | NULL    |      35 |   100.00 | NULL                                                                                  |
|  3 | DEPENDENT DERIVED | resources                            | NULL       | eq_ref | resource_id | 4       |       1 |   100.00 | NULL                                                                                  |
|  4 | DEPENDENT DERIVED | aggregated_job_group_resources_v3    | NULL       | ref    | PRIMARY     | 12      |      35 |   100.00 | Using temporary                                                                       |

If I replace `ORDER BY batches.id DESC` with `ORDER BY job_groups.batch_id DESC` the query plan excludes a filesort.

| id | select_type       | table                                | partitions | type    | key         | key_len | rows    | filtered | Extra                                                                     |
| -- | ----------------- | ------------------------------------ | ---------- | ------  | ----------- | ------- | ------- | -------- | ------------------------------------------------------------------------- |
|  1 | PRIMARY           | job_groups                           | NULL       | range   | PRIMARY     | 8       | 5420371 |    10.00 | Using where; Backward index scan; Using index; Rematerialize (<derived3>) |
|  1 | PRIMARY           | batches                              | NULL       | eq_ref  | PRIMARY     | 8       |       1 |    50.00 | Using where                                                               |
|  1 | PRIMARY           | billing_projects                     | NULL       | eq_ref  | PRIMARY     | 302     |       1 |   100.00 | Using index                                                               |
|  1 | PRIMARY           | job_groups_n_jobs_in_complete_states | NULL       | eq_ref  | PRIMARY     | 12      |       1 |   100.00 | NULL                                                                      |
|  1 | PRIMARY           | job_groups_cancelled                 | NULL       | ref     | PRIMARY     | 8       |       1 |   100.00 | Using index                                                               |
|  1 | PRIMARY           | job_group_self_and_ancestors         | NULL       | eq_ref  | PRIMARY     | 16      |       1 |   100.00 | Using index                                                               |
|  1 | PRIMARY           | billing_project_users                | NULL       | eq_ref  | PRIMARY     | 604     |       1 |   100.00 | Using index                                                               |
|  1 | PRIMARY           | <derived3>                           | NULL       | ALL     | NULL        | NULL    |       2 |   100.00 | Using where                                                               |
|  3 | DEPENDENT DERIVED | <derived4>                           | NULL       | ALL     | NULL        | NULL    |      35 |   100.00 | NULL                                                                      |
|  3 | DEPENDENT DERIVED | resources                            | NULL       | eq_ref  | resource_id | 4       |       1 |   100.00 | NULL                                                                      |
|  4 | DEPENDENT DERIVED | aggregated_job_group_resources_v3    | NULL       | ref     | PRIMARY     | 12      |      35 |   100.00 | Using temporary                                                           |

As far as I can tell this is a query planner "bug" in MySQL. batches.id and job_groups.batch_id are equal because of the `ON` sub-clause of the `LEFT JOIN` clause.

This change ensures that everywhere we query the job_groups table we order by batch_id and job_group_id *from that table* in descending order. This ensures were consistent across the codebase.

This query now takes 0.01 seconds.