### PR TITLE
[hailtop] Prevent event loop RecursionError during highly concurrent file uploads

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -12,7 +12,7 @@ from hail.ir.renderer import CSERenderer
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
 from hailtop.aiotools.validators import validate_file
 from hailtop.fs.router_fs import RouterFS
-from hailtop.utils import find_spark_home
+from hailtop.utils import async_to_blocking, find_spark_home
 
 from ..expr import Expression
 from ..expr.types import HailType
@@ -101,7 +101,7 @@ class LocalBackend(Py4JBackend):
         self._initialize_flags(flags)
 
     def validate_file(self, uri: str) -> None:
-        validate_file(uri, self._fs.afs)
+        async_to_blocking(validate_file(uri, self._fs.afs))
 
     def register_ir_function(
         self,

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -303,7 +303,7 @@ class ServiceBackend(Backend):
         return self._batch_client.create_batch(attributes=self.batch_attributes)
 
     def validate_file(self, uri: str) -> None:
-        validate_file(uri, self._async_fs, validate_scheme=True)
+        async_to_blocking(validate_file(uri, self._async_fs, validate_scheme=True))
 
     def debug_info(self) -> Dict[str, Any]:
         return {

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -14,6 +14,7 @@ from hail.table import Table
 from hail.utils import copy_log
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
+from hailtop.utils import async_to_blocking
 
 from .backend import local_jar_information
 from .py4j_backend import Py4JBackend
@@ -173,7 +174,7 @@ class SparkBackend(Py4JBackend):
         self._copy_log_on_error = copy_log_on_error
 
     def validate_file(self, uri: str) -> None:
-        validate_file(uri, self._router_async_fs)
+        async_to_blocking(validate_file(uri, self._router_async_fs))
 
     def stop(self):
         super().stop()

--- a/hail/python/hailtop/aiotools/validators.py
+++ b/hail/python/hailtop/aiotools/validators.py
@@ -4,10 +4,9 @@ from urllib.parse import urlparse
 
 from hailtop.aiocloud.aiogoogle.client.storage_client import GoogleStorageAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.hail_event_loop import hail_event_loop
 
 
-def validate_file(uri: str, router_async_fs: RouterAsyncFS, *, validate_scheme: Optional[bool] = False) -> None:
+async def validate_file(uri: str, router_async_fs: RouterAsyncFS, *, validate_scheme: Optional[bool] = False) -> None:
     """
     Validates a URI's scheme if a file scheme cache was provided, and its cloud location's default storage policy if
     the URI points to a cloud with an ``AsyncFS`` implementation that supports checking that policy.
@@ -17,14 +16,6 @@ def validate_file(uri: str, router_async_fs: RouterAsyncFS, *, validate_scheme: 
     :class:`ValueError`
         If one of the validation steps fails.
     """
-    return hail_event_loop().run_until_complete(
-        _async_validate_file(uri, router_async_fs, validate_scheme=validate_scheme)
-    )
-
-
-async def _async_validate_file(
-    uri: str, router_async_fs: RouterAsyncFS, *, validate_scheme: Optional[bool] = False
-) -> None:
     if validate_scheme:
         scheme = urlparse(uri).scheme
         if not scheme or scheme == "file":

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -262,9 +262,7 @@ class Batch:
             await self._fs.makedirs(os.path.dirname(code_path), exist_ok=True)
             await self._fs.write(code_path, pipe.getvalue())
 
-        code_input_file = self.read_input(code_path)
-
-        return code_input_file
+        return await self._async_read_input(code_path)
 
     async def _serialize_python_functions_to_input_files(self, path: str, dry_run: bool = False) -> None:
         for function_id, function in self._python_function_defs.items():
@@ -425,7 +423,7 @@ class Batch:
         self._resource_map[jrf._uid] = jrf  # pylint: disable=no-member
         return jrf
 
-    def _new_input_resource_file(self, input_path, root=None):
+    async def _new_input_resource_file(self, input_path, root=None):
         if isinstance(input_path, str):
             pass
         elif isinstance(input_path, os.PathLike):
@@ -434,7 +432,7 @@ class Batch:
         else:
             raise BatchException(f"path value is neither string nor path-like. Found '{type(input_path)}' instead.")
 
-        self._backend.validate_file(input_path, self.requester_pays_project)
+        await self._backend.validate_file(input_path, self.requester_pays_project)
 
         # Take care not to include an Azure SAS token query string in the local name.
         if AzureAsyncFS.valid_url(input_path):
@@ -500,8 +498,10 @@ class Batch:
             File path to read.
         """
 
-        irf = self._new_input_resource_file(path)
-        return irf
+        return async_to_blocking(self._async_read_input(path))
+
+    async def _async_read_input(self, path: Union[str, os.PathLike]) -> _resource.InputResourceFile:
+        return await self._new_input_resource_file(path)
 
     def read_input_group(self, **kwargs: Union[str, os.PathLike]) -> _resource.ResourceGroup:
         """Create a new resource group representing a mapping of identifier to
@@ -562,7 +562,9 @@ class Batch:
         """
 
         root = secret_alnum_string(5)
-        new_resources = {name: self._new_input_resource_file(file, root) for name, file in kwargs.items()}
+        new_resources = {
+            name: async_to_blocking(self._new_input_resource_file(file, root)) for name, file in kwargs.items()
+        }
         rg = _resource.ResourceGroup(None, root, **new_resources)
         self._resource_map.update({rg._uid: rg})
         return rg
@@ -656,7 +658,7 @@ class Batch:
             if dest_scheme == '':
                 dest = os.path.abspath(os.path.expanduser(dest))
 
-        self._backend.validate_file(dest, self.requester_pays_project)
+        async_to_blocking(self._backend.validate_file(dest, self.requester_pays_project))
 
         resource._add_output_path(dest)
 


### PR DESCRIPTION
We use `nest_asyncio` to allow synchronous blocking on a coroutine execution inside an async context. For example, if a user is using the synchronous interface of hail inside a jupyter cell (which runs an event loop). `nest_asyncio` achieves this by patching the `asyncio` event loop to make it reentrant, and with that there are footguns. This allows us to do things like create 100 tasks that all concurrently invoke `run_until_complete`, each of which will add stack frames to the event loop stack that can pile up and trigger a cryptic `RecursionError`.

But internally we never *need* to make concurrent calls to `run_until_complete`, and more broadly we should never have `async / sync / async` inside hail code. This change exposes an asynchronous `validate_file` so that asynchronous methods in `hailtop` can use it directly instead of inserting a synchronous layer (`async_to_blocking`) between them.