### PR TITLE
[github] run release action if repo is hail-is/hail

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -6,6 +6,7 @@ on:
     - cron: 0 0 1 */2 *
 jobs:
   create-release-pr:
+    if: github.repository == 'hail-is/hail'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This change has no security impact.
Fixes #14940