### PR TITLE
[ci] Run the test-dataproc jobs on non-preemptible instances

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3257,6 +3257,8 @@ steps:
     name: test_dataproc-37
     image:
       valueFrom: ci_utils_image.image
+    resources:
+      preemptible: False
     script: |
       set -ex
 
@@ -3298,6 +3300,8 @@ steps:
     name: test_dataproc-38
     image:
       valueFrom: ci_utils_image.image
+    resources:
+      preemptible: False
     script: |
       set -ex
 


### PR DESCRIPTION
These tests start up whole clusters and can take >30min, so while they are idempotent the cost of preemption is substantial.