### PR TITLE
[hailctl|batch] Truncate job name when used as a directory name under /io

### DIFF
--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -115,7 +115,8 @@ class Job:
                     new_s.append('_')
             return ''.join(new_s)
 
-        self._dirname = f'{safe_str(name)}-{self._token}' if name else self._token
+        maxnamelen = 250 - len(self._token)  # typical file system maximum name component length is 255
+        self._dirname = f'{safe_str(name)[:maxnamelen]}-{self._token}' if name else self._token
 
     def _get_resource(self, item: str) -> 'Resource':
         if item not in self._resources:


### PR DESCRIPTION
Job names are unlimited in length; avoid ENAMETOOLONG by truncating the name when it is used as part of the job's working directory.

## Security Assessment

- This change has a low security impact

### Impact Description

One-liner to truncate the existing text of a directory name.

(Reviewers: please confirm the security impact before approving)
