### PR TITLE
[batch] remove hailgenetics/genetics mirroring

### DIFF
--- a/hail/python/hailtop/batch/hail_genetics_images.py
+++ b/hail/python/hailtop/batch/hail_genetics_images.py
@@ -4,7 +4,7 @@ from hailtop import __pip_version__
 
 HAIL_GENETICS = 'hailgenetics/'
 HAIL_GENETICS_IMAGES = [
-    HAIL_GENETICS + name for name in ('hail', 'hailtop', 'genetics', 'python-dill', 'vep-grch37-85', 'vep-grch38-95')
+    HAIL_GENETICS + name for name in ('hail', 'hailtop', 'python-dill', 'vep-grch37-85', 'vep-grch38-95')
 ]
 
 


### PR DESCRIPTION
Removes support for mirroring `hailgenetics/genetics` images  
on batch workers. These have been deprecated for some time now,  
but are still available on dockehub should users require them.

This does not impact the Broad-managed hail batch service in GCP.