### PR TITLE
[batch] Remove hardcoded eastus assert

### DIFF
--- a/batch/batch/cloud/terra/azure/driver/driver.py
+++ b/batch/batch/cloud/terra/azure/driver/driver.py
@@ -401,7 +401,6 @@ class TerraAzureResourceManager(CloudResourceManager):
         if not local_ssd_data_disk:
             raise ValueError('VMs without a local ssd data disk are not yet supported')
 
-        assert location == 'eastus'
         vm_config = create_vm_config(
             file_store,
             location,


### PR DESCRIPTION
This was basically a debugging assertion that slipped into `main`. We run our clusters in Azure's `eastus` region, but other than this line there's nothing stopping anyone from running clusters elsewhere.