### PR TITLE
[Batch Driver] Stop importing reserved resource prices

### DIFF
--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -313,6 +313,8 @@ def process_local_ssd_sku(sku: dict, regions: List[str]) -> List[GCPLocalSSDDisk
 
     if sku['skuId'] is 'E725-3CC5-D4BE' or sku['skuId'] is '3C20-2B95-CA0D':
         print(f'sku {sku["skuId"]}: {sku}')
+    else:
+        print(f'Not logging extra details for sku {sku["skuId"]}')
 
     category = sku['category']
     assert category['resourceFamily'] == 'Storage', sku

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -310,6 +310,10 @@ def process_memory_sku(sku: dict, regions: List[str]) -> List[GCPMemoryPrice]:
 
 
 def process_local_ssd_sku(sku: dict, regions: List[str]) -> List[GCPLocalSSDDiskPrice]:
+
+    if sku['skuId'] is 'E725-3CC5-D4BE' or sku['skuId'] is '3C20-2B95-CA0D':
+        print(f'sku {sku["skuId"]}: {sku}')
+
     category = sku['category']
     assert category['resourceFamily'] == 'Storage', sku
     assert category['resourceGroup'] == 'LocalSSD', sku

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -311,7 +311,7 @@ def process_memory_sku(sku: dict, regions: List[str]) -> List[GCPMemoryPrice]:
 
 def process_local_ssd_sku(sku: dict, regions: List[str]) -> List[GCPLocalSSDDiskPrice]:
 
-    if sku['skuId'] == 'E725-3CC5-D4BE' or sku['skuId'] == '3C20-2B95-CA0D':
+    if sku['skuId'] == '6F51-46EA-FD60' or sku['skuId'] == '3C20-2B95-CA0D':
         print(f'sku {sku["skuId"]}: {sku}')
     else:
         print(f'Not logging extra details for sku {sku["skuId"]}')

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -125,7 +125,7 @@ class GCPLocalSSDDiskPrice(Price):
 
     @property
     def product(self):
-        return GCPLocalSSDStaticSizedDiskResource.product_name(self.preemptible, self.region)
+        return f'{self.sku}:{GCPLocalSSDStaticSizedDiskResource.product_name(self.preemptible, self.region)}'
 
     @property
     def rate(self):

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -311,7 +311,7 @@ def process_memory_sku(sku: dict, regions: List[str]) -> List[GCPMemoryPrice]:
 
 def process_local_ssd_sku(sku: dict, regions: List[str]) -> List[GCPLocalSSDDiskPrice]:
 
-    if sku['skuId'] is 'E725-3CC5-D4BE' or sku['skuId'] is '3C20-2B95-CA0D':
+    if sku['skuId'] == 'E725-3CC5-D4BE' or sku['skuId'] == '3C20-2B95-CA0D':
         print(f'sku {sku["skuId"]}: {sku}')
     else:
         print(f'Not logging extra details for sku {sku["skuId"]}')

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -125,7 +125,7 @@ class GCPLocalSSDDiskPrice(Price):
 
     @property
     def product(self):
-        return f'{self.sku}:{GCPLocalSSDStaticSizedDiskResource.product_name(self.preemptible, self.region)}'
+        return GCPLocalSSDStaticSizedDiskResource.product_name(self.preemptible, self.region)
 
     @property
     def rate(self):
@@ -310,12 +310,6 @@ def process_memory_sku(sku: dict, regions: List[str]) -> List[GCPMemoryPrice]:
 
 
 def process_local_ssd_sku(sku: dict, regions: List[str]) -> List[GCPLocalSSDDiskPrice]:
-
-    if sku['skuId'] == '6F51-46EA-FD60' or sku['skuId'] == '3C20-2B95-CA0D':
-        print(f'sku {sku["skuId"]}: {sku}')
-    else:
-        print(f'Not logging extra details for sku {sku["skuId"]}')
-
     category = sku['category']
     assert category['resourceFamily'] == 'Storage', sku
     assert category['resourceGroup'] == 'LocalSSD', sku


### PR DESCRIPTION
## Change Description

Stop importing prices for reserved resources. They cause clashes with our database primary keys and can never be part of user billing. (By definition, we can't be running jobs on reservations of future resources)

## Security Assessment

Delete all except the correct answer:
- This change has a low security impact

### Impact Description

We are doing a simple string match and then choosing not to import something that we otherwise might have into our database. 

(Reviewers: please confirm the security impact before approving)
