### PR TITLE
[hailctl] Initialize buckets without soft delete on

### DIFF
--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -180,6 +180,9 @@ async def setup_new_remote_tmpdir(
         await grant_service_account_bucket_access_with_role(
             bucket_name, service_account, 'roles/storage.objectAdmin', verbose=verbose
         )
+        await grant_service_account_bucket_access_with_role(
+            bucket_name, service_account, 'roles/storage.legacyBucketOwner', verbose=verbose
+        )
     except InsufficientPermissions as e:
         typer.secho(e.message, fg=typer.colors.RED)
         raise Abort() from e

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -88,7 +88,7 @@ async def setup_new_remote_tmpdir(
 
     token = secret_alnum_string(5).lower()
     maybe_bucket_name = f'hail-batch-{username}-{token}'
-    bucket_name = Prompt.ask(f'What is the name of the new bucket?', default=maybe_bucket_name)
+    bucket_name = Prompt.ask('What is the name of the new bucket?', default=maybe_bucket_name)
 
     default_project = await get_gcp_default_project(verbose=verbose)
     bucket_prompt = f'Which google project should {bucket_name} be created in? This project will incur costs for storing your Hail generated data.'

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -180,6 +180,9 @@ async def setup_new_remote_tmpdir(
         await grant_service_account_bucket_access_with_role(
             bucket_name, service_account, 'roles/storage.objectAdmin', verbose=verbose
         )
+        await grant_service_account_bucket_access_with_role(
+            bucket_name, service_account, 'roles/storage.objectUser', verbose=verbose
+        )
     except InsufficientPermissions as e:
         typer.secho(e.message, fg=typer.colors.RED)
         raise Abort() from e

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -86,13 +86,19 @@ async def setup_new_remote_tmpdir(
         update_gcp_bucket,
     )
 
+    default_project = await get_gcp_default_project(verbose=verbose)
+
     token = secret_alnum_string(5).lower()
-    maybe_bucket_name = f'hail-batch-{username}-{token}'
+    default_project_str = f'-{default_project}' if default_project is not None else ''
+
+    maybe_bucket_name = f'hail-batch-{username}{default_project_str}-{token}'
     bucket_name = Prompt.ask('What is the name of the new bucket?', default=maybe_bucket_name)
 
-    default_project = await get_gcp_default_project(verbose=verbose)
     bucket_prompt = f'Which google project should {bucket_name} be created in? This project will incur costs for storing your Hail generated data.'
-    project = Prompt.ask(bucket_prompt, default=default_project)
+    if default_project is not None:
+        project = Prompt.ask(bucket_prompt, default=default_project)
+    else:
+        project = Prompt.ask(bucket_prompt)
 
     if 'us-central1' in supported_regions:
         default_compute_region = 'us-central1'

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -88,7 +88,7 @@ async def setup_new_remote_tmpdir(
 
     token = secret_alnum_string(5).lower()
     maybe_bucket_name = f'hail-batch-{username}-{token}'
-    bucket_name = Prompt.ask(f'What is the name of the new bucket (Example: {maybe_bucket_name})', default=maybe_bucket_name)
+    bucket_name = Prompt.ask(f'What is the name of the new bucket?', default=maybe_bucket_name)
 
     default_project = await get_gcp_default_project(verbose=verbose)
     bucket_prompt = f'Which google project should {bucket_name} be created in? This project will incur costs for storing your Hail generated data.'

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -180,9 +180,6 @@ async def setup_new_remote_tmpdir(
         await grant_service_account_bucket_access_with_role(
             bucket_name, service_account, 'roles/storage.objectAdmin', verbose=verbose
         )
-        await grant_service_account_bucket_access_with_role(
-            bucket_name, service_account, 'roles/storage.objectUser', verbose=verbose
-        )
     except InsufficientPermissions as e:
         typer.secho(e.message, fg=typer.colors.RED)
         raise Abort() from e

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -99,7 +99,7 @@ async def setup_new_remote_tmpdir(
     else:
         default_compute_region = supported_regions[0]
 
-    bucket_region = Prompt.ask(f'Which region does your data reside in?', default=default_compute_region)
+    bucket_region = Prompt.ask('Which region does your data reside in?', default=default_compute_region)
     if bucket_region not in supported_regions:
         typer.secho(
             f'The region where your data lives ({bucket_region}) is not in one of the supported regions of the Batch Service ({supported_regions}). '

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -4,7 +4,7 @@ import typer
 from rich.prompt import Confirm, IntPrompt, Prompt
 from typer import Abort, Exit
 
-from hailtop.config import ConfigVariable
+from hailtop.config import ConfigVariable, configuration_of
 
 
 async def setup_existing_remote_tmpdir(service_account: str, verbose: bool) -> Tuple[Optional[str], str, bool]:
@@ -88,20 +88,18 @@ async def setup_new_remote_tmpdir(
 
     token = secret_alnum_string(5).lower()
     maybe_bucket_name = f'hail-batch-{username}-{token}'
-    bucket_name = Prompt.ask(f'What is the name of the new bucket (Example: {maybe_bucket_name})')
+    bucket_name = Prompt.ask(f'What is the name of the new bucket (Example: {maybe_bucket_name})', default=maybe_bucket_name)
 
     default_project = await get_gcp_default_project(verbose=verbose)
     bucket_prompt = f'Which google project should {bucket_name} be created in? This project will incur costs for storing your Hail generated data.'
-    if default_project is not None:
-        bucket_prompt += f' (Example: {default_project})'
-    project = Prompt.ask(bucket_prompt)
+    project = Prompt.ask(bucket_prompt, default=default_project)
 
     if 'us-central1' in supported_regions:
         default_compute_region = 'us-central1'
     else:
         default_compute_region = supported_regions[0]
 
-    bucket_region = Prompt.ask(f'Which region does your data reside in? (Example: {default_compute_region})')
+    bucket_region = Prompt.ask(f'Which region does your data reside in?', default=default_compute_region)
     if bucket_region not in supported_regions:
         typer.secho(
             f'The region where your data lives ({bucket_region}) is not in one of the supported regions of the Batch Service ({supported_regions}). '
@@ -286,8 +284,9 @@ async def async_basic_initialize(verbose: bool = False):
         )
         warnings = True
 
-    if trial_bp_name:
-        set_config(ConfigVariable.BATCH_BILLING_PROJECT, trial_bp_name)
+    billing_project = configuration_of(ConfigVariable.BATCH_BILLING_PROJECT, trial_bp_name, None)
+    if billing_project:
+        set_config(ConfigVariable.BATCH_BILLING_PROJECT, billing_project)
 
     if remote_tmpdir:
         set_config(ConfigVariable.BATCH_REMOTE_TMPDIR, remote_tmpdir)

--- a/hail/python/hailtop/hailctl/batch/utils.py
+++ b/hail/python/hailtop/hailctl/batch/utils.py
@@ -84,6 +84,18 @@ async def create_gcp_bucket(*, project: str, bucket: str, location: str, verbose
             f'--location={location}',
             echo=verbose,
         )
+
+        await check_exec_output(
+            'gcloud',
+            '--project',
+            project,
+            'storage',
+            'buckets',
+            'update',
+            '--clear-soft-delete',
+            f'gs://{bucket}',
+            echo=verbose,
+        )
     except CalledProcessError as e:
         if 'does not have storage.buckets.create access to the Google Cloud project' in e.stderr.decode('utf-8'):
             msg = (


### PR DESCRIPTION
## Change Description

We ran into a problem where soft-delete is automatically enabled for new buckets. This caused a ton of unexpected costs as my mental model was that Batch temp buckets should have no retention policy on them. This change makes it such that all new batch remote temporary directories are set up correctly both with regards to retention and regions.

## Security Assessment

- This change has no security impact

### Impact Description

Only impacts hailctl and no backend code.

(Reviewers: please confirm the security impact before approving)
