### PR TITLE
[query/vds] Don't error if combiner is finished and output exists

### DIFF
--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -372,6 +372,8 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
             return combiner
 
     def _raise_if_output_exists(self):
+        if self.finished:
+            return
         fs = hl.current_backend().fs
         ref_success_path = os.path.join(VariantDataset._reference_path(self._output_path), '_SUCCESS')
         var_success_path = os.path.join(VariantDataset._variants_path(self._output_path), '_SUCCESS')


### PR DESCRIPTION
We want to error if the output exists since the combiner will overwrite the output path. However we don't want to do this if the combiner is done, since if the user is rerunning a script with the combiner in the middle of it, they are generally doing some post-processing on the combiner's output and we (and the users) would probably rather just skip the combiner if possible.