### PR TITLE
[batch/auth] Updated CLI login with ToS and privacy policy links

### DIFF
--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -27,7 +27,7 @@ def tos_agreement():
     Please read and agree to the Terms of Service: https://batch.hail.is/tos
     Please read the Privacy Policy: https://batch.hail.is/privacy
 
-    Do you agree to these terms? y/n:
+    Enter 'y' to agree or 'n' to disagree with the following statement: I have reviewed and agree to the [Terms of Service](https://batch.hail.is/tos) and have read the [Privacy Policy](https://batch.hail.is/privacy)? y/n:
     """
 
     print(tos_statement)

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -36,7 +36,7 @@ def tos_agreement():
     while True:
         if response in {'y', 'n'}:
             break
-        response = input('Invalid input. Enter 'y' to agree or 'n' to disagree with the following statement: I have reviewed and agree to the [Terms of Service](https://batch.hail.is/tos) and have read the [Privacy Policy](https://batch.hail.is/privacy). y/n: ').strip().lower()
+        response = input("Invalid input. Enter 'y' to agree or 'n' to disagree with the following statement: I have reviewed and agree to the [Terms of Service](https://batch.hail.is/tos) and have read the [Privacy Policy](https://batch.hail.is/privacy). y/n: ").strip().lower()
     if response != 'y':
         print("You must agree to the Terms of Service to log in.")
         return False

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -23,8 +23,11 @@ def tos_agreement():
     This broad surveillance enables the protection of the Hail system from malicious actors.
     """
     agree_statement = """
-    Notice: By signing up or logging in and continuing to use the system, you agree to these terms of service.
-    Do you agree to these terms? Y/n:
+    Use of Hail requires you to agree to our Terms of Service and Privacy Policy.
+    Please review the following Terms of Service: https://batch.hail.is/tos
+    Please review the following Privacy Policy: https://batch.hail.is/privacy
+
+    Do you agree to these terms? y/n:
     """
 
     print(tos_statement)
@@ -33,7 +36,7 @@ def tos_agreement():
     while True:
         if response in {'y', 'n'}:
             break
-        response = input('Please enter a valid input. Do you agree to the Terms of Service? Y/n: ').strip().lower()
+        response = input('Please enter a valid input. Do you agree to the Terms of Service? y/n: ').strip().lower()
     if response != 'y':
         print("You must agree to the Terms of Service to log in.")
         return False

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -36,7 +36,7 @@ def tos_agreement():
     while True:
         if response in {'y', 'n'}:
             break
-        response = input('Please enter a valid input. Do you agree to the Terms of Service? y/n: ').strip().lower()
+        response = input('Invalid input. Enter 'y' to agree or 'n' to disagree with the following statement: I have reviewed and agree to the [Terms of Service](https://batch.hail.is/tos) and have read the [Privacy Policy](https://batch.hail.is/privacy). y/n: ').strip().lower()
     if response != 'y':
         print("You must agree to the Terms of Service to log in.")
         return False

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -24,7 +24,7 @@ def tos_agreement():
     """
     agree_statement = """
     Use of Hail requires you to read and agree to our Terms of Service, and to read the Privacy Policy.
-    Please review the following Terms of Service: https://batch.hail.is/tos
+    Please read and agree to the Terms of Service: https://batch.hail.is/tos
     Please review the following Privacy Policy: https://batch.hail.is/privacy
 
     Do you agree to these terms? y/n:

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -23,7 +23,7 @@ def tos_agreement():
     This broad surveillance enables the protection of the Hail system from malicious actors.
     """
     agree_statement = """
-    Use of Hail requires you to agree to our Terms of Service and Privacy Policy.
+    Use of Hail requires you to read and agree to our Terms of Service, and to read the Privacy Policy.
     Please review the following Terms of Service: https://batch.hail.is/tos
     Please review the following Privacy Policy: https://batch.hail.is/privacy
 

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -36,7 +36,13 @@ def tos_agreement():
     while True:
         if response in {'y', 'n'}:
             break
-        response = input("Invalid input. Enter 'y' to agree or 'n' to disagree with the following statement: I have reviewed and agree to the [Terms of Service](https://batch.hail.is/tos) and have read the [Privacy Policy](https://batch.hail.is/privacy). y/n: ").strip().lower()
+        response = (
+            input(
+                "Invalid input. Enter 'y' to agree or 'n' to disagree with the following statement: I have reviewed and agree to the [Terms of Service](https://batch.hail.is/tos) and have read the [Privacy Policy](https://batch.hail.is/privacy). y/n: "
+            )
+            .strip()
+            .lower()
+        )
     if response != 'y':
         print("You must agree to the Terms of Service to log in.")
         return False

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -25,7 +25,7 @@ def tos_agreement():
     agree_statement = """
     Use of Hail requires you to read and agree to our Terms of Service, and to read the Privacy Policy.
     Please read and agree to the Terms of Service: https://batch.hail.is/tos
-    Please review the following Privacy Policy: https://batch.hail.is/privacy
+    Please read the Privacy Policy: https://batch.hail.is/privacy
 
     Do you agree to these terms? y/n:
     """


### PR DESCRIPTION
## Change Description

Adds links to cli login for new Privacy Policy and Terms of Service. Prompts users to review and agree to both before logging in. As before, login cannot occur without explicitly agreeing to both documents.

## Security Assessment

Delete all except the correct answer:
- This change has a low security impact

### Impact Description

Though related to login, this functionality was already in place; this PR simply updates the user prompt to include links to the new ToS and privacy statement.

- [ ] AppSec approval has been granted for this PR

(Reviewers: please confirm the security impact before approving)
