### PR TITLE
[query] fix lowered blockmatrix densify

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -519,7 +519,7 @@ case class SparseContexts(
   }
 
   def mapDense(ib: IRBuilder)(f: (IR, IR, IR) => IR): DenseContexts = {
-    val newContexts = ib.memoize(flatMapIR(rangeIR(nCols)) { j =>
+    val newContexts = ib.memoize(ToArray(flatMapIR(rangeIR(nCols)) { j =>
       bindIRs(ArrayRef(rowPos, j), ArrayRef(rowPos, j + 1)) { case Seq(start, end) =>
         val allIdxs = mapIR(rangeIR(nRows))(i => makestruct("idx" -> i))
         val idxedExisting = mapIR(rangeIR(start, end)) { pos =>
@@ -532,7 +532,7 @@ case class SparseContexts(
             f(i, j, context)
         }
       }
-    })
+    }))
     DenseContexts(nRows, nCols, newContexts)
   }
 
@@ -718,7 +718,7 @@ class BlockMatrixStage2 private (
             IsNA(oldContext),
             MakeNDArray.fill(
               zero(typ.elementType),
-              FastSeq(GetField(oldContext, "nRows"), GetField(oldContext, "nCols")),
+              FastSeq(GetField(context, "nRows"), GetField(context, "nCols")),
               False(),
             ),
             blockIR(oldContext),

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -280,4 +280,13 @@ class BlockMatrixIRSuite extends HailSuite {
 
     assertBMEvalsTo(BlockMatrixRead(BlockMatrixNativeReader(ctx.fs, path)), expected)
   }
+
+  @Test def testBlockMatrixDensify(): Unit = {
+    val dense = fill(1, nRows = 10, nCols = 10, blockSize = 5)
+    val sparse = BlockMatrixSparsify(dense, PerBlockSparsifier(FastSeq(0, 1, 2)))
+    val densified = BlockMatrixDensify(sparse)
+    val expected = BDM.fill(10, 10)(1.0)
+    expected(5 until 10, 5 until 10) := BDM.fill(5, 5)(0.0)
+    assertBMEvalsTo(densified, expected)
+  }
 }


### PR DESCRIPTION
fixes #14537