### PR TITLE
[batch] increase shared memory in a container to be up to half the actual memory

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1303,7 +1303,7 @@ class Container:
                     'source': 'shm',
                     'destination': '/dev/shm',
                     'type': 'tmpfs',
-                    'options': ['nosuid', 'noexec', 'nodev', 'mode=1777', 'size=67108864'],
+                    'options': ['nosuid', 'noexec', 'nodev', 'mode=1777', f'size={self.memory_in_bytes//2}'],
                 },
                 {
                     'source': f'/etc/netns/{self.netns.network_ns_name}/resolv.conf',


### PR DESCRIPTION
## Change Description
Currently, the available shared memory (/dev/shm) in a Docker image is capped at 64M by default. On a regular machine, this is instead capped at half the machine's available RAM. While there exists a flag you can specify during `docker run` that can increase your `/dev/shm`, this change modifies the default shared memory in a container to now be half the available memory.

Memory usage comparison allocating 512M to `/dev/shm`:

Prior to this change, allocation capped at 64M:
```

free -m
df -h
dd if=/dev/zero of=/dev/shm/file bs=512M count=1
               total        used        free      shared  buff/cache   available
Mem:           60262        5407       48518           2        7017       54855
Swap:              0           0           0
Filesystem      Size  Used Avail Use% Mounted on
overlay         5.0G   16K  5.0G   1% /
/dev/nvme0n1    5.0G   16K  5.0G   1% /io
tmpfs            64M     0   64M   0% /dev
shm              64M     0   64M   0% /dev/shm
/dev/root       9.6G  5.0G  4.6G  52% /etc/hosts
dd: error writing '/dev/shm/file': No space left on device
1+0 records in
0+0 records out
67108864 bytes (67 MB, 64 MiB) copied, 0.370408 s, 181 MB/s

```
This PR, full 512M allocated:
```

free -m
df -h
dd if=/dev/zero of=/dev/shm/file bs=512M count=1
free -m
df -h
               total        used        free      shared  buff/cache   available
Mem:           60262        5407       48518           2        7017       54855
Swap:              0           0           0
Filesystem      Size  Used Avail Use% Mounted on
overlay         5.0G   20K  5.0G   1% /
/dev/nvme0n1    5.0G   20K  5.0G   1% /io
tmpfs            64M     0   64M   0% /dev
shm             1.9G     0  1.9G   0% /dev/shm
/dev/root        20G  5.0G   15G  26% /etc/hosts
devtmpfs         30G     0   30G   0% /proc/keys
1+0 records in
1+0 records out
536870912 bytes (537 MB, 512 MiB) copied, 0.504301 s, 1.1 GB/s
               total        used        free      shared  buff/cache   available
Mem:           60262        5921       48002         514        7530       54341
Swap:              0           0           0
Filesystem      Size  Used Avail Use% Mounted on
overlay         5.0G  252K  5.0G   1% /
/dev/nvme0n1    5.0G  252K  5.0G   1% /io
tmpfs            64M     0   64M   0% /dev
shm             1.9G  512M  1.4G  27% /dev/shm
/dev/root        20G  5.0G   15G  26% /etc/hosts
devtmpfs         30G     0   30G   0% /proc/keys

```
## Security Assessment
- This change has a low security impact

### Impact Description


(Reviewers: please confirm the security impact before approving)
