### PR TITLE
[hailctl] Disable more logging by default

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -19,8 +19,11 @@ DEFAULT_PROPERTIES = {
     "spark:spark.executor.extraJavaOptions": "-Xss4M",
     'spark:spark.speculation': 'true',
     "hdfs:dfs.replication": "1",
+    'dataproc:dataproc.logging.extended.enabled': 'false',
     'dataproc:dataproc.logging.stackdriver.enable': 'false',
+    'dataproc:dataproc.logging.syslog.enabled': 'false',
     'dataproc:dataproc.monitoring.stackdriver.enable': 'false',
+    'dataproc:diagnostic.capture.enabled': 'false',
 }
 
 # leadre (master) machine type to memory map, used for setting


### PR DESCRIPTION
Dataproc appears to be logging much more now than in the past, leading to increased log storage costs for our users. On recommendation from Google, add the following properties to be disabled by default:

    - `dataproc:dataproc.logging.extended.enabled`
    - `dataproc:dataproc.logging.syslog.enabled`
    - `dataproc:diagnostic.capture.enabled`

To re-enable these settings, users should pass `--properties` to `hailctl dataproc start`, which will override these defaults, like so:

```sh
hailctl dataproc start \
    --properties 'dataproc:dataproc.logging.extended.enabled=true,dataproc:dataproc.logging.stackdriver.enable=true' \
    <CLUSTERNAME>
```

Resolves #14899 

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections can be deleted

