### PR TITLE
[release] Fix EV syntax in release job for WHEEL variable

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3367,7 +3367,7 @@ steps:
           exit 0
       fi
 
-      make upload-artifacts DEPLOY_REMOTE=origin --assume-old=$(WHEEL)
+      make upload-artifacts DEPLOY_REMOTE=origin --assume-old=$WHEEL
 
       echo Setting arguments and invoking release.sh.
 


### PR DESCRIPTION
I'm guessing this was a Make-ism that spilled over into the bash script.