### PR TITLE
[hailtop.batch] remove_tmpdir jobs run in correct region

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -892,6 +892,7 @@ class ServiceBackend(Backend[bc.Batch]):
                 resources={'cpu': '0.25'},
                 attributes={'name': 'remove_tmpdir'},
                 always_run=True,
+                regions=self.regions,
             )
             n_jobs_submitted += 1
 


### PR DESCRIPTION
## Change Description

Fixes bug where `remove_tmpdir` Batch jobs were not run in the regions the user specified.

### Impact Rating

- This change has no security impact

### Impact Description

Only changes the hailtop.batch client library.
- For medium/high impact: provide a description of the impact and the mitigations in place.
