### PR TITLE
[query] Add more transient error handling

### DIFF
--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -64,7 +64,7 @@ package object services {
           if e.getMessage != null && e.getMessage == Constants.STREAM_CLOSED =>
         true
       case e: SocketException
-          if e.getMessage != null && e.getMessage.contains("Connection reset") =>
+          if e.getMessage != null && (e.getMessage.contains("Connection reset") || e.getMessage.contains("Unexpected end of file")) =>
         true
       case e: HttpResponseException
           if e.getStatusCode() == 400 && e.getMessage != null && (
@@ -100,6 +100,8 @@ package object services {
     // ReactiveException it returns the exception unmodified.
     val e = is.hail.shadedazure.reactor.core.Exceptions.unwrap(_e)
     e match {
+      case _: java.nio.channels.ClosedByInterruptException =>
+        true
       case _: NoHttpResponseException =>
         true
       case e: HttpResponseException

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -64,7 +64,9 @@ package object services {
           if e.getMessage != null && e.getMessage == Constants.STREAM_CLOSED =>
         true
       case e: SocketException
-          if e.getMessage != null && (e.getMessage.contains("Connection reset") || e.getMessage.contains("Unexpected end of file")) =>
+          if e.getMessage != null && (e.getMessage.contains(
+            "Connection reset"
+          ) || e.getMessage.contains("Unexpected end of file")) =>
         true
       case e: HttpResponseException
           if e.getStatusCode() == 400 && e.getMessage != null && (


### PR DESCRIPTION
Additional transient errors from GCS