### PR TITLE
Revert "[ci] Poll for batch and github changes every 1 minute instead of 5"

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -747,7 +747,7 @@ async def update_loop(app: web.Application):
         except Exception:  # pylint: disable=broad-except
             if wb:
                 log.exception(f'{wb.branch.short_str()} update failed due to exception')
-        await asyncio.sleep(60)
+        await asyncio.sleep(300)
 
 
 class AppKeys(CommonAiohttpAppKeys):


### PR DESCRIPTION
Reverts hail-is/hail#14461. We're hitting [github rate limits](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.container_name%3D%22ci%22%0A--%20severity%3DERROR%20OR%20WARNING;pinnedLogId=2024-04-18T15:42:12.920462831Z%2Fvdlhscspn377olu0;cursorTimestamp=2024-04-18T15:42:14.785330871Z;duration=P1D?project=hail-vdc) which is preventing actions like dev deploys. The limit is apparently [5,000 requests/hour](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users). This feels excessive to me, and I feel like we most be using the API poorly, but I want to just revert this before investigating further so CI doesn't get stuck.