### PR TITLE
[compiler] refactor types in bindings

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/FreeVariables.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FreeVariables.scala
@@ -27,25 +27,30 @@ case class FreeVariableBindingEnv(
   scanVars: Option[FreeVariableEnv],
 ) extends GenericBindingEnv[FreeVariableBindingEnv, Type] {
   def extend(bindings: Bindings[Type]): FreeVariableBindingEnv = {
-    val Bindings(eval, agg, scan, relational, dropEval) = bindings
+    val Bindings(all, eval, agg, scan, relational, dropEval) = bindings
     var newEnv = this
     if (dropEval) newEnv = newEnv.noEval
     agg match {
       case AggEnv.Drop => newEnv = newEnv.noAgg
       case AggEnv.Promote => newEnv = newEnv.promoteAgg
-      case AggEnv.Create(bindings) => newEnv = newEnv.createAgg.bindAgg(bindings: _*)
-      case AggEnv.Bind(bindings) => newEnv = newEnv.bindAgg(bindings: _*)
+      case AggEnv.Create(bindings) =>
+        newEnv = newEnv.createAgg.bindAgg(bindings.map(all): _*)
+      case AggEnv.Bind(bindings) =>
+        newEnv = newEnv.bindAgg(bindings.map(all): _*)
       case _ =>
     }
     scan match {
       case AggEnv.Drop => newEnv = newEnv.noScan
       case AggEnv.Promote => newEnv = newEnv.promoteScan
-      case AggEnv.Create(bindings) => newEnv = newEnv.createScan.bindScan(bindings: _*)
-      case AggEnv.Bind(bindings) => newEnv = newEnv.bindScan(bindings: _*)
+      case AggEnv.Create(bindings) =>
+        newEnv = newEnv.createScan.bindScan(bindings.map(all): _*)
+      case AggEnv.Bind(bindings) =>
+        newEnv = newEnv.bindScan(bindings.map(all): _*)
       case _ =>
     }
-    if (eval.nonEmpty) newEnv = newEnv.bindEval(eval: _*)
-    if (relational.nonEmpty) newEnv = newEnv.bindRelational(relational: _*)
+    if (eval.nonEmpty) newEnv = newEnv.bindEval(eval.map(all): _*)
+    if (relational.nonEmpty)
+      newEnv = newEnv.bindRelational(relational.map(all): _*)
     newEnv
   }
 

--- a/hail/src/main/scala/is/hail/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/MatrixType.scala
@@ -33,6 +33,13 @@ object MatrixType {
 
   def getEntriesIndex(rvRowType: PStruct): Int = rvRowType.fieldIdx(entriesIdentifier)
 
+  def globalBindings: IndexedSeq[Int] = FastSeq(0)
+  def rowInRowBindings: IndexedSeq[Int] = FastSeq(0, 1)
+  def colInColBindings: IndexedSeq[Int] = FastSeq(0, 1)
+  def rowInEntryBindings: IndexedSeq[Int] = FastSeq(0, 2)
+  def colInEntryBindings: IndexedSeq[Int] = FastSeq(0, 1)
+  def entryBindings: IndexedSeq[Int] = FastSeq(0, 1, 2, 3)
+
   def fromTableType(
     typ: TableType,
     colsFieldName: String,

--- a/hail/src/main/scala/is/hail/types/TableType.scala
+++ b/hail/src/main/scala/is/hail/types/TableType.scala
@@ -22,6 +22,10 @@ object TableType {
 
   def valueType(ts: TStruct, key: IndexedSeq[String]): TStruct =
     ts.filterSet(key.toSet, include = false)._1
+
+  def globalBindings: IndexedSeq[Int] = FastSeq(0)
+
+  def rowBindings: IndexedSeq[Int] = FastSeq(0, 1)
 }
 
 case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStruct)


### PR DESCRIPTION
Slightly tweak the `Bindings` class to store a single array of (name, type) pairs, with the various environments referring back to that array. This simplifies passes that want to create a single mutable state for each binding, even those that are bound in multiple environments (e.g. eval and agg).