### PR TITLE
Passes `--public-ip-address` to `hailctl dataproc start`

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -191,6 +191,9 @@ def start(
     debug_mode: Ann[
         bool, Opt(help='Enable debug features on created cluster (heap dump on out-of-memory error)')
     ] = False,
+    public_ip_address: Ann[
+        bool, Opt(help='Allow nodes to have a public IP address, and hence make requests on the public internet (default is internal-only from dataproc 2.2).')
+    ] = False,
 ):
     """
     Start a Dataproc cluster configured for Hail.
@@ -243,6 +246,7 @@ def start(
         requester_pays_allow_annotation_db,
         debug_mode,
         use_gcloud_beta,
+        public_ip_address,
     )
 
 

--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -191,12 +191,6 @@ def start(
     debug_mode: Ann[
         bool, Opt(help='Enable debug features on created cluster (heap dump on out-of-memory error)')
     ] = False,
-    public_ip_address: Ann[
-        bool,
-        Opt(
-            help='Allow nodes to have a public IP address, and hence make requests on the public internet (default is internal-only from dataproc 2.2).'
-        ),
-    ] = True,
 ):
     """
     Start a Dataproc cluster configured for Hail.
@@ -249,7 +243,6 @@ def start(
         requester_pays_allow_annotation_db,
         debug_mode,
         use_gcloud_beta,
-        public_ip_address,
     )
 
 

--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -192,8 +192,11 @@ def start(
         bool, Opt(help='Enable debug features on created cluster (heap dump on out-of-memory error)')
     ] = False,
     public_ip_address: Ann[
-        bool, Opt(help='Allow nodes to have a public IP address, and hence make requests on the public internet (default is internal-only from dataproc 2.2).')
-    ] = False,
+        bool,
+        Opt(
+            help='Allow nodes to have a public IP address, and hence make requests on the public internet (default is internal-only from dataproc 2.2).'
+        ),
+    ] = True,
 ):
     """
     Start a Dataproc cluster configured for Hail.

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -177,6 +177,7 @@ def start(
     requester_pays_allow_annotation_db: bool,
     debug_mode: bool,
     beta: bool,
+    public_ip_address: bool,
 ):
     conf = ClusterConfig()
     conf.extend_flag('image-version', IMAGE_VERSION)
@@ -395,6 +396,8 @@ def start(
         cmd.append('--expiration_time={}'.format(expiration_time))
     if service_account:
         cmd.append('--service-account={}'.format(service_account))
+    if public_ip_address:
+        cmd.append('--public-ip-address')
 
     cmd.extend(pass_through_args)
 

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -177,7 +177,6 @@ def start(
     requester_pays_allow_annotation_db: bool,
     debug_mode: bool,
     beta: bool,
-    public_ip_address: bool,
 ):
     conf = ClusterConfig()
     conf.extend_flag('image-version', IMAGE_VERSION)
@@ -396,8 +395,8 @@ def start(
         cmd.append('--expiration_time={}'.format(expiration_time))
     if service_account:
         cmd.append('--service-account={}'.format(service_account))
-    if public_ip_address:
-        cmd.append('--public-ip-address')
+
+    cmd.append('--public-ip-address')
 
     cmd.extend(pass_through_args)
 


### PR DESCRIPTION
Closes https://github.com/hail-is/hail/issues/14652.

See https://github.com/populationgenomics/hail/pull/346. Thanks for the contribution @illusional!

Gives Dataproc clusters started via `hailctl dataproc start` internet access by default, since we need it to install some of our dependencies, per the error message in the linked issue.