### PR TITLE
[batch] Check that batch jobs is nonempty in Previous Page button

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -121,7 +121,7 @@ batch_state_indicator, job_state_indicator, danger_button, submit_button, link
     </div>
 
     <div class='pt-2 flex w-full justify-end'>
-      {% if batch['jobs'][0]['job_id'] is not none and batch['jobs'][0]['job_id'] > 1 %}
+      {% if batch['jobs'] and batch['jobs'][0]['job_id'] is not none and batch['jobs'][0]['job_id'] > 1 %}
         <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
           {% if q is not none %}
           <input type="hidden" name="q" value="{{ q }}" />


### PR DESCRIPTION
From @jmarshall on [zulip].

[zulip]: https://hail.zulipchat.com/#narrow/channel/223457-Hail-Batch-support/topic/Batch.20UI.20Previous.20Page.20button.20causing.20500.20Server.20Errors/near/481042141

## Security Assessment

Delete all except the correct answer:
- This change has no security impact

### Impact Description
Tiny change in logic in a template that doesn't add any new information to view/exploit.