### PR TITLE
[hailctl] Add support for multiple configuration profiles

### DIFF
--- a/hail/python/hailtop/config/__init__.py
+++ b/hail/python/hailtop/config/__init__.py
@@ -1,10 +1,13 @@
 from .deploy_config import DeployConfig, get_deploy_config
 from .user_config import (
     configuration_of,
+    get_config_profile_name,
+    get_config_from_file,
     get_hail_config_path,
     get_remote_tmpdir,
     get_user_config,
     get_user_config_path,
+    get_user_config_path_by_profile_name,
     get_user_identity_config_path,
 )
 from .variables import ConfigVariable
@@ -13,10 +16,13 @@ __all__ = [
     'ConfigVariable',
     'DeployConfig',
     'configuration_of',
+    'get_config_from_file',
+    'get_config_profile_name',
     'get_deploy_config',
     'get_hail_config_path',
     'get_remote_tmpdir',
     'get_user_config',
     'get_user_config_path',
+    'get_user_config_path_by_profile_name',
     'get_user_identity_config_path',
 ]

--- a/hail/python/hailtop/config/__init__.py
+++ b/hail/python/hailtop/config/__init__.py
@@ -8,6 +8,7 @@ from .user_config import (
     get_user_config,
     get_user_config_path,
     get_user_config_path_by_profile_name,
+    get_user_config_with_profile_overrides_and_source,
     get_user_identity_config_path,
 )
 from .variables import ConfigVariable
@@ -24,5 +25,6 @@ __all__ = [
     'get_user_config',
     'get_user_config_path',
     'get_user_config_path_by_profile_name',
+    'get_user_config_with_profile_overrides_and_source',
     'get_user_identity_config_path',
 ]

--- a/hail/python/hailtop/config/__init__.py
+++ b/hail/python/hailtop/config/__init__.py
@@ -1,8 +1,8 @@
 from .deploy_config import DeployConfig, get_deploy_config
 from .user_config import (
     configuration_of,
-    get_config_profile_name,
     get_config_from_file,
+    get_config_profile_name,
     get_hail_config_path,
     get_remote_tmpdir,
     get_user_config,

--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -25,9 +25,9 @@ def get_user_config_path(*, _config_dir: Optional[str] = None) -> Path:
     return Path(get_hail_config_path(_config_dir=_config_dir), 'config.ini')
 
 
-def get_user_config_path_by_profile_name(*,
-                                         profile_name: Optional[str] = None,
-                                         _config_dir: Optional[str] = None) -> Path:
+def get_user_config_path_by_profile_name(
+    *, profile_name: Optional[str] = None, _config_dir: Optional[str] = None
+) -> Path:
     profile_name = profile_name or 'config'  # this is necessary for backwards compatibility
     return Path(get_hail_config_path(_config_dir=_config_dir), f'{profile_name}.ini')
 
@@ -63,7 +63,9 @@ def get_user_config() -> configparser.ConfigParser:
     return user_config
 
 
-def get_user_config_with_profile_overrides_and_source() -> Tuple[configparser.ConfigParser, Dict[Tuple[str, str], Tuple[str, Path]]]:
+def get_user_config_with_profile_overrides_and_source() -> Tuple[
+    configparser.ConfigParser, Dict[Tuple[str, str], Tuple[str, Path]]
+]:
     config_file = get_user_config_path_by_profile_name(profile_name=None)
 
     # in older versions, the config file was accidentally named
@@ -83,9 +85,9 @@ def get_user_config_with_profile_overrides_and_source() -> Tuple[configparser.Co
         user_config.read(profile_config_file)
 
     source = {}
-    for (default_config_option, default_config_value) in default_source.items():
+    for default_config_option, default_config_value in default_source.items():
         source[default_config_option] = default_config_value
-    for (profile_config_option, profile_config_value) in profile_source.items():
+    for profile_config_option, profile_config_value in profile_source.items():
         source[profile_config_option] = profile_config_value
 
     return (user_config, source)

--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -3,7 +3,7 @@ import os
 import re
 import warnings
 from pathlib import Path
-from typing import Optional, TypeVar, Union
+from typing import Dict, Optional, TypeVar, Tuple, Union
 
 from .variables import ConfigVariable
 
@@ -38,7 +38,7 @@ def get_user_identity_config_path() -> Path:
 
 def get_config_profile_name() -> Optional[str]:
     default_config_path = get_user_config_path()
-    global_config = get_config_from_file(default_config_path)
+    global_config, _ = get_config_from_file(default_config_path)
 
     if 'global' in global_config.sections():
         if 'profile' in global_config['global']:
@@ -48,13 +48,22 @@ def get_config_profile_name() -> Optional[str]:
     return None
 
 
-def get_config_from_file(file: Path) -> configparser.ConfigParser:
+def get_config_from_file(file: Path) -> Tuple[configparser.ConfigParser, Dict[Tuple[str, str], Tuple[str, Path]]]:
     config = configparser.ConfigParser()
     config.read(file)
-    return config
+    source = {}
+    for section in config.sections():
+        for option, value in config[section].items():
+            source[(section, option)] = (value, file)
+    return (config, source)
 
 
 def get_user_config() -> configparser.ConfigParser:
+    user_config, _ = get_user_config_with_profile_overrides_and_source()
+    return user_config
+
+
+def get_user_config_with_profile_overrides_and_source() -> Tuple[configparser.ConfigParser, Dict[Tuple[str, str], Tuple[str, Path]]]:
     config_file = get_user_config_path_by_profile_name(profile_name=None)
 
     # in older versions, the config file was accidentally named
@@ -64,14 +73,22 @@ def get_user_config() -> configparser.ConfigParser:
     if old_path.exists() and not config_file.exists():
         old_path.rename(config_file)
 
-    user_config = get_config_from_file(config_file)
+    user_config, default_source = get_config_from_file(config_file)
 
     profile_name = get_config_profile_name()
+    profile_source = {}
     if profile_name:
         profile_config_file = get_user_config_path_by_profile_name(profile_name=profile_name)
+        _, profile_source = get_config_from_file(profile_config_file)
         user_config.read(profile_config_file)
 
-    return user_config
+    source = {}
+    for (default_config_option, default_config_value) in default_source.items():
+        source[default_config_option] = default_config_value
+    for (profile_config_option, profile_config_value) in profile_source.items():
+        source[profile_config_option] = profile_config_value
+
+    return (user_config, source)
 
 
 VALID_SECTION_AND_OPTION_RE = re.compile('[a-z0-9_]+')

--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -3,7 +3,7 @@ import os
 import re
 import warnings
 from pathlib import Path
-from typing import Dict, Optional, TypeVar, Tuple, Union
+from typing import Dict, Optional, Tuple, TypeVar, Union
 
 from .variables import ConfigVariable
 

--- a/hail/python/hailtop/config/variables.py
+++ b/hail/python/hailtop/config/variables.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class ConfigVariable(str, Enum):
     DOMAIN = 'domain'
+    PROFILE = 'profile'
     GCS_REQUESTER_PAYS_PROJECT = 'gcs_requester_pays/project'
     GCS_REQUESTER_PAYS_BUCKETS = 'gcs_requester_pays/buckets'
     GCS_BUCKET_ALLOW_LIST = 'gcs/bucket_allow_list'

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -236,7 +236,7 @@ async def async_basic_initialize(verbose: bool = False):
     from hailtop.auth import async_get_userinfo  # pylint: disable=import-outside-toplevel
     from hailtop.batch_client.aioclient import BatchClient  # pylint: disable=import-outside-toplevel
     from hailtop.config.deploy_config import get_deploy_config  # pylint: disable=import-outside-toplevel
-    from hailtop.hailctl.config.cli import list_config # pylint: disable=import-outside-toplevel
+    from hailtop.hailctl.config.cli import list_config  # pylint: disable=import-outside-toplevel
     from hailtop.hailctl.config.cli import (  # pylint: disable=import-outside-toplevel
         set as set_config,
     )

--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -236,9 +236,7 @@ async def async_basic_initialize(verbose: bool = False):
     from hailtop.auth import async_get_userinfo  # pylint: disable=import-outside-toplevel
     from hailtop.batch_client.aioclient import BatchClient  # pylint: disable=import-outside-toplevel
     from hailtop.config.deploy_config import get_deploy_config  # pylint: disable=import-outside-toplevel
-    from hailtop.hailctl.config.cli import (  # pylint: disable=import-outside-toplevel
-        list as list_config,
-    )
+    from hailtop.hailctl.config.cli import list_config # pylint: disable=import-outside-toplevel
     from hailtop.hailctl.config.cli import (  # pylint: disable=import-outside-toplevel
         set as set_config,
     )

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -38,7 +38,7 @@ def get_section_key_path(parameter: str) -> Tuple[str, str, Tuple[str, ...]]:
         return 'global', path[0], tuple(path)
     if len(path) == 2:
         return path[0], path[1], tuple(path)
-    outc.print(
+    errc.print(
         """
 Parameters must contain at most one slash separating the configuration section
 from the configuration parameter, for example: "batch/billing_project".
@@ -49,7 +49,6 @@ parameter, for example: "domain".
 A parameter with more than one slash is invalid, for example:
 "batch/billing/project".
 """.lstrip('\n'),
-        file=sys.stderr,
     )
     sys.exit(1)
 

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -63,7 +63,11 @@ def set(
     value: str,
 ):
     """Set a Hail configuration parameter."""
-    from hailtop.config import get_config_from_file, get_config_profile_name, get_user_config_path_by_profile_name  # pylint: disable=import-outside-toplevel
+    from hailtop.config import (  # pylint: disable=import-outside-toplevel
+        get_config_from_file,
+        get_config_profile_name,
+        get_user_config_path_by_profile_name,
+    )
 
     if parameter not in config_variables():
         print(f"Error: unknown parameter {parameter!r}", file=sys.stderr)
@@ -152,7 +156,11 @@ def get(parameter: Ann[str, Arg(help="Configuration variable to get", autocomple
 @app.command(name='config-location')
 def config_location():
     """Print the location of the config file."""
-    from hailtop.config import get_config_profile_name, get_user_config_path, get_user_config_path_by_profile_name  # pylint: disable=import-outside-toplevel
+    from hailtop.config import (  # pylint: disable=import-outside-toplevel
+        get_config_profile_name,
+        get_user_config_path,
+        get_user_config_path_by_profile_name,
+    )
 
     print(f'Default settings: {get_user_config_path()}')
 
@@ -165,7 +173,9 @@ def config_location():
 @app.command(name='list')
 def list_config(section: Ann[Optional[str], Arg(show_default='all sections')] = None):
     """Lists every config variable in the section."""
-    from hailtop.config import get_user_config_with_profile_overrides_and_source  # pylint: disable=import-outside-toplevel
+    from hailtop.config import (
+        get_user_config_with_profile_overrides_and_source,  # pylint: disable=import-outside-toplevel
+    )
 
     _, source = get_user_config_with_profile_overrides_and_source()
 
@@ -265,7 +275,10 @@ def create_profile(profile_name: Ann[str, Arg(help='Name of configuration profil
 @profile_app.command(name='delete')
 def delete_profile(profile_name: Ann[str, Arg(help='Name of configuration profile to delete.', autocompletion=_get_profile)]):
     """Delete a Hail configuration profile."""
-    from hailtop.config import get_config_profile_name, get_user_config_path_by_profile_name  # pylint: disable=import-outside-toplevel
+    from hailtop.config import (  # pylint: disable=import-outside-toplevel
+        get_config_profile_name,
+        get_user_config_path_by_profile_name,
+    )
 
     if profile_name == 'default':
         print('Cannot delete the "default" profile.')

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -1,8 +1,7 @@
 import os
 import sys
 from collections import defaultdict
-from typing import Annotated as Ann
-from typing import Optional, Tuple
+from typing import Annotated as Ann, Generator, Optional, Tuple
 
 import typer
 from rich import print
@@ -224,7 +223,7 @@ def list_profiles():
             print(f'  {profile}')
 
 
-def _get_profile(incomplete: str) -> str:
+def _get_profile(incomplete: str) -> Generator[str, None, None]:
     profiles = _list_profiles()
     for profile in profiles:
         if profile.startswith(incomplete):

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -1,7 +1,8 @@
 import os
 import sys
 from collections import defaultdict
-from typing import Annotated as Ann, Generator, Optional, Tuple
+from typing import Annotated as Ann
+from typing import Generator, Optional, Tuple
 
 import typer
 from rich import print

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -173,8 +173,8 @@ def config_location():
 @app.command(name='list')
 def list_config(section: Ann[Optional[str], Arg(show_default='all sections')] = None):
     """Lists every config variable in the section."""
-    from hailtop.config import (
-        get_user_config_with_profile_overrides_and_source,  # pylint: disable=import-outside-toplevel
+    from hailtop.config import (  # pylint: disable=import-outside-toplevel
+        get_user_config_with_profile_overrides_and_source,
     )
 
     _, source = get_user_config_with_profile_overrides_and_source()
@@ -263,15 +263,15 @@ def create_profile(profile_name: Ann[str, Arg(help='Name of configuration profil
 
     profile_config_file = get_user_config_path_by_profile_name(profile_name=profile_name)
 
-    if os.path.isfile(profile_config_file):
+    if profile_config_file.is_file():
         print(f'Error: profile {profile_name} already exists!')
         sys.exit(1)
 
     try:
-        open(profile_config_file, 'w', encoding='utf-8')
+        profile_config_file.touch()
     except FileNotFoundError:
         os.makedirs(profile_config_file.parent, exist_ok=True)
-        open(profile_config_file, 'w', encoding='utf-8')
+        profile_config_file.touch()
 
     print(
         f'Created profile "{profile_name}". You can load the profile with `hailctl config profile load {profile_name}`.'

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -181,7 +181,8 @@ def list_config(section: Ann[Optional[str], Arg(show_default='all sections')] = 
             output.append(f'{_section}/{option}={value}\n')
         output.append('\n')
 
-    print(''.join(output).rstrip('\n'))
+    if output:
+        print(''.join(output).rstrip('\n'))
 
 
 

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -180,20 +180,19 @@ def list_config(section: Ann[Optional[str], Arg(show_default='all sections')] = 
     _, source = get_user_config_with_profile_overrides_and_source()
 
     grouped_source = defaultdict(list)
-    for ((_section, option), (value, path)) in source.items():
+    for (_section, option), (value, path) in source.items():
         if section is None or _section == section:
             grouped_source[path].append(((_section, option), value))
 
     output = []
     for path, values in grouped_source.items():
         output.append(f'Config settings from {path}:\n')
-        for ((_section, option), value) in values:
+        for (_section, option), value in values:
             output.append(f'{_section}/{option}={value}\n')
         output.append('\n')
 
     if output:
         print(''.join(output).rstrip('\n'))
-
 
 
 def _list_profiles():
@@ -233,7 +232,9 @@ def _get_profile(incomplete: str) -> str:
 
 
 @profile_app.command(name='load')
-def load_profile(profile_name: Ann[str, Arg(help='Name of configuration profile to load.', autocompletion=_get_profile)] = 'default'):
+def load_profile(
+    profile_name: Ann[str, Arg(help='Name of configuration profile to load.', autocompletion=_get_profile)] = 'default',
+):
     """Load a Hail configuration profile."""
     from hailtop.config import get_user_config_path_by_profile_name  # pylint: disable=import-outside-toplevel
 
@@ -243,7 +244,10 @@ def load_profile(profile_name: Ann[str, Arg(help='Name of configuration profile 
         config_file = get_user_config_path_by_profile_name(profile_name=profile_name)
 
     if not os.path.exists(config_file):
-        print(f"Error: profile '{profile_name}' does not exist. Use `hailctl config profile create {profile_name}` to create it.", file=sys.stderr)
+        print(
+            f"Error: profile '{profile_name}' does not exist. Use `hailctl config profile create {profile_name}` to create it.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     set(ConfigVariable.PROFILE, profile_name)
@@ -269,11 +273,15 @@ def create_profile(profile_name: Ann[str, Arg(help='Name of configuration profil
         os.makedirs(profile_config_file.parent, exist_ok=True)
         open(profile_config_file, 'w', encoding='utf-8')
 
-    print(f'Created profile "{profile_name}". You can load the profile with `hailctl config profile load {profile_name}`.')
+    print(
+        f'Created profile "{profile_name}". You can load the profile with `hailctl config profile load {profile_name}`.'
+    )
 
 
 @profile_app.command(name='delete')
-def delete_profile(profile_name: Ann[str, Arg(help='Name of configuration profile to delete.', autocompletion=_get_profile)]):
+def delete_profile(
+    profile_name: Ann[str, Arg(help='Name of configuration profile to delete.', autocompletion=_get_profile)],
+):
     """Delete a Hail configuration profile."""
     from hailtop.config import (  # pylint: disable=import-outside-toplevel
         get_config_profile_name,
@@ -286,7 +294,9 @@ def delete_profile(profile_name: Ann[str, Arg(help='Name of configuration profil
 
     current_profile = get_config_profile_name()
     if current_profile == profile_name:
-        print('Cannot delete a profile that is currently being used. Use `hailctl config profile list` to see available profiles. Load a different environment with `hailctl config profile load <profile_name>`.')
+        print(
+            'Cannot delete a profile that is currently being used. Use `hailctl config profile list` to see available profiles. Load a different environment with `hailctl config profile load <profile_name>`.'
+        )
         sys.exit(1)
 
     profile_config_file = get_user_config_path_by_profile_name(profile_name=profile_name)

--- a/hail/python/hailtop/hailctl/config/config_variables.py
+++ b/hail/python/hailtop/hailctl/config/config_variables.py
@@ -29,8 +29,7 @@ def config_variables():
                 validation=(lambda x: re.fullmatch(r'.+\..+', x) is not None, 'should be valid domain'),
             ),
             ConfigVariable.PROFILE: ConfigVariableInfo(
-                help_msg='Configuration profile name to use',
-                validation=(lambda _: True, 'can be anything')
+                help_msg='Configuration profile name to use', validation=(lambda _: True, 'can be anything')
             ),
             ConfigVariable.GCS_REQUESTER_PAYS_PROJECT: ConfigVariableInfo(
                 help_msg='Project when using requester pays buckets in GCS',

--- a/hail/python/hailtop/hailctl/config/config_variables.py
+++ b/hail/python/hailtop/hailctl/config/config_variables.py
@@ -28,6 +28,10 @@ def config_variables():
                 help_msg='Domain of the Batch service',
                 validation=(lambda x: re.fullmatch(r'.+\..+', x) is not None, 'should be valid domain'),
             ),
+            ConfigVariable.PROFILE: ConfigVariableInfo(
+                help_msg='Configuration profile name to use',
+                validation=(lambda _: True, 'can be anything')
+            ),
             ConfigVariable.GCS_REQUESTER_PAYS_PROJECT: ConfigVariableInfo(
                 help_msg='Project when using requester pays buckets in GCS',
                 validation=(lambda x: re.fullmatch(r'[^:/\s]+', x) is not None, 'should be valid GCS project name'),

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -148,12 +148,18 @@ def test_profile(runner: CliRunner, config_dir: str):
     # list the default config variables
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f'Config settings from {config_dir}/config.ini:\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}'
+    assert (
+        res.stdout.strip()
+        == f'Config settings from {config_dir}/config.ini:\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}'
+    )
 
     # create a new profile
     res = runner.invoke(cli.profile_app, ['create', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == 'Created profile "profile1". You can load the profile with `hailctl config profile load profile1`.'
+    assert (
+        res.stdout.strip()
+        == 'Created profile "profile1". You can load the profile with `hailctl config profile load profile1`.'
+    )
 
     # make sure the profile is still the default one
     res = runner.invoke(cli.app, ['get', 'global/profile'], catch_exceptions=False)
@@ -167,20 +173,26 @@ def test_profile(runner: CliRunner, config_dir: str):
     # load the new profile
     res = runner.invoke(cli.profile_app, ['load', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Loaded profile profile1 with settings:
+    assert (
+        res.stdout.strip()
+        == f"""Loaded profile profile1 with settings:
 
 Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir=gs://my-bucket/tmp/batch/
 query/backend=spark
 global/profile=profile1"""
+    )
 
     # Make sure the original config is still there
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Config settings from {config_dir}/config.ini:
+    assert (
+        res.stdout.strip()
+        == f"""Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir={orig_remote_tmpdir}
 query/backend={default_backend}
 global/profile=profile1"""
+    )
 
     # the value for profile should be the new one (not the default one)
     res = runner.invoke(cli.app, ['get', 'global/profile'], catch_exceptions=False)
@@ -194,12 +206,15 @@ global/profile=profile1"""
     # List the new config to make sure the defaults are overridden if a profile-specific value exists while keeping additional defaults
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Config settings from {config_dir}/profile1.ini:
+    assert (
+        res.stdout.strip()
+        == f"""Config settings from {config_dir}/profile1.ini:
 batch/remote_tmpdir={new_remote_tmpdir}
 
 Config settings from {config_dir}/config.ini:
 query/backend=spark
 global/profile=profile1"""
+    )
 
     # List the available profiles
     res = runner.invoke(cli.profile_app, ['list'], catch_exceptions=False)
@@ -214,13 +229,19 @@ global/profile=profile1"""
     # Test config location
     res = runner.invoke(cli.app, 'config-location', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Default settings: {config_dir}/config.ini
+    assert (
+        res.stdout.strip()
+        == f"""Default settings: {config_dir}/config.ini
 Overrode default settings with profile "profile1": {config_dir}/profile1.ini"""
+    )
 
     # can't delete an active profile
     res = runner.invoke(cli.profile_app, ['delete', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 1
-    assert res.stdout.strip() == "Cannot delete a profile that is currently being used. Use `hailctl config profile list` to see available profiles. Load a different environment with `hailctl config profile load <profile_name>`."
+    assert (
+        res.stdout.strip()
+        == "Cannot delete a profile that is currently being used. Use `hailctl config profile list` to see available profiles. Load a different environment with `hailctl config profile load <profile_name>`."
+    )
 
     # can't delete the default profile
     res = runner.invoke(cli.profile_app, ['delete', 'default'], catch_exceptions=False)
@@ -230,20 +251,26 @@ Overrode default settings with profile "profile1": {config_dir}/profile1.ini"""
     # load the original profile
     res = runner.invoke(cli.profile_app, ['load', 'default'], catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Loaded profile default with settings:
+    assert (
+        res.stdout.strip()
+        == f"""Loaded profile default with settings:
 
 Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir={orig_remote_tmpdir}
 query/backend={default_backend}
 global/profile=default"""
+    )
 
     # Make sure the original config is still there
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Config settings from {config_dir}/config.ini:
+    assert (
+        res.stdout.strip()
+        == f"""Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir={orig_remote_tmpdir}
 query/backend={default_backend}
 global/profile=default"""
+    )
 
     # delete non-active profile
     res = runner.invoke(cli.profile_app, ['delete', 'profile1'], catch_exceptions=False)

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -130,8 +130,6 @@ def test_all_config_variables_in_map():
 
 
 def test_profile(runner: CliRunner, config_dir: str):
-    os.remove(f'{config_dir}/hail/config.ini')
-
     # check there are no variables set
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
@@ -148,7 +146,7 @@ def test_profile(runner: CliRunner, config_dir: str):
     # list the default config variables
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f'Config settings from {config_dir}/hail/config.ini:\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}'
+    assert res.stdout.strip() == f'Config settings from {config_dir}/config.ini:\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}'
 
     # create a new profile
     res = runner.invoke(cli.profile_app, ['create', 'profile1'], catch_exceptions=False)
@@ -169,7 +167,7 @@ def test_profile(runner: CliRunner, config_dir: str):
     assert res.exit_code == 0
     assert res.stdout.strip() == f"""Loaded profile profile1 with settings:
 
-Config settings from {config_dir}/hail/config.ini:
+Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir=gs://my-bucket/tmp/batch/
 query/backend=spark
 global/profile=profile1"""
@@ -177,7 +175,7 @@ global/profile=profile1"""
     # Make sure the original config is still there
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Config settings from {config_dir}/hail/config.ini:
+    assert res.stdout.strip() == f"""Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir={orig_remote_tmpdir}
 query/backend={default_backend}
 global/profile=profile1"""
@@ -194,10 +192,10 @@ global/profile=profile1"""
     # List the new config to make sure the defaults are overridden if a profile-specific value exists while keeping additional defaults
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Config settings from {config_dir}/hail/profile1.ini:
+    assert res.stdout.strip() == f"""Config settings from {config_dir}/profile1.ini:
 batch/remote_tmpdir={new_remote_tmpdir}
 
-Config settings from {config_dir}/hail/config.ini:
+Config settings from {config_dir}/config.ini:
 query/backend=spark
 global/profile=profile1"""
 
@@ -214,8 +212,8 @@ global/profile=profile1"""
     # Test config location
     res = runner.invoke(cli.app, 'config-location', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Default settings: {config_dir}/hail/config.ini
-Overrode default settings with profile "profile1": {config_dir}/hail/profile1.ini"""
+    assert res.stdout.strip() == f"""Default settings: {config_dir}/config.ini
+Overrode default settings with profile "profile1": {config_dir}/profile1.ini"""
 
     # can't delete an active profile
     res = runner.invoke(cli.profile_app, ['delete', 'profile1'], catch_exceptions=False)
@@ -232,7 +230,7 @@ Overrode default settings with profile "profile1": {config_dir}/hail/profile1.in
     assert res.exit_code == 0
     assert res.stdout.strip() == f"""Loaded profile default with settings:
 
-Config settings from {config_dir}/hail/config.ini:
+Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir={orig_remote_tmpdir}
 query/backend={default_backend}
 global/profile=default"""
@@ -240,7 +238,7 @@ global/profile=default"""
     # Make sure the original config is still there
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f"""Config settings from {config_dir}/hail/config.ini:
+    assert res.stdout.strip() == f"""Config settings from {config_dir}/config.ini:
 batch/remote_tmpdir={orig_remote_tmpdir}
 query/backend={default_backend}
 global/profile=default"""

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -130,6 +130,8 @@ def test_all_config_variables_in_map():
 
 
 def test_profile(runner: CliRunner, config_dir: str):
+    config_dir = config_dir.rstrip('/')
+
     # check there are no variables set
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -39,14 +39,14 @@ def test_config_list_empty_config(runner: CliRunner):
         ('query/disable_progress_bar', '1'),
     ],
 )
-def test_config_set_get_list_unset(name: str, value: str, runner: CliRunner):
+def test_config_set_get_list_unset(name: str, value: str, runner: CliRunner, config_dir: str):
     runner.invoke(cli.app, ['set', name, value], catch_exceptions=False)
 
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
     if '/' not in name:
         name = f'global/{name}'
-    assert res.stdout.strip() == f'{name}={value}'
+    assert res.stdout.strip() == f'Config settings from {config_dir}/hail/config.ini:\n{name}={value}'
 
     res = runner.invoke(cli.app, ['get', name], catch_exceptions=False)
     assert res.exit_code == 0
@@ -148,25 +148,39 @@ def test_profile(runner: CliRunner, config_dir: str):
     # list the default config variables
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f'Config settings from {config_dir}/hail/config.ini:\n\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}\n'
+    assert res.stdout.strip() == f'Config settings from {config_dir}/hail/config.ini:\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}'
 
     # create a new profile
     res = runner.invoke(cli.profile_app, ['create', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 0
+    assert res.stdout.strip() == 'Created profile "profile1". You can load the profile with `hailctl config profile load profile1`.'
 
     # make sure the profile is still the default one
     res = runner.invoke(cli.app, ['get', 'global/profile'], catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == 'default'
+    assert res.stdout.strip() == ''
+
+    res = runner.invoke(cli.profile_app, ['list'], catch_exceptions=False)
+    assert res.exit_code == 0
+    assert res.stdout.strip() == '* default\n  profile1'
 
     # load the new profile
     res = runner.invoke(cli.profile_app, ['load', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 0
+    assert res.stdout.strip() == f"""Loaded profile profile1 with settings:
+
+Config settings from {config_dir}/hail/config.ini:
+batch/remote_tmpdir=gs://my-bucket/tmp/batch/
+query/backend=spark
+global/profile=profile1"""
 
     # Make sure the original config is still there
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f'Config settings from {config_dir}/hail/config.ini:\n\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}\nglobal/profile=profile1\n'
+    assert res.stdout.strip() == f"""Config settings from {config_dir}/hail/config.ini:
+batch/remote_tmpdir={orig_remote_tmpdir}
+query/backend={default_backend}
+global/profile=profile1"""
 
     # the value for profile should be the new one (not the default one)
     res = runner.invoke(cli.app, ['get', 'global/profile'], catch_exceptions=False)
@@ -180,7 +194,12 @@ def test_profile(runner: CliRunner, config_dir: str):
     # List the new config to make sure the defaults are overridden if a profile-specific value exists while keeping additional defaults
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f'Config settings from {config_dir}/hail/config.ini:\n\nquery/backend={default_backend}\nglobal/profile=profile1\n\nConfig settings from {config_dir}/hail/profile1.ini:\nbatch/remote_tmpdir={new_remote_tmpdir}\n'
+    assert res.stdout.strip() == f"""Config settings from {config_dir}/hail/profile1.ini:
+batch/remote_tmpdir={new_remote_tmpdir}
+
+Config settings from {config_dir}/hail/config.ini:
+query/backend=spark
+global/profile=profile1"""
 
     # List the available profiles
     res = runner.invoke(cli.profile_app, ['list'], catch_exceptions=False)
@@ -195,28 +214,41 @@ def test_profile(runner: CliRunner, config_dir: str):
     # Test config location
     res = runner.invoke(cli.app, 'config-location', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f'Default settings: {config_dir}/hail/config.ini\nOverrode default settings with profile "profile1": {config_dir}/hail/profile1.ini'
+    assert res.stdout.strip() == f"""Default settings: {config_dir}/hail/config.ini
+Overrode default settings with profile "profile1": {config_dir}/hail/profile1.ini"""
 
     # can't delete an active profile
     res = runner.invoke(cli.profile_app, ['delete', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 1
+    assert res.stdout.strip() == "Cannot delete a profile that is currently being used. Use `hailctl config profile list` to see available profiles. Load a different environment with `hailctl config profile load <profile_name>`."
 
     # can't delete the default profile
     res = runner.invoke(cli.profile_app, ['delete', 'default'], catch_exceptions=False)
     assert res.exit_code == 1
+    assert res.stdout.strip() == 'Cannot delete the "default" profile.'
 
     # load the original profile
     res = runner.invoke(cli.profile_app, ['load', 'default'], catch_exceptions=False)
     assert res.exit_code == 0
+    assert res.stdout.strip() == f"""Loaded profile default with settings:
+
+Config settings from {config_dir}/hail/config.ini:
+batch/remote_tmpdir={orig_remote_tmpdir}
+query/backend={default_backend}
+global/profile=default"""
 
     # Make sure the original config is still there
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == f'Config settings from {config_dir}/hail/config.ini:\n\nbatch/remote_tmpdir={orig_remote_tmpdir}\nquery/backend={default_backend}\nglobal/profile=profile1\n'
+    assert res.stdout.strip() == f"""Config settings from {config_dir}/hail/config.ini:
+batch/remote_tmpdir={orig_remote_tmpdir}
+query/backend={default_backend}
+global/profile=default"""
 
     # delete non-active profile
     res = runner.invoke(cli.profile_app, ['delete', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 0
+    assert res.stdout.strip() == 'Deleted profile "profile1".'
 
     # list profiles
     res = runner.invoke(cli.profile_app, ['list'], catch_exceptions=False)

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -219,7 +219,7 @@ global/profile=profile1"""
     # List the available profiles
     res = runner.invoke(cli.profile_app, ['list'], catch_exceptions=False)
     assert res.exit_code == 0
-    assert res.stdout.strip() == '  default\n* profile1'
+    assert res.stdout.rstrip() == '  default\n* profile1'
 
     # the value for remote tmpdir should be the new one (not the default one)
     res = runner.invoke(cli.app, ['get', 'batch/remote_tmpdir'], catch_exceptions=False)
@@ -239,14 +239,14 @@ Overrode default settings with profile "profile1": {config_dir}/profile1.ini"""
     res = runner.invoke(cli.profile_app, ['delete', 'profile1'], catch_exceptions=False)
     assert res.exit_code == 1
     assert (
-        res.stdout.strip()
+        res.stderr.strip()
         == "Cannot delete a profile that is currently being used. Use `hailctl config profile list` to see available profiles. Load a different environment with `hailctl config profile load <profile_name>`."
     )
 
     # can't delete the default profile
     res = runner.invoke(cli.profile_app, ['delete', 'default'], catch_exceptions=False)
     assert res.exit_code == 1
-    assert res.stdout.strip() == 'Cannot delete the "default" profile.'
+    assert res.stderr.strip() == 'Cannot delete the "default" profile.'
 
     # load the original profile
     res = runner.invoke(cli.profile_app, ['load', 'default'], catch_exceptions=False)

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -130,7 +130,7 @@ def test_all_config_variables_in_map():
 
 
 def test_profile(runner: CliRunner, config_dir: str):
-    config_dir = config_dir.rstrip('/')
+    config_dir = config_dir.rstrip('/') + '/hail'
 
     # check there are no variables set
     res = runner.invoke(cli.app, 'list', catch_exceptions=False)


### PR DESCRIPTION
## Change Description

Fixes #14894 

This PR allows multiple simultaneous Hail configuration profiles to customize settings for different projects, especially batch/remote_tmpdir and batch/billing_project

## Security Assessment

Delete all except the correct answer:
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

Only impacts "hailctl" -- the Hail CLI running on the user's computer.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec

---

The design of this PR is that we have `config.ini` in `~/.config/hail/` that contains the default values. We load this config first. Then we update any overlapping values and add new ones from `my-profile.ini`. To find available configs, we look for any `.ini` files that are not `config.ini`. To delete a profile, we remove `~/.config/hail/my-profile.ini`.

Important! -- to maintain backwards compatibility, we must keep the existing `config.ini` file and have that be the default values. `profile_name=None` means the default configuration.

The function `get_user_config()` is super important to make sure it's correct as that's where the correct representation of values comes from.

```python
def get_user_config() -> configparser.ConfigParser:
    config_file = get_user_config_path_by_profile_name(profile_name=None)

    # in older versions, the config file was accidentally named
    # config.yaml, if the new config does not exist, and the old
    # one does, silently rename it
    old_path = config_file.with_name('config.yaml')
    if old_path.exists() and not config_file.exists():
        old_path.rename(config_file)

    user_config = get_config_from_file(config_file)

    profile_name = get_config_profile_name()
    if profile_name:
        profile_config_file = get_user_config_path_by_profile_name(profile_name=profile_name)
        user_config.read(profile_config_file)

    return user_config
```

Here is the user interface:

```bash
(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile --help
                                                                                                                                                                                                     
 Usage: hailctl config profile [OPTIONS] COMMAND [ARGS]...                                                                                                                                           
                                                                                                                                                                                                     
 Manage Hail configuration profiles.                                                                                                                                                                 
                                                                                                                                                                                                     
│ list     List the available Hail configuration profiles.                                                                                                                                          
│ load     Load a Hail configuration profile.                                                                                                                                                       
│ create   Create a new Hail configuration profile.                                                                                                                                                 
│ delete   Delete a Hail configuration profile.                                                                                                                                                     

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config list                  
batch/regions=us-central1
batch/backend=service
batch/remote_tmpdir=gs://test-hailctl-batch-init-settings/batch/tmp
batch/billing_project=my-project
query/backend=batch
gcs/bucket_allow_list=jigold-batch-tmp-ezxyx,hail-batch-jigold-wlzly
global/profile=default

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile create my-project-1
Created profile "my-project-1". You can load the profile with `hailctl config profile load my-project-1`.

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile load my-project-1
Loaded profile my-project-1 with settings:
batch/regions=us-central1
batch/backend=service
batch/remote_tmpdir=gs://test-hailctl-batch-init-settings/batch/tmp
batch/billing_project=my-project
query/backend=batch
gcs/bucket_allow_list=jigold-batch-tmp-ezxyx,hail-batch-jigold-wlzly
global/profile=my-project-1

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config set batch/remote_tmpdir gs://my-project-1-bucket/tmp/ 

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config list                                                 
batch/regions=us-central1
batch/backend=service
batch/remote_tmpdir=gs://my-project-1-bucket/tmp/
batch/billing_project=my-project
query/backend=batch
gcs/bucket_allow_list=jigold-batch-tmp-ezxyx,hail-batch-jigold-wlzly
global/profile=my-project-1

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile create my-project-2                                  
Created profile "my-project-2". You can load the profile with `hailctl config profile load my-project-2`.

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile load my-project-2
Loaded profile my-project-2 with settings:
batch/regions=us-central1
batch/backend=service
batch/remote_tmpdir=gs://test-hailctl-batch-init-settings/batch/tmp
batch/billing_project=my-project
query/backend=batch
gcs/bucket_allow_list=jigold-batch-tmp-ezxyx,hail-batch-jigold-wlzly
global/profile=my-project-2

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config set batch/remote_tmpdir gs://my-project-2-bucket/tmp/

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile list
  default
  my-project-1
* my-project-2

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile delete my-project-2
Cannot delete a profile that is currently being used. Use `hailctl config profile list` to see available profiles. Load a different environment with `hailctl config profile load <profile_name>`.

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile delete my-project-1
Deleted profile "my-project-1".

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile load default                                 
Loaded profile default with settings:
batch/regions=us-central1
batch/backend=service
batch/remote_tmpdir=gs://test-hailctl-batch-init-settings/batch/tmp
batch/billing_project=my-project
query/backend=batch
gcs/bucket_allow_list=jigold-batch-tmp-ezxyx,hail-batch-jigold-wlzly
global/profile=default

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile delete my-project-2
Deleted profile "my-project-2".

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config list
batch/regions=us-central1
batch/backend=service
batch/remote_tmpdir=gs://test-hailctl-batch-init-settings/batch/tmp
batch/billing_project=my-project
query/backend=batch
gcs/bucket_allow_list=jigold-batch-tmp-ezxyx,hail-batch-jigold-wlzly
global/profile=default

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile list
* default

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile delete non-exist-profile
Unknown profile "non-exist-profile".

(hail-cost-progress) jigold@wm349-8c4 hail % hailctl config profile delete default          
Cannot delete the "default" profile.
```