### PR TITLE
[compiler] declarative `Bindings`

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
@@ -64,7 +64,7 @@ abstract class BaseIR {
 
   def forEachChildWithEnv[E <: GenericBindingEnv[E, Type]](env: E)(f: (BaseIR, E) => Unit): Unit =
     childrenSeq.view.zipWithIndex.foreach { case (child, i) =>
-      val childEnv = Bindings.get(this, i, env)
+      val childEnv = env.extend(Bindings.get(this, i))
       f(child, childEnv)
     }
 
@@ -73,7 +73,7 @@ abstract class BaseIR {
     val newChildren = childrenSeq.toArray
     var res = this
     for (i <- newChildren.indices) {
-      val childEnv = Bindings.get(res, i, env)
+      val childEnv = env.extend(Bindings.get(res, i))
       val child = newChildren(i)
       val newChild = f(child, childEnv)
       if (!(newChild eq child)) {
@@ -90,7 +90,7 @@ abstract class BaseIR {
     f: (BaseIR, Int, E) => StackFrame[Unit]
   ): StackFrame[Unit] =
     childrenSeq.view.zipWithIndex.foreachRecur { case (child, i) =>
-      val childEnv = Bindings.get(this, i, env)
+      val childEnv = env.extend(Bindings.get(this, i))
       f(child, i, childEnv)
     }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
@@ -42,10 +42,10 @@ object ComputeUsesAndDefs {
       ir.children
         .zipWithIndex
         .foreach { case (child, i) =>
-          val bindings = Bindings.segregated(ir, i, env).mapNewBindings((_, _) => ir)
-          if (!bindings.newBindings.allEmpty && !uses.contains(ir))
+          val newBindings = Bindings.get(ir, i).map((_, _) => ir)
+          if (!newBindings.allEmpty && !uses.contains(ir))
             uses.bind(ir, mutable.Set.empty[RefEquality[BaseRef]])
-          compute(child, bindings.unified)
+          compute(child, env.extend(newBindings))
         }
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Env.scala
@@ -1,7 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.types.virtual.Type
-
 object Env {
   type K = String
 
@@ -20,6 +18,22 @@ sealed abstract class AggEnv[+A] {
     case AggEnv.Drop => AggEnv.Drop
     case AggEnv.Promote => AggEnv.Promote
   }
+
+  def map[B](f: (String, A) => B): AggEnv[B] = this match {
+    case AggEnv.Create(bindings) => AggEnv.Create(bindings.map { case (n, v) => n -> f(n, v) })
+    case AggEnv.Bind(bindings) => AggEnv.Bind(bindings.map { case (n, v) => n -> f(n, v) })
+    case AggEnv.NoOp => AggEnv.NoOp
+    case AggEnv.Drop => AggEnv.Drop
+    case AggEnv.Promote => AggEnv.Promote
+  }
+
+  def isEmpty: Boolean = getBindings.forall(_.isEmpty)
+
+  def getBindings: Option[Seq[(String, A)]] = this match {
+    case AggEnv.Create(bindings) => Some(bindings)
+    case AggEnv.Bind(bindings) => Some(bindings)
+    case _ => None
+  }
 }
 
 object AggEnv {
@@ -33,24 +47,8 @@ object AggEnv {
     if (bindings.nonEmpty) Bind(bindings) else NoOp
 }
 
-object GenericBindingEnv {
-  implicit class GenericBindingEnvType[Self](private val env: GenericBindingEnv[Self, Type])
-      extends AnyVal {
-    def extend(bindings: Bindings): Self = {
-      val Bindings(eval, agg, scan, relational, dropEval) = bindings
-      env.newBlock(eval, agg, scan, relational, dropEval)
-    }
-  }
-}
-
 trait GenericBindingEnv[Self, V] {
-  def newBlock(
-    eval: Seq[(String, V)] = Seq.empty,
-    agg: AggEnv[V] = AggEnv.NoOp,
-    scan: AggEnv[V] = AggEnv.NoOp,
-    relational: Seq[(String, V)] = Seq.empty,
-    dropEval: Boolean = false,
-  ): Self
+  def extend(bindings: Bindings[V]): Self
 
   def promoteAgg: Self
 
@@ -96,13 +94,14 @@ case class BindingEnv[V](
   scan: Option[Env[V]] = None,
   relational: Env[V] = Env.empty[V],
 ) extends GenericBindingEnv[BindingEnv[V], V] {
-  def newBlock(
-    eval: Seq[(String, V)] = Seq.empty,
-    agg: AggEnv[V] = AggEnv.NoOp,
-    scan: AggEnv[V] = AggEnv.NoOp,
-    relational: Seq[(String, V)] = Seq.empty,
-    dropEval: Boolean = false,
-  ): BindingEnv[V] = {
+
+  private def modifyWithoutNewBindings[T](bindings: Bindings[T]): BindingEnv[V] = {
+    def error(): Unit =
+      throw new RuntimeException(s"found inconsistent agg or scan environments:" +
+        s"\n  env: agg is ${if (this.agg.isDefined) "" else "not "}defined, " +
+        s"scan is ${if (this.scan.isDefined) "" else "not "}defined" +
+        s"\n  bindings: agg = ${bindings.agg}, scan = ${bindings.scan}")
+    val Bindings(_, agg, scan, _, dropEval) = bindings
     var newEnv = this
     if (dropEval) newEnv = newEnv.noEval
     if (agg.isInstanceOf[AggEnv.Create[V]] || scan.isInstanceOf[AggEnv.Create[V]])
@@ -110,22 +109,67 @@ case class BindingEnv[V](
         newEnv.copy(agg = newEnv.agg.map(_ => Env.empty), scan = newEnv.scan.map(_ => Env.empty))
     agg match {
       case AggEnv.Drop => newEnv = newEnv.noAgg
-      case AggEnv.Promote => newEnv = newEnv.promoteAgg
-      case AggEnv.Create(bindings) =>
-        newEnv = newEnv.copy(agg = Some(newEnv.eval.bindIterable(bindings)))
-      case AggEnv.Bind(bindings) => newEnv = newEnv.bindAgg(bindings: _*)
+      case AggEnv.Promote =>
+        if (newEnv.agg.isEmpty) error()
+        newEnv = newEnv.promoteAgg
+      case AggEnv.Create(_) =>
+        newEnv = newEnv.copy(agg = Some(newEnv.eval))
+      case AggEnv.Bind(_) =>
+        if (newEnv.agg.isEmpty) error()
       case _ =>
     }
     scan match {
       case AggEnv.Drop => newEnv = newEnv.noScan
-      case AggEnv.Promote => newEnv = newEnv.promoteScan
-      case AggEnv.Create(bindings) =>
-        newEnv = newEnv.copy(scan = Some(newEnv.eval.bindIterable(bindings)))
+      case AggEnv.Promote =>
+        if (newEnv.scan.isEmpty) error()
+        newEnv = newEnv.promoteScan
+      case AggEnv.Create(_) =>
+        newEnv = newEnv.copy(scan = Some(newEnv.eval))
+      case AggEnv.Bind(_) =>
+        if (newEnv.scan.isEmpty) error()
+      case _ =>
+    }
+    newEnv
+  }
+
+  def extend(bindings: Bindings[V]): BindingEnv[V] = {
+    val Bindings(eval, agg, scan, relational, _) = bindings
+    var newEnv = modifyWithoutNewBindings(bindings)
+    agg match {
+      case AggEnv.Create(bindings) => newEnv = newEnv.bindAgg(bindings: _*)
+      case AggEnv.Bind(bindings) => newEnv = newEnv.bindAgg(bindings: _*)
+      case _ =>
+    }
+    scan match {
+      case AggEnv.Create(bindings) => newEnv = newEnv.bindScan(bindings: _*)
       case AggEnv.Bind(bindings) => newEnv = newEnv.bindScan(bindings: _*)
       case _ =>
     }
     if (eval.nonEmpty) newEnv = newEnv.bindEval(eval: _*)
     if (relational.nonEmpty) newEnv = newEnv.bindRelational(relational: _*)
+    newEnv
+  }
+
+  def subtract[T](bindings: Bindings[T]): BindingEnv[V] = {
+    val Bindings(eval, agg, scan, relational, _) = bindings
+    var newEnv = modifyWithoutNewBindings(bindings)
+    agg match {
+      case AggEnv.Create(bindings) =>
+        newEnv = newEnv.copy(agg = Some(newEnv.agg.get.delete(bindings.view.map(_._1))))
+      case AggEnv.Bind(bindings) =>
+        newEnv = newEnv.copy(agg = Some(newEnv.agg.get.delete(bindings.view.map(_._1))))
+      case _ =>
+    }
+    scan match {
+      case AggEnv.Create(bindings) =>
+        newEnv = newEnv.copy(scan = Some(newEnv.scan.get.delete(bindings.view.map(_._1))))
+      case AggEnv.Bind(bindings) =>
+        newEnv = newEnv.copy(scan = Some(newEnv.scan.get.delete(bindings.view.map(_._1))))
+      case _ =>
+    }
+    if (eval.nonEmpty) newEnv = newEnv.copy(eval = newEnv.eval.delete(eval.view.map(_._1)))
+    if (relational.nonEmpty)
+      newEnv = newEnv.copy(relational = newEnv.relational.delete(relational.view.map(_._1)))
     newEnv
   }
 
@@ -200,42 +244,6 @@ case class BindingEnv[V](
        |  Relational: ${relational.m.map { case (k, v) =>
         s"\n    $k -> ${valuePrinter(v)}"
       }.mkString("")}""".stripMargin
-
-  def merge(newBindings: BindingEnv[V]): BindingEnv[V] = {
-    if (agg.isDefined != newBindings.agg.isDefined || scan.isDefined != newBindings.scan.isDefined)
-      throw new RuntimeException(s"found inconsistent agg or scan environments:" +
-        s"\n  left: ${agg.isDefined}, ${scan.isDefined}" +
-        s"\n  right: ${newBindings.agg.isDefined}, ${newBindings.scan.isDefined}")
-    if (allEmpty)
-      newBindings
-    else if (newBindings.allEmpty)
-      this
-    else {
-      copy(
-        eval = eval.bindIterable(newBindings.eval.m),
-        agg = agg.map(a => a.bindIterable(newBindings.agg.get.m)),
-        scan = scan.map(a => a.bindIterable(newBindings.scan.get.m)),
-        relational = relational.bindIterable(newBindings.relational.m),
-      )
-    }
-  }
-
-  def subtract(newBindings: BindingEnv[_]): BindingEnv[V] = {
-    if (agg.isDefined != newBindings.agg.isDefined || scan.isDefined != newBindings.scan.isDefined)
-      throw new RuntimeException(s"found inconsistent agg or scan environments:" +
-        s"\n  left: ${agg.isDefined}, ${scan.isDefined}" +
-        s"\n  right: ${newBindings.agg.isDefined}, ${newBindings.scan.isDefined}")
-    if (allEmpty || newBindings.allEmpty)
-      this
-    else {
-      copy(
-        eval = eval.delete(newBindings.eval.m.keys),
-        agg = agg.map(a => a.delete(newBindings.agg.get.m.keys)),
-        scan = scan.map(a => a.delete(newBindings.scan.get.m.keys)),
-        relational = relational.delete(newBindings.relational.m.keys),
-      )
-    }
-  }
 
   def mapValues[T](f: V => T): BindingEnv[T] =
     copy[T](

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -61,7 +61,7 @@ object ForwardLets {
             .getOrElse(x)
         case _ =>
           ir.mapChildrenWithIndex((ir1, i) =>
-            rewrite(ir1, Bindings.segregated(ir, i, env).childEnvWithoutBindings)
+            rewrite(ir1, env.extend(Bindings.get(ir, i).dropBindings))
           )
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/FreeVariables.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FreeVariables.scala
@@ -26,13 +26,8 @@ case class FreeVariableBindingEnv(
   aggVars: Option[FreeVariableEnv],
   scanVars: Option[FreeVariableEnv],
 ) extends GenericBindingEnv[FreeVariableBindingEnv, Type] {
-  def newBlock(
-    eval: Seq[(String, Type)],
-    agg: AggEnv[Type],
-    scan: AggEnv[Type],
-    relational: Seq[(String, Type)],
-    dropEval: Boolean,
-  ): FreeVariableBindingEnv = {
+  def extend(bindings: Bindings[Type]): FreeVariableBindingEnv = {
+    val Bindings(eval, agg, scan, relational, dropEval) = bindings
     var newEnv = this
     if (dropEval) newEnv = newEnv.noEval
     agg match {

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -288,7 +288,7 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         x.mapChildrenWithIndexStackSafe { (child, i) =>
           normalizeBaseIR(
             child,
-            Bindings.segregated(x, i, env).mapNewBindings((name, _) => name).unified,
+            env.extend(Bindings.get(x, i).map((name, _) => name)),
           )
         }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -15,9 +15,7 @@ object Subst {
         env.eval.lookupOption(name).getOrElse(x)
       case _ =>
         e.mapChildrenWithIndex {
-          case (child: IR, i) =>
-            val bindings = Bindings.segregated(e, i, env)
-            subst(child, bindings.childEnvWithoutBindings.subtract(bindings.newBindings))
+          case (child: IR, i) => subst(child, env.subtract(Bindings.get(e, i)))
           case (child, _) => child
         }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -712,8 +712,7 @@ object Extract {
         x
       case x =>
         x.mapChildrenWithIndex { case (child: IR, i) =>
-          val newEnv =
-            Bindings.segregated(x, i, env).mapNewBindings((_, _) => RefEquality(x)).unified
+          val newEnv = env.extend(Bindings.get(x, i).map((_, _) => RefEquality(x)))
 
           this.extract(child, newEnv, bindingNodesReferenced, rewriteMap, ab, seqBuilder, memo,
             result, r, isScan)


### PR DESCRIPTION
Refactors `Bindings` to return an object encoding the change to the environment (any new bindings, whether the agg/scan env is promoted, etc). This allows the deletion of `SegregatedBindingEnv`. Follow up work will use this to replace the other specializations of `GenericBindingEnv`, and to greatly simplify compiler passes, such as `NormalizeNames` and `PruneDeadFields`, which currently need to redundantly encode the binding structure of every node.