### PR TITLE
[query] Add `unitialized` pytest marker to initialisation tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1062,17 +1062,15 @@ steps:
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       python3 -m pytest \
-              -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
+              -Werror:::hail -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
               -r A \
               -vv \
               --instafail \
               --durations=50 \
-              --ignore=test/hailtop/batch/ \
-              --ignore=test/hailtop/inter_cloud \
               --timeout=120 \
-              test
+              test/hail
     inputs:
       - from: /derived/debug/hail/build/deploy/dist
         to: /io/debug-wheel
@@ -1096,7 +1094,7 @@ steps:
     clouds:
       - gcp
   - kind: runImage
-    name: test_hail_python_fs
+    name: test_hailtop_python_fs
     numSplits: 5
     image:
       valueFrom: hailgenetics_hailtop_image.image
@@ -3025,7 +3023,7 @@ steps:
       - hail_dev_image
       - create_ci_test_repo
   - kind: runImage
-    name: test_hailtop_batch
+    name: test_hailtop_python
     resources:
       memory: standard
       cpu: '0.25'
@@ -3033,22 +3031,28 @@ steps:
     image:
       valueFrom: hail_dev_image.image
     script: |
-      cd /io/hailtop
+      cd /io
       set -ex
-      export HAIL_CLOUD={{ global.cloud }}
-      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+      
+      tar xzf test.tar.gz
+      python3 -m pip install --no-dependencies /io/debug-wheel/hail-*-py3-none-any.whl
+            
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
+      export HAIL_CLOUD={{ global.cloud }}
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_GENETICS_HAIL_IMAGE="{{ hailgenetics_hail_image.image }}"
       export HAIL_GENETICS_HAILTOP_IMAGE="{{ hailgenetics_hailtop_image.image }}"
+      export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
 
       {% if global.cloud == 'gcp' %}
       export GCS_REQUESTER_PAYS_PROJECT={{ global.gcp_project }}
       {% endif %}
 
       hailctl config set batch/billing_project test
-      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/test_hailtop_batch/{{ token }}/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/test_hailtop_python/{{ token }}/
 
       python3 -m pytest \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
@@ -3059,14 +3063,13 @@ steps:
               --instafail \
               --durations=50 \
               --timeout=360 \
-              /io/test/hailtop/batch/
+              --ignore=test/hailtop/inter_cloud \
+              test/hailtop
     inputs:
-      - from: /repo/hail/python/pytest.ini
-        to: /io/pytest.ini
-      - from: /repo/hail/python/test
-        to: /io/test
-      - from: /repo/hail/python/hailtop
-        to: /io/hailtop
+      - from: /test.tar.gz
+        to: /io/test.tar.gz
+      - from: /derived/debug/hail/build/deploy/dist
+        to: /io/debug-wheel
     timeout: 1200
     secrets:
       - name: test-gsa-key
@@ -3079,8 +3082,8 @@ steps:
       - create_deploy_config
       - create_accounts
       - default_ns
-      - merge_code
       - hail_dev_image
+      - hail_debug_wheel
       - deploy_batch
   - kind: runImage
     name: test_hailctl_batch
@@ -3484,6 +3487,8 @@ steps:
       - build_hail_jar_and_wheel
       - build_azure_wheel
       - test_hail_java
+      - test_hail_python
+      - test_hailtop_python
       - test_hail_python_local_backend
       - test_hail_python_service_backend_gcp
       - test_hail_python_service_backend_azure
@@ -3833,7 +3838,7 @@ steps:
       - deploy_batch
       - test_batch
       - test_ci
-      - test_hailtop_batch
+      - test_hailtop_python
       - test_hail_python_service_backend_gcp
       - test_hail_python_service_backend_azure
       - test_hail_services_java
@@ -3882,7 +3887,7 @@ steps:
       - deploy_batch
       - test_batch
       - test_ci
-      - test_hailtop_batch
+      - test_hailtop_python
       - test_hail_python_service_backend_gcp
       - test_hail_python_service_backend_azure
       - cancel_all_running_test_batches
@@ -3929,7 +3934,7 @@ steps:
       - test_batch_invariants
       - test_batch
       - test_ci
-      - test_hailtop_batch
+      - test_hailtop_python
       - test_hail_python_service_backend_gcp
       - test_hail_python_service_backend_azure
       - cancel_all_running_test_batches
@@ -3979,7 +3984,7 @@ steps:
       - test_batch_invariants
       - test_batch
       - test_ci
-      - test_hailtop_batch
+      - test_hailtop_python
       - test_hail_python_service_backend_gcp
       - test_hail_python_service_backend_azure
       - cancel_all_running_test_batches

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -305,7 +305,11 @@ class Py4JBackend(Backend):
         return self._parse_blockmatrix_ir(self._render_ir(ir))
 
     def stop(self):
-        self._backend_server.close()
+        try:
+            self._backend_server.close()
+        except requests.exceptions.ConnectionError:
+            pass
+
         self._jbackend.close()
         self._jhc.stop()
         self._jhc = None

--- a/hail/python/pytest.ini
+++ b/hail/python/pytest.ini
@@ -10,6 +10,7 @@ markers =
     backend: tests that relate only to one or more backend types
     cloud: tests that relate only to one or more clouds
     benchmark: placeholder for benchmarks
+    uninitialized: tests that require the hail library to be uninitialized
 filterwarnings =
     error
     ignore::UserWarning

--- a/hail/python/test/hail/backend/test_spark_backend.py
+++ b/hail/python/test/hail/backend/test_spark_backend.py
@@ -10,10 +10,10 @@ def fatal(typ: hl.HailType, msg: str = "") -> hl.Expression:
     return hl.construct_expr(hl.ir.Die(hl.to_expr(msg, hl.tstr)._ir, typ), typ)
 
 
-@skip_unless_spark_backend()
+@pytest.mark.uninitialized
+@pytest.mark.backend('spark')
 @pytest.mark.parametrize('copy', [True, False])
 def test_copy_spark_log(copy):
-    hl.stop()
     hl.init(copy_spark_log_on_error=copy)
 
     expr = fatal(hl.tint32)

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -7,9 +7,9 @@ from typing import Dict
 import pytest
 from pytest import CollectReport, StashKey
 
-from hail import current_backend, reset_global_randomness
+from hail import current_backend
 from hail.backend.service_backend import ServiceBackend
-from hail.utils.java import choose_backend
+from hail.utils.java import Env, choose_backend
 from hailtop.hail_event_loop import hail_event_loop
 
 from .helpers import hl_init_for_test, hl_stop_for_test
@@ -34,48 +34,87 @@ def pytest_collection_modifyitems(items):
     n_splits = int(os.getenv('HAIL_RUN_IMAGE_SPLITS', '1'))
     split_index = int(os.getenv('HAIL_RUN_IMAGE_SPLIT_INDEX', '-1'))
     if n_splits > 1:
+        use_splits = True
         if not (0 <= split_index < n_splits):
             raise RuntimeError(f"invalid split_index: index={split_index}, n_splits={n_splits}\n  env={os.environ}")
-
-        use_splits = True
 
     backend = choose_backend()
     cloud = os.getenv('HAIL_CLOUD')
 
-    skip_not_in_split = pytest.mark.skip(reason=f'not included in split index {split_index}')
+    bins = [[] for _ in range(2)]
+
     for item in items:
         if use_splits and not digest(item.name) % n_splits == split_index:
-            item.add_marker(skip_not_in_split)
+            skip_reason = f'not included in split index {split_index} modulo {n_splits}'
+            item.add_marker(pytest.mark.skip(reason=skip_reason))
+            continue
 
-        backend_mark = item.get_closest_marker('backend')
-        if backend_mark is not None and backend_mark.args is not None:
-            if backend not in backend_mark.args:
-                reason = f'current backend "{backend}" not listed in "{backend_mark.args}"'
-                item.add_marker(pytest.mark.skip(reason=reason))
-            elif backend == 'batch':
-                item.fixturenames.insert(0, 'reinitialize_hail_for_testing')
+        if (backend_mark := item.get_closest_marker('backend')) is not None and backend not in backend_mark.args:
+            skip_reason = f'current backend "{backend}" not listed in "{backend_mark.args}"'
+            item.add_marker(pytest.mark.skip(reason=skip_reason))
+            continue
 
-        cloud_mark = item.get_closest_marker('cloud')
         if (
-            cloud is not None
-            and cloud_mark is not None
-            and cloud_mark.args is not None
+            (cloud_mark := item.get_closest_marker('cloud')) is not None
+            and cloud is not None
             and cloud not in cloud_mark.args
         ):
-            reason = f'current cloud "{cloud}" not listed in "{cloud_mark.args}"'
-            item.add_marker(pytest.mark.skip(reason=reason))
+            skip_reason = f'current cloud "{cloud}" not listed in "{cloud_mark.args}"'
+            item.add_marker(pytest.mark.skip(reason=skip_reason))
+            continue
+
+        init_fixture_name, priority = (
+            ('uninitialized', 0)
+            if item.get_closest_marker('uninitialized') is not None
+            else ('init_query_on_batch', 1)
+            if backend == 'batch'
+            else ('init_hail', 1)
+        )
+
+        item.fixturenames.insert(0, init_fixture_name)
+        bins[priority].append(item)
+
+    # Attempt to run tests that require no initialisation first
+    items[:] = sum(bins, [])
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope='function')
+def uninitialized():
+    assert not Env.is_fully_initialized()
+    try:
+        yield
+    finally:
+        hl_stop_for_test()
+
+
+@pytest.fixture(scope='session')
 def init_hail():
     hl_init_for_test()
-    yield
+    try:
+        yield
+    finally:
+        hl_stop_for_test()
+
+
+@pytest.fixture
+def init_query_on_batch(request):
     hl_stop_for_test()
+    hl_init_for_test(backend='batch', app_name=request.node.name)
+    try:
+        yield
+    finally:
+        new_backend = current_backend()
+        assert isinstance(new_backend, ServiceBackend)
+        batch = new_backend._batch
+        report: Dict[str, CollectReport] = request.node.stash[test_results_key]
+        if any(r.failed for r in report.values()):
+            log.info(f'cancelling failed test batch {batch.id}')
+            hail_event_loop().run_until_complete(batch.cancel())
 
 
 @pytest.fixture(autouse=True)
-def reset_randomness(init_hail):
-    reset_global_randomness()
+def reset_global_randomness():
+    Env.reset_global_randomness()
 
 
 test_results_key = StashKey[Dict[str, CollectReport]]()
@@ -87,17 +126,3 @@ def pytest_runtest_makereport(item, call):
     report = yield
     item.stash.setdefault(test_results_key, {})[report.when] = report
     return report
-
-
-@pytest.fixture
-def reinitialize_hail_for_testing(init_hail, request):
-    hl_stop_for_test()
-    hl_init_for_test(app_name=request.node.name)
-    yield
-    new_backend = current_backend()
-    if isinstance(new_backend, ServiceBackend) and new_backend._batch_was_submitted:
-        batch = new_backend._batch
-        report: Dict[str, CollectReport] = request.node.stash[test_results_key]
-        if any(r.failed for r in report.values()):
-            log.info(f'cancelling failed test batch {batch.id}')
-            hail_event_loop().run_until_complete(batch.cancel())

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -14,20 +14,24 @@ GCS_REQUESTER_PAYS_PROJECT = os.environ.get('GCS_REQUESTER_PAYS_PROJECT')
 HAIL_QUERY_N_CORES = os.environ.get('HAIL_QUERY_N_CORES', '2')
 
 
-def hl_init_for_test(*args, **kwargs):
-    backend_name = choose_backend()
+def hl_init_for_test(**kwargs):
+    backend_name = choose_backend(kwargs.get('backend'))
+
+    init_kwargs = {
+        **kwargs,
+        'backend': backend_name,
+        'global_seed': 0,
+    }
+
     if backend_name == 'spark':
-        hl.init(
-            backend=backend_name,
-            master=f'local[{HAIL_QUERY_N_CORES}]',
-            min_block_size=0,
-            quiet=True,
-            global_seed=0,
-            *args,
-            **kwargs,
-        )
-    else:
-        hl.init(global_seed=0, backend=backend_name, *args, **kwargs)
+        init_kwargs = {
+            **init_kwargs,
+            'master': f'local[{HAIL_QUERY_N_CORES}]',
+            'min_block_size': 0,
+            'quiet': True,
+        }
+
+    hl.init(**init_kwargs)
 
 
 def hl_stop_for_test():

--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -1,6 +1,8 @@
 from test.hail.helpers import hl_init_for_test, hl_stop_for_test, qobtest, skip_unless_spark_backend, with_flags
 from typing import Dict, Optional, Tuple
 
+import pytest
+
 import hail as hl
 from hail.backend.backend import Backend
 from hail.backend.spark_backend import SparkBackend
@@ -25,7 +27,9 @@ def _scala_map_str_to_tuple_str_str_to_dict(scala) -> Dict[str, Tuple[Optional[s
 
 
 @qobtest
+@pytest.mark.uninitialized
 def test_init_hail_context_twice():
+    hl_init_for_test()
     hl_init_for_test(idempotent=True)  # Should be no error
     hl_stop_for_test()
 
@@ -37,7 +41,7 @@ def test_init_hail_context_twice():
     hl_init_for_test(idempotent=True)  # Should be no error
 
     if isinstance(Env.backend(), SparkBackend):
-        hl_init_for_test(hl.spark_context(), idempotent=True)  # Should be no error
+        hl_init_for_test(sc=hl.spark_context(), idempotent=True)  # Should be no error
 
 
 @qobtest


### PR DESCRIPTION
A number of tests require hail be unitialised and call `hail.stop`. This change
- provides a mechanism to do that automatically
- separates running tests in test/hailtop from test/hail as pytest was mixing `conftest.py`
  in non-obvious ways. 

This change affects test code only and thus has low security impact.