### PR TITLE
[ci] Add operator knob to adjust rate limits

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1966,6 +1966,9 @@ steps:
       - name: record-failure-notifications
         script: /io/sql/record-failure-notifications.sql
         online: true
+      - name: add-service-rate-limits
+        script: /io/sql/add-service-rate-limits.sql
+        online: true
     inputs:
       - from: /repo/ci/sql
         to: /io/sql

--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -1,12 +1,23 @@
 import sys
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import yaml
 
+LOAD_BALANCER_REPLICAS = 3
+
+
+class Service:
+    def __init__(self, name: str, rate_limit_rps: Optional[int] = None):
+        self.name = name
+        if rate_limit_rps is not None:
+            self.rate_limit_rps = rate_limit_rps
+        else:
+            self.rate_limit_rps = 180 if name == 'batch-driver' else 600
+
 
 def create_rds_response(
-    default_services: List[str],
-    internal_services_per_namespace: Dict[str, List[str]],
+    default_services: List[Service],
+    internal_services_per_namespace: Dict[str, List[Service]],
     proxy: str,
     *,
     domain: str,
@@ -45,7 +56,7 @@ def create_rds_response(
 
 
 def create_cds_response(
-    default_services: List[str], internal_services_per_namespace: Dict[str, List[str]], proxy: str
+    default_services: List[Service], internal_services_per_namespace: Dict[str, List[Service]], proxy: str
 ) -> dict:
     return {
         'version_info': 'dummy',
@@ -57,15 +68,15 @@ def create_cds_response(
     }
 
 
-def gateway_default_host(service: str, domain: str) -> dict:
-    domains = [f'{service}.{domain}']
+def gateway_default_host(service: Service, domain: str) -> dict:
+    domains = [f'{service.name}.{domain}']
     if service == 'www':
         domains.append(domain)
 
     if service == 'ukbb-rg':
         return {
             '@type': 'type.googleapis.com/envoy.config.route.v3.VirtualHost',
-            'name': service,
+            'name': service.name,
             'domains': domains,
             'routes': [
                 {
@@ -87,12 +98,12 @@ def gateway_default_host(service: str, domain: str) -> dict:
 
     return {
         '@type': 'type.googleapis.com/envoy.config.route.v3.VirtualHost',
-        'name': service,
+        'name': service.name,
         'domains': domains,
         'routes': [
             {
                 'match': {'prefix': '/'},
-                'route': route_to_cluster(service),
+                'route': route_to_cluster(service.name),
                 'typed_per_filter_config': {
                     'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                     'envoy.filters.http.ext_authz': auth_check_exemption(),
@@ -102,15 +113,15 @@ def gateway_default_host(service: str, domain: str) -> dict:
     }
 
 
-def gateway_internal_host(services_per_namespace: Dict[str, List[str]], domain: str) -> dict:
+def gateway_internal_host(services_per_namespace: Dict[str, List[Service]], domain: str) -> dict:
     return {
         '@type': 'type.googleapis.com/envoy.config.route.v3.VirtualHost',
         'name': 'internal',
         'domains': [f'internal.{domain}'],
         'routes': [
             {
-                'match': {'path_separated_prefix': f'/{namespace}/{service}'},
-                'route': route_to_cluster(f'{namespace}-{service}'),
+                'match': {'path_separated_prefix': f'/{namespace}/{service.name}'},
+                'route': route_to_cluster(f'{namespace}-{service.name}'),
                 'typed_per_filter_config': {
                     'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                 },
@@ -121,15 +132,15 @@ def gateway_internal_host(services_per_namespace: Dict[str, List[str]], domain: 
     }
 
 
-def internal_gateway_default_host(service: str) -> dict:
+def internal_gateway_default_host(service: Service) -> dict:
     return {
         '@type': 'type.googleapis.com/envoy.config.route.v3.VirtualHost',
-        'name': service,
-        'domains': [f'{service}.hail'],
+        'name': service.name,
+        'domains': [f'{service.name}.hail'],
         'routes': [
             {
                 'match': {'prefix': '/'},
-                'route': route_to_cluster(service),
+                'route': route_to_cluster(service.name),
                 'typed_per_filter_config': {
                     'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                 },
@@ -138,15 +149,15 @@ def internal_gateway_default_host(service: str) -> dict:
     }
 
 
-def internal_gateway_internal_host(services_per_namespace: Dict[str, List[str]]) -> dict:
+def internal_gateway_internal_host(services_per_namespace: Dict[str, List[Service]]) -> dict:
     return {
         '@type': 'type.googleapis.com/envoy.config.route.v3.VirtualHost',
         'name': 'internal',
         'domains': ['internal.hail'],
         'routes': [
             {
-                'match': {'path_separated_prefix': f'/{namespace}/{service}'},
-                'route': route_to_cluster(f'{namespace}-{service}'),
+                'match': {'path_separated_prefix': f'/{namespace}/{service.name}'},
+                'route': route_to_cluster(f'{namespace}-{service.name}'),
                 'typed_per_filter_config': {
                     'envoy.filters.http.local_ratelimit': rate_limit_config(service),
                 },
@@ -173,8 +184,10 @@ def auth_check_exemption() -> dict:
     }
 
 
-def rate_limit_config(service: str) -> dict:
-    max_rps = 60 if service == 'batch-driver' else 200
+def rate_limit_config(service: Service) -> dict:
+    # The config is set per load balancer pod, so we must account for
+    # multiple replicas of the load balancer
+    max_rps = service.rate_limit_rps // LOAD_BALANCER_REPLICAS
 
     return {
         '@type': 'type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit',
@@ -202,23 +215,28 @@ def rate_limit_config(service: str) -> dict:
 
 
 def clusters(
-    default_services: List[str], internal_services_per_namespace: Dict[str, List[str]], proxy: str
+    default_services: List[Service], internal_services_per_namespace: Dict[str, List[Service]], proxy: str
 ) -> List[dict]:
     clusters = []
     for service in default_services:
-        if service == 'ukbb-rg':
+        if service.name == 'ukbb-rg':
             browser_cluster = make_cluster('ukbb-rg-browser', 'ukbb-rg-browser.ukbb-rg', proxy, verify_ca=True)
             static_cluster = make_cluster('ukbb-rg-static', 'ukbb-rg-static.ukbb-rg', proxy, verify_ca=True)
             clusters.append(browser_cluster)
             clusters.append(static_cluster)
         else:
-            clusters.append(make_cluster(service, f'{service}.default.svc.cluster.local', proxy, verify_ca=True))
+            clusters.append(
+                make_cluster(service.name, f'{service.name}.default.svc.cluster.local', proxy, verify_ca=True)
+            )
 
     for namespace, services in internal_services_per_namespace.items():
         for service in services:
             clusters.append(
                 make_cluster(
-                    f'{namespace}-{service}', f'{service}.{namespace}.svc.cluster.local', proxy, verify_ca=False
+                    f'{namespace}-{service.name}',
+                    f'{service.name}.{namespace}.svc.cluster.local',
+                    proxy,
+                    verify_ca=False,
                 )
             )
 
@@ -290,7 +308,7 @@ if __name__ == '__main__':
     proxy = sys.argv[1]
     domain = sys.argv[2]
     with open(sys.argv[3], 'r', encoding='utf-8') as services_file:
-        services = [service.rstrip() for service in services_file.readlines()]
+        services = [Service(service.rstrip()) for service in services_file.readlines()]
 
     with open(sys.argv[4], 'w', encoding='utf-8') as cds_file:
         cds_file.write(yaml.dump(create_cds_response(services, {}, proxy)))

--- a/ci/ci/templates/namespaces.html
+++ b/ci/ci/templates/namespaces.html
@@ -9,7 +9,12 @@
       <th colspan="1">Namespace</th>
       <th colspan="1">Creation Time</th>
       <th colspan="1">Expiration Time</th>
-      <th colspan="2">Services</th>
+      <th colspan="3">Services</th>
+    </tr>
+    <tr>
+      <th colspan="3"></th>
+      <th>Name</th>
+      <th>Inbound Requests Per Second Limit</th>
     </tr>
   </thead>
   {% for ns in namespaces %}
@@ -34,31 +39,36 @@
       <td>
         {{ service }}
       </td>
+      <td>
+        <form action="{{ base_path }}/namespaces/{{ ns['namespace'] }}/services/{{ service }}/edit" method="POST">
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+          {% if ns['services'][service] %}
+          <input type="number" name="rate_limit" value="{{ ns['services'][service] }}" placeholder='default'>
+          {% else %}
+          <input type="number" name="rate_limit" placeholder='default'>
+          {% endif %}
+          <button>
+            Update
+          </button>
+        </form>
+      </td>
     </tr>
     {% endfor %}
     <tr>
       <form action="{{ base_path }}/namespaces/{{ ns['namespace'] }}/services/add" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-        <td><input type="text" name="service"></td>
         <td>
+          <input type="text" name="service">
           <button>Add</button>
         </td>
       </form>
     </tr>
   </tbody>
   {% endfor %}
-  <tbody>
-    <form action="{{ base_path }}/namespaces/add" method="POST">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-      <tr>
-        <td><input type="text" name="namespace"></td>
-        <td>
-          <button>Add</button>
-        </td>
-        <td></td>
-        <td></td>
-      </tr>
-    </form>
-  </tbody>
 </table>
+<form action="{{ base_path }}/namespaces/add" method="POST">
+  <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+  <input type="text" name="namespace">
+  <button>Add</button>
+</form>
 {% endblock %}

--- a/ci/sql/add-service-rate-limits.sql
+++ b/ci/sql/add-service-rate-limits.sql
@@ -1,0 +1,1 @@
+ALTER TABLE deployed_services ADD COLUMN rate_limit_rps INT, ALGORITHM=INSTANT;

--- a/ci/sql/estimated-current.sql
+++ b/ci/sql/estimated-current.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS `active_namespaces` (
 CREATE TABLE IF NOT EXISTS `deployed_services` (
   `namespace` VARCHAR(100) NOT NULL,
   `service` VARCHAR(100) NOT NULL,
+  `rate_limit_rps` INT,
   PRIMARY KEY (`namespace`, `service`),
   FOREIGN KEY (`namespace`) REFERENCES active_namespaces(namespace) ON DELETE CASCADE
 ) ENGINE = InnoDB;

--- a/ci/test/envoy/test_gateway_rds_response.yaml
+++ b/ci/test/envoy/test_gateway_rds_response.yaml
@@ -72,5 +72,5 @@ resources:
             stat_prefix: http_local_rate_limiter
             token_bucket:
               fill_interval: 1s
-              max_tokens: 200
-              tokens_per_fill: 200
+              max_tokens: 33
+              tokens_per_fill: 33

--- a/ci/test/envoy/test_internal_gateway_rds_response.yaml
+++ b/ci/test/envoy/test_internal_gateway_rds_response.yaml
@@ -69,5 +69,5 @@ resources:
             stat_prefix: http_local_rate_limiter
             token_bucket:
               fill_interval: 1s
-              max_tokens: 200
-              tokens_per_fill: 200
+              max_tokens: 33
+              tokens_per_fill: 33

--- a/ci/test/test_envoy.py
+++ b/ci/test/test_envoy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from ci.envoy import create_cds_response, create_rds_response
+from ci.envoy import Service, create_cds_response, create_rds_response
 
 
 @pytest.mark.parametrize(
@@ -17,7 +17,7 @@ from ci.envoy import create_cds_response, create_rds_response
 def test_gateway_cds_generation(proxy, expected_config):
     with open(Path(os.path.dirname(__file__)) / 'envoy' / expected_config, encoding='utf-8') as f:
         expected_cluster_config = yaml.safe_load(f.read())
-    actual_cluster_config = create_cds_response(['foo'], {'test': ['bar']}, proxy)
+    actual_cluster_config = create_cds_response([Service('foo')], {'test': [Service('bar', 100)]}, proxy)
     assert expected_cluster_config == actual_cluster_config
 
 
@@ -31,5 +31,7 @@ def test_gateway_cds_generation(proxy, expected_config):
 def test_gateway_rds_generation(proxy, expected_config):
     with open(Path(os.path.dirname(__file__)) / 'envoy' / expected_config, encoding='utf-8') as f:
         expected_routes_config = yaml.safe_load(f.read())
-    actual_routes_config = create_rds_response(['foo'], {'test': ['bar']}, proxy, domain='hail.is')
+    actual_routes_config = create_rds_response(
+        [Service('foo')], {'test': [Service('bar', 100)]}, proxy, domain='hail.is'
+    )
     assert expected_routes_config == actual_routes_config

--- a/dev-docs/services/gateways.md
+++ b/dev-docs/services/gateways.md
@@ -32,4 +32,6 @@ of new namespaces/services, CI tracks which namespaces are active and periodical
 updates a K8s `ConfigMap` with fresh Envoy configuration. The gateways, using the
 [Envoy xDS API](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration#xds-configuration-api-overview)
 can dynamically load this new configuration as it changes without dropping existing traffic.
-You can see CI's current view of the cluster's namespaces/services at ci.hail.is/namespaces.
+You can see CI's current view of the cluster's namespaces/services at ci.hail.is/namespaces
+and can inspect the current Envoy config at ci.hail.is/envoy-config/gateway and
+ci.hail.is/envoy-config/internal-gateway.


### PR DESCRIPTION
This adds a control to CI where an operator can adjust the rate limit on a particular service in a particular namespace. CI stores and propagates that information when it generates the Envoy configs for `gateway` and `internal-gateway`. This enables operators to shield an overwhelmed batch driver by decreasing its rate limit without needing to push a code change. Increasing the rate limit can increase throughput if workers are being rate limited but the batch driver is not fully utilized.