### PR TITLE
[auth] Allow ci and monitoring as valid next_urls in auth flows

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -203,7 +203,7 @@ def cleanup_session(session):
 def validate_next_page_url(next_page):
     if not next_page:
         raise web.HTTPBadRequest(text='Invalid next page: empty')
-    valid_next_services = ['batch', 'auth']
+    valid_next_services = ['batch', 'auth', 'ci', 'monitoring']
     valid_next_domains = [urlparse(deploy_config.external_url(s, '/')).netloc for s in valid_next_services]
     actual_next_page_domain = urlparse(next_page).netloc
 


### PR DESCRIPTION
## Change Description

Addresses a bug introduced in #14776 which didn't allow `ci` or `monitoring` as valid "next" urls

## Security Assessment

- This change has a medium security impact

### Impact Description

Additional `next_url`s are allowed, but they are still tightly constrained to the standard set of hail services.

(Reviewers: please confirm the security impact before approving)
