### PR TITLE
[Dev processes] Replacing pyright with pyright[nodejs] in /dev/requirements.txt

### DIFF
--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -42,7 +42,7 @@ attrs==24.2.0
     #   aiohttp
 dictdiffer==0.9.0
     # via -r batch/requirements.txt
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c batch/../gear/pinned-requirements.txt
     #   -c batch/../hail/python/dev/pinned-requirements.txt
@@ -121,7 +121,7 @@ tzdata==2024.2
     # via
     #   -c batch/../hail/python/pinned-requirements.txt
     #   pandas
-yarl==1.14.0
+yarl==1.16.0
     # via
     #   -c batch/../gear/pinned-requirements.txt
     #   -c batch/../hail/python/dev/pinned-requirements.txt

--- a/ci/pinned-requirements.txt
+++ b/ci/pinned-requirements.txt
@@ -22,7 +22,7 @@ click==8.1.7
     #   -c ci/../hail/python/dev/pinned-requirements.txt
     #   -c ci/../hail/python/pinned-requirements.txt
     #   zulip
-cryptography==43.0.1
+cryptography==43.0.3
     # via
     #   -c ci/../hail/python/pinned-requirements.txt
     #   pyjwt

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -43,6 +43,16 @@ This creates git hooks that run certain linting checks, pyright on some sub-proj
 auto-formatting on changed files every commit. For example, services code uses the [Black python
 formatter](https://black.readthedocs.io/en/stable/) to enforce PEP8 compliance.
 
+Regarding pyright: this package requires node to work. While pip/conda installing pyright directly
+will automatically install node for you, doing so through the above `make` may not. If it doesn't,
+install node version 20 (a version which appears to be compatible with everything installed during the `make`)
+and add it to your path as follows:
+
+```bash
+brew install node@20
+echo 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"' >> ~/.zshrc
+```
+
 Sometimes large formatting or refactoring commits can muddle the git history
 for a file. If your change is one of these, follow up by adding the commit SHA to
 `.git-blame-ignore-revs`. To configure `git blame` to ignore these commits, run

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -43,16 +43,6 @@ This creates git hooks that run certain linting checks, pyright on some sub-proj
 auto-formatting on changed files every commit. For example, services code uses the [Black python
 formatter](https://black.readthedocs.io/en/stable/) to enforce PEP8 compliance.
 
-Regarding pyright: this package requires node to work. While pip/conda installing pyright directly
-will automatically install node for you, doing so through the above `make` may not. If it doesn't,
-install node version 20 (a version which appears to be compatible with everything installed during the `make`)
-and add it to your path as follows:
-
-```bash
-brew install node@20
-echo 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"' >> ~/.zshrc
-```
-
 Sometimes large formatting or refactoring commits can muddle the git history
 for a file. If your change is one of these, follow up by adding the commit SHA to
 `.git-blame-ignore-revs`. To configure `git blame` to ignore these commits, run

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -53,7 +53,7 @@ charset-normalizer==3.4.0
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
     #   requests
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c gear/../hail/python/dev/pinned-requirements.txt
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
@@ -113,7 +113,7 @@ propcache==0.2.0
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
     #   yarl
-proto-plus==1.24.0
+proto-plus==1.25.0
     # via google-api-core
 protobuf==3.20.2
     # via
@@ -138,7 +138,7 @@ pymysql==1.1.1
     # via
     #   -r gear/requirements.txt
     #   aiomysql
-pyparsing==3.1.4
+pyparsing==3.2.0
     # via
     #   -c gear/../hail/python/dev/pinned-requirements.txt
     #   httplib2
@@ -166,7 +166,7 @@ rsa==4.9
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
     #   google-auth
-setuptools==75.1.0
+setuptools==75.2.0
     # via
     #   -c gear/../hail/python/dev/pinned-requirements.txt
     #   kubernetes-asyncio
@@ -202,7 +202,7 @@ wrapt==1.16.0
     #   -c gear/../hail/python/dev/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
     #   prometheus-async
-yarl==1.14.0
+yarl==1.16.0
     # via
     #   -c gear/../hail/python/dev/pinned-requirements.txt
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -16,7 +16,7 @@ aiosignal==1.3.1
     #   aiohttp
 alabaster==0.7.16
     # via sphinx
-anyio==4.6.0
+anyio==4.6.2.post1
     # via
     #   httpx
     #   jupyter-server
@@ -130,7 +130,7 @@ fonttools==4.54.1
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   aiohttp
@@ -255,7 +255,7 @@ kiwisolver==1.4.7
     # via matplotlib
 lazy-object-proxy==1.10.0
     # via astroid
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   jinja2
@@ -301,6 +301,8 @@ nodeenv==1.9.1
     # via
     #   pre-commit
     #   pyright
+nodejs-wheel-binaries==20.18.0
+    # via pyright
 notebook==7.2.2
     # via jupyter
 notebook-shim==0.2.4
@@ -336,7 +338,7 @@ pathspec==0.12.1
     # via curlylint
 pexpect==4.9.0
     # via ipython
-pillow==10.4.0
+pillow==11.0.0
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   -r hail/python/dev/requirements.txt
@@ -360,7 +362,7 @@ propcache==0.2.0
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   yarl
-psutil==6.0.0
+psutil==6.1.0
     # via ipykernel
 ptyprocess==0.7.0
     # via
@@ -385,11 +387,11 @@ pygments==2.18.0
     #   sphinx
 pylint==2.17.7
     # via -r hail/python/dev/requirements.txt
-pyparsing==3.1.4
+pyparsing==3.2.0
     # via matplotlib
 pyproject-hooks==1.2.0
     # via build
-pyright==1.1.384
+pyright==1.1.386
     # via -r hail/python/dev/requirements.txt
 pytest==7.4.4
     # via
@@ -467,7 +469,7 @@ ruff==0.1.13
     # via -r hail/python/dev/requirements.txt
 send2trash==1.8.3
     # via jupyter-server
-setuptools==75.1.0
+setuptools==75.2.0
     # via jupyterlab
 six==1.16.0
     # via
@@ -518,7 +520,7 @@ terminado==0.18.1
     # via
     #   jupyter-server
     #   jupyter-server-terminals
-tinycss2==1.3.0
+tinycss2==1.4.0
     # via nbconvert
 toml==0.10.2
     # via curlylint
@@ -572,7 +574,7 @@ types-pyyaml==6.0.12.20240917
     # via -r hail/python/dev/requirements.txt
 types-requests==2.31.0.6
     # via -r hail/python/dev/requirements.txt
-types-setuptools==75.1.0.20240917
+types-setuptools==75.2.0.20241019
     # via -r hail/python/dev/requirements.txt
 types-six==1.16.21.20241009
     # via -r hail/python/dev/requirements.txt
@@ -600,7 +602,7 @@ urllib3==1.26.20
     #   requests
 uv==0.2.37
     # via -r hail/python/dev/requirements.txt
-virtualenv==20.26.6
+virtualenv==20.27.0
     # via pre-commit
 watchfiles==0.24.0
     # via aiohttp-devtools
@@ -620,7 +622,7 @@ wrapt==1.16.0
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   astroid
-yarl==1.14.0
+yarl==1.16.0
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   aiohttp

--- a/hail/python/dev/requirements.txt
+++ b/hail/python/dev/requirements.txt
@@ -18,7 +18,7 @@ pytest-asyncio>=0.14.0,<0.23
 pytest-timestamper>=0.0.9,<1
 pytest-timeout>=2.1,<3
 pytest-mock>=3.14,<4
-pyright>=1.1.349,<1.2
+pyright[nodejs]>=1.1.349,<1.2
 sphinx>=6,<7
 sphinx-autodoc-typehints==1.23.0
 nbsphinx>=0.8.8,<1

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -28,9 +28,9 @@ azure-mgmt-storage==20.1.0
     # via -r hail/python/hailtop/requirements.txt
 azure-storage-blob==12.23.1
     # via -r hail/python/hailtop/requirements.txt
-boto3==1.35.39
+boto3==1.35.48
     # via -r hail/python/hailtop/requirements.txt
-botocore==1.35.39
+botocore==1.35.48
     # via
     #   -r hail/python/hailtop/requirements.txt
     #   boto3
@@ -51,7 +51,7 @@ click==8.1.7
     # via typer
 commonmark==0.9.1
     # via rich
-cryptography==43.0.1
+cryptography==43.0.3
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -59,7 +59,7 @@ cryptography==43.0.1
     #   pyjwt
 dill==0.3.9
     # via -r hail/python/hailtop/requirements.txt
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
@@ -104,7 +104,7 @@ nest-asyncio==1.6.0
     # via -r hail/python/hailtop/requirements.txt
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.10.7
+orjson==3.10.10
     # via -r hail/python/hailtop/requirements.txt
 portalocker==2.10.1
     # via msal-extensions
@@ -173,7 +173,7 @@ urllib3==1.26.20
     # via
     #   botocore
     #   requests
-uvloop==0.20.0
+uvloop==0.21.0
     # via -r hail/python/hailtop/requirements.txt
-yarl==1.14.0
+yarl==1.16.0
     # via aiohttp

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -55,11 +55,11 @@ azure-storage-blob==12.23.1
     #   -r hail/python/hailtop/requirements.txt
 bokeh==3.4.3
     # via -r hail/python/requirements.txt
-boto3==1.35.39
+boto3==1.35.48
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-botocore==1.35.39
+botocore==1.35.48
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -93,7 +93,7 @@ commonmark==0.9.1
     #   rich
 contourpy==1.3.0
     # via bokeh
-cryptography==43.0.1
+cryptography==43.0.3
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
@@ -108,7 +108,7 @@ dill==0.3.9
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -152,7 +152,7 @@ jproperties==2.1.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via jinja2
 msal==1.31.0
     # via
@@ -187,7 +187,7 @@ oauthlib==3.2.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   requests-oauthlib
-orjson==3.10.7
+orjson==3.10.10
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -201,7 +201,7 @@ pandas==2.2.3
     #   bokeh
 parsimonious==0.10.0
     # via -r hail/python/requirements.txt
-pillow==10.4.0
+pillow==11.0.0
     # via bokeh
 plotly==5.24.1
     # via -r hail/python/requirements.txt
@@ -334,7 +334,7 @@ urllib3==1.26.20
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   botocore
     #   requests
-uvloop==0.20.0
+uvloop==0.21.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -342,7 +342,7 @@ wrapt==1.16.0
     # via deprecated
 xyzservices==2024.9.0
     # via bokeh
-yarl==1.14.0
+yarl==1.16.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   aiohttp

--- a/web_common/pinned-requirements.txt
+++ b/web_common/pinned-requirements.txt
@@ -32,7 +32,7 @@ attrs==24.2.0
     #   -c web_common/../hail/python/dev/pinned-requirements.txt
     #   -c web_common/../hail/python/pinned-requirements.txt
     #   aiohttp
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c web_common/../gear/pinned-requirements.txt
     #   -c web_common/../hail/python/dev/pinned-requirements.txt
@@ -53,7 +53,7 @@ jinja2==3.1.4
     #   aiohttp-jinja2
 libsass==0.23.0
     # via -r web_common/requirements.txt
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via
     #   -c web_common/../hail/python/dev/pinned-requirements.txt
     #   -c web_common/../hail/python/pinned-requirements.txt
@@ -77,7 +77,7 @@ typing-extensions==4.12.2
     #   -c web_common/../hail/python/dev/pinned-requirements.txt
     #   -c web_common/../hail/python/pinned-requirements.txt
     #   multidict
-yarl==1.14.0
+yarl==1.16.0
     # via
     #   -c web_common/../gear/pinned-requirements.txt
     #   -c web_common/../hail/python/dev/pinned-requirements.txt


### PR DESCRIPTION
## Change Description

Replacing pyright with pyright[nodejs] in /dev/requirements.txt, allowing for installation of necessary node.js binaries to run pyright when one installs dev requirements.

As per https://pypi.org/project/pyright/, pyright needs node to run, but pip installing pyright doesn't also install node. Pyright acknowledges this, and they have a separate pip installation command that will also give you the necessary node binaries to run pyright. We now specify that proper pyright+node install in our requirements.txt.

## Security Assessment

Delete all except the correct answer:
- This change has a low security impact
  - [ ] Required: The impact has been assessed and approved by appsec

### Impact Description

Updating old pyright installation in /dev/requirements.txt, no impact on security-sensitive systems.

(Reviewers: please confirm the security impact before approving)
