### PR TITLE
[batch] Async _compile should use async read_input

### DIFF
--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -881,7 +881,7 @@ class BashJob(Job):
 
         job_path = f'{remote_tmpdir}/{self._dirname}'
         code_path = f'{job_path}/code.sh'
-        code = self._batch.read_input(code_path)
+        code = await self._batch._async_read_input(code_path)
 
         wrapper_command = f"""
 chmod u+x {code}


### PR DESCRIPTION
See #14576 for full details, this is another instance of the batch client improperly blocking on coroutines from within our own async code.