### PR TITLE
[auth] Validate next page urls

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -195,7 +195,7 @@ def cleanup_session(session):
 def validate_next_page_url(next_page):
     if not next_page:
         raise web.HTTPBadRequest('Invalid next page: empty')
-    valid_next_services = [ 'batch', 'auth' ]
+    valid_next_services = ['batch', 'auth']
     for service in valid_next_services:
         if next_page.startswith(deploy_config.external_url(service, '')):
             return

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -38,8 +38,6 @@ from hailtop.auth import AzureFlow, Flow, GoogleFlow, IdentityProvider
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.utils import secret_alnum_string
-
-from hail.python.hailtop.hailctl.dev.cli import deploy
 from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
 from .exceptions import (

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -223,7 +223,7 @@ async def creating_account(request: web.Request, userdata: Optional[UserData]) -
         login_id = session['login_id']
         user = await user_from_login_id(db, login_id)
 
-        next_url = deploy_config.external_url('auth', '/user')
+        next_url = deploy_config.external_url('auth', deploy_config.external_url('auth', '/user'))
         next_page = session.pop('next', next_url)
         validate_next_page_url(next_page)
 

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -201,7 +201,9 @@ def validate_next_page_url(next_page):
     actual_next_page_domain = urlparse(next_page).netloc
 
     if actual_next_page_domain not in valid_next_domains:
-        raise web.HTTPBadRequest(text=f'Invalid next page: \'{next_page}\'. Domain \'{actual_next_page_domain}\' not in {valid_next_domains}')
+        raise web.HTTPBadRequest(
+            text=f'Invalid next page: \'{next_page}\'. Domain \'{actual_next_page_domain}\' not in {valid_next_domains}'
+        )
 
 
 @routes.get('/healthcheck')

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -197,11 +197,14 @@ def validate_next_page_url(next_page):
     if not next_page:
         raise web.HTTPBadRequest(text='Invalid next page: empty')
     valid_next_services = ['batch', 'auth']
-    valid_next_domains = [urlparse(deploy_config.domain(s)).netloc for s in valid_next_services]
+    valid_next_urls = [deploy_config.external_url(s, '/') for s in valid_next_services]
+    valid_next_domains = [urlparse(url).netloc for url in valid_next_urls]
     actual_next_page_domain = urlparse(next_page).netloc
 
     if actual_next_page_domain not in valid_next_domains:
-        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}. Domain {actual_next_page_domain} not in {valid_next_domains} (calculated from {[deploy_config.domain(s) for s in valid_next_services]})')
+        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}. Domain {actual_next_page_domain} not in {valid_next_domains} (calculated from {[valid_next_urls]})')
+    else:
+        raise web.HTTPBadRequest(text=f'Valid next page: {next_page}. Domain {actual_next_page_domain} IS in {valid_next_domains} (calculated from {[valid_next_urls]})')
 
 
 @routes.get('/healthcheck')

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -200,7 +200,7 @@ def validate_next_page_url(next_page):
     valid_next_domains = [urlparse(deploy_config.domain(s)).netloc for s in valid_next_services]
     actual_next_page_domain = urlparse(next_page).netloc
 
-    if not actual_next_page_domain in valid_next_domains:
+    if actual_next_page_domain not in valid_next_domains:
         raise web.HTTPBadRequest(f'Invalid next page: {next_page}')
 
 

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -223,7 +223,7 @@ async def creating_account(request: web.Request, userdata: Optional[UserData]) -
         login_id = session['login_id']
         user = await user_from_login_id(db, login_id)
 
-        next_url = deploy_config.external_url('auth', deploy_config.external_url('auth', '/user'))
+        next_url = deploy_config.external_url('auth', '/user')
         next_page = session.pop('next', next_url)
         validate_next_page_url(next_page)
 

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -202,8 +202,6 @@ def validate_next_page_url(next_page):
 
     if actual_next_page_domain not in valid_next_domains:
         raise web.HTTPBadRequest(text=f'Invalid next page: \'{next_page}\'. Domain \'{actual_next_page_domain}\' not in {valid_next_domains}')
-    else:
-        raise web.HTTPBadRequest(text='Yup that was good.')
 
 
 @routes.get('/healthcheck')

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -201,7 +201,7 @@ def validate_next_page_url(next_page):
     actual_next_page_domain = urlparse(next_page).netloc
 
     if actual_next_page_domain not in valid_next_domains:
-        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}. Domain {actual_next_page_domain} not in {valid_next_domains}')
+        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}. Domain {actual_next_page_domain} not in {valid_next_domains} (calculated from {[deploy_config.domain(s) for s in valid_next_services]})')
 
 
 @routes.get('/healthcheck')

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -197,14 +197,13 @@ def validate_next_page_url(next_page):
     if not next_page:
         raise web.HTTPBadRequest(text='Invalid next page: empty')
     valid_next_services = ['batch', 'auth']
-    valid_next_urls = [deploy_config.external_url(s, '/') for s in valid_next_services]
-    valid_next_domains = [urlparse(url).netloc for url in valid_next_urls]
+    valid_next_domains = [urlparse(deploy_config.external_url(s, '/')).netloc for s in valid_next_services]
     actual_next_page_domain = urlparse(next_page).netloc
 
     if actual_next_page_domain not in valid_next_domains:
-        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}. Domain {actual_next_page_domain} not in {valid_next_domains} (calculated from {[valid_next_urls]})')
+        raise web.HTTPBadRequest(text=f'Invalid next page: \'{next_page}\'. Domain \'{actual_next_page_domain}\' not in {valid_next_domains}')
     else:
-        raise web.HTTPBadRequest(text=f'Valid next page: {next_page}. Domain {actual_next_page_domain} IS in {valid_next_domains} (calculated from {[valid_next_urls]})')
+        raise web.HTTPBadRequest(text='Yup that was good.')
 
 
 @routes.get('/healthcheck')

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -201,7 +201,7 @@ def validate_next_page_url(next_page):
     actual_next_page_domain = urlparse(next_page).netloc
 
     if actual_next_page_domain not in valid_next_domains:
-        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}')
+        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}. Domain {actual_next_page_domain} not in {valid_next_domains}')
 
 
 @routes.get('/healthcheck')

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -195,13 +195,13 @@ def cleanup_session(session):
 
 def validate_next_page_url(next_page):
     if not next_page:
-        raise web.HTTPBadRequest('Invalid next page: empty')
+        raise web.HTTPBadRequest(text='Invalid next page: empty')
     valid_next_services = ['batch', 'auth']
     valid_next_domains = [urlparse(deploy_config.domain(s)).netloc for s in valid_next_services]
     actual_next_page_domain = urlparse(next_page).netloc
 
     if actual_next_page_domain not in valid_next_domains:
-        raise web.HTTPBadRequest(f'Invalid next page: {next_page}')
+        raise web.HTTPBadRequest(text=f'Invalid next page: {next_page}')
 
 
 @routes.get('/healthcheck')


### PR DESCRIPTION
## Change Description

Updates the handling of the `next` query parameters on various auth URLs to only accept absolute paths within the same domain as the auth service or its equivalent batch service. Prevents a potential class of attacks exploiting unvalidated redirects.

## Security Assessment

Delete all except the correct answer:
- This change has a medium security impact

### Impact Description

For medium/high impact: provide a description of the impact and the mitigations in place.
Changes how an auth API works, but in a way that reduces its overall functional surface. Defends against inappropriate redirections following login.

(Reviewers: please confirm the security impact before approving)
