### PR TITLE
[query] Update ExportVCF error messages

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -1022,9 +1022,9 @@ case class VCFPartitionWriter(
         cb.if_(ploidy.ceq(0), cb._fatal("VCF does not support 0-ploid calls."))
         cb.if_(
           ploidy.ceq(1) && v.isPhased(cb),
-          // FIXME: VCFv4.4 released Jan. 2023, supports phased haploid calls, when support is better
-          //        and we update the version of vcf that we output to 4.5 to account for SVCR additions,
-          //        we'll want to change this
+          /* FIXME: VCFv4.4 released Jan. 2023, supports phased haploid calls, when support is
+           * better and we update the version of vcf that we output to 4.5 to account for SVCR
+           * additions, we'll want to change this */
           cb._fatal("VCFv4.2 does not support phased haploid calls."),
         )
         val c = v.canonicalCall(cb)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -1022,7 +1022,10 @@ case class VCFPartitionWriter(
         cb.if_(ploidy.ceq(0), cb._fatal("VCF does not support 0-ploid calls."))
         cb.if_(
           ploidy.ceq(1) && v.isPhased(cb),
-          cb._fatal("VCFv4.2 does not support phased haploid calls."), // FIXME(chrisvittal): it does as of VCFv4.4 released Jan. 2023, but we
+          // FIXME: VCFv4.4 released Jan. 2023, supports phased haploid calls, when support is better
+          //        and we update the version of vcf that we output to 4.5 to account for SVCR additions,
+          //        we'll want to change this
+          cb._fatal("VCFv4.2 does not support phased haploid calls."),
         )
         val c = v.canonicalCall(cb)
         _writeB(cb, Code.invokeScalaObject1[Int, Array[Byte]](Call.getClass, "toUTF8", c))

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -1019,10 +1019,10 @@ case class VCFPartitionWriter(
         _writeB(cb, v.toBytes(cb).loadBytes(cb))
       case v: SCallValue =>
         val ploidy = v.ploidy(cb)
-        cb.if_(ploidy.ceq(0), cb._fatal("VCF spec does not support 0-ploid calls."))
+        cb.if_(ploidy.ceq(0), cb._fatal("VCF does not support 0-ploid calls."))
         cb.if_(
           ploidy.ceq(1) && v.isPhased(cb),
-          cb._fatal("VCF spec does not support phased haploid calls."),
+          cb._fatal("VCFv4.2 does not support phased haploid calls."), // FIXME(chrisvittal): it does as of VCFv4.4 released Jan. 2023, but we
         )
         val c = v.canonicalCall(cb)
         _writeB(cb, Code.invokeScalaObject1[Int, Array[Byte]](Call.getClass, "toUTF8", c))


### PR DESCRIPTION
It is no longer the case that VCF does not support phased haploid calls. Make a note of this in the code.

## Security Assessment
- This change has no security impact

### Impact Description
Change error messages only.