### PR TITLE
[ci] switch to a new personal access token

### DIFF
--- a/infra/gcp-broad/hail-is/ci_config.enc.json
+++ b/infra/gcp-broad/hail-is/ci_config.enc.json
@@ -1,33 +1,33 @@
 {
 	"deploy_steps": [],
-	"github_context": "ENC[AES256_GCM,data:JN5usSTHOg==,iv:CIA4ELD6Q/v06KbISOHeDCsnSjwWb51VpzrhN+3WKvs=,tag:EwSRVoerxqgxbx5+Q0G/Fg==,type:str]",
-	"storage_uri": "ENC[AES256_GCM,data:S9R83B6rVVTSozyBnfFpbeqJ,iv:85Y90Bg2jMGRt7lq3gaCQLxzQ+4pbRA+Hedw8/fGrak=,tag:ouZIcQAWBkgWll7GugW8ag==,type:str]",
-	"bucket_location": "ENC[AES256_GCM,data:AHTjUUbf6JamtYE=,iv:g9L8ceIQx0xUmE5xGHJJkwCrFilf165bYtjF2alVztU=,tag:QawH9d1WLm6SPLt7gBZnhQ==,type:str]",
-	"bucket_storage_class": "ENC[AES256_GCM,data:NX6xM/R9Bp8=,iv:WWskNj+PWD4UxWMsRyIqZroxIijNaadGJvFMJcH7NU8=,tag:ncV4dCcWEx+iF6RbsICKeQ==,type:str]",
-	"test_oauth2_callback_urls": "ENC[AES256_GCM,data:jObH1oS9+3OBoGu4VlQqj2OWlE2Fus3XuWYZ2pYWUq8pm3JYU7CK1KhWJfjioUh82f/67N2Y62JO+sI0+YBrpHk7cSWNCW4qrv/YSMRYr9x8VmcGg2kGIMXpcik9xdSidmpma4nWchXCARTuYATr0MHicDndxYkkQva0ImgWd3QrYRjjy/ZI1EGDyXIHSVTcSSqybErh/tM5vg8p0SnClrU7GSwFrMUV+80l7m1Qar+CIMd4gMYsBVTmdxEjeK5S+Z/tKQ434LduV8u21LrsQe4Q5DjgNRdgRNrn4llWfen9ie8+6onLjDfyfLr6/sh+50oGV6SFyEYPytKBToY2t1QnYrJaH/xcuGP9oPSDfvPdgdn7GzBUahcAEA72juIGN/RotnITws2iduAMNFjIFUEGKYVgFQWeHswmhzNhztIhKwlncq/RQzeuGVgB4prPTFqbT/7eT/57eHqFx84kedD7XEC5eCeqSdbCIcXMIzLAtwSFCHh/gL++luQ3jlriklw/bZ/OJVAISLWAgINKrmqbli7RW8gmDJ3Rlq2k20KgI2TLbAyUYCJm00jWTAGBy/jdrIQImrY2EIjdoBTnUFErcKIshkc7751R28lin22ybQCaXvmYfvy7Tuf0gp5pnn+U/znXLRBo/lW3kJadDilpkAcusdqlEtB6s/JcaBEhchVkfvpufJUXdyo5kMBjr2XSiWvu3xvMZbaMq59jdSwFhQu/tWCUdLL7bB8cXHshODihDvQGaEixx7NLffmzK3NO0aizBvOiPTyuBNRD+Q+RSSKKyi5AOqDSH3Umbhqe8RtMfUgYLZTsqozWBMopfsiECB+I8teapvpuJtI5+dvOmkIjrvcaUnZAVmRpcE7xF+wDUIZGETiscEYTv/7Y+G4ylLy6E5z4zk7ugiQjY79/H0xSm8mIYXyduDcFa4ZgWxYIZbghLgbi2FJj7J0+6SDm00eD1NfHkaozke7KvFlILW1VUOcrqqlxGzXlxQLoT27LxWQXSrwp+5SYvJHQfeSxT03ksHLHqoSa3lEMiYXHFh2mzwmtjK4wkkZpTUt0RJcfOnIy5SI1bkubnL0FU3ARbftYXL+aFWBdl86y7Hu+397srrZ4SZ2LNr3I33XzrHowUMxfvDLDAgSKxUCWuBm1EggaIQit7WMg9hDHxHc6QCWbupO0oFeGrvUbQoZZEqrLFc/cGbDGFZTURPrvTcE9Lrr2R7kzn3nKhHSAzCZrndhY5mCCOfR60cE04H857x1HhAJKxIsS3D1izDyQpoI//mbz+fKEEwDjWR5bnE1K8umy1CUMJYoPibzcVFpuBdTzvqwO4WeD8fiwdL6kFL788n/8+K4qERkVEip0PyhleAtvjxER4Xt/JSjNvikukfF07/GouPulnh8S7JeRGEgn0Lx/NeBLFbCQvdibsr/knCzDXbO5EoBd78AIkqBSD/2i1M4XEFsJNZOGpP9ZYNUUWdRrDyLKgqJkaEyTIyJ3mPiZcOo7htKyHol3,iv:BwWT2b31zTn1ELC9fZofIptqRDkJj2ybtAhwFQQtBKs=,tag:zkbT2TolS1XG7Ixa8lLwQw==,type:str]",
+	"github_context": "ENC[AES256_GCM,data:uuAIsXg52A==,iv:pHqi8cTPKC7dubMiPhYxy7Gc9GX8pTrjxlmCcmdnPiQ=,tag:6BvGUwKMN+j/ejpyR8UpzA==,type:str]",
+	"storage_uri": "ENC[AES256_GCM,data:tujcZ3WmeDYWtCZFDsRL/BbB,iv:p81TCKElG/3L78oA4J5gF8m99+6YIAZHmscr85GEvUw=,tag:qWTxVh8SgVf+eF1MSA+fAg==,type:str]",
+	"bucket_location": "ENC[AES256_GCM,data:KwYNP+er99qin6Y=,iv:7aD4RpevQosLkTcD0aqJ556Wx58PhUryKd96WtD7gFo=,tag:cr/6qfX8WoZt4COnemNoZw==,type:str]",
+	"bucket_storage_class": "ENC[AES256_GCM,data:U5uAnvELyjI=,iv:N63oG6h4ELTy9WEuZcT7cYOQ96MUcrCy69NJgR5MuSc=,tag:hA22zXOByZXEiRy6nYG9CA==,type:str]",
+	"test_oauth2_callback_urls": "ENC[AES256_GCM,data:7w8rvlLneiXP0js4p4cqR31hWczs1alNKLdCDebeOr8b3LRN2cV770YmtwBtmxW0ei8CqO7nNtp9UZg/LaqyRMyogm2feWaIhd+j0flVytDVXGvVMDf8cB0oY4/MCoFANFQnJ1xP3CB0ESBRKk695pdFp3ZPmmdy6qF5+r9JbIq3ELcxkwuzKATaDgljhWu00H3s3Y6pdwF8ueX8cFh51+a3+BnJlONDLNV8PG1rzsz3ReP2Kjv82EcjMwk4BrU2cMMqka2ILAuLcTCvX7a2FOSq11OLAGqJ2enFdymSUQJM+one/ZkwAWgAW9rnvLFgSu1PkbjaQ9PbeotopypUVyhLrMqJUAxB4qeckEudkKuGM1dfZWqOPAXT7iuXB/X7EN5uRKrIcoJ746PJgnskAJDRDpK1lNbWeuv+dm3DSowaH+cEAHU5XGYI0JWWXa6TU7nYNsFh0G30SVYVWvQEmnTdT4Hv3Yi1ptr8FhYcR8oHtC+oOfqxXYiGcbTdvmI6Iwwm6reTqTWN904/oVdvOcjF2wAuge/agxfWA8TjT8zBNgLmyr2cNwbmhz4jz/COTZd/fOanXyUH3i4DcYIp9zBOQQdweptYVdAIbRDBl/SG72wHqjI0981KThQ2Kt3Blt1omshwhtgrf2tXouk3+sgYnZZm1OuDQDKF8lRlPqSNhEiK6BI0Q8GhncAlvaRxG6DiXRCiu+zdh+0PgsvsiL553Ki9oI0OVgHTwx/GRLuwEGkQCLYDmaTbvyLznNmUjxWtXBl8ETIUhOVTiWE+Lnq+dPl0dhA0jgPRSBKAa9+IRmrRlUHI0iW9Y4UTJXX3+W81qCSI1nq540V9vr/jYGIKeTwncdroZF0MzF9zMOp6C9ELQoZikUcxPpgq6J04ULdrDNO8RYJxowL/ZtsegoUBZlJKFvHwqm9h1fRlZ1kIYopjxY/LM6f1KxEGrUwspFvP7fMwc0IURQhhRgn0GQPh0FKzkVkE3Um9yZS3xcM0OJOfZGcNWZTwsIg7c2UHuazsB73o2g4fIK5RJTlkvH7X2WzbqE8abXhRjWPN3BP/XEozvZhoZook2yhNM8qpzn3eGD0fOqyQEkA2O2qT9C3IJVP98FL5y1R7Julb7FDYOk8F8xGo8I7Zmd8nAqHeP8QvNJFIO4fMQLrh3dqciV1ofwP+qLtUAAgaM8NghvX86Mp4jOql0HQxDTCU6ZHFTQIV9+b3ZBmMwyf+EFC/35S01bNY3sSANGMKU5PTaghrjLuvXnlBy/oCH1Ev6Jyx8V8AVEQdm6THnMoLhofOmw3SMcLQMDsUDUkDLUv1P/Y6SNLrX6ZLz2djZnarBaPxKuzks101kMRaoSUO2jxON9X9JGS/Xxsz+wMCq3NmUjIm6hk0H9ciYg1Iavu26HZ1pqreNpoVNtTnUj1ggPwke90dwfl9y61orhTIaioR7j2MxKNbS/SuL05pIroUAXZsEFkiuN5LRWPqdwwwq47TCq1QnsAVAnG7lyaqNslD,iv:tO64hGXtVNioCGYcGUHNcimNNWCZe83eM/XVhqTyVtk=,tag:yBAkDCCnYiWJXBDEsfpzeg==,type:str]",
 	"watched_branches": [
 		[
-			"ENC[AES256_GCM,data:89ey6FPaU863AVhw/cXAJQk=,iv:mea/Zkiso71LCd+WMOyUzLxRhdTEvo+iCZCJEkOY9Hg=,tag:ay8YrryybQFeFGSwwRwcjA==,type:str]",
-			"ENC[AES256_GCM,data:UTQKiA==,iv:wRgansKSpx+LxP0qTXQtGjCaTjE6cjEDVFXFx7PYlZY=,tag:LSCQKiuXxRx8S/O04c57oQ==,type:bool]",
-			"ENC[AES256_GCM,data:4ER1XA==,iv:kBXFBG+9FV28yAPlrYHGrmVcoZKTryI6wt07fqrBr4k=,tag:6rdzwJ7e+14yScGqQGmmiA==,type:bool]"
+			"ENC[AES256_GCM,data:UL1yY1feFvUsudXLlPSjCcI=,iv:5b5vJrT07kXuj9XOafKZSPfL6KG+trVSv9dRjFyR1vo=,tag:K1hyoeM0HS7GO7b6JLIyhg==,type:str]",
+			"ENC[AES256_GCM,data:QQ3Osg==,iv:2Yb8NPJrEkG2xFHSEHn9wHctRgVldSk0QvjHd5LeCv4=,tag:IpGeM4ZjNArwXzVgCPWKug==,type:bool]",
+			"ENC[AES256_GCM,data:RidTJQ==,iv:Co9iJ5DNZ/XJCWWGi9wclFH9dp7dZVD4G+p3Rl5VbXc=,tag:280mUXJTTAykTeUo9pqRSA==,type:bool]"
 		]
 	],
-	"github_oauth_token": "ENC[AES256_GCM,data:vrcdC7SFoC92Gp9hzCzAsS19UsxEP1vfwY7kxHs4ngpjTvAmjDAYwg==,iv:uodttuaHtdOiw3jiwQPPhj6vkGOnEQsmw6XmrKnoCmg=,tag:gOeJGgOLj0gc6/C9X4et2w==,type:str]",
-	"github_user1_oauth_token": "ENC[AES256_GCM,data:4UpueIA+DJsqowuqT/CM6LWO23+AOCnla7F/En9uLm/KeTghKpxx3A==,iv:w70hLt2b1zTbyFZfuX9cjFtN2BJvvpM2/9qg1pGDlfc=,tag:uEprSZGsAyaEz5hZwKyB2w==,type:str]",
+	"github_oauth_token": "ENC[AES256_GCM,data:fU8dHJvwbaj985PFSglwk+XdUtE9gdOkdwi62lsploetzj0J/mLC7o7443xKOCd9ASJu3Esc6Nhlmi9gYbukR12wDd07sUJF5zxWZ7Im7jkWfdXx7kMO2ee3SFV5,iv:/9XzhBaUlxMhC+UMgE3VgbIdcc6XKkvRcgmQL82Ykt4=,tag:SqSEJR51krrToR1zOU3YHQ==,type:str]",
+	"github_user1_oauth_token": "ENC[AES256_GCM,data:VKKbJpwK4FdqNVahB8ulKnnk9H99AHqjFJ8MF/Cu/wCKG/pAAodf9A==,iv:4lCiAZZUakA1XsSAS65ttRY9kwDOxYCFU/tD5Q8wimY=,tag:meq8BpYJ0LG5nhgJ061Vbw==,type:str]",
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/hail-vdc/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2023-05-09T19:53:50Z",
-				"enc": "CiQA0ec+W0aC8bSdWP22np+CuMKieVOLkuzgXwQ9L3fYe8KuG9MSSQCe82Ad9tL4LzDEnBpALOvttYTDL8vIrBeS1IeFIimyNgfitkWSXcKWsB7hc08iI/8S/1pJRyUFpioMLI7aV0r0JZjeXajiofM="
+				"created_at": "2024-02-29T18:01:13Z",
+				"enc": "CiQA0ec+W/cAt2qYQY/buQOQqKg+NcYOqdKOJvGnI+ZXfitg344SSQCe82AdO3iHE/Wqgvb9yxLyJGOpyH8sOgMb208I6S4l+CtCXS8sv2Icuk8GLrN/eBQenJR8/AXptdszsrvND2ngz5M/+8q2kN0="
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-05-09T19:53:50Z",
-		"mac": "ENC[AES256_GCM,data:ow71s2AziKKv6bmNPpddL7T87p8irYRzg+sLfYa2sHJ6OxSLpahT+Usjh70RE2Xmidycc8tvl+VFgFYUOFPocwEDReIbhM4B6gHbTThizgaV6tnIcSypzk+YUj/C3sl00668uOOtd5HAdnv1Ne1j4zOfuJGuXeVVZOB4zD+S25o=,iv:74+qhgXteCUeZKxh7GvTl7NPXgnoHPltwa8W0vBwG38=,tag:Yknyjubbr8ASIdZQ1RzPvA==,type:str]",
+		"lastmodified": "2024-02-29T18:01:14Z",
+		"mac": "ENC[AES256_GCM,data:8XiJ+3b7fMsJkGcraWfBh703a3Av9F1yshDbmz2J5NXpZsaHxZ8pIR6hap+ST6wp9CvBxYMmcP5XOVp17p9O/WIa1CboRIctXqkFsUYt41f6GFjP6hwlsdeFW/yP55Mv681sq1bBmeMrfU2LFaTG+z8lzeAM9VaI5E0xf2YILpU=,iv:x1Zy0k5UmXMJ1rzoys9XBNCMpyqYoivRLbhy8JebxYo=,tag:NSreDd2t1FgJgjO5Dyq+Xg==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.3"

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -89,7 +89,15 @@ Instructions:
    use_artifact_registry = false
    ```
 
-- You can optionally create a `/tmp/ci_config.json` file to enable CI triggered by GitHub events:
+- You can optionally create a `/tmp/ci_config.json` file to enable CI triggered by GitHub
+  events. Note that `github_oauth_token` is not necessarily an OAuth2 access token. In fact, it
+  should be a fine-grained personal access token. The currently public documentation on fine-grained
+  access tokens is not very good. Check this [page in
+  `github/docs`](https://github.com/github/docs/blob/main/content/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens.md)
+  for information on how to create a personal access token that is privileged to access the
+  `hail-is` organization. Note in particular that personal access tokens have a "resource owner"
+  field which is fixed at creation time. The token can only read or write to repositories owned by
+  the "resource owner".
 
   ```json
   {


### PR DESCRIPTION
I created @hail-ci-robot, created a personal access token with the "resource owner" set to "hail-is". It has permission to read and write pull requests and statuses. The token expires in just under a year. I created a calendar event on Hail General Calendar to remind us to rotate it.