### PR TITLE
[query] code cleanup

### DIFF
--- a/hail/python/hail/vds/functions.py
+++ b/hail/python/hail/vds/functions.py
@@ -89,11 +89,6 @@ def local_to_global(array, local_alleles, n_alleles, fill_value, number):
 
     if number == 'G':
         return _func("local_to_global_g", array.dtype, array, local_alleles, n_alleles, fill_value)
-    elif number == 'R':
-        omit_first = False
-    elif number == 'A':
-        omit_first = True
-    else:
-        raise ValueError(f'unrecognized number {number}')
 
-    return _func("local_to_global_a_r", array.dtype, array, local_alleles, n_alleles, fill_value, hl.bool(omit_first))
+    omit_first = hl.bool(number == 'A')
+    return _func("local_to_global_a_r", array.dtype, array, local_alleles, n_alleles, fill_value, omit_first)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -201,8 +201,8 @@ object CallFunctions extends RegistryFunctions {
       TCall,
       { case (_: Type, sc: SCall, _: SType) => sc },
     ) {
-      case (_, cb, _, call, localAlleles, errorID) =>
-        call.asCall.lgtToGT(cb, localAlleles.asIndexable, errorID)
+      case (_, cb, _, call: SCallValue, localAlleles: SIndexableValue, errorID) =>
+        call.lgtToGT(cb, localAlleles, errorID)
     }
 
     registerWrappedScalaFunction2(


### PR DESCRIPTION
Noticed these during other work.

- For `local_to_global`, we already check for number being `A`, `G`, or `R` in typecheck, and it's not good python style to have an else clause after a return. 
- For `lgt_to_gt`, the case type matching is cleaner than the explicit conversion methods.

## Security Assessment

- This change has no security impact

### Impact Description
Query only changes that have identical functionality to previous code
