### PR TITLE
[batch] Remove unused cost_from_msec_mcpu code

### DIFF
--- a/batch/batch/cloud/gcp/resource_utils.py
+++ b/batch/batch/cloud/gcp/resource_utils.py
@@ -57,44 +57,6 @@ def family_worker_type_cores_to_gcp_machine_type(family: str, worker_type: str, 
     return f'{family}-{worker_type}-{cores}'
 
 
-def gcp_cost_from_msec_mcpu(msec_mcpu: int) -> float:
-    assert msec_mcpu is not None
-
-    worker_type = 'standard'
-    worker_cores = 16
-    worker_disk_size_gb = 100
-
-    # https://cloud.google.com/compute/all-pricing
-
-    # per instance costs
-    # persistent SSD: $0.17 GB/month
-    # average number of days per month = 365.25 / 12 = 30.4375
-    avg_n_days_per_month = 30.4375
-
-    disk_cost_per_instance_hour = 0.17 * worker_disk_size_gb / avg_n_days_per_month / 24
-
-    ip_cost_per_instance_hour = 0.004
-
-    instance_cost_per_instance_hour = disk_cost_per_instance_hour + ip_cost_per_instance_hour
-
-    # per core costs
-    if worker_type == 'standard':
-        cpu_cost_per_core_hour = 0.01
-    elif worker_type == 'highcpu':
-        cpu_cost_per_core_hour = 0.0075
-    else:
-        assert worker_type == 'highmem'
-        cpu_cost_per_core_hour = 0.0125
-
-    service_cost_per_core_hour = 0.01
-
-    total_cost_per_core_hour = (
-        cpu_cost_per_core_hour + instance_cost_per_instance_hour / worker_cores + service_cost_per_core_hour
-    )
-
-    return (msec_mcpu * 0.001 * 0.001) * (total_cost_per_core_hour / 3600)
-
-
 def gcp_worker_memory_per_core_mib(worker_type: str) -> int:
     if worker_type == 'standard':
         m = 3840

--- a/batch/batch/cloud/resource_utils.py
+++ b/batch/batch/cloud/resource_utils.py
@@ -14,7 +14,6 @@ from .azure.resource_utils import (
     azure_worker_memory_per_core_mib,
 )
 from .gcp.resource_utils import (
-    gcp_cost_from_msec_mcpu,
     gcp_is_valid_storage_request,
     gcp_local_ssd_size,
     gcp_machine_type_to_worker_type_and_cores,
@@ -58,13 +57,6 @@ def machine_type_to_worker_type_cores(cloud: str, machine_type: str) -> Tuple[st
         return azure_machine_type_to_worker_type_and_cores(machine_type)
     assert cloud == 'gcp'
     return gcp_machine_type_to_worker_type_and_cores(machine_type)
-
-
-def cost_from_msec_mcpu(msec_mcpu: int) -> Optional[float]:
-    if msec_mcpu is None:
-        return None
-    # msec_mcpu is deprecated and only applicable to GCP
-    return gcp_cost_from_msec_mcpu(msec_mcpu)
 
 
 def worker_memory_per_core_mib(cloud: str, worker_type: str) -> int:


### PR DESCRIPTION
This function is an unused relic of the first version of our billing system, that just computed the cost of a slot on a Batch VM per mcpu milliseconds based on some hard-coded prices. We long ago migrated to a system where we track GCP SKUs and price changes through their API and properly itemize usage by SKU in the database.