### PR TITLE
[pip] Update orjson and transitive dependencies

### DIFF
--- a/batch/batch/cloud/terra/azure/worker/worker_api.py
+++ b/batch/batch/cloud/terra/azure/worker/worker_api.py
@@ -53,7 +53,8 @@ class TerraAzureWorkerAPI(CloudWorkerAPI):
             f'WORKSPACE_MANAGER_URL={self.workspace_manager_url}',
         ]
 
-    def create_disk(self, *_) -> CloudDisk:
+    def create_disk(self, instance_name: str, disk_name: str, size_in_gb: int, mount_path: str) -> CloudDisk:
+        del instance_name, disk_name, size_in_gb, mount_path
         raise NotImplementedError
 
     def get_cloud_async_fs(self) -> AsyncFS:
@@ -75,7 +76,14 @@ class TerraAzureWorkerAPI(CloudWorkerAPI):
         token = await self._managed_identity_credentials.access_token()
         return {'Authorization': f'Bearer {token}'}
 
-    async def _mount_cloudfuse(self, *_):
+    async def _mount_cloudfuse(
+        self,
+        credentials: Dict[str, str],
+        mount_base_path_data: str,
+        mount_base_path_tmp: str,
+        config: dict,
+    ):
+        del credentials, mount_base_path_data, mount_base_path_tmp, config
         raise NotImplementedError
 
     async def unmount_cloudfuse(self, mount_base_path_data: str):

--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -6,7 +6,7 @@
 #
 aiodocker==0.21.0
     # via -r hail/batch/requirements.txt
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   -c hail/batch/../gear/pinned-requirements.txt
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
@@ -47,7 +47,7 @@ frozenlist==1.4.1
     #   -c hail/batch/../web_common/pinned-requirements.txt
     #   aiohttp
     #   aiosignal
-idna==3.6
+idna==3.7
     # via
     #   -c hail/batch/../gear/pinned-requirements.txt
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
@@ -66,16 +66,16 @@ numpy==1.26.4
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   pandas
-packaging==23.2
+packaging==24.0
     # via
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   plotly
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt
-plotly==5.19.0
+plotly==5.20.0
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt
@@ -99,7 +99,7 @@ tenacity==8.2.3
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   plotly
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt
     #   -c hail/batch/../hail/python/pinned-requirements.txt

--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -6,7 +6,7 @@
 #
 aiodocker==0.21.0
     # via -r hail/batch/requirements.txt
-aiohttp==3.9.4
+aiohttp==3.9.5
     # via
     #   -c hail/batch/../gear/pinned-requirements.txt
     #   -c hail/batch/../hail/python/dev/pinned-requirements.txt

--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -75,7 +75,7 @@ pandas==2.2.2
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt
-plotly==5.20.0
+plotly==5.21.0
     # via
     #   -c hail/batch/../hail/python/pinned-requirements.txt
     #   -r hail/batch/requirements.txt

--- a/benchmark/python/pinned-requirements.txt
+++ b/benchmark/python/pinned-requirements.txt
@@ -4,36 +4,36 @@
 #
 #    pip-compile --output-file=hail/benchmark/python/pinned-requirements.txt hail/benchmark/python/requirements.txt
 #
-contourpy==1.2.0
+contourpy==1.2.1
     # via
     #   -c hail/benchmark/python/../../hail/python/pinned-requirements.txt
     #   matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.49.0
+fonttools==4.51.0
     # via matplotlib
-importlib-resources==6.1.2
+importlib-resources==6.4.0
     # via matplotlib
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.3
+matplotlib==3.8.4
     # via -r hail/benchmark/python/requirements.txt
 numpy==1.26.4
     # via
     #   -c hail/benchmark/python/../../hail/python/pinned-requirements.txt
     #   contourpy
     #   matplotlib
-packaging==23.2
+packaging==24.0
     # via
     #   -c hail/benchmark/python/../../hail/python/dev/pinned-requirements.txt
     #   -c hail/benchmark/python/../../hail/python/pinned-requirements.txt
     #   matplotlib
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -c hail/benchmark/python/../../hail/python/dev/pinned-requirements.txt
     #   -c hail/benchmark/python/../../hail/python/pinned-requirements.txt
     #   matplotlib
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via matplotlib
 python-dateutil==2.9.0.post0
     # via
@@ -45,7 +45,7 @@ six==1.16.0
     #   -c hail/benchmark/python/../../hail/python/dev/pinned-requirements.txt
     #   -c hail/benchmark/python/../../hail/python/pinned-requirements.txt
     #   python-dateutil
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   -c hail/benchmark/python/../../hail/python/dev/pinned-requirements.txt
     #   importlib-resources

--- a/ci/pinned-requirements.txt
+++ b/ci/pinned-requirements.txt
@@ -34,14 +34,14 @@ distro==1.9.0
     # via zulip
 gidgethub==5.3.0
     # via -r hail/ci/requirements.txt
-idna==3.6
+idna==3.7
     # via
     #   -c hail/ci/../gear/pinned-requirements.txt
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt
     #   -c hail/ci/../web_common/pinned-requirements.txt
     #   requests
-pycparser==2.21
+pycparser==2.22
     # via
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt
@@ -56,7 +56,7 @@ requests[security]==2.31.0
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt
     #   zulip
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -c hail/ci/../hail/python/dev/pinned-requirements.txt
     #   -c hail/ci/../hail/python/pinned-requirements.txt

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=hail/gear/pinned-requirements.txt hail/gear/requirements.txt
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
@@ -58,11 +58,11 @@ frozenlist==1.4.1
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   aiosignal
-google-api-core==2.17.1
+google-api-core==2.18.0
     # via google-api-python-client
-google-api-python-client==2.120.0
+google-api-python-client==2.125.0
     # via google-cloud-profiler
-google-auth==2.28.1
+google-auth==2.29.0
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
@@ -76,13 +76,13 @@ google-auth-httplib2==0.2.0
     #   google-cloud-profiler
 google-cloud-profiler==3.1.0
     # via -r hail/gear/requirements.txt
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via google-api-core
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.6
+idna==3.7
     # via
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
@@ -98,11 +98,6 @@ multidict==6.0.5
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   yarl
-orjson==3.9.10
-    # via
-    #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
-    #   -c hail/gear/../hail/python/pinned-requirements.txt
-    #   -r hail/gear/requirements.txt
 prometheus-async==19.2.0
     # via -r hail/gear/requirements.txt
 prometheus-client==0.20.0
@@ -110,19 +105,23 @@ prometheus-client==0.20.0
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
     #   -r hail/gear/requirements.txt
     #   prometheus-async
+proto-plus==1.23.0
+    # via google-api-core
 protobuf==3.20.2
     # via
+    #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   -r hail/gear/requirements.txt
     #   google-api-core
     #   google-cloud-profiler
     #   googleapis-common-protos
-pyasn1==0.5.1
+    #   proto-plus
+pyasn1==0.6.0
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c hail/gear/../hail/python/pinned-requirements.txt
@@ -131,7 +130,7 @@ pymysql==1.1.0
     # via
     #   -r hail/gear/requirements.txt
     #   aiomysql
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via httplib2
 python-dateutil==2.9.0.post0
     # via

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -60,7 +60,7 @@ frozenlist==1.4.1
     #   aiosignal
 google-api-core==2.18.0
     # via google-api-python-client
-google-api-python-client==2.126.0
+google-api-python-client==2.127.0
     # via google-cloud-profiler
 google-auth==2.29.0
     # via

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=hail/gear/pinned-requirements.txt hail/gear/requirements.txt
 #
-aiohttp==3.9.4
+aiohttp==3.9.5
     # via
     #   -c hail/gear/../hail/python/dev/pinned-requirements.txt
     #   -c hail/gear/../hail/python/hailtop/pinned-requirements.txt
@@ -60,7 +60,7 @@ frozenlist==1.4.1
     #   aiosignal
 google-api-core==2.18.0
     # via google-api-python-client
-google-api-python-client==2.125.0
+google-api-python-client==2.126.0
     # via google-cloud-profiler
 google-auth==2.29.0
     # via

--- a/gear/requirements.txt
+++ b/gear/requirements.txt
@@ -16,5 +16,3 @@ prometheus_async>=19.2.0,<20
 prometheus_client>=0.11.0,<1
 PyMySQL>=1,<2
 sortedcontainers>=2.4.0,<3
-# <3.9.11: https://github.com/hail-is/hail/issues/14299
-orjson>=3.6.4,<3.9.11

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=hail/hail/python/dev/pinned-requirements.txt hail/hail/python/dev/requirements.txt
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   aiohttp-devtools
@@ -76,7 +76,7 @@ click==8.1.7
     #   -r hail/hail/python/dev/requirements.txt
     #   aiohttp-devtools
     #   curlylint
-comm==0.2.1
+comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
@@ -108,7 +108,7 @@ exceptiongroup==1.2.0
     #   anyio
     #   ipython
     #   pytest
-execnet==2.0.2
+execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via
@@ -116,7 +116,7 @@ executing==2.0.1
     #   stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.1
+filelock==3.13.4
     # via virtualenv
 fqdn==1.5.1
     # via jsonschema
@@ -129,13 +129,13 @@ fswatch==0.1.1
     # via -r hail/hail/python/dev/requirements.txt
 h11==0.14.0
     # via httpcore
-httpcore==1.0.4
+httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via jupyterlab
 identify==2.5.35
     # via pre-commit
-idna==3.6
+idna==3.7
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   anyio
@@ -145,7 +145,7 @@ idna==3.6
     #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==7.0.1
+importlib-metadata==7.1.0
     # via
     #   jupyter-client
     #   jupyter-lsp
@@ -155,7 +155,7 @@ importlib-metadata==7.0.1
     #   sphinx
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.3
+ipykernel==6.29.4
     # via
     #   jupyter
     #   jupyter-console
@@ -183,7 +183,7 @@ jinja2==3.1.3
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.9.20
+json5==0.9.24
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
@@ -196,7 +196,7 @@ jsonschema-specifications==2023.12.1
     # via jsonschema
 jupyter==1.0.0
     # via -r hail/hail/python/dev/requirements.txt
-jupyter-client==8.6.0
+jupyter-client==8.6.1
     # via
     #   ipykernel
     #   jupyter-console
@@ -205,7 +205,7 @@ jupyter-client==8.6.0
     #   qtconsole
 jupyter-console==6.6.3
     # via jupyter
-jupyter-core==5.7.1
+jupyter-core==5.7.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -216,24 +216,24 @@ jupyter-core==5.7.1
     #   nbconvert
     #   nbformat
     #   qtconsole
-jupyter-events==0.9.0
+jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.3
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
     #   jupyterlab-server
     #   notebook
     #   notebook-shim
-jupyter-server-terminals==0.5.2
+jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.2
+jupyterlab==4.1.6
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.25.3
+jupyterlab-server==2.26.0
     # via
     #   jupyterlab
     #   notebook
@@ -259,7 +259,7 @@ multidict==6.0.5
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   aiohttp
     #   yarl
-nbclient==0.9.0
+nbclient==0.10.0
     # via nbconvert
 nbconvert==7.13.1
     # via
@@ -267,7 +267,7 @@ nbconvert==7.13.1
     #   jupyter
     #   jupyter-server
     #   nbsphinx
-nbformat==5.9.2
+nbformat==5.10.4
     # via
     #   jupyter-server
     #   nbclient
@@ -283,7 +283,7 @@ nodeenv==1.8.0
     # via
     #   pre-commit
     #   pyright
-notebook==7.1.1
+notebook==7.1.2
     # via jupyter
 notebook-shim==0.2.4
     # via
@@ -291,7 +291,7 @@ notebook-shim==0.2.4
     #   notebook
 overrides==7.7.0
     # via jupyter-server
-packaging==23.2
+packaging==24.0
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   ipykernel
@@ -305,7 +305,7 @@ packaging==23.2
     #   sphinx
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.3
+parso==0.8.4
     # via jedi
 parsy==1.1.0
     # via curlylint
@@ -313,7 +313,7 @@ pathspec==0.12.1
     # via curlylint
 pexpect==4.9.0
     # via ipython
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   -r hail/hail/python/dev/requirements.txt
@@ -324,7 +324,7 @@ platformdirs==4.2.0
     #   virtualenv
 pluggy==1.4.0
     # via pytest
-pre-commit==3.6.2
+pre-commit==3.7.0
     # via -r hail/hail/python/dev/requirements.txt
 prometheus-client==0.20.0
     # via jupyter-server
@@ -342,7 +342,7 @@ pure-eval==0.2.2
     # via stack-data
 py==1.11.0
     # via pytest-forked
-pycparser==2.21
+pycparser==2.22
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   cffi
@@ -358,7 +358,7 @@ pygments==2.17.2
     #   sphinx
 pylint==2.17.7
     # via -r hail/hail/python/dev/requirements.txt
-pyright==1.1.352
+pyright==1.1.358
     # via -r hail/hail/python/dev/requirements.txt
 pytest==7.4.4
     # via
@@ -380,9 +380,9 @@ pytest-instafail==0.5.0
     # via -r hail/hail/python/dev/requirements.txt
 pytest-metadata==3.1.1
     # via pytest-html
-pytest-timeout==2.2.0
+pytest-timeout==2.3.1
     # via -r hail/hail/python/dev/requirements.txt
-pytest-timestamper==0.0.9
+pytest-timestamper==0.0.10
     # via -r hail/hail/python/dev/requirements.txt
 pytest-xdist==2.5.0
     # via -r hail/hail/python/dev/requirements.txt
@@ -411,7 +411,7 @@ qtconsole==5.5.1
     # via jupyter
 qtpy==2.4.1
     # via qtconsole
-referencing==0.33.0
+referencing==0.34.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -435,7 +435,7 @@ rpds-py==0.18.0
     #   referencing
 ruff==0.1.13
     # via -r hail/hail/python/dev/requirements.txt
-send2trash==1.8.2
+send2trash==1.8.3
     # via jupyter-server
 six==1.16.0
     # via
@@ -482,7 +482,7 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 stack-data==0.6.3
     # via ipython
-terminado==0.18.0
+terminado==0.18.1
     # via
     #   jupyter-server
     #   jupyter-server-terminals
@@ -506,7 +506,7 @@ tornado==6.4
     #   jupyterlab
     #   notebook
     #   terminado
-traitlets==5.14.1
+traitlets==5.14.2
     # via
     #   comm
     #   ipykernel
@@ -526,23 +526,23 @@ traitlets==5.14.1
     #   qtconsole
 types-chardet==5.0.4.6
     # via -r hail/hail/python/dev/requirements.txt
-types-decorator==5.1.8.20240106
+types-decorator==5.1.8.20240310
     # via -r hail/hail/python/dev/requirements.txt
-types-deprecated==1.2.9.20240106
+types-deprecated==1.2.9.20240311
     # via -r hail/hail/python/dev/requirements.txt
 types-pymysql==1.1.0.1
     # via -r hail/hail/python/dev/requirements.txt
-types-python-dateutil==2.8.19.20240106
+types-python-dateutil==2.9.0.20240316
     # via
     #   -r hail/hail/python/dev/requirements.txt
     #   arrow
-types-pyyaml==6.0.12.12
+types-pyyaml==6.0.12.20240311
     # via -r hail/hail/python/dev/requirements.txt
 types-requests==2.31.0.6
     # via -r hail/hail/python/dev/requirements.txt
-types-setuptools==69.1.0.20240302
+types-setuptools==69.2.0.20240317
     # via -r hail/hail/python/dev/requirements.txt
-types-six==1.16.21.20240301
+types-six==1.16.21.20240311
     # via -r hail/hail/python/dev/requirements.txt
 types-tabulate==0.9.0.20240106
     # via -r hail/hail/python/dev/requirements.txt
@@ -550,7 +550,7 @@ types-urllib3==1.26.25.14
     # via
     #   -r hail/hail/python/dev/requirements.txt
     #   types-requests
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   anyio
@@ -590,7 +590,7 @@ yarl==1.9.4
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   aiohttp
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=hail/hail/python/dev/pinned-requirements.txt hail/hail/python/dev/requirements.txt
 #
-aiohttp==3.9.4
+aiohttp==3.9.5
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   aiohttp-devtools
@@ -183,7 +183,7 @@ jinja2==3.1.3
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
@@ -246,7 +246,7 @@ markupsafe==2.1.5
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   jinja2
     #   nbconvert
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -400,7 +400,7 @@ pyyaml==6.0.1
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   jupyter-events
     #   pre-commit
-pyzmq==25.1.2
+pyzmq==26.0.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -540,7 +540,7 @@ types-pyyaml==6.0.12.20240311
     # via -r hail/hail/python/dev/requirements.txt
 types-requests==2.31.0.6
     # via -r hail/hail/python/dev/requirements.txt
-types-setuptools==69.2.0.20240317
+types-setuptools==69.5.0.20240415
     # via -r hail/hail/python/dev/requirements.txt
 types-six==1.16.21.20240311
     # via -r hail/hail/python/dev/requirements.txt
@@ -564,7 +564,7 @@ urllib3==1.26.18
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   requests
-virtualenv==20.25.1
+virtualenv==20.25.2
     # via pre-commit
 watchfiles==0.21.0
     # via aiohttp-devtools

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -103,7 +103,7 @@ docutils==0.18.1
     #   nbsphinx
     #   sphinx
     #   sphinx-rtd-theme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   anyio
     #   ipython
@@ -133,7 +133,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via jupyterlab
-identify==2.5.35
+identify==2.5.36
     # via pre-commit
 idna==3.7
     # via
@@ -233,7 +233,7 @@ jupyterlab==4.1.6
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.26.0
+jupyterlab-server==2.27.1
     # via
     #   jupyterlab
     #   notebook
@@ -283,7 +283,7 @@ nodeenv==1.8.0
     # via
     #   pre-commit
     #   pyright
-notebook==7.1.2
+notebook==7.1.3
     # via jupyter
 notebook-shim==0.2.4
     # via
@@ -317,12 +317,12 @@ pillow==10.3.0
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   -r hail/hail/python/dev/requirements.txt
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   jupyter-core
     #   pylint
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 pre-commit==3.7.0
     # via -r hail/hail/python/dev/requirements.txt
@@ -358,7 +358,7 @@ pygments==2.17.2
     #   sphinx
 pylint==2.17.7
     # via -r hail/hail/python/dev/requirements.txt
-pyright==1.1.358
+pyright==1.1.360
     # via -r hail/hail/python/dev/requirements.txt
 pytest==7.4.4
     # via
@@ -400,7 +400,7 @@ pyyaml==6.0.1
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   jupyter-events
     #   pre-commit
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -411,7 +411,7 @@ qtconsole==5.5.1
     # via jupyter
 qtpy==2.4.1
     # via qtconsole
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -486,7 +486,7 @@ terminado==0.18.1
     # via
     #   jupyter-server
     #   jupyter-server-terminals
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via nbconvert
 toml==0.10.2
     # via curlylint
@@ -506,7 +506,7 @@ tornado==6.4
     #   jupyterlab
     #   notebook
     #   terminado
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -530,7 +530,7 @@ types-decorator==5.1.8.20240310
     # via -r hail/hail/python/dev/requirements.txt
 types-deprecated==1.2.9.20240311
     # via -r hail/hail/python/dev/requirements.txt
-types-pymysql==1.1.0.1
+types-pymysql==1.1.0.20240425
     # via -r hail/hail/python/dev/requirements.txt
 types-python-dateutil==2.9.0.20240316
     # via
@@ -540,9 +540,9 @@ types-pyyaml==6.0.12.20240311
     # via -r hail/hail/python/dev/requirements.txt
 types-requests==2.31.0.6
     # via -r hail/hail/python/dev/requirements.txt
-types-setuptools==69.5.0.20240415
+types-setuptools==69.5.0.20240423
     # via -r hail/hail/python/dev/requirements.txt
-types-six==1.16.21.20240311
+types-six==1.16.21.20240425
     # via -r hail/hail/python/dev/requirements.txt
 types-tabulate==0.9.0.20240106
     # via -r hail/hail/python/dev/requirements.txt
@@ -564,7 +564,7 @@ urllib3==1.26.18
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
     #   requests
-virtualenv==20.25.2
+virtualenv==20.26.0
     # via pre-commit
 watchfiles==0.21.0
     # via aiohttp-devtools
@@ -576,7 +576,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via jupyter-server
 wheel==0.41.3
     # via -r hail/hail/python/dev/requirements.txt

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/bigquery_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/bigquery_client.py
@@ -73,6 +73,7 @@ class PagedQueriesIterator:
             config = {'kind': 'bigquery#queryRequest', 'useLegacySql': False, 'query': self._query}
 
             self._page = await self._client.post('/queries', json=config, **self._request_kwargs)
+            assert self._page
             self._row_index = 0
             self._total_rows = self._page['totalRows']
             self._parser = ResultsParser(self._page['schema'])

--- a/hail/python/hailtop/auth/flow.py
+++ b/hail/python/hailtop/auth/flow.py
@@ -248,12 +248,12 @@ class AzureFlow(Flow):
             if AzureFlow._aad_keys is None:
                 resp = await session.get_read_json('https://login.microsoftonline.com/common/discovery/keys')
                 AzureFlow._aad_keys = resp['keys']
+            assert AzureFlow._aad_keys
 
             # This code is taken nearly verbatim from
             # https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/147
             # At time of writing, the community response in that issue is the recommended way to validate
             # AAD access tokens in python as it is not a part of the MSAL library.
-
             jwk = next(key for key in AzureFlow._aad_keys if key['kid'] == kid)
             der_cert = base64.b64decode(jwk['x5c'][0])
             cert = x509.load_der_x509_certificate(der_cert)

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -6,7 +6,7 @@
 #
 aiodns==2.0.0
     # via -r hail/hail/python/hailtop/requirements.txt
-aiohttp==3.9.4
+aiohttp==3.9.5
     # via -r hail/hail/python/hailtop/requirements.txt
 aiosignal==1.3.1
     # via aiohttp
@@ -30,9 +30,9 @@ azure-mgmt-storage==20.1.0
     # via -r hail/hail/python/hailtop/requirements.txt
 azure-storage-blob==12.19.1
     # via -r hail/hail/python/hailtop/requirements.txt
-boto3==1.34.83
+boto3==1.34.85
     # via -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.83
+botocore==1.34.85
     # via
     #   -r hail/hail/python/hailtop/requirements.txt
     #   boto3
@@ -106,7 +106,7 @@ nest-asyncio==1.6.0
     # via -r hail/hail/python/hailtop/requirements.txt
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.10.0
+orjson==3.10.1
     # via -r hail/hail/python/hailtop/requirements.txt
 packaging==24.0
     # via msal-extensions

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -6,7 +6,7 @@
 #
 aiodns==2.0.0
     # via -r hail/hail/python/hailtop/requirements.txt
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via -r hail/hail/python/hailtop/requirements.txt
 aiosignal==1.3.1
     # via aiohttp
@@ -22,17 +22,17 @@ azure-core==1.30.1
     #   azure-mgmt-core
     #   azure-storage-blob
     #   msrest
-azure-identity==1.15.0
+azure-identity==1.16.0
     # via -r hail/hail/python/hailtop/requirements.txt
 azure-mgmt-core==1.4.0
     # via azure-mgmt-storage
 azure-mgmt-storage==20.1.0
     # via -r hail/hail/python/hailtop/requirements.txt
-azure-storage-blob==12.19.0
+azure-storage-blob==12.19.1
     # via -r hail/hail/python/hailtop/requirements.txt
-boto3==1.34.55
+boto3==1.34.83
     # via -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.55
+botocore==1.34.83
     # via
     #   -r hail/hail/python/hailtop/requirements.txt
     #   boto3
@@ -66,7 +66,7 @@ frozenlist==1.4.1
     #   -r hail/hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-auth==2.28.1
+google-auth==2.29.0
     # via
     #   -r hail/hail/python/hailtop/requirements.txt
     #   google-auth-oauthlib
@@ -74,7 +74,7 @@ google-auth-oauthlib==0.8.0
     # via -r hail/hail/python/hailtop/requirements.txt
 humanize==1.1.0
     # via -r hail/hail/python/hailtop/requirements.txt
-idna==3.6
+idna==3.7
     # via
     #   requests
     #   yarl
@@ -90,7 +90,7 @@ jmespath==1.0.1
     #   botocore
 jproperties==2.1.1
     # via -r hail/hail/python/hailtop/requirements.txt
-msal==1.27.0
+msal==1.28.0
     # via
     #   azure-identity
     #   msal-extensions
@@ -106,21 +106,21 @@ nest-asyncio==1.6.0
     # via -r hail/hail/python/hailtop/requirements.txt
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.9.10
+orjson==3.10.0
     # via -r hail/hail/python/hailtop/requirements.txt
-packaging==23.2
+packaging==24.0
     # via msal-extensions
 portalocker==2.8.2
     # via msal-extensions
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via google-auth
 pycares==4.4.0
     # via aiodns
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pygments==2.17.2
     # via rich
@@ -138,16 +138,20 @@ requests==2.31.0
     #   msal
     #   msrest
     #   requests-oauthlib
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   google-auth-oauthlib
     #   msrest
 rich==12.6.0
-    # via -r hail/hail/python/hailtop/requirements.txt
+    # via
+    #   -r hail/hail/python/hailtop/requirements.txt
+    #   typer
 rsa==4.9
     # via google-auth
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
+shellingham==1.5.4
+    # via typer
 six==1.16.0
     # via
     #   azure-core
@@ -158,9 +162,9 @@ sortedcontainers==2.4.0
     # via -r hail/hail/python/hailtop/requirements.txt
 tabulate==0.9.0
     # via -r hail/hail/python/hailtop/requirements.txt
-typer==0.9.0
+typer==0.12.3
     # via -r hail/hail/python/hailtop/requirements.txt
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   azure-core
     #   azure-storage-blob

--- a/hail/python/hailtop/requirements.txt
+++ b/hail/python/hailtop/requirements.txt
@@ -12,8 +12,7 @@ google-auth-oauthlib>=0.5.2,<1
 humanize>=1.0.0,<2
 janus>=0.6,<1.1
 nest_asyncio>=1.5.8,<2
-# <3.9.11: https://github.com/hail-is/hail/issues/14299
-orjson>=3.6.4,<3.9.11
+orjson>=3.9.15,<4
 rich>=12.6.0,<13
 typer>=0.9.0,<1
 python-json-logger>=2.0.2,<3

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -8,7 +8,7 @@ aiodns==2.0.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -37,7 +37,7 @@ azure-core==1.30.1
     #   azure-mgmt-core
     #   azure-storage-blob
     #   msrest
-azure-identity==1.15.0
+azure-identity==1.16.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -49,17 +49,17 @@ azure-mgmt-storage==20.1.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-azure-storage-blob==12.19.0
+azure-storage-blob==12.19.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-bokeh==3.3.4
+bokeh==3.4.1
     # via -r hail/hail/python/requirements.txt
-boto3==1.34.55
+boto3==1.34.83
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.55
+botocore==1.34.83
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -91,7 +91,7 @@ commonmark==0.9.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   rich
-contourpy==1.2.0
+contourpy==1.2.1
     # via bokeh
 cryptography==42.0.5
     # via
@@ -114,7 +114,7 @@ frozenlist==1.4.1
     #   -r hail/hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-auth==2.28.1
+google-auth==2.29.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -127,7 +127,7 @@ humanize==1.1.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-idna==3.6
+idna==3.7
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   requests
@@ -154,7 +154,7 @@ jproperties==2.1.1
     #   -r hail/hail/python/hailtop/requirements.txt
 markupsafe==2.1.5
     # via jinja2
-msal==1.27.0
+msal==1.28.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
@@ -187,43 +187,40 @@ oauthlib==3.2.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   requests-oauthlib
-orjson==3.9.10
+orjson==3.10.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-packaging==23.2
+packaging==24.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   bokeh
     #   msal-extensions
     #   plotly
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   -r hail/hail/python/requirements.txt
     #   bokeh
 parsimonious==0.10.0
     # via -r hail/hail/python/requirements.txt
-pillow==10.2.0
+pillow==10.3.0
     # via bokeh
-plotly==5.19.0
+plotly==5.20.0
     # via -r hail/hail/python/requirements.txt
 portalocker==2.8.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   msal-extensions
 protobuf==3.20.2
-    # via
-    #   -c hail/hail/python/hailtop/pinned-requirements.txt
-    #   -r hail/hail/python/hailtop/requirements.txt
-    #   -r hail/hail/python/requirements.txt
+    # via -r hail/hail/python/requirements.txt
 py4j==0.10.9.7
     # via pyspark
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   google-auth
@@ -231,7 +228,7 @@ pycares==4.4.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   aiodns
-pycparser==2.21
+pycparser==2.22
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   cffi
@@ -273,7 +270,7 @@ requests==2.31.0
     #   msal
     #   msrest
     #   requests-oauthlib
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   google-auth-oauthlib
@@ -282,16 +279,21 @@ rich==12.6.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
+    #   typer
 rsa==4.9
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   google-auth
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   boto3
 scipy==1.11.4
     # via -r hail/hail/python/requirements.txt
+shellingham==1.5.4
+    # via
+    #   -c hail/hail/python/hailtop/pinned-requirements.txt
+    #   typer
 six==1.16.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
@@ -311,11 +313,11 @@ tenacity==8.2.3
     # via plotly
 tornado==6.4
     # via bokeh
-typer==0.9.0
+typer==0.12.3
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   azure-core
@@ -335,7 +337,7 @@ uvloop==0.19.0 ; sys_platform != "win32"
     #   -r hail/hail/python/hailtop/requirements.txt
 wrapt==1.16.0
     # via deprecated
-xyzservices==2023.10.1
+xyzservices==2024.4.0
     # via bokeh
 yarl==1.9.4
     # via

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -8,7 +8,7 @@ aiodns==2.0.0
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-aiohttp==3.9.4
+aiohttp==3.9.5
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -55,11 +55,11 @@ azure-storage-blob==12.19.1
     #   -r hail/hail/python/hailtop/requirements.txt
 bokeh==3.4.1
     # via -r hail/hail/python/requirements.txt
-boto3==1.34.83
+boto3==1.34.85
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.83
+botocore==1.34.85
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -187,7 +187,7 @@ oauthlib==3.2.2
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   requests-oauthlib
-orjson==3.10.0
+orjson==3.10.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
@@ -260,7 +260,7 @@ pyyaml==6.0.1
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
     #   bokeh
-regex==2023.12.25
+regex==2024.4.16
     # via parsimonious
 requests==2.31.0
     # via

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -53,7 +53,7 @@ azure-storage-blob==12.19.1
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-bokeh==3.4.1
+bokeh==3.3.4
     # via -r hail/hail/python/requirements.txt
 boto3==1.34.85
     # via
@@ -205,7 +205,7 @@ parsimonious==0.10.0
     # via -r hail/hail/python/requirements.txt
 pillow==10.3.0
     # via bokeh
-plotly==5.20.0
+plotly==5.21.0
     # via -r hail/hail/python/requirements.txt
 portalocker==2.8.2
     # via

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -3,7 +3,7 @@
 -r hailtop/requirements.txt
 
 avro>=1.10,<1.12
-bokeh>=3,<4
+bokeh>=3,<3.4
 decorator<5
 Deprecated>=1.2.10,<1.3
 numpy<2

--- a/web_common/pinned-requirements.txt
+++ b/web_common/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=hail/web_common/pinned-requirements.txt hail/web_common/requirements.txt
 #
-aiohttp==3.9.4
+aiohttp==3.9.5
     # via
     #   -c hail/web_common/../gear/pinned-requirements.txt
     #   -c hail/web_common/../hail/python/dev/pinned-requirements.txt

--- a/web_common/pinned-requirements.txt
+++ b/web_common/pinned-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=hail/web_common/pinned-requirements.txt hail/web_common/requirements.txt
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   -c hail/web_common/../gear/pinned-requirements.txt
     #   -c hail/web_common/../hail/python/dev/pinned-requirements.txt
@@ -37,7 +37,7 @@ frozenlist==1.4.1
     #   -c hail/web_common/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   aiosignal
-idna==3.6
+idna==3.7
     # via
     #   -c hail/web_common/../gear/pinned-requirements.txt
     #   -c hail/web_common/../hail/python/dev/pinned-requirements.txt


### PR DESCRIPTION
`orjson` 3.9.15 fixed the rare segfault that we saw in `3.9.11`. Besides just updating to latest patch and minor versions:

- Removed a redundant requirement of `orjson` in `gear/requirements.txt` -- it inherits `orjson` from hailtop
- Bokeh `3.4` made a breaking change w.r.t. the `circle` method on figures. I have restricted the bounds for `bokeh` to avoid this breaking change but will follow up with a PR that changes our usage of bokeh to follow the deprecation/upgrade advice and undo the bounds restriction