### PR TITLE
[Dev processes] Fixup gsa-key copying instructions, add debug line to rotate_keys.py

### DIFF
--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -200,8 +200,8 @@ The service accounts used in developer namespaces do not have permission to crea
 to run real jobs on the developer namespaces' batch services:
 ```bash
 $ download-secret <username>-gsa-key
-$ mv secret.json key.json
-$ kubectl create secret generic <username>-gsa-key --namespace=<username> --from-file=key.json
+$ kubectl create secret generic <username>-gsa-key --namespace=<username> --from-file=contents/key.json
+$ cd - # Return to your original directory
 ```
 
 To submit jobs to your dev namespace, you need to configure your local hail

--- a/devbin/rotate_keys.py
+++ b/devbin/rotate_keys.py
@@ -56,6 +56,8 @@ class GSAKeySecret:
         return self.key_data['client_email']
 
     def private_key_id(self):
+        if not 'private_key_id' in self.key_data:
+            raise ValueError(f'No private_key_id field found for {self} in {self.key_data}.')
         return self.key_data['private_key_id']
 
     def matches_iam_key(self, k: 'IAMKey'):


### PR DESCRIPTION
## Change Description

Corrects our gsa-key copying instructions (from #14664) to copy the key contents, not the entire secret metadata.

The batch service seems resilient to these badly formed secrets, but the rotate_keys.py script was not.

## Security Assessment

Delete all except the correct answer:
- This change has a low security impact


### Impact Description

- Not a production change
- Does not add any new information to the secrets, only formats them a useable way. 
- Only in dev namespaces

(Reviewers: please confirm the security impact before approving)
