### PR TITLE
[query] enable a few easy 2.13 warnings

### DIFF
--- a/hail/build.mill
+++ b/hail/build.mill
@@ -210,7 +210,6 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
         // Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
         "-Wconf:cat=deprecation&msg=Widening conversion from Long to Double:s",
         "-Wconf:cat=deprecation&msg=symbol literal is deprecated:s",
-        "-Wconf:cat=other-match-analysis:s",
         "-Wconf:cat=other-implicit-type:s",
         "-Wconf:msg=legacy-binding:s",
         raw"-Wconf:cat=unused-imports&origin=scala\.collection\.compat\._:s",

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -205,8 +205,6 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
         // method transform in trait SeqOps is deprecated (since 2.13.0): Use `mapInPlace` on an `IndexedSeq` instead
         "-Wconf:cat=deprecation&msg=method transform in trait SeqOps is deprecated:s",
       // other
-        // Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3
-        "-Wconf:cat=deprecation&msg=`export`:s",
         // Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
         "-Wconf:cat=deprecation&msg=Widening conversion from Long to Double:s",
         "-Wconf:cat=deprecation&msg=symbol literal is deprecated:s",

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -211,7 +211,6 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
         "-Wconf:cat=deprecation&msg=Widening conversion from Long to Double:s",
         "-Wconf:cat=deprecation&msg=symbol literal is deprecated:s",
         "-Wconf:cat=other-implicit-type:s",
-        "-Wconf:msg=legacy-binding:s",
         raw"-Wconf:cat=unused-imports&origin=scala\.collection\.compat\._:s",
         raw"-Wconf:cat=unused-imports&origin=scala\.Option\.option2Iterable:s",
         raw"-Wconf:cat=unused-imports&origin=is\.hail\.utils\.compat\._:s",

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -210,7 +210,6 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
         // Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
         "-Wconf:cat=deprecation&msg=Widening conversion from Long to Double:s",
         "-Wconf:cat=deprecation&msg=symbol literal is deprecated:s",
-        "-Wconf:cat=other-implicit-type:s",
         raw"-Wconf:cat=unused-imports&origin=scala\.collection\.compat\._:s",
         raw"-Wconf:cat=unused-imports&origin=scala\.Option\.option2Iterable:s",
         raw"-Wconf:cat=unused-imports&origin=is\.hail\.utils\.compat\._:s",

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -113,7 +113,6 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
       ScalacOptions.warnUnusedParams, ScalacOptions.privateWarnUnusedParams,
       ScalacOptions.warnUnusedImplicits, ScalacOptions.privateWarnUnusedImplicits,
       ScalacOptions.warnUnusedExplicits,
-      ScalacOptions.warnDeadCode, ScalacOptions.privateWarnDeadCode,
       // we don't enable the unused imports warning in 2.12, as the wconf origin filter doesn't work
       ScalacOptions.privateWarnUnusedImports,
       // 2.13 added the -Wnonunit-discard flag, which is a stronger check than -Wvalue-discard

--- a/hail/hail/src/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/hail/src/is/hail/annotations/ExtendedOrdering.scala
@@ -20,7 +20,7 @@ object ExtendedOrdering {
     }
   }
 
-  def iterableOrdering[T](ord: ExtendedOrdering, _missingEqual: Boolean = true): ExtendedOrdering =
+  def iterableOrdering(ord: ExtendedOrdering, _missingEqual: Boolean = true): ExtendedOrdering =
     new ExtendedOrdering {
       val missingEqual = _missingEqual
 

--- a/hail/hail/src/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/hail/src/is/hail/annotations/OrderedRVIterator.scala
@@ -28,7 +28,7 @@ case class OrderedRVIterator(
   iterator: Iterator[RegionValue],
   ctx: RVDContext,
   sm: HailStateManager,
-) {
+) { outer =>
 
   def staircase: StagingIterator[FlipbookIterator[RegionValue]] =
     iterator.toFlipbookIterator.staircased(t.kRowOrdView(sm, ctx.freshRegion()))
@@ -181,7 +181,7 @@ case class OrderedRVIterator(
     val consumerRegion = ctx.region
 
     new Iterator[RegionValue] {
-      private val bit = iterator.buffered
+      private val bit = outer.iterator.buffered
 
       private val q = new mutable.PriorityQueue[RegionValue]()(
         t.copy(key = newKey).kInRowOrd(sm).toRVOrdering.reverse

--- a/hail/hail/src/is/hail/asm4s/Code.scala
+++ b/hail/hail/src/is/hail/asm4s/Code.scala
@@ -1333,8 +1333,8 @@ class VCode[+T](
 }
 
 object CodeKind extends Enumeration {
-  type Kind = Value
-  val V, C = Value
+  type Kind = this.Value
+  val V, C = this.Value
 }
 
 class CCode(

--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -8,7 +8,7 @@ import is.hail.services._
 import is.hail.utils._
 
 import scala.collection.mutable
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.concurrent.duration.Duration
 
 import java.io._
@@ -89,9 +89,10 @@ object Worker {
   private[this] val log = Logger.getLogger(getClass.getName())
   private[this] val myRevision = HAIL_REVISION
 
-  implicit private[this] val ec = ExecutionContext.fromExecutorService(
-    javaConcurrent.Executors.newCachedThreadPool()
-  )
+  implicit private[this] val ec: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(
+      javaConcurrent.Executors.newCachedThreadPool()
+    )
 
   private[this] def writeString(out: DataOutputStream, s: String): Unit = {
     val bytes = s.getBytes(StandardCharsets.UTF_8)

--- a/hail/hail/src/is/hail/expr/ir/AggOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/AggOp.scala
@@ -85,7 +85,7 @@ object AggOp {
     case "min" | "Min" => Min()
     case "count" | "Count" => Count()
     case "take" | "Take" => Take()
-    case "ReservoirSample" | "Take" => ReservoirSample()
+    case "reservoirSample" | "ReservoirSample" => ReservoirSample()
     case "densify" | "Densify" => Densify()
     case "takeBy" | "TakeBy" => TakeBy()
     case "callStats" | "CallStats" => CallStats()

--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
@@ -305,7 +305,7 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: Name, f: IR, needsDense
   val blockCostIsLinear: Boolean = child.blockCostIsLinear
 
   private def evalIR(ctx: ExecuteContext, ir: IR): Double = {
-    val res: Any = CompileAndEvaluate(ctx, ir)
+    val res: Any = CompileAndEvaluate[Any](ctx, ir)
     if (res == null)
       fatal("can't perform BlockMatrix operation on missing values!")
     res.asInstanceOf[Double]

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -44,7 +44,7 @@ object Interpret {
   }
 
   def apply[T](ctx: ExecuteContext, ir: IR): T =
-    apply(ctx, ir, Env.empty[(Any, Type)], FastSeq[(Any, Type)]()).asInstanceOf[T]
+    apply[T](ctx, ir, Env.empty[(Any, Type)], FastSeq[(Any, Type)]())
 
   def apply[T](
     ctx: ExecuteContext,

--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -2339,7 +2339,7 @@ case class MatrixBlockMatrixWriter(
     val rm = r.asMatrixType(colsFieldName, entriesFieldName)
 
     val countColumnsIR = ArrayLen(GetField(ts.getGlobals(), colsFieldName))
-    val numCols: Int = CompileAndEvaluate(ctx, countColumnsIR).asInstanceOf[Int]
+    val numCols: Int = CompileAndEvaluate[Int](ctx, countColumnsIR)
     val numBlockCols: Int = (numCols - 1) / blockSize + 1
     val lastBlockNumCols = (numCols - 1) % blockSize + 1
 
@@ -2347,7 +2347,7 @@ case class MatrixBlockMatrixWriter(
       StreamLen(paritionIR)
     )
     val inputRowCountPerPartition: IndexedSeq[Int] =
-      CompileAndEvaluate(ctx, rowCountIR).asInstanceOf[IndexedSeq[Int]]
+      CompileAndEvaluate[IndexedSeq[Int]](ctx, rowCountIR)
     val inputPartStartsPlusLast = inputRowCountPerPartition.scanLeft(0L)(_ + _)
     val inputPartStarts = inputPartStartsPlusLast.dropRight(1)
     val inputPartStops = inputPartStartsPlusLast.tail

--- a/hail/hail/src/is/hail/expr/ir/Parser.scala
+++ b/hail/hail/src/is/hail/expr/ir/Parser.scala
@@ -1511,11 +1511,6 @@ object IRParser {
           case Array(value, path, stagingFile) => WriteValue(value, path, writer, Some(stagingFile))
         }
       case "LiftMeOut" => ir_value_expr(ctx)(it).map(LiftMeOut)
-      case "ReadPartition" =>
-        val rowType = tcoerce[TStruct](type_expr(it))
-        import PartitionReader.formats
-        val reader = JsonMethods.parse(string_literal(it)).extract[PartitionReader]
-        ir_value_expr(ctx)(it).map(context => ReadPartition(context, rowType, reader))
     }
   }
 

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -1472,7 +1472,7 @@ case class PartitionZippedNativeIntervalReader(
     codeContext: EmitCode,
     requestedType: TStruct,
   ): IEmitCode = {
-    val zipContextType: TBaseStruct = tcoerce(zippedReader.contextType)
+    val zipContextType = tcoerce[TBaseStruct](zippedReader.contextType)
     val valueContext = cb.memoize(codeContext)
     val contexts: IndexedSeq[EmitCode] = FastSeq(valueContext, valueContext)
     val st = SStackStruct(zipContextType, contexts.map(_.emitType))

--- a/hail/hail/src/is/hail/expr/ir/TableValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableValue.scala
@@ -324,7 +324,7 @@ case class TableValue(ctx: ExecuteContext, typ: TableType, globals: BroadcastRow
   def persist(ctx: ExecuteContext, level: StorageLevel) =
     TableValue(ctx, typ, globals, rvd.persist(ctx, level))
 
-  def export(
+  def `export`(
     ctx: ExecuteContext,
     path: String,
     typesFile: String = null,

--- a/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
@@ -561,7 +561,7 @@ abstract class RegistryFunctions {
           val res = impl(cb, r, rpt, errorID, args.toArray)
           if (res.emitType != calculateReturnType(rpt.virtualType, args.map(_.emitType)))
             throw new RuntimeException(
-              s"type mismatch while registering $name" +
+              s"type mismatch while registering ${this.name}" +
                 s"\n  got ${res.emitType}, got ${calculateReturnType(rpt.virtualType, args.map(_.emitType))}"
             )
           res

--- a/hail/hail/src/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -8,7 +8,7 @@ import is.hail.types.{RTable, TypeWithRequiredness}
 import is.hail.types.virtual.{BlockMatrixType, MatrixType, TableType, Type}
 import is.hail.utils._
 
-import org.json4s.{Extraction, JValue, ShortTypeHints}
+import org.json4s.{Extraction, Formats, JValue, ShortTypeHints}
 import org.json4s.jackson.JsonMethods
 
 abstract class MatrixToMatrixFunction {
@@ -109,7 +109,7 @@ abstract class BlockMatrixToValueFunction {
 }
 
 object RelationalFunctions {
-  implicit val formats = RelationalSpec.formats + ShortTypeHints(
+  implicit val formats: Formats = RelationalSpec.formats + ShortTypeHints(
     List(
       classOf[LinearRegressionRowsSingle],
       classOf[LinearRegressionRowsChained],

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -501,7 +501,7 @@ class TableStage(
       )
     } else {
       val location = ec.createTmpPath(genUID())
-      CompileAndEvaluate(
+      CompileAndEvaluate[Unit](
         ec,
         TableNativeWriter(location).lower(ec, this, RTable.fromTableStage(ec, this)),
       )
@@ -1434,7 +1434,7 @@ object LowerTableIR {
 
         val bindRelationLetsNewCtx = Let(loweredChild.letBindings, ToArray(newCtxs))
         val newCtxSeq =
-          CompileAndEvaluate(ctx, bindRelationLetsNewCtx).asInstanceOf[IndexedSeq[Any]]
+          CompileAndEvaluate[IndexedSeq[Any]](ctx, bindRelationLetsNewCtx)
         val numNewParts = newCtxSeq.length
         val newIntervals = loweredChild.partitioner.rangeBounds.slice(0, numNewParts)
         val newPartitioner = loweredChild.partitioner.copy(rangeBounds = newIntervals)
@@ -1583,7 +1583,7 @@ object LowerTableIR {
         }
 
         val letBindNewCtx = Let(loweredChild.letBindings, ToArray(newCtxs))
-        val newCtxSeq = CompileAndEvaluate(ctx, letBindNewCtx).asInstanceOf[IndexedSeq[Any]]
+        val newCtxSeq = CompileAndEvaluate[IndexedSeq[Any]](ctx, letBindNewCtx)
         val numNewParts = newCtxSeq.length
         val oldParts = loweredChild.partitioner.rangeBounds
         val newIntervals = oldParts.slice(oldParts.length - numNewParts, oldParts.length)

--- a/hail/hail/src/is/hail/io/ElasticsearchConnector.scala
+++ b/hail/hail/src/is/hail/io/ElasticsearchConnector.scala
@@ -8,7 +8,7 @@ import org.elasticsearch.spark.sql._
 
 object ElasticsearchConnector {
 
-  def export(
+  def `export`(
     df: spark.sql.DataFrame,
     host: String,
     port: Int,
@@ -30,7 +30,7 @@ object ElasticsearchConnector {
     )
   }
 
-  def export(
+  def `export`(
     df: spark.sql.DataFrame,
     host: String = "localhost",
     port: Int = 9200,

--- a/hail/hail/src/is/hail/linalg/RowMatrix.scala
+++ b/hail/hail/src/is/hail/linalg/RowMatrix.scala
@@ -115,7 +115,7 @@ class RowMatrix(
     new DenseMatrix[Double](nRowsInt, nCols, a.flatten, 0, nCols, isTranspose = true)
   }
 
-  def export(
+  def `export`(
     ctx: ExecuteContext,
     path: String,
     columnDelimiter: String,

--- a/hail/hail/src/is/hail/rvd/RVD.scala
+++ b/hail/hail/src/is/hail/rvd/RVD.scala
@@ -1234,11 +1234,11 @@ object RVD {
 
       new RVDCoercer(fullType) {
         val unfixedPartitioner =
-          new RVDPartitioner(execCtx.stateManager, fullType.kType.virtualType, bounds)
+          new RVDPartitioner(execCtx.stateManager, this.fullType.kType.virtualType, bounds)
         val newPartitioner = RVDPartitioner.generate(
           execCtx.stateManager,
-          fullType.key.take(partitionKey),
-          fullType.kType.virtualType,
+          this.fullType.key.take(partitionKey),
+          this.fullType.kType.virtualType,
           bounds,
         )
 
@@ -1262,13 +1262,13 @@ object RVD {
       new RVDCoercer(fullType) {
         val unfixedPartitioner = new RVDPartitioner(
           execCtx.stateManager,
-          fullType.kType.virtualType.truncate(partitionKey),
+          this.fullType.kType.virtualType.truncate(partitionKey),
           pkBounds,
         )
         val newPartitioner = RVDPartitioner.generate(
           execCtx.stateManager,
-          fullType.key.take(partitionKey),
-          fullType.kType.virtualType.truncate(partitionKey),
+          this.fullType.key.take(partitionKey),
+          this.fullType.kType.virtualType.truncate(partitionKey),
           pkBounds,
         )
 
@@ -1289,7 +1289,7 @@ object RVD {
 
       new RVDCoercer(fullType) {
         val newPartitioner =
-          calculateKeyRanges(execCtx, fullType, keyInfo, keys.getNumPartitions, partitionKey)
+          calculateKeyRanges(execCtx, this.fullType, keyInfo, keys.getNumPartitions, partitionKey)
 
         def _coerce(typ: RVDType, crdd: CRDD): RVD =
           RVD.unkeyed(typ.rowType, crdd)

--- a/hail/hail/src/is/hail/types/encoded/EStructOfArrays.scala
+++ b/hail/hail/src/is/hail/types/encoded/EStructOfArrays.scala
@@ -29,8 +29,8 @@ object EStructOfArrays {
   }
 
   def fromTypeAndRequiredness(t: TIterable, r: RIterable): EStructOfArrays = {
-    val et: TBaseStruct = tcoerce(t.elementType)
-    val ret: RBaseStruct = tcoerce(r.elementType)
+    val et = tcoerce[TBaseStruct](t.elementType)
+    val ret = tcoerce[RBaseStruct](r.elementType)
     val fields = et.fields.zip(ret.fields).map { case (TField(name, typ, index), r) =>
       val encodedType = typ match {
         case TBoolean => EArray(EBoolean(r.typ.required), required = true)
@@ -80,9 +80,9 @@ final case class EStructOfArrays(
 
   def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer])
     : SValue = {
-    val st: SIndexablePointer = tcoerce(decodedSType(t))
-    val pt: PCanonicalArray = tcoerce(st.pType)
-    val ept: PBaseStruct = tcoerce(pt.elementType)
+    val st = tcoerce[SIndexablePointer](decodedSType(t))
+    val pt = tcoerce[PCanonicalArray](st.pType)
+    val ept = tcoerce[PBaseStruct](pt.elementType)
     assert(
       pt.elementType.required == elementType.required,
       s"${pt.elementType.required} | ${elementType.required}",
@@ -111,7 +111,7 @@ final case class EStructOfArrays(
         field.typ.buildSkip(cb.emb.ecb)(cb, scratchRegion, in)
       } else {
         val pFieldIdx = ept.fieldIdx(field.name)
-        val pFieldType: PPrimitive = tcoerce(ept.types(pFieldIdx))
+        val pFieldType = tcoerce[PPrimitive](ept.types(pFieldIdx))
 
         val array = field.typ.buildDecoder(t, cb.emb.ecb)(cb, scratchRegion, in).asIndexable
         cb.if_(
@@ -192,7 +192,7 @@ final case class EStructOfArrays(
         if (arrayType.elementType.required) {
           sv.loadElement(cb, i).consumeI(
             cb, {
-              val elementSType: SBaseStruct = tcoerce(sv.st.elementType)
+              val elementSType = tcoerce[SBaseStruct](sv.st.elementType)
               val fieldSType = elementSType.fieldTypes(elementSType.fieldIdx(field.name))
               IEmitCode.present(
                 cb,

--- a/hail/hail/src/is/hail/types/virtual/Type.scala
+++ b/hail/hail/src/is/hail/types/virtual/Type.scala
@@ -77,7 +77,7 @@ abstract class Type extends VType with Serializable {
       s
   }
 
-  def export(a: Annotation): JValue =
+  def `export`(a: Annotation): JValue =
     JSONAnnotationImpex.exportAnnotation(a, this)
 
   override def toJSON: JValue =

--- a/hail/hail/test/src/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/hail/test/src/is/hail/backend/ServiceBackendSuite.scala
@@ -83,8 +83,8 @@ class ServiceBackendSuite extends HailSuite with IdiomaticMockito with OptionVal
 
       failure.foreach(throw _)
 
-      batchClient.newJobGroup(any) wasCalled once
-      batchClient.waitForJobGroup(any, any) wasCalled once
+      batchClient.newJobGroup(any[JobGroupRequest]) wasCalled once
+      batchClient.waitForJobGroup(any[Int], any[Int]) wasCalled once
     }
 
   @Test def testFailedJobGroup(): Unit =

--- a/hail/hail/test/src/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/AggregatorsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.DeprecatedIRBuilder._
 import is.hail.expr.ir.defs.{
   AggFilter, AggGroupBy, ApplyAggOp, ApplyBinaryPrimOp, ArrayRef, Cast, GetField, I32, InsertFields,
@@ -17,7 +18,7 @@ import org.testng.annotations.Test
 
 class AggregatorsSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.compileOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
 
   def runAggregator(
     op: AggOp,

--- a/hail/hail/test/src/is/hail/expr/ir/ArrayDeforestationSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ArrayDeforestationSuite.scala
@@ -10,7 +10,7 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class ArrayDeforestationSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.values
+  implicit val execStrats: ExecStrategy.ValueSet = ExecStrategy.values
 
   def primitiveArrayNoRegion(len: IR): IR =
     ToArray(mapIR(StreamRange(0, len, 1))(_ + 5))

--- a/hail/hail/test/src/is/hail/expr/ir/ArrayFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ArrayFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs.{ArraySlice, F32, F64, I32, In, MakeArray, NA, Str}
 import is.hail.types.virtual._
@@ -11,7 +12,7 @@ import org.testng.annotations.{DataProvider, Test}
 class ArrayFunctionsSuite extends HailSuite {
   val naa = NA(TArray(TInt32))
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = Array(

--- a/hail/hail/test/src/is/hail/expr/ir/CallFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/CallFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.TestUtils.{IRArray, IRCall}
 import is.hail.expr.ir.defs.{False, I32, Str, True}
 import is.hail.types.virtual.{TArray, TBoolean, TCall, TInt32}
@@ -10,7 +11,7 @@ import org.testng.annotations.{DataProvider, Test}
 
 class CallFunctionsSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = {

--- a/hail/hail/test/src/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs.{NA, ToSet, ToStream}
 import is.hail.types.virtual._
@@ -13,7 +14,7 @@ class DictFunctionsSuite extends HailSuite {
   def tuplesToMap(a: IndexedSeq[(Integer, Integer)]): Map[Integer, Integer] =
     Option(a).map(_.filter(_ != null).toMap).orNull
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = Array(

--- a/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue}
 import is.hail.asm4s._
 import is.hail.expr.ir.agg.{CollectStateSig, PhysicalAggSig, TypedStateSig}
@@ -25,7 +26,7 @@ import org.testng.annotations.Test
 
 class EmitStreamSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.compileOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
 
   def log(str: Code[String], enabled: Boolean = false): Code[Unit] =
     if (enabled) Code._println(str) else Code._empty

--- a/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.asm4s._
 import is.hail.expr.ir.defs.{ApplyBinaryPrimOp, I32, In}
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions}
@@ -47,7 +48,7 @@ object TestRegisterFunctions extends RegistryFunctions {
 
 class FunctionSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   TestRegisterFunctions.registerAll()
 

--- a/hail/hail/test/src/is/hail/expr/ir/GenotypeFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/GenotypeFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.TestUtils._
 import is.hail.types.virtual.TFloat64
 import is.hail.utils.FastSeq
@@ -9,7 +10,7 @@ import org.testng.annotations.{DataProvider, Test}
 
 class GenotypeFunctionsSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @DataProvider(name = "gps")
   def gpData(): Array[Array[Any]] = Array(

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -3248,7 +3248,7 @@ class IRSuite extends HailSuite {
   def valueIRs(ctx: ExecuteContext): Array[Array[Object]] = {
     val fs = ctx.fs
 
-    CompileAndEvaluate(
+    CompileAndEvaluate[Unit](
       ctx,
       invoke(
         "index_bgen",
@@ -3693,7 +3693,7 @@ class IRSuite extends HailSuite {
     try {
       val fs = ctx.fs
 
-      CompileAndEvaluate(
+      CompileAndEvaluate[Unit](
         ctx,
         invoke(
           "index_bgen",

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -34,7 +34,7 @@ import org.scalatest.enablers.InspectorAsserting.assertingNatureOfAssertion
 import org.testng.annotations.{DataProvider, Test}
 
 class IRSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.nonLowering
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.nonLowering
 
   @Test def testRandDifferentLengthUIDStrings(): Unit = {
     implicit val execStrats = ExecStrategy.lowering

--- a/hail/hail/test/src/is/hail/expr/ir/IntervalSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IntervalSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.defs.{
   ErrorIDs, False, GetTupleElement, I32, If, Literal, MakeTuple, NA, True,
 }
@@ -15,7 +16,7 @@ import org.testng.annotations.{BeforeMethod, Test}
 
 class IntervalSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   val tpoint1 = TTuple(TInt32)
   val tinterval1 = TInterval(tpoint1)

--- a/hail/hail/test/src/is/hail/expr/ir/LiftLiteralsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/LiftLiteralsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.defs.{ApplyBinaryPrimOp, I64, MakeStruct, TableCount, TableGetGlobals}
 import is.hail.expr.ir.lowering.ExecuteRelational
 import is.hail.utils.FastSeq
@@ -9,7 +10,7 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class LiftLiteralsSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.interpretOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.interpretOnly
 
   @Test def testNestedGlobalsRewrite(): Unit = {
     val tab =

--- a/hail/hail/test/src/is/hail/expr/ir/LocusFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/LocusFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.defs.{Apply, ErrorIDs, False, I32, I64, MakeArray, MakeTuple, NA, Str, True}
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, Interval}
@@ -11,7 +12,7 @@ import org.testng.annotations.Test
 
 class LocusFunctionsSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   private def grch38: ReferenceGenome = ctx.references(ReferenceGenome.GRCh38)
   private def tlocus = TLocus(grch38.name)

--- a/hail/hail/test/src/is/hail/expr/ir/MathFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/MathFunctionsSuite.scala
@@ -10,7 +10,7 @@ import org.testng.annotations.{DataProvider, Test}
 
 class MathFunctionsSuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.values
+  implicit val execStrats: ExecStrategy.ValueSet = ExecStrategy.values
 
   val tfloat = TFloat64
 

--- a/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
@@ -18,6 +18,7 @@ import is.hail.utils._
 import is.hail.utils.compat._
 import is.hail.utils.compat.immutable.ArraySeq
 
+import is.hail
 import org.apache.spark.sql.Row
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
@@ -28,7 +29,7 @@ import org.testng.annotations.{DataProvider, Test}
 
 class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
 
-  implicit val execStrats = ExecStrategy.values
+  implicit val execStrats: hail.ExecStrategy.ValueSet = ExecStrategy.values
 
   def sm = ctx.stateManager
 

--- a/hail/hail/test/src/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs.{I32, NA, ToSet, ToStream}
 import is.hail.types.virtual._
@@ -11,7 +12,7 @@ class SetFunctionsSuite extends HailSuite {
   val naa = NA(TArray(TInt32))
   val nas = NA(TSet(TInt32))
 
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @Test def toSet(): Unit = {
     assertEvalsTo(IRSet(3, 7), Set(3, 7))

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs._
 import is.hail.types.virtual._
@@ -19,7 +20,7 @@ import org.testng.annotations.{DataProvider, Test}
 
 class SimplifySuite extends HailSuite {
 
-  implicit val execStrats = ExecStrategy.interpretOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.interpretOnly
 
   def simplifyTo(expected: BaseIR): MatcherFactory1[BaseIR, Equivalence] =
     new MatcherFactory1[BaseIR, Equivalence] {

--- a/hail/hail/test/src/is/hail/expr/ir/StringFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/StringFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs.{F32, I32, I64, MakeTuple, NA, Str}
 import is.hail.types.virtual._
@@ -10,7 +11,7 @@ import org.json4s.jackson.JsonMethods
 import org.testng.annotations.{DataProvider, Test}
 
 class StringFunctionsSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @Test def testRegexMatch(): Unit = {
     assertEvalsTo(invoke("regexMatch", TBoolean, Str("a"), NA(TString)), null)

--- a/hail/hail/test/src/is/hail/expr/ir/StringLengthSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/StringLengthSuite.scala
@@ -1,13 +1,14 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.defs.Str
 import is.hail.types.virtual.TInt32
 
 import org.testng.annotations.Test
 
 class StringLengthSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @Test def sameAsJavaStringLength(): Unit = {
     val strings = Array("abc", "", "\uD83D\uDCA9")

--- a/hail/hail/test/src/is/hail/expr/ir/StringSliceSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/StringSliceSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.defs.{I32, In, NA, Str}
 import is.hail.types.virtual.TString
 import is.hail.utils._
@@ -9,7 +10,7 @@ import org.scalatest.Inspectors.forEvery
 import org.testng.annotations.Test
 
 class StringSliceSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @Test def unicodeSlicingSlicesCodePoints(): Unit = {
     val poopEmoji = "\uD83D\uDCA9"

--- a/hail/hail/test/src/is/hail/expr/ir/TrapNodeSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TrapNodeSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.defs.{ArrayRef, Die, GetTupleElement, I32, If, IsNA, Literal, Str, Trap}
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -9,7 +10,7 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class TrapNodeSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   @Test def testTrapNode(): Unit = {
     assertEvalsTo(Trap(ArrayRef(Literal(TArray(TInt32), FastSeq(0, 1, 2)), I32(1))), Row(null, 1))

--- a/hail/hail/test/src/is/hail/expr/ir/UtilFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/UtilFunctionsSuite.scala
@@ -1,13 +1,14 @@
 package is.hail.expr.ir
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.defs.{Die, False, MakeStream, NA, Str, True}
 import is.hail.types.virtual.{TBoolean, TInt32, TStream}
 
 import org.testng.annotations.Test
 
 class UtilFunctionsSuite extends HailSuite {
-  implicit val execStrats = ExecStrategy.javaOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.javaOnly
 
   val na = NA(TBoolean)
   val die = Die("it ded", TBoolean)

--- a/hail/hail/test/src/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.lowering
 
 import is.hail.{ExecStrategy, HailSuite, TestUtils}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir.{
   mapIR, Ascending, Descending, LoweringAnalyses, SortField, TableIR, TableMapRows, TableRange,
 }
@@ -17,7 +18,7 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class LowerDistributedSortSuite extends HailSuite with TestUtils {
-  implicit val execStrats = ExecStrategy.compileOnly
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
 
   @Test def testSamplePartition(): Unit = {
     val dataKeys = IndexedSeq(

--- a/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.table
 
 import is.hail.{ExecStrategy, HailSuite}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.expr.ir._
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs.{
@@ -19,7 +20,7 @@ import org.testng.annotations.Test
 
 class TableGenSuite extends HailSuite {
 
-  implicit val execStrategy = ExecStrategy.lowering
+  implicit val execStrategy: Set[ExecStrategy] = ExecStrategy.lowering
 
   @Test(groups = Array("construction", "typecheck"))
   def testWithInvalidContextsType(): Unit = {

--- a/hail/hail/test/src/is/hail/linalg/RowMatrixSuite.scala
+++ b/hail/hail/test/src/is/hail/linalg/RowMatrixSuite.scala
@@ -92,9 +92,9 @@ class RowMatrixSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
         .toArray[Array[Double]]
     )
 
-  private def exportImportAssert(export: (String) => Unit, expected: Array[Double]*): Unit = {
+  private def exportImportAssert(`export`: (String) => Unit, expected: Array[Double]*): Unit = {
     val fname = ctx.createTmpPath("test")
-    export(fname)
+    `export`(fname)
     assert(readCSV(fname) === expected.toArray[Array[Double]])
   }
 


### PR DESCRIPTION
## Change Description

Enables the following 2.13 warnings:

- Dead code - when an expression is inferred to have type `Nothing`​, anything using that value is dead code
- "export" deprecation - "export" is a keyword in Scala 3, so in 2.13 it is deprecated to use unless wrapped in backticks
- match analysis - unused match cases
- implicit types - implicit declarations must have explicit types
- legacy bindings - In 2.13, inside a class defined inside an outer scope, it is deprecated to refer to a name ambiguously bound in both the outer scope and a parent class or trait. The fix is just to make it explicit which is being referred to.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP