### PR TITLE
[qob] Use getOrCreate to ensure HailContext initialization

### DIFF
--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -176,7 +176,7 @@ object Worker {
     timer.start("executeFunction")
 
     // FIXME: workers should not have backends, but some things do need hail contexts
-    HailContext(new ServiceBackend(null, null, null, null, null))
+    HailContext.getOrCreate(new ServiceBackend(null, null, null, null, null))
     val result =
       try
         using(new ServiceTaskContext(i)) { htc =>


### PR DESCRIPTION
I've seen this odd error in QoB on occasion, and I have no idea why. Does it have to do with a process being reused for a JVM job?

```
2025-08-19 06:09:59.177 JVMEntryway: ERROR: QoB Job threw an exception.
java.lang.reflect.InvocationTargetException: null
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at is.hail.JVMEntryway$1.run(JVMEntryway.java:119) [jvm-entryway.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.lang.IllegalArgumentException: requirement failed
	at scala.Predef$.require(Predef.scala:268) ~[scala-library-2.12.18.jar:?]
	at is.hail.HailContext$.apply(HailContext.scala:115) ~[gs:__hail-query-ger0g_jars_dev_b6eb4c07a1d5830b3bb4e23882b503e2ee41db10.jar.jar:?]
	at is.hail.backend.service.Worker$.main(Worker.scala:179) ~[gs:__hail-query-ger0g_jars_dev_b6eb4c07a1d5830b3bb4e23882b503e2ee41db10.jar.jar:?]
	at is.hail.backend.service.Main$.main(Main.scala:22) ~[gs:__hail-query-ger0g_jars_dev_b6eb4c07a1d5830b3bb4e23882b503e2ee41db10.jar.jar:?]
	at is.hail.backend.service.Main.main(Main.scala) ~[gs:__hail-query-ger0g_jars_dev_b6eb4c07a1d5830b3bb4e23882b503e2ee41db10.jar.jar:?]
	... 12 more
```

To solve this, use getOrCreate, which will short circuit if a HailContext exists.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

