### PR TITLE
[dev-docs] More detailed certificate rotation instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,10 @@ $(PRIVATE_REGISTRY_IMAGES): pushed-private-%-image: %-image
 	docker push $(DOCKER_PREFIX)/$(shell cat $*-image)
 	echo $(DOCKER_PREFIX)/$(shell cat $*-image) > $@
 
+.PHONY: clean-image-targets
+clean-image-targets:
+	rm -f *-image
+
 .PHONY: local-mysql
 local-mysql:
 	cd docker/mysql && docker compose up -d

--- a/dev-docs/services/letsencrypt.md
+++ b/dev-docs/services/letsencrypt.md
@@ -40,7 +40,7 @@ After setting the `kubectl` context to the appropriate cluster, clean the
 `letsencrypt-image` and `pushed-private-letsencrypt-image` files left by make.
 
 ```
-rm -f letsencrypt-image pushed-private-letsencrypt-image
+make clean-image-targets
 ```
 
 Update the `letsencrypt-config` secret:

--- a/dev-docs/services/letsencrypt.md
+++ b/dev-docs/services/letsencrypt.md
@@ -4,6 +4,45 @@ Hail uses Let's Encrypt certificates for the gateway pod.
 
 ## Refreshing Certificates
 
+Certificates must be updated once per cluster.
+
+### Setting the `kubectl` Context
+
+The hail project itself maintains two kubernetes clusters, one in GCP and one in
+Azure.
+
+If you have authenticated with `kubectl` to the appropriate cluster and `docker`
+for the corresponding container registry, then you should only need to set the
+current `kubectl` context by running:
+
+```
+kubectl config use-context <CONTEXT NAME>
+```
+
+The contexts can be listed with:
+```
+kubectl config get-contexts
+```
+
+If you are not authenticated, then you can run the following functions from
+[`devbin/functions.sh`](/devbin/functions.sh):
+
+```
+# for GCP
+gcpsetcluster <PROJECT>
+# for Azure
+azsetcluster <RESOURCE_GROUP>
+```
+
+### Rotating One Cluster's Certificates
+
+After setting the `kubectl` context to the appropriate cluster, clean the
+`letsencrypt-image` and `pushed-private-letsencrypt-image` files left by make.
+
+```
+rm -f letsencrypt-image pushed-private-letsencrypt-image
+```
+
 Update the `letsencrypt-config` secret:
 
 ```


### PR DESCRIPTION
## Change Description
Add section on authenticating to GKS+GAR and AKS+ACR and then setting the kubectl context to the appropriate cluster.

Note that the one should clean the letsencrypt image files created by make.

## Security Assessment

- This change has no security impact

### Impact Description

Only documentation changes.