### PR TITLE
 [query/vds] Add LEN field to VDS 

### DIFF
--- a/hail/python/hail/vds/combiner/combine.py
+++ b/hail/python/hail/vds/combiner/combine.py
@@ -98,8 +98,11 @@ def make_ref_entry_struct(e, entry_to_keep, row):
     reference_fields = {k: v for k, v in e.items() if k in entry_to_keep and k not in handled_names}
     return (
         hl.case()
-        .when(e.GT.is_hom_ref(), hl.struct(END=row.info.END, **reference_fields, **handled_fields))
-        .or_error('found END with non reference-genotype at' + hl.str(row.locus))
+        .when(
+            e.GT.is_hom_ref(),
+            hl.struct(LEN=row.info.END - row.locus.position + 1, **reference_fields, **handled_fields),
+        )
+        .or_error('found reference block with non reference-genotype at' + hl.str(row.locus))
     )
 
 
@@ -107,7 +110,7 @@ def make_variants_matrix_table(mt: MatrixTable, info_to_keep: Optional[Collectio
     if info_to_keep is None:
         info_to_keep = []
     if not info_to_keep:
-        info_to_keep = [name for name in mt.info if name not in ['END', 'DP']]
+        info_to_keep = [name for name in mt.info if name not in ('END', 'LEN', 'DP')]
     info_key = tuple(sorted(info_to_keep))  # hashable stable value
     mt = localize(mt)
     mt = mt.filter(hl.is_missing(mt.info.END))

--- a/hail/python/hail/vds/combiner/combine.py
+++ b/hail/python/hail/vds/combiner/combine.py
@@ -170,7 +170,7 @@ def make_variant_stream(stream, info_to_keep):
     if info_to_keep is None:
         info_to_keep = []
     if not info_to_keep:
-        info_to_keep = [name for name in info_t if name not in ['END', 'DP']]
+        info_to_keep = [name for name in info_t if name not in ('END', 'LEN', 'DP')]
     info_key = tuple(sorted(info_to_keep))  # hashable stable value
     stream = stream.filter(lambda elt: hl.is_missing(elt.info.END))
 
@@ -283,7 +283,7 @@ def combine_r(ts, ref_block_max_len_field):
 
 
 def combine_reference_row(row, globals):
-    merge_function = _merge_function_map.get((row.dtype, globals))
+    merge_function = _merge_function_map.get((row.dtype, globals.dtype))
     if merge_function is None or not hl.current_backend()._is_registered_ir_function_name(merge_function._name):
         merge_function = hl.experimental.define_function(
             lambda row, gbl: hl.struct(

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -467,6 +467,7 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
             _assert_reference_type=self._dataset_type.reference_type,
             _assert_variant_type=self._dataset_type.variant_type,
             _warn_no_ref_block_max_length=False,
+            _drop_end=True,
         )
 
         interval_bin = floor(log(new_n_samples, self._branch_factor))
@@ -638,6 +639,7 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
                 _assert_reference_type=reference_type,
                 _assert_variant_type=variant_type,
                 _warn_no_ref_block_max_length=False,
+                _drop_end=True,
             )
             for path in inputs
         ]
@@ -793,7 +795,7 @@ def new_combiner(
     gvcf_type = None
     if vds_paths:
         # sync up gvcf_reference_entry_fields_to_keep and they reference entry types from the VDS
-        vds = hl.vds.read_vds(vds_paths[0], _warn_no_ref_block_max_length=False)
+        vds = hl.vds.read_vds(vds_paths[0], _warn_no_ref_block_max_length=False, _drop_end=True)
         vds_ref_entry = set(
             name[1:] if name in ('LGT', 'LPGT') else name
             for name in vds.reference_data.entry
@@ -842,9 +844,7 @@ def new_combiner(
                 mt._key_rows_by_assert_sorted('locus'), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep
             )
 
-    dataset_type = CombinerOutType(
-        reference_type=VariantDataset._fix_ref_for_write(vds.reference_data)._type, variant_type=vds.variant_data._type
-    )
+    dataset_type = CombinerOutType(reference_type=vds.reference_data._type, variant_type=vds.variant_data._type)
 
     if save_path is None:
         sha = hashlib.sha256()

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -797,9 +797,7 @@ def new_combiner(
         # sync up gvcf_reference_entry_fields_to_keep and they reference entry types from the VDS
         vds = hl.vds.read_vds(vds_paths[0], _warn_no_ref_block_max_length=False, _drop_end=True)
         vds_ref_entry = set(
-            name[1:] if name in ('LGT', 'LPGT') else name
-            for name in vds.reference_data.entry
-            if name not in ('LEN', 'END')
+            name[1:] if name in ('LGT', 'LPGT') else name for name in vds.reference_data.entry if name != 'LEN'
         )
         if gvcf_reference_entry_fields_to_keep is not None and vds_ref_entry != gvcf_reference_entry_fields_to_keep:
             warning(

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -795,7 +795,9 @@ def new_combiner(
         # sync up gvcf_reference_entry_fields_to_keep and they reference entry types from the VDS
         vds = hl.vds.read_vds(vds_paths[0], _warn_no_ref_block_max_length=False)
         vds_ref_entry = set(
-            name[1:] if name in ('LGT', 'LPGT') else name for name in vds.reference_data.entry if name != 'END'
+            name[1:] if name in ('LGT', 'LPGT') else name
+            for name in vds.reference_data.entry
+            if name not in ('LEN', 'END')
         )
         if gvcf_reference_entry_fields_to_keep is not None and vds_ref_entry != gvcf_reference_entry_fields_to_keep:
             warning(
@@ -839,7 +841,10 @@ def new_combiner(
             vds = transform_gvcf(
                 mt._key_rows_by_assert_sorted('locus'), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep
             )
-    dataset_type = CombinerOutType(reference_type=vds.reference_data._type, variant_type=vds.variant_data._type)
+
+    dataset_type = CombinerOutType(
+        reference_type=VariantDataset._fix_ref_for_write(vds.reference_data)._type, variant_type=vds.variant_data._type
+    )
 
     if save_path is None:
         sha = hashlib.sha256()

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -18,6 +18,7 @@ def read_vds(
     _assert_reference_type=None,
     _assert_variant_type=None,
     _warn_no_ref_block_max_length=True,
+    _drop_end=False,
 ) -> 'VariantDataset':
     """Read in a :class:`.VariantDataset` written with :meth:`.VariantDataset.write`.
 
@@ -41,6 +42,8 @@ def read_vds(
         variant_data = hl.read_matrix_table(VariantDataset._variants_path(path), _intervals=intervals)
 
     reference_data = VariantDataset._add_len_end(reference_data)
+    if _drop_end:
+        reference_data = reference_data.drop('END')
     vds = VariantDataset(reference_data, variant_data)
     if VariantDataset.ref_block_max_length_field not in vds.reference_data.globals:
         fs = hl.current_backend().fs

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -92,9 +92,8 @@ def store_ref_block_max_length(vds_path):
         warning(f"VDS at {vds_path} already contains a global annotation with the max reference block length")
         return
     rd = vds.reference_data
-    rd = rd.annotate_rows(__start_pos=rd.locus.position)
     fs = hl.current_backend().fs
-    ref_block_max_len = rd.aggregate_entries(hl.agg.max(rd.END - rd.__start_pos + 1))
+    ref_block_max_len = rd.aggregate_entries(hl.agg.max(rd.LEN))
     with fs.open(os.path.join(vds_path, extra_ref_globals_file), 'w') as f:
         json.dump({VariantDataset.ref_block_max_length_field: ref_block_max_len}, f)
 

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -288,10 +288,14 @@ class VariantDataset:
         if not isinstance(vd_col_key, hl.tstruct) or len(vd_col_key) != 1 or vd_col_key.types[0] != hl.tstr:
             error(f"expect variant data to have a single col key of type string, found {vd_col_key}")
 
-        invalid_end = 'END' not in rd.entry or rd.END.dtype != hl.tint32
-        invalid_len = 'LEN' not in rd.entry or rd.LEN.dtype != hl.tint32
-        if invalid_end and invalid_len:
-            error("expect at least one of 'END' or 'LEN' in entry of reference data with type int32")
+        end_exists = 'END' in rd.entry
+        len_exists = 'LEN' in rd.entry
+        if not (end_exists or len_exists):
+            error("expect at least one of 'END' or 'LEN' in entry of reference data")
+        if end_exists and rd.END.dtype != hl.tint32:
+            error("'END' field in entry of reference data must have type tint32")
+        if len_exists and rd.LEN.dtype != hl.tint32:
+            error("'LEN' field in entry of reference data must have type tint32")
 
         if check_data:
             # check cols

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -160,9 +160,7 @@ class VariantDataset:
 
         gt_field = 'LGT' if 'LGT' in mt.entry else 'GT'
 
-        # remove LGT/GT and LA fields, which are trivial for reference blocks and do not need to be represented
-        if gt_field in used_ref_block_fields:
-            used_ref_block_fields.remove(gt_field)
+        # remove the LA field, which is trivial for reference blocks and does not need to be represented
         if 'LA' in used_ref_block_fields:
             used_ref_block_fields.remove('LA')
 

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -241,8 +241,8 @@ def test_combiner_manual_filtration():
 
     plan.run()
     vds = hl.vds.read_vds(out_file)
-    assert list(vds.variant_data.gvcf_info) == ['ExcessHet']
-    assert list(vds.reference_data.entry) == ['END', 'GQ']
+    assert sorted(vds.variant_data.gvcf_info) == ['ExcessHet']
+    assert sorted(vds.reference_data.entry) == ['END', 'GQ', 'LEN']
 
 
 @test_timeout(10 * 60)

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -814,6 +814,9 @@ def test_combiner_max_len():
 @test_timeout(4 * 60, local=6 * 60)
 def test_split_sparse_roundtrip():
     vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
+    # this doesn't actually roundtrip because 1kg_chr22_5_samples was generated before
+    # we added GT to reference_data, to_merged_sparse_mt adds a reference GT
+    vds.reference_data = vds.reference_data.annotate_entries(LGT=hl.call(0, 0))
     smt = hl.vds.to_merged_sparse_mt(vds)
     smt = hl.experimental.sparse_split_multi(smt)
     vds2 = hl.vds.VariantDataset.from_merged_representation(


### PR DESCRIPTION
This is the beginning of a series of changes to support export of VDS to VCF 4.5, the version of VCF that contains the standardized form of our work that culminated in SVCR/VDS.

Reference blocks were standardized with a LEN rather than an END. So, now, by default, add LEN to all VDS reads and drop END in favor of LEN on all VDS writes. Our optimizer will be able to take care of pruning away the dead field in pipelines that don't use it.

We make sure that all VDS creation (other than the combiner), such as read_vds and from_merged_representation, contains both LEN and END preserving user code that depends on the presence of the END field.

Furthermore, this change contains necessary combiner updates to prefer LEN over END, and to use LEN in the combiner itself.