### PR TITLE
[batch] Reorder locking to avoid cancel/create deadlocks

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import logging
 import os
 import secrets
 import time
@@ -1999,15 +2000,18 @@ def test_cancel_job_group(client: BatchClient):
 
 
 def test_submit_new_job_groups_after_a_group_was_cancelled(client: BatchClient):
-    b = create_batch(client)
-    g1 = b.create_job_group()
-    g1.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b.submit()
-    g1.cancel()
-    g2 = b.create_job_group()
-    g2.create_job(DOCKER_ROOT_IMAGE, ['true'])
-    b.submit()
-    assert g2.wait()['state'] == 'success', str(g2.debug_info())
+    # Do this in a loop to make sure that the bug is fixed.
+    for i in range(100):
+        logging.info('test_submit_new_job_groups_after_a_group_was_cancelled: iteration %s', i)
+        b = create_batch(client)
+        g1 = b.create_job_group()
+        g1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+        b.submit()
+        g1.cancel()
+        g2 = b.create_job_group()
+        g2.create_job(DOCKER_ROOT_IMAGE, ['true'])
+        b.submit()
+        assert g2.wait()['state'] == 'success', str(g2.debug_info())
 
 
 def test_get_job_group_from_client_batch(client: BatchClient):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,6 +1,5 @@
 import asyncio
 import collections
-import logging
 import os
 import secrets
 import time
@@ -2000,18 +1999,15 @@ def test_cancel_job_group(client: BatchClient):
 
 
 def test_submit_new_job_groups_after_a_group_was_cancelled(client: BatchClient):
-    # Do this in a loop to make sure that the bug is fixed.
-    for i in range(100):
-        logging.info('test_submit_new_job_groups_after_a_group_was_cancelled: iteration %s', i)
-        b = create_batch(client)
-        g1 = b.create_job_group()
-        g1.create_job(DOCKER_ROOT_IMAGE, ['true'])
-        b.submit()
-        g1.cancel()
-        g2 = b.create_job_group()
-        g2.create_job(DOCKER_ROOT_IMAGE, ['true'])
-        b.submit()
-        assert g2.wait()['state'] == 'success', str(g2.debug_info())
+    b = create_batch(client)
+    g1 = b.create_job_group()
+    g1.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
+    g1.cancel()
+    g2 = b.create_job_group()
+    g2.create_job(DOCKER_ROOT_IMAGE, ['true'])
+    b.submit()
+    assert g2.wait()['state'] == 'success', str(g2.debug_info())
 
 
 def test_get_job_group_from_client_batch(client: BatchClient):


### PR DESCRIPTION
## Change Description

Fixes #14413

Change the order of operations in the cancel operation. There should be no functional change since this is within a transaction, but this should mean our locking order matches other operations, avoiding the risk of deadlocks

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a low security impact

### Impact Description

Small re-ordering of operations to remove a risk of deadlocks for job group delete / create operations in quick succession

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
