### PR TITLE
[compiler] fix overeager cast simplification

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Casts.scala
+++ b/hail/hail/src/is/hail/expr/ir/Casts.scala
@@ -5,52 +5,59 @@ import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.virtual._
 
+// Consider a cast from t1 to t2 to be lossless when casting from t1 to t2 and back is identity.
+case class CastInfo(impl: (EmitCodeBuilder, SValue) => SValue, isLossless: Boolean = false) {
+  def apply(cb: EmitCodeBuilder, x: SValue): SValue = impl(cb, x)
+}
+
 object Casts {
-  private val casts: Map[(Type, Type), (EmitCodeBuilder, SValue) => SValue] = Map(
-    (TInt32, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) => x),
-    (TInt32, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) =>
-      primitive(cb.memoize(x.asInt.value.toL))
+  private val casts: Map[(Type, Type), CastInfo] = Map(
+    (TInt32, TInt32) -> CastInfo((_, x) => x, isLossless = true),
+    (TInt32, TInt64) -> CastInfo(
+      (cb, x) => primitive(cb.memoize(x.asInt.value.toL)),
+      isLossless = true,
     ),
-    (TInt32, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TInt32, TFloat32) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asInt.value.toF))
     ),
-    (TInt32, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) =>
-      primitive(cb.memoize(x.asInt.value.toD))
+    (TInt32, TFloat64) -> CastInfo(
+      (cb, x) => primitive(cb.memoize(x.asInt.value.toD)),
+      isLossless = true,
     ),
-    (TInt64, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TInt64, TInt32) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asLong.value.toI))
     ),
-    (TInt64, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) => x),
-    (TInt64, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TInt64, TInt64) -> CastInfo((_, x) => x, isLossless = true),
+    (TInt64, TFloat32) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asLong.value.toF))
     ),
-    (TInt64, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TInt64, TFloat64) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asLong.value.toD))
     ),
-    (TFloat32, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TFloat32, TInt32) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asFloat.value.toI))
     ),
-    (TFloat32, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TFloat32, TInt64) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asFloat.value.toL))
     ),
-    (TFloat32, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) => x),
-    (TFloat32, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) =>
-      primitive(cb.memoize(x.asFloat.value.toD))
+    (TFloat32, TFloat32) -> CastInfo((_, x) => x, isLossless = true),
+    (TFloat32, TFloat64) -> CastInfo(
+      (cb, x) => primitive(cb.memoize(x.asFloat.value.toD)),
+      isLossless = true,
     ),
-    (TFloat64, TInt32) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TFloat64, TInt32) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asDouble.value.toI))
     ),
-    (TFloat64, TInt64) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TFloat64, TInt64) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asDouble.value.toL))
     ),
-    (TFloat64, TFloat32) -> ((cb: EmitCodeBuilder, x: SValue) =>
+    (TFloat64, TFloat32) -> CastInfo((cb, x) =>
       primitive(cb.memoize(x.asDouble.value.toF))
     ),
-    (TFloat64, TFloat64) -> ((cb: EmitCodeBuilder, x: SValue) => x),
+    (TFloat64, TFloat64) -> CastInfo((_, x) => x, isLossless = true),
   )
 
-  def get(from: Type, to: Type): (EmitCodeBuilder, SValue) => SValue =
-    casts(from -> to)
+  def get(from: Type, to: Type): CastInfo = casts(from -> to)
 
   def valid(from: Type, to: Type): Boolean =
     casts.contains(from -> to)

--- a/hail/hail/src/is/hail/expr/ir/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/Simplify.scala
@@ -265,7 +265,7 @@ object Simplify {
       default
 
     case Cast(x, t) if x.typ == t => x
-    case Cast(Cast(x, _), t) if x.typ == t => x
+    case Cast(Cast(x, t2), t) if x.typ == t && Casts.get(t, t2).isLossless => x
 
     case CastRename(x, t) if x.typ == t => x
     case CastRename(CastRename(x, _), t) => CastRename(x, t)

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -758,4 +758,23 @@ class SimplifySuite extends HailSuite {
     assert(x == expected)
   }
 
+  @DataProvider(name = "CastRules")
+  def castRules: Array[Array[Any]] = {
+    Array(
+      Array(TInt32, TFloat32, false),
+      Array(TInt32, TInt64, true),
+      Array(TInt64, TInt32, false),
+      Array(TInt32, TFloat64, true),
+      Array(TFloat32, TFloat64, true),
+      Array(TFloat64, TFloat32, false),
+    )
+  }
+
+  @Test(dataProvider = "CastRules")
+  def testCastSimplify(t1: Type, t2: Type, simplifies: Boolean): Unit = {
+    val x = ref(t1)
+    val ir = Cast(Cast(x, t2), t1)
+    val expected = if (simplifies) x else ir
+    assert(Simplify(ctx, ir) == expected)
+  }
 }


### PR DESCRIPTION
## Change Description

Fixes #14868

Marks some casts as being lossless, and only allows simplifying a t1->t2->t1 cast when the t1->t2 cast is lossless.

## Security Assessment

Delete all except the correct answer:
- This change has no security impact

### Impact Description

Only changes the behavior of arithmetic in query.

(Reviewers: please confirm the security impact before approving)
