### PR TITLE
[compiler] remove AggSignature

### DIFF
--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -991,14 +991,14 @@ object Main {
       "ApplyAggOp",
       in("initOpArgs", child.*),
       in("seqOpArgs", child.*),
-      in("aggSig", att("AggSignature")),
+      in("op", att("AggOp")),
     )
-      .withClassExtension.withCompanionExtension
+      .withCompanionExtension
     r += node(
       "ApplyScanOp",
       in("initOpArgs", child.*),
       in("seqOpArgs", child.*),
-      in("aggSig", att("AggSignature")),
+      in("op", att("AggOp")),
     )
       .withClassExtension.withCompanionExtension
     r += node(
@@ -1216,8 +1216,8 @@ object Main {
       "is.hail.io.{AbstractTypedCodecSpec, BufferSpec}",
       "is.hail.types.virtual.{Type, TArray, TStream, TVoid, TStruct, TTuple}",
       "is.hail.utils.{FastSeq, StringEscapeUtils}",
-      "is.hail.expr.ir.{BaseIR, IR, TableIR, MatrixIR, BlockMatrixIR, Name, UnaryOp, BinaryOp, " +
-        "ComparisonOp, CanEmit, AggSignature, EmitParamType, TableWriter, " +
+      "is.hail.expr.ir.{AggOp, BaseIR, IR, TableIR, MatrixIR, BlockMatrixIR, Name, UnaryOp, BinaryOp, " +
+        "ComparisonOp, CanEmit, EmitParamType, TableWriter, " +
         "WrappedMatrixNativeMultiWriter, MatrixWriter, MatrixNativeMultiWriter, BlockMatrixWriter, " +
         "BlockMatrixMultiWriter, ValueReader, ValueWriter}",
       "is.hail.expr.ir.lowering.TableStageDependency",

--- a/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
@@ -67,11 +67,9 @@ object DeprecatedIRBuilder {
     initOpArgs: IndexedSeq[IRProxy] = FastSeq(),
     seqOpArgs: IndexedSeq[IRProxy] = FastSeq(),
   ): IRProxy = (env: E) => {
-
     val i = initOpArgs.map(x => x(env))
     val s = seqOpArgs.map(x => x(env))
-
-    ApplyAggOp(i, s, AggSignature(op, i.map(_.typ), s.map(_.typ)))
+    ApplyAggOp(i, s, op)
   }
 
   def aggFilter(filterCond: IRProxy, query: IRProxy, isScan: Boolean = false): IRProxy = (env: E) =>

--- a/hail/hail/src/is/hail/expr/ir/Exists.scala
+++ b/hail/hail/src/is/hail/expr/ir/Exists.scala
@@ -102,7 +102,7 @@ object AggIsCommutative {
 
 object ContainsNonCommutativeAgg {
   def apply(root: IR): Boolean = root match {
-    case ApplyAggOp(_, _, sig) => !AggIsCommutative(sig.op)
+    case ApplyAggOp(_, _, op) => !AggIsCommutative(op)
     case _: TableAggregate => false
     case _: MatrixAggregate => false
     case _ => root.children.exists {

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -754,19 +754,7 @@ package defs {
 
     abstract class ApplyAggOpCompanionExt {
       def apply(op: AggOp, initOpArgs: IR*)(seqOpArgs: IR*): ApplyAggOp =
-        ApplyAggOp(
-          initOpArgs.toIndexedSeq,
-          seqOpArgs.toIndexedSeq,
-          AggSignature(op, initOpArgs.map(_.typ), seqOpArgs.map(_.typ)),
-        )
-    }
-
-    trait ApplyAggOpExt { self: ApplyAggOp =>
-      def nSeqOpArgs = seqOpArgs.length
-
-      def nInitArgs = initOpArgs.length
-
-      def op: AggOp = aggSig.op
+        ApplyAggOp(initOpArgs.toIndexedSeq, seqOpArgs.toIndexedSeq, op)
     }
 
     abstract class AggFoldCompanionExt {
@@ -838,19 +826,13 @@ package defs {
 
     abstract class ApplyScanOpCompanionExt {
       def apply(op: AggOp, initOpArgs: IR*)(seqOpArgs: IR*): ApplyScanOp =
-        ApplyScanOp(
-          initOpArgs.toIndexedSeq,
-          seqOpArgs.toIndexedSeq,
-          AggSignature(op, initOpArgs.map(_.typ), seqOpArgs.map(_.typ)),
-        )
+        ApplyScanOp(initOpArgs.toIndexedSeq, seqOpArgs.toIndexedSeq, op)
     }
 
     trait ApplyScanOpExt { self: ApplyScanOp =>
       def nSeqOpArgs = seqOpArgs.length
 
       def nInitArgs = initOpArgs.length
-
-      def op: AggOp = aggSig.op
     }
 
     abstract class ResultOpCompanionExt {

--- a/hail/hail/src/is/hail/expr/ir/InferType.scala
+++ b/hail/hail/src/is/hail/expr/ir/InferType.scala
@@ -248,10 +248,10 @@ object InferType {
       case AggGroupBy(key, aggIR, _) =>
         TDict(key.typ, aggIR.typ)
       case AggArrayPerElement(_, _, _, aggBody, _, _) => TArray(aggBody.typ)
-      case ApplyAggOp(_, _, aggSig) =>
-        aggSig.returnType
-      case ApplyScanOp(_, _, aggSig) =>
-        aggSig.returnType
+      case ApplyAggOp(_, seqOpArgs, op) =>
+        AggOp.getReturnType(op, seqOpArgs.map(_.typ))
+      case ApplyScanOp(_, seqOpArgs, op) =>
+        AggOp.getReturnType(op, seqOpArgs.map(_.typ))
       case AggFold(zero, _, _, _, _, _) =>
         zero.typ
       case MakeStruct(fields) =>

--- a/hail/hail/src/is/hail/expr/ir/Pretty.scala
+++ b/hail/hail/src/is/hail/expr/ir/Pretty.scala
@@ -196,8 +196,8 @@ class Pretty(
   def single(d: Doc): Iterable[Doc] = RichIterable.single(d)
 
   def header(ir: BaseIR, elideBindings: Boolean = false): Iterable[Doc] = ir match {
-    case ApplyAggOp(_, _, aggSig) => single(Pretty.prettyClass(aggSig.op))
-    case ApplyScanOp(_, _, aggSig) => single(Pretty.prettyClass(aggSig.op))
+    case ApplyAggOp(_, _, op) => single(Pretty.prettyClass(op))
+    case ApplyScanOp(_, _, op) => single(Pretty.prettyClass(op))
     case InitOp(i, _, aggSig) => FastSeq(i.toString, prettyPhysicalAggSig(aggSig))
     case SeqOp(i, _, aggSig) => FastSeq(i.toString, prettyPhysicalAggSig(aggSig))
     case CombOp(i1, i2, aggSig) => FastSeq(i1.toString, i2.toString, prettyPhysicalAggSig(aggSig))

--- a/hail/hail/src/is/hail/expr/ir/Requiredness.scala
+++ b/hail/hail/src/is/hail/expr/ir/Requiredness.scala
@@ -735,22 +735,16 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         val rit = tcoerce[RIterable](requiredness)
         rit.union(lookup(a).required)
         rit.elementType.unionFrom(lookup(body))
-      case ApplyAggOp(_, seqOpArgs, aggSig) => // FIXME round-tripping through ptype
+      case ApplyAggOp(_, seqOpArgs, op) => // FIXME round-tripping through ptype
         val emitResult = agg.PhysicalAggSig(
-          aggSig.op,
-          agg.AggStateSig(
-            aggSig.op,
-            seqOpArgs.map(s => s -> lookup(s)),
-          ),
+          op,
+          agg.AggStateSig(op, seqOpArgs.map(s => s -> lookup(s))),
         ).emitResultType
         requiredness.fromEmitType(emitResult)
-      case ApplyScanOp(_, seqOpArgs, aggSig) =>
+      case ApplyScanOp(_, seqOpArgs, op) =>
         val emitResult = agg.PhysicalAggSig(
-          aggSig.op,
-          agg.AggStateSig(
-            aggSig.op,
-            seqOpArgs.map(s => s -> lookup(s)),
-          ),
+          op,
+          agg.AggStateSig(op, seqOpArgs.map(s => s -> lookup(s))),
         ).emitResultType
         requiredness.fromEmitType(emitResult)
       case AggFold(zero, seqOp, combOp, _, _, _) =>

--- a/hail/hail/src/is/hail/expr/ir/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/Simplify.scala
@@ -668,7 +668,7 @@ object Simplify {
               )) {
                 case (comb, s) => GetField(comb, s)
               })).toL),
-              AggSignature(Sum(), FastSeq(), FastSeq(TInt64)),
+              Sum(),
             ),
           )
         )
@@ -1138,7 +1138,6 @@ object Simplify {
         // n < 256 is arbitrary for memory concerns
         val row = Ref(TableIR.rowName, child.typ.rowType)
         val keyStruct = MakeStruct(sortFields.map(f => f.field -> GetField(row, f.field)))
-        val aggSig = AggSignature(TakeBy(), FastSeq(TInt32), FastSeq(row.typ, keyStruct.typ))
         val te =
           TableExplode(
             TableKeyByAndAggregate(
@@ -1147,7 +1146,7 @@ object Simplify {
                 "row" -> ApplyAggOp(
                   FastSeq(I32(n.toInt)),
                   Array(row, keyStruct),
-                  aggSig,
+                  TakeBy(),
                 )
               )),
               MakeStruct(FastSeq()), // aggregate to one row

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -493,14 +493,10 @@ object TypeCheck {
       case InitFromSerializedValue(_, value, _) => assert(value.typ == TBinary)
       case _: SerializeAggs =>
       case _: DeserializeAggs =>
-      case x @ ApplyAggOp(initOpArgs, seqOpArgs, aggSig) =>
-        assert(x.typ == aggSig.returnType)
-        assert(initOpArgs.map(_.typ).zip(aggSig.initOpArgs).forall { case (l, r) => l == r })
-        assert(seqOpArgs.map(_.typ).zip(aggSig.seqOpArgs).forall { case (l, r) => l == r })
-      case x @ ApplyScanOp(initOpArgs, seqOpArgs, aggSig) =>
-        assert(x.typ == aggSig.returnType)
-        assert(initOpArgs.map(_.typ).zip(aggSig.initOpArgs).forall { case (l, r) => l == r })
-        assert(seqOpArgs.map(_.typ).zip(aggSig.seqOpArgs).forall { case (l, r) => l == r })
+      case x @ ApplyAggOp(_, seqOpArgs, op) =>
+        assert(x.typ == AggOp.getReturnType(op, seqOpArgs.map(_.typ)))
+      case x @ ApplyScanOp(_, seqOpArgs, op) =>
+        assert(x.typ == AggOp.getReturnType(op, seqOpArgs.map(_.typ)))
       case AggFold(zero, seqOp, combOp, _, _, _) =>
         assert(zero.typ == seqOp.typ)
         assert(zero.typ == combOp.typ)

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -567,7 +567,7 @@ object Extract {
           x, {
             val i = initBuilder.length
             bindInitArgRefs(x.initOpArgs)
-            val op = x.aggSig.op
+            val op = x.op
             val state = PhysicalAggSig(op, AggStateSig(op, x.seqOpArgs, r))
             initBuilder += InitOp(i, x.initOpArgs, state)
             seqBuilder += freshName() -> SeqOp(i, x.seqOpArgs, state)
@@ -582,7 +582,7 @@ object Extract {
           x, {
             val i = initBuilder.length
             bindInitArgRefs(x.initOpArgs)
-            val op = x.aggSig.op
+            val op = x.op
             val state = PhysicalAggSig(op, AggStateSig(op, x.seqOpArgs, r))
             initBuilder += InitOp(i, x.initOpArgs, state)
             seqBuilder += freshName() -> SeqOp(i, x.seqOpArgs, state)

--- a/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -97,10 +97,8 @@ case object SemanticHash extends Logging {
         tyArgs.foreach(buffer ++= EncodeTypename(_))
         buffer ++= EncodeTypename(retTy)
 
-      case ApplyAggOp(_, _, AggSignature(op, initOpTys, seqOpTys)) =>
+      case ApplyAggOp(_, _, op) =>
         buffer ++= Bytes.fromClass(op.getClass)
-        initOpTys.foreach(buffer ++= EncodeTypename(_))
-        seqOpTys.foreach(buffer ++= EncodeTypename(_))
 
       case ApplyBinaryPrimOp(op, _, _) =>
         buffer ++= Bytes.fromClass(op.getClass)

--- a/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
@@ -483,7 +483,7 @@ class Aggregators2Suite extends HailSuite {
           invoke("str", TString, GetField(Ref(TableIR.rowName, tr.typ.rowType), "idx")),
           I32(9999) - GetField(Ref(TableIR.rowName, tr.typ.rowType), "idx"),
         ),
-        AggSignature(TakeBy(), FastSeq(TInt32), FastSeq(TString, TInt32)),
+        TakeBy(),
       ),
     )
 
@@ -1002,7 +1002,7 @@ class Aggregators2Suite extends HailSuite {
               bar.toL + bar.toL + ApplyAggOp(
                 FastSeq(),
                 FastSeq(GetField(Ref(MatrixIR.rowName, t.rowType), "row_idx").toL),
-                AggSignature(Sum(), FastSeq(), FastSeq(TInt64)),
+                Sum(),
               ),
               false,
             )

--- a/hail/hail/test/src/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -1096,7 +1096,7 @@ class ExtractIntervalFiltersSuite extends HailSuite { outer =>
 
     val count = TableAggregate(
       TableRange(10, 1),
-      ApplyAggOp(FastSeq(), FastSeq(), AggSignature(Count(), FastSeq(), FastSeq())),
+      ApplyAggOp(Count())(),
     )
     print(count.typ)
     val filter = gt(count, Cast(k1, TInt64))

--- a/hail/hail/test/src/is/hail/expr/ir/ForwardLetsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ForwardLetsSuite.scala
@@ -69,8 +69,7 @@ class ForwardLetsSuite extends HailSuite {
     ).map(ir => Array[IR](Let(FastSeq(x.name -> (In(0, TInt32) + In(0, TInt32))), ir)))
   }
 
-  def aggMin(value: IR): ApplyAggOp =
-    ApplyAggOp(FastSeq(), FastSeq(value), AggSignature(Min(), FastSeq(), FastSeq(value.typ)))
+  def aggMin(value: IR): ApplyAggOp = ApplyAggOp(Min())(value)
 
   @DataProvider(name = "nonForwardingAggOps")
   def nonForwardingAggOps(): Array[Array[IR]] = {
@@ -235,11 +234,7 @@ class ForwardLetsSuite extends HailSuite {
     val row = Ref(freshName(), TStruct("idx" -> TInt32))
     val aggEnv = Env[Type](row.name -> row.typ)
 
-    val ir0 = ApplyAggOp(
-      FastSeq(),
-      FastSeq(bindIR(GetField(row, "idx") - 1)(x => Cast(x, TFloat64))),
-      AggSignature(Sum(), FastSeq(), FastSeq(TFloat64)),
-    )
+    val ir0 = ApplyAggOp(Sum())(bindIR(GetField(row, "idx") - 1)(x => Cast(x, TFloat64)))
 
     TypeCheck(ctx, ForwardLets(ctx, ir0), BindingEnv(Env.empty, agg = Some(aggEnv)))
     succeed

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -298,15 +298,7 @@ class SimplifySuite extends HailSuite {
     forAll(doesRewrite)(a => a should simplifyTo(a.query))
 
     val doesNotRewrite: Array[StreamAgg] = Array(
-      streamAggIR(
-        ToStream(In(0, TArray(TInt32)))
-      ) { foo =>
-        ApplyAggOp(
-          FastSeq(),
-          FastSeq(foo),
-          AggSignature(Sum(), FastSeq(), FastSeq(TInt32)),
-        )
-      },
+      streamAggIR(ToStream(In(0, TArray(TInt32))))(ApplyAggOp(Sum())(_)),
       streamAggIR(ToStream(In(0, TArray(TInt32)))) { _ =>
         aggBindIR(In(1, TInt32) * In(1, TInt32))(_ => Ref(freshName(), TInt32))
       },

--- a/hail/hail/test/src/is/hail/expr/ir/TestUtils.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TestUtils.scala
@@ -98,25 +98,13 @@ object TestUtils {
 
   def IRCall(c: Call): IR = invoke("callFromRepr", TCall, I32(c))
 
-  def IRAggCount: IR = {
-    val aggSig = AggSignature(Count(), FastSeq.empty, FastSeq.empty)
-    ApplyAggOp(FastSeq.empty, FastSeq.empty, aggSig)
-  }
+  def IRAggCount: IR = ApplyAggOp(Count())()
 
-  def IRScanCount: IR = {
-    val aggSig = AggSignature(Count(), FastSeq.empty, FastSeq.empty)
-    ApplyScanOp(FastSeq.empty, FastSeq.empty, aggSig)
-  }
+  def IRScanCount: IR = ApplyScanOp(Count())()
 
-  def IRAggCollect(ir: IR): IR = {
-    val aggSig = AggSignature(Collect(), FastSeq.empty, FastSeq[Type](ir.typ))
-    ApplyAggOp(FastSeq(), FastSeq(ir), aggSig)
-  }
+  def IRAggCollect(ir: IR): IR = ApplyAggOp(Collect())(ir)
 
-  def IRScanCollect(ir: IR): IR = {
-    val aggSig = AggSignature(Collect(), FastSeq.empty, FastSeq[Type](ir.typ))
-    ApplyScanOp(FastSeq(), FastSeq(ir), aggSig)
-  }
+  def IRScanCollect(ir: IR): IR = ApplyScanOp(Collect())(ir)
 
   def IRStruct(fields: (String, IR)*): IR =
     MakeStruct(fields.toArray[(String, IR)])


### PR DESCRIPTION
## Change Description

`AggSignature`, which groups an `AggOp` together with the types of the init op and seq op arguments, was not contributing any value, and needing to keep the types in sync with the arguments of `ApplyAggOp` created complexity.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP