### PR TITLE
[query] StagedIndexReader now requires an index spec

### DIFF
--- a/hail/hail/src/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/hail/src/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -77,8 +77,8 @@ object BgenRDDPartitions extends Logging {
 
     val nonEmptyFilesAfterFilter = sortedFiles.filter(_.nVariants > 0)
 
-    val (leafSpec, intSpec) = BgenSettings.indexCodecSpecs(files.head.indexVersion, rg)
-    val getKeysFromFile = StagedBGENReader.queryIndexByPosition(ctx, leafSpec, intSpec)
+    val indexSpec = BgenSettings.getIndexSpec(files.head.indexVersion, rg)
+    val getKeysFromFile = StagedBGENReader.queryIndexByPosition(ctx, indexSpec)
 
     nonEmptyFilesAfterFilter.zipWithIndex.map { case (file, fileIndex) =>
       val nPartitions = math.min(fileNPartitions(fileIndex), file.nVariants).toInt

--- a/hail/hail/src/is/hail/io/bgen/BgenSettings.scala
+++ b/hail/hail/src/is/hail/io/bgen/BgenSettings.scala
@@ -2,6 +2,7 @@ package is.hail.io.bgen
 
 import is.hail.expr.ir.PruneDeadFields
 import is.hail.io._
+import is.hail.rvd.AbstractIndexSpec
 import is.hail.types.encoded._
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -26,8 +27,7 @@ object BgenSettings {
       BufferSpec.lz4HCCompressionLEB
     }
 
-  def indexCodecSpecs(indexVersion: SemanticVersion, rg: Option[String])
-    : (AbstractTypedCodecSpec, AbstractTypedCodecSpec) = {
+  def getIndexSpec(indexVersion: SemanticVersion, rg: Option[String]): AbstractIndexSpec = {
     val bufferSpec = specFromVersion(indexVersion)
 
     val keyVType = indexKeyType(rg)
@@ -114,10 +114,13 @@ object BgenSettings {
       )
     ))
 
-    (
-      TypedCodecSpec(leafEType, leafVType, bufferSpec),
-      (TypedCodecSpec(internalNodeEType, internalNodeVType, bufferSpec)),
-    )
+    new AbstractIndexSpec {
+      def relPath = fatal("relPath called for bgen index spec")
+      val leafCodec = TypedCodecSpec(leafEType, leafVType, bufferSpec)
+      val internalNodeCodec = TypedCodecSpec(internalNodeEType, internalNodeVType, bufferSpec)
+      val keyType = keyVType
+      val annotationType = annotationVType
+    }
   }
 }
 

--- a/hail/hail/src/is/hail/io/bgen/StagedBGENReader.scala
+++ b/hail/hail/src/is/hail/io/bgen/StagedBGENReader.scala
@@ -13,6 +13,7 @@ import is.hail.io._
 import is.hail.io.fs.SeekableDataInputStream
 import is.hail.io.index.{StagedIndexReader, StagedIndexWriter}
 import is.hail.lir
+import is.hail.rvd.AbstractIndexSpec
 import is.hail.types.{RStruct, TypeWithRequiredness}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.SingleCodeType
@@ -561,8 +562,7 @@ object StagedBGENReader {
 
   def queryIndexByPosition(
     ctx: ExecuteContext,
-    leafSpec: AbstractTypedCodecSpec,
-    internalSpec: AbstractTypedCodecSpec,
+    indexSpec: AbstractIndexSpec,
   ): (String, Array[Long]) => Array[AnyRef] = {
     val fb = EmitFunctionBuilder[String, Array[Long], Array[AnyRef]](ctx, "bgen_query_index")
 
@@ -570,7 +570,7 @@ object StagedBGENReader {
       val mb = fb.apply_method
       val path = mb.getCodeParam[String](1)
       val indices = mb.getCodeParam[Array[Long]](2)
-      val index = new StagedIndexReader(mb, leafSpec, internalSpec)
+      val index = new StagedIndexReader(mb, indexSpec)
       index.initialize(cb, path)
 
       val len = cb.memoize(indices.length())


### PR DESCRIPTION
For legacy reasons, the data contained by an index leaf node includes a field called `offset` and another called `annotation`. The `offset` is always an int64, and `annotation` contains arbitrary data. When writing a matrix table, we use a field in `annotation` called `entries_offset`. In the index spec, we make a note of if there is a different offset than `offset`.

This means, that if we have an index spec, we can't assume that the offset field is always `offset`, and so, add a helper method that takes a leaf node, and give us the offset the index spec is expecting.

## Security Assessment
- This change has no security impact
### Impact Description
Code generated is identical to previous version.
