### PR TITLE
[release] script-ify change log generation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -32,26 +32,10 @@ jobs:
           echo "next=${prefix}.$((n + 1))" >> "${GITHUB_OUTPUT}"
 
       - name: Generate Changelog Entries
+        working-directory: hail
         run: |
           git fetch --unshallow --filter=tree:0 --no-tags origin tag ${{ steps.version.outputs.old }}
-          
-          git log ${{ steps.version.outputs.old }}.. --format='%s' |\
-            grep -P '\[all|(com(biner|piler)|dep(s|endencies)|hail(?!ctl|genetics|jwt|top)|ir|jvm|p(ip|ython)|q(uery|ob)|vds)[^\]]*\]' |\
-            sed -E 's/\[[^\]+\] (.*) \(#([[:digit:]]*)\)/- (hail#\2) \1/' |\
-            sed 1i"## Version ${{ steps.version.outputs.new }}\n" |\
-            sed -e '$a\'$'\n' > HAIL_ENTRY
-          
-          sed -i '/## Version '"${{ steps.version.outputs.old }}"'/e cat HAIL_ENTRY' \
-            hail/python/hail/docs/change_log.md
-          
-          git log ${{ steps.version.outputs.old }}.. --format='%s' |\
-            grep -P '\[(a(ll|uth)|batch|dataproc|fs|hail(ctl|genetics|top)|infra|services)[^\]]*\]' |\
-            sed -E 's$\[[^\]+\] (.*) \(#([[:digit:]]*)\)$- (\`#\2 <https://github.com/hail-is/hail/pull/\2>\`__) \1$' |\
-            sed 1i"**Version ${{ steps.version.outputs.new }}**\n" |\
-            sed -e '$a\'$'\n' > HAILTOP_ENTRY
-          
-          sed -i -e '/Change Log/{N; N; r HAILTOP_ENTRY' -e '}' \
-            hail/python/hailtop/batch/docs/change_log.rst
+          bash scripts/update-changelog
 
       # identity from https://api.github.com/users/github-actions%5Bbot%5D
       - name: Commit and Push

--- a/hail/scripts/update-changelog
+++ b/hail/scripts/update-changelog
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+usage() {
+cat << EOF
+Update hail and hailtop changelogs with new entries,
+populated from commit messages since the last release tag.
+
+usage: $(basename "${0}")
+EOF
+}
+
+last-tag() {
+  git describe --tags $(git rev-list --tags --max-count=1)
+}
+
+inc() {
+  IFS='.' read -r major minor patch <<< "$1"
+  echo "$major.$minor.$((patch + 1))"
+}
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed-inplace() { sed -i '' "$@"; }
+else
+  sed-inplace() { sed -i "$@"; }
+fi
+
+write-hailtop-entries() {
+  entries=$(mktemp)
+
+  git log ${1}.. --format='%s' |\
+    grep -P '\[[^\]]*(a(ll|uth)|batch|dataproc|fs|hail(ctl|genetics|top)|infra|services)[^\]]*\]' |\
+    sed -E 's|\[[^\]+\] (.*) \(#([[:digit:]]*)\)|- (\`#\2 <https://github.com/hail-is/hail/pull/\2>\`__) \1|' \
+    > ${entries}
+
+  sed-inplace -f - -- python/hailtop/batch/docs/change_log.rst <<< "
+    /Change Log/ {
+      N
+      N
+      a\
+      **Version ${2}**\\n
+      r ${entries}
+      a\
+
+    }
+  "
+
+  rm ${entries}
+}
+
+write-hail-entries() {
+  entries=$(mktemp)
+
+  git log ${1}.. --format='%s' |\
+    grep -P '\[[^\]]*(all|com(biner|piler)|dep(s|endencies)|hail(?!ctl|genetics|jwt|top)|ir|jvm|p(ip|ython)|q(uery|ob)|vds)[^\]]*\]' |\
+    sed -E 's/\[[^\]+\] (.*) \(#([[:digit:]]*)\)/- (hail#\2) \1/' \
+    > ${entries}
+
+  sed-inplace -f - -- python/hail/docs/change_log.md <<< "
+    /## Version "${1}"/ {
+      i\
+      ## Version ${2} \\n
+      i\
+      Released $(date --iso-8601) \\n
+      r ${entries}
+      N
+      i\
+
+      }
+  "
+
+  rm ${entries}
+}
+
+main() {
+  prev=$(last-tag)
+  next=$(inc $prev)
+  write-hailtop-entries $prev $next
+  write-hail-entries $prev $next
+}
+
+main


### PR DESCRIPTION
Moves the shell commands that update the hail and batch changelogs into
callable scripts and updates them to work with bsd sed.

This change has no security impact and does not impact the hail batch
service managed by Broad Institute in GCP. 
