### PR TITLE
[pip] Re-remove hail's protobuf dependency.

### DIFF
--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -213,8 +213,6 @@ propcache==0.2.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   yarl
-protobuf==3.20.2
-    # via -r hail/python/requirements.txt
 py4j==0.10.9.7
     # via pyspark
 pyasn1==0.6.1

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -10,7 +10,6 @@ numpy<2
 pandas>=2,<3
 parsimonious<1
 plotly>=5.18.0,<6
-protobuf==3.20.2
 pyspark>=3.5.0,<3.6
 requests>=2.31.0,<3
 scipy>1.2,<1.12


### PR DESCRIPTION
It seems to have been erroneously re-added in #14158

## Change Description

Fixes problem reported on Zulip.

## Security Assessment
- This change has no security impact

### Impact Description
Removal of unnecessary dependency.