### PR TITLE
[worker] log fs availability for copies

### DIFF
--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -2,8 +2,8 @@ import argparse
 import asyncio
 import json
 import logging
-import sys
 import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from typing import AsyncContextManager, Dict, List, Optional, Tuple
 


### PR DESCRIPTION
## Change Description

Adds some logging before we begin the input copying process. This will hopefully help debug issues with running out of storage during input copying.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Low impact, just adding some more logging before file copying begins. The worst thing that will happen is we will log file names being copied, but those are already available elsewhere in the job metadata.

Note: Codacy is unhappy with using subprocess, but:
- This happens within the user sandbox, not mainline server code
- The subprocess is a hard-coded command, no possible vector for command injection

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
