### PR TITLE
[query] Fix AssertionError signature

### DIFF
--- a/hail/hail/src/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/CodeBuilder.scala
@@ -278,7 +278,7 @@ trait CodeBuilderLike {
       val assertion = Code.newInstance[AssertionError, String, Throwable](message, traceback)
       if_(cond, {}, _throw(assertion))
     } else {
-      if_(cond, {}, _throw(Code.newInstance[AssertionError, String](message)))
+      if_(cond, {}, _throw(Code.newInstance[AssertionError, Object](message)))
     }
   }
 }


### PR DESCRIPTION
While running in QoB, I encoutered this strange error:

```
Caused by: java.lang.IllegalAccessError: class __C2828stream_to_iter tried to access private method 'void java.lang.AssertionError.<init>(java.lang.String)' (__C2828stream_to_iter is in unnamed module of loader is.hail.asm4s.HailClassLoader @4319052; java.lang.AssertionError is in module java.base of loader 'bootstrap')
```

I have _no idea_ why this is ocurring. However, the public constructors of [AssertionError], does not include `AssertionError(String message)`, so, we attempt to correct this by using the `AssertionError(Object)` constructor instead.

[AssertionError]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/AssertionError.html

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP