### PR TITLE
[query] Clarify import_vcf docs

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2986,8 +2986,8 @@ def import_vcf(
     Parameters
     ----------
     path : :class:`str` or :obj:`list` of :obj:`str`
-        One or more paths to VCF files to read. Each path may or may not include glob expressions
-        like ``*``, ``?``, or ``[abc123]``.
+        One or more paths to VCF files to read. Each path may include glob expressions like ``*``,
+        ``?``, or ``[abc123]``, which, if present, will be expanded.
     force : :obj:`bool`
         If ``True``, load **.vcf.gz** files serially. No downstream operations
         can be parallelized, so this mode is strongly discouraged.


### PR DESCRIPTION
'may or may not' is redundant phrasing. The word 'may' is sufficient to indicate the optional nature of glob expressions in the `path` argument to `import_vcf`

## Security Assessment
- This change has no security impact

### Impact Description
Docs only