### PR TITLE
[query] Use scalac-options library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ hail/install-editable
 hail/python/install-editable
 batch/jvm-entryway/bin
 .helix
+/hail/mill-build/config/hail-build-mode

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ pylint-hailtop:
 
 .PHONY: check-hail
 check-hail: check-hail-fast pylint-hailtop
-	cd hail && sh mill --no-server __.checkFormat + __.fix --check
+	cd hail && HAIL_BUILD_MODE=Dev sh mill --no-server __.checkFormat + __.fix --check
 
 .PHONY: check-services
 check-services: $(CHECK_SERVICES_MODULES)
@@ -130,7 +130,7 @@ hail-run-image: base-image hail/Dockerfile.hail-run hail/python/pinned-requireme
 	echo $(IMAGE_NAME) > $@
 
 hailgenetics-hail-image: hail-ubuntu-image docker/hailgenetics/hail/Dockerfile $(shell git ls-files hail/src/main hail/python)
-	$(MAKE) HAIL_RELEASE_MODE=1 -C hail wheel
+	$(MAKE) HAIL_BUILD_MODE=Release -C hail wheel
 	./docker-build.sh . docker/hailgenetics/hail/Dockerfile $(IMAGE_NAME) \
 		--build-arg BASE_IMAGE=$(shell cat hail-ubuntu-image)
 	echo $(IMAGE_NAME) > $@
@@ -196,7 +196,7 @@ terra-batch-image: batch-image
 	echo $(IMAGE_NAME) > $@
 
 terra-batch-worker-image: batch-worker-image
-	$(MAKE) -C hail shadowJar HAIL_RELEASE_MODE=1
+	$(MAKE) -C hail shadowJar HAIL_BUILD_MODE=Release
 	./docker-build.sh . batch/terra-chart/Dockerfile.worker $(IMAGE_NAME) \
 		--build-arg BASE_IMAGE=$(shell cat batch-worker-image)
 	echo $(IMAGE_NAME) > $@

--- a/build.yaml
+++ b/build.yaml
@@ -21,7 +21,7 @@ steps:
       mkdir -p repo
       cd repo
       {{ code.checkout_script }}
-      make -C hail python-version-info HAIL_RELEASE_MODE=1 MILLOPTS=--no-server
+      make -C hail python-version-info HAIL_BUILD_MODE=Release MILLOPTS=--no-server
     outputs:
       - from: /io/repo/
         to: /repo
@@ -763,7 +763,7 @@ steps:
       set -ex
       cd /io/repo/hail
 
-      export MILLOPTS='--no-server' HAIL_RELEASE_MODE=1
+      export MILLOPTS='--no-server' HAIL_BUILD_MODE=Release
       time retry sh mill --no-server --version
 
       # We've encountered the following sporadic error in CI between `mill`
@@ -808,7 +808,7 @@ steps:
       cd /io/repo/hail
 
       gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
-      make HAIL_RELEASE_MODE=1 DEV_CLARIFIER=hail-ci-build upload-artifacts \
+      make HAIL_BUILD_MODE=Release DEV_CLARIFIER=hail-ci-build upload-artifacts \
           -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
     dependsOn:
       - ci_utils_image
@@ -841,7 +841,7 @@ steps:
       set -ex
       cd /io/repo/hail
 
-      export MILLOPTS='--no-server'
+      export MILLOPTS='--no-server' HAIL_BUILD_MODE=CI
       time retry sh mill --no-server --version
 
       # See `build_hail_jar_and_wheel`
@@ -874,7 +874,7 @@ steps:
       set -ex
       cd /io/repo/hail
 
-      export MILLOPTS='--no-server'
+      export MILLOPTS='--no-server' HAIL_BUILD_MODE=CI
       time retry sh mill --no-server --version
 
       # See `build_hail_jar_and_wheel`
@@ -934,7 +934,7 @@ steps:
       set -ex
       cd /io/repo/hail
 
-      export SPARK_VERSION="3.0.2" SCALA_VERSION="2.12.13" HAIL_RELEASE_MODE=1 MILLOPTS='--no-server'
+      export SPARK_VERSION="3.0.2" SCALA_VERSION="2.12.13" HAIL_BUILD_MODE=Release MILLOPTS='--no-server'
       time retry sh mill --no-server --version
 
       # See `build_hail_jar_and_wheel`
@@ -3392,7 +3392,7 @@ steps:
       fi
 
       cd hail
-      make test-dataproc-37 HAIL_RELEASE_MODE=1 \
+      make test-dataproc-37 HAIL_BUILD_MODE=Release \
           -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
     dependsOn:
       - ci_utils_image
@@ -3436,7 +3436,7 @@ steps:
       fi
 
       cd hail
-      make test-dataproc-38 HAIL_RELEASE_MODE=1 \
+      make test-dataproc-38 HAIL_BUILD_MODE=Release \
           -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
     dependsOn:
       - ci_utils_image
@@ -3491,7 +3491,7 @@ steps:
 
       # #14452 - must build wheel with release `hailtop/hailctl/deploy.yaml`
       # use `-o` to prevent `mill` from rebuilding the "SHADOW_JAR"
-      make upload-artifacts HAIL_RELEASE_MODE=1 DEPLOY_REMOTE=origin \
+      make upload-artifacts HAIL_BUILD_MODE=Release DEPLOY_REMOTE=origin \
         -o out/hail/assembly.dest/out.jar
 
       echo Setting arguments and invoking release.sh.

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -1,11 +1,10 @@
-//| mill-version: 1.0.3
+//| mill-version: 1.0.4
 //| mill-jvm-version: 11
-//| mvnDeps:
-//| - com.goyeau::mill-scalafix::0.6.0
 
 package build
 
 import com.goyeau.mill.scalafix.ScalafixModule
+import org.typelevel.scalacoptions._
 import mill.*
 import mill.api.{Result, BuildCtx}
 import mill.javalib.UnresolvedPath
@@ -14,6 +13,7 @@ import mill.scalalib.Assembly.*
 import mill.scalalib.TestModule.TestNg
 import mill.scalalib.scalafmt.ScalafmtModule
 import mill.util.{Jvm, VcsVersion}
+import upickle.default.ReadWriter
 
 object Settings {
   val hailMajorMinorVersion = "0.2"
@@ -49,8 +49,8 @@ object Deps {
   }
 
   object Spark {
-    def core: Task[Dep] = Task.Anon(mvn"org.apache.spark::spark-core:${build.env.sparkVersion()}")
-    def mllib: Task[Dep] = Task.Anon(mvn"org.apache.spark::spark-mllib:${build.env.sparkVersion()}")
+    def core: Task[Dep] = Task.Anon(mvn"org.apache.spark::spark-core:${Env.sparkVersion()}")
+    def mllib: Task[Dep] = Task.Anon(mvn"org.apache.spark::spark-mllib:${Env.sparkVersion()}")
   }
 
   val samtools = mvn"com.github.samtools:htsjdk:3.0.5"
@@ -76,7 +76,11 @@ object Deps {
   }
 }
 
-object env extends Module {
+enum BuildMode derives ReadWriter {
+  case Dev, CI, Release
+}
+
+object Env extends Module {
   def scalaVersion: T[String] = Task.Input {
     val v = Task.env.getOrElse("SCALA_VERSION", "2.12.20")
     if (!v.startsWith("2.12"))
@@ -93,50 +97,53 @@ object env extends Module {
     Result.Success(Task.env.getOrElse("SPARK_VERSION", "3.5.0"))
   }
 
-  def getDebugMode(env: Map[String, String]): Boolean =
-    !env.contains("HAIL_RELEASE_MODE")
-
-  def debugMode: T[Boolean] = Task.Input {
-    val isDebug = getDebugMode(Task.env)
-    Task.log.info(s"Building in ${if (isDebug) "debug" else "release"} mode")
-    isDebug
-  }
-
-  def debugOrRelease: Task[String] = Task.Anon {
-    if (debugMode()) "debug" else "release"
-  }
+  val buildMode: BuildMode = BuildMode.valueOf(millbuild.BuildConfig.buildMode)
 }
 
 trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { outer =>
-  override def scalaVersion: T[String] = build.env.scalaVersion()
+  override def scalaVersion: T[String] = Env.scalaVersion()
 
   override def javacOptions: T[Seq[String]] = Seq(
     "-Xlint:all",
     "-Werror",
-    if (build.env.debugMode()) "-g" else "-O",
-  ) ++ (if (!build.env.javaVersion().startsWith("1.8")) Seq("-Xlint:-processing") else Seq())
+    if (Env.buildMode == BuildMode.Release) "-O" else "-g",
+  ) ++ (if (!Env.javaVersion().startsWith("1.8")) Seq("-Xlint:-processing") else Seq())
 
   override def scalacOptions: T[Seq[String]] = Task {
-    Seq(
-      "-explaintypes",
-      "-unchecked",
-      "-Xsource:2.13",
-      "-Xno-patmat-analysis",
-      "-Ypartial-unification",
-      "-Yno-adapted-args", // will be removed in 2.13
-      "-Ywarn-value-discard",
-      "-Xlint",
-      "-Ywarn-unused:_,-explicits,-implicits",
-      "-Wconf:msg=legacy-binding:s",
-      "-feature",
-    ) ++ (
-      if (build.env.debugMode()) Seq()
-      else Seq(
-        "-Xfatal-warnings",
-        "-opt:l:method",
-        "-opt:-closure-invocations",
-      )
+    val disabledOptions = Set(
+      ScalacOptions.warnNumericWiden, ScalacOptions.privateWarnNumericWiden,
+      ScalacOptions.warnUnusedParams, ScalacOptions.privateWarnUnusedParams,
+      ScalacOptions.warnUnusedImplicits, ScalacOptions.privateWarnUnusedImplicits,
+      ScalacOptions.warnUnusedExplicits,
+      ScalacOptions.warnDeadCode, ScalacOptions.privateWarnDeadCode,
+      ScalacOptions.warnUnusedImports, ScalacOptions.privateWarnUnusedImports,
+
+      ScalacOptions.lintInferAny,
     )
+    
+    val baseOptions = ScalacOptions.default +
+      ScalacOptions.source213 +
+      ScalacOptions.advancedOption("no-patmat-analysis")
+    
+    val additionalOptions = Env.buildMode match {
+      case BuildMode.Dev =>
+        ScalacOptions.verboseOptions
+      // enable to help debug accessing unitialized fields
+      //     + ScalacOptions.checkInit
+      case BuildMode.CI => 
+        Set(ScalacOptions.fatalWarnings)
+      case BuildMode.Release =>
+        Set(
+          ScalacOptions.fatalWarnings,
+          ScalacOptions.optimizerMethodLocal,
+          ScalacOptions.optimizerOption(":-closure-invocations"),
+        )
+    }
+
+    ScalacOptions.tokensForVersion(
+      ScalaVersion.unsafeFromString(scalaVersion()),
+      baseOptions -- disabledOptions ++ additionalOptions
+    ) :+ "-Wconf:msg=legacy-binding:s"
   }
 
   trait HailTests extends ScalaTests with TestNg with ScalafmtModule with ScalafixModule {
@@ -162,9 +169,9 @@ object hail extends HailModule { outer =>
       Task.dest / "build-info.properties",
       s"""[Build Metadata]
          |revision=$revision
-         |sparkVersion=${env.sparkVersion()}
+         |sparkVersion=${Env.sparkVersion()}
          |hailPipVersion=${Settings.hailMajorMinorVersion}.${Settings.hailPatchVersion}
-         |hailBuildConfiguration=${env.debugOrRelease()}
+         |hailBuildConfiguration=${Env.buildMode}
          |""".stripMargin,
     )
     PathRef(Task.dest)
@@ -281,7 +288,7 @@ object hail extends HailModule { outer =>
 
     override def javacOptions: T[Seq[String]] =
       outer.javacOptions() ++ (
-        if (env.javaVersion().startsWith("1.8")) Seq(
+        if (Env.javaVersion().startsWith("1.8")) Seq(
           "-XDenableSunApiLintControl",
           "-Xlint:-sunapi",
         )
@@ -289,7 +296,7 @@ object hail extends HailModule { outer =>
       )
 
     override def sources: T[Seq[PathRef]] = Task.Sources {
-      val debugOrRelease = if (env.getDebugMode(Task.env)) "debug" else "release"
+      val debugOrRelease = if (Env.buildMode == BuildMode.CI) "debug" else "release"
       os.sub / debugOrRelease / "src"
     }
   }

--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -1,5 +1,4 @@
 import scala.annotation.nowarn
-import scala.language.{higherKinds, implicitConversions}
 
 import mainargs.{main, ParserForMethods}
 

--- a/hail/hail/macros/src/is/hail/macros.scala
+++ b/hail/hail/macros/src/is/hail/macros.scala
@@ -1,6 +1,5 @@
 package is.hail
 
-import scala.language.experimental.{macros => scalamacros}
 import scala.reflect.macros.blackbox
 
 package object macros extends VoidImpl {

--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -5,7 +5,6 @@ import is.hail.lir
 import is.hail.utils._
 
 import scala.collection.mutable
-import scala.language.existentials
 
 import java.io._
 import java.nio.charset.StandardCharsets

--- a/hail/hail/src/is/hail/asm4s/package.scala
+++ b/hail/hail/src/is/hail/asm4s/package.scala
@@ -1,6 +1,5 @@
 package is.hail
 
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 import org.objectweb.asm.Opcodes._

--- a/hail/hail/src/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/hail/src/is/hail/expr/ir/ArraySorter.scala
@@ -7,8 +7,6 @@ import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TArray, TDict, TSet, Type}
 import is.hail.utils.FastSeq
 
-import scala.language.existentials
-
 class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
   val ti: TypeInfo[_] = array.elt.ti
   val mb: EmitMethodBuilder[_] = r.mb

--- a/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
@@ -4,7 +4,7 @@ import is.hail.expr.ir.defs._
 import is.hail.types.virtual._
 import is.hail.utils.{toRichIterable, FastSeq}
 
-import scala.language.{dynamics, implicitConversions}
+import scala.language.dynamics
 
 object DeprecatedIRBuilder {
   type E = Env[Type]

--- a/hail/hail/src/is/hail/expr/ir/Emit.scala
+++ b/hail/hail/src/is/hail/expr/ir/Emit.scala
@@ -27,7 +27,6 @@ import is.hail.variant.ReferenceGenome
 
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
-import scala.language.existentials
 
 import java.io._
 

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -18,7 +18,6 @@ import is.hail.utils.prettyPrint.ArrayOfByteArrayInputStream
 import is.hail.variant.ReferenceGenome
 
 import scala.collection.mutable
-import scala.language.existentials
 
 import java.io._
 import java.lang.reflect.InvocationTargetException

--- a/hail/hail/src/is/hail/expr/ir/TableValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableValue.scala
@@ -106,7 +106,7 @@ object TableValue {
     def newGlobalType = TStruct(globalName -> TArray(childValues.head.typ.globalType))
     def newValueType = TStruct(fieldName -> TArray(childValues.head.typ.valueType))
     def newRowType = childValues.head.typ.keyType ++ newValueType
-    val typ = childValues.head.typ.copy(
+    val typ: TableType = childValues.head.typ.copy(
       rowType = newRowType,
       globalType = newGlobalType,
     )

--- a/hail/hail/src/is/hail/expr/ir/lowering/Invariant.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/Invariant.scala
@@ -9,8 +9,6 @@ import is.hail.expr.ir.{
 import is.hail.expr.ir.defs.{ApplyIR, RelationalLet, RelationalRef}
 import is.hail.utils.toRichPredicate
 
-import scala.language.implicitConversions
-
 abstract class Invariant(implicit E: sourcecode.Enclosing) extends (BaseIR => Boolean) {
   final def verify(ctx: ExecuteContext, ir: BaseIR): Unit =
     ctx.time {

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -11,8 +11,6 @@ import is.hail.types.virtual._
 import is.hail.types.virtual.TIterable.elementType
 import is.hail.utils._
 
-import scala.language.implicitConversions
-
 import java.util.UUID
 
 package object ir {

--- a/hail/hail/src/is/hail/expr/package.scala
+++ b/hail/hail/src/is/hail/expr/package.scala
@@ -1,7 +1,5 @@
 package is.hail
 
-import scala.language.implicitConversions
-
 package object expr {
   implicit def toRichParser[T](parser: Parser.Parser[T]): RichParser[T] = new RichParser(parser)
 }

--- a/hail/hail/src/is/hail/io/tabix/TabixReader.scala
+++ b/hail/hail/src/is/hail/io/tabix/TabixReader.scala
@@ -6,7 +6,6 @@ import is.hail.io.fs.FS
 import is.hail.utils._
 
 import scala.collection.mutable
-import scala.language.implicitConversions
 
 import java.io.InputStream
 

--- a/hail/hail/src/is/hail/package.scala
+++ b/hail/hail/src/is/hail/package.scala
@@ -59,10 +59,15 @@ object BuildConfiguration {
     override def isDebug: Boolean = true
   }
 
+  case object CI extends BuildConfiguration {
+    override def isDebug: Boolean = true
+  }
+
   def parseString(c: String): Option[BuildConfiguration] =
     c match {
-      case "release" => Some(BuildConfiguration.Release)
-      case "debug" => Some(BuildConfiguration.Debug)
+      case "Release" => Some(BuildConfiguration.Release)
+      case "Dev" => Some(BuildConfiguration.Debug)
+      case "CI" => Some(BuildConfiguration.CI)
       case _ => None
     }
 }

--- a/hail/hail/src/is/hail/utils/EitherIsAMonad.scala
+++ b/hail/hail/src/is/hail/utils/EitherIsAMonad.scala
@@ -1,7 +1,5 @@
 package is.hail.utils
 
-import scala.language.implicitConversions
-
 object EitherIsAMonad {
   implicit def eitherIsAMonad[A, B](eab: Either[A, B]): EitherOps[A, B] = new EitherOps(eab)
 }

--- a/hail/hail/src/is/hail/utils/NumericImplicits.scala
+++ b/hail/hail/src/is/hail/utils/NumericImplicits.scala
@@ -1,7 +1,5 @@
 package is.hail.utils
 
-import scala.language.implicitConversions
-
 import breeze.linalg.{DenseVector => BDenseVector, SparseVector => BSparseVector, Vector => BVector}
 import breeze.linalg.operators.{OpAdd, OpSub}
 import org.apache.spark.mllib.linalg.{

--- a/hail/hail/src/is/hail/utils/package.scala
+++ b/hail/hail/src/is/hail/utils/package.scala
@@ -9,7 +9,6 @@ import scala.collection.{mutable, GenTraversableOnce, TraversableOnce}
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionException
-import scala.language.{higherKinds, implicitConversions}
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 

--- a/hail/hail/src/is/hail/utils/prettyPrint/package.scala
+++ b/hail/hail/src/is/hail/utils/prettyPrint/package.scala
@@ -1,7 +1,5 @@
 package is.hail.utils
 
-import scala.language.implicitConversions
-
 package object prettyPrint {
   implicit def text(t: String): Doc = Text(t)
 

--- a/hail/hail/src/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/Implicits.scala
@@ -7,7 +7,6 @@ import is.hail.sparkextras._
 import is.hail.utils.{HailIterator, MultiArray2, Truncatable, WithContext}
 
 import scala.collection.{mutable, TraversableOnce}
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
 

--- a/hail/hail/test/src/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/AggregatorsSuite.scala
@@ -1357,7 +1357,7 @@ class AggregatorsSuite extends HailSuite {
   }
 
   // fails because there is no "lowest binding referenced in an init op"
-  @Test def testStreamAgg(): Unit = {
+  @Test def testStreamAgg(): scalatest.Assertion = {
     implicit val execStrats = Set(ExecStrategy.JvmCompileUnoptimized)
     val foo = StreamRange(I32(0), I32(10), I32(1))
 
@@ -1372,7 +1372,7 @@ class AggregatorsSuite extends HailSuite {
     assertEvalsTo(ir, 1)
   }
 
-  @Test def testLetBoundInitOpArg(): Unit = {
+  @Test def testLetBoundInitOpArg(): scalatest.Assertion = {
     implicit val execStrats = ExecStrategy.allRelational
     var tir: TableIR = TableRange(10, 3)
     tir =

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -25,7 +25,6 @@ import is.hail.utils.{FastSeq, _}
 import is.hail.variant.{Call2, Locus}
 
 import scala.collection.mutable
-import scala.language.implicitConversions
 
 import org.apache.spark.sql.Row
 import org.json4s.jackson.{JsonMethods, Serialization}

--- a/hail/hail/test/src/is/hail/scalacheck/package.scala
+++ b/hail/hail/test/src/is/hail/scalacheck/package.scala
@@ -2,7 +2,6 @@ package is.hail
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.language.{higherKinds, implicitConversions}
 import scala.reflect.ClassTag
 
 import org.apache.commons.math3.distribution.{

--- a/hail/mill-build/build.mill
+++ b/hail/mill-build/build.mill
@@ -1,0 +1,40 @@
+package build
+
+import mill.*, scalalib.*
+import mill.meta.MillBuildRootModule
+
+object `package` extends MillBuildRootModule {
+  def mvnDeps = Seq(
+    mvn"com.goyeau::mill-scalafix::0.6.0",
+    mvn"org.typelevel::scalac-options:0.1.8",
+  )
+
+  def generatedSources: T[Seq[PathRef]] = Task {
+    os.write(
+      Task.dest / "BuildConfig.scala",
+      s"""
+         |package millbuild
+         |object BuildConfig{
+         |  def buildMode = "${buildMode()}"
+         |}
+      """.stripMargin
+    )
+    super.generatedSources() ++ Seq(PathRef(Task.dest))
+  }
+
+  def envBuildMode: T[Option[String]] = Task.Input {
+    Task.env.get("HAIL_BUILD_MODE")
+  }
+
+  def configDir: T[PathRef] = Task.Source("config")
+
+  def buildMode: T[String] = Task {
+    val path = configDir().path / "hail-build-mode"
+    envBuildMode().getOrElse {
+      if (os.exists(path))
+        os.read(path)
+      else
+        "Release"
+    }
+  }
+}

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -36,7 +36,7 @@ The next block of commands downloads, builds, and installs Hail from source.
 
     git clone https://github.com/hail-is/hail.git
     cd hail/hail
-    make install-on-cluster HAIL_RELEASE_MODE=1 HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.12.18 SPARK_VERSION=3.5.0
+    make install-on-cluster HAIL_BUILD_MODE=Release HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.12.18 SPARK_VERSION=3.5.0
 
 If you forget to install any of the requirements before running `make install-on-cluster`, it's possible
 to get into a bad state where `make` insists you don't have a requirement that you have in fact installed.


### PR DESCRIPTION
## Change Description

The main changes here are:

- Use the typelevel scalac-options library to more easily manage scalac compiler flags, especially once we start maintaining a cross-version build.
- Change how we specify build modes (previously debug vs release).
- Use language feature flags, instead of importing from `scala.language`​ in every file where we use some gated feature like higher-kinded types or implicit conversions. This is effectively the only change to our compiler options.

### Build modes

There are now three build modes: Dev, CI, and Release:

|  | Verbose | Fatal Warnings | Optimize | Checked Allocator |
| --- | --- | --- | --- | --- |
| Dev | :white_check_mark: | :x: | :x: | :x: |
| CI | :x: | :white_check_mark: | :x: | :white_check_mark: |
| Release | :x: | :white_check_mark: | :white_check_mark: | :x: |

(“Verbose” is compiler flags like `-explaintypes`​ which enable more verbose warnings and errors.)

To work around limitations of Mill/BSP/IntelliJ, namely that we can’t set environment variables to control the IntelliJ build, I’ve split off the meta-build in Mill, and have it check both an environment variable and a file, as follows:

- If the `HAIL_BUILD_MODE`​ variable is set, use it,
- else, if the `hail/hail/mill-build/config/hail-build-mode`​​ file exists, use it’s contents,
- else, default to Release.

Those of us using IntelliJ can create the file, which I’ve added to `.gitignore`​, to use the Dev mode, and can still use the envvar to e.g. build a release jar. Others can simply add the envvar to their shell config.

This use of the Mill meta-build is really the right way to handle the build mode anyways, since it’s an input that changes the structure of the build itself (in particular, the source directories of the `memory`​ module). We were previously doing something a bit hacky to deal with this.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP