### PR TITLE
[batch] Do not lock when querying billing projects

### DIFF
--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -157,8 +157,7 @@ LEFT JOIN LATERAL (
   ) AS usage_t
   LEFT JOIN resources ON resources.resource_id = usage_t.resource_id
 ) AS cost_t ON TRUE
-{where_condition}
-LOCK IN SHARE MODE;
+{where_condition};
 """
 
     billing_projects = []


### PR DESCRIPTION
Decided to tackle this as it was causing noise in the logs. There is no reason this read-only select query should lock any rows.