### PR TITLE
[query] don't lower inside CompileAndEvaluate

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/hail/src/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -5,35 +5,42 @@ import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.{Begin, EncodedLiteral, Literal, MakeTuple, NA}
-import is.hail.expr.ir.lowering.LoweringPipeline
+import is.hail.expr.ir.lowering.{Invariant, LoweringPipeline}
 import is.hail.types.physical.PTuple
 import is.hail.types.physical.stypes.PTypeReferenceSingleCodeType
 import is.hail.types.virtual._
 import is.hail.utils.FastSeq
 
+import java.io.PrintWriter
+
 import org.apache.spark.sql.Row
 
 object CompileAndEvaluate {
-  def apply[T](ctx: ExecuteContext, ir0: IR, optimize: Boolean = true): T = {
+  def apply[T](
+    ctx: ExecuteContext,
+    ir: IR,
+    optimize: Boolean = true,
+    lower: LoweringPipeline = LoweringPipeline(),
+  ): T = {
     ctx.time {
-      _apply(ctx, ir0, optimize) match {
+      _apply(ctx, ir, optimize, lower) match {
         case Left(()) => ().asInstanceOf[T]
         case Right((t, off)) => SafeRow(t, off).getAs[T](0)
       }
     }
   }
 
-  def evalToIR(ctx: ExecuteContext, ir0: IR, optimize: Boolean = true): IR = {
-    if (IsConstant(ir0))
-      return ir0
+  def evalToIR(ctx: ExecuteContext, ir: IR, optimize: Boolean = true): IR = {
+    if (IsConstant(ir))
+      return ir
 
-    _apply(ctx, ir0, optimize) match {
+    _apply(ctx, ir, optimize) match {
       case Left(_) => Begin(FastSeq())
       case Right((pt, addr)) =>
-        ir0.typ match {
-          case _ if pt.isFieldMissing(addr, 0) => NA(ir0.typ)
+        ir.typ match {
+          case _ if pt.isFieldMissing(addr, 0) => NA(ir.typ)
           case TInt32 | TInt64 | TFloat32 | TFloat64 | TBoolean | TString =>
-            Literal.coerce(ir0.typ, SafeRow.read(pt, addr).asInstanceOf[Row].get(0))
+            Literal.coerce(ir.typ, SafeRow.read(pt, addr).asInstanceOf[Row].get(0))
           case _ => EncodedLiteral.fromPTypeAndAddress(pt.types(0), pt.loadField(addr, 0), ctx)
         }
     }
@@ -43,9 +50,12 @@ object CompileAndEvaluate {
     ctx: ExecuteContext,
     ir0: IR,
     optimize: Boolean = true,
+    lower: LoweringPipeline = LoweringPipeline(),
+    print: Option[PrintWriter] = None,
   ): Either[Unit, (PTuple, Long)] =
     ctx.time {
-      val ir = LoweringPipeline.relationalLowerer(optimize)(ctx, ir0).asInstanceOf[IR]
+      val ir = lower(ctx, ir0).asInstanceOf[IR]
+      Invariant.CompilableIR.verify(ctx, ir)
 
       ir.typ match {
         case TVoid =>
@@ -55,7 +65,7 @@ object CompileAndEvaluate {
             FastSeq(classInfo[Region]),
             UnitInfo,
             ir,
-            print = None,
+            print = print,
             optimize = optimize,
           )
 
@@ -74,7 +84,7 @@ object CompileAndEvaluate {
               FastSeq(classInfo[Region]),
               LongInfo,
               MakeTuple.ordered(FastSeq(ir)),
-              print = None,
+              print = print,
               optimize = optimize,
             )
 

--- a/hail/hail/src/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -5,10 +5,9 @@ import is.hail.expr.ir.{BaseIR, IRSize, Pretty, TypeCheck}
 import is.hail.utils._
 
 case class LoweringPipeline(lowerings: LoweringPass*) {
-  assert(lowerings.nonEmpty)
-
-  final def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR =
-    ctx.time {
+  final def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR = {
+    if (lowerings.isEmpty) ir
+    else ctx.time {
       var x = ir
 
       def render(context: String): Unit =
@@ -36,6 +35,7 @@ case class LoweringPipeline(lowerings: LoweringPass*) {
 
       x
     }
+  }
 
   def noOptimization(): LoweringPipeline =
     LoweringPipeline(lowerings.filter(l => !l.isInstanceOf[OptimizePass]): _*)
@@ -45,7 +45,6 @@ case class LoweringPipeline(lowerings: LoweringPass*) {
 }
 
 object LoweringPipeline {
-
   def fullLoweringPipeline(context: String, baseTransformer: LoweringPass): LoweringPipeline = {
 
     val base = LoweringPipeline(

--- a/hail/hail/test/src/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/RequirednessSuite.scala
@@ -4,6 +4,7 @@ import is.hail.HailSuite
 import is.hail.expr.Nat
 import is.hail.expr.ir.agg.CallStatsState
 import is.hail.expr.ir.defs._
+import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.stats.fetStruct
 import is.hail.types._
@@ -720,7 +721,8 @@ class RequirednessSuite extends HailSuite {
     CompileAndEvaluate[Unit](
       ctx,
       TableWrite(table, TableNativeWriter(path, overwrite = true)),
-      false,
+      optimize = false,
+      LoweringPipeline.relationalLowerer(optimize = false),
     )
 
     val reader = TableNativeReader(fs, TableNativeReaderParameters(path, None))


### PR DESCRIPTION
## Change Description

Before this change, `CompileAndEvaluate` always invoked the `relationalLowerer` lowering pipeline, despite the fact that this is often called *after* lowering, sometimes on many fragments of a larger IR. So not only is the lowering pipeline not needed, I believe this is at least one of the causes of our logs being polluted with so many IRs in so many stages of lowering it's hard to keep track of what's happening.

As a step towards untangling the compilation process, this instead makes `CompileAndEvaluate` take a lowering pipeline as an argument, with a default of a trivial no-op pipeline. This also allowed the cleanup of some code duplication.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
