### PR TITLE
[infra] Update ubuntu images

### DIFF
--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -14,7 +14,7 @@ PROJECT=$(get_global_config_field gcp_project $NAMESPACE)
 ZONE=$(get_global_config_field gcp_zone $NAMESPACE)
 DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image $NAMESPACE)
 
-WORKER_IMAGE_VERSION=15
+WORKER_IMAGE_VERSION=16
 
 if [ "$NAMESPACE" == "default" ]; then
     WORKER_IMAGE=batch-worker-${WORKER_IMAGE_VERSION}
@@ -24,7 +24,7 @@ else
     BUILDER=build-batch-worker-$NAMESPACE-image
 fi
 
-UBUNTU_IMAGE=ubuntu-minimal-2204-jammy-v20230726
+UBUNTU_IMAGE=ubuntu-minimal-2204-jammy-v20250311
 
 create_build_image_instance() {
     echo "Deleting any preexisting $BUILDER instance. This is expected to print an ERROR if the image does not exist."

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKER_PREFIX={{ global.docker_prefix }}
-FROM $DOCKER_PREFIX/ubuntu:jammy-20230624
+FROM $DOCKER_PREFIX/ubuntu:jammy-20250126
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -16,4 +16,4 @@ ubuntu:19.04
 ubuntu:22.04
 ubuntu:bionic-20200921
 ubuntu:focal-20221019
-ubuntu:jammy-20230624
+ubuntu:jammy-20250126


### PR DESCRIPTION
We update our batch worker image to GCP's latest ubuntu-minimal-jammy version (v20250311), as well as the base version for our ubuntu derived docker images (jammy-20250126).

As a part of this update, we need to update our worker images.

## Security Assessment

Delete all except the correct answer:
- This change has a high security impact
  - [ ] Required: The impact has been assessed and approved by appsec

### Impact Description
Major underpinning software update.