### PR TITLE
[github] tweak release action

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -46,17 +46,18 @@ jobs:
           
           git log ${{ steps.version.outputs.old }}.. --format='%s' |\
             grep -P '\[(a(ll|uth)|batch|dataproc|fs|hail(ctl|genetics|top)|infra|services)[^\]]*\]' |\
-            sed -E 's$\[[^\]+\] (.*) \(#([[:digit:]]*)\)$- (\`#\2 <https://github.com/hail-is/hail/pulls/\2>\`__) \1$' |\
+            sed -E 's$\[[^\]+\] (.*) \(#([[:digit:]]*)\)$- (\`#\2 <https://github.com/hail-is/hail/pull/\2>\`__) \1$' |\
             sed 1i"**Version ${{ steps.version.outputs.new }}**\n" |\
             sed -e '$a\'$'\n' > HAILTOP_ENTRY
           
           sed -i -e '/Change Log/{N; N; r HAILTOP_ENTRY' -e '}' \
             hail/python/hailtop/batch/docs/change_log.rst
 
+      # identity from https://api.github.com/users/github-actions%5Bbot%5D
       - name: Commit and Push
         run: |
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           
           git checkout -B "release/${{ steps.version.outputs.new }}"
           git commit -m "[release] ${{ steps.version.outputs.new }}" \
@@ -74,10 +75,10 @@ jobs:
           cat << 'EOF' | gh pr create --base=main --head=$(git branch --show-current) --draft --fill -F -
           # Release Checklist (delete before merge)
           
-          [ ] Verify new PATCH version is correct 
-          [ ] Organise / format / expand / delete new entries from
-          - [ ] hail/python/hail/docs/change_log.md
-          - [ ] hail/python/hailtop/batch/docs/change_log.rst
+          - [ ] Verify new PATCH version is correct 
+          - [ ] Organise / format / expand / delete new entries from
+            - [ ] hail/python/hail/docs/change_log.md
+            - [ ] hail/python/hailtop/batch/docs/change_log.rst
           
           # Security Assessment
           This change has low security impact as:
@@ -91,4 +92,4 @@ jobs:
         run: |
           gh api -X POST "/repos/${GITHUB_REPOSITORY}/milestones" \
             -f "title=${{ steps.version.outputs.next }}" \
-            -f "due_on=$(date --iso-8601=seconds --utc --date='00:00 +2 month +1 week')"
+            -f "due_on=$(date --iso-8601=seconds --utc --date='+2 months +1 week 00:00')"


### PR DESCRIPTION
Updates the GitHub release action to:
- author commits as github-actions[bot], not me
- fix pull-request links in generated batch changelog
- correctly schedule next release milestone 
- correctly format check boxes in generated PR description

This change has no security impact
