### PR TITLE
[ci] download more ram for `check_hail`

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1562,6 +1562,8 @@ steps:
     name: check_hail
     image:
       valueFrom: hail_linting_image.image
+    resources:
+      memory: 8G
     script: |
       set -ex
       cd /io/repo


### PR DESCRIPTION
The `check_hail` CI job is failing routinely. 
Resource usage plots show that the jobs are hitting their 4G memory limit. 
Downloading more ram should help.