### PR TITLE
[query] Preserve field order in StructExpression.rename

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -2064,8 +2064,7 @@ class StructExpression(Mapping[Union[str, int], Expression], Expression):
 
         if len(named_exprs) == 0:
             return selected_expr
-        else:
-            return selected_expr.annotate(**named_exprs)
+        return selected_expr.annotate(**named_exprs)
 
     @typecheck_method(mapping=dictof(str, str))
     def rename(self, mapping):
@@ -2110,7 +2109,8 @@ class StructExpression(Mapping[Union[str, int], Expression], Expression):
             new_to_old[new] = old
 
         return self.select(
-            *list(set(self._fields) - set(mapping)), **{new: self._get_field(old) for old, new in mapping.items()}
+            *[field for field in self._fields if field not in mapping],
+            **{new: self._get_field(old) for old, new in mapping.items()},
         )
 
     @typecheck_method(fields=str)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1,5 +1,6 @@
 import math
 import random
+import string
 import unittest
 
 import numpy as np
@@ -4536,6 +4537,18 @@ def test_reservoir_sampling():
             sample_size,
             abs(mean - sample_mean) / expected_stdev,
         )
+
+
+def test_struct_expr_rename_order():
+    keys = set(''.join(random.choice(string.ascii_letters) for _ in range(8)) for _ in range(10))
+    values = {k: random.randrange(30) for k in keys}
+    to_rename = set(x for i, x in enumerate(keys) if i % 2 == 1)
+    mapping = {old: ''.join(random.choice(string.ascii_letters) for _ in range(7)) for old in to_rename}
+    struct_expr = hl.struct(**values)
+    renamed_expr = struct_expr.rename(mapping)
+    common_left = struct_expr.drop(*to_rename)
+    common_right = renamed_expr.drop(*mapping.values())
+    assert common_left.dtype == common_right.dtype
 
 
 def test_local_agg():


### PR DESCRIPTION
Either set construction from an iterator or set difference is not order preserving. If we iterate through the struct fields in order, then our select inside of rename will preserve order for existing fields.

Brief description and justification of what this PR is doing.

## Security Assessment

Delete all except the correct answer:
- This change has no security impact

### Impact Description
Query only. Simply causes a single iteration to happen in a different order.