### PR TITLE
[compiler] simplify NormalizeNames

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -70,7 +70,7 @@ sealed abstract class BlockMatrixIR extends BaseIR {
   protected[ir] def execute(ctx: ExecuteContext): BlockMatrix =
     fatal("tried to execute unexecutable IR:\n" + Pretty(ctx, this))
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR
 
   def blockCostIsLinear: Boolean
 
@@ -82,7 +82,7 @@ case class BlockMatrixRead(reader: BlockMatrixReader) extends BlockMatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array.empty[BlockMatrixIR]
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixRead = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixRead = {
     assert(newChildren.isEmpty)
     BlockMatrixRead(reader)
   }
@@ -302,7 +302,7 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: Name, f: IR, needsDense
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, f)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixMap = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixMap = {
     val IndexedSeq(newChild: BlockMatrixIR, newF: IR) = newChildren
     BlockMatrixMap(newChild, eltName, newF, needsDense)
   }
@@ -450,7 +450,7 @@ case class BlockMatrixMap2(
 
   val blockCostIsLinear: Boolean = left.blockCostIsLinear && right.blockCostIsLinear
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixMap2 = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixMap2 = {
     assert(newChildren.length == 3)
     BlockMatrixMap2(
       newChildren(0).asInstanceOf[BlockMatrixIR],
@@ -581,7 +581,7 @@ case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends Blo
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(left, right)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixDot = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixDot = {
     assert(newChildren.length == 2)
     BlockMatrixDot(
       newChildren(0).asInstanceOf[BlockMatrixIR],
@@ -680,7 +680,8 @@ case class BlockMatrixBroadcast(
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixBroadcast = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : BlockMatrixBroadcast = {
     assert(newChildren.length == 1)
     BlockMatrixBroadcast(newChildren(0).asInstanceOf[BlockMatrixIR], inIndexExpr, shape, blockSize)
   }
@@ -760,7 +761,7 @@ case class BlockMatrixAgg(
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixAgg = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixAgg = {
     assert(newChildren.length == 1)
     BlockMatrixAgg(newChildren(0).asInstanceOf[BlockMatrixIR], axesToSumOut)
   }
@@ -815,7 +816,7 @@ case class BlockMatrixFilter(
 
   override def childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixFilter = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixFilter = {
     assert(newChildren.length == 1)
     BlockMatrixFilter(newChildren(0).asInstanceOf[BlockMatrixIR], indices)
   }
@@ -844,7 +845,7 @@ case class BlockMatrixDensify(child: BlockMatrixIR) extends BlockMatrixIR {
 
   val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
     val IndexedSeq(newChild: BlockMatrixIR) = newChildren
     BlockMatrixDensify(newChild)
   }
@@ -965,7 +966,7 @@ case class BlockMatrixSparsify(
 
   val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
     val IndexedSeq(newChild: BlockMatrixIR) = newChildren
     BlockMatrixSparsify(newChild, sparsifier)
   }
@@ -1010,7 +1011,7 @@ case class BlockMatrixSlice(child: BlockMatrixIR, slices: IndexedSeq[IndexedSeq[
 
   override def childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
     assert(newChildren.length == 1)
     BlockMatrixSlice(newChildren(0).asInstanceOf[BlockMatrixIR], slices)
   }
@@ -1062,7 +1063,8 @@ case class ValueToBlockMatrix(
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): ValueToBlockMatrix = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : ValueToBlockMatrix = {
     assert(newChildren.length == 1)
     ValueToBlockMatrix(newChildren(0).asInstanceOf[IR], shape, blockSize)
   }
@@ -1108,7 +1110,7 @@ case class BlockMatrixRandom(
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixRandom = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixRandom = {
     assert(newChildren.isEmpty)
     BlockMatrixRandom(staticUID, gaussian, shape, blockSize)
   }
@@ -1125,7 +1127,7 @@ case class RelationalLetBlockMatrix(name: Name, value: IR, body: BlockMatrixIR)
 
   val blockCostIsLinear: Boolean = body.blockCostIsLinear
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BlockMatrixIR = {
     val IndexedSeq(newValue: IR, newBody: BlockMatrixIR) = newChildren
     RelationalLetBlockMatrix(name, newValue, newBody)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -44,7 +44,7 @@ object Compile {
   ): (Option[SingleCodeType], (HailClassLoader, FS, HailTaskContext, Region) => F) = {
 
     val normalizedBody =
-      new NormalizeNames(_.toString, allowFreeVariables = true)(ctx, body).asInstanceOf[IR]
+      NormalizeNames(ctx, body, allowFreeVariables = true)
     val k =
       CodeCacheKey(FastSeq[AggStateSig](), params.map { case (n, pt) => (n, pt) }, normalizedBody)
     (ctx.backend.lookupOrCompileCachedFunction[F](k) {
@@ -107,7 +107,7 @@ object CompileWithAggregators {
     (HailClassLoader, FS, HailTaskContext, Region) => (F with FunctionWithAggRegion),
   ) = {
     val normalizedBody =
-      new NormalizeNames(_.toString, allowFreeVariables = true)(ctx, body).asInstanceOf[IR]
+      NormalizeNames(ctx, body, allowFreeVariables = true)
     val k = CodeCacheKey(aggSigs, params.map { case (n, pt) => (n, pt) }, normalizedBody)
     (ctx.backend.lookupOrCompileCachedFunction[F with FunctionWithAggRegion](k) {
 

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -8,7 +8,7 @@ import scala.collection.Set
 
 object ForwardLets {
   def apply[T <: BaseIR](ctx: ExecuteContext)(ir0: T): T = {
-    val ir1 = new NormalizeNames(_ => genUID(), allowFreeVariables = true)(ctx, ir0)
+    val ir1 = NormalizeNames(ctx, ir0, allowFreeVariables = true)
     val UsesAndDefs(uses, defs, _) = ComputeUsesAndDefs(ir1, errorIfFreeVariables = false)
     val nestingDepth = NestingDepth(ir1)
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -43,7 +43,7 @@ sealed trait IR extends BaseIR {
   protected lazy val childrenSeq: IndexedSeq[BaseIR] =
     Children(this)
 
-  override protected def copy(newChildren: IndexedSeq[BaseIR]): IR =
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): IR =
     Copy(this, newChildren)
 
   override def mapChildren(f: BaseIR => BaseIR): IR = super.mapChildren(f).asInstanceOf[IR]
@@ -217,6 +217,8 @@ object Let {
 case class Binding(name: Name, value: IR, scope: Int = Scope.EVAL)
 
 final case class Block(bindings: IndexedSeq[Binding], body: IR) extends IR {
+//  assert(bindings.map(_.name).areDistinct(), bindings.map(_.name.str))
+
   override lazy val size: Int =
     bindings.length + 1
 }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -58,7 +58,7 @@ sealed abstract class MatrixIR extends BaseIR {
 
   def columnCount: Option[Int] = None
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixIR
 
   def unpersist(): MatrixIR =
     this match {
@@ -104,7 +104,7 @@ case class MatrixLiteral(typ: MatrixType, tl: TableLiteral) extends MatrixIR {
 
   lazy val rowCountUpperBound: Option[Long] = None
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixLiteral = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixLiteral = {
     assert(newChildren.isEmpty)
     MatrixLiteral(typ, tl)
   }
@@ -506,7 +506,7 @@ case class MatrixRead(
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixRead = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixRead = {
     assert(newChildren.isEmpty)
     MatrixRead(typ, dropCols, dropRows, reader)
   }
@@ -538,7 +538,7 @@ case class MatrixFilterCols(child: MatrixIR, pred: IR) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, pred)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixFilterCols = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixFilterCols = {
     assert(newChildren.length == 2)
     MatrixFilterCols(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
@@ -554,7 +554,7 @@ case class MatrixFilterRows(child: MatrixIR, pred: IR) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, pred)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixFilterRows = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixFilterRows = {
     assert(newChildren.length == 2)
     MatrixFilterRows(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
@@ -569,7 +569,7 @@ case class MatrixFilterRows(child: MatrixIR, pred: IR) extends MatrixIR {
 case class MatrixChooseCols(child: MatrixIR, oldIndices: IndexedSeq[Int]) extends MatrixIR {
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixChooseCols = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixChooseCols = {
     assert(newChildren.length == 1)
     MatrixChooseCols(newChildren(0).asInstanceOf[MatrixIR], oldIndices)
   }
@@ -586,7 +586,8 @@ case class MatrixChooseCols(child: MatrixIR, oldIndices: IndexedSeq[Int]) extend
 case class MatrixCollectColsByKey(child: MatrixIR) extends MatrixIR {
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixCollectColsByKey = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixCollectColsByKey = {
     assert(newChildren.length == 1)
     MatrixCollectColsByKey(newChildren(0).asInstanceOf[MatrixIR])
   }
@@ -611,7 +612,8 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, entryExpr: IR, rowExpr: IR)
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, entryExpr, rowExpr)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixAggregateRowsByKey = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixAggregateRowsByKey = {
     val IndexedSeq(newChild: MatrixIR, newEntryExpr: IR, newRowExpr: IR) = newChildren
     MatrixAggregateRowsByKey(newChild, newEntryExpr, newRowExpr)
   }
@@ -632,7 +634,8 @@ case class MatrixAggregateColsByKey(child: MatrixIR, entryExpr: IR, colExpr: IR)
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, entryExpr, colExpr)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixAggregateColsByKey = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixAggregateColsByKey = {
     val IndexedSeq(newChild: MatrixIR, newEntryExpr: IR, newColExpr: IR) = newChildren
     MatrixAggregateColsByKey(newChild, newEntryExpr, newColExpr)
   }
@@ -664,7 +667,7 @@ case class MatrixUnionCols(left: MatrixIR, right: MatrixIR, joinType: String) ex
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(left, right)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixUnionCols = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixUnionCols = {
     assert(newChildren.length == 2)
     MatrixUnionCols(
       newChildren(0).asInstanceOf[MatrixIR],
@@ -715,7 +718,7 @@ case class MatrixUnionCols(left: MatrixIR, right: MatrixIR, joinType: String) ex
 case class MatrixMapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, newEntries)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapEntries = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixMapEntries = {
     assert(newChildren.length == 2)
     MatrixMapEntries(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
@@ -741,7 +744,7 @@ case class MatrixKeyRowsBy(child: MatrixIR, keys: IndexedSeq[String], isSorted: 
 
   lazy val typ: MatrixType = child.typ.copy(rowKey = keys)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixKeyRowsBy = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixKeyRowsBy = {
     assert(newChildren.length == 1)
     MatrixKeyRowsBy(newChildren(0).asInstanceOf[MatrixIR], keys, isSorted)
   }
@@ -755,7 +758,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, newRow)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapRows = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixMapRows = {
     assert(newChildren.length == 2)
     MatrixMapRows(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
@@ -774,7 +777,7 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[
     extends MatrixIR {
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, newCol)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapCols = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixMapCols = {
     assert(newChildren.length == 2)
     MatrixMapCols(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR], newKey)
   }
@@ -798,7 +801,7 @@ case class MatrixMapGlobals(child: MatrixIR, newGlobals: IR) extends MatrixIR {
   lazy val typ: MatrixType =
     child.typ.copy(globalType = newGlobals.typ.asInstanceOf[TStruct])
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapGlobals = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixMapGlobals = {
     assert(newChildren.length == 2)
     MatrixMapGlobals(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
@@ -813,7 +816,8 @@ case class MatrixMapGlobals(child: MatrixIR, newGlobals: IR) extends MatrixIR {
 case class MatrixFilterEntries(child: MatrixIR, pred: IR) extends MatrixIR {
   val childrenSeq: IndexedSeq[BaseIR] = Array(child, pred)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixFilterEntries = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixFilterEntries = {
     assert(newChildren.length == 2)
     MatrixFilterEntries(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
@@ -845,7 +849,8 @@ case class MatrixAnnotateColsTable(
     colType = child.typ.colType.structInsert(table.typ.valueType, FastSeq(root))
   )
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixAnnotateColsTable =
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixAnnotateColsTable =
     MatrixAnnotateColsTable(
       newChildren(0).asInstanceOf[MatrixIR],
       newChildren(1).asInstanceOf[TableIR],
@@ -887,7 +892,8 @@ case class MatrixAnnotateRowsTable(
   lazy val typ: MatrixType =
     child.typ.copy(rowType = child.typ.rowType.appendKey(root, annotationType))
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixAnnotateRowsTable = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixAnnotateRowsTable = {
     val IndexedSeq(child: MatrixIR, table: TableIR) = newChildren
     MatrixAnnotateRowsTable(child, table, root, product)
   }
@@ -900,7 +906,7 @@ case class MatrixExplodeRows(child: MatrixIR, path: IndexedSeq[String]) extends 
 
   lazy val rowCountUpperBound: Option[Long] = None
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixExplodeRows = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixExplodeRows = {
     val IndexedSeq(newChild) = newChildren
     MatrixExplodeRows(newChild.asInstanceOf[MatrixIR], path)
   }
@@ -923,7 +929,7 @@ case class MatrixRepartition(child: MatrixIR, n: Int, strategy: Int) extends Mat
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixRepartition = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixRepartition = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixRepartition(newChild, n, strategy)
   }
@@ -950,7 +956,7 @@ case class MatrixUnionRows(childrenSeq: IndexedSeq[MatrixIR]) extends MatrixIR {
       t1.rowKey == t2.rowKey &&
       t1.entryType == t2.entryType
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixUnionRows =
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixUnionRows =
     MatrixUnionRows(newChildren.asInstanceOf[IndexedSeq[MatrixIR]])
 
   override def columnCount: Option[Int] =
@@ -973,7 +979,8 @@ case class MatrixDistinctByRow(child: MatrixIR) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixDistinctByRow = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixDistinctByRow = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixDistinctByRow(newChild)
   }
@@ -999,7 +1006,7 @@ case class MatrixRowsHead(child: MatrixIR, n: Long) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixRowsHead = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixRowsHead = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixRowsHead(newChild, n)
   }
@@ -1018,7 +1025,7 @@ case class MatrixColsHead(child: MatrixIR, n: Int) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixColsHead = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixColsHead = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixColsHead(newChild, n)
   }
@@ -1036,7 +1043,7 @@ case class MatrixRowsTail(child: MatrixIR, n: Long) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixRowsTail = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixRowsTail = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixRowsTail(newChild, n)
   }
@@ -1055,7 +1062,7 @@ case class MatrixColsTail(child: MatrixIR, n: Int) extends MatrixIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixColsTail = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixColsTail = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixColsTail(newChild, n)
   }
@@ -1071,7 +1078,7 @@ case class MatrixExplodeCols(child: MatrixIR, path: IndexedSeq[String]) extends 
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixExplodeCols = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixExplodeCols = {
     val IndexedSeq(newChild) = newChildren
     MatrixExplodeCols(newChild.asInstanceOf[MatrixIR], path)
   }
@@ -1114,7 +1121,7 @@ case class CastTableToMatrix(
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): CastTableToMatrix = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): CastTableToMatrix = {
     assert(newChildren.length == 1)
     CastTableToMatrix(
       newChildren(0).asInstanceOf[TableIR],
@@ -1132,7 +1139,7 @@ case class CastTableToMatrix(
 case class MatrixToMatrixApply(child: MatrixIR, function: MatrixToMatrixFunction) extends MatrixIR {
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixIR = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixToMatrixApply(newChild, function)
   }
@@ -1177,7 +1184,7 @@ case class MatrixRename(
 
   override def columnCount: Option[Int] = child.columnCount
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixRename = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixRename = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixRename(newChild, globalMap, colMap, rowMap, entryMap)
   }
@@ -1187,7 +1194,7 @@ case class MatrixFilterIntervals(child: MatrixIR, intervals: IndexedSeq[Interval
     extends MatrixIR {
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixIR = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixFilterIntervals(newChild, intervals, keep)
   }
@@ -1204,7 +1211,7 @@ case class RelationalLetMatrixTable(name: Name, value: IR, body: MatrixIR) exten
 
   def childrenSeq: IndexedSeq[BaseIR] = Array(value, body)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixIR = {
     val IndexedSeq(newValue: IR, newBody: MatrixIR) = newChildren
     RelationalLetMatrixTable(name, newValue, newBody)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -1,28 +1,22 @@
 package is.hail.expr.ir
 
 import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.NormalizeNames.needsRenaming
+import is.hail.types.virtual.Type
 import is.hail.utils.StackSafe._
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.tailrec
+import scala.collection.mutable
 
-class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = false) {
-  var count: Int = 0
-
-  @tailrec private def gen(freeVariables: Set[Name]): Name = {
-    count += 1
-    val name = Name(normFunction(count))
-    if (freeVariables.contains(name)) {
-      gen(freeVariables)
-    } else {
-      name
-    }
-  }
-
-  def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR = {
-    val env = BindingEnv[Name](agg = Some(Env.empty), scan = Some(Env.empty))
-    ir match {
+object NormalizeNames {
+  def apply[T <: BaseIR](
+    ctx: ExecuteContext,
+    ir: T,
+    allowFreeVariables: Boolean = false,
+  ): T = {
+    val freeVariables: Set[Name] = ir match {
       case ir: IR =>
-        val freeVariables: Set[Name] = if (allowFreeVariables) {
+        if (allowFreeVariables) {
           val env = FreeVariables(ir, true, true)
           env.eval.m.keySet union
             env.agg.map(_.m.keySet).getOrElse(Set.empty) union
@@ -31,29 +25,200 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         } else {
           Set.empty
         }
-        normalizeIR(ir.noSharing(ctx), env, freeVariables = freeVariables).run().asInstanceOf[IR]
       case _ =>
-        normalizeIR(ir.noSharing(ctx), env).run()
+        Set.empty
+    }
+    val env = BindingEnv.empty[Name].createAgg.createScan
+    val noSharing = ir.noSharing(ctx)
+    val old = new NormalizeNames(freeVariables)
+      .normalizeIROld(noSharing, env).run().asInstanceOf[T]
+    val normalize = new NormalizeNames(freeVariables)
+    val new_ = normalize.normalizeIR(noSharing, env).run().asInstanceOf[T]
+    val newOld = new NormalizeNames(freeVariables)
+      .normalizeIR(old, env).run().asInstanceOf[T]
+    uidCounter = math.max(uidCounter, normalize.count)
+    assert(new_ == newOld, s"new:\n${Pretty.sexprStyle(new_)}\nold:\n${Pretty.sexprStyle(newOld)}")
+    old
+  }
+
+  protected def needsRenaming(ir: BaseIR): Boolean = ir match {
+    case _: RelationalLetMatrixTable | _: TableGen | _: TableMapPartitions | _: RelationalLetTable =>
+      true
+    case _: MatrixIR | _: TableIR =>
+      false
+    case _: TableAggregate | _: MatrixAggregate =>
+      false
+    case _: IR | _: BlockMatrixIR =>
+      true
+  }
+}
+
+class NormalizeNames(freeVariables: Set[Name]) {
+  var count: Int = 0
+
+  @tailrec private def gen(): Name = {
+    count += 1
+    val name = Name(iruid(count))
+    if (freeVariables.contains(name)) {
+      gen()
+    } else {
+      name
     }
   }
 
-  private def normalizeIR(
-    ir: BaseIR,
-    env: BindingEnv[Name],
-    context: Array[String] = Array(),
-    freeVariables: Set[Name] = Set.empty,
-  ): StackFrame[BaseIR] = {
+  private def normalizeIR(ir: BaseIR, env: BindingEnv[Name]): StackFrame[BaseIR] = ir match {
+    case Block(bindings, body) =>
+      var newEnv = env
+      for {
+        newBindings <- bindings.mapRecur { case Binding(name, value, scope) =>
+          for (newValue <- normalizeIR(value, newEnv.promoteScope(scope))) yield {
+            val newName = gen()
+            newEnv = newEnv.bindInScope(name, newName, scope)
+            Binding(newName, newValue.asInstanceOf[IR], scope)
+          }
+        }
+        newBody <- normalizeIR(body, newEnv)
+      } yield Block(newBindings, newBody.asInstanceOf[IR])
+    case Ref(name, typ) =>
+      val newName = env.eval.lookupOption(name).getOrElse {
+        if (!freeVariables.contains(name)) throw new RuntimeException(
+          s"found free variable in normalize: $name; ${env.pretty(x => x.str)}"
+        )
+        else name
+      }
+      done(Ref(newName, typ))
+    case RelationalRef(name, typ) =>
+      val newName = env.relational.lookupOption(name).getOrElse(
+        if (!freeVariables.contains(name)) throw new RuntimeException(
+          s"found free variable in normalize: $name; ${env.pretty(x => x.str)}"
+        )
+        else name
+      )
+      done(RelationalRef(newName, typ))
+    case Recur(name, args, typ) =>
+      val newName = env.eval.lookupOption(name) match {
+        case Some(n) => n
+        case None =>
+          if (!freeVariables.contains(name))
+            throw new RuntimeException(s"found free loop variable in normalize: $name")
+          else
+            name
+      }
+      Recur(newName, args, typ).mapChildrenStackSafe(normalizeIR(_, env))
+    case ir =>
+      val bindingsMap = mutable.AnyRefMap.empty[Name, Name]
+      val updateEnv: (BindingEnv[Name], Bindings[Type]) => BindingEnv[Name] =
+        if (needsRenaming(ir)) { (env, bindings) =>
+          val bindingsNames = bindings.map((name, _) => bindingsMap.getOrElseUpdate(name, gen()))
+          env.extend(bindingsNames)
+        } else { (env, bindings) => env.extend(bindings.map((name, _) => name)) }
+      ir.mapChildrenWithEnvStackSafe(env, updateEnv)(normalizeIR).map(modifyNames(_, bindingsMap))
+  }
 
-    @nowarn("cat=unused-locals&msg=default argument")
-    def normalizeBaseIR(next: BaseIR, env: BindingEnv[Name] = env): StackFrame[BaseIR] =
-      call(normalizeIR(next, env, context :+ ir.getClass().getName()))
-
-    def normalize(next: IR, env: BindingEnv[Name] = env): StackFrame[IR] =
-      call(normalizeIR(next, env, context :+ ir.getClass().getName()).asInstanceOf[StackFrame[IR]])
-
-    def gen(): Name = this.gen(freeVariables)
+  private def modifyNames(ir: BaseIR, map: collection.Map[Name, Name]): BaseIR = {
+    def rename(name: Name): Name = map.getOrElse(name, name)
 
     ir match {
+      case TailLoop(name, args, resultType, body) =>
+        TailLoop(rename(name), args.map { case (name, ir) => (rename(name), ir) }, resultType, body)
+      case x: StreamMap => x.copy(name = rename(x.name))
+      case x: StreamZip => x.copy(names = x.names.map(rename))
+      case x: StreamZipJoin => x.copy(curKey = rename(x.curKey), curVals = rename(x.curVals))
+      case x: StreamZipJoinProducers =>
+        x.copy(ctxName = rename(x.ctxName), curKey = rename(x.curKey), curVals = rename(x.curVals))
+      case x: StreamLeftIntervalJoin =>
+        x.copy(lname = rename(x.lname), rname = rename(x.rname))
+      case x: StreamFor => x.copy(valueName = rename(x.valueName))
+      case x: StreamFlatMap => x.copy(name = rename(x.name))
+      case x: StreamFilter => x.copy(name = rename(x.name))
+      case x: StreamTakeWhile => x.copy(elementName = rename(x.elementName))
+      case x: StreamDropWhile => x.copy(elementName = rename(x.elementName))
+      case x: StreamFold => x.copy(accumName = rename(x.accumName), valueName = rename(x.valueName))
+      case x: StreamFold2 => x.copy(
+          accum = x.accum.map { case (name, ir) => (rename(name), ir) },
+          valueName = rename(x.valueName),
+        )
+      case x: StreamBufferedAggregate => x.copy(name = rename(x.name))
+      case x: RunAggScan => x.copy(name = rename(x.name))
+      case x: StreamAgg => x.copy(name = rename(x.name))
+      case x: StreamScan => x.copy(accumName = rename(x.accumName), valueName = rename(x.valueName))
+      case x: StreamAggScan => x.copy(name = rename(x.name))
+      case x: StreamJoinRightDistinct => x.copy(l = rename(x.l), r = rename(x.r))
+      case x: ArraySort => x.copy(left = rename(x.left), right = rename(x.right))
+      case x: ArrayMaximalIndependentSet =>
+        x.copy(tieBreaker = x.tieBreaker.map { case (l, r, f) => (rename(l), rename(r), f) })
+      case x: AggArrayPerElement =>
+        x.copy(indexName = rename(x.indexName), elementName = rename(x.elementName))
+      case x: AggFold =>
+        x.copy(accumName = rename(x.accumName), otherAccumName = rename(x.otherAccumName))
+      case x: NDArrayMap => x.copy(valueName = rename(x.valueName))
+      case x: NDArrayMap2 => x.copy(lName = rename(x.lName), rName = rename(x.rName))
+      case x: CollectDistributedArray => x.copy(cname = rename(x.cname), gname = rename(x.gname))
+      case x: AggExplode => x.copy(name = rename(x.name))
+      case x: RelationalLet => x.copy(name = rename(x.name))
+      case x: RelationalLetTable => x.copy(name = rename(x.name))
+      case x: RelationalLetMatrixTable => x.copy(name = rename(x.name))
+      case x: TableMapPartitions => x.copy(
+          globalName = rename(x.globalName),
+          partitionStreamName = rename(x.partitionStreamName),
+        )
+      case x: TableGen => x.copy(cname = rename(x.cname), gname = rename(x.gname))
+      case x: BlockMatrixMap => x.copy(eltName = rename(x.eltName))
+      case x: BlockMatrixMap2 =>
+        x.copy(leftName = rename(x.leftName), rightName = rename(x.rightName))
+      case x: RelationalLetBlockMatrix => x.copy(name = rename(x.name))
+
+      case x => x
+    }
+  }
+
+  def normalizeIROld(ir: BaseIR, env: BindingEnv[Name], context: Array[String] = Array())
+    : StackFrame[BaseIR] = {
+
+//    @nowarn("cat=unused-locals&msg=default argument")
+    def normalizeBaseIR(next: BaseIR, env: BindingEnv[Name] = env): StackFrame[BaseIR] =
+      call(normalizeIROld(next, env, context :+ ir.getClass().getName()))
+
+    def normalize(next: IR, env: BindingEnv[Name] = env): StackFrame[IR] =
+      call(
+        normalizeIROld(next, env, context :+ ir.getClass().getName()).asInstanceOf[StackFrame[IR]]
+      )
+
+    ir match {
+      case Ref(name, typ) =>
+        val newName = env.eval.lookupOption(name) match {
+          case Some(n) => n
+          case None =>
+            if (!freeVariables.contains(name))
+              throw new RuntimeException(
+                s"found free variable in normalize: $name, ${context.reverse.mkString(", ")}; ${env.pretty(x => x.str)}"
+              )
+            else
+              name
+        }
+        done(Ref(newName, typ))
+      case RelationalRef(name, typ) =>
+        val newName = env.relational.lookupOption(name).getOrElse(
+          if (!freeVariables.contains(name)) throw new RuntimeException(
+            s"found free variable in normalize: $name, ${context.reverse.mkString(", ")}; ${env.pretty(x => x.str)}"
+          )
+          else name
+        )
+        done(RelationalRef(newName, typ))
+      case Recur(name, args, typ) =>
+        val newName = env.eval.lookupOption(name) match {
+          case Some(n) => n
+          case None =>
+            if (!freeVariables.contains(name))
+              throw new RuntimeException(
+                s"found free loop variable in normalize: $name, ${context.reverse.mkString(", ")}; ${env.pretty(x => x.str)}"
+              )
+            else
+              name
+        }
+        for {
+          newArgs <- args.mapRecur(v => normalize(v))
+        } yield Recur(newName, newArgs, typ)
       case Block(bindings, body) =>
         val newBindings: Array[Binding] = Array.ofDim(bindings.length)
 
@@ -72,32 +237,6 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newBody <- normalize(body, env)
         } yield Block(newBindings, newBody)
 
-      case Ref(name, typ) =>
-        val newName = env.eval.lookupOption(name) match {
-          case Some(n) => n
-          case None =>
-            if (!allowFreeVariables)
-              throw new RuntimeException(
-                s"found free variable in normalize: $name, ${context.reverse.mkString(", ")}; ${env.pretty(x => x.str)}"
-              )
-            else
-              name
-        }
-        done(Ref(newName, typ))
-      case Recur(name, args, typ) =>
-        val newName = env.eval.lookupOption(name) match {
-          case Some(n) => n
-          case None =>
-            if (!allowFreeVariables)
-              throw new RuntimeException(
-                s"found free loop variable in normalize: $name, ${context.reverse.mkString(", ")}; ${env.pretty(x => x.str)}"
-              )
-            else
-              name
-        }
-        for {
-          newArgs <- args.mapRecur(v => normalize(v))
-        } yield Recur(newName, newArgs, typ)
       case TailLoop(name, args, resultType, body) =>
         val newFName = gen()
         val newNames = Array.tabulate(args.length)(i => gen())
@@ -109,13 +248,6 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
             env.copy(eval = env.eval.bind(names.zip(newNames) :+ name -> newFName: _*)),
           )
         } yield TailLoop(newFName, newNames.zip(newValues), resultType, newBody)
-      case ArraySort(a, left, right, lessThan) =>
-        val newLeft = gen()
-        val newRight = gen()
-        for {
-          newA <- normalize(a)
-          newLessThan <- normalize(lessThan, env.bindEval(left -> newLeft, right -> newRight))
-        } yield ArraySort(newA, newLeft, newRight, newLessThan)
       case StreamMap(a, name, body) =>
         val newName = gen()
         for {
@@ -153,6 +285,18 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newR <- normalize(right)
           newB <- normalize(body, env.bindEval(lEltName -> newLName, rEltName -> newRName))
         } yield StreamLeftIntervalJoin(newL, newR, lKeyNames, rIntrvlName, newLName, newRName, newB)
+      case StreamFor(a, valueName, body) =>
+        val newValueName = gen()
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.bindEval(valueName, newValueName))
+        } yield StreamFor(newA, newValueName, newBody)
+      case StreamFlatMap(a, name, body) =>
+        val newName = gen()
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.bindEval(name, newName))
+        } yield StreamFlatMap(newA, newName, newBody)
       case StreamFilter(a, name, body) =>
         val newName = gen()
         for {
@@ -171,12 +315,6 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newA <- normalize(a)
           newBody <- normalize(body, env.bindEval(name, newName))
         } yield StreamDropWhile(newA, newName, newBody)
-      case StreamFlatMap(a, name, body) =>
-        val newName = gen()
-        for {
-          newA <- normalize(a)
-          newBody <- normalize(body, env.bindEval(name, newName))
-        } yield StreamFlatMap(newA, newName, newBody)
       case StreamFold(a, zero, accumName, valueName, body) =>
         val newAccumName = gen()
         val newValueName = gen()
@@ -202,29 +340,16 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newSeq <- seq.mapRecur(normalize(_, seqEnv))
           newRes <- normalize(res, resEnv)
         } yield StreamFold2(newA, newAcc, newValueName, newSeq, newRes)
-      case StreamScan(a, zero, accumName, valueName, body) =>
-        val newAccumName = gen()
-        val newValueName = gen()
-        for {
-          newA <- normalize(a)
-          newZero <- normalize(zero)
-          newBody <-
-            normalize(body, env.bindEval(accumName -> newAccumName, valueName -> newValueName))
-        } yield StreamScan(newA, newZero, newAccumName, newValueName, newBody)
-      case StreamFor(a, valueName, body) =>
-        val newValueName = gen()
-        for {
-          newA <- normalize(a)
-          newBody <- normalize(body, env.bindEval(valueName, newValueName))
-        } yield StreamFor(newA, newValueName, newBody)
-      case StreamAgg(a, name, body) =>
-        // FIXME: Uncomment when bindings are threaded through test suites
-        // assert(env.agg.isEmpty)
+      case StreamBufferedAggregate(child, initAggs, newKey, seqOps, name, aggSigs, bufferSize) =>
         val newName = gen()
         for {
-          newA <- normalize(a)
-          newBody <- normalize(body, env.copy(agg = Some(env.eval.bind(name, newName))))
-        } yield StreamAgg(newA, newName, newBody)
+          newChild <- normalize(child)
+          newEnv = env.bindEval(name -> newName)
+          newInitAggs <- normalize(initAggs, newEnv)
+          newNewKey <- normalize(newKey, newEnv)
+          newSeqOps <- normalize(seqOps, newEnv)
+        } yield StreamBufferedAggregate(newChild, newInitAggs, newNewKey, newSeqOps, newName,
+          aggSigs, bufferSize)
       case RunAggScan(a, name, init, seq, result, sig) =>
         val newName = gen()
         val e2 = env.bindEval(name, newName)
@@ -234,6 +359,23 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newSeq <- normalize(seq, e2)
           newResult <- normalize(result, e2)
         } yield RunAggScan(newA, newName, newInit, newSeq, newResult, sig)
+      case StreamAgg(a, name, body) =>
+        // FIXME: Uncomment when bindings are threaded through test suites
+        // assert(env.agg.isEmpty)
+        val newName = gen()
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.copy(agg = Some(env.eval.bind(name, newName))))
+        } yield StreamAgg(newA, newName, newBody)
+      case StreamScan(a, zero, accumName, valueName, body) =>
+        val newAccumName = gen()
+        val newValueName = gen()
+        for {
+          newA <- normalize(a)
+          newZero <- normalize(zero)
+          newBody <-
+            normalize(body, env.bindEval(accumName -> newAccumName, valueName -> newValueName))
+        } yield StreamScan(newA, newZero, newAccumName, newValueName, newBody)
       case StreamAggScan(a, name, body) =>
         // FIXME: Uncomment when bindings are threaded through test suites
         // assert(env.scan.isEmpty)
@@ -253,6 +395,47 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newJoinF <- normalize(joinF, newEnv)
         } yield StreamJoinRightDistinct(newLeft, newRight, lKey, rKey, newL, newR, newJoinF,
           joinType)
+      case ArraySort(a, left, right, lessThan) =>
+        val newLeft = gen()
+        val newRight = gen()
+        for {
+          newA <- normalize(a)
+          newLessThan <- normalize(lessThan, env.bindEval(left -> newLeft, right -> newRight))
+        } yield ArraySort(newA, newLeft, newRight, newLessThan)
+      case ArrayMaximalIndependentSet(edges, Some((l, r, tieBreaker))) =>
+        val newLeft = gen()
+        val newRight = gen()
+        for {
+          newEdges <- normalize(edges)
+          newTieBreaker <- normalize(tieBreaker, env.bindEval(l -> newLeft, r -> newRight))
+        } yield ArrayMaximalIndependentSet(newEdges, Some((newLeft, newRight, newTieBreaker)))
+      case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan) =>
+        val newElementName = gen()
+        val newIndexName = gen()
+        val (aEnv, bodyEnv) = if (isScan)
+          env.promoteScan -> env.bindScan(elementName, newElementName)
+        else
+          env.promoteAgg -> env.bindAgg(elementName, newElementName)
+        for {
+          newA <- normalize(a, aEnv)
+          newAggBody <- normalize(aggBody, bodyEnv.bindEval(indexName, newIndexName))
+          newKnownLength <- knownLength.mapRecur(normalize(_, env))
+        } yield AggArrayPerElement(newA, newElementName, newIndexName, newAggBody, newKnownLength,
+          isScan)
+      case AggFold(zero, seqOp, combOp, accumName, otherAccumName, isScan) =>
+        val newAccumName = gen()
+        val newOtherAccumName = gen()
+        for {
+          newZero <- normalize(zero)
+          newSeqOp <- normalize(
+            seqOp,
+            (if (isScan) env.promoteScan else env.promoteAgg).bindEval(accumName -> newAccumName),
+          )
+          newCombOp <- normalize(
+            combOp,
+            env.bindEval(accumName -> newAccumName, otherAccumName -> newOtherAccumName),
+          )
+        } yield AggFold(newZero, newSeqOp, newCombOp, newAccumName, newOtherAccumName, isScan)
       case NDArrayMap(nd, name, body) =>
         val newName = gen()
         for {
@@ -267,19 +450,6 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newR <- normalize(r)
           newBody <- normalize(body, env.bindEval(lName -> newLName, rName -> newRName))
         } yield NDArrayMap2(newL, newR, newLName, newRName, newBody, errorID)
-      case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan) =>
-        val newElementName = gen()
-        val newIndexName = gen()
-        val (aEnv, bodyEnv) = if (isScan)
-          env.promoteScan -> env.bindScan(elementName, newElementName)
-        else
-          env.promoteAgg -> env.bindAgg(elementName, newElementName)
-        for {
-          newA <- normalize(a, aEnv)
-          newAggBody <- normalize(aggBody, bodyEnv.bindEval(indexName, newIndexName))
-          newKnownLength <- knownLength.mapRecur(normalize(_, env))
-        } yield AggArrayPerElement(newA, newElementName, newIndexName, newAggBody, newKnownLength,
-          isScan)
       case CollectDistributedArray(ctxs, globals, cname, gname, body, dynamicID, staticID, tsd) =>
         val newC = gen()
         val newG = gen()
@@ -290,21 +460,86 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           newDynamicID <- normalize(dynamicID)
         } yield CollectDistributedArray(newCtxs, newGlobals, newC, newG, newBody, newDynamicID,
           staticID, tsd)
+      case AggExplode(array, name, aggBody, isScan) =>
+        val newName = gen()
+        for {
+          newArray <- normalize(array, if (isScan) env.promoteScan else env.promoteAgg)
+          newAggBody <- normalize(
+            aggBody,
+            if (isScan) env.bindScan(name -> newName) else env.bindAgg(name -> newName),
+          )
+        } yield AggExplode(newArray, newName, newAggBody, isScan)
       case RelationalLet(name, value, body) =>
         val newName = gen()
         for {
           newValue <- normalize(value, env)
           newBody <- normalize(body, env.noAgg.noScan.bindRelational(name, newName))
         } yield RelationalLet(newName, newValue, newBody)
-      case RelationalRef(name, typ) =>
-        val newName = env.relational.lookupOption(name).getOrElse(
-          if (!allowFreeVariables) throw new RuntimeException(
-            s"found free variable in normalize: $name, ${context.reverse.mkString(", ")}; ${env.pretty(x => x.str)}"
+      case RelationalLetTable(name, value, body) =>
+        val newName = gen()
+        for {
+          newValue <- normalize(value, env)
+          newBody <- normalizeBaseIR(body, env.noAgg.noScan.bindRelational(name, newName))
+        } yield RelationalLetTable(newName, newValue, newBody.asInstanceOf[TableIR])
+      case RelationalLetMatrixTable(name, value, body) =>
+        val newName = gen()
+        for {
+          newValue <- normalize(value, env)
+          newBody <- normalizeBaseIR(body, env.noAgg.noScan.bindRelational(name, newName))
+        } yield RelationalLetMatrixTable(newName, newValue, newBody.asInstanceOf[MatrixIR])
+      case TableMapPartitions(child, globalName, streamName, body, requestedKey, allowedOverlap) =>
+        val newGlobalName = gen()
+        val newStreamName = gen()
+        for {
+          newChild <- normalizeBaseIR(child)
+          newBody <- normalize(
+            body,
+            env.onlyRelational().bindEval(globalName -> newGlobalName, streamName -> newStreamName),
           )
-          else name
+        } yield TableMapPartitions(
+          newChild.asInstanceOf[TableIR],
+          newGlobalName,
+          newStreamName,
+          newBody,
+          requestedKey,
+          allowedOverlap,
         )
-        done(RelationalRef(newName, typ))
-
+      case TableGen(contexts, globals, cname, gname, body, partitioner, errorId) =>
+        val newCname = gen()
+        val newGname = gen()
+        for {
+          newContexts <- normalize(contexts)
+          newGlobals <- normalize(globals)
+          newBody <-
+            normalize(body, env.onlyRelational().bindEval(cname -> newCname, gname -> newGname))
+        } yield TableGen(newContexts, newGlobals, newCname, newGname, newBody, partitioner, errorId)
+      case BlockMatrixMap(child, eltName, f, needsDense) =>
+        val newEltName = gen()
+        for {
+          newChild <- normalizeBaseIR(child)
+          newF <- normalize(f, env.bindEval(eltName -> newEltName))
+        } yield BlockMatrixMap(newChild.asInstanceOf[BlockMatrixIR], newEltName, newF, needsDense)
+      case BlockMatrixMap2(left, right, leftName, rightName, f, sparsityStrategy) =>
+        val newLeftName = gen()
+        val newRightName = gen()
+        for {
+          newLeft <- normalizeBaseIR(left)
+          newRight <- normalizeBaseIR(right)
+          newF <- normalize(f, env.bindEval(leftName -> newLeftName, rightName -> newRightName))
+        } yield BlockMatrixMap2(
+          newLeft.asInstanceOf[BlockMatrixIR],
+          newRight.asInstanceOf[BlockMatrixIR],
+          newLeftName,
+          newRightName,
+          newF,
+          sparsityStrategy,
+        )
+      case RelationalLetBlockMatrix(name, value, body) =>
+        val newName = gen()
+        for {
+          newValue <- normalize(value, env)
+          newBody <- normalizeBaseIR(body, env.noAgg.noScan.bindRelational(name, newName))
+        } yield RelationalLetBlockMatrix(newName, newValue, newBody.asInstanceOf[BlockMatrixIR])
       case x =>
         x.mapChildrenWithIndexStackSafe { (child, i) =>
           normalizeBaseIR(

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.HailContext
 import is.hail.backend.ExecuteContext
+import is.hail.utils.fatal
 
 object Optimize {
   def apply[T <: BaseIR](ir0: T, context: String, ctx: ExecuteContext): T = {
@@ -14,15 +15,29 @@ object Optimize {
       ir = ctx.timer.time(optContext)(f(ir).asInstanceOf[T])
 
     ctx.timer.time("Optimize") {
-      val normalizeNames = new NormalizeNames(_ => genUID(), allowFreeVariables = true)
       while (iter < maxIter && ir != last) {
         last = ir
         runOpt(FoldConstants(ctx, _), iter, "FoldConstants")
         runOpt(ExtractIntervalFilters(ctx, _), iter, "ExtractIntervalFilters")
-        runOpt(normalizeNames(ctx, _), iter, "NormalizeNames")
+        runOpt(
+          NormalizeNames(ctx, _, allowFreeVariables = true),
+          iter,
+          "NormalizeNames",
+        )
         runOpt(Simplify(ctx, _), iter, "Simplify")
+        val ircopy = ir.deepCopy()
         runOpt(ForwardLets(ctx), iter, "ForwardLets")
+        try
+          TypeCheck(ctx, ir)
+        catch {
+          case e: Exception =>
+            fatal(
+              s"bad ir from forward lets, started as\n${Pretty(ctx, ircopy, preserveNames = true)}",
+              e,
+            )
+        }
         runOpt(ForwardRelationalLets(_), iter, "ForwardRelationalLets")
+        TypeCheck(ctx, ir)
         runOpt(PruneDeadFields(ctx, _), iter, "PruneDeadFields")
 
         iter += 1

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -112,7 +112,7 @@ object PruneDeadFields {
       }
     } catch {
       case e: Throwable =>
-        fatal(s"error trying to rebuild IR:\n${Pretty(ctx, ir, elideLiterals = true)}", e)
+        fatal(s"error trying to rebuild IR:\n${Pretty(ctx, ir, allowUnboundRefs = true)}", e)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -70,7 +70,7 @@ sealed abstract class TableIR extends BaseIR {
   protected[ir] def execute(ctx: ExecuteContext, r: LoweringAnalyses): TableExecuteIntermediate =
     fatal("tried to execute unexecutable IR:\n" + Pretty(ctx, this))
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): TableIR
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR
 
   def unpersist(): TableIR =
     this match {
@@ -104,7 +104,7 @@ case class TableLiteral(
 
   lazy val rowCountUpperBound: Option[Long] = None
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableLiteral = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableLiteral = {
     assert(newChildren.isEmpty)
     TableLiteral(typ, rvd, enc, encodedGlobals)
   }
@@ -2129,7 +2129,7 @@ case class TableRead(typ: TableType, dropRows: Boolean, tr: TableReader) extends
 
   val childrenSeq: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableRead = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableRead = {
     assert(newChildren.isEmpty)
     TableRead(typ, dropRows, tr)
   }
@@ -2150,7 +2150,7 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
 
   val childrenSeq: IndexedSeq[BaseIR] = FastSeq(rowsAndGlobal)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableParallelize = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableParallelize = {
     val IndexedSeq(newrowsAndGlobal: IR) = newChildren
     TableParallelize(newrowsAndGlobal, nPartitions)
   }
@@ -2252,7 +2252,7 @@ case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolea
 
   def definitelyDoesNotShuffle: Boolean = child.typ.key.startsWith(keys) || isSorted
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableKeyBy = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableKeyBy = {
     assert(newChildren.length == 1)
     TableKeyBy(newChildren(0).asInstanceOf[TableIR], keys, isSorted)
   }
@@ -2319,7 +2319,7 @@ case class TableGen(
   override val rowCountUpperBound: Option[Long] =
     None
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(contexts: IR, globals: IR, body: IR) = newChildren
     TableGen(contexts, globals, cname, gname, body, partitioner, errorId)
   }
@@ -2343,7 +2343,7 @@ case class TableRange(n: Int, nPartitions: Int) extends TableIR {
   private val nPartitionsAdj = math.max(math.min(n, nPartitions), 1)
   val childrenSeq: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableRange = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableRange = {
     assert(newChildren.isEmpty)
     TableRange(n, nPartitions)
   }
@@ -2406,7 +2406,7 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableFilter = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableFilter = {
     assert(newChildren.length == 2)
     TableFilter(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[IR])
   }
@@ -2484,7 +2484,7 @@ case class TableHead(child: TableIR, n: Long) extends TableSubset {
   require(n >= 0, fatal(s"TableHead: n must be non-negative! Found '$n'."))
   val subsetKind = TableSubset.HEAD
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableHead = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableHead = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableHead(newChild, n)
   }
@@ -2494,7 +2494,7 @@ case class TableTail(child: TableIR, n: Long) extends TableSubset {
   require(n >= 0, fatal(s"TableTail: n must be non-negative! Found '$n'."))
   val subsetKind = TableSubset.TAIL
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableTail = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableTail = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableTail(newChild, n)
   }
@@ -2513,7 +2513,7 @@ case class TableRepartition(child: TableIR, n: Int, strategy: Int) extends Table
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableRepartition = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableRepartition = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableRepartition(newChild, n, strategy)
   }
@@ -2597,7 +2597,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
     TableType(newRowType, newKey, newGlobalType)
   }
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableJoin = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableJoin = {
     assert(newChildren.length == 2)
     TableJoin(
       newChildren(0).asInstanceOf[TableIR],
@@ -2630,7 +2630,7 @@ case class TableIntervalJoin(
     left.typ.copy(rowType = left.typ.rowType.appendKey(root, rightType))
   }
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): TableIR =
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR =
     TableIntervalJoin(
       newChildren(0).asInstanceOf[TableIR],
       newChildren(1).asInstanceOf[TableIR],
@@ -2755,7 +2755,8 @@ case class TableMultiWayZipJoin(
     globalType = newGlobalType,
   )
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableMultiWayZipJoin =
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : TableMultiWayZipJoin =
     TableMultiWayZipJoin(newChildren.asInstanceOf[IndexedSeq[TableIR]], fieldName, globalName)
 
   override protected[ir] def execute(ctx: ExecuteContext, r: LoweringAnalyses)
@@ -2860,7 +2861,8 @@ case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: Strin
 
   override def partitionCounts: Option[IndexedSeq[Long]] = left.partitionCounts
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableLeftJoinRightDistinct = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : TableLeftJoinRightDistinct = {
     val IndexedSeq(newLeft: TableIR, newRight: TableIR) = newChildren
     TableLeftJoinRightDistinct(newLeft, newRight, root)
   }
@@ -2920,7 +2922,8 @@ case class TableMapPartitions(
 
   val rowCountUpperBound: Option[Long] = None
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): TableMapPartitions = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : TableMapPartitions = {
     assert(newChildren.length == 2)
     TableMapPartitions(
       newChildren(0).asInstanceOf[TableIR],
@@ -3017,7 +3020,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
   lazy val typ: TableType = child.typ.copy(rowType = newRow.typ.asInstanceOf[TStruct])
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableMapRows = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableMapRows = {
     assert(newChildren.length == 2)
     TableMapRows(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[IR])
   }
@@ -3410,7 +3413,7 @@ case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
   lazy val typ: TableType =
     child.typ.copy(globalType = newGlobals.typ.asInstanceOf[TStruct])
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableMapGlobals = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableMapGlobals = {
     assert(newChildren.length == 2)
     TableMapGlobals(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[IR])
   }
@@ -3478,7 +3481,7 @@ case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableI
 
   lazy val typ: TableType = child.typ.copy(rowType = newRow.typ)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableExplode = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableExplode = {
     assert(newChildren.length == 1)
     TableExplode(newChildren(0).asInstanceOf[TableIR], path)
   }
@@ -3575,7 +3578,7 @@ case class TableUnion(childrenSeq: IndexedSeq[TableIR]) extends TableIR {
       None
   }
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableUnion =
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableUnion =
     TableUnion(newChildren.map(_.asInstanceOf[TableIR]))
 
   def typ: TableType = childrenSeq(0).typ
@@ -3598,7 +3601,7 @@ case class MatrixRowsTable(child: MatrixIR) extends TableIR {
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixRowsTable = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixRowsTable = {
     assert(newChildren.length == 1)
     MatrixRowsTable(newChildren(0).asInstanceOf[MatrixIR])
   }
@@ -3611,7 +3614,7 @@ case class MatrixColsTable(child: MatrixIR) extends TableIR {
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixColsTable = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixColsTable = {
     assert(newChildren.length == 1)
     MatrixColsTable(newChildren(0).asInstanceOf[MatrixIR])
   }
@@ -3624,7 +3627,8 @@ case class MatrixEntriesTable(child: MatrixIR) extends TableIR {
 
   lazy val rowCountUpperBound: Option[Long] = None
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MatrixEntriesTable = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : MatrixEntriesTable = {
     assert(newChildren.length == 1)
     MatrixEntriesTable(newChildren(0).asInstanceOf[MatrixIR])
   }
@@ -3637,7 +3641,7 @@ case class TableDistinct(child: TableIR) extends TableIR {
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableDistinct = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableDistinct = {
     val IndexedSeq(newChild) = newChildren
     TableDistinct(newChild.asInstanceOf[TableIR])
   }
@@ -3671,7 +3675,8 @@ case class TableKeyByAndAggregate(
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableKeyByAndAggregate = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : TableKeyByAndAggregate = {
     val IndexedSeq(newChild: TableIR, newExpr: IR, newNewKey: IR) = newChildren
     TableKeyByAndAggregate(newChild, newExpr, newNewKey, nPartitions, bufferSize)
   }
@@ -3873,7 +3878,8 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, expr)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableAggregateByKey = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR])
+    : TableAggregateByKey = {
     assert(newChildren.length == 2)
     val IndexedSeq(newChild: TableIR, newExpr: IR) = newChildren
     TableAggregateByKey(newChild, newExpr)
@@ -4038,7 +4044,7 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
 
   val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableOrderBy = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableOrderBy = {
     val IndexedSeq(newChild) = newChildren
     TableOrderBy(newChild.asInstanceOf[TableIR], sortFields)
   }
@@ -4092,7 +4098,7 @@ case class CastMatrixToTable(
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): CastMatrixToTable = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): CastMatrixToTable = {
     val IndexedSeq(newChild) = newChildren
     CastMatrixToTable(newChild.asInstanceOf[MatrixIR], entriesFieldName, colsFieldName)
   }
@@ -4121,7 +4127,7 @@ case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: M
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = FastSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableRename = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableRename = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableRename(newChild, rowMap, globalMap)
   }
@@ -4139,7 +4145,7 @@ case class TableFilterIntervals(child: TableIR, intervals: IndexedSeq[Interval],
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableFilterIntervals(newChild, intervals, keep)
   }
@@ -4167,7 +4173,7 @@ case class MatrixToTableApply(child: MatrixIR, function: MatrixToTableFunction) 
   lazy val rowCountUpperBound: Option[Long] =
     if (function.preservesPartitionCounts) child.rowCountUpperBound else None
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
     MatrixToTableApply(newChild, function)
   }
@@ -4181,7 +4187,7 @@ case class MatrixToTableApply(child: MatrixIR, function: MatrixToTableFunction) 
 case class TableToTableApply(child: TableIR, function: TableToTableFunction) extends TableIR {
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableToTableApply(newChild, function)
   }
@@ -4209,7 +4215,7 @@ case class BlockMatrixToTableApply(
 
   lazy val rowCountUpperBound: Option[Long] = None
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): TableIR =
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR =
     BlockMatrixToTableApply(
       newChildren(0).asInstanceOf[BlockMatrixIR],
       newChildren(1).asInstanceOf[IR],
@@ -4231,7 +4237,7 @@ case class BlockMatrixToTable(child: BlockMatrixIR) extends TableIR {
 
   lazy val rowCountUpperBound: Option[Long] = None
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newChild: BlockMatrixIR) = newChildren
     BlockMatrixToTable(newChild)
   }
@@ -4253,7 +4259,7 @@ case class RelationalLetTable(name: Name, value: IR, body: TableIR) extends Tabl
 
   def childrenSeq: IndexedSeq[BaseIR] = Array(value, body)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
+  override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newValue: IR, newBody: TableIR) = newChildren
     RelationalLetTable(name, newValue, newBody)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -15,14 +15,18 @@ object TypeCheck {
       check(ctx, ir, BindingEnv.empty).run()
     catch {
       case e: Throwable =>
-        fatal(s"Error while typechecking IR:\n${Pretty(ctx, ir, preserveNames = true)}", e)
+        fatal(
+          s"Error while typechecking IR:\n${Pretty(ctx, ir, preserveNames = true, allowUnboundRefs = true)}",
+          e,
+        )
     }
 
   def apply(ctx: ExecuteContext, ir: IR, env: BindingEnv[Type]): Unit =
     try
       check(ctx, ir, env).run()
     catch {
-      case e: Throwable => fatal(s"Error while typechecking IR:\n${Pretty(ctx, ir)}", e)
+      case e: Throwable =>
+        fatal(s"Error while typechecking IR:\n${Pretty(ctx, ir, allowUnboundRefs = true)}", e)
     }
 
   def check(ctx: ExecuteContext, ir: BaseIR, env: BindingEnv[Type]): StackFrame[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -30,7 +30,7 @@ case object SemanticHash extends Logging {
       // Running the algorithm on the name-normalised IR
       // removes sensitivity to compiler-generated names
       val nameNormalizedIR = ctx.timer.time("NormalizeNames") {
-        new NormalizeNames(i => iruid(i), allowFreeVariables = true)(ctx, root)
+        NormalizeNames(ctx, root, allowFreeVariables = true)
       }
 
       val semhash = ctx.timer.time("Hash") {

--- a/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
@@ -120,15 +120,14 @@ class ForwardLetsSuite extends HailSuite {
     )
     val after: IR = ForwardLets(ctx)(ir)
     val expected = ApplyAggOp(Sum())(I32(1))
-    val normalize = new NormalizeNames(_.toString)
-    assert(normalize(ctx, after) == normalize(ctx, expected))
+    assert(NormalizeNames(ctx, after) == NormalizeNames(ctx, expected))
   }
 
   @Test(dataProvider = "nonForwardingOps")
   def testNonForwardingOps(ir: IR): Unit = {
     val after = ForwardLets(ctx)(ir)
-    val normalizedBefore = (new NormalizeNames(_.toString))(ctx, ir)
-    val normalizedAfter = (new NormalizeNames(_.toString))(ctx, after)
+    val normalizedBefore = NormalizeNames(ctx, ir)
+    val normalizedAfter = NormalizeNames(ctx, after)
     assert(normalizedBefore == normalizedAfter)
   }
 
@@ -219,10 +218,11 @@ class ForwardLetsSuite extends HailSuite {
   }
 
   @Test(dataProvider = "TrivialIRCases")
-  def testTrivialCases(input: IR, expected: IR, reason: String): Unit = {
-    val result = ForwardLets(ctx)(input)
+  def testTrivialCases(input: IR, _expected: IR, reason: String): Unit = {
+    val result = NormalizeNames(ctx, ForwardLets(ctx)(input), allowFreeVariables = true)
+    val expected = NormalizeNames(ctx, _expected, allowFreeVariables = true)
     assert(
-      result == new NormalizeNames(iruid(_), allowFreeVariables = true)(ctx, expected),
+      result == NormalizeNames(ctx, expected, allowFreeVariables = true),
       s"\ninput:\n${Pretty.sexprStyle(input)}\nexpected:\n${Pretty.sexprStyle(expected)}\ngot:\n${Pretty.sexprStyle(result)}\n$reason",
     )
   }


### PR DESCRIPTION
Greatly simplifies the `NormalizeNames` pass to be logically independent of the binding structure. This leaves the old implementation, and asserts that they agree. Will delete the old implementation in a follow up.