### PR TITLE
[compiler] simplify PruneDeadFields

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
@@ -17,6 +17,8 @@ abstract class BaseIR {
 
   def children: Iterable[BaseIR] = childrenSeq
 
+  def getChild(idx: Int): BaseIR = childrenSeq(idx)
+
   protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BaseIR
 
   def deepCopy(): this.type =

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -302,7 +302,7 @@ object Bindings {
       case StreamFold(a, zero, accumName, valueName, _) if i == 2 =>
         Bindings(FastSeq(accumName -> zero.typ, valueName -> elementType(a.typ)))
       case StreamFold2(a, accum, valueName, _, _) =>
-        if (i <= accum.length)
+        if (i < accum.length + 1)
           Bindings.empty
         else if (i < 2 * accum.length + 1)
           Bindings(

--- a/hail/src/main/scala/is/hail/expr/ir/DeprecatedIRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/DeprecatedIRBuilder.scala
@@ -220,10 +220,10 @@ object DeprecatedIRBuilder {
 
     def castRename(t: Type): IRProxy = (env: E) => CastRename(ir(env), t)
 
-    def insertFields(fields: (Symbol, IRProxy)*): IRProxy = insertFieldsList(fields)
+    def insertFields(fields: (Symbol, IRProxy)*): IRProxy = insertFieldsList(fields.toFastSeq)
 
     def insertFieldsList(
-      fields: Seq[(Symbol, IRProxy)],
+      fields: IndexedSeq[(Symbol, IRProxy)],
       ordering: Option[IndexedSeq[String]] = None,
     ): IRProxy = (env: E) =>
       InsertFields(ir(env), fields.map { case (s, fir) => (s.name, fir(env)) }, ordering)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -217,8 +217,6 @@ object Let {
 case class Binding(name: Name, value: IR, scope: Int = Scope.EVAL)
 
 final case class Block(bindings: IndexedSeq[Binding], body: IR) extends IR {
-//  assert(bindings.map(_.name).areDistinct(), bindings.map(_.name.str))
-
   override lazy val size: Int =
     bindings.length + 1
 }
@@ -957,12 +955,13 @@ final case class MakeStruct(fields: IndexedSeq[(String, IR)]) extends IR
 final case class SelectFields(old: IR, fields: IndexedSeq[String]) extends IR
 
 object InsertFields {
-  def apply(old: IR, fields: Seq[(String, IR)]): InsertFields = InsertFields(old, fields, None)
+  def apply(old: IR, fields: IndexedSeq[(String, IR)]): InsertFields =
+    InsertFields(old, fields, None)
 }
 
 final case class InsertFields(
   old: IR,
-  fields: Seq[(String, IR)],
+  fields: IndexedSeq[(String, IR)],
   fieldOrder: Option[IndexedSeq[String]],
 ) extends TypedIR[TStruct]
 

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -5,7 +5,7 @@ import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.Pretty.prettyBooleanLiteral
 import is.hail.expr.ir.agg._
 import is.hail.expr.ir.functions.RelationalFunctions
-import is.hail.types.TableType
+import is.hail.types.{MatrixType, TableType}
 import is.hail.types.virtual.{TArray, TInterval, TStream, Type}
 import is.hail.utils.{space => _, _}
 import is.hail.utils.prettyPrint._
@@ -851,7 +851,7 @@ class Pretty(
       case I32(i) => s"c$i"
       case stream if stream.typ.isInstanceOf[TStream] => "s"
       case table if table.typ.isInstanceOf[TableType] => "ht"
-      case mt if mt.typ.isInstanceOf[TableType] => "mt"
+      case mt if mt.typ.isInstanceOf[MatrixType] => "mt"
       case _ => ""
     }
 
@@ -904,12 +904,12 @@ class Pretty(
       ir match {
         case Ref(name, _) =>
           val body =
-            blockBindings.lookupOption(name).getOrElse(uniqueify("%undefined_ref", Some(name)))
+            blockBindings.lookupOption(name).getOrElse("#" + uniqueify("undefined_ref", Some(name)))
           concat(openBlock, group(nest(2, concat(line, body, line)), "}"))
         case RelationalRef(name, _) =>
           val body =
-            blockBindings.lookupOption(name).getOrElse(uniqueify(
-              "%undefined_relational_ref",
+            blockBindings.lookupOption(name).getOrElse("#" + uniqueify(
+              "undefined_relational_ref",
               Some(name),
             ))
           concat(openBlock, group(nest(2, concat(line, body, line)), "}"))
@@ -953,10 +953,10 @@ class Pretty(
         } yield {
           child match {
             case Ref(name, _) =>
-              bindings.lookupOption(name).getOrElse(uniqueify("%undefined_ref", Some(name)))
+              bindings.lookupOption(name).getOrElse("#" + uniqueify("undefined_ref", Some(name)))
             case RelationalRef(name, _) =>
-              bindings.lookupOption(name).getOrElse(uniqueify(
-                "%undefined_relational_ref",
+              bindings.lookupOption(name).getOrElse("#" + uniqueify(
+                "undefined_relational_ref",
                 Some(name),
               ))
             case _ =>

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -25,6 +25,31 @@ object PruneDeadFields {
     relationalRefs: mutable.HashMap[Name, Type],
   )
 
+  object TypeState {
+    def apply(origType: Type): TypeState = new TypeState(origType)
+  }
+
+  class TypeState(val origType: Type) {
+    private var _newType: Type = null
+    def newType: Type = if (_newType == null) minimal(origType) else _newType
+    def newStructType: TStruct = newType.asInstanceOf[TStruct]
+    def isUndefined: Boolean = _newType == null
+
+    def union(requestedType: Type): TypeState = {
+      _newType = if (_newType == null) requestedType else unify(origType, _newType, requestedType)
+      this
+    }
+
+    def requireFields(fields: IndexedSeq[String]): TypeState =
+      union(selectKey(origType.asInstanceOf[TStruct], fields))
+
+    def requireFieldsInElt(fields: IndexedSeq[String]): TypeState = origType match {
+      case TArray(eltType) => union(TArray(selectKey(eltType.asInstanceOf[TStruct], fields)))
+      case TStream(eltType) => union(TStream(selectKey(eltType.asInstanceOf[TStruct], fields)))
+    }
+
+  }
+
   def subsetType(t: Type, path: Array[String], index: Int = 0): Type = {
     if (index == path.length)
       PruneDeadFields.minimal(t)
@@ -118,14 +143,14 @@ object PruneDeadFields {
 
   def selectKey(t: TStruct, k: IndexedSeq[String]): TStruct = t.filterSet(k.toSet)._1
 
-  def minimal(tt: TableType): TableType =
+  private def minimal(tt: TableType): TableType =
     TableType(
       rowType = TStruct.empty,
       key = FastSeq(),
       globalType = TStruct.empty,
     )
 
-  def minimal(mt: MatrixType): MatrixType = {
+  private def minimal(mt: MatrixType): MatrixType = {
     MatrixType(
       rowKey = FastSeq(),
       colKey = FastSeq(),
@@ -136,7 +161,7 @@ object PruneDeadFields {
     )
   }
 
-  def minimal[T <: Type](base: T): T = {
+  private def minimal[T <: Type](base: T): T = {
     val result = base match {
       case _: TStruct => TStruct.empty
       case ta: TArray => TArray(minimal(ta.elementType))
@@ -146,22 +171,19 @@ object PruneDeadFields {
     result.asInstanceOf[T]
   }
 
-  def minimalBT[T <: BaseType](base: T): T =
+  private def minimalBT[T <: BaseType](base: T): T =
     (base match {
       case tt: TableType => minimal(tt)
       case mt: MatrixType => minimal(mt)
       case t: Type => minimal(t)
     }).asInstanceOf[T]
 
-  def unifyKey(children: Seq[IndexedSeq[String]]): IndexedSeq[String] =
+  private def unifyKey(children: Seq[IndexedSeq[String]]): IndexedSeq[String] =
     children.foldLeft(FastSeq[String]()) { case (comb, k) =>
       if (k.length > comb.length) k else comb
     }
 
-  def unifyBaseType(base: BaseType, children: BaseType*): BaseType =
-    unifyBaseTypeSeq(base, children)
-
-  def unifyBaseTypeSeq(base: BaseType, _children: Seq[BaseType]): BaseType = {
+  private def unifyBaseTypeSeq(base: BaseType, _children: Seq[BaseType]): BaseType = {
     try {
       if (_children.isEmpty)
         return minimalBT(base)
@@ -290,47 +312,8 @@ object PruneDeadFields {
   def unify[T <: BaseType](base: T, children: T*): T =
     unifyBaseTypeSeq(base, children).asInstanceOf[T]
 
-  def unifySeq[T <: BaseType](base: T, children: Seq[T]): T =
+  private def unifySeq[T <: BaseType](base: T, children: Seq[T]): T =
     unifyBaseTypeSeq(base, children).asInstanceOf[T]
-
-  def unifyEnvs(envs: BindingEnv[BoxedArrayBuilder[Type]]*): BindingEnv[BoxedArrayBuilder[Type]] =
-    unifyEnvsSeq(envs)
-
-  def concatEnvs(envs: Seq[Env[BoxedArrayBuilder[Type]]]): Env[BoxedArrayBuilder[Type]] = {
-    if (envs.isEmpty)
-      Env.empty
-    else {
-      var e1 = envs.head
-      envs.iterator
-        .drop(1)
-        .foreach { e =>
-          e.m.foreach { case (k, v) =>
-            e1.lookupOption(k) match {
-              case Some(ab) => ab ++= v.result()
-              case None => e1 = e1.bind(k, v.clone())
-            }
-          }
-        }
-
-      e1
-    }
-  }
-
-  def unifyEnvsSeq(envs: Seq[BindingEnv[BoxedArrayBuilder[Type]]])
-    : BindingEnv[BoxedArrayBuilder[Type]] = {
-    val lc = envs.lengthCompare(1)
-    if (lc < 0)
-      BindingEnv.empty[BoxedArrayBuilder[Type]]
-    else if (lc == 0)
-      envs.head
-    else {
-      val evalEnv = concatEnvs(envs.map(_.eval))
-      val aggEnv = if (envs.exists(_.agg.isDefined)) Some(concatEnvs(envs.flatMap(_.agg))) else None
-      val scanEnv =
-        if (envs.exists(_.scan.isDefined)) Some(concatEnvs(envs.flatMap(_.scan))) else None
-      BindingEnv(evalEnv, aggEnv, scanEnv)
-    }
-  }
 
   def relationalTypeToEnv(bt: BaseType): BindingEnv[Type] = {
     val e = bt match {
@@ -359,16 +342,13 @@ object PruneDeadFields {
   ): Unit = {
     memo.requestedType.bind(tir, requestedType)
     tir match {
-      case TableRead(_, _, _) =>
-      case TableLiteral(_, _, _, _) =>
-      case TableParallelize(rowsAndGlobal, _) =>
-        memoizeValueIR(
-          ctx,
-          rowsAndGlobal,
-          TStruct("rows" -> TArray(requestedType.rowType), "global" -> requestedType.globalType),
-          memo,
-        )
-      case TableRange(_, _) =>
+      case _: TableRead =>
+      case _: TableLiteral =>
+      case tir: TableParallelize =>
+        val typ =
+          TStruct("rows" -> TArray(requestedType.rowType), "global" -> requestedType.globalType)
+        createTypeStatesAndMemoize(ctx, tir, 0, typ, memo)
+      case _: TableRange =>
       case TableRepartition(child, _, _) => memoizeTableIR(ctx, child, requestedType, memo)
       case TableHead(child, _) => memoizeTableIR(
           ctx,
@@ -399,16 +379,15 @@ object PruneDeadFields {
           memo,
         )
 
-      case TableGen(contexts, globals, cname, gname, body, _, _) =>
-        val bodyEnv = memoizeValueIR(ctx, body, TStream(requestedType.rowType), memo)
+      case tir: TableGen =>
+        val Seq(contextState, globalState) =
+          createTypeStatesAndMemoize(ctx, tir, 2, TStream(requestedType.rowType), memo)
         // Contexts are only used in the body so we only need to keep the fields used therein
-        val contextsElemType =
-          unifySeq(TIterable.elementType(contexts.typ), uses(cname, bodyEnv.eval))
+        val contextsElemType = contextState.newType
         // Globals are exported and used in body, so keep the union of the used fields
-        val globalsType =
-          unifySeq(globals.typ, uses(gname, bodyEnv.eval) :+ requestedType.globalType)
-        memoizeValueIR(ctx, contexts, TStream(contextsElemType), memo)
-        memoizeValueIR(ctx, globals, globalsType, memo)
+        val globalsType = globalState.union(requestedType.globalType).newType
+        createTypeStatesAndMemoize(ctx, tir, 0, TStream(contextsElemType), memo)
+        createTypeStatesAndMemoize(ctx, tir, 1, globalsType, memo)
 
       case TableJoin(left, right, _, joinKey) =>
         val lk =
@@ -547,7 +526,7 @@ object PruneDeadFields {
         )
         memoizeTableIR(ctx, child, dep, memo)
       case TableFilter(child, pred) =>
-        val irDep = memoizeAndGetDep(ctx, pred, pred.typ, child.typ, memo)
+        val irDep = memoizeAndGetDep(ctx, tir, 1, pred.typ, memo)
         memoizeTableIR(ctx, child, unify(child.typ, requestedType, irDep), memo)
       case TableKeyBy(child, _, isSorted) =>
         val reqKey = requestedType.key
@@ -607,58 +586,54 @@ object PruneDeadFields {
           globalType = requestedType.globalType,
         )
         memoizeTableIR(ctx, child, dep, memo)
-      case TableMapPartitions(child, gName, pName, body, requestedKey, _) =>
+      case TableMapPartitions(child, _, _, body, requestedKey, _) =>
         val requestedKeyStruct =
           child.typ.keyType.truncate(math.max(requestedType.key.length, requestedKey))
         val reqRowsType =
           unify(body.typ, TStream(requestedType.rowType), TStream(requestedKeyStruct))
-        val bodyDep = memoizeValueIR(ctx, body, reqRowsType, memo)
-        val depGlobalType = unifySeq(
-          child.typ.globalType,
-          uses(gName, bodyDep.eval) :+ requestedType.globalType,
-        )
-        val depRowType = unifySeq(
-          child.typ.rowType,
-          uses(pName, bodyDep.eval).map(TIterable.elementType) :+ requestedKeyStruct,
-        )
+        val Seq(globalState, partitionState) =
+          createTypeStatesAndMemoize(ctx, tir, 1, reqRowsType, memo)
+        val newGlobalType = globalState.union(requestedType.globalType).newStructType
+        val newRowType = elementType(partitionState.union(TStream(requestedKeyStruct)).newType)
         val dep = TableType(
           key = requestedKeyStruct.fieldNames,
-          rowType = depRowType.asInstanceOf[TStruct],
-          globalType = depGlobalType.asInstanceOf[TStruct],
+          rowType = newRowType.asInstanceOf[TStruct],
+          globalType = newGlobalType,
         )
         memoizeTableIR(ctx, child, dep, memo)
       case TableMapRows(child, newRow) =>
-        val (reqKey, reqRowType) = if (ContainsScan(newRow))
-          (
-            child.typ.key,
-            unify(
-              newRow.typ,
-              requestedType.rowType,
-              selectKey(newRow.typ.asInstanceOf[TStruct], child.typ.key),
-            ),
+        val (reqKey, reqRowType) = if (ContainsScan(newRow)) {
+          val reqRowType = unify(
+            newRow.typ,
+            requestedType.rowType,
+            selectKey(newRow.typ.asInstanceOf[TStruct], child.typ.key),
           )
-        else
+          (child.typ.key, reqRowType)
+        } else {
           (requestedType.key, requestedType.rowType)
-        val rowDep = memoizeAndGetDep(ctx, newRow, reqRowType, child.typ, memo)
-
+        }
+        val rowDep = memoizeAndGetDep(ctx, tir, 1, reqRowType, memo)
         val dep = TableType(
           key = reqKey,
           rowType = unify(child.typ.rowType, selectKey(child.typ.rowType, reqKey), rowDep.rowType),
           globalType = unify(child.typ.globalType, requestedType.globalType, rowDep.globalType),
         )
         memoizeTableIR(ctx, child, dep, memo)
-      case TableMapGlobals(child, newGlobals) =>
-        val globalDep = memoizeAndGetDep(ctx, newGlobals, requestedType.globalType, child.typ, memo)
+      case TableMapGlobals(child, _) =>
+        val Seq(globalState) =
+          createTypeStatesAndMemoize(ctx, tir, 1, requestedType.globalType, memo)
         memoizeTableIR(
           ctx,
           child,
-          unify(child.typ, requestedType.copy(globalType = globalDep.globalType), globalDep),
+          requestedType.copy(
+            globalType = globalState.newStructType
+          ),
           memo,
         )
       case TableAggregateByKey(child, expr) =>
         val exprRequestedType =
           requestedType.rowType.filter(f => expr.typ.asInstanceOf[TStruct].hasField(f.name))._1
-        val aggDep = memoizeAndGetDep(ctx, expr, exprRequestedType, child.typ, memo)
+        val aggDep = memoizeAndGetDep(ctx, tir, 1, exprRequestedType, memo)
         memoizeTableIR(
           ctx,
           child,
@@ -670,9 +645,9 @@ object PruneDeadFields {
           ),
           memo,
         )
-      case TableKeyByAndAggregate(child, expr, newKey, _, _) =>
-        val keyDep = memoizeAndGetDep(ctx, newKey, newKey.typ, child.typ, memo)
-        val exprDep = memoizeAndGetDep(ctx, expr, requestedType.valueType, child.typ, memo)
+      case TableKeyByAndAggregate(child, _, newKey, _, _) =>
+        val keyDep = memoizeAndGetDep(ctx, tir, 2, newKey.typ, memo)
+        val exprDep = memoizeAndGetDep(ctx, tir, 1, requestedType.valueType, memo)
         memoizeTableIR(
           ctx,
           child,
@@ -805,13 +780,13 @@ object PruneDeadFields {
     memo.requestedType.bind(mir, requestedType)
     mir match {
       case MatrixFilterCols(child, pred) =>
-        val irDep = memoizeAndGetDep(ctx, pred, pred.typ, child.typ, memo)
+        val irDep = memoizeValueIRColBindings(ctx, mir, 1, pred.typ, memo)
         memoizeMatrixIR(ctx, child, unify(child.typ, requestedType, irDep), memo)
       case MatrixFilterRows(child, pred) =>
-        val irDep = memoizeAndGetDep(ctx, pred, pred.typ, child.typ, memo)
+        val irDep = memoizeValueIRRowBindings(ctx, mir, 1, pred.typ, memo)
         memoizeMatrixIR(ctx, child, unify(child.typ, requestedType, irDep), memo)
       case MatrixFilterEntries(child, pred) =>
-        val irDep = memoizeAndGetDep(ctx, pred, pred.typ, child.typ, memo)
+        val irDep = memoizeValueIREntryBindings(ctx, mir, 1, pred.typ, memo)
         memoizeMatrixIR(ctx, child, unify(child.typ, requestedType, irDep), memo)
       case MatrixUnionCols(left, right, _) =>
         val leftRequestedType = requestedType.copy(
@@ -833,8 +808,8 @@ object PruneDeadFields {
         )
         memoizeMatrixIR(ctx, left, leftRequestedType, memo)
         memoizeMatrixIR(ctx, right, rightRequestedType, memo)
-      case MatrixMapEntries(child, newEntries) =>
-        val irDep = memoizeAndGetDep(ctx, newEntries, requestedType.entryType, child.typ, memo)
+      case MatrixMapEntries(child, _) =>
+        val irDep = memoizeValueIREntryBindings(ctx, mir, 1, requestedType.entryType, memo)
         val depMod = requestedType.copy(entryType = TStruct.empty)
         memoizeMatrixIR(ctx, child, unify(child.typ, depMod, irDep), memo)
       case MatrixKeyRowsBy(child, _, isSorted) =>
@@ -872,12 +847,12 @@ object PruneDeadFields {
         else
           (requestedType.rowKey, requestedType.rowType)
 
-        val irDep = memoizeAndGetDep(ctx, newRow, reqRowType, child.typ, memo)
+        val irDep = memoizeValueIREntryBindings(ctx, mir, 1, reqRowType, memo)
         val depMod =
           requestedType.copy(rowType = selectKey(child.typ.rowType, reqKey), rowKey = reqKey)
         memoizeMatrixIR(ctx, child, unify(child.typ, depMod, irDep), memo)
-      case MatrixMapCols(child, newCol, newKey) =>
-        val irDep = memoizeAndGetDep(ctx, newCol, requestedType.colType, child.typ, memo)
+      case MatrixMapCols(child, _, newKey) =>
+        val irDep = memoizeValueIREntryBindings(ctx, mir, 1, requestedType.colType, memo)
         val reqKey = newKey match {
           case Some(_) => FastSeq()
           case None => requestedType.colKey
@@ -885,12 +860,13 @@ object PruneDeadFields {
         val depMod =
           requestedType.copy(colType = selectKey(child.typ.colType, reqKey), colKey = reqKey)
         memoizeMatrixIR(ctx, child, unify(child.typ, depMod, irDep), memo)
-      case MatrixMapGlobals(child, newGlobals) =>
-        val irDep = memoizeAndGetDep(ctx, newGlobals, requestedType.globalType, child.typ, memo)
+      case MatrixMapGlobals(child, _) =>
+        val Seq(globalState) =
+          createTypeStatesAndMemoize(ctx, mir, 1, requestedType.globalType, memo)
         memoizeMatrixIR(
           ctx,
           child,
-          unify(child.typ, requestedType.copy(globalType = irDep.globalType), irDep),
+          unify(child.typ, requestedType.copy(globalType = globalState.newStructType)),
           memo,
         )
       case MatrixRead(_, _, _, _) =>
@@ -918,50 +894,44 @@ object PruneDeadFields {
           )),
         )
         memoizeMatrixIR(ctx, child, explodedDep, memo)
-      case MatrixAggregateRowsByKey(child, entryExpr, rowExpr) =>
-        val irDepEntry = memoizeAndGetDep(ctx, entryExpr, requestedType.entryType, child.typ, memo)
-        val irDepRow = memoizeAndGetDep(ctx, rowExpr, requestedType.rowValueStruct, child.typ, memo)
+      case MatrixAggregateRowsByKey(child, _, _) =>
+        val Seq(entryGlobalState, entryColState, entryRowState, entryEntryState) =
+          createTypeStatesAndMemoize(ctx, mir, 1, requestedType.entryType, memo)
+        val Seq(rowGlobalState, rowRowState) =
+          createTypeStatesAndMemoize(ctx, mir, 2, requestedType.rowValueStruct, memo)
         val childDep = MatrixType(
           rowKey = child.typ.rowKey,
           colKey = requestedType.colKey,
-          entryType = irDepEntry.entryType,
-          rowType = unify(
-            child.typ.rowType,
-            selectKey(child.typ.rowType, child.typ.rowKey),
-            irDepRow.rowType,
-            irDepEntry.rowType,
-          ),
-          colType =
-            unify(child.typ.colType, requestedType.colType, irDepEntry.colType, irDepRow.colType),
-          globalType = unify(
-            child.typ.globalType,
-            requestedType.globalType,
-            irDepEntry.globalType,
-            irDepRow.globalType,
-          ),
+          entryType = entryEntryState.newStructType,
+          rowType = rowRowState
+            .union(entryRowState.newType)
+            .requireFields(child.typ.rowKey)
+            .newStructType,
+          colType = entryColState.union(requestedType.colType).newStructType,
+          globalType = rowGlobalState
+            .union(entryGlobalState.newType)
+            .union(requestedType.globalType)
+            .newStructType,
         )
         memoizeMatrixIR(ctx, child, childDep, memo)
-      case MatrixAggregateColsByKey(child, entryExpr, colExpr) =>
-        val irDepEntry = memoizeAndGetDep(ctx, entryExpr, requestedType.entryType, child.typ, memo)
-        val irDepCol = memoizeAndGetDep(ctx, colExpr, requestedType.colValueStruct, child.typ, memo)
+      case MatrixAggregateColsByKey(child, _, _) =>
+        val Seq(entryGlobalState, entryColState, entryRowState, entryEntryState) =
+          createTypeStatesAndMemoize(ctx, mir, 1, requestedType.entryType, memo)
+        val Seq(colGlobalState, colColState) =
+          createTypeStatesAndMemoize(ctx, mir, 2, requestedType.colValueStruct, memo)
         val childDep: MatrixType = MatrixType(
           rowKey = requestedType.rowKey,
           colKey = child.typ.colKey,
-          colType = unify(
-            child.typ.colType,
-            irDepCol.colType,
-            irDepEntry.colType,
-            selectKey(child.typ.colType, child.typ.colKey),
-          ),
-          globalType = unify(
-            child.typ.globalType,
-            requestedType.globalType,
-            irDepEntry.globalType,
-            irDepCol.globalType,
-          ),
-          rowType =
-            unify(child.typ.rowType, irDepEntry.rowType, irDepCol.rowType, requestedType.rowType),
-          entryType = irDepEntry.entryType,
+          colType = entryColState
+            .union(colColState.newType)
+            .requireFields(child.typ.colKey)
+            .newStructType,
+          globalType = entryGlobalState
+            .union(colGlobalState.newType)
+            .union(requestedType.globalType)
+            .newStructType,
+          rowType = entryRowState.union(requestedType.rowType).newStructType,
+          entryType = entryEntryState.newStructType,
         )
         memoizeMatrixIR(ctx, child, childDep, memo)
       case MatrixAnnotateRowsTable(child, table, root, product) =>
@@ -1040,7 +1010,7 @@ object PruneDeadFields {
         val dep = requestedType.copy(rowType =
           unify(
             child.typ.rowType,
-            requestedType.rowType.insert(prunedPreExlosionFieldType, path)._1.asInstanceOf[TStruct],
+            requestedType.rowType.insert(prunedPreExlosionFieldType, path)._1,
           )
         )
         memoizeMatrixIR(ctx, child, dep, memo)
@@ -1061,7 +1031,7 @@ object PruneDeadFields {
         val dep = requestedType.copy(colType =
           unify(
             child.typ.colType,
-            requestedType.colType.insert(prunedPreExplosionFieldType, path)._1.asInstanceOf[TStruct],
+            requestedType.colType.insert(prunedPreExplosionFieldType, path)._1,
           )
         )
         memoizeMatrixIR(ctx, child, dep, memo)
@@ -1158,7 +1128,7 @@ object PruneDeadFields {
     }
   }
 
-  def memoizeBlockMatrixIR(
+  private def memoizeBlockMatrixIR(
     ctx: ExecuteContext,
     bmir: BlockMatrixIR,
     requestedType: BlockMatrixType,
@@ -1171,81 +1141,46 @@ object PruneDeadFields {
         val usages = memo.relationalRefs.get(name).map(_.result()).getOrElse(Array())
         memoizeValueIR(ctx, value, unifySeq(value.typ, usages), memo)
       case _ =>
-        bmir.children.foreach {
-          case mir: MatrixIR => memoizeMatrixIR(ctx, mir, mir.typ, memo)
-          case tir: TableIR => memoizeTableIR(ctx, tir, tir.typ, memo)
-          case bmir: BlockMatrixIR => memoizeBlockMatrixIR(ctx, bmir, bmir.typ, memo)
-          case ir: IR => memoizeValueIR(ctx, ir, ir.typ, memo)
+        bmir.children.zipWithIndex.foreach {
+          case (mir: MatrixIR, _) => memoizeMatrixIR(ctx, mir, mir.typ, memo)
+          case (tir: TableIR, _) => memoizeTableIR(ctx, tir, tir.typ, memo)
+          case (bmir: BlockMatrixIR, _) => memoizeBlockMatrixIR(ctx, bmir, bmir.typ, memo)
+          case (ir: IR, i) => createTypeStatesAndMemoize(ctx, bmir, i, ir.typ, memo)
         }
     }
   }
 
-  def memoizeAndGetDep(
+  private def memoizeAndGetDep(
     ctx: ExecuteContext,
-    ir: IR,
+    ir: TableIR,
+    childIdx: Int,
     requestedType: Type,
-    base: TableType,
     memo: ComputeMutableState,
   ): TableType = {
-    val depEnv = memoizeValueIR(ctx, ir, requestedType, memo)
-    val depEnvUnified = concatEnvs(FastSeq(depEnv.eval) ++ FastSeq(depEnv.agg, depEnv.scan).flatten)
-
-    val expectedBindingSet = Set(TableIR.rowName, TableIR.globalName)
-    depEnvUnified.m.keys.foreach { k =>
-      if (!expectedBindingSet.contains(k))
-        throw new RuntimeException(s"found unexpected free variable in pruning: $k\n" +
-          s"  ${depEnv.pretty(_.result().mkString(","))}\n" +
-          s"  ${Pretty(ctx, ir)}")
-    }
-
-    val min = minimal(base)
-    val rowType = unifySeq(base.rowType, Array(min.rowType) ++ uses(TableIR.rowName, depEnvUnified))
-    val globalType =
-      unifySeq(base.globalType, Array(min.globalType) ++ uses(TableIR.globalName, depEnvUnified))
+    val Seq(globalState, rowState) =
+      createTypeStatesAndMemoize(ctx, ir, childIdx, requestedType, memo)
+    val rowType = rowState.newStructType
+    val globalType = globalState.newStructType
     TableType(
       key = FastSeq(),
-      rowType = rowType.asInstanceOf[TStruct],
-      globalType = globalType.asInstanceOf[TStruct],
+      rowType = rowType,
+      globalType = globalType,
     )
   }
 
-  /** Return the minimal super-type of `base` containing all fields referred to by `ir`. Also
-    * memoizes minimal types for `ir` and descendants
-    */
-  def memoizeAndGetDep(
+  private def memoizeValueIREntryBindings(
     ctx: ExecuteContext,
-    ir: IR,
+    ir: MatrixIR,
+    childIdx: Int,
     requestedType: Type,
-    base: MatrixType,
     memo: ComputeMutableState,
   ): MatrixType = {
-    val depEnv = memoizeValueIR(ctx, ir, requestedType, memo)
-    val depEnvUnified = concatEnvs(FastSeq(depEnv.eval) ++ FastSeq(depEnv.agg, depEnv.scan).flatten)
+    val bindings = createTypeStatesAndMemoize(ctx, ir, childIdx, requestedType, memo)
 
-    val expectedBindingSet = Set(
-      MatrixIR.rowName,
-      MatrixIR.colName,
-      MatrixIR.entryName,
-      MatrixIR.globalName,
-      Name("n_rows"),
-      Name("n_cols"),
-    )
-    depEnvUnified.m.keys.foreach { k =>
-      if (!expectedBindingSet.contains(k))
-        throw new RuntimeException(
-          s"found unexpected free variable in pruning: $k\n  ${Pretty(ctx, ir)}"
-        )
-    }
-
-    val globalType =
-      unifySeq(base.globalType, uses(MatrixIR.globalName, depEnvUnified))
-        .asInstanceOf[TStruct]
-    val rowType = unifySeq(base.rowType, uses(MatrixIR.rowName, depEnvUnified))
-      .asInstanceOf[TStruct]
-    val colType = unifySeq(base.colType, uses(MatrixIR.colName, depEnvUnified))
-      .asInstanceOf[TStruct]
-    val entryType = unifySeq(base.entryType, uses(MatrixIR.entryName, depEnvUnified))
-      .asInstanceOf[TStruct]
+    val globalType = bindings(0).newStructType
+    val colType = bindings(1).newStructType
+    val rowType = bindings(2).newStructType
+    val entryType = bindings(3).newStructType
 
     if (rowType.hasField(MatrixType.entriesIdentifier))
       throw new RuntimeException(
@@ -1262,6 +1197,82 @@ object PruneDeadFields {
     )
   }
 
+  private def memoizeValueIRRowBindings(
+    ctx: ExecuteContext,
+    ir: MatrixIR,
+    childIdx: Int,
+    requestedType: Type,
+    memo: ComputeMutableState,
+  ): MatrixType = {
+    val bindings = createTypeStatesAndMemoize(ctx, ir, childIdx, requestedType, memo)
+    val globalType = bindings(0).newStructType
+    val rowType = bindings(1).newStructType
+    MatrixType(
+      rowKey = FastSeq(),
+      colKey = FastSeq(),
+      globalType = globalType,
+      colType = TStruct.empty,
+      rowType = rowType,
+      entryType = TStruct.empty,
+    )
+  }
+
+  private def memoizeValueIRColBindings(
+    ctx: ExecuteContext,
+    ir: MatrixIR,
+    childIdx: Int,
+    requestedType: Type,
+    memo: ComputeMutableState,
+  ): MatrixType = {
+    val bindings = createTypeStatesAndMemoize(ctx, ir, childIdx, requestedType, memo)
+    val globalType = bindings(0).newStructType
+    val colType = bindings(1).newStructType
+    MatrixType(
+      rowKey = FastSeq(),
+      colKey = FastSeq(),
+      globalType = globalType,
+      colType = colType,
+      rowType = TStruct.empty,
+      entryType = TStruct.empty,
+    )
+  }
+
+  private def createTypeStatesAndMemoize(
+    ctx: ExecuteContext,
+    ir: BaseIR,
+    childIdx: Int,
+    requestedType: Type,
+    memo: ComputeMutableState,
+  ): IndexedSeq[TypeState] =
+    createTypeStatesAndMemoize(
+      ctx,
+      ir,
+      childIdx,
+      requestedType,
+      memo,
+      BindingEnv.empty.createAgg.createScan,
+    )
+
+  private def createTypeStatesAndMemoize(
+    ctx: ExecuteContext,
+    ir: BaseIR,
+    childIdx: Int,
+    requestedType: Type,
+    memo: ComputeMutableState,
+    env: BindingEnv[TypeState],
+  ): IndexedSeq[TypeState] = {
+    val bindings = Bindings.get(ir, childIdx)
+    val bindingsStates = bindings.map((_, typ) => TypeState(typ))
+    memoizeValueIR(
+      ctx,
+      ir.getChild(childIdx).asInstanceOf[IR],
+      requestedType,
+      memo,
+      env.extend(bindingsStates),
+    )
+    bindingsStates.all.map(_._2)
+  }
+
   /** This function does *not* necessarily bind each child node in `memo`. Known dead code is not
     * memoized. For instance:
     *
@@ -1276,112 +1287,132 @@ object PruneDeadFields {
     ir: IR,
     requestedType: Type,
     memo: ComputeMutableState,
-  ): BindingEnv[BoxedArrayBuilder[Type]] = {
+    env: BindingEnv[TypeState] = BindingEnv.empty.createAgg.createScan,
+  ): Unit = {
+    def recurMax(ir: IR, childIdx: Int): IndexedSeq[TypeState] =
+      recur(ir, childIdx, ir.getChild(childIdx).asInstanceOf[IR].typ)
+
+    def recurMin(ir: IR, childIdx: Int): IndexedSeq[TypeState] =
+      recur(ir, childIdx, minimal(ir.getChild(childIdx).asInstanceOf[IR].typ))
+
+    def recur(ir: IR, childIdx: Int, requestedType: Type): IndexedSeq[TypeState] =
+      createTypeStatesAndMemoize(ctx, ir, childIdx, requestedType, memo, env)
+
+    def recurMaxWithTypeStates(ir: IR, childIdx: Int, bindingsMap: mutable.Map[Name, TypeState])
+      : Unit =
+      recurWithTypeStates(ir, childIdx, ir.getChild(childIdx).asInstanceOf[IR].typ, bindingsMap)
+
+    def recurWithTypeStates(
+      ir: IR,
+      childIdx: Int,
+      requestedType: Type,
+      bindingsMap: mutable.Map[Name, TypeState],
+    ): Unit = {
+      val bindings = Bindings.get(ir, childIdx).map { (name, typ) =>
+        val state = bindingsMap.getOrElseUpdate(name, TypeState(typ))
+        assert(typ == state.origType)
+        state
+      }
+      memoizeValueIR(
+        ctx,
+        ir.getChild(childIdx).asInstanceOf[IR],
+        requestedType,
+        memo,
+        env.extend(bindings),
+      )
+    }
+
     memo.requestedType.bind(ir, requestedType)
     ir match {
-      case IsNA(value) => memoizeValueIR(ctx, value, minimal(value.typ), memo)
+      case ir: IsNA =>
+        recurMin(ir, 0)
+
       case CastRename(v, _typ) =>
-        def recur(reqType: Type, castType: Type, baseType: Type): Type = {
+        def loop(reqType: Type, castType: Type, baseType: Type): Type = {
           ((reqType, castType, baseType): @unchecked) match {
             case (TStruct(reqFields), cast: TStruct, base: TStruct) =>
               TStruct(reqFields.map { f =>
                 val idx = cast.fieldIdx(f.name)
-                Field(base.fieldNames(idx), recur(f.typ, cast.types(idx), base.types(idx)), f.index)
+                Field(base.fieldNames(idx), loop(f.typ, cast.types(idx), base.types(idx)), f.index)
               })
             case (TTuple(req), TTuple(cast), TTuple(base)) =>
               assert(base.length == cast.length)
               val castFields = cast.map(f => f.index -> f.typ).toMap
               val baseFields = base.map(f => f.index -> f.typ).toMap
               TTuple(req.map { f =>
-                TupleField(f.index, recur(f.typ, castFields(f.index), baseFields(f.index)))
+                TupleField(f.index, loop(f.typ, castFields(f.index), baseFields(f.index)))
               })
             case (TArray(req), TArray(cast), TArray(base)) =>
-              TArray(recur(req, cast, base))
+              TArray(loop(req, cast, base))
             case (TSet(req), TSet(cast), TSet(base)) =>
-              TSet(recur(req, cast, base))
+              TSet(loop(req, cast, base))
             case (TDict(reqK, reqV), TDict(castK, castV), TDict(baseK, baseV)) =>
-              TDict(recur(reqK, castK, baseK), recur(reqV, castV, baseV))
+              TDict(loop(reqK, castK, baseK), loop(reqV, castV, baseV))
             case (TInterval(req), TInterval(cast), TInterval(base)) =>
-              TInterval(recur(req, cast, base))
+              TInterval(loop(req, cast, base))
             case _ => reqType
           }
         }
 
-        memoizeValueIR(ctx, v, recur(requestedType, _typ, v.typ), memo)
-      case If(cond, cnsq, alt) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, cond, cond.typ, memo),
-          memoizeValueIR(ctx, cnsq, requestedType, memo),
-          memoizeValueIR(ctx, alt, requestedType, memo),
-        )
-      case Switch(x, default, cases) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, x, x.typ, memo),
-          memoizeValueIR(ctx, default, requestedType, memo),
-          unifyEnvsSeq(cases.map(case_ => memoizeValueIR(ctx, case_, requestedType, memo))),
-        )
-      case Coalesce(values) => unifyEnvsSeq(values.map(memoizeValueIR(ctx, _, requestedType, memo)))
-      case Consume(value) => memoizeValueIR(ctx, value, value.typ, memo)
-      case Block(bindings, body) =>
-        val bodyEnv = memoizeValueIR(ctx, body, requestedType, memo)
-        bindings.foldRight(bodyEnv) {
-          case (Binding(name, value, Scope.EVAL), bodyEnv) =>
-            val valueType = unifySeq(value.typ, uses(name, bodyEnv.eval))
-            unifyEnvs(
-              bodyEnv.deleteEval(name),
-              memoizeValueIR(ctx, value, valueType, memo),
-            )
-          case (Binding(name, value, Scope.SCAN), bodyEnv) =>
-            val valueType = unifySeq(value.typ, uses(name, bodyEnv.scanOrEmpty))
-            val valueEnv = memoizeValueIR(ctx, value, valueType, memo)
-            unifyEnvs(
-              bodyEnv.copy(scan = bodyEnv.scan.map(_.delete(name))),
-              valueEnv.copy(eval = Env.empty, scan = Some(valueEnv.eval)),
-            )
-          case (Binding(name, value, Scope.AGG), bodyEnv) =>
-            val valueType = unifySeq(value.typ, uses(name, bodyEnv.aggOrEmpty))
-            val valueEnv = memoizeValueIR(ctx, value, valueType, memo)
-            unifyEnvs(
-              bodyEnv.copy(agg = bodyEnv.agg.map(_.delete(name))),
-              valueEnv.copy(eval = Env.empty, agg = Some(valueEnv.eval)),
-            )
-        }
+        recur(ir, 0, loop(requestedType, _typ, v.typ))
+
+      case ir: If =>
+        recurMax(ir, 0)
+        recur(ir, 1, requestedType)
+        recur(ir, 2, requestedType)
+
+      case Switch(_, _, cases) =>
+        recurMax(ir, 0)
+        recur(ir, 1, requestedType)
+        cases.indices.foreach(i => recur(ir, i + 2, requestedType))
+
+      case Coalesce(values) =>
+        values.indices.foreach(recur(ir, _, requestedType))
+
+      case Consume(_) =>
+        recurMax(ir, 0)
+
+      case Block(bindings, _) =>
+        val typeStates = mutable.AnyRefMap.empty[Name, TypeState]
+        recurWithTypeStates(ir, bindings.length, requestedType, typeStates)
+        for (i <- bindings.indices.reverse)
+          recurWithTypeStates(ir, i, typeStates(bindings(i).name).newType, typeStates)
+
       case Ref(name, _) =>
-        val ab = new BoxedArrayBuilder[Type]()
-        ab += requestedType
-        BindingEnv.empty.bindEval(name -> ab)
-      case RelationalLet(name, value, body) =>
-        val e = memoizeValueIR(ctx, body, requestedType, memo)
+//        env.eval.lookupOption(name).foreach(_.union(requestedType))
+        env.eval(name).union(requestedType)
+
+      case RelationalLet(name, value, _) =>
+        recur(ir, 1, requestedType)
         val usages = memo.relationalRefs.get(name).map(_.result()).getOrElse(Array())
-        memoizeValueIR(ctx, value, unifySeq(value.typ, usages), memo)
-        e
+        recur(ir, 0, unifySeq(value.typ, usages))
+
       case RelationalRef(name, _) =>
         memo.relationalRefs.getOrElseUpdate(name, new BoxedArrayBuilder[Type]) += requestedType
-        BindingEnv.empty
+
       case MakeArray(args, _) =>
         val eltType = TIterable.elementType(requestedType)
-        unifyEnvsSeq(args.map(a => memoizeValueIR(ctx, a, eltType, memo)))
+        args.indices.foreach(recur(ir, _, eltType))
+
       case MakeStream(args, _, _) =>
         val eltType = TIterable.elementType(requestedType)
-        unifyEnvsSeq(args.map(a => memoizeValueIR(ctx, a, eltType, memo)))
-      case ArrayRef(a, i, s) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, a, TArray(requestedType), memo),
-          memoizeValueIR(ctx, i, i.typ, memo),
-          memoizeValueIR(ctx, s, s.typ, memo),
-        )
-      case ArrayLen(a) =>
-        memoizeValueIR(ctx, a, minimal(a.typ), memo)
-      case StreamTake(a, len) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, a, requestedType, memo),
-          memoizeValueIR(ctx, len, len.typ, memo),
-        )
-      case StreamDrop(a, len) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, a, requestedType, memo),
-          memoizeValueIR(ctx, len, len.typ, memo),
-        )
+        args.indices.foreach(recur(ir, _, eltType))
+
+      case ir: ArrayRef =>
+        recur(ir, 0, TArray(requestedType))
+        recurMax(ir, 1)
+
+      case ir: ArrayLen =>
+        recurMin(ir, 0)
+
+      case ir: StreamTake =>
+        recur(ir, 0, requestedType)
+        recurMax(ir, 1)
+
+      case ir: StreamDrop =>
+        recur(ir, 0, requestedType)
+        recurMax(ir, 1)
+
       case StreamWhiten(a, newChunk, prevWindow, _, _, _, _, _) =>
         val matType = TNDArray(TFloat64, Nat(2))
         val unifiedStructType = unify(
@@ -1389,399 +1420,215 @@ object PruneDeadFields {
           requestedType.asInstanceOf[TStream].elementType,
           TStruct((newChunk, matType), (prevWindow, matType)),
         )
-        unifyEnvs(
-          memoizeValueIR(ctx, a, TStream(unifiedStructType), memo)
-        )
-      case StreamMap(a, name, body) =>
-        val bodyEnv = memoizeValueIR(ctx, body, TIterable.elementType(requestedType), memo)
-        val valueType = unifySeq(TIterable.elementType(a.typ), uses(name, bodyEnv.eval))
-        unifyEnvs(
-          bodyEnv.deleteEval(name),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
-      case StreamGrouped(a, size) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, a, TIterable.elementType(requestedType), memo),
-          memoizeValueIR(ctx, size, size.typ, memo),
-        )
+        recur(ir, 0, TStream(unifiedStructType))
+
+      case ir: StreamMap =>
+        val Seq(eltState) = recur(ir, 1, TIterable.elementType(requestedType))
+        recur(ir, 0, TStream(eltState.newType))
+
+      case ir: StreamGrouped =>
+        recur(ir, 0, TIterable.elementType(requestedType))
+        recurMax(ir, 1)
+
       case StreamGroupByKey(a, key, _) =>
         val reqStructT = tcoerce[TStruct](
           tcoerce[TStream](tcoerce[TStream](requestedType).elementType).elementType
         )
         val origStructT = tcoerce[TStruct](tcoerce[TStream](a.typ).elementType)
-        memoizeValueIR(
-          ctx,
-          a,
+        recur(
+          ir,
+          0,
           TStream(unify(origStructT, reqStructT, selectKey(origStructT, key))),
-          memo,
         )
-      case StreamZip(as, names, body, behavior, _) =>
-        val bodyEnv = memoizeValueIR(ctx, body, TIterable.elementType(requestedType), memo)
-        val valueTypes = (names, as).zipped.map { (name, a) =>
-          bodyEnv.eval.lookupOption(name).map(ab =>
-            unifySeq(tcoerce[TStream](a.typ).elementType, ab.result())
-          )
-        }
-        if (behavior == ArrayZipBehavior.AssumeSameLength && valueTypes.forall(_.isEmpty)) {
-          unifyEnvs(memoizeValueIR(
-            ctx,
-            as.head,
-            TStream(minimal(tcoerce[TStream](as.head.typ).elementType)),
-            memo,
-          ) +:
-            Array(bodyEnv.deleteEval(names)): _*)
+
+      case StreamZip(as, _, _, behavior, _) =>
+        val bodyBindings = recur(ir, as.length, TIterable.elementType(requestedType))
+        if (behavior == ArrayZipBehavior.AssumeSameLength && bodyBindings.forall(_.isUndefined)) {
+          recurMin(ir, 0)
         } else {
-          unifyEnvs(
-            (as, valueTypes).zipped.map { (a, vtOption) =>
-              val at = tcoerce[TStream](a.typ)
-              if (behavior == ArrayZipBehavior.AssumeSameLength) {
-                vtOption.map(vt => memoizeValueIR(ctx, a, TStream(vt), memo)).getOrElse(
-                  BindingEnv.empty
-                )
-              } else
-                memoizeValueIR(ctx, a, TStream(vtOption.getOrElse(minimal(at.elementType))), memo)
-            } ++ Array(bodyEnv.deleteEval(names)): _*
-          )
+          as.indices.map { i =>
+            val state = bodyBindings(i)
+            if (behavior != ArrayZipBehavior.AssumeSameLength || !state.isUndefined)
+              recur(ir, i, TStream(state.newType))
+          }
         }
-      case StreamZipJoin(as, key, _, curVals, joinF) =>
-        val eltType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
+
+      case StreamZipJoin(as, key, _, _, _) =>
         val requestedEltType = tcoerce[TStream](requestedType).elementType
-        val bodyEnv = memoizeValueIR(ctx, joinF, requestedEltType, memo)
-        val childRequestedEltType = unifySeq(
-          eltType,
-          uses(curVals, bodyEnv.eval).map(TIterable.elementType) :+ selectKey(eltType, key),
-        )
-        unifyEnvsSeq(as.map(memoizeValueIR(ctx, _, TStream(childRequestedEltType), memo)))
-      case StreamZipJoinProducers(contexts, ctxName, makeProducer, key, _, curVals, joinF) =>
-        val baseEltType = tcoerce[TStruct](TIterable.elementType(makeProducer.typ))
+        val Seq(_, valsState) = recur(ir, as.length, requestedEltType)
+        val childRequestedEltType = elementType(valsState.requireFieldsInElt(key).newType)
+        as.indices.foreach(recur(ir, _, TStream(childRequestedEltType)))
+
+      case StreamZipJoinProducers(_, _, _, key, _, _, _) =>
         val requestedEltType = tcoerce[TStream](requestedType).elementType
-        val bodyEnv = memoizeValueIR(ctx, joinF, requestedEltType, memo)
-        val producerRequestedEltType = unifySeq(
-          baseEltType,
-          uses(curVals, bodyEnv.eval).map(TIterable.elementType) :+ selectKey(baseEltType, key),
-        )
-        val producerEnv = memoizeValueIR(ctx, makeProducer, TStream(producerRequestedEltType), memo)
-        val ctxEnv = memoizeValueIR(
-          ctx,
-          contexts,
-          TArray(unifySeq(TIterable.elementType(contexts.typ), uses(ctxName, producerEnv.eval))),
-          memo,
-        )
-        unifyEnvsSeq(Array(bodyEnv, producerEnv, ctxEnv))
+        val Seq(_, valsState) = recur(ir, 2, requestedEltType)
+        val producerRequestedEltType = elementType(valsState.requireFieldsInElt(key).newType)
+        val Seq(ctxState) = recur(ir, 1, TStream(producerRequestedEltType))
+        recur(ir, 0, TArray(ctxState.newType))
+
       case StreamMultiMerge(as, key) =>
         val eltType = tcoerce[TStruct](tcoerce[TStream](as.head.typ).elementType)
         val requestedEltType = tcoerce[TStream](requestedType).elementType
         val childRequestedEltType = unify(eltType, requestedEltType, selectKey(eltType, key))
-        unifyEnvsSeq(as.map(memoizeValueIR(ctx, _, TStream(childRequestedEltType), memo)))
-      case StreamFilter(a, name, cond) =>
-        val bodyEnv = memoizeValueIR(ctx, cond, cond.typ, memo)
-        val valueType = unifySeq(
-          TIterable.elementType(a.typ),
-          FastSeq(TIterable.elementType(requestedType)) ++ uses(name, bodyEnv.eval),
-        )
-        unifyEnvs(
-          bodyEnv.deleteEval(name),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
-      case StreamTakeWhile(a, name, cond) =>
-        val bodyEnv = memoizeValueIR(ctx, cond, cond.typ, memo)
-        val valueType = unifySeq(
-          TIterable.elementType(a.typ),
-          FastSeq(TIterable.elementType(requestedType)) ++ uses(name, bodyEnv.eval),
-        )
-        unifyEnvs(
-          bodyEnv.deleteEval(name),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
-      case StreamDropWhile(a, name, cond) =>
-        val bodyEnv = memoizeValueIR(ctx, cond, cond.typ, memo)
-        val valueType = unifySeq(
-          TIterable.elementType(a.typ),
-          FastSeq(TIterable.elementType(requestedType)) ++ uses(name, bodyEnv.eval),
-        )
-        unifyEnvs(
-          bodyEnv.deleteEval(name),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
-      case StreamFlatMap(a, name, body) =>
-        val bodyEnv = memoizeValueIR(ctx, body, requestedType, memo)
-        val valueType = unifySeq(TIterable.elementType(a.typ), uses(name, bodyEnv.eval))
-        unifyEnvs(
-          bodyEnv.deleteEval(name),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
-      case StreamFold(a, zero, accumName, valueName, body) =>
-        val zeroEnv = memoizeValueIR(ctx, zero, zero.typ, memo)
-        val bodyEnv = memoizeValueIR(ctx, body, body.typ, memo)
-        val valueType = unifySeq(TIterable.elementType(a.typ), uses(valueName, bodyEnv.eval))
+        as.indices.foreach(recur(ir, _, TStream(childRequestedEltType)))
 
-        unifyEnvs(
-          zeroEnv,
-          bodyEnv.deleteEval(valueName).deleteEval(accumName),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
-      case StreamFold2(a, accum, valueName, seq, res) =>
-        val zeroEnvs = accum.map { case (_, zval) => memoizeValueIR(ctx, zval, zval.typ, memo) }
-        val seqEnvs = seq.map(seq => memoizeValueIR(ctx, seq, seq.typ, memo))
-        val resEnv = memoizeValueIR(ctx, res, requestedType, memo)
-        val valueType = unifySeq(
-          TIterable.elementType(a.typ),
-          uses(valueName, resEnv.eval) ++ seqEnvs.flatMap(e => uses(valueName, e.eval)),
-        )
+      case StreamFilter(_, _, _) =>
+        val Seq(eltState) = recurMax(ir, 1)
+        val valueType = eltState.union(TIterable.elementType(requestedType)).newType
+        recur(ir, 0, TStream(valueType))
 
-        val accumNames = accum.map(_._1)
-        val seqNames = accumNames ++ Array(valueName)
-        unifyEnvsSeq(
-          zeroEnvs
-            ++ Array(resEnv.copy(eval = resEnv.eval.delete(accumNames)))
-            ++ seqEnvs.map(e => e.copy(eval = e.eval.delete(seqNames)))
-            ++ Array(memoizeValueIR(ctx, a, TStream(valueType), memo))
-        )
-      case StreamScan(a, zero, accumName, valueName, body) =>
-        val zeroEnv = memoizeValueIR(ctx, zero, zero.typ, memo)
-        val bodyEnv = memoizeValueIR(ctx, body, body.typ, memo)
-        val valueType = unifySeq(TIterable.elementType(a.typ), uses(valueName, bodyEnv.eval))
-        unifyEnvs(
-          zeroEnv,
-          bodyEnv.deleteEval(valueName).deleteEval(accumName),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
+      case StreamTakeWhile(_, _, _) =>
+        val Seq(eltState) = recurMax(ir, 1)
+        val valueType = eltState.union(TIterable.elementType(requestedType)).newType
+        recur(ir, 0, TStream(valueType))
 
-      case StreamJoinRightDistinct(left, right, lKey, rKey, l, r, join, _) =>
-        val lElemType = TIterable.elementType(left.typ).asInstanceOf[TStruct]
-        val rElemType = TIterable.elementType(right.typ).asInstanceOf[TStruct]
+      case StreamDropWhile(_, _, _) =>
+        val Seq(eltState) = recurMax(ir, 1)
+        val valueType = eltState.union(TIterable.elementType(requestedType)).newType
+        recur(ir, 0, TStream(valueType))
 
-        val joinEnv = memoizeValueIR(ctx, join, TIterable.elementType(requestedType), memo)
-        val lRequested = unifySeq(lElemType, uses(l, joinEnv.eval) :+ selectKey(lElemType, lKey))
-        val rRequested = unifySeq(rElemType, uses(r, joinEnv.eval) :+ selectKey(rElemType, rKey))
+      case StreamFlatMap(_, _, _) =>
+        val Seq(eltState) = recur(ir, 1, requestedType)
+        recur(ir, 0, TStream(eltState.newType))
 
-        unifyEnvs(
-          joinEnv.deleteEval(l).deleteEval(r),
-          memoizeValueIR(ctx, left, TStream(lRequested), memo),
-          memoizeValueIR(ctx, right, TStream(rRequested), memo),
-        )
+      case StreamFold(_, _, _, _, _) =>
+        val Seq(_, valueState) = recurMax(ir, 2)
+        recurMax(ir, 1)
+        recur(ir, 0, TStream(valueState.newType))
 
-      case StreamLeftIntervalJoin(left, right, keyFieldName, intervalFieldName, lname, rname,
-            body) =>
-        val joinEnv = memoizeValueIR(ctx, body, elementType(requestedType), memo)
+      case StreamFold2(_, accum, valueName, seq, _) =>
+        recur(ir, 2 * accum.length + 1, requestedType)
+        val seqBindings = mutable.AnyRefMap.empty[Name, TypeState]
+        seq.indices.foreach(i => recurMaxWithTypeStates(ir, accum.length + 1 + i, seqBindings))
+        accum.indices.foreach(i => recurMax(ir, i + 1))
+        recur(ir, 0, TStream(seqBindings(valueName).newType))
 
-        val lEltType = elementType(left.typ).asInstanceOf[TStruct]
-        val lRequestedType = unifySeq(
-          lEltType,
-          uses(lname, joinEnv.eval) :+ selectKey(lEltType, FastSeq(keyFieldName)),
-        )
+      case StreamScan(_, _, _, _, _) =>
+        val Seq(_, valueState) = recurMax(ir, 2)
+        recurMax(ir, 1)
+        recur(ir, 0, TStream(valueState.newType))
 
-        val rEltType = elementType(right.typ).asInstanceOf[TStruct]
-        val rRequestedType = unifySeq(
-          TArray(rEltType),
-          uses(rname, joinEnv.eval) :+ TArray(selectKey(rEltType, FastSeq(intervalFieldName))),
-        )
+      case StreamJoinRightDistinct(_, _, lKey, rKey, _, _, _, _) =>
+        val Seq(lState, rState) = recur(ir, 2, TIterable.elementType(requestedType))
+        val lRequested = lState.requireFields(lKey).newType
+        val rRequested = rState.requireFields(rKey).newType
+        recur(ir, 0, TStream(lRequested))
+        recur(ir, 1, TStream(rRequested))
 
-        unifyEnvs(
-          joinEnv.deleteEval(lname).deleteEval(rname),
-          memoizeValueIR(ctx, left, TStream(lRequestedType), memo),
-          memoizeValueIR(ctx, right, TStream(elementType(rRequestedType)), memo),
-        )
+      case StreamLeftIntervalJoin(_, _, keyFieldName, intervalFieldName, _, _, _) =>
+        val Seq(lState, rState) = recur(ir, 2, elementType(requestedType))
+        val lRequestedType = lState.requireFields(FastSeq(keyFieldName)).newType
+        val rEltType = elementType(rState.origType).asInstanceOf[TStruct]
+        val rRequestedType =
+          rState.union(TArray(selectKey(rEltType, FastSeq(intervalFieldName)))).newType
+        recur(ir, 0, TStream(lRequestedType))
+        recur(ir, 1, TStream(elementType(rRequestedType)))
 
-      case ArraySort(a, left, right, lessThan) =>
-        val compEnv = memoizeValueIR(ctx, lessThan, lessThan.typ, memo)
+      case ArraySort(_, _, _, _) =>
+        val Seq(lState, rState) = recurMax(ir, 1)
+        val requestedElementType = lState
+          .union(rState.newType)
+          .union(TIterable.elementType(requestedType))
+          .newType
+        recur(ir, 0, TStream(requestedElementType))
 
-        val requestedElementType = unifySeq(
-          TIterable.elementType(a.typ),
-          Array(TIterable.elementType(requestedType)) ++ uses(left, compEnv.eval) ++ uses(
-            right,
-            compEnv.eval,
-          ),
-        )
+      case ArrayMaximalIndependentSet(_, tiebreaker) =>
+        if (tiebreaker.nonEmpty) recurMax(ir, 1)
+        recurMax(ir, 0)
 
-        unifyEnvs(
-          compEnv.deleteEval(left).deleteEval(right),
-          memoizeValueIR(ctx, a, TStream(requestedElementType), memo),
-        )
-
-      case ArrayMaximalIndependentSet(a, tiebreaker) =>
-        tiebreaker.foreach { case (_, _, tb) => memoizeValueIR(ctx, tb, tb.typ, memo) }
-        memoizeValueIR(ctx, a, a.typ, memo)
-      case StreamFor(a, valueName, body) =>
+      case StreamFor(_, _, _) =>
         assert(requestedType == TVoid)
-        val bodyEnv = memoizeValueIR(ctx, body, body.typ, memo)
-        val valueType = unifySeq(
-          TIterable.elementType(a.typ),
-          uses(valueName, bodyEnv.eval),
-        )
-        unifyEnvs(
-          bodyEnv.deleteEval(valueName),
-          memoizeValueIR(ctx, a, TStream(valueType), memo),
-        )
-      case MakeNDArray(data, shape, rowMajor, _) =>
+        val Seq(eltState) = recurMax(ir, 1)
+        recur(ir, 0, TStream(eltState.newType))
+
+      case MakeNDArray(data, _, _, _) =>
         val elementType = requestedType.asInstanceOf[TNDArray].elementType
         val dataType =
           if (data.typ.isInstanceOf[TArray]) TArray(elementType) else TStream(elementType)
-        unifyEnvs(
-          memoizeValueIR(ctx, data, dataType, memo),
-          memoizeValueIR(ctx, shape, shape.typ, memo),
-          memoizeValueIR(ctx, rowMajor, rowMajor.typ, memo),
-        )
-      case NDArrayMap(nd, valueName, body) =>
-        val ndType = nd.typ.asInstanceOf[TNDArray]
-        val bodyEnv =
-          memoizeValueIR(ctx, body, requestedType.asInstanceOf[TNDArray].elementType, memo)
-        val valueType = unifySeq(
-          ndType.elementType,
-          uses(valueName, bodyEnv.eval),
-        )
-        unifyEnvs(
-          bodyEnv.deleteEval(valueName),
-          memoizeValueIR(ctx, nd, ndType.copy(elementType = valueType), memo),
-        )
-      case NDArrayMap2(left, right, leftName, rightName, body, _) =>
-        val leftType = left.typ.asInstanceOf[TNDArray]
-        val rightType = right.typ.asInstanceOf[TNDArray]
-        val bodyEnv =
-          memoizeValueIR(ctx, body, requestedType.asInstanceOf[TNDArray].elementType, memo)
+        recur(ir, 0, dataType)
+        recurMax(ir, 1)
+        recurMax(ir, 2)
 
-        val leftValueType = unifySeq(leftType.elementType, uses(leftName, bodyEnv.eval))
-        val rightValueType = unifySeq(rightType.elementType, uses(rightName, bodyEnv.eval))
+      case NDArrayMap(nd, _, _) =>
+        val Seq(eltState) = recur(ir, 1, requestedType.asInstanceOf[TNDArray].elementType)
+        val eltType =
+          nd.typ.asInstanceOf[TNDArray].copy(elementType = eltState.newType)
+        recur(ir, 0, eltType)
 
-        unifyEnvs(
-          bodyEnv.deleteEval(leftName).deleteEval(rightName),
-          memoizeValueIR(ctx, left, leftType.copy(elementType = leftValueType), memo),
-          memoizeValueIR(ctx, right, rightType.copy(elementType = rightValueType), memo),
-        )
-      case AggExplode(a, name, body, isScan) =>
-        val bodyEnv = memoizeValueIR(ctx, body, requestedType, memo)
-        if (isScan) {
-          val valueType = unifySeq(TIterable.elementType(a.typ), uses(name, bodyEnv.scanOrEmpty))
-          val aEnv = memoizeValueIR(ctx, a, TStream(valueType), memo)
-          unifyEnvs(
-            BindingEnv(scan = bodyEnv.scan.map(_.delete(name))),
-            BindingEnv(scan = Some(aEnv.eval)),
-          )
-        } else {
-          val valueType = unifySeq(TIterable.elementType(a.typ), uses(name, bodyEnv.aggOrEmpty))
-          val aEnv = memoizeValueIR(ctx, a, TStream(valueType), memo)
-          unifyEnvs(
-            BindingEnv(agg = bodyEnv.agg.map(_.delete(name))),
-            BindingEnv(agg = Some(aEnv.eval)),
-          )
-        }
-      case AggFilter(cond, aggIR, isScan) =>
-        val condEnv = memoizeValueIR(ctx, cond, cond.typ, memo)
-        unifyEnvs(
-          if (isScan)
-            BindingEnv(scan = Some(condEnv.eval))
-          else
-            BindingEnv(agg = Some(condEnv.eval)),
-          memoizeValueIR(ctx, aggIR, requestedType, memo),
-        )
-      case AggGroupBy(key, aggIR, isScan) =>
-        val keyEnv = memoizeValueIR(ctx, key, requestedType.asInstanceOf[TDict].keyType, memo)
-        unifyEnvs(
-          if (isScan)
-            BindingEnv(scan = Some(keyEnv.eval))
-          else
-            BindingEnv(agg = Some(keyEnv.eval)),
-          memoizeValueIR(ctx, aggIR, requestedType.asInstanceOf[TDict].valueType, memo),
-        )
-      case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan) =>
-        val bodyEnv = memoizeValueIR(ctx, aggBody, TIterable.elementType(requestedType), memo)
-        if (isScan) {
-          val valueType =
-            unifySeq(TIterable.elementType(a.typ), uses(elementName, bodyEnv.scanOrEmpty))
-          val aEnv = memoizeValueIR(ctx, a, TArray(valueType), memo)
-          unifyEnvsSeq(FastSeq(
-            bodyEnv.copy(
-              eval = bodyEnv.eval.delete(indexName),
-              scan = bodyEnv.scan.map(_.delete(elementName)),
-            ),
-            BindingEnv(scan = Some(aEnv.eval)),
-          ) ++ knownLength.map(x => memoizeValueIR(ctx, x, x.typ, memo)))
-        } else {
-          val valueType =
-            unifySeq(TIterable.elementType(a.typ), uses(elementName, bodyEnv.aggOrEmpty))
-          val aEnv = memoizeValueIR(ctx, a, TArray(valueType), memo)
-          unifyEnvsSeq(FastSeq(
-            bodyEnv.copy(
-              eval = bodyEnv.eval.delete(indexName),
-              agg = bodyEnv.agg.map(_.delete(elementName)),
-            ),
-            BindingEnv(agg = Some(aEnv.eval)),
-          ) ++ knownLength.map(x => memoizeValueIR(ctx, x, x.typ, memo)))
-        }
-      case ApplyAggOp(initOpArgs, seqOpArgs, sig) =>
+      case NDArrayMap2(left, right, _, _, _, _) =>
+        val Seq(lState, rState) = recur(ir, 2, requestedType.asInstanceOf[TNDArray].elementType)
+        recur(ir, 0, left.typ.asInstanceOf[TNDArray].copy(elementType = lState.newType))
+        recur(ir, 1, right.typ.asInstanceOf[TNDArray].copy(elementType = rState.newType))
+
+      case AggExplode(_, _, _, _) =>
+        val Seq(eltState) = recur(ir, 1, requestedType)
+        recur(ir, 0, TStream(eltState.newType))
+
+      case AggFilter(_, _, _) =>
+        recur(ir, 1, requestedType)
+        recurMax(ir, 0)
+
+      case AggGroupBy(_, _, _) =>
+        recur(ir, 1, requestedType.asInstanceOf[TDict].valueType)
+        recur(ir, 0, requestedType.asInstanceOf[TDict].keyType)
+
+      case AggArrayPerElement(_, _, _, _, knownLength, _) =>
+        val Seq(eltState, _) = recur(ir, 1, TIterable.elementType(requestedType))
+        recur(ir, 0, TArray(eltState.newType))
+        if (knownLength.nonEmpty) recurMax(ir, 2)
+
+      case ApplyAggOp(initOpArgs, _, sig) =>
         val prunedSig = AggSignature.prune(sig, requestedType)
-        val initEnv = unifyEnvsSeq((initOpArgs, prunedSig.initOpArgs).zipped.map { (arg, req) =>
-          memoizeValueIR(ctx, arg, req, memo)
-        })
-        val seqOpEnv = unifyEnvsSeq((seqOpArgs, prunedSig.seqOpArgs).zipped.map { (arg, req) =>
-          memoizeValueIR(ctx, arg, req, memo)
-        })
-        BindingEnv(eval = initEnv.eval, agg = Some(seqOpEnv.eval))
-      case ApplyScanOp(initOpArgs, seqOpArgs, sig) =>
-        val prunedSig = AggSignature.prune(sig, requestedType)
-        val initEnv = unifyEnvsSeq((initOpArgs, prunedSig.initOpArgs).zipped.map { (arg, req) =>
-          memoizeValueIR(ctx, arg, req, memo)
-        })
-        val seqOpEnv = unifyEnvsSeq((seqOpArgs, prunedSig.seqOpArgs).zipped.map { (arg, req) =>
-          memoizeValueIR(ctx, arg, req, memo)
-        })
-        BindingEnv(eval = initEnv.eval, scan = Some(seqOpEnv.eval))
-      case AggFold(zero, seqOp, combOp, accumName, _, isScan) =>
-        val initEnv = memoizeValueIR(ctx, zero, zero.typ, memo)
-        val seqEnv = memoizeValueIR(ctx, seqOp, seqOp.typ, memo)
-        memoizeValueIR(ctx, combOp, combOp.typ, memo)
+        prunedSig.initOpArgs.zipWithIndex.foreach { case (req, i) =>
+          recur(ir, i, req)
+        }
+        prunedSig.seqOpArgs.zipWithIndex.foreach { case (req, i) =>
+          recur(ir, initOpArgs.length + i, req)
+        }
 
-        if (isScan)
-          BindingEnv(eval = initEnv.eval, scan = Some(seqEnv.eval.delete(accumName)))
-        else
-          BindingEnv(eval = initEnv.eval, agg = Some(seqEnv.eval.delete(accumName)))
-      case StreamAgg(a, name, query) =>
-        val queryEnv = memoizeValueIR(ctx, query, requestedType, memo)
-        val requestedElemType =
-          unifySeq(TIterable.elementType(a.typ), uses(name, queryEnv.aggOrEmpty))
-        val aEnv = memoizeValueIR(ctx, a, TStream(requestedElemType), memo)
-        unifyEnvs(
-          BindingEnv(eval = concatEnvs(Array(queryEnv.eval, queryEnv.aggOrEmpty.delete(name)))),
-          aEnv,
-        )
-      case StreamAggScan(a, name, query) =>
-        val queryEnv = memoizeValueIR(ctx, query, TIterable.elementType(requestedType), memo)
-        val requestedElemType = unifySeq(
-          TIterable.elementType(a.typ),
-          uses(name, queryEnv.scanOrEmpty) ++ uses(name, queryEnv.eval),
-        )
-        val aEnv = memoizeValueIR(ctx, a, TStream(requestedElemType), memo)
-        unifyEnvs(
-          BindingEnv(eval =
-            concatEnvs(Array(queryEnv.eval.delete(name), queryEnv.scanOrEmpty.delete(name)))
-          ),
-          aEnv,
-        )
-      case RunAgg(body, result, _) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, body, body.typ, memo),
-          memoizeValueIR(ctx, result, requestedType, memo),
-        )
-      case RunAggScan(array, name, init, seqs, result, _) =>
-        val resultEnv = memoizeValueIR(ctx, result, TIterable.elementType(requestedType), memo)
-        val seqEnv = memoizeValueIR(ctx, seqs, seqs.typ, memo)
-        val elemEnv = unifyEnvs(resultEnv, seqEnv)
-        val requestedElemType = unifySeq(TIterable.elementType(array.typ), uses(name, elemEnv.eval))
-        unifyEnvs(
-          elemEnv,
-          memoizeValueIR(ctx, array, TStream(requestedElemType), memo),
-          memoizeValueIR(ctx, init, init.typ, memo),
-        )
+      case ApplyScanOp(initOpArgs, _, sig) =>
+        val prunedSig = AggSignature.prune(sig, requestedType)
+        prunedSig.initOpArgs.zipWithIndex.foreach { case (req, i) =>
+          recur(ir, i, req)
+        }
+        prunedSig.seqOpArgs.zipWithIndex.foreach { case (req, i) =>
+          recur(ir, initOpArgs.length + i, req)
+        }
+
+      case ir: AggFold =>
+        recurMax(ir, 0)
+        recurMax(ir, 1)
+        recurMax(ir, 2)
+
+      case StreamAgg(_, _, _) =>
+        val Seq(eltState) = recur(ir, 1, requestedType)
+        recur(ir, 0, TStream(eltState.newType))
+
+      case StreamAggScan(_, _, _) =>
+        val Seq(eltState) = recur(ir, 1, TIterable.elementType(requestedType))
+        recur(ir, 0, TStream(eltState.newType))
+
+      case ir: RunAgg =>
+        recurMax(ir, 0)
+        recur(ir, 1, requestedType)
+
+      case RunAggScan(_, name, _, _, _, _) =>
+        val bindings = mutable.AnyRefMap.empty[Name, TypeState]
+        recurWithTypeStates(ir, 3, TIterable.elementType(requestedType), bindings)
+        recurMaxWithTypeStates(ir, 2, bindings)
+        recurMax(ir, 1)
+        recur(ir, 0, TStream(bindings(name).newType))
+
       case MakeStruct(fields) =>
         val sType = requestedType.asInstanceOf[TStruct]
-        unifyEnvsSeq(fields.flatMap { case (fname, fir) =>
+        fields.view.zipWithIndex.foreach { case ((fname, _), i) =>
           // ignore unreachable fields, these are eliminated on the upwards pass
-          sType.selfField(fname).map(f => memoizeValueIR(ctx, fir, f.typ, memo))
-        })
+          sType.selfField(fname).foreach(f => recur(ir, i, f.typ))
+        }
+
       case InsertFields(old, fields, _) =>
         val sType = requestedType.asInstanceOf[TStruct]
-        val insFieldNames = fields.map(_._1).toSet
-        val rightDep = sType.filter(f => insFieldNames.contains(f.name))._1
+        val rightDep = sType.typeAfterSelectNames(sType.fieldNames.intersect(fields.map(_._1)))
         val leftDep = TStruct(
           old.typ.asInstanceOf[TStruct]
             .fields
@@ -1792,53 +1639,45 @@ object PruneDeadFields {
                 sType.selfField(f.name).map(f.name -> _.typ)
             }: _*
         )
-        unifyEnvsSeq(
-          FastSeq(memoizeValueIR(ctx, old, leftDep, memo)) ++
-            // ignore unreachable fields, these are eliminated on the upwards pass
-            fields.flatMap { case (fname, fir) =>
-              rightDep.selfField(fname).map(f => memoizeValueIR(ctx, fir, f.typ, memo))
-            }
-        )
+        recur(ir, 0, leftDep)
+        fields.view.zipWithIndex.foreach { case ((fname, _), i) =>
+          rightDep.selfField(fname).foreach(f => recur(ir, i + 1, f.typ))
+        }
+
       case SelectFields(old, _) =>
         val sType = requestedType.asInstanceOf[TStruct]
         val oldReqType = TStruct(old.typ.asInstanceOf[TStruct]
           .fieldNames
           .flatMap(fn => sType.selfField(fn).map(fd => (fd.name, fd.typ))): _*)
-        memoizeValueIR(ctx, old, oldReqType, memo)
-      case GetField(o, name) =>
-        memoizeValueIR(ctx, o, TStruct(name -> requestedType), memo)
+        recur(ir, 0, oldReqType)
+
+      case GetField(_, name) =>
+        recur(ir, 0, TStruct(name -> requestedType))
+
       case MakeTuple(fields) =>
         val tType = requestedType.asInstanceOf[TTuple]
-
-        unifyEnvsSeq(
-          fields.flatMap { case (i, value) =>
-            // ignore unreachable fields, these are eliminated on the upwards pass
-            tType.fieldIndex.get(i)
-              .map(idx => memoizeValueIR(ctx, value, tType.types(idx), memo))
-          }
-        )
-      case GetTupleElement(o, idx) =>
+        fields.view.zipWithIndex.foreach { case ((fieldIdx, _), childIdx) =>
+          // ignore unreachable fields, these are eliminated on the upwards pass
+          tType.fieldIndex.get(fieldIdx).foreach(idx => recur(ir, childIdx, tType.types(idx)))
+        }
+      case GetTupleElement(_, idx) =>
         val tupleDep = TTuple(FastSeq(TupleField(idx, requestedType)))
-        memoizeValueIR(ctx, o, tupleDep, memo)
-      case ConsoleLog(message, result) =>
-        unifyEnvs(
-          memoizeValueIR(ctx, message, TString, memo),
-          memoizeValueIR(ctx, result, result.typ, memo),
-        )
+        recur(ir, 0, tupleDep)
+
+      case ir: ConsoleLog =>
+        recur(ir, 0, TString)
+        recurMax(ir, 1)
+
       case MatrixCount(child) =>
         memoizeMatrixIR(ctx, child, minimal(child.typ), memo)
-        BindingEnv.empty
+
       case TableCount(child) =>
         memoizeTableIR(ctx, child, minimal(child.typ), memo)
-        BindingEnv.empty
+
       case TableGetGlobals(child) =>
-        memoizeTableIR(
-          ctx,
-          child,
-          minimal(child.typ).copy(globalType = requestedType.asInstanceOf[TStruct]),
-          memo,
-        )
-        BindingEnv.empty
+        val childReqType = minimal(child.typ).copy(globalType = requestedType.asInstanceOf[TStruct])
+        memoizeTableIR(ctx, child, childReqType, memo)
+
       case TableCollect(child) =>
         val rStruct = requestedType.asInstanceOf[TStruct]
         memoizeTableIR(
@@ -1857,81 +1696,60 @@ object PruneDeadFields {
           ),
           memo,
         )
-        BindingEnv.empty
+
       case TableToValueApply(child, _) =>
         memoizeTableIR(ctx, child, child.typ, memo)
-        BindingEnv.empty
+
       case MatrixToValueApply(child, _) =>
         memoizeMatrixIR(ctx, child, child.typ, memo)
-        BindingEnv.empty
+
       case BlockMatrixToValueApply(child, _) =>
         memoizeBlockMatrixIR(ctx, child, child.typ, memo)
-        BindingEnv.empty
-      case TableAggregate(child, query) =>
-        val queryDep = memoizeAndGetDep(ctx, query, query.typ, child.typ, memo)
+
+      case TableAggregate(child, _) =>
+        val Seq(globalState, rowState) = recurMax(ir, 1)
         val dep = TableType(
           key = child.typ.key,
-          rowType =
-            unify(child.typ.rowType, queryDep.rowType, selectKey(child.typ.rowType, child.typ.key)),
-          globalType = queryDep.globalType,
+          rowType = rowState.requireFields(child.typ.key).newStructType,
+          globalType = globalState.newStructType,
         )
         memoizeTableIR(ctx, child, dep, memo)
-        BindingEnv.empty
-      case MatrixAggregate(child, query) =>
-        val queryDep = memoizeAndGetDep(ctx, query, query.typ, child.typ, memo)
+
+      case MatrixAggregate(child, _) =>
+        val Seq(globalState, colState, rowState, entryState) = recurMax(ir, 1)
         val dep = MatrixType(
           rowKey = child.typ.rowKey,
           colKey = FastSeq(),
-          rowType = unify(
-            child.typ.rowType,
-            queryDep.rowType,
-            selectKey(child.typ.rowType, child.typ.rowKey),
-          ),
-          entryType = queryDep.entryType,
-          colType = queryDep.colType,
-          globalType = queryDep.globalType,
+          rowType = rowState.requireFields(child.typ.rowKey).newStructType,
+          entryType = entryState.newStructType,
+          colType = colState.newStructType,
+          globalType = globalState.newStructType,
         )
         memoizeMatrixIR(ctx, child, dep, memo)
-        BindingEnv.empty
-      case TailLoop(_, params, _, body) =>
-        val bodyEnv = memoizeValueIR(ctx, body, body.typ, memo)
-        val paramTypes = params.map { case (paramName, paramIR) =>
-          unifySeq(paramIR.typ, uses(paramName, bodyEnv.eval))
+
+      case TailLoop(_, params, _, _) =>
+        val paramStates = recurMax(ir, params.length)
+        paramStates.view.zipWithIndex.take(params.length).foreach { case (paramState, i) =>
+          recur(ir, i, paramState.newType)
         }
-        unifyEnvsSeq(
-          IndexedSeq(bodyEnv.deleteEval(params.map(_._1))) ++
-            (params, paramTypes).zipped.map { case ((_, paramIR), paramType) =>
-              memoizeValueIR(ctx, paramIR, paramType, memo)
-            }
-        )
-      case CollectDistributedArray(contexts, globals, cname, gname, body, dynamicID, _, _) =>
-        val rArray = requestedType.asInstanceOf[TArray]
-        val bodyEnv = memoizeValueIR(ctx, body, rArray.elementType, memo)
-        assert(bodyEnv.scan.isEmpty)
-        assert(bodyEnv.agg.isEmpty)
 
-        val cDep = unifySeq(TIterable.elementType(contexts.typ), uses(cname, bodyEnv.eval))
-        val gDep = unifySeq(globals.typ, uses(gname, bodyEnv.eval))
+      case CollectDistributedArray(_, _, _, _, _, _, _, _) =>
+        recur(ir, 3, TString)
+        val Seq(contextState, globalState) =
+          recur(ir, 2, requestedType.asInstanceOf[TArray].elementType)
+        recur(ir, 1, globalState.newType)
+        recur(ir, 0, TStream(contextState.newType))
 
-        unifyEnvs(
-          memoizeValueIR(ctx, contexts, TStream(cDep), memo),
-          memoizeValueIR(ctx, globals, gDep, memo),
-          memoizeValueIR(ctx, dynamicID, TString, memo),
-        )
       case _: IR =>
-        val envs = ir.children.flatMap {
-          case mir: MatrixIR =>
+        ir.children.zipWithIndex.foreach {
+          case (mir: MatrixIR, _) =>
             memoizeMatrixIR(ctx, mir, mir.typ, memo)
-            None
-          case tir: TableIR =>
+          case (tir: TableIR, _) =>
             memoizeTableIR(ctx, tir, tir.typ, memo)
-            None
-          case _: BlockMatrixIR => // NOTE Currently no BlockMatrixIRs would have dead fields
-            None
-          case ir: IR =>
-            Some(memoizeValueIR(ctx, ir, ir.typ, memo))
+          case (_: BlockMatrixIR, _) => // NOTE Currently no BlockMatrixIRs would have dead fields
+          case (_: IR, i) =>
+            recurMax(ir, i)
         }
-        unifyEnvsSeq(envs.toFastSeq)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -11,22 +11,17 @@ import scala.reflect.ClassTag
 
 object TypeCheck {
   def apply(ctx: ExecuteContext, ir: BaseIR): Unit =
+    apply(ctx, ir, BindingEnv.empty)
+
+  def apply(ctx: ExecuteContext, ir: BaseIR, env: BindingEnv[Type]): Unit =
     try
-      check(ctx, ir, BindingEnv.empty).run()
+      check(ctx, ir, env).run()
     catch {
       case e: Throwable =>
         fatal(
           s"Error while typechecking IR:\n${Pretty(ctx, ir, preserveNames = true, allowUnboundRefs = true)}",
           e,
         )
-    }
-
-  def apply(ctx: ExecuteContext, ir: IR, env: BindingEnv[Type]): Unit =
-    try
-      check(ctx, ir, env).run()
-    catch {
-      case e: Throwable =>
-        fatal(s"Error while typechecking IR:\n${Pretty(ctx, ir, allowUnboundRefs = true)}", e)
     }
 
   def check(ctx: ExecuteContext, ir: BaseIR, env: BindingEnv[Type]): StackFrame[Unit] = {
@@ -161,7 +156,7 @@ object TypeCheck {
         }
       case MakeStream(args, typ, _) =>
         assert(typ != null)
-        assert(typ.elementType.isRealizable)
+        assert(typ.elementType.isRealizable, typ.elementType)
 
         args.map(_.typ).zipWithIndex.foreach { case (x, i) =>
           assert(

--- a/hail/src/test/scala/is/hail/expr/ir/FakeTableReader.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FakeTableReader.scala
@@ -16,7 +16,7 @@ class FakeTableReader extends TableReader {
   override def globalRequiredness(ctx: ExecuteContext, requestedType: TableType)
     : VirtualTypeWithReq = ???
 
-  override def renderShort(): String = ???
+  override def renderShort(): String = "FakeTableReader"
   override def lowerGlobals(ctx: ExecuteContext, requestedGlobalsType: TStruct): IR = ???
   override def lower(ctx: ExecuteContext, requestedType: TableType): TableStage = ???
 }

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -102,7 +102,7 @@ class MatrixIRSuite extends HailSuite {
     val mt = rangeMatrix()
     val oldRow = Ref(MatrixIR.rowName, mt.typ.rowType)
 
-    val newRow = InsertFields(oldRow, Seq("idx" -> IRScanCount))
+    val newRow = InsertFields(oldRow, FastSeq("idx" -> IRScanCount))
 
     val newMatrix = MatrixMapRows(mt, newRow)
     val rows = getRows(newMatrix)
@@ -113,7 +113,8 @@ class MatrixIRSuite extends HailSuite {
     val mt = rangeMatrix()
     val oldRow = Ref(MatrixIR.rowName, mt.typ.rowType)
 
-    val newRow = InsertFields(oldRow, Seq("range" -> IRScanCollect(GetField(oldRow, "row_idx"))))
+    val newRow =
+      InsertFields(oldRow, FastSeq("range" -> IRScanCollect(GetField(oldRow, "row_idx"))))
 
     val newMatrix = MatrixMapRows(mt, newRow)
     val rows = getRows(newMatrix)
@@ -128,7 +129,7 @@ class MatrixIRSuite extends HailSuite {
 
     val newRow = InsertFields(
       oldRow,
-      Seq("n" -> IRAggCount, "range" -> IRScanCollect(GetField(oldRow, "row_idx").toL)),
+      FastSeq("n" -> IRAggCount, "range" -> IRScanCollect(GetField(oldRow, "row_idx").toL)),
     )
 
     val newMatrix = MatrixMapRows(mt, newRow)
@@ -142,7 +143,7 @@ class MatrixIRSuite extends HailSuite {
     val mt = rangeMatrix()
     val oldCol = Ref(MatrixIR.colName, mt.typ.colType)
 
-    val newCol = InsertFields(oldCol, Seq("idx" -> IRScanCount))
+    val newCol = InsertFields(oldCol, FastSeq("idx" -> IRScanCount))
 
     val newMatrix = MatrixMapCols(mt, newCol, None)
     val cols = getCols(newMatrix)
@@ -153,7 +154,8 @@ class MatrixIRSuite extends HailSuite {
     val mt = rangeMatrix()
     val oldCol = Ref(MatrixIR.colName, mt.typ.colType)
 
-    val newCol = InsertFields(oldCol, Seq("range" -> IRScanCollect(GetField(oldCol, "col_idx"))))
+    val newCol =
+      InsertFields(oldCol, FastSeq("range" -> IRScanCollect(GetField(oldCol, "col_idx"))))
 
     val newMatrix = MatrixMapCols(mt, newCol, None)
     val cols = getCols(newMatrix)
@@ -168,7 +170,7 @@ class MatrixIRSuite extends HailSuite {
 
     val newCol = InsertFields(
       oldCol,
-      Seq("n" -> IRAggCount, "range" -> IRScanCollect(GetField(oldCol, "col_idx").toL)),
+      FastSeq("n" -> IRAggCount, "range" -> IRScanCollect(GetField(oldCol, "col_idx").toL)),
     )
 
     val newMatrix = MatrixMapCols(mt, newCol, None)

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -39,36 +39,44 @@ class SimplifySuite extends HailSuite {
   lazy val base = Literal(TStruct("1" -> TInt32, "2" -> TInt32), Row(1, 2))
 
   @Test def testInsertFieldsRewriteRules(): Unit = {
-    val ir1 = InsertFields(InsertFields(base, Seq("1" -> I32(2)), None), Seq("1" -> I32(3)), None)
-    assert(Simplify(ctx, ir1) == InsertFields(base, Seq("1" -> I32(3)), Some(FastSeq("1", "2"))))
+    val ir1 =
+      InsertFields(InsertFields(base, FastSeq("1" -> I32(2)), None), FastSeq("1" -> I32(3)), None)
+    assert(Simplify(ctx, ir1) == InsertFields(
+      base,
+      FastSeq("1" -> I32(3)),
+      Some(FastSeq("1", "2")),
+    ))
 
     val ir2 = InsertFields(
-      InsertFields(base, Seq("3" -> I32(2)), Some(FastSeq("3", "1", "2"))),
-      Seq("3" -> I32(3)),
+      InsertFields(base, FastSeq("3" -> I32(2)), Some(FastSeq("3", "1", "2"))),
+      FastSeq("3" -> I32(3)),
       None,
     )
     assert(Simplify(ctx, ir2) == InsertFields(
       base,
-      Seq("3" -> I32(3)),
+      FastSeq("3" -> I32(3)),
       Some(FastSeq("3", "1", "2")),
     ))
 
     val ir3 = InsertFields(
-      InsertFields(base, Seq("3" -> I32(2)), Some(FastSeq("3", "1", "2"))),
-      Seq("4" -> I32(3)),
+      InsertFields(base, FastSeq("3" -> I32(2)), Some(FastSeq("3", "1", "2"))),
+      FastSeq("4" -> I32(3)),
       Some(FastSeq("3", "1", "2", "4")),
     )
     assert(Simplify(ctx, ir3) == InsertFields(
       base,
-      Seq("3" -> I32(2), "4" -> I32(3)),
+      FastSeq("3" -> I32(2), "4" -> I32(3)),
       Some(FastSeq("3", "1", "2", "4")),
     ))
 
     val ir4 =
-      InsertFields(InsertFields(base, Seq("3" -> I32(0), "4" -> I32(1))), Seq("3" -> I32(5)))
+      InsertFields(
+        InsertFields(base, FastSeq("3" -> I32(0), "4" -> I32(1))),
+        FastSeq("3" -> I32(5)),
+      )
     assert(Simplify(ctx, ir4) == InsertFields(
       base,
-      Seq("4" -> I32(1), "3" -> I32(5)),
+      FastSeq("4" -> I32(1), "3" -> I32(5)),
       Some(FastSeq("1", "2", "3", "4")),
     ))
   }
@@ -125,7 +133,7 @@ class SimplifySuite extends HailSuite {
       ir,
       InsertFields(
         Ref(TableIR.rowName, ir.typ.rowType),
-        Seq("foo" -> Literal(TSet(TInt32), Set(1))),
+        FastSeq("foo" -> Literal(TSet(TInt32), Set(1))),
       ),
     )
     ir = TableExplode(ir, FastSeq("foo"))

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -285,7 +285,7 @@ class TableIRSuite extends HailSuite {
     val t = rangeKT
     val oldRow = Ref(TableIR.rowName, t.typ.rowType)
 
-    val newRow = InsertFields(oldRow, Seq("idx2" -> IRScanCount))
+    val newRow = InsertFields(oldRow, FastSeq("idx2" -> IRScanCount))
     val newTable = TableMapRows(t, newRow)
     val expected = Array.tabulate(20)(i => Row(i, i.toLong)).toFastSeq
     assertEvalsTo(
@@ -302,7 +302,7 @@ class TableIRSuite extends HailSuite {
     val t = rangeKT
     val oldRow = Ref(TableIR.rowName, t.typ.rowType)
 
-    val newRow = InsertFields(oldRow, Seq("range" -> IRScanCollect(GetField(oldRow, "idx"))))
+    val newRow = InsertFields(oldRow, FastSeq("range" -> IRScanCollect(GetField(oldRow, "idx"))))
     val newTable = TableMapRows(t, newRow)
 
     val expected = Array.tabulate(20)(i => Row(i, Array.range(0, i).toFastSeq)).toFastSeq
@@ -1155,7 +1155,7 @@ class TableIRSuite extends HailSuite {
     var ir: IR = rangeIR(5)
     ir = StreamGrouped(ir, 2)
     ir = ToArray(mapIR(ir)(ToArray))
-    ir = InsertFields(Ref(TableIR.rowName, tir.typ.rowType), Seq("foo" -> ir))
+    ir = InsertFields(Ref(TableIR.rowName, tir.typ.rowType), FastSeq("foo" -> ir))
     tir = TableMapRows(tir, ir)
     assertEvalsTo(
       collect(tir),


### PR DESCRIPTION
Makes some further progress on simplifying the `PruneDeadFields` pass, with the primary goal of decoupling it from the details of the binding structure.

The primary change is to `memoizeValueIR`. Before, it passed in only the requested type of the node, and returned and environment containing all free variables and their requested types. Any bound variables would then need to be removed, and the environments of all children then merged. This low-level manipulation of environments made it closely tied to the binding structure, essentially redundantly encoding everything in `Binds.scala`.

Now we pass an environment down into the children, which maps variables to a mutable state tracking the requested type. Each `Ref` node unions the requested type at the reference with the state in the environment. This lets us use the general environment infrastructure.

I didn't do an assertion directly comparing the old and new implementations, as I've done with some other pass rewrites. But `PruneDeadFields` has pretty good test coverage.