### PR TITLE
[qob] Add ability to attach to existing batch

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -23,7 +23,7 @@ from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration, get_gcs_re
 from hailtop.aiotools.fs.exceptions import UnexpectedEOFError
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
-from hailtop.batch_client.aioclient import Batch, BatchClient
+from hailtop.batch_client.aioclient import Batch, BatchClient, JobGroup
 from hailtop.config import ConfigVariable, configuration_of, get_remote_tmpdir
 from hailtop.fs.fs import FS
 from hailtop.fs.router_fs import RouterFS
@@ -292,7 +292,7 @@ class ServiceBackend(Backend):
         self._sync_fs = sync_fs
         self._async_fs = async_fs
         self._batch_client = batch_client
-        self._batch_was_submitted: bool = False
+        self._job_group_was_submitted: bool = False
         self.disable_progress_bar = disable_progress_bar
         self.batch_attributes = batch_attributes
         self.remote_tmpdir = remote_tmpdir
@@ -306,6 +306,7 @@ class ServiceBackend(Backend):
         self.regions = regions
 
         self._batch: Batch = self._create_batch() if batch is None else batch
+        self._job_group: Optional[JobGroup] = None
         self._async_exit_stack = async_exit_stack
 
     def _create_batch(self) -> Batch:
@@ -386,6 +387,8 @@ class ServiceBackend(Backend):
                 if service_backend_config.storage != '0Gi':
                     resources['storage'] = service_backend_config.storage
 
+                self._job_group = self._batch.create_job_group(attributes={'name': name})
+
                 j = self._batch.create_jvm_job(
                     jar_spec=self.jar_spec,
                     argv=[
@@ -394,7 +397,7 @@ class ServiceBackend(Backend):
                         iodir + '/in',
                         iodir + '/out',
                     ],
-                    job_group=self._batch.create_job_group(attributes={'name': name}),
+                    job_group=self._job_group,
                     resources=resources,
                     attributes={'name': name + '_driver'},
                     regions=self.regions,
@@ -402,23 +405,21 @@ class ServiceBackend(Backend):
                     profile=self.flags['profile'] is not None,
                 )
                 await self._batch.submit(disable_progress_bar=True)
-                self._batch_was_submitted = True
+                self._job_group_was_submitted = True
 
             with timings.step("wait driver"):
                 try:
                     await asyncio.sleep(0.6)  # it is not possible for the batch to be finished in less than 600ms
-                    await self._batch.wait(
+                    await self._job_group.wait(
                         description=name,
                         disable_progress_bar=self.disable_progress_bar,
-                        progress=progress,
-                        starting_job=j.job_id,
+                        progress=progress
                     )
                 except KeyboardInterrupt:
                     raise
                 except Exception:
-                    await self._batch.cancel()
-                    self._batch = self._create_batch()
-                    self._batch_was_submitted = False
+                    await self._job_group.cancel()
+                    self._job_group_was_submitted = False
                     raise
 
             with timings.step("read output"):
@@ -464,11 +465,10 @@ class ServiceBackend(Backend):
         try:
             return async_to_blocking(coro)
         except KeyboardInterrupt:
-            if self._batch_was_submitted:
+            if self._job_group_was_submitted:
                 print("Received a keyboard interrupt, cancelling the batch...")
-                async_to_blocking(self._batch.cancel())
-                self._batch = self._create_batch()
-                self._batch_was_submitted = False
+                async_to_blocking(self._job_group.cancel())
+                self._job_group_was_submitted = False
             raise
 
     def _rpc(self, action: ActionTag, payload: ActionPayload) -> Tuple[bytes, Optional[dict]]:

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -180,6 +180,7 @@ class HailContext(object):
     driver_memory=nullable(str),
     worker_cores=nullable(oneof(str, int)),
     worker_memory=nullable(str),
+    batch_id=nullable(int),
     gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
     regions=nullable(sequenceof(str)),
     gcs_bucket_allow_list=nullable(dictof(str, sequenceof(str))),
@@ -209,6 +210,7 @@ def init(
     driver_memory=None,
     worker_cores=None,
     worker_memory=None,
+    batch_id=None,
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
     regions: Optional[List[str]] = None,
     gcs_bucket_allow_list: Optional[Dict[str, List[str]]] = None,
@@ -322,6 +324,8 @@ def init(
     worker_memory : :class:`str`, optional
         Batch backend only. Memory tier to use for the worker processes. May be standard or
         highmem. Default is standard.
+    batch_id: :class:`int`, optional
+        Batch backend only. An existing batch id to add jobs to.
     gcs_requester_pays_configuration : either :class:`str` or :class:`tuple` of :class:`str` and :class:`list` of :class:`str`, optional
         If a string is provided, configure the Google Cloud Storage file system to bill usage to the
         project identified by that string. If a tuple is provided, configure the Google Cloud
@@ -379,6 +383,7 @@ def init(
                 driver_memory=driver_memory,
                 worker_cores=worker_cores,
                 worker_memory=worker_memory,
+                batch_id=batch_id,
                 name_prefix=app_name,
                 gcs_requester_pays_configuration=gcs_requester_pays_configuration,
                 regions=regions,
@@ -523,6 +528,7 @@ def init_spark(
     driver_memory=nullable(str),
     worker_cores=nullable(oneof(str, int)),
     worker_memory=nullable(str),
+    batch_id=nullable(int),
     name_prefix=nullable(str),
     token=nullable(str),
     gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
@@ -545,6 +551,7 @@ async def init_batch(
     driver_memory: Optional[str] = None,
     worker_cores: Optional[Union[str, int]] = None,
     worker_memory: Optional[str] = None,
+    batch_id: Optional[int] = None,
     name_prefix: Optional[str] = None,
     token: Optional[str] = None,
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
@@ -562,6 +569,7 @@ async def init_batch(
         driver_memory=driver_memory,
         worker_cores=worker_cores,
         worker_memory=worker_memory,
+        batch_id=batch_id,
         name_prefix=name_prefix,
         credentials_token=token,
         regions=regions,

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -9,6 +9,7 @@ import pytest
 import hail as hl
 from hail.backend.service_backend import ServiceBackend
 from hailtop.batch_client.client import Batch, BatchClient, Job, JobGroup
+from hailtop.config import ConfigVariable, configuration_of
 
 
 @dataclass
@@ -35,6 +36,16 @@ def run_on_batch_mocks(mocker):
 
     outfile = type('Settable', (object,), {'value': None})
 
+    async def write_output(*args, **kwargs):
+        async with await backend._async_fs.create(outfile.value) as f:
+            payload = hl.ttuple(hl.tint64)._to_encoding([0])
+            await f.write(struct.pack('<b', 1))
+            await f.write(struct.pack('<i', len(payload)))
+            await f.write(payload)
+
+    mjob_group = mocker.patch(classname(JobGroup))
+    mjob_group.wait = write_output
+
     def set_outdir(*args, **kwargs):
         outfile.value = kwargs['argv'][3]
         with backend.fs.open(kwargs['argv'][2]) as f:
@@ -46,20 +57,10 @@ def run_on_batch_mocks(mocker):
     m.create_jvm_job.side_effect = set_outdir
 
     m.create_job_group = mocker.patch.object(batch, 'create_job_group')
-    m.create_job_group.return_value = mocker.patch(classname(JobGroup))
+    m.create_job_group.return_value = mjob_group
 
     m.submit = mocker.patch.object(batch, 'submit')
     m.submit.return_value = None
-
-    async def write_output(*args, **kwargs):
-        async with await backend._async_fs.create(outfile.value) as f:
-            payload = hl.ttuple(hl.tint64)._to_encoding([0])
-            await f.write(struct.pack('<b', 1))
-            await f.write(struct.pack('<i', len(payload)))
-            await f.write(payload)
-
-    m.wait = mocker.patch.object(batch, 'wait')
-    m.wait.side_effect = write_output
     return m
 
 
@@ -132,20 +133,21 @@ def test_driver_and_worker_job_groups():
 
 
 @pytest.mark.backend('batch')
-def test_attach_to_existing_batch():
-    backend = hl.current_backend()
-    assert isinstance(backend, ServiceBackend)
+@pytest.mark.uninitialized
+def test_attach_to_existing_batch(request):
+    billing_project = configuration_of(ConfigVariable.BATCH_BILLING_PROJECT, None, None)
+    assert billing_project is not None
 
-    batch_client = BatchClient.from_async(backend._batch_client)
-    b = batch_client.create_batch()
-    b.submit()
-    batch_id = b.id
+    client = BatchClient(billing_project)
+    batch = client.create_batch(attributes={'name': request.node.nodeid})
+    batch.submit()
 
-    hl.stop()
-    hl.init(backend='batch', batch_id=batch_id)
-
+    hl.init(backend='batch', batch_id=batch.id)
     hl.utils.range_table(2)._force_count()
 
-    b = batch_client.get_batch(batch_id)
-    status = b.status()
-    assert status['n_jobs'] > 0, str(b.debug_info())
+    backend = hl.current_backend()
+    assert isinstance(backend, ServiceBackend)
+    assert backend._batch.id == batch.id
+
+    status = batch.status()
+    assert status['n_jobs'] > 0, repr(batch.debug_info())

--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -1,23 +1,17 @@
 import pytest
 
 import hail as hl
-from hail.backend.service_backend import ServiceBackend
 
 
 class TestAnnotationDB:
     @pytest.fixture(scope="class")
-    def db_json(init_hail):
-        backend = hl.current_backend()
-        if isinstance(backend, ServiceBackend):
-            backend.batch_attributes = dict(name='setupAnnotationDBTests')
+    def db_json(self):
         t = hl.utils.genomic_range_table(10)
         t = t.annotate(annotation=hl.str(t.locus.position - 1))
         tempdir_manager = hl.TemporaryDirectory()
         d = tempdir_manager.__enter__()
         fname = d + '/f.mt'
         t.write(fname)
-        if isinstance(backend, ServiceBackend):
-            backend.batch_attributes = dict()
         db_json = {
             'unique_dataset': {
                 'description': 'now with unique rows!',

--- a/hail/python/test/hailtop/batch/test_batch_service_backend.py
+++ b/hail/python/test/hailtop/batch/test_batch_service_backend.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import textwrap
 from configparser import ConfigParser
 from shlex import quote as shq
 from typing import Tuple
@@ -11,12 +12,14 @@ from hailtop.aiotools.validators import validate_file
 from hailtop.batch import Batch, ResourceGroup, ServiceBackend
 from hailtop.batch.exceptions import BatchException
 from hailtop.batch.globals import arg_max
+from hailtop.batch.job import Job
 from hailtop.config import get_user_config, user_config
 from hailtop.httpx import ClientResponseError
 from hailtop.test_utils import skip_in_azure
 from hailtop.utils import grouped
 
 from .utils import (
+    HAIL_GENETICS_HAIL_IMAGE,
     REQUESTER_PAYS_PROJECT,
     batch,
 )
@@ -801,3 +804,54 @@ async def test_validate_cloud_storage_policy(service_backend: ServiceBackend, mo
     arg = [fake_bucket1]
     ServiceBackend(remote_tmpdir=fake_uri1, gcs_bucket_allow_list=arg)
     await _test_raises_no_bucket_error(fake_uri2, arg)
+
+
+def new_query_in_batch_job(b: Batch, name: str) -> Job:
+    # creates a query-on-batch job in the current batch
+    backend = b._backend
+    assert isinstance(backend, ServiceBackend)
+
+    run_query_pipeline = textwrap.dedent(
+        f"""
+        hailctl config set batch/remote_tmpdir {backend.remote_tmpdir}
+        hailctl config set batch/billing_project {backend._billing_project}
+
+        cat << EOF | python3
+        from os import getenv
+        import hail as hl
+
+        hl.init(backend='batch', batch_id=int(getenv('HAIL_BATCH_ID')))
+        hl.utils.range_table(2356)._force_count()
+        EOF
+        """,
+    )
+
+    j = b.new_bash_job(name=name)
+    j.command(run_query_pipeline)
+    return j
+
+
+def test_submit_sequential_qob_pipelines(request, service_backend: ServiceBackend):
+    b = Batch(request.node.nodeid, service_backend, default_image=HAIL_GENETICS_HAIL_IMAGE)
+
+    ja = new_query_in_batch_job(b, 'Query Pipeline A')
+    jb = new_query_in_batch_job(b, 'Query Pipeline B')
+    jb.depends_on(ja)
+
+    r = b.run()
+    assert r is not None
+    status = r.status()
+    assert status['state'] == 'success', str((status, r.debug_info()))
+
+
+@pytest.mark.xfail(reason='Concurrent QoB pipelines are not supported', strict=False)
+def test_race_qob_pipelines(request, service_backend: ServiceBackend):
+    b = Batch(request.node.nodeid, service_backend, default_image=HAIL_GENETICS_HAIL_IMAGE)
+
+    for c in ['A', 'B', 'C']:
+        new_query_in_batch_job(b, f'Query Pipeline {c}')
+
+    r = b.run()
+    assert r is not None
+    status = r.status()
+    assert status['state'] == 'success', str((status, r.debug_info()))


### PR DESCRIPTION
The goal of this change is to be able to group QoB queries together to allow for
easier visibility of how much a pipeline costs as well as make the batches page
less cluttered so it's easier to tell what is running.

Adds `batch_id` parameter to `hl.init` that, when used with the `'batch'` backend, 
allows users to add query-on-batch jobs to an existing batch. Note that racing two
or more QoB jobs concurrently in the same batch will likely fail. Instead, users
should add dependences between query jobs so that they're scheduled consecutively.

This change has low security impact as it only modifies client code: users cannot
attach to batches that they do not already have access to.
