### PR TITLE
[query] Improve error handling and job tracking in ServiceBackend

### DIFF
--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -98,6 +98,14 @@ object Worker {
     out.write(bytes)
   }
 
+  def writeException(out: DataOutputStream, e: Throwable): Unit = {
+    val (shortMessage, expandedMessage, errorId) = handleForPython(e)
+    out.writeBoolean(false)
+    writeString(out, shortMessage)
+    writeString(out, expandedMessage)
+    out.writeInt(errorId)
+  }
+
   def main(argv: Array[String]): Unit = {
     val theHailClassLoader = new HailClassLoader(getClass().getClassLoader())
 
@@ -219,12 +227,7 @@ object Worker {
             dos.writeBoolean(true)
             dos.write(bytes)
           case Left(throwableWhileExecutingUserCode) =>
-            val (shortMessage, expandedMessage, errorId) =
-              handleForPython(throwableWhileExecutingUserCode)
-            dos.writeBoolean(false)
-            writeString(dos, shortMessage)
-            writeString(dos, expandedMessage)
-            dos.writeInt(errorId)
+            writeException(dos, throwableWhileExecutingUserCode)
         }
       }
     }

--- a/hail/hail/src/is/hail/utils/ErrorHandling.scala
+++ b/hail/hail/src/is/hail/utils/ErrorHandling.scala
@@ -8,7 +8,7 @@ class HailException(val msg: String, val logMsg: Option[String], cause: Throwabl
   def this(msg: String, errorId: Int) = this(msg, None, null, errorId)
 }
 
-class HailWorkerException(
+case class HailWorkerException(
   val partitionId: Int,
   val shortMessage: String,
   val expandedMessage: String,


### PR DESCRIPTION
## Change Description
-  Added ability to check job status in individual jobs in a JobGroup
- Cancel JobGroup if any jobs in the partition fail
- Added test functionality for detecting cancelled, failed jobs
- Query batch for which jobs have failed within a JobGroup, rather than go through every job in the group.

## Security Assessment

Delete all except the correct answer:
- This change has no security impact

### Impact Description
Mainly just code for testing, nothing security related

(Reviewers: please confirm the security impact before approving)
