### PR TITLE
[vep] Use system package manager for perl libraries

### DIFF
--- a/docker/hailgenetics/vep/grch38/95/Dockerfile
+++ b/docker/hailgenetics/vep/grch38/95/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
 FROM $BASE_IMAGE
 
-ENV VEP_VERSION 95
-ENV VEP_DIR /vep
+ENV VEP_VERSION=95
+ENV VEP_DIR=/vep
 
 RUN apt-get update && apt-get -y install \
     build-essential \
@@ -26,15 +26,16 @@ RUN apt-get update && apt-get -y install \
     tabix \
     unzip \
     vim \
-    wget
-
-RUN cpanm DBI \
-    DBD::mysql \
-    DBD::SQLite \
-    Archive::Zip \
-    PerlIO::gzip \
-    Set::IntervalTree \
-    JSON || { for i in /root/.cpanm/work/*/build.log; do echo $i; cat $i; done }
+    wget \
+    libarchive-zip-perl \
+    libdbd-mysql-perl \
+    libdbd-sqlite3-perl \
+    libdbi-perl \
+    libipc-run-perl \
+    libjson-perl \
+    libperlio-gzip-perl \
+    libset-intervaltree-perl \
+    libxml-libxml-perl
 
 RUN mkdir ${VEP_DIR}
 WORKDIR ${VEP_DIR}
@@ -45,7 +46,7 @@ WORKDIR ${VEP_DIR}
 RUN git clone -b release/95.1 https://github.com/Ensembl/ensembl-vep.git && \
     cd ensembl-vep && \
     perl INSTALL.pl -a a --NO_UPDATE && \
-    echo "#!/bin/bash" > /vep/vep && \
+    echo '#!/bin/bash' > /vep/vep && \
     echo "export PERL5LIB=\$PERL5LIB:${VEP_DIR}/ensembl-vep/Plugins/" >> /vep/vep && \
     echo "exec perl ${VEP_DIR}/ensembl-vep/vep \"\$@\"" >> /vep/vep && \
     chmod +x /vep/vep && \


### PR DESCRIPTION
### Change Description

The changes in #14708 caused our vep images to be rebuilt, breaking them. The solution here is the one that we should have done from the beginning, install dependencies through the system package manager. In the interest of my sanity and effort, I only added the libraries that were being problematic from CPAN to the list of system installed ones.

### Security Assessment
- [x] This change has no security impact