### PR TITLE
[query] Cleanup Code-Duplication around `parallelizeAndComputeWithIndex`

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -80,19 +80,10 @@ abstract class Backend {
   def parallelizeAndComputeWithIndex(
     backendContext: BackendContext,
     fs: FS,
-    collection: Array[Array[Byte]],
+    contexts: IndexedSeq[Array[Byte]],
     stageIdentifier: String,
     dependency: Option[TableStageDependency] = None,
-  )(
-    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
-  ): Array[Array[Byte]]
-
-  def parallelizeAndComputeWithIndexReturnAllErrors(
-    backendContext: BackendContext,
-    fs: FS,
-    collection: IndexedSeq[(Array[Byte], Int)],
-    stageIdentifier: String,
-    dependency: Option[TableStageDependency] = None,
+    partitions: Option[IndexedSeq[Int]] = None,
   )(
     f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
   ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)])

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -10,8 +10,7 @@ import is.hail.io.fs._
 import is.hail.services._
 import is.hail.utils._
 
-import scala.annotation.nowarn
-import scala.util.Try
+import scala.util.control.NonFatal
 
 object BackendUtils {
   type F = AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]]
@@ -28,17 +27,6 @@ class BackendUtils(
 
   def getModule(id: String): (HailClassLoader, FS, HailTaskContext, Region) => F = loadedModules(id)
 
-  private[this] def lookupSemanticHashResults(
-    backendContext: BackendContext,
-    stageName: String,
-    semanticHash: Option[SemanticHash.Type],
-  ): Option[IndexedSeq[(Array[Byte], Int)]] = semanticHash.map { s =>
-    log.info(s"[collectDArray|$stageName]: querying cache for $s")
-    val cachedResults = backendContext.executionCache.lookup(s)
-    log.info(s"[collectDArray|$stageName]: found ${cachedResults.length} entries for $s.")
-    cachedResults
-  }
-
   def collectDArray(
     backendContext: BackendContext,
     theDriverHailClassLoader: HailClassLoader,
@@ -49,115 +37,75 @@ class BackendUtils(
     stageName: String,
     semhash: Option[SemanticHash.Type],
     tsd: Option[TableStageDependency],
-  ): Array[Array[Byte]] = lookupSemanticHashResults(backendContext, stageName, semhash) match {
-    case None =>
-      if (contexts.isEmpty)
-        return Array()
+  ): Array[Array[Byte]] = {
 
-      val backend = HailContext.backend
-      val f = getModule(modID)
-
-      log.info(
-        s"[collectDArray|$stageName]: executing ${contexts.length} tasks, " +
-          s"contexts size = ${formatSpace(contexts.map(_.length.toLong).sum)}, " +
-          s"globals size = ${formatSpace(globals.length)}"
-      )
-
-      val t = System.nanoTime()
-      val results = if (backend.canExecuteParallelTasksOnDriver && contexts.length == 1) {
-        val context = contexts(0)
-        using(new LocalTaskContext(0, 0)) { htc =>
-          using(htc.getRegionPool().getRegion()) { r =>
-            val run = f(theDriverHailClassLoader, fs, htc, r)
-            val result = retryTransientErrors {
-              run(r, context, globals)
-            }
-            Array(result)
-          }
+    val cachedResults =
+      semhash
+        .map { s =>
+          log.info(s"[collectDArray|$stageName]: querying cache for $s")
+          val cachedResults = backendContext.executionCache.lookup(s)
+          log.info(s"[collectDArray|$stageName]: found ${cachedResults.length} entries for $s.")
+          cachedResults
         }
-      } else {
-        val globalsBC = backend.broadcast(globals)
-        val fsConfigBC = backend.broadcast(fs.getConfiguration())
-        backend.parallelizeAndComputeWithIndex(backendContext, fs, contexts, stageName, tsd) {
-          (ctx, htc, theHailClassLoader, fs) =>
+        .getOrElse(IndexedSeq.empty)
+
+    val remainingPartitions =
+      contexts.indices.filterNot(k => cachedResults.containsOrdered[Int](k, _ < _, _._2))
+
+    val backend = HailContext.backend
+    val mod = getModule(modID)
+    val t = System.nanoTime()
+    val (failureOpt, successes) =
+      remainingPartitions match {
+        case Seq() =>
+          (None, IndexedSeq.empty)
+        case Seq(k) if backend.canExecuteParallelTasksOnDriver =>
+          try
+            using(new LocalTaskContext(k, 0)) { htc =>
+              using(htc.getRegionPool().getRegion()) { r =>
+                val f = mod(theDriverHailClassLoader, fs, htc, r)
+                val res = retryTransientErrors(f(r, contexts(k), globals))
+                (None, FastSeq(res -> k))
+              }
+            }
+          catch {
+            case NonFatal(ex) =>
+              (Some(ex), IndexedSeq.empty)
+          }
+        case partitions =>
+          val globalsBC = backend.broadcast(globals)
+          val fsConfigBC = backend.broadcast(fs.getConfiguration())
+          backend.parallelizeAndComputeWithIndex(
+            backendContext,
+            fs,
+            contexts,
+            stageName,
+            tsd,
+            Some(partitions),
+          ) { (ctx, htc, theHailClassLoader, fs) =>
             val fsConfig = fsConfigBC.value
             val gs = globalsBC.value
             fs.setConfiguration(fsConfig)
             htc.getRegionPool().scopedRegion { region =>
-              f(theHailClassLoader, fs, htc, region)(region, ctx, gs)
+              mod(theHailClassLoader, fs, htc, region)(region, ctx, gs)
             }
-        }
+          }
       }
 
-      log.info(s"[collectDArray|$stageName]: executed ${contexts.length} tasks " +
-        s"in ${formatTime(System.nanoTime() - t)}")
+    log.info(
+      s"[collectDArray|$stageName]: executed ${remainingPartitions.length} tasks in ${formatTime(System.nanoTime() - t)}"
+    )
 
-      results
-    case Some(cachedResults) =>
-      @nowarn("cat=unused-pat-vars&msg=pattern var c")
-      val remainingContexts =
-        for {
-          c @ (_, k) <- contexts.zipWithIndex
-          if !cachedResults.containsOrdered[Int](k, _ < _, _._2)
-        } yield c
-      val results =
-        if (remainingContexts.isEmpty) {
-          cachedResults
-        } else {
-          val backend = HailContext.backend
-          val f = getModule(modID)
+    val results =
+      merge[(Array[Byte], Int)](
+        cachedResults,
+        successes.sortBy(_._2),
+        _._2 < _._2,
+      )
 
-          log.info(
-            s"[collectDArray|$stageName]: executing ${remainingContexts.length} tasks, " +
-              s"contexts size = ${formatSpace(contexts.map(_.length.toLong).sum)}, " +
-              s"globals size = ${formatSpace(globals.length)}"
-          )
+    semhash.foreach(s => backendContext.executionCache.put(s, results))
+    failureOpt.foreach(throw _)
 
-          val t = System.nanoTime()
-          val (failureOpt, successes) =
-            remainingContexts match {
-              case Array((context, k)) if backend.canExecuteParallelTasksOnDriver =>
-                Try {
-                  using(new LocalTaskContext(k, 0)) { htc =>
-                    using(htc.getRegionPool().getRegion()) { r =>
-                      val run = f(theDriverHailClassLoader, fs, htc, r)
-                      val res = retryTransientErrors {
-                        run(r, context, globals)
-                      }
-                      FastSeq(res -> k)
-                    }
-                  }
-                }
-                  .fold(t => (Some(t), IndexedSeq.empty), (None, _))
-
-              case _ =>
-                val globalsBC = backend.broadcast(globals)
-                val fsConfigBC = backend.broadcast(fs.getConfiguration())
-                val (failureOpt, successes) =
-                  backend.parallelizeAndComputeWithIndexReturnAllErrors(backendContext, fs,
-                    remainingContexts, stageName, tsd) {
-                    (ctx, htc, theHailClassLoader, fs) =>
-                      val fsConfig = fsConfigBC.value
-                      val gs = globalsBC.value
-                      fs.setConfiguration(fsConfig)
-                      htc.getRegionPool().scopedRegion { region =>
-                        f(theHailClassLoader, fs, htc, region)(region, ctx, gs)
-                      }
-                  }
-                (failureOpt, successes)
-            }
-
-          log.info(s"[collectDArray|$stageName]: executed ${remainingContexts.length} tasks " +
-            s"in ${formatTime(System.nanoTime() - t)}")
-
-          val results =
-            merge[(Array[Byte], Int)](cachedResults, successes.sortBy(_._2), _._2 < _._2)
-          semhash.foreach(s => backendContext.executionCache.put(s, results))
-          failureOpt.foreach(throw _)
-
-          results
-        }
-
-      results.map(_._1).toArray
+    results.map(_._1).toArray
   }
 }

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.local
 
-import is.hail.{HailContext, HailFeatureFlags}
+import is.hail.{CancellingExecutorService, HailContext, HailFeatureFlags}
 import is.hail.annotations.{Region, SafeRow}
 import is.hail.asm4s._
 import is.hail.backend._
@@ -24,10 +24,10 @@ import scala.reflect.ClassTag
 
 import java.io.PrintWriter
 
+import com.google.common.util.concurrent.MoreExecutors
 import org.apache.hadoop
 import org.json4s._
 import org.json4s.jackson.Serialization
-import org.sparkproject.guava.util.concurrent.MoreExecutors
 
 class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T] with Serializable
 
@@ -130,37 +130,24 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
     current
   }
 
-  def parallelizeAndComputeWithIndex(
+  override def parallelizeAndComputeWithIndex(
     backendContext: BackendContext,
     fs: FS,
-    collection: Array[Array[Byte]],
+    contexts: IndexedSeq[Array[Byte]],
     stageIdentifier: String,
-    dependency: Option[TableStageDependency] = None,
-  )(
-    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
-  ): Array[Array[Byte]] = {
-    val stageId = nextStageId()
-    collection.zipWithIndex.map { case (c, i) =>
-      using(new LocalTaskContext(i, stageId))(htc => f(c, htc, theHailClassLoader, fs))
-    }
-  }
-
-  override def parallelizeAndComputeWithIndexReturnAllErrors(
-    backendContext: BackendContext,
-    fs: FS,
-    collection: IndexedSeq[(Array[Byte], Int)],
-    stageIdentifier: String,
-    dependency: Option[TableStageDependency] = None,
+    dependency: Option[TableStageDependency],
+    partitions: Option[IndexedSeq[Int]],
   )(
     f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
   ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) = {
+
     val stageId = nextStageId()
-    runAllKeepFirstError(MoreExecutors.sameThreadExecutor) {
-      collection.map { case (c, i) =>
+    runAllKeepFirstError(new CancellingExecutorService(MoreExecutors.newDirectExecutorService())) {
+      partitions.getOrElse(contexts.indices).map { i =>
         (
           () =>
             using(new LocalTaskContext(i, stageId)) {
-              f(c, _, theHailClassLoader, fs)
+              f(contexts(i), _, theHailClassLoader, fs)
             },
           i,
         )

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -312,11 +312,13 @@ class ServiceBackend(
 
     log.info(s"parallelizeAndComputeWithIndex: $token: reading results")
     val startTime = System.nanoTime()
-    val r @ (_, results) = runAllKeepFirstError(new CancellingExecutorService(executor)) {
+    val r @ (error, results) = runAllKeepFirstError(new CancellingExecutorService(executor)) {
       (partIdxs, parts.indices).zipped.map { (partIdx, jobIndex) =>
         (() => readResult(root, jobIndex), partIdx)
       }
     }
+
+    error.foreach(throw _)
 
     val resultsReadingSeconds = (System.nanoTime() - startTime) / 1000000000.0
     val rate = results.length / resultsReadingSeconds

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.service
 
-import is.hail.{HailContext, HailFeatureFlags}
+import is.hail.{CancellingExecutorService, HailContext, HailFeatureFlags}
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend._
@@ -25,7 +25,6 @@ import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 
 import scala.annotation.switch
-import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 import java.io._
@@ -155,7 +154,7 @@ class ServiceBackend(
   private[this] def submitAndWaitForBatch(
     _backendContext: BackendContext,
     fs: FS,
-    collection: Array[Array[Byte]],
+    collection: IndexedSeq[Array[Byte]],
     stageIdentifier: String,
     f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte],
   ): (String, String, Int) = {
@@ -295,52 +294,30 @@ class ServiceBackend(
   override def parallelizeAndComputeWithIndex(
     _backendContext: BackendContext,
     fs: FS,
-    collection: Array[Array[Byte]],
+    contexts: IndexedSeq[Array[Byte]],
     stageIdentifier: String,
-    dependency: Option[TableStageDependency] = None,
-  )(
-    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
-  ): Array[Array[Byte]] = {
-    val (token, root, n) =
-      submitAndWaitForBatch(_backendContext, fs, collection, stageIdentifier, f)
-
-    log.info(s"parallelizeAndComputeWithIndex: $token: reading results")
-    val startTime = System.nanoTime()
-    val results =
-      try
-        executor.invokeAll[Array[Byte]](
-          IndexedSeq.range(0, n).map { i =>
-            (() => readResult(root, i)): Callable[Array[Byte]]
-          }.asJavaCollection
-        ).asScala.map(_.get).toArray
-      catch {
-        case exc: ExecutionException if exc.getCause() != null => throw exc.getCause()
-      }
-    val resultsReadingSeconds = (System.nanoTime() - startTime) / 1000000000.0
-    val rate = results.length / resultsReadingSeconds
-    val byterate = results.map(_.length).sum / resultsReadingSeconds / 1024 / 1024
-    log.info(s"all results read. $resultsReadingSeconds s. $rate result/s. $byterate MiB/s.")
-    results
-  }
-
-  override def parallelizeAndComputeWithIndexReturnAllErrors(
-    _backendContext: BackendContext,
-    fs: FS,
-    collection: IndexedSeq[(Array[Byte], Int)],
-    stageIdentifier: String,
-    dependency: Option[TableStageDependency] = None,
+    dependency: Option[TableStageDependency],
+    partitions: Option[IndexedSeq[Int]],
   )(
     f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
   ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) = {
+
+    val (partIdxs, parts) =
+      partitions
+        .map(ps => (ps, ps.map(contexts)))
+        .getOrElse((contexts.indices, contexts))
+
     val (token, root, _) =
-      submitAndWaitForBatch(_backendContext, fs, collection.map(_._1).toArray, stageIdentifier, f)
+      submitAndWaitForBatch(_backendContext, fs, parts, stageIdentifier, f)
+
     log.info(s"parallelizeAndComputeWithIndex: $token: reading results")
     val startTime = System.nanoTime()
-    val r @ (_, results) = runAllKeepFirstError(executor) {
-      collection.zipWithIndex.map { case ((_, i), jobIndex) =>
-        (() => readResult(root, jobIndex), i)
+    val r @ (_, results) = runAllKeepFirstError(new CancellingExecutorService(executor)) {
+      (partIdxs, parts.indices).zipped.map { (partIdx, jobIndex) =>
+        (() => readResult(root, jobIndex), partIdx)
       }
     }
+
     val resultsReadingSeconds = (System.nanoTime() - startTime) / 1000000000.0
     val rate = results.length / resultsReadingSeconds
     val byterate = results.map(_._1.length).sum / resultsReadingSeconds / 1024 / 1024

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -27,9 +27,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
-
 import java.io.{Closeable, PrintWriter}
-
 import org.apache.hadoop
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark._
@@ -39,6 +37,8 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s
 import org.json4s.DefaultFormats
 import org.json4s.jackson.{JsonMethods, Serialization}
+
+import scala.concurrent.ExecutionException
 
 class SparkBroadcastValue[T](bc: Broadcast[T]) extends BroadcastValue[T] with Serializable {
   def value: T = bc.value
@@ -451,6 +451,7 @@ class SparkBackend(
         (idx, result: Array[Byte]) => buffer += result -> idx,
       )
     catch {
+      case e: ExecutionException => failure.orElse(Some(e.getCause))
       case NonFatal(t) => failure = failure.orElse(Some(t))
     }
 

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -451,7 +451,7 @@ class SparkBackend(
         (idx, result: Array[Byte]) => buffer += result -> idx,
       )
     catch {
-      case e: ExecutionException => failure.orElse(Some(e.getCause))
+      case e: ExecutionException => failure = failure.orElse(Some(e.getCause))
       case NonFatal(t) => failure = failure.orElse(Some(t))
     }
 

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -25,9 +25,12 @@ import is.hail.variant.ReferenceGenome
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.ExecutionException
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
+
 import java.io.{Closeable, PrintWriter}
+
 import org.apache.hadoop
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark._
@@ -37,8 +40,6 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s
 import org.json4s.DefaultFormats
 import org.json4s.jackson.{JsonMethods, Serialization}
-
-import scala.concurrent.ExecutionException
 
 class SparkBroadcastValue[T](bc: Broadcast[T]) extends BroadcastValue[T] with Serializable {
   def value: T = bc.value

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1810,7 +1810,6 @@ object MatrixVCFReader {
           fs,
           files.tail.map(_.getBytes),
           "load_vcf_parse_header",
-          None,
         ) { (bytes, htc, _, fs) =>
           val fsConfig = fsConfigBC.value
           fs.setConfiguration(fsConfig)

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1805,7 +1805,7 @@ object MatrixVCFReader {
         val localFilterAndReplace = params.filterAndReplace
 
         val fsConfigBC = backend.broadcast(fs.getConfiguration())
-        backend.parallelizeAndComputeWithIndex(
+        val (failureOpt, _) = backend.parallelizeAndComputeWithIndex(
           ctx.backendContext,
           fs,
           files.tail.map(_.getBytes),
@@ -1856,6 +1856,8 @@ object MatrixVCFReader {
 
           bytes
         }
+
+        failureOpt.foreach(throw _)
       }
     }
 

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -5,12 +5,14 @@ import is.hail.check.Gen
 import is.hail.expr.ir.ByteArrayBuilder
 import is.hail.io.fs.{FS, FileListEntry}
 
-import scala.collection.{GenTraversableOnce, TraversableOnce, mutable}
+import scala.collection.{mutable, GenTraversableOnce, TraversableOnce}
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.ExecutionException
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
+
 import java.io._
 import java.lang.reflect.Method
 import java.net.{URI, URLClassLoader}
@@ -18,8 +20,12 @@ import java.security.SecureRandom
 import java.text.SimpleDateFormat
 import java.util
 import java.util.{Base64, Date}
-import java.util.concurrent.{AbstractExecutorService, Callable, CancellationException, ExecutorCompletionService, ExecutorService, RunnableFuture, TimeUnit}
+import java.util.concurrent.{
+  AbstractExecutorService, Callable, CancellationException, ExecutorCompletionService,
+  ExecutorService, RunnableFuture, TimeUnit,
+}
 import java.util.concurrent.atomic.AtomicBoolean
+
 import com.google.common.util.concurrent.AbstractFuture
 import org.apache.commons.io.output.TeeOutputStream
 import org.apache.commons.lang3.StringUtils
@@ -33,8 +39,6 @@ import org.json4s.{Extraction, Formats, JObject, NoTypeHints, Serializer}
 import org.json4s.JsonAST.{JArray, JString}
 import org.json4s.jackson.Serialization
 import org.json4s.reflect.TypeInfo
-
-import scala.concurrent.ExecutionException
 
 package utils {
   trait Truncatable {

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -5,13 +5,12 @@ import is.hail.check.Gen
 import is.hail.expr.ir.ByteArrayBuilder
 import is.hail.io.fs.{FS, FileListEntry}
 
-import scala.collection.{mutable, GenTraversableOnce, TraversableOnce}
+import scala.collection.{GenTraversableOnce, TraversableOnce, mutable}
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ArrayBuffer
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
-
 import java.io._
 import java.lang.reflect.Method
 import java.net.{URI, URLClassLoader}
@@ -19,12 +18,8 @@ import java.security.SecureRandom
 import java.text.SimpleDateFormat
 import java.util
 import java.util.{Base64, Date}
-import java.util.concurrent.{
-  AbstractExecutorService, Callable, CancellationException, ExecutorCompletionService,
-  ExecutorService, RunnableFuture, TimeUnit,
-}
+import java.util.concurrent.{AbstractExecutorService, Callable, CancellationException, ExecutorCompletionService, ExecutorService, RunnableFuture, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
-
 import com.google.common.util.concurrent.AbstractFuture
 import org.apache.commons.io.output.TeeOutputStream
 import org.apache.commons.lang3.StringUtils
@@ -38,6 +33,8 @@ import org.json4s.{Extraction, Formats, JObject, NoTypeHints, Serializer}
 import org.json4s.JsonAST.{JArray, JString}
 import org.json4s.jackson.Serialization
 import org.json4s.reflect.TypeInfo
+
+import scala.concurrent.ExecutionException
 
 package utils {
   trait Truncatable {
@@ -1036,6 +1033,8 @@ package object utils
     tasks.foreach { _ =>
       try buffer += completer.take().get()
       catch {
+        case e: ExecutionException =>
+          err = accum(err, e.getCause)
         case NonFatal(ex) =>
           err = accum(err, ex)
       }

--- a/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -1,14 +1,13 @@
 package is.hail.utils
 
-import is.hail.HailSuite
+import com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService
 import is.hail.check.{Gen, Prop}
 import is.hail.io.fs.HadoopFS
-
-import scala.collection.mutable.ArrayBuffer
-
+import is.hail.{CancellingExecutorService, HailSuite}
 import org.apache.spark.storage.StorageLevel
-import org.sparkproject.guava.util.concurrent.MoreExecutors
 import org.testng.annotations.Test
+
+import java.util.concurrent.{AbstractExecutorService, Executors}
 
 class UtilsSuite extends HailSuite {
   @Test def testD_==(): Unit = {
@@ -198,19 +197,29 @@ class UtilsSuite extends HailSuite {
   }
 
   @Test def testRunAll(): Unit = {
-    type F[_] = ArrayBuffer[Int]
+    type F[_] = Null
 
-    val (failures, successes) =
-      runAll[F, Int](
-        MoreExecutors.sameThreadExecutor()
-      ) { case (acc, (_, index)) => acc :+ index }(
-        new ArrayBuffer[Int](2)
-      )(
+    val (_, successes) =
+      runAll[F, Int](newDirectExecutorService())((_, _) => null)(null)(
         for { k <- 0 until 4 } yield (() => if (k % 2 == 0) k else throw new Exception(), k)
       )
 
-    assert(failures == Seq(1, 3))
     assert(successes == Seq(0 -> 0, 2 -> 2))
+  }
+
+  @Test def testRunAllWithCancellingExecutorService(): Unit = {
+    type F[_] = Null
+
+    val delegate = Executors.newSingleThreadExecutor()
+
+    try {
+      val (_, successes) =
+        runAll[F, Int](new CancellingExecutorService(delegate))((_, _) => null)(null)(
+          for { k <- 0 until 4 } yield (() => if (k % 2 == 0) k else throw new Exception(), k)
+        )
+
+      assert(successes == Seq(0 -> 0))
+    } finally delegate.shutdown()
   }
 
   @Test def testMerge(): Unit = {

--- a/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -7,7 +7,7 @@ import is.hail.{CancellingExecutorService, HailSuite}
 import org.apache.spark.storage.StorageLevel
 import org.testng.annotations.Test
 
-import java.util.concurrent.{AbstractExecutorService, Executors}
+import java.util.concurrent.Executors
 
 class UtilsSuite extends HailSuite {
   @Test def testD_==(): Unit = {


### PR DESCRIPTION
https://github.com/hail-is/hail/pull/14085 fixed a change in semantics for `parallelizeAndComputeWithIndex` didn't fail early anymore.
It also noted that the `SparkTaskContext.partitionId` could be wrong when used with call caching, but left the fix to another change.
This change takes inspiration from `SparkContext.runJob` in its `partitions` optional argument.
By supplying this, we can limit the number of partitions that we compute (useful for call caching) without doing dodgy things that breaks the `partitionId`.
This change also reduces code duplication wile preserving semantics - `parallelizeAndComputeWithIndex` still fails early for the local and spark backends.
