### PR TITLE
[query] Pin VEP base image os version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -586,7 +586,6 @@ steps:
         to: /io/repo
     dependsOn:
       - merge_code
-      - hail_ubuntu_image
   - kind: buildImage2
     name: hailgenetics_vep_grch38_95_image
     dockerFile: /io/repo/docker/hailgenetics/vep/grch38/95/Dockerfile
@@ -597,7 +596,6 @@ steps:
         to: /io/repo
     dependsOn:
       - merge_code
-      - hail_ubuntu_image
   - kind: buildImage2
     name: monitoring_image
     dockerFile: /io/repo/monitoring/Dockerfile

--- a/docker/hailgenetics/vep/grch37/85/Dockerfile
+++ b/docker/hailgenetics/vep/grch37/85/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
-FROM $BASE_IMAGE
+ARG DOCKER_PREFIX={{ global.docker_prefix }}
+FROM $DOCKER_PREFIX/ubuntu:22.04
 
 ENV VEP_VERSION=85
 ENV VEP_DIR=/vep
@@ -10,21 +10,21 @@ RUN apt-get update && apt-get -y install \
     cpanminus \
     curl \
     git \
-    libmysqlclient-dev \
-    libpng-dev \
-    libssl-dev \
     locales \
     manpages \
     mysql-client \
     openssl \
     perl \
     perl-base \
-    samtools \
+    python3 \
     sqlite3 \
     tabix \
     unzip \
-    vim \
     wget \
+    libmysqlclient-dev \
+    libpng-dev \
+    libssl-dev \
+    zlib1g-dev \
     libarchive-extract-perl \
     libarchive-zip-perl \
     libbio-db-hts-perl \
@@ -48,5 +48,13 @@ RUN wget https://github.com/Ensembl/ensembl-tools/archive/release/${VEP_VERSION}
     chmod +x /vep/vep
 
 RUN git clone -b v1.0.2 https://github.com/konradjk/loftee.git
+
+RUN wget https://github.com/samtools/samtools/releases/download/1.22/samtools-1.22.tar.bz2 && \
+    bzip2 -d samtools-1.22.tar.bz2 && \
+    tar -xf samtools-1.22.tar && \
+    cd samtools-1.22 && \
+    ./configure && \
+    make && \
+    make install
 
 COPY vep.py /hail-vep/

--- a/docker/hailgenetics/vep/grch37/85/Dockerfile
+++ b/docker/hailgenetics/vep/grch37/85/Dockerfile
@@ -5,13 +5,11 @@ ENV VEP_VERSION=85
 ENV VEP_DIR=/vep
 
 RUN apt-get update && apt-get -y install \
-    apache2 \
     build-essential \
     cpanminus \
     curl \
     git \
     locales \
-    manpages \
     mysql-client \
     openssl \
     perl \
@@ -21,8 +19,14 @@ RUN apt-get update && apt-get -y install \
     tabix \
     unzip \
     wget \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    liblzma-dev \
     libmysqlclient-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
     libpng-dev \
+    libsqlite3-dev \
     libssl-dev \
     zlib1g-dev \
     libarchive-extract-perl \

--- a/docker/hailgenetics/vep/grch38/95/Dockerfile
+++ b/docker/hailgenetics/vep/grch38/95/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get -y install \
     unzip \
     wget \
     libbz2-dev \
+    libcurl4-openssl-dev \
     liblzma-dev \
     libmysqlclient-dev \
     libncurses5-dev \

--- a/docker/hailgenetics/vep/grch38/95/Dockerfile
+++ b/docker/hailgenetics/vep/grch38/95/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
-FROM $BASE_IMAGE
+ARG DOCKER_PREFIX={{ global.docker_prefix }}
+FROM $DOCKER_PREFIX/ubuntu:22.04
 
 ENV VEP_VERSION=95
 ENV VEP_DIR=/vep
@@ -9,6 +9,16 @@ RUN apt-get update && apt-get -y install \
     cpanminus \
     curl \
     git \
+    locales \
+    mysql-client \
+    openssl \
+    perl \
+    perl-base \
+    python3 \
+    sqlite3 \
+    tabix \
+    unzip \
+    wget \
     libbz2-dev \
     liblzma-dev \
     libmysqlclient-dev \
@@ -17,16 +27,7 @@ RUN apt-get update && apt-get -y install \
     libpng-dev \
     libsqlite3-dev \
     libssl-dev \
-    locales \
-    mysql-client \
-    openssl \
-    perl \
-    perl-base \
-    sqlite3 \
-    tabix \
-    unzip \
-    vim \
-    wget \
+    zlib1g-dev \
     libarchive-zip-perl \
     libdbd-mysql-perl \
     libdbd-sqlite3-perl \
@@ -71,11 +72,10 @@ RUN export KENT_SRC=$PWD/kent-335_base/src && \
     export PERL5LIB=\$PERL5LIB:$HOME/cpanm/lib/perl5 && \
     cpanm Bio::DB::BigFile
 
-RUN apt-get update && apt-get -y install zlib1g-dev && \
-    wget https://github.com/samtools/samtools/releases/download/1.18/samtools-1.18.tar.bz2 && \
-    bzip2 -d samtools-1.18.tar.bz2 && \
-    tar -xf samtools-1.18.tar && \
-    cd samtools-1.18 && \
+RUN wget https://github.com/samtools/samtools/releases/download/1.22/samtools-1.22.tar.bz2 && \
+    bzip2 -d samtools-1.22.tar.bz2 && \
+    tar -xf samtools-1.22.tar && \
+    cd samtools-1.22 && \
     ./configure && \
     make && \
     make install


### PR DESCRIPTION
We'd like vep results to remain consistent. I've noticed in #14927 when upgrading hail-ubuntu to 24.04, some results changed, and I'm not sure why. I'd like to upgrade our images to the newer version. So, I've pinned our VEP containers to be based on ubuntu:22.04.

Also here is some minor reorganization to how we group dependencies, a harmonization of samtools installation across both the 85 and 95 images, and an upgrade to the latest version of samtools.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP