### PR TITLE
[query] fix memory leak in lowered blockmatrix diagonal

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
@@ -22,8 +22,10 @@ class IRBuilder {
     case _ => strictMemoize(ir)
   }
 
-  def strictMemoize(ir: IR): Ref = {
-    val name = freshName()
+  def strictMemoize(ir: IR): Ref =
+    strictMemoize(ir, freshName())
+
+  def strictMemoize(ir: IR, name: Name): Ref = {
     bindings += name -> ir
     Ref(name, ir.typ)
   }


### PR DESCRIPTION
## Change Description

Fixes the BlockMatrix lowering rule for extracting the diagonal of a blockmatrix. Before it was inlining the parent BM's block IR inside a loop to read out the diagonal elements. So the parent block was being allocated and recomputed once for each diagonal element, without freeing allocations from previous iterations. Fixed by changing `BlockMatrixStage2.collectBlocks` to provide the block IR as a reference.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

