### PR TITLE
Making session timeout duration configurable

### DIFF
--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -52,6 +52,13 @@ spec:
                 key: cloud
           - name: HAIL_SHA
             value: "{{ code.sha }}"
+          - name: SESSION_MAX_AGE_SECS
+            value: "86400" # 86400 seconds = 1 day
+            valueFrom:
+              secretKeyRef:
+                name: auth-oauth2-client-secret
+                key: sp_oauth_scope
+                optional: true
 {% if scope != "test" %}
           - name: HAIL_SHOULD_PROFILE
             value: "1"

--- a/gear/gear/auth_utils.py
+++ b/gear/gear/auth_utils.py
@@ -1,9 +1,13 @@
+import os
 import secrets
 from typing import Optional
 
 from hailtop.auth import session_id_encode_to_str
 
 from .database import Database
+
+# Default value: 86400 seconds (1 day)
+MAX_AGE_SECS = os.environ["SESSION_MAX_AGE_SECS"]
 
 
 async def insert_user(db, spec):
@@ -18,8 +22,7 @@ VALUES ({', '.join([f'%({k})s' for k in spec.keys()])})
     )
 
 
-# 2592000s = 30d
-async def create_session(db: Database, user_id: int, max_age_secs: Optional[int] = 2592000) -> str:
+async def create_session(db: Database, user_id: int, max_age_secs: Optional[int] = MAX_AGE_SECS) -> str:
     session_id = session_id_encode_to_str(secrets.token_bytes(32))
     await db.just_execute(
         'INSERT INTO sessions (session_id, user_id, max_age_secs) VALUES (%s, %s, %s);',


### PR DESCRIPTION
## Change Description

Adding SESSION_MAX_AGE_SECS environment variable, allowing this session timeout window to be configurable in different deployments.

## Security Assessment
- This change has a low security impact

### Impact Description
Enables configuration of this timeout duration, however we already have had a notion of timing out sessions. Additionally, this will shorten our default timeout window from 30 days to 1 day.

(Reviewers: please confirm the security impact before approving)
