### PR TITLE
[query] Run benchmarks after wheel is published to PyPI

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3734,13 +3734,6 @@ steps:
     dependsOn:
       - default_ns
       - hail_dev_image
-      - test_hail_java
-      - test_hail_python_local_backend
-      - test_hail_python_service_backend_gcp
-      - test_hail_python_service_backend_azure
-      - test_hail_scala_fs
-      - test_hail_services_java
-      - test_hail_spark_conf_requester_pays_parsing
       - release
     image:
       valueFrom: hail_dev_image.image


### PR DESCRIPTION
We publish release artifacts independently of tests passing in the release pipeline. Flaky tests were causing the benchmarks to not run. This change takes the pragmatic view that if publishing does not depend on tests, then neither should starting the benchmark batch.

## Security Assessment
- This change has no security impact