### PR TITLE
[batch] Handle duplicate resource names when refreshing prices

### DIFF
--- a/batch/batch/driver/billing_manager.py
+++ b/batch/batch/driver/billing_manager.py
@@ -98,7 +98,9 @@ class CloudBillingManager(abc.ABC):
                 resource_name = product_version_to_resource(product, latest_product_version)
                 rate = resource_updates.setdefault(resource_name, latest_resource_rate)
                 if rate != latest_resource_rate:
-                    raise ValueError(f'product {product} is duplicated with differing rates ({rate}) vs ({latest_resource_rate})')
+                    raise ValueError(
+                        f'product {product} is duplicated with differing rates ({rate}) vs ({latest_resource_rate})'
+                    )
                 product_version_updates.append((product, latest_product_version, latest_sku))
                 log.info(
                     f'adding new resource {resource_name} {latest_product_version} with rate change of {latest_resource_rate} and sku {latest_sku}'
@@ -136,7 +138,9 @@ class CloudBillingManager(abc.ABC):
                         latest_resource_name = product_version_to_resource(product, latest_product_version)
                         rate = resource_updates.setdefault(latest_resource_name, latest_resource_rate)
                         if rate != latest_resource_rate:
-                            raise ValueError(f'product {product} is duplicated with differing rates ({rate}) vs ({latest_resource_rate})')
+                            raise ValueError(
+                                f'product {product} is duplicated with differing rates ({rate}) vs ({latest_resource_rate})'
+                            )
                         product_version_updates.append((product, latest_product_version, latest_sku))
                         log.info(
                             f'product {product} changed from {current_product_version} to {latest_product_version} with rate change of '


### PR DESCRIPTION
It appears that GCP has introduced products with identical names and versions, so inserting into the resources table is failing with primary key uniqueness errors. This is not a good solution, but at current, this issue is blocking development and any solution must be implemented. If the `resource_name` is duplicated and the prices are the same for both resources, then we're fine. Otherwise, this change will throw an error. Thus, if resource names ever diverge in price while having the same name, we'll need to find a more robust solution.

## Security Assessment

Delete all except the correct answer:
- This change has low security impact

### Impact Description
Unexpected alterations of products by cloud providers may cause loss of service if it crashes due to these errors.