### PR TITLE
[compiler] refactor ApplyIR

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Copy.scala
+++ b/hail/hail/src/is/hail/expr/ir/Copy.scala
@@ -506,11 +506,8 @@ object Copy {
       case ConsoleLog(_, _) =>
         assert(newChildren.length == 2)
         ConsoleLog(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
-      case x @ ApplyIR(fn, typeArgs, _, rt, errorID) =>
-        val r = ApplyIR(fn, typeArgs, newChildren.map(_.asInstanceOf[IR]), rt, errorID)
-        r.conversion = x.conversion
-        r.inline = x.inline
-        r
+      case ApplyIR(fn, typeArgs, _, rt, errorID) =>
+        ApplyIR(fn, typeArgs, newChildren.map(_.asInstanceOf[IR]), rt, errorID)
       case Apply(fn, typeArgs, _, t, errorID) =>
         Apply(fn, typeArgs, newChildren.map(_.asInstanceOf[IR]), t, errorID)
       case ApplySeeded(fn, _, _, staticUID, t) =>

--- a/hail/hail/src/is/hail/expr/ir/Requiredness.scala
+++ b/hail/hail/src/is/hail/expr/ir/Requiredness.scala
@@ -190,7 +190,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         }
         states.bind(node, s)
       case x @ ApplyIR(_, _, args, _, _) =>
-        x.refIdx.foreach { case (n, i) => addBinding(n, args(i)) }
+        x.refs.zipWithIndex.foreach { case (r, i) => addBinding(r.name, args(i)) }
       case ArraySort(a, l, r, _) =>
         addElementBinding(l, a, makeRequired = true)
         addElementBinding(r, a, makeRequired = true)

--- a/hail/hail/src/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.functions
 
 import is.hail.asm4s._
 import is.hail.expr.ir._
-import is.hail.expr.ir.defs.{ErrorIDs, If, NA}
+import is.hail.expr.ir.defs.{If, NA}
 import is.hail.types.physical.stypes.SType
 import is.hail.types.physical.stypes.concrete.SJavaString
 import is.hail.types.physical.stypes.interfaces._
@@ -92,21 +92,9 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
       typeParameters = Array(LocusFunctions.tlocus("R")),
     ) {
       case (tl, Seq(contig, pos, before, after), _) =>
-        val getRef = IRFunctionRegistry.lookupUnseeded(
-          name = "getReferenceSequenceFromValidLocus",
-          returnType = TString,
-          typeParameters = tl,
-          arguments = Seq(TString, TInt32, TInt32, TInt32),
-        ).get
-        val isValid = IRFunctionRegistry.lookupUnseeded(
-          "isValidLocus",
-          TBoolean,
-          typeParameters = tl,
-          Seq(TString, TInt32),
-        ).get
-
-        val r = isValid(tl, Seq(contig, pos), ErrorIDs.NO_ERROR)
-        val p = getRef(tl, Seq(contig, pos, before, after), ErrorIDs.NO_ERROR)
+        val r = invoke("isValidLocus", TBoolean, tl, contig, pos)
+        val p =
+          invoke("getReferenceSequenceFromValidLocus", TString, tl, contig, pos, before, after)
         If(r, p, NA(TString))
     }
   }

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -45,13 +45,13 @@ package object ir {
 
   def invoke(name: String, rt: Type, typeArgs: Seq[Type], errorID: Int, args: IR*): IR =
     IRFunctionRegistry.lookupUnseeded(name, rt, typeArgs, args.map(_.typ)) match {
-      case Some(f) => f(typeArgs, args, errorID)
+      case Some(f) => f(args, errorID)
       case None => fatal(
           s"no conversion found for $name(${typeArgs.mkString(", ")}, ${args.map(_.typ).mkString(", ")}) => $rt"
         )
     }
 
-  def invoke(name: String, rt: Type, typeArgs: Array[Type], args: IR*): IR =
+  def invoke(name: String, rt: Type, typeArgs: Seq[Type], args: IR*): IR =
     invoke(name, rt, typeArgs, ErrorIDs.NO_ERROR, args: _*)
 
   def invoke(name: String, rt: Type, args: IR*): IR =

--- a/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
 import is.hail.asm4s._
-import is.hail.expr.ir.defs.{ApplyBinaryPrimOp, ErrorIDs, I32, In}
+import is.hail.expr.ir.defs.{ApplyBinaryPrimOp, I32, In}
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions}
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.virtual._
@@ -51,15 +51,10 @@ class FunctionSuite extends HailSuite {
 
   TestRegisterFunctions.registerAll()
 
-  def lookup(meth: String, rt: Type, types: Type*)(irs: IR*): IR = {
-    val l = IRFunctionRegistry.lookupUnseeded(meth, rt, types).get
-    l(Seq(), irs, ErrorIDs.NO_ERROR)
-  }
-
   @Test
   def testCodeFunction(): Unit =
     assertEvalsTo(
-      lookup("triangle", TInt32, TInt32)(In(0, TInt32)),
+      invoke("triangle", TInt32, In(0, TInt32)),
       FastSeq(5 -> TInt32),
       (5 * (5 + 1)) / 2,
     )
@@ -67,22 +62,22 @@ class FunctionSuite extends HailSuite {
   @Test
   def testStaticFunction(): Unit =
     assertEvalsTo(
-      lookup("compare", TInt32, TInt32, TInt32)(In(0, TInt32), I32(0)) > 0,
+      invoke("compare", TInt32, In(0, TInt32), I32(0)) > 0,
       FastSeq(5 -> TInt32),
       true,
     )
 
   @Test
   def testScalaFunction(): Unit =
-    assertEvalsTo(lookup("foobar1", TInt32)(), 1)
+    assertEvalsTo(invoke("foobar1", TInt32), 1)
 
   @Test
   def testIRConversion(): Unit =
-    assertEvalsTo(lookup("addone", TInt32, TInt32)(In(0, TInt32)), FastSeq(5 -> TInt32), 6)
+    assertEvalsTo(invoke("addone", TInt32, In(0, TInt32)), FastSeq(5 -> TInt32), 6)
 
   @Test
   def testScalaFunctionCompanion(): Unit =
-    assertEvalsTo(lookup("foobar2", TInt32)(), 2)
+    assertEvalsTo(invoke("foobar2", TInt32), 2)
 
   @Test
   def testVariableUnification(): Unit = {
@@ -111,7 +106,7 @@ class FunctionSuite extends HailSuite {
   @Test
   def testUnphasedDiploidGtIndexCall(): Unit =
     assertEvalsTo(
-      lookup("UnphasedDiploidGtIndexCall", TCall, TInt32)(In(0, TInt32)),
+      invoke("UnphasedDiploidGtIndexCall", TCall, In(0, TInt32)),
       FastSeq(0 -> TInt32),
       Call2.fromUnphasedDiploidGtIndex(0),
     )


### PR DESCRIPTION
## Change Description

This PR refactors the `ApplyIR` node to behave more consistently with the rest of the IR nodes. In particular, before this change it had mutable fields `conversion` and `inline` which were not set in the constructor (instead being set after construction by the function registry), but were copied by the `Copy` implementation.

The primary changes are as follows:
* Functions can be registered with polymorphic types. We previously supported also looking up functions with polymorphic signatures. However, I noticed that we only ever look up concrete signatures. This allowed me to make several simplifications.
* Instead of caching the implementation in the `ApplyIR` node, and preserving the cached implementation across copies, I now simply re-lookup the implementation in the function registry as needed. (It's still cached in the node, but it isn't preserved across copies.)
* I made a few other small changes to more consistently use the `invoke` method, instead of calling the function registry directly.

## Security Assessment

Delete all except the correct answer:
- This change has no security impact

### Impact Description

Non-functional change to the compiler

(Reviewers: please confirm the security impact before approving)
