### PR TITLE
Prevent iteration of Job and ResourceGroup objects

### DIFF
--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -123,6 +123,9 @@ class Job:
 
         return self._resources[item]
 
+    def __iter__(self):
+        raise TypeError(f'{type(self).__name__!r} object is not iterable')
+
     def __getitem__(self, item: str) -> '_resource.Resource':
         return self._get_resource(item)
 

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -264,6 +264,10 @@ class ResourceGroup(Resource):
             )
         return self._resources[item]
 
+    def __iter__(self):
+        # TODO Iteration over the group's resources could perhaps be useful to implement
+        raise TypeError(f'{type(self).__name__!r} object is not iterable')
+
     def __getitem__(self, item: str) -> ResourceFile:
         return self._get_resource(item)
 


### PR DESCRIPTION
We recently had a debugging odyssey due to the following code:

```python
import hailtop.batch as hb

def make_job(batch):
    job = batch.new_job(name='test')
    return job  # Oops, forgot to also return the output resource

batch = hb.Batch(name='test')
my_job, my_output = make_job(batch)
```

This lead to the following error message:

```
Traceback (most recent call last):
  File "…/borkscript.py", line 8, in <module>
    my_job, my_output = make_job(batch)
  File "…/site-packages/hailtop/batch/job.py", line 125, in __getitem__
    return self._get_resource(item)
  File "…/site-packages/hailtop/batch/job.py", line 118, in _get_resource
    r = self._batch._new_job_resource_file(self, value=item)
  File "…/site-packages/hailtop/batch/batch.py", line 405, in _new_job_resource_file
    jrf = _resource.JobResourceFile(value, source)
  File "…/site-packages/hailtop/batch/resource.py", line 128, in __init__
    super().__init__(value)
  File "…/site-packages/hailtop/batch/resource.py", line 48, in __init__
    assert value is None or isinstance(value, str)
AssertionError
```

Of course, in a 400-line script it took a long while to figure out what the traceback that seemed to have little to do with any dubious code of ours was trying to tell us, and to notice that the actual problem was the `return` 200 lines away!

The problem is that these classes define `__getitem__()` so their resources can be accessed as if via a dict. The assignment into multiple variables causes Python to try to interpret the RHS as something iterable, and as `__getitem__` is defined, it will use `__getitem__(0)`, `__getitem__(1)`,... to implement that iteration. These classes are not really iterable, so define a no-op `__iter__()` to prevent this.

With this, we get:

```
Traceback (most recent call last):
  File "…/borkscript.py", line 8, in <module>
    my_job, my_output = make_job(batch)
  File "…/site-packages/hailtop/batch/job.py", line 127, in __iter__
    raise TypeError(f'{type(self).__name__!r} object is not iterable')
TypeError: 'BashJob' object is not iterable
```

Which, while still not pointing directly at the problem, is much clearer.

Especially for ResourceGroup, it may be worth defining iteration for these classes in future. But at the moment `__getitem__`-based iteration fails, so this ensures it fails with a clear TypeError message.