### PR TITLE
[auth] Require tos acceptance on UI login

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -455,7 +455,7 @@ async def create_user(request: web.Request, _) -> web.Response:
 @routes.get('/user')
 @web_security_headers
 @auth.maybe_authenticated_user
-async def user_page(request: web.Request, userdata: UserData) -> web.Response:
+async def user_page(request: web.Request, userdata: Optional[UserData]) -> web.Response:
     context_dict = {'cloud': CLOUD, **({'next_page': request.query['next']} if 'next' in request.query else {})}
 
     return await render_template('auth', request, userdata, 'user.html', context_dict)

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -454,7 +454,7 @@ async def create_user(request: web.Request, _) -> web.Response:
 
 @routes.get('/user')
 @web_security_headers
-@auth.maybe_authenticated_user()
+@auth.maybe_authenticated_user
 async def user_page(request: web.Request, userdata: UserData) -> web.Response:
     return await render_template('auth', request, userdata, 'user.html', {'cloud': CLOUD})
 

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -454,7 +454,7 @@ async def create_user(request: web.Request, _) -> web.Response:
 
 @routes.get('/user')
 @web_security_headers
-@auth.authenticated_users_only()
+@auth.maybe_authenticated_user()
 async def user_page(request: web.Request, userdata: UserData) -> web.Response:
     return await render_template('auth', request, userdata, 'user.html', {'cloud': CLOUD})
 

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -456,12 +456,9 @@ async def create_user(request: web.Request, _) -> web.Response:
 @web_security_headers
 @auth.maybe_authenticated_user
 async def user_page(request: web.Request, userdata: UserData) -> web.Response:
-    maybe_next = request.query.get('next')
-    next_page_param = f'?next={maybe_next}' if maybe_next else ''
+    context_dict = {'cloud': CLOUD, **({'next_page': request.query['next']} if 'next' in request.query else {})}
 
-    return await render_template(
-        'auth', request, userdata, 'user.html', {'cloud': CLOUD, 'next_page_param': next_page_param}
-    )
+    return await render_template('auth', request, userdata, 'user.html', context_dict)
 
 
 async def create_copy_paste_token(db, session_id, max_age_secs=300):

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -456,7 +456,12 @@ async def create_user(request: web.Request, _) -> web.Response:
 @web_security_headers
 @auth.maybe_authenticated_user
 async def user_page(request: web.Request, userdata: UserData) -> web.Response:
-    return await render_template('auth', request, userdata, 'user.html', {'cloud': CLOUD})
+    maybe_next = request.query.get('next')
+    next_page_param = f'?next={maybe_next}' if maybe_next else ''
+
+    return await render_template(
+        'auth', request, userdata, 'user.html', {'cloud': CLOUD, 'next_page_param': next_page_param}
+    )
 
 
 async def create_copy_paste_token(db, session_id, max_age_secs=300):

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -22,6 +22,19 @@
     {{ submit_button('Get a copy-paste login token') }}
   </form>
   {% else %}
+  <h1 class='text-4xl mb-4'>Log in to continue</h1>
+  {% if next_page %}
+  <p>You must sign up or log in to continue to {{ next_page }}</p>
+  {% else %}
+    <p>You must sign up or log in to continue</p>
+  {% end %}
+  <form action="{{ auth_base_url }}/signup" method="GET">
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+    {% if next_page %}
+    <input type="hidden" name="next" value="{{ next_page }}" />
+    {% endif %}
+    {{ submit_button('Sign up') }}
+  </form>
   <form action="{{ auth_base_url }}/login" method="GET">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
     {% if next_page %}
@@ -31,13 +44,13 @@
   </form>
   {% endif %}
   <p>
-    <b>Notice:</b> The Hail system records your email address and IP address. Your email address
+    The Hail system records your email address and IP address. Your email address
     is recorded so that we can authenticate you. Your IP address is tracked as part of our
     surveillance of all traffic to and from the Hail system. This broad surveillance enables the
     protection of the Hail system from malicious actors.
   </p>
   <p>
-    By logging in and continuing to use the system, you agree to these terms of service.
+    <b>Notice:</b> By signing up or logging in and continuing to use the system, you agree to these terms of service.
   </p>
 </div>
 {% endblock %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -28,22 +28,28 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
-  <div style="display: inline-flex;">
-    <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline;">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-      {% if next_page %}
-      <input type="hidden" name="next" value="{{ next_page }}" />
-      {% endif %}
-      {{ submit_button('Sign up') }}
-    </form>
-    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline;">
+  <table>
+    <tr>
+      <td>
+        <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline;">
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+          {% if next_page %}
+          <input type="hidden" name="next" value="{{ next_page }}" />
+          {% endif %}
+          {{ submit_button('Sign up') }}
+        </form>
+      </td>
+      <td>
+        <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline;">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
       <input type="hidden" name="next" value="{{ next_page }}" />
       {% endif %}
       {{ submit_button('Log in') }}
     </form>
-  </div>
+      </td>
+    </tr>
+  </table>
   {% endif %}
   <p>
     The Hail system records your email address and IP address. Your email address

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -28,7 +28,7 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
-  <div style="display: flex; flex-direction: row;">
+  <div style="display: inline-flex; flex-direction: row;">
     <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline-flex;">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
@@ -44,20 +44,6 @@
       {{ submit_button('Log in') }}
     </form>
   </div>
-  <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline-flex;">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-      {% if next_page %}
-      <input type="hidden" name="next" value="{{ next_page }}" />
-      {% endif %}
-      {{ submit_button('Sign up') }}
-    </form>
-    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline-flex;">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-      {% if next_page %}
-      <input type="hidden" name="next" value="{{ next_page }}" />
-      {% endif %}
-      {{ submit_button('Log in') }}
-    </form>
   {% endif %}
   <p>
     The Hail system records your email address and IP address. Your email address

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -22,8 +22,11 @@
     {{ submit_button('Get a copy-paste login token') }}
   </form>
   {% else %}
-  <form action="{{ auth_base_url }}/login{{ next_page_param }}" method="GET">
+  <form action="{{ auth_base_url }}/login" method="GET">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+    {% if next_page %}
+    <input type="hidden" name="next" value="{{ next_page }}" />
+    {% endif %}
     {{ submit_button('Log in') }}
   </form>
   {% endif %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -3,7 +3,7 @@
 {% block title %}User{% endblock %}
 {% block content %}
 <div id="profile" class="vcentered space-y-2">
-  {% if logged_in %}
+  {% if userdata %}
   <h1 class='text-4xl mb-4'>{{ userdata['username'] }}</h1>
   <form action="{{ auth_base_url }}/logout" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -29,14 +29,14 @@
     <p>You must sign up or log in to continue</p>
   {% endif %}
   <div style="display: flex; flex-direction: row;">
-    <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem">
+    <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline-flex;">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
       <input type="hidden" name="next" value="{{ next_page }}" />
       {% endif %}
       {{ submit_button('Sign up') }}
     </form>
-    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem">
+    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline-flex;">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
       <input type="hidden" name="next" value="{{ next_page }}" />
@@ -44,6 +44,20 @@
       {{ submit_button('Log in') }}
     </form>
   </div>
+  <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline-flex;">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+      {% if next_page %}
+      <input type="hidden" name="next" value="{{ next_page }}" />
+      {% endif %}
+      {{ submit_button('Sign up') }}
+    </form>
+    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline-flex;">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+      {% if next_page %}
+      <input type="hidden" name="next" value="{{ next_page }}" />
+      {% endif %}
+      {{ submit_button('Log in') }}
+    </form>
   {% endif %}
   <p>
     The Hail system records your email address and IP address. Your email address

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -29,14 +29,14 @@
     <p>You must sign up or log in to continue</p>
   {% endif %}
   <div style="display: inline-flex; flex-direction: row;">
-    <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline-flex;">
+    <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline;">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
       <input type="hidden" name="next" value="{{ next_page }}" />
       {% endif %}
       {{ submit_button('Sign up') }}
     </form>
-    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline-flex;">
+    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline;">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
       <input type="hidden" name="next" value="{{ next_page }}" />

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -27,7 +27,7 @@
   <p>You must sign up or log in to continue to {{ next_page }}</p>
   {% else %}
     <p>You must sign up or log in to continue</p>
-  {% end %}
+  {% endif %}
   <form action="{{ auth_base_url }}/signup" method="GET">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
     {% if next_page %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -3,6 +3,7 @@
 {% block title %}User{% endblock %}
 {% block content %}
 <div id="profile" class="vcentered space-y-2">
+  {% if logged_in %}
   <h1 class='text-4xl mb-4'>{{ userdata['username'] }}</h1>
   <form action="{{ auth_base_url }}/logout" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
@@ -20,11 +21,19 @@
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
     {{ submit_button('Get a copy-paste login token') }}
   </form>
+  {% else %}
+  <a class="header-link" href="{{ auth_base_url }}/login">
+    Login
+  </a>
+  {% endif %}
   <p>
     <b>Notice:</b> The Hail system records your email address and IP address. Your email address
     is recorded so that we can authenticate you. Your IP address is tracked as part of our
     surveillance of all traffic to and from the Hail system. This broad surveillance enables the
     protection of the Hail system from malicious actors.
+  </p>
+  <p>
+    By logging in and continuing to use the system, you agree to these terms of service.
   </p>
 </div>
 {% endblock %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -30,8 +30,8 @@
   {% endif %}
   <table>
     <tr>
-      <td>
-        <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline;">
+      <td style="width: 100px">
+        <form action="{{ auth_base_url }}/signup" method="GET">
           <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
           {% if next_page %}
           <input type="hidden" name="next" value="{{ next_page }}" />
@@ -39,14 +39,14 @@
           {{ submit_button('Sign up') }}
         </form>
       </td>
-      <td>
-        <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem; display: inline;">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-      {% if next_page %}
-      <input type="hidden" name="next" value="{{ next_page }}" />
-      {% endif %}
-      {{ submit_button('Log in') }}
-    </form>
+      <td style="width: 100px">
+        <form action="{{ auth_base_url }}/login" method="GET">
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+          {% if next_page %}
+          <input type="hidden" name="next" value="{{ next_page }}" />
+          {% endif %}
+          {{ submit_button('Log in') }}
+        </form>
       </td>
     </tr>
   </table>

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -28,20 +28,22 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
-  <form action="{{ auth_base_url }}/signup" method="GET">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-    {% if next_page %}
-    <input type="hidden" name="next" value="{{ next_page }}" />
-    {% endif %}
-    {{ submit_button('Sign up') }}
-  </form>
-  <form action="{{ auth_base_url }}/login" method="GET">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-    {% if next_page %}
-    <input type="hidden" name="next" value="{{ next_page }}" />
-    {% endif %}
-    {{ submit_button('Log in') }}
-  </form>
+  <div style="display: flex">
+    <form action="{{ auth_base_url }}/signup" method="GET">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+      {% if next_page %}
+      <input type="hidden" name="next" value="{{ next_page }}" />
+      {% endif %}
+      {{ submit_button('Sign up') }}
+    </form>
+    <form action="{{ auth_base_url }}/login" method="GET">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+      {% if next_page %}
+      <input type="hidden" name="next" value="{{ next_page }}" />
+      {% endif %}
+      {{ submit_button('Log in') }}
+    </form>
+  </div>
   {% endif %}
   <p>
     The Hail system records your email address and IP address. Your email address

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -28,7 +28,7 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
-  <table>
+  <table style="table-layout: fixed; width: 200px">
     <tr>
       <td style="width: 100px">
         <form action="{{ auth_base_url }}/signup" method="GET">

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -22,9 +22,10 @@
     {{ submit_button('Get a copy-paste login token') }}
   </form>
   {% else %}
-  <a class="header-link" href="{{ auth_base_url }}/login">
-    Login
-  </a>
+  <form action="{{ auth_base_url }}/login{{ next_page_param }}" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+    {{ submit_button('Log out') }}
+  </form>
   {% endif %}
   <p>
     <b>Notice:</b> The Hail system records your email address and IP address. Your email address

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -28,7 +28,7 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
-  <div style="display: inline-flex; flex-direction: row;">
+  <div style="display: inline-flex;">
     <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem; display: inline;">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -22,9 +22,9 @@
     {{ submit_button('Get a copy-paste login token') }}
   </form>
   {% else %}
-  <form action="{{ auth_base_url }}/login{{ next_page_param }}" method="POST">
+  <form action="{{ auth_base_url }}/login{{ next_page_param }}" method="GET">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-    {{ submit_button('Log out') }}
+    {{ submit_button('Log in') }}
   </form>
   {% endif %}
   <p>

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -28,15 +28,15 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
-  <div style="display: flex">
-    <form action="{{ auth_base_url }}/signup" method="GET">
+  <div style="display: flex; flex-direction: row;">
+    <form action="{{ auth_base_url }}/signup" method="GET" style="padding-right: 1rem">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
       <input type="hidden" name="next" value="{{ next_page }}" />
       {% endif %}
       {{ submit_button('Sign up') }}
     </form>
-    <form action="{{ auth_base_url }}/login" method="GET">
+    <form action="{{ auth_base_url }}/login" method="GET" style="padding-right: 1rem">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
       <input type="hidden" name="next" value="{{ next_page }}" />

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -28,9 +28,9 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
-  <table style="table-layout: fixed; width: 200px">
+  <table class="table-auto w-64">
     <tr>
-      <td style="width: 100px">
+      <td>
         <form action="{{ auth_base_url }}/signup" method="GET">
           <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
           {% if next_page %}
@@ -39,7 +39,7 @@
           {{ submit_button('Sign up') }}
         </form>
       </td>
-      <td style="width: 100px">
+      <td>
         <form action="{{ auth_base_url }}/login" method="GET">
           <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
           {% if next_page %}

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -171,7 +171,7 @@ async def get_session_id(request: web.Request) -> Optional[str]:
 
 
 def login_redirect(request) -> web.HTTPFound:
-    login_url = deploy_config.external_url('auth', '/login')
+    login_url = deploy_config.external_url('auth', '/user')
 
     # request.url is a yarl.URL
     request_url = request.url

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -76,7 +76,7 @@
   </a>
   {% else %}
   <a class="header-link" href="{{ auth_base_url }}/user">
-    Click here to sign up or log in
+    Log in or sign up
   </a>
   {% endif %}
 </div>

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -74,13 +74,6 @@
   <a href="{{ auth_base_url }}/user" class="header-link">
     <b>{{ userdata["username"] }}</b>
   </a>
-  |
-  <form action="{{ auth_base_url }}/logout" method="POST">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
-    <button class="button-header-link" type="submit">
-      Log out
-    </button>
-  </form>
   {% else %}
   <a class="header-link" href="{{ auth_base_url }}/user">
     Click here to sign up or log in

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -82,11 +82,8 @@
     </button>
   </form>
   {% else %}
-  <a class="header-link" href="{{ auth_base_url }}/signup">
-    Sign Up
-  </a>
-  <a class="header-link" href="{{ auth_base_url }}/login">
-    Login
+  <a class="header-link" href="{{ auth_base_url }}/user">
+    Click here to sign up or log in
   </a>
   {% endif %}
 </div>

--- a/web_common/web_common/templates/new_header.html
+++ b/web_common/web_common/templates/new_header.html
@@ -62,13 +62,9 @@
       <b class='font-semibold'>{{ userdata["username"] }}</b>
     </a>
     {% else %}
-    <a href="{{ auth_base_url }}/signup">
-      Sign Up
-    </a>
-    <span>|</span>
-    <a href="{{ auth_base_url }}/login">
-      Login
-    </a>
+  <a class="header-link" href="{{ auth_base_url }}/user">
+    Click here to sign up or log in
+  </a>
     {% endif %}
   </div>
 </div>

--- a/web_common/web_common/templates/new_header.html
+++ b/web_common/web_common/templates/new_header.html
@@ -63,7 +63,7 @@
     </a>
     {% else %}
   <a class="header-link" href="{{ auth_base_url }}/user">
-    Click here to sign up or log in
+    Log in or sign up
   </a>
     {% endif %}
   </div>


### PR DESCRIPTION
## Change Description

Changes login flow in the UI to go via the user page, which gives us a chance to show (and require acceptance of) the terms of service:

<img width="940" alt="image" src="https://github.com/user-attachments/assets/b656a577-4432-47fe-acd5-971a2373207f" />
Notes to reviewers:
- It should not be possible to log in via the UI except via the `/user` page (ignoring direct url-surfing to the `/login` url)
- The next_url mechanism should continue to work as before (ie navigate to `/batches` > prompted to login > login success > should end up on the batches page)

## Security Assessment

Delete all except the correct answer:
- This change has a medium security impact

### Impact Description

Moves the login button and updates some redirects, but does not fundamentally alter anything about the login flow.

(Reviewers: please confirm the security impact before approving)
