### PR TITLE
Update development_tools.md to recommend `uv` instead of conda

### DIFF
--- a/dev-docs/compiler-team/development_tools.md
+++ b/dev-docs/compiler-team/development_tools.md
@@ -44,20 +44,17 @@ https://zulip.com/
 
 Our Zulip server is https://hail.zulipchat.com
 
-##### Anaconda - manage Python installations and packages
+##### uv - managed Python environment
 
-https://www.anaconda.com/download/#macos
+Homebrew is able to install uv for you - `brew install uv`
 
-After installing Anaconda, you should create a new dev environment
-for Hail with:
-
-    conda create --name hail python=3.9
-
-and
-
-    conda activate hail
-
-(put the latter in a shell .rc file so this is done on shell startup)
+After installing, cd to the repo and create a new environment there:
+```bash
+% cd repos/hail
+% uv venv --python 3.11
+[...]
+% source .venv/bin/activate
+```
 
 ##### IntelliJ IDEA - IDE for java/scala/python
 

--- a/dev-docs/compiler-team/development_tools.md
+++ b/dev-docs/compiler-team/development_tools.md
@@ -50,7 +50,7 @@ Homebrew is able to install uv for you - `brew install uv`
 
 After installing, cd to the repo and create a new environment there:
 ```bash
-% cd repos/hail
+% cd hail
 % uv venv --seed --python 3.11
 [...]
 % source .venv/bin/activate

--- a/dev-docs/compiler-team/development_tools.md
+++ b/dev-docs/compiler-team/development_tools.md
@@ -46,7 +46,7 @@ Our Zulip server is https://hail.zulipchat.com
 
 ##### uv - managed Python environment
 
-Homebrew is able to install uv for you - `brew install uv`
+Homebrew is able to install uv for you - `brew install uv`.
 
 After installing, cd to the repo and create a new environment there:
 ```bash

--- a/dev-docs/compiler-team/development_tools.md
+++ b/dev-docs/compiler-team/development_tools.md
@@ -51,7 +51,7 @@ Homebrew is able to install uv for you - `brew install uv`
 After installing, cd to the repo and create a new environment there:
 ```bash
 % cd repos/hail
-% uv venv --python 3.11
+% uv venv --seed --python 3.11
 [...]
 % source .venv/bin/activate
 ```


### PR DESCRIPTION
## Change Description

Update development_tools.md to recommend `uv` instead of conda, and python 3.11 instead of 3.9

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
