### PR TITLE
[query] remove *.out from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ hs_err_pid*.log
 *hail/python/hailtop/pipeline/docs/output*
 .mypy_cache/
 node_modules
-*.out
 GPATH
 GRTAGS
 GTAGS


### PR DESCRIPTION
## Change Description

Removes `*.out` from our `.gitignore`. There are files in our test resources directory with a `.out` extension.

## Security Assessment

- This change has no security impact

### Impact Description

Only affects commit creation

(Reviewers: please confirm the security impact before approving)
