### PR TITLE
[docs] Change input/output bucket warning to recommend regional buckets

### DIFF
--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -473,8 +473,7 @@ class Batch:
         .. warning::
 
             To avoid expensive egress charges, input files should be located in buckets
-            that are multi-regional in the United States because Batch runs jobs in any
-            US region.
+            that are in the same region in which your Batch jobs run.
 
         Examples
         --------
@@ -503,8 +502,7 @@ class Batch:
         .. warning::
 
             To avoid expensive egress charges, input files should be located in buckets
-            that are multi-regional in the United States because Batch runs jobs in any
-            US region.
+            that are in the same region in which your Batch jobs run.
 
         Examples
         --------
@@ -599,8 +597,7 @@ class Batch:
         .. warning::
 
             To avoid expensive egress charges, output files should be located in buckets
-            that are multi-regional in the United States because Batch runs jobs in any
-            US region.
+            that are in the same region in which your Batch jobs run.
 
         Notes
         -----


### PR DESCRIPTION
These docstrings weren't updated since the GCP multi-regional egress changes. It is no longer free to egress from/to multi-regional buckets, so the best thing to do would be to put your storage and compute into the same region.