### PR TITLE
[batch] Add default_region API endpoint

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -44,6 +44,7 @@ from gear import (
 )
 from gear.auth import get_session_id, impersonate_user
 from gear.clients import get_cloud_async_fs
+from gear.cloud_config import get_azure_config, get_gcp_config
 from gear.database import CallError
 from gear.profiling import install_profiler_if_requested
 from gear.time_limited_max_size_cache import TimeLimitedMaxSizeCache
@@ -266,6 +267,13 @@ async def rest_cloud(_) -> web.Response:
 @auth.authenticated_users_only()
 async def rest_get_supported_regions(request: web.Request, _) -> web.Response:
     return json_response(list(request.app['regions'].keys()))
+
+
+@routes.get('/api/v1alpha/default_region')
+@api_security_headers
+@auth.authenticated_users_only()
+async def rest_get_default_region(request: web.Request, _) -> web.Response:
+    return web.Response(text=request.app['default_region'])
 
 
 async def _handle_ui_error(
@@ -3582,6 +3590,12 @@ SELECT instance_id, n_tokens, frozen FROM globals;
 
     app['hail_credentials'] = hail_credentials()
     exit_stack.push_async_callback(app['hail_credentials'].close)
+
+    if CLOUD == 'gcp':
+        app['default_region'] = get_gcp_config().region
+    else:
+        assert CLOUD == 'azure'
+        app['default_region'] = get_azure_config().region
 
     app['frozen'] = row['frozen']
 


### PR DESCRIPTION
## Change Description

Adds a new API endpoint to the Batch front end server to get the region the Batch instance is running in.

This will be used in a future change for clients to be able to set the region automatically to this default region.

## Security Assessment

- This change impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Addition of API endpoint that returns a single value that is just a global parameter value of the system configuration.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
