### PR TITLE
[qob] write any throwable to worker out file

### DIFF
--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -11,7 +11,6 @@ import is.hail.utils._
 import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
-import scala.util.control.NonFatal
 
 import java.io._
 import java.nio.charset._
@@ -214,7 +213,7 @@ object Worker {
           Right(f(context, htc, theHailClassLoader, fs))
         }
       catch {
-        case NonFatal(err) => Left(err)
+        case t: Throwable => Left(t)
       }
     }
 


### PR DESCRIPTION
This change logs all throwables on the worker during partition execution to the output.

QoB jobs are failing with FileNotFound exceptions when trying to read the failed partition logs when the worker dies with OOM. This is because OOM is  considered a fatal error and so we were never writing it to the output.

This change has no security impact.