### PR TITLE
[query] remove `branchingFactor` from `HailContext`

### DIFF
--- a/hail/hail/src/is/hail/HailContext.scala
+++ b/hail/hail/src/is/hail/HailContext.scala
@@ -92,19 +92,13 @@ object HailContext {
     }
   }
 
-  def getOrCreate(backend: Backend, branchingFactor: Int = 50): HailContext = {
-    if (theContext == null)
-      return HailContext(backend, branchingFactor)
+  def getOrCreate(backend: Backend): HailContext =
+    synchronized {
+      if (isInitialized) theContext
+      else HailContext(backend)
+    }
 
-    if (theContext.branchingFactor != branchingFactor)
-      warn(
-        s"Requested branchingFactor $branchingFactor, but already initialized to ${theContext.branchingFactor}.  Ignoring requested setting."
-      )
-
-    theContext
-  }
-
-  def apply(backend: Backend, branchingFactor: Int = 50): HailContext = synchronized {
+  def apply(backend: Backend): HailContext = synchronized {
     require(theContext == null)
     checkJavaVersion()
 
@@ -122,7 +116,7 @@ object HailContext {
       )
     }
 
-    theContext = new HailContext(backend, branchingFactor)
+    theContext = new HailContext(backend)
 
     info(s"Running Hail version ${theContext.version}")
 
@@ -164,8 +158,7 @@ object HailContext {
 }
 
 class HailContext private (
-  var backend: Backend,
-  val branchingFactor: Int,
+  var backend: Backend
 ) {
   def stop(): Unit = HailContext.stop()
 

--- a/hail/hail/src/is/hail/HailFeatureFlags.scala
+++ b/hail/hail/src/is/hail/HailFeatureFlags.scala
@@ -2,7 +2,7 @@ package is.hail
 
 import is.hail.backend.ExecutionCache
 import is.hail.backend.spark.SparkBackend
-import is.hail.expr.ir.Optimize
+import is.hail.expr.ir.{agg, Optimize}
 import is.hail.io.fs.RequesterPaysConfig
 import is.hail.types.encoded.EType
 import is.hail.utils._
@@ -37,6 +37,7 @@ object HailFeatureFlags {
     ("use_new_shuffle", ("HAIL_USE_NEW_SHUFFLE" -> null)),
     ("use_ssa_logs", "HAIL_USE_SSA_LOGS" -> "1"),
     ("write_ir_files", ("HAIL_WRITE_IR_FILES" -> null)),
+    (agg.Flags.BranchingFactor, "HAIL_BRANCHING_FACTOR" -> null),
     (EType.Flags.UseUnstableEncodings, EType.Flags.UseUnstableEncodingsVar -> null),
     (ExecutionCache.Flags.Cachedir, "HAIL_CACHE_DIR" -> null),
     (ExecutionCache.Flags.UseFastRestarts, "HAIL_USE_FAST_RESTARTS" -> null),

--- a/hail/hail/src/is/hail/expr/ir/agg/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/package.scala
@@ -1,0 +1,39 @@
+package is.hail.expr.ir
+
+import is.hail.backend.ExecuteContext
+import is.hail.utils.HailException
+
+package agg {
+  object Flags {
+    val BranchingFactor = "branching_factor"
+  }
+}
+
+package object agg {
+  private[this] val DefaultBranchingFactor: Int = 50
+
+  implicit class AggExecuteContextExtensions(private val ctx: ExecuteContext) extends AnyVal {
+    def branchingFactor: Int =
+      ctx.flags
+        .lookup(Flags.BranchingFactor)
+        .map { s =>
+          val factor =
+            try s.toInt
+            catch {
+              case _: NumberFormatException =>
+                throw new HailException(
+                  f"'${Flags.BranchingFactor}' must be a positive integer, got '$s'."
+                )
+            }
+
+          if (factor < 0)
+            throw new HailException(
+              f"'${Flags.BranchingFactor}' must be greater than 0, got '$factor'."
+            )
+
+          factor
+        }
+        .getOrElse(DefaultBranchingFactor)
+  }
+
+}

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1,8 +1,8 @@
 package is.hail.expr.ir.lowering
 
-import is.hail.HailContext
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{agg, TableNativeWriter, _}
+import is.hail.expr.ir.agg.AggExecuteContextExtensions
 import is.hail.expr.ir.analyses.PartitionCounts
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.defs.ArrayZipBehavior.AssertSameLength
@@ -825,7 +825,7 @@ object LowerTableIR {
 
         val initFromSerializedStates = aggSigs.initFromSerializedValueOp(initStateRef)
 
-        val branchFactor = HailContext.get.branchingFactor
+        val branchFactor = ctx.branchingFactor
         val useTreeAggregate = aggSigs.shouldTreeAggregate && branchFactor < lc.numPartitions
         val isCommutative = aggSigs.isCommutative
         log.info(s"Aggregate: useTreeAggregate=$useTreeAggregate")
@@ -1625,7 +1625,7 @@ object LowerTableIR {
           )
 
           val initFromSerializedStates = aggSigs.initFromSerializedValueOp(initStateRef)
-          val branchFactor = HailContext.get.branchingFactor
+          val branchFactor = ctx.branchingFactor
           val big = aggSigs.shouldTreeAggregate && branchFactor < lc.numPartitions
           val (partitionPrefixSumValues, transformPrefixSum): (IR, IR => IR) = if (big) {
             val tmpDir = ctx.createTmpPath("aggregate_intermediates/")

--- a/hail/hail/src/is/hail/rvd/RVD.scala
+++ b/hail/hail/src/is/hail/rvd/RVD.scala
@@ -5,8 +5,9 @@ import is.hail.annotations._
 import is.hail.asm4s.{theHailClassLoaderForSparkWorkers, HailClassLoader}
 import is.hail.backend.{ExecuteContext, HailStateManager, HailTaskContext}
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
-import is.hail.expr.ir.InferPType
+import is.hail.expr.ir.{agg, InferPType}
 import is.hail.expr.ir.PruneDeadFields.isSupertype
+import is.hail.expr.ir.agg.AggExecuteContextExtensions
 import is.hail.io._
 import is.hail.io.index.IndexWriter
 import is.hail.sparkextras._
@@ -722,7 +723,7 @@ class RVD(
     }
 
     if (tree) {
-      val depth = treeAggDepth(getNumPartitions, HailContext.get.branchingFactor)
+      val depth = treeAggDepth(getNumPartitions, execCtx.branchingFactor)
       val scale = math.max(
         math.ceil(math.pow(getNumPartitions, 1.0 / depth)).toInt,
         2,

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -170,6 +170,7 @@ class FromFASTAFilePayload(ActionPayload):
 class Backend(abc.ABC):
     # Must match knownFlags in HailFeatureFlags.scala
     _flags_env_vars_and_defaults: ClassVar[Dict[str, Tuple[str, Optional[str]]]] = {
+        "branching_factor": ("HAIL_BRANCHING_FACTOR", None),
         "cachedir": ("HAIL_CACHE_DIR", None),
         "distributed_scan_comb_op": ("HAIL_DEV_DISTRIBUTED_SCAN_COMB_OP", None),
         "gcs_requester_pays_buckets": ("HAIL_GCS_REQUESTER_PAYS_BUCKETS", None),

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 from contextlib import ExitStack
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from py4j.java_gateway import GatewayParameters, JavaGateway, launch_gateway
 
@@ -78,7 +78,7 @@ class LocalBackend(Py4JBackend):
             append,
             skip_logging_configuration,
         )
-        jhc = hail_package.HailContext.apply(jbackend, branching_factor)
+        jhc = hail_package.HailContext.apply(jbackend)
 
         super().__init__(self._gateway.jvm, jbackend, jhc, tmpdir, tmpdir)
         self.gcs_requester_pays_configuration = gcs_requester_pays_configuration
@@ -87,7 +87,12 @@ class LocalBackend(Py4JBackend):
         )
 
         self._logger = None
-        self._initialize_flags({})
+
+        flags: Dict[str, str] = {}
+        if branching_factor is not None:
+            flags['branching_factor'] = str(branching_factor)
+
+        self._initialize_flags(flags)
 
     def validate_file(self, uri: str) -> None:
         async_to_blocking(validate_file(uri, self._fs.afs))

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -117,6 +117,7 @@ class ServiceBackend(Backend):
         regions: Optional[List[str]] = None,
         gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
         gcs_bucket_allow_list: Optional[List[str]] = None,
+        branching_factor: Optional[int] = None,
     ):
         async_exit_stack = AsyncExitStack()
         billing_project = configuration_of(ConfigVariable.BATCH_BILLING_PROJECT, billing_project, None)
@@ -170,6 +171,9 @@ class ServiceBackend(Backend):
                 disable_progress_bar = len(disable_progress_bar_str) > 0
 
         flags = flags or {}
+        if branching_factor is not None:
+            flags['branching_factor'] = str(branching_factor)
+
         if 'gcs_requester_pays_project' in flags or 'gcs_requester_pays_buckets' in flags:
             raise ValueError(
                 'Specify neither gcs_requester_pays_project nor gcs_requester_'

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import orjson
 import pyspark
@@ -117,7 +117,7 @@ class SparkBackend(Py4JBackend):
                 skip_logging_configuration,
                 min_block_size,
             )
-            jhc = hail_package.HailContext.getOrCreate(jbackend, branching_factor)
+            jhc = hail_package.HailContext.getOrCreate(jbackend)
         else:
             jbackend = hail_package.backend.spark.SparkBackend.apply(
                 jsc,
@@ -130,7 +130,7 @@ class SparkBackend(Py4JBackend):
                 skip_logging_configuration,
                 min_block_size,
             )
-            jhc = hail_package.HailContext.apply(jbackend, branching_factor)
+            jhc = hail_package.HailContext.apply(jbackend)
 
         self._jsc = jbackend.sc()
         if sc:
@@ -152,7 +152,11 @@ class SparkBackend(Py4JBackend):
 
             jbackend.pyStartProgressBar()
 
-        self._initialize_flags({})
+        flags: Dict[str, str] = {}
+        if branching_factor is not None:
+            flags['branching_factor'] = str(branching_factor)
+
+        self._initialize_flags(flags)
 
         self._router_async_fs = RouterAsyncFS(
             gcs_kwargs={"gcs_requester_pays_configuration": gcs_requester_pays_config}

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -383,6 +383,7 @@ def init(
                 gcs_requester_pays_configuration=gcs_requester_pays_configuration,
                 regions=regions,
                 gcs_bucket_allow_list=gcs_bucket_allow_list,
+                branching_factor=branching_factor,
             )
         )
     if backend == 'spark':
@@ -518,6 +519,7 @@ def init_spark(
     gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
     regions=nullable(sequenceof(str)),
     gcs_bucket_allow_list=nullable(sequenceof(str)),
+    branching_factor=nullable(int),
 )
 async def init_batch(
     *,
@@ -540,6 +542,7 @@ async def init_batch(
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
     regions: Optional[List[str]] = None,
     gcs_bucket_allow_list: Optional[List[str]] = None,
+    branching_factor: Optional[int] = None,
 ):
     from hail.backend.service_backend import ServiceBackend
 
@@ -558,6 +561,7 @@ async def init_batch(
         regions=regions,
         gcs_requester_pays_configuration=gcs_requester_pays_configuration,
         gcs_bucket_allow_list=gcs_bucket_allow_list,
+        branching_factor=branching_factor,
     )
 
     log = _get_log(log)


### PR DESCRIPTION
## Change Description

Refactored the branching factor parameter to be controlled through feature flags instead of being passed directly to the HailContext constructor. This change:

1. Removes the branching factor parameter from HailContext constructor and methods
2. Adds a new feature flag "branching_factor" with a default value of 50
3. Creates a new `agg` package with utility functions to retrieve the branch factor from context
4. Modifies Python backends to pass branching factor through flags rather than constructor parameters

This approach provides a more consistent way to configure the branching factor through environment variables or programmatic flags, aligning with how other Hail parameters are managed.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP