### PR TITLE
[query] Exclude `benchmark/` from hail wheel

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -266,10 +266,10 @@ copy-py-files: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS) $(PY_FILES) $(PYTHON_JAR)
 	cp ../README.md build/deploy/
 	rsync -r \
 	    --exclude '.eggs/' \
+	    --exclude '.mypy_cache/' \
 	    --exclude '.pytest_cache/' \
 	    --exclude '__pycache__/' \
-	    --exclude 'benchmark_hail/' \
-	    --exclude '.mypy_cache/' \
+	    --exclude 'benchmark/' \
 	    --exclude 'docs/' \
 	    --exclude 'dist/' \
 	    --exclude 'test/' \


### PR DESCRIPTION
## Change Description
This change prevents packaging benchmark code in the hail wheel by updating the rsync exclude patterns in `hail/Makefile` to exclude `benchmark/`.

## Security Assessment

This change has no security impact

### Impact Description

Low-level build configuration change that only affects which directories are excluded during file copying operations.