### PR TITLE
[batch] Use spend instead of cost on the billing page

### DIFF
--- a/batch/batch/front_end/templates/billing.html
+++ b/batch/batch/front_end/templates/billing.html
@@ -34,19 +34,19 @@
         </div>
     </div>
 
-    <h2>Total Cost</h2>
+    <h2>Total Spend</h2>
     <ul>
         <li>{{ total_cost }}</li>
     </ul>
 
     {% if is_developer %}
-    <h2>Cost by Billing Project</h2>
+    <h2>Spend by Billing Project</h2>
     <div class='flex-col' style="overflow: auto;">
         <table class="data-table" id="billing_by_project">
             <thead>
             <tr>
                 <th>Billing Project</th>
-                <th>Cost</th>
+                <th>Spend</th>
             </tr>
             </thead>
             <tbody>
@@ -60,13 +60,13 @@
         </table>
     </div>
 
-    <h2>Cost by User</h2>
+    <h2>Spend by User</h2>
     <div class='flex-col' style="overflow: auto;">
         <table class="data-table" id="billing_by_user">
             <thead>
             <tr>
                 <th>User</th>
-                <th>Cost</th>
+                <th>Spend</th>
             </tr>
             </thead>
             <tbody>
@@ -81,14 +81,14 @@
     </div>
     {% endif %}
 
-    <h2>Cost by Billing Project and User</h2>
+    <h2>Spend by Billing Project and User</h2>
     <div class='flex-col' style="overflow: auto;">
         <table class="data-table" id="billing_by_project_user">
             <thead>
             <tr>
                 <th>Billing Project</th>
                 <th>User</th>
-                <th>Cost</th>
+                <th>Spend</th>
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
I sometimes find the term "Cost" on this page confusing, and I think its inferred meaning differs depending on who's reading the page. This page shows what users are spending on the Batch service, not what it is *costing* operators to run the service (since we charge a service fee).