### PR TITLE
[vds] Unify GT/LGT after split_multi for reference data

### DIFF
--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -644,10 +644,11 @@ def split_multi(vds: 'VariantDataset', *, filter_changed_loci: bool = False) -> 
     variant_data = hl.experimental.sparse_split_multi(vds.variant_data, filter_changed_loci=filter_changed_loci)
     reference_data = vds.reference_data
 
-    if 'GT' in reference_data.entry and 'LGT' in reference_data.entry:
-        reference_data = reference_data.drop('LGT')
-    elif 'LGT' in reference_data.entry:
-        reference_data = reference_data.transmute_entries(GT=reference_data.LGT)
+    if 'LGT' in reference_data.entry:
+        if 'GT' in reference_data.entry:
+            reference_data = reference_data.drop('LGT')
+        else:
+            reference_data = reference_data.transmute_entries(GT=reference_data.LGT)
 
     return VariantDataset(reference_data=reference_data, variant_data=variant_data)
 

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -642,7 +642,14 @@ def split_multi(vds: 'VariantDataset', *, filter_changed_loci: bool = False) -> 
     :class:`.VariantDataset`
     """
     variant_data = hl.experimental.sparse_split_multi(vds.variant_data, filter_changed_loci=filter_changed_loci)
-    return VariantDataset(vds.reference_data, variant_data)
+    reference_data = vds.reference_data
+
+    if 'GT' in reference_data.entry and 'LGT' in reference_data.entry:
+        reference_data = reference_data.drop('LGT')
+    elif 'LGT' in reference_data.entry:
+        reference_data = reference_data.transmute_entries(GT=reference_data.LGT)
+
+    return VariantDataset(reference_data=reference_data, variant_data=variant_data)
 
 
 @typecheck(ref=MatrixTable, intervals=Table)

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -4,6 +4,7 @@ import pytest
 
 import hail as hl
 from hail.utils import new_temp_file
+from hail.vds import VariantDataset
 from hail.vds.combiner.combine import defined_entry_fields
 
 from ..helpers import qobtest, resource, test_timeout
@@ -824,6 +825,14 @@ def test_split_sparse_roundtrip():
         vds2.variant_data.select_entries(*vds_split.variant_data.entry).select_globals()._same(vds_split.variant_data)
     )
     assert vds2.reference_data._same(vds_split.reference_data.drop('ref_allele'))
+
+
+def test_split_alters_ref_gt():
+    vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
+    vds = VariantDataset(vds.reference_data.annotate_entries(LGT=hl.call(0, 0)), vds.variant_data)
+    vds_split = hl.vds.split_multi(vds)
+    assert 'GT' in vds_split.reference_data.entry, vds_split.reference_data.entry
+    assert 'LGT' not in vds_split.reference_data.entry, vds_split.reference_data.entry
 
 
 def test_ref_block_max_len_patch():

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -848,7 +848,9 @@ def test_split_alters_ref_gt():
     assert 'LGT' not in vds_split.reference_data.entry, vds_split.reference_data.entry
 
     # both lgt and gt
-    vds = VariantDataset(vds_base.reference_data.annotate_entries(LGT=hl.call(0,0), GT=hl.call(0, 0)), vds_base.variant_data)
+    vds = VariantDataset(
+        vds_base.reference_data.annotate_entries(LGT=hl.call(0, 0), GT=hl.call(0, 0)), vds_base.variant_data
+    )
     vds_split = hl.vds.split_multi(vds)
     assert 'GT' in vds_split.reference_data.entry, vds_split.reference_data.entry
     assert 'LGT' not in vds_split.reference_data.entry, vds_split.reference_data.entry

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -828,8 +828,27 @@ def test_split_sparse_roundtrip():
 
 
 def test_split_alters_ref_gt():
-    vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
-    vds = VariantDataset(vds.reference_data.annotate_entries(LGT=hl.call(0, 0)), vds.variant_data)
+    vds_base = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
+
+    # no lgt or gt
+    vds_split = hl.vds.split_multi(vds_base)
+    assert 'GT' not in vds_split.reference_data.entry, vds_split.reference_data.entry
+    assert 'LGT' not in vds_split.reference_data.entry, vds_split.reference_data.entry
+
+    # lgt only
+    vds = VariantDataset(vds_base.reference_data.annotate_entries(LGT=hl.call(0, 0)), vds_base.variant_data)
+    vds_split = hl.vds.split_multi(vds)
+    assert 'GT' in vds_split.reference_data.entry, vds_split.reference_data.entry
+    assert 'LGT' not in vds_split.reference_data.entry, vds_split.reference_data.entry
+
+    # gt only
+    vds = VariantDataset(vds_base.reference_data.annotate_entries(GT=hl.call(0, 0)), vds_base.variant_data)
+    vds_split = hl.vds.split_multi(vds)
+    assert 'GT' in vds_split.reference_data.entry, vds_split.reference_data.entry
+    assert 'LGT' not in vds_split.reference_data.entry, vds_split.reference_data.entry
+
+    # both lgt and gt
+    vds = VariantDataset(vds_base.reference_data.annotate_entries(LGT=hl.call(0,0), GT=hl.call(0, 0)), vds_base.variant_data)
     vds_split = hl.vds.split_multi(vds)
     assert 'GT' in vds_split.reference_data.entry, vds_split.reference_data.entry
     assert 'LGT' not in vds_split.reference_data.entry, vds_split.reference_data.entry


### PR DESCRIPTION
After split_multi, LGT is dropped from the variant data of a VDS. After PR #14560, LGT is added to datasets after creation via the combiner. After #14675 the same is true for `from_merged_representation`. We should keep the GT/LGT field consistent across ref and var data. This change does so for split_multi.

Resolves #14694