### PR TITLE
[query] Load each missing byte once during struct decoding.

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -269,7 +269,7 @@ package object asm4s {
 
   implicit def toCodeInt(c: Code[Int]): CodeInt = new CodeInt(c)
 
-  implicit def byteToCodeInt(c: Code[Byte]): Code[Int] = c.asInstanceOf[Code[Int]]
+  implicit def byteToCodeInt(c: Code[Byte]): Code[Int] = coerce(c)
 
   implicit def byteToCodeInt2(c: Code[Byte]): CodeInt = toCodeInt(byteToCodeInt(c))
 

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -165,7 +165,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
     val m = cb.newLocal[Int]("cached_mbyte")
 
     fields.foreach { f =>
-      if (midx == 0 && f.typ.required) {
+      if (midx == 0 && !f.typ.required) {
         cb.assign[Int](m, Region.loadByte(mbytes + byteIdx))
         byteIdx += 1
       }
@@ -193,7 +193,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
         else
           cb.if_((const(1 << midx) & m).ceq(0), skip(cb, region, in))
       }
-      midx = (midx + f.typ.required.toInt) & 0x7
+      midx = (midx + (!f.typ.required).toInt) & 0x7
     }
   }
 


### PR DESCRIPTION
Resolves #13811