### PR TITLE
[dataproc] bumps version of notebook

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -43,7 +43,7 @@ if role == 'Master':
         'ipywidgets==8.0.6',
         'jupyter-console==6.6.3',
         'nbconvert==7.3.1',
-        'notebook==6.5.4',
+        'notebook==6.5.6',
         'qtconsole==5.4.2',
     ]
 


### PR DESCRIPTION
When trying to create a dataproc cluster using the results of `make -C hail install-editable` and `make -C hail install-hailctl`, the Jupyter server can't be connected to because it runs into the error described [here](https://stackoverflow.com/questions/77549493/modulenotfounderror-no-module-named-jupyter-server-contents). This change bumps the version of `notebook` that we use in the `init_notebook.py` script in order to make that work again.