### PR TITLE
[query] run `ServiceBackend` in `Py4jQueryDriver`

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -366,12 +366,14 @@ def init(
         backend = 'batch'
 
     if backend == 'batch':
-        return hail_event_loop().run_until_complete(
-            init_batch(
+        if os.getenv('HAIL_QUERY_USE_EXPERIMENTAL_BATCH_BACKEND') is not None:
+            return hail.experimental.init(
+                backend=backend,
+                app_name=app_name,
                 log=log,
                 quiet=quiet,
                 append=append,
-                tmpdir=tmp_dir,
+                tmp_dir=tmp_dir,
                 default_reference=default_reference,
                 global_seed=global_seed,
                 driver_cores=driver_cores,
@@ -379,13 +381,32 @@ def init(
                 worker_cores=worker_cores,
                 worker_memory=worker_memory,
                 batch_id=batch_id,
-                name_prefix=app_name,
                 gcs_requester_pays_configuration=gcs_requester_pays_configuration,
                 regions=regions,
                 gcs_bucket_allow_list=gcs_bucket_allow_list,
                 branching_factor=branching_factor,
             )
-        )
+        else:
+            return hail_event_loop().run_until_complete(
+                init_batch(
+                    log=log,
+                    quiet=quiet,
+                    append=append,
+                    tmpdir=tmp_dir,
+                    default_reference=default_reference,
+                    global_seed=global_seed,
+                    driver_cores=driver_cores,
+                    driver_memory=driver_memory,
+                    worker_cores=worker_cores,
+                    worker_memory=worker_memory,
+                    batch_id=batch_id,
+                    name_prefix=app_name,
+                    gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+                    regions=regions,
+                    gcs_bucket_allow_list=gcs_bucket_allow_list,
+                    branching_factor=branching_factor,
+                )
+            )
     if backend == 'spark':
         return init_spark(
             sc=sc,

--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -1,3 +1,4 @@
+from .context import init
 from .datasets import load_dataset
 from .db import DB
 from .export_entries_by_col import export_entries_by_col
@@ -35,6 +36,7 @@ __all__ = [
     'hail_metadata',
     'haplotype_freq_em',
     'import_gtf',
+    'init',
     'ld_score',
     'ld_score_regression',
     'load_dataset',

--- a/hail/python/hail/experimental/context.py
+++ b/hail/python/hail/experimental/context.py
@@ -1,0 +1,145 @@
+from py4j.java_gateway import JavaGateway, JavaObject
+from py4j.protocol import Py4JJavaError
+
+from hail.backend.backend import fatal_error_from_java_error_triplet
+from hail.backend.local_backend import LocalBackend
+from hail.backend.py4j_backend import raise_when_mismatched_hail_versions, start_py4j_gateway
+from hail.context import HailContext, _get_log
+from hail.context import init as init_
+from hail.utils.java import BackendType, array_of, choose_backend, scala_object, scala_package_object
+from hail.version import __version__
+from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
+from hailtop.config import ConfigVariable, configuration_of, get_remote_tmpdir
+
+
+def init(
+    app_name: str | None = None,
+    log: str | None = None,
+    quiet: bool = False,
+    append: bool = False,
+    branching_factor: int = 50,
+    tmp_dir: str | None = None,
+    default_reference: str = 'GRCh37',
+    global_seed: int | None = None,
+    _optimizer_iterations: int | None = None,
+    *,
+    backend: BackendType | None = None,
+    worker_cores: int | None = None,
+    worker_memory: str | None = None,
+    batch_id: int | None = None,
+    gcs_requester_pays_configuration: GCSRequesterPaysConfiguration | None = None,
+    regions: list[str] | None = None,
+    gcs_bucket_allow_list: dict[str, list[str]] | None = None,
+    jvm_heap_size: str | None = None,
+    skip_logging_configuration: bool = False,
+    **kwargs,
+) -> None:
+    backend = choose_backend(backend)
+    if backend != 'batch':
+        return init_(
+            app_name=app_name,
+            log=log,
+            quiet=quiet,
+            append=append,
+            branching_factor=branching_factor,
+            tmp_dir=tmp_dir,
+            default_reference=default_reference,
+            global_seed=global_seed,
+            _optimizer_iterations=_optimizer_iterations,
+            backend=backend,
+            worker_cores=worker_cores,
+            worker_memory=worker_memory,
+            batch_id=batch_id,
+            gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+            regions=regions,
+            gcs_bucket_allow_list=gcs_bucket_allow_list,
+            skip_logging_configuration=skip_logging_configuration,
+            **kwargs,
+        )
+
+    log = _get_log(log)
+    remote_tmpdir = get_remote_tmpdir('ServiceBackend', remote_tmpdir=tmp_dir)
+
+    gateway = start_py4j_gateway(max_heap_size=jvm_heap_size)
+    try:
+        raise_when_mismatched_hail_versions(gateway.jvm)
+        _is = getattr(gateway.jvm, 'is')
+        py4jutils = scala_package_object(_is.hail.utils)
+
+        try:
+            if not skip_logging_configuration:
+                py4jutils.configureLogging(log, quiet, append)
+
+            jbackend = __init_batch_backend(
+                gateway=gateway,
+                name=app_name,
+                batch_id=batch_id,
+                worker_cores=worker_cores,
+                worker_memory=worker_memory,
+                regions=regions,
+            )
+
+            flags = {}
+            if branching_factor is not None:
+                flags['branching_factor'] = str(branching_factor)
+
+            if _optimizer_iterations is not None:
+                flags['optimizer_iterations'] = str(_optimizer_iterations)
+
+            backend = LocalBackend(gateway, jbackend, flags)
+            backend.remote_tmpdir = remote_tmpdir
+            backend.local_tmpdir = tmp_dir
+            backend.gcs_requester_pays_configuration = gcs_requester_pays_configuration
+
+            backend.logger.info(f'Hail {__version__}')
+
+            HailContext.create(log, quiet, append, default_reference, global_seed, backend)
+        except Py4JJavaError as e:
+            tpl = py4jutils.handleForPython(e.java_exception)
+            deepest, full, error_id = tpl._1(), tpl._2(), tpl._3()
+            raise fatal_error_from_java_error_triplet(deepest, full, error_id) from None
+    except:
+        gateway.shutdown()
+        raise
+
+
+def __init_batch_backend(
+    gateway: JavaGateway,
+    name: str | None = None,
+    batch_id: int | None = None,
+    billing_project: str | None = None,
+    deploy_config_file: str | None = None,
+    worker_cores: str | None = None,
+    worker_memory: str | None = None,
+    storage: str | None = None,
+    cloudfuse_configs: list[str] | None = None,
+    regions: list[str] | None = None,
+) -> JavaObject:
+    jvm = gateway.jvm
+    _is = getattr(jvm, 'is')
+
+    if batch_id is None:
+        billing_project = configuration_of(ConfigVariable.BATCH_BILLING_PROJECT, billing_project, None)
+        if billing_project is None:
+            raise ValueError(
+                "No billing project.  Call 'init' with the billing "
+                "project or run 'hailctl config set batch/billing_project "
+                "MY_BILLING_PROJECT'"
+            )
+
+    if regions is None:
+        config_regions = configuration_of(ConfigVariable.BATCH_REGIONS, None, None)
+        regions = config_regions.split(',') if config_regions is not None else []
+
+    ServiceBackend = scala_object(_is.hail.backend.service, 'ServiceBackend')
+    return ServiceBackend.pyServiceBackend(
+        name or 'hail',
+        batch_id,
+        billing_project,
+        deploy_config_file,
+        configuration_of(ConfigVariable.QUERY_BATCH_WORKER_CORES, worker_cores, str(1)),
+        configuration_of(ConfigVariable.QUERY_BATCH_WORKER_MEMORY, worker_memory, 'standard'),
+        storage or '0Gi',
+        array_of(gateway, _is.hail.services.CloudfuseConfig),
+        array_of(gateway, jvm.String, *regions),
+    )

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -2,6 +2,8 @@ import re
 import sys
 from typing import Literal, Optional, Union
 
+from py4j.java_gateway import JavaClass, JavaGateway
+
 from hailtop.config import ConfigVariable, configuration_of
 
 BackendType = Literal['batch', 'local', 'spark']
@@ -130,6 +132,13 @@ def scala_object(jpackage, name):
 
 def scala_package_object(jpackage):
     return scala_object(jpackage, 'package')
+
+
+def array_of(gateway: JavaGateway, clazz: JavaClass, *elems):
+    array = gateway.new_array(clazz, len(elems))
+    for i, elem in enumerate(elems):
+        array[i] = elem
+    return array
 
 
 def jindexed_seq(x):

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -88,8 +88,8 @@ def uninitialized():
 
 
 @pytest.fixture(scope='session')
-def init_hail():
-    hl_init_for_test()
+def init_hail(request):
+    hl_init_for_test(app_name=request.node.name)
     try:
         yield
     finally:

--- a/hail/python/test/hailtop/batch/test_batch_service_backend.py
+++ b/hail/python/test/hailtop/batch/test_batch_service_backend.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import string
 import textwrap
 from configparser import ConfigParser
 from shlex import quote as shq
@@ -823,13 +824,15 @@ async def test_validate_cloud_storage_policy(service_backend: ServiceBackend, mo
     await _test_raises_no_bucket_error(fake_uri2, arg)
 
 
-def new_query_in_batch_job(b: Batch, name: str) -> Job:
+def new_query_in_batch_job(b: Batch, name: str, env: dict[str, str] | None = None) -> Job:
     # creates a query-on-batch job in the current batch
     backend = b._backend
     assert isinstance(backend, ServiceBackend)
 
     run_query_pipeline = textwrap.dedent(
         f"""
+        hailctl config set batch/backend service
+        hailctl config set batch/regions {' '.join(backend.regions or [])}
         hailctl config set batch/remote_tmpdir {backend.remote_tmpdir}
         hailctl config set batch/billing_project {backend._billing_project}
 
@@ -837,7 +840,8 @@ def new_query_in_batch_job(b: Batch, name: str) -> Job:
         from os import getenv
         import hail as hl
 
-        hl.init(backend='batch', batch_id=int(getenv('HAIL_BATCH_ID')))
+        batch_id = int(getenv('HAIL_BATCH_ID'))
+        hl.init(backend='batch', batch_id=batch_id, app_name='{name}')
         hl.utils.range_table(2356)._force_count()
         EOF
         """,
@@ -845,6 +849,8 @@ def new_query_in_batch_job(b: Batch, name: str) -> Job:
 
     j = b.new_bash_job(name=name)
     j.command(run_query_pipeline)
+    for k, v in (env or dict()).items():
+        j.env(k, v)
     return j
 
 
@@ -865,8 +871,28 @@ def test_submit_sequential_qob_pipelines(request, service_backend: ServiceBacken
 def test_race_qob_pipelines(request, service_backend: ServiceBackend):
     b = Batch(request.node.nodeid, service_backend, default_image=HAIL_GENETICS_HAIL_IMAGE)
 
-    for c in ['A', 'B', 'C']:
+    for c in string.ascii_uppercase[:3]:
         new_query_in_batch_job(b, f'Query Pipeline {c}')
+
+    r = b.run()
+    assert r is not None
+    status = r.status()
+    assert status['state'] == 'success', str((status, r.debug_info()))
+
+
+def test_race_local_qob_pipelines(request, service_backend: ServiceBackend):
+    b = Batch(request.node.nodeid, service_backend, default_image=HAIL_GENETICS_HAIL_IMAGE)
+
+    for c in string.ascii_uppercase[:3]:
+        j = new_query_in_batch_job(
+            b,
+            f'Query Pipeline {c}',
+            {
+                'HAIL_QUERY_USE_EXPERIMENTAL_BATCH_BACKEND': '1',
+                'HAIL_CLOUD': os.getenv('HAIL_CLOUD', 'gcp'),
+            },
+        )
+        j.spot(False)
 
     r = b.run()
     assert r is not None


### PR DESCRIPTION
This PR adds EXPERIMENTAL support for query-on-batch-in-batch by running the driver process locally while offloading partition computation to Batch. This differs from the traditional "batch" backend which requires an additional driver job. 

Use the snippet below to try it out. You can supply the same kwargs as you would `hl.init`​. See the `test_race_local_qob_pipelines`​ for how to configure `hailctl`​ in batch to run query pipelines in batch. I'd advise against using spot instances for the main python job as if that gets preempted, the whole pipeline will re-run.

```python
import hail as hl

hl.experimental.init(backend='batch', ...) # usual kwargs
```

By adding a new experimental feature, my hope is to commit this small proof of concept and then improve it incrementally.

Key changes:

- Added `pyServiceBackend` method to create a ServiceBackend from Python
- Added proper interrupt handling in ServiceBackend to cancel jobs when interrupted
- Implemented retry logic for job group creation to handle situations where multiple driver jobs create batch updates concurrently.
- Added a new experimental Python API for initializing Hail with a local driver and Batch backend

This change has no impact on the hail batch service in GCP.