### PR TITLE
[query] Copy spark driver log to remote tmpdir on error

### DIFF
--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 import orjson
 import pyspark
@@ -8,8 +8,10 @@ import pyspark.sql
 
 from hail.expr.table_type import ttable
 from hail.fs.hadoop_fs import HadoopFS
+from hail.ir import BaseIR
 from hail.ir.renderer import CSERenderer
 from hail.table import Table
+from hail.utils import copy_log
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
 
@@ -46,6 +48,7 @@ class SparkBackend(Py4JBackend):
         *,
         gcs_requester_pays_project: Optional[str] = None,
         gcs_requester_pays_buckets: Optional[str] = None,
+        copy_log_on_error: bool = False
     ):
         assert gcs_requester_pays_project is not None or gcs_requester_pays_buckets is None
 
@@ -166,6 +169,9 @@ class SparkBackend(Py4JBackend):
             gcs_kwargs={"gcs_requester_pays_configuration": gcs_requester_pays_project}
         )
 
+        self._tmpdir = tmpdir
+        self._copy_log_on_error = copy_log_on_error
+
     def validate_file(self, uri: str) -> None:
         validate_file(uri, self._router_async_fs)
 
@@ -206,6 +212,18 @@ class SparkBackend(Py4JBackend):
             return_type._parsable_string(),
             jbody,
         )
+
+    def execute(self, ir: BaseIR, timed: bool = False) -> Any:
+        try:
+            return super().execute(ir, timed)
+        except Exception as err:
+            if self._copy_log_on_error:
+                try:
+                    copy_log(self._tmpdir)
+                except Exception as fatal:
+                    raise err from fatal
+
+            raise err
 
     @property
     def requires_lowering(self):

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -48,7 +48,7 @@ class SparkBackend(Py4JBackend):
         *,
         gcs_requester_pays_project: Optional[str] = None,
         gcs_requester_pays_buckets: Optional[str] = None,
-        copy_log_on_error: bool = False
+        copy_log_on_error: bool = False,
     ):
         assert gcs_requester_pays_project is not None or gcs_requester_pays_buckets is None
 

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -462,7 +462,7 @@ def init_spark(
     local_tmpdir=None,
     _optimizer_iterations=None,
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
-    copy_log_on_error: bool=False,
+    copy_log_on_error: bool = False,
 ):
     from hail.backend.py4j_backend import connect_logger
     from hail.backend.spark_backend import SparkBackend

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -185,6 +185,7 @@ class HailContext(object):
     gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
     regions=nullable(sequenceof(str)),
     gcs_bucket_allow_list=nullable(dictof(str, sequenceof(str))),
+    copy_spark_log_on_error=nullable(bool),
 )
 def init(
     sc=None,
@@ -213,6 +214,7 @@ def init(
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
     regions: Optional[List[str]] = None,
     gcs_bucket_allow_list: Optional[Dict[str, List[str]]] = None,
+    copy_spark_log_on_error: bool = False,
 ):
     """Initialize and configure Hail.
 
@@ -334,6 +336,8 @@ def init(
     gcs_bucket_allow_list:
         A list of buckets that Hail should be permitted to read from or write to, even if their default policy is to
         use "cold" storage. Should look like ``["bucket1", "bucket2"]``.
+    copy_spark_log_on_error: :class:`bool`, optional
+        Spark backend only. If `True`, copy the log from the spark driver node to `tmp_dir` on error.
     """
     if Env._hc:
         if idempotent:
@@ -402,6 +406,7 @@ def init(
             global_seed=global_seed,
             skip_logging_configuration=skip_logging_configuration,
             gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+            copy_log_on_error=copy_spark_log_on_error,
         )
     if backend == 'local':
         return init_local(
@@ -436,6 +441,7 @@ def init(
     local_tmpdir=nullable(str),
     _optimizer_iterations=nullable(int),
     gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
+    copy_log_on_error=nullable(bool),
 )
 def init_spark(
     sc=None,
@@ -456,6 +462,7 @@ def init_spark(
     local_tmpdir=None,
     _optimizer_iterations=None,
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+    copy_log_on_error: bool=False,
 ):
     from hail.backend.py4j_backend import connect_logger
     from hail.backend.spark_backend import SparkBackend
@@ -492,6 +499,7 @@ def init_spark(
         optimizer_iterations,
         gcs_requester_pays_project=gcs_requester_pays_project,
         gcs_requester_pays_buckets=gcs_requester_pays_buckets,
+        copy_log_on_error=copy_log_on_error,
     )
     if not backend.fs.exists(tmpdir):
         backend.fs.mkdir(tmpdir)

--- a/hail/python/test/hail/backend/test_spark_backend.py
+++ b/hail/python/test/hail/backend/test_spark_backend.py
@@ -6,7 +6,7 @@ import pytest
 import hail as hl
 
 
-def fatal(typ: hl.HailType, msg: str="") -> hl.Expression:
+def fatal(typ: hl.HailType, msg: str = "") -> hl.Expression:
     return hl.construct_expr(hl.ir.Die(hl.to_expr(msg, hl.tstr)._ir, typ), typ)
 
 
@@ -26,8 +26,4 @@ def test_copy_spark_log(copy):
     _, filename = os.path.split(hc._log)
     log = os.path.join(hc._tmpdir, filename)
 
-    assert (
-        Env.fs().exists(log)
-        if copy
-        else not Env.fs().exists(log)
-    )
+    assert Env.fs().exists(log) if copy else not Env.fs().exists(log)

--- a/hail/python/test/hail/backend/test_spark_backend.py
+++ b/hail/python/test/hail/backend/test_spark_backend.py
@@ -1,0 +1,33 @@
+import os
+from test.hail.helpers import skip_unless_spark_backend
+
+import pytest
+
+import hail as hl
+
+
+def fatal(typ: hl.HailType, msg: str="") -> hl.Expression:
+    return hl.construct_expr(hl.ir.Die(hl.to_expr(msg, hl.tstr)._ir, typ), typ)
+
+
+@skip_unless_spark_backend()
+@pytest.mark.parametrize('copy', [True, False])
+def test_copy_spark_log(copy):
+    hl.stop()
+    hl.init(copy_spark_log_on_error=copy)
+
+    expr = fatal(hl.tint32)
+    with pytest.raises(Exception):
+        hl.eval(expr)
+
+    from hail.utils.java import Env
+
+    hc = Env.hc()
+    _, filename = os.path.split(hc._log)
+    log = os.path.join(hc._tmpdir, filename)
+
+    assert (
+        Env.fs().exists(log)
+        if copy
+        else not Env.fs().exists(log)
+    )


### PR DESCRIPTION
Adds `copy_spark_log_on_error` init configuration option. When true, driver logs are copied to the remote tmpdir if an error occurs. This is useful in support cases where users cannot copy logs off the dataproc server themselves as it has already shut down.