### PR TITLE
[query] remove uses of `HailContext.backend` 

### DIFF
--- a/hail/hail/src/is/hail/backend/BackendUtils.scala
+++ b/hail/hail/src/is/hail/backend/BackendUtils.scala
@@ -52,7 +52,7 @@ class BackendUtils(
     val remainingPartitions =
       contexts.indices.filterNot(k => cachedResults.containsOrdered[Int](k, _ < _, _._2))
 
-    val backend = HailContext.backend
+    val backend = HailContext.get.backend
     val mod = getModule(modID)
     val t = System.nanoTime()
     val (failureOpt, successes) =

--- a/hail/hail/src/is/hail/backend/ExecuteContext.scala
+++ b/hail/hail/src/is/hail/backend/ExecuteContext.scala
@@ -138,7 +138,7 @@ class ExecuteContext(
 
   val stateManager = HailStateManager(references)
 
-  def fsBc: BroadcastValue[FS] = fs.broadcast
+  lazy val fsBc: BroadcastValue[FS] = backend.broadcast(fs)
 
   val memo: mutable.Map[Any, Any] = new mutable.HashMap[Any, Any]()
 

--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -138,7 +138,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable {
   ): Unit = {
     void {
       withExecuteContext() { ctx =>
-        val rm = linalg.RowMatrix.readBlockMatrix(ctx.fs, pathIn, partitionSize)
+        val rm = linalg.RowMatrix.readBlockMatrix(ctx, pathIn, partitionSize)
         entries match {
           case "full" =>
             rm.export(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
@@ -225,7 +225,8 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable {
   def pyToDF(s: String): DataFrame =
     withExecuteContext(selfContainedExecution = false) { ctx =>
       val tir = IRParser.parse_table_ir(ctx, s)
-      Interpret(tir, ctx).toDF()
+      val tv = Interpret(tir, ctx)
+      tv.toDF(ctx)
     }._1
 
   def pyReadMultipleMatrixTables(jsonQuery: String): util.List[MatrixIR] =

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -83,7 +83,11 @@ object SparkBackend {
 
   private var theSparkBackend: SparkBackend = _
 
-  def sparkContext(implicit E: Enclosing): SparkContext = HailContext.sparkBackend.sc
+  def sparkContext(implicit E: Enclosing): SparkContext =
+    synchronized {
+      if (theSparkBackend == null) throw new IllegalStateException(E.value)
+      else theSparkBackend.sc
+    }
 
   def checkSparkCompatibility(jarVersion: String, sparkVersion: String): Unit = {
     def majorMinor(version: String): String = version.split("\\.", 3).take(2).mkString(".")

--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
@@ -31,12 +31,14 @@ object BlockMatrixIR {
   }
 
   def toBlockMatrix(
+    ctx: ExecuteContext,
     nRows: Int,
     nCols: Int,
     data: Array[Double],
     blockSize: Int = BlockMatrix.defaultBlockSize,
   ): BlockMatrix =
     BlockMatrix.fromBreezeMatrix(
+      ctx,
       new DenseMatrix[Double](nRows, nCols, data, 0, nCols, isTranspose = true),
       blockSize,
     )
@@ -164,7 +166,7 @@ class BlockMatrixNativeReader(
     if (ctx.memo.contains(key)) {
       ctx.memo(key).asInstanceOf[BlockMatrix]
     } else {
-      val bm = BlockMatrix.read(ctx.fs, params.path)
+      val bm = BlockMatrix.read(ctx, params.path)
       ctx.memo.update(key, bm)
       bm
     }
@@ -226,14 +228,15 @@ case class BlockMatrixBinaryReader(path: String, shape: IndexedSeq[Long], blockS
     BlockMatrixType.dense(TFloat64, nRows, nCols, blockSize)
 
   def apply(ctx: ExecuteContext): BlockMatrix = {
-    val breezeMatrix = RichDenseMatrixDouble.importFromDoubles(
-      ctx.fs,
-      path,
-      nRows.toInt,
-      nCols.toInt,
-      rowMajor = true,
-    )
-    BlockMatrix.fromBreezeMatrix(breezeMatrix, blockSize)
+    val breezeMatrix =
+      RichDenseMatrixDouble.importFromDoubles(
+        ctx.fs,
+        path,
+        nRows.toInt,
+        nCols.toInt,
+        rowMajor = true,
+      )
+    BlockMatrix.fromBreezeMatrix(ctx, breezeMatrix, blockSize)
   }
 
   override def lower(ctx: ExecuteContext, evalCtx: IRBuilder): BlockMatrixStage2 = {
@@ -469,7 +472,7 @@ case class BlockMatrixMap2(
     right: BlockMatrixIR,
     f: IR,
   ): BlockMatrix =
-    opWithRowVector(right.execute(ctx), rowVector, f, reverse = true)
+    opWithRowVector(ctx, right.execute(ctx), rowVector, f, reverse = true)
 
   private def colVectorOnLeft(
     ctx: ExecuteContext,
@@ -477,7 +480,7 @@ case class BlockMatrixMap2(
     right: BlockMatrixIR,
     f: IR,
   ): BlockMatrix =
-    opWithColVector(right.execute(ctx), colVector, f, reverse = true)
+    opWithColVector(ctx, right.execute(ctx), colVector, f, reverse = true)
 
   private def matrixOnLeft(ctx: ExecuteContext, matrix: BlockMatrix, right: BlockMatrixIR, f: IR)
     : BlockMatrix = {
@@ -486,10 +489,10 @@ case class BlockMatrixMap2(
         x match {
           case 1 =>
             val rightAsRowVec = coerceToVector(ctx, vectorIR)
-            opWithRowVector(matrix, rightAsRowVec, f, reverse = false)
+            opWithRowVector(ctx, matrix, rightAsRowVec, f, reverse = false)
           case 0 =>
             val rightAsColVec = coerceToVector(ctx, vectorIR)
-            opWithColVector(matrix, rightAsColVec, f, reverse = false)
+            opWithColVector(ctx, matrix, rightAsColVec, f, reverse = false)
         }
       case _ =>
         opWithTwoBlockMatrices(matrix, right.execute(ctx), f)
@@ -510,27 +513,41 @@ case class BlockMatrixMap2(
     }
   }
 
-  private def opWithRowVector(left: BlockMatrix, right: Array[Double], f: IR, reverse: Boolean)
-    : BlockMatrix = {
+  private def opWithRowVector(
+    ctx: ExecuteContext,
+    left: BlockMatrix,
+    right: Array[Double],
+    f: IR,
+    reverse: Boolean,
+  ): BlockMatrix = {
     (f: @unchecked) match {
-      case ApplyBinaryPrimOp(Add(), _, _) => left.rowVectorAdd(right)
-      case ApplyBinaryPrimOp(Multiply(), _, _) => left.rowVectorMul(right)
+      case ApplyBinaryPrimOp(Add(), _, _) => left.rowVectorAdd(ctx, right)
+      case ApplyBinaryPrimOp(Multiply(), _, _) => left.rowVectorMul(ctx, right)
       case ApplyBinaryPrimOp(Subtract(), _, _) =>
-        if (reverse) left.reverseRowVectorSub(right) else left.rowVectorSub(right)
+        if (reverse) left.reverseRowVectorSub(ctx, right)
+        else left.rowVectorSub(ctx, right)
       case ApplyBinaryPrimOp(FloatingPointDivide(), _, _) =>
-        if (reverse) left.reverseRowVectorDiv(right) else left.rowVectorDiv(right)
+        if (reverse) left.reverseRowVectorDiv(ctx, right)
+        else left.rowVectorDiv(ctx, right)
     }
   }
 
-  private def opWithColVector(left: BlockMatrix, right: Array[Double], f: IR, reverse: Boolean)
-    : BlockMatrix = {
+  private def opWithColVector(
+    ctx: ExecuteContext,
+    left: BlockMatrix,
+    right: Array[Double],
+    f: IR,
+    reverse: Boolean,
+  ): BlockMatrix = {
     (f: @unchecked) match {
-      case ApplyBinaryPrimOp(Add(), _, _) => left.colVectorAdd(right)
-      case ApplyBinaryPrimOp(Multiply(), _, _) => left.colVectorMul(right)
+      case ApplyBinaryPrimOp(Add(), _, _) => left.colVectorAdd(ctx, right)
+      case ApplyBinaryPrimOp(Multiply(), _, _) => left.colVectorMul(ctx, right)
       case ApplyBinaryPrimOp(Subtract(), _, _) =>
-        if (reverse) left.reverseColVectorSub(right) else left.colVectorSub(right)
+        if (reverse) left.reverseColVectorSub(ctx, right)
+        else left.colVectorSub(ctx, right)
       case ApplyBinaryPrimOp(FloatingPointDivide(), _, _) =>
-        if (reverse) left.reverseColVectorDiv(right) else left.colVectorDiv(right)
+        if (reverse) left.reverseColVectorDiv(ctx, right)
+        else left.colVectorDiv(ctx, right)
     }
   }
 
@@ -674,31 +691,33 @@ case class BlockMatrixBroadcast(
         BlockMatrix.fill(nRows, nCols, scalar, blockSize)
       case IndexedSeq(0) =>
         BlockMatrixIR.checkFitsIntoArray(nRows, nCols)
-        broadcastColVector(childBm.toBreezeMatrix().data, nRows.toInt, nCols.toInt)
+        broadcastColVector(ctx, childBm.toBreezeMatrix().data, nRows.toInt, nCols.toInt)
       case IndexedSeq(1) =>
         BlockMatrixIR.checkFitsIntoArray(nRows, nCols)
-        broadcastRowVector(childBm.toBreezeMatrix().data, nRows.toInt, nCols.toInt)
+        broadcastRowVector(ctx, childBm.toBreezeMatrix().data, nRows.toInt, nCols.toInt)
       // FIXME: I'm pretty sure this case is broken.
       case IndexedSeq(0, 0) =>
         BlockMatrixIR.checkFitsIntoArray(nRows, nCols)
-        BlockMatrixIR.toBlockMatrix(nRows.toInt, nCols.toInt, childBm.diagonal(), blockSize)
+        BlockMatrixIR.toBlockMatrix(ctx, nRows.toInt, nCols.toInt, childBm.diagonal(), blockSize)
       case IndexedSeq(1, 0) => childBm.transpose()
       case IndexedSeq(0, 1) => childBm
     }
   }
 
-  private def broadcastRowVector(vec: Array[Double], nRows: Int, nCols: Int): BlockMatrix = {
+  private def broadcastRowVector(ctx: ExecuteContext, vec: Array[Double], nRows: Int, nCols: Int)
+    : BlockMatrix = {
     val data = ArrayBuffer[Double]()
     data.sizeHint(nRows * nCols)
     (0 until nRows).foreach(_ => data ++= vec)
-    BlockMatrixIR.toBlockMatrix(nRows, nCols, data.toArray, blockSize)
+    BlockMatrixIR.toBlockMatrix(ctx, nRows, nCols, data.toArray, blockSize)
   }
 
-  private def broadcastColVector(vec: Array[Double], nRows: Int, nCols: Int): BlockMatrix = {
+  private def broadcastColVector(ctx: ExecuteContext, vec: Array[Double], nRows: Int, nCols: Int)
+    : BlockMatrix = {
     val data = ArrayBuffer[Double]()
     data.sizeHint(nRows * nCols)
     (0 until nRows).foreach(row => (0 until nCols).foreach(_ => data += vec(row)))
-    BlockMatrixIR.toBlockMatrix(nRows, nCols, data.toArray, blockSize)
+    BlockMatrixIR.toBlockMatrix(ctx, nRows, nCols, data.toArray, blockSize)
   }
 }
 
@@ -748,7 +767,7 @@ case class BlockMatrixAgg(
 
     axesToSumOut match {
       case IndexedSeq(0, 1) =>
-        BlockMatrixIR.toBlockMatrix(nRows = 1, nCols = 1, Array(childBm.sum()), typ.blockSize)
+        BlockMatrixIR.toBlockMatrix(ctx, nRows = 1, nCols = 1, Array(childBm.sum()), typ.blockSize)
       case IndexedSeq(0) => childBm.rowSum()
       case IndexedSeq(1) => childBm.colSum()
     }
@@ -834,7 +853,7 @@ case class BlockMatrixDensify(child: BlockMatrixIR) extends BlockMatrixIR {
 sealed abstract class BlockMatrixSparsifier {
   def typ: Type
   def definedBlocks(childType: BlockMatrixType): BlockMatrixSparsity
-  def sparsify(bm: BlockMatrix): BlockMatrix
+  def sparsify(ctx: ExecuteContext, bm: BlockMatrix): BlockMatrix
   def pretty(): String
 }
 
@@ -855,7 +874,7 @@ case class BandSparsifier(blocksOnly: Boolean, l: Long, u: Long) extends BlockMa
     BlockMatrixSparsity(blocks)
   }
 
-  def sparsify(bm: BlockMatrix): BlockMatrix =
+  override def sparsify(ctx: ExecuteContext, bm: BlockMatrix): BlockMatrix =
     bm.filterBand(l, u, blocksOnly)
 
   def pretty(): String =
@@ -881,8 +900,8 @@ case class RowIntervalSparsifier(
     }
   }
 
-  def sparsify(bm: BlockMatrix): BlockMatrix =
-    bm.filterRowIntervals(starts.toArray, stops.toArray, blocksOnly)
+  override def sparsify(ctx: ExecuteContext, bm: BlockMatrix): BlockMatrix =
+    bm.filterRowIntervals(ctx, starts.toArray, stops.toArray, blocksOnly)
 
   def pretty(): String =
     s"(RowIntervalSparsifier ${Pretty.prettyBooleanLiteral(blocksOnly)} ${starts.mkString("(", " ", ")")} ${stops.mkString("(", " ", ")")})"
@@ -909,7 +928,7 @@ case class RectangleSparsifier(rectangles: IndexedSeq[IndexedSeq[Long]])
     BlockMatrixSparsity(definedBlocks)
   }
 
-  def sparsify(bm: BlockMatrix): BlockMatrix =
+  override def sparsify(ctx: ExecuteContext, bm: BlockMatrix): BlockMatrix =
     bm.filterRectangles(rectangles.flatten.toArray)
 
   def pretty(): String =
@@ -927,7 +946,8 @@ case class PerBlockSparsifier(blocks: IndexedSeq[Int]) extends BlockMatrixSparsi
         blockSet.contains(i + j * childType.nRowBlocks)
     }
 
-  override def sparsify(bm: BlockMatrix): BlockMatrix = bm.filterBlocks(blocks.toArray)
+  override def sparsify(ctx: ExecuteContext, bm: BlockMatrix): BlockMatrix =
+    bm.filterBlocks(blocks.toArray)
 
   override def pretty(): String = s"(PerBlockSparsifier with blocks $blocks)"
 }
@@ -949,7 +969,7 @@ case class BlockMatrixSparsify(
   }
 
   override def execute(ctx: ExecuteContext): BlockMatrix =
-    sparsifier.sparsify(child.execute(ctx))
+    sparsifier.sparsify(ctx, child.execute(ctx))
 }
 
 case class BlockMatrixSlice(child: BlockMatrixIR, slices: IndexedSeq[IndexedSeq[Long]])
@@ -1050,6 +1070,7 @@ case class ValueToBlockMatrix(
         BlockMatrix.fill(nRows, nCols, scalar, blockSize)
       case data: IndexedSeq[_] =>
         BlockMatrixIR.toBlockMatrix(
+          ctx,
           nRows.toInt,
           nCols.toInt,
           data.asInstanceOf[IndexedSeq[Double]].toArray,
@@ -1057,6 +1078,7 @@ case class ValueToBlockMatrix(
         )
       case ndData: NDArray =>
         BlockMatrixIR.toBlockMatrix(
+          ctx,
           nRows.toInt,
           nCols.toInt,
           ndData.getRowMajorElements().asInstanceOf[IndexedSeq[Double]].toArray,

--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -220,7 +220,7 @@ case class BlockMatrixBinaryMultiWriter(
 ) extends BlockMatrixMultiWriter {
 
   def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
-    BlockMatrix.binaryWriteBlockMatrices(ctx.fs, bms, prefix, overwrite)
+    BlockMatrix.binaryWriteBlockMatrices(ctx, bms, prefix, overwrite)
 
   def loweredTyp: Type = TVoid
 }
@@ -237,7 +237,7 @@ case class BlockMatrixTextMultiWriter(
 
   def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
     BlockMatrix.exportBlockMatrices(
-      ctx.fs,
+      ctx,
       bms,
       prefix,
       overwrite,

--- a/hail/hail/src/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/LowerMatrixIR.scala
@@ -859,7 +859,7 @@ object LowerMatrixIR {
       case MatrixExplodeRows(child, path) =>
         TableExplode(lower(ctx, child, liftedRelationalLets), path)
 
-      case mr: MatrixRead => mr.lower()
+      case mr: MatrixRead => mr.lower(ctx)
 
       case MatrixAggregateColsByKey(child, entryExpr, colExpr) =>
         val colKey = child.typ.colKey

--- a/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.io.{BufferSpec, FileWriteMetadata}
@@ -264,11 +263,11 @@ case class MatrixValue(
       s"\n    * Largest partition:  $largestStr")
   }
 
-  def toRowMatrix(entryField: String): RowMatrix = {
+  def toRowMatrix(ctx: ExecuteContext, entryField: String): RowMatrix = {
     val partCounts: Array[Long] = rvd.countPerPartition()
     val partStarts = partCounts.scanLeft(0L)(_ + _)
     assert(partStarts.length == rvd.getNumPartitions + 1)
-    val partStartsBc = HailContext.backend.broadcast(partStarts)
+    val partStartsBc = ctx.backend.broadcast(partStarts)
 
     val localRvRowPType = rvRowPType
     val localEntryArrayPType = entryArrayPType

--- a/hail/hail/src/is/hail/expr/ir/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/Simplify.scala
@@ -1506,7 +1506,12 @@ object Simplify {
             t,
             dr,
             dc,
-            MatrixRangeReader(r.params.nRows, math.min(r.params.nCols, n), r.params.nPartitions),
+            MatrixRangeReader(
+              ctx,
+              r.params.nRows,
+              math.min(r.params.nCols, n),
+              r.params.nPartitions,
+            ),
           )
         )
       case MatrixColsHead(MatrixMapRows(child, newRow), n)

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend.{ExecuteContext, HailStateManager, HailTaskContext, TaskFinalizer}
@@ -1950,7 +1949,7 @@ object TableFromBlockMatrixNativeReader {
   def apply(
     fs: FS,
     path: String,
-    nPartitions: Option[Int] = None,
+    nPartitions: Int,
     maximumCacheMemoryInBytes: Option[Int] = None,
   ): TableFromBlockMatrixNativeReader =
     TableFromBlockMatrixNativeReader(
@@ -1967,7 +1966,7 @@ object TableFromBlockMatrixNativeReader {
 
 case class TableFromBlockMatrixNativeReaderParameters(
   path: String,
-  nPartitions: Option[Int],
+  nPartitions: Int,
   maximumCacheMemoryInBytes: Option[Int],
 )
 
@@ -1977,12 +1976,10 @@ case class TableFromBlockMatrixNativeReader(
 ) extends TableReaderWithExtraUID {
   def pathsUsed: Seq[String] = FastSeq(params.path)
 
-  val getNumPartitions: Int = params.nPartitions.getOrElse(HailContext.backend.defaultParallelism)
-
-  val partitionRanges = (0 until getNumPartitions).map { i =>
+  val partitionRanges = (0 until params.nPartitions).map { i =>
     val nRows = metadata.nRows
-    val start = (i * nRows) / getNumPartitions
-    val end = ((i + 1) * nRows) / getNumPartitions
+    val start = (i * nRows) / params.nPartitions
+    val end = ((i + 1) * nRows) / params.nPartitions
     start until end
   }
 

--- a/hail/hail/src/is/hail/expr/ir/TableValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableValue.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
@@ -367,8 +366,8 @@ case class TableValue(ctx: ExecuteContext, typ: TableType, globals: BroadcastRow
     )
   }
 
-  def toDF(): DataFrame =
-    HailContext.sparkBackend.sparkSession.createDataFrame(
+  def toDF(ctx: ExecuteContext): DataFrame =
+    ctx.backend.asSpark.sparkSession.createDataFrame(
       rvd.toRows,
       typ.rowType.schema.asInstanceOf[StructType],
     )
@@ -1195,7 +1194,7 @@ case class TableValue(ctx: ExecuteContext, typ: TableType, globals: BroadcastRow
     }
 
     if (ctx.getFlag("distributed_scan_comb_op") != null && extracted.sigs.shouldTreeAggregate) {
-      val fsBc = ctx.fs.broadcast
+      val fsBc = ctx.fsBc
       val tmpBase = ctx.createTmpPath("table-map-rows-distributed-scan")
       val d = digitsNeeded(rvd.getNumPartitions)
       val files = rvd.mapPartitionsWithIndex { (i, ctx, it) =>

--- a/hail/hail/src/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
@@ -42,7 +42,7 @@ object MatrixWriteBlockMatrix {
     fs.mkDir(path + "/parts")
     val gp = GridPartitioner(blockSize, nRows, localNCols)
     val blockPartFiles =
-      new WriteBlocksRDD(fs.broadcast, ctx.localTmpdir, path, rvd, partStarts, entryField, gp)
+      new WriteBlocksRDD(ctx.fsBc, ctx.localTmpdir, path, rvd, partStarts, entryField, gp)
         .collect()
 
     val blockCount = blockPartFiles.length

--- a/hail/hail/src/is/hail/io/fs/FS.scala
+++ b/hail/hail/src/is/hail/io/fs/FS.scala
@@ -1,7 +1,5 @@
 package is.hail.io.fs
 
-import is.hail.HailContext
-import is.hail.backend.BroadcastValue
 import is.hail.io.compress.{BGzipInputStream, BGzipOutputStream}
 import is.hail.io.fs.FSUtil.{containsWildcard, dropTrailingSlash}
 import is.hail.services._
@@ -743,8 +741,6 @@ trait FS extends Serializable with Logging {
 
   def touch(url: URL): Unit =
     using(createNoCompression(url))(_ => ())
-
-  lazy val broadcast: BroadcastValue[FS] = HailContext.backend.broadcast(this)
 
   def getConfiguration(): Any
 

--- a/hail/hail/src/is/hail/io/plink/LoadPlink.scala
+++ b/hail/hail/src/is/hail/io/plink/LoadPlink.scala
@@ -364,7 +364,7 @@ class MatrixPLINKReader(
 
   val columnCount: Option[Int] = Some(nSamples)
 
-  val partitionCounts: Option[IndexedSeq[Long]] = None
+  def partitionCounts: Option[IndexedSeq[Long]] = None
 
   val globals = Row(sampleInfo.zipWithIndex.map { case (s, idx) =>
     Row((0 until s.length).map(s.apply) :+ idx.toLong: _*)

--- a/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
@@ -1969,7 +1969,7 @@ class MatrixVCFReader(
 
   val columnCount: Option[Int] = Some(nCols)
 
-  val partitionCounts: Option[IndexedSeq[Long]] = None
+  def partitionCounts: Option[IndexedSeq[Long]] = None
 
   def partitioner(sm: HailStateManager): Option[RVDPartitioner] =
     params.partitionsJSON.map { partitionsJSON =>

--- a/hail/hail/src/is/hail/linalg/RowMatrix.scala
+++ b/hail/hail/src/is/hail/linalg/RowMatrix.scala
@@ -32,9 +32,10 @@ object RowMatrix {
     partitionCounts
   }
 
-  def readBlockMatrix(fs: FS, uri: String, maybePartSize: java.lang.Integer): RowMatrix = {
+  def readBlockMatrix(ctx: ExecuteContext, uri: String, maybePartSize: java.lang.Integer)
+    : RowMatrix = {
     val BlockMatrixMetadata(blockSize, nRows, nCols, maybeFiltered, partFiles) =
-      BlockMatrix.readMetadata(fs, uri)
+      BlockMatrix.readMetadata(ctx.fs, uri)
     if (nCols >= Int.MaxValue) {
       fatal(s"Number of columns must be less than 2^31, found $nCols")
     }
@@ -42,7 +43,7 @@ object RowMatrix {
     val partSize: Int = if (maybePartSize != null) maybePartSize else blockSize
     val partitionCounts = computePartitionCounts(partSize, gp.nRows)
     RowMatrix(
-      new ReadBlocksAsRowsRDD(fs.broadcast, uri, partFiles, partitionCounts, gp),
+      new ReadBlocksAsRowsRDD(ctx.fsBc, uri, partFiles, partitionCounts, gp),
       gp.nCols.toInt,
       gp.nRows,
       partitionCounts,

--- a/hail/hail/src/is/hail/methods/LinearRegression.scala
+++ b/hail/hail/src/is/hail/methods/LinearRegression.scala
@@ -1,6 +1,5 @@
 package is.hail.methods
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
@@ -67,7 +66,7 @@ case class LinearRegressionRowsSingle(
 
     val Qty = Qt * y
 
-    val backend = HailContext.backend
+    val backend = ctx.backend
     val completeColIdxBc = backend.broadcast(completeColIdx)
     val yBc = backend.broadcast(y)
     val QtBc = backend.broadcast(Qt)
@@ -251,7 +250,7 @@ case class LinearRegressionRowsChained(
       ChainedLinregInput(n, y, completeColIdx, Qt, Qty, yyp, d)
     }
 
-    val bc = HailContext.backend.broadcast(bcData)
+    val bc = ctx.backend.broadcast(bcData)
     val nGroups = bcData.length
 
     val fullRowType = mv.rvd.rowPType

--- a/hail/hail/src/is/hail/methods/LogisticRegression.scala
+++ b/hail/hail/src/is/hail/methods/LogisticRegression.scala
@@ -1,6 +1,5 @@
 package is.hail.methods
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
@@ -91,7 +90,7 @@ case class LogisticRegression(
       nullFit
     }
 
-    val backend = HailContext.backend
+    val backend = ctx.backend
     val completeColIdxBc = backend.broadcast(completeColIdx)
 
     val yVecsBc = backend.broadcast(yVecs)

--- a/hail/hail/src/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/hail/src/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -1,9 +1,7 @@
 package is.hail.methods
 
-import is.hail.HailContext
 import is.hail.annotations.{UnsafeIndexedSeq, UnsafeRow}
 import is.hail.backend.ExecuteContext
-import is.hail.backend.spark.SparkBackend
 import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.ir.MatrixValue
 import is.hail.expr.ir.functions.MatrixToValueFunction
@@ -69,13 +67,13 @@ case class MatrixExportEntriesByCol(
       val extension = if (bgzip) ".tsv.bgz" else ".tsv"
       val localHeaderJsonInFile = headerJsonInFile
 
-      val colValuesJSON = HailContext.backend.broadcast(
+      val colValuesJSON = ctx.backend.broadcast(
         (startIdx until endIdx)
           .map(allColValuesJSON)
           .toArray
       )
 
-      val fsBc = fs.broadcast
+      val fsBc = ctx.fsBc
       val localTempDir = ctx.localTmpdir
       val partFolders = mv.rvd.crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
         val partFolder = partFileBase + partFile(d, i, TaskContext.get())
@@ -196,8 +194,8 @@ case class MatrixExportEntriesByCol(
 
     // clean up temporary files
     val temps = tempFolders.result()
-    val fsBc = fs.broadcast
-    SparkBackend.sparkContext.parallelize(
+    val fsBc = ctx.fsBc
+    ctx.backend.asSpark.sc.parallelize(
       temps,
       (temps.length / 32).max(1),
     ).foreach(path => fsBc.value.delete(path, recursive = true))

--- a/hail/hail/src/is/hail/methods/PCA.scala
+++ b/hail/hail/src/is/hail/methods/PCA.scala
@@ -1,6 +1,5 @@
 package is.hail.methods
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{MatrixValue, TableValue}
@@ -34,7 +33,7 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean) extends Mat
       fatal(s"""requested invalid number of components: $k
                |  Expect componenents >= 1""".stripMargin)
 
-    val rowMatrix = mv.toRowMatrix(entryField)
+    val rowMatrix = mv.toRowMatrix(ctx, entryField)
     val indexedRows = rowMatrix.rows.map { case (i, a) => IndexedRow(i, Vectors.dense(a)) }
       .cache()
     val irm = new IndexedRowMatrix(indexedRows, rowMatrix.nRows, rowMatrix.nCols)
@@ -63,7 +62,7 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean) extends Mat
     ) ++ TStruct("loadings" -> TArray(TFloat64)))
       .setRequired(true)
       .asInstanceOf[PStruct]
-    val rowKeysBc = HailContext.backend.broadcast(collectRowKeys())
+    val rowKeysBc = ctx.backend.broadcast(collectRowKeys())
     val localRowKeySignature = mv.typ.rowKeyStruct.types
 
     val crdd: ContextRDD[Long] = if (computeLoadings) {

--- a/hail/hail/src/is/hail/methods/PCRelate.scala
+++ b/hail/hail/src/is/hail/methods/PCRelate.scala
@@ -172,7 +172,7 @@ case class PCRelate(
   private def writeRead(ctx: ExecuteContext, m: M): M = {
     val file = ctx.createTmpPath("pcrelate-write-read", "bm")
     m.write(ctx, file)
-    BlockMatrix.read(ctx.fs, file)
+    BlockMatrix.read(ctx, file)
   }
 
   private def gram(ctx: ExecuteContext, m: M): M = {
@@ -229,9 +229,9 @@ case class PCRelate(
 
     val qr.QR(q, r) = qr.reduced(pcsWithIntercept)
 
-    val halfBeta = writeRead(ctx, (inv(2.0 * r) * q.t).matrixMultiply(blockedG.T))
+    val halfBeta = writeRead(ctx, (inv(2.0 * r) * q.t).matrixMultiply(ctx, blockedG.T))
 
-    writeRead(ctx, pcsWithIntercept.matrixMultiply(halfBeta).T)
+    writeRead(ctx, pcsWithIntercept.matrixMultiply(ctx, halfBeta).T)
   }
 
   private[methods] def phi(ctx: ExecuteContext, mu: M, variance: M, g: M): M = {

--- a/hail/hail/src/is/hail/methods/PoissonRegression.scala
+++ b/hail/hail/src/is/hail/methods/PoissonRegression.scala
@@ -1,6 +1,5 @@
 package is.hail.methods
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
@@ -69,7 +68,7 @@ case class PoissonRegression(
           "Newton iteration failed to converge"
       ))
 
-    val backend = HailContext.backend
+    val backend = ctx.backend
     val completeColIdxBc = backend.broadcast(completeColIdx)
 
     val yBc = backend.broadcast(y)

--- a/hail/hail/src/is/hail/methods/Skat.scala
+++ b/hail/hail/src/is/hail/methods/Skat.scala
@@ -1,6 +1,5 @@
 package is.hail.methods
 
-import is.hail.HailContext
 import is.hail.annotations.{Annotation, Region, UnsafeRow}
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
@@ -202,9 +201,9 @@ case class Skat(
     }
 
     val (keyGsWeightRdd, _) =
-      computeKeyGsWeightRdd(mv, xField, completeColIdx, keyField, weightField)
+      computeKeyGsWeightRdd(ctx, mv, xField, completeColIdx, keyField, weightField)
 
-    val backend = HailContext.backend
+    val backend = ctx.backend
 
     def linearSkat(): RDD[Row] = {
       // fit null model
@@ -318,6 +317,7 @@ case class Skat(
   }
 
   def computeKeyGsWeightRdd(
+    ctx: ExecuteContext,
     mv: MatrixValue,
     xField: String,
     completeColIdx: Array[Int],
@@ -345,7 +345,7 @@ case class Skat(
     val fieldIdx = entryType.fieldIdx(xField)
 
     val n = completeColIdx.length
-    val completeColIdxBc = HailContext.backend.broadcast(completeColIdx)
+    val completeColIdxBc = ctx.backend.broadcast(completeColIdx)
 
     /* I believe no `boundary` is needed here because `mapPartitions` calls `run` which calls
      * `cleanupRegions`. */

--- a/hail/hail/src/is/hail/rvd/RVD.scala
+++ b/hail/hail/src/is/hail/rvd/RVD.scala
@@ -1379,7 +1379,6 @@ object RVD {
     val sc = SparkBackend.sparkContext
     val localTmpdir = execCtx.localTmpdir
     val fs = execCtx.fs
-    val fsBc = fs.broadcast
 
     val nRVDs = rvds.length
     val partitioner = first.partitioner
@@ -1411,6 +1410,7 @@ object RVD {
       fs.mkDir(path + "/index")
     }
 
+    val fsBc = execCtx.fsBc
     val partF = {
       (originIdx: Int, originPartIdx: Int, it: Iterator[RVDContext => Iterator[Long]]) =>
         Iterator.single { ctx: RVDContext =>

--- a/hail/hail/src/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/ContextRDD.scala
@@ -1,6 +1,6 @@
 package is.hail.sparkextras
 
-import is.hail.HailContext
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.macros.void
 import is.hail.rvd.RVDContext
@@ -102,13 +102,14 @@ object ContextRDD {
     new ContextRDD(rdd.mapPartitions(it => Iterator.single((ctx: RVDContext) => it)))
 
   def textFilesLines(
+    ctx: ExecuteContext,
     files: Array[String],
     nPartitions: Option[Int] = None,
     filterAndReplace: TextInputFilterAndReplace = TextInputFilterAndReplace(),
   ): ContextRDD[WithContext[String]] =
     textFilesLines(
       files,
-      nPartitions.getOrElse(HailContext.backend.defaultParallelism),
+      nPartitions.getOrElse(ctx.backend.defaultParallelism),
       filterAndReplace,
     )
 

--- a/hail/hail/src/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -1,5 +1,6 @@
 package is.hail.utils.richUtils
 
+import is.hail.backend.ExecuteContext
 import is.hail.io._
 import is.hail.io.fs.FS
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, GridPartitioner}
@@ -71,12 +72,12 @@ object RichDenseMatrixDouble {
 
 class RichDenseMatrixDouble(val m: BDM[Double]) extends AnyVal {
   // dot is overloaded in Breeze
-  def matrixMultiply(bm: BlockMatrix): BlockMatrix = {
+  def matrixMultiply(ctx: ExecuteContext, bm: BlockMatrix): BlockMatrix = {
     require(
       m.cols == bm.nRows,
       s"incompatible matrix dimensions: ${m.rows} x ${m.cols} and ${bm.nRows} x ${bm.nCols} ",
     )
-    BlockMatrix.fromBreezeMatrix(m, bm.blockSize).dot(bm)
+    BlockMatrix.fromBreezeMatrix(ctx, m, bm.blockSize).dot(bm)
   }
 
   def forceSymmetry(): Unit = {

--- a/hail/hail/test/src/is/hail/HailSuite.scala
+++ b/hail/hail/test/src/is/hail/HailSuite.scala
@@ -183,7 +183,7 @@ class HailSuite extends TestNGSuite with TestUtils {
     assert(t == TVoid || t.typeCheck(expected), s"$t, $expected")
 
     val filteredExecStrats: Set[ExecStrategy] =
-      if (HailContext.backend.isInstanceOf[SparkBackend])
+      if (backend.isInstanceOf[SparkBackend])
         execStrats
       else {
         info("skipping interpret and non-lowering compile steps on non-spark backend")
@@ -289,7 +289,7 @@ class HailSuite extends TestNGSuite with TestUtils {
   )(implicit execStrats: Set[ExecStrategy]
   ): scalatest.Assertion = {
     val filteredExecStrats: Set[ExecStrategy] =
-      if (HailContext.backend.isInstanceOf[SparkBackend]) execStrats
+      if (backend.isInstanceOf[SparkBackend]) execStrats
       else {
         info("skipping interpret and non-lowering compile steps on non-spark backend")
         execStrats.intersect(ExecStrategy.backendOnly)

--- a/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
@@ -991,7 +991,7 @@ class Aggregators2Suite extends HailSuite {
       TStruct.empty,
     )
     val ir = TableCollect(MatrixColsTable(MatrixMapCols(
-      MatrixRead(t, false, false, MatrixRangeReader(10, 10, None)),
+      MatrixRead(t, false, false, MatrixRangeReader(ctx, 10, 10, None)),
       InsertFields(
         Ref(MatrixIR.colName, t.colType),
         FastSeq((

--- a/hail/hail/test/src/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -237,7 +237,7 @@ class BlockMatrixIRSuite extends HailSuite {
       getTestResource(
         "blockmatrix_example/0/parts/part-0-28-0-0-0feb7ac2-ab02-6cd4-5547-bfcb94dacb33"
       )
-    val matrix = BlockMatrix.read(fs, getTestResource("blockmatrix_example/0")).toBreezeMatrix()
+    val matrix = BlockMatrix.read(ctx, getTestResource("blockmatrix_example/0")).toBreezeMatrix()
     val expected = Array.tabulate(2)(i => Array.tabulate(2)(j => matrix(i, j)).toFastSeq).toFastSeq
 
     val typ = TNDArray(TFloat64, Nat(2))
@@ -261,7 +261,7 @@ class BlockMatrixIRSuite extends HailSuite {
 
   @Test def readWriteBlockMatrix(): scalatest.Assertion = {
     val original = getTestResource("blockmatrix_example/0")
-    val expected = BlockMatrix.read(ctx.fs, original).toBreezeMatrix()
+    val expected = BlockMatrix.read(ctx, original).toBreezeMatrix()
 
     val path = ctx.createTmpPath("read-blockmatrix-ir", "bm")
 

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -3133,7 +3133,7 @@ class IRSuite extends HailSuite {
   @Test def testMatrixAggregate(): scalatest.Assertion = {
     implicit val execStrats = ExecStrategy.interpretOnly
 
-    val matrix = MatrixIR.range(5, 5, None)
+    val matrix = MatrixIR.range(ctx, 5, 5, None)
     val count = ApplyAggOp(Count())()
     assertEvalsTo(MatrixAggregate(matrix, MakeStruct(IndexedSeq("foo" -> count))), Row(25L))
   }
@@ -3298,7 +3298,7 @@ class IRSuite extends HailSuite {
 
     val table = TableRange(100, 10)
 
-    val mt = MatrixIR.range(20, 2, Some(3))
+    val mt = MatrixIR.range(ctx, 20, 2, Some(3))
     val vcf = importVCF(ctx, getTestResource("sample.vcf"))
     val bgenReader = MatrixBGENReader(
       ctx,
@@ -3710,7 +3710,7 @@ class IRSuite extends HailSuite {
       val tableRead = TableIR.read(fs, getTestResource("backward_compatability/1.1.0/table/0.ht"))
       val read =
         MatrixIR.read(fs, getTestResource("backward_compatability/1.0.0/matrix_table/0.hmt"))
-      val range = MatrixIR.range(3, 7, None)
+      val range = MatrixIR.range(ctx, 3, 7, None)
       val vcf = importVCF(ctx, getTestResource("sample.vcf"))
 
       val bgenReader = MatrixBGENReader(
@@ -3724,8 +3724,8 @@ class IRSuite extends HailSuite {
       )
       val bgen = MatrixRead(bgenReader.fullMatrixType, false, false, bgenReader)
 
-      val range1 = MatrixIR.range(20, 2, Some(3))
-      val range2 = MatrixIR.range(20, 2, Some(4))
+      val range1 = MatrixIR.range(ctx, 20, 2, Some(3))
+      val range2 = MatrixIR.range(ctx, 20, 2, Some(4))
 
       val b = True()
 

--- a/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
@@ -25,7 +25,7 @@ class MatrixIRSuite extends HailSuite {
     Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
 
   @Test def testMatrixWriteRead(): scalatest.Assertion = {
-    val range = MatrixIR.range(10, 10, Some(3))
+    val range = MatrixIR.range(ctx, 10, 10, Some(3))
     val withEntries = MatrixMapEntries(
       range,
       makestruct(
@@ -90,7 +90,7 @@ class MatrixIRSuite extends HailSuite {
     nPartitions: Option[Int] = Some(4),
     uids: Boolean = false,
   ): MatrixIR = {
-    val reader = MatrixRangeReader(nRows, nCols, nPartitions)
+    val reader = MatrixRangeReader(ctx, nRows, nCols, nPartitions)
     val requestedType = if (uids)
       reader.fullMatrixType
     else

--- a/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.HailSuite
+import is.hail.backend.ExecuteContext
 import is.hail.expr.Nat
 import is.hail.expr.ir.PruneDeadFields.TypeState
 import is.hail.expr.ir.defs._
@@ -213,7 +214,12 @@ class PruneSuite extends HailSuite {
 
       def fullMatrixTypeWithoutUIDs: MatrixType = mat.typ
 
-      def lower(requestedType: MatrixType, dropCols: Boolean, dropRows: Boolean): TableIR = ???
+      def lower(
+        ctx: ExecuteContext,
+        requestedType: MatrixType,
+        dropCols: Boolean,
+        dropRows: Boolean,
+      ): TableIR = ???
 
       def toJValue: JValue = ???
 

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -337,7 +337,7 @@ class SimplifySuite extends HailSuite {
   }
 
   @Test def testMatrixColsTableMatrixMapColsWithAggLetDoesNotSimplify(): scalatest.Assertion = {
-    val reader = MatrixRangeReader(1, 1, None)
+    val reader = MatrixRangeReader(ctx, 1, 1, None)
     var mir: MatrixIR = MatrixRead(reader.fullMatrixType, false, false, reader)
     val colType = reader.fullMatrixType.colType
     mir = MatrixMapCols(
@@ -404,7 +404,7 @@ class SimplifySuite extends HailSuite {
     val tnr = TableNativeReader(fs, TableNativeReaderParameters(src + "/rows", None))
     val tr = TableRead(tnr.fullType, false, tnr)
 
-    val tzr = mr.lower().asInstanceOf[TableMapGlobals].child.asInstanceOf[TableRead]
+    val tzr = mr.lower(ctx).asInstanceOf[TableMapGlobals].child.asInstanceOf[TableRead]
     val tzrr = tzr.tr.asInstanceOf[TableNativeZippedReader]
 
     val intervals1 = FastSeq(

--- a/hail/hail/test/src/is/hail/linalg/RowMatrixSuite.scala
+++ b/hail/hail/test/src/is/hail/linalg/RowMatrixSuite.scala
@@ -43,7 +43,7 @@ class RowMatrixSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
     val rowMatrix = rowArrayToRowMatrix(rowArrays)
     val localMatrix = rowArrayToLocalMatrix(rowArrays)
 
-    BlockMatrix.fromBreezeMatrix(localMatrix).write(ctx, fname)
+    BlockMatrix.fromBreezeMatrix(ctx, localMatrix).write(ctx, fname)
 
     assert(rowMatrix.toBreezeMatrix() === localMatrix)
   }
@@ -57,9 +57,9 @@ class RowMatrixSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
       Array(4.0, 5.0, 6.0),
     )
 
-    BlockMatrix.fromBreezeMatrix(localMatrix).write(ctx, fname, forceRowMajor = true)
+    BlockMatrix.fromBreezeMatrix(ctx, localMatrix).write(ctx, fname, forceRowMajor = true)
 
-    val rowMatrixFromBlock = RowMatrix.readBlockMatrix(fs, fname, 1)
+    val rowMatrixFromBlock = RowMatrix.readBlockMatrix(ctx, fname, 1)
 
     assert(rowMatrixFromBlock.toBreezeMatrix() == localMatrix)
   }
@@ -74,13 +74,13 @@ class RowMatrixSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
           Seq(1, 2, 4, 9, 11),
         )
       } { case (blockSize, partSize) =>
-        BlockMatrix.fromBreezeMatrix(lm, blockSize).write(
+        BlockMatrix.fromBreezeMatrix(ctx, lm, blockSize).write(
           ctx,
           fname,
           overwrite = true,
           forceRowMajor = true,
         )
-        val rowMatrix = RowMatrix.readBlockMatrix(fs, fname, partSize)
+        val rowMatrix = RowMatrix.readBlockMatrix(ctx, fname, partSize)
         assert(rowMatrix.toBreezeMatrix() === lm)
       }
     }

--- a/hail/hail/test/src/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/hail/test/src/is/hail/variant/vsm/PartitioningSuite.scala
@@ -23,7 +23,7 @@ class PartitioningSuite extends HailSuite {
       ),
       theHailClassLoader,
     )
-    val rangeReader = ir.MatrixRangeReader(100, 10, Some(10))
+    val rangeReader = ir.MatrixRangeReader(ctx, 100, 10, Some(10))
     unoptimized { ctx =>
       Interpret(
         MatrixAnnotateRowsTable(

--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -131,7 +131,7 @@ class StringTableReader(TableReader):
 
 
 class TableFromBlockMatrixNativeReader(TableReader):
-    @typecheck_method(path=str, n_partitions=nullable(int), maximum_cache_memory_in_bytes=nullable(int))
+    @typecheck_method(path=str, n_partitions=int, maximum_cache_memory_in_bytes=nullable(int))
     def __init__(self, path, n_partitions, maximum_cache_memory_in_bytes):
         self.path = path
         self.n_partitions = n_partitions

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1823,6 +1823,9 @@ class BlockMatrix:
             )
 
         self.write(path, overwrite=True, force_row_major=True)
+
+        # target 16k rows per partition for a sizeable block matrix with default block size
+        n_partitions = max(1, n_partitions or self._n_block_rows // 4)
         reader = TableFromBlockMatrixNativeReader(path, n_partitions, maximum_cache_memory_in_bytes)
         return Table(TableRead(reader))
 


### PR DESCRIPTION
This change removes uses of `HailContext.backend`​ as part of an effort to remove the `HailContext`​ singleton. Instead, the current `Backend`​ is accessed by threading `ExecuteContext`​. 

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP