### PR TITLE
[auth] Allow re-login after session timeout

### DIFF
--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -148,7 +148,8 @@ async def impersonate_user(session_id: str, client_session: httpx.ClientSession,
     try:
         return await retry_transient_errors(client_session.get_read_json, url, headers=headers)
     except aiohttp.ClientResponseError as err:
-        if err.status == 401:
+        if err.status in (401, 403):
+            # Unauthorized or forbidden => no valid user to impersonate
             return None
         raise
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -155,8 +155,7 @@ async def impersonate_user(session_id: str, client_session: httpx.ClientSession,
     try:
         return await retry_transient_errors(client_session.get_read_json, url, headers=headers)
     except aiohttp.ClientResponseError as err:
-        if err.status in (401, 403):
-            # Unauthorized or forbidden => no valid user to impersonate
+        if err.status == 401:
             return None
         raise
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -77,8 +77,10 @@ class Authenticator(abc.ABC):
         async def wrapped(request: web.Request) -> web.StreamResponse:
             try:
                 userdata = await self._fetch_userdata(request)
-            except Exception as e:
-                log.warning('error fetching userdata', exc_info=e)
+            except web.HTTPUnauthorized:
+                # Authorization problem against maybe_authenticated endpoint. This is most likely an expired session.
+                # Expired sessions are fine, and we need to allow access to endpoints for re-authentication.
+                # Therefore: treat this situation the same as 'no user / unauthenticated' and zero out userdata
                 userdata = None
             return await fun(request, userdata)
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -75,7 +75,12 @@ class Authenticator(abc.ABC):
     def maybe_authenticated_user(self, fun: MaybeAuthenticatedAIOHTTPHandler) -> AIOHTTPHandler:
         @wraps(fun)
         async def wrapped(request: web.Request) -> web.StreamResponse:
-            return await fun(request, await self._fetch_userdata(request))
+            try:
+                userdata = await self._fetch_userdata(request)
+            except Exception as e:
+                log.warning('error fetching userdata', exc_info=e)
+                userdata = None
+            return await fun(request, userdata)
 
         return wrapped
 


### PR DESCRIPTION
## Change Description

Currently: when a user's session times out or becomes invalid for any reason, they are redirected to a login page which (because of the existing but stale session cookie) just returns 401: Unauthorized.

With this change: we allow users with invalid or stale session cookies to access the user page and re-login

## Security Assessment

- This change has a medium security impact

### Impact Description

Allow access to pages that previously would have failed when a user's session was invalid. 
However: 
- The pages in question are accessible for unauthorized users
- We treat the page access as though the user were unauthorized

So this is essentially equivalent to the user clearing out their cookie cache before attempting to access the page.

