### PR TITLE
[pip] Move protobuf pin from query to gear

### DIFF
--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -71,7 +71,7 @@ packaging==23.2
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   plotly
-pandas==2.2.0
+pandas==2.2.1
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt
@@ -79,7 +79,7 @@ plotly==5.19.0
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c hail/batch/../gear/pinned-requirements.txt
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
@@ -99,7 +99,7 @@ tenacity==8.2.3
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   plotly
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
     #   -c hail/batch/../hail/python/pinned-requirements.txt

--- a/benchmark/python/pinned-requirements.txt
+++ b/benchmark/python/pinned-requirements.txt
@@ -12,7 +12,7 @@ cycler==0.12.1
     # via matplotlib
 fonttools==4.49.0
     # via matplotlib
-importlib-resources==6.1.1
+importlib-resources==6.1.2
     # via matplotlib
 kiwisolver==1.4.5
     # via matplotlib
@@ -35,7 +35,7 @@ pillow==10.2.0
     #   matplotlib
 pyparsing==3.1.1
     # via matplotlib
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c hail/benchmark/python/../../hail/python/dev/pinned-requirements.txt
     #   -c hail/benchmark/python/../../hail/python/pinned-requirements.txt

--- a/ci/pinned-requirements.txt
+++ b/ci/pinned-requirements.txt
@@ -26,7 +26,7 @@ click==8.1.7
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt
     #   zulip
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   -c hail/ci/../hail/python/pinned-requirements.txt
     #   pyjwt
@@ -56,7 +56,7 @@ requests[security]==2.31.0
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt
     #   zulip
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -33,7 +33,7 @@ attrs==23.2.0
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
-cachetools==5.3.2
+cachetools==5.3.3
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
@@ -60,7 +60,7 @@ frozenlist==1.4.1
     #   aiosignal
 google-api-core==2.17.1
     # via google-api-python-client
-google-api-python-client==2.118.0
+google-api-python-client==2.120.0
     # via google-cloud-profiler
 google-auth==2.28.1
     # via
@@ -112,8 +112,7 @@ prometheus-client==0.20.0
     #   prometheus-async
 protobuf==3.20.2
     # via
-    #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
-    #   -c hail/gear/../hail/python/pinned-requirements.txt
+    #   -r hail/gear/requirements.txt
     #   google-api-core
     #   google-cloud-profiler
     #   googleapis-common-protos
@@ -134,7 +133,7 @@ pymysql==1.1.0
     #   aiomysql
 pyparsing==3.1.1
     # via httplib2
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt

--- a/gear/requirements.txt
+++ b/gear/requirements.txt
@@ -9,6 +9,8 @@
 aiohttp_session>=2.7,<2.13
 aiomysql>=0.0.20,<1
 google-cloud-profiler<4.0.0
+# google-cloud-profiler<4 is incompatible with protobuf 4 but does not place an upper bound on its pin
+protobuf==3.20.2
 kubernetes-asyncio>=19.15.1,<20
 prometheus_async>=19.2.0,<20
 prometheus_client>=0.11.0,<1

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -155,7 +155,7 @@ importlib-metadata==7.0.1
     #   sphinx
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.2
+ipykernel==6.29.3
     # via
     #   jupyter
     #   jupyter-console
@@ -183,7 +183,7 @@ jinja2==3.1.3
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.9.17
+json5==0.9.20
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
@@ -218,9 +218,9 @@ jupyter-core==5.7.1
     #   qtconsole
 jupyter-events==0.9.0
     # via jupyter-server
-jupyter-lsp==2.2.2
+jupyter-lsp==2.2.3
     # via jupyterlab
-jupyter-server==2.12.5
+jupyter-server==2.13.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -283,7 +283,7 @@ nodeenv==1.8.0
     # via
     #   pre-commit
     #   pyright
-notebook==7.1.0
+notebook==7.1.1
     # via jupyter
 notebook-shim==0.2.4
     # via
@@ -358,7 +358,7 @@ pygments==2.17.2
     #   sphinx
 pylint==2.17.7
     # via -r hail/hail/python/dev/requirements.txt
-pyright==1.1.351
+pyright==1.1.352
     # via -r hail/hail/python/dev/requirements.txt
 pytest==7.4.4
     # via
@@ -386,7 +386,7 @@ pytest-timestamper==0.0.9
     # via -r hail/hail/python/dev/requirements.txt
 pytest-xdist==2.5.0
     # via -r hail/hail/python/dev/requirements.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   arrow
@@ -444,7 +444,7 @@ six==1.16.0
     #   bleach
     #   python-dateutil
     #   rfc3339-validator
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
@@ -495,7 +495,7 @@ tomli==2.0.1
     #   jupyterlab
     #   pylint
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
 tornado==6.4
     # via
@@ -540,9 +540,9 @@ types-pyyaml==6.0.12.12
     # via -r hail/hail/python/dev/requirements.txt
 types-requests==2.31.0.6
     # via -r hail/hail/python/dev/requirements.txt
-types-setuptools==69.1.0.20240217
+types-setuptools==69.1.0.20240302
     # via -r hail/hail/python/dev/requirements.txt
-types-six==1.16.21.20240106
+types-six==1.16.21.20240301
     # via -r hail/hail/python/dev/requirements.txt
 types-tabulate==0.9.0.20240106
     # via -r hail/hail/python/dev/requirements.txt
@@ -550,7 +550,7 @@ types-urllib3==1.26.25.14
     # via
     #   -r hail/hail/python/dev/requirements.txt
     #   types-requests
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   anyio
@@ -564,7 +564,7 @@ urllib3==1.26.18
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   requests
-virtualenv==20.25.0
+virtualenv==20.25.1
     # via pre-commit
 watchfiles==0.21.0
     # via aiohttp-devtools

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -16,7 +16,7 @@ attrs==23.2.0
     # via aiohttp
 azure-common==1.1.28
     # via azure-mgmt-storage
-azure-core==1.30.0
+azure-core==1.30.1
     # via
     #   azure-identity
     #   azure-mgmt-core
@@ -30,14 +30,14 @@ azure-mgmt-storage==20.1.0
     # via -r hail/hail/python/hailtop/requirements.txt
 azure-storage-blob==12.19.0
     # via -r hail/hail/python/hailtop/requirements.txt
-boto3==1.34.46
+boto3==1.34.55
     # via -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.46
+botocore==1.34.55
     # via
     #   -r hail/hail/python/hailtop/requirements.txt
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
     # via
@@ -53,7 +53,7 @@ click==8.1.7
     # via typer
 commonmark==0.9.1
     # via rich
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -90,7 +90,7 @@ jmespath==1.0.1
     #   botocore
 jproperties==2.1.1
     # via -r hail/hail/python/hailtop/requirements.txt
-msal==1.26.0
+msal==1.27.0
     # via
     #   azure-identity
     #   msal-extensions
@@ -112,8 +112,6 @@ packaging==23.2
     # via msal-extensions
 portalocker==2.8.2
     # via msal-extensions
-protobuf==3.20.2
-    # via -r hail/hail/python/hailtop/requirements.txt
 pyasn1==0.5.1
     # via
     #   pyasn1-modules
@@ -128,7 +126,7 @@ pygments==2.17.2
     # via rich
 pyjwt[crypto]==2.8.0
     # via msal
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via botocore
 python-json-logger==2.0.7
     # via -r hail/hail/python/hailtop/requirements.txt
@@ -162,7 +160,7 @@ tabulate==0.9.0
     # via -r hail/hail/python/hailtop/requirements.txt
 typer==0.9.0
     # via -r hail/hail/python/hailtop/requirements.txt
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   azure-core
     #   azure-storage-blob

--- a/hail/python/hailtop/requirements.txt
+++ b/hail/python/hailtop/requirements.txt
@@ -14,7 +14,6 @@ janus>=0.6,<1.1
 nest_asyncio>=1.5.8,<2
 # <3.9.11: https://github.com/hail-is/hail/issues/14299
 orjson>=3.6.4,<3.9.11
-protobuf==3.20.2
 rich>=12.6.0,<13
 typer>=0.9.0,<1
 python-json-logger>=2.0.2,<3

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -30,7 +30,7 @@ azure-common==1.1.28
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-mgmt-storage
-azure-core==1.30.0
+azure-core==1.30.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
@@ -55,17 +55,17 @@ azure-storage-blob==12.19.0
     #   -r hail/hail/python/hailtop/requirements.txt
 bokeh==3.3.4
     # via -r hail/hail/python/requirements.txt
-boto3==1.34.46
+boto3==1.34.55
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.46
+botocore==1.34.55
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==5.3.3
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   google-auth
@@ -93,7 +93,7 @@ commonmark==0.9.1
     #   rich
 contourpy==1.2.0
     # via bokeh
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
@@ -154,7 +154,7 @@ jproperties==2.1.1
     #   -r hail/hail/python/hailtop/requirements.txt
 markupsafe==2.1.5
     # via jinja2
-msal==1.26.0
+msal==1.27.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
@@ -197,7 +197,7 @@ packaging==23.2
     #   bokeh
     #   msal-extensions
     #   plotly
-pandas==2.2.0
+pandas==2.2.1
     # via
     #   -r hail/hail/python/requirements.txt
     #   bokeh
@@ -211,11 +211,6 @@ portalocker==2.8.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   msal-extensions
-protobuf==3.20.2
-    # via
-    #   -c hail/hail/python/hailtop/pinned-requirements.txt
-    #   -r hail/hail/python/hailtop/requirements.txt
-    #   -r hail/hail/python/requirements.txt
 py4j==0.10.9.5
     # via pyspark
 pyasn1==0.5.1
@@ -247,7 +242,7 @@ pyspark==3.3.2
     # via
     #   -c hail/hail/python/dataproc-pre-installed-requirements.txt
     #   -r hail/hail/python/requirements.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   botocore
@@ -315,7 +310,7 @@ typer==0.9.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-core

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -10,7 +10,6 @@ numpy<2
 pandas>=2,<3
 parsimonious<1
 plotly>=5.18.0,<6
-protobuf==3.20.2
 pyspark>=3.3.2,<3.4
 requests>=2.31.0,<3
 scipy>1.2,<1.12


### PR DESCRIPTION
`protobuf` was pinned not because it is a direct dependency of `hail` but because the version of `google-cloud-profiler` that we use is incompatible with greater versions of protobuf despite not putting an upper bound on its pin. However, the current solution of pinning it in `hailtop/requirements.txt` and `python/requirements.txt` is problematic in three ways:

1. Users of the `hail` pip package cannot use a newer version of protobuf if they want to
2. The `protobuf` version is only a problem for `google-cloud-profiler`, which we only use in the batch/ci/auth services, not the hail package
3. `protobuf` no longer a transitive dependency of anything in `hailtop`/`hail`, so why include it (and why include it twice?)

This is all fixable by moving the `protobuf` pin "up" to `gear/requirements.txt`, where we also install `google-cloud-profiler`. Whether or not we should be upgrading `google-cloud-profiler` to remove the `protobuf` pin is a valid but unfortunately thornier issue since `google-cloud-profiler` statically linking libc breaks `libsass`. This allows us to punt on that upgrade while freeing users of the `protobuf` restriction.