### PR TITLE
[query] don't hardcode paths to test resources, cont'd

### DIFF
--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3261,8 +3261,8 @@ class IRSuite extends HailSuite {
         "index_bgen",
         TInt64,
         Array[Type](TLocus("GRCh37")),
-        Str("src/test/resources/example.8bits.bgen"),
-        Str("src/test/resources/example.8bits.bgen.idx2"),
+        Str(getTestResource("example.8bits.bgen")),
+        Str(getTestResource("example.8bits.bgen.idx2")),
         Literal(TDict(TString, TString), Map("01" -> "1")),
         False(),
         I32(1000000),
@@ -3312,11 +3312,11 @@ class IRSuite extends HailSuite {
     val table = TableRange(100, 10)
 
     val mt = MatrixIR.range(20, 2, Some(3))
-    val vcf = is.hail.TestUtils.importVCF(ctx, "src/test/resources/sample.vcf")
+    val vcf = is.hail.TestUtils.importVCF(ctx, getTestResource("sample.vcf"))
 
     val bgenReader = MatrixBGENReader(
       ctx,
-      FastSeq("src/test/resources/example.8bits.bgen"),
+      FastSeq(getTestResource("example.8bits.bgen")),
       None,
       Map.empty[String, String],
       None,
@@ -3326,7 +3326,7 @@ class IRSuite extends HailSuite {
     val bgen = MatrixRead(bgenReader.fullMatrixType, false, false, bgenReader)
 
     val blockMatrix =
-      BlockMatrixRead(BlockMatrixNativeReader(fs, "src/test/resources/blockmatrix_example/0"))
+      BlockMatrixRead(BlockMatrixNativeReader(fs, getTestResource("blockmatrix_example/0")))
     val blockMatrixWriter = BlockMatrixNativeWriter("/path/to/file.bm", false, false, false)
     val blockMatrixMultiWriter = BlockMatrixBinaryMultiWriter("/path/to/prefix", false)
     val nd = MakeNDArray(
@@ -3601,9 +3601,9 @@ class IRSuite extends HailSuite {
     try {
       val fs = ctx.fs
 
-      val read = TableIR.read(fs, "src/test/resources/backward_compatability/1.1.0/table/0.ht")
+      val read = TableIR.read(fs, getTestResource("backward_compatability/1.1.0/table/0.ht"))
       val mtRead =
-        MatrixIR.read(fs, "src/test/resources/backward_compatability/1.0.0/matrix_table/0.hmt")
+        MatrixIR.read(fs, getTestResource("backward_compatability/1.0.0/matrix_table/0.hmt"))
       val b = True()
 
       val xs: Array[TableIR] = Array(

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -377,7 +377,7 @@ class MatrixIRSuite extends HailSuite {
   }
 
   @Test def testMatrixMultiWriteDifferentTypesRaisesError(): Unit = {
-    val vcf = is.hail.TestUtils.importVCF(ctx, "src/test/resources/sample.vcf")
+    val vcf = is.hail.TestUtils.importVCF(ctx, getTestResource("sample.vcf"))
     val range = rangeMatrix(10, 2, None)
     val path1 = ctx.createTmpPath("test1")
     val path2 = ctx.createTmpPath("test2")

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -360,7 +360,7 @@ class SimplifySuite extends HailSuite {
   }
 
   @Test def testSimplifyReadFilterIntervals(): Unit = {
-    val src = "src/test/resources/sample-indexed-0.2.52.mt"
+    val src = getTestResource("sample-indexed-0.2.52.mt")
 
     val mnr = MatrixNativeReader(fs, src, None)
     val mr = MatrixRead(mnr.fullMatrixType, false, false, mnr)

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -65,7 +65,7 @@ class TableIRSuite extends HailSuite {
 
   @Test def testCountRead(): Unit = {
     implicit val execStrats = ExecStrategy.lowering
-    val tir: TableIR = TableRead.native(fs, "src/test/resources/three_key.ht")
+    val tir: TableIR = TableRead.native(fs, getTestResource("three_key.ht"))
     assertEvalsTo(TableCount(tir), 120L)
   }
 
@@ -672,10 +672,10 @@ class TableIRSuite extends HailSuite {
 
   // Catches a bug in the partitioner created by the importer.
   @Test def testTableJoinOfImport(): Unit = {
-    val mnr = MatrixNativeReader(fs, "src/test/resources/sample.vcf.mt")
+    val mnr = MatrixNativeReader(fs, getTestResource("sample.vcf.mt"))
     val mt2 = MatrixRead(mnr.fullMatrixType, false, false, mnr)
     val t2 = MatrixRowsTable(mt2)
-    val mt = importVCF(ctx, "src/test/resources/sample.vcf")
+    val mt = importVCF(ctx, getTestResource("sample.vcf"))
     var t: TableIR = MatrixRowsTable(mt)
     t = TableMapRows(
       t,
@@ -686,7 +686,7 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testNativeReaderWithOverlappingPartitions(): Unit = {
-    val path = "src/test/resources/sample.vcf-20-partitions-with-overlap.mt/rows"
+    val path = getTestResource("sample.vcf-20-partitions-with-overlap.mt/rows")
     // i1 overlaps the first two partitions
     val i1 = Interval(Row(Locus("20", 10200000)), Row(Locus("20", 10500000)), true, true)
 
@@ -1081,7 +1081,7 @@ class TableIRSuite extends HailSuite {
 
   @Test def testTableAggregateByKey(): Unit = {
     implicit val execStrats = ExecStrategy.allRelational
-    var tir: TableIR = TableRead.native(fs, "src/test/resources/three_key.ht")
+    var tir: TableIR = TableRead.native(fs, getTestResource("three_key.ht"))
     tir = TableKeyBy(tir, FastSeq("x", "y"), true)
     tir = TableAggregateByKey(
       tir,
@@ -1107,7 +1107,7 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testTableDistinct(): Unit = {
-    val tir: TableIR = TableRead.native(fs, "src/test/resources/three_key.ht")
+    val tir: TableIR = TableRead.native(fs, getTestResource("three_key.ht"))
     val keyedByX = TableKeyBy(tir, FastSeq("x"), true)
     val distinctByX = TableDistinct(keyedByX)
     assertEvalsTo(TableCount(distinctByX), 8L)
@@ -1285,7 +1285,7 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testTableKeyByAndAggregate(): Unit = {
-    val tir: TableIR = TableRead.native(fs, "src/test/resources/three_key.ht")
+    val tir: TableIR = TableRead.native(fs, getTestResource("three_key.ht"))
     val unkeyed = TableKeyBy(tir, IndexedSeq[String]())
     val rowRef = Ref(TableIR.rowName, unkeyed.typ.rowType)
     val aggSignature = AggSignature(Sum(), FastSeq(), FastSeq(TInt64))
@@ -1472,10 +1472,10 @@ class TableIRSuite extends HailSuite {
     /* This test is important because it tests that we can handle lowering with a
      * TableNativeZippedReader when elements of the original key get pruned away (so I copy key to
      * only be "locus" instead of "locus", "alleles") */
-    val rowsPath = "src/test/resources/sample.vcf.mt/rows"
-    val entriesPath = "src/test/resources/sample.vcf.mt/entries"
+    val rowsPath = getTestResource("sample.vcf.mt/rows")
+    val entriesPath = getTestResource("sample.vcf.mt/entries")
 
-    val mnr = MatrixNativeReader(fs, "src/test/resources/sample.vcf.mt")
+    val mnr = MatrixNativeReader(fs, getTestResource("sample.vcf.mt"))
     val mnrSpec = mnr.getSpec()
 
     val reader =

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -236,8 +236,8 @@ class BGzipCodecSuite extends HailSuite {
     // offsets into the uncompressed file
     val uncompBlockStarts = Array[Int](0, 326400, 652800, 913920)
 
-    val uncompPath = "src/test/resources/sample.vcf"
-    val compPath = "src/test/resources/sample.vcf.gz"
+    val uncompPath = getTestResource("sample.vcf")
+    val compPath = getTestResource("sample.vcf.gz")
 
     using(fs.openNoCompression(uncompPath)) { uncompIS =>
       using(new BGzipInputStream(fs.openNoCompression(compPath))) { decompIS =>

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -111,7 +111,7 @@ class LocalLDPruneSuite extends HailSuite {
   val nCores = 4
 
   lazy val mt = Interpret(
-    TestUtils.importVCF(ctx, "src/test/resources/sample.vcf.bgz", nPartitions = Option(10)),
+    TestUtils.importVCF(ctx, getTestResource("sample.vcf.bgz"), nPartitions = Option(10)),
     ctx,
     false,
   ).toMatrixValue(Array("s"))
@@ -250,7 +250,7 @@ class LocalLDPruneSuite extends HailSuite {
     val actualR2 = new MultiArray2(
       7,
       7,
-      fs.readLines("src/test/resources/ldprune_corrtest.txt")(_.flatMap(_.map { line =>
+      fs.readLines(getTestResource("ldprune_corrtest.txt"))(_.flatMap(_.map { line =>
         line.trim.split("\t").map(r2 => if (r2 == "NA") None else Some(r2.toDouble))
       }.value).toArray),
     )

--- a/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -236,7 +236,7 @@ class ReferenceGenomeSuite extends HailSuite {
   @Test def testSerializeWithLiftoverOnFB(): Unit = {
     withExecuteContext() { ctx =>
       val grch37 = ctx.getReference(ReferenceGenome.GRCh37)
-      val liftoverFile = "src/test/resources/grch37_to_grch38_chr20.over.chain.gz"
+      val liftoverFile = getTestResource("grch37_to_grch38_chr20.over.chain.gz")
 
       grch37.addLiftover(ctx, liftoverFile, "GRCh38")
 


### PR DESCRIPTION
## Change Description

#14775 missed some places in the scala tests where the test resources directory is hardcoded. This fixes the remaining cases.

## Security Assessment

Delete all except the correct answer:

- This change has no security impact

### Impact Description

Tests-only change

(Reviewers: please confirm the security impact before approving)
