### PR TITLE
[query] delete stale `Py4JBackend/index_bgen`

### DIFF
--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -264,9 +264,6 @@ class Py4JBackend(Backend):
     def remove_liftover(self, name, dest_reference_genome):
         self._jbackend.pyRemoveLiftover(name, dest_reference_genome)
 
-    def index_bgen(self, files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci):
-        self._jbackend.pyIndexBgen(files, index_file_map, referenceGenomeName, contig_recoding, skip_invalid_loci)
-
     def _parse_value_ir(self, code, ref_map={}):
         return self._jbackend.parse_value_ir(
             code,


### PR DESCRIPTION
Contains dangeling reference to `pyIndexBgen`, deleted since 92e4776