### PR TITLE
[query] Unify Let and AggLet into new Block node

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -328,7 +328,7 @@ class Let(IR):
         return Let(self.name, value, body)
 
     def head_str(self):
-        return escape_id(self.name)
+        return f'eval {escape_id(self.name)}'
 
     @property
     def bound_variables(self):

--- a/hail/python/hail/ir/renderer.py
+++ b/hail/python/hail/ir/renderer.py
@@ -434,7 +434,7 @@ class CSEPrintPass:
                     continue
 
                 if lift_type == 'value':
-                    child_builder = [f'(Let {name} ']
+                    child_builder = [f'(Let eval {name} ']
                 elif lift_type == 'agg':
                     child_builder = [f'(AggLet {name} False ']
                 else:

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -502,7 +502,7 @@ class CSETests(unittest.TestCase):
     def test_cse(self):
         x = ir.I32(5)
         x = ir.ApplyBinaryPrimOp('+', x, x)
-        expected = '(Let __cse_1 (I32 5)' ' (ApplyBinaryPrimOp `+`' ' (Ref __cse_1)' ' (Ref __cse_1)))'
+        expected = '(Let eval __cse_1 (I32 5)' ' (ApplyBinaryPrimOp `+`' ' (Ref __cse_1)' ' (Ref __cse_1)))'
         assert expected == CSERenderer()(x)
 
     def test_cse_debug(self):
@@ -517,10 +517,10 @@ class CSETests(unittest.TestCase):
         prod = ir.ApplyBinaryPrimOp('*', sum, sum)
         cond = ir.If(ir.ApplyComparisonOp('EQ', prod, x), sum, x)
         expected = (
-            '(Let __cse_1 (I32 5)'
-            ' (Let __cse_2 (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
+            '(Let eval __cse_1 (I32 5)'
+            ' (Let eval __cse_2 (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
             ' (If (ApplyComparisonOp EQ (ApplyBinaryPrimOp `*` (Ref __cse_2) (Ref __cse_2)) (Ref __cse_1))'
-            ' (Let __cse_3 (I32 5)'
+            ' (Let eval __cse_3 (I32 5)'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_3) (Ref __cse_3)))'
             ' (I32 5))))'
         )
@@ -532,9 +532,9 @@ class CSETests(unittest.TestCase):
         a2 = ir.ToArray(x)
         t = ir.MakeTuple([a1, a2])
         expected_re = (
-            '(Let __cse_1 (I32 0)'
-            ' (Let __cse_2 (I32 10)'
-            ' (Let __cse_3 (I32 1)'
+            '(Let eval __cse_1 (I32 0)'
+            ' (Let eval __cse_2 (I32 10)'
+            ' (Let eval __cse_3 (I32 1)'
             ' (MakeTuple (0 1)'
             ' (ToArray (StreamRange [0-9]+ False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))'
             ' (ToArray (StreamRange [0-9]+ False (Ref __cse_1) (Ref __cse_2) (Ref __cse_3)))))))'
@@ -549,8 +549,8 @@ class CSETests(unittest.TestCase):
         prod = ir.ApplyBinaryPrimOp('*', sum, y)
         div = ir.ApplyBinaryPrimOp('/', prod, sum)
         expected = (
-            '(Let __cse_1 (I32 5)'
-            ' (Let __cse_2 (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
+            '(Let eval __cse_1 (I32 5)'
+            ' (Let eval __cse_2 (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
             ' (ApplyBinaryPrimOp `/`'
             ' (ApplyBinaryPrimOp `*`'
             ' (Ref __cse_2)'
@@ -567,7 +567,7 @@ class CSETests(unittest.TestCase):
         cond = ir.If(ir.TrueIR(), prod, outer_repeated)
         expected = (
             '(If (True)'
-            ' (Let __cse_1 (I32 1)'
+            ' (Let eval __cse_1 (I32 1)'
             ' (ApplyBinaryPrimOp `*`'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
             ' (I32 5)))'
@@ -581,11 +581,11 @@ class CSETests(unittest.TestCase):
         inner = ir.Let('row', sum, sum)
         outer = ir.Let('row', ir.I32(5), inner)
         expected = (
-            '(Let __cse_2 (I32 2)'
-            ' (Let row (I32 5)'
-            ' (Let __cse_1 (ApplyBinaryPrimOp `*` (Ref row) (Ref __cse_2))'
-            ' (Let row (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
-            ' (Let __cse_3 (ApplyBinaryPrimOp `*` (Ref row) (Ref __cse_2))'
+            '(Let eval __cse_2 (I32 2)'
+            ' (Let eval row (I32 5)'
+            ' (Let eval __cse_1 (ApplyBinaryPrimOp `*` (Ref row) (Ref __cse_2))'
+            ' (Let eval row (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
+            ' (Let eval __cse_3 (ApplyBinaryPrimOp `*` (Ref row) (Ref __cse_2))'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_3) (Ref __cse_3)))))))'
         )
         assert expected == CSERenderer()(outer)
@@ -602,11 +602,11 @@ class CSETests(unittest.TestCase):
             '(TableAggregate (TableRange 5 1)'
             ' (AggLet __cse_1 False (GetField idx (Ref row))'
             ' (AggLet __cse_3 False (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
-            ' (Let __cse_2 (ApplyAggOp AggOp () ((Ref __cse_3)))'
+            ' (Let eval __cse_2 (ApplyAggOp AggOp () ((Ref __cse_3)))'
             ' (MakeTuple (0 1)'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_2) (Ref __cse_2))'
             ' (AggFilter False (True)'
-            ' (Let __cse_4 (ApplyAggOp AggOp () ((Ref __cse_3)))'
+            ' (Let eval __cse_4 (ApplyAggOp AggOp () ((Ref __cse_3)))'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_4) (Ref __cse_4)))))))))'
         )
         assert expected == CSERenderer()(table_agg)
@@ -617,12 +617,12 @@ class CSETests(unittest.TestCase):
         agg = ir.ApplyAggOp('CallStats', [sum], [sum])
         top = ir.ApplyBinaryPrimOp('+', sum, agg)
         expected = (
-            '(Let __cse_1 (I32 5)'
+            '(Let eval __cse_1 (I32 5)'
             ' (AggLet __cse_3 False (I32 5)'
             ' (ApplyBinaryPrimOp `+`'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))'
             ' (ApplyAggOp CallStats'
-            ' ((Let __cse_2 (I32 5)'
+            ' ((Let eval __cse_2 (I32 5)'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_2) (Ref __cse_2))))'
             ' ((ApplyBinaryPrimOp `+` (Ref __cse_3) (Ref __cse_3)))))))'
         )
@@ -634,7 +634,7 @@ class CSETests(unittest.TestCase):
         agglet = ir.AggLet('foo', ir.I32(2), sum, False)
         expected = (
             '(AggLet foo False (I32 2)'
-            ' (Let __cse_1 (ApplyAggOp AggOp () ((Ref foo)))'
+            ' (Let eval __cse_1 (ApplyAggOp AggOp () ((Ref foo)))'
             ' (ApplyBinaryPrimOp `+` (Ref __cse_1) (Ref __cse_1))))'
         )
         assert expected == CSERenderer()(agglet)

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -257,9 +257,16 @@ object Bindings {
   private def childEnvValue[E <: GenericBindingEnv[E, Type]](ir: IR, i: Int, baseEnv: E): E =
     ir match {
       case Let(bindings, _) =>
-        val result = Array.ofDim[(String, Type)](i)
-        for (k <- 0 until i) result(k) = bindings(k)._1 -> bindings(k)._2.typ
-        baseEnv.bindEval(result: _*)
+        var env = baseEnv
+        for (k <- 0 until i) bindings(k) match {
+          case Binding(name, value, scope) =>
+            env = env.bindInScope(name, value.typ, scope)
+        }
+        if (i < bindings.length) bindings(i).scope match {
+          case Scope.EVAL => env
+          case Scope.AGG => env.promoteAgg
+          case Scope.SCAN => env.promoteScan
+        } else env
       case TailLoop(name, args, resultType, _) if i == args.length =>
         baseEnv
           .bindEval(args.map { case (name, ir) => name -> ir.typ }: _*)
@@ -385,9 +392,6 @@ object Bindings {
       case ApplyScanOp(init, _, _) =>
         if (i < init.length) baseEnv.noScan
         else baseEnv.promoteScan
-      case AggLet(name, value, _, isScan) =>
-        if (i == 0) baseEnv.promoteAggOrScan(isScan)
-        else baseEnv.bindAggOrScan(isScan, name -> value.typ)
       case AggFilter(_, _, isScan) if i == 0 =>
         baseEnv.promoteAggOrScan(isScan)
       case AggGroupBy(_, _, isScan) if i == 0 =>

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -266,7 +266,8 @@ object Bindings {
           case Scope.EVAL => env
           case Scope.AGG => env.promoteAgg
           case Scope.SCAN => env.promoteScan
-        } else env
+        }
+        else env
       case TailLoop(name, args, resultType, _) if i == args.length =>
         baseEnv
           .bindEval(args.map { case (name, ir) => name -> ir.typ }: _*)

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -256,7 +256,7 @@ object Bindings {
 
   private def childEnvValue[E <: GenericBindingEnv[E, Type]](ir: IR, i: Int, baseEnv: E): E =
     ir match {
-      case Let(bindings, _) =>
+      case Block(bindings, _) =>
         var env = baseEnv
         for (k <- 0 until i) bindings(k) match {
           case Binding(name, value, scope) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -34,7 +34,7 @@ object Children {
       children(1) = default
       for (i <- cases.indices) children(2 + i) = cases(i)
       children
-    case Let(bindings, body) =>
+    case Block(bindings, body) =>
       val children = Array.ofDim[BaseIR](x.size)
       for (i <- bindings.indices) children(i) = bindings(i).value
       children(bindings.size) = body

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -36,12 +36,10 @@ object Children {
       children
     case Let(bindings, body) =>
       val children = Array.ofDim[BaseIR](x.size)
-      for (i <- bindings.indices) children(i) = bindings(i)._2
+      for (i <- bindings.indices) children(i) = bindings(i).value
       children(bindings.size) = body
       children
     case RelationalLet(_, value, body) =>
-      Array(value, body)
-    case AggLet(_, value, body, _) =>
       Array(value, body)
     case TailLoop(_, args, _, body) =>
       args.map(_._2).toFastSeq :+ body

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -47,11 +47,8 @@ object Copy {
         val newBindings =
           (bindings, newChildren.init)
             .zipped
-            .map { case ((name, _), ir: IR) => name -> ir }
-        Let(newBindings, newChildren.last.asInstanceOf[IR])
-      case AggLet(name, _, _, isScan) =>
-        assert(newChildren.length == 2)
-        AggLet(name, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], isScan)
+            .map { case (binding, ir: IR) => binding.copy(value = ir) }
+        Let.withAgg(newBindings, newChildren.last.asInstanceOf[IR])
       case TailLoop(name, params, resultType, _) =>
         assert(newChildren.length == params.length + 1)
         TailLoop(

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -42,13 +42,13 @@ object Copy {
           newChildren(1).asInstanceOf[IR],
           newChildren.drop(2).asInstanceOf[IndexedSeq[IR]],
         )
-      case Let(bindings, _) =>
+      case Block(bindings, _) =>
         assert(newChildren.length == x.size)
         val newBindings =
           (bindings, newChildren.init)
             .zipped
             .map { case (binding, ir: IR) => binding.copy(value = ir) }
-        Let.withAgg(newBindings, newChildren.last.asInstanceOf[IR])
+        Block(newBindings, newChildren.last.asInstanceOf[IR])
       case TailLoop(name, params, resultType, _) =>
         assert(newChildren.length == params.length + 1)
         TailLoop(

--- a/hail/src/main/scala/is/hail/expr/ir/DeprecatedIRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/DeprecatedIRBuilder.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.types._
 import is.hail.types.virtual._
-import is.hail.utils.FastSeq
+import is.hail.utils.{FastSeq, toRichIterable}
 
 import scala.language.{dynamics, implicitConversions}
 
@@ -377,43 +377,35 @@ object DeprecatedIRBuilder {
     def ~>(body: IRProxy): LambdaProxy = new LambdaProxy(s, body)
   }
 
-  case class BindingProxy(s: Symbol, value: IRProxy)
+  case class BindingProxy(s: Symbol, value: IRProxy, scope: Int)
 
-  object LetProxy {
-    def bind(bindings: Seq[BindingProxy], body: IRProxy, env: E, scope: Int): IR =
-      bindings match {
-        case BindingProxy(sym, binding) +: rest =>
-          val name = sym.name
-          val value = binding(env)
-          scope match {
-            case Scope.EVAL =>
-              Let(FastSeq(name -> value), bind(rest, body, env.bind(name -> value.typ), scope))
-            case Scope.AGG => AggLet(
-                name,
-                value,
-                bind(rest, body, env.bind(name -> value.typ), scope),
-                isScan = false,
-              )
-            case Scope.SCAN => AggLet(
-                name,
-                value,
-                bind(rest, body, env.bind(name -> value.typ), scope),
-                isScan = true,
-              )
-          }
-        case Seq() =>
-          body(env)
+  private object LetProxy {
+    def bind(bindings: IndexedSeq[BindingProxy], body: IRProxy, env: E, scope: Int): IR = {
+      var newEnv = env
+      val resolvedBindings = bindings.map { case BindingProxy(sym, value, scope) =>
+        val resolvedValue = value(newEnv)
+        newEnv = env.bind(sym.name -> resolvedValue.typ)
+        Binding(sym.name, resolvedValue, scope)
       }
+      Let.withAgg(resolvedBindings, body(newEnv))
+    }
   }
 
   object let extends Dynamic {
     def applyDynamicNamed(method: String)(args: (String, IRProxy)*): LetProxy = {
       assert(method == "apply")
-      new LetProxy(args.map { case (s, b) => BindingProxy(Symbol(s), b) })
+      letDyn(args: _*)
+    }
+
+  }
+
+  object letDyn {
+    def apply(args: (String, IRProxy)*): LetProxy = {
+      new LetProxy(args.map { case (s, b) => BindingProxy(Symbol(s), b, Scope.EVAL) }.toFastSeq)
     }
   }
 
-  class LetProxy(val bindings: Seq[BindingProxy]) extends AnyVal with Dynamic {
+  class LetProxy(val bindings: IndexedSeq[BindingProxy]) extends AnyVal {
     def apply(body: IRProxy): IRProxy = in(body)
 
     def in(body: IRProxy): IRProxy = { (env: E) =>
@@ -424,11 +416,11 @@ object DeprecatedIRBuilder {
   object aggLet extends Dynamic {
     def applyDynamicNamed(method: String)(args: (String, IRProxy)*): AggLetProxy = {
       assert(method == "apply")
-      new AggLetProxy(args.map { case (s, b) => BindingProxy(Symbol(s), b) })
+      new AggLetProxy(args.map { case (s, b) => BindingProxy(Symbol(s), b, Scope.AGG) }.toFastSeq)
     }
   }
 
-  class AggLetProxy(val bindings: Seq[BindingProxy]) extends AnyVal with Dynamic {
+  class AggLetProxy(val bindings: IndexedSeq[BindingProxy]) extends AnyVal {
     def apply(body: IRProxy): IRProxy = in(body)
 
     def in(body: IRProxy): IRProxy = { (env: E) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -824,7 +824,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
         emitI(cond).consume(cb, {}, m => cb.if_(m.asBoolean.value, emitVoid(cnsq), emitVoid(altr)))
 
       case let: Block =>
-        val newEnv = emitLetBindings(let, cb, env, region, container, loopEnv)
+        val newEnv = emitBlock(let, cb, env, region, container, loopEnv)
         emitVoid(let.body, env = newEnv)
 
       case StreamFor(a, valueName, body) =>
@@ -1108,7 +1108,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
         presentPC(primitive(m))
 
       case let: Block =>
-        val newEnv = emitLetBindings(let, cb, env, region, container, loopEnv)
+        val newEnv = emitBlock(let, cb, env, region, container, loopEnv)
         emitI(let.body, env = newEnv)
 
       case Coalesce(values) =>
@@ -3621,7 +3621,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
     * emit each chunk in a separate method.
     */
   // TODO: splitting logic should get lifted into ComputeMethodSplits
-  def emitLetBindings(
+  def emitBlock(
     let: Block,
     cb: EmitCodeBuilder,
     env: EmitEnv,

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -823,7 +823,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
 
         emitI(cond).consume(cb, {}, m => cb.if_(m.asBoolean.value, emitVoid(cnsq), emitVoid(altr)))
 
-      case let: Let =>
+      case let: Block =>
         val newEnv = emitLetBindings(let, cb, env, region, container, loopEnv)
         emitVoid(let.body, env = newEnv)
 
@@ -1107,7 +1107,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
         val m = emitI(v).consumeCode(cb, true, _ => false)
         presentPC(primitive(m))
 
-      case let: Let =>
+      case let: Block =>
         val newEnv = emitLetBindings(let, cb, env, region, container, loopEnv)
         emitI(let.body, env = newEnv)
 
@@ -3622,7 +3622,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
     */
   // TODO: splitting logic should get lifted into ComputeMethodSplits
   def emitLetBindings(
-    let: Let,
+    let: Block,
     cb: EmitCodeBuilder,
     env: EmitEnv,
     r: Value[Region],

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -3646,9 +3646,9 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
     /* Emit a sequence of bindings into a code builder. Each is added to the environment of all
      * following bindings. Any bindings which is unused and has no side effects is skipped (this is
      * mostly an optimization, but it is important not to emit unused streams). */
-    def emitChunk(cb: EmitCodeBuilder, bindings: Seq[(String, IR)], env: EmitEnv, r: Value[Region])
+    def emitChunk(cb: EmitCodeBuilder, bindings: Seq[Binding], env: EmitEnv, r: Value[Region])
       : EmitEnv =
-      bindings.foldLeft(env) { case (newEnv, (name, ir)) =>
+      bindings.foldLeft(env) { case (newEnv, Binding(name, ir, Scope.EVAL)) =>
         if (ir.typ == TVoid) {
           emitVoid(ir, cb, newEnv, r)
           newEnv
@@ -3698,7 +3698,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
           return env
       }
 
-      val (curName, curIR) = let.bindings(pos)
+      val Binding(curName, curIR, Scope.EVAL) = let.bindings(pos)
 
       // skip over unused streams
       if (curIR.typ.isInstanceOf[TStream] && !uses.contains(curName)) {

--- a/hail/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Env.scala
@@ -29,6 +29,12 @@ trait GenericBindingEnv[Self, V] {
   def bindAggOrScan(isScan: Boolean, bindings: (String, V)*): Self =
     if (isScan) bindScan(bindings: _*) else bindAgg(bindings: _*)
 
+  def bindInScope(name: String, v: V, scope: Int): Self = scope match {
+    case Scope.EVAL => bindEval(name -> v)
+    case Scope.AGG => bindAgg(name -> v)
+    case Scope.SCAN => bindScan(name -> v)
+  }
+
   def createAgg: Self
 
   def createScan: Self
@@ -66,6 +72,12 @@ case class BindingEnv[V](
   def promoteAgg: BindingEnv[V] = copy(eval = agg.get, agg = None)
 
   def promoteScan: BindingEnv[V] = copy(eval = scan.get, scan = None)
+
+  def promoteScope(scope: Int): BindingEnv[V] = scope match {
+    case Scope.EVAL => this
+    case Scope.AGG => promoteAgg
+    case Scope.SCAN => promoteScan
+  }
 
   def noAgg: BindingEnv[V] = copy(agg = None)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Exists.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Exists.scala
@@ -56,7 +56,7 @@ object IsAggResult {
 
 object ContainsAgg {
   def apply(root: IR): Boolean = IsAggResult(root) || (root match {
-    case Let(bindings, body) =>
+    case Block(bindings, body) =>
       bindings.exists {
         case Binding(_, value, Scope.EVAL) => ContainsAgg(value)
         case Binding(_, _, Scope.AGG) => true
@@ -112,7 +112,7 @@ object ContainsNonCommutativeAgg {
 
 object ContainsScan {
   def apply(root: IR): Boolean = IsScanResult(root) || (root match {
-    case Let(bindings, body) =>
+    case Block(bindings, body) =>
       bindings.exists {
         case Binding(_, value, Scope.EVAL) => ContainsScan(value)
         case Binding(_, _, Scope.AGG) => false

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -905,7 +905,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
     var res: AbstractLattice.Value = if (env.keySet == KeySetLattice.bottom)
       AbstractLattice.bottom
     else x match {
-      case Let(bindings, body) =>
+      case Block(bindings, body) =>
         val newEnv = bindings.foldLeft[Option[AbstractEnv]](Some(env)) {
           case (Some(env), Binding(name, value, Scope.EVAL)) =>
             Some(env.bind(name -> recur(value, env)))

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -906,12 +906,15 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
       AbstractLattice.bottom
     else x match {
       case Let(bindings, body) =>
-        recur(
-          body,
-          bindings.foldLeft(env) { case (env, (name, value)) =>
-            env.bind(name -> recur(value, env))
-          },
-        )
+        val newEnv = bindings.foldLeft[Option[AbstractEnv]](Some(env)) {
+          case (Some(env), Binding(name, value, Scope.EVAL)) =>
+            Some(env.bind(name -> recur(value, env)))
+          case _ => None
+        }
+        newEnv match {
+          case Some(env) => recur(body, env)
+          case None => null
+        }
       case Ref(name, _) => env(name)
       case GetField(o, name) => recur(o).asInstanceOf[StructValue](name)
       case MakeStruct(fields) => StructValue(fields.view.map { case (name, field) =>

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -20,7 +20,6 @@ object FoldConstants {
             _: UUID4 |
             _: ApplyAggOp |
             _: ApplyScanOp |
-            _: AggLet |
             _: MakeNDArray |
             _: NDArrayShape |
             _: NDArrayReshape |

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -40,11 +40,7 @@ object ForwardLets {
                 rewriteValue.typ != TVoid
                 && shouldForward(rewriteValue, refs.filter(_.t.name == name), l, scope)
               ) {
-                scope match {
-                  case Scope.EVAL => env.bindEval(name -> rewriteValue)
-                  case Scope.AGG => env.copy(agg = Some(env.agg.get.bind(name -> rewriteValue)))
-                  case Scope.SCAN => env.copy(scan = Some(env.scan.get.bind(name -> rewriteValue)))
-                }
+                env.bindInScope(name, rewriteValue, scope)
               } else {
                 keep += Binding(name, rewriteValue, scope)
                 env

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -14,7 +14,8 @@ object ForwardLets {
 
     def rewrite(ir: BaseIR, env: BindingEnv[IR]): BaseIR = {
 
-      def shouldForward(value: IR, refs: Set[RefEquality[BaseRef]], base: Let, scope: Int): Boolean = {
+      def shouldForward(value: IR, refs: Set[RefEquality[BaseRef]], base: Block, scope: Int)
+        : Boolean = {
         IsPure(value) && (
           value.isInstanceOf[Ref] ||
             value.isInstanceOf[In] ||
@@ -29,7 +30,7 @@ object ForwardLets {
       }
 
       ir match {
-        case l: Let =>
+        case l: Block =>
           val keep = new BoxedArrayBuilder[Binding]
           val refs = uses(l)
           val newEnv = l.bindings.foldLeft(env) {
@@ -52,7 +53,7 @@ object ForwardLets {
 
           val newBody = rewrite(l.body, newEnv).asInstanceOf[IR]
           if (keep.isEmpty) newBody
-          else Let.withAgg(keep.result(), newBody)
+          else Block(keep.result(), newBody)
 
         case x @ Ref(name, _) =>
           env.eval

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -14,14 +14,14 @@ object ForwardLets {
 
     def rewrite(ir: BaseIR, env: BindingEnv[IR]): BaseIR = {
 
-      def shouldForward(value: IR, refs: Set[RefEquality[BaseRef]], base: IR): Boolean = {
+      def shouldForward(value: IR, refs: Set[RefEquality[BaseRef]], base: Let, scope: Int): Boolean = {
         IsPure(value) && (
           value.isInstanceOf[Ref] ||
             value.isInstanceOf[In] ||
             (IsConstant(value) && !value.isInstanceOf[Str]) ||
             refs.isEmpty ||
             (refs.size == 1 &&
-              nestingDepth.lookup(refs.head) == nestingDepth.lookup(base) &&
+              nestingDepth.lookupRef(refs.head) == nestingDepth.lookupBinding(base, scope) &&
               !ContainsScan(value) &&
               !ContainsAgg(value)) &&
             !ContainsAggIntermediate(value)
@@ -29,37 +29,31 @@ object ForwardLets {
       }
 
       ir match {
-        case l @ Let(bindings, body) =>
-          val keep = new BoxedArrayBuilder[(String, IR)]
-          val refs = uses(ir)
-          val newEnv = bindings.foldLeft(env) { case (env, (name, value)) =>
-            val rewriteValue = rewrite(value, env).asInstanceOf[IR]
-            if (
-              rewriteValue.typ != TVoid
-              && shouldForward(rewriteValue, refs.filter(_.t.name == name), l)
-            ) {
-              env.bindEval(name -> rewriteValue)
-            } else {
-              keep += (name -> rewriteValue)
-              env
-            }
+        case l: Let =>
+          val keep = new BoxedArrayBuilder[Binding]
+          val refs = uses(l)
+          val newEnv = l.bindings.foldLeft(env) {
+            case (env, Binding(name, value, scope)) =>
+              val rewriteValue = rewrite(value, env.promoteScope(scope)).asInstanceOf[IR]
+              if (
+                rewriteValue.typ != TVoid
+                && shouldForward(rewriteValue, refs.filter(_.t.name == name), l, scope)
+              ) {
+                scope match {
+                  case Scope.EVAL => env.bindEval(name -> rewriteValue)
+                  case Scope.AGG => env.copy(agg = Some(env.agg.get.bind(name -> rewriteValue)))
+                  case Scope.SCAN => env.copy(scan = Some(env.scan.get.bind(name -> rewriteValue)))
+                }
+              } else {
+                keep += Binding(name, rewriteValue, scope)
+                env
+              }
           }
 
-          val newBody = rewrite(body, newEnv).asInstanceOf[IR]
+          val newBody = rewrite(l.body, newEnv).asInstanceOf[IR]
           if (keep.isEmpty) newBody
-          else Let(keep.result(), newBody)
+          else Let.withAgg(keep.result(), newBody)
 
-        case l @ AggLet(name, value, body, isScan) =>
-          val refs = uses.lookup(ir)
-          val rewriteValue =
-            rewrite(value, if (isScan) env.promoteScan else env.promoteAgg).asInstanceOf[IR]
-          if (shouldForward(rewriteValue, refs, l))
-            if (isScan)
-              rewrite(body, env.copy(scan = Some(env.scan.get.bind(name -> rewriteValue))))
-            else
-              rewrite(body, env.copy(agg = Some(env.agg.get.bind(name -> rewriteValue))))
-          else
-            AggLet(name, rewriteValue, rewrite(body, env).asInstanceOf[IR], isScan)
         case x @ Ref(name, _) =>
           env.eval
             .lookupOption(name)

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardRelationalLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardRelationalLets.scala
@@ -21,7 +21,7 @@ object ForwardRelationalLets {
           usages(name) = (0, 0)
         case x @ RelationalRef(name, _) =>
           val (n, nd) = usages(name)
-          usages(name) = (n + 1, math.max(nd, nestingDepth.lookup(x)))
+          usages(name) = (n + 1, math.max(nd, nestingDepth.lookupRef(x)))
         case _ =>
       }
       ir1.children.foreach(visit)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -197,6 +197,15 @@ final case class Let(bindings: IndexedSeq[(String, IR)], body: IR) extends IR {
 }
 
 object Let {
+  def void(bindings: IndexedSeq[(String, IR)]): IR = {
+    if (bindings.isEmpty) {
+      Void()
+    } else {
+      assert(bindings.last._2.typ == TVoid)
+      Let(bindings.init, bindings.last._2)
+    }
+  }
+
   case class Extract(p: ((String, IR)) => Boolean) {
     def unapply(bindings: IndexedSeq[(String, IR)])
       : Option[(IndexedSeq[(String, IR)], IndexedSeq[(String, IR)])] = {

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -222,15 +222,20 @@ final case class Block(bindings: IndexedSeq[Binding], body: IR) extends IR {
 }
 
 object Block {
-  case class Extract(p: IR => Boolean) {
+  object Insert {
     def unapply(bindings: IndexedSeq[Binding])
       : Option[(IndexedSeq[Binding], Binding, IndexedSeq[Binding])] = {
-      val idx = bindings.indexWhere(b => p(b.value))
+      val idx = bindings.indexWhere(_.value.isInstanceOf[InsertFields])
       if (idx == -1) None else Some((bindings.take(idx), bindings(idx), bindings.drop(idx + 1)))
     }
   }
 
-  object Insert extends Extract(_.isInstanceOf[InsertFields])
+  object Nested {
+    def unapply(bindings: IndexedSeq[Binding]): Option[(Int, IndexedSeq[Binding])] = {
+      val idx = bindings.indexWhere(_.value.isInstanceOf[Block])
+      if (idx == -1) None else Some((idx, bindings))
+    }
+  }
 }
 
 sealed abstract class BaseRef extends IR with TrivialIR {

--- a/hail/src/main/scala/is/hail/expr/ir/InTailPosition.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InTailPosition.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 object InTailPosition {
   def apply(x: IR, i: Int): Boolean = x match {
-    case Let(bindings, _) => i == bindings.length
+    case Block(bindings, _) => i == bindings.length
     case If(_, _, _) => i != 0
     case _: Switch => i != 0
     case TailLoop(_, params, _, _) => i == params.length

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -63,8 +63,6 @@ object InferType {
         default.typ
       case Let(_, body) =>
         body.typ
-      case AggLet(_, _, body, _) =>
-        body.typ
       case TailLoop(_, _, resultType, _) =>
         resultType
       case Recur(_, _, typ) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -61,7 +61,7 @@ object InferType {
         cnsq.typ
       case Switch(_, default, _) =>
         default.typ
-      case Let(_, body) =>
+      case Block(_, body) =>
         body.typ
       case TailLoop(_, _, resultType, _) =>
         resultType

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -940,9 +940,7 @@ object Interpret {
         val globalsBc = value.globals.broadcast(ctx.theHailClassLoader)
         val globalsOffset = value.globals.value.offset
 
-        val res = genUID()
-
-        val extracted = agg.Extract(query, res, Requiredness(x, ctx))
+        val extracted = agg.Extract(query, Requiredness(x, ctx))
 
         val wrapped = if (extracted.aggs.isEmpty) {
           val (Some(PTypeReferenceSingleCodeType(rt: PTuple)), f) =
@@ -1080,7 +1078,7 @@ object Interpret {
               FastSeq(classInfo[Region], LongInfo),
               LongInfo,
               Let(
-                FastSeq(res -> extracted.results),
+                FastSeq(extracted.resultRef.name -> extracted.results),
                 MakeTuple.ordered(FastSeq(extracted.postAggIR)),
               ),
             )

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -140,7 +140,7 @@ object Interpret {
             null
         }
       case Let(bindings, body) =>
-        val newEnv = bindings.foldLeft(env) { case (env, (name, value)) =>
+        val newEnv = bindings.foldLeft(env) { case (env, Binding(name, value, Scope.EVAL)) =>
           env.bind(name -> interpret(value, env, args))
         }
         interpret(body, newEnv, args)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -139,7 +139,7 @@ object Interpret {
           case null =>
             null
         }
-      case Let(bindings, body) =>
+      case Block(bindings, body) =>
         val newEnv = bindings.foldLeft(env) { case (env, Binding(name, value, Scope.EVAL)) =>
           env.bind(name -> interpret(value, env, args))
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -43,6 +43,8 @@ object Interpretable {
           _: StreamZipJoinProducers |
           _: ArrayMaximalIndependentSet |
           _: RNGStateLiteral => false
+      case Let(bindings, _) =>
+        bindings.forall(_.scope == Scope.EVAL)
       case x: ApplyIR =>
         !Exists(
           x.body,

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -43,7 +43,7 @@ object Interpretable {
           _: StreamZipJoinProducers |
           _: ArrayMaximalIndependentSet |
           _: RNGStateLiteral => false
-      case Let(bindings, _) =>
+      case Block(bindings, _) =>
         bindings.forall(_.scope == Scope.EVAL)
       case x: ApplyIR =>
         !Exists(

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -103,14 +103,14 @@ object LowerMatrixIR {
   private[this] def lower(
     ctx: ExecuteContext,
     mir: MatrixIR,
-    ab: BoxedArrayBuilder[(String, IR)],
+    liftedRelationalLets: BoxedArrayBuilder[(String, IR)],
   ): TableIR = {
     val lowered = mir match {
       case RelationalLetMatrixTable(name, value, body) =>
-        RelationalLetTable(name, lower(ctx, value, ab), lower(ctx, body, ab))
+        RelationalLetTable(name, lower(ctx, value, liftedRelationalLets), lower(ctx, body, liftedRelationalLets))
 
       case CastTableToMatrix(child, entries, cols, _) =>
-        val lc = lower(ctx, child, ab)
+        val lc = lower(ctx, child, liftedRelationalLets)
         val row = Ref("row", lc.typ.rowType)
         val glob = Ref("global", lc.typ.globalType)
         TableMapRows(
@@ -145,11 +145,11 @@ object LowerMatrixIR {
         ).rename(Map(entries -> entriesFieldName), Map(cols -> colsFieldName))
 
       case MatrixToMatrixApply(child, function) =>
-        val loweredChild = lower(ctx, child, ab)
+        val loweredChild = lower(ctx, child, liftedRelationalLets)
         TableToTableApply(loweredChild, function.lower())
 
       case MatrixRename(child, globalMap, colMap, rowMap, entryMap) =>
-        var t = lower(ctx, child, ab).rename(rowMap, globalMap)
+        var t = lower(ctx, child, liftedRelationalLets).rename(rowMap, globalMap)
 
         if (colMap.nonEmpty) {
           val newColsType = TArray(child.typ.colType.rename(colMap))
@@ -170,19 +170,19 @@ object LowerMatrixIR {
         t
 
       case MatrixKeyRowsBy(child, keys, isSorted) =>
-        lower(ctx, child, ab).keyBy(keys, isSorted)
+        lower(ctx, child, liftedRelationalLets).keyBy(keys, isSorted)
 
       case MatrixFilterRows(child, pred) =>
-        lower(ctx, child, ab)
-          .filter(subst(lower(ctx, pred, ab), matrixSubstEnv(child)))
+        lower(ctx, child, liftedRelationalLets)
+          .filter(subst(lower(ctx, pred, liftedRelationalLets), matrixSubstEnv(child)))
 
       case MatrixFilterCols(child, pred) =>
-        lower(ctx, child, ab)
+        lower(ctx, child, liftedRelationalLets)
           .mapGlobals('global.insertFields('newColIdx ->
             irRange(0, 'global(colsField).len)
               .filter('i ~>
                 (let(sa = 'global(colsField)('i))
-                  in subst(lower(ctx, pred, ab), matrixGlobalSubstEnv(child))))))
+                  in subst(lower(ctx, pred, liftedRelationalLets), matrixGlobalSubstEnv(child))))))
           .mapRows('row.insertFields(
             entriesField -> 'global('newColIdx).map('i ~> 'row(entriesField)('i))
           ))
@@ -194,12 +194,12 @@ object LowerMatrixIR {
       case MatrixAnnotateRowsTable(child, table, root, product) =>
         val kt = table.typ.keyType
         if (kt.size == 1 && kt.types(0) == TInterval(child.typ.rowKeyStruct.types(0)))
-          TableIntervalJoin(lower(ctx, child, ab), lower(ctx, table, ab), root, product)
+          TableIntervalJoin(lower(ctx, child, liftedRelationalLets), lower(ctx, table, liftedRelationalLets), root, product)
         else
-          TableLeftJoinRightDistinct(lower(ctx, child, ab), lower(ctx, table, ab), root)
+          TableLeftJoinRightDistinct(lower(ctx, child, liftedRelationalLets), lower(ctx, table, liftedRelationalLets), root)
 
       case MatrixChooseCols(child, oldIndices) =>
-        lower(ctx, child, ab)
+        lower(ctx, child, liftedRelationalLets)
           .mapGlobals('global.insertFields('newColIdx -> oldIndices.map(I32)))
           .mapRows('row.insertFields(
             entriesField -> 'global('newColIdx).map('i ~> 'row(entriesField)('i))
@@ -213,9 +213,9 @@ object LowerMatrixIR {
         val colKey = makeStruct(table.typ.key.zip(child.typ.colKey).map { case (tk, mck) =>
           Symbol(tk) -> col(Symbol(mck))
         }: _*)
-        lower(ctx, child, ab)
+        lower(ctx, child, liftedRelationalLets)
           .mapGlobals(let(__dictfield =
-            lower(ctx, table, ab)
+            lower(ctx, table, liftedRelationalLets)
               .keyBy(FastSeq())
               .collect()
               .apply('rows)
@@ -230,10 +230,10 @@ object LowerMatrixIR {
           })
 
       case MatrixMapGlobals(child, newGlobals) =>
-        lower(ctx, child, ab)
+        lower(ctx, child, liftedRelationalLets)
           .mapGlobals(
             subst(
-              lower(ctx, newGlobals, ab),
+              lower(ctx, newGlobals, liftedRelationalLets),
               BindingEnv(Env[IRProxy](
                 "global" -> 'global.selectFields(child.typ.globalType.fieldNames: _*)
               )),
@@ -305,17 +305,30 @@ object LowerMatrixIR {
                 Let(aggs.map { case (name, _) => name -> GetField(eltUID, name) }, liftedBody)
               })
 
-            case AggLet(name, value, body, true) =>
-              val ab = new BoxedArrayBuilder[(String, IR)]
-              val liftedBody = lift(body, ab)
-              val aggs = ab.result()
-              val structResult = MakeStruct(aggs)
-              val uid = genUID()
-              builder += (uid -> AggLet(name, value, structResult, true))
-              Let(
-                aggs.map { case (name, _) => name -> GetField(Ref(uid, structResult.typ), name) },
-                liftedBody,
-              )
+            case Let(bindings, body) =>
+              val newBindings = new BoxedArrayBuilder[Binding]
+              def go(i: Int, builder: BoxedArrayBuilder[(String, IR)]): IR = {
+                if (i == bindings.length) {
+                  lift(body, builder)
+                } else bindings(i) match {
+                  case Binding(name, value, Scope.SCAN) =>
+                    val ab = new BoxedArrayBuilder[(String, IR)]
+                    val liftedBody = go(i + 1, ab)
+                    val aggs = ab.result()
+                    val structResult = MakeStruct(aggs)
+                    val uid = genUID()
+                    builder += (uid -> Let.withAgg(FastSeq(Binding(name, value, Scope.EVAL)), structResult))
+                    newBindings ++= aggs.map { case (name, _) =>
+                      Binding(name, GetField(Ref(uid, structResult.typ), name), Scope.EVAL)
+                    }
+                    liftedBody
+                  case Binding(name, value, scope) =>
+                    newBindings += Binding(name, lift(value, builder), scope)
+                    go(i + 1, builder)
+                }
+              }
+              val newBody = go(0, builder)
+              Let.withAgg(newBindings.result(), newBody)
 
             case _ =>
               MapIR(lift(_, builder))(ir)
@@ -324,7 +337,7 @@ object LowerMatrixIR {
           val ab = new BoxedArrayBuilder[(String, IR)]
           val b0 = lift(ir, ab)
 
-          val scans = ab.result()
+          val scans = ab.result().toFastSeq
           val scanStruct = MakeStruct(scans)
 
           val scanResultRef = Ref(genUID(), scanStruct.typ)
@@ -338,21 +351,20 @@ object LowerMatrixIR {
           } else
             irToProxy(b0)
 
-          let.applyDynamicNamed("apply")((scanResultRef.name, scanStruct))(
-            scans.foldLeft[IRProxy](b1) { case (acc, (name, _)) =>
-              let.applyDynamicNamed("apply")((name, GetField(scanResultRef, name)))(acc)
-            }
-          )
+          letDyn(
+            ((scanResultRef.name, irToProxy(scanStruct))
+              +: scans.map { case (name, _) => name -> irToProxy(GetField(scanResultRef, name))}): _*
+          )(b1)
         }
 
-        val lc = lower(ctx, child, ab)
+        val lc = lower(ctx, child, liftedRelationalLets)
         lc.mapRows(let(n_cols = 'global(colsField).len) {
-          liftScans(Subst(lower(ctx, newRow, ab), matrixSubstEnvIR(child, lc)))
+          liftScans(Subst(lower(ctx, newRow, liftedRelationalLets), matrixSubstEnvIR(child, lc)))
             .insertFields(entriesField -> 'row(entriesField))
         })
 
       case MatrixMapCols(child, newCol, _) =>
-        val loweredChild = lower(ctx, child, ab)
+        val loweredChild = lower(ctx, child, liftedRelationalLets)
 
         def lift(
           ir: IR,
@@ -446,18 +458,34 @@ object LowerMatrixIR {
               Let(aggs.map { case (name, _) => name -> GetField(eltUID, name) }, liftedBody)
             })
 
-          case AggLet(name, value, body, isScan) =>
-            val ab = new BoxedArrayBuilder[(String, IR)]
-            val (liftedBody, builder) =
-              if (isScan) (lift(body, ab, aggBindings), scanBindings)
-              else (lift(body, scanBindings, ab), aggBindings)
+          case Let(bindings, body) =>
+            val newBindings = new BoxedArrayBuilder[Binding]
+            def go(i: Int, scanBindings: BoxedArrayBuilder[(String, IR)], aggBindings: BoxedArrayBuilder[(String, IR)]): IR = {
+              if (i == bindings.length) {
+                lift(body, scanBindings, aggBindings)
+              } else bindings(i) match {
+                case Binding(name, value, Scope.EVAL) =>
+                  newBindings += Binding(name, lift(value, scanBindings, aggBindings), Scope.EVAL)
+                  go(i + 1, scanBindings, aggBindings)
+                case Binding(name, value, scope) =>
+                  val ab = new BoxedArrayBuilder[(String, IR)]
+                  val (liftedBody, builder) =
+                    if (scope == Scope.SCAN) (go(i + 1, ab, aggBindings), scanBindings)
+                    else (go(i + 1, scanBindings, ab), aggBindings)
 
-            val aggs = ab.result()
-            val structResult = MakeStruct(aggs)
+                  val aggs = ab.result()
+                  val structResult = MakeStruct(aggs)
 
-            val uid = Ref(genUID(), structResult.typ)
-            builder += (uid.name -> AggLet(name, value, structResult, isScan))
-            Let(aggs.map { case (name, _) => name -> GetField(uid, name) }, liftedBody)
+                  val uid = genUID()
+                  builder += (uid -> Let.withAgg(FastSeq(Binding(name, value, scope)), structResult))
+                  newBindings ++= aggs.map { case (name, _) =>
+                    Binding(name, GetField(Ref(uid, structResult.typ), name), Scope.EVAL)
+                  }
+                  liftedBody
+              }
+            }
+            val newBody = go(0, scanBindings, aggBindings)
+            Let.withAgg(newBindings.result(), newBody)
 
           case x: StreamAgg => x
           case x: StreamAggScan => x
@@ -470,7 +498,7 @@ object LowerMatrixIR {
         val aggBuilder = new BoxedArrayBuilder[(String, IR)]
 
         val b0 = lift(
-          Subst(lower(ctx, newCol, ab), matrixSubstEnvIR(child, loweredChild)),
+          Subst(lower(ctx, newCol, liftedRelationalLets), matrixSubstEnvIR(child, loweredChild)),
           scanBuilder,
           aggBuilder,
         )
@@ -513,7 +541,7 @@ object LowerMatrixIR {
           )
 
           val ident = genUID()
-          ab += ((ident, aggResult))
+          liftedRelationalLets += ((ident, aggResult))
 
           val aggResultRef = Ref(genUID(), aggResult.typ)
           val aggResultElementRef = Ref(
@@ -585,13 +613,13 @@ object LowerMatrixIR {
           )))))
 
       case MatrixFilterEntries(child, pred) =>
-        val lc = lower(ctx, child, ab)
+        val lc = lower(ctx, child, liftedRelationalLets)
         lc.mapRows('row.insertFields(entriesField ->
           irRange(0, 'global(colsField).len).map {
             'i ~>
               let(g = 'row(entriesField)('i)) {
                 irIf(let(sa = 'global(colsField)('i))
-                  in !subst(lower(ctx, pred, ab), matrixSubstEnv(child))) {
+                  in !subst(lower(ctx, pred, liftedRelationalLets), matrixSubstEnv(child))) {
                   NA(child.typ.entryType)
                 } {
                   'g
@@ -602,7 +630,7 @@ object LowerMatrixIR {
       case MatrixUnionCols(left, right, joinType) =>
         val rightEntries = genUID()
         val rightCols = genUID()
-        val ll = lower(ctx, left, ab).distinct()
+        val ll = lower(ctx, left, liftedRelationalLets).distinct()
         def handleMissingEntriesArray(entries: Symbol, cols: Symbol): IRProxy =
           if (joinType == "inner")
             'row(entries)
@@ -615,7 +643,7 @@ object LowerMatrixIR {
             } {
               'row(entries)
             }
-        val rr = lower(ctx, right, ab).distinct()
+        val rr = lower(ctx, right, liftedRelationalLets).distinct()
         TableJoin(
           ll,
           rr.mapRows('row.castRename(rr.typ.rowType.rename(Map(entriesFieldName -> rightEntries))))
@@ -638,7 +666,7 @@ object LowerMatrixIR {
             .dropFields(Symbol(rightCols)))
 
       case MatrixMapEntries(child, newEntries) =>
-        val loweredChild = lower(ctx, child, ab)
+        val loweredChild = lower(ctx, child, liftedRelationalLets)
         val rt = loweredChild.typ.rowType
         val gt = loweredChild.typ.globalType
         TableMapRows(
@@ -654,7 +682,7 @@ object LowerMatrixIR {
                 ),
                 FastSeq("g", "sa"),
                 Subst(
-                  lower(ctx, newEntries, ab),
+                  lower(ctx, newEntries, liftedRelationalLets),
                   BindingEnv(Env(
                     "global" -> SelectFields(Ref("global", gt), child.typ.globalType.fieldNames),
                     "va" -> SelectFields(Ref("row", rt), child.typ.rowType.fieldNames),
@@ -667,24 +695,24 @@ object LowerMatrixIR {
         )
 
       case MatrixRepartition(child, n, shuffle) =>
-        TableRepartition(lower(ctx, child, ab), n, shuffle)
+        TableRepartition(lower(ctx, child, liftedRelationalLets), n, shuffle)
 
       case MatrixFilterIntervals(child, intervals, keep) =>
-        TableFilterIntervals(lower(ctx, child, ab), intervals, keep)
+        TableFilterIntervals(lower(ctx, child, liftedRelationalLets), intervals, keep)
 
       case MatrixUnionRows(children) =>
         // FIXME: this should check that all children have the same column keys.
-        val first = lower(ctx, children.head, ab)
+        val first = lower(ctx, children.head, liftedRelationalLets)
         TableUnion(FastSeq(first) ++
-          children.tail.map(lower(ctx, _, ab)
+          children.tail.map(lower(ctx, _, liftedRelationalLets)
             .mapRows('row.selectFields(first.typ.rowType.fieldNames: _*))))
 
-      case MatrixDistinctByRow(child) => TableDistinct(lower(ctx, child, ab))
+      case MatrixDistinctByRow(child) => TableDistinct(lower(ctx, child, liftedRelationalLets))
 
-      case MatrixRowsHead(child, n) => TableHead(lower(ctx, child, ab), n)
-      case MatrixRowsTail(child, n) => TableTail(lower(ctx, child, ab), n)
+      case MatrixRowsHead(child, n) => TableHead(lower(ctx, child, liftedRelationalLets), n)
+      case MatrixRowsTail(child, n) => TableTail(lower(ctx, child, liftedRelationalLets), n)
 
-      case MatrixColsHead(child, n) => lower(ctx, child, ab)
+      case MatrixColsHead(child, n) => lower(ctx, child, liftedRelationalLets)
           .mapGlobals('global.insertFields(colsField -> 'global(colsField).arraySlice(
             0,
             Some(n),
@@ -692,12 +720,12 @@ object LowerMatrixIR {
           )))
           .mapRows('row.insertFields(entriesField -> 'row(entriesField).arraySlice(0, Some(n), 1)))
 
-      case MatrixColsTail(child, n) => lower(ctx, child, ab)
+      case MatrixColsTail(child, n) => lower(ctx, child, liftedRelationalLets)
           .mapGlobals('global.insertFields(colsField -> 'global(colsField).arraySlice(-n, None, 1)))
           .mapRows('row.insertFields(entriesField -> 'row(entriesField).arraySlice(-n, None, 1)))
 
       case MatrixExplodeCols(child, path) =>
-        val loweredChild = lower(ctx, child, ab)
+        val loweredChild = lower(ctx, child, liftedRelationalLets)
         val lengths = Symbol(genUID())
         val colIdx = Symbol(genUID())
         val nestedIdx = Symbol(genUID())
@@ -740,9 +768,9 @@ object LowerMatrixIR {
 
       case MatrixAggregateRowsByKey(child, entryExpr, rowExpr) =>
         val substEnv = matrixSubstEnv(child)
-        val eeSub = subst(lower(ctx, entryExpr, ab), substEnv)
-        val reSub = subst(lower(ctx, rowExpr, ab), substEnv)
-        lower(ctx, child, ab)
+        val eeSub = subst(lower(ctx, entryExpr, liftedRelationalLets), substEnv)
+        val reSub = subst(lower(ctx, rowExpr, liftedRelationalLets), substEnv)
+        lower(ctx, child, liftedRelationalLets)
           .aggregateByKey(
             reSub.insertFields(entriesField -> irRange(0, 'global(colsField).len)
               .aggElements('__element_idx, '__result_idx, Some('global(colsField).len))(
@@ -758,7 +786,7 @@ object LowerMatrixIR {
           )
 
       case MatrixCollectColsByKey(child) =>
-        lower(ctx, child, ab)
+        lower(ctx, child, liftedRelationalLets)
           .mapGlobals('global.insertFields('newColIdx ->
             irRange(0, 'global(colsField).len).map {
               'i ~>
@@ -788,7 +816,7 @@ object LowerMatrixIR {
               })
             .dropFields('newColIdx))
 
-      case MatrixExplodeRows(child, path) => TableExplode(lower(ctx, child, ab), path)
+      case MatrixExplodeRows(child, path) => TableExplode(lower(ctx, child, liftedRelationalLets), path)
 
       case mr: MatrixRead => mr.lower()
 
@@ -807,10 +835,10 @@ object LowerMatrixIR {
           "va" -> 'row.selectFields(child.typ.rowType.fieldNames: _*),
         )
         val e2 = Env[IRProxy]("global" -> 'global.selectFields(child.typ.globalType.fieldNames: _*))
-        val ceSub = subst(lower(ctx, colExpr, ab), BindingEnv(e2, agg = Some(e1)))
-        val eeSub = subst(lower(ctx, entryExpr, ab), BindingEnv(e1, agg = Some(e1)))
+        val ceSub = subst(lower(ctx, colExpr, liftedRelationalLets), BindingEnv(e2, agg = Some(e1)))
+        val eeSub = subst(lower(ctx, entryExpr, liftedRelationalLets), BindingEnv(e1, agg = Some(e1)))
 
-        lower(ctx, child, ab)
+        lower(ctx, child, liftedRelationalLets)
           .mapGlobals('global.insertFields(keyMap ->
             let(__cols_field = 'global(colsField)) {
               irRange(0, '__cols_field.len)

--- a/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
@@ -19,7 +19,8 @@ case class ScopedDepth(eval: Int, agg: Int, scan: Int) {
 final class NestingDepth(private val memo: Memo[ScopedDepth]) {
   def lookupRef(x: RefEquality[BaseRef]): Int = memo.lookup(x).eval
   def lookupRef(x: BaseRef): Int = memo.lookup(x).eval
-  def lookupBinding(x: Let, scope: Int): Int = scope match {
+
+  def lookupBinding(x: Block, scope: Int): Int = scope match {
     case Scope.EVAL => memo(x).eval
     case Scope.AGG => memo(x).agg
     case Scope.SCAN => memo(x).scan
@@ -50,7 +51,7 @@ object NestingDepth {
 
     def computeIR(ir: IR, depth: ScopedDepth): Unit = {
       ir match {
-        case _: Let | _: BaseRef =>
+        case _: Block | _: BaseRef =>
           memo.bind(ir, depth)
         case _ =>
       }

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -33,7 +33,7 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
       call(normalizeIR(next, env, context :+ ir.getClass().getName()).asInstanceOf[StackFrame[IR]])
 
     ir match {
-      case Let(bindings, body) =>
+      case Block(bindings, body) =>
         val newBindings: Array[Binding] = Array.ofDim(bindings.length)
 
         for {
@@ -49,7 +49,7 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
               }
           }
           newBody <- normalize(body, env)
-        } yield Let.withAgg(newBindings, newBody)
+        } yield Block(newBindings, newBody)
 
       case Ref(name, typ) =>
         val newName = env.eval.lookupOption(name) match {

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1316,29 +1316,27 @@ object PruneDeadFields {
       case Consume(value) => memoizeValueIR(ctx, value, value.typ, memo)
       case Let(bindings, body) =>
         val bodyEnv = memoizeValueIR(ctx, body, requestedType, memo)
-        bindings.foldRight(bodyEnv) { case ((name, value), bodyEnv) =>
-          val valueType = unifySeq(value.typ, uses(name, bodyEnv.eval))
-          unifyEnvs(
-            bodyEnv.deleteEval(name),
-            memoizeValueIR(ctx, value, valueType, memo),
-          )
-        }
-      case AggLet(name, value, body, isScan) =>
-        val bodyEnv = memoizeValueIR(ctx, body, requestedType, memo)
-        if (isScan) {
-          val valueType = unifySeq(value.typ, uses(name, bodyEnv.scanOrEmpty))
-          val valueEnv = memoizeValueIR(ctx, value, valueType, memo)
-          unifyEnvs(
-            bodyEnv.copy(scan = bodyEnv.scan.map(_.delete(name))),
-            valueEnv.copy(eval = Env.empty, scan = Some(valueEnv.eval)),
-          )
-        } else {
-          val valueType = unifySeq(value.typ, uses(name, bodyEnv.aggOrEmpty))
-          val valueEnv = memoizeValueIR(ctx, value, valueType, memo)
-          unifyEnvs(
-            bodyEnv.copy(agg = bodyEnv.agg.map(_.delete(name))),
-            valueEnv.copy(eval = Env.empty, agg = Some(valueEnv.eval)),
-          )
+        bindings.foldRight(bodyEnv) {
+          case (Binding(name, value, Scope.EVAL), bodyEnv) =>
+            val valueType = unifySeq(value.typ, uses(name, bodyEnv.eval))
+            unifyEnvs(
+              bodyEnv.deleteEval(name),
+              memoizeValueIR(ctx, value, valueType, memo),
+            )
+          case (Binding(name, value, Scope.SCAN), bodyEnv) =>
+            val valueType = unifySeq(value.typ, uses(name, bodyEnv.scanOrEmpty))
+            val valueEnv = memoizeValueIR(ctx, value, valueType, memo)
+            unifyEnvs(
+              bodyEnv.copy(scan = bodyEnv.scan.map(_.delete(name))),
+              valueEnv.copy(eval = Env.empty, scan = Some(valueEnv.eval)),
+            )
+          case (Binding(name, value, Scope.AGG), bodyEnv) =>
+            val valueType = unifySeq(value.typ, uses(name, bodyEnv.aggOrEmpty))
+            val valueEnv = memoizeValueIR(ctx, value, valueType, memo)
+            unifyEnvs(
+              bodyEnv.copy(agg = bodyEnv.agg.map(_.delete(name))),
+              valueEnv.copy(eval = Env.empty, agg = Some(valueEnv.eval)),
+            )
         }
       case Ref(name, _) =>
         val ab = new BoxedArrayBuilder[Type]()
@@ -2380,27 +2378,14 @@ object PruneDeadFields {
         val value2 = rebuildIR(ctx, value, env, memo)
         Consume(value2)
       case Let(bindings, body) =>
-        val newBindings = new Array[(String, IR)](bindings.length)
-        val (_, newEnv) = bindings.foldLeft((0, env)) { case ((idx, env), (name, value)) =>
-          val newValue = rebuildIR(ctx, value, env, memo)
-          newBindings(idx) = (name -> newValue)
-          (idx + 1, env.bindEval(name -> newValue.typ))
+        val newBindings = new Array[Binding](bindings.length)
+        val (_, newEnv) = bindings.foldLeft((0, env)) {
+          case ((idx, env), Binding(name, value, scope)) =>
+            val newValue = rebuildIR(ctx, value, env.promoteScope(scope), memo)
+            newBindings(idx) = Binding(name, newValue, scope)
+            (idx + 1, env.bindInScope(name, newValue.typ, scope))
         }
-
-        Let(newBindings, rebuildIR(ctx, body, newEnv, memo))
-      case AggLet(name, value, body, isScan) =>
-        val value2 = rebuildIR(ctx, value, if (isScan) env.promoteScan else env.promoteAgg, memo)
-        AggLet(
-          name,
-          value2,
-          rebuildIR(
-            ctx,
-            body,
-            if (isScan) env.bindScan(name, value2.typ) else env.bindAgg(name, value2.typ),
-            memo,
-          ),
-          isScan,
-        )
+        Let.withAgg(newBindings, rebuildIR(ctx, body, newEnv, memo))
       case Ref(name, t) =>
         Ref(name, env.eval.lookupOption(name).getOrElse(t))
       case RelationalLet(name, value, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -732,22 +732,20 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         val rit = tcoerce[RIterable](requiredness)
         rit.union(lookup(a).required)
         rit.elementType.unionFrom(lookup(body))
-      case ApplyAggOp(initOpArgs, seqOpArgs, aggSig) => // FIXME round-tripping through ptype
+      case ApplyAggOp(_, seqOpArgs, aggSig) => // FIXME round-tripping through ptype
         val emitResult = agg.PhysicalAggSig(
           aggSig.op,
           agg.AggStateSig(
             aggSig.op,
-            initOpArgs.map(i => i -> lookup(i)),
             seqOpArgs.map(s => s -> lookup(s)),
           ),
         ).emitResultType
         requiredness.fromEmitType(emitResult)
-      case ApplyScanOp(initOpArgs, seqOpArgs, aggSig) =>
+      case ApplyScanOp(_, seqOpArgs, aggSig) =>
         val emitResult = agg.PhysicalAggSig(
           aggSig.op,
           agg.AggStateSig(
             aggSig.op,
-            initOpArgs.map(i => i -> lookup(i)),
             seqOpArgs.map(s => s -> lookup(s)),
           ),
         ).emitResultType

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -169,7 +169,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       dependents.getOrElseUpdate(table, mutable.Set[RefEquality[BaseIR]]()) ++= refs
     }
     node match {
-      case Let(bindings, _) => bindings.foreach(b => addBinding(b.name, b.value))
+      case Block(bindings, _) => bindings.foreach(b => addBinding(b.name, b.value))
       case RelationalLet(name, value, _) => addBinding(name, value)
       case RelationalLetTable(name, value, _) => addBinding(name, value)
       case TailLoop(loopName, params, _, body) =>
@@ -597,7 +597,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.union(lookup(x).required)
         requiredness.unionFrom(lookup(default))
         requiredness.unionFrom(cases.map(lookup))
-      case Let(_, body) =>
+      case Block(_, body) =>
         requiredness.unionFrom(lookup(body))
       case RelationalLet(_, _, body) =>
         requiredness.unionFrom(lookup(body))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -169,8 +169,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       dependents.getOrElseUpdate(table, mutable.Set[RefEquality[BaseIR]]()) ++= refs
     }
     node match {
-      case AggLet(name, value, _, _) => addBinding(name, value)
-      case Let(bindings, _) => bindings.foreach(Function.tupled(addBinding))
+      case Let(bindings, _) => bindings.foreach(b => addBinding(b.name, b.value))
       case RelationalLet(name, value, _) => addBinding(name, value)
       case RelationalLetTable(name, value, _) => addBinding(name, value)
       case TailLoop(loopName, params, _, body) =>
@@ -598,8 +597,6 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.union(lookup(x).required)
         requiredness.unionFrom(lookup(default))
         requiredness.unionFrom(cases.map(lookup))
-      case AggLet(_, _, body, _) =>
-        requiredness.unionFrom(lookup(body))
       case Let(_, body) =>
         requiredness.unionFrom(lookup(body))
       case RelationalLet(_, _, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Scope.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Scope.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 object UsesAggEnv {
   def apply(ir0: BaseIR, i: Int): Boolean = ir0 match {
-    case Let(bindings, _) if i < bindings.length =>
+    case Block(bindings, _) if i < bindings.length =>
       bindings(i).scope == Scope.AGG
     case AggGroupBy(_, _, false) => i == 0
     case AggFilter(_, _, false) => i == 0
@@ -16,7 +16,7 @@ object UsesAggEnv {
 
 object UsesScanEnv {
   def apply(ir0: BaseIR, i: Int): Boolean = ir0 match {
-    case Let(bindings, _) if i < bindings.length =>
+    case Block(bindings, _) if i < bindings.length =>
       bindings(i).scope == Scope.SCAN
     case AggGroupBy(_, _, true) => i == 0
     case AggFilter(_, _, true) => i == 0

--- a/hail/src/main/scala/is/hail/expr/ir/Scope.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Scope.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir
 
 object UsesAggEnv {
   def apply(ir0: BaseIR, i: Int): Boolean = ir0 match {
-    case AggLet(_, _, _, false) => i == 0
+    case Let(bindings, _) if i < bindings.length =>
+      bindings(i).scope == Scope.AGG
     case AggGroupBy(_, _, false) => i == 0
     case AggFilter(_, _, false) => i == 0
     case AggExplode(_, _, _, false) => i == 0
@@ -15,7 +16,8 @@ object UsesAggEnv {
 
 object UsesScanEnv {
   def apply(ir0: BaseIR, i: Int): Boolean = ir0 match {
-    case AggLet(_, _, _, true) => i == 0
+    case Let(bindings, _) if i < bindings.length =>
+      bindings(i).scope == Scope.SCAN
     case AggGroupBy(_, _, true) => i == 0
     case AggFilter(_, _, true) => i == 0
     case AggExplode(_, _, _, true) => i == 0

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -1221,10 +1221,8 @@ object Simplify {
       MatrixMapGlobals(child, bindIR(ng1)(uid => Subst(ng2, BindingEnv(Env("global" -> uid)))))
 
     /* Note: the following MMR and MMC fusing rules are much weaker than they could be. If they
-     * contain aggregations */
-    /* but those aggregations that mention "row" / "sa" but do not depend on the updated value, we
-     * should locally */
-    // prune and fuse anyway.
+     * contain aggregations but those aggregations that mention "row" / "sa" but do not depend on
+     * the updated value, we should locally prune and fuse anyway. */
     case MatrixMapRows(MatrixMapRows(child, newRow1), newRow2)
         if !Mentions.inAggOrScan(newRow2, "va")
           && !Exists.inIR(

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -3074,8 +3074,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     : TableExecuteIntermediate = {
     val tv = child.execute(ctx, r).asTableValue(ctx)
     val fsBc = ctx.fsBc
-    val scanRef = genUID()
-    val extracted = agg.Extract.apply(newRow, scanRef, Requiredness(this, ctx), isScan = true)
+    val extracted = agg.Extract.apply(newRow, Requiredness(this, ctx), isScan = true)
 
     if (extracted.aggs.isEmpty) {
       val (Some(PTypeReferenceSingleCodeType(rTyp)), f) =
@@ -3162,7 +3161,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
       ),
       FastSeq(classInfo[Region], LongInfo, LongInfo),
       UnitInfo,
-      extracted.eltOp(ctx),
+      extracted.seqPerElt,
     )
 
     val read = extracted.deserialize(ctx, spec)
@@ -3180,7 +3179,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
         FastSeq(classInfo[Region], LongInfo, LongInfo),
         LongInfo,
         Let(
-          FastSeq(scanRef -> extracted.results),
+          FastSeq(extracted.resultRef.name -> extracted.results),
           Coalesce(FastSeq(
             extracted.postAggIR,
             Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ),
@@ -3733,9 +3732,8 @@ case class TableKeyByAndAggregate(
     val globalsBc = prev.globals.broadcast(ctx.theHailClassLoader)
 
     val spec = BufferSpec.blockedUncompressed
-    val res = genUID()
 
-    val extracted = agg.Extract(expr, res, Requiredness(this, ctx))
+    val extracted = agg.Extract(expr, Requiredness(this, ctx))
 
     val (_, makeInit) = ir.CompileWithAggregators[AsmFunction2RegionLongUnit](
       ctx,
@@ -3771,7 +3769,7 @@ case class TableKeyByAndAggregate(
         )),
         FastSeq(classInfo[Region], LongInfo),
         LongInfo,
-        Let(FastSeq(res -> extracted.results), extracted.postAggIR),
+        Let(FastSeq(extracted.resultRef.name -> extracted.results), extracted.postAggIR),
       )
     assert(rTyp.virtualType == typ.valueType, s"$rTyp, ${typ.valueType}")
 
@@ -3902,8 +3900,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
     val fsBc = ctx.fsBc
     val sm = ctx.stateManager
 
-    val res = genUID()
-    val extracted = agg.Extract(expr, res, Requiredness(this, ctx))
+    val extracted = agg.Extract(expr, Requiredness(this, ctx))
 
     val (_, makeInit) = ir.CompileWithAggregators[AsmFunction2RegionLongUnit](
       ctx,
@@ -3929,7 +3926,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
       extracted.seqPerElt,
     )
 
-    val valueIR = Let(FastSeq(res -> extracted.results), extracted.postAggIR)
+    val valueIR = Let(FastSeq(extracted.resultRef.name -> extracted.results), extracted.postAggIR)
     val keyType = prevRVD.typ.kType
 
     val key = Ref(genUID(), keyType.virtualType)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -95,8 +95,6 @@ object TypeCheck {
         assert(cases.forall(_.typ == default.typ))
       case x @ Let(_, body) =>
         assert(x.typ == body.typ)
-      case x @ AggLet(_, _, body, _) =>
-        assert(x.typ == body.typ)
       case x @ Ref(name, _) =>
         env.eval.lookupOption(name) match {
           case Some(expected) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -14,7 +14,8 @@ object TypeCheck {
     try
       check(ctx, ir, BindingEnv.empty).run()
     catch {
-      case e: Throwable => fatal(s"Error while typechecking IR:\n${Pretty(ctx, ir)}", e)
+      case e: Throwable =>
+        fatal(s"Error while typechecking IR:\n${Pretty(ctx, ir, preserveNames = true)}", e)
     }
 
   def apply(ctx: ExecuteContext, ir: IR, env: BindingEnv[Type]): Unit =
@@ -39,7 +40,7 @@ object TypeCheck {
 
   private def checkVoidTypedChild(ctx: ExecuteContext, ir: BaseIR, i: Int, env: BindingEnv[Type])
     : Unit = ir match {
-    case l: Let if i == l.bindings.length || l.body.typ == TVoid =>
+    case l: Block if i == l.bindings.length || l.body.typ == TVoid =>
     case _: StreamFor if i == 1 =>
     case _: RunAggScan if (i == 1 || i == 2) =>
     case _: StreamBufferedAggregate if (i == 1 || i == 3) =>
@@ -93,7 +94,7 @@ object TypeCheck {
       case Switch(x, default, cases) =>
         assert(x.typ == TInt32)
         assert(cases.forall(_.typ == default.typ))
-      case x @ Let(_, body) =>
+      case x @ Block(_, body) =>
         assert(x.typ == body.typ)
       case x @ Ref(name, _) =>
         env.eval.lookupOption(name) match {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -18,17 +18,17 @@ import org.apache.spark.TaskContext
 
 class UnsupportedExtraction(msg: String) extends Exception(msg)
 
+// --- AggStateSig --
+
 object AggStateSig {
-  def apply(op: AggOp, initOpArgs: Seq[IR], seqOpArgs: Seq[IR], r: RequirednessAnalysis)
-    : AggStateSig = {
-    val inits = initOpArgs.map(i => i -> (if (i.typ == TVoid) null else r(i)))
+  def apply(op: AggOp, seqOpArgs: Seq[IR], r: RequirednessAnalysis): AggStateSig = {
     val seqs = seqOpArgs.map(s => s -> (if (s.typ == TVoid) null else r(s)))
-    apply(op, inits, seqs)
+    apply(op, seqs)
   }
 
+  // FIXME: factor out requiredness inference part
   def apply(
     op: AggOp,
-    initOpArgs: Seq[(IR, TypeWithRequiredness)],
     seqOpArgs: Seq[(IR, TypeWithRequiredness)],
   ): AggStateSig = {
     val seqVTypes = seqOpArgs.map { case (a, r) => VirtualTypeWithReq(a.typ, r) }
@@ -63,9 +63,6 @@ object AggStateSig {
 
   def grouped(k: IR, aggs: Seq[AggStateSig], r: RequirednessAnalysis): GroupedStateSig =
     GroupedStateSig(VirtualTypeWithReq(k.typ, r(k)), aggs)
-
-  def arrayelements(aggs: Seq[AggStateSig]): ArrayAggStateSig =
-    ArrayAggStateSig(aggs)
 
   def getState(sig: AggStateSig, cb: EmitClassBuilder[_]): AggregatorState = sig match {
     case TypedStateSig(vt) if vt.t.isPrimitive => new PrimitiveRVAState(Array(vt), cb)
@@ -140,6 +137,8 @@ case class FoldStateSig(
   combOpIR: IR,
 ) extends AggStateSig(Array[VirtualTypeWithReq](resultEmitType.typeWithRequiredness), None)
 
+// --- PhysicalAggSig --
+
 object PhysicalAggSig {
   def apply(op: AggOp, state: AggStateSig): PhysicalAggSig = BasicPhysicalAggSig(op, state)
 
@@ -147,6 +146,7 @@ object PhysicalAggSig {
     if (v.nestedOps.isEmpty) Some(v.op -> v.state) else None
 }
 
+// A pair of an agg state and an op. If the state is compound, also encodes ops for nested states.
 class PhysicalAggSig(val op: AggOp, val state: AggStateSig, val nestedOps: Array[AggOp]) {
   val allOps: Array[AggOp] = nestedOps :+ op
   def initOpTypes: IndexedSeq[Type] = Extract.getAgg(this).initOpTypes.toFastSeq
@@ -177,12 +177,24 @@ case class ArrayLenAggSig(knownLength: Boolean, nested: Seq[PhysicalAggSig]) ext
       nested.flatMap(sig => sig.allOps).toArray,
     )
 
+// --- Aggs --
+
+// The result of Extract
 class Aggs(
+  // The pre-extract IR
   original: IR,
+  /* map each descendant of the original ir to its extract result (all contained aggs replaced with
+   * their results) */
   rewriteMap: Memo[IR],
+  // nodes which bind variables which are referenced in init op arguments
   bindingNodesReferenced: Memo[Unit],
+  // The extracted void-typed initialization ir
   val init: IR,
+  // The extracted void-typed update ir
   val seqPerElt: IR,
+  // Must be bound to raw aggregators results in postAggIR
+  val resultRef: Ref,
+  // All (top-level) aggregators used
   val aggs: Array[PhysicalAggSig],
 ) {
   val states: Array[AggStateSig] = aggs.map(_.state)
@@ -192,18 +204,17 @@ class Aggs(
     rewriteMap.lookup(original)
 
   def rewriteFromInitBindingRoot(f: IR => IR): IR = {
-    val irNumberMemo = Memo.empty[Int]
-    var i = 0
-    // depth first search -- either DFS or BFS should work here given IR assumptions
-    VisitIR(original) { x =>
-      irNumberMemo.bind(x, i)
-      i += 1
-    }
-
     if (bindingNodesReferenced.m.isEmpty) {
       f(rewriteMap.lookup(original))
-      // find deepest binding node referenced
     } else {
+      val irNumberMemo = Memo.empty[Int]
+      var i = 0
+      // find deepest binding node referenced
+      // depth first search -- either DFS or BFS should work here given IR assumptions
+      VisitIR(original) { x =>
+        irNumberMemo.bind(x, i)
+        i += 1
+      }
       val rewriteRoot = bindingNodesReferenced.m.keys.maxBy(irNumberMemo.lookup)
       // only support let nodes here -- other binders like stream operators are undefined behavior
       RewriteTopDown.rewriteTopDown(
@@ -239,8 +250,6 @@ class Aggs(
     }
     aggs.exists(containsBigAggregator)
   }
-
-  def eltOp(ctx: ExecuteContext): IR = seqPerElt
 
   def deserialize(ctx: ExecuteContext, spec: BufferSpec)
     : ((HailClassLoader, HailTaskContext, Region, Array[Byte]) => Long) = {
@@ -391,55 +400,41 @@ class Aggs(
     ResultOp.makeTuple(aggs)
 }
 
+// --- Extract --
+
 object Extract {
 
-  def partitionDependentLets(lets: Array[AggLet], name: String): (Array[AggLet], Array[AggLet]) = {
+  // All lets whose value depends on `name` (either directly or transitively through previous lets)
+  // are returned in the first array, the rest are in the second.
+  /* TODO: this is only being used to do ad hoc code motion. Remove when we have a real code motion
+   * pass. */
+  private def partitionDependentLets(lets: Array[(String, IR)], name: String)
+    : (Array[(String, IR)], Array[(String, IR)]) = {
     val depBindings = mutable.HashSet.empty[String]
     depBindings += name
 
-    val dep = new BoxedArrayBuilder[AggLet]
-    val indep = new BoxedArrayBuilder[AggLet]
+    val dep = new BoxedArrayBuilder[(String, IR)]
+    val indep = new BoxedArrayBuilder[(String, IR)]
 
-    lets.foreach { l =>
-      val fv = FreeVariables(l.value, supportsAgg = false, supportsScan = false)
-      if (fv.eval.m.keysIterator.exists(k => depBindings.contains(k))) {
-        dep += l
-        depBindings += l.name
-      } else
-        indep += l
+    lets.foreach { case x @ (name, value) =>
+      if (value.typ == TVoid || value.isInstanceOf[ResultOp] || value.isInstanceOf[AggStateValue]) {
+        /* if the value is side effecting, or implicitly reads the aggregator state, we can't lift
+         * it */
+        dep += x
+      } else {
+        val fv = FreeVariables(value, supportsAgg = false, supportsScan = false)
+        if (fv.eval.m.keysIterator.exists(k => depBindings.contains(k))) {
+          dep += x
+          depBindings += name
+        } else {
+          indep += x
+        }
+      }
     }
     (dep.result(), indep.result())
   }
 
-  def addLets(ir: IR, lets: Array[AggLet]): IR = {
-    assert(lets.areDistinct())
-    Let(lets.map(al => al.name -> al.value), ir)
-  }
-
-  def getResultType(aggSig: AggSignature): Type = aggSig match {
-    case AggSignature(Sum(), _, Seq(t)) => t
-    case AggSignature(Product(), _, Seq(t)) => t
-    case AggSignature(Min(), _, Seq(t)) => t
-    case AggSignature(Max(), _, Seq(t)) => t
-    case AggSignature(Count(), _, _) => TInt64
-    case AggSignature(Take(), _, Seq(t)) => TArray(t)
-    case AggSignature(ReservoirSample(), _, Seq(t)) => TArray(t)
-    case AggSignature(CallStats(), _, _) => CallStatsState.resultPType.virtualType
-    case AggSignature(TakeBy(_), _, Seq(value, _)) => TArray(value)
-    case AggSignature(PrevNonnull(), _, Seq(t)) => t
-    case AggSignature(CollectAsSet(), _, Seq(t)) => TSet(t)
-    case AggSignature(Collect(), _, Seq(t)) => TArray(t)
-    case AggSignature(Densify(), _, Seq(t)) => t
-    case AggSignature(ImputeType(), _, _) => ImputeTypeState.resultEmitType.virtualType
-    case AggSignature(LinearRegression(), _, _) =>
-      LinearRegressionAggregator.resultPType.virtualType
-    case AggSignature(ApproxCDF(), _, _) => QuantilesAggregator.resultPType.virtualType
-    case AggSignature(Downsample(), _, Seq(_, _, _)) => DownsampleAggregator.resultType
-    case AggSignature(NDArraySum(), _, Seq(t)) => t
-    case AggSignature(NDArrayMultiplyAdd(), _, Seq(a: TNDArray, _)) => a
-    case _ => throw new UnsupportedExtraction(aggSig.toString)
-  }
-
+  // FIXME: move this to StagedAggregator?
   def getAgg(sig: PhysicalAggSig): StagedAggregator = sig match {
     case PhysicalAggSig(Sum(), TypedStateSig(t)) => new SumAggregator(t.t)
     case PhysicalAggSig(Product(), TypedStateSig(t)) => new ProductAggregator(t.t)
@@ -475,11 +470,10 @@ object Extract {
       new FoldAggregator(res, accumName, otherAccumName, combOpIR)
   }
 
-  def apply(ir: IR, resultName: String, r: RequirednessAnalysis, isScan: Boolean = false): Aggs = {
+  def apply(ir: IR, r: RequirednessAnalysis, isScan: Boolean = false): Aggs = {
     val ab = new BoxedArrayBuilder[(InitOp, PhysicalAggSig)]()
-    val seq = new BoxedArrayBuilder[IR]()
-    val let = new BoxedArrayBuilder[AggLet]()
-    val ref = Ref(resultName, null)
+    val seq = new BoxedArrayBuilder[(String, IR)]()
+    val ref = Ref(genUID(), null)
     val memo = mutable.Map.empty[IR, Int]
 
     val bindingNodesReferenced = Memo.empty[Unit]
@@ -491,7 +485,6 @@ object Extract {
       rewriteMap,
       ab,
       seq,
-      let,
       memo,
       ref,
       r,
@@ -506,28 +499,36 @@ object Extract {
       rewriteMap,
       bindingNodesReferenced,
       Begin(initOps),
-      addLets(Begin(seq.result()), let.result()),
+      Let.void(seq.result()),
+      ref,
       pAggSigs,
     )
   }
 
   private def extract(
     ir: IR,
+    // bindings in scope for init op arguments
     env: BindingEnv[RefEquality[IR]],
+    // nodes which bind variables which are referenced in init op arguments
     bindingNodesReferenced: Memo[Unit],
+    /* map each desendant of the original ir to its extract result (all contained aggs replaced with
+     * their results) */
     rewriteMap: Memo[IR],
+    // set of contained aggs, and the init op for each
     ab: BoxedArrayBuilder[(InitOp, PhysicalAggSig)],
-    seqBuilder: BoxedArrayBuilder[IR],
-    letBuilder: BoxedArrayBuilder[AggLet],
+    // set of updates for contained aggs
+    seqBuilder: BoxedArrayBuilder[(String, IR)],
+    /* Map each contained ApplyAggOp, ApplyScanOp, or AggFold, to the index of the corresponding agg
+     * state, used to perform CSE on agg ops */
     memo: mutable.Map[IR, Int],
+    // a reference to the tuple of results of contained aggs
     result: IR,
     r: RequirednessAnalysis,
     isScan: Boolean,
   ): IR = {
-    // the env argument here tracks variable bindings that are accessible to init op arguments
-
     def newMemo: mutable.Map[IR, Int] = mutable.Map.empty[IR, Int]
 
+    // For each free variable in each init op arg, add the binding site to bindingNodesReferenced
     def bindInitArgRefs(initArgs: IndexedSeq[IR]): Unit = {
       initArgs.foreach { arg =>
         val fv = FreeVariables(arg, false, false).eval
@@ -538,19 +539,19 @@ object Extract {
     }
 
     val newNode = ir match {
-      case x @ AggLet(_, _, body, _) =>
-        letBuilder += x
-        this.extract(body, env, bindingNodesReferenced, rewriteMap, ab, seqBuilder, letBuilder,
-          memo, result, r, isScan)
+      case AggLet(name, value, body, _) =>
+        seqBuilder += name -> value
+        this.extract(body, env, bindingNodesReferenced, rewriteMap, ab, seqBuilder, memo, result, r,
+          isScan)
       case x: ApplyAggOp if !isScan =>
         val idx = memo.getOrElseUpdate(
           x, {
             val i = ab.length
             val op = x.aggSig.op
             bindInitArgRefs(x.initOpArgs)
-            val state = PhysicalAggSig(op, AggStateSig(op, x.initOpArgs, x.seqOpArgs, r))
+            val state = PhysicalAggSig(op, AggStateSig(op, x.seqOpArgs, r))
             ab += InitOp(i, x.initOpArgs, state) -> state
-            seqBuilder += SeqOp(i, x.seqOpArgs, state)
+            seqBuilder += "__void" -> SeqOp(i, x.seqOpArgs, state)
             i
           },
         )
@@ -561,9 +562,9 @@ object Extract {
             val i = ab.length
             val op = x.aggSig.op
             bindInitArgRefs(x.initOpArgs)
-            val state = PhysicalAggSig(op, AggStateSig(op, x.initOpArgs, x.seqOpArgs, r))
+            val state = PhysicalAggSig(op, AggStateSig(op, x.seqOpArgs, r))
             ab += InitOp(i, x.initOpArgs, state) -> state
-            seqBuilder += SeqOp(i, x.seqOpArgs, state)
+            seqBuilder += "__void" -> SeqOp(i, x.seqOpArgs, state)
             i
           },
         )
@@ -581,40 +582,33 @@ object Extract {
             val signature = PhysicalAggSig(op, foldStateSig)
             ab += InitOp(i, initOpArgs, signature) -> signature
             // So seqOp has to be able to reference accumName.
-            val seqWithLet =
-              Let(FastSeq(accumName -> ResultOp(i, signature)), SeqOp(i, seqOpArgs, signature))
-            seqBuilder += seqWithLet
+            seqBuilder += accumName -> ResultOp(i, signature)
+            seqBuilder += "__void" -> SeqOp(i, seqOpArgs, signature)
             i
           },
         )
         GetTupleElement(result, idx)
       case AggFilter(cond, aggIR, _) =>
-        val newSeq = new BoxedArrayBuilder[IR]()
-        val newLet = new BoxedArrayBuilder[AggLet]()
+        val newSeq = new BoxedArrayBuilder[(String, IR)]()
         val transformed = this.extract(aggIR, env, bindingNodesReferenced, rewriteMap, ab, newSeq,
-          newLet, newMemo, result, r, isScan)
+          newMemo, result, r, isScan)
 
-        seqBuilder += If(
-          cond,
-          addLets(Begin(newSeq.result()), newLet.result()),
-          Begin(FastSeq[IR]()),
-        )
+        seqBuilder += "__void" -> If(cond, Let.void(newSeq.result()), Void())
         transformed
 
       case AggExplode(array, name, aggBody, _) =>
-        val newSeq = new BoxedArrayBuilder[IR]()
-        val newLet = new BoxedArrayBuilder[AggLet]()
+        val newSeq = new BoxedArrayBuilder[(String, IR)]()
         val transformed = this.extract(aggBody, env, bindingNodesReferenced, rewriteMap, ab, newSeq,
-          newLet, newMemo, result, r, isScan)
+          newMemo, result, r, isScan)
 
-        val (dependent, independent) = partitionDependentLets(newLet.result(), name)
-        letBuilder ++= independent
-        seqBuilder += StreamFor(array, name, addLets(Begin(newSeq.result()), dependent))
+        val (dependent, independent) = partitionDependentLets(newSeq.result(), name)
+        seqBuilder ++= independent
+        seqBuilder += "__void" -> StreamFor(array, name, Let.void(dependent))
         transformed
 
       case AggGroupBy(key, aggIR, _) =>
         val newAggs = new BoxedArrayBuilder[(InitOp, PhysicalAggSig)]()
-        val newSeq = new BoxedArrayBuilder[IR]()
+        val newSeq = new BoxedArrayBuilder[(String, IR)]()
         val newRef = Ref(genUID(), null)
         val transformed = this.extract(
           aggIR,
@@ -623,7 +617,6 @@ object Extract {
           rewriteMap,
           newAggs,
           newSeq,
-          letBuilder,
           newMemo,
           GetField(newRef, "value"),
           r,
@@ -639,7 +632,11 @@ object Extract {
         val groupState = AggStateSig.grouped(key, pAggSigs.map(_.state), r)
         val groupSig = GroupedAggSig(groupState.kt, pAggSigs.toFastSeq)
         ab += InitOp(i, FastSeq(Begin(initOps)), groupSig) -> groupSig
-        seqBuilder += SeqOp(i, FastSeq(key, Begin(newSeq.result().toFastSeq)), groupSig)
+        seqBuilder += "__void" -> SeqOp(
+          i,
+          FastSeq(key, Let.void(newSeq.result())),
+          groupSig,
+        )
 
         ToDict(StreamMap(
           ToStream(GetTupleElement(result, i)),
@@ -649,14 +646,12 @@ object Extract {
 
       case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, _) =>
         val newAggs = new BoxedArrayBuilder[(InitOp, PhysicalAggSig)]()
-        val newSeq = new BoxedArrayBuilder[IR]()
-        val newLet = new BoxedArrayBuilder[AggLet]()
+        val newSeq = new BoxedArrayBuilder[(String, IR)]()
         val newRef = Ref(genUID(), null)
         val transformed = this.extract(aggBody, env, bindingNodesReferenced, rewriteMap, newAggs,
-          newSeq, newLet, newMemo, newRef, r, isScan)
+          newSeq, newMemo, newRef, r, isScan)
 
-        val (dependent, independent) = partitionDependentLets(newLet.result(), elementName)
-        letBuilder ++= independent
+        val (dependent, independent) = partitionDependentLets(newSeq.result(), elementName)
 
         val i = ab.length
         val (initOps, pAggSigs) = newAggs.result().unzip
@@ -674,27 +669,22 @@ object Extract {
           knownLength.map(FastSeq(_)).getOrElse(FastSeq[IR]()) :+ Begin(initOps),
           checkSig,
         ) -> checkSig
+
+        seqBuilder ++= independent
+        seqBuilder += aRef.name -> a
+        seqBuilder += "__void" -> SeqOp(i, FastSeq(ArrayLen(aRef)), checkSig)
         seqBuilder +=
-          Let(
-            FastSeq(aRef.name -> a),
-            Begin(FastSeq(
-              SeqOp(i, FastSeq(ArrayLen(aRef)), checkSig),
-              StreamFor(
-                StreamRange(I32(0), ArrayLen(aRef), I32(1)),
-                indexName,
-                Let(
-                  FastSeq(elementName -> ArrayRef(aRef, Ref(indexName, TInt32))),
-                  addLets(
-                    SeqOp(
-                      i,
-                      FastSeq(Ref(indexName, TInt32), Begin(newSeq.result().toFastSeq)),
-                      eltSig,
-                    ),
-                    dependent,
-                  ),
-                ),
+          "__void" -> StreamFor(
+            StreamRange(I32(0), ArrayLen(aRef), I32(1)),
+            indexName,
+            SeqOp(
+              i,
+              FastSeq(
+                Ref(indexName, TInt32),
+                Let.void((elementName, ArrayRef(aRef, Ref(indexName, TInt32))) +: dependent),
               ),
-            )),
+              eltSig,
+            ),
           )
 
         val rUID = Ref(genUID(), rt)
@@ -721,8 +711,8 @@ object Extract {
           val newEnv =
             Bindings.segregated(x, i, env).mapNewBindings((_, _) => RefEquality(x)).unified
 
-          this.extract(child, newEnv, bindingNodesReferenced, rewriteMap, ab, seqBuilder,
-            letBuilder, memo, result, r, isScan)
+          this.extract(child, newEnv, bindingNodesReferenced, rewriteMap, ab, seqBuilder, memo,
+            result, r, isScan)
         }
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -222,7 +222,7 @@ class Aggs(
         {
           case ir if RefEquality(ir) == rewriteRoot =>
             val Let(bindings, body) = ir
-            Let(bindings, f(rewriteMap.lookup(body)))
+            Let.withAgg(bindings, f(rewriteMap.lookup(body)))
         },
       ).asInstanceOf[IR]
     }
@@ -539,10 +539,22 @@ object Extract {
     }
 
     val newNode = ir match {
-      case AggLet(name, value, body, _) =>
-        seqBuilder += name -> value
-        this.extract(body, env, bindingNodesReferenced, rewriteMap, ab, seqBuilder, memo, result, r,
-          isScan)
+      case x @ Let(bindings, body) =>
+        var newEnv = env
+        val newBindings = Array.newBuilder[Binding]
+        newBindings.sizeHint(bindings)
+        for (binding <- bindings) binding match {
+          case Binding(name, value, Scope.EVAL) =>
+            val newValue = this.extract(value, newEnv, bindingNodesReferenced, rewriteMap, ab,
+              seqBuilder, memo, result, r, isScan)
+            newBindings += Binding(name, newValue)
+            newEnv = env.bindEval(name, RefEquality(x))
+          case Binding(name, value, _) =>
+            seqBuilder += name -> value
+        }
+        val newBody = this.extract(body, newEnv, bindingNodesReferenced, rewriteMap, ab, seqBuilder,
+          memo, result, r, isScan)
+        Let.withAgg(newBindings.result(), newBody)
       case x: ApplyAggOp if !isScan =>
         val idx = memo.getOrElseUpdate(
           x, {
@@ -707,7 +719,7 @@ object Extract {
         assert(!ContainsAgg(x))
         x
       case x =>
-        ir.mapChildrenWithIndex { case (child: IR, i) =>
+        x.mapChildrenWithIndex { case (child: IR, i) =>
           val newEnv =
             Bindings.segregated(x, i, env).mapNewBindings((_, _) => RefEquality(x)).unified
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -18,8 +18,6 @@ import org.apache.spark.TaskContext
 
 class UnsupportedExtraction(msg: String) extends Exception(msg)
 
-// --- AggStateSig --
-
 object AggStateSig {
   def apply(op: AggOp, seqOpArgs: Seq[IR], r: RequirednessAnalysis): AggStateSig = {
     val seqs = seqOpArgs.map(s => s -> (if (s.typ == TVoid) null else r(s)))
@@ -137,8 +135,6 @@ case class FoldStateSig(
   combOpIR: IR,
 ) extends AggStateSig(Array[VirtualTypeWithReq](resultEmitType.typeWithRequiredness), None)
 
-// --- PhysicalAggSig --
-
 object PhysicalAggSig {
   def apply(op: AggOp, state: AggStateSig): PhysicalAggSig = BasicPhysicalAggSig(op, state)
 
@@ -176,8 +172,6 @@ case class ArrayLenAggSig(knownLength: Boolean, nested: Seq[PhysicalAggSig]) ext
       ArrayAggStateSig(nested.map(_.state)),
       nested.flatMap(sig => sig.allOps).toArray,
     )
-
-// --- Aggs --
 
 // The result of Extract
 class Aggs(
@@ -399,8 +393,6 @@ class Aggs(
   def results: IR =
     ResultOp.makeTuple(aggs)
 }
-
-// --- Extract --
 
 object Extract {
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -221,8 +221,8 @@ class Aggs(
         original,
         {
           case ir if RefEquality(ir) == rewriteRoot =>
-            val Let(bindings, body) = ir
-            Let.withAgg(bindings, f(rewriteMap.lookup(body)))
+            val Block(bindings, body) = ir
+            Block(bindings, f(rewriteMap.lookup(body)))
         },
       ).asInstanceOf[IR]
     }
@@ -539,7 +539,7 @@ object Extract {
     }
 
     val newNode = ir match {
-      case x @ Let(bindings, body) =>
+      case x @ Block(bindings, body) =>
         var newEnv = env
         val newBindings = Array.newBuilder[Binding]
         newBindings.sizeHint(bindings)
@@ -554,7 +554,7 @@ object Extract {
         }
         val newBody = this.extract(body, newEnv, bindingNodesReferenced, rewriteMap, ab, seqBuilder,
           memo, result, r, isScan)
-        Let.withAgg(newBindings.result(), newBody)
+        Block(newBindings.result(), newBody)
       case x: ApplyAggOp if !isScan =>
         val idx = memo.getOrElseUpdate(
           x, {

--- a/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -91,8 +91,18 @@ case object SemanticHash extends Logging {
       case a: AggGroupBy =>
         buffer += a.isScan.toByte
 
-      case a: AggLet =>
-        buffer += a.isScan.toByte
+      case Let(bindings, _) =>
+        // encode scopes
+        for {
+          group <- bindings.map(_.scope).grouped(4)
+        } {
+          var byte: Int = 0
+          for (i <- group) {
+            byte <<= 2
+            byte |= i
+          }
+          buffer += byte.toByte
+        }
 
       case a: AggArrayPerElement =>
         buffer += a.isScan.toByte

--- a/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -92,17 +92,7 @@ case object SemanticHash extends Logging {
         buffer += a.isScan.toByte
 
       case Block(bindings, _) =>
-        // encode scopes
-        for {
-          group <- bindings.map(_.scope).grouped(4)
-        } {
-          var byte: Int = 0
-          for (i <- group) {
-            byte <<= 2
-            byte |= i
-          }
-          buffer += byte.toByte
-        }
+        for (b <- bindings) buffer += b.scope.toByte
 
       case a: AggArrayPerElement =>
         buffer += a.isScan.toByte

--- a/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -91,7 +91,7 @@ case object SemanticHash extends Logging {
       case a: AggGroupBy =>
         buffer += a.isScan.toByte
 
-      case Let(bindings, _) =>
+      case Block(bindings, _) =>
         // encode scopes
         for {
           group <- bindings.map(_.scope).grouped(4)
@@ -322,7 +322,7 @@ case object SemanticHash extends Logging {
           _: If |
           _: InsertFields |
           _: IsNA |
-          _: Let |
+          _: Block |
           _: LiftMeOut |
           _: MakeArray |
           _: MakeNDArray |

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerAndExecuteShuffles.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerAndExecuteShuffles.scala
@@ -35,11 +35,10 @@ object LowerAndExecuteShuffles {
 
         case t @ TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize) =>
           val newKeyType = newKey.typ.asInstanceOf[TStruct]
-          val resultUID = genUID()
 
           val req = Requiredness(t, ctx)
 
-          val aggs = Extract(expr, resultUID, req)
+          val aggs = Extract(expr, req)
           val postAggIR = aggs.postAggIR
           val init = aggs.init
           val seq = aggs.seqPerElt
@@ -170,7 +169,7 @@ object LowerAndExecuteShuffles {
                   )),
                   Let(
                     FastSeq(
-                      resultUID -> ResultOp.makeTuple(aggs.aggs),
+                      aggs.resultRef.name -> ResultOp.makeTuple(aggs.aggs),
                       postAggUID -> postAggIR,
                       resultFromTakeUID -> result,
                     ), {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -823,8 +823,7 @@ object LowerTableIR {
         lower(child).collectWithGlobals("table_collect")
 
       case TableAggregate(child, query) =>
-        val resultUID = genUID()
-        val aggs = agg.Extract(query, resultUID, analyses.requirednessAnalysis, false)
+        val aggs = agg.Extract(query, analyses.requirednessAnalysis, false)
 
         def results: IR = ResultOp.makeTuple(aggs.aggs)
 
@@ -973,7 +972,7 @@ object LowerTableIR {
             )) { finalParts =>
               RunAgg(
                 combineGroup(finalParts, true),
-                Let(FastSeq("global" -> globals, resultUID -> results), aggs.postAggIR),
+                Let(FastSeq("global" -> globals, aggs.resultRef.name -> results), aggs.postAggIR),
                 aggs.states,
               )
             }
@@ -1005,7 +1004,7 @@ object LowerTableIR {
                     })
                   },
                 )),
-                Let(FastSeq(resultUID -> results), aggs.postAggIR),
+                Let(FastSeq(aggs.resultRef.name -> results), aggs.postAggIR),
                 aggs.states,
               ),
             )
@@ -1661,8 +1660,7 @@ object LowerTableIR {
             )
           }
         } else {
-          val resultUID = genUID()
-          val aggs = agg.Extract(newRow, resultUID, analyses.requirednessAnalysis, isScan = true)
+          val aggs = agg.Extract(newRow, analyses.requirednessAnalysis, isScan = true)
 
           val results: IR = ResultOp.makeTuple(aggs.aggs)
           val initState = RunAgg(
@@ -2010,7 +2008,7 @@ object LowerTableIR {
                           InitFromSerializedValue(i, GetTupleElement(scanState, i), agg.state)
                         }),
                         aggs.seqPerElt,
-                        Let(FastSeq(resultUID -> results), aggs.postAggIR),
+                        Let(FastSeq(aggs.resultRef.name -> results), aggs.postAggIR),
                         aggs.states,
                       ),
                     )

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -366,7 +366,7 @@ object EmitStream {
             SStreamValue(producer)
           }
 
-      case let: Let =>
+      case let: Block =>
         val newEnv = emitter.emitLetBindings(let, cb, env, outerRegion, container, None)
         produce(let.body, cb, env = newEnv)
 

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -367,7 +367,7 @@ object EmitStream {
           }
 
       case let: Block =>
-        val newEnv = emitter.emitLetBindings(let, cb, env, outerRegion, container, None)
+        val newEnv = emitter.emitBlock(let, cb, env, outerRegion, container, None)
         produce(let.body, cb, env = newEnv)
 
       case In(n, _) =>

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -48,6 +48,11 @@ class AggregatorsSuite extends HailSuite {
     )
   }
 
+  @Test def nestedAgg(): Unit = {
+    val agg = ToArray(StreamMap(StreamRange(0, 10, 1), "elt", ApplyAggOp(Count())()))
+    assertEvalsTo(agg, (FastSeq(1, 2).map(i => Row(i)), TStruct("x" -> TInt32)), FastSeq(0L))
+  }
+
   @Test def sumFloat64(): Unit = {
     runAggregator(Sum(), TFloat64, (0 to 100).map(_.toDouble), 5050.0)
     runAggregator(Sum(), TFloat64, FastSeq(), 0.0)

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -50,7 +50,7 @@ class AggregatorsSuite extends HailSuite {
 
   @Test def nestedAgg(): Unit = {
     val agg = ToArray(StreamMap(StreamRange(0, 10, 1), "elt", ApplyAggOp(Count())()))
-    assertEvalsTo(agg, (FastSeq(1, 2).map(i => Row(i)), TStruct("x" -> TInt32)), FastSeq(0L))
+    assertEvalsTo(agg, (FastSeq(1, 2).map(i => Row(i)), TStruct("x" -> TInt32)), IndexedSeq.fill(10)(2L))
   }
 
   @Test def sumFloat64(): Unit = {

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -50,7 +50,11 @@ class AggregatorsSuite extends HailSuite {
 
   @Test def nestedAgg(): Unit = {
     val agg = ToArray(StreamMap(StreamRange(0, 10, 1), "elt", ApplyAggOp(Count())()))
-    assertEvalsTo(agg, (FastSeq(1, 2).map(i => Row(i)), TStruct("x" -> TInt32)), IndexedSeq.fill(10)(2L))
+    assertEvalsTo(
+      agg,
+      (FastSeq(1, 2).map(i => Row(i)), TStruct("x" -> TInt32)),
+      IndexedSeq.fill(10)(2L),
+    )
   }
 
   @Test def sumFloat64(): Unit = {

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -1635,7 +1635,7 @@ class PruneSuite extends HailSuite {
       Let(FastSeq("x" -> NA(ts)), Ref("x", ts)),
       subsetTS("b"),
       (_: BaseIR, r: BaseIR) => {
-        val ir = r.asInstanceOf[Let]
+        val ir = r.asInstanceOf[Block]
         ir.bindings.head.value.typ == subsetTS("b")
       },
     )
@@ -1656,10 +1656,11 @@ class PruneSuite extends HailSuite {
         false,
       ),
       TArray(subsetTS("a")),
-      (_: BaseIR, r: BaseIR) => r match {
-        case Let(Seq(Binding(_, value, Scope.AGG)), _) =>
-          value.typ == subsetTS("a")
-      },
+      (_: BaseIR, r: BaseIR) =>
+        r match {
+          case Block(Seq(Binding(_, value, Scope.AGG)), _) =>
+            value.typ == subsetTS("a")
+        },
     )
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -1636,7 +1636,7 @@ class PruneSuite extends HailSuite {
       subsetTS("b"),
       (_: BaseIR, r: BaseIR) => {
         val ir = r.asInstanceOf[Let]
-        ir.bindings.head._2.typ == subsetTS("b")
+        ir.bindings.head.value.typ == subsetTS("b")
       },
     )
   }
@@ -1656,9 +1656,9 @@ class PruneSuite extends HailSuite {
         false,
       ),
       TArray(subsetTS("a")),
-      (_: BaseIR, r: BaseIR) => {
-        val ir = r.asInstanceOf[AggLet]
-        ir.value.typ == subsetTS("a")
+      (_: BaseIR, r: BaseIR) => r match {
+        case Let(Seq(Binding(_, value, Scope.AGG)), _) =>
+          value.typ == subsetTS("a")
       },
     )
   }

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -389,7 +389,7 @@ class SimplifySuite extends HailSuite {
 
     assert(Simplify(ctx, StreamLen(rangeIR)) == Simplify(ctx, StreamLen(mapOfRange)))
     assert(Simplify(ctx, StreamLen(mapBlockedByLet)) match {
-      case Let(_, body) => body == Simplify(ctx, StreamLen(mapOfRange))
+      case Block(_, body) => body == Simplify(ctx, StreamLen(mapOfRange))
     })
   }
 


### PR DESCRIPTION
~Stacked on #14404~

This set of changes started out as refactoring and trying to better understand `extract.scala`. But the bigger change ended up being getting rid of AggLet in favor of allowing bindings in `Let` to be agg/scan bindings.

So each binding in a `Let` now has a binding scope, encoded using the pre-existing `Scope` enum. I also renamed `Let` to `Block`. While I think that's a better name for what `Let` has become, and what I hope it will further become in the future, I initially tried to keep the name `Let`. I changed it so that I could keep `Let.apply` the way it is, specialized to bindings all in the eval scope. We can change all the uses of `Let.apply` seperately, I didn't want to pollute this already large pr with that.