### PR TITLE
[infra] Update GCP DB terraform to reflect backup region change

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -335,7 +335,7 @@ resource "google_sql_database_instance" "db" {
     backup_configuration {
       binary_log_enabled             = false
       enabled                        = true
-      location                       = "us"
+      location                       = "us-central1"
       point_in_time_recovery_enabled = false
       start_time                     = "13:00"
       transaction_log_retention_days = 7


### PR DESCRIPTION
I manually changed the Cloud SQL automated backups storage from the `us` multi-region to `us-central1`. There's no reason to store it in a multi-region and it's more expensive. What I didn't realize is that this configuration is actually owned by the terraform that we have managing the lifecycle of the database and other infra, so we need to update the terraform to reflect the desired (and current) state.