### PR TITLE
Update Hail on AWS documentation

### DIFF
--- a/hail/python/hail/docs/cloud/amazon_web_services.rst
+++ b/hail/python/hail/docs/cloud/amazon_web_services.rst
@@ -2,8 +2,7 @@
 Amazon Web Services
 ===================
 
-While Hail does not have any built-in tools for working with `Amazon EMR
-<https://aws.amazon.com/emr/>`__, there are two approaches maintained by third parties:
+Hail does not have any built-in tools for working with `Amazon EMR
+<https://aws.amazon.com/emr/>`__.
 
-1. AWS maintains a `Hail on AWS quickstart <https://aws.amazon.com/quickstart/architecture/hail/>`__.
-2. The `Avillach Lab <https://avillach-lab.hms.harvard.edu/>`_ at Harvard Medical School maintains an `open-source tool <https://github.com/hms-dbmi/hail-on-AWS-spot-instances>`__.
+If you'd like to deploy Hail on AWS, we recommend that you try the `open-source Cloudformation tool <https://github.com/hms-dbmi/hail-on-AWS-spot-instances>`__ maintained by the `Avillach Lab <https://avillach-lab.hms.harvard.edu/>`_ at Harvard Medical School.


### PR DESCRIPTION
## Change Description

AWS no longer maintains the Hail on AWS quickstart.

This PR removes the reference to this now-broken documentation.

## Security Assessment

- This change has no security impact

### Impact Description

This PR removes broken documentation. There is no end user impact.
