### PR TITLE
Allow os.PathLike paths for Batch.write_output()

### DIFF
--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -145,4 +145,5 @@ __all__ = [
     'rich_progress_bar',
     'time_ns',
     'am_i_interactive',
+    'path_str',
 ]

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -46,6 +46,7 @@ from .utils import (
     is_transient_error,
     parse_docker_image_reference,
     partition,
+    path_str,
     periodically_call,
     periodically_call_with_dynamic_sleep,
     retry_all_errors,

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1038,6 +1038,17 @@ def url_and_params(url: str) -> Tuple[str, Dict[str, str]]:
     return without_query, params
 
 
+def path_str(path: Union[str, os.PathLike]) -> str:
+    """Given a path/url as a string or PathLike, returns it as a string."""
+    if isinstance(path, str):
+        return path
+    elif isinstance(path, os.PathLike):
+        # Avoid os.fspath(), which causes some pathlikes to return a path to a downloaded copy instead.
+        return str(path)
+    else:
+        raise ValueError(f'path value is neither string nor path-like. Found {type(path)!r} instead.')
+
+
 RegistryProvider = Literal['google', 'azure', 'dockerhub']
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -20,7 +20,7 @@ ignore-paths=^.*.sql$,^.*hail/python/cluster-tests/.*$,^.*hail/python/dev/.*$,^.
 # Reasons for disabling:
 # no-value-for-parameter -- See bug in pylint https://github.com/pylint-dev/pylint/issues/259 and this is covered by mypy
 
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,unnecessary-lambda-assignment,too-many-public-methods,broad-except,too-many-return-statements,bare-except,invalid-name,unsubscriptable-object,consider-using-f-string,try-except-raise,no-value-for-parameter
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,unnecessary-lambda-assignment,too-many-public-methods,broad-except,too-many-return-statements,bare-except,invalid-name,unsubscriptable-object,consider-using-f-string,try-except-raise,no-value-for-parameter,no-else-return
 
 [FORMAT]
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1


### PR DESCRIPTION
Extends PR #14544 which did this for read_input()/read_input_group().
Refactor type coercion previously added to _new_input_resource_file()
into a new hailtop.utils.path_str() utility routine, and also invoke
it from Batch.write_output().

## Security Assessment

Delete all except the correct answer:
- This change has low security impact

### Impact Description

Client side change only. Standard function call on a standard library class. Analogous to existing calls for similar functionality.

(Reviewers: please confirm the security impact before approving)