### PR TITLE
[CI] Remove Iris and M Franklin from authorized users and teams lists

### DIFF
--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -26,8 +26,6 @@ AUTHORIZED_USERS = [
     User('chrisvittal', 'cvittal', HAIL_TEAM),
     User('cjllanwarne', 'chrisl', HAIL_TEAM),
     User('ehigham', 'ehigham', HAIL_TEAM),
-    User('illusional', 'mfrankli'),
-    User('iris-garden', 'irademac', HAIL_TEAM),
     User('jkgoodrich', 'jgoodric'),
     User('konradjk', 'konradk'),
     User('patrick-schultz', 'pschultz', HAIL_TEAM),


### PR DESCRIPTION
### Change Description

Seems like only yesterday that we had #14668

Also removes @illusional as I believe he's no longer in a contributing role (... but please shout out if you disagree! And cc @jmarshall)

### Security Assessment

- [ ] This change has a high security impact
  - [ ] Required: and the impact has been assessed and approved by appsec
- [ ] This change has a medium security impact
- [X] This change has a low security impact
- [ ] This change has no security impact

Description of the security impact and necessary mitigations:

Removes entries from the allow-list of contributors and recommended reviewers. 