### PR TITLE
[query] Remove `lookupOrCompileCachedFunction` from `Backend` interface

### DIFF
--- a/hail/hail/src/is/hail/backend/ExecuteContext.scala
+++ b/hail/hail/src/is/hail/backend/ExecuteContext.scala
@@ -4,6 +4,7 @@ import is.hail.{HailContext, HailFeatureFlags}
 import is.hail.annotations.{Region, RegionPool}
 import is.hail.asm4s.HailClassLoader
 import is.hail.backend.local.LocalTaskContext
+import is.hail.expr.ir.{CodeCacheKey, CompiledFunction}
 import is.hail.expr.ir.lowering.IrMetadata
 import is.hail.io.fs.FS
 import is.hail.linalg.BlockMatrix
@@ -73,6 +74,7 @@ object ExecuteContext {
     backendContext: BackendContext,
     irMetadata: IrMetadata,
     blockMatrixCache: mutable.Map[String, BlockMatrix],
+    codeCache: mutable.Map[CodeCacheKey, CompiledFunction[_]],
   )(
     f: ExecuteContext => T
   ): T = {
@@ -92,6 +94,7 @@ object ExecuteContext {
           backendContext,
           irMetadata,
           blockMatrixCache,
+          codeCache,
         ))(f(_))
       }
     }
@@ -122,6 +125,7 @@ class ExecuteContext(
   val backendContext: BackendContext,
   val irMetadata: IrMetadata,
   val BlockMatrixCache: mutable.Map[String, BlockMatrix],
+  val CodeCache: mutable.Map[CodeCacheKey, CompiledFunction[_]],
 ) extends Closeable {
 
   val rngNonce: Long =
@@ -189,6 +193,7 @@ class ExecuteContext(
     backendContext: BackendContext = this.backendContext,
     irMetadata: IrMetadata = this.irMetadata,
     blockMatrixCache: mutable.Map[String, BlockMatrix] = this.BlockMatrixCache,
+    codeCache: mutable.Map[CodeCacheKey, CompiledFunction[_]] = this.CodeCache,
   )(
     f: ExecuteContext => A
   ): A =
@@ -206,5 +211,6 @@ class ExecuteContext(
       backendContext,
       irMetadata,
       blockMatrixCache,
+      codeCache,
     ))(f)
 }

--- a/hail/hail/src/is/hail/backend/local/LocalBackend.scala
+++ b/hail/hail/src/is/hail/backend/local/LocalBackend.scala
@@ -8,6 +8,7 @@ import is.hail.backend.py4j.Py4JBackendExtensions
 import is.hail.expr.Validate
 import is.hail.expr.ir._
 import is.hail.expr.ir.analyses.SemanticHash
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.MakeTuple
 import is.hail.expr.ir.lowering._
 import is.hail.io.fs._
@@ -84,13 +85,14 @@ object LocalBackend {
 class LocalBackend(
   val tmpdir: String,
   override val references: mutable.Map[String, ReferenceGenome],
-) extends Backend with BackendWithCodeCache with Py4JBackendExtensions {
+) extends Backend with Py4JBackendExtensions {
 
   override def backend: Backend = this
   override val flags: HailFeatureFlags = HailFeatureFlags.fromEnv()
   override def longLifeTempFileManager: TempFileManager = null
 
-  private[this] val theHailClassLoader = new HailClassLoader(getClass().getClassLoader())
+  private[this] val theHailClassLoader = new HailClassLoader(getClass.getClassLoader)
+  private[this] val codeCache = new Cache[CodeCacheKey, CompiledFunction[_]](50)
 
   // flags can be set after construction from python
   def fs: FS = RouterFS.buildRoutes(CloudStorageFSConfig.fromFlagsAndEnv(None, flags))
@@ -114,6 +116,7 @@ class LocalBackend(
         },
         new IrMetadata(),
         ImmutableMap.empty,
+        codeCache,
       )(f)
     }
 

--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -6,9 +6,10 @@ import is.hail.asm4s._
 import is.hail.backend._
 import is.hail.expr.Validate
 import is.hail.expr.ir.{
-  Compile, IR, IRParser, IRSize, LoweringAnalyses, SortField, TableIR, TableReader, TypeCheck,
+  IR, IRParser, IRSize, LoweringAnalyses, SortField, TableIR, TableReader, TypeCheck,
 }
 import is.hail.expr.ir.analyses.SemanticHash
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.MakeTuple
 import is.hail.expr.ir.functions.IRFunctionRegistry
 import is.hail.expr.ir.lowering._
@@ -51,7 +52,6 @@ class ServiceBackendContext(
 ) extends BackendContext with Serializable {}
 
 object ServiceBackend {
-  private val log = Logger.getLogger(getClass.getName())
 
   def apply(
     jarLocation: String,
@@ -130,8 +130,7 @@ class ServiceBackend(
   val fs: FS,
   val serviceBackendContext: ServiceBackendContext,
   val scratchDir: String,
-) extends Backend with BackendWithNoCodeCache {
-  import ServiceBackend.log
+) extends Backend with Logging {
 
   private[this] var stageCount = 0
   private[this] val MAX_AVAILABLE_GCS_CONNECTIONS = 1000
@@ -399,6 +398,7 @@ class ServiceBackend(
         serviceBackendContext,
         new IrMetadata(),
         ImmutableMap.empty,
+        mutable.Map.empty,
       )(f)
     }
 

--- a/hail/hail/src/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/hail/src/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.annotations.{Region, SafeRow}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.{Begin, EncodedLiteral, Literal, MakeTuple, NA}
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.types.physical.PTuple

--- a/hail/hail/src/is/hail/expr/ir/Emit.scala
+++ b/hail/hail/src/is/hail/expr/ir/Emit.scala
@@ -7,6 +7,7 @@ import is.hail.expr.ir.agg.{AggStateSig, ArrayAggStateSig, GroupedStateSig}
 import is.hail.expr.ir.analyses.{
   ComputeMethodSplits, ControlFlowPreventsSplit, ParentPointers, SemanticHash,
 }
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.TableStageDependency
 import is.hail.expr.ir.ndarrays.EmitNDArray

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -4,6 +4,7 @@ import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.SparkTaskContext
+import is.hail.expr.ir.compile.{Compile, CompileWithAggregators}
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.io.BufferSpec

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -5,7 +5,7 @@ import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend.{ExecuteContext, HailStateManager, HailTaskContext, TaskFinalizer}
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
-import is.hail.expr.ir
+import is.hail.expr.ir.compile.{Compile, CompileWithAggregators}
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.{
   BlockMatrixToTableFunction, IntervalFunctions, MatrixToTableFunction, TableToTableFunction,
@@ -1890,7 +1890,7 @@ case class TableNativeZippedReader(
     val leftRef = Ref(freshName(), pLeft.virtualType)
     val rightRef = Ref(freshName(), pRight.virtualType)
     val (Some(PTypeReferenceSingleCodeType(t: PStruct)), mk) =
-      ir.Compile[AsmFunction3RegionLongLongLong](
+      Compile[AsmFunction3RegionLongLongLong](
         ctx,
         FastSeq(
           leftRef.name -> SingleCodeEmitParamType(true, PTypeReferenceSingleCodeType(pLeft)),
@@ -2379,7 +2379,7 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
     else if (pred == False())
       return TableValueIntermediate(tv.copy(rvd = RVD.empty(ctx, typ.canonicalRVDType)))
 
-    val (Some(BooleanSingleCodeType), f) = ir.Compile[AsmFunction3RegionLongLongBoolean](
+    val (Some(BooleanSingleCodeType), f) = Compile[AsmFunction3RegionLongLongBoolean](
       ctx,
       FastSeq(
         (
@@ -2994,7 +2994,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
     if (extracted.aggs.isEmpty) {
       val (Some(PTypeReferenceSingleCodeType(rTyp)), f) =
-        ir.Compile[AsmFunction3RegionLongLongLong](
+        Compile[AsmFunction3RegionLongLongLong](
           ctx,
           FastSeq(
             (
@@ -3060,7 +3060,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     // 3. load in partition aggregations, comb op as necessary, serialize.
     // 4. load in partStarts, calculate newRow based on those results.
 
-    val (_, initF) = ir.CompileWithAggregators[AsmFunction2RegionLongUnit](
+    val (_, initF) = CompileWithAggregators[AsmFunction2RegionLongUnit](
       ctx,
       extracted.states,
       FastSeq((
@@ -3074,7 +3074,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
     val serializeF = extracted.serialize(ctx, spec)
 
-    val (_, eltSeqF) = ir.CompileWithAggregators[AsmFunction3RegionLongLongUnit](
+    val (_, eltSeqF) = CompileWithAggregators[AsmFunction3RegionLongLongUnit](
       ctx,
       extracted.states,
       FastSeq(
@@ -3097,7 +3097,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     val combOpFNeedsPool = extracted.combOpFSerializedFromRegionPool(ctx, spec)
 
     val (Some(PTypeReferenceSingleCodeType(rTyp)), f) =
-      ir.CompileWithAggregators[AsmFunction3RegionLongLongLong](
+      CompileWithAggregators[AsmFunction3RegionLongLongLong](
         ctx,
         extracted.states,
         FastSeq(
@@ -3656,7 +3656,7 @@ case class TableKeyByAndAggregate(
 
     val localKeyType = keyType
     val (Some(PTypeReferenceSingleCodeType(localKeyPType: PStruct)), makeKeyF) =
-      ir.Compile[AsmFunction3RegionLongLongLong](
+      Compile[AsmFunction3RegionLongLongLong](
         ctx,
         FastSeq(
           (
@@ -3682,7 +3682,7 @@ case class TableKeyByAndAggregate(
 
     val extracted = agg.Extract(expr, Requiredness(this, ctx))
 
-    val (_, makeInit) = ir.CompileWithAggregators[AsmFunction2RegionLongUnit](
+    val (_, makeInit) = CompileWithAggregators[AsmFunction2RegionLongUnit](
       ctx,
       extracted.states,
       FastSeq((
@@ -3694,7 +3694,7 @@ case class TableKeyByAndAggregate(
       extracted.init,
     )
 
-    val (_, makeSeq) = ir.CompileWithAggregators[AsmFunction3RegionLongLongUnit](
+    val (_, makeSeq) = CompileWithAggregators[AsmFunction3RegionLongLongUnit](
       ctx,
       extracted.states,
       FastSeq(
@@ -3713,7 +3713,7 @@ case class TableKeyByAndAggregate(
     )
 
     val (Some(PTypeReferenceSingleCodeType(rTyp: PStruct)), makeAnnotate) =
-      ir.CompileWithAggregators[AsmFunction2RegionLongLong](
+      CompileWithAggregators[AsmFunction2RegionLongLong](
         ctx,
         extracted.states,
         FastSeq((
@@ -3856,7 +3856,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
 
     val extracted = agg.Extract(expr, Requiredness(this, ctx))
 
-    val (_, makeInit) = ir.CompileWithAggregators[AsmFunction2RegionLongUnit](
+    val (_, makeInit) = CompileWithAggregators[AsmFunction2RegionLongUnit](
       ctx,
       extracted.states,
       FastSeq((
@@ -3868,7 +3868,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
       extracted.init,
     )
 
-    val (_, makeSeq) = ir.CompileWithAggregators[AsmFunction3RegionLongLongUnit](
+    val (_, makeSeq) = CompileWithAggregators[AsmFunction3RegionLongLongUnit](
       ctx,
       extracted.states,
       FastSeq(
@@ -3892,7 +3892,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
     val key = Ref(freshName(), keyType.virtualType)
     val value = Ref(freshName(), valueIR.typ)
     val (Some(PTypeReferenceSingleCodeType(rowType: PStruct)), makeRow) =
-      ir.CompileWithAggregators[AsmFunction3RegionLongLongLong](
+      CompileWithAggregators[AsmFunction3RegionLongLongLong](
         ctx,
         extracted.states,
         FastSeq(

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -6,6 +6,7 @@ import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.SparkTaskContext
 import is.hail.expr.ir
 import is.hail.expr.ir._
+import is.hail.expr.ir.compile.CompileWithAggregators
 import is.hail.expr.ir.defs._
 import is.hail.io.BufferSpec
 import is.hail.types.{TypeWithRequiredness, VirtualTypeWithReq}
@@ -248,7 +249,7 @@ class Aggs(
 
   def deserialize(ctx: ExecuteContext, spec: BufferSpec)
     : ((HailClassLoader, HailTaskContext, Region, Array[Byte]) => Long) = {
-    val (_, f) = ir.CompileWithAggregators[AsmFunction1RegionUnit](
+    val (_, f) = CompileWithAggregators[AsmFunction1RegionUnit](
       ctx,
       states,
       FastSeq(),
@@ -269,7 +270,7 @@ class Aggs(
 
   def serialize(ctx: ExecuteContext, spec: BufferSpec)
     : (HailClassLoader, HailTaskContext, Region, Long) => Array[Byte] = {
-    val (_, f) = ir.CompileWithAggregators[AsmFunction1RegionUnit](
+    val (_, f) = CompileWithAggregators[AsmFunction1RegionUnit](
       ctx,
       states,
       FastSeq(),
@@ -306,7 +307,7 @@ class Aggs(
     : (() => (RegionPool, HailClassLoader, HailTaskContext)) => (
       (Array[Byte], Array[Byte]) => Array[Byte],
     ) = {
-    val (_, f) = ir.CompileWithAggregators[AsmFunction1RegionUnit](
+    val (_, f) = CompileWithAggregators[AsmFunction1RegionUnit](
       ctx,
       states ++ states,
       FastSeq(),

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.{Annotation, ExtendedOrdering, Region, SafeRow}
 import is.hail.asm4s.{classInfo, AsmFunction1RegionLong, LongInfo}
 import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.expr.ir._
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.{ArrayFunctions, IRRandomness, UtilFunctions}
 import is.hail.io.{BufferSpec, TypedCodecSpec}

--- a/hail/hail/src/is/hail/expr/ir/lowering/RVDToTableStage.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/RVDToTableStage.scala
@@ -5,6 +5,7 @@ import is.hail.asm4s._
 import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.{AnonymousDependency, SparkTaskContext}
 import is.hail.expr.ir._
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.{
   GetField, In, Let, MakeStruct, ReadPartition, Ref, StreamRange, ToArray,
 }

--- a/hail/hail/src/is/hail/utils/Cache.scala
+++ b/hail/hail/src/is/hail/utils/Cache.scala
@@ -2,20 +2,32 @@ package is.hail.utils
 
 import is.hail.annotations.{Region, RegionMemory}
 
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.asScalaIteratorConverter
+
 import java.io.Closeable
 import java.util
 import java.util.Map.Entry
 
-class Cache[K, V](capacity: Int) {
+class Cache[K, V](capacity: Int) extends mutable.AbstractMap[K, V] {
   private[this] val m = new util.LinkedHashMap[K, V](capacity, 0.75f, true) {
     override def removeEldestEntry(eldest: Entry[K, V]): Boolean = size() > capacity
   }
 
-  def get(k: K): Option[V] = synchronized(Option(m.get(k)))
+  override def +=(kv: (K, V)): Cache.this.type =
+    synchronized { m.put(kv._1, kv._2); this }
 
-  def +=(p: (K, V)): Unit = synchronized(m.put(p._1, p._2))
+  override def -=(key: K): Cache.this.type =
+    synchronized { m.remove(key); this }
 
-  def size: Int = synchronized(m.size())
+  override def get(key: K): Option[V] =
+    synchronized(Option(m.get(key)))
+
+  override def iterator: Iterator[(K, V)] =
+    for { e <- m.entrySet().iterator().asScala } yield (e.getKey, e.getValue)
+
+  override def clear(): Unit =
+    m.clear()
 }
 
 class LongToRegionValueCache(capacity: Int) extends Closeable {

--- a/hail/hail/test/src/is/hail/TestUtils.scala
+++ b/hail/hail/test/src/is/hail/TestUtils.scala
@@ -4,9 +4,10 @@ import is.hail.annotations.{Region, RegionValueBuilder, SafeRow}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{
-  freshName, streamAggIR, BindingEnv, Compile, Env, IR, Interpret, MapIR, MatrixIR, MatrixRead,
-  Name, SingleCodeEmitParamType, Subst,
+  freshName, streamAggIR, BindingEnv, Env, IR, Interpret, MapIR, MatrixIR, MatrixRead, Name,
+  SingleCodeEmitParamType, Subst,
 }
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.{GetField, GetTupleElement, In, MakeTuple, Ref, ToStream}
 import is.hail.expr.ir.lowering.LowererUnsupportedOperation
 import is.hail.io.vcf.MatrixVCFReader

--- a/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
@@ -4,6 +4,7 @@ import is.hail.{ExecStrategy, HailSuite}
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.agg._
+import is.hail.expr.ir.compile.CompileWithAggregators
 import is.hail.expr.ir.defs._
 import is.hail.io.BufferSpec
 import is.hail.types.VirtualTypeWithReq

--- a/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
@@ -6,6 +6,7 @@ import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.agg.{CollectStateSig, PhysicalAggSig, TypedStateSig}
+import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.expr.ir.streams.{EmitStream, StreamUtils}


### PR DESCRIPTION
In the spirit of shrinking the `Backend` functionality to a core set of functions, move code cache access via execute context.