### PR TITLE
[batch] Fix accidental mutation in GoogleComputeClient.list that broke disk cleanup

### DIFF
--- a/batch/batch/cloud/gcp/driver/disks.py
+++ b/batch/batch/cloud/gcp/driver/disks.py
@@ -27,12 +27,12 @@ async def delete_orphaned_disks(
     params = {'filter': f'(labels.namespace = {namespace})'}
 
     for zone in zones:
-        async for disk in await compute_client.list(f'/zones/{zone}/disks', params=params):
+        async for disk in compute_client.list(f'/zones/{zone}/disks', params=params):
             disk_name = disk['name']
             instance_name = disk['labels']['instance-name']
             instance = inst_coll_manager.get_instance(instance_name)
 
-            creation_timestamp_msecs = parse_timestamp_msecs(disk.get('creationTimestamp'))
+            creation_timestamp_msecs = parse_timestamp_msecs(disk['creationTimestamp'])
             last_attach_timestamp_msecs = parse_timestamp_msecs(disk.get('lastAttachTimestamp'))
             last_detach_timestamp_msecs = parse_timestamp_msecs(disk.get('lastDetachTimestamp'))
 

--- a/batch/batch/cloud/gcp/driver/zones.py
+++ b/batch/batch/cloud/gcp/driver/zones.py
@@ -166,7 +166,7 @@ async def fetch_machine_valid_zones(
     zones = [url_basename(z) for r in region_info.values() for z in r['zones']]
     machine_family_valid_zones = collections.defaultdict(set)
     for zone in zones:
-        async for machine_type in await compute_client.list(f'/zones/{zone}/machineTypes'):
+        async for machine_type in compute_client.list(f'/zones/{zone}/machineTypes'):
             machine_family = machine_type['name'].split('-')[0]
             machine_family_valid_zones[machine_family].add(machine_type['zone'])
     return machine_family_valid_zones


### PR DESCRIPTION
Workers can dynamically attach disks to themselves to accommodate jobs that request storage that the VM cannot accommodate. In certain circumstances like preemption, the VM can disappear before it is able to delete its own disks, so the Batch Driver scans for disks that are no longer attached (orphaned) and deletes them. It looks like our disk cleanup loop was broken due to inadvertent mutation that leads to an assertion error if the same `params` argument is used in multiple invocations of `GoogleComputeClient.list`. This is preventing orphaned disks from being deleted, costing us money. Additional details are in #14613.


Fixes #14613 