### PR TITLE
[auth / ui] Make Sign Up button less prominent

### DIFF
--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -42,28 +42,26 @@
     </label>
   </div>
 
-  <table class="table-auto w-64">
-    <tr>
-      <td>
-        <form action="{{ auth_base_url }}/signup" method="GET">
-          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-          {% if next_page %}
-          <input type="hidden" name="next" value="{{ next_page }}" />
-          {% endif %}
-          {{ submit_button_with_attrs('Sign up', 'id=signupButton disabled') }}
-        </form>
-      </td>
-      <td>
-        <form action="{{ auth_base_url }}/login" method="GET">
-          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-          {% if next_page %}
-          <input type="hidden" name="next" value="{{ next_page }}" />
-          {% endif %}
-          {{ submit_button_with_attrs('Log in', 'id=loginButton disabled') }}
-        </form>
-      </td>
-    </tr>
-  </table>
+  <div class="space-y-6">
+    <form action="{{ auth_base_url }}/login" method="GET">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+      {% if next_page %}
+      <input type="hidden" name="next" value="{{ next_page }}" />
+      {% endif %}
+      {{ submit_button_with_attrs('Log in', 'id=loginButton disabled') }}
+    </form>
+
+    <div class="pt-4 border-t border-gray-200">
+      <p class="text-gray-600 mb-2">No account yet? Click below to sign up:</p>
+      <form action="{{ auth_base_url }}/signup" method="GET">
+        <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+        {% if next_page %}
+        <input type="hidden" name="next" value="{{ next_page }}" />
+        {% endif %}
+        {{ submit_button_with_attrs('Sign up', 'id=signupButton disabled') }}
+      </form>
+    </div>
+  </div>
 
   <script>
     function updateButtons() {

--- a/auth/auth/templates/user.html
+++ b/auth/auth/templates/user.html
@@ -42,7 +42,7 @@
     </label>
   </div>
 
-  <div class="space-y-6">
+  <div>
     <form action="{{ auth_base_url }}/login" method="GET">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% if next_page %}
@@ -51,7 +51,7 @@
       {{ submit_button_with_attrs('Log in', 'id=loginButton disabled') }}
     </form>
 
-    <div class="pt-4 border-t border-gray-200">
+    <div class="pt-4">
       <p class="text-gray-600 mb-2">No account yet? Click below to sign up:</p>
       <form action="{{ auth_base_url }}/signup" method="GET">
         <input type="hidden" name="_csrf" value="{{ csrf_token }}" />


### PR DESCRIPTION
## Change Description

UI change only. Moves the "Sign Up" button lower so that it's less easy to click on "Sign Up" when the intended action is "Log in". This has become even more easy to do now that we have the "I have reviewed the ToS" checkbox.

## Examples

### Before
Too easy to click "Sign up" right after accepting the ToS even if the intended action is to log in.

<img width="856" alt="image" src="https://github.com/user-attachments/assets/32664acf-2c75-44d6-ada2-457a7854fdba" />

### After
The "easiest flow" is now to click on Log in, which is the most likely action for existing users.

<img width="915" alt="image" src="https://github.com/user-attachments/assets/4f3fb14c-13c3-447a-8cbd-a4262d85c115" />

## Security Assessment

Delete all except the correct answer:
- This change has a low security impact

### Appsec Review

This is a change which impacts Hail Batch. Appsec approval is required:
  - [ ] Approved by appsec

### Impact Description

Moving UI elements around, no functional changes.

(Reviewers: please confirm the security impact before approving)
