### PR TITLE
[qob] Remove unnecessary serialization in ServiceBackend broadcast

### DIFF
--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -138,19 +138,10 @@ class ServiceBackend(
 
   def defaultParallelism: Int = 4
 
-  def broadcast[T: ClassTag](_value: T): BroadcastValue[T] = {
-    using(new ObjectOutputStream(new ByteArrayOutputStream())) { os =>
-      try
-        os.writeObject(_value)
-      catch {
-        case e: Exception =>
-          fatal(_value.toString, e)
-      }
-    }
+  def broadcast[T: ClassTag](_value: T): BroadcastValue[T] =
     new BroadcastValue[T] with Serializable {
       def value: T = _value
     }
-  }
 
   private[this] def readString(in: DataInputStream): String = {
     val n = in.readInt()


### PR DESCRIPTION
We were serializing and then throwing away the serialized data.

QoB relies on serializing broadcast values into the partition functions, it will be sufficient to diagnose pipeline bugs via those serialization errors, we don't need to do extra work.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP