### PR TITLE
[tests] increase `VCFTests::test_combiner_works` timeout

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -549,6 +549,7 @@ class VCFTests(unittest.TestCase):
         mt = hl.read_matrix_table(vcf_path + '.mt')
         self.assertTrue(mt._same(vcf))
 
+    @test_timeout(4 * 60)
     def test_combiner_works(self):
         from hail.vds.combiner.combine import combine_variant_datasets, transform_gvcf
 


### PR DESCRIPTION
This test is very sensitive to cloud noise and can require repeated retries in ci.
Worth stating that our benchmarks handle identifying regressions while tests such
as these handle correctness.
