### PR TITLE
[vds/combiner] Add extra logging to new_combiner

### DIFF
--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -835,7 +835,12 @@ def new_combiner(
         gvcf_type = mt._type
         if gvcf_reference_entry_fields_to_keep is None:
             rmt = mt.filter_rows(hl.is_defined(mt.info.END))
+            info(
+                "Computing defined reference entry fields. To avoid this in the future, "
+                "set `gvcf_reference_entry_fields_to_keep` in `new_combiner`."
+            )
             gvcf_reference_entry_fields_to_keep = defined_entry_fields(rmt, 100_000) - {'PGT', 'PL'}
+            info(f"Defined reference entry fields: {gvcf_reference_entry_fields_to_keep}")
         if vds is None:
             vds = transform_gvcf(
                 mt._key_rows_by_assert_sorted('locus'), gvcf_reference_entry_fields_to_keep, gvcf_info_to_keep


### PR DESCRIPTION
It may be confusing for users to wait for computing the defined reference entries, so we add logging when we compute those fields.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP