### PR TITLE
[UI] Remove broken Log out; provide another option

### DIFF
--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -4,7 +4,12 @@
 {% block content %}
 <div id="profile" class="vcentered space-y-2">
   <h1 class='text-4xl mb-4'>{{ userdata['username'] }}</h1>
-
+  <form action="{{ auth_base_url }}/logout" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+    <button type="submit">
+      Log out
+    </button>
+  </form>
   {% if cloud == "gcp" %}
   <p><b>Google Service Account: </b>{{ userdata['display_name'] }}</p>
   {% endif %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -4,6 +4,7 @@
 {% block content %}
 <div id="profile" class="vcentered space-y-2">
   <h1 class='text-4xl mb-4'>{{ userdata['username'] }}</h1>
+
   {% if cloud == "gcp" %}
   <p><b>Google Service Account: </b>{{ userdata['display_name'] }}</p>
   {% endif %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -6,9 +6,7 @@
   <h1 class='text-4xl mb-4'>{{ userdata['username'] }}</h1>
   <form action="{{ auth_base_url }}/logout" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-    <button type="submit">
-      Log out
-    </button>
+    {{ submit_button('Log out') }}
   </form>
   {% if cloud == "gcp" %}
   <p><b>Google Service Account: </b>{{ userdata['display_name'] }}</p>

--- a/web_common/web_common/templates/new_header.html
+++ b/web_common/web_common/templates/new_header.html
@@ -61,11 +61,11 @@
     <a href="{{ auth_base_url }}/user">
       <b class='font-semibold'>{{ userdata["username"] }}</b>
     </a>
-    <span>|</span>
     {% else %}
     <a href="{{ auth_base_url }}/signup">
       Sign Up
     </a>
+    <span>|</span>
     <a href="{{ auth_base_url }}/login">
       Login
     </a>

--- a/web_common/web_common/templates/new_header.html
+++ b/web_common/web_common/templates/new_header.html
@@ -62,12 +62,6 @@
       <b class='font-semibold'>{{ userdata["username"] }}</b>
     </a>
     <span>|</span>
-    <form action="{{ auth_base_url }}/logout" method="POST">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-      <button type="submit">
-        Log out
-      </button>
-    </form>
     {% else %}
     <a href="{{ auth_base_url }}/signup">
       Sign Up


### PR DESCRIPTION
Fixes #14635. Logout is only possible from `auth` pages due to per-subdomain CRSF tokens. Security/design thought process as documented in a comment on the issue: https://github.com/hail-is/hail/issues/14635#issuecomment-2253086187