### PR TITLE
[query] make make error on unsupported make version

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -1,3 +1,7 @@
+ifeq (3.82,$(lastword $(sort $(MAKE_VERSION) 3.82)))
+$(error requires gmake version at least 3.82)
+endif
+
 HAIL_HAIL_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 REVISION := $(shell git rev-parse HEAD)


### PR DESCRIPTION
## Change Description

`hail/Makefile` fails with an inscrutable error when using a gmake version prior to 3.82. Mac OS by default comes with 3.81 installed, so this is a common encounter for people first setting up a hail dev environment. This adds a version check to the makefile, to provide a clear error message. Note that `MAKE_VERSION` still assumes gmake, so running this with non-gnu make might still fail in a confusing way. I don't think that's a serious issue, but let me know if anyone disagrees.

On my mac:
```
❯ /usr/bin/make foo
makefile:2: *** requires gmake version at least 3.82.  Stop.
```

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

