### PR TITLE
[QoB] Set StreamReadConstraints maxStringLength as early as possible

### DIFF
--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -1,4 +1,5 @@
 import functools
+import random
 import re
 import unittest
 from test.hail.helpers import resource, skip_unless_spark_backend, skip_when_service_backend
@@ -774,3 +775,12 @@ def test_locus_interval_encoding():
     _assert_encoding_roundtrip(start)
     _assert_encoding_roundtrip(end)
     _assert_encoding_roundtrip(interval)
+
+
+def test_very_large_ir_deserializes():
+    # see: https://github.com/hail-is/hail/issues/14580
+    #      https://github.com/hail-is/hail/issues/14650
+    large_list = [random.getrandbits(63) for _ in range(5_000_000)]
+    large_lit = hl.literal(large_list, hl.tarray(hl.tint64))
+    round_trip = hl.eval(large_lit)
+    assert large_list == round_trip

--- a/hail/src/main/scala/is/hail/backend/service/Main.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Main.scala
@@ -1,13 +1,26 @@
 package is.hail.backend.service
 
+import com.fasterxml.jackson.core.StreamReadConstraints
+
 object Main {
   val WORKER = "worker"
   val DRIVER = "driver"
 
-  def main(argv: Array[String]): Unit =
+  /* This constraint should be overridden as early as possible. See:
+   * - https://github.com/hail-is/hail/issues/14580
+   * - https://github.com/hail-is/hail/issues/14749
+   * - The note on this setting in is.hail.backend.Backend
+   */
+  StreamReadConstraints.overrideDefaultStreamReadConstraints(
+    StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
+  )
+
+  def main(argv: Array[String]): Unit = {
+
     argv(3) match {
       case WORKER => Worker.main(argv)
       case DRIVER => ServiceBackendAPI.main(argv)
       case kind => throw new RuntimeException(s"unknown kind: $kind")
     }
+  }
 }

--- a/hail/src/main/scala/is/hail/backend/service/Main.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Main.scala
@@ -9,18 +9,15 @@ object Main {
   /* This constraint should be overridden as early as possible. See:
    * - https://github.com/hail-is/hail/issues/14580
    * - https://github.com/hail-is/hail/issues/14749
-   * - The note on this setting in is.hail.backend.Backend
-   */
+   * - The note on this setting in is.hail.backend.Backend */
   StreamReadConstraints.overrideDefaultStreamReadConstraints(
     StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
   )
 
-  def main(argv: Array[String]): Unit = {
-
+  def main(argv: Array[String]): Unit =
     argv(3) match {
       case WORKER => Worker.main(argv)
       case DRIVER => ServiceBackendAPI.main(argv)
       case kind => throw new RuntimeException(s"unknown kind: $kind")
     }
-  }
 }


### PR DESCRIPTION
resolves #14749

Leave the override in Backend as well to avoid duplication. Future enhancements may enable us to construct a ServiceBackend from argv alone, allowing this to be reverted.

## Security Assessment

Delete all except the correct answer:
- This change has no security impact

### Impact Description
This change restores known good functionality.
