### PR TITLE
[batch] `hailctl batch submit` improvements and testing

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1027,6 +1027,7 @@ steps:
       export HAIL_DOCTEST_DATA_DIR=$(realpath ./data)
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
+      
       python3 -m pytest \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
@@ -1037,6 +1038,7 @@ steps:
               --durations=50 \
               --ignore=test/hailtop/batch/ \
               --ignore=test/hailtop/inter_cloud \
+              --ignore=test/hailtop/hailctl/batch \
               --timeout=120 \
               test
     inputs:
@@ -3025,7 +3027,8 @@ steps:
               --instafail \
               --durations=50 \
               --timeout=360 \
-              /io/test/hailtop/batch/
+              /io/test/hailtop/batch/ /io/test/hailtop/hailctl/batch
+
     inputs:
       - from: /repo/hail/python/pytest.ini
         to: /io/pytest.ini
@@ -3077,7 +3080,7 @@ steps:
       mkdir -p foo
       echo "bar" > foo/baz.txt
 
-      cat >simple_hail.py <<EOF
+      cat > simple_hail.py << EOF
       import hail as hl
 
       with open('foo/baz.txt') as f:
@@ -3090,14 +3093,12 @@ steps:
       BATCH_ID=$(hailctl batch submit simple_hail.py --name=test-hailctl-batch-submit --files=foo -o json | jq '.id')
       STATUS=$(hailctl batch wait -o json $BATCH_ID)
       STATE=$(echo $STATUS | jq -jr '.state')
-      if [ "$STATE" == "success" ]; then
-          exit 0;
-      else
+      if [ "$STATE" != "success" ]; then
           echo $STATUS;
           exit 1;
       fi
 
-      cat >hail_with_args.py <<EOF
+      cat > hail_with_args.py << EOF
       import hail as hl
       import sys
 
@@ -3108,34 +3109,30 @@ steps:
       assert hl.utils.range_table(int(sys.argv[1]))._force_count() == 100
       EOF
 
-      BATCH_ID=$(hailctl batch submit --name=test-hailctl-batch-submit --files=foo -o json hail_with_args.py 100 | jq '.id')
+      BATCH_ID=$(hailctl batch submit hail_with_args.py --name=test-hailctl-batch-submit --files=foo -o json -- 100 | jq '.id')
       STATUS=$(hailctl batch wait -o json $BATCH_ID)
       STATE=$(echo $STATUS | jq -jr '.state')
-      if [ "$STATE" == "success" ]; then
-          exit 0;
-      else
+      if [ "$STATE" != "success" ]; then
           echo $STATUS;
           exit 1;
       fi
 
-      cat >file.sh <<EOF
+      cat > file.sh << 'EOF'
       set -ex
 
-      cat foo
+      cat foo/baz.txt
       echo "Hello World!"
       EOF
 
-      BATCH_ID=$(hailctl batch submit --name=test-hailctl-batch-submit --files=foo -o json file.sh | jq '.id')
+      BATCH_ID=$(hailctl batch submit file.sh --name=test-hailctl-batch-submit --files=foo -o json --image busybox:latest | jq '.id')
       STATUS=$(hailctl batch wait -o json $BATCH_ID)
       STATE=$(echo $STATUS | jq -jr '.state')
-      if [ "$STATE" == "success" ]; then
-          exit 0;
-      else
+      if [ "$STATE" != "success" ]; then
           echo $STATUS;
           exit 1;
       fi
 
-      cat >file-with-args.sh <<EOF
+      cat > file-with-args.sh << EOF
       set -ex
 
       [[ $# -eq 2 ]]
@@ -3144,12 +3141,10 @@ steps:
       echo "Hello World! $1 $2"
       EOF
 
-      BATCH_ID=$(hailctl batch submit --name=test-hailctl-batch-submit --files=foo -o json file-with-args.sh abc 123 | jq '.id')
+      BATCH_ID=$(hailctl batch submit file-with-args.sh --name=test-hailctl-batch-submit --files=foo -o json --image ubuntu:latest -- abc 123 | jq '.id')
       STATUS=$(hailctl batch wait -o json $BATCH_ID)
       STATE=$(echo $STATUS | jq -jr '.state')
-      if [ "$STATE" == "success" ]; then
-          exit 0;
-      else
+      if [ "$STATE" != "success" ]; then
           echo $STATUS;
           exit 1;
       fi
@@ -4008,8 +4003,6 @@ steps:
     dependsOn:
       - ci_utils_image
       - default_ns
-    scopes:
-      - deploy
   - kind: runImage
     name: test_gcp_ar_cleanup_policies
     resources:

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -247,6 +247,9 @@ class AsyncFSURL(abc.ABC):
     def __str__(self) -> str:
         pass
 
+    def __truediv__(self, part: str) -> 'AsyncFSURL':
+        return self.with_new_path_components(part)
+
 
 class AsyncFS(abc.ABC):
     FILE = "file"

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -158,7 +158,7 @@ class Batch:
         from hailtop.batch.backend import ServiceBackend  # pylint: disable=import-outside-toplevel
 
         b = Batch(*args, **kwargs)
-        assert isinstance(b._backend, ServiceBackend)
+        assert isinstance(b._backend, ServiceBackend), repr(b._backend)
         b._async_batch = await (await b._backend._batch_client()).get_batch(batch_id)
         return b
 

--- a/hail/python/hailtop/hailctl/batch/submit.py
+++ b/hail/python/hailtop/hailctl/batch/submit.py
@@ -1,108 +1,231 @@
 import os
-import re
-from shlex import quote as shq
-from typing import Tuple
+import shlex
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Any, Generator, List, NoReturn, Optional, Set, Tuple, Union
 
 import orjson
+import typer
 
-from hailtop import __pip_version__
+from hailtop import yamlx
+from hailtop.aiotools.copy import copy_from_dict
+from hailtop.aiotools.fs import AsyncFSURL
+from hailtop.aiotools.router_fs import RouterAsyncFS
+from hailtop.batch import Batch, ServiceBackend
+from hailtop.batch.job import BashJob
+from hailtop.config import (
+    get_deploy_config,
+    get_remote_tmpdir,
+    get_user_config_path,
+)
+from hailtop.utils import secret_alnum_string
+from hailtop.version import __pip_version__
 
-FILE_REGEX = re.compile(r'(?P<src>[^:]+)(:(?P<dest>.+))?')
+from .batch_cli_utils import StructuredFormatPlusTextOption
 
 
-async def submit(name, image_name, files, output, script, arguments):
-    import hailtop.batch as hb  # pylint: disable=import-outside-toplevel
-    from hailtop.aiotools.copy import copy_from_dict  # pylint: disable=import-outside-toplevel
-    from hailtop.config import (  # pylint: disable=import-outside-toplevel
-        get_deploy_config,
-        get_remote_tmpdir,
-        get_user_config_path,
-    )
-    from hailtop.utils import (  # pylint: disable=import-outside-toplevel
-        secret_alnum_string,
-        unpack_comma_delimited_inputs,
-    )
+class HailctlBatchSubmitError(Exception):
+    def __init__(self, message: str, exit_code: int):
+        self.message = message
+        self.exit_code = exit_code
 
-    files = unpack_comma_delimited_inputs(files)
-    user_config = str(get_user_config_path())
 
-    quiet = output != 'text'
+async def submit(
+    script: Path,
+    name: Optional[str],
+    image: Optional[str],
+    files_options: List[str],
+    output: StructuredFormatPlusTextOption,
+    wait: bool,
+    quiet: bool,
+    *arguments: str,
+):
+    async with AsyncExitStack() as exitstack:
+        fs = RouterAsyncFS()
+        exitstack.push_async_callback(fs.close)
 
-    remote_tmpdir = get_remote_tmpdir('hailctl batch submit')
+        remote_tmpdir = fs.parse_url(get_remote_tmpdir('hailctl batch submit')) / secret_alnum_string()
 
-    tmpdir_path_prefix = secret_alnum_string()
+        backend = ServiceBackend()
+        exitstack.push_async_callback(backend._async_close)
 
-    def cloud_prefix(path):
-        path = path.lstrip('/')
-        return f'{remote_tmpdir}/{tmpdir_path_prefix}/{path}'
+        b = Batch(name=name, backend=backend)
+        j = b.new_job(shell='/bin/sh')
+        j.image(image or os.getenv('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{__pip_version__}'))
+        j.env('HAIL_QUERY_BACKEND', 'batch')
+        await transfer_user_config_into_job(b, j, remote_tmpdir)
 
-    def file_input_to_src_dest(file: str) -> Tuple[str, str, str]:
-        match = FILE_REGEX.match(file)
-        if match is None:
-            raise ValueError(f'invalid file specification {file}. Must have the form "src" or "src:dest"')
+        # The knowledge of why the current working directory is mirrored onto the
+        # worker has been lost to the sands of time. Some speculate that a user's
+        # code didn't work because it relied on the state of the local filesystem.
+        # Nonetheless, we continue the fine work of our forebears like good sheep.
+        remote_working_dir = __real_absolute_local_path('.', strict=True)
+        j.command(f'mkdir -p {shq(remote_working_dir)} && cd {shq(remote_working_dir)}')
 
-        result = match.groupdict()
+        script_path = __real_absolute_local_path(script, strict=True)
+        xfers = [(script_path, Path(script_path.name))]
+        xfers += [parse_files_to_src_dest(files) for files in files_options]
+        await transfer_files_options_files_into_job(xfers, remote_working_dir, remote_tmpdir, b, j)
 
-        src = result.get('src')
-        if src is None:
-            raise ValueError(f'invalid file specification {file}. Must have a "src" defined.')
-        src = os.path.abspath(os.path.expanduser(src))
-        src = src.rstrip('/')
+        executable = shq(script_path.name)
+        j.name = executable
 
-        dest = result.get('dest')
-        if dest is not None:
-            dest = os.path.abspath(os.path.expanduser(dest))
+        command = 'python3' if executable.endswith(".py") else f'chmod +x ./{executable} &&'
+        shargs = ' '.join([shq(x) for x in arguments])
+        j.command(f'{command} ./{executable} {shargs}')
+
+        # Mix `async` calls with those that internally use `async_to_blocking` at your own peril.
+        batch_handle = await b._async_run(wait=False, disable_progress_bar=quiet)
+        assert batch_handle
+        async_batch = batch_handle._async_batch
+
+        if not wait:
+            deploy_config = get_deploy_config()
+            url = deploy_config.external_url('batch', f'/batches/{async_batch.id}/jobs/1')
+            print(
+                f'Submitted batch {async_batch.id}, see {url}.'
+                if output == 'text'
+                else orjson.dumps({'batch_id': async_batch.id, 'url': url}).decode('utf-8')
+                if output == 'json'
+                else yamlx.dump({'batch_id': async_batch.id, 'url': url})
+            )
         else:
-            dest = os.getcwd()
+            out = await async_batch.wait(disable_progress_bar=quiet)
+            try:
+                out['log'] = (await async_batch.get_job_log(1))['main']
+            except Exception as e:
+                out['log'] = f'Could not retrieve job log: {e}'
 
-        cloud_file = cloud_prefix(src)
+            print(orjson.dumps(out).decode('utf-8') if output == 'json' else yamlx.dump(out))
 
-        return (src, dest, cloud_file)
+            if out['state'] != 'success':
+                raise typer.Exit(1)
 
-    backend = hb.ServiceBackend()
-    b = hb.Batch(name=name, backend=backend)
-    j = b.new_bash_job()
-    j.image(image_name or os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{__pip_version__}'))
 
-    local_files_to_cloud_files = []
+async def transfer_files_options_files_into_job(
+    src_dst_pairs: List[Tuple[Path, Optional[Path]]],
+    remote_working_dir: Path,
+    remote_tmpdir: AsyncFSURL,
+    b: Batch,
+    j: BashJob,
+) -> None:
+    src_dst_staging_triplets = [
+        (src, dst, str(remote_tmpdir / 'in' / str(src).lstrip('/')))
+        for src, dst in generate_file_xfers(src_dst_pairs, remote_working_dir)
+    ]
 
-    for file in files:
-        src, dest, cloud_file = file_input_to_src_dest(file)
-        local_files_to_cloud_files.append({'from': src, 'to': cloud_file})
-        in_file = b.read_input(cloud_file)
-        j.command(f'mkdir -p {os.path.dirname(dest)}; ln -s {in_file} {dest}')
+    if non_existing_files := [str(src) for src, _, _ in src_dst_staging_triplets if not src.exists()]:
+        non_existing_files_str = '- ' + '\n- '.join(non_existing_files)
+        raise ValueError(f'Some --files did not exist:\n{non_existing_files_str}')
 
-    script_src, _, script_cloud_file = file_input_to_src_dest(script)
-    user_config_src, _, user_config_cloud_file = file_input_to_src_dest(user_config)
+    await copy_from_dict(files=[{'from': str(src), 'to': staging} for src, _, staging in src_dst_staging_triplets])
 
-    await copy_from_dict(files=local_files_to_cloud_files)
-    await copy_from_dict(
-        files=[
-            {'from': script_src, 'to': script_cloud_file},
-            {'from': user_config_src, 'to': user_config_cloud_file},
-        ]
+    mkdirs = {remote_working_dir, *remote_working_dir.parents}
+
+    for _, dst, staging in src_dst_staging_triplets:
+        in_file = await b._async_read_input(staging)
+
+        if dst.parent not in mkdirs:
+            j.command(f'mkdir -p {shq(dst.parent)}')
+            mkdirs.update(dst.parents)
+
+        j.command(f'ln -sT {shq(in_file)} {shq(dst)}')
+
+
+async def transfer_user_config_into_job(b: Batch, j: BashJob, remote_tmpdir: AsyncFSURL) -> None:
+    user_config_path = get_user_config_path()
+    if not user_config_path.exists():
+        return
+
+    staging = str(remote_tmpdir / user_config_path.name)
+    await copy_from_dict(files=[{'from': str(user_config_path), 'to': str(staging)}])
+    file = await b._async_read_input(staging)
+    j.command(f'mkdir -p $HOME/.config/hail && ln -sT {file} $HOME/.config/hail/config.ini')
+
+
+def parse_files_to_src_dest(fileopt: str) -> Tuple[Path, Optional[Path]]:
+    def raise_value_error(msg: str) -> NoReturn:
+        raise ValueError(f'Invalid file specification {fileopt}: {msg}.')
+
+    try:
+        from_, *to_ = fileopt.split(':')
+    except ValueError:
+        raise_value_error('Must have the form "src" or "src:dst"')
+
+    return (
+        __real_absolute_local_path(from_, strict=False)  # defer strictness checks and globbing
+        if len(from_) != 0  # src is non-empty
+        else raise_value_error('Must have a "src" defined'),
+        None
+        if len(to_) == 0  # dst = []
+        else Path(to_[0])
+        if len(to_) == 1  # dst = [folder]
+        else raise_value_error('Specify at most one "dst".'),
     )
 
-    script_file = b.read_input(script_cloud_file)
-    config_file = b.read_input(user_config_cloud_file)
 
-    j.env('HAIL_QUERY_BACKEND', 'batch')
+def generate_file_xfers(
+    src_dst: List[Tuple[Path, Optional[Path]]],
+    absolute_remote_cwd: Path,
+) -> Generator[Tuple[Path, Path], None, None]:
+    known_remote_files: Set[Path] = set()
+    known_remote_folders: Set[Path] = {absolute_remote_cwd, *absolute_remote_cwd.parents}
 
-    command = 'python3' if script.endswith('.py') else 'bash'
-    script_arguments = " ".join(shq(x) for x in arguments)
+    def raise_when_overwrites_file(src, dst):
+        if dst in known_remote_files:
+            raise ValueError(f"Cannot overwrite non-directory '{dst}' with directory '{src}'", 1)
 
-    j.command(f'mkdir -p $HOME/.config/hail && ln -s {config_file} $HOME/.config/hail/config.ini')
-    j.command(f'cd {os.getcwd()}')
-    j.command(f'{command} {script_file} {script_arguments}')
-    batch_handle = await b._async_run(wait=False, disable_progress_bar=quiet)
-    assert batch_handle
+    q = list(reversed(src_dst))
 
-    if output == 'text':
-        deploy_config = get_deploy_config()
-        url = deploy_config.external_url('batch', f'/batches/{batch_handle.id}/jobs/1')
-        print(f'Submitted batch {batch_handle.id}, see {url}')
-    else:
-        assert output == 'json'
-        print(orjson.dumps({'id': batch_handle.id}).decode('utf-8'))
+    while len(q) != 0:
+        src, dst = q.pop()
 
-    await backend.async_close()
+        if '**' in src.parts:
+            raise ValueError(f'Recursive SRC glob patterns are not supported: {src}')
+
+        dst = Path.resolve(
+            absolute_remote_cwd
+            if dst is None
+            else absolute_remote_cwd / dst
+            if not dst.is_absolute()  # enough, ruff
+            else Path(dst)
+        )
+
+        if src.is_dir() and dst in known_remote_folders:
+            __raise_when_whole_filesystem_xfer(src)
+            raise_when_overwrites_file(src, dst)
+            q += [(path, dst / path.name) for path in src.iterdir()]
+            continue
+
+        if '*' in src.name:
+            __raise_when_whole_filesystem_xfer(src.parent)
+            raise_when_overwrites_file(src.parent, dst)
+            q += [(path, dst / path.name) for path in src.parent.glob(src.name)]
+            continue
+
+        if src.is_file():
+            if dst in known_remote_folders:
+                dst = dst / src.name
+
+            known_remote_files.add(dst)
+        else:
+            known_remote_folders.add(dst)
+
+        known_remote_folders.update(dst.parents)
+        yield src, dst
+
+
+# Note well, friends:
+# This uses the local environment to support paths with variables like $HOME or $XDG_ directories.
+# Consequently, it is inappropriate to resolve paths on the worker with this function.
+def __real_absolute_local_path(path: Union[str, os.PathLike[str]], *, strict: bool) -> Path:
+    return Path(os.path.expandvars(path)).expanduser().resolve(strict=strict)
+
+
+def __raise_when_whole_filesystem_xfer(path: Path):
+    if path.parent == path:
+        raise ValueError('Cannot transfer whole drive or root filesystem to remote worker.')
+
+
+def shq(p: Any) -> str:
+    return shlex.quote(str(p))

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -1,0 +1,280 @@
+import os
+import re
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Union
+
+import orjson
+import pytest
+from typer.testing import CliRunner, Result
+
+from hailtop import __pip_version__
+from hailtop.batch import Batch
+from hailtop.hailctl.batch import cli
+from hailtop.hailctl.batch.submit import parse_files_to_src_dest
+from hailtop.utils import secret_alnum_string
+
+
+@pytest.fixture(scope='function', autouse=True)
+def expect_timeouts_as_image_pulling_is_very_slow(request):
+    five_minutes = 5 * 60
+    timeout = pytest.mark.timeout(five_minutes)
+    request.node.add_marker(timeout)
+
+
+@pytest.fixture
+def submit(request):
+    runner = CliRunner(mix_stderr=False)
+
+    def invoker(script: Union[str, os.PathLike], *args: str, **kwargs):
+        command = ['submit', str(script), *args]
+
+        # For ease of identifying the test in the batch ui
+        if '--name' not in command:
+            command += ['--name', request.node.nodeid]
+
+        return runner.invoke(
+            cli.app,
+            command,
+            catch_exceptions=kwargs.get('catch_exceptions', False),
+            **kwargs,
+        )
+
+    return invoker
+
+
+@contextmanager
+def tmp_cwd(path: Path):
+    cwd = os.getcwd()
+    path.mkdir(parents=True, exist_ok=True)
+    os.chdir(path)
+    try:
+        yield path
+    finally:
+        os.chdir(cwd)
+
+
+@pytest.fixture(name='tmp_cwd')
+def tmp_cwd_fixture(tmp_path):
+    with tmp_cwd(tmp_path) as cd:
+        yield cd
+
+
+def assert_exit_code(res: Result, exit_code: int):
+    assert res.exit_code == exit_code, repr((res.output, res.stdout, res.stderr, res.exception))
+
+
+def parse_batch_from_text_output(res: Result) -> Batch:
+    batch_id = re.findall(r'\d+', res.output)[0]
+    return Batch.from_batch_id(int(batch_id))
+
+
+def puts(filename: Path, content: str):
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    filename.write_text(content)
+
+
+def echo0(dir: Path) -> Path:
+    script = dir / f'script{secret_alnum_string(6)}'
+    puts(script, 'echo 0')
+    return script
+
+
+def write_pyscript(dir: Union[str, Path], file_to_echo: Union[str, Path]) -> Path:
+    script = Path(dir) / f'test_job_{secret_alnum_string(6)}.py'
+    puts(script, f'print(open("{file_to_echo}").read())')
+    return script
+
+
+def write_hello(filename: Path):
+    puts(filename, 'hello\n')
+
+
+def test_name(submit, tmp_path, request):
+    batch_name = request.node.nodeid + secret_alnum_string()
+    res = submit(echo0(tmp_path), '--name', batch_name)
+    assert_exit_code(res, 0)
+
+    b = parse_batch_from_text_output(res)
+    assert b.run().attributes['name'] == batch_name
+
+
+def test_image(submit, tmp_path):
+    image = 'busybox:latest'
+    res = submit(echo0(tmp_path), '--image', image)
+    assert_exit_code(res, 0)
+
+    b = parse_batch_from_text_output(res)
+    j = b.run().get_job(1)
+    assert j.status()['spec']['process']['image'] == image
+
+
+def test_default_image(submit, tmp_path):
+    res = submit(echo0(tmp_path))
+    assert_exit_code(res, 0)
+
+    b = parse_batch_from_text_output(res)
+    j = b.run().get_job(1)
+    assert j.status()['spec']['process']['image'] == f'hailgenetics/hail:{__pip_version__}'
+
+
+def test_image_environment_variable(submit, tmp_path):
+    res = submit(echo0(tmp_path), env={'HAIL_GENETICS_HAIL_IMAGE': 'busybox:latest'})
+    assert_exit_code(res, 0)
+
+    b = parse_batch_from_text_output(res)
+    j = b.run().get_job(1)
+    assert j.status()['spec']['process']['image'] == 'busybox:latest'
+
+
+def test_script_shebang(submit, tmp_path):
+    script_text = """\
+#!/usr/bin/env cat
+hello,
+world!
+"""
+
+    script = tmp_path / 'script'
+    script.write_text(script_text)
+    res = submit(script, '--wait', '-o', 'json')
+    assert_exit_code(res, 0)
+
+    output = orjson.loads(res.output)
+    assert output['log'] == script_text
+
+
+@pytest.mark.parametrize('files', ['', ':', ':dst'])
+def test_files_invalid_format(submit, files):
+    with pytest.raises(ValueError, match='Invalid file specification'):
+        submit(__file__, '--wait', '--files', files)
+
+
+def test_files_copy_rename(submit, tmp_cwd):
+    write_hello(tmp_cwd / 'hello.txt')
+    pyscript = write_pyscript(tmp_cwd, '/child')
+    res = submit(pyscript, '--wait', '--files', 'hello.txt:/child')
+    assert_exit_code(res, 0)
+
+
+@pytest.mark.parametrize('files', ['.', '.:.', '*', '*.txt'])
+def test_files_copy_cwd(submit, tmp_cwd, files):
+    write_hello(tmp_cwd / 'hello.txt')
+    write_hello(tmp_cwd / 'hello2.txt')
+
+    script = tmp_cwd / 'script'
+    script.write_text(
+        """\
+cat hello.txt
+cat hello2.txt
+""",
+    )
+
+    res = submit(script, '--wait', '--files', files)
+    assert_exit_code(res, 0)
+
+
+@pytest.mark.parametrize(
+    'files, remote',
+    [
+        ('a', '.'),
+        ('a:/', '/'),
+        ('a:a', 'a'),
+        ('a/b:a', 'a'),
+        ('a/../b:b', 'b'),
+        ('a:a/b', 'a/b'),
+        ('a:a/../b', 'b'),
+    ],
+)
+def test_files_copy_folder(submit, tmp_cwd, files, remote):
+    src, dst = parse_files_to_src_dest(files)
+    write_hello(src / 'hello.txt')
+    pyscript = write_pyscript(tmp_cwd, Path(remote) / 'hello.txt')
+    res = submit(pyscript, '--wait', '--files', files)
+    assert_exit_code(res, 0)
+
+
+def test_files_nested_folders(submit, tmp_path):
+    puts(tmp_path / 'python' / 'main' / '__init__.py', '')
+    puts(tmp_path / 'python' / 'main' / 'a' / '__init__.py', 'message: str = "hello"')
+    puts(tmp_path / 'python' / 'main' / 'b' / '__init__.py', 'message: str = "world"')
+
+    script = tmp_path / 'script'
+    script.write_text(
+        """\
+#!/usr/bin/env python3
+from main import a, b
+print(f'{a.message}, {b.message}')
+""",
+    )
+
+    res = submit(script, '--wait', '--files', str(tmp_path / 'python'))
+    assert_exit_code(res, 0)
+
+
+def test_files_mount_multiple_files_options(submit, tmp_cwd):
+    write_hello(tmp_cwd / 'hello1.txt')
+    write_hello(tmp_cwd / 'hello2.txt')
+
+    script = tmp_cwd / 'script'
+    script.write_text(
+        """
+        cat a/hello.txt
+        cat b/hello.txt
+        """,
+    )
+
+    res = submit(script, '--wait', '--files', 'hello1.txt:a/hello.txt', '--files', 'hello2.txt:b/hello.txt')
+    assert_exit_code(res, 0)
+
+
+def test_files_outside_current_dir(submit, tmp_path):
+    with tmp_cwd(tmp_path / 'working') as cwd:
+        write_hello(tmp_path / 'data' / 'hello.txt')
+        pyscript = write_pyscript(cwd, '/hello.txt')
+        res = submit(pyscript, '--wait', '--files', f'{tmp_path}/data/hello.txt:/')
+        assert_exit_code(res, 0)
+
+
+def test_files_relative_dst(submit, tmp_path):
+    with tmp_cwd(tmp_path / 'working') as cwd:
+        write_hello(tmp_path / 'hello.txt')
+        pyscript = write_pyscript(cwd, '../hello.txt')
+        res = submit(pyscript, '--wait', '--files', '../hello.txt:../')
+        assert_exit_code(res, 0)
+
+
+def test_files_dir_outside_curdir(submit, tmp_path):
+    with tmp_cwd(tmp_path / 'working'):
+        write_hello(tmp_path / 'hello1.txt')
+        write_hello(tmp_path / 'hello2.txt')
+        pyscript = write_pyscript(tmp_path, '/foo/hello1.txt')
+        res = submit(pyscript, '--wait', '--files', f'{tmp_path}:/foo')
+        assert_exit_code(res, 0)
+
+
+def test_files_environment_variables(submit, tmp_path):
+    write_hello(tmp_path / 'hello.txt')
+    pyscript = write_pyscript(tmp_path, 'hello.txt')
+
+    varname = secret_alnum_string(6)
+    os.environ[varname] = str(tmp_path)
+    res = submit(pyscript, '--wait', '--files', f'${varname}')
+    assert_exit_code(res, 0)
+
+
+def test_files_unsupported_glob_patterns(submit):
+    with pytest.raises(ValueError, match='Recursive SRC glob patterns are not supported'):
+        submit(__file__, '--wait', '--files', '../**/*.txt')
+
+
+@pytest.mark.parametrize('files', ['/', '/*'])
+def test_files_unsupported_transfer_root(submit, files):
+    with pytest.raises(ValueError, match='Cannot transfer whole drive or root filesystem to remote worker'):
+        submit(__file__, '--wait', '--files', files)
+
+
+def test_files_clobber_file_with_folder(submit, tmp_path):
+    write_hello(tmp_path / 'hello.txt')
+    pyscript = write_pyscript(tmp_path, 'hello.txt')
+    res = submit(pyscript, '--files', f'{tmp_path}/hello.txt', '--files', f'{tmp_path}:hello.txt')
+    assert_exit_code(res, 1)


### PR DESCRIPTION
Potentially backwards incompatible `hailctl batch submit` rewrite and various other fixes. Originally authored by @danking in  #14186 and later @jigold in #14351. It's had some tweaks since then as well as a liberal sprinkling of my biases.

Issues resolved:

1. `build.yaml` tests must not use `exit 0` as it exits the test early.

2. Always prefer `orjson` to `json`.

3. The `--files` option has been changed significantly, allowing for special characters, environment variables and glob patterns in `SRC` paths. DST paths may be absolute or relative to the job's working directory.

4. Contra to @danking's approach, I'm not giving special dispensation to trailing slashes in DST paths. Instead I'm mimicking the behaviour of gnu tools `cp -RT SRC DST`.

Fixes #14274

This change has low security impact.