### PR TITLE
[benchmark] fix `start_hail_benchmark` step failing from missing `env` mount

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3742,6 +3742,8 @@ steps:
     inputs:
       - from: /repo/hail/python
         to: /io/repo/hail/python
+      - from: /repo/hail/env
+        to: /io/repo/hail/env
       - from: /repo/hail/scripts/benchmark_in_batch.py
         to: /io/repo/hail/scripts/benchmark_in_batch.py
       - from: /release-hail-flag


### PR DESCRIPTION
This change has no security impact.