### PR TITLE
[logging] Log identity as part of API call logging 

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1681,14 +1681,7 @@ class BatchDriverAccessLogger(AccessLogger):
             if path_expr.fullmatch(request.path) and method == request.method:
                 return
 
-        self.logger.info(
-            f'{request.remote} '
-            f'"{request.method} {request.path} '
-            f'done in {time}s: {response.status}'
-            f'userdata: {request.userdata}'
-        )
-
-        # super().log(request, response, time)
+        super().log(request, response, time)
 
 
 async def on_startup(app):

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1681,7 +1681,14 @@ class BatchDriverAccessLogger(AccessLogger):
             if path_expr.fullmatch(request.path) and method == request.method:
                 return
 
-        super().log(request, response, time)
+        self.logger.info(
+            f'{request.remote} '
+            f'"{request.method} {request.path} '
+            f'done in {time}s: {response.status}'
+            f'userdata: {request.userdata}'
+        )
+
+        # super().log(request, response, time)
 
 
 async def on_startup(app):

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -65,6 +65,7 @@ class Authenticator(abc.ABC):
                     if redirect or (redirect is None and '/api/' not in request.path):
                         raise login_redirect(request)
                     raise web.HTTPUnauthorized()
+                request['userdata'] = userdata
                 return await fun(request, userdata)
 
             return wrapped

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -65,5 +65,5 @@ class AccessLogger(AbstractAccessLogger):
 
         self.logger.info(
             f'{request.scheme} {request.method} {request.path} ' f'done in {time}s: {response.status}',
-            extra={**extra, **request.get('batch_telemetry', {})},
+            extra={**extra, **request.get('batch_telemetry', {}), **request.get('userdata', {})},
         )

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -63,7 +63,18 @@ class AccessLogger(AbstractAccessLogger):
             'x_real_ip': request.headers.get("X-Real-IP"),
         }
 
+        userdata_maybe = request.get('userdata', {})
+        if 'username' in userdata_maybe:
+            extra['username'] = userdata_maybe['username']
+        if 'login_id' in userdata_maybe:
+            extra['login_id'] = userdata_maybe['login_id']
+        if 'is_developer' in userdata_maybe:
+            extra['is_developer'] = userdata_maybe['is_developer']
+        if 'hail_identity' in userdata_maybe:
+            extra['hail_identity'] = userdata_maybe['hail_identity']
+
+
         self.logger.info(
             f'{request.scheme} {request.method} {request.path} ' f'done in {time}s: {response.status}',
-            extra={**extra, **request.get('batch_telemetry', {}), **request.get('userdata', {})},
+            extra={**extra, **request.get('batch_telemetry', {})},
         )


### PR DESCRIPTION
## Change Description

- Adds the username dict to requests during auth checks
- Adds logging of that username dict (if available) during call logging

## Security Assessment

- This change has a medium security impact

### Impact Description

- Makes usernames explicitly visible in the system logs, so admins are now able to track what individual users are doing or looking at. 
- The userdata in request objects should be handled carefully, though it does not include anything secret (ie nothing which would allow impersonation if leaked)


(Reviewers: please confirm the security impact before approving)
