### PR TITLE
[hailctl] Update dataproc image version to 2.2.60

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -43,7 +43,7 @@ if role == 'Master':
         'ipywidgets==8.1.7',
         'jupyter-console==6.6.3',
         'nbconvert==7.13.1',
-        'notebook==7.4.6',
+        'notebook==7.4.4',
         'qtconsole==5.6.1',
     ]
 

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -129,7 +129,7 @@ VEP_SUPPORTED_REGIONS = {'us-central1', 'europe-west1', 'europe-west2', 'austral
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us-central1", "hail-datasets-europe-west1"]
 
-IMAGE_VERSION = '2.2.5-debian12'
+IMAGE_VERSION = '2.2.60-debian12'
 
 
 def start(


### PR DESCRIPTION
We haven't updated this value since February of 2024.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
