### PR TITLE
[query] Fix `MatrixBlockMatrixWriter` for when `n_cols mod block_size == 0`

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -2359,7 +2359,7 @@ case class MatrixBlockMatrixWriter(
     val countColumnsIR = ArrayLen(GetField(ts.getGlobals(), colsFieldName))
     val numCols: Int = CompileAndEvaluate(ctx, countColumnsIR, true).asInstanceOf[Int]
     val numBlockCols: Int = (numCols - 1) / blockSize + 1
-    val lastBlockNumCols = numCols % blockSize
+    val lastBlockNumCols = (numCols - 1) % blockSize + 1
 
     val rowCountIR = ts.mapCollect("matrix_block_matrix_writer_partition_counts")(paritionIR =>
       StreamLen(paritionIR)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1386,3 +1386,11 @@ def test_write_from_entry_expr_simple():
         BlockMatrix.write_from_entry_expr(mt.x, path, block_size=32)
         actual = hl.eval(BlockMatrix.read(path).to_ndarray())
         assert np.array_equal(expected, actual)
+
+
+def test_write_block_matrix_with_block_size_eq_n_cols():
+    n_cols = 10
+    mt = hl.utils.range_matrix_table(10, n_cols)
+    mt = mt.annotate_entries(x=mt.row_idx * mt.col_idx)
+    bm = hl.linalg.BlockMatrix.from_entry_expr(mt.x, block_size=n_cols)
+    assert bm.shape == bm.to_numpy().shape


### PR DESCRIPTION
`MatrixBlockMatrixWriter` writes 0 columns in the final block 
when block size evenly divides the number of columms.

This change has no security impact.