### PR TITLE
[qob] Don't set hail off heap memory limits in QoB

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2538,8 +2538,7 @@ class JVMContainer:
         # We allocate 60% of memory per core to off heap memory
 
         memory_mib = total_memory_bytes // (1024**2)
-        heap_memory_mib = int(0.4 * memory_mib)
-        off_heap_memory_per_core_mib = memory_mib - heap_memory_mib
+        heap_memory_mib = int(0.9 * memory_mib)
 
         command = [
             'java',
@@ -2599,7 +2598,7 @@ class JVMContainer:
             cpu_in_mcpu=n_cores * 1000,
             memory_in_bytes=total_memory_bytes,
             user_credentials=None,
-            env=[f'HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB={off_heap_memory_per_core_mib}', f'HAIL_CLOUD={CLOUD}'],
+            env=[f'HAIL_CLOUD={CLOUD}'],
             volume_mounts=volume_mounts,
             log_path=f'/batch/jvm-container-logs/jvm-{index}.log',
         )

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2535,8 +2535,6 @@ class JVMContainer:
             CLOUD, INSTANCE_CONFIG["machine_type"]
         )
         total_memory_bytes = int((n_cores / total_machine_cores) * total_machine_memory_bytes)
-        # We allocate 60% of memory per core to off heap memory
-
         memory_mib = total_memory_bytes // (1024**2)
         heap_memory_mib = int(0.9 * memory_mib)
 


### PR DESCRIPTION
Also, set the java heap limit to 90% of machine memory.

The intention here was to give nicer error messages for when hail was using too much memory. Unfortunately, this drastically reduces the jobs that will succeed, as we partition the heap into a JVM portion and a native portion. And so, the job may hit a memory limit while the machine still has ample memory.

## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has low security impact

### Impact Description
This is a change to the environment of our java containers, where we run Query on Batch jobs. As this is simply a change to how a container is set up, this has low to no impact on the service as a whole.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec