### PR TITLE
[QoB] don't make assumptions about failed job groups

### DIFF
--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -322,11 +322,12 @@ class ServiceBackend(
             jobGroup.job_group_id,
             Some(JobStates.Failed),
           )
-          assert(
-            failedEntries.nonEmpty,
-            s"Job group ${jobGroup.job_group_id} for batch ${batchConfig.batchId} failed, but no failed jobs found.",
-          )
-          val error = readPartitionError(root, failedEntries.head.head.job_id - startJobId)
+          val error = if (failedEntries.isEmpty)
+            new HailException(
+              s"Job group ${jobGroup.job_group_id} for batch ${batchConfig.batchId} failed, but no failed jobs found. The billing project may be low on funds."
+            )
+          else
+            readPartitionError(root, failedEntries.head.head.job_id - startJobId)
 
           (Some(error), streamSuccessfulJobResults.toIndexedSeq)
         case Cancelled =>


### PR DESCRIPTION
## Change Description

A user [reported](https://hail.zulipchat.com/#narrow/channel/123010-Hail-Query-0.2E2-support/topic/OutOfMemoryError.3A.20Java.20heap.20space.20in.20Query-on-Batch/near/526616315) hitting an assertion that a failed job group must contain at least one failed job. It appears that the billing project was low on funds, so the contained jobs were cancelled.

This fixes the QoB code to not assume that a failed job group contains a failed job, instead propagating a generic exception suggesting that they should check the total spend on their billing project.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP