### PR TITLE
[hailtop] Add job groups to hailtop.batch

### DIFF
--- a/hail/python/hailtop/batch/__init__.py
+++ b/hail/python/hailtop/batch/__init__.py
@@ -5,19 +5,25 @@ from .batch import Batch
 from .batch_pool_executor import BatchPoolExecutor
 from .docker import build_python_image
 from .exceptions import BatchException
+from .job import BashJob, Job, PythonJob
+from .job_group import JobGroup
 from .resource import PythonResult, Resource, ResourceFile, ResourceGroup
 from .utils import concatenate, plink_merge
 
 __all__ = [
     'Batch',
+    'BashJob',
     'LocalBackend',
     'ServiceBackend',
     'Backend',
     'BatchException',
     'BatchPoolExecutor',
+    'Job',
+    'JobGroup',
     'build_python_image',
     'concatenate',
     'plink_merge',
+    'PythonJob',
     'PythonResult',
     'Resource',
     'ResourceFile',

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -710,6 +710,13 @@ class ServiceBackend(Backend[bc.Batch]):
 
         async_batch = batch._async_batch
 
+        for job_group in batch._job_groups:
+            if job_group._async_job_group is None:
+                job_group._async_job_group = async_batch.create_job_group(
+                    attributes=copy.deepcopy(job_group.attributes),
+                    cancel_after_n_failures=job_group.cancel_after_n_failures
+                )
+
         n_jobs_submitted = 0
         used_remote_tmpdir = False
 
@@ -855,7 +862,7 @@ class ServiceBackend(Backend[bc.Batch]):
 
             env = {**job._env, 'BATCH_TMPDIR': local_tmpdir}
 
-            j = async_batch.create_job(
+            j = job._job_group._create_aiobc_job(
                 image=image,
                 command=[job._shell if job._shell else DEFAULT_SHELL, '-c', cmd],
                 parents=[parent._async_job for parent in parents],  # type: ignore

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -12,7 +12,7 @@ from typing_extensions import Self
 import hailtop.batch_client.client as bc
 from hailtop.batch.resource import PythonResult, Resource, ResourceFile, ResourceGroup, ResourceType
 
-from . import backend, batch  # pylint: disable=cyclic-import
+from . import backend, batch, job_group  # pylint: disable=cyclic-import
 from .exceptions import BatchException
 
 
@@ -63,6 +63,7 @@ class Job:
     def __init__(
         self,
         batch: 'batch.Batch',
+        job_group: 'job_group.JobGroup',
         token: str,
         *,
         name: Optional[str] = None,
@@ -70,6 +71,8 @@ class Job:
         shell: Optional[str] = None,
     ):
         self._batch = batch
+        self._job_group = job_group
+
         self._shell = shell
         self._token = token
 
@@ -727,13 +730,14 @@ class BashJob(Job):
     def __init__(
         self,
         batch: 'batch.Batch',
+        job_group: 'job_group.JobGroup',
         token: str,
         *,
         name: Optional[str] = None,
         attributes: Optional[Dict[str, str]] = None,
         shell: Optional[str] = None,
     ):
-        super().__init__(batch, token, name=name, attributes=attributes, shell=shell)
+        super().__init__(batch, job_group, token, name=name, attributes=attributes, shell=shell)
         self._command: List[str] = []
 
     def declare_resource_group(self, **mappings: Dict[str, Any]) -> 'BashJob':
@@ -981,12 +985,13 @@ class PythonJob(Job):
     def __init__(
         self,
         batch: 'batch.Batch',
+        job_group: 'job_group.JobGroup',
         token: str,
         *,
         name: Optional[str] = None,
         attributes: Optional[Dict[str, str]] = None,
     ):
-        super().__init__(batch, token, name=name, attributes=attributes, shell=None)
+        super().__init__(batch, job_group, token, name=name, attributes=attributes, shell=None)
         self._resources: Dict[str, Resource] = {}
         self._resources_inverse: Dict[Resource, str] = {}
         self._function_calls: List[Tuple[PythonResult, int, Tuple[UnpreparedArg, ...], Dict[str, UnpreparedArg]]] = []

--- a/hail/python/hailtop/batch/job_group.py
+++ b/hail/python/hailtop/batch/job_group.py
@@ -1,0 +1,122 @@
+from typing import Dict, Optional
+
+import hailtop.batch_client.aioclient as _aiobc
+
+from . import batch as _batch, job  # pylint: disable=cyclic-import
+
+
+class JobGroup:
+    @staticmethod
+    def from_job_group_id(batch: '_batch.Batch', job_group_id: int) -> 'JobGroup':
+        jg = batch.create_job_group()
+        assert batch._async_batch
+        jg._async_job_group = batch._async_batch.get_job_group(job_group_id)
+        return jg
+
+    def __init__(self,
+                 batch: '_batch.Batch',
+                 parent_job_group: Optional['JobGroup'],
+                 *,
+                 attributes: Optional[Dict[str, str]] = None,
+                 cancel_after_n_failures: Optional[int] = None
+                 ):
+        self._batch = batch
+        self._parent_job_group = parent_job_group
+        self.attributes = attributes
+        self.cancel_after_n_failures = cancel_after_n_failures
+        self._async_job_group: Optional[_aiobc.JobGroup] = None
+
+    @property
+    def _is_root_job_group(self):
+        return self._parent_job_group is None
+
+    def _create_aiobc_job(self, *args, **kwargs):
+        if self._is_root_job_group:
+            return self._batch._async_batch.create_job(*args, **kwargs)
+        assert self._async_job_group
+        return self._async_job_group.create_job(*args, **kwargs)
+
+    def create_job_group(self,
+                         attributes: Optional[Dict[str, str]] = None,
+                         cancel_after_n_failures: Optional[int] = None) -> 'JobGroup':
+        return self._batch._create_job_group(self, attributes=attributes, cancel_after_n_failures=cancel_after_n_failures)
+
+    def new_bash_job(
+        self, name: Optional[str] = None, attributes: Optional[Dict[str, str]] = None, shell: Optional[str] = None
+    ) -> 'job.BashJob':
+        """
+        Initialize a :class:`.BashJob` object with default memory, storage,
+        image, and CPU settings (defined in :class:`.Batch`) upon batch creation.
+
+        Examples
+        --------
+        Create and execute a batch `b` with one job `j` that prints "hello world":
+
+        >>> import hailtop.batch as hb
+        >>> b = hb.Batch()
+        >>> jg = b.create_job_group()
+        >>> j = jg.new_bash_job(name='hello', attributes={'language': 'english'})
+        >>> j.command('echo "hello world"')
+        >>> b.run()
+
+        Parameters
+        ----------
+        name:
+            Name of the job.
+        attributes:
+            Key-value pairs of additional attributes. 'name' is not a valid keyword.
+            Use the name argument instead.
+        """
+
+        return self._batch._new_bash_job(self, name=name, attributes=attributes, shell=shell)
+
+    def new_python_job(self, name: Optional[str] = None, attributes: Optional[Dict[str, str]] = None) -> 'job.PythonJob':
+        """
+        Initialize a new :class:`.PythonJob` object with default
+        Python image, memory, storage, and CPU settings (defined in :class:`.Batch`)
+        upon batch creation.
+
+        Examples
+        --------
+        Create and execute a batch `b` with one job `j` that prints "hello alice":
+
+        .. code-block:: python
+
+            b = Batch(default_python_image='hailgenetics/python-dill:3.9-slim')
+            jg = b.create_job_group()
+
+            def hello(name):
+                return f'hello {name}'
+
+            j = jg.new_python_job()
+            output = j.call(hello, 'alice')
+
+            # Write out the str representation of result to a file
+
+            b.write_output(output.as_str(), 'hello.txt')
+
+            b.run()
+
+        Notes
+        -----
+
+        The image to use for Python jobs can be specified by `default_python_image`
+        when constructing a :class:`.Batch`. The image specified must have the `dill`
+        package installed. If ``default_python_image`` is not specified, then a Docker
+        image will automatically be created for you with the base image
+        `hailgenetics/python-dill:[major_version].[minor_version]-slim` and the Python
+        packages specified by ``python_requirements`` will be installed. The default name
+        of the image is `batch-python` with a random string for the tag unless ``python_build_image_name``
+        is specified. If the :class:`.ServiceBackend` is the backend, the locally built
+        image will be pushed to the repository specified by ``image_repository``.
+
+        Parameters
+        ----------
+        name:
+            Name of the job.
+        attributes:
+            Key-value pairs of additional attributes. 'name' is not a valid keyword.
+            Use the name argument instead.
+        """
+
+        return self._batch._new_python_job(self, name=name, attributes=attributes)


### PR DESCRIPTION
## Change Description

This change exposes JobGroups to the user in `hailtop.batch`.

## Security Assessment

- This change has no security impact

### Impact Description

This change does not touch any of the backend Batch server code. It is only in the user-facing client library.

(Reviewers: please confirm the security impact before approving)

---

I can make a follow-up PR to this once we're happy with the change that adds the docstring for the JobGroup class and some sort of additional tutorial page.
