### PR TITLE
[docker] Publish python 3.12 and 3.13 hailgenetics/hail images

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -124,6 +124,42 @@ steps:
     dependsOn:
       - merge_code
       - copy_third_party_images
+  - kind: buildImage2
+    name: hail_ubuntu_image_python_3_12
+    dockerFile: /io/hail-ubuntu/Dockerfile
+    contextPath: /io/hail-ubuntu
+    publishAs: hail-ubuntu-python-3-12
+    buildArgs:
+      - name: PYTHON_VERSION
+        value: "3.12"
+    resources:
+      storage: 10Gi
+      cpu: "2"
+      memory: standard
+    inputs:
+      - from: /repo/docker/hail-ubuntu
+        to: /io/hail-ubuntu
+    dependsOn:
+      - merge_code
+      - copy_third_party_images
+  - kind: buildImage2
+    name: hail_ubuntu_image_python_3_13
+    dockerFile: /io/hail-ubuntu/Dockerfile
+    contextPath: /io/hail-ubuntu
+    publishAs: hail-ubuntu-python-3-13
+    buildArgs:
+      - name: PYTHON_VERSION
+        value: "3.13"
+    resources:
+      storage: 10Gi
+      cpu: "2"
+      memory: standard
+    inputs:
+      - from: /repo/docker/hail-ubuntu
+        to: /io/hail-ubuntu
+    dependsOn:
+      - merge_code
+      - copy_third_party_images
   - kind: deploy
     name: deploy_batch_sa
     namespace:
@@ -1406,6 +1442,50 @@ steps:
       - merge_code
       - build_hail_jar_and_wheel
       - hail_ubuntu_image_python_3_10
+  - kind: buildImage2
+    name: hailgenetics_hail_image_python_3_12
+    dockerFile: /io/repo/docker/hailgenetics/hail/Dockerfile
+    contextPath: /io/repo
+    publishAs: hailgenetics/hail
+    buildArgs:
+      - name: BASE_IMAGE
+        value:
+          valueFrom: hail_ubuntu_image_python_3_12.image
+      - name: HAIL_WHEEL_DIR
+        value: /wheel
+    inputs:
+      - from: /repo/docker/hailgenetics/hail
+        to: /io/repo/docker/hailgenetics/hail
+      - from: /repo/hail/python/pinned-requirements.txt
+        to: /io/repo/hail/python/pinned-requirements.txt
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/repo/wheel
+    dependsOn:
+      - merge_code
+      - build_hail_jar_and_wheel
+      - hail_ubuntu_image_python_3_12
+  - kind: buildImage2
+    name: hailgenetics_hail_image_python_3_13
+    dockerFile: /io/repo/docker/hailgenetics/hail/Dockerfile
+    contextPath: /io/repo
+    publishAs: hailgenetics/hail
+    buildArgs:
+      - name: BASE_IMAGE
+        value:
+          valueFrom: hail_ubuntu_image_python_3_13.image
+      - name: HAIL_WHEEL_DIR
+        value: /wheel
+    inputs:
+      - from: /repo/docker/hailgenetics/hail
+        to: /io/repo/docker/hailgenetics/hail
+      - from: /repo/hail/python/pinned-requirements.txt
+        to: /io/repo/hail/python/pinned-requirements.txt
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/repo/wheel
+    dependsOn:
+      - merge_code
+      - build_hail_jar_and_wheel
+      - hail_ubuntu_image_python_3_13
   - kind: runImage
     name: test_hailgenetics_hail_image
     image:
@@ -1428,6 +1508,28 @@ steps:
       python3 -c 'import numpy; import pandas; import sklearn; import scipy'
     dependsOn:
       - hailgenetics_hail_image_python_3_10
+  - kind: runImage
+    name: test_hailgenetics_hail_image_python_3_12
+    image:
+      valueFrom: hailgenetics_hail_image_python_3_12.image
+    script: |
+      set -ex
+      python3 -c 'import sys; assert sys.version_info.major == 3 and sys.version_info.minor == 12, sys.version_info'
+      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
+      python3 -c 'import numpy; import pandas; import sklearn; import scipy'
+    dependsOn:
+      - hailgenetics_hail_image_python_3_12
+  - kind: runImage
+    name: test_hailgenetics_hail_image_python_3_13
+    image:
+      valueFrom: hailgenetics_hail_image_python_3_13.image
+    script: |
+      set -ex
+      python3 -c 'import sys; assert sys.version_info.major == 3 and sys.version_info.minor == 13, sys.version_info'
+      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
+      python3 -c 'import numpy; import pandas; import sklearn; import scipy'
+    dependsOn:
+      - hailgenetics_hail_image_python_3_13
   - kind: buildImage2
     name: hail_dev_image
     dockerFile: /io/repo/docker/Dockerfile.hail-dev

--- a/hail/python/hailtop/batch/hail_genetics_images.py
+++ b/hail/python/hailtop/batch/hail_genetics_images.py
@@ -10,10 +10,10 @@ HAIL_GENETICS_IMAGES = [
 
 def hailgenetics_hail_image_for_current_python_version():
     version = sys.version_info
-    if version.major != 3 or version.minor not in (10, 11):
+    if version.major != 3 or version.minor not in (10, 11, 12, 13):
         raise ValueError(
             f'You must specify an "image" for Python jobs and the BatchPoolExecutor if you are '
-            f'using a Python version other than 3.10, or 3.11 (you are using {version})'
+            f'using a Python version not between 3.10 and 3.13 inclusive (you are using {version})'
         )
     if version.minor == 11:
         return f'hailgenetics/hail:{__pip_version__}'


### PR DESCRIPTION
## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP