### PR TITLE
[batch/auth] Set accounts to "inactive" after extended inactivity

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -769,7 +769,7 @@ async def get_userinfo_from_hail_session_id(request: web.Request, session_id: st
 SELECT users.*
 FROM users
 INNER JOIN sessions ON users.id = sessions.user_id
-WHERE users.state = 'active' AND sessions.session_id = %s AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
+WHERE (users.state = 'active' OR users.state = 'inactive') AND sessions.session_id = %s AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
 """,
             session_id,
             'get_userinfo',
@@ -778,6 +778,18 @@ WHERE users.state = 'active' AND sessions.session_id = %s AND (ISNULL(sessions.m
 
     if len(users) != 1:
         return None
+
+    if users[0]['state'] == 'active' and len(users) == 1:
+        current_uid = users[0]['id']
+        await db.execute_update(
+            """
+UPDATE users
+SET last_active = NOW()
+WHERE id = %s;
+""",
+            current_uid,
+        )
+
     return typing.cast(UserData, users[0])
 
 

--- a/auth/sql/estimated-current.sql
+++ b/auth/sql/estimated-current.sql
@@ -1,13 +1,12 @@
 CREATE TABLE `users` (
   `id` INT(11) NOT NULL AUTO_INCREMENT,
   `state` VARCHAR(100) NOT NULL,
-  -- creating, active, deleting, deleted
+  -- creating, active, deleting, deleted, inactive
   `username` varchar(255) NOT NULL COLLATE utf8mb4_0900_as_cs,
   `login_id` varchar(255) DEFAULT NULL COLLATE utf8mb4_0900_as_cs,
   `display_name` varchar(255) DEFAULT NULL,
   `is_developer` tinyint(1) NOT NULL DEFAULT 0,
   `is_service_account` tinyint(1) NOT NULL DEFAULT 0,
-  `last_active` DATETIME NOT NULL,
   -- session
   `tokens_secret_name` varchar(255) DEFAULT NULL,
   -- identity
@@ -17,20 +16,24 @@ CREATE TABLE `users` (
   -- namespace, for developers
   `namespace_name` varchar(255) DEFAULT NULL,
   `trial_bp_name` varchar(300) DEFAULT NULL,
+  -- "last active" tracking
+  `last_active` TIMESTAMP NOT NULL DEFAULT NOW(),
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`),
   UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB;
 
+CREATE TABLE `inactive` (
+
+)
+
 CREATE EVENT `disable_inactive`
-    ON SCHEDULE EVERY 5 MINUTE
+    ON SCHEDULE EVERY 60 MINUTE
     ON COMPLETION PRESERVE
     DO
-        DELETE FROM users
-        WHERE (users.last_active IS NOT NULL) AND (DATEDIFF(day, NOW(), users.last_active) > 180);
-        -- placeholder: 180 days of inactivity
-        -- TBD: this is going to be more involved than just deleting users.
-        -- Updating last_active will be addressed elsewhere (e.g. when one submits a job).
+        UPDATE users
+        SET users.state = 'inactive'
+        WHERE (users.last_active IS NOT NULL) AND (DATEDIFF(CURRENT_DATE(), users.last_active) > 180);
 
 CREATE TABLE `sessions` (
   `session_id` VARCHAR(255) NOT NULL,

--- a/auth/sql/estimated-current.sql
+++ b/auth/sql/estimated-current.sql
@@ -23,10 +23,6 @@ CREATE TABLE `users` (
   UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB;
 
-CREATE TABLE `users_activity` (
-
-)
-
 CREATE EVENT `disable_inactive`
     ON SCHEDULE EVERY 1 DAY
     ON COMPLETION PRESERVE

--- a/auth/sql/estimated-current.sql
+++ b/auth/sql/estimated-current.sql
@@ -23,12 +23,12 @@ CREATE TABLE `users` (
   UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB;
 
-CREATE TABLE `inactive` (
+CREATE TABLE `users_activity` (
 
 )
 
 CREATE EVENT `disable_inactive`
-    ON SCHEDULE EVERY 60 MINUTE
+    ON SCHEDULE EVERY 1 DAY
     ON COMPLETION PRESERVE
     DO
         UPDATE users

--- a/auth/sql/estimated-current.sql
+++ b/auth/sql/estimated-current.sql
@@ -7,6 +7,7 @@ CREATE TABLE `users` (
   `display_name` varchar(255) DEFAULT NULL,
   `is_developer` tinyint(1) NOT NULL DEFAULT 0,
   `is_service_account` tinyint(1) NOT NULL DEFAULT 0,
+  `last_active` DATETIME NOT NULL,
   -- session
   `tokens_secret_name` varchar(255) DEFAULT NULL,
   -- identity
@@ -20,6 +21,16 @@ CREATE TABLE `users` (
   UNIQUE KEY `email` (`email`),
   UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB;
+
+CREATE EVENT `disable_inactive`
+    ON SCHEDULE EVERY 5 MINUTE
+    ON COMPLETION PRESERVE
+    DO
+        DELETE FROM users
+        WHERE (users.last_active IS NOT NULL) AND (DATEDIFF(day, NOW(), users.last_active) > 180);
+        -- placeholder: 180 days of inactivity
+        -- TBD: this is going to be more involved than just deleting users.
+        -- Updating last_active will be addressed elsewhere (e.g. when one submits a job).
 
 CREATE TABLE `sessions` (
   `session_id` VARCHAR(255) NOT NULL,

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -65,6 +65,8 @@ class Authenticator(abc.ABC):
                     if redirect or (redirect is None and '/api/' not in request.path):
                         raise login_redirect(request)
                     raise web.HTTPUnauthorized()
+                elif userdata['state'] == 'inactive':
+                    raise web.HTTPUnauthorized()
                 return await fun(request, userdata)
 
             return wrapped


### PR DESCRIPTION
## Change Description

Addressing compliance requirement wherein Hail accounts must be disabled/marked as inactive after a certain number of days of inactivity. This is accomplished as follows:
- A `last_active` column has been added to the `users` table, used for storing a given user's last active timestamp;
- Anytime a user does anything requiring authorization, their `last_active` timestamp is updated to the current date/time;
- An error is raised to the user if they attempt to do anything requiring authorization while their account has a status of 'inactive'; and
- A SQL event has been added that checks the users table once a day, and any 'active' users are marked as 'inactive' if their `last_active` timestamp is more than 180 days old.

## Security Assessment
- This change has a medium security impact

### Impact Description
This change entails a change to the `users` table schema and additional authorization-related checks thereof, but none of this is exposed to users and all happens internally.

(Reviewers: please confirm the security impact before approving)
