### PR TITLE
[query] fix flaky scalacheck test

### DIFF
--- a/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
@@ -511,9 +511,8 @@ class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
     val compareGen =
       for {
         tdict <- arbitrary[TDict]
-        dict: Map[Annotation, Annotation] <- genNullableT(ctx, tdict)
-        key <- genNullable(ctx, tdict.keyType)
-        if dict != null && key != null
+        dict: Map[Annotation, Annotation] <- genNonMissingT(ctx, tdict, innerRequired = false)
+        key <- genNonMissing(ctx, tdict.keyType, innerRequired = false)
       } yield (tdict, dict, key)
 
     forAll(compareGen) { case (tDict, dict, key) =>

--- a/hail/hail/test/src/is/hail/scalacheck/GenVal.scala
+++ b/hail/hail/test/src/is/hail/scalacheck/GenVal.scala
@@ -15,8 +15,8 @@ import org.scalacheck.Gen._
 
 private[scalacheck] trait GenVal {
 
-  def genNonMissing(ctx: ExecuteContext, typ: Type): Gen[An] =
-    genVal(ctx, PType.canonical(typ, required = true, innerRequired = true))
+  def genNonMissing(ctx: ExecuteContext, typ: Type, innerRequired: Boolean = true): Gen[An] =
+    genVal(ctx, PType.canonical(typ, required = true, innerRequired = innerRequired))
 
   def genNullable(ctx: ExecuteContext, typ: Type): Gen[An] =
     genVal(ctx, PType.canonical(typ))
@@ -85,8 +85,8 @@ private[scalacheck] trait GenVal {
   def genNullableT[A <: Null](ctx: ExecuteContext, typ: Type): Gen[A] =
     genNullable(ctx, typ).asInstanceOf[Gen[A]]
 
-  def genNonMissingT[A](ctx: ExecuteContext, typ: Type): Gen[A] =
-    genNonMissing(ctx, typ).asInstanceOf[Gen[A]]
+  def genNonMissingT[A](ctx: ExecuteContext, typ: Type, innerRequired: Boolean = true): Gen[A] =
+    genNonMissing(ctx, typ, innerRequired).asInstanceOf[Gen[A]]
 
   def genTypeVal[T <: Type: Arbitrary](ctx: ExecuteContext): Gen[(T, An)] =
     genTypeValImpl[T](genNullable(ctx, _))


### PR DESCRIPTION
## Change Description

The conditional in the generator was causing the test to fail non-deterministically, due to the generator failing to pass the filter too many times. This avoids generating top-level nulls in the first place.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
