### PR TITLE
[query] remove unused `scalaClassTag` method on `Type`

### DIFF
--- a/hail/hail/src/is/hail/types/virtual/TArray.scala
+++ b/hail/hail/src/is/hail/types/virtual/TArray.scala
@@ -4,8 +4,6 @@ import is.hail.annotations.{Annotation, ExtendedOrdering}
 import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 
-import scala.reflect.{classTag, ClassTag}
-
 import org.json4s.jackson.JsonMethods
 
 final case class TArray(elementType: Type) extends TContainer {
@@ -50,8 +48,6 @@ final case class TArray(elementType: Type) extends TContainer {
 
   def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.iterableOrdering(elementType.ordering(sm), missingEqual)
-
-  override def scalaClassTag: ClassTag[IndexedSeq[AnyRef]] = classTag[IndexedSeq[AnyRef]]
 
   override def valueSubsetter(subtype: Type): Any => Any = {
     if (this == subtype)

--- a/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.utils._
 
-import scala.reflect.{classTag, ClassTag}
-
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods
 
@@ -118,5 +116,4 @@ abstract class TBaseStruct extends Type {
             t.valuesSimilar(x1, x2, tolerance, absolute)
         })
 
-  override def scalaClassTag: ClassTag[Row] = classTag[Row]
 }

--- a/hail/hail/src/is/hail/types/virtual/TBinary.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBinary.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 
-import scala.reflect.{ClassTag, _}
-
 case object TBinary extends Type {
   def _toPretty = "Binary"
 
@@ -14,8 +12,6 @@ case object TBinary extends Type {
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] =
     Gen.buildableOf(arbitrary[Byte])
-
-  override def scalaClassTag: ClassTag[Array[Byte]] = classTag[Array[Byte]]
 
   def mkOrdering(sm: HailStateManager, _missingEqual: Boolean = true): ExtendedOrdering =
     ExtendedOrdering.iterableOrdering(new ExtendedOrdering {

--- a/hail/hail/src/is/hail/types/virtual/TBoolean.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBoolean.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 
-import scala.reflect.{ClassTag, _}
-
 case object TBoolean extends Type {
   def _toPretty = "Boolean"
 
@@ -20,8 +18,6 @@ case object TBoolean extends Type {
   def parse(s: String): Annotation = s.toBoolean
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Boolean]
-
-  override def scalaClassTag: ClassTag[java.lang.Boolean] = classTag[java.lang.Boolean]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Boolean]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TCall.scala
+++ b/hail/hail/src/is/hail/types/virtual/TCall.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.variant.Call
 
-import scala.reflect.{ClassTag, _}
-
 case object TCall extends Type {
   def _toPretty = "Call"
 
@@ -18,8 +16,6 @@ case object TCall extends Type {
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = Call.genNonmissingValue
-
-  override def scalaClassTag: ClassTag[java.lang.Integer] = classTag[java.lang.Integer]
 
   override def str(a: Annotation): String =
     if (a == null) "NA" else Call.toString(a.asInstanceOf[Call])

--- a/hail/hail/src/is/hail/types/virtual/TDict.scala
+++ b/hail/hail/src/is/hail/types/virtual/TDict.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.utils._
 
-import scala.reflect.{classTag, ClassTag}
-
 import org.json4s.jackson.JsonMethods
 
 final case class TDict(keyType: Type, valueType: Type) extends TContainer {
@@ -73,8 +71,6 @@ final case class TDict(keyType: Type, valueType: Type) extends TContainer {
             valueType.valuesSimilar(v1, v2, tolerance, absolute)
           }
         })
-
-  override def scalaClassTag: ClassTag[Map[_, _]] = classTag[Map[_, _]]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.mapOrdering(elementType.ordering(sm), missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TFloat32.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat32.scala
@@ -6,8 +6,6 @@ import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.utils._
 
-import scala.reflect.{ClassTag, _}
-
 case object TFloat32 extends TNumeric {
   def _toPretty = "Float32"
 
@@ -38,8 +36,6 @@ case object TFloat32 extends TNumeric {
 
       f1 == f2 || withinTol || (f1.isNaN && f2.isNaN)
     })
-
-  override def scalaClassTag: ClassTag[java.lang.Float] = classTag[java.lang.Float]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Float]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TFloat64.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat64.scala
@@ -6,8 +6,6 @@ import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.utils._
 
-import scala.reflect.{ClassTag, _}
-
 case object TFloat64 extends TNumeric {
   override def _toPretty = "Float64"
 
@@ -37,8 +35,6 @@ case object TFloat64 extends TNumeric {
 
       f1 == f2 || withinTol || (f1.isNaN && f2.isNaN)
     })
-
-  override def scalaClassTag: ClassTag[java.lang.Double] = classTag[java.lang.Double]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Double]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TInt32.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInt32.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 
-import scala.reflect.{ClassTag, _}
-
 case object TInt32 extends TIntegral {
   def _toPretty = "Int32"
 
@@ -16,8 +14,6 @@ case object TInt32 extends TIntegral {
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Int]
-
-  override def scalaClassTag: ClassTag[java.lang.Integer] = classTag[java.lang.Integer]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TInt64.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInt64.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 
-import scala.reflect.{ClassTag, _}
-
 case object TInt64 extends TIntegral {
   def _toPretty = "Int64"
 
@@ -16,8 +14,6 @@ case object TInt64 extends TIntegral {
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Long]
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[Long]
-
-  override def scalaClassTag: ClassTag[java.lang.Long] = classTag[java.lang.Long]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Long]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TInterval.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInterval.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.utils.{FastSeq, Interval}
 
-import scala.reflect.{classTag, ClassTag}
-
 case class TInterval(pointType: Type) extends Type {
 
   override def children = FastSeq(pointType)
@@ -32,8 +30,6 @@ case class TInterval(pointType: Type) extends Type {
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] =
     Interval.gen(pointType.ordering(sm), pointType.genValue(sm))
-
-  override def scalaClassTag: ClassTag[Interval] = classTag[Interval]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     Interval.ordering(pointType.ordering(sm), startPrimary = true, missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TLocus.scala
+++ b/hail/hail/src/is/hail/types/virtual/TLocus.scala
@@ -6,8 +6,6 @@ import is.hail.check._
 import is.hail.utils._
 import is.hail.variant._
 
-import scala.reflect.{classTag, ClassTag}
-
 object TLocus {
   val representation: TStruct =
     TStruct(
@@ -38,8 +36,6 @@ case class TLocus(rgName: String) extends Type {
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] =
     Locus.gen(sm.referenceGenomes(rgName))
-
-  override def scalaClassTag: ClassTag[Locus] = classTag[Locus]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering =
     sm.referenceGenomes(rgName).extendedLocusOrdering

--- a/hail/hail/src/is/hail/types/virtual/TNDArray.scala
+++ b/hail/hail/src/is/hail/types/virtual/TNDArray.scala
@@ -5,10 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 import is.hail.expr.{Nat, NatBase}
 
-import scala.reflect.{classTag, ClassTag}
-
-import org.apache.spark.sql.Row
-
 object TNDArray {
   def matMulNDims(l: Int, r: Int): Int = {
     (l, r) match {
@@ -109,8 +105,6 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
   }
 
   override def subst(): TNDArray = TNDArray(elementType.subst(), nDimsBase.subst())
-
-  override def scalaClassTag: ClassTag[Row] = classTag[Row]
 
   def _typeCheck(a: Annotation): Boolean = a match {
     case nd: NDArray => nd.forall(e => elementType.typeCheck(e))

--- a/hail/hail/src/is/hail/types/virtual/TRNGState.scala
+++ b/hail/hail/src/is/hail/types/virtual/TRNGState.scala
@@ -16,8 +16,6 @@ case object TRNGState extends Type {
   def mkOrdering(sm: HailStateManager, missingEqual: Boolean)
     : is.hail.annotations.ExtendedOrdering = ???
 
-  def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] = ???
-
   override def isIsomorphicTo(t: Type): Boolean =
     this == t
 }

--- a/hail/hail/src/is/hail/types/virtual/TSet.scala
+++ b/hail/hail/src/is/hail/types/virtual/TSet.scala
@@ -4,8 +4,6 @@ import is.hail.annotations.{Annotation, ExtendedOrdering}
 import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 
-import scala.reflect.{classTag, ClassTag}
-
 import org.json4s.jackson.JsonMethods
 
 final case class TSet(elementType: Type) extends TContainer {
@@ -50,8 +48,6 @@ final case class TSet(elementType: Type) extends TContainer {
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] =
     Gen.buildableOf[Set](elementType.genValue(sm))
-
-  override def scalaClassTag: ClassTag[Set[AnyRef]] = classTag[Set[AnyRef]]
 
   override def valueSubsetter(subtype: Type): Any => Any = {
     assert(elementType == subtype.asInstanceOf[TSet].elementType)

--- a/hail/hail/src/is/hail/types/virtual/TStream.scala
+++ b/hail/hail/src/is/hail/types/virtual/TStream.scala
@@ -4,8 +4,6 @@ import is.hail.annotations.{Annotation, ExtendedOrdering}
 import is.hail.backend.HailStateManager
 import is.hail.check.Gen
 
-import scala.reflect.{classTag, ClassTag}
-
 import org.json4s.jackson.JsonMethods
 
 final case class TStream(elementType: Type) extends TIterable {
@@ -45,8 +43,6 @@ final case class TStream(elementType: Type) extends TIterable {
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     throw new UnsupportedOperationException("Stream comparison is currently undefined.")
-
-  override def scalaClassTag: ClassTag[Iterator[AnyRef]] = classTag[Iterator[AnyRef]]
 
   override def isIsomorphicTo(t: Type): Boolean =
     t match {

--- a/hail/hail/src/is/hail/types/virtual/TString.scala
+++ b/hail/hail/src/is/hail/types/virtual/TString.scala
@@ -5,8 +5,6 @@ import is.hail.backend.HailStateManager
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 
-import scala.reflect.{ClassTag, _}
-
 case object TString extends Type {
   def _toPretty = "String"
 
@@ -18,8 +16,6 @@ case object TString extends Type {
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[String]
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = arbitrary[String]
-
-  override def scalaClassTag: ClassTag[String] = classTag[String]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[String]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TUnion.scala
+++ b/hail/hail/src/is/hail/types/virtual/TUnion.scala
@@ -6,8 +6,6 @@ import is.hail.check.Gen
 import is.hail.expr.ir.IRParser
 import is.hail.utils._
 
-import scala.reflect.ClassTag
-
 import org.json4s.CustomSerializer
 import org.json4s.JsonAST.JString
 
@@ -126,8 +124,6 @@ final case class TUnion(cases: IndexedSeq[Case]) extends Type {
   }
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = ???
-
-  override def scalaClassTag: ClassTag[AnyRef] = ???
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = ???
 

--- a/hail/hail/src/is/hail/types/virtual/TVariable.scala
+++ b/hail/hail/src/is/hail/types/virtual/TVariable.scala
@@ -6,7 +6,6 @@ import is.hail.check.Gen
 import is.hail.types.Box
 
 import scala.collection.mutable
-import scala.reflect.ClassTag
 
 object TVariable {
   val condMap: Map[String, (Type) => Boolean] = Map(
@@ -72,9 +71,6 @@ final case class TVariable(name: String, cond: String = null) extends Type {
   }
 
   override def genNonmissingValue(sm: HailStateManager): Gen[Annotation] = ???
-
-  override def scalaClassTag: ClassTag[AnyRef] =
-    throw new RuntimeException("TVariable is not realizable")
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = null
 

--- a/hail/hail/src/is/hail/types/virtual/TVoid.scala
+++ b/hail/hail/src/is/hail/types/virtual/TVoid.scala
@@ -14,9 +14,6 @@ case object TVoid extends Type {
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = null
 
-  override def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] =
-    throw new UnsupportedOperationException("No ClassTag for Void")
-
   override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Unit]
 
   override def isRealizable = false

--- a/hail/hail/src/is/hail/types/virtual/Type.scala
+++ b/hail/hail/src/is/hail/types/virtual/Type.scala
@@ -9,8 +9,6 @@ import is.hail.utils
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.sql.types.DataType
 import org.json4s.{CustomSerializer, JValue}
 import org.json4s.JsonAST.JString
@@ -194,8 +192,6 @@ abstract class Type extends VType with Serializable {
     tolerance: Double = utils.defaultTolerance,
     absolute: Boolean = false,
   ): Boolean = a1 == a2
-
-  def scalaClassTag: ClassTag[_ <: AnyRef]
 
   def canCompare(other: Type): Boolean = this == other
 


### PR DESCRIPTION
A project-wide search showed no uses.
This change has no security impact.