### PR TITLE
[query/vds] Fix removal of ref GT in `from_merged_representation`

### DIFF
--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -160,9 +160,7 @@ class VariantDataset:
 
         gt_field = 'LGT' if 'LGT' in mt.entry else 'GT'
 
-        # remove LGT/GT and LA fields, which are trivial for reference blocks and do not need to be represented
-        if gt_field in used_ref_block_fields:
-            used_ref_block_fields.remove(gt_field)
+        # remove the LA field, which is trivial for reference blocks and does not need to be represented
         if 'LA' in used_ref_block_fields:
             used_ref_block_fields.remove('LA')
 

--- a/hail/python/test/hail/vds/test_vds.py
+++ b/hail/python/test/hail/vds/test_vds.py
@@ -814,6 +814,9 @@ def test_combiner_max_len():
 @test_timeout(4 * 60, local=6 * 60)
 def test_split_sparse_roundtrip():
     vds = hl.vds.read_vds(os.path.join(resource('vds'), '1kg_chr22_5_samples.vds'))
+    # this doesn't actually roundtrip because 1kg_chr22_5_samples was generated before
+    # we added GT to reference_data, to_merged_sparse_mt adds a reference GT
+    vds.reference_data = vds.reference_data.annotate_entries(LGT=hl.call(0, 0))
     smt = hl.vds.to_merged_sparse_mt(vds)
     smt = hl.experimental.sparse_split_multi(smt)
     vds2 = hl.vds.VariantDataset.from_merged_representation(


### PR DESCRIPTION
We can't do this anymore since genotype may be something other than diploid.

Missed this in the original VDS ploidy changes

Split off from #14675 to shrink that change to assist in debugging it.