### PR TITLE
[query] Build Hail Wheel With Python build

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -19,3 +19,4 @@ RUN hail-apt-get-install \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
 
 RUN hail-apt-get-install maven
+RUN hail-pip-install build

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -280,7 +280,7 @@ copy-py-files: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS) $(PY_FILES) $(PYTHON_JAR)
 wheel: $(WHEEL)
 
 $(WHEEL): copy-py-files
-	# Clear the bdist build cache before building the wheel
+	# Clear the build cache before building the wheel
 	cd build/deploy; rm -rf build; $(HAIL_PYTHON3) -m build -w
 
 # if the DEPLOY_REMOTE flag is not set, then deploy init scripts into a dev-username location

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -281,7 +281,7 @@ wheel: $(WHEEL)
 
 $(WHEEL): copy-py-files
 	# Clear the bdist build cache before building the wheel
-	cd build/deploy; rm -rf build; $(HAIL_PYTHON3) setup.py -q sdist bdist_wheel
+	cd build/deploy; rm -rf build; $(HAIL_PYTHON3) -m build -w
 
 # if the DEPLOY_REMOTE flag is not set, then deploy init scripts into a dev-username location
 ifndef DEPLOY_REMOTE

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -362,6 +362,8 @@ pygments==2.17.2
     #   sphinx
 pylint==2.17.7
     # via -r hail/hail/python/dev/requirements.txt
+pyproject-hooks==1.0.0
+    # via build
 pyright==1.1.360
     # via -r hail/hail/python/dev/requirements.txt
 pytest==7.4.4

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -54,6 +54,8 @@ beautifulsoup4==4.12.3
     # via nbconvert
 bleach==6.1.0
     # via nbconvert
+build==1.1.1
+    # via -r hail/hail/python/dev/requirements.txt
 certifi==2024.2.2
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
@@ -147,6 +149,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==7.1.0
     # via
+    #   build
     #   jupyter-client
     #   jupyter-lsp
     #   jupyterlab
@@ -294,6 +297,7 @@ overrides==7.7.0
 packaging==24.0
     # via
     #   -c hail/hail/python/dev/../pinned-requirements.txt
+    #   build
     #   ipykernel
     #   jupyter-server
     #   jupyterlab
@@ -492,8 +496,10 @@ toml==0.10.2
     # via curlylint
 tomli==2.0.1
     # via
+    #   build
     #   jupyterlab
     #   pylint
+    #   pyproject-hooks
     #   pytest
 tomlkit==0.12.4
     # via pylint
@@ -578,8 +584,6 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-wheel==0.41.3
-    # via -r hail/hail/python/dev/requirements.txt
 widgetsnbextension==4.0.10
     # via ipywidgets
 wrapt==1.16.0

--- a/hail/python/dev/requirements.txt
+++ b/hail/python/dev/requirements.txt
@@ -1,6 +1,7 @@
 -c ../pinned-requirements.txt
 
 aiohttp-devtools>=1.1,<2
+build>=1.1,<1.2
 pylint>=2.13.5,<3
 pre-commit>=3.3.3,<4
 ruff==0.1.13
@@ -22,7 +23,6 @@ sphinx_rtd_theme>=1.0.0,<2
 jupyter>=1.0.0,<2
 sphinxcontrib.katex>=0.9.0,<1
 fswatch>=0.1.1,<1
-wheel>=0.41,<0.42
 # https://github.com/jupyter/nbconvert/issues/2092
 nbconvert<7.14
 

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -30,9 +30,9 @@ azure-mgmt-storage==20.1.0
     # via -r hail/hail/python/hailtop/requirements.txt
 azure-storage-blob==12.19.1
     # via -r hail/hail/python/hailtop/requirements.txt
-boto3==1.34.85
+boto3==1.34.92
     # via -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.85
+botocore==1.34.92
     # via
     #   -r hail/hail/python/hailtop/requirements.txt
     #   boto3

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -55,11 +55,11 @@ azure-storage-blob==12.19.1
     #   -r hail/hail/python/hailtop/requirements.txt
 bokeh==3.3.4
     # via -r hail/hail/python/requirements.txt
-boto3==1.34.85
+boto3==1.34.92
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt
-botocore==1.34.85
+botocore==1.34.92
     # via
     #   -c hail/hail/python/hailtop/pinned-requirements.txt
     #   -r hail/hail/python/hailtop/requirements.txt


### PR DESCRIPTION
setup.py complains awfully when you invoke it directly. Apparently this sort of thing is unacceptable and the recommended workflow for building wheels is to use build. See the link below for more information. https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html