### PR TITLE
[github] include granting iam roles for new developers in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-developer.yml
+++ b/.github/ISSUE_TEMPLATE/new-developer.yml
@@ -13,8 +13,10 @@ body:
         Hail username - <proposed hail username>
 
         Action items:
-        - Existing developer: Coordinate with appsec
-        - Existing developer: Create a new developer account - see [here](https://github.com/hail-is/hail/blob/main/dev-docs/services/creating-a-developer-account.md#creating-a-developer-account)
+        - Existing developer:
+          - Coordinate with appsec
+          - Create a new developer account - see [here](https://github.com/hail-is/hail/blob/main/dev-docs/services/creating-a-developer-account.md#creating-a-developer-account)
+          - Grant appropriate IAM roles to new developer on Hail Google Projects, Azure subscriptions, etc
         - New developer: Create a PR to add yourself as a new CI user (see [here](https://github.com/hail-is/hail/blob/main/ci/ci/constants.py))
           - Existing developers: review and approve PR
   - type: textarea


### PR DESCRIPTION
This change has no security impact as it modifies githib issue templates.
