### PR TITLE
[query] Use getResource to find test resources in tests

### DIFF
--- a/hail/src/test/scala/is/hail/HailSuite.scala
+++ b/hail/src/test/scala/is/hail/HailSuite.scala
@@ -92,6 +92,8 @@ class HailSuite extends TestNGSuite {
       throw new RuntimeException(s"method stopped spark context!")
   }
 
+  def getResource(path: String): String = getClass.getResource(path).getPath
+
   def withExecuteContext[T]()(f: ExecuteContext => T)(implicit E: Enclosing): T =
     hc.sparkBackend("HailSuite.withExecuteContext").withExecuteContext(f)
 

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -672,10 +672,10 @@ class TableIRSuite extends HailSuite {
 
   // Catches a bug in the partitioner created by the importer.
   @Test def testTableJoinOfImport(): Unit = {
-    val mnr = MatrixNativeReader(fs, "src/test/resources/sample.vcf.mt")
+    val mnr = MatrixNativeReader(fs, getResource("/sample.vcf.mt"))
     val mt2 = MatrixRead(mnr.fullMatrixType, false, false, mnr)
     val t2 = MatrixRowsTable(mt2)
-    val mt = importVCF(ctx, "src/test/resources/sample.vcf")
+    val mt = importVCF(ctx, getResource("/sample.vcf"))
     var t: TableIR = MatrixRowsTable(mt)
     t = TableMapRows(
       t,
@@ -686,7 +686,7 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testNativeReaderWithOverlappingPartitions(): Unit = {
-    val path = "src/test/resources/sample.vcf-20-partitions-with-overlap.mt/rows"
+    val path = getResource("/sample.vcf-20-partitions-with-overlap.mt/rows")
     // i1 overlaps the first two partitions
     val i1 = Interval(Row(Locus("20", 10200000)), Row(Locus("20", 10500000)), true, true)
 


### PR DESCRIPTION
## Change Description

Use `getResource` to find test resources, rather than hardcoded paths. This prevents tests from breaking when we modify the directory structure.

## Security Assessment

Delete all except the correct answer:

- This change has no security impact

### Impact Description

test only change
