### PR TITLE
[CI] Use github's graphQL to query review state directly

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -497,7 +497,7 @@ class PR(Code):
         """
 
         response = await gh.post('/graphql', data={'query': review_state_query})
-        review_decision = response["data"]["repository"]["pullRequest"]["reviewDecision"]
+        review_decision = response['data']['repository']['pullRequest']['reviewDecision']
 
         if review_decision == 'APPROVED':
             review_state = 'approved'

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -512,7 +512,7 @@ class PR(Code):
             review_state = 'pending'
         else:
             # Should be impossible, per https://docs.github.com/en/graphql/reference/enums#pullrequestreviewdecision
-            log.error(f'Unexpected review decision: {review_decision} in PR {self.number}')
+            log.error(f'{self.short_str()}: unexpected review decision from github: {review_decision}')
             review_state = 'pending'
 
         if review_state != self.review_state:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -516,6 +516,7 @@ class PR(Code):
             review_state = 'pending'
 
         if review_state != self.review_state:
+            log.info(f'{self.short_str()}: review state changing from {self.review_state} => {review_state}')
             self.set_review_state(review_state)
             self.target_branch.state_changed = True
 

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -490,7 +490,6 @@ class PR(Code):
         query {{
             repository(owner: "{self.target_branch.branch.repo.owner}", name: "{self.target_branch.branch.repo.name}") {{
                 pullRequest(number: {self.number}) {{
-                      number
                       reviewDecision
                 }}
             }}


### PR DESCRIPTION
Fixes #14660 by using the graphQL API to query github directly. Replaces our current parallel interpretation of reviews into a review decision, which is brittle if we ever change review requirements in github again.

Tested by manually updating the live CI to use the test batch generated image. Results:
- Review decisions correctly fetched from github, not based on CI's parallel interpretation of individual reviews:
![image](https://github.com/user-attachments/assets/67c03aa9-000a-44e7-91aa-3a42d04238dc)
- No merge candidate was being incorrectly nominated (in particular, #14645 is now considered pending, rather than approved, which is what we are currently, incorrectly, calculating)