### PR TITLE
[query] Check for None/empty paths in vds combiner

### DIFF
--- a/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
@@ -2213,11 +2213,23 @@ case class GVCFPartitionReader(
     context.toI(cb).map(cb) { case ctxValue: SBaseStructValue =>
       val fileNum = cb.memoizeField(ctxValue.loadField(cb, "fileNum").getOrAssert(cb).asInt32.value)
       val filePath =
-        cb.memoizeField(ctxValue.loadField(cb, "path").getOrAssert(cb).asString.loadString(cb))
+        cb.memoizeField(ctxValue.loadField(cb, "path").getOrFatal(
+          cb,
+          "expected present gvcf path",
+        ).asString.loadString(cb))
       val contig =
-        cb.memoizeField(ctxValue.loadField(cb, "contig").getOrAssert(cb).asString.loadString(cb))
-      val start = cb.memoizeField(ctxValue.loadField(cb, "start").getOrAssert(cb).asInt32.value)
-      val end = cb.memoizeField(ctxValue.loadField(cb, "end").getOrAssert(cb).asInt32.value)
+        cb.memoizeField(ctxValue.loadField(cb, "contig").getOrFatal(
+          cb,
+          "expected present interval contig",
+        ).asString.loadString(cb))
+      val start = cb.memoizeField(ctxValue.loadField(cb, "start").getOrFatal(
+        cb,
+        "expected present interval start position",
+      ).asInt32.value)
+      val end = cb.memoizeField(ctxValue.loadField(cb, "end").getOrFatal(
+        cb,
+        "expected present interval end position",
+      ).asInt32.value)
 
       val requestedPType = fullRowPType.subsetTo(requestedType).asInstanceOf[PStruct]
       val eltRegion = mb.genFieldThisRef[Region]("gvcf_elt_region")

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -680,6 +680,9 @@ def new_combiner(
             duplicates = [gvcf for gvcf, count in collections.Counter(gvcf_paths).items() if count > 1]
             duplicates = '\n    '.join(duplicates)
             raise ValueError(f'gvcf paths should be unique, the following paths are repeated:{duplicates}')
+        empty_idxs = [index for index, path in enumerate(gvcf_paths) if not path]
+        if len(empty_idxs) > 0:
+            raise ValueError(f'gvcf paths should not be empty or None, found such values at indicies {empty_idxs}')
         if gvcf_sample_names is not None and len(set(gvcf_sample_names)) != len(gvcf_sample_names):
             duplicates = [gvcf for gvcf, count in collections.Counter(gvcf_sample_names).items() if count > 1]
             duplicates = '\n    '.join(duplicates)
@@ -690,6 +693,10 @@ def new_combiner(
 
     if vds_paths is None:
         vds_paths = []
+    if len(vds_paths) > 0:
+        empty_idxs = [index for index, path in enumerate(gvcf_paths) if not path]
+        if len(empty_idxs) > 0:
+            raise ValueError(f'vds paths should not be empty or None, found such values at indicies {empty_idxs}')
     if vds_sample_counts is not None and len(vds_paths) != len(vds_sample_counts):
         raise ValueError(
             "'vds_paths' and 'vds_sample_counts' (if present) must have the same length "


### PR DESCRIPTION
While running a combine job. I encountered a missing path which lead to a very confusing set of errors where we were treating the missing path as a hail assertion error rather than the data error that it was.

To fix this, change the getOrAssert calls in GVCF partition reader to getOrFatal, causing a user error with missing data. Furthermore, add checks to `new_combiner` to make sure that no paths are missing/empty either.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP