### PR TITLE
[services] Add user agent and auth-level metadata to API logs

### DIFF
--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -59,6 +59,9 @@ class Authenticator(abc.ABC):
         def wrap(fun: AuthenticatedAIOHTTPHandler):
             @wraps(fun)
             async def wrapped(request: web.Request) -> web.StreamResponse:
+                if 'api_info' not in request:
+                    request['api_info'] = {}
+                request['api_info']['authenticated_users_only'] = True
                 userdata = await self._fetch_userdata(request)
                 if not userdata:
                     # Only web routes should redirect by default
@@ -91,6 +94,9 @@ class Authenticator(abc.ABC):
             @self.authenticated_users_only(redirect)
             @wraps(fun)
             async def wrapped(request: web.Request, userdata: UserData, *args, **kwargs):
+                if 'api_info' not in request:
+                    request['api_info'] = {}
+                request['api_info']['developers_only'] = True
                 if userdata['is_developer'] == 1:
                     return await fun(request, userdata, *args, **kwargs)
                 raise web.HTTPUnauthorized()

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -61,11 +61,23 @@ class AccessLogger(AbstractAccessLogger):
             'request_duration': time,
             'response_status': response.status,
             'x_real_ip': request.headers.get("X-Real-IP"),
+            'user_agent': request.headers.get("User-Agent"),
         }
 
         userdata_maybe = request.get('userdata', {})
         userdata_keys = ['username', 'login_id', 'is_developer', 'hail_identity']
         extra.update({k: userdata_maybe[k] for k in userdata_keys if k in userdata_maybe})
+
+        api_info_maybe = request.get('api_info', {})
+        api_info_keys_and_defaults = {
+            'authenticated_users_only': False,
+            'developers_only': False,
+        }
+        for k, default in api_info_keys_and_defaults.items():
+            if k in api_info_maybe:
+                extra[k] = api_info_maybe[k]
+            else:
+                extra[k] = default
 
         self.logger.info(
             f'{request.scheme} {request.method} {request.path} done in {time}s: {response.status}',


### PR DESCRIPTION
## Change Description

Adds to our API call logs:
- The user_agent
- Whether the API call required authentication or developer privilege 

#### Examples

From a sample payloadJson, after calling a non-developer page:
```json
{
  "authenticated_users_only": true,
  "developers_only": false,
  "is_developer": 1,
  "message": "https GET /chrisl/batch/batches done in 0.24499999999989086s: 200",
  "response_status": 200,
  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X ...) AppleWebKit/... (KHTML, like Gecko) Chrome/... Safari/..."
}
```

And from a developer-only page:
```json
{
  "authenticated_users_only": true,
  "developers_only": true,
  "is_developer": 1,
  "message": "https GET /chrisl/batch/batches done in 0.07899999999995089s: 200",
  "response_status": 200,
  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X ...) AppleWebKit/... (KHTML, like Gecko) Chrome/... Safari/..."
}
```


## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a low security impact

### Impact Description

Logs only, no functional changes

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
