### PR TITLE
[gateway] Fix top level domain for website

### DIFF
--- a/ci/ci/envoy.py
+++ b/ci/ci/envoy.py
@@ -70,7 +70,7 @@ def create_cds_response(
 
 def gateway_default_host(service: Service, domain: str) -> dict:
     domains = [f'{service.name}.{domain}']
-    if service == 'www':
+    if service.name == 'www':
         domains.append(domain)
 
     if service == 'ukbb-rg':

--- a/ci/test/envoy/test_gateway_cds_response.yaml
+++ b/ci/test/envoy/test_gateway_cds_response.yaml
@@ -29,6 +29,31 @@ resources:
         validation_context:
           filename: /ssl-config/gateway-outgoing.pem
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: www
+    lb_policy: ROUND_ROBIN
+    type: STRICT_DNS
+    load_assignment:
+      cluster_name: www
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: www.default.svc.cluster.local
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: /ssl-config/gateway-cert.pem
+            private_key:
+              filename: /ssl-config/gateway-key.pem
+        validation_context:
+          filename: /ssl-config/gateway-outgoing.pem
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     name: test-bar
     lb_policy: ROUND_ROBIN
     type: STRICT_DNS

--- a/ci/test/envoy/test_gateway_rds_response.yaml
+++ b/ci/test/envoy/test_gateway_rds_response.yaml
@@ -46,6 +46,40 @@ resources:
               tokens_per_fill: 200
     - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
       domains:
+      - www.hail.is
+      - hail.is
+      name: www
+      routes:
+      - match:
+          prefix: /
+        route:
+          append_x_forwarded_host: true
+          auto_host_rewrite: true
+          cluster: www
+          timeout: 0s
+        typed_per_filter_config:
+          envoy.filters.http.ext_authz:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+            disabled: true
+          envoy.filters.http.local_ratelimit:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            filter_enabled:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            filter_enforced:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              fill_interval: 1s
+              max_tokens: 200
+              tokens_per_fill: 200
+    - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
+      domains:
       - internal.hail.is
       name: internal
       routes:

--- a/ci/test/envoy/test_internal_gateway_cds_response.yaml
+++ b/ci/test/envoy/test_internal_gateway_cds_response.yaml
@@ -29,6 +29,31 @@ resources:
         validation_context:
           filename: /ssl-config/internal-gateway-outgoing.pem
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: www
+    lb_policy: ROUND_ROBIN
+    type: STRICT_DNS
+    load_assignment:
+      cluster_name: www
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: www.default.svc.cluster.local
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: /ssl-config/internal-gateway-cert.pem
+            private_key:
+              filename: /ssl-config/internal-gateway-key.pem
+        validation_context:
+          filename: /ssl-config/internal-gateway-outgoing.pem
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     name: test-bar
     lb_policy: ROUND_ROBIN
     type: STRICT_DNS

--- a/ci/test/envoy/test_internal_gateway_rds_response.yaml
+++ b/ci/test/envoy/test_internal_gateway_rds_response.yaml
@@ -43,6 +43,36 @@ resources:
               tokens_per_fill: 200
     - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
       domains:
+      - www.hail
+      name: www
+      routes:
+      - match:
+          prefix: /
+        route:
+          append_x_forwarded_host: true
+          auto_host_rewrite: true
+          cluster: www
+          timeout: 0s
+        typed_per_filter_config:
+          envoy.filters.http.local_ratelimit:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            filter_enabled:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            filter_enforced:
+              default_value:
+                denominator: HUNDRED
+                numerator: 100
+              runtime_key: local_rate_limit_enabled
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              fill_interval: 1s
+              max_tokens: 200
+              tokens_per_fill: 200
+    - '@type': type.googleapis.com/envoy.config.route.v3.VirtualHost
+      domains:
       - internal.hail
       name: internal
       routes:

--- a/ci/test/test_envoy.py
+++ b/ci/test/test_envoy.py
@@ -6,6 +6,9 @@ import yaml
 
 from ci.envoy import Service, create_cds_response, create_rds_response
 
+PROD_SERVICES = [Service('foo'), Service('www')]
+TEST_SERVICES = {'test': [Service('bar', 100)]}
+
 
 @pytest.mark.parametrize(
     'proxy, expected_config',
@@ -17,7 +20,7 @@ from ci.envoy import Service, create_cds_response, create_rds_response
 def test_gateway_cds_generation(proxy, expected_config):
     with open(Path(os.path.dirname(__file__)) / 'envoy' / expected_config, encoding='utf-8') as f:
         expected_cluster_config = yaml.safe_load(f.read())
-    actual_cluster_config = create_cds_response([Service('foo')], {'test': [Service('bar', 100)]}, proxy)
+    actual_cluster_config = create_cds_response(PROD_SERVICES, TEST_SERVICES, proxy)
     assert expected_cluster_config == actual_cluster_config
 
 
@@ -31,7 +34,5 @@ def test_gateway_cds_generation(proxy, expected_config):
 def test_gateway_rds_generation(proxy, expected_config):
     with open(Path(os.path.dirname(__file__)) / 'envoy' / expected_config, encoding='utf-8') as f:
         expected_routes_config = yaml.safe_load(f.read())
-    actual_routes_config = create_rds_response(
-        [Service('foo')], {'test': [Service('bar', 100)]}, proxy, domain='hail.is'
-    )
+    actual_routes_config = create_rds_response(PROD_SERVICES, TEST_SERVICES, proxy, domain='hail.is')
     assert expected_routes_config == actual_routes_config


### PR DESCRIPTION
#14609 broke the routing for https://hail.is. The `domains` variable here indicates to `gateway` which domains in incoming requests should be routed to the given service. Since #14609 changed the `service` parameter from `str` to `Service`, it silently broke this branch.

This wasn't covered by the envoy config generation tests because we didn't have a `www` service in the test configuration. I've added it so that this branch is covered.

Fixes #14616