### PR TITLE
[admin-pod] Fix admin-pod Makefile to push pod image

### DIFF
--- a/admin-pod/Makefile
+++ b/admin-pod/Makefile
@@ -2,10 +2,10 @@ include ../config.mk
 
 .PHONY: build
 build:
-	$(MAKE) -C .. admin-pod-image
+	$(MAKE) -C .. pushed-private-admin-pod-image
 
 .PHONY: deploy
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	python3 ../ci/jinja2_render.py '{"admin_pod_image":{"image":"'$$(cat ../admin-pod-image)'"}}' admin-pod.yaml admin-pod.yaml.out
+	python3 ../ci/jinja2_render.py '{"admin_pod_image":{"image":"'$$(cat ../pushed-private-admin-pod-image)'"}}' admin-pod.yaml admin-pod.yaml.out
 	kubectl -n $(NAMESPACE) apply -f admin-pod.yaml.out


### PR DESCRIPTION
The `admin-pod-image` target just builds the docker image locally, so just using that results in the pod failing to pull an image that does not exist where the cluster does. We want to push the image, hence `pushed-private-admin-pod-image`, and then use that pushed image name in the pod manifest.
Fixes #14642