### PR TITLE
[ci] Add tests for generating envoy xds configs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2892,6 +2892,8 @@ steps:
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export REPO_NAME=ci-test-"{{ create_ci_test_repo.token }}"
       export NAMESPACE="{{ default_ns.name }}"
+      export HAIL_PRODUCTION_DOMAIN="{{ global.domain }}"
+      pip install /io/ci
       python3 -m pytest \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
@@ -2908,8 +2910,8 @@ steps:
         mountPath: /test-dev-gsa-key
     timeout: 5400
     inputs:
-      - from: /repo/ci/test
-        to: /io/ci/test
+      - from: /repo/ci
+        to: /io/ci
     scopes:
       - test
       - dev

--- a/build.yaml
+++ b/build.yaml
@@ -2892,7 +2892,6 @@ steps:
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export REPO_NAME=ci-test-"{{ create_ci_test_repo.token }}"
       export NAMESPACE="{{ default_ns.name }}"
-      export HAIL_PRODUCTION_DOMAIN="{{ global.domain }}"
       pip install /io/ci
       python3 -m pytest \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -40,7 +40,7 @@ from hailtop.utils import collect_aiter, humanize_timedelta_msecs, periodically_
 from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
 from .constants import AUTHORIZED_USERS, TEAMS
-from .environment import CLOUD, DEFAULT_NAMESPACE, STORAGE_URI
+from .environment import CLOUD, DEFAULT_NAMESPACE, DOMAIN, STORAGE_URI
 from .envoy import create_cds_response, create_rds_response
 from .github import PR, WIP, FQBranch, MergeFailureBatch, Repo, UnwatchedBranch, WatchedBranch, select_random_teammate
 from .utils import gcp_logging_queries
@@ -747,7 +747,7 @@ ON active_namespaces.namespace = deployed_services.namespace
     assert set(['batch', 'auth', 'batch-driver', 'ci']).issubset(set(default_services)), default_services
 
     cds_config = create_cds_response(default_services, services_per_namespace, proxy)
-    rds_config = create_rds_response(default_services, services_per_namespace, proxy)
+    rds_config = create_rds_response(default_services, services_per_namespace, proxy, domain=DOMAIN)
     return cds_config, rds_config
 
 

--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -1,18 +1,19 @@
-import os
 import sys
 from typing import Dict, List
 
 import yaml
 
-DOMAIN = os.environ['HAIL_PRODUCTION_DOMAIN']
-
 
 def create_rds_response(
-    default_services: List[str], internal_services_per_namespace: Dict[str, List[str]], proxy: str
+    default_services: List[str],
+    internal_services_per_namespace: Dict[str, List[str]],
+    proxy: str,
+    *,
+    domain: str,
 ) -> dict:
     if proxy == 'gateway':
-        default_host = gateway_default_host
-        internal_host = gateway_internal_host
+        default_host = lambda service: gateway_default_host(service, domain)
+        internal_host = lambda services_per_namespace: gateway_internal_host(services_per_namespace, domain)
     else:
         assert proxy == 'internal-gateway'
         default_host = internal_gateway_default_host
@@ -56,10 +57,10 @@ def create_cds_response(
     }
 
 
-def gateway_default_host(service: str) -> dict:
-    domains = [f'{service}.{DOMAIN}']
+def gateway_default_host(service: str, domain: str) -> dict:
+    domains = [f'{service}.{domain}']
     if service == 'www':
-        domains.append(DOMAIN)
+        domains.append(domain)
 
     if service == 'ukbb-rg':
         return {
@@ -101,11 +102,11 @@ def gateway_default_host(service: str) -> dict:
     }
 
 
-def gateway_internal_host(services_per_namespace: Dict[str, List[str]]) -> dict:
+def gateway_internal_host(services_per_namespace: Dict[str, List[str]], domain: str) -> dict:
     return {
         '@type': 'type.googleapis.com/envoy.config.route.v3.VirtualHost',
         'name': 'internal',
-        'domains': [f'internal.{DOMAIN}'],
+        'domains': [f'internal.{domain}'],
         'routes': [
             {
                 'match': {'path_separated_prefix': f'/{namespace}/{service}'},
@@ -287,10 +288,11 @@ def upstream_transport_socket(proxy: str, verify_ca: bool) -> dict:
 
 if __name__ == '__main__':
     proxy = sys.argv[1]
-    with open(sys.argv[2], 'r', encoding='utf-8') as services_file:
+    domain = sys.argv[2]
+    with open(sys.argv[3], 'r', encoding='utf-8') as services_file:
         services = [service.rstrip() for service in services_file.readlines()]
 
-    with open(sys.argv[3], 'w', encoding='utf-8') as cds_file:
+    with open(sys.argv[4], 'w', encoding='utf-8') as cds_file:
         cds_file.write(yaml.dump(create_cds_response(services, {}, proxy)))
-    with open(sys.argv[4], 'w', encoding='utf-8') as rds_file:
-        rds_file.write(yaml.dump(create_rds_response(services, {}, proxy)))
+    with open(sys.argv[5], 'w', encoding='utf-8') as rds_file:
+        rds_file.write(yaml.dump(create_rds_response(services, {}, proxy, domain=domain)))

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -70,11 +70,6 @@ spec:
                secretKeyRef:
                  name: ci-config
                  key: storage_uri
-           - name: HAIL_PRODUCTION_DOMAIN
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: domain
            - name: CLOUD
              valueFrom:
                secretKeyRef:

--- a/ci/test/envoy/test_gateway_cds_response.yaml
+++ b/ci/test/envoy/test_gateway_cds_response.yaml
@@ -1,0 +1,51 @@
+version_info: 'dummy'
+type_url: type.googleapis.com/envoy.config.cluster.v3.Cluster
+control_plane:
+  identifier: ci
+resources:
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: foo
+    lb_policy: ROUND_ROBIN
+    type: STRICT_DNS
+    load_assignment:
+      cluster_name: foo
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: foo.default.svc.cluster.local
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: /ssl-config/gateway-cert.pem
+            private_key:
+              filename: /ssl-config/gateway-key.pem
+        validation_context:
+          filename: /ssl-config/gateway-outgoing.pem
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: test-bar
+    lb_policy: ROUND_ROBIN
+    type: STRICT_DNS
+    load_assignment:
+      cluster_name: test-bar
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: bar.test.svc.cluster.local
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates: []
+        validation_context:
+          trust_chain_verification: ACCEPT_UNTRUSTED

--- a/ci/test/envoy/test_gateway_rds_response.yaml
+++ b/ci/test/envoy/test_gateway_rds_response.yaml
@@ -1,0 +1,76 @@
+version_info: 'dummy'
+type_url: type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+control_plane:
+  identifier: ci
+resources:
+- '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+  name: https_routes
+  request_headers_to_add:
+  - append_action: OVERWRITE_IF_EXISTS_OR_ADD
+    header:
+      key: X-Real-IP
+      value: '%DOWNSTREAM_REMOTE_ADDRESS%'
+  virtual_hosts:
+    - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
+      domains:
+      - foo.hail.is
+      name: foo
+      routes:
+      - match:
+          prefix: /
+        route:
+          append_x_forwarded_host: true
+          auto_host_rewrite: true
+          cluster: foo
+          timeout: 0s
+        typed_per_filter_config:
+          envoy.filters.http.ext_authz:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+            disabled: true
+          envoy.filters.http.local_ratelimit:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            filter_enabled:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            filter_enforced:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              fill_interval: 1s
+              max_tokens: 200
+              tokens_per_fill: 200
+    - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
+      domains:
+      - internal.hail.is
+      name: internal
+      routes:
+      - match:
+          path_separated_prefix: /test/bar
+        route:
+          append_x_forwarded_host: true
+          auto_host_rewrite: true
+          cluster: test-bar
+          timeout: 0s
+        typed_per_filter_config:
+          envoy.filters.http.local_ratelimit:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            filter_enabled:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            filter_enforced:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              fill_interval: 1s
+              max_tokens: 200
+              tokens_per_fill: 200

--- a/ci/test/envoy/test_internal_gateway_cds_response.yaml
+++ b/ci/test/envoy/test_internal_gateway_cds_response.yaml
@@ -1,0 +1,51 @@
+version_info: 'dummy'
+type_url: type.googleapis.com/envoy.config.cluster.v3.Cluster
+control_plane:
+  identifier: ci
+resources:
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: foo
+    lb_policy: ROUND_ROBIN
+    type: STRICT_DNS
+    load_assignment:
+      cluster_name: foo
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: foo.default.svc.cluster.local
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: /ssl-config/internal-gateway-cert.pem
+            private_key:
+              filename: /ssl-config/internal-gateway-key.pem
+        validation_context:
+          filename: /ssl-config/internal-gateway-outgoing.pem
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: test-bar
+    lb_policy: ROUND_ROBIN
+    type: STRICT_DNS
+    load_assignment:
+      cluster_name: test-bar
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: bar.test.svc.cluster.local
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates: []
+        validation_context:
+          trust_chain_verification: ACCEPT_UNTRUSTED

--- a/ci/test/envoy/test_internal_gateway_rds_response.yaml
+++ b/ci/test/envoy/test_internal_gateway_rds_response.yaml
@@ -1,0 +1,73 @@
+version_info: 'dummy'
+type_url: type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+control_plane:
+  identifier: ci
+resources:
+- '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+  name: https_routes
+  request_headers_to_add:
+  - append_action: OVERWRITE_IF_EXISTS_OR_ADD
+    header:
+      key: X-Real-IP
+      value: '%DOWNSTREAM_REMOTE_ADDRESS%'
+  virtual_hosts:
+    - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
+      domains:
+      - foo.hail
+      name: foo
+      routes:
+      - match:
+          prefix: /
+        route:
+          append_x_forwarded_host: true
+          auto_host_rewrite: true
+          cluster: foo
+          timeout: 0s
+        typed_per_filter_config:
+          envoy.filters.http.local_ratelimit:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            filter_enabled:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            filter_enforced:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              fill_interval: 1s
+              max_tokens: 200
+              tokens_per_fill: 200
+    - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
+      domains:
+      - internal.hail
+      name: internal
+      routes:
+      - match:
+          path_separated_prefix: /test/bar
+        route:
+          append_x_forwarded_host: true
+          auto_host_rewrite: true
+          cluster: test-bar
+          timeout: 0s
+        typed_per_filter_config:
+          envoy.filters.http.local_ratelimit:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            filter_enabled:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            filter_enforced:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              fill_interval: 1s
+              max_tokens: 200
+              tokens_per_fill: 200

--- a/ci/test/test_envoy.py
+++ b/ci/test/test_envoy.py
@@ -8,16 +8,28 @@ from ci.envoy import create_cds_response, create_rds_response
 
 
 @pytest.mark.parametrize(
-    'proxy, create_xds_response, expected_config',
+    'proxy, expected_config',
     [
-        ('gateway', create_cds_response, 'test_gateway_cds_response.yaml'),
-        ('gateway', create_rds_response, 'test_gateway_rds_response.yaml'),
-        ('internal-gateway', create_cds_response, 'test_internal_gateway_cds_response.yaml'),
-        ('internal-gateway', create_rds_response, 'test_internal_gateway_rds_response.yaml'),
+        ('gateway', 'test_gateway_cds_response.yaml'),
+        ('internal-gateway', 'test_internal_gateway_cds_response.yaml'),
     ],
 )
-def test_gateway_cds_generation(proxy, create_xds_response, expected_config):
+def test_gateway_cds_generation(proxy, expected_config):
     with open(Path(os.path.dirname(__file__)) / 'envoy' / expected_config, encoding='utf-8') as f:
         expected_cluster_config = yaml.safe_load(f.read())
-    actual_cluster_config = create_xds_response(['foo'], {'test': ['bar']}, proxy)
+    actual_cluster_config = create_cds_response(['foo'], {'test': ['bar']}, proxy)
     assert expected_cluster_config == actual_cluster_config
+
+
+@pytest.mark.parametrize(
+    'proxy, expected_config',
+    [
+        ('gateway', 'test_gateway_rds_response.yaml'),
+        ('internal-gateway', 'test_internal_gateway_rds_response.yaml'),
+    ],
+)
+def test_gateway_rds_generation(proxy, expected_config):
+    with open(Path(os.path.dirname(__file__)) / 'envoy' / expected_config, encoding='utf-8') as f:
+        expected_routes_config = yaml.safe_load(f.read())
+    actual_routes_config = create_rds_response(['foo'], {'test': ['bar']}, proxy, domain='hail.is')
+    assert expected_routes_config == actual_routes_config

--- a/ci/test/test_envoy.py
+++ b/ci/test/test_envoy.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ci.envoy import create_cds_response, create_rds_response
+
+
+@pytest.mark.parametrize(
+    'proxy, create_xds_response, expected_config',
+    [
+        ('gateway', create_cds_response, 'test_gateway_cds_response.yaml'),
+        ('gateway', create_rds_response, 'test_gateway_rds_response.yaml'),
+        ('internal-gateway', create_cds_response, 'test_internal_gateway_cds_response.yaml'),
+        ('internal-gateway', create_rds_response, 'test_internal_gateway_rds_response.yaml'),
+    ],
+)
+def test_gateway_cds_generation(proxy, create_xds_response, expected_config):
+    with open(Path(os.path.dirname(__file__)) / 'envoy' / expected_config, encoding='utf-8') as f:
+        expected_cluster_config = yaml.safe_load(f.read())
+    actual_cluster_config = create_xds_response(['foo'], {'test': ['bar']}, proxy)
+    assert expected_cluster_config == actual_cluster_config

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -6,7 +6,7 @@ IP := $(shell kubectl get secret global-config --template={{.data.ip}} | base64 
 SHA := $(shell git rev-parse --short=12 HEAD)
 
 envoy-xds-config:
-	HAIL_PRODUCTION_DOMAIN=$(DOMAIN) python3 ../ci/ci/envoy.py gateway ${HAIL}/letsencrypt/subdomains.txt ${HAIL}/gateway/cds.yaml.out ${HAIL}/gateway/rds.yaml.out
+	python3 ../ci/ci/envoy.py gateway $(DOMAIN) ${HAIL}/letsencrypt/subdomains.txt ${HAIL}/gateway/cds.yaml.out ${HAIL}/gateway/rds.yaml.out
 	kubectl -n default create configmap gateway-xds-config \
 		--from-file=cds.yaml=cds.yaml.out \
 		--from-file=rds.yaml=rds.yaml.out \


### PR DESCRIPTION
This adds simple unit tests to the CI functionality that generates the configs for `gateway` and `internal-gateway`. It also adds a developer-only endpoint to CI for easier inspection of what configs CI is currently generating in production. These configs do not contain any sensitive information.