### PR TITLE
[auth|batch|ci|monitoring] Upgrade all default images to ubuntu:24.04

### DIFF
--- a/admin-pod/Dockerfile
+++ b/admin-pod/Dockerfile
@@ -1,9 +1,4 @@
 ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
 FROM $BASE_IMAGE
 
-# https://bugs.mysql.com/bug.php?id=105288&thanks=sub
-RUN hail-apt-get-install xz-utils libncurses5 && \
-    curl --remote-name https://downloads.mysql.com/archives/get/p/23/file/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \
-    mkdir -p /opt && \
-    tar -vx -C /opt -f mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \
-    ln -s /opt/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild/bin/* /usr/bin/
+RUN hail-apt-get-install mysql-client

--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -16,13 +16,13 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 {% if global.cloud == "gcp" %}
 RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     hail-apt-get-install curl gnupg && \
-    export GCSFUSE_REPO=gcsfuse-jammy && \
+    export GCSFUSE_REPO=gcsfuse-noble && \
     echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     hail-apt-get-install fuse gcsfuse=1.2.0
 
 RUN curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && \
-    curl -s -L https://nvidia.github.io/libnvidia-container/ubuntu22.04/libnvidia-container.list | \
+    curl -s -L https://nvidia.github.io/libnvidia-container/ubuntu24.04/libnvidia-container.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
     tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
@@ -35,7 +35,7 @@ RUN apt-get update && \
 
 # https://github.com/Azure/azure-storage-fuse/issues/603
 RUN hail-apt-get-install ca-certificates pkg-config libfuse-dev cmake libcurl4-gnutls-dev libgnutls28-dev uuid-dev libgcrypt20-dev && \
-    curl -LO https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb && \
+    curl -LO https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
     apt-get update && \
     hail-apt-get-install blobfuse2

--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -22,7 +22,7 @@ RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     hail-apt-get-install fuse gcsfuse=1.2.0
 
 RUN curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && \
-    curl -s -L https://nvidia.github.io/libnvidia-container/ubuntu24.04/libnvidia-container.list | \
+    curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
     tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 

--- a/batch/build-batch-worker-image-startup-gcp.sh
+++ b/batch/build-batch-worker-image-startup-gcp.sh
@@ -46,7 +46,7 @@ curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/release
 
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
      | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-curl -s -L https://nvidia.github.io/libnvidia-container/ubuntu22.04/libnvidia-container.list | \
+curl -s -L https://nvidia.github.io/libnvidia-container/ubuntu24.04/libnvidia-container.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
     tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 

--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -24,7 +24,7 @@ else
     BUILDER=build-batch-worker-$NAMESPACE-image
 fi
 
-UBUNTU_IMAGE=ubuntu-minimal-2204-jammy-v20250311
+UBUNTU_IMAGE=ubuntu-minimal-2404-noble-amd64-v20250606
 
 create_build_image_instance() {
     echo "Deleting any preexisting $BUILDER instance. This is expected to print an ERROR if the image does not exist."

--- a/batch/terra-chart/Dockerfile.batch
+++ b/batch/terra-chart/Dockerfile.batch
@@ -1,12 +1,7 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-# https://bugs.mysql.com/bug.php?id=105288&thanks=sub
-RUN hail-apt-get-install xz-utils libncurses5 && \
-    curl --remote-name https://downloads.mysql.com/archives/get/p/23/file/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \
-    mkdir -p /opt && \
-    tar -vx -C /opt -f mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \
-    ln -s /opt/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild/bin/* /usr/bin/
+RUN hail-apt-get-install mysql-client
 
 COPY batch/sql /batch/sql/
 COPY build.yaml /

--- a/batch/terra-chart/templates/config.yaml
+++ b/batch/terra-chart/templates/config.yaml
@@ -6,7 +6,7 @@ data:
   cloud: "azure"
   default_namespace: "default"
   docker_prefix: "terradevacrpublic.azurecr.io/hail/batch"
-  docker_root_image: "ubuntu:22.04"
+  docker_root_image: "ubuntu:24.04"
   batch_logs_storage_uri: "{{ .Values.persistence.workspaceManager.storageContainerUrl }}/{{ .Values.persistence.leoAppName }}/hailbatch/logs"
   query_storage_uri: "{{ .Values.persistence.workspaceManager.storageContainerUrl }}/{{ .Values.persistence.leoAppName }}/hailbatch/query"
   internal_ip: "dummy"

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -6,7 +6,7 @@ import hailtop.batch_client.aioclient as aiobc
 import hailtop.batch_client.client as bc
 from hailtop import __pip_version__
 
-DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:22.04')
+DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:24.04')
 HAIL_GENETICS_HAIL_IMAGE = os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{__pip_version__}')
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -2652,7 +2652,7 @@ steps:
       inline: |
         ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
         FROM $BASE_IMAGE
-        RUN hail-apt-get-install netcat
+        RUN hail-apt-get-install netcat-openbsd
     dependsOn:
       - hail_ubuntu_image
   - kind: buildImage2

--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -1,12 +1,7 @@
 ARG BASE_IMAGE={{ base_image.image }}
 FROM $BASE_IMAGE AS base
 
-# https://bugs.mysql.com/bug.php?id=105288&thanks=sub
-RUN hail-apt-get-install xz-utils libncurses5 git google-cloud-cli kubectl && \
-    curl --remote-name https://downloads.mysql.com/archives/get/p/23/file/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \
-    mkdir -p /opt && \
-    tar -vx -C /opt -f mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild.tar.xz && \
-    ln -s /opt/mysql-8.0.26-linux-glibc2.17-x86_64-minimal-rebuild/bin/* /usr/bin/
+RUN hail-apt-get-install git google-cloud-cli kubectl mysql-client
 
 COPY hail/python/hailtop/pinned-requirements.txt hailtop-requirements.txt
 COPY gear/pinned-requirements.txt gear-requirements.txt

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,7 +6,6 @@ RUN hail-apt-get-install \
     htop \
     unzip bzip2 zip tar \
     rsync \
-    emacs-nox \
     xsltproc pandoc \
     openjdk-11-jdk-headless \
     liblapack3 \

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKER_PREFIX={{ global.docker_prefix }}
-FROM $DOCKER_PREFIX/ubuntu:jammy-20250404
+FROM $DOCKER_PREFIX/ubuntu:noble-20250529
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
@@ -21,9 +21,9 @@ RUN chmod 755 /bin/retry && \
     hail-apt-get-install curl apt-transport-https ca-certificates gnupg jq rsync && \
     curl 'https://keyserver.ubuntu.com/pks/lookup?search=0xF23C5A6CF475977595C89F51BA6932366A755776&hash=on&exact=on&options=mr&op=get' \
          | gpg --dearmor > /usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg && \
-    echo 'deb [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main' \
+    echo 'deb [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu noble main' \
          >> /etc/apt/sources.list && \
-    echo 'deb-src [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main' \
+    echo 'deb-src [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu noble main' \
          >> /etc/apt/sources.list && \
     curl 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' \
         | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -12,8 +12,10 @@ python:3.10
 python:3.10-slim
 redis:6.0.6-alpine
 ubuntu:18.04
-ubuntu:19.04
+ubuntu:20.04
 ubuntu:22.04
-ubuntu:bionic-20200921
-ubuntu:focal-20221019
-ubuntu:jammy-20250404
+ubuntu:24.04
+ubuntu:bionic-20230530
+ubuntu:focal-20250404
+ubuntu:jammy-20250530
+ubuntu:noble-20250529

--- a/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
+++ b/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
@@ -59,7 +59,7 @@ class BatchClientSuite extends TestNGSuite {
           JobRequest(
             always_run = false,
             process = BashJob(
-              image = "ubuntu:22.04",
+              image = "ubuntu:24.04",
               command = Array("/bin/bash", "-c", "sleep 5m"),
             ),
             resources = Some(JobResources(preemptible = true)),
@@ -67,7 +67,7 @@ class BatchClientSuite extends TestNGSuite {
           JobRequest(
             always_run = false,
             process = BashJob(
-              image = "ubuntu:22.04",
+              image = "ubuntu:24.04",
               command = Array("/bin/bash", "-c", "exit 1"),
             ),
           ),
@@ -90,14 +90,14 @@ class BatchClientSuite extends TestNGSuite {
           JobRequest(
             always_run = false,
             process = BashJob(
-              image = "ubuntu:22.04",
+              image = "ubuntu:24.04",
               command = Array("/bin/bash", "-c", "exit 0"),
             ),
           ),
           JobRequest(
             always_run = false,
             process = BashJob(
-              image = "ubuntu:22.04",
+              image = "ubuntu:24.04",
               command = Array("/bin/bash", "-c", "exit 1"),
             ),
           ),
@@ -126,7 +126,7 @@ class BatchClientSuite extends TestNGSuite {
             JobRequest(
               always_run = false,
               process = BashJob(
-                image = "ubuntu:22.04",
+                image = "ubuntu:24.04",
                 command = Array("/bin/bash", "-c", s"echo 'job $k'"),
               ),
             )

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -717,7 +717,7 @@ class ServiceBackend(Backend[bc.Batch]):
         batch_remote_tmpdir = f'{self.remote_tmpdir}{uid}'
         local_tmpdir = f'/io/batch/{uid}'
 
-        default_image = 'ubuntu:22.04'
+        default_image = 'ubuntu:24.04'
 
         attributes = copy.deepcopy(batch.attributes)
         if batch.name is not None:

--- a/hail/python/hailtop/batch/docs/cookbook/clumping.rst
+++ b/hail/python/hailtop/batch/docs/cookbook/clumping.rst
@@ -210,7 +210,7 @@ Merge Clumping Results
 
 The third function concatenates all of the clumping results per chromosome into a single file
 with one header line. The inputs are the :class:`.Batch` for which to create a new :class:`.BashJob`
-and a list containing all of the individual clumping results files. We use the ``ubuntu:22.04``
+and a list containing all of the individual clumping results files. We use the ``ubuntu:24.04``
 Docker image for this job. The return value is the new :class:`.BashJob` created.
 
 .. code-block:: python
@@ -220,7 +220,7 @@ Docker image for this job. The return value is the new :class:`.BashJob` created
         Merge clumped results files together
         """
         merger = batch.new_job(name='merge-results')
-        merger.image('ubuntu:22.04')
+        merger.image('ubuntu:24.04')
         if results:
             merger.command(f'''
     head -n 1 {results[0]} > {merger.ofile}

--- a/hail/python/hailtop/batch/docs/cookbook/files/batch_clumping.py
+++ b/hail/python/hailtop/batch/docs/cookbook/files/batch_clumping.py
@@ -49,7 +49,7 @@ def merge(batch, results):
     Merge clumped results files together
     """
     merger = batch.new_job(name='merge-results')
-    merger.image('ubuntu:22.04')
+    merger.image('ubuntu:24.04')
     if results:
         merger.command(f"""
 head -n 1 {results[0]} > {merger.ofile}

--- a/hail/python/hailtop/batch/docs/docker_resources.rst
+++ b/hail/python/hailtop/batch/docs/docker_resources.rst
@@ -24,13 +24,13 @@ Creating a Dockerfile
 
 A Dockerfile contains the instructions for creating an image and is typically called `Dockerfile`.
 The first directive at the top of each Dockerfile is `FROM` which states what image to create this
-image on top of. For example, we can build off of `ubuntu:22.04` which contains a complete Ubuntu
+image on top of. For example, we can build off of `ubuntu:24.04` which contains a complete Ubuntu
 operating system, but does not have Python installed by default. You can use any image that already
 exists to base your image on. An image that has Python preinstalled is `python:3.6-slim-stretch` and
 one that has `gcloud` installed is `google/cloud-sdk:slim`. Be careful when choosing images from
 unknown sources!
 
-In the example below, we create a Dockerfile that is based on `ubuntu:22.04`. In this file, we show an
+In the example below, we create a Dockerfile that is based on `ubuntu:24.04`. In this file, we show an
 example of installing PLINK in the image with the `RUN` directive, which is an arbitrary bash command.
 First, we download a bunch of utilities that do not come with Ubuntu using `apt-get`. Next, we
 download and install PLINK from source. Finally, we can copy files from your local computer to the
@@ -39,7 +39,7 @@ docker image using the `COPY` directive.
 
 .. code-block:: text
 
-    FROM 'ubuntu:22.04'
+    FROM 'ubuntu:24.04'
 
     RUN apt-get update && apt-get install -y \
         python3 \

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -790,11 +790,11 @@ class BashJob(Job):
         Examples
         --------
 
-        Set the job's docker image to `ubuntu:22.04`:
+        Set the job's docker image to `ubuntu:24.04`:
 
         >>> b = Batch()
         >>> j = b.new_job()
-        >>> (j.image('ubuntu:22.04')
+        >>> (j.image('ubuntu:24.04')
         ...   .command(f'echo "hello"'))
         >>> b.run()  # doctest: +SKIP
 

--- a/hail/python/test/hailtop/batch/test_batch_local_backend.py
+++ b/hail/python/test/hailtop/batch/test_batch_local_backend.py
@@ -12,7 +12,7 @@ from hailtop.batch import Batch, LocalBackend, ResourceGroup
 from hailtop.batch.resource import JobResourceFile
 from hailtop.batch.utils import concatenate
 
-DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:22.04')
+DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:24.04')
 PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.9-slim'
 HAIL_GENETICS_HAIL_IMAGE = os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{__pip_version__}')
 REQUESTER_PAYS_PROJECT = os.environ.get('GCS_REQUESTER_PAYS_PROJECT')

--- a/hail/python/test/hailtop/batch/utils.py
+++ b/hail/python/test/hailtop/batch/utils.py
@@ -4,7 +4,7 @@ import os
 from hailtop import __pip_version__
 from hailtop.batch import Batch
 
-DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:22.04')
+DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'ubuntu:24.04')
 PYTHON_DILL_IMAGE = 'hailgenetics/python-dill:3.9-slim'
 HAIL_GENETICS_HAIL_IMAGE = os.environ.get('HAIL_GENETICS_HAIL_IMAGE', f'hailgenetics/hail:{__pip_version__}')
 REQUESTER_PAYS_PROJECT = os.environ.get('GCS_REQUESTER_PAYS_PROJECT')

--- a/infra/azure/modules/batch/main.tf
+++ b/infra/azure/modules/batch/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_shared_image" "batch_worker_22_04" {
   identifier {
     publisher = "Hail"
     offer     = "BatchWorker"
-    sku       = "Ubuntu-22.04-LTS"
+    sku       = "Ubuntu-24.04-LTS"
   }
 }
 

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -57,7 +57,7 @@ locals {
     "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}/hail" :
     "gcr.io/${var.gcp_project}"
   )
-  docker_root_image = "${local.docker_prefix}/ubuntu:22.04"
+  docker_root_image = "${local.docker_prefix}/ubuntu:24.04"
 }
 
 provider "google" {

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -40,12 +40,12 @@ infrastructure.
 - Go to the Google Cloud console, API & Services.
   - Configure the consent screen.
     - You can probably leave most fields on the first page empty. Give it a sensible name and management email.
-    - Add the scope: `../auth/userinfo.email`.  
+    - Add the scope: `../auth/userinfo.email`.
   - Back in Credentials, create an OAuth client ID of type `Web application`. Authorize the redirect URIs:
     - `https://auth.<domain>/oauth2callback`
     - `http://127.0.0.1/oauth2callback`
   - Download the client secret as `/tmp/auth_oauth2_client_secret.json`.
-  - Create another OAuth client ID of type `Desktop app` 
+  - Create another OAuth client ID of type `Desktop app`
     - Download it as `/tmp/hailctl_client_secret.json`.
 
 ## Set up Terraform configuration
@@ -228,9 +228,9 @@ rm -rf .terraform terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
 - Run `terraform apply -var-file=$GITHUB_ORGANIZATION/global.tfvars`.  At the
   time of writing, this takes ~15m.
 
-## Register the domain 
+## Register the domain
 
-   Register the predetermined `domain` with a DNS registry. 
+   Register the predetermined `domain` with a DNS registry.
 
    The IP address to use will be available in GCP cloud console under `Network Services -> Load balancing`.
    Click through to the external load balancer and find its IP address.
@@ -262,15 +262,15 @@ Using the Google cloud console, create a VM in Compute Engine:
   - Region / zone: use the same as the GKE cluster
   - n1-standard-8
   - OS and storage
-    - Ubuntu 22.04 LTS
+    - Ubuntu 24.04 LTS
     - 100GB PD-SSD
   - On the internal network
   - Security
-    - Allow full access to all Cloud APIs 
-    - Run as the Terraform service account 
+    - Allow full access to all Cloud APIs
+    - Run as the Terraform service account
 
-Note: 10GB will run out of space.  
-  
+Note: 10GB will run out of space.
+
 An example command to create a VM via the gcloud CLI is given below, but be careful to make sure the settings
 are correct for your deployment.
 
@@ -283,13 +283,13 @@ gcloud compute instances create bootstrap-vm \
     --provisioning-model=STANDARD \
     --service-account=<TERRAFORM-SERVICE-ACCOUNT> \
     --scopes=https://www.googleapis.com/auth/cloud-platform \
-    --create-disk=auto-delete=yes,boot=yes,device-name=instance-20240716-184710,image=projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20240701,mode=rw,size=200,type=projects/hail-vdc-dgoldste/zones/us-central1-a/diskTypes/pd-balanced
+    --create-disk=auto-delete=yes,boot=yes,device-name=instance-20240716-184710,image=projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-amd64-v20250606,mode=rw,size=200,type=projects/hail-vdc-dgoldste/zones/us-central1-a/diskTypes/pd-balanced
 ```
 
 #### Cloud VM commands
 
-We assume the rest of the commands are run on the VM. You will need to connect to this instance with ssh. 
-You can copy a `gcloud compute ssh` command to do this directly from the VM details page in the cloud console, 
+We assume the rest of the commands are run on the VM. You will need to connect to this instance with ssh.
+You can copy a `gcloud compute ssh` command to do this directly from the VM details page in the cloud console,
 or construct it manually via the gcloud CLI. It will look something like:
 
 ```
@@ -298,20 +298,20 @@ gcloud compute ssh --zone "us-central1-a" "<VM-NAME>" --project "<PROJECT>"
 
 ##### Prerequisites
 
-- If necessary, install `gke-gcloud-auth-plugin`: 
+- If necessary, install `gke-gcloud-auth-plugin`:
 
   ```
   # Check for necessity:
   gke-gcloud-auth-plugin --version
   ```
-  
-  - Follow the instructions [here](https://cloud.google.com/sdk/docs/install#deb) to install the Google Cloud SDK 
+
+  - Follow the instructions [here](https://cloud.google.com/sdk/docs/install#deb) to install the Google Cloud SDK
     package source.
   - Follow the `apt-get` instructions [here](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin)
     to install the `gke-gcloud-auth-plugin`.
 
 - Install the `docker-buildx-plugin`:
-  - Follow the instructions [here](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) to set 
+  - Follow the instructions [here](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) to set
     up the repository (ie step 1).
   - Install the `docker-buildx-plugin`:
     ```

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -55,7 +55,7 @@ locals {
     "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}/hail" :
     "gcr.io/${var.gcp_project}"
   )
-  docker_root_image = "${local.docker_prefix}/ubuntu:22.04"
+  docker_root_image = "${local.docker_prefix}/ubuntu:24.04"
 }
 
 data "sops_file" "terraform_sa_key_sops" {

--- a/infra/k8s/global_config/main.tf
+++ b/infra/k8s/global_config/main.tf
@@ -21,7 +21,7 @@ resource "kubernetes_secret" "global_config" {
     cloud                  = var.cloud
     default_namespace      = "default"
     docker_prefix          = var.docker_prefix
-    docker_root_image      = "${var.docker_prefix}/ubuntu:22.04"
+    docker_root_image      = "${var.docker_prefix}/ubuntu:24.04"
     domain                 = var.domain
     organization_domain    = var.organization_domain
     internal_ip            = var.internal_gateway_ip


### PR DESCRIPTION
In #14859 and #14918, I was getting segfaults in libsass, that went away when I upgraded to ubuntu 24.04. This change separates out the upgrade as there should be no issues running python3.9 on ubuntu 24.04 until we upgrade our default version of python.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a low security impact

### Impact Description
Core OS image upgrade.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
