### PR TITLE
 [vds] More updates for preferring LEN over END

### DIFF
--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -40,7 +40,7 @@ def to_dense_mt(vds: 'VariantDataset') -> 'MatrixTable':
     # Garbage in, garbage out.
     ref = vds.reference_data
     ref = ref.annotate_rows(_locus_global_pos=ref.locus.global_position())
-    ref = ref.transmute_entries(_END_GLOBAL=ref._locus_global_pos + ref.LEN)
+    ref = ref.transmute_entries(_END_GLOBAL=ref._locus_global_pos + ref.LEN - 1)
 
     to_drop = 'alleles', 'rsid', 'ref_allele', '_locus_global_pos'
     ref = ref.drop(*(x for x in to_drop if x in ref.row))
@@ -84,7 +84,7 @@ def to_dense_mt(vds: 'VariantDataset') -> 'MatrixTable':
                 lambda tup: coalesce_join(
                     hl.coalesce(
                         refs_at_this_row[tup[0]],
-                        hl.or_missing(tup[1][1]._END_GLOBAL > dr.locus.global_position(), tup[1][1]),
+                        hl.or_missing(tup[1][1]._END_GLOBAL >= dr.locus.global_position(), tup[1][1]),
                     ),
                     tup[1][0],
                 )

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -983,7 +983,7 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None, ref_block_wi
 
     # we've changed LEN so we need to make sure that END is correct.
     if 'END' in new_rd.entry:
-        new_rd = VariantDataset._add_end(new_rd.drop('END'))
+        new_rd = new_rd.annotate_entries(END=new_rd.LEN + new_rd.locus.position - 1)
 
     if isinstance(ds, hl.vds.VariantDataset):
         return VariantDataset(reference_data=new_rd, variant_data=ds.variant_data)

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -944,7 +944,7 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None, ref_block_wi
                 f" recommended values are <0.05."
             )
         max_ref_block_base_pairs = rd.aggregate_entries(
-            hl.agg.approx_quantiles(rd.END - rd.locus.position + 1, 1 - ref_block_winsorize_fraction, k=200)
+            hl.agg.approx_quantiles(rd.LEN, 1 - ref_block_winsorize_fraction, k=200)
         )
 
     assert (
@@ -952,20 +952,20 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None, ref_block_wi
     ), 'truncate_reference_blocks: "max_ref_block_base_pairs" must be between greater than zero'
     info(f"splitting VDS reference blocks at {max_ref_block_base_pairs} base pairs")
 
-    rd_under_limit = rd.filter_entries(rd.END - rd.locus.position < max_ref_block_base_pairs).localize_entries(
-        'fixed_blocks', 'cols'
-    )
+    rd_under_limit = rd.filter_entries(rd.LEN <= max_ref_block_base_pairs).localize_entries('fixed_blocks', 'cols')
 
-    rd_over_limit = rd.filter_entries(rd.END - rd.locus.position >= max_ref_block_base_pairs).key_cols_by(
-        col_idx=hl.scan.count()
-    )
+    rd_over_limit = rd.filter_entries(rd.LEN > max_ref_block_base_pairs).key_cols_by(col_idx=hl.scan.count())
     rd_over_limit = rd_over_limit.select_rows().select_cols().key_rows_by().key_cols_by()
     es = rd_over_limit.entries()
-    es = es.annotate(new_start=hl.range(es.locus.position, es.END + 1, max_ref_block_base_pairs))
+    es = es.annotate(new_start=hl.range(es.locus.position, es.locus.position + es.LEN, max_ref_block_base_pairs))
     es = es.explode('new_start')
     es = es.transmute(
         locus=hl.locus(es.locus.contig, es.new_start, reference_genome=es.locus.dtype.reference_genome),
-        END=hl.min(es.new_start + max_ref_block_base_pairs - 1, es.END),
+        LEN=hl.if_else(
+            es.new_start + max_ref_block_base_pairs <= es.locus.position + es.LEN,
+            max_ref_block_base_pairs,
+            es.LEN % max_ref_block_base_pairs,
+        ),
     )
     es = es.key_by(es.locus).collect_by_key("new_blocks")
     es = es.transmute(moved_blocks_dict=hl.dict(es.new_blocks.map(lambda x: (x.col_idx, x.drop('col_idx')))))
@@ -980,6 +980,10 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None, ref_block_wi
         entries_field_name='merged_blocks', cols_field_name='cols', col_key=list(rd.col_key)
     )
     new_rd = new_rd.annotate_globals(**{fd_name: max_ref_block_base_pairs})
+
+    # we've changed LEN so we need to make sure that END is correct.
+    if 'END' in new_rd.entry:
+        new_rd = VariantDataset._add_end(new_rd.drop('END'))
 
     if isinstance(ds, hl.vds.VariantDataset):
         return VariantDataset(reference_data=new_rd, variant_data=ds.variant_data)

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -961,10 +961,9 @@ def truncate_reference_blocks(ds, *, max_ref_block_base_pairs=None, ref_block_wi
     es = es.explode('new_start')
     es = es.transmute(
         locus=hl.locus(es.locus.contig, es.new_start, reference_genome=es.locus.dtype.reference_genome),
-        LEN=hl.if_else(
-            es.new_start + max_ref_block_base_pairs <= es.locus.position + es.LEN,
+        LEN=hl.min(
+            es.locus.position + es.LEN - es.new_start,
             max_ref_block_base_pairs,
-            es.LEN % max_ref_block_base_pairs,
         ),
     )
     # we've changed LEN so we need to make sure that END is correct

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -895,11 +895,12 @@ def test_ref_block_does_not_densify_to_next_contig():
     ref = vds.reference_data
     var = vds.variant_data.filter_entries(False)
     # max out all chr1 refblocks, and truncate all chr2 refblocks so that nothing in chr2 should be densified
+    chr1_end = hl.parse_locus_interval('chr1', reference_genome=ref.locus.dtype.reference_genome).end.position
     ref = ref.annotate_entries(
-        END=hl.if_else(
+        LEN=hl.if_else(
             ref.locus.contig == 'chr1',
-            hl.parse_locus_interval('chr1', reference_genome=ref.locus.dtype.reference_genome).end.position,
-            ref.locus.position,
+            chr1_end - ref.locus.position + 1,
+            1,
         )
     )
     vds = hl.vds.VariantDataset(reference_data=ref, variant_data=var)


### PR DESCRIPTION
- Use LEN for `to_dense_mt`. We still need to calculate a global position for the end of a reference block, but this version is cleaner.
- Update `truncate_reference_blocks`.