### PR TITLE
don't hardcode paths to test resources

### DIFF
--- a/hail/src/test/scala/is/hail/HailSuite.scala
+++ b/hail/src/test/scala/is/hail/HailSuite.scala
@@ -71,6 +71,8 @@ class HailSuite extends TestNGSuite {
 
   var pool: RegionPool = _
 
+  def getTestResource(localPath: String): String = s"src/test/resources/$localPath"
+
   @BeforeMethod
   def setupContext(context: ITestContext): Unit = {
     assert(timer == null)

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -226,8 +226,10 @@ class BlockMatrixIRSuite extends HailSuite {
     implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
     val etype = EBlockMatrixNDArray(EFloat64Required, required = true)
     val path =
-      "src/test/resources/blockmatrix_example/0/parts/part-0-28-0-0-0feb7ac2-ab02-6cd4-5547-bfcb94dacb33"
-    val matrix = BlockMatrix.read(fs, "src/test/resources/blockmatrix_example/0").toBreezeMatrix()
+      getTestResource(
+        "blockmatrix_example/0/parts/part-0-28-0-0-0feb7ac2-ab02-6cd4-5547-bfcb94dacb33"
+      )
+    val matrix = BlockMatrix.read(fs, getTestResource("blockmatrix_example/0")).toBreezeMatrix()
     val expected = Array.tabulate(2)(i => Array.tabulate(2)(j => matrix(i, j)).toFastSeq).toFastSeq
 
     val typ = TNDArray(TFloat64, Nat(2))
@@ -250,7 +252,7 @@ class BlockMatrixIRSuite extends HailSuite {
   }
 
   @Test def readWriteBlockMatrix(): Unit = {
-    val original = "src/test/resources/blockmatrix_example/0"
+    val original = getTestResource("blockmatrix_example/0")
     val expected = BlockMatrix.read(ctx.fs, original).toBreezeMatrix()
 
     val path = ctx.createTmpPath("read-blockmatrix-ir", "bm")

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3716,23 +3716,23 @@ class IRSuite extends HailSuite {
           "index_bgen",
           TInt64,
           Array[Type](TLocus("GRCh37")),
-          Str("src/test/resources/example.8bits.bgen"),
-          Str("src/test/resources/example.8bits.bgen.idx2"),
+          Str(getTestResource("example.8bits.bgen")),
+          Str(getTestResource("example.8bits.bgen.idx2")),
           Literal(TDict(TString, TString), Map("01" -> "1")),
           False(),
           I32(1000000),
         ),
       )
 
-      val tableRead = TableIR.read(fs, "src/test/resources/backward_compatability/1.1.0/table/0.ht")
+      val tableRead = TableIR.read(fs, getTestResource("backward_compatability/1.1.0/table/0.ht"))
       val read =
-        MatrixIR.read(fs, "src/test/resources/backward_compatability/1.0.0/matrix_table/0.hmt")
+        MatrixIR.read(fs, getTestResource("backward_compatability/1.0.0/matrix_table/0.hmt"))
       val range = MatrixIR.range(3, 7, None)
-      val vcf = is.hail.TestUtils.importVCF(ctx, "src/test/resources/sample.vcf")
+      val vcf = is.hail.TestUtils.importVCF(ctx, getTestResource("sample.vcf"))
 
       val bgenReader = MatrixBGENReader(
         ctx,
-        FastSeq("src/test/resources/example.8bits.bgen"),
+        FastSeq(getTestResource("example.8bits.bgen")),
         None,
         Map.empty[String, String],
         None,
@@ -3839,7 +3839,7 @@ class IRSuite extends HailSuite {
   @DataProvider(name = "blockMatrixIRs")
   def blockMatrixIRs(): Array[Array[BlockMatrixIR]] = {
     val read =
-      BlockMatrixRead(BlockMatrixNativeReader(fs, "src/test/resources/blockmatrix_example/0"))
+      BlockMatrixRead(BlockMatrixNativeReader(fs, getTestResource("blockmatrix_example/0")))
     val transpose = BlockMatrixBroadcast(read, FastSeq(1, 0), FastSeq(2, 2), 2)
     val dot = BlockMatrixDot(read, transpose)
     val slice = BlockMatrixSlice(read, FastSeq(FastSeq(0, 2, 1), FastSeq(0, 1, 1)))
@@ -4055,7 +4055,7 @@ class IRSuite extends HailSuite {
   @DataProvider(name = "relationalFunctions")
   def relationalFunctionsData(): Array[Array[Any]] = Array(
     Array(TableFilterPartitions(Array(1, 2, 3), keep = true)),
-    Array(VEP(fs, "src/test/resources/dummy_vep_config.json", false, 1, true)),
+    Array(VEP(fs, getTestResource("dummy_vep_config.json"), false, 1, true)),
     Array(WrappedMatrixToTableFunction(
       LinearRegressionRowsSingle(Array("foo"), "bar", Array("baz"), 1, Array("a", "b")),
       "foo",

--- a/hail/src/test/scala/is/hail/io/TabixSuite.scala
+++ b/hail/src/test/scala/is/hail/io/TabixSuite.scala
@@ -11,7 +11,7 @@ import org.testng.asserts.SoftAssert
 class TabixSuite extends HailSuite {
   // use .gz for several tests and .bgz for another to test handling of both
   // extensions.
-  val vcfFile = "src/test/resources/trioDup.vcf"
+  val vcfFile = getTestResource("trioDup.vcf")
   val vcfGzFile = vcfFile + ".gz"
   val vcfGzTbiFile = vcfGzFile + ".tbi"
 
@@ -21,7 +21,7 @@ class TabixSuite extends HailSuite {
     hc // reference to initialize
 
   @Test def testLargeNumberOfSequences(): Unit = {
-    val tbx = new TabixReader(null, fs, Some("src/test/resources/large-tabix.tbi"))
+    val tbx = new TabixReader(null, fs, Some(getTestResource("large-tabix.tbi")))
     // known length of sequences
     assert(tbx.index.seqs.length == 3366)
   }
@@ -132,10 +132,10 @@ class TabixSuite extends HailSuite {
   }
 
   @Test def testLineIterator2(): Unit =
-    _testLineIterator2("src/test/resources/sample.vcf.bgz")
+    _testLineIterator2(getTestResource("sample.vcf.bgz"))
 
   @Test def testWriter(): Unit = {
-    val vcfFile = "src/test/resources/sample.vcf.bgz"
+    val vcfFile = getTestResource("sample.vcf.bgz")
     val path = ctx.createTmpPath("test-tabix-write", "bgz")
     fs.copy(vcfFile, path)
     TabixVCF(fs, vcfFile)

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -53,10 +53,10 @@ class TestFileInputFormat extends hd.mapreduce.lib.input.TextInputFormat {
 }
 
 class BGzipCodecSuite extends HailSuite {
-  val uncompPath = "src/test/resources/sample.vcf"
+  val uncompPath = getTestResource("sample.vcf")
 
   // is actually a bgz file
-  val gzPath = "src/test/resources/sample.vcf.gz"
+  val gzPath = getTestResource("sample.vcf.gz")
 
   /* bgz.test.sample.vcf.bgz was created as follows:
    * - split sample.vcf into 60-line chunks: `split -l 60 sample.vcf sample.vcf.`
@@ -64,7 +64,7 @@ class BGzipCodecSuite extends HailSuite {
    * - bgzip compressed the chunks
    * - stripped the empty terminate block in chunks except ad and ag (the last)
    * - concatenated the chunks */
-  val compPath = "src/test/resources/bgz.test.sample.vcf.bgz"
+  val compPath = getTestResource("bgz.test.sample.vcf.bgz")
 
   def compareLines(lines2: IndexedSeq[String], lines: IndexedSeq[String]): Unit = {
     val n2 = lines2.length

--- a/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -90,7 +90,7 @@ class UtilsSuite extends HailSuite {
   @Test def testSortFileListEntry(): Unit = {
     val fs = new HadoopFS(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
 
-    val partFileNames = fs.glob("src/test/resources/part-*")
+    val partFileNames = fs.glob(getTestResource("part-*"))
       .sortBy(fileListEntry => getPartNumber(fileListEntry.getPath)).map(_.getPath.split(
         "/"
       ).last)

--- a/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -141,9 +141,9 @@ class ReferenceGenomeSuite extends HailSuite {
   }
 
   @Test def testFasta(): Unit = {
-    val fastaFile = "src/test/resources/fake_reference.fasta"
-    val fastaFileGzip = "src/test/resources/fake_reference.fasta.gz"
-    val indexFile = "src/test/resources/fake_reference.fasta.fai"
+    val fastaFile = getTestResource("fake_reference.fasta")
+    val fastaFileGzip = getTestResource("fake_reference.fasta.gz")
+    val indexFile = getTestResource("fake_reference.fasta.fai")
 
     val rg = ReferenceGenome("test", Array("a", "b", "c"), Map("a" -> 25, "b" -> 15, "c" -> 10))
 


### PR DESCRIPTION
## Change Description

Factor out the location of the test resources directory in the scala tests, so we only need to change one place when we rearrange the directory structure.

## Security Assessment

- This change has no security impact

### Impact Description

Tests only
