### PR TITLE
[query] Use RouterFS With LocalBackend

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1198,7 +1198,7 @@ steps:
 
       # The test should use the test credentials, not CI's credentials
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
-      export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/credentials.json
+      export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
 
       export HAIL_QUERY_N_CORES=2
       export OMP_NUM_THREADS=2

--- a/build.yaml
+++ b/build.yaml
@@ -1197,9 +1197,8 @@ steps:
       mkdir -p /io/tmp
 
       # The test should use the test credentials, not CI's credentials
-      sed -i 's/gsa-key/test-gsa-key/g' ${SPARK_HOME}/conf/core-site.xml
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
-      export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export AZURE_APPLICATION_CREDENTIALS=/test-azure-key/credentials.json
 
       export HAIL_QUERY_N_CORES=2
       export OMP_NUM_THREADS=2

--- a/build.yaml
+++ b/build.yaml
@@ -1198,7 +1198,7 @@ steps:
 
       # The test should use the test credentials, not CI's credentials
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
-      export AZURE_APPLICATION_CREDENTIALS=/test-azure-key/credentials.json
+      export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/credentials.json
 
       export HAIL_QUERY_N_CORES=2
       export OMP_NUM_THREADS=2

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -67,8 +67,6 @@ class LocalBackend(Py4JBackend):
 
         jbackend = hail_package.backend.local.LocalBackend.apply(
             tmpdir,
-            gcs_requester_pays_project,
-            gcs_requester_pays_buckets,
             log,
             True,
             append,
@@ -81,7 +79,10 @@ class LocalBackend(Py4JBackend):
         self._fs = self._exit_stack.enter_context(RouterFS())
         self._logger = None
 
-        self._initialize_flags({})
+        self._initialize_flags({
+            'gcs_requester_pays_project': gcs_requester_pays_project,
+            'gcs_requester_pays_buckets': gcs_requester_pays_buckets
+        })
 
     def validate_file(self, uri: str) -> None:
         validate_file(uri, self._fs.afs)

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -81,7 +81,7 @@ class LocalBackend(Py4JBackend):
 
         self._initialize_flags({
             'gcs_requester_pays_project': gcs_requester_pays_project,
-            'gcs_requester_pays_buckets': gcs_requester_pays_buckets
+            'gcs_requester_pays_buckets': gcs_requester_pays_buckets,
         })
 
     def validate_file(self, uri: str) -> None:

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -607,14 +607,6 @@ def init_local(
     optimizer_iterations = get_env_or_default(_optimizer_iterations, 'HAIL_OPTIMIZER_ITERATIONS', 3)
 
     jvm_heap_size = get_env_or_default(jvm_heap_size, 'HAIL_LOCAL_BACKEND_HEAP_SIZE', None)
-    (
-        gcs_requester_pays_project,
-        gcs_requester_pays_buckets,
-    ) = convert_gcs_requester_pays_configuration_to_hadoop_conf_style(
-        get_gcs_requester_pays_configuration(
-            gcs_requester_pays_configuration=gcs_requester_pays_configuration,
-        )
-    )
     backend = LocalBackend(
         tmpdir,
         log,
@@ -624,8 +616,7 @@ def init_local(
         skip_logging_configuration,
         optimizer_iterations,
         jvm_heap_size,
-        gcs_requester_pays_project=gcs_requester_pays_project,
-        gcs_requester_pays_buckets=gcs_requester_pays_buckets,
+        gcs_requester_pays_configuration,
     )
 
     if not backend.fs.exists(tmpdir):

--- a/hail/python/test/hail/fs/test_worker_driver_fs.py
+++ b/hail/python/test/hail/fs/test_worker_driver_fs.py
@@ -34,7 +34,6 @@ def test_requester_pays_write_no_settings():
 
 
 @skip_in_azure
-@fails_local_backend()
 def test_requester_pays_write_with_project():
     hl_stop_for_test()
     hl_init_for_test(gcs_requester_pays_configuration='hail-vdc')
@@ -148,7 +147,6 @@ def test_requester_pays_with_project_more_than_one_partition():
 
 
 @run_if_azure
-@fails_local_backend
 def test_can_access_public_blobs():
     public_mt = 'https://azureopendatastorage.blob.core.windows.net/gnomad/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt'
     assert hl.hadoop_exists(public_mt)

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -1,6 +1,7 @@
 package is.hail
 
 import is.hail.backend.ExecutionCache
+import is.hail.io.fs.RequesterPaysConfig
 import is.hail.utils._
 
 import scala.collection.mutable
@@ -30,8 +31,8 @@ object HailFeatureFlags {
     ("shuffle_cutoff_to_local_sort", ("HAIL_SHUFFLE_CUTOFF" -> "512000000")), // This is in bytes
     ("grouped_aggregate_buffer_size", ("HAIL_GROUPED_AGGREGATE_BUFFER_SIZE" -> "50")),
     ("use_ssa_logs", "HAIL_USE_SSA_LOGS" -> "1"),
-    ("gcs_requester_pays_project", "HAIL_GCS_REQUESTER_PAYS_PROJECT" -> null),
-    ("gcs_requester_pays_buckets", "HAIL_GCS_REQUESTER_PAYS_BUCKETS" -> null),
+    (RequesterPaysConfig.Flags.RequesterPaysProject, "HAIL_GCS_REQUESTER_PAYS_PROJECT" -> null),
+    (RequesterPaysConfig.Flags.RequesterPaysBuckets, "HAIL_GCS_REQUESTER_PAYS_BUCKETS" -> null),
     ("index_branching_factor", "HAIL_INDEX_BRANCHING_FACTOR" -> null),
     ("rng_nonce", "HAIL_RNG_NONCE" -> "0x0"),
     ("profile", "HAIL_PROFILE" -> null),
@@ -72,7 +73,7 @@ class HailFeatureFlags private (
   def get(flag: String): String = flags(flag)
 
   def lookup(flag: String): Option[String] =
-    Option(flags(flag))
+    Option(flags(flag)).filter(_.nonEmpty)
 
   def exists(flag: String): Boolean = flags.contains(flag)
 

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -71,6 +71,9 @@ class HailFeatureFlags private (
 
   def get(flag: String): String = flags(flag)
 
+  def lookup(flag: String): Option[String] =
+    Option(flags(flag))
+
   def exists(flag: String): Boolean = flags.contains(flag)
 
   def toJSONEnv: JArray =

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -64,7 +64,7 @@ object ServiceBackend {
 
     val flags = HailFeatureFlags.fromMap(rpcConfig.flags)
     val shouldProfile = flags.get("profile") != null
-    val fs = FS.cloudSpecificFS(s"$scratchDir/secrets/gsa-key/key.json", Some(flags))
+    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), Some(flags))
 
     val backendContext = new ServiceBackendContext(
       rpcConfig.billing_project,
@@ -454,12 +454,12 @@ object ServiceBackendAPI {
     val inputURL = argv(5)
     val outputURL = argv(6)
 
-    val fs = FS.cloudSpecificFS(s"$scratchDir/secrets/gsa-key/key.json", None)
+    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), None)
     val deployConfig = DeployConfig.fromConfigFile(
       s"$scratchDir/secrets/deploy-config/deploy-config.json"
     )
     DeployConfig.set(deployConfig)
-    sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir(_))
+    sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 
     val batchClient = new BatchClient(s"$scratchDir/secrets/gsa-key/key.json")
     log.info("BatchClient allocated.")

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -117,7 +117,7 @@ object Worker {
       s"$scratchDir/secrets/deploy-config/deploy-config.json"
     )
     DeployConfig.set(deployConfig)
-    sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir(_))
+    sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 
     log.info(s"is.hail.backend.service.Worker $myRevision")
     log.info(s"running job $i/$n at root $root with scratch directory '$scratchDir'")
@@ -125,7 +125,7 @@ object Worker {
     timer.start(s"Job $i/$n")
 
     timer.start("readInputs")
-    val fs = FS.cloudSpecificFS(s"$scratchDir/secrets/gsa-key/key.json", None)
+    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), None)
 
     def open(x: String): SeekableDataInputStream =
       fs.openNoCompression(x)

--- a/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/AzureStorageFS.scala
@@ -61,6 +61,10 @@ class AzureStorageFSURL(
 }
 
 object AzureStorageFS {
+  object EnvVars {
+    val AzureApplicationCredentials = "AZURE_APPLICATION_CREDENTIALS"
+  }
+
   private val AZURE_HTTPS_URI_REGEX =
     "^https:\\/\\/([a-z0-9_\\-\\.]+)\\.blob\\.core\\.windows\\.net\\/([a-z0-9_\\-\\.]+)(\\/.*)?".r
 

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -158,7 +158,7 @@ class GoogleStorageFS(
         case exc: GoogleJsonResponseException =>
           Option(exc.getMessage).exists { message =>
             message == "userProjectMissing" ||
-            (exc.getStatusCode == 400 && exc.getMessage.contains("requester pays"))
+            (exc.getStatusCode == 400 && message.contains("requester pays"))
           }
 
         case _ =>


### PR DESCRIPTION
A long-standing fixme in the LocalBackend was to not rely on HadoopFS, which we use with the SparkBackend for compatibility with dataproc and hdfs urls.

By default, the HadoopFS doesn't understand gs urls. Users need to install the gcs-hadoop-connector (preinstalled in dataproc) to communicate with google cloud storage. Spark handles supplying credentials to the connector.

Issue #13904 is caused by failing to properly supply the gcs-hadoop-connector with credentials in the LocalBackend. In the absence of config, the connector hangs while trying to fetch a token form a non-existant metadata server.

The LocalBackend was designed to be a testing ground for lowered and compiled code that would eventually be run on batch, where we use the RouterFS. I propose a pragmatic fix for #13904 that ditches the HadoopFS for all but local filesystem access in the LocalBackend instead of identifying and fixing the root cause.

In doing so, I made a couple of changes to how the RouterFS is configured: In the absence of the `HAIL_CLOUD` environment variable, RouterFS can handle gs and az urls iff credentials are not supplied. If the user supplies creditials, we use `HAIL_CLOUD` to decide which cloud to route to.

fixes #13904