### PR TITLE
[auth] Login UI requires ToS acceptance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,6 @@ wheel-container.tar
 hail/python/hail/backend/extra_classpath
 hail/python/hail/backend/hail.jar
 hail/install-editable
+hail/python/install-editable
+batch/jvm-entryway/bin
 .helix

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -1,30 +1,18 @@
-{% from "utils.html" import submit_button %}
+{% from "utils.html" import submit_button, submit_button_with_attrs %}
 {% extends "layout.html" %}
 {% block title %}User{% endblock %}
 {% block content %}
 <div id="profile" class="vcentered space-y-2">
-  <p>
-    The Hail system records your email address and IP address. Your email address
-    is recorded so that we can authenticate you. Your IP address is tracked as part of our
-    surveillance of all traffic to and from the Hail system. This broad surveillance enables the
-    protection of the Hail system from malicious actors.
-  </p>
-  <p>
-    <b>Notice:</b> To log in and use the Hail system, you must review and agree to be bound by the Hail Terms of Service.
-  </p>
-  <p>
-    <b>Terms of Service:</b> <a href="https://batch.hail.is/tos" target="_blank">Link</a>
-  </p>
-  <p>
-    <b>Privacy Policy:</b> <a href="https://batch.hail.is/privacy" target="_blank">Link</a>
-  </p>
-
   {% if userdata %}
   <h1 class='text-4xl mb-4'>{{ userdata['username'] }}</h1>
   <form action="{{ auth_base_url }}/logout" method="POST">
     <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
     {{ submit_button('Log out') }}
   </form>
+  <p> <b>Notice:</b>
+    By continuing to use the Hail system, you agree that you have reviewed and will be bound by the Hail <a href="https://batch.hail.is/tos" target="_blank" class="text-blue-600 hover:underline">Terms of Service</a>
+    and have read the <a href="https://batch.hail.is/privacy" target="_blank" class="text-blue-600 hover:underline">Privacy Policy</a>. If not you must log out and stop using the Hail system immediately.
+  </p>
   {% if cloud == "gcp" %}
   <p><b>Google Service Account: </b>{{ userdata['display_name'] }}</p>
   {% endif %}
@@ -48,7 +36,9 @@
   <div class="mb-4">
     <label class="flex items-center">
       <input type="checkbox" id="tosCheckbox" class="mr-2" onchange="updateButtons()">
-      <span>I have reviewed and agree to the <a href="https://batch.hail.is/tos" target="_blank" class="text-blue-600 hover:underline">Terms of Service</a></span>
+      <span>I have reviewed and agree to the <a href="https://batch.hail.is/tos" target="_blank" class="text-blue-600 hover:underline">Terms of Service</a>
+        and have read the <a href="https://batch.hail.is/privacy" target="_blank" class="text-blue-600 hover:underline">Privacy Policy</a>
+      </span>
     </label>
   </div>
 
@@ -100,5 +90,13 @@
     updateButtons();
   </script>
   {% endif %}
+
+  <p>
+    The Hail system records your email address and IP address. Your email address
+    is recorded so that we can authenticate you. Your IP address is tracked as part of our
+    surveillance of all traffic to and from the Hail system. This broad surveillance enables the
+    protection of the Hail system from malicious actors.
+  </p>
+
 </div>
 {% endblock %}

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -60,7 +60,7 @@
           {% if next_page %}
           <input type="hidden" name="next" value="{{ next_page }}" />
           {% endif %}
-          {{ submit_button('Sign up', attrs='id=signupButton disabled') }}
+          {{ submit_button_with_attrs('Sign up', 'id=signupButton disabled') }}
         </form>
       </td>
       <td>
@@ -69,7 +69,7 @@
           {% if next_page %}
           <input type="hidden" name="next" value="{{ next_page }}" />
           {% endif %}
-          {{ submit_button('Log in', attrs='id=loginButton disabled') }}
+          {{ submit_button_with_attrs('Log in', 'id=loginButton disabled') }}
         </form>
       </td>
     </tr>

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -3,6 +3,22 @@
 {% block title %}User{% endblock %}
 {% block content %}
 <div id="profile" class="vcentered space-y-2">
+  <p>
+    The Hail system records your email address and IP address. Your email address
+    is recorded so that we can authenticate you. Your IP address is tracked as part of our
+    surveillance of all traffic to and from the Hail system. This broad surveillance enables the
+    protection of the Hail system from malicious actors.
+  </p>
+  <p>
+    <b>Notice:</b> To log in and use the Hail system, you must review and agree to be bound by the Hail Terms of Service.
+  </p>
+  <p>
+    <b>Terms of Service:</b> <a href="https://batch.hail.is/tos" target="_blank">Link</a>
+  </p>
+  <p>
+    <b>Privacy Policy:</b> <a href="https://batch.hail.is/privacy" target="_blank">Link</a>
+  </p>
+
   {% if userdata %}
   <h1 class='text-4xl mb-4'>{{ userdata['username'] }}</h1>
   <form action="{{ auth_base_url }}/logout" method="POST">
@@ -28,6 +44,14 @@
   {% else %}
     <p>You must sign up or log in to continue</p>
   {% endif %}
+  
+  <div class="mb-4">
+    <label class="flex items-center">
+      <input type="checkbox" id="tosCheckbox" class="mr-2" onchange="updateButtons()">
+      <span>I have reviewed and agree to the <a href="https://batch.hail.is/tos" target="_blank" class="text-blue-600 hover:underline">Terms of Service</a></span>
+    </label>
+  </div>
+
   <table class="table-auto w-64">
     <tr>
       <td>
@@ -36,7 +60,7 @@
           {% if next_page %}
           <input type="hidden" name="next" value="{{ next_page }}" />
           {% endif %}
-          {{ submit_button('Sign up') }}
+          {{ submit_button('Sign up', attrs='id=signupButton disabled') }}
         </form>
       </td>
       <td>
@@ -45,20 +69,36 @@
           {% if next_page %}
           <input type="hidden" name="next" value="{{ next_page }}" />
           {% endif %}
-          {{ submit_button('Log in') }}
+          {{ submit_button('Log in', attrs='id=loginButton disabled') }}
         </form>
       </td>
     </tr>
   </table>
+
+  <script>
+    function updateButtons() {
+      const checkbox = document.getElementById('tosCheckbox');
+      const signupButton = document.getElementById('signupButton');
+      const loginButton = document.getElementById('loginButton');
+      
+      signupButton.disabled = !checkbox.checked;
+      loginButton.disabled = !checkbox.checked;
+      
+      // Update button styles based on state
+      [signupButton, loginButton].forEach(button => {
+        if (button.disabled) {
+          button.classList.add('opacity-50', 'cursor-not-allowed');
+          button.classList.remove('hover:bg-blue-700');
+        } else {
+          button.classList.remove('opacity-50', 'cursor-not-allowed');
+          button.classList.add('hover:bg-blue-700');
+        }
+      });
+    }
+
+    // Initialize button states
+    updateButtons();
+  </script>
   {% endif %}
-  <p>
-    The Hail system records your email address and IP address. Your email address
-    is recorded so that we can authenticate you. Your IP address is tracked as part of our
-    surveillance of all traffic to and from the Hail system. This broad surveillance enables the
-    protection of the Hail system from malicious actors.
-  </p>
-  <p>
-    <b>Notice:</b> By signing up or logging in and continuing to use the system, you agree to these terms of service.
-  </p>
 </div>
 {% endblock %}

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -3495,7 +3495,6 @@ async def openapi(request):
     return await render_template('batch', request, None, 'openapi.yaml', page_context)
 
 
-
 @routes.get('/tos')
 @web_security_headers
 async def tos(request):

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -3495,6 +3495,19 @@ async def openapi(request):
     return await render_template('batch', request, None, 'openapi.yaml', page_context)
 
 
+
+@routes.get('/tos')
+@web_security_headers
+async def tos(request):
+    return await render_template('batch', request, None, 'tos.html', {})
+
+
+@routes.get('/privacy')
+@web_security_headers
+async def privacy(request):
+    return await render_template('batch', request, None, 'privacy.html', {})
+
+
 async def cancel_batch_loop_body(app):
     client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
     await retry_transient_errors(

--- a/batch/batch/front_end/templates/privacy.html
+++ b/batch/batch/front_end/templates/privacy.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hail Privacy Policy</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+        }
+        h1 {
+            text-align: center;
+            color: #2c3e50;
+            margin-bottom: 30px;
+        }
+        h2 {
+            color: #2c3e50;
+            margin-top: 30px;
+        }
+        .last-updated {
+            text-align: center;
+            font-style: italic;
+            margin-bottom: 30px;
+        }
+        .section {
+            margin-bottom: 20px;
+        }
+        ul {
+            padding-left: 20px;
+        }
+        li {
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hail Privacy Policy</h1>
+    <p class="last-updated">Last Updated: May 6, 2025</p>
+
+    <div class="section">
+        <p>The Broad Institute, Inc. ("Broad," "we," "us," or "our") values your privacy. This Privacy Policy ("Policy") provides important information about how Broad collects and uses your Personal Data when you access or use the Hail application. Please review this Policy, which is incorporated into and made part of the Hail Terms of Use. By accessing or using Hail, you consent to our collection, use, and disclosure of your information in accordance with this Policy and our Terms of Use. If you do not agree to our Policy or Terms of Use, you may not use Hail.</p>
+
+        <p>This Privacy Policy applies to Broad where Broad is the "controller" of your Personal Data, i.e., the entity that determines the purposes and means for processing such data. Broad may in some cases process Personal Data on behalf of users of Hail, such as where users perform analysis of Personal Data including genomics data on Hail. In that case, Broad is a "processor" with respect to such information, and you should refer to the user's own privacy notices to receive additional information about their privacy practices.</p>
+    </div>
+
+    <div class="section">
+        <h2>Information We Collect</h2>
+        <p>We collect information (including Personal Information) about you in two ways. The first is information you voluntarily provide to us when you choose to do any of the following:</p>
+        <ul>
+            <li>Register to use Hail.</li>
+            <li>Communicate with us (e.g., by email).</li>
+        </ul>
+
+        <p>The second way we collect information is through certain automated technologies that are used when you access Hail. An example is a "cookie," which is a small piece of computer code that is placed on your computer or other device that can be used for various purposes, such as to recognize a user or to track their activities on a website. We describe automated technologies in more detail below. We collect various information through these automated technologies, including your Device Information as described below, along with how you use Hail, such as the web pages within Hail that you view, the links you click, the length of time you spend visiting Hail, and the web page or web site that led you to Hail.</p>
+    </div>
+
+    <div class="section">
+        <h2>What kind of information do we collect?</h2>
+        <p>We collect various types of information:</p>
+        <ul>
+            <li><strong>"Personal Information"</strong> is information that alone or in combination with other information may be used to readily identify, contact, or locate you. For example, your name and email address are Personal Information we may collect through your use of the Platform.</li>
+            <li><strong>"Device Information"</strong> is information that relates to a particular computer, mobile device, or other device (e.g., iPad) that you use to access the Platform. Device Information includes such things as an IP address (which is a number assigned by an internet service provider to the computer you use to access the Internet), a device ID (which is a number assigned to a mobile phone by the device manufacturer), or the type of operating system or web browser used to access the Platform.</li>
+            <li>Other information you choose to provide, such as when you request technical or customer support.</li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>Do we use cookies and other tracking technologies?</h2>
+        <p>Yes. We use cookies for various purposes, such as to make it easier for you to navigate Hail, to enable a faster log-in process, or to allow us to track your activities on Hail. There are two types of cookies: session and persistent cookies.</p>
+
+        <p><strong>Session Cookies.</strong> Session Cookies exist only during a session. They disappear from your computer or device when you close your browser or turn off your computer or device. We use Session Cookies to allow our systems to uniquely identify you during a session or while you are logged in to Hail. This allows us to process your communications and requests and verify your identity after you have logged in and as you move through Hail, and to optimize your experience in using Hail.</p>
+
+        <p><strong>Persistent Cookies.</strong> Persistent Cookies remain on your computer or device after you have closed your browser or turned off your computer or mobile device. We use Persistent Cookies to track aggregate and statistical information about user activity on Hail (see "Tracking Technologies" below).</p>
+
+        <p><strong>Disabling Cookies.</strong> Most web browsers automatically accept cookies, but if you prefer, you can edit your browser options to block them in the future. The Help portion of the toolbar on most browsers will tell you how to prevent your computer from accepting new cookies, how to have the browser notify you when you receive a new cookie, or how to disable cookies altogether. Visitors to Hail who disable cookies may not be able to use Hail.</p>
+
+        <p><strong>Tracking Technologies.</strong> We may use automated devices and applications to evaluate usage of Hail. We also may use other analytics tools, including Google Analytics, to evaluate Hail. We use these tools to help us improve our application, performance, and user experiences. We may also use third-party tracking technologies to detect malicious code or attacks on Hail. These entities may use cookies and other tracking technologies to perform their services. We do not share your personal information with these third parties.</p>
+    </div>
+
+    <div class="section">
+        <h2>Do you respond to Do Not Track signals?</h2>
+        <p>Do Not Track ("DNT") is a privacy preference that users can set in their web browsers. When users turn on DNT, their browser sends a message to websites requesting that they do not track the user. However, Hail does not change its information collection in response to DNT browser settings or signals. For information about DNT, visit www.allaboutdnt.org.</p>
+    </div>
+
+    <div class="section">
+        <h2>How do we use your information?</h2>
+        <p>We use your information, including your Personal Information, for various purposes:</p>
+        <ul>
+            <li><strong>Provide the Application.</strong> We, and our vendors and service providers, use your information (e.g., user identification and password) to provide Hail, respond to your inquiries, and troubleshoot issues with Hail, and for other customer service purposes.</li>
+            <li><strong>Improve and Develop Our Application.</strong> We use your information to ensure Hail is working as intended, to better understand how users access and use our application, both on an aggregated and individualized basis, to make improvements to our application, to develop new features and services, and for other research and analytical purposes.</li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>With whom do we share your information?</h2>
+        <p>We may need to share your information, including your Personal Information, with third parties. The following are the categories of third parties with whom we may share your Personal Information:</p>
+        <ul>
+            <li><strong>Vendors and Service Providers.</strong> We use various third-party vendors and service providers that assist us in providing Hail. For example, we may use third-party vendors to store and authenticate account credentials, and for hosting and storing information collected through our application. We may share your information with these vendors and service providers to enable them to provide these services to us. These service providers and vendors are required to only use your information to provide their services to us and in a manner consistent with this Policy.</li>
+            <li><strong>As Required By Law.</strong> We may be required by law to disclose your Personal Information to third parties, such as in the following situations:
+                <ul>
+                    <li>In response to a request by law enforcement;</li>
+                    <li>In response to legal process, such as a subpoena, a request for discovery in a civil proceeding, or in response to a court order.</li>
+                </ul>
+            </li>
+            <li><strong>Enforce Our Terms and Protect You, Us, and Others.</strong> We may access, preserve, and disclose your Personal Information to enforce the Terms of Use for the Platform and protect your, our, or others' rights, property, or safety.</li>
+            <li><strong>Merger, Sale, or Other Corporate Transactions.</strong> A legal entity, such as Broad, may be involved in a business transaction where its ownership or assets are sold or transferred to another legal entity. This can happen in a merger with another legal entity, an acquisition by another legal entity, a corporate reorganization, or a legal proceeding (e.g., bankruptcy or receivership) where a trustee or other takes over control of the entity. In each of these situations, your information, including your Personal Information, may be transferred as part of such a transaction as permitted by law and/or contract.</li>
+            <li><strong>With Your Consent.</strong> We may ask you from time to time to give us permission to share your information with other third parties not described in this section. In each case, we will describe that third party and the purpose for sharing your information.</li>
+            <li><strong>Aggregate and De-Identified Information.</strong> We may share aggregate or de-identified information about users and their use of the Platform with third parties and publicly for marketing, advertising, research, or similar purposes. This information will not identify you personally.</li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>What rights do I have with respect to my information?</h2>
+        <p>We will respond to any user request as soon as we reasonably can, and within the time and in the manner required by law. We may request additional information from you to verify the request. We may not be able to accommodate all requests; for example, we may be unable to accommodate a deletion request if we are required to maintain information under law or a legal obligation or if information is used as part of a study.</p>
+    </div>
+
+    <div class="section">
+        <h2>Authority (Privacy Act)</h2>
+        <p>To the extent that you are using Hail to process selected research data from certain U.S. Government Sources, we are collecting and processing your personal information on behalf of a U.S. Federal Agency as authorized by federal law, especially the Privacy Act of 1974.</p>
+    </div>
+
+    <div class="section">
+        <h2>What kind of security does Hail use to protect my information?</h2>
+        <p>We seek to use reasonable physical, technical, and administrative measures designed to protect personal information within our organization. Unfortunately, no data transmission, processing, or storage system can be guaranteed to be 100% secure. If you have reason to believe that your use of Hail is no longer secure (for example, if you feel that the security of your account has been compromised), please immediately notify us in accordance with the "Contacting Us" section below.</p>
+    </div>
+
+    <div class="section">
+        <h2>Is there any transfer of Personal Information from one country to another?</h2>
+        <p>We store the information you provide on servers in the United States. If you are a user of Hail located outside of the United States, you agree to the transfer of your Personal Information to the United States and acknowledge that the laws in the United States may offer less protection to your Personal Information than the laws where you are located.</p>
+    </div>
+
+    <div class="section">
+        <h2>Links to Third-Party Websites</h2>
+        <p>Our Platform may reference or provide links to third-party websites. Other websites may also reference or link to Hail. Because these websites are not controlled by Broad, we are not responsible for these third-party websites. We encourage our users to be aware when they leave our application to review the privacy policies posted on each and every website that collects personally identifiable information. Please be aware that Broad does not control, endorse, screen or approve, nor are we responsible for, the privacy policies or information practices of third parties or their websites or mobile applications. Visiting these other websites is at your own risk.</p>
+    </div>
+
+    <div class="section">
+        <h2>Whom do I contact if I have a question or a complaint?</h2>
+        <p>You may contact us at the address below if you have any questions or complaints about information practices or this Policy:</p>
+        <p><strong>For inquiries specific to Hail:</strong><br>
+        By email to: <a href="mailto:hail-team@broadinstitute.org">hail-team@broadinstitute.org</a></p>
+        <p><strong>For inquiries regarding Broad's privacy practices or policies:</strong><br>
+        By email to: <a href="mailto:privacy@broadinstitute.org">privacy@broadinstitute.org</a></p>
+    </div>
+
+    <div class="section">
+        <h2>Will you update or change this Policy?</h2>
+        <p>Yes, we may need to update or change this Policy for various reasons, such as to comply with changes in the law or to cover new features or services. If we update or change this Policy we will post the changes to the Policy on Hail.</p>
+        <p>To make sure you are aware of any updates or changes, you should review this Policy periodically and make sure you have your most current email address in your account. We will post the effective date of any new policy.</p>
+    </div>
+</body>
+</html>

--- a/batch/batch/front_end/templates/tos.html
+++ b/batch/batch/front_end/templates/tos.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hail Terms of Service</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+        }
+        h1 {
+            text-align: center;
+            color: #2c3e50;
+            margin-bottom: 30px;
+        }
+        h2 {
+            color: #2c3e50;
+            margin-top: 30px;
+        }
+        .effective-date {
+            text-align: center;
+            font-style: italic;
+            margin-bottom: 30px;
+        }
+        .section {
+            margin-bottom: 20px;
+        }
+        ul {
+            padding-left: 20px;
+        }
+        li {
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hail Terms of Service</h1>
+    <p class="effective-date">Effective Date: May 6, 2025</p>
+
+    <div class="section">
+        <p>Please read these Terms of Use (these "Terms") carefully, as they constitute a binding contract between you, an individual user ("you" or "your"), and The Broad Institute, Inc. ("Broad," "we," "us," or "our"). These Terms of Use ("Terms") apply to your use of Broad's instance of the Hail application, which can be accessed by our website [batch.hail.is] ("Hail"). By clicking "I accept" or by using or accessing Hail, you agree to be bound by these Terms. If you do not agree to these Terms, you may not access or use Hail.</p>
+
+        <p>We reserve the right to change or otherwise modify these Terms at any time. All changes are effective immediately when we post them, and apply to all access to and use of Hail thereafter. We may also notify you by sending an email notification to the address associated with your Account (as defined below) or by providing notice through Hail. Your continued access or use of Hail after receiving notice of any update, modification, or other change to these Terms signifies your acceptance thereof. If you do not wish to accept modifications to the Terms, you may cease using Hail at any time.</p>
+
+        <p>If you suspect or have confirmed you have identified a vulnerability in Hail, please report said vulnerability to us immediately at <a href="mailto:infosec@broadinstitute.org">infosec@broadinstitute.org</a>.</p>
+    </div>
+
+    <div class="section">
+        <h2>1. GENERAL OVERVIEW OF HAIL</h2>
+        <p>We have developed Hail to enable users to manage and analyze multi-dimensional structured data, particularly genomic data in genome-wide association studies (GWAS). The system primarily serves bioinformaticians, providing a platform that leverages computational power for large-scale genomic research without requiring in-depth knowledge of distributed computing. Hail is intended to be used for research purposes only. You use Hail at your own risk.</p>
+    </div>
+
+    <div class="section">
+        <h2>2. YOUR USE OF HAIL</h2>
+        <p><strong>Individual Use.</strong> Any individual with a Google account within the broadinstitute.org domain may become a Hail User. Users may use Hail, either in an individual capacity or on behalf of a company or other entity, for data analysis, sharing reproducible research, developing scientific software tools, teaching and educational activities, and/or in connection with sponsored research. Individual use of Hail is governed by these Terms.</p>
+
+        <p><strong>Your Hail Account.</strong> To access and use certain features of Hail, you need to register for an account ("Account") by logging in through your Google account. If you register for an Account, you must provide accurate information and promptly update this information if it changes. You may not permit any other person to access Hail using your user name and password, and the use of your Account is your responsibility. If you learn or suspect that your user name or password has been wrongfully used or disclosed, you should promptly notify us and immediately reset your password. To help ensure the security of your password or Account, please sign out of your Account at the end of each session.</p>
+
+        <p><strong>Accessing a Government Website.</strong> To the extent you have selected research data from certain U.S. Government sources, you acknowledge that the following terms apply:</p>
+        <ol>
+            <li>Users are accessing a U.S. Government information system;</li>
+            <li>Information system usage may be monitored, recorded and subject to audit;</li>
+            <li>Unauthorized use of the information system is prohibited and subject to criminal and civil penalties;</li>
+            <li>Use of the information system indicates consent to monitoring and recording.</li>
+        </ol>
+
+        <p><strong>Age Restrictions.</strong> In order to use Hail you must be 18 years of age or older.</p>
+
+        <p><strong>No Medical Advice.</strong> Hail does not provide medical advice. All Content connected to Hail is for research purposes only and is not a substitute for professional medical advice or treatment. Always seek the advice of your physician or other qualified health provider with any questions you may have regarding your health. Never disregard professional medical advice or delay in seeking it because of something you have read on Hail. If you think you may have a medical emergency, call your doctor or 911 immediately. We do not recommend or endorse any specific tests, physicians, products, procedures, opinions, or other information that may be mentioned on Hail. Reliance on any information provided by us, available on Hail, or by other Users is solely at your own risk.</p>
+    </div>
+
+    <div class="section">
+        <h2>3. PRIVACY</h2>
+        <p>Broad understands the importance of confidentiality and privacy regarding your user information. Please see our Privacy Policy [insert hyperlink] for a description of how we collect, use, and disclose your personal information when you access or use Hail. By using Hail or by clicking to accept or agree to these Terms when this option is made available to you, you consent to our use of your information and our contacting you, in each case, in compliance with our Privacy Policy.</p>
+    </div>
+
+    <div class="section">
+        <h2>4. COMMUNICATION PREFERENCES</h2>
+        <p>By creating an Account, you also consent to receive electronic communications from Broad (e.g., via email or by posting notices to Hail). These communications may include operational notices about your Account (e.g., password changes and other transactional information) and are part of your relationship with us. You agree that any communications that we send to you electronically will satisfy any legal communication requirements, including that such communications be in writing.</p>
+    </div>
+
+    <div class="section">
+        <h2>5. PROPRIETARY RIGHTS</h2>
+        <p>Some or all of the coding underlying Hail is made available on an open source basis under the MIT License.</p>
+
+        <p>Broad grants you a limited right to use Hail (as defined above) for as set forth in Section 2 above. All original content, materials, features, and functionality (including text, information, images, photos, graphics, artworks, logos, videos, audios, directories, listings, databases, and search engines) available via Hail (the "Content") are or may be the property of Broad or other third parties, including the United States federal government, and may be protected by U.S. and foreign copyright, trademark, and other intellectual property laws.</p>
+
+        <p>Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable right and license to access and use Hail and any Content accessible therein owned and provided publicly by Broad solely for your personal, non-commercial use; provided, however, that such license does not include any right to:</p>
+        <ol type="a">
+            <li>sell or resell Hail and the Content;</li>
+            <li>copy, reproduce, distribute, publicly perform or publicly display Content, except as expressly permitted by us or our licensors;</li>
+            <li>modify the Content, remove any proprietary rights notices or markings, or otherwise make any derivative uses of Hail and the Content;</li>
+            <li>use any data mining, medical robots, or similar data gathering or extraction methods;</li>
+            <li>use Hail and the Content other than for their intended purposes.</li>
+        </ol>
+
+        <p>Except for this limited license granted to you, we reserve all other rights. This license may be revoked and terminated by us at any time and for any reason.</p>
+
+        <p>Any unauthorized use, reproduction, or distribution of Hail or Content is strictly prohibited and may result in termination of the license granted herein, as well as civil and/or criminal penalties. The "Broad Institute" name and logo and all other Broad names, marks, logos and other identifiers are trademarks and service marks of Broad. You may not use or display any Broad trademarks, trade names, or logos without our prior written permission. We reserve all rights. If you choose to provide us with any comments, suggestions, ideas or other feedback, you agree that we have an unrestricted right to use them, and you are not entitled to receive any compensation.</p>
+    </div>
+
+    <div class="section">
+        <h2>6. UPLOADED INFORMATION AND USER CONTENT</h2>
+        <p>Hail may contain features that allow you to upload, connect, or otherwise provide content (including but not limited to data) owned by you; we refer to this as "User Content". You retain all right, title, and interest in your User Content. Subject to any existing written agreement between you and Broad with regard to the User Content, in order to utilize your User Content in connection with Hail, you grant to Broad the fully transferable and royalty-free right and license to use the User Content for any purpose related to providing and allowing you to utilize Hail, including without limitation, to reproduce, modify, display, perform, make derivative works, in any and all media and formats, whether now known or hereafter created.</p>
+
+        <p>This means we can use the User Content you submit in order to provide Hail to you, including as may be needed for Hail to perform the queries and operations you assign to it, for Broad to provide you with technical support and assistance in your use of Hail, and for Broad's quality control and development purposes. Broad shall not knowingly or intentionally use or sell your User Content for any purpose other than providing Hail.</p>
+    </div>
+
+    <div class="section">
+        <h2>7. YOUR CONDUCT AND PROHIBITED USES</h2>
+        <p>Don't misuse Hail. You may use Hail only as permitted by law, including the applicable export and re-export control laws and regulations of the United States and your home jurisdiction. You are responsible for your conduct and your User Content connected to Hail. Broad provides no representations or warranties as to the security or confidentiality of any User Content that you connect to Hail, and you connect any User Content solely at your own risk.</p>
+
+        <p>Broad shall under no circumstances be liable for the actions of other Users in connection with your User Content, and you indemnify, defend, and hold harmless Broad and its affiliates against any and all claims with regard to other Uses' use of your User Content connected to Hail. Do not connect highly sensitive or confidential information, or Protected Health Information as defined under HIPAA (45 C.F.R. Parts 160 and 164), to Hail.</p>
+
+        <p>By accessing Hail, you acknowledge and agree that we may monitor your conduct, your use of Hail, and your Content to filter spam, viruses, and other malware, ensure interoperability, fix bugs and resolve problems, ensure compliance with these Terms and applicable law, provide you with help desk services and support, and that our understanding of the way Users interact with Hail may be used to improve Hail. This analysis may occur when you connect User Content to Hail or access User Content connected to Hail. If you request technical support, we may also use eyes on monitoring to provide you with such technical support. When using or accessing User Content other than your User Content, you agree to comply with all restrictions and controls imposed by the owner of that User Content.</p>
+
+        <p>We want to make sure Hail is a safe place for us and our Users. For this reason, we need to have certain rules about the use of Hail, including certain conduct that is prohibited. You agree not to use Hail in any way, provide User Content, or engage in any conduct that:</p>
+        <ul>
+            <li>is unlawful, illegal, or unauthorized;</li>
+            <li>is defamatory of any other person;</li>
+            <li>is obscene, sexually explicit, or offensive;</li>
+            <li>advertises or promotes any other product or business;</li>
+            <li>is likely to harass, upset, embarrass, alarm, or annoy any other person;</li>
+            <li>is likely to disrupt our service in any way;</li>
+            <li>promotes discrimination based on race, sex, religion, nationality, disability, sexual orientation, or age;</li>
+            <li>infringes any copyright, trademark, trade secret, or other proprietary right of any other person;</li>
+            <li>contains highly confidential or sensitive information, including but not limited to Protected Health Information and trade secrets;</li>
+            <li>advocates, promotes or assists any violence or any unlawful act.</li>
+        </ul>
+
+        <p>We reserve the right, but do not have the obligation, at our sole discretion to edit, delete, remove or block any User Content that violates these Terms. In addition, we reserve the right at our sole discretion to terminate any user's access to Hail if they violate this Section 7 or any other provision of these Terms.</p>
+    </div>
+
+    <div class="section">
+        <h2>8. USER SECURITY RESPONSIBILITIES</h2>
+        <p>Hail maintains an information security posture that aligns with best practices and the NIST 800-53 standard. Though we implement these controls at the level of the system and its environment, there are some aspects of these controls that Broad is not able to enforce without your help. Some controls are shared between us and the User while others are fully the User's responsibility. These controls are called "User Responsibilities." By using Hail, you acknowledge that you are responsible for adhering to these User Responsibilities.</p>
+
+        <ul>
+            <li>Implement Multi-Factor Authentication on User identities registered with Hail
+                <ul>
+                    <li>Use a device separate from the system gaining access as one factor of authentication</li>
+                </ul>
+            </li>
+            <li>Adhere to the following password requirements for User identities used with Hail:
+                <ul>
+                    <li>Should be at least 15 characters in length</li>
+                    <li>Should not include unique identifiers such as name, username, SSN, date of birth, etc.</li>
+                    <li>Should not be a commonly used password</li>
+                    <li>Should be rotated at leave every 365 days unless Multi-Factor Authentication is used, in which case routine password rotation is not required per NIST 800-63B</li>
+                    <li>Must be changed immediately in the event of a password compromise</li>
+                </ul>
+            </li>
+            <li>Log out of your Hail account after ninety (90) minutes of inactivity and at the end of the work period.</li>
+            <li>Users are responsible for the security of endpoints (desktops, laptops). Endpoints must be configured to automatically lock the screen after no more than 30 minutes of inactivity and require User re-authentication to unlock, must have anti-virus/anti-malware software installed, hard drives must leverage encryption at rest that meets FIPS 140-2 compliance, and must be configured to automatically receive and install operating system updates on a weekly basis and updates to other applications when security updates are released.</li>
+            <li>Hail uses TLS 1.2 (or higher) to protect data in transit throughout Hail. However, users are able to remove information from Hail to fulfill their research needs. It is the user's responsibility to ensure that a commensurate protocol is used to protect any information retrieved via Hail while in transit. Users are responsible for protecting data retrieved from Hail in transit using TLS 1.2 (or higher) or a commensurate protocol.</li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>9. WARNING NOTICE</h2>
+        <p>To the extent you have elected to use research data from certain U.S. Government sources with Hail, you acknowledge that the following terms apply:</p>
+
+        <ol>
+            <li>You are accessing a website funded by the U.S. Government which may contain information that must be protected under the U.S. Privacy Act or other sensitive information and is intended for government-authorized use only.</li>
+            <li>Unauthorized attempts to upload information, change information, or use this website may result in disciplinary action and civil and/or criminal penalties. Unauthorized users of this website should have no expectation of privacy regarding any communications or data processed by this website.</li>
+            <li>Anyone accessing this website expressly consents to monitoring of their actions and all communications or data transiting or stored on related to this website and is advised that if such monitoring reveals possible evidence of criminal activity, Broad may provide that evidence to law enforcement officials.</li>
+        </ol>
+    </div>
+
+    <div class="section">
+        <h2>10. BROAD IS NOT RESPONSIBLE FOR THIRD-PARTY CONTENT</h2>
+        <p>Hail may contain links to third-party web sites, products, and services, and it may redirect you to third party applications on your mobile device (each, a "Linked Third-Party Service"). Broad is not responsible for the content of Linked Third-Party Services, and does not make any representations or warranties regarding the content or accuracy of any such content.</p>
+
+        <p>When you access and use a Linked Third-Party Service, you are subject to that third party's terms and conditions of use and privacy policy and you agree that Broad is not responsible for and has made no representations or warranties, express or implied, regarding any Linked Third-Party Service and that Broad shall have no liability relating to such Linked Third-Party Service except to the extent such liability is caused by the negligence of Broad. Your use of any Linked Third-Party Service is at your own risk and subject to the terms and conditions of use for such offerings.</p>
+    </div>
+
+    <div class="section">
+        <h2>11. DISCLAIMER OF WARRANTIES</h2>
+        <p>We provide Hail on an 'as is' and 'as available' basis without any promises or representations, expressed or implied. For example, we make no promises about how Hail will work, that they will be error-free, uninterrupted, or have no defects. The law also provides certain implied warranties, such as warranties of merchantability and fitness for a particular use; we disclaim those warranties, meaning they do not apply to Hail. Notwithstanding the foregoing, nothing in this paragraph is intended to free Broad from liability for its own negligence.</p>
+    </div>
+
+    <div class="section">
+        <h2>12. LIMITATION OF LIABILITY</h2>
+        <p>THIS SECTION LIMITS THE DAMAGE YOU CAN RECOVER FROM US. NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY OF ANY KIND, TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE ARE NOT RESPONSIBLE OR LIABLE FOR ANY INDIRECT, INCIDENTAL, CONSEQUENTIAL, SPECIAL, EXEMPLARY, PUNITIVE, OR OTHER DAMAGES (INCLUDING WITHOUT LIMITATION ANY LOSS OF PROFITS, LOST SAVINGS, OR LOSS OF DATA) OR LIABILITIES UNDER ANY CONTRACT, STRICT LIABILITY, OR OTHER THEORY ARISING OUT OF OR RELATING IN ANY MANNER TO HAIL, WHETHER OR NOT WE HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES OR LIABILITIES. YOUR SOLE REMEDY WITH RESPECT TO HAIL IS TO STOP USING HAIL.</p>
+
+        <p>NOTWITHSTANDING THE FOREGOING, NOTHING IN THIS PARAGRAPH IS INTENDED TO FREE BROAD FROM LIABILITY FOR ITS OWN NEGLIGENCE. SOME STATES DO NOT ALLOW THE EXCLUSION OR LIMITATION OF CERTAIN WARRANTIES AND/OR LIABILITIES, SO CERTAIN OF THE ABOVE LIMITATIONS OR EXCLUSIONS MAY NOT APPLY TO YOU.</p>
+
+        <p>In the event that applicable law does not allow the disclaimer of certain warranties and/or the limitation of liability for direct, indirect, consequential or other damages, in no event shall Broad's liability arising under or in connection with these Terms and your use of Hail exceed $100, except to the extent such damages result from Broad's negligence.</p>
+    </div>
+
+    <div class="section">
+        <h2>13. TERMINATION</h2>
+        <p>These Terms are effective unless and until terminated by either you or Broad. You may terminate these Terms at any time by discontinuing any further use of Hail. We also may terminate or suspend these Terms, at any time, without notice and accordingly deny you access to Hail, for any reason, including without limitation, if at our sole discretion you fail to comply with any provision of these Terms or your use is harmful to the interests of another user of Hail.</p>
+
+        <p>Upon any termination of the Terms by either you or us, you must promptly cease using Hail. Termination will not limit any of our other rights and remedies. Any provision that must survive in order to give proper effect to the intent and purpose of these Terms shall survive termination.</p>
+    </div>
+
+    <div class="section">
+        <h2>14. GENERAL</h2>
+        <p>These Terms, including the Privacy Policy and other policies incorporated herein, constitute the entire and only agreement between you and Broad with respect to the subject matter of these Terms, and supersede any and all prior or contemporaneous agreements, representations, warranties and understandings, written or oral, with respect to the subject matter of these Terms.</p>
+
+        <p>If any provision of these Terms is found to be unlawful, void or for any reason unenforceable, then that provision shall be deemed severable from these Terms and shall not affect the validity and enforceability of any remaining provisions. Neither these Terms nor any right, obligation or remedy hereunder is assignable, transferable, delegable or sub-licensable by you except with Broad's prior written consent, and any attempted assignment, transfer, delegation or sublicense shall be null and void.</p>
+
+        <p>Broad may assign, transfer or delegate this or any right or obligation or remedy hereunder in its sole discretion. No waiver by either party of any breach or default hereunder shall be deemed to be a waiver of any preceding or subsequent breach or default. Any heading, caption, or section title contained in these Terms is inserted only as a matter of convenience and in no way defines or explains any section or provision hereof.</p>
+    </div>
+
+    <div class="section">
+        <h2>15. CONTACT US</h2>
+        <p>If you have any questions regarding Hail or these Terms, you can contact us at <a href="mailto:hail-team@broadinstitute.org">hail-team@broadinstitute.org</a>.</p>
+    </div>
+</body>
+</html>

--- a/web_common/web_common/templates/utils.html
+++ b/web_common/web_common/templates/utils.html
@@ -62,6 +62,13 @@
 {% endmacro %}
 
 
+{% macro submit_button_with_attrs(text, attrs) %}
+<button class='border border-gray-200 bg-gray-50 hover:bg-slate-400 hover:text-white px-2 py-1 rounded-md {{ attrs }}'>
+  {{ text }}
+</button>
+{% endmacro %}
+
+
 {% macro link(href, text) %}
 <a class='block hover:cursor-pointer hover:text-sky-600 hover:underline underline-offset-2' href="{{ href }}">
   {{ text }}

--- a/web_common/web_common/templates/utils.html
+++ b/web_common/web_common/templates/utils.html
@@ -63,7 +63,7 @@
 
 
 {% macro submit_button_with_attrs(text, attrs) %}
-<button class='border border-gray-200 bg-gray-50 hover:bg-slate-400 hover:text-white px-2 py-1 rounded-md {{ attrs }}'>
+<button class='border border-gray-200 bg-gray-50 hover:bg-slate-400 hover:text-white px-2 py-1 rounded-md' {{ attrs }}>
   {{ text }}
 </button>
 {% endmacro %}


### PR DESCRIPTION
## Change Description

Require on login that users accept the ToS and Privacy Policy

## Security Assessment

Delete all except the correct answer:
- This change has a medium security impact

Requires infosec approval:
- [x] Approved by infosec

### Impact Description

- Adds two new endpoints, however they both serve only static content.
- Adds some script functionality to the auth users page, to allow enabling/disabling of login/sign up buttons based on checkbox state. These scripts are entirely self contained and only serve to enable or disable pre-existing content.

(Reviewers: please confirm the security impact before approving)

### Examples

Before logging in (ToS not accepted):
<img width="955" alt="image" src="https://github.com/user-attachments/assets/b8e9a3fb-aa08-480b-80ed-82faaa8858a4" />

Before logging in (ToS accepted):
<img width="878" alt="image" src="https://github.com/user-attachments/assets/1b9694a6-d0b1-4e03-8494-84afdeab4b92" />


After logging in:
<img width="916" alt="image" src="https://github.com/user-attachments/assets/f1e2ecf7-d2f6-4d13-b3d9-996168cadd50" />

