### PR TITLE
Create requested JVM only when there aren't already enough

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -3026,7 +3026,8 @@ class Worker:
         while True:
             try:
                 requested_n_cores = self._waiting_for_jvm_with_n_cores.get_nowait()
-                await self._jvmpools_by_cores[requested_n_cores].create_jvm()
+                if not self._jvmpools_by_cores[requested_n_cores].full():
+                    await self._jvmpools_by_cores[requested_n_cores].create_jvm()
             except asyncio.QueueEmpty:
                 next_unfull_jvmpool = None
                 for jvmpool in self._jvmpools_by_cores.values():


### PR DESCRIPTION
## Change Description

When many JVM-requiring jobs are starting at once, many requests will be queued up on _waiting_for_jvm_with_n_cores. There may in fact be more pending requests than max_jvms, so the excess requests should simply wait for an existing JVM to become available rather than try to create another -- which would fail.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
 
### Impact Rating

- This change has no security impact

### Impact Description

Prevents _jvm_initializer_task from aborting when it receives very many not-immediately-satisfiable borrow_jvm() requests. No new behaviour otherwise.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
