### PR TITLE
[dev] Regenerage test DB certificates after their 1 year expiration

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -269,8 +269,37 @@ steps:
     script: |
       set -ex
 
-      if ! kubectl get secret -n {{ default_ns.name }} database-server-config;
-      then
+      # Check if secret exists and get its age
+      if kubectl get secret -n {{ default_ns.name }} database-server-config >/dev/null 2>&1; then
+          echo "Secret exists, checking age..."
+          
+          # Extract the latest timestamp from managed fields
+          LATEST_TIME=$(kubectl get secret database-server-config -n {{ default_ns.name }} -o json --show-managed-fields | \
+              jq -r '.metadata.managedFields[] | .time' | \
+              sort -r | head -n1)
+          
+          echo "Latest secret modification time: $LATEST_TIME"
+          
+          # Convert to timestamp and check if over 1 year old (365 days)
+          TIMESTAMP=$(date -d "$LATEST_TIME" +%s 2>/dev/null || echo "0")
+          CURRENT_TIME=$(date +%s)
+          AGE_DAYS=$(( (CURRENT_TIME - TIMESTAMP) / 86400 ))
+          
+          echo "Secret age: $AGE_DAYS days"
+          
+          if [ "$AGE_DAYS" -gt 365 ]; then
+              echo "Secret is over 1 year old, regenerating certificates while preserving password..."
+              
+              # Extract existing password
+              EXISTING_PASSWORD=$(kubectl get secret database-server-config -n {{ default_ns.name }} -o jsonpath='{.data.db-root-password}' | base64 -d)
+              
+              # Regenerate certificates with existing password
+              NAMESPACE={{ default_ns.name }} bash /create_test_db_config.sh --keep-password "$EXISTING_PASSWORD"
+          else
+              echo "Secret is less than 1 year old, skipping regeneration"
+          fi
+      else
+          echo "Secret does not exist, creating new one..."
           NAMESPACE={{ default_ns.name }} bash /create_test_db_config.sh
       fi
     serviceAccount:
@@ -3972,8 +4001,6 @@ steps:
     dependsOn:
       - ci_utils_image
       - default_ns
-    scopes:
-      - deploy
   - kind: runImage
     name: test_gcp_ar_cleanup_policies
     resources:

--- a/build.yaml
+++ b/build.yaml
@@ -4004,6 +4004,8 @@ steps:
     dependsOn:
       - ci_utils_image
       - default_ns
+    scopes:
+      - deploy
   - kind: runImage
     name: test_gcp_ar_cleanup_policies
     resources:

--- a/build.yaml
+++ b/build.yaml
@@ -290,11 +290,14 @@ steps:
           if [ "$AGE_DAYS" -gt 365 ]; then
               echo "Secret is over 1 year old, regenerating certificates while preserving password..."
               
-              # Extract existing password
+              # Turn off set -x to avoid logging password:
+              set +x
+              echo 'Running: EXISTING_PASSWORD=$(kubectl get secret database-server-config -n {{ default_ns.name }} -o jsonpath='{.data.db-root-password}' | base64 -d)'
               EXISTING_PASSWORD=$(kubectl get secret database-server-config -n {{ default_ns.name }} -o jsonpath='{.data.db-root-password}' | base64 -d)
-              
-              # Regenerate certificates with existing password
+              # Regenerate certificates with existing password (disable set -x to avoid logging password)
+              echo 'Running: NAMESPACE={{ default_ns.name }} bash /create_test_db_config.sh --keep-password "$EXISTING_PASSWORD"'
               NAMESPACE={{ default_ns.name }} bash /create_test_db_config.sh --keep-password "$EXISTING_PASSWORD"
+              set -x
           else
               echo "Secret is less than 1 year old, skipping regeneration"
           fi

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -162,13 +162,13 @@ async def _create_database():
             await db.just_execute(f"""
                 GRANT {allowed_operations} ON `{_name}`.* TO '{mysql_username}'@'%';
                 """)
-            return
+        else:
+            await db.just_execute(f"""
+                CREATE USER '{mysql_username}'@'%' IDENTIFIED BY '{mysql_password}';
+                GRANT {allowed_operations} ON `{_name}`.* TO '{mysql_username}'@'%';
+                """)
 
-        await db.just_execute(f"""
-            CREATE USER '{mysql_username}'@'%' IDENTIFIED BY '{mysql_password}';
-            GRANT {allowed_operations} ON `{_name}`.* TO '{mysql_username}'@'%';
-            """)
-
+        # Always update the user config secret with latest certificates
         await _write_user_config(
             namespace,
             database_name,

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -162,7 +162,7 @@ async def _create_database():
             await db.just_execute(f"""
                 GRANT {allowed_operations} ON `{_name}`.* TO '{mysql_username}'@'%';
                 """)
-            
+
             # For existing users, patch the certificates in the secret in case they were regenerated
             await _patch_user_config_certificates(namespace, database_name, admin_or_user)
             return

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -165,31 +165,32 @@ async def _create_database():
             
             # For existing users, patch the certificates in the secret in case they were regenerated
             await _patch_user_config_certificates(namespace, database_name, admin_or_user)
-        else:
-            await db.just_execute(f"""
-                CREATE USER '{mysql_username}'@'%' IDENTIFIED BY '{mysql_password}';
-                GRANT {allowed_operations} ON `{_name}`.* TO '{mysql_username}'@'%';
-                """)
+            return
+        
+        await db.just_execute(f"""
+            CREATE USER '{mysql_username}'@'%' IDENTIFIED BY '{mysql_password}';
+            GRANT {allowed_operations} ON `{_name}`.* TO '{mysql_username}'@'%';
+            """)
 
-            # For new users, create the full secret
-            await _write_user_config(
-                namespace,
-                database_name,
-                admin_or_user,
-                SQLConfig(
-                    host=sql_config.host,
-                    port=sql_config.port,
-                    instance=sql_config.instance,
-                    connection_name=sql_config.connection_name,
-                    user=mysql_username,
-                    password=mysql_password,
-                    db=_name,
-                    ssl_ca=sql_config.ssl_ca,
-                    ssl_cert=sql_config.ssl_cert,
-                    ssl_key=sql_config.ssl_key,
-                    ssl_mode=sql_config.ssl_mode,
-                ),
-            )
+        # For new users, create the full secret
+        await _write_user_config(
+            namespace,
+            database_name,
+            admin_or_user,
+            SQLConfig(
+                host=sql_config.host,
+                port=sql_config.port,
+                instance=sql_config.instance,
+                connection_name=sql_config.connection_name,
+                user=mysql_username,
+                password=mysql_password,
+                db=_name,
+                ssl_ca=sql_config.ssl_ca,
+                ssl_cert=sql_config.ssl_cert,
+                ssl_key=sql_config.ssl_key,
+                ssl_mode=sql_config.ssl_mode,
+            ),
+        )
 
     admin_username = create_database_config['admin_username']
     user_username = create_database_config['user_username']

--- a/tls/create_test_db_config.sh
+++ b/tls/create_test_db_config.sh
@@ -57,6 +57,8 @@ if [ -n "$KEEP_PASSWORD" ]; then
     echo "Using provided password"
     echo "$KEEP_PASSWORD" > db-root-password
     password=$KEEP_PASSWORD
+    # Disable set -x to avoid logging password
+    set +x
 else
     echo "Generating new password"
     LC_ALL=C tr -dc '[:alnum:]' </dev/urandom | head -c 16 > db-root-password
@@ -90,6 +92,7 @@ cat >sql-config.json <<EOF
 }
 EOF
 
+# Always use dry-run | apply for consistency
 kubectl create secret generic database-server-config \
     --namespace=$NAMESPACE \
     --from-file=server-ca.pem \
@@ -99,4 +102,5 @@ kubectl create secret generic database-server-config \
     --from-file=client-key.pem \
     --from-file=sql-config.cnf \
     --from-file=sql-config.json \
-    --from-file=db-root-password
+    --from-file=db-root-password \
+    --dry-run=client -o yaml | kubectl apply -n $NAMESPACE -f -


### PR DESCRIPTION
## Change Description

Fixes #14979 by making a couple of changes:

- In `build.yaml` / `create_test_database_server_config`:
  - We now check whether the database server config secret already exists
  - If so, we check whether the secret was updated over a year ago
  - If so, we re-run the `create_test_db_config` script but with a new `--keep-password` option enabled which preserves the existing root password while replacing the expired certificates
- In `tls/create_test_db_config.sh`
  - Adds the handling of the `--keep-password` option so that we can replace certificates while preserving the previous password
- In  `create_database.py`:
  - If the `sql-<database>-<user>-config` secret already exists, we always patch it with the most recent database config certificates, but leave the other fields the same.
  - **Note**: It might be possible to add a gate around this, so we only patch the user secrets if they were modified longer ago than the `database-server-config` secret (indicating that the database server has newer config). This might help avoid churning overwrites of the same content... 🤔 

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Change to the deploy script, in sections which deploy test and production secrets.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
