### PR TITLE
[query] Batch Backend Job Creation Contract Tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2468,6 +2468,7 @@ steps:
               --durations=50 \
               --ignore=test/hailtop/ \
               --ignore=test/hail/matrixtable/test_file_formats.py \
+              -m backend \
               --timeout=600 \
               test
     timeout: 5400
@@ -2539,6 +2540,7 @@ steps:
               --durations=50 \
               --ignore=test/hailtop/ \
               --ignore=test/hail/matrixtable/test_file_formats.py \
+              -m backend \
               --timeout=600 \
               test
     timeout: 5400

--- a/build.yaml
+++ b/build.yaml
@@ -2468,7 +2468,6 @@ steps:
               --durations=50 \
               --ignore=test/hailtop/ \
               --ignore=test/hail/matrixtable/test_file_formats.py \
-              -m qobtest \
               --timeout=600 \
               test
     timeout: 5400
@@ -2540,7 +2539,6 @@ steps:
               --durations=50 \
               --ignore=test/hailtop/ \
               --ignore=test/hail/matrixtable/test_file_formats.py \
-              -m qobtest \
               --timeout=600 \
               test
     timeout: 5400

--- a/hail/build.sc
+++ b/hail/build.sc
@@ -161,6 +161,7 @@ trait HailScalaModule extends SbtModule with ScalafmtModule with ScalafixModule 
         ivy"org.scalatest::scalatest-shouldmatchers:3.2.18",
         ivy"org.scalatestplus::testng-7-9:3.2.18.0",
         ivy"org.testng:testng:7.9.0",
+        ivy"org.mockito::mockito-scala:1.17.31",
       )
 
     // needed to force IntelliJ to include resources in the classpath when running tests

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -226,6 +226,7 @@ mccabe==0.7.0
     # via pylint
 mistune==3.0.2
     # via nbconvert
+mock==5.1.0
 multidict==6.0.5
     # via
     #   aiohttp
@@ -327,6 +328,7 @@ pytest==7.4.4
     #   pytest-html
     #   pytest-instafail
     #   pytest-metadata
+    #   pytest-mock
     #   pytest-timeout
     #   pytest-xdist
 pytest-asyncio==0.21.2
@@ -336,6 +338,7 @@ pytest-html==1.22.1
 pytest-instafail==0.5.0
 pytest-metadata==3.1.1
     # via pytest-html
+pytest-mock==3.14.0
 pytest-timeout==2.3.1
 pytest-timestamper==0.0.10
 pytest-xdist==2.5.0

--- a/hail/python/dev/requirements.txt
+++ b/hail/python/dev/requirements.txt
@@ -8,6 +8,7 @@ ruff==0.1.13
 uv>=0.1.38,<0.2
 curlylint>=0.13.1,<1
 click>=8.1.2,<9
+mock>=5.1,<5.2
 pytest>=7.1.3,<8
 pytest-html>=1.20.0,<2
 pytest-xdist>=2.2.1,<3
@@ -16,6 +17,7 @@ pytest-instafail>=0.4.2,<1
 pytest-asyncio>=0.14.0,<0.23
 pytest-timestamper>=0.0.9,<1
 pytest-timeout>=2.1,<3
+pytest-mock>=3.14,<4
 pyright>=1.1.349,<1.2
 sphinx>=6,<7
 sphinx-autodoc-typehints==1.23.0

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -14,7 +14,7 @@ from hail.backend import Backend
 from hail.genetics.reference_genome import ReferenceGenome, reference_genome_type
 from hail.typecheck import dictof, enumeration, nullable, oneof, sequenceof, sized_tupleof, typecheck, typecheck_method
 from hail.utils import get_env_or_default
-from hail.utils.java import Env, choose_backend, warning
+from hail.utils.java import BackendType, Env, choose_backend, warning
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration, get_gcs_requester_pays_configuration
 from hailtop.fs.fs import FS
 from hailtop.hail_event_loop import hail_event_loop
@@ -177,7 +177,7 @@ class HailContext(object):
     skip_logging_configuration=bool,
     local_tmpdir=nullable(str),
     _optimizer_iterations=nullable(int),
-    backend=nullable(str),
+    backend=nullable(BackendType),
     driver_cores=nullable(oneof(str, int)),
     driver_memory=nullable(str),
     worker_cores=nullable(oneof(str, int)),
@@ -206,7 +206,7 @@ def init(
     local_tmpdir=None,
     _optimizer_iterations=None,
     *,
-    backend=None,
+    backend: Optional[BackendType] = None,
     driver_cores=None,
     driver_memory=None,
     worker_cores=None,

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -1,11 +1,13 @@
 import re
 import sys
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from hailtop.config import ConfigVariable, configuration_of
 
+BackendType = Literal['batch', 'local', 'spark']
 
-def choose_backend(backend: Optional[str] = None) -> str:
+
+def choose_backend(backend: Optional[BackendType] = None) -> BackendType:
     return configuration_of(ConfigVariable.QUERY_BACKEND, backend, 'spark')
 
 

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -6,79 +6,20 @@ from hailtop.batch_client.client import Batch
 
 from ..helpers import qobtest, skip_unless_service_backend, test_timeout
 
+import pytest
 
 @qobtest
 @skip_unless_service_backend()
-def test_tiny_driver_has_tiny_memory():
-    try:
-        hl.eval(hl.range(1024 * 1024).map(lambda _: hl.range(1024 * 1024)))
-    except hl.utils.FatalError as exc:
-        assert "HailException: Hail off-heap memory exceeded maximum threshold: limit " in exc.args[0]
-    else:
-        assert False
-
-
-@qobtest
-@skip_unless_service_backend()
-@test_timeout(batch=6 * 60)
-def test_big_driver_has_big_memory():
-    backend = hl.current_backend()
-    assert isinstance(backend, ServiceBackend)
-    # A fresh backend is used for every test so this should only affect this method
-    backend.driver_cores = 8
-    backend.driver_memory = 'highmem'
-    t = hl.utils.range_table(100_000_000, 50)
-    # The pytest (client-side) worker dies if we try to realize all 100M rows in memory.
-    # Instead, we realize the 100M rows in memory on the driver and then take just the first 10M
-    # rows back to the client.
-    hl.eval(t.aggregate(hl.agg.collect(t.idx), _localize=False)[:10_000_000])
-
-
-@qobtest
-@skip_unless_service_backend()
-def test_tiny_worker_has_tiny_memory():
-    try:
-        t = hl.utils.range_table(2, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
-        t = t.annotate(nd_sum=t.nd.sum())
-        t.aggregate(hl.agg.sum(t.nd_sum))
-    except Exception as exc:
-        assert 'HailException: Hail off-heap memory exceeded maximum threshold' in exc.args[0]
-    else:
-        assert False
-
-
-@qobtest
-@skip_unless_service_backend()
-@test_timeout(batch=10 * 60)
-def test_big_worker_has_big_memory():
+def test_big_worker_has_big_memory(mocker):
     backend = hl.current_backend()
     assert isinstance(backend, ServiceBackend)
     backend.worker_cores = 8
     backend.worker_memory = 'highmem'
     t = hl.utils.range_table(2, n_partitions=2).annotate(nd=hl.nd.ones((30_000, 30_000)))
     t = t.annotate(nd_sum=t.nd.sum())
-    # We only eval the small thing so that we trigger an OOM on the worker
-    # but not the driver or client
+    spy = mocker.spy(backend, '_run_on_batch')
+    spy.return_value = ('','')
     hl.eval(t.aggregate(hl.agg.sum(t.nd_sum), _localize=False))
-
-
-@qobtest
-@skip_unless_service_backend()
-@test_timeout(batch=24 * 60)
-def test_regions():
-    backend = hl.current_backend()
-    assert isinstance(backend, ServiceBackend)
-    old_regions = backend.regions
-    CLOUD = os.environ['HAIL_CLOUD']
-    try:
-        if CLOUD == 'gcp':
-            backend.regions = ['us-east1']
-        else:
-            assert CLOUD == 'azure'
-            backend.regions = ['eastus']
-        hl.utils.range_table(1, 1).to_pandas()
-    finally:
-        backend.regions = old_regions
 
 
 @qobtest

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -10,8 +10,6 @@ import hail as hl
 from hail.backend.service_backend import ServiceBackend
 from hailtop.batch_client.client import Batch, Job, JobGroup
 
-from ..helpers import qobtest, skip_unless_service_backend
-
 
 @dataclass
 class BatchServiceMocks:
@@ -65,8 +63,7 @@ def run_on_batch_mocks(mocker):
     return m
 
 
-@qobtest
-@skip_unless_service_backend()
+@pytest.mark.backend('batch')
 def test_big_worker_has_big_memory(run_on_batch_mocks):
     backend = hl.current_backend()
     assert isinstance(backend, ServiceBackend)
@@ -81,8 +78,7 @@ def test_big_worker_has_big_memory(run_on_batch_mocks):
     assert config['worker_memory'] == 'highmem'
 
 
-@qobtest
-@skip_unless_service_backend()
+@pytest.mark.backend('batch')
 def test_regions(run_on_batch_mocks):
     backend = hl.current_backend()
     assert isinstance(backend, ServiceBackend)
@@ -104,8 +100,7 @@ def test_regions(run_on_batch_mocks):
         backend.regions = old_regions
 
 
-@qobtest
-@skip_unless_service_backend()
+@pytest.mark.backend('batch')
 def test_driver_and_worker_job_groups():
     backend = hl.current_backend()
     assert isinstance(backend, ServiceBackend)

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -40,6 +40,7 @@ def pytest_collection_modifyitems(items):
         use_splits = True
 
     backend = choose_backend()
+    cloud = os.getenv('HAIL_CLOUD')
 
     skip_not_in_split = pytest.mark.skip(reason=f'not included in split index {split_index}')
     for item in items:
@@ -53,6 +54,16 @@ def pytest_collection_modifyitems(items):
                 item.add_marker(pytest.mark.skip(reason=reason))
             elif backend == 'batch':
                 item.fixturenames.insert(0, 'reinitialize_hail_for_testing')
+
+        cloud_mark = item.get_closest_marker('backend')
+        if (
+            cloud is not None
+            and cloud_mark is not None
+            and cloud_mark.args is not None
+            and cloud not in cloud_mark.args
+        ):
+            reason = f'current cloud "{cloud}" not listed in "{cloud_mark.args}"'
+            item.add_marker(pytest.mark.skip(reason=reason))
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -144,7 +144,7 @@ def skip_when_local_backend(reason='skipping for Local Backend'):
 
 
 def skip_when_service_backend(reason='skipping for Service Backend'):
-    return pytest.mark.backend('local', 'batch')
+    return pytest.mark.backend('local', 'spark')
 
 
 def skip_when_service_backend_in_azure(reason='skipping for Service Backend in Azure'):

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from timeit import default_timer as timer
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 import pytest
 from typing_extensions import ParamSpec
@@ -136,42 +136,15 @@ T = TypeVar('T')
 
 
 def skip_unless_spark_backend(reason='requires Spark'):
-    from hail.backend.spark_backend import SparkBackend
-
-    @decorator
-    def wrapper(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
-        if isinstance(hl.utils.java.Env.backend(), SparkBackend):
-            return func(*args, **kwargs)
-        else:
-            raise unittest.SkipTest(reason)
-
-    return wrapper
+    return pytest.mark.backend('spark')
 
 
 def skip_when_local_backend(reason='skipping for Local Backend'):
-    from hail.backend.local_backend import LocalBackend
-
-    @decorator
-    def wrapper(func, *args, **kwargs):
-        if isinstance(hl.utils.java.Env.backend(), LocalBackend):
-            raise unittest.SkipTest(reason)
-        else:
-            return func(*args, **kwargs)
-
-    return wrapper
+    return pytest.mark.backend('spark', 'batch')
 
 
 def skip_when_service_backend(reason='skipping for Service Backend'):
-    from hail.backend.service_backend import ServiceBackend
-
-    @decorator
-    def wrapper(func, *args, **kwargs):
-        if isinstance(hl.utils.java.Env.backend(), ServiceBackend):
-            raise unittest.SkipTest(reason)
-        else:
-            return func(*args, **kwargs)
-
-    return wrapper
+    return pytest.mark.backend('local', 'batch')
 
 
 def skip_when_service_backend_in_azure(reason='skipping for Service Backend in Azure'):
@@ -188,18 +161,7 @@ def skip_when_service_backend_in_azure(reason='skipping for Service Backend in A
 
 
 def skip_unless_service_backend(reason='only relevant to service backend', clouds=None):
-    from hail.backend.service_backend import ServiceBackend
-
-    @decorator
-    def wrapper(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
-        if not isinstance(hl.utils.java.Env.backend(), ServiceBackend):
-            raise unittest.SkipTest(reason)
-        else:
-            if clouds is None or os.environ['HAIL_CLOUD'] in clouds:
-                return func(*args, **kwargs)
-            raise unittest.SkipTest(f'{reason} for clouds {clouds}')
-
-    return wrapper
+    return pytest.mark.backend('batch')
 
 
 fails_local_backend = pytest.mark.xfail(
@@ -217,7 +179,7 @@ fails_spark_backend = pytest.mark.xfail(
 )
 
 
-qobtest = pytest.mark.qobtest
+qobtest = pytest.mark.backend('batch')
 
 
 def test_timeout(overall=None, *, batch=None, local=None, spark=None):

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -160,10 +160,6 @@ def skip_when_service_backend_in_azure(reason='skipping for Service Backend in A
     return wrapper
 
 
-def skip_unless_service_backend(reason='only relevant to service backend', clouds=None):
-    return pytest.mark.backend('batch')
-
-
 fails_local_backend = pytest.mark.xfail(
     choose_backend() == 'local', reason="doesn't yet work on local backend", strict=True
 )

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -9,10 +9,8 @@ from hail.methods.qc import VEPConfigGRCh37Version85, VEPConfigGRCh38Version95
 
 from ..helpers import (
     get_dataset,
-    qobtest,
     resource,
     set_gcs_requester_pays_configuration,
-    skip_unless_service_backend,
     test_timeout,
 )
 
@@ -42,7 +40,7 @@ class Tests(unittest.TestCase):
             data_bucket_is_requester_pays=True,
         )
 
-    @qobtest
+    @pytest.mark.backend('batch')
     def test_sample_qc(self):
         data = [
             {'v': '1:1:A:T', 's': '1', 'GT': hl.Call([0, 0]), 'GQ': 10, 'DP': 0},
@@ -84,7 +82,7 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(r[0].sqc.r_het_hom_var, 0.3333333333)
         self.assertAlmostEqual(r[0].sqc.r_insertion_deletion, None)
 
-    @qobtest
+    @pytest.mark.backend('batch')
     def test_variant_qc(self):
         data = [
             {'v': '1:1:A:T', 's': '1', 'GT': hl.Call([0, 0]), 'GQ': 10, 'DP': 0},
@@ -336,8 +334,8 @@ class Tests(unittest.TestCase):
         assert pytest.approx(d['C1046::HG02024'], abs=0.0001) == 0.00126
         assert pytest.approx(d['C1046::HG02025'], abs=0.0001) == 0.00124
 
-    @qobtest
-    @skip_unless_service_backend(clouds=['gcp'])
+    @pytest.mark.backend('batch')
+    @pytest.mark.cloud('gcp')
     @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch37_consequence_true(self):
@@ -359,8 +357,8 @@ class Tests(unittest.TestCase):
         vep_csq_header = hl.eval(hail_vep_result.vep_csq_header)
         assert 'Consequence annotations from Ensembl VEP' in vep_csq_header, vep_csq_header
 
-    @qobtest
-    @skip_unless_service_backend(clouds=['gcp'])
+    @pytest.mark.backend('batch')
+    @pytest.mark.cloud('gcp')
     @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_consequence_true(self):
@@ -384,8 +382,8 @@ class Tests(unittest.TestCase):
         vep_csq_header = hl.eval(hail_vep_result.vep_csq_header)
         assert 'Consequence annotations from Ensembl VEP' in vep_csq_header, vep_csq_header
 
-    @qobtest
-    @skip_unless_service_backend(clouds=['gcp'])
+    @pytest.mark.backend('batch')
+    @pytest.mark.cloud('gcp')
     @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch37_consequence_false(self):
@@ -398,8 +396,8 @@ class Tests(unittest.TestCase):
         result = ht.head(1).collect()[0]
         assert result.variant_class == 'SNV', result
 
-    @qobtest
-    @skip_unless_service_backend(clouds=['gcp'])
+    @pytest.mark.backend('batch')
+    @pytest.mark.cloud('gcp')
     @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_consequence_false(self):
@@ -412,8 +410,8 @@ class Tests(unittest.TestCase):
         result = ht.head(1).collect()[0]
         assert result.variant_class == 'SNV', result
 
-    @qobtest
-    @skip_unless_service_backend(clouds=['gcp'])
+    @pytest.mark.backend('batch')
+    @pytest.mark.cloud('gcp')
     @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch37_against_dataproc(self):
@@ -466,8 +464,8 @@ class Tests(unittest.TestCase):
 
         assert hail_vep_result._same(dataproc_result)
 
-    @qobtest
-    @skip_unless_service_backend(clouds=['gcp'])
+    @pytest.mark.backend('batch')
+    @pytest.mark.cloud('gcp')
     @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_against_dataproc(self):
@@ -520,8 +518,8 @@ class Tests(unittest.TestCase):
 
         assert hail_vep_result._same(dataproc_result)
 
-    @qobtest
-    @skip_unless_service_backend(clouds=['gcp'])
+    @pytest.mark.backend('batch')
+    @pytest.mark.cloud('gcp')
     @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_with_large_positions(self):

--- a/hail/python/test/pytest.ini
+++ b/hail/python/test/pytest.ini
@@ -5,6 +5,7 @@ markers =
     unchecked_allocator: tests that use the unchecked allocator
     asyncio: test files that use asyncio
     backend: tests that relate only to one or more backend types
+    cloud: tests that relate only to one or more clouds
 filterwarnings =
     error
     ignore::UserWarning

--- a/hail/python/test/pytest.ini
+++ b/hail/python/test/pytest.ini
@@ -2,9 +2,9 @@
 asyncio_mode = auto
 addopts = --strict-markers
 markers =
-    qobtest: integration tests for Query-on-Batch
     unchecked_allocator: tests that use the unchecked allocator
     asyncio: test files that use asyncio
+    backend: tests that relate only to one or more backend types
 filterwarnings =
     error
     ignore::UserWarning

--- a/hail/python/test/pytest.ini
+++ b/hail/python/test/pytest.ini
@@ -9,4 +9,5 @@ filterwarnings =
     error
     ignore::UserWarning
     ignore::DeprecationWarning
+mock_use_standalone_module = true
 xfail_strict=true

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -42,15 +42,6 @@ object HailFeatureFlags {
     (RequesterPaysConfig.Flags.RequesterPaysProject, "HAIL_GCS_REQUESTER_PAYS_PROJECT" -> null),
   )
 
-  def fromEnv(): HailFeatureFlags =
-    new HailFeatureFlags(
-      mutable.Map(
-        HailFeatureFlags.defaults.mapValues { case (env, default) =>
-          sys.env.getOrElse(env, default)
-        }.toFastSeq: _*
-      )
-    )
-
   def fromMap(m: Map[String, String]): HailFeatureFlags =
     new HailFeatureFlags(
       mutable.Map(

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -69,7 +69,7 @@ object LocalBackend {
 
 class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache {
 
-  private[this] val flags = HailFeatureFlags.fromEnv()
+  private[this] val flags = HailFeatureFlags.fromMap(sys.env)
   private[this] val theHailClassLoader = new HailClassLoader(getClass().getClassLoader())
 
   def getFlag(name: String): String = flags.get(name)
@@ -81,7 +81,7 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
     flags.available
 
   // flags can be set after construction from python
-  def fs: FS = FS.buildRoutes(None, Some(flags))
+  def fs: FS = FS.buildRoutes(None, Some(flags), sys.env)
 
   def withExecuteContext[T](timer: ExecutionTimer): (ExecuteContext => T) => T = {
     val fs = this.fs

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -81,7 +81,7 @@ object ServiceBackend {
     val backend = new ServiceBackend(
       jarLocation,
       name,
-      new HailClassLoader(getClass().getClassLoader()),
+      theHailClassLoader,
       batchClient,
       batchId,
       jobGroupId,

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -160,7 +160,7 @@ class ServiceBackend(
   ): (String, String, Int) = {
     val backendContext = _backendContext.asInstanceOf[ServiceBackendContext]
     val n = collection.length
-    val token = tokenUrlSafe(32)
+    val token = tokenUrlSafe
     val root = s"${backendContext.remoteTmpDir}parallelizeAndComputeWithIndex/$token"
 
     log.info(s"parallelizeAndComputeWithIndex: $token: nPartitions $n")

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -58,7 +58,7 @@ object ServiceBackend {
     batchClient: BatchClient,
     batchId: Option[Long],
     jobGroupId: Option[Long],
-    scratchDir: String = sys.env.get("HAIL_WORKER_SCRATCH_DIR").getOrElse(""),
+    scratchDir: String = sys.env.getOrElse("HAIL_WORKER_SCRATCH_DIR", ""),
     rpcConfig: ServiceBackendRPCPayload,
   ): ServiceBackend = {
 

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -60,11 +60,12 @@ object ServiceBackend {
     jobGroupId: Option[Long],
     scratchDir: String = sys.env.getOrElse("HAIL_WORKER_SCRATCH_DIR", ""),
     rpcConfig: ServiceBackendRPCPayload,
+    env: Map[String, String],
   ): ServiceBackend = {
 
     val flags = HailFeatureFlags.fromMap(rpcConfig.flags)
     val shouldProfile = flags.get("profile") != null
-    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), Some(flags))
+    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), Some(flags), env)
 
     val backendContext = new ServiceBackendContext(
       rpcConfig.billing_project,
@@ -446,7 +447,7 @@ object ServiceBackendAPI {
     val inputURL = argv(5)
     val outputURL = argv(6)
 
-    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), None)
+    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), None, sys.env)
     val deployConfig = DeployConfig.fromConfigFile(
       s"$scratchDir/secrets/deploy-config/deploy-config.json"
     )
@@ -475,6 +476,7 @@ object ServiceBackendAPI {
       jobGroupId,
       scratchDir,
       rpcConfig,
+      sys.env,
     )
     log.info("ServiceBackend allocated.")
     if (HailContext.isInitialized) {

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -125,7 +125,7 @@ object Worker {
     timer.start(s"Job $i/$n")
 
     timer.start("readInputs")
-    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), None)
+    val fs = FS.buildRoutes(Some(s"$scratchDir/secrets/gsa-key/key.json"), None, sys.env)
 
     def open(x: String): SeekableDataInputStream =
       fs.openNoCompression(x)

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -329,7 +329,7 @@ class SparkBackend(
 
   val bmCache: SparkBlockMatrixCache = SparkBlockMatrixCache()
 
-  private[this] val flags = HailFeatureFlags.fromEnv()
+  private[this] val flags = HailFeatureFlags.fromMap(sys.env)
 
   def getFlag(name: String): String = flags.get(name)
 

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -259,7 +259,11 @@ abstract class FSPositionedOutputStream(val capacity: Int) extends OutputStream 
 }
 
 object FS {
-  def buildRoutes(credentialsPath: Option[String], flags: Option[HailFeatureFlags]): FS =
+  def buildRoutes(
+    credentialsPath: Option[String],
+    flags: Option[HailFeatureFlags],
+    env: Map[String, String],
+  ): FS =
     retryTransientErrors {
 
       def readString(path: String): String =
@@ -270,14 +274,14 @@ object FS {
         flags.flatMap(RequesterPaysConfig.fromFlags),
       )
 
-      def az = sys.env.get("HAIL_TERRA") match {
+      def az = env.get("HAIL_TERRA") match {
         case Some(_) => new TerraAzureStorageFS()
         case None => new AzureStorageFS(
             credentialsPath.orElse(sys.env.get(AzureApplicationCredentials)).map(readString)
           )
       }
 
-      val cloudSpecificFSs = sys.env.get("HAIL_CLOUD") match {
+      val cloudSpecificFSs = env.get("HAIL_CLOUD") match {
         case Some("gcp") => FastSeq(gcs)
         case Some("azure") => FastSeq(az)
         case Some(cloud) =>

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -949,7 +949,7 @@ package object utils
   def virtualOffsetCompressedOffset(offset: Long): Long =
     offset >> 16
 
-  def tokenUrlSafe(n: Int): String = {
+  def tokenUrlSafe: String = {
     val bytes = new Array[Byte](32)
     val random = new SecureRandom()
     random.nextBytes(bytes)

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -97,6 +97,8 @@ package object utils
     extends Logging with richUtils.Implicits with NumericPairImplicits with utils.NumericImplicits
     with Py4jUtils with ErrorHandling {
 
+  type UtilsType = this.type
+
   def utilsPackageClass = getClass
 
   def getStderrAndLogOutputStream[T](implicit tct: ClassTag[T]): OutputStream =

--- a/hail/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/hail/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
@@ -31,6 +31,7 @@ class ServiceBackendSuite extends TestNGSuite with IdiomaticMockito {
           jobGroupId = None,
           scratchDir = rpcPayload.remote_tmpdir,
           rpcConfig = rpcPayload,
+          sys.env + ("HAIL_CLOUD" -> "gcp"),
         )
 
       val contexts = Array.tabulate(1)(_.toString.getBytes)
@@ -94,6 +95,7 @@ class ServiceBackendSuite extends TestNGSuite with IdiomaticMockito {
           jobGroupId = None,
           scratchDir = config.remote_tmpdir,
           rpcConfig = config,
+          sys.env + ("HAIL_CLOUD" -> "gcp"),
         )
 
       val contexts = Array.tabulate(1)(_.toString.getBytes)

--- a/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
@@ -4,64 +4,100 @@ import is.hail.asm4s.HailClassLoader
 import is.hail.backend.service.{ServiceBackend, ServiceBackendRPCPayload}
 import is.hail.services.batch_client.BatchClient
 import is.hail.utils.tokenUrlSafe
-import org.json4s.{JObject, JString}
+import org.json4s.{JBool, JObject, JString}
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
-import org.mockito.MockitoSugar.{mock, when}
+import org.mockito.IdiomaticMockito
+import org.mockito.MockitoSugar.when
 import org.scalatestplus.testng.TestNGSuite
 import org.testng.annotations.Test
 
-class ServiceBackendSuite extends TestNGSuite {
+import scala.reflect.io.{Directory, Path}
 
-  @Test def testWorkerJobsHaveCorrectMemory(): Unit = {
-    val batchClient = mock[BatchClient]
+class ServiceBackendSuite extends TestNGSuite with IdiomaticMockito {
 
-    val config =
-      ServiceBackendRPCPayload(
-        tmp_dir = "",
-        remote_tmpdir = "",
-        billing_project = "",
-        worker_cores = "128",
-        worker_memory = "a lot.",
-        storage = "",
-        cloudfuse_configs = Array(),
-        regions = Array(),
-        flags = Map(),
-        custom_references = Array(),
-        liftovers = Map(),
-        sequences = Map(),
-      )
-
-    val backend =
-      ServiceBackend(
-        jarLocation = "/path/to/jar",
-        name = "name",
-        theHailClassLoader = new HailClassLoader(getClass.getClassLoader),
-        batchClient,
-        batchId = None,
-        jobGroupId = None,
-        scratchDir = "/path/to/scratch",
-        rpcConfig = config,
-      )
-
-    // configure mocks
-    when(batchClient.create(any[JObject], any[IndexedSeq[JObject]])) thenReturn 0L
-    when(batchClient.waitForJobGroup(eqTo(0L), any[Long])) thenAnswer {
-      val hideous =
-        f"${backend.serviceBackendContext.remoteTmpDir}parallelizeAndComputeWithIndex/" +
-          f"${tokenUrlSafe(32)}/result.0"
-
-      backend.fs.write(hideous)(_.write(Array(0xFF, 0xFF).map(_.toByte)))
-      JObject("state" -> JString("success"))
-    }
-
-    backend.parallelizeAndComputeWithIndex(
-      backend.serviceBackendContext,
-      backend.fs,
-      Array.tabulate(1)(_.toString.getBytes),
-      "stage1",
-    )((bytes, _, _, _) => bytes)
-
-    assert(true)
+  def withNewLocalTmpFolder[A](f: Directory => A): A = {
+    val tmp = Directory.makeTemp("hail-testing-tmp", "")
+    try f(tmp)
+    finally tmp.deleteRecursively()
   }
+
+  @Test def testWorkerJobsHaveCorrectResources(): Unit =
+    withNewLocalTmpFolder { scratchDir =>
+      withObjectSpied[is.hail.utils.UtilsType] {
+
+        val batchClient = mock[BatchClient]
+
+        val config =
+          ServiceBackendRPCPayload(
+            tmp_dir = scratchDir.path,
+            remote_tmpdir = f"$scratchDir/",
+            billing_project = "",
+            worker_cores = "128",
+            worker_memory = "a lot.",
+            storage = "a big ssd?",
+            cloudfuse_configs = Array(),
+            regions = Array(),
+            flags = Map(),
+            custom_references = Array(),
+            liftovers = Map(),
+            sequences = Map(),
+          )
+
+        // Workers have cloud credentials installed to a well-known location
+        val gcsKeyDir = scratchDir / "secrets" / "gsa-key"
+        gcsKeyDir.createDirectory()
+        (gcsKeyDir / "key.json").toFile.writeAll("password1234")
+
+        val backend =
+          ServiceBackend(
+            jarLocation =
+              classOf[ServiceBackend].getProtectionDomain.getCodeSource.getLocation.getPath,
+            name = "name",
+            theHailClassLoader = new HailClassLoader(getClass.getClassLoader),
+            batchClient,
+            batchId = None,
+            jobGroupId = None,
+            scratchDir = scratchDir.toString,
+            rpcConfig = config,
+          )
+
+        val contexts = Array.tabulate(1)(_.toString.getBytes)
+
+        // configure mocks
+        when(is.hail.utils.tokenUrlSafe(any)) thenAnswer "{random}"
+        when(batchClient.create(any[JObject], any[IndexedSeq[JObject]])) thenAnswer {
+          (_: JObject, jobs: IndexedSeq[JObject]) =>
+            assert(jobs.length == contexts.length)
+            jobs.foreach { payload =>
+              assert(payload \ "resources" == JObject(
+                "preemptible" -> JBool(true),
+                "cpu" -> JString(config.worker_cores),
+                "memory" -> JString(config.worker_memory),
+                "storage" -> JString(config.storage),
+              ))
+            }
+            0L
+        }
+        when(batchClient.waitForJobGroup(eqTo(0L), any[Long])) thenAnswer {
+          val resultsDir =
+            Path(backend.serviceBackendContext.remoteTmpDir) /
+              "parallelizeAndComputeWithIndex" /
+              tokenUrlSafe(32)
+
+          resultsDir.createDirectory()
+          for (i <- contexts.indices) (resultsDir / f"result.$i").toFile.writeAll("11")
+          JObject("state" -> JString("success"))
+        }
+
+        backend.parallelizeAndComputeWithIndex(
+          backend.serviceBackendContext,
+          backend.fs,
+          contexts,
+          "stage1",
+        )((bytes, _, _, _) => bytes)
+
+        batchClient.create(any[JObject], any[IndexedSeq[JObject]]) wasCalled once
+      }
+    }
 
 }

--- a/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
@@ -140,7 +140,7 @@ class ServiceBackendSuite extends TestNGSuite with IdiomaticMockito {
 
       when(batchClient.waitForJobGroup(any[Long], any[Long])) thenAnswer {
         (batchId: Long, jobGroupId: Long) =>
-          batchId shouldEqual 37L
+          batchId shouldEqual 23L
           jobGroupId shouldEqual 3L
 
           val resultsDir =

--- a/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
@@ -1,0 +1,67 @@
+package is.hail.backend
+
+import is.hail.asm4s.HailClassLoader
+import is.hail.backend.service.{ServiceBackend, ServiceBackendRPCPayload}
+import is.hail.services.batch_client.BatchClient
+import is.hail.utils.tokenUrlSafe
+import org.json4s.{JObject, JString}
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.MockitoSugar.{mock, when}
+import org.scalatestplus.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class ServiceBackendSuite extends TestNGSuite {
+
+  @Test def testWorkerJobsHaveCorrectMemory(): Unit = {
+    val batchClient = mock[BatchClient]
+
+    val config =
+      ServiceBackendRPCPayload(
+        tmp_dir = "",
+        remote_tmpdir = "",
+        billing_project = "",
+        worker_cores = "128",
+        worker_memory = "a lot.",
+        storage = "",
+        cloudfuse_configs = Array(),
+        regions = Array(),
+        flags = Map(),
+        custom_references = Array(),
+        liftovers = Map(),
+        sequences = Map(),
+      )
+
+    val backend =
+      ServiceBackend(
+        jarLocation = "/path/to/jar",
+        name = "name",
+        theHailClassLoader = new HailClassLoader(getClass.getClassLoader),
+        batchClient,
+        batchId = None,
+        jobGroupId = None,
+        scratchDir = "/path/to/scratch",
+        rpcConfig = config,
+      )
+
+    // configure mocks
+    when(batchClient.create(any[JObject], any[IndexedSeq[JObject]])) thenReturn 0L
+    when(batchClient.waitForJobGroup(eqTo(0L), any[Long])) thenAnswer {
+      val hideous =
+        f"${backend.serviceBackendContext.remoteTmpDir}parallelizeAndComputeWithIndex/" +
+          f"${tokenUrlSafe(32)}/result.0"
+
+      backend.fs.write(hideous)(_.write(Array(0xFF, 0xFF).map(_.toByte)))
+      JObject("state" -> JString("success"))
+    }
+
+    backend.parallelizeAndComputeWithIndex(
+      backend.serviceBackendContext,
+      backend.fs,
+      Array.tabulate(1)(_.toString.getBytes),
+      "stage1",
+    )((bytes, _, _, _) => bytes)
+
+    assert(true)
+  }
+
+}

--- a/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
@@ -4,10 +4,11 @@ import is.hail.asm4s.HailClassLoader
 import is.hail.backend.service.{ServiceBackend, ServiceBackendRPCPayload}
 import is.hail.services.batch_client.BatchClient
 import is.hail.utils.tokenUrlSafe
-import org.json4s.{JBool, JObject, JString}
+import org.json4s.{JArray, JBool, JInt, JObject, JString}
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.mockito.IdiomaticMockito
 import org.mockito.MockitoSugar.when
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.testng.TestNGSuite
 import org.testng.annotations.Test
 
@@ -15,80 +16,57 @@ import scala.reflect.io.{Directory, Path}
 
 class ServiceBackendSuite extends TestNGSuite with IdiomaticMockito {
 
-  def withNewLocalTmpFolder[A](f: Directory => A): A = {
-    val tmp = Directory.makeTemp("hail-testing-tmp", "")
-    try f(tmp)
-    finally tmp.deleteRecursively()
-  }
+  @Test def testCreateJobPayload(): Unit =
+    withMockDriverContext { rpcPayload =>
+      val batchClient = mock[BatchClient]
 
-  @Test def testWorkerJobsHaveCorrectResources(): Unit =
-    withNewLocalTmpFolder { scratchDir =>
-      withObjectSpied[is.hail.utils.UtilsType] {
+      val backend =
+        ServiceBackend(
+          jarLocation =
+            classOf[ServiceBackend].getProtectionDomain.getCodeSource.getLocation.getPath,
+          name = "name",
+          theHailClassLoader = new HailClassLoader(getClass.getClassLoader),
+          batchClient,
+          batchId = None,
+          jobGroupId = None,
+          scratchDir = rpcPayload.remote_tmpdir,
+          rpcConfig = rpcPayload,
+        )
 
-        val batchClient = mock[BatchClient]
+      val contexts = Array.tabulate(1)(_.toString.getBytes)
 
-        val config =
-          ServiceBackendRPCPayload(
-            tmp_dir = scratchDir.path,
-            remote_tmpdir = f"$scratchDir/",
-            billing_project = "",
-            worker_cores = "128",
-            worker_memory = "a lot.",
-            storage = "a big ssd?",
-            cloudfuse_configs = Array(),
-            regions = Array(),
-            flags = Map(),
-            custom_references = Array(),
-            liftovers = Map(),
-            sequences = Map(),
-          )
+      when(batchClient.create(any[JObject], any[IndexedSeq[JObject]])) thenAnswer {
+        (batch: JObject, jobs: IndexedSeq[JObject]) =>
+          batch \ "billing_project" shouldBe JString(rpcPayload.billing_project)
+          batch \ "n_jobs" shouldBe JInt(contexts.length)
 
-        // Workers have cloud credentials installed to a well-known location
-        val gcsKeyDir = scratchDir / "secrets" / "gsa-key"
-        gcsKeyDir.createDirectory()
-        (gcsKeyDir / "key.json").toFile.writeAll("password1234")
+          jobs.length shouldEqual contexts.length
+          jobs.foreach { payload =>
+            payload \ "regions" shouldBe JArray(rpcPayload.regions.map(JString).toList)
 
-        val backend =
-          ServiceBackend(
-            jarLocation =
-              classOf[ServiceBackend].getProtectionDomain.getCodeSource.getLocation.getPath,
-            name = "name",
-            theHailClassLoader = new HailClassLoader(getClass.getClassLoader),
-            batchClient,
-            batchId = None,
-            jobGroupId = None,
-            scratchDir = scratchDir.toString,
-            rpcConfig = config,
-          )
+            payload \ "resources" shouldBe JObject(
+              "preemptible" -> JBool(true),
+              "cpu" -> JString(rpcPayload.worker_cores),
+              "memory" -> JString(rpcPayload.worker_memory),
+              "storage" -> JString(rpcPayload.storage),
+            )
+          }
 
-        val contexts = Array.tabulate(1)(_.toString.getBytes)
+          37L
+      }
 
-        // configure mocks
-        when(is.hail.utils.tokenUrlSafe(any)) thenAnswer "{random}"
-        when(batchClient.create(any[JObject], any[IndexedSeq[JObject]])) thenAnswer {
-          (_: JObject, jobs: IndexedSeq[JObject]) =>
-            assert(jobs.length == contexts.length)
-            jobs.foreach { payload =>
-              assert(payload \ "resources" == JObject(
-                "preemptible" -> JBool(true),
-                "cpu" -> JString(config.worker_cores),
-                "memory" -> JString(config.worker_memory),
-                "storage" -> JString(config.storage),
-              ))
-            }
-            0L
-        }
-        when(batchClient.waitForJobGroup(eqTo(0L), any[Long])) thenAnswer {
-          val resultsDir =
-            Path(backend.serviceBackendContext.remoteTmpDir) /
-              "parallelizeAndComputeWithIndex" /
-              tokenUrlSafe(32)
+      when(batchClient.waitForJobGroup(eqTo(37L), eqTo(1L))) thenAnswer {
+        val resultsDir =
+          Path(backend.serviceBackendContext.remoteTmpDir) /
+            "parallelizeAndComputeWithIndex" /
+            tokenUrlSafe
 
-          resultsDir.createDirectory()
-          for (i <- contexts.indices) (resultsDir / f"result.$i").toFile.writeAll("11")
-          JObject("state" -> JString("success"))
-        }
+        resultsDir.createDirectory()
+        for (i <- contexts.indices) (resultsDir / f"result.$i").toFile.writeAll("11")
+        JObject("state" -> JString("success"))
+      }
 
+      val (failure, _) =
         backend.parallelizeAndComputeWithIndex(
           backend.serviceBackendContext,
           backend.fs,
@@ -96,8 +74,116 @@ class ServiceBackendSuite extends TestNGSuite with IdiomaticMockito {
           "stage1",
         )((bytes, _, _, _) => bytes)
 
-        batchClient.create(any[JObject], any[IndexedSeq[JObject]]) wasCalled once
+      failure.foreach(throw _)
+
+      batchClient.create(any[JObject], any[IndexedSeq[JObject]]) wasCalled once
+    }
+
+  @Test def testUpdateJobPayload(): Unit =
+    withMockDriverContext { config =>
+      val batchClient = mock[BatchClient]
+
+      val backend =
+        ServiceBackend(
+          jarLocation =
+            classOf[ServiceBackend].getProtectionDomain.getCodeSource.getLocation.getPath,
+          name = "name",
+          theHailClassLoader = new HailClassLoader(getClass.getClassLoader),
+          batchClient,
+          batchId = Some(23L),
+          jobGroupId = None,
+          scratchDir = config.remote_tmpdir,
+          rpcConfig = config,
+        )
+
+      val contexts = Array.tabulate(1)(_.toString.getBytes)
+
+      when(
+        batchClient.update(any[Long], any[String], any[JObject], any[IndexedSeq[JObject]])
+      ) thenAnswer {
+        (batchId: Long, _: String, _: JObject, jobs: IndexedSeq[JObject]) =>
+          batchId shouldEqual 23L
+
+          jobs.length shouldEqual contexts.length
+          jobs.foreach { payload =>
+            payload \ "regions" shouldBe JArray(config.regions.map(JString).toList)
+
+            payload \ "resources" shouldBe JObject(
+              "preemptible" -> JBool(true),
+              "cpu" -> JString(config.worker_cores),
+              "memory" -> JString(config.worker_memory),
+              "storage" -> JString(config.storage),
+            )
+          }
+
+          (2L, 3L)
+      }
+
+      when(batchClient.waitForJobGroup(eqTo(23L), eqTo(3L))) thenAnswer {
+        val resultsDir =
+          Path(backend.serviceBackendContext.remoteTmpDir) /
+            "parallelizeAndComputeWithIndex" /
+            tokenUrlSafe
+
+        resultsDir.createDirectory()
+        for (i <- contexts.indices) (resultsDir / f"result.$i").toFile.writeAll("11")
+        JObject("state" -> JString("success"))
+      }
+
+      val (failure, _) =
+        backend.parallelizeAndComputeWithIndex(
+          backend.serviceBackendContext,
+          backend.fs,
+          contexts,
+          "stage1",
+        )((bytes, _, _, _) => bytes)
+
+      failure.foreach(throw _)
+
+      batchClient.create(any[JObject], any[IndexedSeq[JObject]]) wasNever called
+      batchClient.update(
+        any[Long],
+        any[String],
+        any[JObject],
+        any[IndexedSeq[JObject]],
+      ) wasCalled once
+    }
+
+  def withMockDriverContext(test: ServiceBackendRPCPayload => Any): Any =
+    withNewLocalTmpFolder { tmp =>
+      // The `ServiceBackend` assumes credentials are installed to a well known location
+      val gcsKeyDir = tmp / "secrets" / "gsa-key"
+      gcsKeyDir.createDirectory()
+      (gcsKeyDir / "key.json").toFile.writeAll("password1234")
+
+      withObjectSpied[is.hail.utils.UtilsType] {
+        // not obvious how to pull out `tokenUrlSafe` and inject this directory
+        // using a spy is a hack and i don't particularly like it.
+        when(is.hail.utils.tokenUrlSafe) thenAnswer "TOKEN"
+
+        test {
+          ServiceBackendRPCPayload(
+            tmp_dir = "",
+            remote_tmpdir = tmp.path + "/", // because raw strings...
+            billing_project = "fancy",
+            worker_cores = "128",
+            worker_memory = "a lot.",
+            storage = "a big ssd?",
+            cloudfuse_configs = Array(),
+            regions = Array("lunar1"),
+            flags = Map(),
+            custom_references = Array(),
+            liftovers = Map(),
+            sequences = Map(),
+          )
+        }
       }
     }
+
+  def withNewLocalTmpFolder[A](f: Directory => A): A = {
+    val tmp = Directory.makeTemp("hail-testing-tmp", "")
+    try f(tmp)
+    finally tmp.deleteRecursively()
+  }
 
 }

--- a/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/src/test/scala/is/hail/backend/ServiceBackendSuite.scala
@@ -4,6 +4,9 @@ import is.hail.asm4s.HailClassLoader
 import is.hail.backend.service.{ServiceBackend, ServiceBackendRPCPayload}
 import is.hail.services.batch_client.BatchClient
 import is.hail.utils.tokenUrlSafe
+
+import scala.reflect.io.{Directory, Path}
+
 import org.json4s.{JArray, JBool, JInt, JObject, JString}
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.mockito.IdiomaticMockito
@@ -11,8 +14,6 @@ import org.mockito.MockitoSugar.when
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.testng.TestNGSuite
 import org.testng.annotations.Test
-
-import scala.reflect.io.{Directory, Path}
 
 class ServiceBackendSuite extends TestNGSuite with IdiomaticMockito {
 

--- a/hail/src/test/scala/is/hail/services/batch_client/BatchClientSuite.scala
+++ b/hail/src/test/scala/is/hail/services/batch_client/BatchClientSuite.scala
@@ -10,7 +10,7 @@ import org.testng.annotations.Test
 class BatchClientSuite extends TestNGSuite {
   @Test def testBasic(): Unit = {
     val client = new BatchClient("/test-gsa-key/key.json")
-    val token = tokenUrlSafe(32)
+    val token = tokenUrlSafe
     val batch = client.run(
       JObject(
         "billing_project" -> JString("test"),


### PR DESCRIPTION
Python integration tests often fail waiting to allocate highmem instances for worker jobs.
Since we control both APIs, it seems reasonable to move the testing burdon for vm allocation onto batch and use contract testing on the query driver side.

These contract tests cover:
- uploading the the ServiceBackendRPConfig to remote storage in python
- reading that config and forwarding the relevant sections to the batch service in scala

Admittedly these are fairly busy tests and make bare a lot of lower-level implementation details. While I believe these tests are good to have, they perhaps don't warrant the time investment to properly refactor for cleaner mocking. Should details of the main implementation change, these will likely break.

I've made tweaks to the python unittest annotations for backend test filtering. The old system skipped tests after all required fixtures had been acquired. Using `@pytest.mark.{feature}` allows us to exclude tests before fixtures are setup as well as add additional setup/teardown code.