### PR TITLE
ApproxCDF bugfix

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -4220,10 +4220,10 @@ def cdf_max_observed_error(cdf):
     return rank_error / cdf.ranks[-1]
 
 
-@pytest.fixture(scope='module', params=[0, 1])
+@pytest.fixture(scope='module', params=(True, False))
 def cdf_test_data(request):
     with hl.TemporaryDirectory(ensure_exists=False) as f:
-        if request.param == 0:
+        if request.param:
             t = hl.utils.range_table(1_000_000)
             t = t.annotate(x=hl.rand_int64())
             t.key_by(t.x).write(f, overwrite=True)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -4220,16 +4220,20 @@ def cdf_max_observed_error(cdf):
     return rank_error / cdf.ranks[-1]
 
 
-@pytest.fixture(scope='module')
-def cdf_test_data():
+@pytest.fixture(scope='module', params=[0, 1])
+def cdf_test_data(request):
     with hl.TemporaryDirectory(ensure_exists=False) as f:
-        t = hl.utils.range_table(1_000_000)
-        t = t.annotate(x=hl.rand_int64())
-        t.key_by(t.x).write(f, overwrite=True)
-        t = hl.read_table(f)
-        print('generating')
-        yield t
-        print('deleting')
+        if request.param == 0:
+            t = hl.utils.range_table(1_000_000)
+            t = t.annotate(x=hl.rand_int64())
+            t.key_by(t.x).write(f, overwrite=True)
+            t = hl.read_table(f)
+            yield t
+        else:
+            t = hl.utils.range_table(100)
+            t = t.annotate(x=hl.rand_int64())
+            t.key_by(t.x)
+            yield t
 
 
 def test_approx_cdf_accuracy(cdf_test_data):


### PR DESCRIPTION
## Change Description

Fixes a bug which was reported in https://discuss.hail.is/t/arrayindexoutofboundsexception-using-cdf-combine/4008/6.

The bug was caused by an unenforced invariant in the ApproxCDF aggregator state. Roughly, the state consists of a number of "levels" (stored flattened into a single array), where each level contains a number of samples from the data. There is also a notion of the "capacity" of each level. The data structure assumes that whenever the array containing the flattened levels becomes full, there must be at least one level which is above capacity, and can therefore be compacted to free space. In other words, the size of the array must be at least the sum of the capacities of the present levels.

In #13935, we changed the ApproxCDF aggregator to return the raw internal state, and moved the computation of the cdf from the internal state to python. The problem is that we "compress" the states before returning them as hail values by reducing the size of the array of samples to only the number of present samples. But then, when the exposed "combine" function recreates ApproxCDF aggregator states from the returned values, the array of samples is no longer large enough to satisfy the invariant.

In this PR, I
* add a test case in python which fails in main, by running approx_cdf over a very small dataset
* fix `ApproxCDFStateManager.fromData` to "uncompress" the aggregator state
* add a check for the violated invariant in the `ApproxCDFStateManager` constructor. (This isn't a perfect check, as the underlying state can be changed after construction, but I didn't see a way to make a more complete check without significant refactoring, and this would have caught the current bug.)

## Security Assessment

- This change has no security impact

### Impact Description

Low-level refactoring of non-security code
