### PR TITLE
[batch] Have Batch Worker perform auth checks on requests from Batch

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -11,6 +11,7 @@ import aiohttp
 
 from gear import CommonAiohttpAppKeys, Database, K8sCache
 from hailtop import httpx
+from hailtop.aiocloud.common import Session
 from hailtop.aiotools import BackgroundTaskManager
 from hailtop.batch_client.globals import ROOT_JOB_GROUP_ID
 from hailtop.utils import Notice, retry_transient_errors, time_msecs
@@ -347,7 +348,7 @@ async def unschedule_job(app, record):
     cancel_ready_state_changed: asyncio.Event = app['cancel_ready_state_changed']
     scheduler_state_changed: Notice = app['scheduler_state_changed']
     db: Database = app['db']
-    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
+    client_session: Session = app['worker_client_session']
     inst_coll_manager = app['driver'].inst_coll_manager
 
     batch_id = record['batch_id']
@@ -558,7 +559,7 @@ async def schedule_job(app, record, instance):
     assert instance.state == 'active'
 
     db: Database = app['db']
-    client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
+    client_session: Session = app['worker_client_session']
 
     batch_id = record['batch_id']
     job_id = record['job_id']

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -83,6 +83,7 @@ from ..instance_config import InstanceConfig
 from ..publicly_available_images import publicly_available_images
 from ..resource_usage import ResourceUsageMonitor
 from ..semaphore import FIFOWeightedSemaphore
+from ..utils import authorization_token
 from ..worker.worker_api import CloudDisk, CloudWorkerAPI, ContainerRegistryCredentials
 from .jvm_entryway_protocol import EndOfStream, read_bool, read_int, read_str, write_int, write_str
 
@@ -2962,6 +2963,7 @@ class Worker:
         self.file_store = FileStore(self.fs, BATCH_LOGS_STORAGE_URI, INSTANCE_ID)
 
         self.instance_token = os.environ['ACTIVATION_TOKEN']
+        self.batch_identity_uid = None
 
         self.cloudfuse_mount_manager = ReadOnlyCloudfuseManager()
 
@@ -3185,8 +3187,18 @@ class Worker:
         body = {'name': NAME}
         return json_response(body)
 
+    @web.middleware
+    async def batch_and_batch_driver_only(self, request: web.Request, handler):
+        assert CLOUD_WORKER_API
+        assert self.batch_identity_uid
+        token = authorization_token(request)
+        if token and await CLOUD_WORKER_API.identity_uid(token) == self.batch_identity_uid:
+            return await handler(request)
+        raise web.HTTPForbidden()
+
     async def run(self):
-        app = web.Application(client_max_size=HTTP_CLIENT_MAX_SIZE)
+        assert CLOUD_WORKER_API
+        app = web.Application(client_max_size=HTTP_CLIENT_MAX_SIZE, middlewares=[self.batch_and_batch_driver_only])
         app.add_routes([
             web.post('/api/v1alpha/kill', self.kill),
             web.post('/api/v1alpha/batches/jobs/create', self.create_job),
@@ -3381,6 +3393,7 @@ class Worker:
             headers=await self.headers(),
         )
         self.instance_token = resp_json['token']
+        self.batch_identity_uid = resp_json['batch_identity_uid']
         self.active = True
         self.last_updated = time_msecs()
         log.info('activated')
@@ -3444,7 +3457,7 @@ async def async_main():
         if os.environ.get('HAIL_TERRA'):
             CLOUD_WORKER_API = TerraAzureWorkerAPI.from_env()
         else:
-            CLOUD_WORKER_API = AzureWorkerAPI.from_env()
+            CLOUD_WORKER_API = await AzureWorkerAPI.from_env()
 
     assert CLOUD_WORKER_API
     instance_config = CLOUD_WORKER_API.instance_config_from_config_dict(INSTANCE_CONFIG)

--- a/batch/batch/worker/worker_api.py
+++ b/batch/batch/worker/worker_api.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, List, TypedDict, Union
+from typing import Dict, List, Optional, TypedDict, Union
 
 from aiohttp import web
 
@@ -47,6 +47,10 @@ class CloudWorkerAPI(abc.ABC):
 
     @abc.abstractmethod
     def create_metadata_server_app(self, credentials: Dict[str, str]) -> web.Application:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def identity_uid(self, token: str) -> Optional[str]:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -175,8 +175,22 @@ spec:
         env:
          - name: PORT
            value: "5000"
+{% if global.cloud == "gcp" %}
          - name: GOOGLE_APPLICATION_CREDENTIALS
            value: /gsa-key/key.json
+         - name: HAIL_IDENTITY_PROVIDER_JSON
+           value: '{"idp": "Google"}'
+{% else %}
+         - name: AZURE_APPLICATION_CREDENTIALS
+           value: /gsa-key/key.json
+         - name: HAIL_IDENTITY_PROVIDER_JSON
+           value: '{"idp": "Microsoft"}'
+         - name: HAIL_AZURE_OAUTH_SCOPE
+           valueFrom:
+             secretKeyRef:
+               name: auth-oauth2-client-secret
+               key: sp_oauth_scope
+{% endif %}
          - name: HAIL_DEPLOY_CONFIG_FILE
            value: /deploy-config/deploy-config.json
          - name: HAIL_BATCH_WORKER_IMAGE

--- a/hail/python/hailtop/aiocloud/aioazure/credentials.py
+++ b/hail/python/hailtop/aiocloud/aioazure/credentials.py
@@ -60,6 +60,8 @@ class RefreshTokenCredential(AsyncTokenCredential):
 
 
 class AzureCredentials(CloudCredentials):
+    DEFAULT_SCOPE = 'https://management.azure.com/.default'
+
     @staticmethod
     def from_file_or_default(
         credentials_file: Optional[str] = None,
@@ -118,9 +120,7 @@ class AzureCredentials(CloudCredentials):
         self._access_token = None
         self._expires_at = None
 
-        if scopes is None:
-            scopes = ['https://management.azure.com/.default']
-        self.scopes = scopes
+        self.scopes = scopes or [AzureCredentials.DEFAULT_SCOPE]
 
     async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
         access_token, expiration = await self.access_token_with_expiration()

--- a/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
@@ -186,6 +186,10 @@ class GoogleServiceAccountCredentials(GoogleCredentials):
     def email(self) -> str:
         return self.key['client_email']
 
+    @property
+    def identity_uid(self) -> str:
+        return self.key['client_id']
+
     async def _get_access_token(self) -> GoogleExpiringAccessToken:
         now = int(time.time())
         scope = ' '.join(self._scopes)

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -9,7 +9,7 @@ import aiohttp
 
 from hailtop import httpx
 from hailtop.aiocloud.aioazure import AzureCredentials
-from hailtop.aiocloud.aiogoogle import GoogleCredentials
+from hailtop.aiocloud.aiogoogle import GoogleCredentials, GoogleServiceAccountCredentials
 from hailtop.aiocloud.common import Session
 from hailtop.aiocloud.common.credentials import CloudCredentials
 from hailtop.config import DeployConfig, get_deploy_config, get_user_identity_config_path
@@ -47,6 +47,11 @@ class HailCredentials(CloudCredentials):
         self._cloud_credentials = cloud_credentials
         self._deploy_config = deploy_config
         self._authorize_target = authorize_target
+
+    @property
+    def identity_uid(self):
+        assert isinstance(self._cloud_credentials, GoogleServiceAccountCredentials)
+        return self._cloud_credentials.identity_uid
 
     async def auth_headers_with_expiration(self) -> Tuple[Dict[str, str], Optional[float]]:
         headers = {}

--- a/hail/python/hailtop/auth/flow.py
+++ b/hail/python/hailtop/auth/flow.py
@@ -140,9 +140,9 @@ class GoogleFlow(Flow):
 
     @staticmethod
     async def get_identity_uid_from_access_token(
-        session: httpx.ClientSession, access_token: str, *, oauth2_client: dict
+        session: httpx.ClientSession, access_token: str, *, oauth2_client: Optional[dict]
     ) -> Optional[str]:
-        oauth2_client_audience = oauth2_client['installed']['client_id']
+        oauth2_client_audience = oauth2_client['installed']['client_id'] if oauth2_client else None
         try:
             userinfo = await retry_transient_errors(
                 session.get_read_json,
@@ -238,7 +238,10 @@ class AzureFlow(Flow):
 
     @staticmethod
     async def get_identity_uid_from_access_token(
-        session: httpx.ClientSession, access_token: str, *, oauth2_client: dict
+        session: httpx.ClientSession,
+        access_token: str,
+        *,
+        oauth2_client: dict,
     ) -> Optional[str]:
         audience = oauth2_client['appIdentifierUri']
 


### PR DESCRIPTION
We should already have measures in place (like firewall rules) that prevent untrusted code from reaching the Batch Worker server, but this provides an extra layer of protection through which we can enforce that only the Batch front end and the Batch Driver can use the endpoints on the Batch Worker. This, along with #14581 are the final pieces to ensure that every endpoint in our system, both internal and external, uses HTTPS and performs the appropriate auth checks.