### PR TITLE
[batch] Upgrade crun

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -66,7 +66,7 @@ FROM base AS crun_builder
 RUN hail-apt-get-install make git gcc build-essential pkgconf libtool \
    libsystemd-dev libcap-dev libseccomp-dev \
    go-md2man libtool autoconf automake
-RUN git clone --depth 1 --branch 1.4.4 https://github.com/containers/crun.git && \
+RUN git clone --depth 1 --branch 1.21 https://github.com/containers/crun.git && \
    cd crun && \
    ./autogen.sh && \
    ./configure && \


### PR DESCRIPTION
We have not updated crun since 2022.

## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a low security impact

### Impact Description
Dependency upgrade.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
