### PR TITLE
[infra] Update Azure provider 3.93.0

### DIFF
--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.99.0"
+      version = "=3.93.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/infra/azure/modules/batch/main.tf
+++ b/infra/azure/modules/batch/main.tf
@@ -72,6 +72,9 @@ resource "azurerm_storage_account" "batch" {
   location                 = var.resource_group.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version          = "TLS1_0"
+
+  allow_nested_items_to_be_public   = false
 
   blob_properties {
     last_access_time_enabled = true
@@ -96,6 +99,9 @@ resource "azurerm_storage_account" "test" {
   location                 = var.resource_group.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version          = "TLS1_0"
+
+  allow_nested_items_to_be_public   = false
 
   blob_properties {
     last_access_time_enabled = true

--- a/infra/azure/modules/ci/main.tf
+++ b/infra/azure/modules/ci/main.tf
@@ -4,6 +4,9 @@ resource "azurerm_storage_account" "ci" {
   location                 = var.resource_group.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version          = "TLS1_0"
+
+  allow_nested_items_to_be_public   = false
 
   blob_properties {
     last_access_time_enabled = true

--- a/infra/azure/modules/vdc/main.tf
+++ b/infra/azure/modules/vdc/main.tf
@@ -51,6 +51,7 @@ resource "azurerm_kubernetes_cluster" "vdc" {
   dns_prefix          = "example"
 
   automatic_channel_upgrade = "stable"
+  role_based_access_control_enabled = false
 
   default_node_pool {
     name           = "nonpreempt"
@@ -71,16 +72,13 @@ resource "azurerm_kubernetes_cluster" "vdc" {
     type = "SystemAssigned"
   }
 
-  addon_profile {
-    oms_agent {
-      enabled = true
-      log_analytics_workspace_id = azurerm_log_analytics_workspace.logs.id
-    }
+  oms_agent {
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.logs.id
   }
 
   # https://github.com/hashicorp/terraform-provider-azurerm/issues/7396
   lifecycle {
-    ignore_changes = [addon_profile.0, default_node_pool.0.node_count]
+    ignore_changes = [default_node_pool.0.node_count]
   }
 }
 
@@ -158,4 +156,5 @@ resource "azurerm_public_ip" "gateway_ip" {
   location            = var.resource_group.location
   sku                 = "Standard"
   allocation_method   = "Static"
+  zones               = ["1", "2", "3"]
 }


### PR DESCRIPTION
The major version upgrade of the azure provider changed some defaults, so in order to keep our infrastructure the same I explicitly set these changed fields back to their previous v2.99.0 values. The `min_tls_version` now defaults to 1.2, which *should* be fine as I presume all our services are using TLS 1.3, but we should independently verify that before making that change. I will make an issue accordingly.