### PR TITLE
[ci/azure] installs dependencies for azure-cli image

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3789,10 +3789,15 @@ steps:
     alwaysRun: true
     script: |
       set -e -o pipefail
-      curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64 -o /usr/bin/jq
-      chmod +x /usr/bin/jq
-      curl -L "https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl" -o /usr/bin/kubectl
-      chmod +x /usr/bin/kubectl
+      cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
+      [kubernetes]
+      name=Kubernetes
+      baseurl=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/
+      enabled=1
+      gpgcheck=1
+      gpgkey=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/repodata/repomd.xml.key
+      EOF
+      yum install -y kubectl jq
       AZURE_USERNAME=$(jq -r '.appId' /batch-gsa-key/key.json)
       AZURE_PASSWORD=$(jq -r '.password' /batch-gsa-key/key.json)
       AZURE_TENANT_ID=$(jq -r '.tenant' /batch-gsa-key/key.json)

--- a/build.yaml
+++ b/build.yaml
@@ -3789,6 +3789,10 @@ steps:
     alwaysRun: true
     script: |
       set -e -o pipefail
+      curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64 -o /usr/bin/jq
+      chmod +x /usr/bin/jq
+      curl -L "https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl" -o /usr/bin/kubectl
+      chmod +x /usr/bin/kubectl
       AZURE_USERNAME=$(jq -r '.appId' /batch-gsa-key/key.json)
       AZURE_PASSWORD=$(jq -r '.password' /batch-gsa-key/key.json)
       AZURE_TENANT_ID=$(jq -r '.tenant' /batch-gsa-key/key.json)

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -433,6 +433,10 @@ set -x
 date
 
 set +x
+curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64 -o /usr/bin/jq
+chmod +x /usr/bin/jq
+curl -L "https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl" -o /usr/bin/kubectl
+chmod +x /usr/bin/kubectl
 USERNAME=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -j '.appId')
 PASSWORD=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -j '.password')
 TENANT=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -j '.tenant')

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -433,10 +433,15 @@ set -x
 date
 
 set +x
-curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64 -o /usr/bin/jq
-chmod +x /usr/bin/jq
-curl -L "https://dl.k8s.io/release/v1.31.0/bin/linux/arm64/kubectl" -o /usr/bin/kubectl
-chmod +x /usr/bin/kubectl
+cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.31/rpm/repodata/repomd.xml.key
+EOF
+yum install -y kubectl jq
 USERNAME=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -j '.appId')
 PASSWORD=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -j '.password')
 TENANT=$(cat $AZURE_APPLICATION_CREDENTIALS | jq -j '.tenant')


### PR DESCRIPTION
The `delete_azure_batch_instances` step is failing on various PRs with the error `jq: command not found`. This appears to be because we do not pin the version for the `mcr.microsoft.com/azure-cli` image, and while that image was previously based on the Alpine image, [now it is based on the Azure Linux image](https://learn.microsoft.com/en-us/cli/azure/run-azure-cli-docker), and does not appear to have `jq` (or `kubectl`) preinstalled on it.

This change updates the commands run in the `azure-cli` container for this CI step to install `jq` and `kubectl` via `curl` before running the relevant commands. The `curl` commands were tested locally by running `docker run -it mcr.microsoft.com/azure-cli` and trying them out in the image's shell.

This change also adds the installation commands in the other place where this image is used (when cleaning up from `buildImage2` jobs that are run in Azure).