### PR TITLE
[query] Ensure Table group_by + aggregate can't clobber global fields

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -60,6 +60,7 @@ from hail.utils.interval import Interval
 from hail.utils.java import Env, info, warning
 from hail.utils.misc import (
     check_annotate_exprs,
+    check_collisions,
     check_keys,
     get_key_by_exprs,
     get_nice_attr_error,
@@ -277,8 +278,10 @@ class GroupedTable(ExprContainer):
         :class:`.Table`
             Aggregated table.
         """
+        caller = 'GroupedTable.aggregate'
         for name, expr in named_exprs.items():
-            analyze(f'GroupedTable.aggregate: ({name!r})', expr, self._parent._global_indices, {self._parent._row_axis})
+            analyze(f'{caller}: ({name!r})', expr, self._parent._global_indices, {self._parent._row_axis})
+        check_collisions(caller, list(named_exprs), self._parent._row_indices)
         if not named_exprs.keys().isdisjoint(set(self._key_expr)):
             intersection = set(named_exprs.keys()) & set(self._key_expr)
             raise ValueError(

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -2732,3 +2732,10 @@ def test_range_table_biggest_int():
     n = biggest_int32 - 1  # NB: range table is [0, ..., n - 1]
     expected_sum = n * (n + 1) // 2
     assert expected_sum == ht.aggregate(hl.agg.sum(hl.int64(ht.idx)))
+
+
+def test_group_by_aggregate_doesnt_clobber_global_field():
+    # https://github.com/hail-is/hail/issues/14506
+    ht = hl.utils.range_table(10).annotate_globals(x=1)
+    with pytest.raises(ExpressionException):
+        ht = ht.group_by(a=ht.idx < 5).aggregate(x=2)


### PR DESCRIPTION
resolves #14506