### PR TITLE
[batch] Close the aiohttp client session used by the gcp WorkerAPI

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2936,7 +2936,7 @@ class JVMPool:
 
 
 class Worker:
-    def __init__(self, client_session: httpx.ClientSession):
+    def __init__(self):
         self.active = False
         self.cores_mcpu = CORES * 1000
         self.last_updated = time_msecs()
@@ -2948,7 +2948,7 @@ class Worker:
         self.task_manager = aiotools.BackgroundTaskManager()
         os.makedirs('/hail-jars/', exist_ok=True)
         self.jar_download_locks: Dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
-        self.client_session = client_session
+        self.client_session = httpx.client_session()
 
         self.image_data: Dict[str, ImageData] = defaultdict(ImageData)
         self.image_data[BATCH_WORKER_IMAGE_ID] += 1
@@ -3452,7 +3452,7 @@ async def async_main():
     network_allocator = NetworkAllocator(network_allocator_task_manager)
     await network_allocator.reserve()
 
-    worker = Worker(httpx.client_session())
+    worker = Worker()
     try:
         async with AsyncExitStack() as cleanup:
             cleanup.push_async_callback(docker.close)


### PR DESCRIPTION
When workers shut down, we get warning logs about unclosed client sessions, as seen in #14261. While it can be difficult to derive the source of the client session, I think it's the one held by the `GCPWorkerAPI`. I've added an exit stack and added the session's close method to it.

I also made a small change to `Worker`. I find it can be difficult to determine whether or not a particular class should close a client session because it's not always clear who owns it. Without a clear way to communicate this in python, I think we should just never transfer ownership of a `ClientSession` and always assume that if an object's constructor takes a client session, it should be assumed a borrow and not close the session when the object is closed. As such, I moved the call to `client_session()` into the `Worker` constructor so it's clear that the worker owns the session.