### PR TITLE
[auth] Add compiled tailwind css to docker image

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,6 +1,10 @@
 ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
 FROM $BASE_IMAGE
 
+RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.3/tailwindcss-linux-x64 && \
+    chmod +x tailwindcss-linux-x64 && \
+    mv tailwindcss-linux-x64 /usr/bin/tailwindcss
+
 COPY hail/python/hailtop/pinned-requirements.txt hailtop-requirements.txt
 COPY gear/pinned-requirements.txt gear-requirements.txt
 COPY web_common/pinned-requirements.txt web_common-requirements.txt
@@ -16,11 +20,15 @@ COPY hail/python/hailtop /hailtop/hailtop/
 COPY gear/setup.py /gear/setup.py
 COPY gear/gear /gear/gear/
 
-COPY web_common/setup.py web_common/MANIFEST.in /web_common/
+COPY web_common/setup.py web_common/MANIFEST.in web_common/input.css web_common/tailwind.config.js /web_common/
 COPY web_common/web_common /web_common/web_common/
 
 COPY auth/setup.py auth/MANIFEST.in /auth/
 COPY auth/auth /auth/auth/
+
+RUN cd web_common && \
+    mkdir web_common/static/css && \
+    tailwindcss -i input.css -o web_common/static/css/output.css
 
 RUN hail-pip-install /hailtop /gear /web_common /auth && \
     rm -rf /hailtop /gear /web_common /auth


### PR DESCRIPTION
Auth's css is broken because the css isn't compiled in the docker image (something that the local dev server does not test). I deployed this into my namespace to make sure that the css inside the docker image works.