### PR TITLE
[batch] Adjust Batch UI to have less dead space

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -74,28 +74,29 @@ batch_state_indicator, job_state_indicator, danger_button, submit_button, link
   <div class="flex flex-col w-full lg:basis-3/5">
     {{ table_search("job-search", base_path ~ "/batches/" ~ batch["id"]) }}
     <div class='flex flex-col mt-4'>
-      <table class="table-fixed md:table-auto w-full" id="batch">
+      <table class="table-auto w-full" id="batch">
         <thead>
-          <th class='h-16 bg-slate-200 font-light text-md text-left pl-4 rounded-tl w-1/12'>ID</th>
-          <th class='h-16 bg-slate-200 font-light text-md text-left pl-4 rounded-tr md:rounded-tr-none w-3/4 lg:w-1/2'>
+          <th class='h-12 bg-slate-200 font-light text-md text-left px-4 rounded-tl'>ID</th>
+          <th class='h-12 bg-slate-200 font-light text-md text-left rounded-tr md:rounded-tr-none'>
             Name</th>
-          <th class='h-16 bg-slate-200 font-light text-md text-left pl-4 hidden lg:table-cell'>Duration</th>
-          <th class='h-16 bg-slate-200 font-light text-md text-left pl-4 hidden md:table-cell rounded-tr'>Cost</th>
+          <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell'>Exit Code</th>
+          <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell'>Duration</th>
+          <th class='h-12 bg-slate-200 font-light text-md text-left hidden md:table-cell rounded-tr'>Cost</th>
         </thead>
         <tbody class='border border-collapse border-slate-50'>
           {% for job in batch['jobs'] %}
           <tr class='border border-collapse hover:bg-slate-100'>
-            <td class='font-light py-2 px-4'>
+            <td class='font-light pl-4 w-20'>
               {{ link(base_path ~ '/batches/' ~ job['batch_id'] ~ '/jobs/' ~ job['job_id'], job['job_id']) }}
             </td>
-            <td class='py-2 px-4 block overflow-x-auto'>
-              <div class='flex flex-col space-y-1 md:flex-row md:flex-wrap md:space-y-0'>
+            <td class='py-1 block overflow-x-auto'>
+              <div class='flex flex-col space-x-0 md:space-x-2 md:flex-row md:flex-wrap'>
                 {% if 'name' in job and job['name'] is not none %}
-                <div class='text-wrap pr-4 font-normal text-lg'>
+                <div class='text-wrap'>
                   {{ link(base_path ~ '/batches/' ~ job['batch_id'] ~ '/jobs/' ~ job['job_id'], job['name']) }}
                 </div>
                 {% else %}
-                <div class='text-wrap pr-4 text-zinc-400 italic'>
+                <div class='text-wrap text-zinc-400 italic'>
                   {{ link(base_path ~ '/batches/' ~ job['batch_id'] ~ '/jobs/' ~ job['job_id'], 'no name') }}
                 </div>
                 {% endif %}
@@ -104,10 +105,13 @@ batch_state_indicator, job_state_indicator, danger_button, submit_button, link
                 </div>
               </div>
             </td>
-            <td class='hidden lg:table-cell font-light py-2 px-4'>
+            <td class='hidden lg:table-cell font-light'>
+              {{ job.get('exit_code', '') }}
+            </td>
+            <td class='hidden lg:table-cell font-light'>
               {{ job.get('duration') or '' }}
             </td>
-            <td class='hidden md:table-cell font-light py-2 px-4'>
+            <td class='hidden md:table-cell font-light'>
               {{ job.get('cost') or '' }}
             </td>
           </tr>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -6,18 +6,19 @@
 <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
 {% endblock %}
 {% block content %}
-<div class='flex-col m-auto w-full lg:px-10 space-y-4'>
+<div class='flex-col m-auto w-full space-y-4'>
   <h1 class="text-2xl font-light">Batches</h1>
   {{ table_search("batch-search", base_path ~ "/batches") }}
-  <table class='table-fixed w-full' id='batches'>
+  <table class='table-auto w-full' id='batches'>
     <thead>
-      <th class='h-16 bg-slate-200 font-light text-md text-center rounded-tl rounded-tr md:rounded-tr-none'>
+      <th class='h-12 bg-slate-200 font-light text-md text-center rounded-tl rounded-tr md:rounded-tr-none'>
         ID</th>
-      <th class='h-16 bg-slate-200 font-light text-md rounded-tr md:rounded-tr-none text-center w-4/5 lg:w-2/5'>Batch
+      <th class='h-12 bg-slate-200 font-light text-md rounded-tr text-left md:rounded-tr-none'>Batch
       </th>
-      <th class='h-16 bg-slate-200 font-light text-md px-10 text-center hidden lg:table-cell w-1/5'>Job Statuses</th>
-      <th class='h-16 bg-slate-200 font-light text-md text-center hidden lg:table-cell'>Duration</th>
-      <th class='h-16 bg-slate-200 font-light text-md text-center hidden md:table-cell rounded-tr'>Cost</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell'>Billing Project</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell'>Job Statuses</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell'>Duration</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden md:table-cell rounded-tr'>Cost</th>
     </thead>
     <tbody class='border border-collapse border-slate-50'>
       {% for batch in batches %}
@@ -28,10 +29,10 @@
           </div>
         </td>
         <td class='table-cell'>
-          <div class='flex-col space-y-2 py-2 block overflow-x-auto'>
+          <div class='flex-col py-1 block overflow-x-auto'>
             <div class='flex flex-col space-y-1 md:flex-row md:flex-wrap md:items-center md:space-y-0'>
               {% if 'attributes' in batch and 'name' in batch['attributes'] %}
-              <div class='text-wrap pr-4 font-normal text-lg'>
+              <div class='text-wrap pr-4'>
                 {{ link(base_path ~ "/batches/" ~ batch['id'], batch['attributes']['name']) }}
               </div>
               {% else %}
@@ -41,10 +42,12 @@
               {% endif %}
               {{ batch_state_indicator(batch) }}
             </div>
-            <div class='font-light text-zinc-500'>{{ batch['billing_project'] }}</div>
           </div>
         </td>
-        <td class='hidden lg:table-cell overflow-hidden px-5'>
+        <td class='hidden lg:table-cell'>
+          <div class='font-light text-zinc-500'>{{ batch['billing_project'] }}</div>
+        </td>
+        <td class='hidden lg:table-cell overflow-hidden'>
           <div class='flex items-center font-light'>
             {% set statuses = [] %}
             {% if batch['n_jobs'] - batch['n_completed'] != 0 %}
@@ -62,10 +65,10 @@
             {{ statuses|join(', ') }}
           </div>
         </td>
-        <td class='hidden lg:table-cell font-light text-center'>
+        <td class='hidden lg:table-cell font-light'>
           {{ batch.get('duration') or '' }}
         </td>
-        <td class='hidden md:table-cell font-light text-center'>
+        <td class='hidden md:table-cell font-light'>
           {{ batch.get('cost') or '' }}
         </td>
       </tr>

--- a/batch/batch/front_end/templates/billing_limits.html
+++ b/batch/batch/front_end/templates/billing_limits.html
@@ -11,9 +11,9 @@
   <tbody>
     {% for row in open_billing_projects %}
     <tr class='border border-collapse hover:bg-slate-100'>
-      <td class='p-2'>{{ row['billing_project'] }}</td>
-      <td class='p-2'>{{ row['accrued_cost'] }}</td>
-      <td class='p-2'>{{ row['limit'] }}</td>
+      <td class='py-2 pl-2'>{{ row['billing_project'] }}</td>
+      <td class='py-2'>{{ row['accrued_cost'] }}</td>
+      <td class='py-2 pr-2'>{{ row['limit'] }}</td>
     </tr>
     {% endfor %}
     <tr class='border border-collapse bg-slate-200'>
@@ -21,9 +21,9 @@
     </tr>
     {% for row in closed_billing_projects %}
     <tr class='border border-collapse bg-slate-50 font-light hover:bg-slate-100'>
-      <td class='p-2'>{{ row['billing_project'] }}</td>
-      <td class='p-2'>{{ row['accrued_cost'] }}</td>
-      <td class='p-2'>{{ row['limit'] }}</td>
+      <td class='py-2 pl-2'>{{ row['billing_project'] }}</td>
+      <td class='py-2'>{{ row['accrued_cost'] }}</td>
+      <td class='py-2 pr-2'>{{ row['limit'] }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -133,8 +133,8 @@
     </div>
   </div>
 </div>
-<div class='bg-slate-100 border rounded my-8 overflow-hidden w-full md:w-auto'>
-  <h2 class='text-2xl font-light m-4'>Attempts</h2>
+<div class='bg-slate-100 border rounded overflow-hidden w-full md:w-auto'>
+  <h2 class='text-2xl font-light mx-4 my-3'>Attempts</h2>
   <table class='overflow-hidden table-fixed w-full'>
     <thead class='h-12 text-sky-900'>
       <th class='text-center'>Attempt ID</th>
@@ -146,7 +146,7 @@
     </thead>
     <tbody>
       {% for attempt in attempts or [] %}
-      <tr class='h-16 border-y bg-white'>
+      <tr class='h-12 border-y bg-white'>
         <td class='text-center'>{{ attempt['attempt_id'] }}</td>
         <td class='text-center'>{{ attempt['instance_name'] }}</td>
         <td class='text-center hidden md:table-cell'>{{ attempt.get('start_time') or '' }}</td>
@@ -157,6 +157,13 @@
       {% endfor %}
     </tbody>
   </table>
+  {% if plot_resource_usage is not none %}
+  <div class='relative overflow-hidden transition-all bg-white'>
+    <div class='w-full overflow-auto flex justify-center'>
+      <div id="plotly-job-resource-usage"></div>
+    </div>
+  </div>
+  {% endif %}
   {% if job_log or step_errors %}
   <div class='bg-white' x-data='{tab: "main"}'>
     <div class='flex border-b text-lg overflow-auto'>
@@ -171,13 +178,6 @@
       </div>
       {% endif %}
       {% endfor %}
-      {% if plot_resource_usage is not none %}
-      <div class='px-4 pt-4 pb-2 hover:opacity-100 hover:cursor-pointer hover:border-b border-black'
-        :class='{"border-b": tab == "resource-usage", "opacity-50": tab != "resource-usage"}'
-        x-on:click='tab = "resource-usage"'>
-        Resource Usage
-      </div>
-      {% endif %}
       <div class='px-4 pt-4 pb-2 hover:opacity-100 hover:cursor-pointer hover:border-b border-black'
         :class='{"border-b": tab == "status", "opacity-50": tab != "status"}' x-on:click='tab = "status"'>
         Raw Status
@@ -190,8 +190,8 @@
       </div>
     </div>
     <div class='relative overflow-hidden transition-all' x-show='tab == "main"'>
-      <div class='flex flex-col lg:flex-row py-4 pl-4 gap-4'>
-        <div class='w-full overflow-auto lg:w-1/4'>
+      <div class='py-4 pl-4'>
+        <div class='overflow-auto'>
           {{ step_runtime('main') }}
           {% if job_specification %}
           {% if job_specification['image'] != '[jvm]' %}
@@ -223,13 +223,6 @@
         {{ error_and_logs_panel('output') }}
       </div>
     </div>
-    {% if plot_resource_usage is not none %}
-    <div class='relative overflow-hidden transition-all' x-show='tab == "resource-usage"' x-cloak>
-      <div class='w-full overflow-auto pt-4 lg:pl-4'>
-        <div id="plotly-job-resource-usage"></div>
-      </div>
-    </div>
-    {% endif %}
     <div class='relative overflow-hidden transition-all' x-show='tab == "status"' x-cloak>
       <div class='w-full overflow-auto pt-4 pl-4'>
         {{ code_block(job_status_str) }}


### PR DESCRIPTION
The original UI redesign was intended to make it easier to navigate and focus on important information. I received very positive feedback on some aspects like this, for example having the different job steps in separate tabs. There was also feedback though that there was a lot of dead space. This is an attempt to find a good middle ground where the UI is not overwhelmingly cluttered but is more compact and makes better use of screen real estate