### PR TITLE
[compiler] fix testBinarySearchOnSet

### DIFF
--- a/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
@@ -493,15 +493,13 @@ class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
         val asArray = SafeIndexedSeq(pArray, soff)
 
         val f = fb.resultWithIndex()(theHailClassLoader, ctx.fs, ctx.taskContext, region)
-        val closestI = f(region, soff, eoff)
+        val i = f(region, soff, eoff)
+        val ordering = t.ordering(sm)
 
-        whenever(set.contains(elem)) {
-          val maybeEqual = asArray(closestI)
-          assert(
-            (elem == maybeEqual) &&
-              (t.ordering(sm).compare(elem, maybeEqual) <= 0 || (closestI == set.size - 1))
-          )
-        }
+        // if i-1 is in bounds, then asArray(i) < elem
+        // if i is in bounds, then elem <= asArray(i)
+        assert(((i - 1 < 0) || ordering.compare(asArray(i - 1), elem) < 0) &&
+          ((i >= set.size) || ordering.compare(elem, asArray(i)) <= 0))
       }
     }
   }


### PR DESCRIPTION
## Change Description

This test was flaky, as scalacheck was discarding the test case whenever the generated value was not an element of the generated set. Since the empty set is likely to be generated, this failed often, causing the test to fail with a "too many discarded cases" error.

There was some logic in the assertion that was clearly intended to test the behavior in the case that the element is not contained in the set. But as that logic was never exercised, it was no longer correct.

I've rewritten the assertion to never discard a test case, and to correctly verify the post-conditions of the binary search method in all cases. As a side benefit, on my computer, the test has gone from sometimes taking 30-60s, to <2s.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

