### PR TITLE
[query/vds] Reorder LEN field to end of new ref entry struct

### DIFF
--- a/hail/python/hail/vds/combiner/combine.py
+++ b/hail/python/hail/vds/combiner/combine.py
@@ -100,7 +100,7 @@ def make_ref_entry_struct(e, entry_to_keep, row):
         hl.case()
         .when(
             e.GT.is_hom_ref(),
-            hl.struct(LEN=row.info.END - row.locus.position + 1, **reference_fields, **handled_fields),
+            hl.struct(**reference_fields, **handled_fields, LEN=row.info.END - row.locus.position + 1),
         )
         .or_error('found reference block with non reference-genotype at' + hl.str(row.locus))
     )


### PR DESCRIPTION
As of #14675, we are automatically adding a `LEN` field to VDS on read, while also dropping the `END` field on write. For older VDS, this puts the `LEN` field at the end of the reference entry struct. PR #14675 puts `LEN` as the first item in the entry struct when creating new reference data from a GVCF. This leads to an incompatibility when running the combiner on a mixture of old and new datasets. The solution here can be very simple. Just put `LEN` at the end of the entry struct on GVCF import as well.

## Security Assessment

Delete all except the correct answer:
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP