### PR TITLE
[release] build release wheel with correct `deploy.yaml`

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3321,7 +3321,6 @@ steps:
 
       cd /io/repo/hail
       export HAIL_PIP_VERSION=$(cat /io/hail_pip_version)
-      export WHEEL="build/deploy/dist/hail-${HAIL_PIP_VERSION}-py3-none-any.whl"
 
       if git ls-remote --exit-code --tags origin $HAIL_PIP_VERSION
       then
@@ -3330,11 +3329,15 @@ steps:
           exit 0
       fi
 
-      make upload-artifacts DEPLOY_REMOTE=origin --assume-old=$WHEEL
+      # #14452 - must build wheel with release `hailtop/hailctl/deploy.yaml`
+      # use `assume-old` to prevent `mill` from rebuilding the "SHADOW_JAR"
+      make upload-artifacts DEPLOY_REMOTE=origin \
+        --assume-old=out/assembly.dest/out.jar
 
       echo Setting arguments and invoking release.sh.
 
       HAIL_VERSION=$(cat /io/hail_version) \
+      WHEEL="build/deploy/dist/hail-${HAIL_PIP_VERSION}-py3-none-any.whl" \
       GIT_VERSION=$(cat /io/git_version) \
       REMOTE=origin \
       GITHUB_OAUTH_HEADER_FILE=/io/github-oauth \
@@ -3358,8 +3361,8 @@ steps:
         to: /io/git_version
       - from: /repo
         to: /io/repo
-      - from: /wheel
-        to: /io/repo/hail/build/deploy/dist
+      - from: /hail.jar
+        to: /io/repo/hail/out/assembly.dest/out.jar
       - from: /azure-wheel
         to: /io/azure-wheel
       - from: /www.tar.gz


### PR DESCRIPTION
In a89d64a, I modified `build.yaml` to release the wheel we had already built and tested. Unbeknownst to me was that we rebuild the wheel with a different version of `hail/python/hailtop/hailctl/deploy.yaml` and releasing the version used for testing borked `hailctl dataproc` commands.

To fix this, we'll rebuild the wheel but use the `jar` we've already built and tested. This is safe to do as far as I know because we don't bundle any information into the jar that depends on the make flag `DEPLOY_REMOTE`.

Fixes: #14452