### PR TITLE
[compiler] move relational IR typecheck methods out of class

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -10,7 +10,7 @@ import is.hail.expr.ir.functions.{
   BlockMatrixToTableFunction, IntervalFunctions, MatrixToTableFunction, TableToTableFunction,
 }
 import is.hail.expr.ir.lowering._
-import is.hail.expr.ir.streams.{StreamProducer, StreamUtils}
+import is.hail.expr.ir.streams.StreamProducer
 import is.hail.io._
 import is.hail.io.avro.AvroTableReader
 import is.hail.io.fs.FS
@@ -67,8 +67,6 @@ sealed abstract class TableIR extends BaseIR {
     }
 
   def pyUnpersist(): TableIR = unpersist()
-
-  def typecheck(): Unit = {}
 }
 
 object TableLiteral {
@@ -2107,12 +2105,6 @@ case class TableRead(typ: TableType, dropRows: Boolean, tr: TableReader) extends
 }
 
 case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) extends TableIR {
-  override def typecheck(): Unit = {
-    assert(rowsAndGlobal.typ.isInstanceOf[TStruct])
-    assert(rowsAndGlobal.typ.asInstanceOf[TStruct].fieldNames.sameElements(Array("rows", "global")))
-    assert(nPartitions.forall(_ > 0))
-  }
-
   lazy val rowCountUpperBound: Option[Long] = None
 
   val childrenSeq: IndexedSeq[BaseIR] = FastSeq(rowsAndGlobal)
@@ -2147,11 +2139,6 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
   */
 case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolean = false)
     extends TableIR {
-  override def typecheck(): Unit = {
-    val fields = child.typ.rowType.fieldNames.toSet
-    assert(keys.forall(fields.contains), s"${keys.filter(k => !fields.contains(k)).mkString(", ")}")
-  }
-
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   val childrenSeq: IndexedSeq[BaseIR] = Array(child)
@@ -2192,21 +2179,6 @@ case class TableGen(
   partitioner: RVDPartitioner,
   errorId: Int = ErrorIDs.NO_ERROR,
 ) extends TableIR {
-
-  override def typecheck(): Unit = {
-    TypeCheck.coerce[TStream]("contexts", contexts.typ)
-    TypeCheck.coerce[TStruct]("globals", globals.typ)
-    val bodyType = TypeCheck.coerce[TStream]("body", body.typ)
-    val rowType = TypeCheck.coerce[TStruct]("body.elementType", bodyType.elementType)
-
-    if (!partitioner.kType.isSubsetOf(rowType))
-      throw new IllegalArgumentException(
-        s"""'partitioner': key type contains fields absent from row type
-           |  Key type: ${partitioner.kType}
-           |  Row type: $rowType""".stripMargin
-      )
-  }
-
   private def globalType =
     TypeCheck.coerce[TStruct]("globals", globals.typ)
 
@@ -2359,17 +2331,6 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
     joinType == "right" ||
     joinType == "outer")
 
-  override def typecheck(): Unit = {
-    assert(left.typ.key.length >= joinKey)
-    assert(right.typ.key.length >= joinKey)
-    assert(left.typ.keyType.truncate(joinKey) isJoinableWith right.typ.keyType.truncate(joinKey))
-    assert(
-      left.typ.globalType.fieldNames.toSet
-        .intersect(right.typ.globalType.fieldNames.toSet)
-        .isEmpty
-    )
-  }
-
   val childrenSeq: IndexedSeq[BaseIR] = Array(left, right)
 
   lazy val rowCountUpperBound: Option[Long] = None
@@ -2446,17 +2407,6 @@ case class TableMultiWayZipJoin(
 ) extends TableIR {
   require(childrenSeq.nonEmpty, "there must be at least one table as an argument")
 
-  override def typecheck(): Unit = {
-    val first = childrenSeq.head
-    val rest = childrenSeq.tail
-    assert(rest.forall(e => e.typ.rowType == first.typ.rowType), "all rows must have the same type")
-    assert(rest.forall(e => e.typ.key == first.typ.key), "all keys must be the same")
-    assert(
-      rest.forall(e => e.typ.globalType == first.typ.globalType),
-      "all globals must have the same type",
-    )
-  }
-
   private def first = childrenSeq.head
 
   lazy val rowCountUpperBound: Option[Long] = None
@@ -2477,12 +2427,6 @@ case class TableMultiWayZipJoin(
 }
 
 case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: String) extends TableIR {
-  override def typecheck(): Unit =
-    assert(
-      right.typ.keyType isPrefixOf left.typ.keyType,
-      s"\n  L: ${left.typ}\n  R: ${right.typ}",
-    )
-
   lazy val rowCountUpperBound: Option[Long] = left.rowCountUpperBound
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(left, right)
@@ -2514,23 +2458,6 @@ case class TableMapPartitions(
   requestedKey: Int,
   allowedOverlap: Int,
 ) extends TableIR {
-  override def typecheck(): Unit = {
-    assert(body.typ.isInstanceOf[TStream], s"${body.typ}")
-    assert(allowedOverlap >= -1)
-    assert(allowedOverlap <= child.typ.key.size)
-    assert(requestedKey >= 0)
-    assert(requestedKey <= child.typ.key.size)
-    assert(
-      StreamUtils.isIterationLinear(body, partitionStreamName),
-      "must iterate over the partition exactly once",
-    )
-    val newRowType = body.typ.asInstanceOf[TStream].elementType.asInstanceOf[TStruct]
-    child.typ.key.foreach { k =>
-      if (!newRowType.hasField(k))
-        throw new RuntimeException(s"prev key: ${child.typ.key}, new row: $newRowType")
-    }
-  }
-
   lazy val typ: TableType = child.typ.copy(
     rowType = body.typ.asInstanceOf[TStream].elementType.asInstanceOf[TStruct]
   )
@@ -2555,11 +2482,6 @@ case class TableMapPartitions(
 
 // Must leave key fields unchanged.
 case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
-  override def typecheck(): Unit = {
-    val newFieldSet = newRow.typ.asInstanceOf[TStruct].fieldNames.toSet
-    assert(child.typ.key.forall(newFieldSet.contains))
-  }
-
   val childrenSeq: IndexedSeq[BaseIR] = Array(child, newRow)
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
@@ -2593,9 +2515,6 @@ case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
 case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableIR {
   assert(path.nonEmpty)
 
-  override def typecheck(): Unit =
-    assert(!child.typ.key.contains(path.head))
-
   lazy val rowCountUpperBound: Option[Long] = None
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child)
@@ -2617,11 +2536,6 @@ case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableI
 
 case class TableUnion(childrenSeq: IndexedSeq[TableIR]) extends TableIR {
   assert(childrenSeq.nonEmpty)
-
-  override def typecheck(): Unit = {
-    assert(childrenSeq.tail.forall(_.typ.rowType == childrenSeq(0).typ.rowType))
-    assert(childrenSeq.tail.forall(_.typ.key == childrenSeq(0).typ.key))
-  }
 
   lazy val rowCountUpperBound: Option[Long] = {
     val definedChildren = childrenSeq.flatMap(_.rowCountUpperBound)
@@ -2701,11 +2615,6 @@ case class TableKeyByAndAggregate(
 ) extends TableIR {
   assert(bufferSize > 0)
 
-  override def typecheck(): Unit = {
-    assert(expr.typ.isInstanceOf[TStruct])
-    assert(newKey.typ.isInstanceOf[TStruct])
-  }
-
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, expr, newKey)
 
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
@@ -2727,9 +2636,6 @@ case class TableKeyByAndAggregate(
 
 // follows key_by non-empty key
 case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
-  override def typecheck(): Unit =
-    assert(child.typ.key.nonEmpty)
-
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   lazy val childrenSeq: IndexedSeq[BaseIR] = Array(child, expr)
@@ -2796,11 +2702,6 @@ case class CastMatrixToTable(
 
 case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: Map[String, String])
     extends TableIR {
-  override def typecheck(): Unit = {
-    assert(rowMap.keys.forall(child.typ.rowType.hasField))
-    assert(globalMap.keys.forall(child.typ.globalType.hasField))
-  }
-
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   def rowF(old: String): String = rowMap.getOrElse(old, old)

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.backend.ExecuteContext
 import is.hail.expr.Nat
 import is.hail.expr.ir.defs._
+import is.hail.expr.ir.streams.StreamUtils
 import is.hail.types.tcoerce
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -605,9 +606,161 @@ object TypeCheck {
       case LiftMeOut(_) =>
       case Consume(_) =>
 
-      case x: TableIR => x.typecheck()
-      case x: MatrixIR => x.typecheck()
-      case x: BlockMatrixIR => x.typecheck()
+      case TableAggregateByKey(child, _) =>
+        assert(child.typ.key.nonEmpty)
+      case TableExplode(child, path) =>
+        assert(!child.typ.key.contains(path.head))
+      case TableGen(contexts, globals, _, _, body, partitioner, _) =>
+        TypeCheck.coerce[TStream]("contexts", contexts.typ)
+        TypeCheck.coerce[TStruct]("globals", globals.typ)
+        val bodyType = TypeCheck.coerce[TStream]("body", body.typ)
+        val rowType = TypeCheck.coerce[TStruct]("body.elementType", bodyType.elementType)
+
+        if (!partitioner.kType.isSubsetOf(rowType))
+          throw new IllegalArgumentException(
+            s"""'partitioner': key type contains fields absent from row type
+               |  Key type: ${partitioner.kType}
+               |  Row type: $rowType""".stripMargin
+          )
+      case TableJoin(left, right, _, joinKey) =>
+        assert(left.typ.key.length >= joinKey)
+        assert(right.typ.key.length >= joinKey)
+        assert(
+          left.typ.keyType.truncate(joinKey) isJoinableWith right.typ.keyType.truncate(joinKey)
+        )
+        assert(
+          left.typ.globalType.fieldNames.toSet
+            .intersect(right.typ.globalType.fieldNames.toSet)
+            .isEmpty
+        )
+      case TableKeyBy(child, keys, _) =>
+        val fields = child.typ.rowType.fieldNames.toSet
+        assert(
+          keys.forall(fields.contains),
+          s"${keys.filter(k => !fields.contains(k)).mkString(", ")}",
+        )
+      case TableKeyByAndAggregate(_, expr, newKey, _, _) =>
+        assert(expr.typ.isInstanceOf[TStruct])
+        assert(newKey.typ.isInstanceOf[TStruct])
+      case TableLeftJoinRightDistinct(left, right, _) =>
+        assert(
+          right.typ.keyType isPrefixOf left.typ.keyType,
+          s"\n  L: ${left.typ}\n  R: ${right.typ}",
+        )
+      case TableMapPartitions(child, _, partitionStreamName, body, requestedKey, allowedOverlap) =>
+        assert(body.typ.isInstanceOf[TStream], s"${body.typ}")
+        assert(allowedOverlap >= -1)
+        assert(allowedOverlap <= child.typ.key.size)
+        assert(requestedKey >= 0)
+        assert(requestedKey <= child.typ.key.size)
+        assert(
+          StreamUtils.isIterationLinear(body, partitionStreamName),
+          "must iterate over the partition exactly once",
+        )
+        val newRowType = body.typ.asInstanceOf[TStream].elementType.asInstanceOf[TStruct]
+        child.typ.key.foreach { k =>
+          if (!newRowType.hasField(k))
+            throw new RuntimeException(s"prev key: ${child.typ.key}, new row: $newRowType")
+        }
+      case TableMapRows(child, newRow) =>
+        val newFieldSet = newRow.typ.asInstanceOf[TStruct].fieldNames.toSet
+        assert(child.typ.key.forall(newFieldSet.contains))
+      case TableMultiWayZipJoin(childrenSeq, _, _) =>
+        val first = childrenSeq.head
+        val rest = childrenSeq.tail
+        assert(
+          rest.forall(e => e.typ.rowType == first.typ.rowType),
+          "all rows must have the same type",
+        )
+        assert(rest.forall(e => e.typ.key == first.typ.key), "all keys must be the same")
+        assert(
+          rest.forall(e => e.typ.globalType == first.typ.globalType),
+          "all globals must have the same type",
+        )
+      case TableParallelize(rowsAndGlobal, nPartitions) =>
+        assert(rowsAndGlobal.typ.isInstanceOf[TStruct])
+        assert(rowsAndGlobal.typ.asInstanceOf[TStruct].fieldNames.sameElements(Array(
+          "rows",
+          "global",
+        )))
+        assert(nPartitions.forall(_ > 0))
+      case TableRename(child, rowMap, globalMap) =>
+        assert(rowMap.keys.forall(child.typ.rowType.hasField))
+        assert(globalMap.keys.forall(child.typ.globalType.hasField))
+      case TableUnion(childrenSeq) =>
+        assert(childrenSeq.tail.forall(_.typ.rowType == childrenSeq(0).typ.rowType))
+        assert(childrenSeq.tail.forall(_.typ.key == childrenSeq(0).typ.key))
+      case CastTableToMatrix(child, entriesFieldName, _, _) =>
+        child.typ.rowType.fieldType(entriesFieldName) match {
+          case TArray(TStruct(_)) =>
+          case t => fatal(s"expected entry field to be an array of structs, found $t")
+        }
+      case MatrixAggregateColsByKey(child, _, _) =>
+        assert(child.typ.colKey.nonEmpty)
+      case MatrixAggregateRowsByKey(child, _, _) =>
+        assert(child.typ.rowKey.nonEmpty)
+      case MatrixAnnotateColsTable(child, _, root) =>
+        assert(child.typ.colType.selfField(root).isEmpty)
+      case MatrixAnnotateRowsTable(child, table, _, product) =>
+        assert(
+          (!product && table.typ.keyType.isPrefixOf(child.typ.rowKeyStruct)) ||
+            (table.typ.keyType.size == 1 && table.typ.keyType.types(0) == TInterval(
+              child.typ.rowKeyStruct.types(0)
+            )),
+          s"\n  L: ${child.typ}\n  R: ${table.typ}",
+        )
+      case MatrixKeyRowsBy(child, keys, _) =>
+        val fields = child.typ.rowType.fieldNames.toSet
+        assert(
+          keys.forall(fields.contains),
+          s"${keys.filter(k => !fields.contains(k)).mkString(", ")}",
+        )
+      case MatrixRename(child, globalMap, colMap, rowMap, entryMap) =>
+        assert(globalMap.keys.forall(child.typ.globalType.hasField))
+        assert(colMap.keys.forall(child.typ.colType.hasField))
+        assert(rowMap.keys.forall(child.typ.rowType.hasField))
+        assert(entryMap.keys.forall(child.typ.entryType.hasField))
+      case MatrixUnionCols(left, right, _) =>
+        assert(
+          left.typ.rowKeyStruct == right.typ.rowKeyStruct,
+          s"${left.typ.rowKeyStruct} != ${right.typ.rowKeyStruct}",
+        )
+        assert(
+          left.typ.colType == right.typ.colType,
+          s"${left.typ.colType} != ${right.typ.colType}",
+        )
+        assert(
+          left.typ.entryType == right.typ.entryType,
+          s"${left.typ.entryType} != ${right.typ.entryType}",
+        )
+      case MatrixUnionRows(children) =>
+        def compatible(t1: MatrixType, t2: MatrixType): Boolean =
+          t1.colKeyStruct == t2.colKeyStruct &&
+            t1.rowType == t2.rowType &&
+            t1.rowKey == t2.rowKey &&
+            t1.entryType == t2.entryType
+        assert(
+          children.tail.forall(c => compatible(c.typ, children.head.typ)),
+          children.map(_.typ),
+        )
+      case BlockMatrixBroadcast(child, inIndexExpr, shape, _) =>
+        val (nRows, nCols) = BlockMatrixIR.tensorShapeToMatrixShape(child)
+        val childMatrixShape = IndexedSeq(nRows, nCols)
+
+        assert(inIndexExpr.zipWithIndex.forall { case (out: Int, in: Int) =>
+          !child.typ.shape.contains(in) || childMatrixShape(in) == shape(out)
+        })
+      case BlockMatrixMap(child, _, _, needsDense) =>
+        assert(!(needsDense && child.typ.isSparse))
+      case BlockMatrixMap2(left, right, _, _, _, _) =>
+        assert(left.typ.nRows == right.typ.nRows)
+        assert(left.typ.nCols == right.typ.nCols)
+        assert(left.typ.blockSize == right.typ.blockSize)
+      case ValueToBlockMatrix(child, _, _) =>
+        assert(
+          child.typ.isInstanceOf[TArray] || child.typ.isInstanceOf[TNDArray] || child.typ == TFloat64
+        )
+      case _ =>
     }
   }
 

--- a/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
@@ -26,7 +26,7 @@ class TableGenSuite extends HailSuite {
   @Test(groups = Array("construction", "typecheck"))
   def testWithInvalidContextsType(): Unit = {
     val ex = intercept[IllegalArgumentException] {
-      mkTableGen(contexts = Some(Str("oh noes :'("))).typecheck()
+      TypeCheck(ctx, mkTableGen(contexts = Some(Str("oh noes :'("))))
     }
 
     ex.getMessage should include("contexts")
@@ -36,57 +36,69 @@ class TableGenSuite extends HailSuite {
 
   @Test(groups = Array("construction", "typecheck"))
   def testWithInvalidGlobalsType(): Unit = {
-    val ex = intercept[IllegalArgumentException] {
-      mkTableGen(
-        globals = Some(Str("oh noes :'(")),
-        body = Some((_, _) => MakeStream(IndexedSeq(), TStream(TStruct()))),
-      ).typecheck()
+    val ex = intercept[HailException] {
+      TypeCheck(
+        ctx,
+        mkTableGen(
+          globals = Some(Str("oh noes :'(")),
+          body = Some((_, _) => MakeStream(IndexedSeq(), TStream(TStruct()))),
+        ),
+      )
     }
-    ex.getMessage should include("globals")
-    ex.getMessage should include(s"Expected: ${classOf[TStruct].getName}")
-    ex.getMessage should include(s"Actual: ${TString.getClass.getName}")
+    ex.getCause.getMessage should include("globals")
+    ex.getCause.getMessage should include(s"Expected: ${classOf[TStruct].getName}")
+    ex.getCause.getMessage should include(s"Actual: ${TString.getClass.getName}")
   }
 
   @Test(groups = Array("construction", "typecheck"))
   def testWithInvalidBodyType(): Unit = {
-    val ex = intercept[IllegalArgumentException] {
-      mkTableGen(body = Some((_, _) => Str("oh noes :'("))).typecheck()
+    val ex = intercept[HailException] {
+      TypeCheck(ctx, mkTableGen(body = Some((_, _) => Str("oh noes :'("))))
     }
-    ex.getMessage should include("body")
-    ex.getMessage should include(s"Expected: ${classOf[TStream].getName}")
-    ex.getMessage should include(s"Actual: ${TString.getClass.getName}")
+    ex.getCause.getMessage should include("body")
+    ex.getCause.getMessage should include(s"Expected: ${classOf[TStream].getName}")
+    ex.getCause.getMessage should include(s"Actual: ${TString.getClass.getName}")
   }
 
   @Test(groups = Array("construction", "typecheck"))
   def testWithInvalidBodyElementType(): Unit = {
-    val ex = intercept[IllegalArgumentException] {
-      mkTableGen(body =
-        Some((_, _) => MakeStream(IndexedSeq(Str("oh noes :'(")), TStream(TString)))
-      ).typecheck()
+    val ex = intercept[HailException] {
+      TypeCheck(
+        ctx,
+        mkTableGen(body =
+          Some((_, _) => MakeStream(IndexedSeq(Str("oh noes :'(")), TStream(TString)))
+        ),
+      )
     }
-    ex.getMessage should include("body.elementType")
-    ex.getMessage should include(s"Expected: ${classOf[TStruct].getName}")
-    ex.getMessage should include(s"Actual: ${TString.getClass.getName}")
+    ex.getCause.getMessage should include("body.elementType")
+    ex.getCause.getMessage should include(s"Expected: ${classOf[TStruct].getName}")
+    ex.getCause.getMessage should include(s"Actual: ${TString.getClass.getName}")
   }
 
   @Test(groups = Array("construction", "typecheck"))
   def testWithInvalidPartitionerKeyType(): Unit = {
-    val ex = intercept[IllegalArgumentException] {
-      mkTableGen(partitioner =
-        Some(RVDPartitioner.empty(ctx.stateManager, TStruct("does-not-exist" -> TInt32)))
-      ).typecheck()
+    val ex = intercept[HailException] {
+      TypeCheck(
+        ctx,
+        mkTableGen(partitioner =
+          Some(RVDPartitioner.empty(ctx.stateManager, TStruct("does-not-exist" -> TInt32)))
+        ),
+      )
     }
-    ex.getMessage should include("partitioner")
+    ex.getCause.getMessage should include("partitioner")
   }
 
   @Test(groups = Array("construction", "typecheck"))
   def testWithTooLongPartitionerKeyType(): Unit = {
-    val ex = intercept[IllegalArgumentException] {
-      mkTableGen(partitioner =
-        Some(RVDPartitioner.empty(ctx.stateManager, TStruct("does-not-exist" -> TInt32)))
-      ).typecheck()
+    val ex = intercept[HailException] {
+      TypeCheck(
+        ctx,
+        mkTableGen(partitioner =
+          Some(RVDPartitioner.empty(ctx.stateManager, TStruct("does-not-exist" -> TInt32)))
+        ),
+      )
     }
-    ex.getMessage should include("partitioner")
+    ex.getCause.getMessage should include("partitioner")
   }
 
   @Test(groups = Array("requiredness"))


### PR DESCRIPTION
## Change Description

This is a simple relocation of the typecheck methods on relational IR classes to the `Typecheck` function. This removes one of the arbitrary differences between relational and value IR classes, and prepares the way to codegenerating relational IR.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

