### PR TITLE
[qob] Remove mount_tokens job spec parameter for worker jobs

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -223,7 +223,6 @@ class ServiceBackend(
         "attributes" -> JObject(
           "name" -> JString(s"${name}_stage${stageCount}_${stageIdentifier}_job$i")
         ),
-        "mount_tokens" -> JBool(true),
         "resources" -> resources,
         "regions" -> JArray(backendContext.regions.map(JString).toList),
         "cloudfuse" -> JArray(backendContext.cloudfuseConfig.map { config =>


### PR DESCRIPTION
This flag was once used when we used custom hail tokens for authenticating with Batch. Now, we use GCP or Azure access tokens to auth requests so this flag is no longer necessary.