### PR TITLE
[query] Chunk spark backend execution

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -149,6 +149,7 @@ class Backend(abc.ABC):
         "rng_nonce": ("HAIL_RNG_NONCE", "0x0"),
         "shuffle_cutoff_to_local_sort": ("HAIL_SHUFFLE_CUTOFF", "512000000"),  # This is in bytes
         "shuffle_max_branch_factor": ("HAIL_SHUFFLE_MAX_BRANCH", "64"),
+        "spark_max_stage_parallelism": ("HAIL_SPARK_MAX_STAGE_PARALLELISM", str(2**31 - 1)),
         "use_fast_restarts": ("HAIL_USE_FAST_RESTARTS", None),
         "use_new_shuffle": ("HAIL_USE_NEW_SHUFFLE", None),
         "use_ssa_logs": ("HAIL_USE_SSA_LOGS", "1"),

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -1,6 +1,7 @@
 package is.hail
 
 import is.hail.backend.ExecutionCache
+import is.hail.backend.spark.SparkBackend
 import is.hail.io.fs.RequesterPaysConfig
 import is.hail.types.encoded.EType
 import is.hail.utils._
@@ -11,7 +12,7 @@ import org.json4s.JsonAST.{JArray, JObject, JString}
 
 object HailFeatureFlags {
   val defaults = Map[String, (String, String)](
-    // Must match __flags_env_vars_and_defaults in hail/backend/backend.py
+    // Must match _flags_env_vars_and_defaults in hail/backend/backend.py
     //
     // The default values and envvars here are only used in the Scala tests. In all other
     // conditions, Python initializes the flags, see HailContext._initialize_flags in context.py.
@@ -40,6 +41,7 @@ object HailFeatureFlags {
     (ExecutionCache.Flags.UseFastRestarts, "HAIL_USE_FAST_RESTARTS" -> null),
     (RequesterPaysConfig.Flags.RequesterPaysBuckets, "HAIL_GCS_REQUESTER_PAYS_BUCKETS" -> null),
     (RequesterPaysConfig.Flags.RequesterPaysProject, "HAIL_GCS_REQUESTER_PAYS_PROJECT" -> null),
+    (SparkBackend.Flags.MaxStageParallelism, "HAIL_SPARK_MAX_STAGE_PARALLELISM" -> Integer.MAX_VALUE.toString)
   )
 
   def fromMap(m: Map[String, String]): HailFeatureFlags =

--- a/hail/src/main/scala/is/hail/HailFeatureFlags.scala
+++ b/hail/src/main/scala/is/hail/HailFeatureFlags.scala
@@ -41,7 +41,10 @@ object HailFeatureFlags {
     (ExecutionCache.Flags.UseFastRestarts, "HAIL_USE_FAST_RESTARTS" -> null),
     (RequesterPaysConfig.Flags.RequesterPaysBuckets, "HAIL_GCS_REQUESTER_PAYS_BUCKETS" -> null),
     (RequesterPaysConfig.Flags.RequesterPaysProject, "HAIL_GCS_REQUESTER_PAYS_PROJECT" -> null),
-    (SparkBackend.Flags.MaxStageParallelism, "HAIL_SPARK_MAX_STAGE_PARALLELISM" -> Integer.MAX_VALUE.toString)
+    (
+      SparkBackend.Flags.MaxStageParallelism,
+      "HAIL_SPARK_MAX_STAGE_PARALLELISM" -> Integer.MAX_VALUE.toString,
+    ),
   )
 
   def fromMap(m: Map[String, String]): HailFeatureFlags =

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -456,7 +456,7 @@ class SparkBackend(
           rdd,
           (_: TaskContext, it: Iterator[Array[Byte]]) => it.next(),
           subparts,
-          (idx, result: Array[Byte]) => buffer += result -> subparts(idx)
+          (idx, result: Array[Byte]) => buffer += result -> subparts(idx),
         )
       }
     } catch {

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -74,6 +74,10 @@ class SparkTaskContext private[spark] (ctx: TaskContext) extends HailTaskContext
 }
 
 object SparkBackend {
+  object Flags {
+    val MaxStageParallelism = "spark_max_stage_parallelism"
+  }
+
   private var theSparkBackend: SparkBackend = _
 
   def sparkContext(op: String): SparkContext = HailContext.sparkBackend(op).sc
@@ -441,7 +445,7 @@ class SparkBackend(
         }
       }
 
-    val chunkSize = 30000
+    val chunkSize = getFlag(SparkBackend.Flags.MaxStageParallelism).toInt
     val partsToRun = partitions.getOrElse(contexts.indices)
     val buffer = new ArrayBuffer[(Array[Byte], Int)](partsToRun.length)
     var failure: Option[Throwable] = None

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -452,7 +452,7 @@ class SparkBackend(
           rdd,
           (_: TaskContext, it: Iterator[Array[Byte]]) => it.next(),
           subparts,
-          (idx, result: Array[Byte]) => buffer += result -> idx
+          (idx, result: Array[Byte]) => buffer += result -> subparts(idx)
         )
       }
     } catch {


### PR DESCRIPTION
We seem to be running into spark/yarn scheduling limitations causing stages to often fail with a large number of partitions. Here, we implement a very simple chunking strategy to run spark jobs with a limited number of partitions at a time.

The maximum parallelism is controlled by a new `spark_max_stage_parallelism` feature flag, which defaults to MAXINT until we can figure out a good default.

Also, this change corrects a small error in logic for partition indices for call caching. The `resultHandler` argument of [`runJob`] is called with the job's partition index, not the index of the partition within the RDD. So we need to index into the `partitions` sequence when populating the results buffer.

CHANGELOG: Add 'spark_max_stage_parallelism' flag to allow users to run pipelines with a large number of partitions in chunks. By default, hail still attempts to run all partitions in a stage at once. 

[`runJob`]: https://spark.apache.org/docs/latest/api/scala/org/apache/spark/SparkContext.html#runJob[T,U](rdd:org.apache.spark.rdd.RDD[T],func:(org.apache.spark.TaskContext,Iterator[T])=%3EU,partitions:Seq[Int],resultHandler:(Int,U)=%3EUnit)(implicitevidence$11:scala.reflect.ClassTag[U]):Unit