### PR TITLE
 [query] Cleanup following 'PArray implements PArrayBackedContainer' 

### DIFF
--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -38,13 +38,9 @@ final case class EArray(val elementType: EType, override val required: Boolean =
     cb += out.writeInt(prefixLen)
 
     value.st match {
-      case s @ SIndexablePointer(_: PCanonicalArray | _: PCanonicalSet | _: PCanonicalDict)
-          if s.pType.elementType.required == elementType.required =>
-        val pArray = s.pType match {
-          case t: PCanonicalArray => t
-          case t: PCanonicalSet => t.arrayRep
-          case t: PCanonicalDict => t.arrayRep
-        }
+      case SIndexablePointer(pType: PCanonicalArrayBackedContainer)
+          if pType.elementType.required == elementType.required =>
+        val pArray = pType.arrayRep
 
         val array = value.asInstanceOf[SIndexablePointerValue].a
         if (!elementType.required) {
@@ -115,11 +111,7 @@ final case class EArray(val elementType: EType, override val required: Boolean =
   ): SValue = {
     val st = decodedSType(t).asInstanceOf[SIndexablePointer]
 
-    val arrayType: PCanonicalArray = st.pType match {
-      case t: PCanonicalArray => t
-      case t: PCanonicalSet => t.arrayRep
-      case t: PCanonicalDict => t.arrayRep
-    }
+    val arrayType = st.pType.asInstanceOf[PCanonicalArrayBackedContainer].arrayRep
 
     assert(
       arrayType.elementType.required == elementType.required,

--- a/hail/src/main/scala/is/hail/types/encoded/EStructOfArrays.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EStructOfArrays.scala
@@ -159,11 +159,7 @@ final case class EStructOfArrays(
 
   def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = v match {
     case sv: SIndexablePointerValue =>
-      val pArray = sv.st.pType match {
-        case t: PCanonicalArray => t
-        case t: PCanonicalSet => t.arrayRep
-        case t: PCanonicalDict => t.arrayRep
-      }
+      val pArray = sv.st.pType.asInstanceOf[PCanonicalArrayBackedContainer].arrayRep
       val r: Value[Region] = // scratch region
         cb.memoize(cb.emb.ecb.pool().invoke[Region]("getRegion"))
       cb += out.writeInt(sv.length)

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -213,3 +213,7 @@ trait PArrayBackedContainer extends PContainer {
   ): Unit =
     Region.storeAddress(addr, unstagedStoreJavaObject(sm, annotation, region))
 }
+
+trait PCanonicalArrayBackedContainer extends PArrayBackedContainer {
+  def arrayRep: PCanonicalArray
+}

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -11,7 +11,8 @@ import is.hail.types.virtual.{TArray, Type}
 import is.hail.utils._
 
 // This is a pointer array, whose byteSize is the size of its pointer
-final case class PCanonicalArray(elementType: PType, required: Boolean = false) extends PArray {
+final case class PCanonicalArray(elementType: PType, required: Boolean = false)
+    extends PArray with PCanonicalArrayBackedContainer {
   assert(elementType.isRealizable)
 
   def arrayRep = this

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
@@ -18,7 +18,7 @@ object PCanonicalDict {
 }
 
 final case class PCanonicalDict(keyType: PType, valueType: PType, required: Boolean = false)
-    extends PDict with PArrayBackedContainer {
+    extends PDict with PCanonicalArrayBackedContainer {
   val elementType = PCanonicalStruct(required = true, "key" -> keyType, "value" -> valueType)
 
   val arrayRep: PCanonicalArray = PCanonicalArray(elementType, required)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
@@ -16,7 +16,7 @@ object PCanonicalSet {
 }
 
 final case class PCanonicalSet(elementType: PType, required: Boolean = false)
-    extends PSet with PArrayBackedContainer {
+    extends PSet with PCanonicalArrayBackedContainer {
   val arrayRep = PCanonicalArray(elementType, required)
 
   def setRequired(required: Boolean) =


### PR DESCRIPTION
This catches a few things missed in https://github.com/hail-is/hail/pull/14521 and adds `PCanonicalArrayBackedContainer` as an extension trait to `PArrayBackedContainer`, ensuring that types implementing this trait are specifically backed by `PCanonicalArray`.