### PR TITLE
[ci] test artefacts missing pytest.ini

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -831,7 +831,7 @@ steps:
       set -ex
       cd /io/repo/hail
 
-      time tar czf test.tar.gz -C python test
+      time tar czf test.tar.gz -C python test pytest.ini
       time tar czf resources.tar.gz -C src/test resources
       time tar czf data.tar.gz -C python/hail/docs data
       time TESTNG_SPLITS=5 python3 generate_splits.py

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -167,6 +167,7 @@ async def test_weird_urls(gs_filesystem):
     assert await fs.read(base + '???') == b'contents of ???'
 
 
+@pytest.mark.parametrize('gs_filesystem', ['gs'], indirect=True)
 async def test_rewrite(gs_filesystem):
     _, fs, base = gs_filesystem
 


### PR DESCRIPTION
### Change Description

In [09437c5](https://github.com/hail-is/hail/commit/09437c531b47c9af2faa196817c6edeaba17fced), I moved `pytest.ini` up a directory but didn't update the artefacts built in ci.
As a consequence, test stages like `test_unchecked_allocator` have not run since.

### Security Assessment

This change has no security impact
