### PR TITLE
[hailtop] Fix tmpdir bug

### DIFF
--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -283,12 +283,12 @@ def test_input_dependency(client, remote_tmpdir):
     head = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'echo head1 > /io/data1; echo head2 > /io/data2'],
-        output_files=[('/io/data1', f'{remote_tmpdir}data1'), ('/io/data2', f'{remote_tmpdir}data2')],
+        output_files=[('/io/data1', f'{remote_tmpdir}/data1'), ('/io/data2', f'{remote_tmpdir}/data2')],
     )
     tail = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'cat /io/data1; cat /io/data2'],
-        input_files=[(f'{remote_tmpdir}data1', '/io/data1'), (f'{remote_tmpdir}data2', '/io/data2')],
+        input_files=[(f'{remote_tmpdir}/data1', '/io/data1'), (f'{remote_tmpdir}/data2', '/io/data2')],
         parents=[head],
     )
     batch.submit()
@@ -304,12 +304,12 @@ def test_input_dependency_wildcard(client, remote_tmpdir):
     head = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'echo head1 > /io/data1 ; echo head2 > /io/data2'],
-        output_files=[('/io/data1', f'{remote_tmpdir}data1'), ('/io/data2', f'{remote_tmpdir}data2')],
+        output_files=[('/io/data1', f'{remote_tmpdir}/data1'), ('/io/data2', f'{remote_tmpdir}/data2')],
     )
     tail = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'cat /io/data1 ; cat /io/data2'],
-        input_files=[(f'{remote_tmpdir}data1', '/io/data1'), (f'{remote_tmpdir}data2', '/io/data2')],
+        input_files=[(f'{remote_tmpdir}/data1', '/io/data1'), (f'{remote_tmpdir}/data2', '/io/data2')],
         parents=[head],
     )
     batch.submit()
@@ -325,12 +325,12 @@ def test_input_dependency_directory(client, remote_tmpdir):
     head = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'mkdir -p /io/test/; echo head1 > /io/test/data1 ; echo head2 > /io/test/data2'],
-        output_files=[('/io/test', f'{remote_tmpdir}test')],
+        output_files=[('/io/test', f'{remote_tmpdir}/test')],
     )
     tail = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'cat /io/test/data1; cat /io/test/data2'],
-        input_files=[(f'{remote_tmpdir}test', '/io/test')],
+        input_files=[(f'{remote_tmpdir}/test', '/io/test')],
         parents=[head],
     )
     batch.submit()

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -714,7 +714,7 @@ class ServiceBackend(Backend[bc.Batch]):
         build_dag_start = time.time()
 
         uid = uuid.uuid4().hex[:6]
-        batch_remote_tmpdir = f'{self.remote_tmpdir}{uid}'
+        batch_remote_tmpdir = f'{self.remote_tmpdir}/{uid}'
         local_tmpdir = f'/io/batch/{uid}'
 
         default_image = 'ubuntu:24.04'

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -120,7 +120,7 @@ class BatchPoolExecutor:
         if not isinstance(self.backend, ServiceBackend):
             raise ValueError(f'BatchPoolExecutor is not compatible with {type(backend)}')
         self.batches: List[Batch] = []
-        self.directory = self.backend.remote_tmpdir + f'batch-pool-executor/{self.name}/'
+        self.directory = f'{self.backend.remote_tmpdir}/batch-pool-executor/{self.name}/'
         self.inputs = self.directory + 'inputs/'
         self.outputs = self.directory + 'outputs/'
         self.__fs: Optional[RouterAsyncFS]
@@ -368,12 +368,12 @@ class BatchPoolExecutor:
 import base64
 import dill
 import traceback
-with open(\\"{j.ofile}\\", \\"wb\\") as out:
+with open(\"{j.ofile}\", \"wb\") as out:
     try:
-        with open(\\"{pickledfun_local}\\", \\"rb\\") as f:
+        with open(\"{pickledfun_local}\", \"rb\") as f:
             dill.dump((dill.load(f)(), None), out, recurse=True)
     except Exception as e:
-        print(\\"BatchPoolExecutor encountered an exception:\\")
+        print(\"BatchPoolExecutor encountered an exception:\")
         traceback.print_exc()
         dill.dump((e, traceback.format_exception(type(e), e, e.__traceback__)), out, recurse=True)
 "''')


### PR DESCRIPTION
## Change Description

Fixes #14936 

Following [this](https://github.com/hail-is/hail/pull/14684/files#diff-00fcab89dad87f243267f011f6f2d0edf55b3abb9f0ec77cdcb8d9271627a658L147-L149) change to remove the trailing '/' from the tmpdir generator, we now need to add it back in when using the generated tmpdirs.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a low security impact

### Impact Description

Bug fix in the client library to address incorrect formatting of tmpdir paths.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
