### PR TITLE
[compiler] fix RIterable

### DIFF
--- a/hail/hail/test/src/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -58,8 +58,10 @@ class DictFunctionsSuite extends HailSuite {
   )
 
   @Test(dataProvider = "dictToArray")
-  def dictToArray(a: IndexedSeq[(Integer, Integer)], expected: (IndexedSeq[Row])): Unit =
+  def dictToArray(a: IndexedSeq[(Integer, Integer)], expected: (IndexedSeq[Row])): Unit = {
+    implicit val execStrats = Set(ExecStrategy.JvmCompile)
     assertEvalsTo(invoke("dictToArray", TArray(TTuple(TInt32, TInt32)), toIRDict(a)), expected)
+  }
 
   @DataProvider(name = "keysAndValues")
   def keysAndValuesData(): Array[Array[Any]] = Array(


### PR DESCRIPTION
## Change Description

Fixes an apparently long standing bug. The issue is that `RDict` was a subclass of the concrete class `RIterable`, and assumed that all `TypeWithRequirement`s corresponding to a dict are explicitly constructed as the `RDict` subclass. However, `SContainer._typeWithRequiredness` always constructs an `RIterable`, even though it may be a dict type.

To fix, I eliminated the questionable use of inheritance. `RIterable` is now final, `RDict` is deleted in favor of being a special case of `RIterable`, and `RNDArray` (which was also a subclass of `RIterable`, even though `TNDArray` is not a `TIterable`) no longer inherits from `RIterable`.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
