### PR TITLE
[ci] remove unused inputs to `batch_worker_image`

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -894,8 +894,6 @@ steps:
         to: /io/repo/gear
       - from: /repo/web_common
         to: /io/repo/web_common
-      - from: /repo/letsencrypt/subdomains.txt
-        to: /repo/letsencrypt/subdomains.txt
       - from: /jvm-entryway.jar
         to: /io/repo/batch/jvm-entryway/build/libs/jvm-entryway.jar
       - from: /hail_version


### PR DESCRIPTION
### Change Description

The `letsencrypt` inputs to `batch_worker_image` are duplicated (though
the second time were localised to an unreachable location). 

### Security Assessment

- [x] This change has no security impact

Description of the security impact and necessary mitigations:

These files were unreachable from the ci job.

(Reviewers: please confirm the security impact before approving)