### PR TITLE
[compiler] remove types from ComparisonOp

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/ComparisonOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/ComparisonOp.scala
@@ -13,60 +13,51 @@ object ComparisonOp {
       throw new RuntimeException(s"Cannot compare types $lt and $rt")
 
   val fromString: PartialFunction[String, ComparisonOp[_]] = {
-    case "==" | "EQ" =>
-      EQ(null, null)
-    case "!=" | "NEQ" =>
-      NEQ(null, null)
-    case ">=" | "GTEQ" =>
-      GTEQ(null, null)
-    case "<=" | "LTEQ" =>
-      LTEQ(null, null)
-    case ">" | "GT" =>
-      GT(null, null)
-    case "<" | "LT" =>
-      LT(null, null)
-    case "Compare" =>
-      Compare(null, null)
+    case "==" | "EQ" => EQ
+    case "!=" | "NEQ" => NEQ
+    case ">=" | "GTEQ" => GTEQ
+    case "<=" | "LTEQ" => LTEQ
+    case ">" | "GT" => GT
+    case "<" | "LT" => LT
+    case "Compare" => Compare
   }
 
   def negate(op: ComparisonOp[Boolean]): ComparisonOp[Boolean] = {
     op match {
-      case GT(t1, t2) => LTEQ(t1, t2)
-      case LT(t1, t2) => GTEQ(t1, t2)
-      case GTEQ(t1, t2) => LT(t1, t2)
-      case LTEQ(t1, t2) => GT(t1, t2)
-      case EQ(t1, t2) => NEQ(t1, t2)
-      case NEQ(t1, t2) => EQ(t1, t2)
-      case EQWithNA(t1, t2) => NEQWithNA(t1, t2)
-      case NEQWithNA(t1, t2) => EQWithNA(t1, t2)
-      case StructLT(t1, t2, sortFields) => StructGTEQ(t1, t2, sortFields)
-      case StructGT(t1, t2, sortFields) => StructLTEQ(t1, t2, sortFields)
-      case StructLTEQ(t1, t2, sortFields) => StructGT(t1, t2, sortFields)
-      case StructGTEQ(t1, t2, sortFields) => StructLT(t1, t2, sortFields)
+      case GT => LTEQ
+      case LT => GTEQ
+      case GTEQ => LT
+      case LTEQ => GT
+      case EQ => NEQ
+      case NEQ => EQ
+      case EQWithNA => NEQWithNA
+      case NEQWithNA => EQWithNA
+      case StructLT(sortFields) => StructGTEQ(sortFields)
+      case StructGT(sortFields) => StructLTEQ(sortFields)
+      case StructLTEQ(sortFields) => StructGT(sortFields)
+      case StructGTEQ(sortFields) => StructLT(sortFields)
     }
   }
 
   def swap(op: ComparisonOp[Boolean]): ComparisonOp[Boolean] = {
     op match {
-      case GT(t1, t2) => LT(t2, t1)
-      case LT(t1, t2) => GT(t2, t1)
-      case GTEQ(t1, t2) => LTEQ(t2, t1)
-      case LTEQ(t1, t2) => GTEQ(t2, t1)
-      case EQ(t1, t2) => EQ(t2, t1)
-      case NEQ(t1, t2) => NEQ(t2, t1)
-      case EQWithNA(t1, t2) => EQWithNA(t2, t1)
-      case NEQWithNA(t1, t2) => NEQWithNA(t2, t1)
-      case StructLT(t1, t2, sortFields) => StructGT(t2, t1, sortFields)
-      case StructGT(t1, t2, sortFields) => StructLT(t2, t1, sortFields)
-      case StructLTEQ(t1, t2, sortFields) => StructGTEQ(t2, t1, sortFields)
-      case StructGTEQ(t1, t2, sortFields) => StructLTEQ(t2, t1, sortFields)
+      case GT => LT
+      case LT => GT
+      case GTEQ => LTEQ
+      case LTEQ => GTEQ
+      case EQ => EQ
+      case NEQ => NEQ
+      case EQWithNA => EQWithNA
+      case NEQWithNA => NEQWithNA
+      case StructLT(sortFields) => StructGT(sortFields)
+      case StructGT(sortFields) => StructLT(sortFields)
+      case StructLTEQ(sortFields) => StructGTEQ(sortFields)
+      case StructGTEQ(sortFields) => StructLTEQ(sortFields)
     }
   }
 }
 
 sealed trait ComparisonOp[ReturnType] {
-  def t1: Type
-  def t2: Type
   val op: CodeOrdering.Op
   val strict: Boolean = true
 
@@ -77,78 +68,49 @@ sealed trait ComparisonOp[ReturnType] {
   }
 
   def render(): is.hail.utils.prettyPrint.Doc = Pretty.prettyClass(this)
-
-  def copy(t1: Type, t2: Type): ComparisonOp[ReturnType]
 }
 
-case class GT(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object GT extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Gt()
-  override def copy(t1: Type = t1, t2: Type = t2): GT = GT(t1, t2)
 }
 
-object GT { def apply(typ: Type): GT = GT(typ, typ) }
-
-case class GTEQ(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object GTEQ extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Gteq()
-  override def copy(t1: Type = t1, t2: Type = t2): GTEQ = GTEQ(t1, t2)
 }
 
-object GTEQ { def apply(typ: Type): GTEQ = GTEQ(typ, typ) }
-
-case class LTEQ(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object LTEQ extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Lteq()
-  override def copy(t1: Type = t1, t2: Type = t2): LTEQ = LTEQ(t1, t2)
 }
 
-object LTEQ { def apply(typ: Type): LTEQ = LTEQ(typ, typ) }
-
-case class LT(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object LT extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Lt()
-  override def copy(t1: Type = t1, t2: Type = t2): LT = LT(t1, t2)
 }
 
-object LT { def apply(typ: Type): LT = LT(typ, typ) }
-
-case class EQ(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object EQ extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Equiv()
-  override def copy(t1: Type = t1, t2: Type = t2): EQ = EQ(t1, t2)
 }
 
-object EQ { def apply(typ: Type): EQ = EQ(typ, typ) }
-
-case class NEQ(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object NEQ extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Neq()
-  override def copy(t1: Type = t1, t2: Type = t2): NEQ = NEQ(t1, t2)
 }
 
-object NEQ { def apply(typ: Type): NEQ = NEQ(typ, typ) }
-
-case class EQWithNA(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object EQWithNA extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Equiv()
   override val strict: Boolean = false
-  override def copy(t1: Type = t1, t2: Type = t2): EQWithNA = EQWithNA(t1, t2)
 }
 
-object EQWithNA { def apply(typ: Type): EQWithNA = EQWithNA(typ, typ) }
-
-case class NEQWithNA(t1: Type, t2: Type) extends ComparisonOp[Boolean] {
+case object NEQWithNA extends ComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.Neq()
   override val strict: Boolean = false
-  override def copy(t1: Type = t1, t2: Type = t2): NEQWithNA = NEQWithNA(t1, t2)
 }
 
-object NEQWithNA { def apply(typ: Type): NEQWithNA = NEQWithNA(typ, typ) }
-
-case class Compare(t1: Type, t2: Type) extends ComparisonOp[Int] {
+case object Compare extends ComparisonOp[Int] {
   override val strict: Boolean = false
   val op: CodeOrdering.Op = CodeOrdering.Compare()
-  override def copy(t1: Type = t1, t2: Type = t2): Compare = Compare(t1, t2)
 }
 
-object Compare { def apply(typ: Type): Compare = Compare(typ, typ) }
-
 trait StructComparisonOp[T] extends ComparisonOp[T] {
-  val sortFields: Array[SortField]
+  val sortFields: IndexedSeq[SortField]
 
   override def codeOrdering(ecb: EmitClassBuilder[_], t1: SType, t2: SType): F[op.ReturnType] = {
     ComparisonOp.checkCompatible(t1.virtualType, t2.virtualType)
@@ -161,53 +123,23 @@ trait StructComparisonOp[T] extends ComparisonOp[T] {
   }
 }
 
-case class StructCompare(t1: Type, t2: Type, sortFields: Array[SortField])
-    extends StructComparisonOp[Int] {
+case class StructCompare(sortFields: IndexedSeq[SortField]) extends StructComparisonOp[Int] {
   val op: CodeOrdering.Op = CodeOrdering.StructCompare()
   override val strict: Boolean = false
-  override def copy(t1: Type = t1, t2: Type = t2): StructCompare = StructCompare(t1, t2, sortFields)
 }
 
-case class StructLT(t1: Type, t2: Type, sortFields: Array[SortField])
-    extends StructComparisonOp[Boolean] {
+case class StructLT(sortFields: IndexedSeq[SortField]) extends StructComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.StructLt()
-  override def copy(t1: Type = t1, t2: Type = t2): StructLT = StructLT(t1, t2, sortFields)
 }
 
-object StructLT {
-  def apply(typ: Type, sortFields: IndexedSeq[SortField]): StructLT =
-    StructLT(typ, typ, sortFields.toArray)
-}
-
-case class StructLTEQ(t1: Type, t2: Type, sortFields: Array[SortField])
-    extends StructComparisonOp[Boolean] {
+case class StructLTEQ(sortFields: IndexedSeq[SortField]) extends StructComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.StructLteq()
-  override def copy(t1: Type = t1, t2: Type = t2): StructLTEQ = StructLTEQ(t1, t2, sortFields)
 }
 
-object StructLTEQ {
-  def apply(typ: Type, sortFields: IndexedSeq[SortField]): StructLTEQ =
-    StructLTEQ(typ, typ, sortFields.toArray)
-}
-
-case class StructGT(t1: Type, t2: Type, sortFields: Array[SortField])
-    extends StructComparisonOp[Boolean] {
+case class StructGT(sortFields: IndexedSeq[SortField]) extends StructComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.StructGt()
-  override def copy(t1: Type = t1, t2: Type = t2): StructGT = StructGT(t1, t2, sortFields)
 }
 
-object StructGT {
-  def apply(typ: Type, sortFields: IndexedSeq[SortField]): StructGT =
-    StructGT(typ, typ, sortFields.toArray)
-}
-
-case class StructGTEQ(t1: Type, t2: Type, sortFields: Array[SortField])
-    extends StructComparisonOp[Boolean] {
+case class StructGTEQ(sortFields: IndexedSeq[SortField]) extends StructComparisonOp[Boolean] {
   val op: CodeOrdering.Op = CodeOrdering.StructGteq()
-  override def copy(t1: Type = t1, t2: Type = t2): StructGTEQ = StructGTEQ(t1, t2, sortFields)
-}
-
-object StructGTEQ {
-  def apply(typ: Type, sortFields: IndexedSeq[SortField]): StructGTEQ =
-    StructGTEQ(typ, typ, sortFields.toArray)
 }

--- a/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
@@ -174,38 +174,38 @@ object DeprecatedIRBuilder {
 
     def ceq(other: IRProxy): IRProxy = (env: E) => {
       val left = ir(env)
-      val right = other(env);
-      ApplyComparisonOp(EQWithNA(left.typ, right.typ), left, right)
+      val right = other(env)
+      ApplyComparisonOp(EQWithNA, left, right)
     }
 
     def cne(other: IRProxy): IRProxy = (env: E) => {
       val left = ir(env)
       val right = other(env)
-      ApplyComparisonOp(NEQWithNA(left.typ, right.typ), left, right)
+      ApplyComparisonOp(NEQWithNA, left, right)
     }
 
     def <(other: IRProxy): IRProxy = (env: E) => {
       val left = ir(env)
       val right = other(env)
-      ApplyComparisonOp(LT(left.typ, right.typ), left, right)
+      ApplyComparisonOp(LT, left, right)
     }
 
     def >(other: IRProxy): IRProxy = (env: E) => {
       val left = ir(env)
       val right = other(env)
-      ApplyComparisonOp(GT(left.typ, right.typ), left, right)
+      ApplyComparisonOp(GT, left, right)
     }
 
     def <=(other: IRProxy): IRProxy = (env: E) => {
       val left = ir(env)
       val right = other(env)
-      ApplyComparisonOp(LTEQ(left.typ, right.typ), left, right)
+      ApplyComparisonOp(LTEQ, left, right)
     }
 
     def >=(other: IRProxy): IRProxy = (env: E) => {
       val left = ir(env)
       val right = other(env)
-      ApplyComparisonOp(GTEQ(left.typ, right.typ), left, right)
+      ApplyComparisonOp(GTEQ, left, right)
     }
 
     def apply(lookup: Symbol): IRProxy = (env: E) => {

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -669,7 +669,7 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
   def getStructOrderingFunction(
     t1: SBaseStruct,
     t2: SBaseStruct,
-    sortFields: Array[SortField],
+    sortFields: IndexedSeq[SortField],
     op: CodeOrdering.Op,
   ): CodeOrdering.F[op.ReturnType] = {
     (cb: EmitCodeBuilder, v1: EmitValue, v2: EmitValue) =>

--- a/hail/hail/src/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/hail/src/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -350,7 +350,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
 
       def fromComparison(v: Any, op: ComparisonOp[_], wrapped: Boolean = true): BoolValue = {
         (op: @unchecked) match {
-          case _: EQ => BoolValue( // value == key
+          case EQ => BoolValue( // value == key
               KeySet(Interval(endpoint(v, -1, wrapped), endpoint(v, 1, wrapped))),
               KeySet(
                 Interval(negInf, endpoint(v, -1, wrapped)),
@@ -358,7 +358,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
               ),
               KeySet(Interval(endpoint(null, -1), posInf)),
             )
-          case _: NEQ => BoolValue( // value != key
+          case NEQ => BoolValue( // value != key
               KeySet(
                 Interval(negInf, endpoint(v, -1, wrapped)),
                 Interval(endpoint(v, 1, wrapped), endpoint(null, -1)),
@@ -366,27 +366,27 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
               KeySet(Interval(endpoint(v, -1, wrapped), endpoint(v, 1, wrapped))),
               KeySet(Interval(endpoint(null, -1), posInf)),
             )
-          case _: GT => BoolValue( // value > key
+          case GT => BoolValue( // value > key
               KeySet(Interval(negInf, endpoint(v, -1, wrapped))),
               KeySet(Interval(endpoint(v, -1, wrapped), endpoint(null, -1))),
               KeySet(Interval(endpoint(null, -1), posInf)),
             )
-          case _: GTEQ => BoolValue( // value >= key
+          case GTEQ => BoolValue( // value >= key
               KeySet(Interval(negInf, endpoint(v, 1, wrapped))),
               KeySet(Interval(endpoint(v, 1, wrapped), endpoint(null, -1))),
               KeySet(Interval(endpoint(null, -1), posInf)),
             )
-          case _: LT => BoolValue( // value < key
+          case LT => BoolValue( // value < key
               KeySet(Interval(endpoint(v, 1, wrapped), endpoint(null, -1))),
               KeySet(Interval(negInf, endpoint(v, 1, wrapped))),
               KeySet(Interval(endpoint(null, -1), posInf)),
             )
-          case _: LTEQ => BoolValue( // value <= key
+          case LTEQ => BoolValue( // value <= key
               KeySet(Interval(endpoint(v, -1, wrapped), endpoint(null, -1))),
               KeySet(Interval(negInf, endpoint(v, -1, wrapped))),
               KeySet(Interval(endpoint(null, -1), posInf)),
             )
-          case _: EQWithNA => // value == key
+          case EQWithNA => // value == key
             if (v == null)
               BoolValue(
                 KeySet(Interval(endpoint(v, -1, wrapped), posInf)),
@@ -402,7 +402,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
                 ),
                 KeySetLattice.bottom,
               )
-          case _: NEQWithNA => // value != key
+          case NEQWithNA => // value != key
             if (v == null)
               BoolValue(
                 KeySet(Interval(negInf, endpoint(v, -1, wrapped))),
@@ -423,7 +423,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
 
       def fromComparisonKeyPrefix(v: Row, op: ComparisonOp[_]): BoolValue = {
         (op: @unchecked) match {
-          case _: EQ => BoolValue( // value == key
+          case EQ => BoolValue( // value == key
               KeySet(Interval(endpoint(v, -1, false), endpoint(v, 1, false))),
               KeySet(
                 Interval(negInf, endpoint(v, -1, false)),
@@ -431,7 +431,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
               ),
               KeySetLattice.bottom,
             )
-          case _: NEQ => BoolValue( // value != key
+          case NEQ => BoolValue( // value != key
               KeySet(
                 Interval(negInf, endpoint(v, -1, false)),
                 Interval(endpoint(v, 1, false), posInf),
@@ -439,27 +439,27 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
               KeySet(Interval(endpoint(v, -1, false), endpoint(v, 1, false))),
               KeySetLattice.bottom,
             )
-          case _: GT => BoolValue( // value > key
+          case GT => BoolValue( // value > key
               KeySet(Interval(negInf, endpoint(v, -1, false))),
               KeySet(Interval(endpoint(v, -1, false), posInf)),
               KeySetLattice.bottom,
             )
-          case _: GTEQ => BoolValue( // value >= key
+          case GTEQ => BoolValue( // value >= key
               KeySet(Interval(negInf, endpoint(v, 1, false))),
               KeySet(Interval(endpoint(v, 1, false), posInf)),
               KeySetLattice.bottom,
             )
-          case _: LT => BoolValue( // value < key
+          case LT => BoolValue( // value < key
               KeySet(Interval(endpoint(v, 1, false), posInf)),
               KeySet(Interval(negInf, endpoint(v, 1, false))),
               KeySetLattice.bottom,
             )
-          case _: LTEQ => BoolValue( // value <= key
+          case LTEQ => BoolValue( // value <= key
               KeySet(Interval(endpoint(v, -1, false), posInf)),
               KeySet(Interval(negInf, endpoint(v, 1, false))),
               KeySetLattice.bottom,
             )
-          case _: EQWithNA => BoolValue( // value == key
+          case EQWithNA => BoolValue( // value == key
               KeySet(Interval(endpoint(v, -1, false), endpoint(v, 1, false))),
               KeySet(
                 Interval(negInf, endpoint(v, -1, false)),
@@ -467,7 +467,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
               ),
               KeySetLattice.bottom,
             )
-          case _: NEQWithNA => BoolValue( // value != key
+          case NEQWithNA => BoolValue( // value != key
               KeySet(
                 Interval(negInf, endpoint(v, -1, false)),
                 Interval(endpoint(v, 1, false), posInf),
@@ -657,8 +657,8 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
               )
 
               op match {
-                case _: EQ => b
-                case _: NEQ => BoolValue.not(b)
+                case EQ => b
+                case NEQ => BoolValue.not(b)
                 case _ => BoolValue.top(keySet)
               }
             case None =>
@@ -685,7 +685,7 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) {
       }
 
     private def opIsSupported(op: ComparisonOp[_]): Boolean = op match {
-      case _: EQ | _: NEQ | _: LTEQ | _: LT | _: GTEQ | _: GT | _: EQWithNA | _: NEQWithNA => true
+      case EQ | NEQ | LTEQ | LT | GTEQ | GT | EQWithNA | NEQWithNA => true
       case _ => false
     }
   }

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -499,17 +499,17 @@ package defs {
 
     def unary_!(): IR = ApplyUnaryPrimOp(Bang, self)
 
-    def ceq(other: IR): IR = ApplyComparisonOp(EQWithNA(self.typ, other.typ), self, other)
+    def ceq(other: IR): IR = ApplyComparisonOp(EQWithNA, self, other)
 
-    def cne(other: IR): IR = ApplyComparisonOp(NEQWithNA(self.typ, other.typ), self, other)
+    def cne(other: IR): IR = ApplyComparisonOp(NEQWithNA, self, other)
 
-    def <(other: IR): IR = ApplyComparisonOp(LT(self.typ, other.typ), self, other)
+    def <(other: IR): IR = ApplyComparisonOp(LT, self, other)
 
-    def >(other: IR): IR = ApplyComparisonOp(GT(self.typ, other.typ), self, other)
+    def >(other: IR): IR = ApplyComparisonOp(GT, self, other)
 
-    def <=(other: IR): IR = ApplyComparisonOp(LTEQ(self.typ, other.typ), self, other)
+    def <=(other: IR): IR = ApplyComparisonOp(LTEQ, self, other)
 
-    def >=(other: IR): IR = ApplyComparisonOp(GTEQ(self.typ, other.typ), self, other)
+    def >=(other: IR): IR = ApplyComparisonOp(GTEQ, self, other)
   }
 
   object ErrorIDs {
@@ -637,21 +637,21 @@ package defs {
             case _: TStruct =>
               val elt = tcoerce[TStruct](atyp.elementType)
               ApplyComparisonOp(
-                Compare(elt.types(0)),
+                Compare,
                 GetField(Ref(l, elt), elt.fieldNames(0)),
                 GetField(Ref(r, atyp.elementType), elt.fieldNames(0)),
               )
             case _: TTuple =>
               val elt = tcoerce[TTuple](atyp.elementType)
               ApplyComparisonOp(
-                Compare(elt.types(0)),
+                Compare,
                 GetTupleElement(Ref(l, elt), elt.fields(0).index),
                 GetTupleElement(Ref(r, atyp.elementType), elt.fields(0).index),
               )
           }
         } else {
           ApplyComparisonOp(
-            Compare(atyp.elementType),
+            Compare,
             Ref(l, atyp.elementType),
             Ref(r, atyp.elementType),
           )
@@ -773,13 +773,13 @@ package defs {
       def min(element: IR, sortFields: IndexedSeq[SortField]): IR = {
         val elementType = element.typ.asInstanceOf[TStruct]
         val keyType = elementType.select(sortFields.map(_.field))._1
-        minAndMaxHelper(element, keyType, StructLT(keyType, sortFields))
+        minAndMaxHelper(element, keyType, StructLT(sortFields))
       }
 
       def max(element: IR, sortFields: IndexedSeq[SortField]): IR = {
         val elementType = element.typ.asInstanceOf[TStruct]
         val keyType = elementType.select(sortFields.map(_.field))._1
-        minAndMaxHelper(element, keyType, StructGT(keyType, sortFields))
+        minAndMaxHelper(element, keyType, StructGT(sortFields))
       }
 
       def all(element: IR): IR =

--- a/hail/hail/src/is/hail/expr/ir/InferType.scala
+++ b/hail/hail/src/is/hail/expr/ir/InferType.scala
@@ -75,7 +75,7 @@ object InferType {
       case ApplyComparisonOp(op, l, r) =>
         assert(l.typ == r.typ)
         op match {
-          case _: Compare => TInt32
+          case Compare => TInt32
           case _ => TBoolean
         }
       case a: ApplyIR => a.returnType

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -247,19 +247,20 @@ object Interpret {
       case ApplyComparisonOp(op, l, r) =>
         val lValue = interpret(l, env, args)
         val rValue = interpret(r, env, args)
+        val t = l.typ
         if (op.strict && (lValue == null || rValue == null))
           null
         else
           op match {
-            case EQ(t, _) => t.ordering(ctx.stateManager).equiv(lValue, rValue)
-            case EQWithNA(t, _) => t.ordering(ctx.stateManager).equiv(lValue, rValue)
-            case NEQ(t, _) => !t.ordering(ctx.stateManager).equiv(lValue, rValue)
-            case NEQWithNA(t, _) => !t.ordering(ctx.stateManager).equiv(lValue, rValue)
-            case LT(t, _) => t.ordering(ctx.stateManager).lt(lValue, rValue)
-            case GT(t, _) => t.ordering(ctx.stateManager).gt(lValue, rValue)
-            case LTEQ(t, _) => t.ordering(ctx.stateManager).lteq(lValue, rValue)
-            case GTEQ(t, _) => t.ordering(ctx.stateManager).gteq(lValue, rValue)
-            case Compare(t, _) => t.ordering(ctx.stateManager).compare(lValue, rValue)
+            case EQ => t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case EQWithNA => t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case NEQ => !t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case NEQWithNA => !t.ordering(ctx.stateManager).equiv(lValue, rValue)
+            case LT => t.ordering(ctx.stateManager).lt(lValue, rValue)
+            case GT => t.ordering(ctx.stateManager).gt(lValue, rValue)
+            case LTEQ => t.ordering(ctx.stateManager).lteq(lValue, rValue)
+            case GTEQ => t.ordering(ctx.stateManager).gteq(lValue, rValue)
+            case Compare => t.ordering(ctx.stateManager).compare(lValue, rValue)
           }
 
       case MakeArray(elements, _) => elements.map(interpret(_, env, args)).toFastSeq

--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -30,8 +30,6 @@ import is.hail.utils._
 import is.hail.utils.richUtils.ByteTrackingOutputStream
 import is.hail.variant.{Call, ReferenceGenome}
 
-import scala.language.existentials
-
 import java.io.{InputStream, OutputStream}
 import java.nio.file.{FileSystems, Path}
 import java.util.UUID
@@ -571,8 +569,8 @@ case class SplitPartitionNativeWriter(
                   firstSeenSettable,
                   EmitValue.present(key.copyToRegion(cb, region, firstSeenSettable.st)),
                 ),
-                { lastSeen =>
-                  val comparator = EQ(lastSeenSettable.emitType.virtualType).codeOrdering(
+                { _ =>
+                  val comparator = EQ.codeOrdering(
                     cb.emb.ecb,
                     lastSeenSettable.st,
                     key.st,
@@ -2504,7 +2502,7 @@ case class MatrixBlockMatrixWriter(
       }
     val flatPathsAndIndices = flatMapIR(ToStream(pathsWithColMajorIndices))(ToStream(_))
     val sortedColMajorPairs = sortIR(flatPathsAndIndices) { case (l, r) =>
-      ApplyComparisonOp(LT(TInt32), GetTupleElement(l, 0), GetTupleElement(r, 0))
+      ApplyComparisonOp(LT, GetTupleElement(l, 0), GetTupleElement(r, 0))
     }
     val flatPaths = ToArray(mapIR(ToStream(sortedColMajorPairs))(GetTupleElement(_, 1)))
     val bmt = BlockMatrixType(

--- a/hail/hail/src/is/hail/expr/ir/Parser.scala
+++ b/hail/hail/src/is/hail/expr/ir/Parser.scala
@@ -2088,9 +2088,6 @@ object IRParser {
           x.aggSig.initOpArgs = x.initOpArgs.map(_.typ)
           x.aggSig.seqOpArgs = x.seqOpArgs.map(_.typ)
           x
-        case x: ApplyComparisonOp =>
-          x.op = x.op.copy(x.l.typ, x.r.typ)
-          x
         case MakeArray(args, typ) =>
           MakeArray.unify(ctx, args, typ)
         case x @ InitOp(

--- a/hail/hail/src/is/hail/expr/ir/Requiredness.scala
+++ b/hail/hail/src/is/hail/expr/ir/Requiredness.scala
@@ -574,11 +574,9 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case ConsoleLog(_, result) =>
         requiredness.unionFrom(lookup(result))
       case x if x.typ == TVoid =>
-      case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(
-            NEQWithNA(_, _),
-            _,
-            _,
-          ) | ApplyComparisonOp(Compare(_, _), _, _) =>
+      case ApplyComparisonOp(EQWithNA, _, _) |
+          ApplyComparisonOp(NEQWithNA, _, _) |
+          ApplyComparisonOp(Compare, _, _) =>
       case ApplyComparisonOp(op, _, _) =>
         fatal(s"non-strict comparison op $op must have explicit case")
       case TableCount(_) =>

--- a/hail/hail/src/is/hail/expr/ir/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/Simplify.scala
@@ -82,8 +82,8 @@ object Simplify {
           _: MakeStruct |
           _: MakeTuple |
           _: IsNA |
-          ApplyComparisonOp(EQWithNA(_, _), _, _) |
-          ApplyComparisonOp(NEQWithNA(_, _), _, _) |
+          ApplyComparisonOp(EQWithNA, _, _) |
+          ApplyComparisonOp(NEQWithNA, _, _) |
           _: I32 | _: I64 | _: F32 | _: F64 | True() | False() => true
       case _ => false
     }
@@ -165,12 +165,12 @@ object Simplify {
         case ApplyComparisonOp(op, x, y)
             if (!isFloating(x.typ) && x.typ == y.typ) && x == y =>
           op match {
-            case _: LT => Some(False())
-            case _: LTEQ => Some(True())
-            case _: EQ => Some(True())
-            case _: GTEQ => Some(True())
-            case _: GT => Some(False())
-            case _: NEQ => Some(False())
+            case LT => Some(False())
+            case LTEQ => Some(True())
+            case EQ => Some(True())
+            case GTEQ => Some(True())
+            case GT => Some(False())
+            case NEQ => Some(False())
             case _ => None
           }
 
@@ -796,7 +796,6 @@ object Simplify {
         val left = freshName()
         val right = freshName()
         val uid3 = freshName()
-        val sortType = child.typ.rowType.select(sortFields.map(_.field))._1
 
         val kvElement = MakeStruct(FastSeq(
           ("key", SelectFields(Ref(uid2, child.typ.rowType), sortFields.map(_.field))),
@@ -811,7 +810,7 @@ object Simplify {
           left,
           right,
           ApplyComparisonOp(
-            LT(sortType),
+            LT,
             GetField(Ref(left, kvElement.typ), "key"),
             GetField(Ref(right, kvElement.typ), "key"),
           ),
@@ -881,16 +880,16 @@ object Simplify {
         Some(InsertFields(s, fields))
 
       // simplify Boolean equality
-      case ApplyComparisonOp(EQ(_, _), expr, True()) =>
+      case ApplyComparisonOp(EQ, expr, True()) =>
         Some(expr)
 
-      case ApplyComparisonOp(EQ(_, _), True(), expr) =>
+      case ApplyComparisonOp(EQ, True(), expr) =>
         Some(expr)
 
-      case ApplyComparisonOp(EQ(_, _), expr, False()) =>
+      case ApplyComparisonOp(EQ, expr, False()) =>
         Some(ApplyUnaryPrimOp(Bang, expr))
 
-      case ApplyComparisonOp(EQ(_, _), False(), expr) =>
+      case ApplyComparisonOp(EQ, False(), expr) =>
         Some(ApplyUnaryPrimOp(Bang, expr))
 
       case ApplyUnaryPrimOp(Bang, ApplyComparisonOp(op, l, r)) =>

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -197,7 +197,7 @@ object LoweredTableReader {
                 ),
               "ksorted" ->
                 ApplyComparisonOp(
-                  EQ(TInt64),
+                  EQ,
                   ApplyAggOp(
                     FastSeq(),
                     FastSeq(
@@ -209,7 +209,7 @@ object LoweredTableReader {
                           TBoolean,
                           IsNA(GetField(xRef, "prevkey")),
                           ApplyComparisonOp(
-                            LTEQ(keyType),
+                            LTEQ,
                             GetField(xRef, "prevkey"),
                             GetField(xRef, "key"),
                           ),
@@ -222,7 +222,7 @@ object LoweredTableReader {
                 ),
               "pksorted" ->
                 ApplyComparisonOp(
-                  EQ(TInt64),
+                  EQ,
                   ApplyAggOp(
                     FastSeq(),
                     FastSeq(
@@ -234,7 +234,7 @@ object LoweredTableReader {
                           TBoolean,
                           IsNA(selectPK(GetField(xRef, "prevkey"))),
                           ApplyComparisonOp(
-                            LTEQ(pkType),
+                            LTEQ,
                             selectPK(GetField(xRef, "prevkey")),
                             selectPK(GetField(xRef, "key")),
                           ),
@@ -286,7 +286,7 @@ object LoweredTableReader {
       }
     }) { (l, r) =>
       ApplyComparisonOp(
-        LT(TStruct("minkey" -> keyType, "maxkey" -> keyType)),
+        LT,
         SelectFields(l, FastSeq("minkey", "maxkey")),
         SelectFields(r, FastSeq("minkey", "maxkey")),
       )
@@ -308,7 +308,7 @@ object LoweredTableReader {
                   TBoolean,
                   acc,
                   ApplyComparisonOp(
-                    LTEQ(keyType),
+                    LTEQ,
                     GetField(ArrayRef(sortedPartData, i), "maxkey"),
                     GetField(ArrayRef(sortedPartData, i + I32(1)), "minkey"),
                   ),
@@ -329,7 +329,7 @@ object LoweredTableReader {
                   TBoolean,
                   acc,
                   ApplyComparisonOp(
-                    LTEQ(pkType),
+                    LTEQ,
                     selectPK(GetField(ArrayRef(sortedPartData, i), "maxkey")),
                     selectPK(GetField(ArrayRef(sortedPartData, i + I32(1)), "minkey")),
                   ),
@@ -442,7 +442,7 @@ object LoweredTableReader {
           .extendKeyPreservesPartitioning(ctx, key)
           .mapPartition(None) { part =>
             flatMapIR(StreamGroupByKey(part, pkType.fieldNames, missingEqual = true)) {
-              inner => ToStream(sortIR(inner) { case (l, r) => ApplyComparisonOp(LT(l.typ), l, r) })
+              inner => ToStream(sortIR(inner) { case (l, r) => ApplyComparisonOp(LT, l, r) })
             }
           }
       }

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -27,8 +27,6 @@ import is.hail.utils._
 import is.hail.utils.richUtils.ByteTrackingOutputStream
 import is.hail.variant.ReferenceGenome
 
-import scala.language.existentials
-
 import java.io.{BufferedOutputStream, OutputStream}
 import java.nio.file.{FileSystems, Path}
 import java.util.UUID
@@ -325,8 +323,8 @@ case class PartitionNativeWriter(
                 firstSeenSettable,
                 EmitValue.present(key.copyToRegion(cb, region, firstSeenSettable.st)),
               ),
-              { lastSeen =>
-                val comparator = EQ(lastSeenSettable.emitType.virtualType).codeOrdering(
+              { _ =>
+                val comparator = EQ.codeOrdering(
                   cb.emb.ecb,
                   lastSeenSettable.st,
                   key.st,
@@ -522,7 +520,7 @@ case class TableSpecWriter(
                 const("firstKey of curElement can't be missing, part size was ") concat count.toS,
               )
 
-              val comparator = NEQ(lastSeenSettable.emitType.virtualType).codeOrdering(
+              val comparator = NEQ.codeOrdering(
                 cb.emb.ecb,
                 lastSeenSettable.st,
                 curFirst.st,

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -143,11 +143,9 @@ object TypeCheck {
       case x @ ApplyUnaryPrimOp(op, v) =>
         assert(x.typ == UnaryOp.getReturnType(op, v.typ))
       case x @ ApplyComparisonOp(op, l, r) =>
-        assert(op.t1 == l.typ)
-        assert(op.t2 == r.typ)
-        ComparisonOp.checkCompatible(op.t1, op.t2)
+        ComparisonOp.checkCompatible(l.typ, r.typ)
         op match {
-          case _: Compare => assert(x.typ == TInt32)
+          case Compare => assert(x.typ == TInt32)
           case _ => assert(x.typ == TBoolean)
         }
       case MakeArray(args, typ) =>

--- a/hail/hail/src/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/DictFunctions.scala
@@ -16,7 +16,7 @@ object DictFunctions extends RegistryFunctions {
           i.ceq(ArrayLen(CastToArray(dict))),
           False(),
           ApplyComparisonOp(
-            EQWithNA(key.typ),
+            EQWithNA,
             GetField(ArrayRef(CastToArray(dict), i), "key"),
             key,
           ),
@@ -35,7 +35,7 @@ object DictFunctions extends RegistryFunctions {
           default,
           If(
             ApplyComparisonOp(
-              EQWithNA(key.typ),
+              EQWithNA,
               GetField(ArrayRef(CastToArray(dict), i), "key"),
               key,
             ),

--- a/hail/hail/src/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/SetFunctions.scala
@@ -14,7 +14,7 @@ object SetFunctions extends RegistryFunctions {
         If(
           i.ceq(ArrayLen(CastToArray(set))),
           False(),
-          ApplyComparisonOp(EQWithNA(elem.typ), ArrayRef(CastToArray(set), i), elem),
+          ApplyComparisonOp(EQWithNA, ArrayRef(CastToArray(set), i), elem),
         )
       },
     )
@@ -30,8 +30,7 @@ object SetFunctions extends RegistryFunctions {
     registerIR2("contains", TSet(tv("T")), tv("T"), TBoolean)((_, a, b, _) => contains(a, b))
 
     registerIR2("remove", TSet(tv("T")), tv("T"), TSet(tv("T"))) { (_, s, v, _) =>
-      val t = v.typ
-      ToSet(filterIR(ToStream(s))(ApplyComparisonOp(NEQWithNA(t), _, v)))
+      ToSet(filterIR(ToStream(s))(ApplyComparisonOp(NEQWithNA, _, v)))
     }
 
     registerIR2("add", TSet(tv("T")), tv("T"), TSet(tv("T"))) { (_, s, v, _) =>

--- a/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -187,9 +187,9 @@ object UtilFunctions extends RegistryFunctions {
   def nanmax_ignore_missing(l: Double, lMissing: Boolean, r: Double, rMissing: Boolean): Double =
     if (lMissing) r else if (rMissing) l else nanmax(l, r)
 
-  def intMin(a: IR, b: IR): IR = If(ApplyComparisonOp(LT(a.typ), a, b), a, b)
+  def intMin(a: IR, b: IR): IR = If(ApplyComparisonOp(LT, a, b), a, b)
 
-  def intMax(a: IR, b: IR): IR = If(ApplyComparisonOp(GT(a.typ), a, b), a, b)
+  def intMax(a: IR, b: IR): IR = If(ApplyComparisonOp(GT, a, b), a, b)
 
   def format(f: String, args: Row): String =
     try

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -778,7 +778,7 @@ object LowerTableIR {
             ))(inner => ToStream(inner)))
           }
         })) { partData =>
-          val sorted = sortIR(partData)((l, r) => ApplyComparisonOp(LT(keyType, keyType), l, r))
+          val sorted = sortIR(partData)((l, r) => ApplyComparisonOp(LT, l, r))
           bindIR(ToArray(flatMapIR(StreamGroupByKey(
             ToStream(sorted),
             keyType.fieldNames,

--- a/hail/hail/src/is/hail/expr/ir/orderings/StructOrdering.scala
+++ b/hail/hail/src/is/hail/expr/ir/orderings/StructOrdering.scala
@@ -10,7 +10,7 @@ object StructOrdering {
     t1: SBaseStruct,
     t2: SBaseStruct,
     ecb: EmitClassBuilder[_],
-    sortOrders: Array[SortOrder] = null,
+    sortOrders: IndexedSeq[SortOrder] = null,
     missingFieldsEqual: Boolean = true,
   ): CodeOrdering = new CodeOrdering {
 

--- a/hail/hail/test/src/is/hail/expr/ir/DistinctlyKeyedSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/DistinctlyKeyedSuite.scala
@@ -5,7 +5,6 @@ import is.hail.expr.ir.defs.{
   ApplyComparisonOp, GetField, I32, If, InsertFields, MakeStruct, Ref, StreamRange, TableCollect,
   TableWrite, ToArray,
 }
-import is.hail.types.virtual.TInt32
 import is.hail.utils.FastSeq
 
 import org.scalatest
@@ -17,7 +16,7 @@ class DistinctlyKeyedSuite extends HailSuite {
     val tableFilter = TableFilter(
       tableRange,
       ApplyComparisonOp(
-        LT(TInt32),
+        LT,
         GetField(Ref(TableIR.rowName, tableRange.typ.rowType), "idx"),
         I32(5),
       ),
@@ -109,7 +108,7 @@ class DistinctlyKeyedSuite extends HailSuite {
     val tableFilter = TableFilter(
       tableRange,
       ApplyComparisonOp(
-        LT(TInt32),
+        LT,
         GetField(Ref(TableIR.rowName, tableRange.typ.rowType), "idx"),
         I32(5),
       ),

--- a/hail/hail/test/src/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -41,14 +41,14 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
 
   def grch38: ReferenceGenome = ctx.references(ReferenceGenome.GRCh38)
 
-  def lt(l: IR, r: IR): IR = ApplyComparisonOp(LT(l.typ), l, r)
-  def gt(l: IR, r: IR): IR = ApplyComparisonOp(GT(l.typ), l, r)
-  def lteq(l: IR, r: IR): IR = ApplyComparisonOp(LTEQ(l.typ), l, r)
-  def gteq(l: IR, r: IR): IR = ApplyComparisonOp(GTEQ(l.typ), l, r)
-  def eq(l: IR, r: IR): IR = ApplyComparisonOp(EQ(l.typ), l, r)
-  def neq(l: IR, r: IR): IR = ApplyComparisonOp(NEQ(l.typ), l, r)
-  def eqna(l: IR, r: IR): IR = ApplyComparisonOp(EQWithNA(l.typ), l, r)
-  def neqna(l: IR, r: IR): IR = ApplyComparisonOp(NEQWithNA(l.typ), l, r)
+  def lt(l: IR, r: IR): IR = ApplyComparisonOp(LT, l, r)
+  def gt(l: IR, r: IR): IR = ApplyComparisonOp(GT, l, r)
+  def lteq(l: IR, r: IR): IR = ApplyComparisonOp(LTEQ, l, r)
+  def gteq(l: IR, r: IR): IR = ApplyComparisonOp(GTEQ, l, r)
+  def eq(l: IR, r: IR): IR = ApplyComparisonOp(EQ, l, r)
+  def neq(l: IR, r: IR): IR = ApplyComparisonOp(NEQ, l, r)
+  def eqna(l: IR, r: IR): IR = ApplyComparisonOp(EQWithNA, l, r)
+  def neqna(l: IR, r: IR): IR = ApplyComparisonOp(NEQWithNA, l, r)
   def or(l: IR, r: IR): IR = invoke("lor", TBoolean, l, r)
   def and(l: IR, r: IR): IR = invoke("land", TBoolean, l, r)
   def not(b: IR): IR = ApplyUnaryPrimOp(Bang, b)
@@ -93,7 +93,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
       accRef.name,
       rowRef.name,
       ApplyComparisonOp(
-        EQ(TBoolean),
+        EQ,
         filterIsTrue,
         invoke("land", TBoolean, keyInIntervals, residualIsTrue),
       ),
@@ -189,21 +189,21 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
     }
 
     check(
-      LT(TInt32),
+      LT,
       I32(0),
       FastSeq(Interval(Row(), Row(0), true, false)),
       FastSeq(Interval(Row(0), Row(null), true, false)),
       FastSeq(Interval(Row(null), Row(), true, true)),
     )
     check(
-      GT(TInt32),
+      GT,
       I32(0),
       FastSeq(Interval(Row(0), Row(null), false, false)),
       FastSeq(Interval(Row(), Row(0), true, true)),
       FastSeq(Interval(Row(null), Row(), true, true)),
     )
     check(
-      EQ(TInt32),
+      EQ,
       I32(0),
       FastSeq(Interval(Row(0), Row(0), true, true)),
       FastSeq(
@@ -214,12 +214,12 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
     )
 
     // These are never true (always missing), extracts the empty set of intervals
-    check(LT(TInt32), NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
-    check(GT(TInt32), NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
-    check(EQ(TInt32), NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
+    check(LT, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
+    check(GT, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
+    check(EQ, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
 
     check(
-      EQWithNA(TInt32),
+      EQWithNA,
       I32(0),
       FastSeq(Interval(Row(0), Row(0), true, true)),
       FastSeq(
@@ -229,7 +229,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
       FastSeq(),
     )
     check(
-      EQWithNA(TInt32),
+      EQWithNA,
       NA(TInt32),
       FastSeq(Interval(Row(null), Row(), true, true)),
       FastSeq(Interval(Row(), Row(null), true, false)),
@@ -238,7 +238,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
 
     assert(ExtractIntervalFilters.extractPartitionFilters(
       ctx,
-      ApplyComparisonOp(Compare(TInt32), I32(0), k1),
+      ApplyComparisonOp(Compare, I32(0), k1),
       ref1,
       ref1Key,
     ).isEmpty)
@@ -573,14 +573,14 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
     }
 
     check(
-      GT(TInt32),
+      GT,
       100,
       FastSeq(Interval(Row(100), Row(null), false, false)),
       FastSeq(Interval(Row(), Row(100), true, true)),
       FastSeq(Interval(Row(null), Row(), true, true)),
     )
     check(
-      GT(TInt32),
+      GT,
       -1000,
       FastSeq(Interval(Row(1), Row(null), true, false)),
       FastSeq(),
@@ -588,14 +588,14 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
     )
 
     check(
-      LT(TInt32),
+      LT,
       100,
       FastSeq(Interval(Row(), Row(100), true, false)),
       FastSeq(Interval(Row(100), Row(null), true, false)),
       FastSeq(Interval(Row(null), Row(), true, true)),
     )
     check(
-      LT(TInt32),
+      LT,
       -1000,
       FastSeq(),
       FastSeq(Interval(Row(), Row(null), true, false)),
@@ -603,7 +603,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
     )
 
     check(
-      EQ(TInt32),
+      EQ,
       100,
       FastSeq(Interval(Row(100), Row(100), true, true)),
       FastSeq(
@@ -613,7 +613,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
       FastSeq(Interval(Row(null), Row(), true, true)),
     )
     check(
-      EQ(TInt32),
+      EQ,
       -1000,
       FastSeq(),
       FastSeq(Interval(Row(), Row(null), true, false)),
@@ -621,7 +621,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
     )
 
     check(
-      EQWithNA(TInt32),
+      EQWithNA,
       100,
       FastSeq(Interval(Row(100), Row(100), true, true)),
       FastSeq(
@@ -631,7 +631,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
       FastSeq(),
     )
     check(
-      EQWithNA(TInt32),
+      EQWithNA,
       -1000,
       FastSeq(),
       FastSeq(Interval(Row(), Row(), true, true)),
@@ -640,7 +640,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
 
     assert(ExtractIntervalFilters.extractPartitionFilters(
       ctx,
-      ApplyComparisonOp(Compare(TInt32), I32(0), pos),
+      ApplyComparisonOp(Compare, I32(0), pos),
       ref,
       ref1Key,
     ).isEmpty)
@@ -1114,8 +1114,8 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
         invoke(
           "land",
           TBoolean,
-          ApplyComparisonOp(GT(TInt32), k, I32(3)),
-          ApplyComparisonOp(LTEQ(TInt32), k, I32(9)),
+          ApplyComparisonOp(GT, k, I32(3)),
+          ApplyComparisonOp(LTEQ, k, I32(9)),
         ),
         False(),
       )),

--- a/hail/hail/test/src/is/hail/expr/ir/ForwardLetsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ForwardLetsSuite.scala
@@ -22,7 +22,7 @@ class ForwardLetsSuite extends HailSuite {
     val x = Ref(freshName(), TInt32)
     Array(
       mapArray(a)(y => ApplyBinaryPrimOp(Add(), x, y)),
-      ToArray(filterIR(ToStream(a))(y => ApplyComparisonOp(LT(TInt32), x, y))),
+      ToArray(filterIR(ToStream(a))(y => ApplyComparisonOp(LT, x, y))),
       ToArray(flatMapIR(ToStream(a))(y => StreamRange(x, y, I32(1)))),
       foldIR(ToStream(a), I32(0)) { (acc, y) =>
         ApplyBinaryPrimOp(Add(), ApplyBinaryPrimOp(Add(), x, y), acc)

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -472,7 +472,7 @@ class IRSuite extends HailSuite {
 
   @Test def testApplyComparisonOpGT(): scalatest.Assertion = {
     def assertComparesTo(t: Type, x: Any, y: Any, expected: Boolean): scalatest.Assertion =
-      assertEvalsTo(ApplyComparisonOp(GT(t), In(0, t), In(1, t)), FastSeq(x -> t, y -> t), expected)
+      assertEvalsTo(ApplyComparisonOp(GT, In(0, t), In(1, t)), FastSeq(x -> t, y -> t), expected)
 
     assertComparesTo(TInt32, 1, 1, false)
     assertComparesTo(TInt32, 0, 1, false)
@@ -495,7 +495,7 @@ class IRSuite extends HailSuite {
   @Test def testApplyComparisonOpGTEQ(): scalatest.Assertion = {
     def assertComparesTo(t: Type, x: Any, y: Any, expected: Boolean): scalatest.Assertion =
       assertEvalsTo(
-        ApplyComparisonOp(GTEQ(t), In(0, t), In(1, t)),
+        ApplyComparisonOp(GTEQ, In(0, t), In(1, t)),
         FastSeq(x -> t, y -> t),
         expected,
       )
@@ -519,7 +519,7 @@ class IRSuite extends HailSuite {
 
   @Test def testApplyComparisonOpLT(): scalatest.Assertion = {
     def assertComparesTo(t: Type, x: Any, y: Any, expected: Boolean): scalatest.Assertion =
-      assertEvalsTo(ApplyComparisonOp(LT(t), In(0, t), In(1, t)), FastSeq(x -> t, y -> t), expected)
+      assertEvalsTo(ApplyComparisonOp(LT, In(0, t), In(1, t)), FastSeq(x -> t, y -> t), expected)
 
     assertComparesTo(TInt32, 1, 1, false)
     assertComparesTo(TInt32, 0, 1, true)
@@ -542,7 +542,7 @@ class IRSuite extends HailSuite {
   @Test def testApplyComparisonOpLTEQ(): scalatest.Assertion = {
     def assertComparesTo(t: Type, x: Any, y: Any, expected: Boolean): scalatest.Assertion =
       assertEvalsTo(
-        ApplyComparisonOp(LTEQ(t), In(0, t), In(1, t)),
+        ApplyComparisonOp(LTEQ, In(0, t), In(1, t)),
         FastSeq(x -> t, y -> t),
         expected,
       )
@@ -567,7 +567,7 @@ class IRSuite extends HailSuite {
 
   @Test def testApplyComparisonOpEQ(): scalatest.Assertion = {
     def assertComparesTo(t: Type, x: Any, y: Any, expected: Boolean): scalatest.Assertion =
-      assertEvalsTo(ApplyComparisonOp(EQ(t), In(0, t), In(1, t)), FastSeq(x -> t, y -> t), expected)
+      assertEvalsTo(ApplyComparisonOp(EQ, In(0, t), In(1, t)), FastSeq(x -> t, y -> t), expected)
 
     assertComparesTo(TInt32, 1, 1, expected = true)
     assertComparesTo(TInt32, 0, 1, expected = false)
@@ -589,7 +589,7 @@ class IRSuite extends HailSuite {
   @Test def testApplyComparisonOpNE(): scalatest.Assertion = {
     def assertComparesTo(t: Type, x: Any, y: Any, expected: Boolean): scalatest.Assertion =
       assertEvalsTo(
-        ApplyComparisonOp(NEQ(t), In(0, t), In(1, t)),
+        ApplyComparisonOp(NEQ, In(0, t), In(1, t)),
         FastSeq(x -> t, y -> t),
         expected,
       )
@@ -3110,7 +3110,7 @@ class IRSuite extends HailSuite {
   @Test def testSameLiteralsWithDifferentTypes(): scalatest.Assertion = {
     assertEvalsTo(
       ApplyComparisonOp(
-        EQ(TArray(TInt32)),
+        EQ,
         ToArray(
           mapIR(ToStream(Literal(TArray(TFloat64), FastSeq(1.0, 2.0))))(Cast(_, TInt32))
         ),
@@ -3209,47 +3209,47 @@ class IRSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.javaOnly
 
     assertEvalsTo(
-      ApplyComparisonOp(EQ(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(EQ, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       true,
     )
     assertEvalsTo(
-      ApplyComparisonOp(LT(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(LT, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       false,
     )
     assertEvalsTo(
-      ApplyComparisonOp(GT(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(GT, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       false,
     )
     assertEvalsTo(
-      ApplyComparisonOp(LTEQ(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(LTEQ, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       true,
     )
     assertEvalsTo(
-      ApplyComparisonOp(GTEQ(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(GTEQ, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       true,
     )
     assertEvalsTo(
-      ApplyComparisonOp(NEQ(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(NEQ, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       false,
     )
     assertEvalsTo(
-      ApplyComparisonOp(EQWithNA(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(EQWithNA, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       true,
     )
     assertEvalsTo(
-      ApplyComparisonOp(NEQWithNA(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(NEQWithNA, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       false,
     )
     assertEvalsTo(
-      ApplyComparisonOp(Compare(t1, t2), In(0, t1), In(1, t2)),
+      ApplyComparisonOp(Compare, In(0, t1), In(1, t2)),
       FastSeq(a -> t1, a -> t2),
       0,
     )
@@ -3375,7 +3375,7 @@ class IRSuite extends HailSuite {
       },
       ApplyBinaryPrimOp(Add(), i, j),
       ApplyUnaryPrimOp(Negate, i),
-      ApplyComparisonOp(EQ(TInt32), i, j),
+      ApplyComparisonOp(EQ, i, j),
       MakeArray(FastSeq(i, NA(TInt32), I32(-3)), TArray(TInt32)),
       MakeStream(FastSeq(i, NA(TInt32), I32(-3)), TStream(TInt32)),
       nd,
@@ -4421,13 +4421,7 @@ class IRSuite extends HailSuite {
       PCanonicalStruct(("rowIdx", PInt32Required), ("extraInfo", PInt32Required)),
       BufferSpec.default,
     )
-    val dist = StreamDistribute(
-      child,
-      pivots,
-      Str(ctx.localTmpdir),
-      Compare(pivots.typ.asInstanceOf[TArray].elementType),
-      spec,
-    )
+    val dist = StreamDistribute(child, pivots, Str(ctx.localTmpdir), Compare, spec)
     val result = eval(dist).asInstanceOf[IndexedSeq[Row]].map(row =>
       (
         row(0).asInstanceOf[Interval],

--- a/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
@@ -627,15 +627,15 @@ class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
 
     val args = FastSeq(a -> t, a2 -> t)
 
-    assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(NEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(NEQWithNA(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(LT(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(LTEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(GT(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(GTEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(Compare(t, t), In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(EQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(EQWithNA, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(NEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(NEQWithNA, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(LT, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(LTEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(GT, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(GTEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(Compare, In(0, t), In(1, t)), args)
   }
 
   @Test(dataProvider = "arrayDoubleOrderingData")
@@ -649,15 +649,15 @@ class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
     val s2 = if (a2 != null) a2.toSet else null
     val args = FastSeq(s -> t, s2 -> t)
 
-    assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(NEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(NEQWithNA(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(LT(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(LTEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(GT(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(GTEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(Compare(t, t), In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(EQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(EQWithNA, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(NEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(NEQWithNA, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(LT, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(LTEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(GT, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(GTEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(Compare, In(0, t), In(1, t)), args)
   }
 
   @DataProvider(name = "rowDoubleOrderingData")
@@ -686,14 +686,14 @@ class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
 
     val args = FastSeq(r -> t, r2 -> t)
 
-    assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(NEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(NEQWithNA(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(LT(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(LTEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(GT(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(GTEQ(t, t), In(0, t), In(1, t)), args)
-    assertEvalSame(ApplyComparisonOp(Compare(t, t), In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(EQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(EQWithNA, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(NEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(NEQWithNA, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(LT, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(LTEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(GT, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(GTEQ, In(0, t), In(1, t)), args)
+    assertEvalSame(ApplyComparisonOp(Compare, In(0, t), In(1, t)), args)
   }
 }

--- a/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
@@ -1119,7 +1119,7 @@ class PruneSuite extends HailSuite {
     val select = SelectFields(x, IndexedSeq("c"))
     checkMemo(
       AggFilter(
-        ApplyComparisonOp(LT(TInt32, TInt32), GetField(x, "a"), I32(0)),
+        ApplyComparisonOp(LT, GetField(x, "a"), I32(0)),
         ApplyAggOp(
           FastSeq(),
           FastSeq(select),

--- a/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
@@ -185,7 +185,7 @@ class TableIRSuite extends HailSuite {
         MakeStruct(FastSeq("x" -> GetField(ArrayRef(GetField(collect(t), "rows"), 4), "idx"))),
       ),
       ApplyComparisonOp(
-        EQ(TInt32),
+        EQ,
         GetField(Ref(TableIR.rowName, t.typ.rowType), "idx"),
         GetField(Ref(TableIR.globalName, TStruct("x" -> TInt32)), "x"),
       ),


### PR DESCRIPTION
## Change Description

As this change demonstrates, the types on `ComparisonOp` were doing very little, and requiring them to stay in sync with the types of the arguments in `ApplyComparisonOp` created unnecessary complexity.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP