### PR TITLE
[ci] preserve mill + python build area between ci stages

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -21,7 +21,7 @@ steps:
       mkdir -p repo
       cd repo
       {{ code.checkout_script }}
-      make -C hail python-version-info HAIL_RELEASE_MODE=1
+      make -C hail python-version-info HAIL_RELEASE_MODE=1 MILLOPTS=--no-server
       git rev-parse HEAD > git_version
     outputs:
       - from: /io/repo/
@@ -722,7 +722,9 @@ steps:
     script: |
       set -ex
       cd /io/repo/hail
-      time retry sh millw --version
+
+      export MILLOPTS='--no-server' HAIL_RELEASE_MODE=1
+      time retry sh millw --no-server --version
 
       # We've encountered the following sporadic error in CI between `mill`
       # finishing assembling the jar and `Make` copying the jar:
@@ -730,23 +732,21 @@ steps:
       # cp -f out/assembly.dest/out.jar python/hail/backend/hail-all-spark.jar
       # cp: cannot stat 'out/assembly.dest/out.jar': No such file or directory
       #
-      # I suspect mill is exiting before the jar has finished being written.
-      time retry make shadowJar HAIL_RELEASE_MODE=1
+      # This was likely from running mill in server mode; mill main exits before
+      # the jar has finished being written.
+      time retry make shadowJar
       if [ ! -f out/assembly.dest/out.jar ]; then
           echo 'no out.jar found after mill assembly returned. going to sleep'
           sleep 5
       fi
 
-      time retry make wheel HAIL_RELEASE_MODE=1
+      time retry make wheel
 
       # Check wheel size is small enough for pypi (< 200 MiB)
       HAIL_PIP_VERSION=$(cat python/hail/hail_pip_version)
       WHEEL_PATH="build/deploy/dist/hail-$HAIL_PIP_VERSION-py3-none-any.whl"
       du -h $WHEEL_PATH
       $(python3 -c "import os; exit(1) if (os.path.getsize('$WHEEL_PATH')) > (200 * 1024 * 1024) else exit(0)")
-
-      # Remove transients from mill's build area
-      rm -rf out/mill-worker*
     inputs:
       - from: /repo
         to: /io/repo
@@ -768,7 +768,9 @@ steps:
     script: |
       set -ex
       cd /io/repo/hail
-      time retry sh millw --version
+
+      export MILLOPTS='--no-server'
+      time retry sh millw --no-server --version
 
       # See `build_hail_jar_and_wheel`
       time retry make shadowJar
@@ -778,9 +780,6 @@ steps:
       fi
 
       time retry make wheel
-
-      # Remove transients from mill's build area
-      rm -rf out/mill-worker*
     inputs:
       - from: /repo
         to: /io/repo
@@ -802,7 +801,9 @@ steps:
     script: |
       set -ex
       cd /io/repo/hail
-      time retry sh millw --version
+
+      export MILLOPTS='--no-server'
+      time retry sh millw --no-server --version
 
       # See `build_hail_jar_and_wheel`
       time retry make shadowTestJar
@@ -810,9 +811,6 @@ steps:
           echo 'no out.jar found after mill assembly returned. going to sleep'
           sleep 5
       fi
-
-      # Remove transients from mill's build area
-      rm -rf out/mill-worker*
     inputs:
       - from: /repo
         to: /io/repo
@@ -863,17 +861,23 @@ steps:
     script: |
       set -ex
       cd /io/repo/hail
-      time retry sh millw --version
-      export SPARK_VERSION="3.0.2" SCALA_VERSION="2.12.13" HAIL_RELEASE_MODE=1
-      time retry make wheel
 
-      mkdir /io/azure-wheel
-      mv build/deploy/dist/hail-*-py3-none-any.whl /io/azure-wheel/
+      export SPARK_VERSION="3.0.2" SCALA_VERSION="2.12.13" HAIL_RELEASE_MODE=1 MILLOPTS='--no-server'
+      time retry sh millw --no-server --version
+
+      # See `build_hail_jar_and_wheel`
+      time retry make shadowJar
+      if [ ! -f out/assembly.dest/out.jar ]; then
+          echo 'no out.jar found after mill assembly returned. going to sleep'
+          sleep 5
+      fi
+
+      time retry make wheel
     inputs:
       - from: /repo
         to: /io/repo
     outputs:
-      - from: /io/azure-wheel
+      - from: /io/repo/hail/build/deploy/dist
         to: /azure-wheel
     dependsOn:
       - base_image

--- a/build.yaml
+++ b/build.yaml
@@ -717,8 +717,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: 12Gi
-      cpu: '4'
+      memory: standard
+      cpu: '2'
     script: |
       set -ex
       cd /io/repo/hail
@@ -763,8 +763,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: 12Gi
-      cpu: '4'
+      memory: standard
+      cpu: '2'
     script: |
       set -ex
       cd /io/repo/hail
@@ -797,8 +797,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: 12Gi
-      cpu: '4'
+      memory: standard
+      cpu: '2'
     script: |
       set -ex
       cd /io/repo/hail
@@ -858,8 +858,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: 12Gi
-      cpu: '4'
+      memory: standard
+      cpu: '2'
     script: |
       set -ex
       cd /io/repo/hail

--- a/build.yaml
+++ b/build.yaml
@@ -749,7 +749,7 @@ steps:
         to: /io/repo
     outputs:
       - from: /io/repo/hail/out
-      - to: /derived/release/hail/out
+        to: /derived/release/hail/out
       - from: /io/repo/hail/build/deploy/dist
         to: /derived/release/hail/build/deploy/dist
     dependsOn:

--- a/build.yaml
+++ b/build.yaml
@@ -770,14 +770,8 @@ steps:
       cd /io/repo/hail
       time retry sh millw --version
 
-      # We've encountered the following sporadic error in CI between `mill`
-      # finishing assembling the jar and `Make` copying the jar:
-      #
-      # cp -f out/assembly.dest/out.jar python/hail/backend/hail-all-spark.jar
-      # cp: cannot stat 'out/assembly.dest/out.jar': No such file or directory
-      #
-      # I suspect mill is exiting before the jar has finished being written.
-      time retry make jars
+      # See `build_hail_jar_and_wheel`
+      time retry make shadowJar
       if [ ! -f out/assembly.dest/out.jar ]; then
           echo 'no out.jar found after mill assembly returned. going to sleep'
           sleep 5
@@ -798,6 +792,39 @@ steps:
     dependsOn:
       - base_image
       - merge_code
+  - kind: runImage
+    name: build_debug_hail_test_jar
+    image:
+      valueFrom: base_image.image
+    resources:
+      memory: standard
+      cpu: '2'
+    script: |
+      set -ex
+      cd /io/repo/hail
+      time retry sh millw --version
+
+      # See `build_hail_jar_and_wheel`
+      time retry make shadowTestJar
+      if [ ! -f out/test/assembly.dest/out.jar ]; then
+          echo 'no out.jar found after mill assembly returned. going to sleep'
+          sleep 5
+      fi
+
+      # Remove transients from mill's build area
+      rm -rf out/mill-worker*
+    inputs:
+      - from: /repo
+        to: /io/repo
+      - from: /derived/debug/hail/out
+        to: /io/repo/hail/out
+    outputs:
+      - from: /io/repo/hail/out
+        to: /derived/debug/hail/out
+    dependsOn:
+      - base_image
+      - merge_code
+      - build_hail_debug_jar_and_wheel
   - kind: runImage
     name: build_hail_test_artifacts
     image:
@@ -994,7 +1021,7 @@ steps:
       - default_ns
       - hail_run_image
       - create_test_gsa_keys
-      - build_hail_debug_jar_and_wheel
+      - build_debug_hail_test_jar
       - build_hail_test_artifacts
   - kind: runImage
     name: test_hail_python
@@ -3603,7 +3630,7 @@ steps:
       - create_certs
       - create_accounts
       - hail_run_image
-      - build_hail_debug_jar_and_wheel
+      - build_debug_hail_test_jar
       - build_hail_test_artifacts
       - upload_test_resources_to_blob_storage
   - kind: runImage
@@ -3645,7 +3672,7 @@ steps:
       - create_certs
       - create_accounts
       - hail_run_image
-      - build_hail_debug_jar_and_wheel
+      - build_debug_hail_test_jar
       - build_hail_test_artifacts
       - deploy_batch
   - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -785,8 +785,6 @@ steps:
       - from: /repo
         to: /io/repo
     outputs:
-      - from: /io/repo/hail/out/test/assembly.dest/out.jar
-        to: /hail-debug-test.jar
       - from: /io/repo/hail/out
         to: /derived/debug/hail/out
       - from: /io/repo/hail/build/deploy/dist

--- a/build.yaml
+++ b/build.yaml
@@ -744,12 +744,15 @@ steps:
       WHEEL_PATH="build/deploy/dist/hail-$HAIL_PIP_VERSION-py3-none-any.whl"
       du -h $WHEEL_PATH
       $(python3 -c "import os; exit(1) if (os.path.getsize('$WHEEL_PATH')) > (200 * 1024 * 1024) else exit(0)")
+
+      # Remove transients from mill's build area
+      rm -rf out/mill-worker*
     inputs:
       - from: /repo
         to: /io/repo
     outputs:
       - from: /io/repo/hail/out
-        to: /derived/release/hail/out
+        to: /derived/release/hail/out/
       - from: /io/repo/hail/build/deploy/dist
         to: /derived/release/hail/build/deploy/dist
     dependsOn:
@@ -781,6 +784,9 @@ steps:
       fi
 
       time retry make wheel
+
+      # Remove transients from mill's build area
+      rm -rf out/mill-worker*
     inputs:
       - from: /repo
         to: /io/repo

--- a/build.yaml
+++ b/build.yaml
@@ -21,7 +21,7 @@ steps:
       mkdir -p repo
       cd repo
       {{ code.checkout_script }}
-      make -C hail python-version-info
+      make -C hail python-version-info HAIL_RELEASE_MODE=1
       git rev-parse HEAD > git_version
     outputs:
       - from: /io/repo/
@@ -723,24 +723,35 @@ steps:
       set -ex
       cd /io/repo/hail
       time retry sh millw --version
-      time retry make shadowJar wheel HAIL_RELEASE_MODE=1
+
+      # We've encountered the following sporadic error in CI between `mill`
+      # finishing assembling the jar and `Make` copying the jar:
+      #
+      # cp -f out/assembly.dest/out.jar python/hail/backend/hail-all-spark.jar
+      # cp: cannot stat 'out/assembly.dest/out.jar': No such file or directory
+      #
+      # I suspect mill is exiting before the jar has finished being written.
+      time retry make shadowJar HAIL_RELEASE_MODE=1
+      if [ ! -f out/assembly.dest/out.jar ]; then
+          echo 'no out.jar found after mill assembly returned. going to sleep'
+          sleep 5
+      fi
+
+      time retry make wheel HAIL_RELEASE_MODE=1
 
       # Check wheel size is small enough for pypi (< 200 MiB)
       HAIL_PIP_VERSION=$(cat python/hail/hail_pip_version)
       WHEEL_PATH="build/deploy/dist/hail-$HAIL_PIP_VERSION-py3-none-any.whl"
       du -h $WHEEL_PATH
       $(python3 -c "import os; exit(1) if (os.path.getsize('$WHEEL_PATH')) > (200 * 1024 * 1024) else exit(0)")
-
-      mkdir /io/wheel
-      mv build/deploy/dist/hail-*-py3-none-any.whl /io/wheel/
     inputs:
       - from: /repo
         to: /io/repo
     outputs:
-      - from: /io/repo/hail/out/assembly.dest/out.jar
-        to: /hail.jar
-      - from: /io/wheel
-        to: /wheel
+      - from: /io/repo/hail/out
+      - to: /derived/release/hail/out
+      - from: /io/repo/hail/build/deploy/dist
+        to: /derived/release/hail/build/deploy/dist
     dependsOn:
       - base_image
       - merge_code
@@ -755,17 +766,31 @@ steps:
       set -ex
       cd /io/repo/hail
       time retry sh millw --version
-      time retry make jars wheel
-      mkdir /io/debug-wheel
-      mv build/deploy/dist/hail-*-py3-none-any.whl /io/debug-wheel/
+
+      # We've encountered the following sporadic error in CI between `mill`
+      # finishing assembling the jar and `Make` copying the jar:
+      #
+      # cp -f out/assembly.dest/out.jar python/hail/backend/hail-all-spark.jar
+      # cp: cannot stat 'out/assembly.dest/out.jar': No such file or directory
+      #
+      # I suspect mill is exiting before the jar has finished being written.
+      time retry make jars
+      if [ ! -f out/assembly.dest/out.jar ]; then
+          echo 'no out.jar found after mill assembly returned. going to sleep'
+          sleep 5
+      fi
+
+      time retry make wheel
     inputs:
       - from: /repo
         to: /io/repo
     outputs:
       - from: /io/repo/hail/out/test/assembly.dest/out.jar
         to: /hail-debug-test.jar
-      - from: /io/debug-wheel
-        to: /debug-wheel
+      - from: /io/repo/hail/out
+        to: /derived/debug/hail/out
+      - from: /io/repo/hail/build/deploy/dist
+        to: /derived/debug/hail/build/deploy/dist
     dependsOn:
       - base_image
       - merge_code
@@ -779,8 +804,6 @@ steps:
     script: |
       set -ex
       cd /io/repo/hail
-      time retry sh millw --version
-      time retry make shadowTestJar
 
       time tar czf test.tar.gz -C python test
       time tar czf resources.tar.gz -C src/test resources
@@ -791,8 +814,6 @@ steps:
       - from: /repo
         to: /io/repo
     outputs:
-      - from: /io/repo/hail/out/test/assembly.dest/out.jar
-        to: /hail-test.jar
       - from: /io/repo/hail/test.tar.gz
         to: /test.tar.gz
       - from: /io/repo/hail/resources.tar.gz
@@ -953,7 +974,7 @@ steps:
     inputs:
       - from: /resources.tar.gz
         to: /io/resources.tar.gz
-      - from: /hail-debug-test.jar
+      - from: /derived/debug/hail/out/test/assembly.dest/out.jar
         to: /io/hail-test.jar
       - from: /splits.tar.gz
         to: /io/splits.tar.gz
@@ -1014,7 +1035,7 @@ steps:
               --timeout=120 \
               test
     inputs:
-      - from: /debug-wheel
+      - from: /derived/debug/hail/build/deploy/dist
         to: /io/debug-wheel
       - from: /test.tar.gz
         to: /io/test.tar.gz
@@ -1136,7 +1157,7 @@ steps:
               --timeout=120 \
               test
     inputs:
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
       - from: /test.tar.gz
         to: /io/test.tar.gz
@@ -1205,7 +1226,7 @@ steps:
               test
     timeout: 1800
     inputs:
-      - from: /debug-wheel
+      - from: /derived/debug/hail/build/deploy/dist
         to: /io/debug-wheel
       - from: /test.tar.gz
         to: /io/test.tar.gz
@@ -1267,7 +1288,7 @@ steps:
     inputs:
       - from: /repo/hail/python/hail/docs
         to: /io/docs
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
     dependsOn:
       - build_hail_jar_and_wheel
@@ -1314,7 +1335,7 @@ steps:
         to: /io/repo/hail/python/hail/hail_version
       - from: /repo/website/website
         to: /io/website/website
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
     outputs:
       - from: /io/www.tar.gz
@@ -1339,7 +1360,7 @@ steps:
         to: /io/repo/docker/hailgenetics/hail
       - from: /repo/hail/python/pinned-requirements.txt
         to: /io/repo/hail/python/pinned-requirements.txt
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/repo/wheel
     dependsOn:
       - merge_code
@@ -1361,7 +1382,7 @@ steps:
         to: /io/repo/docker/hailgenetics/hail
       - from: /repo/hail/python/pinned-requirements.txt
         to: /io/repo/hail/python/pinned-requirements.txt
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/repo/wheel
     dependsOn:
       - merge_code
@@ -1383,7 +1404,7 @@ steps:
         to: /io/repo/docker/hailgenetics/hail
       - from: /repo/hail/python/pinned-requirements.txt
         to: /io/repo/hail/python/pinned-requirements.txt
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/repo/wheel
     dependsOn:
       - merge_code
@@ -2390,7 +2411,7 @@ steps:
           valueFrom: default_ns.name
         mountPath: /batch-gsa-key
     inputs:
-      - from: /hail.jar
+      - from: /derived/release/hail/out/assembly.dest/out.jar
         to: /io/hail.jar
       - from: /git_version
         to: /io/git_version
@@ -2449,7 +2470,7 @@ steps:
               test
     timeout: 5400
     inputs:
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
       - from: /repo/hail/python/pytest.ini
         to: /io/repo/hail/python/pytest.ini
@@ -2523,7 +2544,7 @@ steps:
               test
     timeout: 5400
     inputs:
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
       - from: /repo/hail/python/pytest.ini
         to: /io/repo/hail/python/pytest.ini
@@ -2574,7 +2595,7 @@ steps:
               --durations=50 \
               /io/test_requester_pays_parsing.py
     inputs:
-      - from: /wheel
+      - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
       - from: /repo/hail/scripts/test_requester_pays_parsing.py
         to: /io/test_requester_pays_parsing.py
@@ -3235,11 +3256,14 @@ steps:
       - ci_utils_image
       - default_ns
       - merge_code
+      - build_hail_jar_and_wheel
     inputs:
       - from: /hail_pip_version
         to: /io/hail_pip_version
       - from: /repo
         to: /io/repo
+      - from: /derived/release/hail/out/
+        to: /io/repo/hail/out/
     secrets:
       - name: test-dataproc-service-account-key
         namespace:
@@ -3278,11 +3302,14 @@ steps:
       - ci_utils_image
       - default_ns
       - merge_code
+      - build_hail_jar_and_wheel
     inputs:
       - from: /hail_pip_version
         to: /io/hail_pip_version
       - from: /repo
         to: /io/repo
+      - from: /derived/release/hail/out
+        to: /io/repo/hail/out
     secrets:
       - name: test-dataproc-service-account-key
         namespace:
@@ -3326,8 +3353,7 @@ steps:
 
       # #14452 - must build wheel with release `hailtop/hailctl/deploy.yaml`
       # use `assume-old` to prevent `mill` from rebuilding the "SHADOW_JAR"
-      make upload-artifacts DEPLOY_REMOTE=origin \
-        --assume-old=out/assembly.dest/out.jar
+      HAIL_RELEASE_MODE=1 DEPLOY_REMOTE=origin make upload-artifacts
 
       echo Setting arguments and invoking release.sh.
 
@@ -3356,8 +3382,8 @@ steps:
         to: /io/git_version
       - from: /repo
         to: /io/repo
-      - from: /hail.jar
-        to: /io/repo/hail/out/assembly.dest/out.jar
+      - from: /derived/release/hail/out/
+        to: /io/repo/hail/out/
       - from: /azure-wheel
         to: /io/azure-wheel
       - from: /www.tar.gz
@@ -3558,7 +3584,7 @@ steps:
     inputs:
       - from: /resources.tar.gz
         to: /io/resources.tar.gz
-      - from: /hail-test.jar
+      - from: /derived/debug/hail/out/test/assembly.dest/out.jar
         to: /io/hail-test.jar
       - from: /repo/hail/testng-fs.xml
         to: /io/testng-fs.xml
@@ -3573,8 +3599,8 @@ steps:
       - create_certs
       - create_accounts
       - hail_run_image
+      - build_hail_debug_jar_and_wheel
       - build_hail_test_artifacts
-      - build_hail_jar_and_wheel
       - upload_test_resources_to_blob_storage
   - kind: runImage
     name: test_hail_services_java
@@ -3600,7 +3626,7 @@ steps:
     inputs:
       - from: /resources.tar.gz
         to: /io/resources.tar.gz
-      - from: /hail-test.jar
+      - from: /derived/debug/hail/out/test/assembly.dest/out.jar
         to: /io/hail-test.jar
       - from: /repo/hail/testng-services.xml
         to: /io/testng-services.xml
@@ -3615,6 +3641,7 @@ steps:
       - create_certs
       - create_accounts
       - hail_run_image
+      - build_hail_debug_jar_and_wheel
       - build_hail_test_artifacts
       - deploy_batch
   - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -717,8 +717,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: standard
-      cpu: '2'
+      memory: 12Gi
+      cpu: '4'
     script: |
       set -ex
       cd /io/repo/hail
@@ -763,8 +763,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: standard
-      cpu: '2'
+      memory: 12Gi
+      cpu: '4'
     script: |
       set -ex
       cd /io/repo/hail
@@ -797,8 +797,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: standard
-      cpu: '2'
+      memory: 12Gi
+      cpu: '4'
     script: |
       set -ex
       cd /io/repo/hail
@@ -829,9 +829,6 @@ steps:
     name: build_hail_test_artifacts
     image:
       valueFrom: base_image.image
-    resources:
-      memory: standard
-      cpu: '2'
     script: |
       set -ex
       cd /io/repo/hail
@@ -861,8 +858,8 @@ steps:
     image:
       valueFrom: base_image.image
     resources:
-      memory: standard
-      cpu: '2'
+      memory: 12Gi
+      cpu: '4'
     script: |
       set -ex
       cd /io/repo/hail

--- a/build.yaml
+++ b/build.yaml
@@ -3278,8 +3278,8 @@ steps:
       fi
 
       cd hail
-      time retry sh millw --version
-      make test-dataproc-37 DEV_CLARIFIER=ci_test_dataproc-37 HAIL_RELEASE_MODE=1
+      make test-dataproc-37 DEV_CLARIFIER=ci_test_dataproc-37 HAIL_RELEASE_MODE=1 \
+          -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
     dependsOn:
       - ci_utils_image
       - default_ns
@@ -3290,8 +3290,8 @@ steps:
         to: /io/hail_pip_version
       - from: /repo
         to: /io/repo
-      - from: /derived/release/hail/out/
-        to: /io/repo/hail/out/
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/repo/hail/build/deploy/dist
     secrets:
       - name: test-dataproc-service-account-key
         namespace:
@@ -3325,7 +3325,8 @@ steps:
 
       cd hail
       time retry sh millw --version
-      make test-dataproc-38 DEV_CLARIFIER=ci_test_dataproc-38 HAIL_RELEASE_MODE=1
+      make test-dataproc-38 DEV_CLARIFIER=ci_test_dataproc-38 HAIL_RELEASE_MODE=1 \
+          -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
     dependsOn:
       - ci_utils_image
       - default_ns
@@ -3336,8 +3337,8 @@ steps:
         to: /io/hail_pip_version
       - from: /repo
         to: /io/repo
-      - from: /derived/release/hail/out
-        to: /io/repo/hail/out
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/repo/hail/build/deploy/dist
     secrets:
       - name: test-dataproc-service-account-key
         namespace:
@@ -3380,8 +3381,9 @@ steps:
       fi
 
       # #14452 - must build wheel with release `hailtop/hailctl/deploy.yaml`
-      # use `assume-old` to prevent `mill` from rebuilding the "SHADOW_JAR"
-      HAIL_RELEASE_MODE=1 DEPLOY_REMOTE=origin make upload-artifacts
+      # use `-o` to prevent `mill` from rebuilding the "SHADOW_JAR"
+      make upload-artifacts HAIL_RELEASE_MODE=1 DEPLOY_REMOTE=origin \
+        -o out/assembly.dest/out.jar
 
       echo Setting arguments and invoking release.sh.
 
@@ -3410,8 +3412,8 @@ steps:
         to: /io/git_version
       - from: /repo
         to: /io/repo
-      - from: /derived/release/hail/out/
-        to: /io/repo/hail/out/
+      - from: /derived/release/hail/out/assembly.dest/out.jar
+        to: /io/repo/hail/out/assembly.dest/out.jar
       - from: /azure-wheel
         to: /io/azure-wheel
       - from: /www.tar.gz

--- a/build.yaml
+++ b/build.yaml
@@ -3324,7 +3324,6 @@ steps:
       fi
 
       cd hail
-      time retry sh millw --version
       make test-dataproc-38 DEV_CLARIFIER=ci_test_dataproc-38 HAIL_RELEASE_MODE=1 \
           -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
     dependsOn:

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -49,11 +49,12 @@ CLOUD_HAIL_DOCTEST_DATA_DIR = $(CLOUD_HAIL_TEST_RESOURCES_PREFIX)/doctest/data/
 
 # mill integration
 
-mill := bash millw
+MILL := bash millw
+MILLOPTS ?=
 
 .PHONY: mill-clean
 mill-clean:
-	$(mill) clean
+	$(MILL) $(MILLOPTS) clean
 
 # Any target depending on this will always be recomputed. We use this for any target that
 # runs mill, so that mill is always invoked and can decide if the target needs to be updated.
@@ -66,7 +67,7 @@ ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_JAR): native-lib-prebuilt
 endif
 $(SHADOW_JAR): FORCE
-	$(mill) assembly
+	$(MILL) $(MILLOPTS) assembly
 
 .PHONY: shadowJar
 shadowJar: $(SHADOW_JAR)
@@ -76,35 +77,35 @@ ifdef HAIL_COMPILE_NATIVES
 $(NON_SHADOW_JAR): native-lib-prebuilt
 endif
 $(NON_SHADOW_JAR): FORCE
-	$(mill) jar
+	$(MILL) $(MILLOPTS) jar
 
 SHADOW_TEST_JAR := out/test/assembly.dest/out.jar
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_TEST_JAR): native-lib-prebuilt
 endif
 $(SHADOW_TEST_JAR): FORCE
-	$(mill) test.assembly
+	$(MILL) $(MILLOPTS) test.assembly
 
 .PHONY: shadowTestJar
 shadowTestJar: $(SHADOW_TEST_JAR)
 
 EXTRA_CLASSPATH := out/writeRunClasspath.dest/runClasspath
 $(EXTRA_CLASSPATH): FORCE
-	$(mill) writeRunClasspath
+	$(MILL) $(MILLOPTS) writeRunClasspath
 
 .PHONY: jvm-test
 ifdef HAIL_COMPILE_NATIVES
 jvm-test: native-lib-prebuilt
 endif
 jvm-test:
-	$(mill) test testng.xml
+	$(MILL) $(MILLOPTS) test testng.xml
 
 .PHONY: services-jvm-test
 ifdef HAIL_COMPILE_NATIVES
 services-jvm-test: native-lib-prebuilt
 endif
 services-jvm-test:
-	$(mill) test testng-services.xml
+	$(MILL) $(MILLOPTS) test testng-services.xml
 
 .PHONY: fs-jvm-test
 ifdef HAIL_COMPILE_NATIVES
@@ -117,7 +118,7 @@ fs-jvm-test: upload-remote-test-resources
 	HAIL_DEFAULT_NAMESPACE=$(NAMESPACE) \
 	HAIL_FS_TEST_CLOUD_RESOURCES_URI=$(CLOUD_HAIL_TEST_RESOURCES_DIR)fs \
 	HAIL_TEST_STORAGE_URI=$(TEST_STORAGE_URI) \
-	$(mill) test testng-fs.xml
+	$(MILL) $(MILLOPTS) test testng-fs.xml
 
 # end mill integration
 


### PR DESCRIPTION
### Change Description

Jobs within our CI pipeline often invoke `mill` indirectly through `Makefile` prerequisites.
By staging mill's build area to and from `/derived/{release/debug}/hail/out`, mill will not rebuild artefacts from previous steps.
Exposing `MILLOPTS` in `hail/Makefile` allows us to build in CI without a compilation server. 
Using a compilation server may have been why we experienced intermittent failures between building the jar and copying to its final destination.
Note that the `--no-server` option must be the first argument to `millw`.

### Security Assessment
- [x] This change has no security impact

Description of the security impact and necessary mitigations:

Only derived files from the mill + python build process are staged and unstaged.
No secrets or otherwise sensitive information are contained therein.

(Reviewers: please confirm the security impact before approving)