### PR TITLE
[query] Use `sourcecode.Enclosing` to handle timed blocks implicitly

### DIFF
--- a/hail/build.sc
+++ b/hail/build.sc
@@ -113,6 +113,7 @@ object Deps {
   val log4j = ivy"org.apache.logging.log4j:log4j-1.2-api:2.17.2"
   val hadoopClient = ivy"org.apache.hadoop:hadoop-client:3.3.4"
   val jackson = ivy"com.fasterxml.jackson.core:jackson-core:2.15.2"
+  val sourcecode = ivy"com.lihaoyi::sourcecode:0.4.2"
 
   object Plugins {
     val betterModadicFor = ivy"com.olegpy::better-monadic-for:0.3.1"
@@ -200,6 +201,7 @@ object main extends RootModule with HailScalaModule { outer =>
     Deps.jna,
     Deps.json4s.excludeOrg("com.fasterxml.jackson.core"),
     Deps.zstd,
+    Deps.sourcecode
   )
 
   override def runIvyDeps: T[Agg[Dep]] = Agg(

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -186,7 +186,7 @@ class Backend(abc.ABC):
         return (value, timings) if timed else value
 
     @abc.abstractmethod
-    def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, str]:
+    def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, Optional[dict]]:
         pass
 
     def _render_ir(self, ir):

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -349,7 +349,7 @@ class ServiceBackend(Backend):
         progress: Optional[BatchProgressBar] = None,
         driver_cores: Optional[Union[int, str]] = None,
         driver_memory: Optional[str] = None,
-    ) -> Tuple[bytes, str]:
+    ) -> Tuple[bytes, Optional[dict]]:
         timings = Timings()
         async with TemporaryDirectory(ensure_exists=False) as iodir:
             with timings.step("write input"):
@@ -414,7 +414,7 @@ class ServiceBackend(Backend):
 
             with timings.step("read output"):
                 result_bytes = await retry_transient_errors(self._read_output, iodir + '/out', iodir + '/in')
-                return result_bytes, str(timings.to_dict())
+                return result_bytes, timings.to_dict()
 
     async def _read_output(self, output_uri: str, input_uri: str) -> bytes:
         try:
@@ -462,7 +462,7 @@ class ServiceBackend(Backend):
                 self._batch_was_submitted = False
             raise
 
-    def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, str]:
+    def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, Optional[str]]:
         return self._cancel_on_ctrl_c(self._async_rpc(action, payload))
 
     async def _async_rpc(self, action: ActionTag, payload: ActionPayload):

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -462,7 +462,7 @@ class ServiceBackend(Backend):
                 self._batch_was_submitted = False
             raise
 
-    def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, Optional[str]]:
+    def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, Optional[dict]]:
         return self._cancel_on_ctrl_c(self._async_rpc(action, payload))
 
     async def _async_rpc(self, action: ActionTag, payload: ActionPayload):

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -161,7 +161,8 @@ def eval_timed(expression):
         uid = Env.get_uid()
         ir = expression._indices.source.select_globals(**{uid: expression}).index_globals()[uid]._ir
 
-    return Env.backend().execute(MakeTuple([ir]), timed=True)[0]
+    (value, timings) = Env.backend().execute(MakeTuple([ir]), timed=True)
+    return (value[0], timings)
 
 
 @typecheck(expression=expr_any)

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -162,7 +162,7 @@ def eval_timed(expression):
         ir = expression._indices.source.select_globals(**{uid: expression}).index_globals()[uid]._ir
 
     (value, timings) = Env.backend().execute(MakeTuple([ir]), timed=True)
-    return (value[0], timings)
+    return value[0], timings
 
 
 @typecheck(expression=expr_any)

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1122,9 +1122,11 @@ class Timings:
         d: Dict[str, int] = {}
         self.timings[name] = d
         d['start_time'] = time_msecs()
-        yield
-        d['finish_time'] = time_msecs()
-        d['duration'] = d['finish_time'] - d['start_time']
+        try:
+            yield
+        finally:
+            d['finish_time'] = time_msecs()
+            d['duration'] = d['finish_time'] - d['start_time']
 
     def to_dict(self):
         return self.timings

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -47,6 +47,25 @@ object Backend {
     irID += 1
     irID
   }
+
+  def encodeToOutputStream(
+    ctx: ExecuteContext,
+    t: PTuple,
+    off: Long,
+    bufferSpecString: String,
+    os: OutputStream,
+  ): Unit = {
+    val bs = BufferSpec.parseOrDefault(bufferSpecString)
+    assert(t.size == 1)
+    val elementType = t.fields(0).typ
+    val codec = TypedCodecSpec(
+      EType.fromPythonTypeEncoding(elementType.virtualType),
+      elementType.virtualType,
+      bs,
+    )
+    assert(t.isFieldDefined(off, 0))
+    codec.encode(ctx, elementType, t.loadField(off, 0), os)
+  }
 }
 
 abstract class BroadcastValue[T] { def value: T }
@@ -266,25 +285,6 @@ abstract class Backend {
   }
 
   def execute(ctx: ExecuteContext, ir: IR): Either[Unit, (PTuple, Long)]
-
-  def encodeToOutputStream(
-    ctx: ExecuteContext,
-    t: PTuple,
-    off: Long,
-    bufferSpecString: String,
-    os: OutputStream,
-  ): Unit = {
-    val bs = BufferSpec.parseOrDefault(bufferSpecString)
-    assert(t.size == 1)
-    val elementType = t.fields(0).typ
-    val codec = TypedCodecSpec(
-      EType.fromPythonTypeEncoding(elementType.virtualType),
-      elementType.virtualType,
-      bs,
-    )
-    assert(t.isFieldDefined(off, 0))
-    codec.encode(ctx, elementType, t.loadField(off, 0), os)
-  }
 }
 
 trait BackendWithCodeCache {

--- a/hail/src/main/scala/is/hail/backend/BackendServer.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendServer.scala
@@ -107,7 +107,7 @@ class BackendHttpHandler(backend: Backend) extends HttpHandler {
             case Right((t, off)) =>
               exchange.sendResponseHeaders(200, 0L) // 0 => an arbitrarily long response body
               using(exchange.getResponseBody) { os =>
-                backend.encodeToOutputStream(ctx, t, off, streamCodec, os)
+                Backend.encodeToOutputStream(ctx, t, off, streamCodec, os)
               }
           }
         }

--- a/hail/src/main/scala/is/hail/backend/BackendServer.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendServer.scala
@@ -3,14 +3,16 @@ package is.hail.backend
 import is.hail.expr.ir.{IRParser, IRParserEnvironment}
 import is.hail.utils._
 
+import scala.util.control.NonFatal
+
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 import java.util.concurrent._
+
 import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
 import org.json4s._
-import org.json4s.jackson.{JsonMethods, Serialization}
-
-import scala.util.control.NonFatal
+import org.json4s.jackson.JsonMethods
+import org.json4s.jackson.JsonMethods.compact
 
 case class IRTypePayload(ir: String)
 case class LoadReferencesFromDatasetPayload(path: String)
@@ -99,8 +101,7 @@ class BackendHttpHandler(backend: Backend) extends HttpHandler {
           }
 
           if (timed) {
-            val ts = Serialization.write(Map("timings" -> timings))
-            exchange.getResponseHeaders.add("X-Hail-Timings", ts)
+            exchange.getResponseHeaders.add("X-Hail-Timings", compact(timings.toJSON))
           }
 
           res match {

--- a/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
@@ -17,7 +17,7 @@ import java.security.SecureRandom
 import sourcecode.Enclosing
 
 trait TempFileManager extends AutoCloseable {
-  def newTmpPath(tmpdir: String, prefix: String, extension: String = ""): String
+  def newTmpPath(tmpdir: String, prefix: String, extension: String = null): String
 }
 
 class OwningTempFileManager(fs: FS) extends TempFileManager {

--- a/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
@@ -114,7 +114,7 @@ class ExecuteContext(
   val theHailClassLoader: HailClassLoader,
   val flags: HailFeatureFlags,
   val backendContext: BackendContext,
-  var irMetadata: IrMetadata,
+  val irMetadata: IrMetadata,
 ) extends Closeable {
 
   val rngNonce: Long =

--- a/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
@@ -36,7 +36,7 @@ class OwningTempFileManager(fs: FS) extends TempFileManager {
   }
 }
 
-case class NonOwningTempFileManager(owner: TempFileManager) extends TempFileManager {
+class NonOwningTempFileManager private (owner: TempFileManager) extends TempFileManager {
   override def newTmpPath(tmpdir: String, prefix: String, extension: String): String =
     owner.newTmpPath(tmpdir, prefix, extension)
 

--- a/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
@@ -14,38 +14,48 @@ import scala.collection.mutable
 import java.io._
 import java.security.SecureRandom
 
-trait TempFileManager {
-  def own(path: String): Unit
+import sourcecode.Enclosing
 
-  def cleanup(): Unit
+trait TempFileManager extends AutoCloseable {
+  def newTmpPath(tmpdir: String, prefix: String, extension: String = ""): String
 }
 
 class OwningTempFileManager(fs: FS) extends TempFileManager {
   private[this] val tmpPaths = mutable.ArrayBuffer[String]()
 
-  def own(path: String): Unit = tmpPaths += path
+  override def newTmpPath(tmpdir: String, prefix: String, extension: String): String = {
+    val tmp = ExecuteContext.createTmpPathNoCleanup(tmpdir, prefix, extension)
+    tmpPaths += tmp
+    tmp
+  }
 
-  override def cleanup(): Unit = {
+  override def close(): Unit = {
     for (p <- tmpPaths)
       fs.delete(p, recursive = true)
     tmpPaths.clear()
   }
 }
 
-class NonOwningTempFileManager(owner: TempFileManager) extends TempFileManager {
-  def own(path: String): Unit = owner.own(path)
+case class NonOwningTempFileManager(owner: TempFileManager) extends TempFileManager {
+  override def newTmpPath(tmpdir: String, prefix: String, extension: String): String =
+    owner.newTmpPath(tmpdir, prefix, extension)
 
-  override def cleanup(): Unit = ()
+  override def close(): Unit = ()
+}
+
+object NonOwningTempFileManager {
+  def apply(owner: TempFileManager): TempFileManager =
+    owner match {
+      case _: NonOwningTempFileManager => owner
+      case _ => new NonOwningTempFileManager(owner)
+    }
 }
 
 object ExecuteContext {
-  def scoped[T]()(f: ExecuteContext => T): T = {
-    val (result, _) = ExecutionTimer.time("ExecuteContext.scoped") { timer =>
-      HailContext.sparkBackend("ExecuteContext.scoped").withExecuteContext(
-        timer,
-        selfContainedExecution = false,
-      )(f)
-    }
+  def scoped[T](f: ExecuteContext => T)(implicit E: Enclosing): T = {
+    val result = HailContext.sparkBackend("ExecuteContext.scoped").withExecuteContext(
+      selfContainedExecution = false
+    )(f)
     result
   }
 
@@ -59,35 +69,26 @@ object ExecuteContext {
     theHailClassLoader: HailClassLoader,
     flags: HailFeatureFlags,
     backendContext: BackendContext,
+    irMetadata: IrMetadata,
   )(
     f: ExecuteContext => T
   ): T = {
     RegionPool.scoped { pool =>
-      using(new ExecuteContext(
-        tmpdir,
-        localTmpdir,
-        backend,
-        fs,
-        Region(pool = pool),
-        timer,
-        tempFileManager,
-        theHailClassLoader,
-        flags,
-        backendContext,
-        IrMetadata(None),
-      ))(f(_))
-    }
-  }
-
-  def scopedNewRegion[T](ctx: ExecuteContext)(f: ExecuteContext => T): T = {
-    val rp = ctx.r.pool
-
-    rp.scopedRegion { r =>
-      val oldR = ctx.r
-      ctx.r = r
-      val t = f(ctx)
-      ctx.r = oldR
-      t
+      pool.scopedRegion { region =>
+        using(new ExecuteContext(
+          tmpdir,
+          localTmpdir,
+          backend,
+          fs,
+          region,
+          timer,
+          tempFileManager,
+          theHailClassLoader,
+          flags,
+          backendContext,
+          irMetadata,
+        ))(f(_))
+      }
     }
   }
 
@@ -107,7 +108,7 @@ class ExecuteContext(
   val localTmpdir: String,
   val backend: Backend,
   val fs: FS,
-  var r: Region,
+  val r: Region,
   val timer: ExecutionTimer,
   _tempFileManager: TempFileManager,
   val theHailClassLoader: HailClassLoader,
@@ -134,27 +135,22 @@ class ExecuteContext(
 
   def fsBc: BroadcastValue[FS] = fs.broadcast
 
-  private val cleanupFunctions = mutable.ArrayBuffer[() => Unit]()
-
   val memo: mutable.Map[Any, Any] = new mutable.HashMap[Any, Any]()
 
   val taskContext: HailTaskContext = new LocalTaskContext(0, 0)
 
-  def scopedExecution[T](f: (HailClassLoader, FS, HailTaskContext, Region) => T): T =
-    using(new LocalTaskContext(0, 0))(f(theHailClassLoader, fs, _, r))
+  def scopedExecution[T](
+    f: (HailClassLoader, FS, HailTaskContext, Region) => T
+  )(implicit E: Enclosing
+  ): T =
+    using(new LocalTaskContext(0, 0)) { tc =>
+      time {
+        f(theHailClassLoader, fs, tc, r)
+      }
+    }
 
-  def createTmpPath(prefix: String, extension: String = null, local: Boolean = false): String = {
-    val path =
-      ExecuteContext.createTmpPathNoCleanup(if (local) localTmpdir else tmpdir, prefix, extension)
-    tempFileManager.own(path)
-    path
-  }
-
-  def ownCloseable(c: Closeable): Unit =
-    cleanupFunctions += c.close
-
-  def ownCleanup(cleanupFunction: () => Unit): Unit =
-    cleanupFunctions += cleanupFunction
+  def createTmpPath(prefix: String, extension: String = null, local: Boolean = false): String =
+    tempFileManager.newTmpPath(if (local) localTmpdir else tmpdir, prefix, extension)
 
   def getFlag(name: String): String = flags.get(name)
 
@@ -167,23 +163,39 @@ class ExecuteContext(
   def shouldLogIR(): Boolean = !shouldNotLogIR()
 
   def close(): Unit = {
-    tempFileManager.cleanup()
+    tempFileManager.close()
     taskContext.close()
-
-    var exception: Exception = null
-    for (cleanupFunction <- cleanupFunctions) {
-      try
-        cleanupFunction()
-      catch {
-        case exc: Exception =>
-          if (exception == null) {
-            exception = new RuntimeException("ExecuteContext could not cleanup all resources")
-          }
-          exception.addSuppressed(exc)
-      }
-    }
-    if (exception != null) {
-      throw exception
-    }
   }
+
+  def time[A](block: => A)(implicit E: Enclosing): A =
+    timer.time(E.value)(block)
+
+  def local[A](
+    tmpdir: String = this.tmpdir,
+    localTmpdir: String = this.localTmpdir,
+    backend: Backend = this.backend,
+    fs: FS = this.fs,
+    r: Region = this.r,
+    timer: ExecutionTimer = this.timer,
+    tempFileManager: TempFileManager = NonOwningTempFileManager(this.tempFileManager),
+    theHailClassLoader: HailClassLoader = this.theHailClassLoader,
+    flags: HailFeatureFlags = this.flags,
+    backendContext: BackendContext = this.backendContext,
+    irMetadata: IrMetadata = this.irMetadata,
+  )(
+    f: ExecuteContext => A
+  ): A =
+    using(new ExecuteContext(
+      tmpdir,
+      localTmpdir,
+      backend,
+      fs,
+      r,
+      timer,
+      tempFileManager,
+      theHailClassLoader,
+      flags,
+      backendContext,
+      irMetadata,
+    ))(f)
 }

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -96,7 +96,7 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
           override val executionCache: ExecutionCache =
             ExecutionCache.fromFlags(flags, fs, tmpdir)
         },
-        IrMetadata(None),
+        new IrMetadata(),
       )(f)
     }
 
@@ -182,9 +182,10 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
     ctx.time {
       TypeCheck(ctx, ir)
       Validate(ir)
+      assert(ir.typ.isRealizable)
       val queryID = Backend.nextID()
       log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
-      ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
+      ctx.irMetadata.semhash = SemanticHash(ctx)(ir)
       val res = _jvmLowerAndExecute(ctx, ir)
       log.info(s"finished execution of query $queryID")
       res

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -1,18 +1,16 @@
 package is.hail.backend.local
 
 import is.hail.{CancellingExecutorService, HailContext, HailFeatureFlags}
-import is.hail.annotations.{Region, SafeRow}
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend._
 import is.hail.expr.Validate
 import is.hail.expr.ir.{IRParser, _}
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.expr.ir.lowering._
-import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.io.fs._
 import is.hail.linalg.BlockMatrix
 import is.hail.types._
-import is.hail.types.encoded.EType
 import is.hail.types.physical.PTuple
 import is.hail.types.physical.stypes.PTypeReferenceSingleCodeType
 import is.hail.types.virtual.{BlockMatrixType, TVoid}
@@ -26,8 +24,7 @@ import java.io.PrintWriter
 
 import com.google.common.util.concurrent.MoreExecutors
 import org.apache.hadoop
-import org.json4s._
-import org.json4s.jackson.Serialization
+import sourcecode.Enclosing
 
 class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T] with Serializable
 
@@ -83,26 +80,8 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
   // flags can be set after construction from python
   def fs: FS = FS.buildRoutes(None, Some(flags), sys.env)
 
-  def withExecuteContext[T](timer: ExecutionTimer): (ExecuteContext => T) => T = {
-    val fs = this.fs
-    ExecuteContext.scoped(
-      tmpdir,
-      tmpdir,
-      this,
-      fs,
-      timer,
-      null,
-      theHailClassLoader,
-      flags,
-      new BackendContext {
-        override val executionCache: ExecutionCache =
-          ExecutionCache.fromFlags(flags, fs, tmpdir)
-      },
-    )
-  }
-
-  override def withExecuteContext[T](methodName: String)(f: ExecuteContext => T): T =
-    ExecutionTimer.logTime(methodName) { timer =>
+  override def withExecuteContext[T](f: ExecuteContext => T)(implicit E: Enclosing): T =
+    ExecutionTimer.logTime { timer =>
       val fs = this.fs
       ExecuteContext.scoped(
         tmpdir,
@@ -117,6 +96,7 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
           override val executionCache: ExecutionCache =
             ExecutionCache.fromFlags(flags, fs, tmpdir)
         },
+        IrMetadata(None),
       )(f)
     }
 
@@ -163,134 +143,69 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
     ctx: ExecuteContext,
     ir0: IR,
     print: Option[PrintWriter] = None,
-  ): Either[Unit, (PTuple, Long)] = {
-    val ir =
-      LoweringPipeline.darrayLowerer(true)(DArrayLowering.All).apply(ctx, ir0).asInstanceOf[IR]
+  ): Either[Unit, (PTuple, Long)] =
+    ctx.time {
+      val ir =
+        LoweringPipeline.darrayLowerer(true)(DArrayLowering.All).apply(ctx, ir0).asInstanceOf[IR]
 
-    if (!Compilable(ir))
-      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${Pretty(ctx, ir)}")
+      if (!Compilable(ir))
+        throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${Pretty(ctx, ir)}")
 
-    if (ir.typ == TVoid) {
-      val (_, f) = ctx.timer.time("Compile") {
-        Compile[AsmFunction1RegionUnit](
-          ctx,
-          FastSeq(),
-          FastSeq(classInfo[Region]),
-          UnitInfo,
-          ir,
-          print = print,
-        )
-      }
-
-      ctx.timer.time("Run") {
-        Left(ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r)))
-      }
-    } else {
-      val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) = ctx.timer.time("Compile") {
-        Compile[AsmFunction1RegionLong](
-          ctx,
-          FastSeq(),
-          FastSeq(classInfo[Region]),
-          LongInfo,
-          MakeTuple.ordered(FastSeq(ir)),
-          print = print,
-        )
-      }
-
-      ctx.timer.time("Run") {
-        Right((pt, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))))
-      }
-    }
-  }
-
-  private[this] def _execute(ctx: ExecuteContext, ir: IR): Either[Unit, (PTuple, Long)] = {
-    TypeCheck(ctx, ir)
-    Validate(ir)
-    val queryID = Backend.nextID()
-    log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
-    ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
-    val res = _jvmLowerAndExecute(ctx, ir)
-    log.info(s"finished execution of query $queryID")
-    res
-  }
-
-  def executeToJavaValue(timer: ExecutionTimer, ir: IR): (Any, ExecutionTimer) =
-    withExecuteContext(timer) { ctx =>
-      val result = _execute(ctx, ir) match {
-        case Left(_) =>
-          (null, ctx.timer)
-        case Right((pt, off)) =>
-          (SafeRow(pt, off).get(0), ctx.timer)
-      }
-      result
-    }
-
-  def executeToEncoded(timer: ExecutionTimer, ir: IR, bs: BufferSpec): Array[Byte] =
-    withExecuteContext(timer) { ctx =>
-      val result = _execute(ctx, ir) match {
-        case Left(_) => Array[Byte]()
-        case Right((pt, off)) =>
-          val elementType = pt.fields(0).typ
-          assert(pt.isFieldDefined(off, 0))
-          val codec = TypedCodecSpec(
-            EType.fromPythonTypeEncoding(elementType.virtualType),
-            elementType.virtualType,
-            bs,
+      ir.typ match {
+        case TVoid =>
+          val (_, f) = Compile[AsmFunction1RegionUnit](
+            ctx,
+            FastSeq(),
+            FastSeq(classInfo[Region]),
+            UnitInfo,
+            ir,
+            print = print,
           )
-          codec.encode(ctx, elementType, pt.loadField(off, 0))
+
+          Left(ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r)))
+        case _ =>
+          val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) =
+            Compile[AsmFunction1RegionLong](
+              ctx,
+              FastSeq(),
+              FastSeq(classInfo[Region]),
+              LongInfo,
+              MakeTuple.ordered(FastSeq(ir)),
+              print = print,
+            )
+
+          Right((pt, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r))))
       }
-      result
     }
 
-  def executeLiteral(irStr: String): Int = {
-    ExecutionTimer.logTime("SparkBackend.executeLiteral") { timer =>
-      withExecuteContext(timer) { ctx =>
-        val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-        val t = ir.typ
-        assert(t.isRealizable)
-        val queryID = Backend.nextID()
-        log.info(s"starting execution of query $queryID} of initial size ${IRSize(ir)}")
-        val retVal = _execute(ctx, ir)
-        val literalIR = retVal match {
-          case Left(_) => throw new HailException("Can't create literal")
-          case Right((pt, addr)) =>
-            GetFieldByIdx(EncodedLiteral.fromPTypeAndAddress(pt, addr, ctx), 0)
-        }
-        log.info(s"finished execution of query $queryID")
-        addJavaIR(literalIR)
-      }
+  override def execute(ctx: ExecuteContext, ir: IR): Either[Unit, (PTuple, Long)] =
+    ctx.time {
+      TypeCheck(ctx, ir)
+      Validate(ir)
+      val queryID = Backend.nextID()
+      log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
+      ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
+      val res = _jvmLowerAndExecute(ctx, ir)
+      log.info(s"finished execution of query $queryID")
+      res
     }
-  }
 
-  override def execute(
-    ir: String,
-    timed: Boolean,
-  )(
-    consume: (ExecuteContext, Either[Unit, (PTuple, Long)], String) => Unit
-  ): Unit = {
-    withExecuteContext("LocalBackend.execute") { ctx =>
-      val res = ctx.timer.time("execute") {
-        val irData =
-          IRParser.parse_value_ir(ir, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-        val queryID = Backend.nextID()
-        log.info(s"starting execution of query $queryID of initial size ${IRSize(irData)}")
-        _execute(ctx, irData)
+  def executeLiteral(irStr: String): Int =
+    withExecuteContext { ctx =>
+      val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, persistedIR.toMap))
+      execute(ctx, ir) match {
+        case Left(_) => throw new HailException("Can't create literal")
+        case Right((pt, addr)) =>
+          val field = GetFieldByIdx(EncodedLiteral.fromPTypeAndAddress(pt, addr, ctx), 0)
+          addJavaIR(field)
       }
-      ctx.timer.finish()
-      val timings = if (timed)
-        Serialization.write(Map("timings" -> ctx.timer.toMap))(new DefaultFormats {})
-      else ""
-      consume(ctx, res, timings)
     }
-  }
 
   def pyAddReference(jsonConfig: String): Unit = addReference(ReferenceGenome.fromJSON(jsonConfig))
   def pyRemoveReference(name: String): Unit = removeReference(name)
 
   def pyAddLiftover(name: String, chainFile: String, destRGName: String): Unit =
-    ExecutionTimer.logTime("LocalBackend.pyReferenceAddLiftover") { timer =>
-      withExecuteContext(timer)(ctx => references(name).addLiftover(ctx, chainFile, destRGName))
-    }
+    withExecuteContext(ctx => references(name).addLiftover(ctx, chainFile, destRGName))
 
   def pyRemoveLiftover(name: String, destRGName: String) =
     references(name).removeLiftover(destRGName)
@@ -303,63 +218,50 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
     yContigs: java.util.List[String],
     mtContigs: java.util.List[String],
     parInput: java.util.List[String],
-  ): String = {
-    ExecutionTimer.logTime("LocalBackend.pyFromFASTAFile") { timer =>
-      withExecuteContext(timer) { ctx =>
-        val rg = ReferenceGenome.fromFASTAFile(
-          ctx,
-          name,
-          fastaFile,
-          indexFile,
-          xContigs.asScala.toArray,
-          yContigs.asScala.toArray,
-          mtContigs.asScala.toArray,
-          parInput.asScala.toArray,
-        )
-        rg.toJSONString
-      }
+  ): String =
+    withExecuteContext { ctx =>
+      val rg = ReferenceGenome.fromFASTAFile(
+        ctx,
+        name,
+        fastaFile,
+        indexFile,
+        xContigs.asScala.toArray,
+        yContigs.asScala.toArray,
+        mtContigs.asScala.toArray,
+        parInput.asScala.toArray,
+      )
+      rg.toJSONString
     }
-  }
 
   def pyAddSequence(name: String, fastaFile: String, indexFile: String): Unit =
-    ExecutionTimer.logTime("LocalBackend.pyAddSequence") { timer =>
-      withExecuteContext(timer)(ctx => references(name).addSequence(ctx, fastaFile, indexFile))
-    }
+    withExecuteContext(ctx => references(name).addSequence(ctx, fastaFile, indexFile))
 
   def pyRemoveSequence(name: String) = references(name).removeSequence()
 
   def parse_value_ir(s: String, refMap: java.util.Map[String, String]): IR =
-    ExecutionTimer.logTime("LocalBackend.parse_value_ir") { timer =>
-      withExecuteContext(timer) { ctx =>
-        IRParser.parse_value_ir(
-          s,
-          IRParserEnvironment(ctx, persistedIR.toMap),
-          BindingEnv.eval(refMap.asScala.toMap.map { case (n, t) =>
-            Name(n) -> IRParser.parseType(t)
-          }.toSeq: _*),
-        )
-      }
+    withExecuteContext { ctx =>
+      IRParser.parse_value_ir(
+        s,
+        IRParserEnvironment(ctx, persistedIR.toMap),
+        BindingEnv.eval(refMap.asScala.toMap.map { case (n, t) =>
+          Name(n) -> IRParser.parseType(t)
+        }.toSeq: _*),
+      )
     }
 
   def parse_table_ir(s: String): TableIR =
-    ExecutionTimer.logTime("LocalBackend.parse_table_ir") { timer =>
-      withExecuteContext(timer) { ctx =>
-        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-      }
+    withExecuteContext { ctx =>
+      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
     }
 
   def parse_matrix_ir(s: String): MatrixIR =
-    ExecutionTimer.logTime("LocalBackend.parse_matrix_ir") { timer =>
-      withExecuteContext(timer) { ctx =>
-        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-      }
+    withExecuteContext { ctx =>
+      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
     }
 
   def parse_blockmatrix_ir(s: String): BlockMatrixIR =
-    ExecutionTimer.logTime("LocalBackend.parse_blockmatrix_ir") { timer =>
-      withExecuteContext(timer) { ctx =>
-        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-      }
+    withExecuteContext { ctx =>
+      IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
     }
 
   override def lowerDistributedSort(

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -182,7 +182,6 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
     ctx.time {
       TypeCheck(ctx, ir)
       Validate(ir)
-      assert(ir.typ.isRealizable)
       val queryID = Backend.nextID()
       log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
       ctx.irMetadata.semhash = SemanticHash(ctx)(ir)
@@ -194,6 +193,7 @@ class LocalBackend(val tmpdir: String) extends Backend with BackendWithCodeCache
   def executeLiteral(irStr: String): Int =
     withExecuteContext { ctx =>
       val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, persistedIR.toMap))
+      assert(ir.typ.isRealizable)
       execute(ctx, ir) match {
         case Left(_) => throw new HailException("Can't create literal")
         case Right((pt, addr)) =>

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -335,9 +335,10 @@ class ServiceBackend(
     ctx.time {
       TypeCheck(ctx, ir)
       Validate(ir)
+      assert(ir.typ.isRealizable)
       val queryID = Backend.nextID()
       log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
-      ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
+      ctx.irMetadata.semhash = SemanticHash(ctx)(ir)
       val res = _jvmLowerAndExecute(ctx, ir)
       log.info(s"finished execution of query $queryID")
       res
@@ -408,7 +409,7 @@ class ServiceBackend(
         theHailClassLoader,
         flags,
         serviceBackendContext,
-        IrMetadata(None),
+        new IrMetadata(),
       )(f)
     }
 

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -6,7 +6,8 @@ import is.hail.asm4s._
 import is.hail.backend._
 import is.hail.expr.Validate
 import is.hail.expr.ir.{
-  Compile, IR, IRParser, LoweringAnalyses, MakeTuple, SortField, TableIR, TableReader, TypeCheck,
+  Compile, IR, IRParser, IRParserEnvironment, IRSize, LoweringAnalyses, MakeTuple, SortField,
+  TableIR, TableReader, TypeCheck,
 }
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.expr.ir.functions.IRFunctionRegistry
@@ -35,6 +36,7 @@ import org.apache.log4j.Logger
 import org.json4s.{DefaultFormats, Formats}
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
+import sourcecode.Enclosing
 
 class ServiceBackendContext(
   val billingProject: String,
@@ -331,55 +333,48 @@ class ServiceBackend(
   def stop(): Unit =
     executor.shutdownNow()
 
-  private[this] def execute(ctx: ExecuteContext, _x: IR, bufferSpecString: String): Array[Byte] = {
-    TypeCheck(ctx, _x)
-    Validate(_x)
-    val x = LoweringPipeline.darrayLowerer(true)(DArrayLowering.All).apply(ctx, _x)
-      .asInstanceOf[IR]
-    if (x.typ == TVoid) {
-      val (_, f) = Compile[AsmFunction1RegionUnit](
-        ctx,
-        FastSeq(),
-        FastSeq[TypeInfo[_]](classInfo[Region]),
-        UnitInfo,
-        x,
-        optimize = true,
-      )
-
-      ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))
-      Array()
-    } else {
-      val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) = Compile[AsmFunction1RegionLong](
-        ctx,
-        FastSeq(),
-        FastSeq(classInfo[Region]),
-        LongInfo,
-        MakeTuple.ordered(FastSeq(x)),
-        optimize = true,
-      )
-      val elementType = pt.fields(0).typ
-      val off = ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r))
-      val codec = TypedCodecSpec(
-        EType.fromPythonTypeEncoding(elementType.virtualType),
-        elementType.virtualType,
-        BufferSpec.parseOrDefault(bufferSpecString),
-      )
-      assert(pt.isFieldDefined(off, 0))
-      codec.encode(ctx, elementType, pt.loadField(off, 0))
+  override def execute(ctx: ExecuteContext, ir: IR): Either[Unit, (PTuple, Long)] =
+    ctx.time {
+      TypeCheck(ctx, ir)
+      Validate(ir)
+      val queryID = Backend.nextID()
+      log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
+      ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
+      val res = _jvmLowerAndExecute(ctx, ir)
+      log.info(s"finished execution of query $queryID")
+      res
     }
-  }
 
-  def execute(
-    ctx: ExecuteContext,
-    code: String,
-    token: String,
-    bufferSpecString: String,
-  ): Array[Byte] = {
-    log.info(s"executing: $token ${ctx.fs.getConfiguration()}")
-    val ir = IRParser.parse_value_ir(ctx, code)
-    ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
-    execute(ctx, ir, bufferSpecString)
-  }
+  private[this] def _jvmLowerAndExecute(ctx: ExecuteContext, ir: IR): Either[Unit, (PTuple, Long)] =
+    ctx.time {
+      val x = LoweringPipeline.darrayLowerer(true)(DArrayLowering.All)(ctx, ir).asInstanceOf[IR]
+
+      x.typ match {
+        case TVoid =>
+          val (_, f) = Compile[AsmFunction1RegionUnit](
+            ctx,
+            FastSeq(),
+            FastSeq[TypeInfo[_]](classInfo[Region]),
+            UnitInfo,
+            x,
+            optimize = true,
+          )
+
+          Left(ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r)))
+        case _ =>
+          val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) =
+            Compile[AsmFunction1RegionLong](
+              ctx,
+              FastSeq(),
+              FastSeq(classInfo[Region]),
+              LongInfo,
+              MakeTuple.ordered(FastSeq(x)),
+              optimize = true,
+            )
+
+          Right((pt, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r))))
+      }
+    }
 
   override def lowerDistributedSort(
     ctx: ExecuteContext,
@@ -403,8 +398,8 @@ class ServiceBackend(
     : TableStage =
     LowerTableIR.applyTable(inputIR, DArrayLowering.All, ctx, analyses)
 
-  override def withExecuteContext[T](methodName: String)(f: ExecuteContext => T): T =
-    ExecutionTimer.logTime(methodName) { timer =>
+  override def withExecuteContext[T](f: ExecuteContext => T)(implicit E: Enclosing): T =
+    ExecutionTimer.logTime { timer =>
       ExecuteContext.scoped(
         tmpdir,
         "file:///tmp",
@@ -415,18 +410,16 @@ class ServiceBackend(
         theHailClassLoader,
         flags,
         serviceBackendContext,
+        IrMetadata(None),
       )(f)
     }
 
   def addLiftover(name: String, chainFile: String, destRGName: String): Unit =
-    withExecuteContext("addLiftover") { ctx =>
-      references(name).addLiftover(ctx, chainFile, destRGName)
-    }
+    withExecuteContext(ctx => references(name).addLiftover(ctx, chainFile, destRGName))
 
   def addSequence(name: String, fastaFile: String, indexFile: String): Unit =
-    withExecuteContext("addSequence") { ctx =>
-      references(name).addSequence(ctx, fastaFile, indexFile)
-    }
+    withExecuteContext(ctx => references(name).addSequence(ctx, fastaFile, indexFile))
+
 }
 
 class EndOfInputException extends RuntimeException
@@ -600,10 +593,23 @@ class ServiceBackendAPI(
         val qobExecutePayload = payload.extract[ServiceBackendExecutePayload]
         val bufferSpecString = qobExecutePayload.payload.stream_codec
         val code = qobExecutePayload.payload.ir
-        val token = qobExecutePayload.idempotency_token
-        backend.withExecuteContext("ServiceBackend.execute") { ctx =>
+        backend.withExecuteContext { ctx =>
           withIRFunctionsReadFromInput(qobExecutePayload.functions, ctx) { () =>
-            backend.execute(ctx, code, token, bufferSpecString)
+            val ir =
+              IRParser.parse_value_ir(code, IRParserEnvironment(ctx, backend.persistedIR.toMap))
+            backend.execute(ctx, ir) match {
+              case Left(()) =>
+                Array()
+              case Right((pt, off)) =>
+                val elementType = pt.fields(0).typ
+                val codec = TypedCodecSpec(
+                  EType.fromPythonTypeEncoding(elementType.virtualType),
+                  elementType.virtualType,
+                  BufferSpec.parseOrDefault(bufferSpecString),
+                )
+                assert(pt.isFieldDefined(off, 0))
+                codec.encode(ctx, elementType, pt.loadField(off, 0))
+            }
           }
         }
       case PARSE_VCF_METADATA =>

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -335,7 +335,6 @@ class ServiceBackend(
     ctx.time {
       TypeCheck(ctx, ir)
       Validate(ir)
-      assert(ir.typ.isRealizable)
       val queryID = Backend.nextID()
       log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
       ctx.irMetadata.semhash = SemanticHash(ctx)(ir)

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -15,7 +15,6 @@ import is.hail.linalg.{BlockMatrix, RowMatrix}
 import is.hail.rvd.RVD
 import is.hail.stats.LinearMixedModel
 import is.hail.types._
-import is.hail.types.encoded.EType
 import is.hail.types.physical.{PStruct, PTuple}
 import is.hail.types.physical.stypes.PTypeReferenceSingleCodeType
 import is.hail.types.virtual._
@@ -565,20 +564,6 @@ class SparkBackend(
           addJavaIR(field)
       }
     }
-
-  def encodeToBytes(ctx: ExecuteContext, t: PTuple, off: Long, bufferSpecString: String)
-    : Array[Byte] = {
-    val bs = BufferSpec.parseOrDefault(bufferSpecString)
-    assert(t.size == 1)
-    val elementType = t.fields(0).typ
-    val codec = TypedCodecSpec(
-      EType.fromPythonTypeEncoding(elementType.virtualType),
-      elementType.virtualType,
-      bs,
-    )
-    assert(t.isFieldDefined(off, 0))
-    codec.encode(ctx, elementType, t.loadField(off, 0))
-  }
 
   def pyFromDF(df: DataFrame, jKey: java.util.List[String]): (Int, String) = {
     val key = jKey.asScala.toArray.toFastSeq

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -542,7 +542,6 @@ class SparkBackend(
     ctx.time {
       TypeCheck(ctx, ir)
       Validate(ir)
-      assert(ir.typ.isRealizable)
       ctx.irMetadata.semhash = SemanticHash(ctx)(ir)
       try {
         val lowerTable = getFlag("lower") != null
@@ -558,6 +557,7 @@ class SparkBackend(
   def executeLiteral(irStr: String): Int =
     withExecuteContext { ctx =>
       val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, persistedIR.toMap))
+      assert(ir.typ.isRealizable)
       execute(ctx, ir) match {
         case Left(_) => throw new HailException("Can't create literal")
         case Right((pt, addr)) =>

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -372,7 +372,7 @@ class SparkBackend(
         override val executionCache: ExecutionCache =
           ExecutionCache.forTesting
       },
-      IrMetadata(None),
+      new IrMetadata(),
     )
 
   def withExecuteContext[T](
@@ -408,7 +408,7 @@ class SparkBackend(
           override val executionCache: ExecutionCache =
             ExecutionCache.fromFlags(flags, fs, tmpdir)
         },
-        IrMetadata(None),
+        new IrMetadata(),
       )(f)
     }
 
@@ -542,7 +542,8 @@ class SparkBackend(
     ctx.time {
       TypeCheck(ctx, ir)
       Validate(ir)
-      ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
+      assert(ir.typ.isRealizable)
+      ctx.irMetadata.semhash = SemanticHash(ctx)(ir)
       try {
         val lowerTable = getFlag("lower") != null
         val lowerBM = getFlag("lower_bm") != null

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -38,8 +38,8 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.json4s
-import org.json4s.DefaultFormats
-import org.json4s.jackson.{JsonMethods, Serialization}
+import org.json4s.jackson.JsonMethods
+import sourcecode.Enclosing
 
 class SparkBroadcastValue[T](bc: Broadcast[T]) extends BroadcastValue[T] with Serializable {
   def value: T = bc.value
@@ -366,7 +366,7 @@ class SparkBackend(
       fs,
       region,
       timer,
-      if (selfContainedExecution) null else new NonOwningTempFileManager(longLifeTempFileManager),
+      if (selfContainedExecution) null else NonOwningTempFileManager(longLifeTempFileManager),
       theHailClassLoader,
       flags,
       new BackendContext {
@@ -376,38 +376,40 @@ class SparkBackend(
       IrMetadata(None),
     )
 
-  def withExecuteContext[T](timer: ExecutionTimer, selfContainedExecution: Boolean = true)
-    : (ExecuteContext => T) => T =
-    ExecuteContext.scoped(
-      tmpdir,
-      localTmpdir,
-      this,
-      fs,
-      timer,
-      if (selfContainedExecution) null else new NonOwningTempFileManager(longLifeTempFileManager),
-      theHailClassLoader,
-      flags,
-      new BackendContext {
-        override val executionCache: ExecutionCache =
-          ExecutionCache.fromFlags(flags, fs, tmpdir)
-      },
-    )
+  def withExecuteContext[T](
+    selfContainedExecution: Boolean = true
+  )(
+    f: ExecuteContext => T
+  )(implicit E: Enclosing
+  ): T =
+    withExecuteContext(
+      if (selfContainedExecution) null else NonOwningTempFileManager(longLifeTempFileManager)
+    )(f)
 
-  override def withExecuteContext[T](methodName: String)(f: ExecuteContext => T): T =
-    ExecutionTimer.logTime(methodName) { timer =>
+  override def withExecuteContext[T](f: ExecuteContext => T)(implicit E: Enclosing): T =
+    withExecuteContext(null.asInstanceOf[TempFileManager])(f)
+
+  def withExecuteContext[T](
+    tmpFileManager: TempFileManager
+  )(
+    f: ExecuteContext => T
+  )(implicit E: Enclosing
+  ): T =
+    ExecutionTimer.logTime { timer =>
       ExecuteContext.scoped(
         tmpdir,
-        tmpdir,
+        localTmpdir,
         this,
         fs,
         timer,
-        null,
+        tmpFileManager,
         theHailClassLoader,
         flags,
         new BackendContext {
           override val executionCache: ExecutionCache =
             ExecutionCache.fromFlags(flags, fs, tmpdir)
         },
+        IrMetadata(None),
       )(f)
     }
 
@@ -476,26 +478,18 @@ class SparkBackend(
   def startProgressBar(): Unit =
     ProgressBarBuilder.build(sc)
 
-  private[this] def executionResultToAnnotation(
-    ctx: ExecuteContext,
-    result: Either[Unit, (PTuple, Long)],
-  ) = result match {
-    case Left(x) => x
-    case Right((pt, off)) => SafeRow(pt, off).get(0)
-  }
-
   def jvmLowerAndExecute(
     ctx: ExecuteContext,
-    timer: ExecutionTimer,
     ir0: IR,
     optimize: Boolean,
     lowerTable: Boolean,
     lowerBM: Boolean,
     print: Option[PrintWriter] = None,
-  ): Any = {
-    val l = _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print)
-    executionResultToAnnotation(ctx, l)
-  }
+  ): Any =
+    _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print) match {
+      case Left(x) => x
+      case Right((pt, off)) => SafeRow(pt, off).get(0)
+    }
 
   private[this] def _jvmLowerAndExecute(
     ctx: ExecuteContext,
@@ -504,22 +498,23 @@ class SparkBackend(
     lowerTable: Boolean,
     lowerBM: Boolean,
     print: Option[PrintWriter] = None,
-  ): Either[Unit, (PTuple, Long)] = {
-    val typesToLower: DArrayLowering.Type = (lowerTable, lowerBM) match {
-      case (true, true) => DArrayLowering.All
-      case (true, false) => DArrayLowering.TableOnly
-      case (false, true) => DArrayLowering.BMOnly
-      case (false, false) => throw new LowererUnsupportedOperation("no lowering enabled")
-    }
-    val ir = LoweringPipeline.darrayLowerer(optimize)(typesToLower).apply(ctx, ir0).asInstanceOf[IR]
+  ): Either[Unit, (PTuple, Long)] =
+    ctx.time {
+      val typesToLower: DArrayLowering.Type = (lowerTable, lowerBM) match {
+        case (true, true) => DArrayLowering.All
+        case (true, false) => DArrayLowering.TableOnly
+        case (false, true) => DArrayLowering.BMOnly
+        case (false, false) => throw new LowererUnsupportedOperation("no lowering enabled")
+      }
+      val ir =
+        LoweringPipeline.darrayLowerer(optimize)(typesToLower).apply(ctx, ir0).asInstanceOf[IR]
 
-    if (!Compilable(ir))
-      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${Pretty(ctx, ir)}")
+      if (!Compilable(ir))
+        throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${Pretty(ctx, ir)}")
 
-    val res = ir.typ match {
-      case TVoid =>
-        val (_, f) = ctx.timer.time("Compile") {
-          Compile[AsmFunction1RegionUnit](
+      ir.typ match {
+        case TVoid =>
+          val (_, f) = Compile[AsmFunction1RegionUnit](
             ctx,
             FastSeq(),
             FastSeq(classInfo[Region]),
@@ -527,99 +522,49 @@ class SparkBackend(
             ir,
             print = print,
           )
-        }
-        ctx.timer.time("Run")(Left(ctx.scopedExecution((hcl, fs, htc, r) =>
-          f(hcl, fs, htc, r).apply(r)
-        )))
 
-      case _ =>
-        val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) = ctx.timer.time("Compile") {
-          Compile[AsmFunction1RegionLong](
-            ctx,
-            FastSeq(),
-            FastSeq(classInfo[Region]),
-            LongInfo,
-            MakeTuple.ordered(FastSeq(ir)),
-            print = print,
-          )
-        }
-        ctx.timer.time("Run")(Right((
-          pt,
-          ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r).apply(r)),
-        )))
-    }
+          Left(ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r)))
+        case _ =>
+          val (Some(PTypeReferenceSingleCodeType(pt: PTuple)), f) =
+            Compile[AsmFunction1RegionLong](
+              ctx,
+              FastSeq(),
+              FastSeq(classInfo[Region]),
+              LongInfo,
+              MakeTuple.ordered(FastSeq(ir)),
+              print = print,
+            )
 
-    res
-  }
-
-  def execute(timer: ExecutionTimer, ir: IR, optimize: Boolean): Any =
-    withExecuteContext(timer) { ctx =>
-      val queryID = Backend.nextID()
-      log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
-      val l = _execute(ctx, ir, optimize)
-      val javaObjResult =
-        ctx.timer.time("convertRegionValueToAnnotation")(executionResultToAnnotation(ctx, l))
-      log.info(s"finished execution of query $queryID")
-      javaObjResult
-    }
-
-  private[this] def _execute(ctx: ExecuteContext, ir: IR, optimize: Boolean)
-    : Either[Unit, (PTuple, Long)] = {
-    TypeCheck(ctx, ir)
-    Validate(ir)
-    ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
-    try {
-      val lowerTable = getFlag("lower") != null
-      val lowerBM = getFlag("lower_bm") != null
-      _jvmLowerAndExecute(ctx, ir, optimize, lowerTable, lowerBM)
-    } catch {
-      case e: LowererUnsupportedOperation if getFlag("lower_only") != null => throw e
-      case _: LowererUnsupportedOperation =>
-        CompileAndEvaluate._apply(ctx, ir, optimize = optimize)
-    }
-  }
-
-  def executeLiteral(irStr: String): Int = {
-    ExecutionTimer.logTime("SparkBackend.executeLiteral") { timer =>
-      withExecuteContext(timer) { ctx =>
-        val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-        val t = ir.typ
-        assert(t.isRealizable)
-        val queryID = Backend.nextID()
-        log.info(s"starting execution of query $queryID} of initial size ${IRSize(ir)}")
-        val retVal = _execute(ctx, ir, true)
-        val literalIR = retVal match {
-          case Left(_) => throw new HailException("Can't create literal")
-          case Right((pt, addr)) =>
-            GetFieldByIdx(EncodedLiteral.fromPTypeAndAddress(pt, addr, ctx), 0)
-        }
-        log.info(s"finished execution of query $queryID")
-        addJavaIR(literalIR)
+          Right((pt, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r))))
       }
     }
-  }
 
-  override def execute(
-    ir: String,
-    timed: Boolean,
-  )(
-    consume: (ExecuteContext, Either[Unit, (PTuple, Long)], String) => Unit
-  ): Unit = {
-    withExecuteContext("SparkBackend.execute") { ctx =>
-      val res = ctx.timer.time("execute") {
-        val irData =
-          IRParser.parse_value_ir(ir, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-        val queryID = Backend.nextID()
-        log.info(s"starting execution of query $queryID of initial size ${IRSize(irData)}")
-        _execute(ctx, irData, true)
+  override def execute(ctx: ExecuteContext, ir: IR): Either[Unit, (PTuple, Long)] =
+    ctx.time {
+      TypeCheck(ctx, ir)
+      Validate(ir)
+      ctx.irMetadata = ctx.irMetadata.copy(semhash = SemanticHash(ctx)(ir))
+      try {
+        val lowerTable = getFlag("lower") != null
+        val lowerBM = getFlag("lower_bm") != null
+        _jvmLowerAndExecute(ctx, ir, optimize = true, lowerTable, lowerBM)
+      } catch {
+        case e: LowererUnsupportedOperation if getFlag("lower_only") != null => throw e
+        case _: LowererUnsupportedOperation =>
+          CompileAndEvaluate._apply(ctx, ir, optimize = true)
       }
-      ctx.timer.finish()
-      val timings = if (timed)
-        Serialization.write(Map("timings" -> ctx.timer.toMap))(new DefaultFormats {})
-      else ""
-      consume(ctx, res, timings)
     }
-  }
+
+  def executeLiteral(irStr: String): Int =
+    withExecuteContext { ctx =>
+      val ir = IRParser.parse_value_ir(irStr, IRParserEnvironment(ctx, persistedIR.toMap))
+      execute(ctx, ir) match {
+        case Left(_) => throw new HailException("Can't create literal")
+        case Right((pt, addr)) =>
+          val field = GetFieldByIdx(EncodedLiteral.fromPTypeAndAddress(pt, addr, ctx), 0)
+          addJavaIR(field)
+      }
+    }
 
   def encodeToBytes(ctx: ExecuteContext, t: PTuple, off: Long, bufferSpecString: String)
     : Array[Byte] = {
@@ -636,35 +581,30 @@ class SparkBackend(
   }
 
   def pyFromDF(df: DataFrame, jKey: java.util.List[String]): (Int, String) = {
-    ExecutionTimer.logTime("SparkBackend.pyFromDF") { timer =>
-      val key = jKey.asScala.toArray.toFastSeq
-      val signature =
-        SparkAnnotationImpex.importType(df.schema).setRequired(true).asInstanceOf[PStruct]
-      withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        val tir = TableLiteral(
-          TableValue(
-            ctx,
-            signature.virtualType.asInstanceOf[TStruct],
-            key,
-            df.rdd,
-            Some(signature),
-          ),
-          ctx.theHailClassLoader,
-        )
-        val id = addJavaIR(tir)
-        (id, JsonMethods.compact(tir.typ.toJSON))
-      }
+    val key = jKey.asScala.toArray.toFastSeq
+    val signature =
+      SparkAnnotationImpex.importType(df.schema).setRequired(true).asInstanceOf[PStruct]
+    withExecuteContext(selfContainedExecution = false) { ctx =>
+      val tir = TableLiteral(
+        TableValue(
+          ctx,
+          signature.virtualType.asInstanceOf[TStruct],
+          key,
+          df.rdd,
+          Some(signature),
+        ),
+        ctx.theHailClassLoader,
+      )
+      val id = addJavaIR(tir)
+      (id, JsonMethods.compact(tir.typ.toJSON))
     }
   }
 
-  def pyToDF(s: String): DataFrame = {
-    ExecutionTimer.logTime("SparkBackend.pyToDF") { timer =>
-      withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        val tir = IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-        Interpret(tir, ctx).toDF()
-      }
+  def pyToDF(s: String): DataFrame =
+    withExecuteContext(selfContainedExecution = false) { ctx =>
+      val tir = IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
+      Interpret(tir, ctx).toDF()
     }
-  }
 
   def pyReadMultipleMatrixTables(jsonQuery: String): java.util.List[MatrixIR] = {
     log.info("pyReadMultipleMatrixTables: got query")
@@ -695,9 +635,7 @@ class SparkBackend(
   def pyRemoveReference(name: String): Unit = removeReference(name)
 
   def pyAddLiftover(name: String, chainFile: String, destRGName: String): Unit =
-    ExecutionTimer.logTime("SparkBackend.pyReferenceAddLiftover") { timer =>
-      withExecuteContext(timer)(ctx => references(name).addLiftover(ctx, chainFile, destRGName))
-    }
+    withExecuteContext(ctx => references(name).addLiftover(ctx, chainFile, destRGName))
 
   def pyRemoveLiftover(name: String, destRGName: String) =
     references(name).removeLiftover(destRGName)
@@ -710,28 +648,23 @@ class SparkBackend(
     yContigs: java.util.List[String],
     mtContigs: java.util.List[String],
     parInput: java.util.List[String],
-  ): String = {
-    ExecutionTimer.logTime("SparkBackend.pyFromFASTAFile") { timer =>
-      withExecuteContext(timer) { ctx =>
-        val rg = ReferenceGenome.fromFASTAFile(
-          ctx,
-          name,
-          fastaFile,
-          indexFile,
-          xContigs.asScala.toArray,
-          yContigs.asScala.toArray,
-          mtContigs.asScala.toArray,
-          parInput.asScala.toArray,
-        )
-        rg.toJSONString
-      }
+  ): String =
+    withExecuteContext { ctx =>
+      val rg = ReferenceGenome.fromFASTAFile(
+        ctx,
+        name,
+        fastaFile,
+        indexFile,
+        xContigs.asScala.toArray,
+        yContigs.asScala.toArray,
+        mtContigs.asScala.toArray,
+        parInput.asScala.toArray,
+      )
+      rg.toJSONString
     }
-  }
 
   def pyAddSequence(name: String, fastaFile: String, indexFile: String): Unit =
-    ExecutionTimer.logTime("SparkBackend.pyAddSequence") { timer =>
-      withExecuteContext(timer)(ctx => references(name).addSequence(ctx, fastaFile, indexFile))
-    }
+    withExecuteContext(ctx => references(name).addSequence(ctx, fastaFile, indexFile))
 
   def pyRemoveSequence(name: String) = references(name).removeSequence()
 
@@ -744,79 +677,64 @@ class SparkBackend(
     exportType: String,
     partitionSize: java.lang.Integer,
     entries: String,
-  ): Unit = {
-    ExecutionTimer.logTime("SparkBackend.pyExportBlockMatrix") { timer =>
-      withExecuteContext(timer) { ctx =>
-        val rm = RowMatrix.readBlockMatrix(fs, pathIn, partitionSize)
-        entries match {
-          case "full" =>
-            rm.export(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
-          case "lower" =>
-            rm.exportLowerTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
-          case "strict_lower" =>
-            rm.exportStrictLowerTriangle(
-              ctx,
-              pathOut,
-              delimiter,
-              Option(header),
-              addIndex,
-              exportType,
-            )
-          case "upper" =>
-            rm.exportUpperTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
-          case "strict_upper" =>
-            rm.exportStrictUpperTriangle(
-              ctx,
-              pathOut,
-              delimiter,
-              Option(header),
-              addIndex,
-              exportType,
-            )
-        }
+  ): Unit =
+    withExecuteContext { ctx =>
+      val rm = RowMatrix.readBlockMatrix(fs, pathIn, partitionSize)
+      entries match {
+        case "full" =>
+          rm.export(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+        case "lower" =>
+          rm.exportLowerTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+        case "strict_lower" =>
+          rm.exportStrictLowerTriangle(
+            ctx,
+            pathOut,
+            delimiter,
+            Option(header),
+            addIndex,
+            exportType,
+          )
+        case "upper" =>
+          rm.exportUpperTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+        case "strict_upper" =>
+          rm.exportStrictUpperTriangle(
+            ctx,
+            pathOut,
+            delimiter,
+            Option(header),
+            addIndex,
+            exportType,
+          )
       }
     }
-  }
 
   def pyFitLinearMixedModel(lmm: LinearMixedModel, pa_t: RowMatrix, a_t: RowMatrix): TableIR =
-    ExecutionTimer.logTime("SparkBackend.pyAddSequence") { timer =>
-      withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        lmm.fit(ctx, pa_t, Option(a_t))
-      }
-    }
+    withExecuteContext(selfContainedExecution = false)(ctx => lmm.fit(ctx, pa_t, Option(a_t)))
 
   def parse_value_ir(s: String, refMap: java.util.Map[String, String]): IR =
-    ExecutionTimer.logTime("SparkBackend.parse_value_ir") { timer =>
-      withExecuteContext(timer) { ctx =>
-        IRParser.parse_value_ir(
-          s,
-          IRParserEnvironment(ctx, irMap = persistedIR.toMap),
-          BindingEnv.eval(refMap.asScala.toMap.map { case (n, t) =>
-            Name(n) -> IRParser.parseType(t)
-          }.toSeq: _*),
-        )
-      }
+    withExecuteContext { ctx =>
+      IRParser.parse_value_ir(
+        s,
+        IRParserEnvironment(ctx, irMap = persistedIR.toMap),
+        BindingEnv.eval(refMap.asScala.toMap.map { case (n, t) =>
+          Name(n) -> IRParser.parseType(t)
+        }.toSeq: _*),
+      )
     }
 
   def parse_table_ir(s: String): TableIR =
-    ExecutionTimer.logTime("SparkBackend.parse_table_ir") { timer =>
-      withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-      }
+    withExecuteContext(selfContainedExecution = false) { ctx =>
+      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
     }
 
   def parse_matrix_ir(s: String): MatrixIR =
-    ExecutionTimer.logTime("SparkBackend.parse_matrix_ir") { timer =>
-      withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-      }
+    withExecuteContext(selfContainedExecution = false) { ctx =>
+      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
     }
 
   def parse_blockmatrix_ir(s: String): BlockMatrixIR =
-    ExecutionTimer.logTime("SparkBackend.parse_blockmatrix_ir") { timer =>
-      withExecuteContext(timer, selfContainedExecution = false) { ctx =>
-        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
-      }
+    withExecuteContext(selfContainedExecution = false) { ctx =>
+      IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, irMap = persistedIR.toMap))
     }
 
   override def lowerDistributedSort(
@@ -858,7 +776,7 @@ class SparkBackend(
   }
 
   def close(): Unit =
-    longLifeTempFileManager.cleanup()
+    longLifeTempFileManager.close()
 
   def tableToTableStage(ctx: ExecuteContext, inputIR: TableIR, analyses: LoweringAnalyses)
     : TableStage = {

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -43,7 +43,7 @@ object CompileAndEvaluate {
     optimize: Boolean = true,
   ): Either[Unit, (PTuple, Long)] =
     ctx.time {
-      val ir = LoweringPipeline.relationalLowerer(optimize).apply(ctx, ir0).asInstanceOf[IR]
+      val ir = LoweringPipeline.relationalLowerer(optimize)(ctx, ir0).asInstanceOf[IR]
 
       ir.typ match {
         case TVoid =>

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -57,7 +57,12 @@ object CompileAndEvaluate {
             optimize = optimize,
           )
 
-          Left(ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r)))
+          val unit: Unit = ctx.scopedExecution { (hcl, fs, htc, r) =>
+            val execute = f(hcl, fs, htc, r)
+            ctx.time(execute(r))
+          }
+
+          Left(unit)
 
         case _ =>
           val (Some(PTypeReferenceSingleCodeType(resType: PTuple)), f) =
@@ -71,7 +76,12 @@ object CompileAndEvaluate {
               optimize = optimize,
             )
 
-          Right((resType, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r))))
+          val res = ctx.scopedExecution { (hcl, fs, htc, r) =>
+            val execute = f(hcl, fs, htc, r)
+            ctx.time(execute(r))
+          }
+
+          Right((resType, res))
       }
     }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.Row
 
 object CompileAndEvaluate {
   def apply[T](ctx: ExecuteContext, ir0: IR, optimize: Boolean = true): T = {
-    ctx.timer.time("CompileAndEvaluate") {
+    ctx.time {
       _apply(ctx, ir0, optimize) match {
         case Left(()) => ().asInstanceOf[T]
         case Right((t, off)) => SafeRow(t, off).getAs[T](0)
@@ -41,46 +41,37 @@ object CompileAndEvaluate {
     ctx: ExecuteContext,
     ir0: IR,
     optimize: Boolean = true,
-  ): Either[Unit, (PTuple, Long)] = {
-    val ir = LoweringPipeline.relationalLowerer(optimize).apply(ctx, ir0).asInstanceOf[IR]
+  ): Either[Unit, (PTuple, Long)] =
+    ctx.time {
+      val ir = LoweringPipeline.relationalLowerer(optimize).apply(ctx, ir0).asInstanceOf[IR]
 
-    if (ir.typ == TVoid) {
-      val (_, f) = ctx.timer.time("Compile")(Compile[AsmFunction1RegionUnit](
-        ctx,
-        FastSeq(),
-        FastSeq(classInfo[Region]),
-        UnitInfo,
-        ir,
-        print = None,
-        optimize = optimize,
-      ))
+      ir.typ match {
+        case TVoid =>
+          val (_, f) = Compile[AsmFunction1RegionUnit](
+            ctx,
+            FastSeq(),
+            FastSeq(classInfo[Region]),
+            UnitInfo,
+            ir,
+            print = None,
+            optimize = optimize,
+          )
 
-      ctx.scopedExecution { (hcl, fs, htc, r) =>
-        val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(hcl, fs, htc, r))
-        ctx.timer.time("RunCompiledVoidFunction")(fRunnable(r))
+          Left(ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r)))
+
+        case _ =>
+          val (Some(PTypeReferenceSingleCodeType(resType: PTuple)), f) =
+            Compile[AsmFunction1RegionLong](
+              ctx,
+              FastSeq(),
+              FastSeq(classInfo[Region]),
+              LongInfo,
+              MakeTuple.ordered(FastSeq(ir)),
+              print = None,
+              optimize = optimize,
+            )
+
+          Right((resType, ctx.scopedExecution((hcl, fs, htc, r) => f(hcl, fs, htc, r)(r))))
       }
-      return Left(())
     }
-
-    val (Some(PTypeReferenceSingleCodeType(resType: PTuple)), f) =
-      ctx.timer.time("Compile")(Compile[AsmFunction1RegionLong](
-        ctx,
-        FastSeq(),
-        FastSeq(classInfo[Region]),
-        LongInfo,
-        MakeTuple.ordered(FastSeq(ir)),
-        print = None,
-        optimize = optimize,
-      ))
-
-    val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(
-      ctx.theHailClassLoader,
-      ctx.fs,
-      ctx.taskContext,
-      ctx.r,
-    ))
-    val resultAddress = ctx.timer.time("RunCompiledFunction")(fRunnable(ctx.r))
-
-    Right((resType, resultAddress))
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -29,8 +29,6 @@ import scala.language.existentials
 
 import java.io._
 
-import sourcecode.Enclosing
-
 // class for holding all information computed ahead-of-time that we need in the emitter
 object EmitContext {
   def analyze(ctx: ExecuteContext, ir: IR, pTypeEnv: Env[PType] = Env.empty): EmitContext = {
@@ -58,10 +56,7 @@ case class EmitContext(
   methodSplits: Memo[Unit],
   inLoopCriticalPath: Memo[Unit],
   tryingToSplit: Memo[Unit],
-) {
-  def time[A](block: => A)(implicit E: Enclosing): A =
-    executeContext.time(block)
-}
+)
 
 case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[EmitValue]) {
   def bind(name: Name, v: EmitValue): EmitEnv = copy(bindings = bindings.bind(name, v))
@@ -106,7 +101,7 @@ object Emit {
     nParams: Int,
     aggs: Option[Array[AggStateSig]] = None,
   ): Option[SingleCodeType] =
-    ctx.time {
+    ctx.executeContext.time {
       TypeCheck(ctx.executeContext, ir)
 
       val mb = fb.apply_method

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -29,10 +29,12 @@ import scala.language.existentials
 
 import java.io._
 
+import sourcecode.Enclosing
+
 // class for holding all information computed ahead-of-time that we need in the emitter
 object EmitContext {
   def analyze(ctx: ExecuteContext, ir: IR, pTypeEnv: Env[PType] = Env.empty): EmitContext = {
-    ctx.timer.time("EmitContext.analyze") {
+    ctx.time {
       val usesAndDefs = ComputeUsesAndDefs(ir, errorIfFreeVariables = false)
       val requiredness = Requiredness(ir, usesAndDefs, ctx, pTypeEnv)
       val inLoopCriticalPath = ControlFlowPreventsSplit(ir, ParentPointers(ir), usesAndDefs)
@@ -49,14 +51,17 @@ object EmitContext {
   }
 }
 
-class EmitContext(
-  val executeContext: ExecuteContext,
-  val req: RequirednessAnalysis,
-  val usesAndDefs: UsesAndDefs,
-  val methodSplits: Memo[Unit],
-  val inLoopCriticalPath: Memo[Unit],
-  val tryingToSplit: Memo[Unit],
-)
+case class EmitContext(
+  executeContext: ExecuteContext,
+  req: RequirednessAnalysis,
+  usesAndDefs: UsesAndDefs,
+  methodSplits: Memo[Unit],
+  inLoopCriticalPath: Memo[Unit],
+  tryingToSplit: Memo[Unit],
+) {
+  def time[A](block: => A)(implicit E: Enclosing): A =
+    executeContext.time(block)
+}
 
 case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[EmitValue]) {
   def bind(name: Name, v: EmitValue): EmitEnv = copy(bindings = bindings.bind(name, v))
@@ -100,46 +105,47 @@ object Emit {
     rti: TypeInfo[_],
     nParams: Int,
     aggs: Option[Array[AggStateSig]] = None,
-  ): Option[SingleCodeType] = {
-    TypeCheck(ctx.executeContext, ir)
+  ): Option[SingleCodeType] =
+    ctx.time {
+      TypeCheck(ctx.executeContext, ir)
 
-    val mb = fb.apply_method
-    val container = aggs.map { a =>
-      val c = fb.addAggStates(a)
-      AggContainer(a, c, () => ())
-    }
-    val emitter = new Emit[C](ctx, fb.ecb)
-    val region = mb.getCodeParam[Region](1)
-    val returnTypeOption: Option[SingleCodeType] = if (ir.typ == TVoid) {
-      fb.apply_method.voidWithBuilder { cb =>
-        val env = EmitEnv(
-          Env.empty,
-          (0 until nParams).map(i => mb.storeEmitParamAsField(cb, i + 2)),
-        ) // this, region, ...
-        emitter.emitVoid(cb, ir, region, env, container, None)
+      val mb = fb.apply_method
+      val container = aggs.map { a =>
+        val c = fb.addAggStates(a)
+        AggContainer(a, c, () => ())
       }
-      None
-    } else {
-      var sct: SingleCodeType = null
-      fb.emitWithBuilder { cb =>
-        val env = EmitEnv(
-          Env.empty,
-          (0 until nParams).map(i => mb.storeEmitParamAsField(cb, i + 2)),
-        ) // this, region, ...
-        val sc = emitter.emitI(ir, cb, region, env, container, None).handle(
-          cb,
-          cb._throw(Code.newInstance[RuntimeException, String]("cannot return empty")),
-        )
+      val emitter = new Emit[C](ctx, fb.ecb)
+      val region = mb.getCodeParam[Region](1)
+      val returnTypeOption: Option[SingleCodeType] = if (ir.typ == TVoid) {
+        fb.apply_method.voidWithBuilder { cb =>
+          val env = EmitEnv(
+            Env.empty,
+            (0 until nParams).map(i => mb.storeEmitParamAsField(cb, i + 2)),
+          ) // this, region, ...
+          emitter.emitVoid(cb, ir, region, env, container, None)
+        }
+        None
+      } else {
+        var sct: SingleCodeType = null
+        fb.emitWithBuilder { cb =>
+          val env = EmitEnv(
+            Env.empty,
+            (0 until nParams).map(i => mb.storeEmitParamAsField(cb, i + 2)),
+          ) // this, region, ...
+          val sc = emitter.emitI(ir, cb, region, env, container, None).handle(
+            cb,
+            cb._throw(Code.newInstance[RuntimeException, String]("cannot return empty")),
+          )
 
-        val scp = SingleCodeSCode.fromSCode(cb, sc, region)
-        assert(scp.typ.ti == rti, s"type info mismatch: expect $rti, got ${scp.typ.ti}")
-        sct = scp.typ
-        scp.code
+          val scp = SingleCodeSCode.fromSCode(cb, sc, region)
+          assert(scp.typ.ti == rti, s"type info mismatch: expect $rti, got ${scp.typ.ti}")
+          sct = scp.typ
+          scp.code
+        }
+        Some(sct)
       }
-      Some(sct)
+      returnTypeOption
     }
-    returnTypeOption
-  }
 }
 
 object AggContainer {

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -6,7 +6,7 @@ import is.hail.utils.HailException
 
 object FoldConstants {
   def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR =
-    ExecuteContext.scopedNewRegion(ctx)(ctx => foldConstants(ctx, ir))
+    ctx.r.pool.scopedRegion(region => ctx.local(r = region)(foldConstants(_, ir)))
 
   private def foldConstants(ctx: ExecuteContext, ir: BaseIR): BaseIR =
     RewriteBottomUp(

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -958,7 +958,7 @@ object Interpret {
 
           // TODO Is this right? where does wrapped run?
           ctx.scopedExecution((hcl, fs, htc, r) =>
-            SafeRow(rt, f(hcl, fs, htc, r).apply(r, globalsOffset))
+            SafeRow(rt, f(hcl, fs, htc, r)(r, globalsOffset))
           )
         } else {
           val spec = BufferSpec.blockedUncompressed

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -2156,12 +2156,13 @@ object IRParser {
     s: String,
     env: IRParserEnvironment,
     typeEnv: BindingEnv[Type] = BindingEnv.empty,
-  ): IR = {
-    var ir = parse(s, ir_value_expr(env)(_).run())
-    ir = annotateTypes(env.ctx, ir, typeEnv).asInstanceOf[IR]
-    TypeCheck(env.ctx, ir, typeEnv)
-    ir
-  }
+  ): IR =
+    env.ctx.time {
+      var ir = parse(s, ir_value_expr(env)(_).run())
+      ir = annotateTypes(env.ctx, ir, typeEnv).asInstanceOf[IR]
+      TypeCheck(env.ctx, ir, typeEnv)
+      ir
+    }
 
   def parse_value_ir(ctx: ExecuteContext, s: String): IR =
     parse_value_ir(s, IRParserEnvironment(ctx))
@@ -2169,29 +2170,32 @@ object IRParser {
   def parse_table_ir(ctx: ExecuteContext, s: String): TableIR =
     parse_table_ir(s, IRParserEnvironment(ctx))
 
-  def parse_table_ir(s: String, env: IRParserEnvironment): TableIR = {
-    var ir = parse(s, table_ir(env)(_).run())
-    ir = annotateTypes(env.ctx, ir, BindingEnv.empty).asInstanceOf[TableIR]
-    TypeCheck(env.ctx, ir)
-    ir
-  }
+  def parse_table_ir(s: String, env: IRParserEnvironment): TableIR =
+    env.ctx.time {
+      var ir = parse(s, table_ir(env)(_).run())
+      ir = annotateTypes(env.ctx, ir, BindingEnv.empty).asInstanceOf[TableIR]
+      TypeCheck(env.ctx, ir)
+      ir
+    }
 
-  def parse_matrix_ir(s: String, env: IRParserEnvironment): MatrixIR = {
-    var ir = parse(s, matrix_ir(env)(_).run())
-    ir = annotateTypes(env.ctx, ir, BindingEnv.empty).asInstanceOf[MatrixIR]
-    TypeCheck(env.ctx, ir)
-    ir
-  }
+  def parse_matrix_ir(s: String, env: IRParserEnvironment): MatrixIR =
+    env.ctx.time {
+      var ir = parse(s, matrix_ir(env)(_).run())
+      ir = annotateTypes(env.ctx, ir, BindingEnv.empty).asInstanceOf[MatrixIR]
+      TypeCheck(env.ctx, ir)
+      ir
+    }
 
   def parse_matrix_ir(ctx: ExecuteContext, s: String): MatrixIR =
     parse_matrix_ir(s, IRParserEnvironment(ctx))
 
-  def parse_blockmatrix_ir(s: String, env: IRParserEnvironment): BlockMatrixIR = {
-    var ir = parse(s, blockmatrix_ir(env)(_).run())
-    ir = annotateTypes(env.ctx, ir, BindingEnv.empty).asInstanceOf[BlockMatrixIR]
-    TypeCheck(env.ctx, ir)
-    ir
-  }
+  def parse_blockmatrix_ir(s: String, env: IRParserEnvironment): BlockMatrixIR =
+    env.ctx.time {
+      var ir = parse(s, blockmatrix_ir(env)(_).run())
+      ir = annotateTypes(env.ctx, ir, BindingEnv.empty).asInstanceOf[BlockMatrixIR]
+      TypeCheck(env.ctx, ir)
+      ir
+    }
 
   def parse_blockmatrix_ir(ctx: ExecuteContext, s: String): BlockMatrixIR =
     parse_blockmatrix_ir(s, IRParserEnvironment(ctx))

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -14,14 +14,16 @@ object TypeCheck {
     apply(ctx, ir, BindingEnv.empty)
 
   def apply(ctx: ExecuteContext, ir: BaseIR, env: BindingEnv[Type]): Unit =
-    try
-      check(ctx, ir, env).run()
-    catch {
-      case e: Throwable =>
-        fatal(
-          s"Error while typechecking IR:\n${Pretty(ctx, ir, preserveNames = true, allowUnboundRefs = true)}",
-          e,
-        )
+    ctx.time {
+      try
+        check(ctx, ir, env).run()
+      catch {
+        case e: Throwable =>
+          fatal(
+            s"Error while typechecking IR:\n${Pretty(ctx, ir, preserveNames = true, allowUnboundRefs = true)}",
+            e,
+          )
+      }
     }
 
   def check(ctx: ExecuteContext, ir: BaseIR, env: BindingEnv[Type]): StackFrame[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -26,23 +26,22 @@ trait LoweringPass {
   val after: IRState
   val context: String
 
-  final def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR = {
+  final def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR =
     ctx.timer.time(context) {
       ctx.timer.time("Verify")(before.verify(ir))
       val result = ctx.timer.time("Transform")(transform(ctx, ir))
       ctx.timer.time("Verify")(after.verify(result))
       result
     }
-  }
 
   protected def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR
 }
 
 case class OptimizePass(_context: String) extends LoweringPass {
-  val context = s"Optimize: ${_context}"
-  val before: IRState = AnyIR
-  val after: IRState = AnyIR
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = Optimize(ctx, ir)
+  override val context = s"Optimize: ${_context}"
+  override val before: IRState = AnyIR
+  override val after: IRState = AnyIR
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = Optimize(ctx, ir)
 }
 
 case object LowerMatrixToTablePass extends LoweringPass {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -29,9 +29,8 @@ trait LoweringPass {
   final def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR = {
     ctx.timer.time(context) {
       ctx.timer.time("Verify")(before.verify(ir))
-      val result = ctx.timer.time("LoweringTransformation")(transform(ctx: ExecuteContext, ir))
+      val result = ctx.timer.time("Transform")(transform(ctx, ir))
       ctx.timer.time("Verify")(after.verify(result))
-
       result
     }
   }
@@ -40,10 +39,10 @@ trait LoweringPass {
 }
 
 case class OptimizePass(_context: String) extends LoweringPass {
-  val context = s"optimize: ${_context}"
+  val context = s"Optimize: ${_context}"
   val before: IRState = AnyIR
   val after: IRState = AnyIR
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = Optimize(ir, context, ctx)
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = Optimize(ctx, ir)
 }
 
 case object LowerMatrixToTablePass extends LoweringPass {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -6,9 +6,11 @@ import is.hail.expr.ir.agg.Extract
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.utils._
 
-final case class IrMetadata(semhash: Option[SemanticHash.Type]) {
+final class IrMetadata() {
   private[this] var hashCounter: Int = 0
   private[this] var markCounter: Int = 0
+
+  var semhash: Option[SemanticHash.Type] = None
 
   def nextHash: Option[SemanticHash.Type] = {
     hashCounter += 1

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -144,762 +144,639 @@ object EmitStream {
     outerRegion: Value[Region],
     env: EmitEnv,
     container: Option[AggContainer],
-  ): IEmitCode = {
+  ): IEmitCode =
+    emitter.ctx.time {
 
-    @nowarn("cat=unused-locals&msg=local default argument")
-    def emitVoid(
-      ir: IR,
-      cb: EmitCodeBuilder,
-      region: Value[Region] = outerRegion,
-      env: EmitEnv = env,
-      container: Option[AggContainer] = container,
-    ): Unit =
-      emitter.emitVoid(cb, ir, region, env, container, None)
+      @nowarn("cat=unused-locals&msg=local default argument")
+      def emitVoid(
+        ir: IR,
+        cb: EmitCodeBuilder,
+        region: Value[Region] = outerRegion,
+        env: EmitEnv = env,
+        container: Option[AggContainer] = container,
+      ): Unit =
+        emitter.emitVoid(cb, ir, region, env, container, None)
 
-    def emit(
-      ir: IR,
-      cb: EmitCodeBuilder,
-      region: Value[Region] = outerRegion,
-      env: EmitEnv = env,
-      container: Option[AggContainer] = container,
-    ): IEmitCode =
-      ir.typ match {
-        case _: TStream => produce(ir, cb, cb.emb, region, env, container)
-        case _ => emitter.emitI(ir, cb, region, env, container, None)
-      }
-
-    // returns IEmitCode of SStreamConcrete
-    def produceIterator(
-      streamIR: IR,
-      elementPType: PType,
-      cb: EmitCodeBuilder,
-      env: EmitEnv,
-    ): IEmitCode = {
-      val ecb = cb.emb.genEmitClass[NoBoxLongIterator]("stream_to_iter")
-      ecb.cb.addInterface(typeInfo[MissingnessAsMethod].iname)
-
-      val fv = FreeVariables(streamIR, false, false).eval
-      val (envParamTypes, envParams, restoreEnv) = env.asParams(fv)
-
-      val isMissing = ecb.genFieldThisRef[Boolean]("isMissing")
-      val eosField = ecb.genFieldThisRef[Boolean]("eos")
-      val outerRegionField = ecb.genFieldThisRef[Region]("outer")
-
-      ecb.makeAddPartitionRegion()
-
-      var producer: StreamProducer = null
-      var producerRequired: Boolean = false
-
-      val next = ecb.newEmitMethod("next", FastSeq[ParamType](), LongInfo)
-      val ctor = ecb.newEmitMethod(
-        "<init>",
-        FastSeq[ParamType](typeInfo[Region], arrayInfo[Long]) ++ envParamTypes,
-        UnitInfo,
-      )
-      ctor.voidWithBuilder { cb =>
-        val L = new lir.Block()
-        L.append(
-          lir.methodStmt(
-            INVOKESPECIAL,
-            "java/lang/Object",
-            "<init>",
-            "()V",
-            false,
-            UnitInfo,
-            FastSeq(lir.load(ctor.mb.this_.asInstanceOf[LocalRef[_]].l)),
-          )
-        )
-        cb += new VCode(L, L, null)
-
-        val newEnv = restoreEnv(cb, 3)
-        val s = EmitStream.produce(
-          new Emit(emitter.ctx, ecb),
-          streamIR,
-          cb,
-          next,
-          outerRegionField,
-          newEnv,
-          None,
-        )
-        producerRequired = s.required
-        s.consume(
-          cb,
-          if (!producerRequired) cb.assign(isMissing, true),
-          { stream =>
-            if (!producerRequired) cb.assign(isMissing, false)
-            producer = stream.asStream.getProducer(next)
-          },
-        )
-
-        val self =
-          cb.memoize(Code.checkcast[FunctionWithPartitionRegion]((ctor.getCodeParam(0)(ecb.cb.ti))))
-
-        ecb.setLiteralsArray(cb, ctor.getCodeParam[Array[Long]](2))
-        val partitionRegion = cb.memoize(ctor.getCodeParam[Region](1))
-        cb += self.invoke[Region, Unit]("addPartitionRegion", partitionRegion)
-        cb += self.invoke[RegionPool, Unit]("setPool", partitionRegion.getPool())
-      }
-
-      next.emitWithBuilder { cb =>
-        val ret = cb.newLocal[Long]("ret")
-        val Lret = CodeLabel()
-        cb.goto(producer.LproduceElement)
-        cb.define(producer.LproduceElementDone)
-        producer.element.toI(cb)
-          .consume(
-            cb,
-            cb.assign(ret, 0L),
-            value => cb.assign(ret, elementPType.store(cb, producer.elementRegion, value, false)),
-          )
-        cb.goto(Lret)
-        cb.define(producer.LendOfStream)
-        cb.assign(eosField, true)
-
-        cb.define(Lret)
-        ret
-      }
-
-      val init =
-        ecb.newEmitMethod("init", FastSeq[ParamType](typeInfo[Region], typeInfo[Region]), UnitInfo)
-      init.voidWithBuilder { cb =>
-        val outerRegion = init.getCodeParam[Region](1)
-        val eltRegion = init.getCodeParam[Region](2)
-
-        cb.assign(producer.elementRegion, eltRegion)
-        cb.assign(outerRegionField, outerRegion)
-        producer.initialize(cb, outerRegion)
-        cb.assign(eosField, false)
-      }
-
-      val isEOS = ecb.newEmitMethod("eos", FastSeq[ParamType](), BooleanInfo)
-      isEOS.emitWithBuilder[Boolean](cb => eosField)
-
-      val isMissingMethod = ecb.newEmitMethod("isMissing", FastSeq[ParamType](), BooleanInfo)
-      isMissingMethod.emitWithBuilder[Boolean](cb => isMissing)
-
-      val close = ecb.newEmitMethod("close", FastSeq[ParamType](), UnitInfo)
-      close.voidWithBuilder(cb => producer.close(cb))
-
-      val obj = cb.memoize(Code.newInstance(
-        ecb.cb,
-        ctor.mb,
-        FastSeq(cb.emb.partitionRegion.get, cb.emb.ecb.literalsArray().get) ++ envParams.map(_.get),
-      ))
-
-      val iter = cb.emb.genFieldThisRef[NoBoxLongIterator]("iter")
-      cb.assign(iter, Code.checkcast[NoBoxLongIterator](obj))
-      IEmitCode(
-        cb,
-        if (producerRequired) false
-        else Code.checkcast[MissingnessAsMethod](obj).invoke[Boolean]("isMissing"),
-        new SStreamConcrete(
-          SStreamIteratorLong(
-            producer.element.required,
-            elementPType,
-            producer.requiresMemoryManagementPerElement,
-          ),
-          iter,
-        ),
-      )
-    }
-
-    def produce(
-      streamIR: IR,
-      cb: EmitCodeBuilder,
-      mb: EmitMethodBuilder[_] = mb,
-      region: Value[Region] = outerRegion,
-      env: EmitEnv = env,
-      container: Option[AggContainer] = container,
-    ): IEmitCode =
-      EmitStream.produce(emitter, streamIR, cb, mb, region, env, container)
-
-    def typeWithReqx(node: IR): VirtualTypeWithReq =
-      VirtualTypeWithReq(node.typ, emitter.ctx.req.lookup(node).asInstanceOf[TypeWithRequiredness])
-    def typeWithReq: VirtualTypeWithReq = typeWithReqx(streamIR)
-
-    streamIR match {
-
-      case NA(_typ: TStream) =>
-        val st = SStream(EmitType(SUnreachable.fromVirtualType(_typ.elementType), true))
-        val region = mb.genFieldThisRef[Region]("na_region")
-        val producer = new StreamProducer {
-          override def method: EmitMethodBuilder[_] = mb
-          override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {}
-
-          override val length: Option[EmitCodeBuilder => Code[Int]] =
-            Some(_ => Code._fatal[Int]("tried to get NA stream length"))
-          override val elementRegion: Settable[Region] = region
-          override val requiresMemoryManagementPerElement: Boolean = false
-          override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-            cb.goto(LendOfStream)
-          }
-          override val element: EmitCode = EmitCode.present(mb, st.elementType.defaultValue)
-
-          override def close(cb: EmitCodeBuilder): Unit = {}
-        }
-        IEmitCode.missing(cb, SStreamValue(producer))
-
-      case Ref(name, _typ) =>
-        assert(_typ.isInstanceOf[TStream])
-        env.bindings.lookup(name).toI(cb)
-          .map(cb) { case stream: SStreamValue =>
-            val childProducer = stream.getProducer(mb)
-            val producer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
-                childProducer.initialize(cb, outerRegion)
-
-              override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
-              override val elementRegion: Settable[Region] = childProducer.elementRegion
-              override val requiresMemoryManagementPerElement: Boolean =
-                childProducer.requiresMemoryManagementPerElement
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.goto(childProducer.LproduceElement)
-                cb.define(childProducer.LproduceElementDone)
-                cb.goto(LproduceElementDone)
-              }
-              override val element: EmitCode = childProducer.element
-
-              override def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
-            }
-            mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-            SStreamValue(producer)
-          }
-
-      case let: Block =>
-        val newEnv = emitter.emitBlock(let, cb, env, outerRegion, container, None)
-        produce(let.body, cb, env = newEnv)
-
-      case In(n, _) =>
-        // this, Code[Region], ...
-        val param = env.inputValues(n).toI(cb)
-        if (!param.st.isInstanceOf[SStream])
-          throw new RuntimeException(
-            s"parameter ${2 + n} is not a stream! t=${param.st} }, params=${mb.emitParamTypes}"
-          )
-        param
-
-      case ToStream(a, _requiresMemoryManagementPerElement) =>
-        emit(a, cb).map(cb) { case _ind: SIndexableValue =>
-          val containerField = cb.memoizeField(_ind, "indexable").asIndexable
-          val container = containerField.asInstanceOf[SIndexableValue]
-          val idx = mb.genFieldThisRef[Int]("tostream_idx")
-          val regionVar = mb.genFieldThisRef[Region]("tostream_region")
-
-          SStreamValue(
-            new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
-                cb.assign(idx, -1)
-
-              override val length: Option[EmitCodeBuilder => Code[Int]] =
-                Some(_ => container.loadLength())
-
-              override val elementRegion: Settable[Region] = regionVar
-
-              override val requiresMemoryManagementPerElement: Boolean =
-                _requiresMemoryManagementPerElement
-
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.assign(idx, idx + 1)
-                cb.if_(idx >= container.loadLength(), cb.goto(LendOfStream))
-                cb.goto(LproduceElementDone)
-              }
-
-              val element: EmitCode = EmitCode.fromI(mb)(cb => container.loadElement(cb, idx))
-
-              def close(cb: EmitCodeBuilder): Unit = {}
-            }
-          )
-
+      def emit(
+        ir: IR,
+        cb: EmitCodeBuilder,
+        region: Value[Region] = outerRegion,
+        env: EmitEnv = env,
+        container: Option[AggContainer] = container,
+      ): IEmitCode =
+        ir.typ match {
+          case _: TStream => produce(ir, cb, cb.emb, region, env, container)
+          case _ => emitter.emitI(ir, cb, region, env, container, None)
         }
 
-      case x @ StreamBufferedAggregate(
-            streamChild,
-            initAggs,
-            newKey,
-            seqOps,
-            name,
-            aggSignatures: IndexedSeq[PhysicalAggSig],
-            bufferSize: Int,
-          ) =>
-        val region = mb.genFieldThisRef[Region]("stream_buff_agg_region")
-        produce(streamChild, cb)
-          .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.getProducer(mb)
-            val eltField = mb.newEmitField("stream_buff_agg_elt", childProducer.element.emitType)
-            val newKeyVType = typeWithReqx(newKey)
-            val kb = mb.ecb
-            val nestedStates = aggSignatures.toArray.map(sig => AggStateSig.getState(sig.state, kb))
-            val nested = StateTuple(nestedStates)
-            val dictState = new DictState(kb, newKeyVType, nested)
-            val maxSize = mb.genFieldThisRef[Int]("stream_buff_agg_max_size")
-            val nodeArray = mb.genFieldThisRef[Array[Long]]("stream_buff_agg_element_array")
-            val idx = mb.genFieldThisRef[Int]("stream_buff_agg_idx")
-            val returnStreamType = x.typ.asInstanceOf[TStream]
-            val returnElemType = returnStreamType.elementType
-            val tupleFieldTypes = aggSignatures.map(_ => TBinary)
-            val tupleFields = (0 to tupleFieldTypes.length).zip(tupleFieldTypes).map {
-              case (fieldIdx, fieldType) => TupleField(fieldIdx, fieldType)
-            }
-            val serializedAggSType = SStackStruct(
-              TTuple(tupleFields),
-              tupleFieldTypes.map(_ =>
-                EmitType(SBinaryPointer(PCanonicalBinary()), true)
-              ).toIndexedSeq,
+      // returns IEmitCode of SStreamConcrete
+      def produceIterator(
+        streamIR: IR,
+        elementPType: PType,
+        cb: EmitCodeBuilder,
+        env: EmitEnv,
+      ): IEmitCode = {
+        val ecb = cb.emb.genEmitClass[NoBoxLongIterator]("stream_to_iter")
+        ecb.cb.addInterface(typeInfo[MissingnessAsMethod].iname)
+
+        val fv = FreeVariables(streamIR, false, false).eval
+        val (envParamTypes, envParams, restoreEnv) = env.asParams(fv)
+
+        val isMissing = ecb.genFieldThisRef[Boolean]("isMissing")
+        val eosField = ecb.genFieldThisRef[Boolean]("eos")
+        val outerRegionField = ecb.genFieldThisRef[Region]("outer")
+
+        ecb.makeAddPartitionRegion()
+
+        var producer: StreamProducer = null
+        var producerRequired: Boolean = false
+
+        val next = ecb.newEmitMethod("next", FastSeq[ParamType](), LongInfo)
+        val ctor = ecb.newEmitMethod(
+          "<init>",
+          FastSeq[ParamType](typeInfo[Region], arrayInfo[Long]) ++ envParamTypes,
+          UnitInfo,
+        )
+        ctor.voidWithBuilder { cb =>
+          val L = new lir.Block()
+          L.append(
+            lir.methodStmt(
+              INVOKESPECIAL,
+              "java/lang/Object",
+              "<init>",
+              "()V",
+              false,
+              UnitInfo,
+              FastSeq(lir.load(ctor.mb.this_.asInstanceOf[LocalRef[_]].l)),
             )
-            val keyAndAggFields = newKeyVType.canonicalPType.asInstanceOf[
-              PCanonicalStruct
-            ].sType.fieldEmitTypes :+ EmitType(serializedAggSType, true)
-            val returnElemSType =
-              SStackStruct(returnElemType.asInstanceOf[TBaseStruct], keyAndAggFields)
-            val newStreamElem =
-              mb.newEmitField("stream_buff_agg_new_stream_elem", EmitType(returnElemSType, true))
-            val numElemInArray = mb.genFieldThisRef[Int]("stream_buff_agg_num_elem_in_size")
-            val childStreamEnded = mb.genFieldThisRef[Boolean]("stream_buff_agg_child_stream_ended")
-            val produceElementMode =
-              mb.genFieldThisRef[Boolean]("stream_buff_agg_child_produce_elt_mode")
-            val producer: StreamProducer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = None
+          )
+          cb += new VCode(L, L, null)
 
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                if (childProducer.requiresMemoryManagementPerElement)
-                  cb.assign(
-                    childProducer.elementRegion,
-                    Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
-                  )
-                else
-                  cb.assign(childProducer.elementRegion, region)
+          val newEnv = restoreEnv(cb, 3)
+          val s = EmitStream.produce(
+            new Emit(emitter.ctx, ecb),
+            streamIR,
+            cb,
+            next,
+            outerRegionField,
+            newEnv,
+            None,
+          )
+          producerRequired = s.required
+          s.consume(
+            cb,
+            if (!producerRequired) cb.assign(isMissing, true),
+            { stream =>
+              if (!producerRequired) cb.assign(isMissing, false)
+              producer = stream.asStream.getProducer(next)
+            },
+          )
 
-                childProducer.initialize(cb, outerRegion)
-                cb.assign(childStreamEnded, false)
-                cb.assign(produceElementMode, false)
-                cb.assign(idx, 0)
-                cb.assign(maxSize, bufferSize)
-                cb.assign(nodeArray, Code.newArray[Long](maxSize))
-                cb.assign(numElemInArray, 0)
-                dictState.createState(cb)
-              }
+          val self =
+            cb.memoize(
+              Code.checkcast[FunctionWithPartitionRegion]((ctor.getCodeParam(0)(ecb.cb.ti)))
+            )
 
-              override val elementRegion: Settable[Region] = region
+          ecb.setLiteralsArray(cb, ctor.getCodeParam[Array[Long]](2))
+          val partitionRegion = cb.memoize(ctor.getCodeParam[Region](1))
+          cb += self.invoke[Region, Unit]("addPartitionRegion", partitionRegion)
+          cb += self.invoke[RegionPool, Unit]("setPool", partitionRegion.getPool())
+        }
 
-              override val requiresMemoryManagementPerElement: Boolean =
-                childProducer.requiresMemoryManagementPerElement
+        next.emitWithBuilder { cb =>
+          val ret = cb.newLocal[Long]("ret")
+          val Lret = CodeLabel()
+          cb.goto(producer.LproduceElement)
+          cb.define(producer.LproduceElementDone)
+          producer.element.toI(cb)
+            .consume(
+              cb,
+              cb.assign(ret, 0L),
+              value => cb.assign(ret, elementPType.store(cb, producer.elementRegion, value, false)),
+            )
+          cb.goto(Lret)
+          cb.define(producer.LendOfStream)
+          cb.assign(eosField, true)
 
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                val elementProduceLabel = CodeLabel()
-                val getElemLabel = CodeLabel()
-                val startLabel = CodeLabel()
+          cb.define(Lret)
+          ret
+        }
 
-                cb.define(startLabel)
-                cb.if_(produceElementMode, cb.goto(elementProduceLabel))
+        val init =
+          ecb.newEmitMethod(
+            "init",
+            FastSeq[ParamType](typeInfo[Region], typeInfo[Region]),
+            UnitInfo,
+          )
+        init.voidWithBuilder { cb =>
+          val outerRegion = init.getCodeParam[Region](1)
+          val eltRegion = init.getCodeParam[Region](2)
 
-                // Garbage collects old aggregator state if moving onto new group
-                dictState.newState(cb)
-                val initContainer = AggContainer(
-                  aggSignatures.toArray.map(sig => sig.state),
-                  dictState.initContainer,
-                  cleanup = () => (),
-                )
-                dictState.init(cb, cb => emitVoid(initAggs, cb, container = Some(initContainer)))
+          cb.assign(producer.elementRegion, eltRegion)
+          cb.assign(outerRegionField, outerRegion)
+          producer.initialize(cb, outerRegion)
+          cb.assign(eosField, false)
+        }
 
-                cb.define(getElemLabel)
-                if (childProducer.requiresMemoryManagementPerElement)
-                  cb += childProducer.elementRegion.clearRegion()
-                cb.goto(childProducer.LproduceElement)
+        val isEOS = ecb.newEmitMethod("eos", FastSeq[ParamType](), BooleanInfo)
+        isEOS.emitWithBuilder[Boolean](cb => eosField)
 
-                cb.define(childProducer.LproduceElementDone)
-                cb.assign(eltField, childProducer.element)
-                val newKeyResultCode = EmitCode.fromI(mb) { cb =>
-                  emit(newKey, cb = cb, env = env.bind(name, eltField), region = region)
-                }
-                val resultKeyValue = newKeyResultCode.memoize(cb, "buff_agg_stream_result_key")
-                val keyedContainer = AggContainer(
-                  aggSignatures.toArray.map(sig => sig.state),
-                  dictState.keyed.container,
-                  cleanup = () => (),
-                )
-                dictState.withContainer(
-                  cb,
-                  resultKeyValue,
-                  cb =>
-                    emitVoid(
-                      seqOps,
-                      cb,
-                      container = Some(keyedContainer),
-                      env = env.bind(name, eltField),
-                    ),
-                )
-                cb.if_(dictState.size >= maxSize, cb.assign(produceElementMode, true))
+        val isMissingMethod = ecb.newEmitMethod("isMissing", FastSeq[ParamType](), BooleanInfo)
+        isMissingMethod.emitWithBuilder[Boolean](cb => isMissing)
 
-                cb.if_(produceElementMode, cb.goto(elementProduceLabel), cb.goto(getElemLabel))
+        val close = ecb.newEmitMethod("close", FastSeq[ParamType](), UnitInfo)
+        close.voidWithBuilder(cb => producer.close(cb))
 
-                cb.define(childProducer.LendOfStream)
-                cb.assign(childStreamEnded, true)
-                cb.assign(produceElementMode, true)
+        val obj = cb.memoize(Code.newInstance(
+          ecb.cb,
+          ctor.mb,
+          FastSeq(cb.emb.partitionRegion.get, cb.emb.ecb.literalsArray().get) ++ envParams.map(
+            _.get
+          ),
+        ))
 
-                cb.define(elementProduceLabel)
-                cb.if_(
-                  numElemInArray ceq 0,
-                  dictState.tree.foreach(cb) { (cb, elementOff) =>
-                    cb += nodeArray.update(numElemInArray, elementOff)
-                    cb.assign(numElemInArray, numElemInArray + 1)
-                  },
-                )
-
-                cb.if_(
-                  numElemInArray <= idx, {
-                    cb.assign(idx, 0)
-                    cb.assign(numElemInArray, 0)
-                    cb.assign(produceElementMode, false)
-                    cb.if_(childStreamEnded, cb.goto(LendOfStream), cb.goto(startLabel))
-                  },
-                )
-                val nodeAddress = cb.memoize(nodeArray(idx))
-                cb.assign(idx, idx + 1)
-                dictState.loadNode(cb, nodeAddress)
-
-                val keyInWrongRegion = dictState.keyed.storageType.loadCheapSCode(cb, nodeAddress)
-                val addrOfKeyInRightRegion =
-                  dictState.keyed.storageType.store(cb, region, keyInWrongRegion, true)
-                val key = dictState.keyed.storageType.loadCheapSCode(
-                  cb,
-                  addrOfKeyInRightRegion,
-                ).loadField(cb, "kt").memoize(cb, "stream_buff_agg_key_right_region")
-
-                val serializedAggValue = keyedContainer.container.states.states.map(state =>
-                  state.serializeToRegion(cb, PCanonicalBinary(), region)
-                )
-                val serializedAggEmitCodes =
-                  serializedAggValue.map(aggValue => EmitCode.present(mb, aggValue))
-                val serializedAggTupleSValue = SStackStruct.constructFromArgs(
-                  cb,
-                  region,
-                  serializedAggSType.virtualType,
-                  serializedAggEmitCodes: _*
-                )
-                val keyValue = key.get(cb).asInstanceOf[SBaseStructValue]
-                val sStructToReturn = keyValue.insert(
-                  cb,
-                  region,
-                  returnElemType.asInstanceOf[TStruct],
-                  (
-                    "agg",
-                    EmitCode.present(mb, serializedAggTupleSValue)
-                      .memoize(cb, "stream_buff_agg_return_val"),
-                  ),
-                )
-                assert(returnElemSType.virtualType == sStructToReturn.st.virtualType)
-                val casted = sStructToReturn.castTo(cb, region, returnElemSType)
-                cb.assign(newStreamElem, EmitCode.present(mb, casted).toI(cb))
-                cb.goto(LproduceElementDone)
-              }
-
-              override val element: EmitCode = newStreamElem.load
-
-              override def close(cb: EmitCodeBuilder): Unit = {
-                childProducer.close(cb)
-                if (childProducer.requiresMemoryManagementPerElement)
-                  cb += childProducer.elementRegion.invalidate()
-                cb += dictState.region.invalidate()
-              }
-            }
-            SStreamValue(producer)
-          }
-
-      case MakeStream(args, _, _requiresMemoryManagementPerElement) =>
-        val region = mb.genFieldThisRef[Region]("makestream_region")
-
-        // FIXME use SType.chooseCompatibleType
-        val unifiedType = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream].elementEmitType
-        val eltField = mb.newEmitField("makestream_elt", unifiedType)
-
-        val staticLen = args.size
-        val current = mb.genFieldThisRef[Int]("makestream_current")
-
-        IEmitCode.present(
+        val iter = cb.emb.genFieldThisRef[NoBoxLongIterator]("iter")
+        cb.assign(iter, Code.checkcast[NoBoxLongIterator](obj))
+        IEmitCode(
           cb,
-          SStreamValue(
-            new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
-                cb.assign(current, 0) // switches on 1..N
+          if (producerRequired) false
+          else Code.checkcast[MissingnessAsMethod](obj).invoke[Boolean]("isMissing"),
+          new SStreamConcrete(
+            SStreamIteratorLong(
+              producer.element.required,
+              elementPType,
+              producer.requiresMemoryManagementPerElement,
+            ),
+            iter,
+          ),
+        )
+      }
 
-              override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => staticLen)
+      def produce(
+        streamIR: IR,
+        cb: EmitCodeBuilder,
+        mb: EmitMethodBuilder[_] = mb,
+        region: Value[Region] = outerRegion,
+        env: EmitEnv = env,
+        container: Option[AggContainer] = container,
+      ): IEmitCode =
+        EmitStream.produce(emitter, streamIR, cb, mb, region, env, container)
 
-              override val elementRegion: Settable[Region] = region
+      def typeWithReqx(node: IR): VirtualTypeWithReq =
+        VirtualTypeWithReq(
+          node.typ,
+          emitter.ctx.req.lookup(node).asInstanceOf[TypeWithRequiredness],
+        )
+      def typeWithReq: VirtualTypeWithReq = typeWithReqx(streamIR)
 
-              override val requiresMemoryManagementPerElement: Boolean =
-                _requiresMemoryManagementPerElement
+      streamIR match {
 
-              override val LproduceElement: CodeLabel =
-                mb.defineAndImplementLabel { cb =>
-                  cb.switch(
-                    current,
-                    cb.goto(LendOfStream),
-                    args.map { a => () =>
-                      val elem = emit(a, cb, region)
-                      cb.assign(
-                        eltField,
-                        elem.map(cb)(pc => pc.castTo(cb, region, unifiedType.st, false)),
-                      )
-                    },
-                  )
+        case NA(_typ: TStream) =>
+          val st = SStream(EmitType(SUnreachable.fromVirtualType(_typ.elementType), true))
+          val region = mb.genFieldThisRef[Region]("na_region")
+          val producer = new StreamProducer {
+            override def method: EmitMethodBuilder[_] = mb
+            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {}
 
-                  cb.assign(current, current + 1)
+            override val length: Option[EmitCodeBuilder => Code[Int]] =
+              Some(_ => Code._fatal[Int]("tried to get NA stream length"))
+            override val elementRegion: Settable[Region] = region
+            override val requiresMemoryManagementPerElement: Boolean = false
+            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+              cb.goto(LendOfStream)
+            }
+            override val element: EmitCode = EmitCode.present(mb, st.elementType.defaultValue)
+
+            override def close(cb: EmitCodeBuilder): Unit = {}
+          }
+          IEmitCode.missing(cb, SStreamValue(producer))
+
+        case Ref(name, _typ) =>
+          assert(_typ.isInstanceOf[TStream])
+          env.bindings.lookup(name).toI(cb)
+            .map(cb) { case stream: SStreamValue =>
+              val childProducer = stream.getProducer(mb)
+              val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
+                  childProducer.initialize(cb, outerRegion)
+
+                override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
+                override val elementRegion: Settable[Region] = childProducer.elementRegion
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.goto(childProducer.LproduceElement)
+                  cb.define(childProducer.LproduceElementDone)
+                  cb.goto(LproduceElementDone)
+                }
+                override val element: EmitCode = childProducer.element
+
+                override def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
+              }
+              mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+              SStreamValue(producer)
+            }
+
+        case let: Block =>
+          val newEnv = emitter.emitBlock(let, cb, env, outerRegion, container, None)
+          produce(let.body, cb, env = newEnv)
+
+        case In(n, _) =>
+          // this, Code[Region], ...
+          val param = env.inputValues(n).toI(cb)
+          if (!param.st.isInstanceOf[SStream])
+            throw new RuntimeException(
+              s"parameter ${2 + n} is not a stream! t=${param.st} }, params=${mb.emitParamTypes}"
+            )
+          param
+
+        case ToStream(a, _requiresMemoryManagementPerElement) =>
+          emit(a, cb).map(cb) { case _ind: SIndexableValue =>
+            val containerField = cb.memoizeField(_ind, "indexable").asIndexable
+            val container = containerField.asInstanceOf[SIndexableValue]
+            val idx = mb.genFieldThisRef[Int]("tostream_idx")
+            val regionVar = mb.genFieldThisRef[Region]("tostream_region")
+
+            SStreamValue(
+              new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
+                  cb.assign(idx, -1)
+
+                override val length: Option[EmitCodeBuilder => Code[Int]] =
+                  Some(_ => container.loadLength())
+
+                override val elementRegion: Settable[Region] = regionVar
+
+                override val requiresMemoryManagementPerElement: Boolean =
+                  _requiresMemoryManagementPerElement
+
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.assign(idx, idx + 1)
+                  cb.if_(idx >= container.loadLength(), cb.goto(LendOfStream))
                   cb.goto(LproduceElementDone)
                 }
 
-              val element: EmitCode = eltField.load
+                val element: EmitCode = EmitCode.fromI(mb)(cb => container.loadElement(cb, idx))
 
-              def close(cb: EmitCodeBuilder): Unit = {}
-            }
-          ),
-        )
-
-      case If(cond, cnsq, altr) =>
-        emit(cond, cb).flatMap(cb) { cond =>
-          val xCond = mb.genFieldThisRef[Boolean]("stream_if_cond")
-          cb.assign(xCond, cond.asBoolean.value)
-
-          val Lmissing = CodeLabel()
-          val Lpresent = CodeLabel()
-
-          val leftEC = EmitCode.fromI(cb.emb)(cb => produce(cnsq, cb))
-          val rightEC = EmitCode.fromI(cb.emb)(cb => produce(altr, cb))
-
-          val leftProducer = leftEC.pv.asStream.getProducer(mb)
-          val rightProducer = rightEC.pv.asStream.getProducer(mb)
-
-          val unifiedStreamSType = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream]
-          val unifiedElementType = unifiedStreamSType.elementEmitType
-
-          val xElt = mb.newEmitField(unifiedElementType)
-
-          val region = mb.genFieldThisRef[Region]("streamif_region")
-          cb.if_(
-            xCond,
-            leftEC.toI(cb).consume(cb, cb.goto(Lmissing), _ => cb.goto(Lpresent)),
-            rightEC.toI(cb).consume(cb, cb.goto(Lmissing), _ => cb.goto(Lpresent)),
-          )
-
-          val producer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
-            override val length: Option[EmitCodeBuilder => Code[Int]] = leftProducer.length
-              .liftedZip(rightProducer.length).map { case (computeL1, computeL2) =>
-                cb: EmitCodeBuilder => {
-                  val len = cb.newLocal[Int]("if_len")
-                  cb.if_(xCond, cb.assign(len, computeL1(cb)), cb.assign(len, computeL2(cb)))
-                  len.get
-                }
+                def close(cb: EmitCodeBuilder): Unit = {}
               }
+            )
 
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-              cb.if_(
-                xCond, {
-                  cb.assign(leftProducer.elementRegion, region)
-                  leftProducer.initialize(cb, outerRegion)
-                }, {
-                  cb.assign(rightProducer.elementRegion, region)
-                  rightProducer.initialize(cb, outerRegion)
-                },
+          }
+
+        case x @ StreamBufferedAggregate(
+              streamChild,
+              initAggs,
+              newKey,
+              seqOps,
+              name,
+              aggSignatures: IndexedSeq[PhysicalAggSig],
+              bufferSize: Int,
+            ) =>
+          val region = mb.genFieldThisRef[Region]("stream_buff_agg_region")
+          produce(streamChild, cb)
+            .map(cb) { case childStream: SStreamValue =>
+              val childProducer = childStream.getProducer(mb)
+              val eltField = mb.newEmitField("stream_buff_agg_elt", childProducer.element.emitType)
+              val newKeyVType = typeWithReqx(newKey)
+              val kb = mb.ecb
+              val nestedStates =
+                aggSignatures.toArray.map(sig => AggStateSig.getState(sig.state, kb))
+              val nested = StateTuple(nestedStates)
+              val dictState = new DictState(kb, newKeyVType, nested)
+              val maxSize = mb.genFieldThisRef[Int]("stream_buff_agg_max_size")
+              val nodeArray = mb.genFieldThisRef[Array[Long]]("stream_buff_agg_element_array")
+              val idx = mb.genFieldThisRef[Int]("stream_buff_agg_idx")
+              val returnStreamType = x.typ.asInstanceOf[TStream]
+              val returnElemType = returnStreamType.elementType
+              val tupleFieldTypes = aggSignatures.map(_ => TBinary)
+              val tupleFields = (0 to tupleFieldTypes.length).zip(tupleFieldTypes).map {
+                case (fieldIdx, fieldType) => TupleField(fieldIdx, fieldType)
+              }
+              val serializedAggSType = SStackStruct(
+                TTuple(tupleFields),
+                tupleFieldTypes.map(_ =>
+                  EmitType(SBinaryPointer(PCanonicalBinary()), true)
+                ).toIndexedSeq,
               )
-            }
-
-            override val elementRegion: Settable[Region] = region
-            override val requiresMemoryManagementPerElement: Boolean =
-              leftProducer.requiresMemoryManagementPerElement || rightProducer.requiresMemoryManagementPerElement
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              cb.if_(
-                xCond,
-                cb.goto(leftProducer.LproduceElement),
-                cb.goto(rightProducer.LproduceElement),
-              )
-
-              cb.define(leftProducer.LproduceElementDone)
-              cb.assign(xElt, leftProducer.element.toI(cb).map(cb)(_.castTo(cb, region, xElt.st)))
-              cb.goto(LproduceElementDone)
-
-              cb.define(rightProducer.LproduceElementDone)
-              cb.assign(xElt, rightProducer.element.toI(cb).map(cb)(_.castTo(cb, region, xElt.st)))
-              cb.goto(LproduceElementDone)
-
-              cb.define(leftProducer.LendOfStream)
-              cb.goto(LendOfStream)
-
-              cb.define(rightProducer.LendOfStream)
-              cb.goto(LendOfStream)
-            }
-
-            override val element: EmitCode = xElt.load
-
-            override def close(cb: EmitCodeBuilder): Unit =
-              cb.if_(xCond, leftProducer.close(cb), rightProducer.close(cb))
-          }
-
-          IEmitCode(Lmissing, Lpresent, SStreamValue(producer), leftEC.required && rightEC.required)
-        }
-
-      case StreamIota(start, step, _requiresMemoryManagementPerElement) =>
-        emit(start, cb).flatMap(cb) { startCode =>
-          emit(step, cb).map(cb) { stepCode =>
-            val curr = mb.genFieldThisRef[Int]("streamrange_curr")
-            val stepVar = mb.genFieldThisRef[Int]("streamrange_stop")
-            val regionVar = mb.genFieldThisRef[Region]("sr_region")
-            val producer: StreamProducer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                val startVar = startCode.asInt.value
-                cb.assign(stepVar, stepCode.asInt.value)
-                cb.assign(curr, startVar - stepVar)
-              }
-
-              override val elementRegion: Settable[Region] = regionVar
-
-              override val requiresMemoryManagementPerElement: Boolean =
-                _requiresMemoryManagementPerElement
-
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.assign(curr, curr + stepVar)
-                cb.goto(LproduceElementDone)
-              }
-
-              val element: EmitCode = EmitCode.present(mb, new SInt32Value(curr))
-
-              def close(cb: EmitCodeBuilder): Unit = {}
-            }
-            SStreamValue(producer)
-
-          }
-        }
-      case StreamRange(start, stop, I32(step), _requiresMemoryManagementPerElement, errorID)
-          if (step != 0) =>
-        emit(start, cb).flatMap(cb) { startCode =>
-          emit(stop, cb).map(cb) { stopCode =>
-            val curr = mb.genFieldThisRef[Int]("streamrange_curr")
-            val startVar = mb.genFieldThisRef[Int]("range_start")
-            val stopVar = mb.genFieldThisRef[Int]("streamrange_stop")
-            val regionVar = mb.genFieldThisRef[Region]("sr_region")
-
-            cb.assign(startVar, startCode.asInt.value)
-            cb.assign(stopVar, stopCode.asInt.value)
-
-            val producer: StreamProducer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = Some({ cb =>
-                val len = cb.newLocal[Int]("streamrange_len")
-                if (step > 0)
-                  cb.if_(
-                    startVar >= stopVar,
-                    cb.assign(len, 0),
-                    cb.assign(len, ((stopVar.toL - startVar.toL - 1L) / step.toLong + 1L).toI),
-                  )
-                else
-                  cb.if_(
-                    startVar <= stopVar,
-                    cb.assign(len, 0),
-                    cb.assign(len, ((startVar.toL - stopVar.toL - 1L) / (-step.toLong) + 1L).toI),
-                  )
-                len
-              })
-
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                start match {
-                  case I32(x)
-                      if step < 0 && ((x.toLong - Int.MinValue.toLong) / step.toLong + 1) < Int.MaxValue =>
-                  case I32(x)
-                      if step > 0 && ((Int.MaxValue.toLong - x.toLong) / step.toLong + 1) < Int.MaxValue =>
-                  case _ =>
-                    cb.if_(
-                      (stopVar.toL - startVar.toL) / step.toLong > const(Int.MaxValue.toLong),
-                      cb._fatalWithError(
-                        errorID,
-                        "Array range cannot have more than MAXINT elements.",
-                      ),
-                    )
-                }
-                cb.assign(curr, startVar - step)
-              }
-
-              override val elementRegion: Settable[Region] = regionVar
-
-              override val requiresMemoryManagementPerElement: Boolean =
-                _requiresMemoryManagementPerElement
-
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.assign(curr, curr + step)
-                if (step > 0)
-                  cb.if_(curr >= stopVar, cb.goto(LendOfStream))
-                else
-                  cb.if_(curr <= stopVar, cb.goto(LendOfStream))
-                cb.goto(LproduceElementDone)
-              }
-
-              val element: EmitCode = EmitCode.present(mb, new SInt32Value(curr))
-
-              def close(cb: EmitCodeBuilder): Unit = {}
-            }
-
-            SStreamValue(producer)
-          }
-        }
-
-      case StreamRange(startIR, stopIR, stepIR, _requiresMemoryManagementPerElement, errorID) =>
-        emit(startIR, cb).flatMap(cb) { startc =>
-          emit(stopIR, cb).flatMap(cb) { stopc =>
-            emit(stepIR, cb).map(cb) { stepc =>
-              val len = mb.genFieldThisRef[Int]("sr_len")
-              val regionVar = mb.genFieldThisRef[Region]("sr_region")
-
-              val start = cb.newField[Int]("sr_step")
-              val stop = cb.newField[Int]("sr_stop")
-              val step = cb.newField[Int]("sr_step")
-
-              val curr = mb.genFieldThisRef[Int]("streamrange_curr")
-              val idx = mb.genFieldThisRef[Int]("streamrange_idx")
-
-              cb.assign(start, startc.asInt.value)
-              cb.assign(stop, stopc.asInt.value)
-              cb.assign(step, stepc.asInt.value)
-
+              val keyAndAggFields = newKeyVType.canonicalPType.asInstanceOf[
+                PCanonicalStruct
+              ].sType.fieldEmitTypes :+ EmitType(serializedAggSType, true)
+              val returnElemSType =
+                SStackStruct(returnElemType.asInstanceOf[TBaseStruct], keyAndAggFields)
+              val newStreamElem =
+                mb.newEmitField("stream_buff_agg_new_stream_elem", EmitType(returnElemSType, true))
+              val numElemInArray = mb.genFieldThisRef[Int]("stream_buff_agg_num_elem_in_size")
+              val childStreamEnded =
+                mb.genFieldThisRef[Boolean]("stream_buff_agg_child_stream_ended")
+              val produceElementMode =
+                mb.genFieldThisRef[Boolean]("stream_buff_agg_child_produce_elt_mode")
               val producer: StreamProducer = new StreamProducer {
                 override def method: EmitMethodBuilder[_] = mb
-                override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => len)
+                override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
                 override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                  val llen = cb.newLocal[Long]("streamrange_llen")
+                  if (childProducer.requiresMemoryManagementPerElement)
+                    cb.assign(
+                      childProducer.elementRegion,
+                      Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
+                    )
+                  else
+                    cb.assign(childProducer.elementRegion, region)
 
-                  cb.if_(
-                    step ceq const(0),
-                    cb._fatalWithError(errorID, "Array range cannot have step size 0."),
-                  )
-                  cb.if_(
-                    step < const(0),
-                    cb.if_(
-                      start.toL <= stop.toL,
-                      cb.assign(llen, 0L),
-                      cb.assign(llen, (start.toL - stop.toL - 1L) / (-step.toL) + 1L),
-                    ),
-                    cb.if_(
-                      start.toL >= stop.toL,
-                      cb.assign(llen, 0L),
-                      cb.assign(llen, (stop.toL - start.toL - 1L) / step.toL + 1L),
-                    ),
-                  )
-                  cb.if_(
-                    llen > const(Int.MaxValue.toLong),
-                    cb._fatalWithError(
-                      errorID,
-                      "Array range cannot have more than MAXINT elements.",
-                    ),
-                  )
-                  cb.assign(len, llen.toI)
-
-                  cb.assign(curr, start - step)
+                  childProducer.initialize(cb, outerRegion)
+                  cb.assign(childStreamEnded, false)
+                  cb.assign(produceElementMode, false)
                   cb.assign(idx, 0)
+                  cb.assign(maxSize, bufferSize)
+                  cb.assign(nodeArray, Code.newArray[Long](maxSize))
+                  cb.assign(numElemInArray, 0)
+                  dictState.createState(cb)
+                }
+
+                override val elementRegion: Settable[Region] = region
+
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  val elementProduceLabel = CodeLabel()
+                  val getElemLabel = CodeLabel()
+                  val startLabel = CodeLabel()
+
+                  cb.define(startLabel)
+                  cb.if_(produceElementMode, cb.goto(elementProduceLabel))
+
+                  // Garbage collects old aggregator state if moving onto new group
+                  dictState.newState(cb)
+                  val initContainer = AggContainer(
+                    aggSignatures.toArray.map(sig => sig.state),
+                    dictState.initContainer,
+                    cleanup = () => (),
+                  )
+                  dictState.init(cb, cb => emitVoid(initAggs, cb, container = Some(initContainer)))
+
+                  cb.define(getElemLabel)
+                  if (childProducer.requiresMemoryManagementPerElement)
+                    cb += childProducer.elementRegion.clearRegion()
+                  cb.goto(childProducer.LproduceElement)
+
+                  cb.define(childProducer.LproduceElementDone)
+                  cb.assign(eltField, childProducer.element)
+                  val newKeyResultCode = EmitCode.fromI(mb) { cb =>
+                    emit(newKey, cb = cb, env = env.bind(name, eltField), region = region)
+                  }
+                  val resultKeyValue = newKeyResultCode.memoize(cb, "buff_agg_stream_result_key")
+                  val keyedContainer = AggContainer(
+                    aggSignatures.toArray.map(sig => sig.state),
+                    dictState.keyed.container,
+                    cleanup = () => (),
+                  )
+                  dictState.withContainer(
+                    cb,
+                    resultKeyValue,
+                    cb =>
+                      emitVoid(
+                        seqOps,
+                        cb,
+                        container = Some(keyedContainer),
+                        env = env.bind(name, eltField),
+                      ),
+                  )
+                  cb.if_(dictState.size >= maxSize, cb.assign(produceElementMode, true))
+
+                  cb.if_(produceElementMode, cb.goto(elementProduceLabel), cb.goto(getElemLabel))
+
+                  cb.define(childProducer.LendOfStream)
+                  cb.assign(childStreamEnded, true)
+                  cb.assign(produceElementMode, true)
+
+                  cb.define(elementProduceLabel)
+                  cb.if_(
+                    numElemInArray ceq 0,
+                    dictState.tree.foreach(cb) { (cb, elementOff) =>
+                      cb += nodeArray.update(numElemInArray, elementOff)
+                      cb.assign(numElemInArray, numElemInArray + 1)
+                    },
+                  )
+
+                  cb.if_(
+                    numElemInArray <= idx, {
+                      cb.assign(idx, 0)
+                      cb.assign(numElemInArray, 0)
+                      cb.assign(produceElementMode, false)
+                      cb.if_(childStreamEnded, cb.goto(LendOfStream), cb.goto(startLabel))
+                    },
+                  )
+                  val nodeAddress = cb.memoize(nodeArray(idx))
+                  cb.assign(idx, idx + 1)
+                  dictState.loadNode(cb, nodeAddress)
+
+                  val keyInWrongRegion = dictState.keyed.storageType.loadCheapSCode(cb, nodeAddress)
+                  val addrOfKeyInRightRegion =
+                    dictState.keyed.storageType.store(cb, region, keyInWrongRegion, true)
+                  val key = dictState.keyed.storageType.loadCheapSCode(
+                    cb,
+                    addrOfKeyInRightRegion,
+                  ).loadField(cb, "kt").memoize(cb, "stream_buff_agg_key_right_region")
+
+                  val serializedAggValue = keyedContainer.container.states.states.map(state =>
+                    state.serializeToRegion(cb, PCanonicalBinary(), region)
+                  )
+                  val serializedAggEmitCodes =
+                    serializedAggValue.map(aggValue => EmitCode.present(mb, aggValue))
+                  val serializedAggTupleSValue = SStackStruct.constructFromArgs(
+                    cb,
+                    region,
+                    serializedAggSType.virtualType,
+                    serializedAggEmitCodes: _*
+                  )
+                  val keyValue = key.get(cb).asInstanceOf[SBaseStructValue]
+                  val sStructToReturn = keyValue.insert(
+                    cb,
+                    region,
+                    returnElemType.asInstanceOf[TStruct],
+                    (
+                      "agg",
+                      EmitCode.present(mb, serializedAggTupleSValue)
+                        .memoize(cb, "stream_buff_agg_return_val"),
+                    ),
+                  )
+                  assert(returnElemSType.virtualType == sStructToReturn.st.virtualType)
+                  val casted = sStructToReturn.castTo(cb, region, returnElemSType)
+                  cb.assign(newStreamElem, EmitCode.present(mb, casted).toI(cb))
+                  cb.goto(LproduceElementDone)
+                }
+
+                override val element: EmitCode = newStreamElem.load
+
+                override def close(cb: EmitCodeBuilder): Unit = {
+                  childProducer.close(cb)
+                  if (childProducer.requiresMemoryManagementPerElement)
+                    cb += childProducer.elementRegion.invalidate()
+                  cb += dictState.region.invalidate()
+                }
+              }
+              SStreamValue(producer)
+            }
+
+        case MakeStream(args, _, _requiresMemoryManagementPerElement) =>
+          val region = mb.genFieldThisRef[Region]("makestream_region")
+
+          // FIXME use SType.chooseCompatibleType
+          val unifiedType = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream].elementEmitType
+          val eltField = mb.newEmitField("makestream_elt", unifiedType)
+
+          val staticLen = args.size
+          val current = mb.genFieldThisRef[Int]("makestream_current")
+
+          IEmitCode.present(
+            cb,
+            SStreamValue(
+              new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
+                  cb.assign(current, 0) // switches on 1..N
+
+                override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => staticLen)
+
+                override val elementRegion: Settable[Region] = region
+
+                override val requiresMemoryManagementPerElement: Boolean =
+                  _requiresMemoryManagementPerElement
+
+                override val LproduceElement: CodeLabel =
+                  mb.defineAndImplementLabel { cb =>
+                    cb.switch(
+                      current,
+                      cb.goto(LendOfStream),
+                      args.map { a => () =>
+                        val elem = emit(a, cb, region)
+                        cb.assign(
+                          eltField,
+                          elem.map(cb)(pc => pc.castTo(cb, region, unifiedType.st, false)),
+                        )
+                      },
+                    )
+
+                    cb.assign(current, current + 1)
+                    cb.goto(LproduceElementDone)
+                  }
+
+                val element: EmitCode = eltField.load
+
+                def close(cb: EmitCodeBuilder): Unit = {}
+              }
+            ),
+          )
+
+        case If(cond, cnsq, altr) =>
+          emit(cond, cb).flatMap(cb) { cond =>
+            val xCond = mb.genFieldThisRef[Boolean]("stream_if_cond")
+            cb.assign(xCond, cond.asBoolean.value)
+
+            val Lmissing = CodeLabel()
+            val Lpresent = CodeLabel()
+
+            val leftEC = EmitCode.fromI(cb.emb)(cb => produce(cnsq, cb))
+            val rightEC = EmitCode.fromI(cb.emb)(cb => produce(altr, cb))
+
+            val leftProducer = leftEC.pv.asStream.getProducer(mb)
+            val rightProducer = rightEC.pv.asStream.getProducer(mb)
+
+            val unifiedStreamSType = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream]
+            val unifiedElementType = unifiedStreamSType.elementEmitType
+
+            val xElt = mb.newEmitField(unifiedElementType)
+
+            val region = mb.genFieldThisRef[Region]("streamif_region")
+            cb.if_(
+              xCond,
+              leftEC.toI(cb).consume(cb, cb.goto(Lmissing), _ => cb.goto(Lpresent)),
+              rightEC.toI(cb).consume(cb, cb.goto(Lmissing), _ => cb.goto(Lpresent)),
+            )
+
+            val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
+              override val length: Option[EmitCodeBuilder => Code[Int]] = leftProducer.length
+                .liftedZip(rightProducer.length).map { case (computeL1, computeL2) =>
+                  cb: EmitCodeBuilder => {
+                    val len = cb.newLocal[Int]("if_len")
+                    cb.if_(xCond, cb.assign(len, computeL1(cb)), cb.assign(len, computeL2(cb)))
+                    len.get
+                  }
+                }
+
+              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                cb.if_(
+                  xCond, {
+                    cb.assign(leftProducer.elementRegion, region)
+                    leftProducer.initialize(cb, outerRegion)
+                  }, {
+                    cb.assign(rightProducer.elementRegion, region)
+                    rightProducer.initialize(cb, outerRegion)
+                  },
+                )
+              }
+
+              override val elementRegion: Settable[Region] = region
+              override val requiresMemoryManagementPerElement: Boolean =
+                leftProducer.requiresMemoryManagementPerElement || rightProducer.requiresMemoryManagementPerElement
+              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                cb.if_(
+                  xCond,
+                  cb.goto(leftProducer.LproduceElement),
+                  cb.goto(rightProducer.LproduceElement),
+                )
+
+                cb.define(leftProducer.LproduceElementDone)
+                cb.assign(xElt, leftProducer.element.toI(cb).map(cb)(_.castTo(cb, region, xElt.st)))
+                cb.goto(LproduceElementDone)
+
+                cb.define(rightProducer.LproduceElementDone)
+                cb.assign(
+                  xElt,
+                  rightProducer.element.toI(cb).map(cb)(_.castTo(cb, region, xElt.st)),
+                )
+                cb.goto(LproduceElementDone)
+
+                cb.define(leftProducer.LendOfStream)
+                cb.goto(LendOfStream)
+
+                cb.define(rightProducer.LendOfStream)
+                cb.goto(LendOfStream)
+              }
+
+              override val element: EmitCode = xElt.load
+
+              override def close(cb: EmitCodeBuilder): Unit =
+                cb.if_(xCond, leftProducer.close(cb), rightProducer.close(cb))
+            }
+
+            IEmitCode(
+              Lmissing,
+              Lpresent,
+              SStreamValue(producer),
+              leftEC.required && rightEC.required,
+            )
+          }
+
+        case StreamIota(start, step, _requiresMemoryManagementPerElement) =>
+          emit(start, cb).flatMap(cb) { startCode =>
+            emit(step, cb).map(cb) { stepCode =>
+              val curr = mb.genFieldThisRef[Int]("streamrange_curr")
+              val stepVar = mb.genFieldThisRef[Int]("streamrange_stop")
+              val regionVar = mb.genFieldThisRef[Region]("sr_region")
+              val producer: StreamProducer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  val startVar = startCode.asInt.value
+                  cb.assign(stepVar, stepCode.asInt.value)
+                  cb.assign(curr, startVar - stepVar)
                 }
 
                 override val elementRegion: Settable[Region] = regionVar
@@ -908,9 +785,78 @@ object EmitStream {
                   _requiresMemoryManagementPerElement
 
                 override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                  cb.if_(idx >= len, cb.goto(LendOfStream))
+                  cb.assign(curr, curr + stepVar)
+                  cb.goto(LproduceElementDone)
+                }
+
+                val element: EmitCode = EmitCode.present(mb, new SInt32Value(curr))
+
+                def close(cb: EmitCodeBuilder): Unit = {}
+              }
+              SStreamValue(producer)
+
+            }
+          }
+        case StreamRange(start, stop, I32(step), _requiresMemoryManagementPerElement, errorID)
+            if (step != 0) =>
+          emit(start, cb).flatMap(cb) { startCode =>
+            emit(stop, cb).map(cb) { stopCode =>
+              val curr = mb.genFieldThisRef[Int]("streamrange_curr")
+              val startVar = mb.genFieldThisRef[Int]("range_start")
+              val stopVar = mb.genFieldThisRef[Int]("streamrange_stop")
+              val regionVar = mb.genFieldThisRef[Region]("sr_region")
+
+              cb.assign(startVar, startCode.asInt.value)
+              cb.assign(stopVar, stopCode.asInt.value)
+
+              val producer: StreamProducer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = Some({ cb =>
+                  val len = cb.newLocal[Int]("streamrange_len")
+                  if (step > 0)
+                    cb.if_(
+                      startVar >= stopVar,
+                      cb.assign(len, 0),
+                      cb.assign(len, ((stopVar.toL - startVar.toL - 1L) / step.toLong + 1L).toI),
+                    )
+                  else
+                    cb.if_(
+                      startVar <= stopVar,
+                      cb.assign(len, 0),
+                      cb.assign(len, ((startVar.toL - stopVar.toL - 1L) / (-step.toLong) + 1L).toI),
+                    )
+                  len
+                })
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  start match {
+                    case I32(x)
+                        if step < 0 && ((x.toLong - Int.MinValue.toLong) / step.toLong + 1) < Int.MaxValue =>
+                    case I32(x)
+                        if step > 0 && ((Int.MaxValue.toLong - x.toLong) / step.toLong + 1) < Int.MaxValue =>
+                    case _ =>
+                      cb.if_(
+                        (stopVar.toL - startVar.toL) / step.toLong > const(Int.MaxValue.toLong),
+                        cb._fatalWithError(
+                          errorID,
+                          "Array range cannot have more than MAXINT elements.",
+                        ),
+                      )
+                  }
+                  cb.assign(curr, startVar - step)
+                }
+
+                override val elementRegion: Settable[Region] = regionVar
+
+                override val requiresMemoryManagementPerElement: Boolean =
+                  _requiresMemoryManagementPerElement
+
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
                   cb.assign(curr, curr + step)
-                  cb.assign(idx, idx + 1)
+                  if (step > 0)
+                    cb.if_(curr >= stopVar, cb.goto(LendOfStream))
+                  else
+                    cb.if_(curr <= stopVar, cb.goto(LendOfStream))
                   cb.goto(LproduceElementDone)
                 }
 
@@ -922,1783 +868,1675 @@ object EmitStream {
               SStreamValue(producer)
             }
           }
-        }
 
-      case SeqSample(totalSize, numToSample, _, _requiresMemoryManagementPerElement) =>
-        // Implemented based on http://www.ittc.ku.edu/~jsv/Papers/Vit84.sampling.pdf Algorithm A
-        emit(totalSize, cb).flatMap(cb) { case totalSizeVal: SInt32Value =>
-          emit(numToSample, cb).map(cb) { case numToSampleVal: SInt32Value =>
-            val len = mb.genFieldThisRef[Int]("seq_sample_len")
-            val regionVar = mb.genFieldThisRef[Region]("seq_sample_region")
+        case StreamRange(startIR, stopIR, stepIR, _requiresMemoryManagementPerElement, errorID) =>
+          emit(startIR, cb).flatMap(cb) { startc =>
+            emit(stopIR, cb).flatMap(cb) { stopc =>
+              emit(stepIR, cb).map(cb) { stepc =>
+                val len = mb.genFieldThisRef[Int]("sr_len")
+                val regionVar = mb.genFieldThisRef[Region]("sr_region")
 
-            val nRemaining = cb.newField[Int]("seq_sample_num_remaining", numToSampleVal.value)
-            val candidate = cb.newField[Int]("seq_sample_candidate", 0)
-            val elementToReturn =
-              cb.newField[Int]("seq_sample_element_to_return", -1) // -1 should never be returned.
+                val start = cb.newField[Int]("sr_step")
+                val stop = cb.newField[Int]("sr_stop")
+                val step = cb.newField[Int]("sr_step")
 
-            val producer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => len)
+                val curr = mb.genFieldThisRef[Int]("streamrange_curr")
+                val idx = mb.genFieldThisRef[Int]("streamrange_idx")
 
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                cb.assign(len, numToSampleVal.asInt.value)
-                cb.assign(nRemaining, numToSampleVal.value)
-                cb.assign(candidate, 0)
-                cb.assign(elementToReturn, -1)
-              }
+                cb.assign(start, startc.asInt.value)
+                cb.assign(stop, stopc.asInt.value)
+                cb.assign(step, stepc.asInt.value)
 
-              override val elementRegion: Settable[Region] = regionVar
-
-              override val requiresMemoryManagementPerElement: Boolean =
-                _requiresMemoryManagementPerElement
-
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.if_(nRemaining <= 0, cb.goto(LendOfStream))
-
-                val u = cb.newLocal[Double](
-                  "seq_sample_rand_unif",
-                  Code.invokeStatic0[Math, Double]("random"),
-                )
-                val fC = cb.newLocal[Double](
-                  "seq_sample_Fc",
-                  (totalSizeVal.value - candidate - nRemaining).toD / (totalSizeVal.value - candidate).toD,
-                )
-
-                cb.while_(
-                  fC > u, {
-                    cb.assign(candidate, candidate + 1)
-                    cb.assign(
-                      fC,
-                      fC * (const(1.0) - (nRemaining.toD / (totalSizeVal.value - candidate).toD)),
-                    )
-                  },
-                )
-                cb.assign(nRemaining, nRemaining - 1)
-                cb.assign(elementToReturn, candidate)
-                cb.assign(candidate, candidate + 1)
-                cb.goto(LproduceElementDone)
-              }
-
-              override val element: EmitCode =
-                EmitCode.present(mb, new SInt32Value(elementToReturn))
-
-              override def close(cb: EmitCodeBuilder): Unit = {}
-            }
-            SStreamValue(producer)
-          }
-        }
-
-      case StreamFilter(a, name, cond) =>
-        produce(a, cb)
-          .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.getProducer(mb)
-
-            val filterEltRegion = mb.genFieldThisRef[Region]("streamfilter_filter_region")
-
-            val elementField =
-              cb.emb.newEmitField("streamfilter_cond", childProducer.element.emitType)
-
-            val producer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                if (childProducer.requiresMemoryManagementPerElement)
-                  cb.assign(
-                    childProducer.elementRegion,
-                    Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
-                  )
-                else
-                  cb.assign(childProducer.elementRegion, outerRegion)
-                childProducer.initialize(cb, outerRegion)
-              }
-
-              override val elementRegion: Settable[Region] = filterEltRegion
-
-              override val requiresMemoryManagementPerElement: Boolean =
-                childProducer.requiresMemoryManagementPerElement
-
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                val Lfiltered = CodeLabel()
-
-                cb.goto(childProducer.LproduceElement)
-
-                cb.define(childProducer.LproduceElementDone)
-                cb.assign(elementField, childProducer.element)
-                // false and NA both fail the filter
-                emit(
-                  cond,
-                  cb = cb,
-                  env = env.bind(name, elementField),
-                  region = childProducer.elementRegion,
-                )
-                  .consume(
-                    cb,
-                    cb.goto(Lfiltered),
-                    sc => cb.if_(!sc.asBoolean.value, cb.goto(Lfiltered)),
-                  )
-
-                if (requiresMemoryManagementPerElement)
-                  cb += filterEltRegion.takeOwnershipOfAndClear(childProducer.elementRegion)
-                cb.goto(LproduceElementDone)
-
-                cb.define(Lfiltered)
-                if (requiresMemoryManagementPerElement)
-                  cb += childProducer.elementRegion.clearRegion()
-                cb.goto(childProducer.LproduceElement)
-              }
-
-              val element: EmitCode = elementField
-
-              def close(cb: EmitCodeBuilder): Unit = {
-                childProducer.close(cb)
-                if (requiresMemoryManagementPerElement)
-                  cb += childProducer.elementRegion.invalidate()
-              }
-            }
-            mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-
-            SStreamValue(producer)
-          }
-
-      case StreamTake(a, num) =>
-        produce(a, cb)
-          .flatMap(cb) { case childStream: SStreamValue =>
-            emit(num, cb).map(cb) { case num: SInt32Value =>
-              val childProducer = childStream.getProducer(mb)
-              val n = mb.genFieldThisRef[Int]("stream_take_n")
-              val idx = mb.genFieldThisRef[Int]("stream_take_idx")
-
-              val producer = new StreamProducer {
-                override def method: EmitMethodBuilder[_] = mb
-                override val length: Option[EmitCodeBuilder => Code[Int]] =
-                  childProducer.length.map(compLen => (cb: EmitCodeBuilder) => compLen(cb).min(n))
-
-                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                  cb.assign(n, num.value)
-                  cb.if_(
-                    n < 0,
-                    cb._fatal(s"stream take: negative number of elements to take: ", n.toS),
-                  )
-                  cb.assign(idx, 0)
-                  childProducer.initialize(cb, outerRegion)
-                }
-
-                override val elementRegion: Settable[Region] = childProducer.elementRegion
-                override val requiresMemoryManagementPerElement: Boolean =
-                  childProducer.requiresMemoryManagementPerElement
-                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                  cb.if_(idx >= n, cb.goto(LendOfStream))
-                  cb.assign(idx, idx + 1)
-                  cb.goto(childProducer.LproduceElement)
-
-                  cb.define(childProducer.LproduceElementDone)
-                  cb.goto(LproduceElementDone)
-
-                  cb.define(childProducer.LendOfStream)
-                  cb.goto(LendOfStream)
-                }
-                override val element: EmitCode = childProducer.element
-
-                override def close(cb: EmitCodeBuilder): Unit =
-                  childProducer.close(cb)
-              }
-
-              SStreamValue(producer)
-            }
-          }
-
-      case StreamDrop(a, num) =>
-        produce(a, cb)
-          .flatMap(cb) { case (childStream: SStreamValue) =>
-            emit(num, cb).map(cb) { case num: SInt32Value =>
-              val childProducer = childStream.getProducer(mb)
-              val n = mb.genFieldThisRef[Int]("stream_drop_n")
-              val idx = mb.genFieldThisRef[Int]("stream_drop_idx")
-
-              val producer = new StreamProducer {
-                override def method: EmitMethodBuilder[_] = mb
-                override val length: Option[EmitCodeBuilder => Code[Int]] =
-                  childProducer.length.map { computeL => (cb: EmitCodeBuilder) =>
-                    (computeL(cb) - n).max(0)
-                  }
-
-                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                  cb.assign(n, num.value)
-                  cb.if_(
-                    n < 0,
-                    cb._fatal(s"stream drop: negative number of elements to drop: ", n.toS),
-                  )
-                  cb.assign(idx, 0)
-                  childProducer.initialize(cb, outerRegion)
-                }
-
-                override val elementRegion: Settable[Region] = childProducer.elementRegion
-                override val requiresMemoryManagementPerElement: Boolean =
-                  childProducer.requiresMemoryManagementPerElement
-                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                  cb.goto(childProducer.LproduceElement)
-                  cb.define(childProducer.LproduceElementDone)
-                  cb.assign(idx, idx + 1)
-                  cb.if_(
-                    idx <= n, {
-                      if (childProducer.requiresMemoryManagementPerElement)
-                        cb += childProducer.elementRegion.clearRegion()
-                      cb.goto(childProducer.LproduceElement)
-                    },
-                  )
-                  cb.goto(LproduceElementDone)
-
-                  cb.define(childProducer.LendOfStream)
-                  cb.goto(LendOfStream)
-                }
-                override val element: EmitCode = childProducer.element
-
-                override def close(cb: EmitCodeBuilder): Unit =
-                  childProducer.close(cb)
-              }
-
-              SStreamValue(producer)
-            }
-          }
-
-      case StreamTakeWhile(a, elt, condIR) =>
-        produce(a, cb)
-          .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.getProducer(mb)
-
-            val eltSettable =
-              mb.newEmitField("stream_take_while_elt", childProducer.element.emitType)
-
-            val producer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
-                childProducer.initialize(cb, outerRegion)
-
-              override val elementRegion: Settable[Region] = childProducer.elementRegion
-              override val requiresMemoryManagementPerElement: Boolean =
-                childProducer.requiresMemoryManagementPerElement
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.goto(childProducer.LproduceElement)
-                cb.define(childProducer.LproduceElementDone)
-                cb.assign(eltSettable, childProducer.element)
-
-                emit(
-                  condIR,
-                  cb,
-                  region = childProducer.elementRegion,
-                  env = env.bind(elt, eltSettable),
-                )
-                  .consume(
-                    cb,
-                    cb.goto(LendOfStream),
-                    code =>
-                      cb.if_(
-                        code.asBoolean.value,
-                        cb.goto(LproduceElementDone),
-                        cb.goto(LendOfStream),
-                      ),
-                  )
-
-                cb.define(childProducer.LendOfStream)
-                cb.goto(LendOfStream)
-              }
-
-              override val element: EmitCode = eltSettable
-
-              override def close(cb: EmitCodeBuilder): Unit =
-                childProducer.close(cb)
-            }
-
-            SStreamValue(producer)
-          }
-
-      case StreamDropWhile(a, elt, condIR) =>
-        produce(a, cb)
-          .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.getProducer(mb)
-            val eltSettable =
-              mb.newEmitField("stream_drop_while_elt", childProducer.element.emitType)
-            val doneComparisons = mb.genFieldThisRef[Boolean]("stream_drop_while_donecomparisons")
-
-            val producer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                childProducer.initialize(cb, outerRegion)
-                cb.assign(doneComparisons, false)
-              }
-
-              override val elementRegion: Settable[Region] = childProducer.elementRegion
-              override val requiresMemoryManagementPerElement: Boolean =
-                childProducer.requiresMemoryManagementPerElement
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.goto(childProducer.LproduceElement)
-                cb.define(childProducer.LproduceElementDone)
-                cb.assign(eltSettable, childProducer.element)
-
-                cb.if_(doneComparisons, cb.goto(LproduceElementDone))
-
-                val LdropThis = CodeLabel()
-                val LdoneDropping = CodeLabel()
-                emit(
-                  condIR,
-                  cb,
-                  region = childProducer.elementRegion,
-                  env = env.bind(elt, eltSettable),
-                )
-                  .consume(
-                    cb,
-                    cb.goto(LdoneDropping),
-                    code => cb.if_(code.asBoolean.value, cb.goto(LdropThis), cb.goto(LdoneDropping)),
-                  )
-
-                cb.define(LdropThis)
-                if (childProducer.requiresMemoryManagementPerElement)
-                  cb += childProducer.elementRegion.clearRegion()
-                cb.goto(childProducer.LproduceElement)
-
-                cb.define(LdoneDropping)
-                cb.assign(doneComparisons, true)
-                cb.goto(LproduceElementDone)
-
-                cb.define(childProducer.LendOfStream)
-                cb.goto(LendOfStream)
-              }
-              override val element: EmitCode = eltSettable
-
-              override def close(cb: EmitCodeBuilder): Unit =
-                childProducer.close(cb)
-            }
-
-            SStreamValue(producer)
-          }
-
-      case StreamMap(a, name, body) =>
-        produce(a, cb)
-          .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.getProducer(mb)
-
-            val bodyResult = EmitCode.fromI(mb) { cb =>
-              cb.withScopedMaybeStreamValue(childProducer.element, "streammap_element") {
-                childProducerElement =>
-                  emit(
-                    body,
-                    cb = cb,
-                    env = env.bind(name, childProducerElement),
-                    region = childProducer.elementRegion,
-                  )
-              }
-            }
-
-            val producer: StreamProducer = new StreamProducer {
-              override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
-
-              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
-                childProducer.initialize(cb, outerRegion)
-
-              override val elementRegion: Settable[Region] = childProducer.elementRegion
-
-              override val requiresMemoryManagementPerElement: Boolean =
-                childProducer.requiresMemoryManagementPerElement
-
-              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                cb.goto(childProducer.LproduceElement)
-                cb.define(childProducer.LproduceElementDone)
-                cb.goto(LproduceElementDone)
-              }
-
-              val element: EmitCode = bodyResult
-
-              def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
-            }
-
-            mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-
-            SStreamValue(producer)
-          }
-
-      case x @ StreamScan(childIR, zeroIR, accName, eltName, bodyIR) =>
-        produce(childIR, cb).map(cb) { case childStream: SStreamValue =>
-          val childProducer = childStream.getProducer(mb)
-
-          val accEmitType = VirtualTypeWithReq(
-            zeroIR.typ,
-            emitter.ctx.req.lookupState(x).head.asInstanceOf[TypeWithRequiredness],
-          ).canonicalEmitType
-
-          val accValueAccRegion = mb.newEmitField(accEmitType)
-          val accValueEltRegion = mb.newEmitField(accEmitType)
-
-          // accRegion is unused if requiresMemoryManagementPerElement is false
-          val accRegion: Settable[Region] = if (childProducer.requiresMemoryManagementPerElement)
-            mb.genFieldThisRef[Region]("streamscan_acc_region")
-          else null
-          val first = mb.genFieldThisRef[Boolean]("streamscan_first")
-
-          val producer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
-            override val length: Option[EmitCodeBuilder => Code[Int]] =
-              childProducer.length.map(compL => (cb: EmitCodeBuilder) => compL(cb) + const(1))
-
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-
-              if (childProducer.requiresMemoryManagementPerElement) {
-                cb.assign(accRegion, Region.stagedCreate(Region.REGULAR, outerRegion.getPool()))
-              }
-              cb.assign(first, true)
-              childProducer.initialize(cb, outerRegion)
-            }
-
-            override val elementRegion: Settable[Region] = childProducer.elementRegion
-
-            override val requiresMemoryManagementPerElement: Boolean =
-              childProducer.requiresMemoryManagementPerElement
-
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              val LcopyAndReturn = CodeLabel()
-
-              cb.if_(
-                first, {
-
-                  cb.assign(first, false)
-                  cb.assign(
-                    accValueEltRegion,
-                    emit(zeroIR, cb, region = elementRegion).map(cb)(sc =>
-                      sc.castTo(cb, elementRegion, accValueAccRegion.st)
-                    ),
-                  )
-
-                  cb.goto(LcopyAndReturn)
-                },
-              )
-
-              cb.goto(childProducer.LproduceElement)
-              cb.define(childProducer.LproduceElementDone)
-
-              if (requiresMemoryManagementPerElement) {
-                // deep copy accumulator into element region, then clear accumulator region
-                cb.assign(
-                  accValueEltRegion,
-                  accValueAccRegion.toI(cb).map(cb)(_.castTo(
-                    cb,
-                    childProducer.elementRegion,
-                    accEmitType.st,
-                    deepCopy = true,
-                  )),
-                )
-                cb += accRegion.clearRegion()
-              }
-
-              val bodyCode =
-                cb.withScopedMaybeStreamValue(childProducer.element, "scan_child_elt") { ev =>
-                  emit(
-                    bodyIR,
-                    cb,
-                    env = env.bind((accName, accValueEltRegion), (eltName, ev)),
-                    region = childProducer.elementRegion,
-                  )
-                    .map(cb)(pc =>
-                      pc.castTo(cb, childProducer.elementRegion, accEmitType.st, deepCopy = false)
-                    )
-                }
-
-              cb.assign(accValueEltRegion, bodyCode)
-
-              cb.define(LcopyAndReturn)
-
-              if (requiresMemoryManagementPerElement) {
-                cb.assign(
-                  accValueAccRegion,
-                  accValueEltRegion.toI(cb).map(cb)(pc =>
-                    pc.castTo(cb, accRegion, accEmitType.st, deepCopy = true)
-                  ),
-                )
-              }
-
-              cb.goto(LproduceElementDone)
-            }
-
-            val element: EmitCode = accValueEltRegion.load
-
-            override def close(cb: EmitCodeBuilder): Unit = {
-              childProducer.close(cb)
-              if (requiresMemoryManagementPerElement)
-                cb += accRegion.invalidate()
-            }
-          }
-
-          mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-
-          SStreamValue(producer)
-        }
-
-      case RunAggScan(child, name, init, seqs, result, states) =>
-        val (newContainer, aggSetup, aggCleanup) =
-          AggContainer.fromMethodBuilder(states.toArray, mb, "run_agg_scan")
-
-        produce(child, cb).map(cb) { case childStream: SStreamValue =>
-          val childProducer = childStream.getProducer(mb)
-
-          val childEltField =
-            mb.newEmitField("runaggscan_child_elt", childProducer.element.emitType)
-          val bodyEnv = env.bind(name -> childEltField)
-          val bodyResult = EmitCode.fromI(mb)(cb =>
-            emit(
-              result,
-              cb = cb,
-              region = childProducer.elementRegion,
-              env = bodyEnv,
-              container = Some(newContainer),
-            )
-          )
-          val bodyResultField = mb.newEmitField("runaggscan_result_elt", bodyResult.emitType)
-
-          val producer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
-            override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
-
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-              aggSetup(cb)
-              emitVoid(init, cb = cb, region = outerRegion, container = Some(newContainer))
-              childProducer.initialize(cb, outerRegion)
-            }
-
-            override val elementRegion: Settable[Region] = childProducer.elementRegion
-            override val requiresMemoryManagementPerElement: Boolean =
-              childProducer.requiresMemoryManagementPerElement
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              cb.goto(childProducer.LproduceElement)
-              cb.define(childProducer.LproduceElementDone)
-              cb.assign(childEltField, childProducer.element)
-              cb.assign(bodyResultField, bodyResult.toI(cb))
-              emitVoid(
-                seqs,
-                cb,
-                region = elementRegion,
-                env = bodyEnv,
-                container = Some(newContainer),
-              )
-              cb.goto(LproduceElementDone)
-            }
-            override val element: EmitCode = bodyResultField.load
-
-            override def close(cb: EmitCodeBuilder): Unit = {
-              childProducer.close(cb)
-              aggCleanup(cb)
-            }
-          }
-
-          mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-
-          SStreamValue(producer)
-        }
-
-      case StreamWhiten(stream, newChunkName, prevWindowName, vecSize, windowSize, chunkSize,
-            blockSize, normalizeAfterWhiten) =>
-        produce(stream, cb).map(cb) { case blocks: SStreamValue =>
-          val state = new LocalWhitening(
-            cb,
-            SizeValueStatic(vecSize.toLong),
-            windowSize.toLong,
-            chunkSize.toLong,
-            blockSize.toLong,
-            outerRegion,
-            normalizeAfterWhiten,
-          )
-          val eltType = blocks.st.elementType.asInstanceOf[SBaseStruct]
-          var resultField: SSettable = null
-
-          val blocksProducer = blocks.getProducer(cb.emb)
-          val producer: StreamProducer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
-
-            override val length: Option[EmitCodeBuilder => Code[Int]] =
-              blocksProducer.length.map { l => (cb: EmitCodeBuilder) =>
-                val len = cb.memoize(l(cb))
-                len
-              }
-
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-              state.reset(cb)
-              blocksProducer.initialize(cb, outerRegion)
-            }
-
-            override val elementRegion: Settable[Region] = blocksProducer.elementRegion
-            override val requiresMemoryManagementPerElement: Boolean =
-              blocksProducer.requiresMemoryManagementPerElement
-
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              cb.goto(blocksProducer.LproduceElement)
-              cb.define(blocksProducer.LproduceElementDone)
-              val row =
-                blocksProducer.element.toI(cb).getOrFatal(
-                  cb,
-                  "StreamWhiten: missing tuple",
-                ).asBaseStruct
-              row.loadField(cb, prevWindowName).consume(
-                cb,
-                {},
-                prevWindow => state.initializeWindow(cb, prevWindow.asNDArray),
-              )
-              val block =
-                row.loadField(cb, newChunkName).getOrFatal(
-                  cb,
-                  "StreamWhiten: missing chunk",
-                ).asNDArray
-              val whitenedBlock =
-                LinalgCodeUtils.checkColMajorAndCopyIfNeeded(block, cb, elementRegion)
-              state.whitenBlock(cb, whitenedBlock)
-              // the 'newChunkName' field of 'row' is mutated in place and given
-              // to the consumer
-              val result = row.insert(
-                cb,
-                elementRegion,
-                eltType.virtualType.asInstanceOf[TStruct],
-                newChunkName -> EmitValue.present(whitenedBlock),
-              )
-              resultField = mb.newPField("StreamWhiten_result", result.st)
-              cb.assign(resultField, result)
-              cb.goto(LproduceElementDone)
-            }
-
-            override val element: EmitCode = EmitCode.present(mb, resultField)
-
-            override def close(cb: EmitCodeBuilder): Unit =
-              blocksProducer.close(cb)
-          }
-
-          mb.implementLabel(blocksProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-
-          SStreamValue(producer)
-        }
-
-      case StreamFlatMap(a, name, body) =>
-        produce(a, cb).map(cb) { case outerStream: SStreamValue =>
-          val outerProducer = outerStream.getProducer(mb)
-
-          // variables used in control flow
-          val first = mb.genFieldThisRef[Boolean]("flatmap_first")
-          val innerUnclosed = mb.genFieldThisRef[Boolean]("flatmap_inner_unclosed")
-
-          val innerStreamEmitCode = EmitCode.fromI(mb) { cb =>
-            cb.withScopedMaybeStreamValue(outerProducer.element, "flatmap_outer_value") {
-              outerProducerValue =>
-                emit(
-                  body,
-                  cb = cb,
-                  env = env.bind(name, outerProducerValue),
-                  region = outerProducer.elementRegion,
-                )
-            }
-          }
-
-          val resultElementRegion = mb.genFieldThisRef[Region]("flatmap_result_region")
-          // grabbing emitcode.pv weird pattern but should be safe
-          val innerProducer = innerStreamEmitCode.pv.asStream.getProducer(mb)
-
-          val producer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
-            override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-              cb.assign(first, true)
-              cb.assign(innerUnclosed, false)
-
-              if (outerProducer.requiresMemoryManagementPerElement)
-                cb.assign(
-                  outerProducer.elementRegion,
-                  Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()),
-                )
-              else
-                cb.assign(outerProducer.elementRegion, outerRegion)
-
-              outerProducer.initialize(cb, outerRegion)
-            }
-
-            override val elementRegion: Settable[Region] = resultElementRegion
-
-            override val requiresMemoryManagementPerElement: Boolean =
-              innerProducer.requiresMemoryManagementPerElement || outerProducer.requiresMemoryManagementPerElement
-
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              val LnextOuter = CodeLabel()
-              val LnextInner = CodeLabel()
-              cb.if_(
-                first, {
-                  cb.assign(first, false)
-
-                  cb.define(LnextOuter)
-                  cb.define(innerProducer.LendOfStream)
-
-                  if (outerProducer.requiresMemoryManagementPerElement)
-                    cb += outerProducer.elementRegion.clearRegion()
-
-                  cb.if_(
-                    innerUnclosed, {
-                      cb.assign(innerUnclosed, false)
-                      innerProducer.close(cb)
-                      if (innerProducer.requiresMemoryManagementPerElement) {
-                        cb += innerProducer.elementRegion.invalidate()
-                      }
-                    },
-                  )
-
-                  cb.goto(outerProducer.LproduceElement)
-                  cb.define(outerProducer.LproduceElementDone)
-
-                  innerStreamEmitCode.toI(cb).consume(
-                    cb,
-                    // missing inner streams mean we should go to the next outer element
-                    cb.goto(LnextOuter),
-                    {
-                      _ =>
-                        // the inner stream/producer is bound to a variable above
-                        cb.assign(innerUnclosed, true)
-                        if (innerProducer.requiresMemoryManagementPerElement)
-                          cb.assign(
-                            innerProducer.elementRegion,
-                            Region.stagedCreate(
-                              Region.REGULAR,
-                              outerProducer.elementRegion.getPool(),
-                            ),
-                          )
-                        else
-                          cb.assign(innerProducer.elementRegion, outerProducer.elementRegion)
-
-                        innerProducer.initialize(cb, outerRegion)
-                        cb.goto(LnextInner)
-                    },
-                  )
-                },
-              )
-
-              cb.define(LnextInner)
-              cb.goto(innerProducer.LproduceElement)
-              cb.define(innerProducer.LproduceElementDone)
-
-              if (requiresMemoryManagementPerElement) {
-                cb += resultElementRegion.trackAndIncrementReferenceCountOf(
-                  innerProducer.elementRegion
-                )
-
-                // if outer requires memory management and inner doesn't,
-                // then innerProducer.elementRegion is outerProducer.elementRegion
-                // and we shouldn't clear it.
-                if (innerProducer.requiresMemoryManagementPerElement) {
-                  cb += resultElementRegion.trackAndIncrementReferenceCountOf(
-                    outerProducer.elementRegion
-                  )
-                  cb += innerProducer.elementRegion.clearRegion()
-                }
-              }
-              cb.goto(LproduceElementDone)
-            }
-            val element: EmitCode = innerProducer.element
-
-            def close(cb: EmitCodeBuilder): Unit = {
-              cb.if_(
-                innerUnclosed, {
-                  cb.assign(innerUnclosed, false)
-                  if (innerProducer.requiresMemoryManagementPerElement) {
-                    cb += innerProducer.elementRegion.invalidate()
-                  }
-                  innerProducer.close(cb)
-                },
-              )
-              outerProducer.close(cb)
-
-              if (outerProducer.requiresMemoryManagementPerElement)
-                cb += outerProducer.elementRegion.invalidate()
-            }
-          }
-
-          mb.implementLabel(outerProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-
-          SStreamValue(producer)
-        }
-
-      case StreamLeftIntervalJoin(left, right, lKeyField, rIntrvlName, lName, rName, body) =>
-        produce(left, cb).flatMap(cb) { case lStream: SStreamValue =>
-          produce(right, cb).map(cb) { case rStream: SStreamValue =>
-            // map over the keyStream
-            val lProd = lStream.getProducer(mb)
-            val rProd = rStream.getProducer(mb)
-
-            val rElemSTy =
-              SBaseStructPointer(rProd.element.st.storageType().asInstanceOf[PBaseStruct])
-
-            def loadInterval(cb: EmitCodeBuilder, rElem: SValue): SIntervalValue =
-              rElem.asBaseStruct.loadField(cb, rIntrvlName).getOrAssert(cb).asInterval
-
-            val q: StagedMinHeap =
-              StagedMinHeap(mb.emodb, rElemSTy) {
-                (cb: EmitCodeBuilder, a: SValue, b: SValue) =>
-                  val l = loadInterval(cb, a)
-                  val r = loadInterval(cb, b)
-                  IntervalFunctions.intervalEndpointCompare(
-                    cb,
-                    l.loadEnd(cb).getOrAssert(cb),
-                    l.includesEnd,
-                    r.loadEnd(cb).getOrAssert(cb),
-                    r.includesEnd,
-                  )
-              }(mb.ecb)
-
-            val lElement: SBaseStructSettable =
-              mb.newPField("LeftElement", lProd.element.st).asInstanceOf[SBaseStructSettable]
-
-            val rElements: SSettable =
-              mb.newPField("RightElements", q.arraySType)
-
-            var jElement: EmitSettable =
-              null
-
-            val rEOS: ThisFieldRef[Boolean] =
-              mb.genFieldThisRef[Boolean]("RightEOS")
-
-            val rPulled: ThisFieldRef[Boolean] =
-              mb.genFieldThisRef[Boolean]("RightPulled")
-
-            SStreamValue {
-              new StreamProducer {
-                override def method: EmitMethodBuilder[_] =
-                  mb
-
-                override val length: Option[EmitCodeBuilder => Code[Int]] =
-                  lProd.length
-
-                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                  cb.assign(rEOS, false)
-                  cb.assign(rPulled, false)
-
-                  for (p <- FastSeq(lProd, rProd)) {
-                    p.initialize(cb, outerRegion)
-                    cb.assign(
-                      p.elementRegion,
-                      if (p.requiresMemoryManagementPerElement)
-                        Region.stagedCreate(REGULAR, mb.ecb.pool())
-                      else outerRegion.get,
-                    )
-                  }
-
-                  q.init(cb, mb.ecb.pool())
-                }
-
-                override val elementRegion: Settable[Region] =
-                  mb.genFieldThisRef[Region]("IntervalJoinRegion")
-
-                override val requiresMemoryManagementPerElement: Boolean =
-                  lProd.requiresMemoryManagementPerElement || rProd.requiresMemoryManagementPerElement
-
-                override val LproduceElement: CodeLabel =
-                  mb.defineAndImplementLabel { cb =>
-                    if (lProd.requiresMemoryManagementPerElement) {
-                      cb += lProd.elementRegion.clearRegion()
-                    }
-
-                    cb.goto(lProd.LproduceElement)
-                    cb.define(lProd.LproduceElementDone)
-
-                    cb.assign(lElement, lProd.element.toI(cb).getOrAssert(cb).asBaseStruct)
-                    val point = lElement.loadField(cb, lKeyField).getOrAssert(cb)
-
-                    /* Drop rows from the priority queue if their interval's right endpoint is
-                     * before the current key. */
-                    cb.loop { Lrecur =>
-                      cb.if_(
-                        q.nonEmpty(cb), {
-                          val interval = loadInterval(cb, q.peek(cb))
-                          val end = interval.loadEnd(cb).getOrAssert(cb)
-                          cb.if_(
-                            pointGTIntervalEndpoint(cb, point, end, interval.includesEnd), {
-                              q.pop(cb)
-                              cb.goto(Lrecur)
-                            },
-                          )
-                        },
-                      )
-                    }
-
-                    q.realloc(cb)
-
-                    val LallIntervalsFound = CodeLabel()
-                    cb.if_(rEOS, cb.goto(LallIntervalsFound))
-
-                    val LproduceRightElement = CodeLabel()
-                    cb.if_(!rPulled, cb.goto(LproduceRightElement))
-
-                    cb.loop { Lrecur =>
-                      val rElement = rElemSTy.coerceOrCopy(
-                        cb,
-                        elementRegion,
-                        rProd.element.toI(cb).getOrAssert(cb),
-                        deepCopy = false,
-                      )
-                      val interval = loadInterval(cb, rElement)
-
-                      // Drop intervals whose right endpoint is before the key
-                      val end = interval.loadEnd(cb).getOrAssert(cb)
-                      cb.if_(
-                        pointGTIntervalEndpoint(cb, point, end, interval.includesEnd),
-                        cb.goto(LproduceRightElement),
-                      )
-
-                      // Stop consuming intervals if the left endpoint is after the key
-                      val start = interval.loadStart(cb).getOrAssert(cb)
-                      cb.if_(
-                        pointLTIntervalEndpoint(
-                          cb,
-                          point,
-                          start,
-                          leansRight = !interval.includesStart,
-                        ),
-                        cb.goto(LallIntervalsFound),
-                      )
-
-                      q.push(cb, rElement)
-
-                      cb.define(LproduceRightElement)
-                      if (rProd.requiresMemoryManagementPerElement) {
-                        cb += rProd.elementRegion.clearRegion()
-                      }
-
-                      cb.goto(rProd.LproduceElement)
-                      cb.define(rProd.LproduceElementDone)
-                      cb.assign(rPulled, true)
-                      cb.goto(Lrecur)
-                    }
-
-                    cb.define(rProd.LendOfStream)
-                    cb.assign(rEOS, true)
-
-                    cb.define(LallIntervalsFound)
-                    cb.assign(rElements, q.toArray(cb, elementRegion))
-                    val result = emit(
-                      body,
-                      cb,
-                      region = elementRegion,
-                      env = env.bind(
-                        lName -> EmitValue.present(lElement),
-                        rName -> EmitValue.present(rElements),
-                      ),
-                    )
-
-                    jElement = mb.newEmitField("IntervalJoinResult", result.emitType)
-                    cb.assign(jElement, result)
-                    cb.goto(LproduceElementDone)
-
-                    cb.define(lProd.LendOfStream)
-                    cb.goto(LendOfStream)
-                  }
-
-                override val element: EmitCode =
-                  jElement
-
-                override def close(cb: EmitCodeBuilder): Unit = {
-                  q.close(cb)
-                  for (p <- FastSeq(rProd, lProd)) {
-                    p.close(cb)
-                    if (p.requiresMemoryManagementPerElement) {
-                      cb += p.elementRegion.invalidate()
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-      case x @ StreamJoinRightDistinct(leftIR, rightIR, lKey, rKey, leftName, rightName, joinIR,
-            joinType) =>
-        produce(leftIR, cb).flatMap(cb) { case leftStream: SStreamValue =>
-          produce(rightIR, cb).map(cb) { case rightStream: SStreamValue =>
-            val leftProducer = leftStream.getProducer(mb)
-            val rightProducer = rightStream.getProducer(mb)
-
-            val lEltType = leftProducer.element.emitType
-            val rEltType = rightProducer.element.emitType
-
-            def compare(cb: EmitCodeBuilder, lelt: EmitValue, relt: EmitValue): Code[Int] = {
-              assert(lelt.emitType == lEltType)
-              assert(relt.emitType == rEltType)
-              if (x.isIntervalJoin) {
-                val rhs = relt.toI(cb).flatMap(cb)(_.asBaseStruct.loadField(cb, rKey(0)))
-                val result = cb.newLocal[Int]("SJRD-interval-compare-result")
-                rhs.consume(
-                  cb,
-                  cb.assign(result, -1),
-                  { case interval: SIntervalValue =>
-                    val lhs = lelt.toI(cb).flatMap(cb)(_.asBaseStruct.loadField(cb, lKey(0)))
-                    lhs.consume(
-                      cb,
-                      cb.assign(result, 1),
-                      { point =>
-                        val c = IntervalFunctions.pointIntervalCompare(cb, point, interval)
-                        c.consume(
-                          cb,
-                          // One of the interval endpoints is missing. In this case,
-                          // consider the point greater, so that the join advances
-                          // past the bad interval, keeping the point.
-                          cb.assign(result, 1),
-                          c => cb.assign(result, c.asInt.value),
-                        )
-                      },
-                    )
-                  },
-                )
-                result
-              } else {
-                val lhs = lelt.map(cb)(_.asBaseStruct.subset(lKey: _*))
-                val rhs = relt.map(cb)(_.asBaseStruct.subset(rKey: _*))
-                StructOrdering.make(
-                  lhs.st.asInstanceOf[SBaseStruct],
-                  rhs.st.asInstanceOf[SBaseStruct],
-                  cb.emb.ecb,
-                  missingFieldsEqual = false,
-                )
-                  .compare(cb, lhs, rhs, missingEqual = false)
-              }
-            }
-
-            // these variables are used as inputs to the joinF
-            val lx = mb.newEmitField("streamjoin_lx", lEltType) // last value received from left
-            val rx = mb.newEmitField("streamjoin_rx", rEltType) // last value received from right
-
-            val lxOut: EmitSettable = joinType match {
-              case "inner" | "left" => lx
-              case "outer" | "right" =>
-                mb.newEmitField("streamjoin_lxout", lx.emitType.copy(required = false))
-            }
-            val rxOut: EmitSettable = joinType match {
-              case "inner" | "right" => rx
-              case "outer" | "left" =>
-                mb.newEmitField("streamjoin_rxout", rx.emitType.copy(required = false))
-            }
-
-            val _elementRegion = mb.genFieldThisRef[Region]("join_right_distinct_element_region")
-            val _requiresMemoryManagementPerElement =
-              leftProducer.requiresMemoryManagementPerElement || rightProducer.requiresMemoryManagementPerElement
-
-            val joinResult = EmitCode.fromI(mb)(cb =>
-              emit(
-                joinIR,
-                cb,
-                region = _elementRegion,
-                env = env.bind(leftName -> lxOut, rightName -> rxOut),
-              )
-            )
-
-            def sharedInit(cb: EmitCodeBuilder): Unit = {
-              if (rightProducer.requiresMemoryManagementPerElement)
-                cb.assign(
-                  rightProducer.elementRegion,
-                  Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
-                )
-              else
-                cb.assign(rightProducer.elementRegion, outerRegion)
-              if (leftProducer.requiresMemoryManagementPerElement)
-                cb.assign(
-                  leftProducer.elementRegion,
-                  Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
-                )
-              else
-                cb.assign(leftProducer.elementRegion, outerRegion)
-
-              leftProducer.initialize(cb, outerRegion)
-              rightProducer.initialize(cb, outerRegion)
-            }
-
-            def sharedClose(cb: EmitCodeBuilder): Unit = {
-              leftProducer.close(cb)
-              rightProducer.close(cb)
-              if (leftProducer.requiresMemoryManagementPerElement)
-                cb += leftProducer.elementRegion.invalidate()
-
-              if (rightProducer.requiresMemoryManagementPerElement)
-                cb += rightProducer.elementRegion.invalidate()
-            }
-
-            joinType match {
-              case "left" =>
-                val rightEOS = mb.genFieldThisRef[Boolean]("left_join_right_distinct_rightEOS")
-                val pulledRight =
-                  mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
-
-                val producer = new StreamProducer {
+                val producer: StreamProducer = new StreamProducer {
                   override def method: EmitMethodBuilder[_] = mb
-                  override val length: Option[EmitCodeBuilder => Code[Int]] = leftProducer.length
+                  override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => len)
 
                   override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                    cb.assign(rightEOS, false)
-                    cb.assign(pulledRight, false)
+                    val llen = cb.newLocal[Long]("streamrange_llen")
 
-                    sharedInit(cb)
+                    cb.if_(
+                      step ceq const(0),
+                      cb._fatalWithError(errorID, "Array range cannot have step size 0."),
+                    )
+                    cb.if_(
+                      step < const(0),
+                      cb.if_(
+                        start.toL <= stop.toL,
+                        cb.assign(llen, 0L),
+                        cb.assign(llen, (start.toL - stop.toL - 1L) / (-step.toL) + 1L),
+                      ),
+                      cb.if_(
+                        start.toL >= stop.toL,
+                        cb.assign(llen, 0L),
+                        cb.assign(llen, (stop.toL - start.toL - 1L) / step.toL + 1L),
+                      ),
+                    )
+                    cb.if_(
+                      llen > const(Int.MaxValue.toLong),
+                      cb._fatalWithError(
+                        errorID,
+                        "Array range cannot have more than MAXINT elements.",
+                      ),
+                    )
+                    cb.assign(len, llen.toI)
+
+                    cb.assign(curr, start - step)
+                    cb.assign(idx, 0)
                   }
 
-                  override val elementRegion: Settable[Region] = _elementRegion
+                  override val elementRegion: Settable[Region] = regionVar
+
                   override val requiresMemoryManagementPerElement: Boolean =
                     _requiresMemoryManagementPerElement
+
                   override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                    if (leftProducer.requiresMemoryManagementPerElement)
-                      cb += leftProducer.elementRegion.clearRegion()
-                    cb.goto(leftProducer.LproduceElement)
-                    cb.define(leftProducer.LproduceElementDone)
-                    cb.assign(lx, leftProducer.element)
-
-                    // if right stream is exhausted, return immediately
-                    cb.if_(rightEOS, cb.goto(LproduceElementDone))
-
-                    val Lpush = CodeLabel()
-
-                    val LpullRight = CodeLabel()
-                    cb.if_(
-                      !pulledRight, {
-                        cb.assign(pulledRight, true)
-                        cb.goto(LpullRight)
-                      },
-                    )
-
-                    val Lcompare = CodeLabel()
-                    cb.define(Lcompare)
-                    val c = cb.newLocal[Int]("left_join_right_distinct_c", compare(cb, lx, rx))
-                    cb.if_(c > 0, cb.goto(LpullRight))
-
-                    cb.if_(
-                      c < 0,
-                      cb.assign(rxOut, EmitCode.missing(mb, rxOut.st)), {
-                        // c == 0
-                        if (rightProducer.requiresMemoryManagementPerElement) {
-                          cb += elementRegion.trackAndIncrementReferenceCountOf(
-                            rightProducer.elementRegion
-                          )
-                        }
-                        cb.assign(rxOut, rx)
-                      },
-                    )
-
-                    cb.goto(Lpush)
-
-                    mb.implementLabel(Lpush) { cb =>
-                      if (leftProducer.requiresMemoryManagementPerElement)
-                        cb += elementRegion.trackAndIncrementReferenceCountOf(
-                          leftProducer.elementRegion
-                        )
-
-                      cb.goto(LproduceElementDone)
-                    }
-
-                    mb.implementLabel(LpullRight) { cb =>
-                      if (rightProducer.requiresMemoryManagementPerElement) {
-                        cb += rightProducer.elementRegion.clearRegion()
-                      }
-                      cb.goto(rightProducer.LproduceElement)
-                      cb.define(rightProducer.LproduceElementDone)
-                      cb.assign(rx, rightProducer.element)
-                      cb.goto(Lcompare)
-                    }
-
-                    // if right stream ends before left
-                    mb.implementLabel(rightProducer.LendOfStream) { cb =>
-                      cb.assign(rxOut, EmitCode.missing(mb, rxOut.st))
-                      cb.assign(rightEOS, true)
-                      cb.goto(Lpush)
-                    }
-
-                    mb.implementLabel(leftProducer.LendOfStream)(cb => cb.goto(LendOfStream))
+                    cb.if_(idx >= len, cb.goto(LendOfStream))
+                    cb.assign(curr, curr + step)
+                    cb.assign(idx, idx + 1)
+                    cb.goto(LproduceElementDone)
                   }
-                  override val element: EmitCode = joinResult
 
-                  override def close(cb: EmitCodeBuilder): Unit =
-                    sharedClose(cb)
+                  val element: EmitCode = EmitCode.present(mb, new SInt32Value(curr))
+
+                  def close(cb: EmitCodeBuilder): Unit = {}
                 }
 
                 SStreamValue(producer)
+              }
+            }
+          }
 
-              case "right" =>
-                val leftEOS = mb.genFieldThisRef[Boolean]("left_join_right_distinct_leftEOS")
-                val pulledRight =
-                  mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
-                val pushedRight =
-                  mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
-                val c = mb.genFieldThisRef[Int]("join_right_distinct_compResult")
+        case SeqSample(totalSize, numToSample, _, _requiresMemoryManagementPerElement) =>
+          // Implemented based on http://www.ittc.ku.edu/~jsv/Papers/Vit84.sampling.pdf Algorithm A
+          emit(totalSize, cb).flatMap(cb) { case totalSizeVal: SInt32Value =>
+            emit(numToSample, cb).map(cb) { case numToSampleVal: SInt32Value =>
+              val len = mb.genFieldThisRef[Int]("seq_sample_len")
+              val regionVar = mb.genFieldThisRef[Region]("seq_sample_region")
+
+              val nRemaining = cb.newField[Int]("seq_sample_num_remaining", numToSampleVal.value)
+              val candidate = cb.newField[Int]("seq_sample_candidate", 0)
+              val elementToReturn =
+                cb.newField[Int]("seq_sample_element_to_return", -1) // -1 should never be returned.
+
+              val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = Some(_ => len)
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  cb.assign(len, numToSampleVal.asInt.value)
+                  cb.assign(nRemaining, numToSampleVal.value)
+                  cb.assign(candidate, 0)
+                  cb.assign(elementToReturn, -1)
+                }
+
+                override val elementRegion: Settable[Region] = regionVar
+
+                override val requiresMemoryManagementPerElement: Boolean =
+                  _requiresMemoryManagementPerElement
+
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.if_(nRemaining <= 0, cb.goto(LendOfStream))
+
+                  val u = cb.newLocal[Double](
+                    "seq_sample_rand_unif",
+                    Code.invokeStatic0[Math, Double]("random"),
+                  )
+                  val fC = cb.newLocal[Double](
+                    "seq_sample_Fc",
+                    (totalSizeVal.value - candidate - nRemaining).toD / (totalSizeVal.value - candidate).toD,
+                  )
+
+                  cb.while_(
+                    fC > u, {
+                      cb.assign(candidate, candidate + 1)
+                      cb.assign(
+                        fC,
+                        fC * (const(1.0) - (nRemaining.toD / (totalSizeVal.value - candidate).toD)),
+                      )
+                    },
+                  )
+                  cb.assign(nRemaining, nRemaining - 1)
+                  cb.assign(elementToReturn, candidate)
+                  cb.assign(candidate, candidate + 1)
+                  cb.goto(LproduceElementDone)
+                }
+
+                override val element: EmitCode =
+                  EmitCode.present(mb, new SInt32Value(elementToReturn))
+
+                override def close(cb: EmitCodeBuilder): Unit = {}
+              }
+              SStreamValue(producer)
+            }
+          }
+
+        case StreamFilter(a, name, cond) =>
+          produce(a, cb)
+            .map(cb) { case childStream: SStreamValue =>
+              val childProducer = childStream.getProducer(mb)
+
+              val filterEltRegion = mb.genFieldThisRef[Region]("streamfilter_filter_region")
+
+              val elementField =
+                cb.emb.newEmitField("streamfilter_cond", childProducer.element.emitType)
+
+              val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  if (childProducer.requiresMemoryManagementPerElement)
+                    cb.assign(
+                      childProducer.elementRegion,
+                      Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
+                    )
+                  else
+                    cb.assign(childProducer.elementRegion, outerRegion)
+                  childProducer.initialize(cb, outerRegion)
+                }
+
+                override val elementRegion: Settable[Region] = filterEltRegion
+
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  val Lfiltered = CodeLabel()
+
+                  cb.goto(childProducer.LproduceElement)
+
+                  cb.define(childProducer.LproduceElementDone)
+                  cb.assign(elementField, childProducer.element)
+                  // false and NA both fail the filter
+                  emit(
+                    cond,
+                    cb = cb,
+                    env = env.bind(name, elementField),
+                    region = childProducer.elementRegion,
+                  )
+                    .consume(
+                      cb,
+                      cb.goto(Lfiltered),
+                      sc => cb.if_(!sc.asBoolean.value, cb.goto(Lfiltered)),
+                    )
+
+                  if (requiresMemoryManagementPerElement)
+                    cb += filterEltRegion.takeOwnershipOfAndClear(childProducer.elementRegion)
+                  cb.goto(LproduceElementDone)
+
+                  cb.define(Lfiltered)
+                  if (requiresMemoryManagementPerElement)
+                    cb += childProducer.elementRegion.clearRegion()
+                  cb.goto(childProducer.LproduceElement)
+                }
+
+                val element: EmitCode = elementField
+
+                def close(cb: EmitCodeBuilder): Unit = {
+                  childProducer.close(cb)
+                  if (requiresMemoryManagementPerElement)
+                    cb += childProducer.elementRegion.invalidate()
+                }
+              }
+              mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+
+              SStreamValue(producer)
+            }
+
+        case StreamTake(a, num) =>
+          produce(a, cb)
+            .flatMap(cb) { case childStream: SStreamValue =>
+              emit(num, cb).map(cb) { case num: SInt32Value =>
+                val childProducer = childStream.getProducer(mb)
+                val n = mb.genFieldThisRef[Int]("stream_take_n")
+                val idx = mb.genFieldThisRef[Int]("stream_take_idx")
 
                 val producer = new StreamProducer {
                   override def method: EmitMethodBuilder[_] = mb
-                  override val length: Option[EmitCodeBuilder => Code[Int]] = None
+                  override val length: Option[EmitCodeBuilder => Code[Int]] =
+                    childProducer.length.map(compLen => (cb: EmitCodeBuilder) => compLen(cb).min(n))
 
                   override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                    cb.assign(leftEOS, false)
-                    cb.assign(pulledRight, false)
-                    cb.assign(pushedRight, false)
-                    cb.assign(c, 0)
-                    sharedInit(cb)
+                    cb.assign(n, num.value)
+                    cb.if_(
+                      n < 0,
+                      cb._fatal(s"stream take: negative number of elements to take: ", n.toS),
+                    )
+                    cb.assign(idx, 0)
+                    childProducer.initialize(cb, outerRegion)
                   }
 
-                  override val elementRegion: Settable[Region] = _elementRegion
+                  override val elementRegion: Settable[Region] = childProducer.elementRegion
                   override val requiresMemoryManagementPerElement: Boolean =
-                    _requiresMemoryManagementPerElement
+                    childProducer.requiresMemoryManagementPerElement
                   override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                    val Lpush = CodeLabel()
-                    val LpullRight = CodeLabel()
-                    val LpullLeft = CodeLabel()
-                    val Lcompare = CodeLabel()
-                    val LmaybePullRight = CodeLabel()
+                    cb.if_(idx >= n, cb.goto(LendOfStream))
+                    cb.assign(idx, idx + 1)
+                    cb.goto(childProducer.LproduceElement)
 
-                    cb.if_(leftEOS, cb.goto(Lcompare))
-                    cb.if_(c <= 0, cb.goto(LpullLeft), cb.goto(LpullRight))
+                    cb.define(childProducer.LproduceElementDone)
+                    cb.goto(LproduceElementDone)
 
-                    cb.define(Lcompare)
-                    cb.if_(leftEOS, cb.if_(pushedRight, cb.goto(LpullRight), cb.goto(Lpush)))
-                    cb.assign(c, compare(cb, lx, rx))
+                    cb.define(childProducer.LendOfStream)
+                    cb.goto(LendOfStream)
+                  }
+                  override val element: EmitCode = childProducer.element
 
-                    cb.if_(c < 0, cb.goto(LpullLeft))
+                  override def close(cb: EmitCodeBuilder): Unit =
+                    childProducer.close(cb)
+                }
+
+                SStreamValue(producer)
+              }
+            }
+
+        case StreamDrop(a, num) =>
+          produce(a, cb)
+            .flatMap(cb) { case (childStream: SStreamValue) =>
+              emit(num, cb).map(cb) { case num: SInt32Value =>
+                val childProducer = childStream.getProducer(mb)
+                val n = mb.genFieldThisRef[Int]("stream_drop_n")
+                val idx = mb.genFieldThisRef[Int]("stream_drop_idx")
+
+                val producer = new StreamProducer {
+                  override def method: EmitMethodBuilder[_] = mb
+                  override val length: Option[EmitCodeBuilder => Code[Int]] =
+                    childProducer.length.map { computeL => (cb: EmitCodeBuilder) =>
+                      (computeL(cb) - n).max(0)
+                    }
+
+                  override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                    cb.assign(n, num.value)
+                    cb.if_(
+                      n < 0,
+                      cb._fatal(s"stream drop: negative number of elements to drop: ", n.toS),
+                    )
+                    cb.assign(idx, 0)
+                    childProducer.initialize(cb, outerRegion)
+                  }
+
+                  override val elementRegion: Settable[Region] = childProducer.elementRegion
+                  override val requiresMemoryManagementPerElement: Boolean =
+                    childProducer.requiresMemoryManagementPerElement
+                  override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                    cb.goto(childProducer.LproduceElement)
+                    cb.define(childProducer.LproduceElementDone)
+                    cb.assign(idx, idx + 1)
+                    cb.if_(
+                      idx <= n, {
+                        if (childProducer.requiresMemoryManagementPerElement)
+                          cb += childProducer.elementRegion.clearRegion()
+                        cb.goto(childProducer.LproduceElement)
+                      },
+                    )
+                    cb.goto(LproduceElementDone)
+
+                    cb.define(childProducer.LendOfStream)
+                    cb.goto(LendOfStream)
+                  }
+                  override val element: EmitCode = childProducer.element
+
+                  override def close(cb: EmitCodeBuilder): Unit =
+                    childProducer.close(cb)
+                }
+
+                SStreamValue(producer)
+              }
+            }
+
+        case StreamTakeWhile(a, elt, condIR) =>
+          produce(a, cb)
+            .map(cb) { case childStream: SStreamValue =>
+              val childProducer = childStream.getProducer(mb)
+
+              val eltSettable =
+                mb.newEmitField("stream_take_while_elt", childProducer.element.emitType)
+
+              val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
+                  childProducer.initialize(cb, outerRegion)
+
+                override val elementRegion: Settable[Region] = childProducer.elementRegion
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.goto(childProducer.LproduceElement)
+                  cb.define(childProducer.LproduceElementDone)
+                  cb.assign(eltSettable, childProducer.element)
+
+                  emit(
+                    condIR,
+                    cb,
+                    region = childProducer.elementRegion,
+                    env = env.bind(elt, eltSettable),
+                  )
+                    .consume(
+                      cb,
+                      cb.goto(LendOfStream),
+                      code =>
+                        cb.if_(
+                          code.asBoolean.value,
+                          cb.goto(LproduceElementDone),
+                          cb.goto(LendOfStream),
+                        ),
+                    )
+
+                  cb.define(childProducer.LendOfStream)
+                  cb.goto(LendOfStream)
+                }
+
+                override val element: EmitCode = eltSettable
+
+                override def close(cb: EmitCodeBuilder): Unit =
+                  childProducer.close(cb)
+              }
+
+              SStreamValue(producer)
+            }
+
+        case StreamDropWhile(a, elt, condIR) =>
+          produce(a, cb)
+            .map(cb) { case childStream: SStreamValue =>
+              val childProducer = childStream.getProducer(mb)
+              val eltSettable =
+                mb.newEmitField("stream_drop_while_elt", childProducer.element.emitType)
+              val doneComparisons = mb.genFieldThisRef[Boolean]("stream_drop_while_donecomparisons")
+
+              val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  childProducer.initialize(cb, outerRegion)
+                  cb.assign(doneComparisons, false)
+                }
+
+                override val elementRegion: Settable[Region] = childProducer.elementRegion
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.goto(childProducer.LproduceElement)
+                  cb.define(childProducer.LproduceElementDone)
+                  cb.assign(eltSettable, childProducer.element)
+
+                  cb.if_(doneComparisons, cb.goto(LproduceElementDone))
+
+                  val LdropThis = CodeLabel()
+                  val LdoneDropping = CodeLabel()
+                  emit(
+                    condIR,
+                    cb,
+                    region = childProducer.elementRegion,
+                    env = env.bind(elt, eltSettable),
+                  )
+                    .consume(
+                      cb,
+                      cb.goto(LdoneDropping),
+                      code =>
+                        cb.if_(code.asBoolean.value, cb.goto(LdropThis), cb.goto(LdoneDropping)),
+                    )
+
+                  cb.define(LdropThis)
+                  if (childProducer.requiresMemoryManagementPerElement)
+                    cb += childProducer.elementRegion.clearRegion()
+                  cb.goto(childProducer.LproduceElement)
+
+                  cb.define(LdoneDropping)
+                  cb.assign(doneComparisons, true)
+                  cb.goto(LproduceElementDone)
+
+                  cb.define(childProducer.LendOfStream)
+                  cb.goto(LendOfStream)
+                }
+                override val element: EmitCode = eltSettable
+
+                override def close(cb: EmitCodeBuilder): Unit =
+                  childProducer.close(cb)
+              }
+
+              SStreamValue(producer)
+            }
+
+        case StreamMap(a, name, body) =>
+          produce(a, cb)
+            .map(cb) { case childStream: SStreamValue =>
+              val childProducer = childStream.getProducer(mb)
+
+              val bodyResult = EmitCode.fromI(mb) { cb =>
+                cb.withScopedMaybeStreamValue(childProducer.element, "streammap_element") {
+                  childProducerElement =>
+                    emit(
+                      body,
+                      cb = cb,
+                      env = env.bind(name, childProducerElement),
+                      region = childProducer.elementRegion,
+                    )
+                }
+              }
+
+              val producer: StreamProducer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit =
+                  childProducer.initialize(cb, outerRegion)
+
+                override val elementRegion: Settable[Region] = childProducer.elementRegion
+
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.goto(childProducer.LproduceElement)
+                  cb.define(childProducer.LproduceElementDone)
+                  cb.goto(LproduceElementDone)
+                }
+
+                val element: EmitCode = bodyResult
+
+                def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
+              }
+
+              mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+
+              SStreamValue(producer)
+            }
+
+        case x @ StreamScan(childIR, zeroIR, accName, eltName, bodyIR) =>
+          produce(childIR, cb).map(cb) { case childStream: SStreamValue =>
+            val childProducer = childStream.getProducer(mb)
+
+            val accEmitType = VirtualTypeWithReq(
+              zeroIR.typ,
+              emitter.ctx.req.lookupState(x).head.asInstanceOf[TypeWithRequiredness],
+            ).canonicalEmitType
+
+            val accValueAccRegion = mb.newEmitField(accEmitType)
+            val accValueEltRegion = mb.newEmitField(accEmitType)
+
+            // accRegion is unused if requiresMemoryManagementPerElement is false
+            val accRegion: Settable[Region] = if (childProducer.requiresMemoryManagementPerElement)
+              mb.genFieldThisRef[Region]("streamscan_acc_region")
+            else null
+            val first = mb.genFieldThisRef[Boolean]("streamscan_first")
+
+            val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
+              override val length: Option[EmitCodeBuilder => Code[Int]] =
+                childProducer.length.map(compL => (cb: EmitCodeBuilder) => compL(cb) + const(1))
+
+              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+
+                if (childProducer.requiresMemoryManagementPerElement) {
+                  cb.assign(accRegion, Region.stagedCreate(Region.REGULAR, outerRegion.getPool()))
+                }
+                cb.assign(first, true)
+                childProducer.initialize(cb, outerRegion)
+              }
+
+              override val elementRegion: Settable[Region] = childProducer.elementRegion
+
+              override val requiresMemoryManagementPerElement: Boolean =
+                childProducer.requiresMemoryManagementPerElement
+
+              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                val LcopyAndReturn = CodeLabel()
+
+                cb.if_(
+                  first, {
+
+                    cb.assign(first, false)
+                    cb.assign(
+                      accValueEltRegion,
+                      emit(zeroIR, cb, region = elementRegion).map(cb)(sc =>
+                        sc.castTo(cb, elementRegion, accValueAccRegion.st)
+                      ),
+                    )
+
+                    cb.goto(LcopyAndReturn)
+                  },
+                )
+
+                cb.goto(childProducer.LproduceElement)
+                cb.define(childProducer.LproduceElementDone)
+
+                if (requiresMemoryManagementPerElement) {
+                  // deep copy accumulator into element region, then clear accumulator region
+                  cb.assign(
+                    accValueEltRegion,
+                    accValueAccRegion.toI(cb).map(cb)(_.castTo(
+                      cb,
+                      childProducer.elementRegion,
+                      accEmitType.st,
+                      deepCopy = true,
+                    )),
+                  )
+                  cb += accRegion.clearRegion()
+                }
+
+                val bodyCode =
+                  cb.withScopedMaybeStreamValue(childProducer.element, "scan_child_elt") { ev =>
+                    emit(
+                      bodyIR,
+                      cb,
+                      env = env.bind((accName, accValueEltRegion), (eltName, ev)),
+                      region = childProducer.elementRegion,
+                    )
+                      .map(cb)(pc =>
+                        pc.castTo(cb, childProducer.elementRegion, accEmitType.st, deepCopy = false)
+                      )
+                  }
+
+                cb.assign(accValueEltRegion, bodyCode)
+
+                cb.define(LcopyAndReturn)
+
+                if (requiresMemoryManagementPerElement) {
+                  cb.assign(
+                    accValueAccRegion,
+                    accValueEltRegion.toI(cb).map(cb)(pc =>
+                      pc.castTo(cb, accRegion, accEmitType.st, deepCopy = true)
+                    ),
+                  )
+                }
+
+                cb.goto(LproduceElementDone)
+              }
+
+              val element: EmitCode = accValueEltRegion.load
+
+              override def close(cb: EmitCodeBuilder): Unit = {
+                childProducer.close(cb)
+                if (requiresMemoryManagementPerElement)
+                  cb += accRegion.invalidate()
+              }
+            }
+
+            mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+
+            SStreamValue(producer)
+          }
+
+        case RunAggScan(child, name, init, seqs, result, states) =>
+          val (newContainer, aggSetup, aggCleanup) =
+            AggContainer.fromMethodBuilder(states.toArray, mb, "run_agg_scan")
+
+          produce(child, cb).map(cb) { case childStream: SStreamValue =>
+            val childProducer = childStream.getProducer(mb)
+
+            val childEltField =
+              mb.newEmitField("runaggscan_child_elt", childProducer.element.emitType)
+            val bodyEnv = env.bind(name -> childEltField)
+            val bodyResult = EmitCode.fromI(mb)(cb =>
+              emit(
+                result,
+                cb = cb,
+                region = childProducer.elementRegion,
+                env = bodyEnv,
+                container = Some(newContainer),
+              )
+            )
+            val bodyResultField = mb.newEmitField("runaggscan_result_elt", bodyResult.emitType)
+
+            val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
+              override val length: Option[EmitCodeBuilder => Code[Int]] = childProducer.length
+
+              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                aggSetup(cb)
+                emitVoid(init, cb = cb, region = outerRegion, container = Some(newContainer))
+                childProducer.initialize(cb, outerRegion)
+              }
+
+              override val elementRegion: Settable[Region] = childProducer.elementRegion
+              override val requiresMemoryManagementPerElement: Boolean =
+                childProducer.requiresMemoryManagementPerElement
+              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                cb.goto(childProducer.LproduceElement)
+                cb.define(childProducer.LproduceElementDone)
+                cb.assign(childEltField, childProducer.element)
+                cb.assign(bodyResultField, bodyResult.toI(cb))
+                emitVoid(
+                  seqs,
+                  cb,
+                  region = elementRegion,
+                  env = bodyEnv,
+                  container = Some(newContainer),
+                )
+                cb.goto(LproduceElementDone)
+              }
+              override val element: EmitCode = bodyResultField.load
+
+              override def close(cb: EmitCodeBuilder): Unit = {
+                childProducer.close(cb)
+                aggCleanup(cb)
+              }
+            }
+
+            mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+
+            SStreamValue(producer)
+          }
+
+        case StreamWhiten(stream, newChunkName, prevWindowName, vecSize, windowSize, chunkSize,
+              blockSize, normalizeAfterWhiten) =>
+          produce(stream, cb).map(cb) { case blocks: SStreamValue =>
+            val state = new LocalWhitening(
+              cb,
+              SizeValueStatic(vecSize.toLong),
+              windowSize.toLong,
+              chunkSize.toLong,
+              blockSize.toLong,
+              outerRegion,
+              normalizeAfterWhiten,
+            )
+            val eltType = blocks.st.elementType.asInstanceOf[SBaseStruct]
+            var resultField: SSettable = null
+
+            val blocksProducer = blocks.getProducer(cb.emb)
+            val producer: StreamProducer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
+
+              override val length: Option[EmitCodeBuilder => Code[Int]] =
+                blocksProducer.length.map { l => (cb: EmitCodeBuilder) =>
+                  val len = cb.memoize(l(cb))
+                  len
+                }
+
+              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                state.reset(cb)
+                blocksProducer.initialize(cb, outerRegion)
+              }
+
+              override val elementRegion: Settable[Region] = blocksProducer.elementRegion
+              override val requiresMemoryManagementPerElement: Boolean =
+                blocksProducer.requiresMemoryManagementPerElement
+
+              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                cb.goto(blocksProducer.LproduceElement)
+                cb.define(blocksProducer.LproduceElementDone)
+                val row =
+                  blocksProducer.element.toI(cb).getOrFatal(
+                    cb,
+                    "StreamWhiten: missing tuple",
+                  ).asBaseStruct
+                row.loadField(cb, prevWindowName).consume(
+                  cb,
+                  {},
+                  prevWindow => state.initializeWindow(cb, prevWindow.asNDArray),
+                )
+                val block =
+                  row.loadField(cb, newChunkName).getOrFatal(
+                    cb,
+                    "StreamWhiten: missing chunk",
+                  ).asNDArray
+                val whitenedBlock =
+                  LinalgCodeUtils.checkColMajorAndCopyIfNeeded(block, cb, elementRegion)
+                state.whitenBlock(cb, whitenedBlock)
+                // the 'newChunkName' field of 'row' is mutated in place and given
+                // to the consumer
+                val result = row.insert(
+                  cb,
+                  elementRegion,
+                  eltType.virtualType.asInstanceOf[TStruct],
+                  newChunkName -> EmitValue.present(whitenedBlock),
+                )
+                resultField = mb.newPField("StreamWhiten_result", result.st)
+                cb.assign(resultField, result)
+                cb.goto(LproduceElementDone)
+              }
+
+              override val element: EmitCode = EmitCode.present(mb, resultField)
+
+              override def close(cb: EmitCodeBuilder): Unit =
+                blocksProducer.close(cb)
+            }
+
+            mb.implementLabel(blocksProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+
+            SStreamValue(producer)
+          }
+
+        case StreamFlatMap(a, name, body) =>
+          produce(a, cb).map(cb) { case outerStream: SStreamValue =>
+            val outerProducer = outerStream.getProducer(mb)
+
+            // variables used in control flow
+            val first = mb.genFieldThisRef[Boolean]("flatmap_first")
+            val innerUnclosed = mb.genFieldThisRef[Boolean]("flatmap_inner_unclosed")
+
+            val innerStreamEmitCode = EmitCode.fromI(mb) { cb =>
+              cb.withScopedMaybeStreamValue(outerProducer.element, "flatmap_outer_value") {
+                outerProducerValue =>
+                  emit(
+                    body,
+                    cb = cb,
+                    env = env.bind(name, outerProducerValue),
+                    region = outerProducer.elementRegion,
+                  )
+              }
+            }
+
+            val resultElementRegion = mb.genFieldThisRef[Region]("flatmap_result_region")
+            // grabbing emitcode.pv weird pattern but should be safe
+            val innerProducer = innerStreamEmitCode.pv.asStream.getProducer(mb)
+
+            val producer = new StreamProducer {
+              override def method: EmitMethodBuilder[_] = mb
+              override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+              override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                cb.assign(first, true)
+                cb.assign(innerUnclosed, false)
+
+                if (outerProducer.requiresMemoryManagementPerElement)
+                  cb.assign(
+                    outerProducer.elementRegion,
+                    Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()),
+                  )
+                else
+                  cb.assign(outerProducer.elementRegion, outerRegion)
+
+                outerProducer.initialize(cb, outerRegion)
+              }
+
+              override val elementRegion: Settable[Region] = resultElementRegion
+
+              override val requiresMemoryManagementPerElement: Boolean =
+                innerProducer.requiresMemoryManagementPerElement || outerProducer.requiresMemoryManagementPerElement
+
+              override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                val LnextOuter = CodeLabel()
+                val LnextInner = CodeLabel()
+                cb.if_(
+                  first, {
+                    cb.assign(first, false)
+
+                    cb.define(LnextOuter)
+                    cb.define(innerProducer.LendOfStream)
+
+                    if (outerProducer.requiresMemoryManagementPerElement)
+                      cb += outerProducer.elementRegion.clearRegion()
 
                     cb.if_(
-                      c > 0, {
-                        cb.if_(pushedRight, cb.goto(LpullRight))
-                        cb.assign(lxOut, EmitCode.missing(mb, lxOut.st))
-                      }, {
-                        // c == 0
-                        if (leftProducer.requiresMemoryManagementPerElement)
-                          cb += elementRegion.trackAndIncrementReferenceCountOf(
-                            leftProducer.elementRegion
-                          )
-                        cb.assign(lxOut, lx)
+                      innerUnclosed, {
+                        cb.assign(innerUnclosed, false)
+                        innerProducer.close(cb)
+                        if (innerProducer.requiresMemoryManagementPerElement) {
+                          cb += innerProducer.elementRegion.invalidate()
+                        }
                       },
                     )
 
-                    cb.goto(Lpush)
+                    cb.goto(outerProducer.LproduceElement)
+                    cb.define(outerProducer.LproduceElementDone)
 
-                    mb.implementLabel(LmaybePullRight) { cb =>
-                      cb.if_(
-                        !pulledRight, {
-                          cb.assign(pulledRight, true)
-                          cb.goto(LpullRight)
-                        },
-                        cb.goto(Lcompare),
+                    innerStreamEmitCode.toI(cb).consume(
+                      cb,
+                      // missing inner streams mean we should go to the next outer element
+                      cb.goto(LnextOuter),
+                      {
+                        _ =>
+                          // the inner stream/producer is bound to a variable above
+                          cb.assign(innerUnclosed, true)
+                          if (innerProducer.requiresMemoryManagementPerElement)
+                            cb.assign(
+                              innerProducer.elementRegion,
+                              Region.stagedCreate(
+                                Region.REGULAR,
+                                outerProducer.elementRegion.getPool(),
+                              ),
+                            )
+                          else
+                            cb.assign(innerProducer.elementRegion, outerProducer.elementRegion)
+
+                          innerProducer.initialize(cb, outerRegion)
+                          cb.goto(LnextInner)
+                      },
+                    )
+                  },
+                )
+
+                cb.define(LnextInner)
+                cb.goto(innerProducer.LproduceElement)
+                cb.define(innerProducer.LproduceElementDone)
+
+                if (requiresMemoryManagementPerElement) {
+                  cb += resultElementRegion.trackAndIncrementReferenceCountOf(
+                    innerProducer.elementRegion
+                  )
+
+                  // if outer requires memory management and inner doesn't,
+                  // then innerProducer.elementRegion is outerProducer.elementRegion
+                  // and we shouldn't clear it.
+                  if (innerProducer.requiresMemoryManagementPerElement) {
+                    cb += resultElementRegion.trackAndIncrementReferenceCountOf(
+                      outerProducer.elementRegion
+                    )
+                    cb += innerProducer.elementRegion.clearRegion()
+                  }
+                }
+                cb.goto(LproduceElementDone)
+              }
+              val element: EmitCode = innerProducer.element
+
+              def close(cb: EmitCodeBuilder): Unit = {
+                cb.if_(
+                  innerUnclosed, {
+                    cb.assign(innerUnclosed, false)
+                    if (innerProducer.requiresMemoryManagementPerElement) {
+                      cb += innerProducer.elementRegion.invalidate()
+                    }
+                    innerProducer.close(cb)
+                  },
+                )
+                outerProducer.close(cb)
+
+                if (outerProducer.requiresMemoryManagementPerElement)
+                  cb += outerProducer.elementRegion.invalidate()
+              }
+            }
+
+            mb.implementLabel(outerProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+
+            SStreamValue(producer)
+          }
+
+        case StreamLeftIntervalJoin(left, right, lKeyField, rIntrvlName, lName, rName, body) =>
+          produce(left, cb).flatMap(cb) { case lStream: SStreamValue =>
+            produce(right, cb).map(cb) { case rStream: SStreamValue =>
+              // map over the keyStream
+              val lProd = lStream.getProducer(mb)
+              val rProd = rStream.getProducer(mb)
+
+              val rElemSTy =
+                SBaseStructPointer(rProd.element.st.storageType().asInstanceOf[PBaseStruct])
+
+              def loadInterval(cb: EmitCodeBuilder, rElem: SValue): SIntervalValue =
+                rElem.asBaseStruct.loadField(cb, rIntrvlName).getOrAssert(cb).asInterval
+
+              val q: StagedMinHeap =
+                StagedMinHeap(mb.emodb, rElemSTy) {
+                  (cb: EmitCodeBuilder, a: SValue, b: SValue) =>
+                    val l = loadInterval(cb, a)
+                    val r = loadInterval(cb, b)
+                    IntervalFunctions.intervalEndpointCompare(
+                      cb,
+                      l.loadEnd(cb).getOrAssert(cb),
+                      l.includesEnd,
+                      r.loadEnd(cb).getOrAssert(cb),
+                      r.includesEnd,
+                    )
+                }(mb.ecb)
+
+              val lElement: SBaseStructSettable =
+                mb.newPField("LeftElement", lProd.element.st).asInstanceOf[SBaseStructSettable]
+
+              val rElements: SSettable =
+                mb.newPField("RightElements", q.arraySType)
+
+              var jElement: EmitSettable =
+                null
+
+              val rEOS: ThisFieldRef[Boolean] =
+                mb.genFieldThisRef[Boolean]("RightEOS")
+
+              val rPulled: ThisFieldRef[Boolean] =
+                mb.genFieldThisRef[Boolean]("RightPulled")
+
+              SStreamValue {
+                new StreamProducer {
+                  override def method: EmitMethodBuilder[_] =
+                    mb
+
+                  override val length: Option[EmitCodeBuilder => Code[Int]] =
+                    lProd.length
+
+                  override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                    cb.assign(rEOS, false)
+                    cb.assign(rPulled, false)
+
+                    for (p <- FastSeq(lProd, rProd)) {
+                      p.initialize(cb, outerRegion)
+                      cb.assign(
+                        p.elementRegion,
+                        if (p.requiresMemoryManagementPerElement)
+                          Region.stagedCreate(REGULAR, mb.ecb.pool())
+                        else outerRegion.get,
                       )
                     }
 
-                    mb.implementLabel(LpullLeft) { cb =>
+                    q.init(cb, mb.ecb.pool())
+                  }
+
+                  override val elementRegion: Settable[Region] =
+                    mb.genFieldThisRef[Region]("IntervalJoinRegion")
+
+                  override val requiresMemoryManagementPerElement: Boolean =
+                    lProd.requiresMemoryManagementPerElement || rProd.requiresMemoryManagementPerElement
+
+                  override val LproduceElement: CodeLabel =
+                    mb.defineAndImplementLabel { cb =>
+                      if (lProd.requiresMemoryManagementPerElement) {
+                        cb += lProd.elementRegion.clearRegion()
+                      }
+
+                      cb.goto(lProd.LproduceElement)
+                      cb.define(lProd.LproduceElementDone)
+
+                      cb.assign(lElement, lProd.element.toI(cb).getOrAssert(cb).asBaseStruct)
+                      val point = lElement.loadField(cb, lKeyField).getOrAssert(cb)
+
+                      /* Drop rows from the priority queue if their interval's right endpoint is
+                       * before the current key. */
+                      cb.loop { Lrecur =>
+                        cb.if_(
+                          q.nonEmpty(cb), {
+                            val interval = loadInterval(cb, q.peek(cb))
+                            val end = interval.loadEnd(cb).getOrAssert(cb)
+                            cb.if_(
+                              pointGTIntervalEndpoint(cb, point, end, interval.includesEnd), {
+                                q.pop(cb)
+                                cb.goto(Lrecur)
+                              },
+                            )
+                          },
+                        )
+                      }
+
+                      q.realloc(cb)
+
+                      val LallIntervalsFound = CodeLabel()
+                      cb.if_(rEOS, cb.goto(LallIntervalsFound))
+
+                      val LproduceRightElement = CodeLabel()
+                      cb.if_(!rPulled, cb.goto(LproduceRightElement))
+
+                      cb.loop { Lrecur =>
+                        val rElement = rElemSTy.coerceOrCopy(
+                          cb,
+                          elementRegion,
+                          rProd.element.toI(cb).getOrAssert(cb),
+                          deepCopy = false,
+                        )
+                        val interval = loadInterval(cb, rElement)
+
+                        // Drop intervals whose right endpoint is before the key
+                        val end = interval.loadEnd(cb).getOrAssert(cb)
+                        cb.if_(
+                          pointGTIntervalEndpoint(cb, point, end, interval.includesEnd),
+                          cb.goto(LproduceRightElement),
+                        )
+
+                        // Stop consuming intervals if the left endpoint is after the key
+                        val start = interval.loadStart(cb).getOrAssert(cb)
+                        cb.if_(
+                          pointLTIntervalEndpoint(
+                            cb,
+                            point,
+                            start,
+                            leansRight = !interval.includesStart,
+                          ),
+                          cb.goto(LallIntervalsFound),
+                        )
+
+                        q.push(cb, rElement)
+
+                        cb.define(LproduceRightElement)
+                        if (rProd.requiresMemoryManagementPerElement) {
+                          cb += rProd.elementRegion.clearRegion()
+                        }
+
+                        cb.goto(rProd.LproduceElement)
+                        cb.define(rProd.LproduceElementDone)
+                        cb.assign(rPulled, true)
+                        cb.goto(Lrecur)
+                      }
+
+                      cb.define(rProd.LendOfStream)
+                      cb.assign(rEOS, true)
+
+                      cb.define(LallIntervalsFound)
+                      cb.assign(rElements, q.toArray(cb, elementRegion))
+                      val result = emit(
+                        body,
+                        cb,
+                        region = elementRegion,
+                        env = env.bind(
+                          lName -> EmitValue.present(lElement),
+                          rName -> EmitValue.present(rElements),
+                        ),
+                      )
+
+                      jElement = mb.newEmitField("IntervalJoinResult", result.emitType)
+                      cb.assign(jElement, result)
+                      cb.goto(LproduceElementDone)
+
+                      cb.define(lProd.LendOfStream)
+                      cb.goto(LendOfStream)
+                    }
+
+                  override val element: EmitCode =
+                    jElement
+
+                  override def close(cb: EmitCodeBuilder): Unit = {
+                    q.close(cb)
+                    for (p <- FastSeq(rProd, lProd)) {
+                      p.close(cb)
+                      if (p.requiresMemoryManagementPerElement) {
+                        cb += p.elementRegion.invalidate()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+        case x @ StreamJoinRightDistinct(leftIR, rightIR, lKey, rKey, leftName, rightName, joinIR,
+              joinType) =>
+          produce(leftIR, cb).flatMap(cb) { case leftStream: SStreamValue =>
+            produce(rightIR, cb).map(cb) { case rightStream: SStreamValue =>
+              val leftProducer = leftStream.getProducer(mb)
+              val rightProducer = rightStream.getProducer(mb)
+
+              val lEltType = leftProducer.element.emitType
+              val rEltType = rightProducer.element.emitType
+
+              def compare(cb: EmitCodeBuilder, lelt: EmitValue, relt: EmitValue): Code[Int] = {
+                assert(lelt.emitType == lEltType)
+                assert(relt.emitType == rEltType)
+                if (x.isIntervalJoin) {
+                  val rhs = relt.toI(cb).flatMap(cb)(_.asBaseStruct.loadField(cb, rKey(0)))
+                  val result = cb.newLocal[Int]("SJRD-interval-compare-result")
+                  rhs.consume(
+                    cb,
+                    cb.assign(result, -1),
+                    { case interval: SIntervalValue =>
+                      val lhs = lelt.toI(cb).flatMap(cb)(_.asBaseStruct.loadField(cb, lKey(0)))
+                      lhs.consume(
+                        cb,
+                        cb.assign(result, 1),
+                        { point =>
+                          val c = IntervalFunctions.pointIntervalCompare(cb, point, interval)
+                          c.consume(
+                            cb,
+                            // One of the interval endpoints is missing. In this case,
+                            // consider the point greater, so that the join advances
+                            // past the bad interval, keeping the point.
+                            cb.assign(result, 1),
+                            c => cb.assign(result, c.asInt.value),
+                          )
+                        },
+                      )
+                    },
+                  )
+                  result
+                } else {
+                  val lhs = lelt.map(cb)(_.asBaseStruct.subset(lKey: _*))
+                  val rhs = relt.map(cb)(_.asBaseStruct.subset(rKey: _*))
+                  StructOrdering.make(
+                    lhs.st.asInstanceOf[SBaseStruct],
+                    rhs.st.asInstanceOf[SBaseStruct],
+                    cb.emb.ecb,
+                    missingFieldsEqual = false,
+                  )
+                    .compare(cb, lhs, rhs, missingEqual = false)
+                }
+              }
+
+              // these variables are used as inputs to the joinF
+              val lx = mb.newEmitField("streamjoin_lx", lEltType) // last value received from left
+              val rx = mb.newEmitField("streamjoin_rx", rEltType) // last value received from right
+
+              val lxOut: EmitSettable = joinType match {
+                case "inner" | "left" => lx
+                case "outer" | "right" =>
+                  mb.newEmitField("streamjoin_lxout", lx.emitType.copy(required = false))
+              }
+              val rxOut: EmitSettable = joinType match {
+                case "inner" | "right" => rx
+                case "outer" | "left" =>
+                  mb.newEmitField("streamjoin_rxout", rx.emitType.copy(required = false))
+              }
+
+              val _elementRegion = mb.genFieldThisRef[Region]("join_right_distinct_element_region")
+              val _requiresMemoryManagementPerElement =
+                leftProducer.requiresMemoryManagementPerElement || rightProducer.requiresMemoryManagementPerElement
+
+              val joinResult = EmitCode.fromI(mb)(cb =>
+                emit(
+                  joinIR,
+                  cb,
+                  region = _elementRegion,
+                  env = env.bind(leftName -> lxOut, rightName -> rxOut),
+                )
+              )
+
+              def sharedInit(cb: EmitCodeBuilder): Unit = {
+                if (rightProducer.requiresMemoryManagementPerElement)
+                  cb.assign(
+                    rightProducer.elementRegion,
+                    Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
+                  )
+                else
+                  cb.assign(rightProducer.elementRegion, outerRegion)
+                if (leftProducer.requiresMemoryManagementPerElement)
+                  cb.assign(
+                    leftProducer.elementRegion,
+                    Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
+                  )
+                else
+                  cb.assign(leftProducer.elementRegion, outerRegion)
+
+                leftProducer.initialize(cb, outerRegion)
+                rightProducer.initialize(cb, outerRegion)
+              }
+
+              def sharedClose(cb: EmitCodeBuilder): Unit = {
+                leftProducer.close(cb)
+                rightProducer.close(cb)
+                if (leftProducer.requiresMemoryManagementPerElement)
+                  cb += leftProducer.elementRegion.invalidate()
+
+                if (rightProducer.requiresMemoryManagementPerElement)
+                  cb += rightProducer.elementRegion.invalidate()
+              }
+
+              joinType match {
+                case "left" =>
+                  val rightEOS = mb.genFieldThisRef[Boolean]("left_join_right_distinct_rightEOS")
+                  val pulledRight =
+                    mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
+
+                  val producer = new StreamProducer {
+                    override def method: EmitMethodBuilder[_] = mb
+                    override val length: Option[EmitCodeBuilder => Code[Int]] = leftProducer.length
+
+                    override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region])
+                      : Unit = {
+                      cb.assign(rightEOS, false)
+                      cb.assign(pulledRight, false)
+
+                      sharedInit(cb)
+                    }
+
+                    override val elementRegion: Settable[Region] = _elementRegion
+                    override val requiresMemoryManagementPerElement: Boolean =
+                      _requiresMemoryManagementPerElement
+                    override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
                       if (leftProducer.requiresMemoryManagementPerElement)
                         cb += leftProducer.elementRegion.clearRegion()
                       cb.goto(leftProducer.LproduceElement)
                       cb.define(leftProducer.LproduceElementDone)
                       cb.assign(lx, leftProducer.element)
-                      cb.goto(LmaybePullRight)
-                    }
 
-                    mb.implementLabel(LpullRight) { cb =>
-                      if (rightProducer.requiresMemoryManagementPerElement)
-                        cb += rightProducer.elementRegion.clearRegion()
-                      cb.goto(rightProducer.LproduceElement)
-                      cb.define(rightProducer.LproduceElementDone)
-                      cb.assign(rx, rightProducer.element)
+                      // if right stream is exhausted, return immediately
+                      cb.if_(rightEOS, cb.goto(LproduceElementDone))
+
+                      val Lpush = CodeLabel()
+
+                      val LpullRight = CodeLabel()
+                      cb.if_(
+                        !pulledRight, {
+                          cb.assign(pulledRight, true)
+                          cb.goto(LpullRight)
+                        },
+                      )
+
+                      val Lcompare = CodeLabel()
+                      cb.define(Lcompare)
+                      val c = cb.newLocal[Int]("left_join_right_distinct_c", compare(cb, lx, rx))
+                      cb.if_(c > 0, cb.goto(LpullRight))
+
+                      cb.if_(
+                        c < 0,
+                        cb.assign(rxOut, EmitCode.missing(mb, rxOut.st)), {
+                          // c == 0
+                          if (rightProducer.requiresMemoryManagementPerElement) {
+                            cb += elementRegion.trackAndIncrementReferenceCountOf(
+                              rightProducer.elementRegion
+                            )
+                          }
+                          cb.assign(rxOut, rx)
+                        },
+                      )
+
+                      cb.goto(Lpush)
+
+                      mb.implementLabel(Lpush) { cb =>
+                        if (leftProducer.requiresMemoryManagementPerElement)
+                          cb += elementRegion.trackAndIncrementReferenceCountOf(
+                            leftProducer.elementRegion
+                          )
+
+                        cb.goto(LproduceElementDone)
+                      }
+
+                      mb.implementLabel(LpullRight) { cb =>
+                        if (rightProducer.requiresMemoryManagementPerElement) {
+                          cb += rightProducer.elementRegion.clearRegion()
+                        }
+                        cb.goto(rightProducer.LproduceElement)
+                        cb.define(rightProducer.LproduceElementDone)
+                        cb.assign(rx, rightProducer.element)
+                        cb.goto(Lcompare)
+                      }
+
+                      // if right stream ends before left
+                      mb.implementLabel(rightProducer.LendOfStream) { cb =>
+                        cb.assign(rxOut, EmitCode.missing(mb, rxOut.st))
+                        cb.assign(rightEOS, true)
+                        cb.goto(Lpush)
+                      }
+
+                      mb.implementLabel(leftProducer.LendOfStream)(cb => cb.goto(LendOfStream))
+                    }
+                    override val element: EmitCode = joinResult
+
+                    override def close(cb: EmitCodeBuilder): Unit =
+                      sharedClose(cb)
+                  }
+
+                  SStreamValue(producer)
+
+                case "right" =>
+                  val leftEOS = mb.genFieldThisRef[Boolean]("left_join_right_distinct_leftEOS")
+                  val pulledRight =
+                    mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
+                  val pushedRight =
+                    mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
+                  val c = mb.genFieldThisRef[Int]("join_right_distinct_compResult")
+
+                  val producer = new StreamProducer {
+                    override def method: EmitMethodBuilder[_] = mb
+                    override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                    override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region])
+                      : Unit = {
+                      cb.assign(leftEOS, false)
+                      cb.assign(pulledRight, false)
                       cb.assign(pushedRight, false)
-                      cb.goto(Lcompare)
+                      cb.assign(c, 0)
+                      sharedInit(cb)
                     }
 
-                    mb.implementLabel(Lpush) { cb =>
-                      if (rightProducer.requiresMemoryManagementPerElement)
-                        cb += elementRegion.trackAndIncrementReferenceCountOf(
-                          rightProducer.elementRegion
+                    override val elementRegion: Settable[Region] = _elementRegion
+                    override val requiresMemoryManagementPerElement: Boolean =
+                      _requiresMemoryManagementPerElement
+                    override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                      val Lpush = CodeLabel()
+                      val LpullRight = CodeLabel()
+                      val LpullLeft = CodeLabel()
+                      val Lcompare = CodeLabel()
+                      val LmaybePullRight = CodeLabel()
+
+                      cb.if_(leftEOS, cb.goto(Lcompare))
+                      cb.if_(c <= 0, cb.goto(LpullLeft), cb.goto(LpullRight))
+
+                      cb.define(Lcompare)
+                      cb.if_(leftEOS, cb.if_(pushedRight, cb.goto(LpullRight), cb.goto(Lpush)))
+                      cb.assign(c, compare(cb, lx, rx))
+
+                      cb.if_(c < 0, cb.goto(LpullLeft))
+
+                      cb.if_(
+                        c > 0, {
+                          cb.if_(pushedRight, cb.goto(LpullRight))
+                          cb.assign(lxOut, EmitCode.missing(mb, lxOut.st))
+                        }, {
+                          // c == 0
+                          if (leftProducer.requiresMemoryManagementPerElement)
+                            cb += elementRegion.trackAndIncrementReferenceCountOf(
+                              leftProducer.elementRegion
+                            )
+                          cb.assign(lxOut, lx)
+                        },
+                      )
+
+                      cb.goto(Lpush)
+
+                      mb.implementLabel(LmaybePullRight) { cb =>
+                        cb.if_(
+                          !pulledRight, {
+                            cb.assign(pulledRight, true)
+                            cb.goto(LpullRight)
+                          },
+                          cb.goto(Lcompare),
                         )
+                      }
 
-                      cb.assign(pushedRight, true)
-                      cb.goto(LproduceElementDone)
-                    }
-
-                    // if left stream ends before right
-                    mb.implementLabel(leftProducer.LendOfStream) { cb =>
-                      cb.assign(lxOut, EmitCode.missing(mb, lxOut.st))
-                      cb.assign(leftEOS, true)
-                      cb.goto(LmaybePullRight)
-                    }
-
-                    // end if right stream ends
-                    mb.implementLabel(rightProducer.LendOfStream)(cb => cb.goto(LendOfStream))
-                  }
-
-                  override val element: EmitCode = joinResult
-
-                  override def close(cb: EmitCodeBuilder): Unit =
-                    sharedClose(cb)
-                }
-                SStreamValue(producer)
-
-              case "inner" =>
-                val pulledRight =
-                  mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
-
-                val producer = new StreamProducer {
-                  override def method: EmitMethodBuilder[_] = mb
-                  override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-                  override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                    cb.assign(pulledRight, false)
-                    sharedInit(cb)
-                  }
-
-                  override val elementRegion: Settable[Region] = _elementRegion
-                  override val requiresMemoryManagementPerElement: Boolean =
-                    _requiresMemoryManagementPerElement
-                  override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                    if (leftProducer.requiresMemoryManagementPerElement)
-                      cb += leftProducer.elementRegion.clearRegion()
-                    cb.goto(leftProducer.LproduceElement)
-                    cb.define(leftProducer.LproduceElementDone)
-                    cb.assign(lx, leftProducer.element)
-
-                    val LpullRight = CodeLabel()
-                    cb.if_(
-                      !pulledRight, {
-                        cb.assign(pulledRight, true)
-                        cb.goto(LpullRight)
-                      },
-                    )
-
-                    val Lcompare = CodeLabel()
-                    cb.define(Lcompare)
-                    val c = cb.newLocal[Int]("left_join_right_distinct_c", compare(cb, lx, rx))
-                    cb.if_(c > 0, cb.goto(LpullRight))
-
-                    cb.if_(
-                      c < 0, {
+                      mb.implementLabel(LpullLeft) { cb =>
                         if (leftProducer.requiresMemoryManagementPerElement)
                           cb += leftProducer.elementRegion.clearRegion()
                         cb.goto(leftProducer.LproduceElement)
-                      },
-                    )
+                        cb.define(leftProducer.LproduceElementDone)
+                        cb.assign(lx, leftProducer.element)
+                        cb.goto(LmaybePullRight)
+                      }
 
-                    cb.goto(LproduceElementDone)
+                      mb.implementLabel(LpullRight) { cb =>
+                        if (rightProducer.requiresMemoryManagementPerElement)
+                          cb += rightProducer.elementRegion.clearRegion()
+                        cb.goto(rightProducer.LproduceElement)
+                        cb.define(rightProducer.LproduceElementDone)
+                        cb.assign(rx, rightProducer.element)
+                        cb.assign(pushedRight, false)
+                        cb.goto(Lcompare)
+                      }
 
-                    mb.implementLabel(LpullRight) { cb =>
+                      mb.implementLabel(Lpush) { cb =>
+                        if (rightProducer.requiresMemoryManagementPerElement)
+                          cb += elementRegion.trackAndIncrementReferenceCountOf(
+                            rightProducer.elementRegion
+                          )
+
+                        cb.assign(pushedRight, true)
+                        cb.goto(LproduceElementDone)
+                      }
+
+                      // if left stream ends before right
+                      mb.implementLabel(leftProducer.LendOfStream) { cb =>
+                        cb.assign(lxOut, EmitCode.missing(mb, lxOut.st))
+                        cb.assign(leftEOS, true)
+                        cb.goto(LmaybePullRight)
+                      }
+
+                      // end if right stream ends
+                      mb.implementLabel(rightProducer.LendOfStream)(cb => cb.goto(LendOfStream))
+                    }
+
+                    override val element: EmitCode = joinResult
+
+                    override def close(cb: EmitCodeBuilder): Unit =
+                      sharedClose(cb)
+                  }
+                  SStreamValue(producer)
+
+                case "inner" =>
+                  val pulledRight =
+                    mb.genFieldThisRef[Boolean]("left_join_right_distinct_pulledRight]")
+
+                  val producer = new StreamProducer {
+                    override def method: EmitMethodBuilder[_] = mb
+                    override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                    override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region])
+                      : Unit = {
+                      cb.assign(pulledRight, false)
+                      sharedInit(cb)
+                    }
+
+                    override val elementRegion: Settable[Region] = _elementRegion
+                    override val requiresMemoryManagementPerElement: Boolean =
+                      _requiresMemoryManagementPerElement
+                    override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                      if (leftProducer.requiresMemoryManagementPerElement)
+                        cb += leftProducer.elementRegion.clearRegion()
+                      cb.goto(leftProducer.LproduceElement)
+                      cb.define(leftProducer.LproduceElementDone)
+                      cb.assign(lx, leftProducer.element)
+
+                      val LpullRight = CodeLabel()
+                      cb.if_(
+                        !pulledRight, {
+                          cb.assign(pulledRight, true)
+                          cb.goto(LpullRight)
+                        },
+                      )
+
+                      val Lcompare = CodeLabel()
+                      cb.define(Lcompare)
+                      val c = cb.newLocal[Int]("left_join_right_distinct_c", compare(cb, lx, rx))
+                      cb.if_(c > 0, cb.goto(LpullRight))
+
+                      cb.if_(
+                        c < 0, {
+                          if (leftProducer.requiresMemoryManagementPerElement)
+                            cb += leftProducer.elementRegion.clearRegion()
+                          cb.goto(leftProducer.LproduceElement)
+                        },
+                      )
+
+                      cb.goto(LproduceElementDone)
+
+                      mb.implementLabel(LpullRight) { cb =>
+                        if (rightProducer.requiresMemoryManagementPerElement)
+                          cb += rightProducer.elementRegion.clearRegion()
+                        cb.goto(rightProducer.LproduceElement)
+                      }
+
+                      mb.implementLabel(rightProducer.LproduceElementDone) { cb =>
+                        cb.assign(rx, rightProducer.element)
+                        cb.goto(Lcompare)
+                      }
+
+                      // Both producer EOS labels should jump directly to EOS
+                      mb.implementLabel(rightProducer.LendOfStream)(cb => cb.goto(LendOfStream))
+                      mb.implementLabel(leftProducer.LendOfStream)(cb => cb.goto(LendOfStream))
+                    }
+                    override val element: EmitCode = joinResult
+
+                    override def close(cb: EmitCodeBuilder): Unit =
+                      sharedClose(cb)
+                  }
+
+                  SStreamValue(producer)
+
+                case "outer" =>
+                  val pulledRight = mb.genFieldThisRef[Boolean]("join_right_distinct_pulledRight")
+                  val pushedRight = mb.genFieldThisRef[Boolean]("join_right_distinct_pushedRight")
+                  val rightEOS = mb.genFieldThisRef[Boolean]("join_right_distinct_rightEOS")
+                  val lOutMissing = mb.genFieldThisRef[Boolean]("join_right_distinct_leftMissing")
+                  val rOutMissing = mb.genFieldThisRef[Boolean]("join_right_distinct_rightMissing")
+                  val leftEOS = mb.genFieldThisRef[Boolean]("join_right_distinct_leftEOS")
+                  val c = mb.genFieldThisRef[Int]("join_right_distinct_compResult")
+
+                  val producer = new StreamProducer {
+                    override def method: EmitMethodBuilder[_] = mb
+                    override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                    override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region])
+                      : Unit = {
+                      cb.assign(pulledRight, false)
+                      cb.assign(leftEOS, false)
+                      cb.assign(rightEOS, false)
+                      cb.assign(c, 0) // lets us start stream with a pull from both
+
+                      sharedInit(cb)
+                    }
+
+                    override val elementRegion: Settable[Region] = _elementRegion
+                    override val requiresMemoryManagementPerElement: Boolean =
+                      _requiresMemoryManagementPerElement
+                    override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                      val LpullRight = CodeLabel()
+                      val LpullLeft = CodeLabel()
+                      val Lpush = CodeLabel()
+
+                      cb.if_(
+                        leftEOS,
+                        cb.goto(LpullRight),
+                        cb.if_(
+                          rightEOS,
+                          cb.goto(LpullLeft),
+                          cb.if_(c <= 0, cb.goto(LpullLeft), cb.goto(LpullRight)),
+                        ),
+                      )
+
+                      cb.define(LpullRight)
                       if (rightProducer.requiresMemoryManagementPerElement)
                         cb += rightProducer.elementRegion.clearRegion()
+                      cb.assign(pulledRight, true)
                       cb.goto(rightProducer.LproduceElement)
-                    }
 
-                    mb.implementLabel(rightProducer.LproduceElementDone) { cb =>
-                      cb.assign(rx, rightProducer.element)
-                      cb.goto(Lcompare)
-                    }
-
-                    // Both producer EOS labels should jump directly to EOS
-                    mb.implementLabel(rightProducer.LendOfStream)(cb => cb.goto(LendOfStream))
-                    mb.implementLabel(leftProducer.LendOfStream)(cb => cb.goto(LendOfStream))
-                  }
-                  override val element: EmitCode = joinResult
-
-                  override def close(cb: EmitCodeBuilder): Unit =
-                    sharedClose(cb)
-                }
-
-                SStreamValue(producer)
-
-              case "outer" =>
-                val pulledRight = mb.genFieldThisRef[Boolean]("join_right_distinct_pulledRight")
-                val pushedRight = mb.genFieldThisRef[Boolean]("join_right_distinct_pushedRight")
-                val rightEOS = mb.genFieldThisRef[Boolean]("join_right_distinct_rightEOS")
-                val lOutMissing = mb.genFieldThisRef[Boolean]("join_right_distinct_leftMissing")
-                val rOutMissing = mb.genFieldThisRef[Boolean]("join_right_distinct_rightMissing")
-                val leftEOS = mb.genFieldThisRef[Boolean]("join_right_distinct_leftEOS")
-                val c = mb.genFieldThisRef[Int]("join_right_distinct_compResult")
-
-                val producer = new StreamProducer {
-                  override def method: EmitMethodBuilder[_] = mb
-                  override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-                  override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                    cb.assign(pulledRight, false)
-                    cb.assign(leftEOS, false)
-                    cb.assign(rightEOS, false)
-                    cb.assign(c, 0) // lets us start stream with a pull from both
-
-                    sharedInit(cb)
-                  }
-
-                  override val elementRegion: Settable[Region] = _elementRegion
-                  override val requiresMemoryManagementPerElement: Boolean =
-                    _requiresMemoryManagementPerElement
-                  override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                    val LpullRight = CodeLabel()
-                    val LpullLeft = CodeLabel()
-                    val Lpush = CodeLabel()
-
-                    cb.if_(
-                      leftEOS,
-                      cb.goto(LpullRight),
-                      cb.if_(
-                        rightEOS,
-                        cb.goto(LpullLeft),
-                        cb.if_(c <= 0, cb.goto(LpullLeft), cb.goto(LpullRight)),
-                      ),
-                    )
-
-                    cb.define(LpullRight)
-                    if (rightProducer.requiresMemoryManagementPerElement)
-                      cb += rightProducer.elementRegion.clearRegion()
-                    cb.assign(pulledRight, true)
-                    cb.goto(rightProducer.LproduceElement)
-
-                    cb.define(LpullLeft)
-                    if (leftProducer.requiresMemoryManagementPerElement)
-                      cb += leftProducer.elementRegion.clearRegion()
-                    cb.goto(leftProducer.LproduceElement)
-
-                    val Lcompare = CodeLabel()
-                    mb.implementLabel(Lcompare) { cb =>
-                      cb.assign(c, compare(cb, lx, rx))
-                      cb.assign(lOutMissing, false)
-                      cb.assign(rOutMissing, false)
-                      cb.if_(
-                        c > 0, {
-                          cb.if_(
-                            pulledRight && !pushedRight, {
-                              cb.assign(lOutMissing, true)
-                              if (rightProducer.requiresMemoryManagementPerElement) {
-                                cb += elementRegion.trackAndIncrementReferenceCountOf(
-                                  rightProducer.elementRegion
-                                )
-                              }
-                              cb.goto(Lpush)
-                            },
-                            cb.goto(LpullRight),
-                          )
-                        }, {
-                          cb.if_(
-                            c < 0, {
-                              cb.assign(rOutMissing, true)
-                              if (leftProducer.requiresMemoryManagementPerElement) {
-                                cb += elementRegion.trackAndIncrementReferenceCountOf(
-                                  leftProducer.elementRegion
-                                )
-                              }
-                              cb.goto(Lpush)
-                            }, {
-                              // c == 0
-                              if (leftProducer.requiresMemoryManagementPerElement) {
-                                cb += elementRegion.trackAndIncrementReferenceCountOf(
-                                  leftProducer.elementRegion
-                                )
-                              }
-                              if (rightProducer.requiresMemoryManagementPerElement) {
-                                cb += elementRegion.trackAndIncrementReferenceCountOf(
-                                  rightProducer.elementRegion
-                                )
-                              }
-                              cb.goto(Lpush)
-                            },
-                          )
-                        },
-                      )
-                    }
-
-                    mb.implementLabel(Lpush) { cb =>
-                      cb.if_(
-                        lOutMissing,
-                        cb.assign(lxOut, EmitCode.missing(mb, lxOut.st)),
-                        cb.assign(lxOut, lx),
-                      )
-                      cb.if_(
-                        rOutMissing,
-                        cb.assign(rxOut, EmitCode.missing(mb, rxOut.st)), {
-                          cb.assign(rxOut, rx)
-                          cb.assign(pushedRight, true)
-                        },
-                      )
-                      cb.goto(LproduceElementDone)
-                    }
-
-                    mb.implementLabel(rightProducer.LproduceElementDone) { cb =>
-                      cb.assign(rx, rightProducer.element)
-                      cb.assign(pushedRight, false)
-                      cb.if_(leftEOS, cb.goto(Lpush), cb.goto(Lcompare))
-                    }
-
-                    mb.implementLabel(leftProducer.LproduceElementDone) { cb =>
-                      cb.assign(lx, leftProducer.element)
-                      cb.if_(
-                        pulledRight,
-                        cb.if_(
-                          rightEOS, {
-                            if (leftProducer.requiresMemoryManagementPerElement) {
-                              cb += elementRegion.trackAndIncrementReferenceCountOf(
-                                leftProducer.elementRegion
-                              )
-                            }
-                            cb.goto(Lpush)
-                          },
-                          cb.goto(Lcompare),
-                        ),
-                        cb.goto(LpullRight),
-                      )
-                    }
-
-                    mb.implementLabel(leftProducer.LendOfStream) { cb =>
-                      cb.if_(
-                        rightEOS,
-                        cb.goto(LendOfStream), {
-                          cb.assign(leftEOS, true)
-                          cb.assign(lOutMissing, true)
-                          cb.assign(rOutMissing, false)
-                          cb.if_(
-                            pulledRight && !pushedRight, {
-                              if (rightProducer.requiresMemoryManagementPerElement) {
-                                cb += elementRegion.trackAndIncrementReferenceCountOf(
-                                  rightProducer.elementRegion
-                                )
-                              }
-                              cb.goto(Lpush)
-                            }, {
-                              if (rightProducer.requiresMemoryManagementPerElement) {
-                                cb += rightProducer.elementRegion.clearRegion()
-                              }
-                              cb.goto(LpullRight)
-                            },
-                          )
-                        },
-                      )
-                    }
-
-                    mb.implementLabel(rightProducer.LendOfStream) { cb =>
-                      cb.if_(leftEOS, cb.goto(LendOfStream))
-                      cb.assign(rightEOS, true)
-                      cb.assign(lOutMissing, false)
-                      cb.assign(rOutMissing, true)
-
-                      if (leftProducer.requiresMemoryManagementPerElement) {
-                        cb += elementRegion.trackAndIncrementReferenceCountOf(
-                          leftProducer.elementRegion
-                        )
+                      cb.define(LpullLeft)
+                      if (leftProducer.requiresMemoryManagementPerElement)
                         cb += leftProducer.elementRegion.clearRegion()
+                      cb.goto(leftProducer.LproduceElement)
+
+                      val Lcompare = CodeLabel()
+                      mb.implementLabel(Lcompare) { cb =>
+                        cb.assign(c, compare(cb, lx, rx))
+                        cb.assign(lOutMissing, false)
+                        cb.assign(rOutMissing, false)
+                        cb.if_(
+                          c > 0, {
+                            cb.if_(
+                              pulledRight && !pushedRight, {
+                                cb.assign(lOutMissing, true)
+                                if (rightProducer.requiresMemoryManagementPerElement) {
+                                  cb += elementRegion.trackAndIncrementReferenceCountOf(
+                                    rightProducer.elementRegion
+                                  )
+                                }
+                                cb.goto(Lpush)
+                              },
+                              cb.goto(LpullRight),
+                            )
+                          }, {
+                            cb.if_(
+                              c < 0, {
+                                cb.assign(rOutMissing, true)
+                                if (leftProducer.requiresMemoryManagementPerElement) {
+                                  cb += elementRegion.trackAndIncrementReferenceCountOf(
+                                    leftProducer.elementRegion
+                                  )
+                                }
+                                cb.goto(Lpush)
+                              }, {
+                                // c == 0
+                                if (leftProducer.requiresMemoryManagementPerElement) {
+                                  cb += elementRegion.trackAndIncrementReferenceCountOf(
+                                    leftProducer.elementRegion
+                                  )
+                                }
+                                if (rightProducer.requiresMemoryManagementPerElement) {
+                                  cb += elementRegion.trackAndIncrementReferenceCountOf(
+                                    rightProducer.elementRegion
+                                  )
+                                }
+                                cb.goto(Lpush)
+                              },
+                            )
+                          },
+                        )
                       }
-                      cb.goto(Lpush)
+
+                      mb.implementLabel(Lpush) { cb =>
+                        cb.if_(
+                          lOutMissing,
+                          cb.assign(lxOut, EmitCode.missing(mb, lxOut.st)),
+                          cb.assign(lxOut, lx),
+                        )
+                        cb.if_(
+                          rOutMissing,
+                          cb.assign(rxOut, EmitCode.missing(mb, rxOut.st)), {
+                            cb.assign(rxOut, rx)
+                            cb.assign(pushedRight, true)
+                          },
+                        )
+                        cb.goto(LproduceElementDone)
+                      }
+
+                      mb.implementLabel(rightProducer.LproduceElementDone) { cb =>
+                        cb.assign(rx, rightProducer.element)
+                        cb.assign(pushedRight, false)
+                        cb.if_(leftEOS, cb.goto(Lpush), cb.goto(Lcompare))
+                      }
+
+                      mb.implementLabel(leftProducer.LproduceElementDone) { cb =>
+                        cb.assign(lx, leftProducer.element)
+                        cb.if_(
+                          pulledRight,
+                          cb.if_(
+                            rightEOS, {
+                              if (leftProducer.requiresMemoryManagementPerElement) {
+                                cb += elementRegion.trackAndIncrementReferenceCountOf(
+                                  leftProducer.elementRegion
+                                )
+                              }
+                              cb.goto(Lpush)
+                            },
+                            cb.goto(Lcompare),
+                          ),
+                          cb.goto(LpullRight),
+                        )
+                      }
+
+                      mb.implementLabel(leftProducer.LendOfStream) { cb =>
+                        cb.if_(
+                          rightEOS,
+                          cb.goto(LendOfStream), {
+                            cb.assign(leftEOS, true)
+                            cb.assign(lOutMissing, true)
+                            cb.assign(rOutMissing, false)
+                            cb.if_(
+                              pulledRight && !pushedRight, {
+                                if (rightProducer.requiresMemoryManagementPerElement) {
+                                  cb += elementRegion.trackAndIncrementReferenceCountOf(
+                                    rightProducer.elementRegion
+                                  )
+                                }
+                                cb.goto(Lpush)
+                              }, {
+                                if (rightProducer.requiresMemoryManagementPerElement) {
+                                  cb += rightProducer.elementRegion.clearRegion()
+                                }
+                                cb.goto(LpullRight)
+                              },
+                            )
+                          },
+                        )
+                      }
+
+                      mb.implementLabel(rightProducer.LendOfStream) { cb =>
+                        cb.if_(leftEOS, cb.goto(LendOfStream))
+                        cb.assign(rightEOS, true)
+                        cb.assign(lOutMissing, false)
+                        cb.assign(rOutMissing, true)
+
+                        if (leftProducer.requiresMemoryManagementPerElement) {
+                          cb += elementRegion.trackAndIncrementReferenceCountOf(
+                            leftProducer.elementRegion
+                          )
+                          cb += leftProducer.elementRegion.clearRegion()
+                        }
+                        cb.goto(Lpush)
+                      }
                     }
+                    override val element: EmitCode = joinResult
+
+                    override def close(cb: EmitCodeBuilder): Unit =
+                      sharedClose(cb)
                   }
-                  override val element: EmitCode = joinResult
 
-                  override def close(cb: EmitCodeBuilder): Unit =
-                    sharedClose(cb)
-                }
-
-                SStreamValue(producer)
-            }
-          }
-        }
-
-      case StreamGroupByKey(a, key, missingEqual) =>
-        produce(a, cb).map(cb) { case childStream: SStreamValue =>
-          val childProducer = childStream.getProducer(mb)
-
-          val xCurElt = mb.newPField("st_grpby_curelt", childProducer.element.st)
-
-          val keyRegion = mb.genFieldThisRef[Region]("st_groupby_key_region")
-          def subsetCode = xCurElt.asBaseStruct.subset(key: _*)
-          val curKey = mb.newPField("st_grpby_curkey", subsetCode.st)
-
-          // This type shouldn't be a subset struct, since it is copied deeply.
-          // We don't want to deep copy the parent.
-          val lastKey = mb.newPField("st_grpby_lastkey", subsetCode.st.copiedType)
-
-          val eos = mb.genFieldThisRef[Boolean]("st_grpby_eos")
-          val nextGroupReady = mb.genFieldThisRef[Boolean]("streamgroupbykey_nextready")
-          val inOuter = mb.genFieldThisRef[Boolean]("streamgroupbykey_inouter")
-          val first = mb.genFieldThisRef[Boolean]("streamgroupbykey_first")
-
-          /* cannot reuse childProducer.elementRegion because consumers might free the region, even
-           * though */
-          /* the outer producer needs to continue pulling. We could add more control flow that sets
-           * some */
-          /* boolean flag when the inner stream is closed, and the outer producer reassigns a region
-           * if */
-          // that flag is set, but that design seems more complicated
-          val innerResultRegion = mb.genFieldThisRef[Region]("streamgroupbykey_inner_result_region")
-
-          val outerElementRegion = mb.genFieldThisRef[Region]("streamgroupbykey_outer_elt_region")
-
-          def equiv(cb: EmitCodeBuilder, l: SBaseStructValue, r: SBaseStructValue): Value[Boolean] =
-            StructOrdering.make(
-              l.st,
-              r.st,
-              cb.emb.ecb,
-              missingFieldsEqual = missingEqual,
-            ).equivNonnull(cb, l, r)
-
-          val LchildProduceDoneInner = CodeLabel()
-          val LchildProduceDoneOuter = CodeLabel()
-          val innerProducer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
-            override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {}
-
-            override val elementRegion: Settable[Region] = innerResultRegion
-            override val requiresMemoryManagementPerElement: Boolean =
-              childProducer.requiresMemoryManagementPerElement
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              val LelementReady = CodeLabel()
-
-              /* the first pull from the inner stream has the next record ready to go from the outer
-               * stream */
-              cb.if_(
-                inOuter, {
-                  cb.assign(inOuter, false)
-                  cb.goto(LelementReady)
-                },
-              )
-
-              if (childProducer.requiresMemoryManagementPerElement)
-                cb += childProducer.elementRegion.clearRegion()
-              cb.goto(childProducer.LproduceElement)
-              // xElt and curKey are assigned before this label is jumped to
-              cb.define(LchildProduceDoneInner)
-
-              // if not equivalent, end inner stream and prepare for next outer iteration
-              cb.if_(
-                !equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
-                  if (requiresMemoryManagementPerElement)
-                    cb += keyRegion.clearRegion()
-
-                  cb.assign(lastKey, subsetCode.castTo(cb, keyRegion, lastKey.st, deepCopy = true))
-                  cb.assign(nextGroupReady, true)
-                  cb.assign(inOuter, true)
-                  cb.goto(LendOfStream)
-                },
-              )
-
-              cb.define(LelementReady)
-
-              if (requiresMemoryManagementPerElement) {
-                cb += innerResultRegion.trackAndIncrementReferenceCountOf(
-                  childProducer.elementRegion
-                )
-              }
-
-              cb.goto(LproduceElementDone)
-            }
-            override val element: EmitCode = EmitCode.present(mb, xCurElt)
-
-            override def close(cb: EmitCodeBuilder): Unit = {}
-          }
-
-          val outerProducer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
-            override val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-              cb.assign(nextGroupReady, false)
-              cb.assign(eos, false)
-              cb.assign(inOuter, true)
-              cb.assign(first, true)
-
-              if (childProducer.requiresMemoryManagementPerElement) {
-                cb.assign(keyRegion, Region.stagedCreate(Region.REGULAR, outerRegion.getPool()))
-                cb.assign(
-                  childProducer.elementRegion,
-                  Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
-                )
-              } else {
-                cb.assign(keyRegion, outerRegion)
-                cb.assign(childProducer.elementRegion, outerRegion)
-              }
-
-              childProducer.initialize(cb, outerRegion)
-            }
-
-            override val elementRegion: Settable[Region] = outerElementRegion
-            override val requiresMemoryManagementPerElement: Boolean =
-              childProducer.requiresMemoryManagementPerElement
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              cb.if_(eos, cb.goto(LendOfStream))
-
-              val LinnerStreamReady = CodeLabel()
-
-              cb.if_(nextGroupReady, cb.goto(LinnerStreamReady))
-
-              cb.assign(inOuter, true)
-
-              if (childProducer.requiresMemoryManagementPerElement)
-                cb += childProducer.elementRegion.clearRegion()
-              cb.goto(childProducer.LproduceElement)
-              // xElt and curKey are assigned before this label is jumped to
-              cb.define(LchildProduceDoneOuter)
-
-              val LdifferentKey = CodeLabel()
-
-              cb.if_(
-                first, {
-                  cb.assign(first, false)
-                  cb.goto(LdifferentKey)
-                },
-              )
-
-              // if equiv, go to next element. Otherwise, fall through to next group
-              cb.if_(
-                equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
-                  if (childProducer.requiresMemoryManagementPerElement)
-                    cb += childProducer.elementRegion.clearRegion()
-                  cb.goto(childProducer.LproduceElement)
-                },
-              )
-
-              cb.define(LdifferentKey)
-              if (requiresMemoryManagementPerElement)
-                cb += keyRegion.clearRegion()
-
-              cb.assign(lastKey, subsetCode.castTo(cb, keyRegion, lastKey.st, deepCopy = true))
-
-              cb.define(LinnerStreamReady)
-              cb.assign(nextGroupReady, false)
-              cb.goto(LproduceElementDone)
-            }
-
-            override val element: EmitCode = EmitCode.present(mb, SStreamValue(innerProducer))
-
-            override def close(cb: EmitCodeBuilder): Unit = {
-              childProducer.close(cb)
-              if (childProducer.requiresMemoryManagementPerElement) {
-                cb += keyRegion.invalidate()
-                cb += childProducer.elementRegion.invalidate()
+                  SStreamValue(producer)
               }
             }
           }
 
-          mb.implementLabel(childProducer.LendOfStream) { cb =>
-            cb.assign(eos, true)
-            cb.if_(
-              inOuter,
-              cb.goto(outerProducer.LendOfStream),
-              cb.goto(innerProducer.LendOfStream),
-            )
-          }
-
-          mb.implementLabel(childProducer.LproduceElementDone) { cb =>
-            cb.assign(xCurElt, childProducer.element.toI(cb).getOrAssert(cb))
-            cb.assign(curKey, subsetCode)
-            cb.if_(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
-          }
-
-          SStreamValue(outerProducer)
-        }
-
-      case StreamGrouped(a, groupSize) =>
-        produce(a, cb).flatMap(cb) { case childStream: SStreamValue =>
-          emit(groupSize, cb).map(cb) { case groupSize: SInt32Value =>
-            val n = mb.genFieldThisRef[Int]("streamgrouped_n")
-
+        case StreamGroupByKey(a, key, missingEqual) =>
+          produce(a, cb).map(cb) { case childStream: SStreamValue =>
             val childProducer = childStream.getProducer(mb)
 
-            val xCounter = mb.genFieldThisRef[Int]("streamgrouped_ctr")
-            val inOuter = mb.genFieldThisRef[Boolean]("streamgrouped_io")
-            val eos = mb.genFieldThisRef[Boolean]("streamgrouped_eos")
+            val xCurElt = mb.newPField("st_grpby_curelt", childProducer.element.st)
 
-            val outerElementRegion = mb.genFieldThisRef[Region]("streamgrouped_outer_elt_region")
+            val keyRegion = mb.genFieldThisRef[Region]("st_groupby_key_region")
+            def subsetCode = xCurElt.asBaseStruct.subset(key: _*)
+            val curKey = mb.newPField("st_grpby_curkey", subsetCode.st)
+
+            // This type shouldn't be a subset struct, since it is copied deeply.
+            // We don't want to deep copy the parent.
+            val lastKey = mb.newPField("st_grpby_lastkey", subsetCode.st.copiedType)
+
+            val eos = mb.genFieldThisRef[Boolean]("st_grpby_eos")
+            val nextGroupReady = mb.genFieldThisRef[Boolean]("streamgroupbykey_nextready")
+            val inOuter = mb.genFieldThisRef[Boolean]("streamgroupbykey_inouter")
+            val first = mb.genFieldThisRef[Boolean]("streamgroupbykey_first")
 
             /* cannot reuse childProducer.elementRegion because consumers might free the region,
              * even though */
@@ -2707,7 +2545,19 @@ object EmitStream {
             /* boolean flag when the inner stream is closed, and the outer producer reassigns a
              * region if */
             // that flag is set, but that design seems more complicated
-            val innerResultRegion = mb.genFieldThisRef[Region]("streamgrouped_inner_result_region")
+            val innerResultRegion =
+              mb.genFieldThisRef[Region]("streamgroupbykey_inner_result_region")
+
+            val outerElementRegion = mb.genFieldThisRef[Region]("streamgroupbykey_outer_elt_region")
+
+            def equiv(cb: EmitCodeBuilder, l: SBaseStructValue, r: SBaseStructValue)
+              : Value[Boolean] =
+              StructOrdering.make(
+                l.st,
+                r.st,
+                cb.emb.ecb,
+                missingFieldsEqual = missingEqual,
+              ).equivNonnull(cb, l, r)
 
             val LchildProduceDoneInner = CodeLabel()
             val LchildProduceDoneOuter = CodeLabel()
@@ -2721,60 +2571,72 @@ object EmitStream {
               override val requiresMemoryManagementPerElement: Boolean =
                 childProducer.requiresMemoryManagementPerElement
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                val LelementReady = CodeLabel()
+
+                /* the first pull from the inner stream has the next record ready to go from the
+                 * outer stream */
                 cb.if_(
                   inOuter, {
                     cb.assign(inOuter, false)
-                    cb.if_(
-                      xCounter.cne(1),
-                      cb._fatal(s"streamgrouped inner producer error, xCounter=", xCounter.toS),
-                    )
-                    cb.goto(LchildProduceDoneInner)
+                    cb.goto(LelementReady)
                   },
                 )
+
+                if (childProducer.requiresMemoryManagementPerElement)
+                  cb += childProducer.elementRegion.clearRegion()
+                cb.goto(childProducer.LproduceElement)
+                // xElt and curKey are assigned before this label is jumped to
+                cb.define(LchildProduceDoneInner)
+
+                // if not equivalent, end inner stream and prepare for next outer iteration
                 cb.if_(
-                  xCounter >= n, {
+                  !equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
+                    if (requiresMemoryManagementPerElement)
+                      cb += keyRegion.clearRegion()
+
+                    cb.assign(
+                      lastKey,
+                      subsetCode.castTo(cb, keyRegion, lastKey.st, deepCopy = true),
+                    )
+                    cb.assign(nextGroupReady, true)
                     cb.assign(inOuter, true)
                     cb.goto(LendOfStream)
                   },
                 )
 
-                cb.goto(childProducer.LproduceElement)
-                cb.define(LchildProduceDoneInner)
+                cb.define(LelementReady)
 
-                if (childProducer.requiresMemoryManagementPerElement) {
+                if (requiresMemoryManagementPerElement) {
                   cb += innerResultRegion.trackAndIncrementReferenceCountOf(
                     childProducer.elementRegion
                   )
-                  cb += childProducer.elementRegion.clearRegion()
                 }
 
                 cb.goto(LproduceElementDone)
               }
-              override val element: EmitCode = childProducer.element
+              override val element: EmitCode = EmitCode.present(mb, xCurElt)
 
               override def close(cb: EmitCodeBuilder): Unit = {}
             }
-            val innerStreamCode = EmitCode.present(mb, SStreamValue(innerProducer))
 
             val outerProducer = new StreamProducer {
               override def method: EmitMethodBuilder[_] = mb
-              override val length: Option[EmitCodeBuilder => Code[Int]] =
-                childProducer.length.map(compL =>
-                  (cb: EmitCodeBuilder) => ((compL(cb).toL + n.toL - 1L) / n.toL).toI
-                )
+              override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                cb.assign(n, groupSize.value)
-                cb.if_(n <= 0, cb._fatal(s"stream grouped: non-positive size: ", n.toS))
+                cb.assign(nextGroupReady, false)
                 cb.assign(eos, false)
-                cb.assign(xCounter, n)
+                cb.assign(inOuter, true)
+                cb.assign(first, true)
 
                 if (childProducer.requiresMemoryManagementPerElement) {
+                  cb.assign(keyRegion, Region.stagedCreate(Region.REGULAR, outerRegion.getPool()))
                   cb.assign(
                     childProducer.elementRegion,
                     Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
                   )
                 } else {
+                  cb.assign(keyRegion, outerRegion)
                   cb.assign(childProducer.elementRegion, outerRegion)
                 }
 
@@ -2787,25 +2649,55 @@ object EmitStream {
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
                 cb.if_(eos, cb.goto(LendOfStream))
 
+                val LinnerStreamReady = CodeLabel()
+
+                cb.if_(nextGroupReady, cb.goto(LinnerStreamReady))
+
                 cb.assign(inOuter, true)
+
+                if (childProducer.requiresMemoryManagementPerElement)
+                  cb += childProducer.elementRegion.clearRegion()
+                cb.goto(childProducer.LproduceElement)
+                // xElt and curKey are assigned before this label is jumped to
                 cb.define(LchildProduceDoneOuter)
 
+                val LdifferentKey = CodeLabel()
+
                 cb.if_(
-                  xCounter <= n, {
+                  first, {
+                    cb.assign(first, false)
+                    cb.goto(LdifferentKey)
+                  },
+                )
+
+                // if equiv, go to next element. Otherwise, fall through to next group
+                cb.if_(
+                  equiv(cb, curKey.asBaseStruct, lastKey.asBaseStruct), {
                     if (childProducer.requiresMemoryManagementPerElement)
                       cb += childProducer.elementRegion.clearRegion()
                     cb.goto(childProducer.LproduceElement)
                   },
                 )
-                cb.assign(xCounter, 1)
+
+                cb.define(LdifferentKey)
+                if (requiresMemoryManagementPerElement)
+                  cb += keyRegion.clearRegion()
+
+                cb.assign(lastKey, subsetCode.castTo(cb, keyRegion, lastKey.st, deepCopy = true))
+
+                cb.define(LinnerStreamReady)
+                cb.assign(nextGroupReady, false)
                 cb.goto(LproduceElementDone)
               }
-              override val element: EmitCode = innerStreamCode
+
+              override val element: EmitCode = EmitCode.present(mb, SStreamValue(innerProducer))
 
               override def close(cb: EmitCodeBuilder): Unit = {
                 childProducer.close(cb)
-                if (childProducer.requiresMemoryManagementPerElement)
+                if (childProducer.requiresMemoryManagementPerElement) {
+                  cb += keyRegion.invalidate()
                   cb += childProducer.elementRegion.invalidate()
+                }
               }
             }
 
@@ -2819,302 +2711,725 @@ object EmitStream {
             }
 
             mb.implementLabel(childProducer.LproduceElementDone) { cb =>
-              cb.assign(xCounter, xCounter + 1)
+              cb.assign(xCurElt, childProducer.element.toI(cb).getOrAssert(cb))
+              cb.assign(curKey, subsetCode)
               cb.if_(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
             }
 
             SStreamValue(outerProducer)
           }
-        }
 
-      case StreamZip(as, names, body, behavior, errorID) =>
-        IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(cb.emb)(cb => produce(a, cb)))) {
-          childStreams =>
-            val producers = childStreams.map(_.asStream.getProducer(mb))
+        case StreamGrouped(a, groupSize) =>
+          produce(a, cb).flatMap(cb) { case childStream: SStreamValue =>
+            emit(groupSize, cb).map(cb) { case groupSize: SInt32Value =>
+              val n = mb.genFieldThisRef[Int]("streamgrouped_n")
 
-            assert(names.length == producers.length)
+              val childProducer = childStream.getProducer(mb)
 
-            val producer: StreamProducer = behavior match {
-              case behavior @ (ArrayZipBehavior.TakeMinLength | ArrayZipBehavior.AssumeSameLength) =>
-                val vars = names.zip(producers).map { case (_, p) =>
-                  mb.newEmitField(p.element.emitType)
-                }
+              val xCounter = mb.genFieldThisRef[Int]("streamgrouped_ctr")
+              val inOuter = mb.genFieldThisRef[Boolean]("streamgrouped_io")
+              val eos = mb.genFieldThisRef[Boolean]("streamgrouped_eos")
 
-                val eltRegion = mb.genFieldThisRef[Region]("streamzip_eltregion")
-                val bodyCode = EmitCode.fromI(mb)(cb =>
-                  emit(body, cb, region = eltRegion, env = env.bind(names.zip(vars): _*))
-                )
+              val outerElementRegion = mb.genFieldThisRef[Region]("streamgrouped_outer_elt_region")
 
-                new StreamProducer {
-                  override def method: EmitMethodBuilder[_] = mb
-                  override val length: Option[EmitCodeBuilder => Code[Int]] = {
-                    behavior match {
-                      case ArrayZipBehavior.AssumeSameLength =>
-                        producers.flatMap(_.length).headOption
-                      case ArrayZipBehavior.TakeMinLength =>
-                        anyFailAllFail((producers, as).zipped.flatMap { (producer, child) =>
-                          child match {
-                            case _: StreamIota => None
-                            case _ => Some(producer.length)
-                          }
-                        }).map { compLens => (cb: EmitCodeBuilder) =>
-                          compLens.map(_.apply(cb)).reduce(_.min(_))
-                        }
-                    }
-                  }
+              /* cannot reuse childProducer.elementRegion because consumers might free the region,
+               * even though */
+              /* the outer producer needs to continue pulling. We could add more control flow that
+               * sets some */
+              /* boolean flag when the inner stream is closed, and the outer producer reassigns a
+               * region if */
+              // that flag is set, but that design seems more complicated
+              val innerResultRegion =
+                mb.genFieldThisRef[Region]("streamgrouped_inner_result_region")
 
-                  override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                    producers.foreach { p =>
-                      if (p.requiresMemoryManagementPerElement)
-                        cb.assign(p.elementRegion, eltRegion)
-                      else
-                        cb.assign(p.elementRegion, outerRegion)
-                      p.initialize(cb, outerRegion)
-                    }
-                  }
+              val LchildProduceDoneInner = CodeLabel()
+              val LchildProduceDoneOuter = CodeLabel()
+              val innerProducer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
-                  override val elementRegion: Settable[Region] = eltRegion
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {}
 
-                  override val requiresMemoryManagementPerElement: Boolean =
-                    producers.exists(_.requiresMemoryManagementPerElement)
-
-                  override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                    producers.zipWithIndex.foreach { case (p, i) =>
-                      cb.goto(p.LproduceElement)
-                      cb.define(p.LproduceElementDone)
-                      cb.assign(vars(i), p.element)
-                    }
-
-                    cb.goto(LproduceElementDone)
-
-                    // all producer EOS jumps should immediately jump to zipped EOS
-                    producers.foreach { p =>
-                      cb.define(p.LendOfStream)
-                      cb.goto(LendOfStream)
-                    }
-                  }
-
-                  val element: EmitCode = bodyCode
-
-                  def close(cb: EmitCodeBuilder): Unit =
-                    producers.foreach(_.close(cb))
-                }
-
-              case ArrayZipBehavior.AssertSameLength =>
-                val vars = names.zip(producers).map { case (_, p) =>
-                  mb.newEmitField(p.element.emitType)
-                }
-
-                val eltRegion = mb.genFieldThisRef[Region]("streamzip_eltregion")
-                val bodyCode = EmitCode.fromI(mb)(cb =>
-                  emit(body, cb, region = eltRegion, env = env.bind(names.zip(vars): _*))
-                )
-
-                val anyEOS = mb.genFieldThisRef[Boolean]("zip_any_eos")
-                val allEOS = mb.genFieldThisRef[Boolean]("zip_all_eos")
-
-                new StreamProducer {
-                  override def method: EmitMethodBuilder[_] = mb
-                  override val length: Option[EmitCodeBuilder => Code[Int]] =
-                    producers.flatMap(_.length) match {
-                      case Seq() => None
-                      case ls =>
-                        Some({ cb: EmitCodeBuilder =>
-                          val len = cb.newLocal[Int]("zip_len", ls.head(cb))
-                          ls.tail.foreach { compL =>
-                            val lenTemp = cb.newLocal[Int]("lenTemp", compL(cb))
-                            cb.if_(
-                              len.cne(lenTemp),
-                              cb._fatalWithError(
-                                errorID,
-                                "zip: length mismatch: ",
-                                len.toS,
-                                ", ",
-                                lenTemp.toS,
-                              ),
-                            )
-                          }
-                          len
-                        })
-                    }
-
-                  override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                    cb.assign(anyEOS, false)
-
-                    producers.foreach { p =>
-                      if (p.requiresMemoryManagementPerElement)
-                        cb.assign(p.elementRegion, eltRegion)
-                      else
-                        cb.assign(p.elementRegion, outerRegion)
-                      p.initialize(cb, outerRegion)
-                    }
-                  }
-
-                  override val elementRegion: Settable[Region] = eltRegion
-
-                  override val requiresMemoryManagementPerElement: Boolean =
-                    producers.exists(_.requiresMemoryManagementPerElement)
-
-                  override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                    cb.assign(allEOS, true)
-
-                    producers.zipWithIndex.foreach { case (p, i) =>
-                      val fallThrough = CodeLabel()
-
-                      cb.goto(p.LproduceElement)
-
-                      cb.define(p.LendOfStream)
-                      cb.assign(anyEOS, true)
-                      cb.goto(fallThrough)
-
-                      cb.define(p.LproduceElementDone)
-                      cb.assign(vars(i), p.element)
-                      cb.assign(allEOS, false)
-
-                      cb.define(fallThrough)
-                    }
-
-                    cb.if_(
-                      anyEOS,
+                override val elementRegion: Settable[Region] = innerResultRegion
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.if_(
+                    inOuter, {
+                      cb.assign(inOuter, false)
                       cb.if_(
-                        allEOS,
-                        cb.goto(LendOfStream),
-                        cb._fatalWithError(errorID, "zip: length mismatch"),
-                      ),
-                    )
+                        xCounter.cne(1),
+                        cb._fatal(s"streamgrouped inner producer error, xCounter=", xCounter.toS),
+                      )
+                      cb.goto(LchildProduceDoneInner)
+                    },
+                  )
+                  cb.if_(
+                    xCounter >= n, {
+                      cb.assign(inOuter, true)
+                      cb.goto(LendOfStream)
+                    },
+                  )
 
-                    cb.goto(LproduceElementDone)
+                  cb.goto(childProducer.LproduceElement)
+                  cb.define(LchildProduceDoneInner)
+
+                  if (childProducer.requiresMemoryManagementPerElement) {
+                    cb += innerResultRegion.trackAndIncrementReferenceCountOf(
+                      childProducer.elementRegion
+                    )
+                    cb += childProducer.elementRegion.clearRegion()
                   }
 
-                  val element: EmitCode = bodyCode
+                  cb.goto(LproduceElementDone)
+                }
+                override val element: EmitCode = childProducer.element
 
-                  def close(cb: EmitCodeBuilder): Unit =
-                    producers.foreach(_.close(cb))
+                override def close(cb: EmitCodeBuilder): Unit = {}
+              }
+              val innerStreamCode = EmitCode.present(mb, SStreamValue(innerProducer))
+
+              val outerProducer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] =
+                  childProducer.length.map(compL =>
+                    (cb: EmitCodeBuilder) => ((compL(cb).toL + n.toL - 1L) / n.toL).toI
+                  )
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  cb.assign(n, groupSize.value)
+                  cb.if_(n <= 0, cb._fatal(s"stream grouped: non-positive size: ", n.toS))
+                  cb.assign(eos, false)
+                  cb.assign(xCounter, n)
+
+                  if (childProducer.requiresMemoryManagementPerElement) {
+                    cb.assign(
+                      childProducer.elementRegion,
+                      Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
+                    )
+                  } else {
+                    cb.assign(childProducer.elementRegion, outerRegion)
+                  }
+
+                  childProducer.initialize(cb, outerRegion)
                 }
 
-              case ArrayZipBehavior.ExtendNA =>
-                val vars = names.zip(producers).map { case (_, p) =>
-                  mb.newEmitField(p.element.emitType.copy(required = false))
-                }
+                override val elementRegion: Settable[Region] = outerElementRegion
+                override val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  cb.if_(eos, cb.goto(LendOfStream))
 
-                val eltRegion = mb.genFieldThisRef[Region]("streamzip_eltregion")
-                val bodyCode = EmitCode.fromI(mb)(cb =>
-                  emit(body, cb, region = eltRegion, env = env.bind(names.zip(vars): _*))
+                  cb.assign(inOuter, true)
+                  cb.define(LchildProduceDoneOuter)
+
+                  cb.if_(
+                    xCounter <= n, {
+                      if (childProducer.requiresMemoryManagementPerElement)
+                        cb += childProducer.elementRegion.clearRegion()
+                      cb.goto(childProducer.LproduceElement)
+                    },
+                  )
+                  cb.assign(xCounter, 1)
+                  cb.goto(LproduceElementDone)
+                }
+                override val element: EmitCode = innerStreamCode
+
+                override def close(cb: EmitCodeBuilder): Unit = {
+                  childProducer.close(cb)
+                  if (childProducer.requiresMemoryManagementPerElement)
+                    cb += childProducer.elementRegion.invalidate()
+                }
+              }
+
+              mb.implementLabel(childProducer.LendOfStream) { cb =>
+                cb.assign(eos, true)
+                cb.if_(
+                  inOuter,
+                  cb.goto(outerProducer.LendOfStream),
+                  cb.goto(innerProducer.LendOfStream),
                 )
+              }
 
-                val eosPerStream =
-                  producers.indices.map(i => mb.genFieldThisRef[Boolean](s"zip_eos_$i"))
-                val nEOS = mb.genFieldThisRef[Int]("zip_n_eos")
+              mb.implementLabel(childProducer.LproduceElementDone) { cb =>
+                cb.assign(xCounter, xCounter + 1)
+                cb.if_(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
+              }
 
-                new StreamProducer {
-                  override def method: EmitMethodBuilder[_] = mb
-                  override val length: Option[EmitCodeBuilder => Code[Int]] =
-                    anyFailAllFail(producers.map(_.length))
-                      .map { compLens => (cb: EmitCodeBuilder) =>
-                        compLens.map(_.apply(cb)).reduce(_.max(_))
+              SStreamValue(outerProducer)
+            }
+          }
+
+        case StreamZip(as, names, body, behavior, errorID) =>
+          IEmitCode.multiMapEmitCodes(
+            cb,
+            as.map(a => EmitCode.fromI(cb.emb)(cb => produce(a, cb))),
+          ) {
+            childStreams =>
+              val producers = childStreams.map(_.asStream.getProducer(mb))
+
+              assert(names.length == producers.length)
+
+              val producer: StreamProducer = behavior match {
+                case behavior @ (ArrayZipBehavior.TakeMinLength | ArrayZipBehavior.AssumeSameLength) =>
+                  val vars = names.zip(producers).map { case (_, p) =>
+                    mb.newEmitField(p.element.emitType)
+                  }
+
+                  val eltRegion = mb.genFieldThisRef[Region]("streamzip_eltregion")
+                  val bodyCode = EmitCode.fromI(mb)(cb =>
+                    emit(body, cb, region = eltRegion, env = env.bind(names.zip(vars): _*))
+                  )
+
+                  new StreamProducer {
+                    override def method: EmitMethodBuilder[_] = mb
+                    override val length: Option[EmitCodeBuilder => Code[Int]] = {
+                      behavior match {
+                        case ArrayZipBehavior.AssumeSameLength =>
+                          producers.flatMap(_.length).headOption
+                        case ArrayZipBehavior.TakeMinLength =>
+                          anyFailAllFail((producers, as).zipped.flatMap { (producer, child) =>
+                            child match {
+                              case _: StreamIota => None
+                              case _ => Some(producer.length)
+                            }
+                          }).map { compLens => (cb: EmitCodeBuilder) =>
+                            compLens.map(_.apply(cb)).reduce(_.min(_))
+                          }
+                      }
+                    }
+
+                    override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region])
+                      : Unit = {
+                      producers.foreach { p =>
+                        if (p.requiresMemoryManagementPerElement)
+                          cb.assign(p.elementRegion, eltRegion)
+                        else
+                          cb.assign(p.elementRegion, outerRegion)
+                        p.initialize(cb, outerRegion)
+                      }
+                    }
+
+                    override val elementRegion: Settable[Region] = eltRegion
+
+                    override val requiresMemoryManagementPerElement: Boolean =
+                      producers.exists(_.requiresMemoryManagementPerElement)
+
+                    override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                      producers.zipWithIndex.foreach { case (p, i) =>
+                        cb.goto(p.LproduceElement)
+                        cb.define(p.LproduceElementDone)
+                        cb.assign(vars(i), p.element)
                       }
 
-                  override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                    producers.foreach { p =>
-                      if (p.requiresMemoryManagementPerElement)
-                        cb.assign(p.elementRegion, eltRegion)
-                      else
-                        cb.assign(p.elementRegion, outerRegion)
-                      p.initialize(cb, outerRegion)
+                      cb.goto(LproduceElementDone)
+
+                      // all producer EOS jumps should immediately jump to zipped EOS
+                      producers.foreach { p =>
+                        cb.define(p.LendOfStream)
+                        cb.goto(LendOfStream)
+                      }
                     }
 
-                    eosPerStream.foreach(eos => cb.assign(eos, false))
-                    cb.assign(nEOS, 0)
+                    val element: EmitCode = bodyCode
+
+                    def close(cb: EmitCodeBuilder): Unit =
+                      producers.foreach(_.close(cb))
                   }
 
-                  override val elementRegion: Settable[Region] = eltRegion
+                case ArrayZipBehavior.AssertSameLength =>
+                  val vars = names.zip(producers).map { case (_, p) =>
+                    mb.newEmitField(p.element.emitType)
+                  }
 
-                  override val requiresMemoryManagementPerElement: Boolean =
-                    producers.exists(_.requiresMemoryManagementPerElement)
+                  val eltRegion = mb.genFieldThisRef[Region]("streamzip_eltregion")
+                  val bodyCode = EmitCode.fromI(mb)(cb =>
+                    emit(body, cb, region = eltRegion, env = env.bind(names.zip(vars): _*))
+                  )
 
-                  override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                    producers.zipWithIndex.foreach { case (p, i) =>
-                      // label at the end of processing this element
-                      val endProduce = CodeLabel()
+                  val anyEOS = mb.genFieldThisRef[Boolean]("zip_any_eos")
+                  val allEOS = mb.genFieldThisRef[Boolean]("zip_all_eos")
 
-                      cb.if_(eosPerStream(i), cb.goto(endProduce))
+                  new StreamProducer {
+                    override def method: EmitMethodBuilder[_] = mb
+                    override val length: Option[EmitCodeBuilder => Code[Int]] =
+                      producers.flatMap(_.length) match {
+                        case Seq() => None
+                        case ls =>
+                          Some({ cb: EmitCodeBuilder =>
+                            val len = cb.newLocal[Int]("zip_len", ls.head(cb))
+                            ls.tail.foreach { compL =>
+                              val lenTemp = cb.newLocal[Int]("lenTemp", compL(cb))
+                              cb.if_(
+                                len.cne(lenTemp),
+                                cb._fatalWithError(
+                                  errorID,
+                                  "zip: length mismatch: ",
+                                  len.toS,
+                                  ", ",
+                                  lenTemp.toS,
+                                ),
+                              )
+                            }
+                            len
+                          })
+                      }
 
-                      cb.goto(p.LproduceElement)
+                    override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region])
+                      : Unit = {
+                      cb.assign(anyEOS, false)
 
-                      /* after an EOS we set the EOS boolean for that stream, and check if all
-                       * streams have ended */
-                      cb.define(p.LendOfStream)
-                      cb.assign(nEOS, nEOS + 1)
-
-                      cb.if_(nEOS.ceq(const(producers.length)), cb.goto(LendOfStream))
-
-                      /* this stream has ended before each other, so we set the eos flag and the
-                       * element EmitSettable */
-                      cb.assign(eosPerStream(i), true)
-                      cb.assign(vars(i), EmitCode.missing(mb, vars(i).st))
-
-                      cb.goto(endProduce)
-
-                      cb.define(p.LproduceElementDone)
-                      cb.assign(vars(i), p.element)
-
-                      cb.define(endProduce)
+                      producers.foreach { p =>
+                        if (p.requiresMemoryManagementPerElement)
+                          cb.assign(p.elementRegion, eltRegion)
+                        else
+                          cb.assign(p.elementRegion, outerRegion)
+                        p.initialize(cb, outerRegion)
+                      }
                     }
 
-                    cb.goto(LproduceElementDone)
+                    override val elementRegion: Settable[Region] = eltRegion
+
+                    override val requiresMemoryManagementPerElement: Boolean =
+                      producers.exists(_.requiresMemoryManagementPerElement)
+
+                    override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                      cb.assign(allEOS, true)
+
+                      producers.zipWithIndex.foreach { case (p, i) =>
+                        val fallThrough = CodeLabel()
+
+                        cb.goto(p.LproduceElement)
+
+                        cb.define(p.LendOfStream)
+                        cb.assign(anyEOS, true)
+                        cb.goto(fallThrough)
+
+                        cb.define(p.LproduceElementDone)
+                        cb.assign(vars(i), p.element)
+                        cb.assign(allEOS, false)
+
+                        cb.define(fallThrough)
+                      }
+
+                      cb.if_(
+                        anyEOS,
+                        cb.if_(
+                          allEOS,
+                          cb.goto(LendOfStream),
+                          cb._fatalWithError(errorID, "zip: length mismatch"),
+                        ),
+                      )
+
+                      cb.goto(LproduceElementDone)
+                    }
+
+                    val element: EmitCode = bodyCode
+
+                    def close(cb: EmitCodeBuilder): Unit =
+                      producers.foreach(_.close(cb))
                   }
 
-                  val element: EmitCode = bodyCode
+                case ArrayZipBehavior.ExtendNA =>
+                  val vars = names.zip(producers).map { case (_, p) =>
+                    mb.newEmitField(p.element.emitType.copy(required = false))
+                  }
 
-                  def close(cb: EmitCodeBuilder): Unit =
-                    producers.foreach(_.close(cb))
+                  val eltRegion = mb.genFieldThisRef[Region]("streamzip_eltregion")
+                  val bodyCode = EmitCode.fromI(mb)(cb =>
+                    emit(body, cb, region = eltRegion, env = env.bind(names.zip(vars): _*))
+                  )
+
+                  val eosPerStream =
+                    producers.indices.map(i => mb.genFieldThisRef[Boolean](s"zip_eos_$i"))
+                  val nEOS = mb.genFieldThisRef[Int]("zip_n_eos")
+
+                  new StreamProducer {
+                    override def method: EmitMethodBuilder[_] = mb
+                    override val length: Option[EmitCodeBuilder => Code[Int]] =
+                      anyFailAllFail(producers.map(_.length))
+                        .map { compLens => (cb: EmitCodeBuilder) =>
+                          compLens.map(_.apply(cb)).reduce(_.max(_))
+                        }
+
+                    override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region])
+                      : Unit = {
+                      producers.foreach { p =>
+                        if (p.requiresMemoryManagementPerElement)
+                          cb.assign(p.elementRegion, eltRegion)
+                        else
+                          cb.assign(p.elementRegion, outerRegion)
+                        p.initialize(cb, outerRegion)
+                      }
+
+                      eosPerStream.foreach(eos => cb.assign(eos, false))
+                      cb.assign(nEOS, 0)
+                    }
+
+                    override val elementRegion: Settable[Region] = eltRegion
+
+                    override val requiresMemoryManagementPerElement: Boolean =
+                      producers.exists(_.requiresMemoryManagementPerElement)
+
+                    override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                      producers.zipWithIndex.foreach { case (p, i) =>
+                        // label at the end of processing this element
+                        val endProduce = CodeLabel()
+
+                        cb.if_(eosPerStream(i), cb.goto(endProduce))
+
+                        cb.goto(p.LproduceElement)
+
+                        /* after an EOS we set the EOS boolean for that stream, and check if all
+                         * streams have ended */
+                        cb.define(p.LendOfStream)
+                        cb.assign(nEOS, nEOS + 1)
+
+                        cb.if_(nEOS.ceq(const(producers.length)), cb.goto(LendOfStream))
+
+                        /* this stream has ended before each other, so we set the eos flag and the
+                         * element EmitSettable */
+                        cb.assign(eosPerStream(i), true)
+                        cb.assign(vars(i), EmitCode.missing(mb, vars(i).st))
+
+                        cb.goto(endProduce)
+
+                        cb.define(p.LproduceElementDone)
+                        cb.assign(vars(i), p.element)
+
+                        cb.define(endProduce)
+                      }
+
+                      cb.goto(LproduceElementDone)
+                    }
+
+                    val element: EmitCode = bodyCode
+
+                    def close(cb: EmitCodeBuilder): Unit =
+                      producers.foreach(_.close(cb))
+                  }
+
+              }
+
+              SStreamValue(producer)
+          }
+
+        case StreamZipJoin(as, key, keyRef, valsRef, joinIR) =>
+          IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(cb.emb)(cb => emit(a, cb)))) {
+            children =>
+              val producers = children.map(_.asStream.getProducer(mb))
+
+              val eltType = VirtualTypeWithReq.union(as.map(a => typeWithReqx(a))).canonicalEmitType
+                .st
+                .asInstanceOf[SStream]
+                .elementType
+                .storageType()
+                .setRequired(false)
+                .asInstanceOf[PCanonicalStruct]
+
+              val keyType = eltType.selectFields(key)
+
+              val curValsType = PCanonicalArray(eltType)
+
+              val _elementRegion = mb.genFieldThisRef[Region]("szj_region")
+              val regionArray = mb.genFieldThisRef[Array[Region]]("szj_region_array")
+
+              val staticMemManagementArray =
+                producers.map(_.requiresMemoryManagementPerElement).toArray
+              val allMatch = staticMemManagementArray.toSet.size == 1
+              val memoryManagementBooleansArray =
+                if (allMatch) null else mb.genFieldThisRef[Array[Int]]("smm_separate_region_array")
+
+              def initMemoryManagementPerElementArray(cb: EmitCodeBuilder): Unit =
+                if (!allMatch)
+                  cb.assign(
+                    memoryManagementBooleansArray,
+                    mb.getObject[Array[Int]](
+                      producers.map(_.requiresMemoryManagementPerElement.toInt).toArray
+                    ),
+                  )
+
+              def lookupMemoryManagementByIndex(cb: EmitCodeBuilder, idx: Code[Int])
+                : Code[Boolean] =
+                if (allMatch)
+                  const(staticMemManagementArray.head)
+                else
+                  memoryManagementBooleansArray.apply(idx).toZ
+
+              // The algorithm maintains a tournament tree of comparisons between the
+              // current values of the k streams. The tournament tree is a complete
+              // binary tree with k leaves. The leaves of the tree are the streams,
+              // and each internal node represents the "contest" between the "winners"
+              // of the two subtrees, where the winner is the stream with the smaller
+              // current key. Each internal node stores the index of the stream which
+              // *lost* that contest.
+              // Each time we remove the overall winner, and replace that stream's
+              // leaf with its next value, we only need to rerun the contests on the
+              // path from that leaf to the root, comparing the new value with what
+              // previously lost that contest to the previous overall winner.
+
+              val k = producers.length
+              // The leaf nodes of the tournament tree, each of which holds a pointer
+              // to the current value of that stream.
+              val heads = mb.genFieldThisRef[Array[Long]]("merge_heads")
+              // The internal nodes of the tournament tree, laid out in breadth-first
+              // order, each of which holds the index of the stream which lost that
+              // contest.
+              val bracket = mb.genFieldThisRef[Array[Int]]("merge_bracket")
+              // When updating the tournament tree, holds the winner of the subtree
+              // containing the updated leaf. Otherwise, holds the overall winner, i.e.
+              // the current least element.
+              val winner = mb.genFieldThisRef[Int]("merge_winner")
+              val result = mb.genFieldThisRef[Array[Long]]("merge_result")
+              val i = mb.genFieldThisRef[Int]("merge_i")
+
+              val curKey = mb.newPField("st_grpby_curkey", keyType.sType)
+
+              val xKey = mb.newEmitField("zipjoin_key", keyType.sType, required = true)
+              val xElts = mb.newEmitField("zipjoin_elts", curValsType.sType, required = true)
+
+              val joinResult: EmitCode = EmitCode.fromI(mb) { cb =>
+                val newEnv = env.bind((keyRef -> xKey), (valsRef -> xElts))
+                emit(joinIR, cb, env = newEnv)
+              }
+
+              val producer = new StreamProducer {
+                override def method: EmitMethodBuilder[_] = mb
+                override val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  cb.assign(regionArray, Code.newArray[Region](k))
+                  producers.zipWithIndex.foreach { case (p, idx) =>
+                    if (p.requiresMemoryManagementPerElement) {
+                      cb.assign(
+                        p.elementRegion,
+                        Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
+                      )
+                    } else
+                      cb.assign(p.elementRegion, outerRegion)
+                    cb += (regionArray(idx) = p.elementRegion)
+                    p.initialize(cb, outerRegion)
+                  }
+                  initMemoryManagementPerElementArray(cb)
+                  cb.assign(bracket, Code.newArray[Int](k))
+                  cb.assign(heads, Code.newArray[Long](k))
+                  cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), cb += (bracket(i) = -1))
+                  cb.assign(result, Code._null)
+                  cb.assign(i, 0)
+                  cb.assign(winner, 0)
                 }
 
-            }
+                override val elementRegion: Settable[Region] = _elementRegion
+                override val requiresMemoryManagementPerElement: Boolean =
+                  producers.exists(_.requiresMemoryManagementPerElement)
+                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  val LrunMatch = CodeLabel()
+                  val LpullChild = CodeLabel()
+                  val LloopEnd = CodeLabel()
+                  val LaddToResult = CodeLabel()
+                  val LstartNewKey = CodeLabel()
+                  val Lpush = CodeLabel()
 
-            SStreamValue(producer)
-        }
+                  def inSetup: Code[Boolean] = result.isNull
 
-      case StreamZipJoin(as, key, keyRef, valsRef, joinIR) =>
-        IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(cb.emb)(cb => emit(a, cb)))) {
-          children =>
-            val producers = children.map(_.asStream.getProducer(mb))
+                  cb.if_(
+                    inSetup, {
+                      cb.assign(i, 0)
+                      cb.goto(LpullChild)
+                    },
+                    cb.if_(winner.ceq(k), cb.goto(LendOfStream), cb.goto(LstartNewKey)),
+                  )
 
-            val eltType = VirtualTypeWithReq.union(as.map(a => typeWithReqx(a))).canonicalEmitType
-              .st
-              .asInstanceOf[SStream]
-              .elementType
-              .storageType()
-              .setRequired(false)
+                  cb.define(Lpush)
+                  cb.assign(xKey, EmitCode.present(cb.emb, curKey))
+                  cb.assign(
+                    xElts,
+                    EmitCode.present(
+                      cb.emb,
+                      curValsType.constructFromElements(cb, elementRegion, k, false) { (cb, i) =>
+                        IEmitCode(cb, result(i).ceq(0L), eltType.loadCheapSCode(cb, result(i)))
+                      },
+                    ),
+                  )
+                  cb.goto(LproduceElementDone)
+
+                  cb.define(LstartNewKey)
+                  cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), cb += (result(i) = 0L))
+                  cb.assign(
+                    curKey,
+                    eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
+                      .castTo(cb, elementRegion, curKey.st, true),
+                  )
+                  cb.goto(LaddToResult)
+
+                  cb.define(LaddToResult)
+                  cb += (result(winner) = heads(winner))
+                  cb.if_(
+                    lookupMemoryManagementByIndex(cb, winner), {
+                      val r = cb.newLocal[Region]("tzj_winner_region", regionArray(winner))
+                      cb += elementRegion.trackAndIncrementReferenceCountOf(r)
+                      cb += r.clearRegion()
+                    },
+                  )
+                  cb.goto(LpullChild)
+
+                  val matchIdx = mb.genFieldThisRef[Int]("merge_match_idx")
+                  val challenger = mb.genFieldThisRef[Int]("merge_challenger")
+                  // Compare 'winner' with value in 'matchIdx', loser goes in 'matchIdx',
+                  // winner goes on to next round. A contestant '-1' beats everything
+                  // (negative infinity), a contestant 'k' loses to everything
+                  // (positive infinity), and values in between are indices into 'heads'.
+
+                  cb.define(LrunMatch)
+                  cb.assign(challenger, bracket(matchIdx))
+                  cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
+
+                  val LafterChallenge = CodeLabel()
+
+                  cb.if_(
+                    challenger.cne(k), {
+                      val LchallengerWins = CodeLabel()
+
+                      cb.if_(winner.ceq(k), cb.goto(LchallengerWins))
+
+                      val left = eltType.loadCheapSCode(cb, heads(challenger)).subset(key: _*)
+                      val right = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
+                      val ord =
+                        StructOrdering.make(
+                          left.st,
+                          right.st,
+                          cb.emb.ecb,
+                          missingFieldsEqual = false,
+                        )
+                      cb.if_(
+                        ord.lteqNonnull(cb, left, right),
+                        cb.goto(LchallengerWins),
+                        cb.goto(LafterChallenge),
+                      )
+
+                      cb.define(LchallengerWins)
+                      cb += (bracket(matchIdx) = winner)
+                      cb.assign(winner, challenger)
+                    },
+                  )
+                  cb.define(LafterChallenge)
+                  cb.assign(matchIdx, matchIdx >>> 1)
+                  cb.goto(LrunMatch)
+
+                  cb.define(LloopEnd)
+                  cb.if_(
+                    matchIdx.ceq(0), {
+                      // 'winner' is smallest of all k heads. If 'winner' = k, all heads
+                      // must be k, and all streams are exhausted.
+
+                      cb.if_(
+                        inSetup, {
+                          cb.if_(
+                            winner.ceq(k),
+                            cb.goto(LendOfStream), {
+                              cb.assign(result, Code.newArray[Long](k))
+                              cb.goto(LstartNewKey)
+                            },
+                          )
+                        }, {
+                          cb.if_(!winner.cne(k), cb.goto(Lpush))
+                          val left = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
+                          val right = curKey
+                          val ord = StructOrdering.make(
+                            left.st,
+                            right.st.asInstanceOf[SBaseStruct],
+                            cb.emb.ecb,
+                            missingFieldsEqual = false,
+                          )
+                          cb.if_(
+                            ord.equivNonnull(cb, left, right),
+                            cb.goto(LaddToResult),
+                            cb.goto(Lpush),
+                          )
+                        },
+                      )
+                    }, {
+                      // We're still in the setup phase
+                      cb += (bracket(matchIdx) = winner)
+                      cb.assign(i, i + 1)
+                      cb.assign(winner, i)
+                      cb.goto(LpullChild)
+                    },
+                  )
+
+                  producers.zipWithIndex.foreach { case (p, idx) =>
+                    cb.define(p.LendOfStream)
+                    cb.assign(winner, k)
+                    cb.assign(matchIdx, (idx + k) >>> 1)
+                    cb.goto(LrunMatch)
+
+                    cb.define(p.LproduceElementDone)
+                    val storedElt =
+                      eltType.store(cb, p.elementRegion, p.element.toI(cb).getOrAssert(cb), false)
+                    cb += (heads(idx) = storedElt)
+                    cb.assign(matchIdx, (idx + k) >>> 1)
+                    cb.goto(LrunMatch)
+                  }
+
+                  cb.define(LpullChild)
+                  cb.switch(
+                    winner,
+                    cb.goto(LendOfStream), // can only happen if k=0
+                    producers.map(p => () => cb.goto(p.LproduceElement)),
+                  )
+                }
+
+                override val element: EmitCode = joinResult
+
+                override def close(cb: EmitCodeBuilder): Unit = {
+                  producers.foreach { p =>
+                    if (p.requiresMemoryManagementPerElement)
+                      cb += p.elementRegion.invalidate()
+                    p.close(cb)
+                  }
+                  cb.assign(bracket, Code._null)
+                  cb.assign(heads, Code._null)
+                  cb.assign(result, Code._null)
+                }
+              }
+
+              SStreamValue(producer)
+          }
+
+        case StreamZipJoinProducers(contexts, ctxName, makeProducer, key, keyRef, valsRef,
+              joinIR) =>
+          emit(contexts, cb).map(cb) { case contextsArray: SIndexableValue =>
+            val nStreams = cb.memoizeField(contextsArray.loadLength())
+            val iterArray = cb.memoizeField(Code.newArray[NoBoxLongIterator](nStreams), "iterArray")
+            val idx = cb.newLocal[Int]("i", 0)
+            val eltType = VirtualTypeWithReq(
+              TIterable.elementType(makeProducer.typ),
+              emitter.ctx.req.lookup(makeProducer).asInstanceOf[RIterable].elementType,
+            ).canonicalPType
               .asInstanceOf[PCanonicalStruct]
+              .setRequired(false)
+            var streamRequiresMemoryManagement = false
+            cb.while_(
+              idx < nStreams, {
+                val iter = produceIterator(
+                  makeProducer,
+                  eltType,
+                  cb,
+                  env.bind(ctxName, cb.memoize(contextsArray.loadElement(cb, idx))),
+                )
+                  .getOrFatal(cb, "streams in zipJoinProducers cannot be missing")
+                  .asInstanceOf[SStreamConcrete]
+                streamRequiresMemoryManagement = iter.st.requiresMemoryManagement
+                cb += iterArray.update(idx, iter.it)
+                cb.assign(idx, idx + 1)
+              },
+            )
 
             val keyType = eltType.selectFields(key)
 
             val curValsType = PCanonicalArray(eltType)
 
             val _elementRegion = mb.genFieldThisRef[Region]("szj_region")
-            val regionArray = mb.genFieldThisRef[Array[Region]]("szj_region_array")
-
-            val staticMemManagementArray =
-              producers.map(_.requiresMemoryManagementPerElement).toArray
-            val allMatch = staticMemManagementArray.toSet.size == 1
-            val memoryManagementBooleansArray =
-              if (allMatch) null else mb.genFieldThisRef[Array[Int]]("smm_separate_region_array")
-
-            def initMemoryManagementPerElementArray(cb: EmitCodeBuilder): Unit =
-              if (!allMatch)
-                cb.assign(
-                  memoryManagementBooleansArray,
-                  mb.getObject[Array[Int]](
-                    producers.map(_.requiresMemoryManagementPerElement.toInt).toArray
-                  ),
-                )
-
-            def lookupMemoryManagementByIndex(cb: EmitCodeBuilder, idx: Code[Int]): Code[Boolean] =
-              if (allMatch)
-                const(staticMemManagementArray.head)
-              else
-                memoryManagementBooleansArray.apply(idx).toZ
 
             // The algorithm maintains a tournament tree of comparisons between the
             // current values of the k streams. The tournament tree is a complete
@@ -3128,7 +3443,7 @@ object EmitStream {
             // path from that leaf to the root, comparing the new value with what
             // previously lost that contest to the previous overall winner.
 
-            val k = producers.length
+            val k = nStreams
             // The leaf nodes of the tournament tree, each of which holds a pointer
             // to the current value of that stream.
             val heads = mb.genFieldThisRef[Array[Long]]("merge_heads")
@@ -3153,27 +3468,34 @@ object EmitStream {
               emit(joinIR, cb, env = newEnv)
             }
 
+            val regionArray: Settable[Array[Region]] = if (streamRequiresMemoryManagement)
+              mb.genFieldThisRef[Array[Region]]("szj_region_array")
+            else
+              null
+
             val producer = new StreamProducer {
               override def method: EmitMethodBuilder[_] = mb
+
               override val length: Option[EmitCodeBuilder => Code[Int]] = None
 
               override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                cb.assign(regionArray, Code.newArray[Region](k))
-                producers.zipWithIndex.foreach { case (p, idx) =>
-                  if (p.requiresMemoryManagementPerElement) {
-                    cb.assign(
-                      p.elementRegion,
-                      Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
-                    )
-                  } else
-                    cb.assign(p.elementRegion, outerRegion)
-                  cb += (regionArray(idx) = p.elementRegion)
-                  p.initialize(cb, outerRegion)
-                }
-                initMemoryManagementPerElementArray(cb)
+                if (streamRequiresMemoryManagement)
+                  cb.assign(regionArray, Code.newArray[Region](nStreams))
                 cb.assign(bracket, Code.newArray[Int](k))
                 cb.assign(heads, Code.newArray[Long](k))
-                cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), cb += (bracket(i) = -1))
+                cb.for_(
+                  cb.assign(i, 0),
+                  i < k,
+                  cb.assign(i, i + 1), {
+                    cb.updateArray(bracket, i, -1)
+                    val eltRegion: Value[Region] = if (streamRequiresMemoryManagement) {
+                      val r = cb.memoize(Region.stagedCreate(Region.REGULAR, outerRegion.getPool()))
+                      cb.updateArray(regionArray, i, r)
+                      r
+                    } else outerRegion
+                    cb += iterArray(i).invoke[Region, Region, Unit]("init", outerRegion, eltRegion)
+                  },
+                )
                 cb.assign(result, Code._null)
                 cb.assign(i, 0)
                 cb.assign(winner, 0)
@@ -3181,7 +3503,7 @@ object EmitStream {
 
               override val elementRegion: Settable[Region] = _elementRegion
               override val requiresMemoryManagementPerElement: Boolean =
-                producers.exists(_.requiresMemoryManagementPerElement)
+                streamRequiresMemoryManagement
               override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
                 val LrunMatch = CodeLabel()
                 val LpullChild = CodeLabel()
@@ -3214,7 +3536,7 @@ object EmitStream {
                 cb.goto(LproduceElementDone)
 
                 cb.define(LstartNewKey)
-                cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), cb += (result(i) = 0L))
+                cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), cb.updateArray(result, i, 0L))
                 cb.assign(
                   curKey,
                   eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
@@ -3224,13 +3546,11 @@ object EmitStream {
 
                 cb.define(LaddToResult)
                 cb += (result(winner) = heads(winner))
-                cb.if_(
-                  lookupMemoryManagementByIndex(cb, winner), {
-                    val r = cb.newLocal[Region]("tzj_winner_region", regionArray(winner))
-                    cb += elementRegion.trackAndIncrementReferenceCountOf(r)
-                    cb += r.clearRegion()
-                  },
-                )
+                if (streamRequiresMemoryManagement) {
+                  val r = cb.newLocal[Region]("tzj_winner_region", regionArray(winner))
+                  cb += elementRegion.trackAndIncrementReferenceCountOf(r)
+                  cb += r.clearRegion()
+                }
                 cb.goto(LpullChild)
 
                 val matchIdx = mb.genFieldThisRef[Int]("merge_match_idx")
@@ -3263,7 +3583,7 @@ object EmitStream {
                     )
 
                     cb.define(LchallengerWins)
-                    cb += (bracket(matchIdx) = winner)
+                    cb.updateArray(bracket, matchIdx, winner)
                     cb.assign(winner, challenger)
                   },
                 )
@@ -3305,43 +3625,43 @@ object EmitStream {
                     )
                   }, {
                     // We're still in the setup phase
-                    cb += (bracket(matchIdx) = winner)
+                    cb.updateArray(bracket, matchIdx, winner)
                     cb.assign(i, i + 1)
                     cb.assign(winner, i)
                     cb.goto(LpullChild)
                   },
                 )
 
-                producers.zipWithIndex.foreach { case (p, idx) =>
-                  cb.define(p.LendOfStream)
-                  cb.assign(winner, k)
-                  cb.assign(matchIdx, (idx + k) >>> 1)
-                  cb.goto(LrunMatch)
-
-                  cb.define(p.LproduceElementDone)
-                  val storedElt =
-                    eltType.store(cb, p.elementRegion, p.element.toI(cb).getOrAssert(cb), false)
-                  cb += (heads(idx) = storedElt)
-                  cb.assign(matchIdx, (idx + k) >>> 1)
-                  cb.goto(LrunMatch)
-                }
-
                 cb.define(LpullChild)
-                cb.switch(
-                  winner,
-                  cb.goto(LendOfStream), // can only happen if k=0
-                  producers.map(p => () => cb.goto(p.LproduceElement)),
+                cb.if_(winner >= nStreams, cb.goto(LendOfStream)) // can only happen if k=0
+                val winnerIter = cb.memoize(iterArray(winner))
+                val winnerNextElt = cb.memoize(winnerIter.invoke[Long]("next"))
+                cb.if_(
+                  winnerIter.invoke[Boolean]("eos"), {
+                    cb.assign(matchIdx, (winner + k) >>> 1)
+                    cb.assign(winner, k)
+                  }, {
+                    cb.assign(matchIdx, (winner + k) >>> 1)
+                    cb.updateArray(heads, winner, winnerNextElt)
+                  },
                 )
+                cb.goto(LrunMatch)
               }
 
               override val element: EmitCode = joinResult
 
               override def close(cb: EmitCodeBuilder): Unit = {
-                producers.foreach { p =>
-                  if (p.requiresMemoryManagementPerElement)
-                    cb += p.elementRegion.invalidate()
-                  p.close(cb)
-                }
+                cb.assign(i, 0)
+                cb.while_(
+                  i < nStreams, {
+                    cb += iterArray(i).invoke[Unit]("close")
+                    if (requiresMemoryManagementPerElement)
+                      cb += regionArray(i).invoke[Unit]("invalidate")
+                    cb.assign(i, i + 1)
+                  },
+                )
+                if (requiresMemoryManagementPerElement)
+                  cb.assign(regionArray, Code._null)
                 cb.assign(bracket, Code._null)
                 cb.assign(heads, Code._null)
                 cb.assign(result, Code._null)
@@ -3349,562 +3669,300 @@ object EmitStream {
             }
 
             SStreamValue(producer)
-        }
-
-      case StreamZipJoinProducers(contexts, ctxName, makeProducer, key, keyRef, valsRef,
-            joinIR) =>
-        emit(contexts, cb).map(cb) { case contextsArray: SIndexableValue =>
-          val nStreams = cb.memoizeField(contextsArray.loadLength())
-          val iterArray = cb.memoizeField(Code.newArray[NoBoxLongIterator](nStreams), "iterArray")
-          val idx = cb.newLocal[Int]("i", 0)
-          val eltType = VirtualTypeWithReq(
-            TIterable.elementType(makeProducer.typ),
-            emitter.ctx.req.lookup(makeProducer).asInstanceOf[RIterable].elementType,
-          ).canonicalPType
-            .asInstanceOf[PCanonicalStruct]
-            .setRequired(false)
-          var streamRequiresMemoryManagement = false
-          cb.while_(
-            idx < nStreams, {
-              val iter = produceIterator(
-                makeProducer,
-                eltType,
-                cb,
-                env.bind(ctxName, cb.memoize(contextsArray.loadElement(cb, idx))),
-              )
-                .getOrFatal(cb, "streams in zipJoinProducers cannot be missing")
-                .asInstanceOf[SStreamConcrete]
-              streamRequiresMemoryManagement = iter.st.requiresMemoryManagement
-              cb += iterArray.update(idx, iter.it)
-              cb.assign(idx, idx + 1)
-            },
-          )
-
-          val keyType = eltType.selectFields(key)
-
-          val curValsType = PCanonicalArray(eltType)
-
-          val _elementRegion = mb.genFieldThisRef[Region]("szj_region")
-
-          // The algorithm maintains a tournament tree of comparisons between the
-          // current values of the k streams. The tournament tree is a complete
-          // binary tree with k leaves. The leaves of the tree are the streams,
-          // and each internal node represents the "contest" between the "winners"
-          // of the two subtrees, where the winner is the stream with the smaller
-          // current key. Each internal node stores the index of the stream which
-          // *lost* that contest.
-          // Each time we remove the overall winner, and replace that stream's
-          // leaf with its next value, we only need to rerun the contests on the
-          // path from that leaf to the root, comparing the new value with what
-          // previously lost that contest to the previous overall winner.
-
-          val k = nStreams
-          // The leaf nodes of the tournament tree, each of which holds a pointer
-          // to the current value of that stream.
-          val heads = mb.genFieldThisRef[Array[Long]]("merge_heads")
-          // The internal nodes of the tournament tree, laid out in breadth-first
-          // order, each of which holds the index of the stream which lost that
-          // contest.
-          val bracket = mb.genFieldThisRef[Array[Int]]("merge_bracket")
-          // When updating the tournament tree, holds the winner of the subtree
-          // containing the updated leaf. Otherwise, holds the overall winner, i.e.
-          // the current least element.
-          val winner = mb.genFieldThisRef[Int]("merge_winner")
-          val result = mb.genFieldThisRef[Array[Long]]("merge_result")
-          val i = mb.genFieldThisRef[Int]("merge_i")
-
-          val curKey = mb.newPField("st_grpby_curkey", keyType.sType)
-
-          val xKey = mb.newEmitField("zipjoin_key", keyType.sType, required = true)
-          val xElts = mb.newEmitField("zipjoin_elts", curValsType.sType, required = true)
-
-          val joinResult: EmitCode = EmitCode.fromI(mb) { cb =>
-            val newEnv = env.bind((keyRef -> xKey), (valsRef -> xElts))
-            emit(joinIR, cb, env = newEnv)
           }
 
-          val regionArray: Settable[Array[Region]] = if (streamRequiresMemoryManagement)
-            mb.genFieldThisRef[Array[Region]]("szj_region_array")
-          else
-            null
+        case StreamMultiMerge(as, key) =>
+          IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(mb)(cb => emit(a, cb)))) {
+            children =>
+              val producers = children.map(_.asStream.getProducer(mb))
 
-          val producer = new StreamProducer {
-            override def method: EmitMethodBuilder[_] = mb
+              val unifiedType =
+                VirtualTypeWithReq.union(as.map(a => typeWithReqx(a))).canonicalEmitType
+                  .st
+                  .asInstanceOf[SStream]
+                  .elementEmitType
+                  .storageType
+                  .asInstanceOf[PCanonicalStruct]
 
-            override val length: Option[EmitCodeBuilder => Code[Int]] = None
+              val regionArray = mb.genFieldThisRef[Array[Region]]("smm_region_array")
 
-            override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-              if (streamRequiresMemoryManagement)
-                cb.assign(regionArray, Code.newArray[Region](nStreams))
-              cb.assign(bracket, Code.newArray[Int](k))
-              cb.assign(heads, Code.newArray[Long](k))
-              cb.for_(
-                cb.assign(i, 0),
-                i < k,
-                cb.assign(i, i + 1), {
-                  cb.updateArray(bracket, i, -1)
-                  val eltRegion: Value[Region] = if (streamRequiresMemoryManagement) {
-                    val r = cb.memoize(Region.stagedCreate(Region.REGULAR, outerRegion.getPool()))
-                    cb.updateArray(regionArray, i, r)
-                    r
-                  } else outerRegion
-                  cb += iterArray(i).invoke[Region, Region, Unit]("init", outerRegion, eltRegion)
-                },
-              )
-              cb.assign(result, Code._null)
-              cb.assign(i, 0)
-              cb.assign(winner, 0)
-            }
+              val staticMemManagementArray =
+                producers.map(_.requiresMemoryManagementPerElement).toArray
+              val allMatch = staticMemManagementArray.toSet.size == 1
+              val memoryManagementBooleansArray =
+                if (allMatch) null else mb.genFieldThisRef[Array[Int]]("smm_separate_region_array")
 
-            override val elementRegion: Settable[Region] = _elementRegion
-            override val requiresMemoryManagementPerElement: Boolean =
-              streamRequiresMemoryManagement
-            override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-              val LrunMatch = CodeLabel()
-              val LpullChild = CodeLabel()
-              val LloopEnd = CodeLabel()
-              val LaddToResult = CodeLabel()
-              val LstartNewKey = CodeLabel()
-              val Lpush = CodeLabel()
-
-              def inSetup: Code[Boolean] = result.isNull
-
-              cb.if_(
-                inSetup, {
-                  cb.assign(i, 0)
-                  cb.goto(LpullChild)
-                },
-                cb.if_(winner.ceq(k), cb.goto(LendOfStream), cb.goto(LstartNewKey)),
-              )
-
-              cb.define(Lpush)
-              cb.assign(xKey, EmitCode.present(cb.emb, curKey))
-              cb.assign(
-                xElts,
-                EmitCode.present(
-                  cb.emb,
-                  curValsType.constructFromElements(cb, elementRegion, k, false) { (cb, i) =>
-                    IEmitCode(cb, result(i).ceq(0L), eltType.loadCheapSCode(cb, result(i)))
-                  },
-                ),
-              )
-              cb.goto(LproduceElementDone)
-
-              cb.define(LstartNewKey)
-              cb.for_(cb.assign(i, 0), i < k, cb.assign(i, i + 1), cb.updateArray(result, i, 0L))
-              cb.assign(
-                curKey,
-                eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
-                  .castTo(cb, elementRegion, curKey.st, true),
-              )
-              cb.goto(LaddToResult)
-
-              cb.define(LaddToResult)
-              cb += (result(winner) = heads(winner))
-              if (streamRequiresMemoryManagement) {
-                val r = cb.newLocal[Region]("tzj_winner_region", regionArray(winner))
-                cb += elementRegion.trackAndIncrementReferenceCountOf(r)
-                cb += r.clearRegion()
-              }
-              cb.goto(LpullChild)
-
-              val matchIdx = mb.genFieldThisRef[Int]("merge_match_idx")
-              val challenger = mb.genFieldThisRef[Int]("merge_challenger")
-              // Compare 'winner' with value in 'matchIdx', loser goes in 'matchIdx',
-              // winner goes on to next round. A contestant '-1' beats everything
-              // (negative infinity), a contestant 'k' loses to everything
-              // (positive infinity), and values in between are indices into 'heads'.
-
-              cb.define(LrunMatch)
-              cb.assign(challenger, bracket(matchIdx))
-              cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
-
-              val LafterChallenge = CodeLabel()
-
-              cb.if_(
-                challenger.cne(k), {
-                  val LchallengerWins = CodeLabel()
-
-                  cb.if_(winner.ceq(k), cb.goto(LchallengerWins))
-
-                  val left = eltType.loadCheapSCode(cb, heads(challenger)).subset(key: _*)
-                  val right = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
-                  val ord =
-                    StructOrdering.make(left.st, right.st, cb.emb.ecb, missingFieldsEqual = false)
-                  cb.if_(
-                    ord.lteqNonnull(cb, left, right),
-                    cb.goto(LchallengerWins),
-                    cb.goto(LafterChallenge),
+              def initMemoryManagementPerElementArray(cb: EmitCodeBuilder): Unit =
+                if (!allMatch)
+                  cb.assign(
+                    memoryManagementBooleansArray,
+                    mb.getObject[Array[Int]](
+                      producers.map(_.requiresMemoryManagementPerElement.toInt).toArray
+                    ),
                   )
 
-                  cb.define(LchallengerWins)
-                  cb.updateArray(bracket, matchIdx, winner)
-                  cb.assign(winner, challenger)
-                },
-              )
-              cb.define(LafterChallenge)
-              cb.assign(matchIdx, matchIdx >>> 1)
-              cb.goto(LrunMatch)
+              def lookupMemoryManagementByIndex(cb: EmitCodeBuilder, idx: Code[Int])
+                : Code[Boolean] =
+                if (allMatch)
+                  const(staticMemManagementArray.head)
+                else
+                  memoryManagementBooleansArray.apply(idx).toZ
 
-              cb.define(LloopEnd)
-              cb.if_(
-                matchIdx.ceq(0), {
-                  // 'winner' is smallest of all k heads. If 'winner' = k, all heads
-                  // must be k, and all streams are exhausted.
+              val producer =
+                new StreamUtils.StreamMultiMergeBase(
+                  key,
+                  unifiedType,
+                  const(producers.length),
+                  mb,
+                ) {
+                  override def method: EmitMethodBuilder[_] = mb
 
-                  cb.if_(
-                    inSetup, {
-                      cb.if_(
-                        winner.ceq(k),
-                        cb.goto(LendOfStream), {
-                          cb.assign(result, Code.newArray[Long](k))
-                          cb.goto(LstartNewKey)
-                        },
-                      )
-                    }, {
-                      cb.if_(!winner.cne(k), cb.goto(Lpush))
-                      val left = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
-                      val right = curKey
-                      val ord = StructOrdering.make(
-                        left.st,
-                        right.st.asInstanceOf[SBaseStruct],
-                        cb.emb.ecb,
-                        missingFieldsEqual = false,
-                      )
-                      cb.if_(
-                        ord.equivNonnull(cb, left, right),
-                        cb.goto(LaddToResult),
-                        cb.goto(Lpush),
-                      )
-                    },
-                  )
-                }, {
-                  // We're still in the setup phase
-                  cb.updateArray(bracket, matchIdx, winner)
-                  cb.assign(i, i + 1)
-                  cb.assign(winner, i)
-                  cb.goto(LpullChild)
-                },
-              )
+                  override val length: Option[EmitCodeBuilder => Code[Int]] =
+                    anyFailAllFail(producers.map(_.length))
+                      .map { compLens => (cb: EmitCodeBuilder) =>
+                        compLens.map(_.apply(cb)).reduce(_ + _)
+                      }
 
-              cb.define(LpullChild)
-              cb.if_(winner >= nStreams, cb.goto(LendOfStream)) // can only happen if k=0
-              val winnerIter = cb.memoize(iterArray(winner))
-              val winnerNextElt = cb.memoize(winnerIter.invoke[Long]("next"))
-              cb.if_(
-                winnerIter.invoke[Boolean]("eos"), {
-                  cb.assign(matchIdx, (winner + k) >>> 1)
-                  cb.assign(winner, k)
-                }, {
-                  cb.assign(matchIdx, (winner + k) >>> 1)
-                  cb.updateArray(heads, winner, winnerNextElt)
-                },
-              )
-              cb.goto(LrunMatch)
-            }
-
-            override val element: EmitCode = joinResult
-
-            override def close(cb: EmitCodeBuilder): Unit = {
-              cb.assign(i, 0)
-              cb.while_(
-                i < nStreams, {
-                  cb += iterArray(i).invoke[Unit]("close")
-                  if (requiresMemoryManagementPerElement)
-                    cb += regionArray(i).invoke[Unit]("invalidate")
-                  cb.assign(i, i + 1)
-                },
-              )
-              if (requiresMemoryManagementPerElement)
-                cb.assign(regionArray, Code._null)
-              cb.assign(bracket, Code._null)
-              cb.assign(heads, Code._null)
-              cb.assign(result, Code._null)
-            }
-          }
-
-          SStreamValue(producer)
-        }
-
-      case StreamMultiMerge(as, key) =>
-        IEmitCode.multiMapEmitCodes(cb, as.map(a => EmitCode.fromI(mb)(cb => emit(a, cb)))) {
-          children =>
-            val producers = children.map(_.asStream.getProducer(mb))
-
-            val unifiedType =
-              VirtualTypeWithReq.union(as.map(a => typeWithReqx(a))).canonicalEmitType
-                .st
-                .asInstanceOf[SStream]
-                .elementEmitType
-                .storageType
-                .asInstanceOf[PCanonicalStruct]
-
-            val regionArray = mb.genFieldThisRef[Array[Region]]("smm_region_array")
-
-            val staticMemManagementArray =
-              producers.map(_.requiresMemoryManagementPerElement).toArray
-            val allMatch = staticMemManagementArray.toSet.size == 1
-            val memoryManagementBooleansArray =
-              if (allMatch) null else mb.genFieldThisRef[Array[Int]]("smm_separate_region_array")
-
-            def initMemoryManagementPerElementArray(cb: EmitCodeBuilder): Unit =
-              if (!allMatch)
-                cb.assign(
-                  memoryManagementBooleansArray,
-                  mb.getObject[Array[Int]](
-                    producers.map(_.requiresMemoryManagementPerElement.toInt).toArray
-                  ),
-                )
-
-            def lookupMemoryManagementByIndex(cb: EmitCodeBuilder, idx: Code[Int]): Code[Boolean] =
-              if (allMatch)
-                const(staticMemManagementArray.head)
-              else
-                memoryManagementBooleansArray.apply(idx).toZ
-
-            val producer =
-              new StreamUtils.StreamMultiMergeBase(key, unifiedType, const(producers.length), mb) {
-                override def method: EmitMethodBuilder[_] = mb
-
-                override val length: Option[EmitCodeBuilder => Code[Int]] =
-                  anyFailAllFail(producers.map(_.length))
-                    .map { compLens => (cb: EmitCodeBuilder) =>
-                      compLens.map(_.apply(cb)).reduce(_ + _)
+                  override def implInit(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                    cb.assign(regionArray, Code.newArray[Region](k))
+                    producers.zipWithIndex.foreach { case (p, i) =>
+                      if (p.requiresMemoryManagementPerElement) {
+                        cb.assign(
+                          p.elementRegion,
+                          Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
+                        )
+                      } else
+                        cb.assign(p.elementRegion, outerRegion)
+                      cb += (regionArray(i) = p.elementRegion)
+                      p.initialize(cb, outerRegion)
                     }
-
-                override def implInit(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                  cb.assign(regionArray, Code.newArray[Region](k))
-                  producers.zipWithIndex.foreach { case (p, i) =>
-                    if (p.requiresMemoryManagementPerElement) {
-                      cb.assign(
-                        p.elementRegion,
-                        Region.stagedCreate(Region.REGULAR, outerRegion.getPool()),
-                      )
-                    } else
-                      cb.assign(p.elementRegion, outerRegion)
-                    cb += (regionArray(i) = p.elementRegion)
-                    p.initialize(cb, outerRegion)
+                    initMemoryManagementPerElementArray(cb)
                   }
-                  initMemoryManagementPerElementArray(cb)
-                }
 
-                override val requiresMemoryManagementPerElement: Boolean =
-                  producers.exists(_.requiresMemoryManagementPerElement)
-                override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                  val LrunMatch = CodeLabel()
-                  val LpullChild = CodeLabel()
-                  val LloopEnd = CodeLabel()
+                  override val requiresMemoryManagementPerElement: Boolean =
+                    producers.exists(_.requiresMemoryManagementPerElement)
+                  override val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                    val LrunMatch = CodeLabel()
+                    val LpullChild = CodeLabel()
+                    val LloopEnd = CodeLabel()
 
-                  cb.define(LpullChild)
-                  cb.switch(
-                    winner,
-                    cb.goto(LendOfStream), // can only happen if k=0
-                    producers.map(p => () => cb.goto(p.LproduceElement)),
-                  )
+                    cb.define(LpullChild)
+                    cb.switch(
+                      winner,
+                      cb.goto(LendOfStream), // can only happen if k=0
+                      producers.map(p => () => cb.goto(p.LproduceElement)),
+                    )
 
-                  cb.define(LrunMatch)
-                  cb.assign(challenger, bracket(matchIdx))
-                  cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
+                    cb.define(LrunMatch)
+                    cb.assign(challenger, bracket(matchIdx))
+                    cb.if_(matchIdx.ceq(0) || challenger.ceq(-1), cb.goto(LloopEnd))
 
-                  val LafterChallenge = CodeLabel()
-                  cb.if_(
-                    challenger.cne(k), {
-                      val Lwon = CodeLabel()
-                      cb.if_(winner.ceq(k), cb.goto(Lwon))
-                      cb.if_(
-                        comp(cb, challenger, heads(challenger), winner, heads(winner)),
-                        cb.goto(Lwon),
-                        cb.goto(LafterChallenge),
-                      )
+                    val LafterChallenge = CodeLabel()
+                    cb.if_(
+                      challenger.cne(k), {
+                        val Lwon = CodeLabel()
+                        cb.if_(winner.ceq(k), cb.goto(Lwon))
+                        cb.if_(
+                          comp(cb, challenger, heads(challenger), winner, heads(winner)),
+                          cb.goto(Lwon),
+                          cb.goto(LafterChallenge),
+                        )
 
-                      cb.define(Lwon)
-                      cb += (bracket(matchIdx) = winner)
-                      cb.assign(winner, challenger)
-                    },
-                  )
-                  cb.define(LafterChallenge)
+                        cb.define(Lwon)
+                        cb += (bracket(matchIdx) = winner)
+                        cb.assign(winner, challenger)
+                      },
+                    )
+                    cb.define(LafterChallenge)
 
-                  cb.assign(matchIdx, matchIdx >>> 1)
-                  cb.goto(LrunMatch)
-
-                  cb.define(LloopEnd)
-
-                  cb.if_(
-                    matchIdx.ceq(0), {
-                      // 'winner' is smallest of all k heads. If 'winner' = k, all heads
-                      // must be k, and all streams are exhausted.
-                      cb.if_(
-                        winner.ceq(k),
-                        cb.goto(LendOfStream), {
-                          // we have a winner
-                          cb.if_(
-                            lookupMemoryManagementByIndex(cb, winner), {
-                              val winnerRegion =
-                                cb.newLocal[Region]("smm_winner_region", regionArray(winner))
-                              cb += elementRegion.trackAndIncrementReferenceCountOf(winnerRegion)
-                              cb += winnerRegion.clearRegion()
-                            },
-                          )
-                          cb.goto(LproduceElementDone)
-                        },
-                      )
-                    }, {
-                      cb += (bracket(matchIdx) = winner)
-                      cb.assign(i, i + 1)
-                      cb.assign(winner, i)
-                      cb.goto(LpullChild)
-                    },
-                  )
-
-                  // define producer labels
-                  producers.zipWithIndex.foreach { case (p, idx) =>
-                    cb.define(p.LendOfStream)
-                    cb.assign(winner, k)
-                    cb.assign(matchIdx, (const(idx) + k) >>> 1)
+                    cb.assign(matchIdx, matchIdx >>> 1)
                     cb.goto(LrunMatch)
 
-                    cb.define(p.LproduceElementDone)
-                    cb += (heads(idx) =
-                      unifiedType.store(
-                        cb,
-                        p.elementRegion,
-                        p.element.toI(cb).getOrAssert(cb),
-                        false,
+                    cb.define(LloopEnd)
+
+                    cb.if_(
+                      matchIdx.ceq(0), {
+                        // 'winner' is smallest of all k heads. If 'winner' = k, all heads
+                        // must be k, and all streams are exhausted.
+                        cb.if_(
+                          winner.ceq(k),
+                          cb.goto(LendOfStream), {
+                            // we have a winner
+                            cb.if_(
+                              lookupMemoryManagementByIndex(cb, winner), {
+                                val winnerRegion =
+                                  cb.newLocal[Region]("smm_winner_region", regionArray(winner))
+                                cb += elementRegion.trackAndIncrementReferenceCountOf(winnerRegion)
+                                cb += winnerRegion.clearRegion()
+                              },
+                            )
+                            cb.goto(LproduceElementDone)
+                          },
+                        )
+                      }, {
+                        cb += (bracket(matchIdx) = winner)
+                        cb.assign(i, i + 1)
+                        cb.assign(winner, i)
+                        cb.goto(LpullChild)
+                      },
+                    )
+
+                    // define producer labels
+                    producers.zipWithIndex.foreach { case (p, idx) =>
+                      cb.define(p.LendOfStream)
+                      cb.assign(winner, k)
+                      cb.assign(matchIdx, (const(idx) + k) >>> 1)
+                      cb.goto(LrunMatch)
+
+                      cb.define(p.LproduceElementDone)
+                      cb += (heads(idx) =
+                        unifiedType.store(
+                          cb,
+                          p.elementRegion,
+                          p.element.toI(cb).getOrAssert(cb),
+                          false,
+                        )
                       )
-                    )
-                    cb.assign(matchIdx, (const(idx) + k) >>> 1)
-                    cb.goto(LrunMatch)
+                      cb.assign(matchIdx, (const(idx) + k) >>> 1)
+                      cb.goto(LrunMatch)
+                    }
                   }
+
+                  override def implClose(cb: EmitCodeBuilder): Unit =
+                    producers.foreach { p =>
+                      if (p.requiresMemoryManagementPerElement)
+                        cb += p.elementRegion.invalidate()
+                      p.close(cb)
+                    }
                 }
-
-                override def implClose(cb: EmitCodeBuilder): Unit =
-                  producers.foreach { p =>
-                    if (p.requiresMemoryManagementPerElement)
-                      cb += p.elementRegion.invalidate()
-                    p.close(cb)
-                  }
-              }
-            SStreamValue(producer)
-        }
-
-      case StreamLocalLDPrune(a, r2Threshold, winSize, maxQueueSize, nSamples) =>
-        produce(a, cb)
-          .map(cb) { case childStream: SStreamValue =>
-            val childProducer = childStream.getProducer(mb)
-            val queueSize = cb.newField[Int]("max_queue_size")
-            val queue = cb.newField[util.ArrayDeque[BitPackedVector]]("queue")
-            val threshold = cb.newField[Double]("r2_threshold")
-            val windowSize = cb.newField[Int]("window_size")
-            val builder = cb.newField[BitPackedVectorBuilder]("vector_builder")
-            val elementType = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream].elementEmitType
-            val elementField = mb.newEmitField(elementType)
-
-            val producer = new StreamProducer {
-              def method: EmitMethodBuilder[_] = mb
-
-              val length: Option[EmitCodeBuilder => Code[Int]] = None
-
-              val elementRegion: Settable[Region] = childProducer.elementRegion
-
-              val element: EmitCode = elementField
-
-              val requiresMemoryManagementPerElement: Boolean =
-                childProducer.requiresMemoryManagementPerElement
-
-              def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
-                cb.assign(queueSize, emit(maxQueueSize, cb).getOrAssert(cb).asInt32.value)
-                cb.assign(queue, Code.newInstance[util.ArrayDeque[BitPackedVector], Int](queueSize))
-                cb.assign(threshold, emit(r2Threshold, cb).getOrAssert(cb).asFloat64.value)
-                cb.assign(windowSize, emit(winSize, cb).getOrAssert(cb).asInt32.value)
-                cb.assign(
-                  builder,
-                  Code.newInstance[BitPackedVectorBuilder, Int](
-                    emit(nSamples, cb).getOrAssert(cb).asInt32.value
-                  ),
-                )
-                childProducer.initialize(cb, outerRegion)
-              }
-
-              val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
-                val Lpruned = CodeLabel()
-
-                cb.goto(childProducer.LproduceElement)
-                cb.define(childProducer.LproduceElementDone)
-
-                childProducer.element.toI(cb).consume(
-                  cb,
-                  cb.goto(Lpruned),
-                  { case sc: SBaseStructValue =>
-                    val locus = sc.loadField(cb, "locus").getOrAssert(cb).asLocus
-                    val locusObj = locus.getLocusObj(cb)
-                    val genotypes = sc.loadField(cb, "genotypes").getOrAssert(cb).asIndexable
-                    cb += builder.invoke[Unit]("reset")
-                    genotypes.forEachDefinedOrMissing(cb)(
-                      (cb, _) => cb += builder.invoke[Unit]("addMissing"),
-                      (cb, _, gt) =>
-                        cb += builder.invoke[Int, Unit]("addGT", gt.asCall.canonicalCall(cb)),
-                    )
-                    val bpv = cb.memoize(builder.invoke[Locus, Array[String], BitPackedVector](
-                      "finish",
-                      locusObj,
-                      Code._null[Array[String]],
-                    ))
-                    cb.if_(bpv.isNull, cb.goto(Lpruned))
-                    val keepVariant = Code.invokeScalaObject5[
-                      util.ArrayDeque[BitPackedVector],
-                      BitPackedVector,
-                      Double,
-                      Int,
-                      Int,
-                      Boolean,
-                    ](
-                      LocalLDPrune.getClass,
-                      "pruneLocal",
-                      queue,
-                      bpv,
-                      threshold,
-                      windowSize,
-                      queueSize,
-                    )
-                    cb.if_(!keepVariant, cb.goto(Lpruned))
-
-                    val mean = SFloat64Value(cb.memoize(bpv.invoke[Double]("mean")))
-                    val centeredLengthRec =
-                      SFloat64Value(cb.memoize(bpv.invoke[Double]("centeredLengthRec")))
-                    val elt = SStackStruct.constructFromArgs(
-                      cb,
-                      elementRegion,
-                      elementType.virtualType.asInstanceOf[TBaseStruct],
-                      EmitCode.present(mb, locus),
-                      EmitCode.fromI(mb)(cb => sc.loadField(cb, "alleles")),
-                      EmitCode.present(mb, mean),
-                      EmitCode.present(mb, centeredLengthRec),
-                    )
-                    cb.assign(
-                      elementField,
-                      EmitCode.present(mb, elt.castTo(cb, elementRegion, elementField.emitType.st)),
-                    )
-                  },
-                )
-
-                cb.goto(LproduceElementDone)
-
-                cb.define(Lpruned)
-                if (requiresMemoryManagementPerElement)
-                  cb += childProducer.elementRegion.clearRegion()
-                cb.goto(childProducer.LproduceElement)
-              }
-
-              def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
-            }
-
-            mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
-            SStreamValue(producer)
+              SStreamValue(producer)
           }
 
-      case ReadPartition(context, rowType, reader) =>
-        val ctxCode = EmitCode.fromI(cb.emb)(cb => emit(context, cb))
-        reader.emitStream(emitter.ctx.executeContext, cb, mb, ctxCode, rowType)
+        case StreamLocalLDPrune(a, r2Threshold, winSize, maxQueueSize, nSamples) =>
+          produce(a, cb)
+            .map(cb) { case childStream: SStreamValue =>
+              val childProducer = childStream.getProducer(mb)
+              val queueSize = cb.newField[Int]("max_queue_size")
+              val queue = cb.newField[util.ArrayDeque[BitPackedVector]]("queue")
+              val threshold = cb.newField[Double]("r2_threshold")
+              val windowSize = cb.newField[Int]("window_size")
+              val builder = cb.newField[BitPackedVectorBuilder]("vector_builder")
+              val elementType =
+                typeWithReq.canonicalEmitType.st.asInstanceOf[SStream].elementEmitType
+              val elementField = mb.newEmitField(elementType)
+
+              val producer = new StreamProducer {
+                def method: EmitMethodBuilder[_] = mb
+
+                val length: Option[EmitCodeBuilder => Code[Int]] = None
+
+                val elementRegion: Settable[Region] = childProducer.elementRegion
+
+                val element: EmitCode = elementField
+
+                val requiresMemoryManagementPerElement: Boolean =
+                  childProducer.requiresMemoryManagementPerElement
+
+                def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                  cb.assign(queueSize, emit(maxQueueSize, cb).getOrAssert(cb).asInt32.value)
+                  cb.assign(
+                    queue,
+                    Code.newInstance[util.ArrayDeque[BitPackedVector], Int](queueSize),
+                  )
+                  cb.assign(threshold, emit(r2Threshold, cb).getOrAssert(cb).asFloat64.value)
+                  cb.assign(windowSize, emit(winSize, cb).getOrAssert(cb).asInt32.value)
+                  cb.assign(
+                    builder,
+                    Code.newInstance[BitPackedVectorBuilder, Int](
+                      emit(nSamples, cb).getOrAssert(cb).asInt32.value
+                    ),
+                  )
+                  childProducer.initialize(cb, outerRegion)
+                }
+
+                val LproduceElement: CodeLabel = mb.defineAndImplementLabel { cb =>
+                  val Lpruned = CodeLabel()
+
+                  cb.goto(childProducer.LproduceElement)
+                  cb.define(childProducer.LproduceElementDone)
+
+                  childProducer.element.toI(cb).consume(
+                    cb,
+                    cb.goto(Lpruned),
+                    { case sc: SBaseStructValue =>
+                      val locus = sc.loadField(cb, "locus").getOrAssert(cb).asLocus
+                      val locusObj = locus.getLocusObj(cb)
+                      val genotypes = sc.loadField(cb, "genotypes").getOrAssert(cb).asIndexable
+                      cb += builder.invoke[Unit]("reset")
+                      genotypes.forEachDefinedOrMissing(cb)(
+                        (cb, _) => cb += builder.invoke[Unit]("addMissing"),
+                        (cb, _, gt) =>
+                          cb += builder.invoke[Int, Unit]("addGT", gt.asCall.canonicalCall(cb)),
+                      )
+                      val bpv = cb.memoize(builder.invoke[Locus, Array[String], BitPackedVector](
+                        "finish",
+                        locusObj,
+                        Code._null[Array[String]],
+                      ))
+                      cb.if_(bpv.isNull, cb.goto(Lpruned))
+                      val keepVariant = Code.invokeScalaObject5[
+                        util.ArrayDeque[BitPackedVector],
+                        BitPackedVector,
+                        Double,
+                        Int,
+                        Int,
+                        Boolean,
+                      ](
+                        LocalLDPrune.getClass,
+                        "pruneLocal",
+                        queue,
+                        bpv,
+                        threshold,
+                        windowSize,
+                        queueSize,
+                      )
+                      cb.if_(!keepVariant, cb.goto(Lpruned))
+
+                      val mean = SFloat64Value(cb.memoize(bpv.invoke[Double]("mean")))
+                      val centeredLengthRec =
+                        SFloat64Value(cb.memoize(bpv.invoke[Double]("centeredLengthRec")))
+                      val elt = SStackStruct.constructFromArgs(
+                        cb,
+                        elementRegion,
+                        elementType.virtualType.asInstanceOf[TBaseStruct],
+                        EmitCode.present(mb, locus),
+                        EmitCode.fromI(mb)(cb => sc.loadField(cb, "alleles")),
+                        EmitCode.present(mb, mean),
+                        EmitCode.present(mb, centeredLengthRec),
+                      )
+                      cb.assign(
+                        elementField,
+                        EmitCode.present(
+                          mb,
+                          elt.castTo(cb, elementRegion, elementField.emitType.st),
+                        ),
+                      )
+                    },
+                  )
+
+                  cb.goto(LproduceElementDone)
+
+                  cb.define(Lpruned)
+                  if (requiresMemoryManagementPerElement)
+                    cb += childProducer.elementRegion.clearRegion()
+                  cb.goto(childProducer.LproduceElement)
+                }
+
+                def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
+              }
+
+              mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
+              SStreamValue(producer)
+            }
+
+        case ReadPartition(context, rowType, reader) =>
+          val ctxCode = EmitCode.fromI(cb.emb)(cb => emit(context, cb))
+          reader.emitStream(emitter.ctx.executeContext, cb, mb, ctxCode, rowType)
+      }
     }
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -145,7 +145,7 @@ object EmitStream {
     env: EmitEnv,
     container: Option[AggContainer],
   ): IEmitCode =
-    emitter.ctx.time {
+    emitter.ctx.executeContext.time {
 
       @nowarn("cat=unused-locals&msg=local default argument")
       def emitVoid(

--- a/hail/src/main/scala/is/hail/io/CodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/CodecSpec.scala
@@ -36,12 +36,6 @@ trait AbstractTypedCodecSpec extends Spec {
   def buildDecoder(ctx: ExecuteContext, requestedType: Type)
     : (PType, (InputStream, HailClassLoader) => Decoder)
 
-  def encode(ctx: ExecuteContext, t: PType, offset: Long): Array[Byte] = {
-    val baos = new ByteArrayOutputStream()
-    encode(ctx, t, offset, baos)
-    baos.toByteArray
-  }
-
   def encode(ctx: ExecuteContext, t: PType, offset: Long, os: OutputStream): Unit =
     using(buildEncoder(ctx, t)(os, ctx.theHailClassLoader))(_.writeRegionValue(ctx.r, offset))
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1434,10 +1434,10 @@ object RVD {
         }
     }
 
-    val partFilePartitionCounts = execCtx.timer.time("writeOriginUnionRDD")(new ContextRDD(
-      new OriginUnionRDD(first.crdd.rdd.sparkContext, rvds.map(_.crdd.rdd), partF)
-    )
-      .collect())
+    val partFilePartitionCounts = execCtx.time {
+      val rdd = new OriginUnionRDD(first.crdd.rdd.sparkContext, rvds.map(_.crdd.rdd), partF)
+      new ContextRDD(rdd).collect()
+    }
 
     val fileDataByOrigin =
       Array.fill[BoxedArrayBuilder[FileWriteMetadata]](nRVDs)(new BoxedArrayBuilder())

--- a/hail/src/test/scala/is/hail/HailSuite.scala
+++ b/hail/src/test/scala/is/hail/HailSuite.scala
@@ -18,6 +18,7 @@ import org.apache.spark.sql.Row
 import org.scalatestplus.testng.TestNGSuite
 import org.testng.ITestContext
 import org.testng.annotations.{AfterMethod, BeforeClass, BeforeMethod}
+import sourcecode.Enclosing
 
 object HailSuite {
   val theHailClassLoader = TestUtils.theHailClassLoader
@@ -91,10 +92,8 @@ class HailSuite extends TestNGSuite {
       throw new RuntimeException(s"method stopped spark context!")
   }
 
-  def withExecuteContext[T]()(f: ExecuteContext => T): T =
-    ExecutionTimer.logTime("HailSuite.withExecuteContext") { timer =>
-      hc.sparkBackend("HailSuite.withExecuteContext").withExecuteContext(timer)(f)
-    }
+  def withExecuteContext[T]()(f: ExecuteContext => T)(implicit E: Enclosing): T =
+    hc.sparkBackend("HailSuite.withExecuteContext").withExecuteContext(f)
 
   def assertEvalsTo(
     x: IR,
@@ -110,7 +109,7 @@ class HailSuite extends TestNGSuite {
     val t = x.typ
     assert(t == TVoid || t.typeCheck(expected), s"$t, $expected")
 
-    ExecuteContext.scoped() { ctx =>
+    ExecuteContext.scoped { ctx =>
       val filteredExecStrats: Set[ExecStrategy] =
         if (HailContext.backend.isInstanceOf[SparkBackend])
           execStrats
@@ -255,7 +254,7 @@ class HailSuite extends TestNGSuite {
     expected: DenseMatrix[Double],
   )(implicit execStrats: Set[ExecStrategy]
   ): Unit = {
-    ExecuteContext.scoped() { ctx =>
+    ExecuteContext.scoped { ctx =>
       val filteredExecStrats: Set[ExecStrategy] =
         if (HailContext.backend.isInstanceOf[SparkBackend]) execStrats
         else {

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -118,14 +118,12 @@ object TestUtils {
     if (agg.isDefined || !env.isEmpty || !args.isEmpty)
       throw new LowererUnsupportedOperation("can't test with aggs or user defined args/env")
 
-    ExecutionTimer.logTime("TestUtils.loweredExecute") { timer =>
-      HailContext.sparkBackend("TestUtils.loweredExecute")
-        .jvmLowerAndExecute(ctx, timer, x, optimize = false, lowerTable = true, lowerBM = true,
-          print = bytecodePrinter)
-    }
+    HailContext.sparkBackend("TestUtils.loweredExecute")
+      .jvmLowerAndExecute(ctx, x, optimize = false, lowerTable = true, lowerBM = true,
+        print = bytecodePrinter)
   }
 
-  def eval(x: IR): Any = ExecuteContext.scoped() { ctx =>
+  def eval(x: IR): Any = ExecuteContext.scoped { ctx =>
     eval(x, Env.empty, FastSeq(), None, None, true, ctx)
   }
 
@@ -273,7 +271,7 @@ object TestUtils {
   def assertEvalSame(x: IR, env: Env[(Any, Type)], args: IndexedSeq[(Any, Type)]): Unit = {
     val t = x.typ
 
-    val (i, i2, c) = ExecuteContext.scoped() { ctx =>
+    val (i, i2, c) = ExecuteContext.scoped { ctx =>
       val i = Interpret[Any](ctx, x, env, args)
       val i2 = Interpret[Any](ctx, x, env, args, optimize = false)
       val c = eval(x, env, args, None, None, true, ctx)
@@ -297,7 +295,7 @@ object TestUtils {
     args: IndexedSeq[(Any, Type)],
     regex: String,
   ): Unit =
-    ExecuteContext.scoped() { ctx =>
+    ExecuteContext.scoped { ctx =>
       interceptException[E](regex)(Interpret[Any](ctx, x, env, args))
       interceptException[E](regex)(Interpret[Any](ctx, x, env, args, optimize = false))
       interceptException[E](regex)(eval(x, env, args, None, None, true, ctx))
@@ -319,7 +317,7 @@ object TestUtils {
     args: IndexedSeq[(Any, Type)],
     regex: String,
   ): Unit =
-    ExecuteContext.scoped() { ctx =>
+    ExecuteContext.scoped { ctx =>
       interceptException[E](regex)(eval(x, env, args, None, None, true, ctx))
     }
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -1062,12 +1062,12 @@ class EmitStreamSuite extends HailSuite {
 
   def assertMemoryDoesNotScaleWithStreamSize(lowSize: Int = 50, highSize: Int = 2500)(f: IR => IR)
     : Unit = {
-    val memUsed1 = ExecuteContext.scoped() { ctx =>
+    val memUsed1 = ExecuteContext.scoped { ctx =>
       eval(f(lowSize), Env.empty, FastSeq(), None, None, false, ctx)
       ctx.r.pool.getHighestTotalUsage
     }
 
-    val memUsed2 = ExecuteContext.scoped() { ctx =>
+    val memUsed2 = ExecuteContext.scoped { ctx =>
       eval(f(highSize), Env.empty, FastSeq(), None, None, false, ctx)
       ctx.r.pool.getHighestTotalUsage
     }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3921,7 +3921,7 @@ class IRSuite extends HailSuite {
   @Test def testCachedIR(): Unit = {
     val cached = Literal(TSet(TInt32), Set(1))
     val s = s"(JavaIR 1)"
-    val x2 = ExecuteContext.scoped() { ctx =>
+    val x2 = ExecuteContext.scoped { ctx =>
       IRParser.parse_value_ir(s, IRParserEnvironment(ctx, irMap = Map(1 -> cached)))
     }
     assert(x2 eq cached)
@@ -3930,7 +3930,7 @@ class IRSuite extends HailSuite {
   @Test def testCachedTableIR(): Unit = {
     val cached = TableRange(1, 1)
     val s = s"(JavaTable 1)"
-    val x2 = ExecuteContext.scoped() { ctx =>
+    val x2 = ExecuteContext.scoped { ctx =>
       IRParser.parse_table_ir(s, IRParserEnvironment(ctx, irMap = Map(1 -> cached)))
     }
     assert(x2 eq cached)
@@ -4153,9 +4153,8 @@ class IRSuite extends HailSuite {
         |       (MakeStruct (locus  (Apply end Locus(GRCh37) (Ref __uid_3)))) (True) (False))))
         |""".stripMargin,
     )
-    val v = ExecutionTimer.logTime("IRSuite.regressionTestUnifyBug") { timer =>
-      backend.execute(timer, ir, optimize = true)
-    }
+    val v = backend.execute(ctx, ir)
+
     assert(
       ir.typ.ordering(ctx.stateManager).equiv(
         FastSeq(
@@ -4217,12 +4216,12 @@ class IRSuite extends HailSuite {
 
     var memUsed = 0L
 
-    ExecuteContext.scoped() { ctx =>
+    ExecuteContext.scoped { ctx =>
       eval(ndSum, Env.empty, FastSeq(2 -> TInt32, startingArg -> ndType), None, None, true, ctx)
       memUsed = ctx.r.pool.getHighestTotalUsage
     }
 
-    ExecuteContext.scoped() { ctx =>
+    ExecuteContext.scoped { ctx =>
       eval(ndSum, Env.empty, FastSeq(100 -> TInt32, startingArg -> ndType), None, None, true, ctx)
       assert(memUsed == ctx.r.pool.getHighestTotalUsage)
     }

--- a/hail/src/test/scala/is/hail/expr/ir/MemoryLeakSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MemoryLeakSuite.scala
@@ -17,7 +17,7 @@ class MemoryLeakSuite extends HailSuite {
     def run(size: Int): Long = {
       val lit = Literal(TSet(TString), (0 until litSize).map(_.toString).toSet)
       val queries = Literal(TArray(TString), (0 until size).map(_.toString).toFastSeq)
-      ExecuteContext.scoped() { ctx =>
+      ExecuteContext.scoped { ctx =>
         eval(
           ToArray(
             mapIR(ToStream(queries))(r => ir.invoke("contains", TBoolean, lit, r))

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -1490,7 +1490,7 @@ class TableIRSuite extends HailSuite {
         ApplyAggOp(Collect())(GetField(Ref(TableIR.rowName, tableType.rowType), "rsid"))
       )),
     )
-    val optimized = Optimize(irToLower, "foo", ctx)
+    val optimized = Optimize(ctx, irToLower)
     val analyses = LoweringAnalyses.apply(optimized, ctx)
     LowerTableIR(optimized, DArrayLowering.All, ctx, analyses)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/analyses/SemanticHashSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/analyses/SemanticHashSuite.scala
@@ -7,7 +7,7 @@ import is.hail.io.fs.{FS, FakeFS, FakeURL, FileListEntry}
 import is.hail.linalg.BlockMatrixMetadata
 import is.hail.rvd.AbstractRVDSpec
 import is.hail.types.virtual._
-import is.hail.utils.{using, FastSeq}
+import is.hail.utils.FastSeq
 
 import scala.util.control.NonFatal
 
@@ -327,21 +327,7 @@ class SemanticHashSuite extends HailSuite {
   }
 
   def semhash(fs: FS)(ir: BaseIR): Option[SemanticHash.Type] =
-    ExecuteContext.scoped() { ctx =>
-      using(new ExecuteContext(
-        ctx.tmpdir,
-        ctx.localTmpdir,
-        ctx.backend,
-        fs,
-        ctx.r,
-        ctx.timer,
-        ctx.tempFileManager,
-        ctx.theHailClassLoader,
-        ctx.flags,
-        ctx.backendContext,
-        ctx.irMetadata,
-      ))(SemanticHash(_)(ir))
-    }
+    ExecuteContext.scoped(_.local(fs = fs)(SemanticHash(_)(ir)))
 
   val fakeFs: FS =
     new FakeFS {

--- a/hail/src/test/scala/is/hail/expr/ir/analyses/SemanticHashSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/analyses/SemanticHashSuite.scala
@@ -9,8 +9,6 @@ import is.hail.rvd.AbstractRVDSpec
 import is.hail.types.virtual._
 import is.hail.utils.FastSeq
 
-import scala.util.control.NonFatal
-
 import java.io.FileNotFoundException
 import java.lang
 
@@ -285,21 +283,11 @@ class SemanticHashSuite extends HailSuite {
 
   @DataProvider(name = "isBaseIRSemanticallyEquivalent")
   def isBaseIRSemanticallyEquivalent: Array[Array[Any]] =
-    try
-      Array.concat(
-        isValueIRSemanticallyEquivalent,
-        isTableIRSemanticallyEquivalent,
-        isBlockMatrixIRSemanticallyEquivalent,
-      ).map { x =>
-        TypeCheck(ctx, x(0).asInstanceOf[BaseIR])
-        TypeCheck(ctx, x(1).asInstanceOf[BaseIR])
-        x
-      }
-    catch {
-      case NonFatal(t) =>
-        t.printStackTrace()
-        throw t
-    }
+    Array.concat(
+      isValueIRSemanticallyEquivalent,
+      isTableIRSemanticallyEquivalent,
+      isBlockMatrixIRSemanticallyEquivalent,
+    )
 
   @Test(dataProvider = "isBaseIRSemanticallyEquivalent")
   def testSemanticEquivalence(a: BaseIR, b: BaseIR, isEqual: Boolean, comment: String): Unit =
@@ -318,8 +306,7 @@ class SemanticHashSuite extends HailSuite {
           throw new FileNotFoundException(url.getPath)
       }
 
-    val ir =
-      importMatrix("gs://fake-bucket/fake-matrix")
+    val ir = importMatrix("gs://fake-bucket/fake-matrix")
 
     assertResult(None, "SemHash should be resilient to FileNotFoundExceptions.")(
       semhash(fs)(ir)

--- a/hail/src/test/scala/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/table/TableGenSuite.scala
@@ -109,7 +109,7 @@ class TableGenSuite extends HailSuite {
     ))
     val lowered = LowerTableIR(table, DArrayLowering.All, ctx, LoweringAnalyses(table, ctx))
     val ex = intercept[HailException] {
-      ExecuteContext.scoped()(ctx => loweredExecute(ctx, lowered, Env.empty, FastSeq(), None))
+      ExecuteContext.scoped(ctx => loweredExecute(ctx, lowered, Env.empty, FastSeq(), None))
     }
     ex.errorId shouldBe errorId
     ex.getMessage should include("partitioner contains 0 partitions, got 2 contexts.")
@@ -131,7 +131,7 @@ class TableGenSuite extends HailSuite {
     ))
     val lowered = LowerTableIR(table, DArrayLowering.All, ctx, LoweringAnalyses(table, ctx))
     val ex = intercept[SparkException] {
-      ExecuteContext.scoped()(ctx => loweredExecute(ctx, lowered, Env.empty, FastSeq(), None))
+      ExecuteContext.scoped(ctx => loweredExecute(ctx, lowered, Env.empty, FastSeq(), None))
     }.getCause.asInstanceOf[HailException]
 
     ex.errorId shouldBe errorId


### PR DESCRIPTION
### Change Description

This change exists as part of larger refactoring work. Herein, I've exchanged
hard-coded contextual strings passed to `ExecutionTimer.time` with implict
contexts, drawing inspiration from scalatest.

These contexts are now supplied after entering functions like `Compile` and
`Emit` instead of before (see `ExecuteContext.time`). By sprinking calls to 
`time` throughout the codebase after entering functions, we obtain a nice trace
of the timings with `sourcecode.Enclosing`, minus the previous verbosity.

See [1] for more information about what pre-built macros are available. We can
always build our own later. See comments in [pull request id] for example output.
Note that `ExectionTimer.time` still accepts a string to support uses like
`Optimise` and `LoweringPass` where those contexts are provided already.
It is also exception-safe now.

This change exposed many similarities between the implementations of query
execution across all three backends. I've stopped short of full unification
which is a greater work, I've instead simplified and moved duplicated result
encoding into the various backend api implementations.

More interesting changes are to `ExecuteContext`, which now supports
- `time`, as discussed above
- `local`, a generalisation for temporarily overriding properties of an 
  `ExecuteContext` (inspired by [2]). While I've long wanted this for testing,
  we were doing some questionable things when reporting timings back to python,
  for which locally overriding the `timer` of a `ctx` has been very useful.
  We also follow this pattern for local regions

[1] https://github.com/com-lihaoyi/sourcecode
[2] https://hackage.haskell.org/package/mtl-2.3.1/docs/Control-Monad-Reader.html#v:local

### Security Assessment

This change has no security impact as it's confined to refactoring of existing non-security-related code.