### PR TITLE
Update Homebrew Java installation docs for OSX

### DIFF
--- a/hail/python/hail/docs/install/macosx.rst
+++ b/hail/python/hail/docs/install/macosx.rst
@@ -9,8 +9,7 @@ Install Hail on Mac OS X
 
   .. code-block::
 
-    brew tap homebrew/cask-versions
-    brew install --cask temurin8
+    brew install temurin@11
 
   You *must* pick a Java installation with a compatible architecture. If you have an Apple M1 or M2
   you must use an "arm64" Java, otherwise you must use an "x86_64" Java. You can check if you have


### PR DESCRIPTION
## Change Description

When going through the [documentation for installing Hail on OSX](https://hail.is/docs/0.2/install/macosx.html), I noticed that the syntax for installing Java via Homebrew was out of date.

This PR updates the documentation to use the latest syntax for Homebrew. It also updates the command to install version 11 of Temurin instead of version 8.

## Security Assessment

- This change has no security impact

### Impact Description

This change updates documentation only and has no immediate end user impact.

This change updates the recommended version of Temurin to a newer version (11 vs. 8). It is reasonable to assume that the newer version is at least as secure as previous versions. So, there also should be no negative security impact on future users of this documentation.
