### PR TITLE
[ci] Poll for batch and github changes every 1 minute instead of 5

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -747,7 +747,7 @@ async def update_loop(app: web.Application):
         except Exception:  # pylint: disable=broad-except
             if wb:
                 log.exception(f'{wb.branch.short_str()} update failed due to exception')
-        await asyncio.sleep(300)
+        await asyncio.sleep(60)
 
 
 class AppKeys(CommonAiohttpAppKeys):


### PR DESCRIPTION
We can always revert this if there are issues, but the polling CI does to refresh its understanding of PRs and batches is pretty light, and I think every minute is still quite reasonable.