### PR TITLE
[docs] Direct users to build with optimisation for cluster install

### DIFF
--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -36,7 +36,7 @@ The next block of commands downloads, builds, and installs Hail from source.
 
     git clone https://github.com/hail-is/hail.git
     cd hail/hail
-    make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.12.18 SPARK_VERSION=3.5.0
+    make install-on-cluster HAIL_RELEASE_MODE=1 HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.12.18 SPARK_VERSION=3.5.0
 
 If you forget to install any of the requirements before running `make install-on-cluster`, it's possible
 to get into a bad state where `make` insists you don't have a requirement that you have in fact installed.


### PR DESCRIPTION
Builds without `HAIL_RELEASE_MODE=1` set will result in a debug
wheel with 10x performance degredations.

This change has no security impact.
