### PR TITLE
[auth] Allow (non-adjacent) hyphens in usernames

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -129,7 +129,7 @@ async def check_valid_new_user(tx: Transaction, username, login_id, is_developer
         raise MultipleUserTypes(username)
     if not is_service_account and not login_id:
         raise EmptyLoginID(username)
-    if not username or not (username.isalnum() and username.islower()):
+    if not is_valid_username(username):
         raise InvalidUsername(username)
 
     existing_users = await users_with_username_or_login_id(tx, username, login_id)
@@ -989,3 +989,32 @@ def run():
         access_log_class=AuthAccessLogger,
         ssl_context=deploy_config.server_ssl_context(),
     )
+
+
+def is_valid_username(username: str) -> bool:
+    """Check if a username is valid.
+
+    Requirements:
+    1. Only alphanumeric characters and hyphens allowed
+    2. Hyphens cannot be at start or end
+    3. Hyphens cannot be adjacent to each other
+
+    Args:
+        username: The username to validate
+
+    Returns:
+        bool: True if username meets all requirements, False otherwise
+    """
+    if not username:  # Check for empty string
+        return False
+
+    # Check for hyphens at start or end
+    if username.startswith('-') or username.endswith('-'):
+        return False
+
+    # Check for adjacent hyphens
+    if '--' in username:
+        return False
+
+    # Check that all characters are alphanumeric or hyphen
+    return all(c.isalnum() or c == '-' for c in username)

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -47,7 +47,7 @@ from web_common import (
     web_security_headers,
 )
 
-from .auth_utils import validate_credentials_secret_name_input
+from .auth_utils import is_valid_username, validate_credentials_secret_name_input
 from .exceptions import (
     AuthUserError,
     DuplicateLoginID,
@@ -989,32 +989,3 @@ def run():
         access_log_class=AuthAccessLogger,
         ssl_context=deploy_config.server_ssl_context(),
     )
-
-
-def is_valid_username(username: str) -> bool:
-    """Check if a username is valid.
-
-    Requirements:
-    1. Only alphanumeric characters and hyphens allowed
-    2. Hyphens cannot be at start or end
-    3. Hyphens cannot be adjacent to each other
-
-    Args:
-        username: The username to validate
-
-    Returns:
-        bool: True if username meets all requirements, False otherwise
-    """
-    if not username:  # Check for empty string
-        return False
-
-    # Check for hyphens at start or end
-    if username.startswith('-') or username.endswith('-'):
-        return False
-
-    # Check for adjacent hyphens
-    if '--' in username:
-        return False
-
-    # Check that all characters are alphanumeric or hyphen
-    return all(c.isalnum() or c == '-' for c in username)

--- a/auth/auth/auth_utils.py
+++ b/auth/auth/auth_utils.py
@@ -42,4 +42,4 @@ def is_valid_username(username: str) -> bool:
         return False
 
     # Check that all characters are numeric or lowercase or hyphen:
-    return all((c.isdigit() or c.islower() or c == '-') for c in username)
+    return all(c.isascii() and (c.isdigit() or c.islower() or c == '-') for c in username)

--- a/auth/auth/auth_utils.py
+++ b/auth/auth/auth_utils.py
@@ -41,5 +41,5 @@ def is_valid_username(username: str) -> bool:
     if '--' in username:
         return False
 
-    # Check that all characters are alphanumeric or hyphen
-    return all((c.isalnum() and c.islower()) or c == '-' for c in username)
+    # Check that all characters are numeric or lowercase or hyphen:
+    return all((c.isdigit() or c.islower() or c == '-') for c in username)

--- a/auth/auth/auth_utils.py
+++ b/auth/auth/auth_utils.py
@@ -14,3 +14,32 @@ def validate_credentials_secret_name_input(secret_name: Optional[str]):
             f'invalid credentials_secret_name {secret_name}. Must match RFC1123 (lowercase alphanumeric plus "." and "-", start and end with alphanumeric)',
             'error',
         )
+
+
+def is_valid_username(username: str) -> bool:
+    """Check if a username is valid.
+
+    Requirements:
+    1. Only alphanumeric characters and hyphens allowed
+    2. Hyphens cannot be at start or end
+    3. Hyphens cannot be adjacent to each other
+
+    Args:
+        username: The username to validate
+
+    Returns:
+        bool: True if username meets all requirements, False otherwise
+    """
+    if not username:  # Check for empty string
+        return False
+
+    # Check for hyphens at start or end
+    if username.startswith('-') or username.endswith('-'):
+        return False
+
+    # Check for adjacent hyphens
+    if '--' in username:
+        return False
+
+    # Check that all characters are alphanumeric or hyphen
+    return all((c.isalnum() and c.islower()) or c == '-' for c in username)

--- a/auth/test/test_auth_utils.py
+++ b/auth/test/test_auth_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from auth.auth_utils import validate_credentials_secret_name_input
+from auth.auth_utils import is_valid_username, validate_credentials_secret_name_input
 from auth.exceptions import AuthUserError
 
 
@@ -62,3 +62,32 @@ def test_validate_credentials_secret_name_input_valid(input_secret_name):
 def test_validate_credentials_secret_name_input_invalid(input_secret_name):
     with pytest.raises(AuthUserError):
         validate_credentials_secret_name_input(input_secret_name)
+
+
+@pytest.mark.parametrize("input_username", ['abc', 'abc-def', 'a3a', 'a3a-3a', '123'])
+def test_is_valid_username_valid(input_username):
+    assert is_valid_username(input_username)
+
+
+@pytest.mark.parametrize(
+    "input_username",
+    [
+        'ABC',
+        'abc!',
+        'a3a.3a',
+        'abc_def',
+        'abc!def',
+        'abc.def.',
+        'abc.def',
+        'abc.def-ghi',
+        'abc-def.ghi',
+        'abc--def',
+        'abc.def--ghi',
+        'abc.def-.ghi',
+        '.abc',
+        'abc.',
+        'abc..def',
+    ],
+)
+def test_is_valid_username_invalid(input_username):
+    assert not is_valid_username(input_username)

--- a/auth/test/test_auth_utils.py
+++ b/auth/test/test_auth_utils.py
@@ -72,6 +72,8 @@ def test_is_valid_username_valid(input_username):
 @pytest.mark.parametrize(
     "input_username",
     [
+        None,
+        '',
         'ABC',
         'abc!',
         'a3a.3a',


### PR DESCRIPTION
## Change Description

Addresses #14840 by allowing well-placed hyphens in usernames again. Not required for the Broad deployment but is perfectly safe to do, and was blocking external collaborators whose usernames frequently require hyphens.

## Security Assessment

- This change has a medium security impact

### Impact Description

Modifies the set of usernames allowed, but only by allowing well-placed individual hyphens, which will still produce "url valid" downstream resource names.

(Reviewers: please confirm the security impact before approving)
