### PR TITLE
Improve documentation for Hail on Dataproc

### DIFF
--- a/hail/python/hail/docs/install/dataproc.rst
+++ b/hail/python/hail/docs/install/dataproc.rst
@@ -8,13 +8,14 @@ Requirements
 Before you can run Hail on Dataproc, you must have both Hail and the Google Cloud CLI installed on your machine.
 
 Installing Hail
-------
+---------------
+
 First, install Hail on your `Mac OS X <macosx.rst>`__ or `Linux <linux.rst>`__ laptop or
 desktop. The Hail pip package includes a tool called ``hailctl dataproc`` which starts, stops, and
 manipulates Hail-enabled Dataproc clusters.
 
 Installing and configuring the Google Cloud SDK
-------------
+-----------------------------------------------
 
 We recommend that you follow the `Google Cloud SDK documentation <https://cloud.google.com/sdk/docs/install>`__ to
 install the Google Cloud SDK.
@@ -34,7 +35,7 @@ If you'd like to set your Dataproc region globally, you can do so by running:
 Otherwise, you can set your Dataproc region using the `hailctl` `--region` command line flag.
 
 Starting your first Dataproc cluster
---------------
+------------------------------------
 
 Start a dataproc cluster named "my-first-cluster". Cluster names may only
 contain a mix lowercase letters and dashes. Starting a cluster can take as long

--- a/hail/python/hail/docs/install/dataproc.rst
+++ b/hail/python/hail/docs/install/dataproc.rst
@@ -5,7 +5,7 @@ Use Hail on Google Dataproc
 Requirements
 ------------
 
-Running Hail on Dataproc requires having both Hail and the Google Cloud CLI installed on your machine.
+Before you can run Hail on Dataproc, you must have both Hail and the Google Cloud CLI installed on your machine.
 
 Installing Hail
 ------

--- a/hail/python/hail/docs/install/dataproc.rst
+++ b/hail/python/hail/docs/install/dataproc.rst
@@ -2,9 +2,39 @@
 Use Hail on Google Dataproc
 ===========================
 
+Requirements
+------------
+
+Running Hail on Dataproc requires having both Hail and the Google Cloud CLI installed on your machine.
+
+Installing Hail
+------
 First, install Hail on your `Mac OS X <macosx.rst>`__ or `Linux <linux.rst>`__ laptop or
 desktop. The Hail pip package includes a tool called ``hailctl dataproc`` which starts, stops, and
 manipulates Hail-enabled Dataproc clusters.
+
+Installing and configuring the Google Cloud SDK
+------------
+
+We recommend that you follow the `Google Cloud SDK documentation <https://cloud.google.com/sdk/docs/install>`__ to
+install the Google Cloud SDK.
+
+You will need to configure your Google Cloud SDK after installation. This is the time to set up your Google Cloud project
+and billing, if you don't already have one.
+
+Running Hail on Dataproc requires passing in a Dataproc region.
+
+If you'd like to set your Dataproc region globally, you can do so by running:
+
+.. code-block:: sh
+
+    gcloud config set dataproc/region <your-region>
+
+
+Otherwise, you can set your Dataproc region using the `hailctl` `--region` command line flag.
+
+Starting your first Dataproc cluster
+--------------
 
 Start a dataproc cluster named "my-first-cluster". Cluster names may only
 contain a mix lowercase letters and dashes. Starting a cluster can take as long


### PR DESCRIPTION
## Change Description

This PR updates the tutorial instructions for running Hail on Dataproc to clarify that the Google Cloud SDK must be installed and configured before Hail can be run.

I made this change to prevent future users from also needing to Google these setup instructions.

## Security Assessment

- This change has no security impact

### Impact Description

This change only updates documentation and has no immediate end user impact.

The updated documentation does not leak any proprietary / confidential / sensitive information about Hail or any related systems.