### PR TITLE
[ci] Remove deleted python_3_11 image references

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3358,7 +3358,6 @@ steps:
       GITHUB_OAUTH_HEADER_FILE=/io/github-oauth \
       HAIL_GENETICS_HAIL_IMAGE=docker://{{ hailgenetics_hail_image.image }} \
       HAIL_GENETICS_HAIL_IMAGE_PY_3_10=docker://{{ hailgenetics_hail_image_python_3_10.image }} \
-      HAIL_GENETICS_HAIL_IMAGE_PY_3_11=docker://{{ hailgenetics_hail_image_python_3_11.image }} \
       HAIL_GENETICS_HAILTOP_IMAGE=docker://{{ hailgenetics_hailtop_image.image }} \
       HAIL_GENETICS_VEP_GRCH37_85_IMAGE=docker://{{ hailgenetics_vep_grch37_85_image.image }} \
       HAIL_GENETICS_VEP_GRCH38_95_IMAGE=docker://{{ hailgenetics_vep_grch38_95_image.image }} \
@@ -3405,7 +3404,6 @@ steps:
       - merge_code
       - hailgenetics_hail_image
       - hailgenetics_hail_image_python_3_10
-      - hailgenetics_hail_image_python_3_11
       - hailgenetics_hailtop_image
       - hailgenetics_vep_grch37_85_image
       - hailgenetics_vep_grch38_95_image


### PR DESCRIPTION
## Security Assessment

Delete all except the correct answer:
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP