### PR TITLE
[query] Move LoweredTableReaderCoercer into ExecuteContext

### DIFF
--- a/hail/hail/src/is/hail/backend/Backend.scala
+++ b/hail/hail/src/is/hail/backend/Backend.scala
@@ -85,8 +85,6 @@ abstract class Backend extends Closeable {
   def asSpark(op: String): SparkBackend =
     fatal(s"${getClass.getSimpleName}: $op requires SparkBackend")
 
-  def shouldCacheQueryInfo: Boolean = true
-
   def lowerDistributedSort(
     ctx: ExecuteContext,
     stage: TableStage,

--- a/hail/hail/src/is/hail/backend/ExecuteContext.scala
+++ b/hail/hail/src/is/hail/backend/ExecuteContext.scala
@@ -5,6 +5,7 @@ import is.hail.annotations.{Region, RegionPool}
 import is.hail.asm4s.HailClassLoader
 import is.hail.backend.local.LocalTaskContext
 import is.hail.expr.ir.{BaseIR, CodeCacheKey, CompiledFunction}
+import is.hail.expr.ir.LoweredTableReader.LoweredTableReaderCoercer
 import is.hail.expr.ir.lowering.IrMetadata
 import is.hail.io.fs.FS
 import is.hail.linalg.BlockMatrix
@@ -76,6 +77,7 @@ object ExecuteContext {
     blockMatrixCache: mutable.Map[String, BlockMatrix],
     codeCache: mutable.Map[CodeCacheKey, CompiledFunction[_]],
     irCache: mutable.Map[Int, BaseIR],
+    coercerCache: mutable.Map[Any, LoweredTableReaderCoercer],
   )(
     f: ExecuteContext => T
   ): T = {
@@ -97,6 +99,7 @@ object ExecuteContext {
           blockMatrixCache,
           codeCache,
           irCache,
+          coercerCache,
         ))(f(_))
       }
     }
@@ -129,6 +132,7 @@ class ExecuteContext(
   val BlockMatrixCache: mutable.Map[String, BlockMatrix],
   val CodeCache: mutable.Map[CodeCacheKey, CompiledFunction[_]],
   val PersistedIrCache: mutable.Map[Int, BaseIR],
+  val PersistedCoercerCache: mutable.Map[Any, LoweredTableReaderCoercer],
 ) extends Closeable {
 
   val rngNonce: Long =
@@ -198,6 +202,7 @@ class ExecuteContext(
     blockMatrixCache: mutable.Map[String, BlockMatrix] = this.BlockMatrixCache,
     codeCache: mutable.Map[CodeCacheKey, CompiledFunction[_]] = this.CodeCache,
     persistedIrCache: mutable.Map[Int, BaseIR] = this.PersistedIrCache,
+    persistedCoercerCache: mutable.Map[Any, LoweredTableReaderCoercer] = this.PersistedCoercerCache,
   )(
     f: ExecuteContext => A
   ): A =
@@ -217,5 +222,6 @@ class ExecuteContext(
       blockMatrixCache,
       codeCache,
       persistedIrCache,
+      persistedCoercerCache,
     ))(f)
 }

--- a/hail/hail/src/is/hail/backend/local/LocalBackend.scala
+++ b/hail/hail/src/is/hail/backend/local/LocalBackend.scala
@@ -7,6 +7,7 @@ import is.hail.backend._
 import is.hail.backend.py4j.Py4JBackendExtensions
 import is.hail.expr.Validate
 import is.hail.expr.ir._
+import is.hail.expr.ir.LoweredTableReader.LoweredTableReaderCoercer
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.MakeTuple
@@ -94,6 +95,7 @@ class LocalBackend(
   private[this] val theHailClassLoader = new HailClassLoader(getClass.getClassLoader)
   private[this] val codeCache = new Cache[CodeCacheKey, CompiledFunction[_]](50)
   private[this] val persistedIR: mutable.Map[Int, BaseIR] = mutable.Map()
+  private[this] val coercerCache = new Cache[Any, LoweredTableReaderCoercer](32)
 
   // flags can be set after construction from python
   def fs: FS = RouterFS.buildRoutes(CloudStorageFSConfig.fromFlagsAndEnv(None, flags))
@@ -119,6 +121,7 @@ class LocalBackend(
         ImmutableMap.empty,
         codeCache,
         persistedIR,
+        coercerCache,
       )(f)
     }
 

--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -136,8 +136,6 @@ class ServiceBackend(
   private[this] val MAX_AVAILABLE_GCS_CONNECTIONS = 1000
   private[this] val executor = Executors.newFixedThreadPool(MAX_AVAILABLE_GCS_CONNECTIONS)
 
-  override def shouldCacheQueryInfo: Boolean = false
-
   def defaultParallelism: Int = 4
 
   def broadcast[T: ClassTag](_value: T): BroadcastValue[T] = {
@@ -432,7 +430,8 @@ class ServiceBackend(
         serviceBackendContext,
         new IrMetadata(),
         ImmutableMap.empty,
-        mutable.Map.empty,
+        ImmutableMap.empty,
+        ImmutableMap.empty,
         ImmutableMap.empty,
       )(f)
     }

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -7,6 +7,7 @@ import is.hail.backend._
 import is.hail.backend.py4j.Py4JBackendExtensions
 import is.hail.expr.Validate
 import is.hail.expr.ir._
+import is.hail.expr.ir.LoweredTableReader.LoweredTableReaderCoercer
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.MakeTuple
@@ -356,6 +357,7 @@ class SparkBackend(
   private[this] val bmCache = mutable.Map.empty[String, BlockMatrix]
   private[this] val codeCache = new Cache[CodeCacheKey, CompiledFunction[_]](50)
   private[this] val persistedIr = mutable.Map.empty[Int, BaseIR]
+  private[this] val coercerCache = new Cache[Any, LoweredTableReaderCoercer](32)
 
   def createExecuteContextForTests(
     timer: ExecutionTimer,
@@ -381,6 +383,7 @@ class SparkBackend(
       ImmutableMap.empty,
       ImmutableMap.empty,
       ImmutableMap.empty,
+      ImmutableMap.empty,
     )
 
   override def withExecuteContext[T](f: ExecuteContext => T)(implicit E: Enclosing): T =
@@ -403,6 +406,7 @@ class SparkBackend(
         bmCache,
         codeCache,
         persistedIr,
+        coercerCache,
       )(f)
     }
 

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -145,7 +145,8 @@ object TableReader {
 
 object LoweredTableReader {
 
-  private[this] val coercerCache: Cache[Any, LoweredTableReaderCoercer] = new Cache(32)
+  type LoweredTableReaderCoercer =
+    (ExecuteContext, IR, Type, IndexedSeq[Any], IR => IR) => TableStage
 
   def makeCoercer(
     ctx: ExecuteContext,
@@ -155,10 +156,9 @@ object LoweredTableReader {
     contextType: TStruct,
     contexts: IndexedSeq[Any],
     keyType: TStruct,
-    bodyPType: (TStruct) => PStruct,
-    keys: (TStruct) => (Region, HailClassLoader, FS, Any) => Iterator[Long],
+    bodyPType: TStruct => PStruct,
+    keys: TStruct => (Region, HailClassLoader, FS, Any) => Iterator[Long],
     context: String,
-    cacheKey: Any,
   ): LoweredTableReaderCoercer = {
     assert(key.nonEmpty)
     assert(contexts.nonEmpty)
@@ -174,379 +174,363 @@ object LoweredTableReader {
     def selectPK(k: IR): IR =
       SelectFields(k, key.take(partitionKey))
 
-    val cacheKeyWithInfo = (partitionKey, keyType, key, cacheKey)
-    coercerCache.get(cacheKeyWithInfo) match {
-      case Some(r) => r
-      case None =>
-        info(s"scanning $context for sortedness...")
-        val prevkey = AggSignature(PrevNonnull(), FastSeq(), FastSeq(keyType))
-        val count = AggSignature(Count(), FastSeq(), FastSeq())
-        val samplekey = AggSignature(TakeBy(), FastSeq(TInt32), FastSeq(keyType, TFloat64))
-        val sum = AggSignature(Sum(), FastSeq(), FastSeq(TInt64))
-        val minkey = AggSignature(TakeBy(), FastSeq(TInt32), FastSeq(keyType, keyType))
-        val maxkey = AggSignature(TakeBy(Descending), FastSeq(TInt32), FastSeq(keyType, keyType))
+    info(s"scanning $context for sortedness...")
+    val prevkey = AggSignature(PrevNonnull(), FastSeq(), FastSeq(keyType))
+    val count = AggSignature(Count(), FastSeq(), FastSeq())
+    val samplekey = AggSignature(TakeBy(), FastSeq(TInt32), FastSeq(keyType, TFloat64))
+    val sum = AggSignature(Sum(), FastSeq(), FastSeq(TInt64))
+    val minkey = AggSignature(TakeBy(), FastSeq(TInt32), FastSeq(keyType, keyType))
+    val maxkey = AggSignature(TakeBy(Descending), FastSeq(TInt32), FastSeq(keyType, keyType))
 
-        val xType = TStruct(
-          "key" -> keyType,
-          "token" -> TFloat64,
-          "prevkey" -> keyType,
-        )
+    val xType = TStruct(
+      "key" -> keyType,
+      "token" -> TFloat64,
+      "prevkey" -> keyType,
+    )
 
-        val keyRef = Ref(freshName(), keyType)
-        val xRef = Ref(freshName(), xType)
-        val nRef = Ref(freshName(), TInt64)
+    val keyRef = Ref(freshName(), keyType)
+    val xRef = Ref(freshName(), xType)
+    val nRef = Ref(freshName(), TInt64)
 
-        val scanBody = (ctx: IR) =>
-          StreamAgg(
-            StreamAggScan(
-              ReadPartition(
-                ctx,
-                keyType,
-                new PartitionIteratorLongReader(
-                  keyType,
-                  uidFieldName,
-                  contextType,
-                  (requestedType: Type) => bodyPType(requestedType.asInstanceOf[TStruct]),
-                  (requestedType: Type) => keys(requestedType.asInstanceOf[TStruct]),
-                ),
-              ),
-              keyRef.name,
-              MakeStruct(FastSeq(
-                "key" -> keyRef,
-                "token" -> invokeSeeded(
-                  "rand_unif",
-                  1,
-                  TFloat64,
-                  RNGStateLiteral(),
-                  F64(0.0),
-                  F64(1.0),
-                ),
-                "prevkey" -> ApplyScanOp(FastSeq(), FastSeq(keyRef), prevkey),
-              )),
+    val scanBody = (ctx: IR) =>
+      StreamAgg(
+        StreamAggScan(
+          ReadPartition(
+            ctx,
+            keyType,
+            new PartitionIteratorLongReader(
+              keyType,
+              uidFieldName,
+              contextType,
+              (requestedType: Type) => bodyPType(requestedType.asInstanceOf[TStruct]),
+              (requestedType: Type) => keys(requestedType.asInstanceOf[TStruct]),
             ),
-            xRef.name,
-            Let(
-              FastSeq(nRef.name -> ApplyAggOp(FastSeq(), FastSeq(), count)),
-              AggLet(
-                keyRef.name,
-                GetField(xRef, "key"),
-                MakeStruct(FastSeq(
-                  "n" -> nRef,
-                  "minkey" ->
-                    ApplyAggOp(
-                      FastSeq(I32(1)),
-                      FastSeq(keyRef, keyRef),
-                      minkey,
-                    ),
-                  "maxkey" ->
-                    ApplyAggOp(
-                      FastSeq(I32(1)),
-                      FastSeq(keyRef, keyRef),
-                      maxkey,
-                    ),
-                  "ksorted" ->
-                    ApplyComparisonOp(
-                      EQ(TInt64),
-                      ApplyAggOp(
-                        FastSeq(),
-                        FastSeq(
-                          invoke(
-                            "toInt64",
-                            TInt64,
-                            invoke(
-                              "lor",
-                              TBoolean,
-                              IsNA(GetField(xRef, "prevkey")),
-                              ApplyComparisonOp(
-                                LTEQ(keyType),
-                                GetField(xRef, "prevkey"),
-                                GetField(xRef, "key"),
-                              ),
-                            ),
-                          )
+          ),
+          keyRef.name,
+          MakeStruct(FastSeq(
+            "key" -> keyRef,
+            "token" -> invokeSeeded(
+              "rand_unif",
+              1,
+              TFloat64,
+              RNGStateLiteral(),
+              F64(0.0),
+              F64(1.0),
+            ),
+            "prevkey" -> ApplyScanOp(FastSeq(), FastSeq(keyRef), prevkey),
+          )),
+        ),
+        xRef.name,
+        Let(
+          FastSeq(nRef.name -> ApplyAggOp(FastSeq(), FastSeq(), count)),
+          AggLet(
+            keyRef.name,
+            GetField(xRef, "key"),
+            MakeStruct(FastSeq(
+              "n" -> nRef,
+              "minkey" ->
+                ApplyAggOp(
+                  FastSeq(I32(1)),
+                  FastSeq(keyRef, keyRef),
+                  minkey,
+                ),
+              "maxkey" ->
+                ApplyAggOp(
+                  FastSeq(I32(1)),
+                  FastSeq(keyRef, keyRef),
+                  maxkey,
+                ),
+              "ksorted" ->
+                ApplyComparisonOp(
+                  EQ(TInt64),
+                  ApplyAggOp(
+                    FastSeq(),
+                    FastSeq(
+                      invoke(
+                        "toInt64",
+                        TInt64,
+                        invoke(
+                          "lor",
+                          TBoolean,
+                          IsNA(GetField(xRef, "prevkey")),
+                          ApplyComparisonOp(
+                            LTEQ(keyType),
+                            GetField(xRef, "prevkey"),
+                            GetField(xRef, "key"),
+                          ),
                         ),
-                        sum,
-                      ),
-                      nRef,
+                      )
                     ),
-                  "pksorted" ->
-                    ApplyComparisonOp(
-                      EQ(TInt64),
-                      ApplyAggOp(
-                        FastSeq(),
-                        FastSeq(
-                          invoke(
-                            "toInt64",
-                            TInt64,
-                            invoke(
-                              "lor",
-                              TBoolean,
-                              IsNA(selectPK(GetField(xRef, "prevkey"))),
-                              ApplyComparisonOp(
-                                LTEQ(pkType),
-                                selectPK(GetField(xRef, "prevkey")),
-                                selectPK(GetField(xRef, "key")),
-                              ),
-                            ),
-                          )
-                        ),
-                        sum,
-                      ),
-                      nRef,
-                    ),
-                  "sample" -> ApplyAggOp(
-                    FastSeq(I32(samplesPerPartition)),
-                    FastSeq(GetField(xRef, "key"), GetField(xRef, "token")),
-                    samplekey,
+                    sum,
                   ),
-                )),
-                isScan = false,
+                  nRef,
+                ),
+              "pksorted" ->
+                ApplyComparisonOp(
+                  EQ(TInt64),
+                  ApplyAggOp(
+                    FastSeq(),
+                    FastSeq(
+                      invoke(
+                        "toInt64",
+                        TInt64,
+                        invoke(
+                          "lor",
+                          TBoolean,
+                          IsNA(selectPK(GetField(xRef, "prevkey"))),
+                          ApplyComparisonOp(
+                            LTEQ(pkType),
+                            selectPK(GetField(xRef, "prevkey")),
+                            selectPK(GetField(xRef, "key")),
+                          ),
+                        ),
+                      )
+                    ),
+                    sum,
+                  ),
+                  nRef,
+                ),
+              "sample" -> ApplyAggOp(
+                FastSeq(I32(samplesPerPartition)),
+                FastSeq(GetField(xRef, "key"), GetField(xRef, "token")),
+                samplekey,
               ),
-            ),
-          )
+            )),
+            isScan = false,
+          ),
+        ),
+      )
 
-        val scanResult = cdaIR(
-          ToStream(Literal(TArray(contextType), contexts)),
-          MakeStruct(FastSeq()),
-          "table_coerce_sortedness",
-          NA(TString),
-        )((context, _) => scanBody(context))
+    val scanResult = cdaIR(
+      ToStream(Literal(TArray(contextType), contexts)),
+      MakeStruct(FastSeq()),
+      "table_coerce_sortedness",
+      NA(TString),
+    )((context, _) => scanBody(context))
 
-        val sortedPartDataIR = sortIR(bindIR(scanResult) { scanResult =>
+    val sortedPartDataIR = sortIR(bindIR(scanResult) { scanResult =>
+      mapIR(
+        filterIR(
           mapIR(
-            filterIR(
-              mapIR(
-                rangeIR(I32(0), ArrayLen(scanResult))
-              ) { i =>
-                InsertFields(
-                  ArrayRef(scanResult, i),
-                  FastSeq("i" -> i),
-                )
-              }
-            )(row => ArrayLen(GetField(row, "minkey")) > 0)
-          ) { row =>
+            rangeIR(I32(0), ArrayLen(scanResult))
+          ) { i =>
             InsertFields(
-              row,
-              FastSeq(
-                ("minkey", ArrayRef(GetField(row, "minkey"), I32(0))),
-                ("maxkey", ArrayRef(GetField(row, "maxkey"), I32(0))),
-              ),
+              ArrayRef(scanResult, i),
+              FastSeq("i" -> i),
             )
           }
-        }) { (l, r) =>
-          ApplyComparisonOp(
-            LT(TStruct("minkey" -> keyType, "maxkey" -> keyType)),
-            SelectFields(l, FastSeq("minkey", "maxkey")),
-            SelectFields(r, FastSeq("minkey", "maxkey")),
-          )
+        )(row => ArrayLen(GetField(row, "minkey")) > 0)
+      ) { row =>
+        InsertFields(
+          row,
+          FastSeq(
+            ("minkey", ArrayRef(GetField(row, "minkey"), I32(0))),
+            ("maxkey", ArrayRef(GetField(row, "maxkey"), I32(0))),
+          ),
+        )
+      }
+    }) { (l, r) =>
+      ApplyComparisonOp(
+        LT(TStruct("minkey" -> keyType, "maxkey" -> keyType)),
+        SelectFields(l, FastSeq("minkey", "maxkey")),
+        SelectFields(r, FastSeq("minkey", "maxkey")),
+      )
+    }
+
+    val summary = bindIR(sortedPartDataIR) { sortedPartData =>
+      MakeStruct(FastSeq(
+        "ksorted" ->
+          invoke(
+            "land",
+            TBoolean,
+            foldIR(ToStream(sortedPartData), True()) { (acc, partDataWithIndex) =>
+              invoke("land", TBoolean, acc, GetField(partDataWithIndex, "ksorted"))
+            },
+            foldIR(StreamRange(I32(0), ArrayLen(sortedPartData) - I32(1), I32(1)), True()) {
+              (acc, i) =>
+                invoke(
+                  "land",
+                  TBoolean,
+                  acc,
+                  ApplyComparisonOp(
+                    LTEQ(keyType),
+                    GetField(ArrayRef(sortedPartData, i), "maxkey"),
+                    GetField(ArrayRef(sortedPartData, i + I32(1)), "minkey"),
+                  ),
+                )
+            },
+          ),
+        "pksorted" ->
+          invoke(
+            "land",
+            TBoolean,
+            foldIR(ToStream(sortedPartData), True()) { (acc, partDataWithIndex) =>
+              invoke("land", TBoolean, acc, GetField(partDataWithIndex, "pksorted"))
+            },
+            foldIR(StreamRange(I32(0), ArrayLen(sortedPartData) - I32(1), I32(1)), True()) {
+              (acc, i) =>
+                invoke(
+                  "land",
+                  TBoolean,
+                  acc,
+                  ApplyComparisonOp(
+                    LTEQ(pkType),
+                    selectPK(GetField(ArrayRef(sortedPartData, i), "maxkey")),
+                    selectPK(GetField(ArrayRef(sortedPartData, i + I32(1)), "minkey")),
+                  ),
+                )
+            },
+          ),
+        "sortedPartData" -> sortedPartData,
+      ))
+    }
+
+    val (Some(PTypeReferenceSingleCodeType(resultPType: PStruct)), f) =
+      Compile[AsmFunction1RegionLong](
+        ctx,
+        FastSeq(),
+        FastSeq[TypeInfo[_]](classInfo[Region]),
+        LongInfo,
+        summary,
+        optimize = true,
+      )
+
+    val s = ctx.scopedExecution { (hcl, fs, htc, r) =>
+      val a = f(hcl, fs, htc, r)(r)
+      SafeRow(resultPType, a)
+    }
+
+    val ksorted = s.getBoolean(0)
+    val pksorted = s.getBoolean(1)
+    val sortedPartData = s.getAs[IndexedSeq[Row]](2)
+
+    if (ksorted) {
+      info(s"Coerced sorted $context - no additional import work to do")
+      (
+        ctx: ExecuteContext,
+        globals: IR,
+        contextType: Type,
+        contexts: IndexedSeq[Any],
+        body: IR => IR,
+      ) => {
+        val partOrigIndex = sortedPartData.map(_.getInt(6))
+
+        val partitioner = new RVDPartitioner(
+          ctx.stateManager,
+          keyType,
+          sortedPartData.map { partData =>
+            Interval(
+              partData.get(1),
+              partData.get(2),
+              includesStart = true,
+              includesEnd = true,
+            )
+          },
+          key.length,
+        )
+
+        TableStage(
+          globals,
+          partitioner,
+          TableStageDependency.none,
+          ToStream(Literal(TArray(contextType), partOrigIndex.map(i => contexts(i)))),
+          body,
+        )
+      }
+    } else if (pksorted) {
+      info(
+        s"Coerced prefix-sorted $context, requiring additional sorting within data partitions on each query."
+      )
+
+      def selectPK(r: Row): Row = {
+        val a = new Array[Any](partitionKey)
+        var i = 0
+        while (i < partitionKey) {
+          a(i) = r.get(i)
+          i += 1
         }
+        Row.fromSeq(a)
+      }
 
-        val summary = bindIR(sortedPartDataIR) { sortedPartData =>
-          MakeStruct(FastSeq(
-            "ksorted" ->
-              invoke(
-                "land",
-                TBoolean,
-                foldIR(ToStream(sortedPartData), True()) { (acc, partDataWithIndex) =>
-                  invoke("land", TBoolean, acc, GetField(partDataWithIndex, "ksorted"))
-                },
-                foldIR(StreamRange(I32(0), ArrayLen(sortedPartData) - I32(1), I32(1)), True()) {
-                  (acc, i) =>
-                    invoke(
-                      "land",
-                      TBoolean,
-                      acc,
-                      ApplyComparisonOp(
-                        LTEQ(keyType),
-                        GetField(ArrayRef(sortedPartData, i), "maxkey"),
-                        GetField(ArrayRef(sortedPartData, i + I32(1)), "minkey"),
-                      ),
-                    )
-                },
-              ),
-            "pksorted" ->
-              invoke(
-                "land",
-                TBoolean,
-                foldIR(ToStream(sortedPartData), True()) { (acc, partDataWithIndex) =>
-                  invoke("land", TBoolean, acc, GetField(partDataWithIndex, "pksorted"))
-                },
-                foldIR(StreamRange(I32(0), ArrayLen(sortedPartData) - I32(1), I32(1)), True()) {
-                  (acc, i) =>
-                    invoke(
-                      "land",
-                      TBoolean,
-                      acc,
-                      ApplyComparisonOp(
-                        LTEQ(pkType),
-                        selectPK(GetField(ArrayRef(sortedPartData, i), "maxkey")),
-                        selectPK(GetField(ArrayRef(sortedPartData, i + I32(1)), "minkey")),
-                      ),
-                    )
-                },
-              ),
-            "sortedPartData" -> sortedPartData,
-          ))
-        }
+      (
+        ctx: ExecuteContext,
+        globals: IR,
+        contextType: Type,
+        contexts: IndexedSeq[Any],
+        body: IR => IR,
+      ) => {
+        val partOrigIndex = sortedPartData.map(_.getInt(6))
 
-        val (Some(PTypeReferenceSingleCodeType(resultPType: PStruct)), f) =
-          Compile[AsmFunction1RegionLong](
-            ctx,
-            FastSeq(),
-            FastSeq[TypeInfo[_]](classInfo[Region]),
-            LongInfo,
-            summary,
-            optimize = true,
-          )
+        val partitioner = new RVDPartitioner(
+          ctx.stateManager,
+          pkType,
+          sortedPartData.map { partData =>
+            Interval(
+              selectPK(partData.getAs[Row](1)),
+              selectPK(partData.getAs[Row](2)),
+              includesStart = true,
+              includesEnd = true,
+            )
+          },
+          pkType.size,
+        )
 
-        val s = ctx.scopedExecution { (hcl, fs, htc, r) =>
-          val a = f(hcl, fs, htc, r)(r)
-          SafeRow(resultPType, a)
-        }
+        val pkPartitioned = TableStage(
+          globals,
+          partitioner,
+          TableStageDependency.none,
+          ToStream(Literal(TArray(contextType), partOrigIndex.map(i => contexts(i)))),
+          body,
+        )
 
-        val ksorted = s.getBoolean(0)
-        val pksorted = s.getBoolean(1)
-        val sortedPartData = s.getAs[IndexedSeq[Row]](2)
-
-        val coercer = if (ksorted) {
-          info(s"Coerced sorted $context - no additional import work to do")
-
-          new LoweredTableReaderCoercer {
-            def coerce(
-              ctx: ExecuteContext,
-              globals: IR,
-              contextType: Type,
-              contexts: IndexedSeq[Any],
-              body: IR => IR,
-            ): TableStage = {
-              val partOrigIndex = sortedPartData.map(_.getInt(6))
-
-              val partitioner = new RVDPartitioner(
-                ctx.stateManager,
-                keyType,
-                sortedPartData.map { partData =>
-                  Interval(
-                    partData.get(1),
-                    partData.get(2),
-                    includesStart = true,
-                    includesEnd = true,
-                  )
-                },
-                key.length,
-              )
-
-              TableStage(
-                globals,
-                partitioner,
-                TableStageDependency.none,
-                ToStream(Literal(TArray(contextType), partOrigIndex.map(i => contexts(i)))),
-                body,
-              )
+        pkPartitioned
+          .extendKeyPreservesPartitioning(ctx, key)
+          .mapPartition(None) { part =>
+            flatMapIR(StreamGroupByKey(part, pkType.fieldNames, missingEqual = true)) {
+              inner => ToStream(sortIR(inner) { case (l, r) => ApplyComparisonOp(LT(l.typ), l, r) })
             }
           }
-        } else if (pksorted) {
-          info(
-            s"Coerced prefix-sorted $context, requiring additional sorting within data partitions on each query."
-          )
+      }
+    } else {
+      info(
+        s"$context is out of order..." +
+          s"\n  Write the dataset to disk before running multiple queries to avoid multiple costly data shuffles."
+      )
 
-          new LoweredTableReaderCoercer {
-            private[this] def selectPK(r: Row): Row = {
-              val a = new Array[Any](partitionKey)
-              var i = 0
-              while (i < partitionKey) {
-                a(i) = r.get(i)
-                i += 1
-              }
-              Row.fromSeq(a)
-            }
+      (
+        ctx: ExecuteContext,
+        globals: IR,
+        contextType: Type,
+        contexts: IndexedSeq[Any],
+        body: IR => IR,
+      ) => {
+        val partOrigIndex = sortedPartData.map(_.getInt(6))
 
-            def coerce(
-              ctx: ExecuteContext,
-              globals: IR,
-              contextType: Type,
-              contexts: IndexedSeq[Any],
-              body: IR => IR,
-            ): TableStage = {
-              val partOrigIndex = sortedPartData.map(_.getInt(6))
+        val partitioner = RVDPartitioner.unkeyed(ctx.stateManager, sortedPartData.length)
 
-              val partitioner = new RVDPartitioner(
-                ctx.stateManager,
-                pkType,
-                sortedPartData.map { partData =>
-                  Interval(
-                    selectPK(partData.getAs[Row](1)),
-                    selectPK(partData.getAs[Row](2)),
-                    includesStart = true,
-                    includesEnd = true,
-                  )
-                },
-                pkType.size,
-              )
+        val tableStage = TableStage(
+          globals,
+          partitioner,
+          TableStageDependency.none,
+          ToStream(Literal(TArray(contextType), partOrigIndex.map(i => contexts(i)))),
+          body,
+        )
 
-              val pkPartitioned = TableStage(
-                globals,
-                partitioner,
-                TableStageDependency.none,
-                ToStream(Literal(TArray(contextType), partOrigIndex.map(i => contexts(i)))),
-                body,
-              )
+        val rowRType =
+          VirtualTypeWithReq(bodyPType(tableStage.rowType)).r.asInstanceOf[RStruct]
+        val globReq = Requiredness(globals, ctx)
+        val globRType = globReq.lookup(globals).asInstanceOf[RStruct]
 
-              pkPartitioned
-                .extendKeyPreservesPartitioning(ctx, key)
-                .mapPartition(None) { part =>
-                  flatMapIR(StreamGroupByKey(part, pkType.fieldNames, missingEqual = true)) {
-                    inner =>
-                      ToStream(sortIR(inner) { case (l, r) => ApplyComparisonOp(LT(l.typ), l, r) })
-                  }
-                }
-            }
-          }
-        } else {
-          info(
-            s"$context is out of order..." +
-              s"\n  Write the dataset to disk before running multiple queries to avoid multiple costly data shuffles."
-          )
-
-          new LoweredTableReaderCoercer {
-            def coerce(
-              ctx: ExecuteContext,
-              globals: IR,
-              contextType: Type,
-              contexts: IndexedSeq[Any],
-              body: IR => IR,
-            ): TableStage = {
-              val partOrigIndex = sortedPartData.map(_.getInt(6))
-
-              val partitioner = RVDPartitioner.unkeyed(ctx.stateManager, sortedPartData.length)
-
-              val tableStage = TableStage(
-                globals,
-                partitioner,
-                TableStageDependency.none,
-                ToStream(Literal(TArray(contextType), partOrigIndex.map(i => contexts(i)))),
-                body,
-              )
-
-              val rowRType =
-                VirtualTypeWithReq(bodyPType(tableStage.rowType)).r.asInstanceOf[RStruct]
-              val globReq = Requiredness(globals, ctx)
-              val globRType = globReq.lookup(globals).asInstanceOf[RStruct]
-
-              ctx.backend.lowerDistributedSort(
-                ctx,
-                tableStage,
-                keyType.fieldNames.map(f => SortField(f, Ascending)),
-                RTable(rowRType, globRType, FastSeq()),
-              ).lower(
-                ctx,
-                TableType(tableStage.rowType, keyType.fieldNames, globals.typ.asInstanceOf[TStruct]),
-              )
-            }
-          }
-        }
-        if (ctx.backend.shouldCacheQueryInfo)
-          coercerCache += (cacheKeyWithInfo -> coercer)
-        coercer
+        ctx.backend.lowerDistributedSort(
+          ctx,
+          tableStage,
+          keyType.fieldNames.map(f => SortField(f, Ascending)),
+          RTable(rowRType, globRType, FastSeq()),
+        ).lower(
+          ctx,
+          TableType(tableStage.rowType, keyType.fieldNames, globals.typ.asInstanceOf[TStruct]),
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
Refactored table reader coercion and caching mechanism.

### What changed?

- Removed `shouldCacheQueryInfo` method from `Backend` class
- Introduced `CoercerCache` in `ExecuteContext`
- Refactored `LoweredTableReader.makeCoercer` to return a function instead of a class
- Removed local caching in `GenericTableValue` and `LoweredTableReader`

### Why make this change?

This change aims to optimize table reader coercion by:
- Centralizing caching logic in `ExecuteContext`
- Allowing more flexible caching strategies across different backend implementations