### PR TITLE
[docker] Fix pip pin

### DIFF
--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -28,6 +28,6 @@ RUN chmod 755 /bin/retry && \
     hail-apt-get-install python$PYTHON_VERSION-minimal python$PYTHON_VERSION-dev python$PYTHON_VERSION-distutils gcc g++ && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PYTHON_VERSION 1 && \
     curl https://bootstrap.pypa.io/get-pip.py | python3 && \
-    python3 -m pip install 'pip>=21<22' && \
+    python3 -m pip install 'pip>=21,<22' && \
     python3 -m pip check && \
     python3 -m pip --version

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -28,6 +28,6 @@ RUN chmod 755 /bin/retry && \
     hail-apt-get-install python$PYTHON_VERSION-minimal python$PYTHON_VERSION-dev python$PYTHON_VERSION-distutils gcc g++ && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PYTHON_VERSION 1 && \
     curl https://bootstrap.pypa.io/get-pip.py | python3 && \
-    python3 -m pip install 'pip>=21,<22' && \
+    python3 -m pip install 'pip>=23,<24.1' && \
     python3 -m pip check && \
     python3 -m pip --version


### PR DESCRIPTION
pip is very permissive and just treats `>=21<22` as `>=21`. The release candidate `24.1b1` for pip dropped yesterday and something about its name normalization broke extras with underscores in them. Since we were previously using `23`, I've pinned above `23` and below this broken release candidate.