### PR TITLE
[batch] Allow startup if price-refreshing fails

### DIFF
--- a/batch/batch/cloud/gcp/driver/billing_manager.py
+++ b/batch/batch/cloud/gcp/driver/billing_manager.py
@@ -40,8 +40,12 @@ class GCPBillingManager(CloudBillingManager):
         self.currency_code = 'USD'
 
     async def refresh_resources_from_retail_prices(self):
-        prices = [price async for price in fetch_prices(self.billing_client, self.regions, self.currency_code)]
-        await self._refresh_resources_from_retail_prices(prices)
+        # Don't break system start-up if price-refreshing fails:
+        try:
+            prices = [price async for price in fetch_prices(self.billing_client, self.regions, self.currency_code)]
+            await self._refresh_resources_from_retail_prices(prices)
+        except Exception as e:
+            log.error('Error refreshing resources from retail prices: %s', e)
 
     async def close(self):
         await self.billing_client.close()

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -188,6 +188,8 @@ def instance_family_from_sku(sku: dict) -> Optional[str]:
 
 def accelerator_from_sku(sku) -> Optional[str]:
     description = sku['description']
+    if 'DWS Defined Duration' in description:
+        return None
     if description.startswith("Nvidia L4 GPU"):
         return 'l4'
     if description.startswith("Nvidia Tesla A100 GPU"):

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -188,8 +188,6 @@ def instance_family_from_sku(sku: dict) -> Optional[str]:
 
 def accelerator_from_sku(sku) -> Optional[str]:
     description = sku['description']
-    if 'DWS Defined Duration' in description:
-        return None
     if description.startswith("Nvidia L4 GPU"):
         return 'l4'
     if description.startswith("Nvidia Tesla A100 GPU"):


### PR DESCRIPTION
## Change Description

Allows the system to start up even if price refreshing fails. This is temporary until we can stop the latest set of SKU collisions 

## Security Assessment

- This change has a low security impact

### Impact Description

Ignore parsing / interpretation errors .

(Reviewers: please confirm the security impact before approving)
