### PR TITLE
[tests] prevent genVal for PInterval exceeding num retries

### DIFF
--- a/hail/hail/test/src/is/hail/annotations/UnsafeSuite.scala
+++ b/hail/hail/test/src/is/hail/annotations/UnsafeSuite.scala
@@ -83,10 +83,9 @@ class UnsafeSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
 
     val g: Gen[(TStruct, Annotation)] =
       for {
-        t <- arbitrary[TStruct]
-        v <- genNullable(ctx, t)
-        if v != null
-      } yield (t, v)
+        pt <- arbitrary[PCanonicalStruct]
+        v <- genVal(ctx, pt.setRequired(true))
+      } yield (pt.virtualType, v)
 
     forAll(g) { case (t, a) =>
       assert(t.typeCheck(a))

--- a/hail/hail/test/src/is/hail/scalacheck/ArbitraryPTypeInstances.scala
+++ b/hail/hail/test/src/is/hail/scalacheck/ArbitraryPTypeInstances.scala
@@ -61,7 +61,7 @@ private[scalacheck] trait ArbitraryPTypeInstances {
   implicit lazy val arbPCanonicalDict: Arbitrary[PCanonicalDict] =
     liftA3(
       PCanonicalDict(_, _, _),
-      smaller[PType] suchThat (_.required),
+      smaller[PType] map { _.setRequired(true) },
       smaller[PType],
       genIsRequired,
     )


### PR DESCRIPTION
Remove uses of `if` or `suchThat` in comprehensions over `Gen` to prevent sporadic errors like the following in scalacheck-driven tests 
```scala
Exception:
org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException: Gave up after 9 successful property evaluations. 51 evaluations were discarded.
```
This change has no security impact.
