### PR TITLE
[compiler] refactor row/col count estimates

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -4,6 +4,7 @@ import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.SparkTaskContext
+import is.hail.expr.ir.analyses.PartitionCounts
 import is.hail.expr.ir.compile.{Compile, CompileWithAggregators}
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.{ExecuteRelational, LoweringPipeline}
@@ -902,7 +903,7 @@ object Interpret {
           }
         }
       case TableCount(child) =>
-        child.partitionCounts
+        PartitionCounts(child)
           .map(_.sum)
           .getOrElse(ExecuteRelational(ctx, child).asTableValue(ctx).rvd.count())
       case TableGetGlobals(child) =>

--- a/hail/hail/src/is/hail/expr/ir/analyses/RowCounts.scala
+++ b/hail/hail/src/is/hail/expr/ir/analyses/RowCounts.scala
@@ -1,0 +1,85 @@
+package is.hail.expr.ir.analyses
+
+import is.hail.expr.ir._
+import is.hail.utils.{toRichOption, FastSeq}
+import is.hail.utils.PartitionCounts.{getHeadPCs, getTailPCs}
+
+object PartitionCounts {
+  def unapply(ir: BaseIR): Option[IndexedSeq[Long]] = PartitionCounts(ir)
+
+  def apply(ir: BaseIR): Option[IndexedSeq[Long]] = ir match {
+    case ir: TableRead =>
+      if (ir.dropRows) Some(FastSeq(0L)) else ir.tr.partitionCounts
+    case ir: MatrixRead =>
+      if (ir.dropRows) Some(FastSeq.empty) else ir.reader.partitionCounts
+    case range: TableRange => Some(range.partitionCounts.map(_.toLong))
+    case TableHead(child, n) =>
+      PartitionCounts(child).map(getHeadPCs(_, n))
+    case TableTail(child, n) =>
+      PartitionCounts(child).map(getTailPCs(_, n))
+    case MatrixRowsHead(child, n) =>
+      PartitionCounts(child).map(getHeadPCs(_, n))
+    case MatrixRowsTail(child, n) =>
+      PartitionCounts(child).map(getTailPCs(_, n))
+    case PreservesRows(child, true) => PartitionCounts(child)
+    case _ => None
+  }
+}
+
+object RowCountUpperBound {
+  def apply(ir: BaseIR): Option[Long] = ir match {
+    case ir: TableRead => PartitionCounts(ir).map(_.sum)
+    case ir: MatrixRead => PartitionCounts(ir).map(_.sum)
+    case TableRange(n, _) => Some(n.toLong)
+    case TableHead(child, n) => Some(RowCountUpperBound(child).getOrElse(Long.MaxValue).min(n))
+    case TableTail(child, n) => Some(RowCountUpperBound(child).getOrElse(Long.MaxValue).min(n))
+    case MatrixRowsHead(child, n) => Some(RowCountUpperBound(child).getOrElse(Long.MaxValue).min(n))
+    case MatrixRowsTail(child, n) => Some(RowCountUpperBound(child).getOrElse(Long.MaxValue).min(n))
+    case TableUnion(children) =>
+      children.foldLeft[Option[Long]](Some(0)) { (sum, child) =>
+        RowCountUpperBound(child).liftedZip(sum).map { case (l, r) => l + r }
+      }
+    case MatrixUnionRows(children) =>
+      children.foldLeft[Option[Long]](Some(0)) { (sum, child) =>
+        RowCountUpperBound(child).liftedZip(sum).map { case (l, r) => l + r }
+      }
+    case MatrixUnionCols(left, right, "inner") =>
+      (RowCountUpperBound(left), RowCountUpperBound(right)) match {
+        case (None, None) => None
+        case (l, r) => Some(Math.min(l.getOrElse(Long.MaxValue), r.getOrElse(Long.MaxValue)))
+      }
+    case MatrixUnionCols(left, right, _) =>
+      RowCountUpperBound(left).liftedZip(RowCountUpperBound(right)).map { case (l, r) => l + r }
+    case PreservesOrRemovesRows(child) => RowCountUpperBound(child)
+    case _ => None
+  }
+}
+
+object ColumnCount {
+  def unapply(ir: MatrixIR): Option[Int] = apply(ir)
+
+  def apply(ir: MatrixIR): Option[Int] = ir match {
+    case ir: MatrixRead => if (ir.dropCols) Some(0) else ir.reader.columnCount
+    case MatrixChooseCols(_, oldIndices) => Some(oldIndices.length)
+    case MatrixColsHead(child, n) => ColumnCount(child).map(n.min)
+    case MatrixColsTail(child, n) => ColumnCount(child).map(n.min)
+    case MatrixUnionRows(children) =>
+      children.foldLeft[Option[Int]](None) { (acc, child) =>
+        val count = ColumnCount(child)
+        acc.liftedZip(count).foreach { case (l, r) => assert(l == r) }
+        acc.orElse(count)
+      }
+    case MatrixUnionCols(left, right, _) =>
+      ColumnCount(left).liftedZip(ColumnCount(right)).map { case (l, r) => l + r }
+    case PreservesCols(child: MatrixIR) => ColumnCount(child)
+    case _ => None
+  }
+}
+
+object PartitionCountsOrColumnCount {
+  def unapply(ir: MatrixIR): Option[(Option[IndexedSeq[Long]], Option[Int])] =
+    (PartitionCounts(ir), ColumnCount(ir)) match {
+      case (None, None) => None
+      case x => Some(x)
+    }
+}

--- a/hail/hail/src/is/hail/expr/ir/lowering/ExecuteRelational.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/ExecuteRelational.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir.lowering
 import is.hail.annotations.{BroadcastRow, RegionValue}
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir._
+import is.hail.expr.ir.analyses.PartitionCounts
 import is.hail.rvd.{RVD, RVDPartitioner}
 import is.hail.types.physical.PStruct
 import is.hail.utils.fatal
@@ -103,7 +104,7 @@ object ExecuteRelational {
       case TableParallelize(rowsAndGlobal, nPartitions) =>
         TableValueIntermediate(TableValue.parallelize(ctx, rowsAndGlobal, nPartitions))
       case ir: TableRange =>
-        TableValueIntermediate(TableValue.range(ctx, ir.partitionCounts.value.map(_.toInt)))
+        TableValueIntermediate(TableValue.range(ctx, ir.partitionCounts))
       case TableRead(typ, dropRows, tr) =>
         tr.toExecuteIntermediate(ctx, typ, dropRows)
       case TableRename(child, rowMap, globalMap) =>
@@ -114,10 +115,10 @@ object ExecuteRelational {
         TableValueIntermediate(recur(child).asTableValue(ctx).repartition(n, strategy))
       case TableHead(child, n) =>
         val prev = recur(child).asTableValue(ctx)
-        TableValueIntermediate(prev.copy(rvd = prev.rvd.head(n, child.partitionCounts)))
+        TableValueIntermediate(prev.copy(rvd = prev.rvd.head(n, PartitionCounts(child))))
       case TableTail(child, n) =>
         val prev = recur(child).asTableValue(ctx)
-        TableValueIntermediate(prev.copy(rvd = prev.rvd.tail(n, child.partitionCounts)))
+        TableValueIntermediate(prev.copy(rvd = prev.rvd.tail(n, PartitionCounts(child))))
       case TableToTableApply(child, function) =>
         TableValueIntermediate(function.execute(ctx, recur(child).asTableValue(ctx)))
       case TableUnion(childrenSeq) =>

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir.lowering
 import is.hail.HailContext
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{agg, TableNativeWriter, _}
+import is.hail.expr.ir.analyses.PartitionCounts
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.defs.ArrayZipBehavior.AssertSameLength
 import is.hail.expr.ir.functions.{TableCalculateNewPartitions, WrappedMatrixToTableFunction}
@@ -1372,7 +1373,7 @@ object LowerTableIR {
             StreamLen(a)
 
         def partitionSizeArray(childContexts: Ref): IR = {
-          child.partitionCounts match {
+          PartitionCounts(child) match {
             case Some(partCounts) =>
               var idx = 0
               var sumSoFar = 0L
@@ -1508,7 +1509,7 @@ object LowerTableIR {
         val loweredChild = lower(child)
 
         def partitionSizeArray(childContexts: Ref, totalNumPartitions: Ref): IR = {
-          child.partitionCounts match {
+          PartitionCounts(child) match {
             case Some(partCounts) =>
               var idx = partCounts.length - 1
               var sumSoFar = 0L

--- a/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
@@ -5,6 +5,7 @@ import is.hail.ExecStrategy.ExecStrategy
 import is.hail.annotations.SafeNDArray
 import is.hail.expr.Nat
 import is.hail.expr.ir.TestUtils._
+import is.hail.expr.ir.analyses.PartitionCounts
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.{DArrayLowering, ExecuteRelational, LowerTableIR}
 import is.hail.methods.{ForceCountTable, NPartitionsTable}
@@ -1015,7 +1016,7 @@ class TableIRSuite extends HailSuite {
       override def fullType: TableType = TableType(TStruct(), FastSeq(), TStruct.empty)
     }
     val tir = TableRead(tr.fullType, true, tr)
-    assert(tir.partitionCounts.forall(_.sum == 0))
+    assert(PartitionCounts(tir).forall(_.sum == 0))
   }
 
   @Test def testScanInAggInMapRows(): scalatest.Assertion = {


### PR DESCRIPTION
## Change Description

This removes another of the arbitrary differences between relational and value IR classes, preparing to codegen relational IR classes.

The difference being removed here is the implementation of row/col count upper bounds and exact but optional partition row counts directly in the IR classes. These are really analysis passes, and should be defined separately from the node definitions.

To do this cleanly, I use a pattern which I think we should look to use more often. The goal is to separate the node definitions from the analysis implementation, so that adding a new node usually doesn't require modifying or knowing about the analysis.

To achieve this, I add a few traits which an IR class can inherit from, which consisely express *semantic* properties of the operation. The analysis then doesn't need to match on specific nodes, instead relying on this set of properties. The semantic traits are added in `BaseIR.scala`, and express whether a node preserves rows/cols (each input row/col corresponds to an output row/col with the same key), preserves or removes rows/cols (each input row/col is either deleted or corresponds to an output row/col with the same key), and in both cases whether it also preserves partitioning (ordering and partition assignment of rows/cols are preserved), in all cases relative to a specified child.

The new analysis passes are defined in `analyses/RowCounts.scala`, and with a few exceptions only match against the new property traits, not against specific IR classes.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

