### PR TITLE
[query] Let-Bind Input Collection Parameter In `hl.nd.array`.

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5174,7 +5174,7 @@ def _ndarray(collection, row_major=None, dtype=None):
             return []
 
     def deep_flatten(xs: Iterable) -> Iterable:
-        return [y for x in xs for y in (deep_flatten(x) if isinstance(x, Iterable) else [x])]
+        return [y for x in xs for y in (deep_flatten(x) if isinstance(x, (list, builtins.tuple)) else [x])]
 
     if isinstance(collection, NumericExpression):
         data_expr = array([collection])
@@ -5221,7 +5221,7 @@ def _ndarray(collection, row_major=None, dtype=None):
     elif isinstance(collection, np.ndarray):
         return hl.literal(collection)
     else:
-        if isinstance(collection, Iterable):
+        if isinstance(collection, (list, builtins.tuple)):
             shape = list_shape(collection)
             data = deep_flatten(collection)
         else:

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5183,7 +5183,7 @@ def _ndarray(collection, row_major=None, dtype=None):
                     lambda expected: hl.case()
                     .when(
                         actual == expected,
-                        xs if dim == ndim - 1 else xs.flatmap(recur(dim + 1)),
+                        xs if dim == builtins.len(shape) - 1 else xs.flatmap(recur(dim + 1)),
                     )
                     .or_error(
                         f'ndarray dimension {dim} did not match.\n'
@@ -5201,7 +5201,7 @@ def _ndarray(collection, row_major=None, dtype=None):
         data = data.map(lambda value: cast_expr(value, dtype))
         ndir = ir.MakeNDArray(data._ir, shape._ir, hl.bool(True)._ir)
         new_indices, new_aggregations = unify_all(data, shape)
-        ndim = builtins.len(shape.dtype.types)
+        ndim = builtins.len(shape)
         return construct_expr(ndir, tndarray(data.dtype.element_type, ndim), new_indices, new_aggregations)
 
     if isinstance(collection, NumericExpression):

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1,13 +1,12 @@
 import math
 import re
+from test.hail.helpers import assert_all_eval_to, assert_evals_to
 
 import numpy as np
 import pytest
 
 import hail as hl
 from hail.utils.java import FatalError, HailUserError
-
-from ..helpers import assert_all_eval_to, assert_evals_to
 
 
 def assert_ndarrays(asserter, exprs_and_expecteds):
@@ -264,11 +263,11 @@ def test_ndarray_eval():
 
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array(hl.array(mishapen_data_list1)))
-    assert "inner dimensions do not match" in str(exc.value)
+    assert "ndarray dimension 1 did not match" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array(hl.array(mishapen_data_list2)))
-    assert "inner dimensions do not match" in str(exc.value)
+    assert "ndarray dimension 2 did not match" in str(exc.value)
 
     with pytest.raises(ValueError) as exc:
         hl.nd.array(mishapen_data_list3)

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1306,3 +1306,12 @@ def test_ndarray_log_broadcasting():
     expected = np.array([math.log(x) for x in [5, 10, 15, 20]]).reshape(2, 2)
     actual = hl.eval(hl.log(hl.nd.array([[5, 10], [15, 20]])))
     assert np.array_equal(actual, expected)
+
+
+# issue #14559
+def test_ndarray_oom_from_stream_pipeline():
+    n = 442075
+    mt = hl.utils.range_matrix_table(n_rows=1, n_cols=n).select_cols(xs=[1.0])
+    xs = mt.aggregate_cols(hl.agg.collect(mt.xs), _localize=False)
+    xs = hl.nd.array(xs)
+    assert np.array_equal(hl.eval(xs), np.array([[1.0]] * n))


### PR DESCRIPTION
Fixes: #14559
`hl.nd.array`s constructed from stream pipelines can cause out of memory exceptions owing to a limitation in the python CSE algorithm that does not eliminate partially redundant expressions in if-expressions. Explicitly `let`-binding the input collection prevents it from being evaluated twice: once for the flattened data stream and once for the original shape.