### PR TITLE
[query] pyToDF must use long lived temp files.

### DIFF
--- a/hail/hail/src/is/hail/backend/py4j/Py4JBackendExtensions.scala
+++ b/hail/hail/src/is/hail/backend/py4j/Py4JBackendExtensions.scala
@@ -163,7 +163,7 @@ trait Py4JBackendExtensions {
   }
 
   def pyToDF(s: String): DataFrame =
-    backend.withExecuteContext { ctx =>
+    withExecuteContext(selfContainedExecution = false) { ctx =>
       val tir = IRParser.parse_table_ir(ctx, s)
       Interpret(tir, ctx).toDF()
     }


### PR DESCRIPTION
It is possible that the partition function can outlive the ExecuteContext in TableValue.toDF. Therefore, any temporary files needed for future stages must still be around, so we need to set selfContainedExecution to false for pyToDF.

Fixes [#Hail Query 0.2 support > MT to parquet throwing FileNotFoundException: Item not found @ 💬](https://hail.zulipchat.com/#narrow/channel/123010-Hail-Query-0.2E2-support/topic/MT.20to.20parquet.20throwing.20FileNotFoundException.3A.20Item.20not.20found/near/522209026) reported by @ch-kr on Zulip.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP