### PR TITLE
[ci-utils] Use google's apt repo to install gcloud and kubectl

### DIFF
--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -1,15 +1,8 @@
 ARG BASE_IMAGE={{ base_image.image }}
 FROM $BASE_IMAGE AS base
 
-# source: https://cloud.google.com/storage/docs/gsutil_install#linux
-RUN curl --remote-name https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-447.0.0-linux-x86_64.tar.gz && \
-    tar -xf google-cloud-sdk-447.0.0-linux-x86_64.tar.gz && \
-    curl --remote-name https://dl.k8s.io/release/v1.21.14/bin/linux/amd64/kubectl && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-ENV PATH $PATH:/google-cloud-sdk/bin
-
 # https://bugs.mysql.com/bug.php?id=105288&thanks=sub
-RUN hail-apt-get-install xz-utils libncurses5 git && \
+RUN hail-apt-get-install xz-utils libncurses5 git google-cloud-cli kubectl && \
     curl --remote-name https://downloads.mysql.com/archives/get/p/23/file/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \
     mkdir -p /opt && \
     tar -vx -C /opt -f mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -18,13 +18,17 @@ RUN chmod 755 /bin/retry && \
     chmod 755 /controller.sh && \
     echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     mkdir -p /usr/share/keyrings/ && \
-    hail-apt-get-install curl gpg jq rsync && \
+    hail-apt-get-install curl apt-transport-https ca-certificates gnupg jq rsync && \
     curl 'https://keyserver.ubuntu.com/pks/lookup?search=0xF23C5A6CF475977595C89F51BA6932366A755776&hash=on&exact=on&options=mr&op=get' \
          | gpg --dearmor > /usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg && \
     echo 'deb [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main' \
          >> /etc/apt/sources.list && \
     echo 'deb-src [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main' \
          >> /etc/apt/sources.list && \
+    curl 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' \
+        | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo 'deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main' \
+        >> /etc/apt/sources.list && \
     hail-apt-get-install python$PYTHON_VERSION-minimal python$PYTHON_VERSION-dev python$PYTHON_VERSION-distutils gcc g++ && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PYTHON_VERSION 1 && \
     curl https://bootstrap.pypa.io/get-pip.py | python3 && \


### PR DESCRIPTION
See https://cloud.google.com/sdk/docs/install#deb 

### Security Assessment

- [x] This change has a low security impact
