### PR TITLE
[fs] Add sink write failure in ABS to transient errors

### DIFF
--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -156,7 +156,8 @@ package object services {
           if e.getMessage != null && e.getMessage.contains("SSL peer shut down incorrectly") =>
         true
       case e: IllegalStateException
-          if e.getMessage.contains("Timeout on blocking read") =>
+          if e.getMessage.contains("Timeout on blocking read") ||
+            e.getMessage.contains("Faulted stream due to underlying sink write failure") =>
         /* Caused by: java.lang.IllegalStateException: Timeout on blocking read for 30000000000
          * NANOSECONDS */
         /* reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:123) */


### PR DESCRIPTION
I run into this ~1/20,000 QoB just when writing result files. I'm going to make a separate issue with the ABS client repo but I suspect this might be difficult to track down and fix.

Example stack trace:

```
RuntimeException: java.lang.IllegalStateException: Faulted stream due to underlying sink write failure	Gjava.lang.RuntimeException: java.lang.IllegalStateException: Faulted stream due to underlying sink write failure
	at is.hail.shadedazure.com.azure.storage.common.StorageOutputStream.checkStreamState(StorageOutputStream.java:92)
	at is.hail.shadedazure.com.azure.storage.common.StorageOutputStream.flush(StorageOutputStream.java:102)
	at is.hail.io.fs.AzureStorageFS$$anon$3.close(AzureStorageFS.scala:308)
	at java.io.FilterOutputStream.close(FilterOutputStream.java:159)
	at java.util.zip.DeflaterOutputStream.close(DeflaterOutputStream.java:241)
	at is.hail.utils.package$.using(package.scala:669)
	at is.hail.io.index.IndexWriterUtils.writeMetadata(IndexWriter.scala:253)
	at __C511collect_distributed_array_table_native_writer.apply_region3_328(Unknown Source)
	at __C511collect_distributed_array_table_native_writer.apply(Unknown Source)
	at __C511collect_distributed_array_table_native_writer.apply(Unknown Source)
	at is.hail.backend.BackendUtils.$anonfun$collectDArray$6(BackendUtils.scala:87)
	at is.hail.utils.package$.using(package.scala:664)
	at is.hail.annotations.RegionPool.scopedRegion(RegionPool.scala:166)
	at is.hail.backend.BackendUtils.$anonfun$collectDArray$5(BackendUtils.scala:86)
	at is.hail.backend.service.Worker$.$anonfun$main$9(Worker.scala:198)
	at is.hail.services.package$.retryTransientErrors(package.scala:187)
	at is.hail.backend.service.Worker$.$anonfun$main$8(Worker.scala:197)
	at is.hail.utils.package$.using(package.scala:664)
	at is.hail.backend.service.Worker$.main(Worker.scala:195)
	at is.hail.backend.service.Main$.main(Main.scala:9)
	at is.hail.backend.service.Main.main(Main.scala)
	at sun.reflect.GeneratedMethodAccessor24.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at is.hail.JVMEntryway$1.run(JVMEntryway.java:119)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```