### PR TITLE
[query] Serialize plink variants per partition

### DIFF
--- a/hail/hail/src/is/hail/io/plink/LoadPlink.scala
+++ b/hail/hail/src/is/hail/io/plink/LoadPlink.scala
@@ -17,12 +17,12 @@ import is.hail.utils._
 import is.hail.utils.StringEscapeUtils._
 import is.hail.variant._
 
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.Row
 import org.json4s.{DefaultFormats, Formats, JValue}
 import org.json4s.jackson.JsonMethods
-
-import java.io.{ObjectInputStream, ObjectOutputStream}
 
 case class FamFileConfig(
   isQuantPheno: Boolean = false,

--- a/hail/hail/src/is/hail/io/plink/LoadPlink.scala
+++ b/hail/hail/src/is/hail/io/plink/LoadPlink.scala
@@ -466,74 +466,74 @@ class MatrixPLINKReader(
         table(3) = if (localA2Reference) Call2.fromUnphasedDiploidGtIndex(0)
         else Call2.fromUnphasedDiploidGtIndex(2)
 
-        Iterator.range(start, end).zip(variants.iterator).map { case (i: Int, variant: PlinkVariant) =>
-
-          val newOffset: Long = 3L + variant.index.toLong * blockLength
-          if (newOffset != offset) {
-            is match {
-              case base: Seekable =>
-                base.seek(newOffset)
-              case base: org.apache.hadoop.fs.Seekable =>
-                base.seek(newOffset)
-            }
-            offset = newOffset
-          }
-
-          is.readFully(input, 0, input.length)
-
-          rvb.start(requestedPType)
-          rvb.startStruct()
-
-          val locusAlleles = variant.locusAlleles.asInstanceOf[Row]
-
-          if (hasLocus)
-            rvb.addAnnotation(localLocusType, locusAlleles.get(0))
-
-          if (hasAlleles) {
-            val alleles = locusAlleles.getAs[IndexedSeq[String]](1)
-            rvb.startArray(2)
-            rvb.addString(alleles(0))
-            rvb.addString(alleles(1))
-            rvb.endArray()
-          }
-
-          if (hasRsid)
-            rvb.addString(variant.rsid)
-          if (hasCmPos)
-            rvb.addDouble(variant.cmPos)
-
-          if (hasEntries) {
-            rvb.startArray(localNSamples)
-            if (hasGT) {
-              var i = 0
-              while (i < localNSamples) {
-                rvb.startStruct() // g
-                val x = (input(i >> 2) >> ((i & 3) << 1)) & 3
-                if (x == 1)
-                  rvb.setMissing()
-                else
-                  rvb.addCall(table(x))
-                rvb.endStruct() // g
-                i += 1
+        Iterator.range(start, end).zip(variants.iterator).map {
+          case (i: Int, variant: PlinkVariant) =>
+            val newOffset: Long = 3L + variant.index.toLong * blockLength
+            if (newOffset != offset) {
+              is match {
+                case base: Seekable =>
+                  base.seek(newOffset)
+                case base: org.apache.hadoop.fs.Seekable =>
+                  base.seek(newOffset)
               }
-            } else {
-              var i = 0
-              while (i < localNSamples) {
-                rvb.startStruct() // g
-                rvb.endStruct() // g
-                i += 1
-              }
+              offset = newOffset
             }
 
-            rvb.endArray()
-          }
+            is.readFully(input, 0, input.length)
 
-          if (hasRowUID)
-            rvb.addLong(i)
+            rvb.start(requestedPType)
+            rvb.startStruct()
 
-          rvb.endStruct()
+            val locusAlleles = variant.locusAlleles.asInstanceOf[Row]
 
-          rvb.end()
+            if (hasLocus)
+              rvb.addAnnotation(localLocusType, locusAlleles.get(0))
+
+            if (hasAlleles) {
+              val alleles = locusAlleles.getAs[IndexedSeq[String]](1)
+              rvb.startArray(2)
+              rvb.addString(alleles(0))
+              rvb.addString(alleles(1))
+              rvb.endArray()
+            }
+
+            if (hasRsid)
+              rvb.addString(variant.rsid)
+            if (hasCmPos)
+              rvb.addDouble(variant.cmPos)
+
+            if (hasEntries) {
+              rvb.startArray(localNSamples)
+              if (hasGT) {
+                var i = 0
+                while (i < localNSamples) {
+                  rvb.startStruct() // g
+                  val x = (input(i >> 2) >> ((i & 3) << 1)) & 3
+                  if (x == 1)
+                    rvb.setMissing()
+                  else
+                    rvb.addCall(table(x))
+                  rvb.endStruct() // g
+                  i += 1
+                }
+              } else {
+                var i = 0
+                while (i < localNSamples) {
+                  rvb.startStruct() // g
+                  rvb.endStruct() // g
+                  i += 1
+                }
+              }
+
+              rvb.endArray()
+            }
+
+            if (hasRowUID)
+              rvb.addLong(i)
+
+            rvb.endStruct()
+
+            rvb.end()
         }
       }
     }

--- a/hail/hail/src/is/hail/io/plink/LoadPlink.scala
+++ b/hail/hail/src/is/hail/io/plink/LoadPlink.scala
@@ -395,12 +395,13 @@ class MatrixPLINKReader(
       "variants" -> TString,
       "start" -> TInt32,
       "end" -> TInt32,
+      "partitionIndex" -> TInt32,
     )
 
-    val fullContexts = contexts.zipWithIndex.map { case (Row(start, end, vars), i) =>
-      val path = ctx.createTmpPath(s"load_plink_variants_$i")
+    val fullContexts = contexts.zipWithIndex.map { case (Row(start, end, vars), idx) =>
+      val path = ctx.createTmpPath(s"load_plink_variants_$idx")
       ctx.fs.writePDOS(path)(os => using(new ObjectOutputStream(os))(oos => oos.writeObject(vars)))
-      Row(params.bed, path, start, end)
+      Row(params.bed, path, start, end, idx)
     }
 
     val fullRowPType = PCanonicalStruct(


### PR DESCRIPTION
PLINK bim records are not huge, but we were observing issues when broadcasting very large numbers of variants leading to unexpected failures in serialization.

We attempt to fix this by serializing each partition's variants to a separate file that is decoded at the beginning of a pipeline.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP