### PR TITLE
[query, bugfix] TableAggregate interpret supports globals in init op

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -967,7 +967,7 @@ object Interpret {
             ctx,
             extracted.states,
             FastSeq((
-              TableIR.rowName,
+              TableIR.globalName,
               SingleCodeEmitParamType(true, PTypeReferenceSingleCodeType(value.globals.t)),
             )),
             FastSeq(classInfo[Region], LongInfo),


### PR DESCRIPTION
There was a typo in the `Interpret` rule for `TableAggregate` which had it refer to the row instead of the globals inside the init op.

I tried to add a test for this, but it's frustratingly difficult to force the compiler to go through this code path. Even when using an `InterpretOnly` compilation, the lowering pipeline often lifts `TableAggregate` to a `RelationalLet`, and then evaluates it, using the compiler not the interpreter. This is a deeper issue we should address, but a user is currently blocked on this bug so I don't want to hold it up.