### PR TITLE
[hailctl] Change hailctl batch init defaults

### DIFF
--- a/hail/python/hailtop/hailctl/batch/initialize.py
+++ b/hail/python/hailtop/hailctl/batch/initialize.py
@@ -90,7 +90,7 @@ async def setup_new_remote_tmpdir(
 
     default_project = await get_gcp_default_project(verbose=verbose)
 
-    bucket_prompt = f'Which google project should the bucket be created in? This project will incur costs for storing your Hail generated data.'
+    bucket_prompt = 'Which google project should the bucket be created in? This project will incur costs for storing your Hail generated data.'
     if default_project is not None:
         project = Prompt.ask(bucket_prompt, default=default_project)
     else:
@@ -115,11 +115,11 @@ async def setup_new_remote_tmpdir(
             raise Abort()
 
     set_lifecycle = Confirm.ask(
-        f'Do you want to set a lifecycle policy (automatically delete files after a time period) on the bucket?'
+        'Do you want to set a lifecycle policy (automatically delete files after a time period) on the bucket?'
     )
     if set_lifecycle:
         lifecycle_days = IntPrompt.ask(
-            f'After how many days should files be automatically deleted from bucket?', default=7
+            'After how many days should files be automatically deleted from bucket?', default=7
         )
         if lifecycle_days <= 0:
             typer.secho(f'Invalid value for lifecycle rule in days {lifecycle_days}', fg=typer.colors.RED)


### PR DESCRIPTION
## Change Description

Cleans up the bucket naming in `hailctl batch init` and sets the default lifecycle to 7 days.

Necessary to try and reduce storage costs while making it clear to users the underlying bucket configuration.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

---

```
(hail-cost-progress) jigold@wm349-8c4 hail % hailctl batch init
You are currently logged in to Hail at domain hail.is.
Do you want to create a new bucket for temporary files generated by Hail? [y/n]: y
Which google project should the bucket be created in? This project will incur costs for storing your Hail generated data. (my-project): my-project2
Which region does your data reside in? (us-central1): 
Do you want to set a lifecycle policy (automatically delete files after a time period) on the bucket? [y/n]: y
After how many days should files be automatically deleted from bucket? (7): 
What is the name of the new bucket? (hail-batch-jigold-my-project-2-mnd8t-7day): ^C^C% 
```


