### PR TITLE
[hailctl] Fix dry-run and docs for `dataproc submit`

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -331,7 +331,7 @@ def submit(
 
 
 
-    $ hailctl dataproc submit name --image-name docker.io/image my_script.py -- some-argument --animal dog
+    $ hailctl dataproc submit cluster-name my_script.py -- some-argument --animal dog
 
     """
     dataproc_submit(

--- a/hail/python/hailtop/hailctl/dataproc/submit.py
+++ b/hail/python/hailtop/hailctl/dataproc/submit.py
@@ -78,7 +78,7 @@ def submit(
 
     # print underlying gcloud command
     print('gcloud command:')
-    print('gcloud ' + ' '.join(cmd[:5]) + ' \\\n    ' + ' \\\n    '.join(cmd[6:]))
+    print('gcloud ' + ' '.join(cmd[:5]) + ' \\\n    ' + ' \\\n    '.join(cmd[5:]))
 
     # submit job
     if not dry_run:


### PR DESCRIPTION
The `--dry-run` option was not outputing the `cluster` argument, and the docs were using a confusing `--image-name` argument that doesn't mean anything in the context of dataproc.

## Security Assessment

Delete all except the correct answer:
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP