### PR TITLE
[github] Require appsec for all batch changes, but only batch changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,17 +7,27 @@ Brief description and justification of what this PR is doing.
 ## Security Assessment
 
 Delete all except the correct answer:
+- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
+  - The Impact Rating, Impact Description, and Appsec Review sections are required
+- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
+  - The Impact Rating, Impact Description, and Appsec Review sections can be deleted
+
+### Impact Rating
+
+Delete all except the correct answer:
 - This change has a high security impact
-  - [ ] Required: The impact has been assessed and approved by appsec
 - This change has a medium security impact
 - This change has a low security impact
 - This change has no security impact
 
 ### Impact Description
 
-For none/low impact: a quick one/two sentence justification of the rating.
+Replace this content with a description of the impact of the change:
+- For none/low impact: a quick one/two sentence justification of the rating.
   - Example: "Docs only", "Low-level refactoring of non-security code", etc.
-For medium/high impact: provide a description of the impact and the mitigations in place.
+- For medium/high impact: provide a description of the impact and the mitigations in place.
   - Example: "New UI text field added in analogy to existing elements, with input strings escaped and validated against code injection"
 
-(Reviewers: please confirm the security impact before approving)
+### Appsec Review
+
+- [ ] Required: The impact has been assessed and approved by appsec


### PR DESCRIPTION
## Change Description

Updates the PR template to require appsec approval for all batch changes, but only batch changes.

## Security Assessment

Delete all except the correct answer:
- This change has no security impact

### Impact Description

Github template change only. But appsec review requested for a process change which involves their team 😄 

(Reviewers: please confirm the security impact before approving)
