### PR TITLE
[batch] Sort jobs by job id in the UI

### DIFF
--- a/batch/batch/front_end/query/query_v1.py
+++ b/batch/batch/front_end/query/query_v1.py
@@ -277,6 +277,7 @@ WITH base_t AS
     jobs.job_id = job_attributes.job_id AND
     job_attributes.`key` = 'name'
   WHERE {' AND '.join(where_conditions)}
+  ORDER BY jobs.job_id
   LIMIT 50
 )
 SELECT base_t.*, cost_t.cost, cost_t.cost_breakdown

--- a/batch/batch/front_end/query/query_v2.py
+++ b/batch/batch/front_end/query/query_v2.py
@@ -311,6 +311,7 @@ FROM (SELECT resource_id, CAST(COALESCE(SUM(`usage`), 0) AS SIGNED) AS `usage`
 LEFT JOIN resources ON usage_t.resource_id = resources.resource_id
 ) AS cost_t ON TRUE
 WHERE {" AND ".join(where_conditions)}
+ORDER BY jobs.job_id
 LIMIT 50;
 """
 


### PR DESCRIPTION
These queries are responsible for getting the paginated list of jobs in the batch UI. I believe this missing order by went unnoticed because the queries were naturally getting returned in order based on the jobs primary key, but we've recently seen a couple page loads of jumbled or missing jobs. Seems like something around the query stats changed and the database adjusted its plan slightly. Regardless, we want this order by explicit.