### PR TITLE
[Auth] Always select user during login prompt

### DIFF
--- a/hail/python/hailtop/auth/flow.py
+++ b/hail/python/hailtop/auth/flow.py
@@ -97,7 +97,9 @@ class GoogleFlow(Flow):
             self._credentials_file, scopes=GoogleFlow.scopes, state=None
         )
         flow.redirect_uri = redirect_uri
-        authorization_url, state = flow.authorization_url(access_type='offline', include_granted_scopes='true', prompt='select_account')
+        authorization_url, state = flow.authorization_url(
+            access_type='offline', include_granted_scopes='true', prompt='select_account'
+        )
 
         return {
             'authorization_url': authorization_url,

--- a/hail/python/hailtop/auth/flow.py
+++ b/hail/python/hailtop/auth/flow.py
@@ -97,7 +97,7 @@ class GoogleFlow(Flow):
             self._credentials_file, scopes=GoogleFlow.scopes, state=None
         )
         flow.redirect_uri = redirect_uri
-        authorization_url, state = flow.authorization_url(access_type='offline', include_granted_scopes='true')
+        authorization_url, state = flow.authorization_url(access_type='offline', include_granted_scopes='true', prompt='select_account')
 
         return {
             'authorization_url': authorization_url,


### PR DESCRIPTION
Fixes #14634. Always prompt for which google account to use during login. Avoids confusion over whether logout succeeded or not (especially considering #14635)