### PR TITLE
[query] don't use deprecated `zipped` method

### DIFF
--- a/hail/build.mill
+++ b/hail/build.mill
@@ -174,10 +174,6 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
         "-Wconf:cat=deprecation&msg=method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated:s",
         // Passing an explicit array value to a Scala varargs method is deprecated (since 2.13.0) and will result in a defensive copy; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
         "-Wconf:cat=deprecation&msg=Passing an explicit array value to a Scala varargs method is deprecated:s",
-        // method zipped in class Ops is deprecated (since 2.13.0): Use xs.lazyZip(ys)
-        "-Wconf:cat=deprecation&msg=method zipped in class Ops is deprecated:s",
-        // object ZippedIterable2 in package runtime is deprecated (since 2.13.0): Use scala.collection.LazyZip2
-        "-Wconf:cat=deprecation&msg=object ZippedIterable2 in package runtime is deprecated:s",
         // method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
         "-Wconf:cat=deprecation&msg=any2stringadd:s",
         // method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`

--- a/hail/hail/src/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/CodeBuilder.scala
@@ -4,6 +4,8 @@ import is.hail.{lir, HAIL_BUILD_CONFIGURATION}
 import is.hail.macros.void
 import is.hail.utils.{toRichIterable, Traceback}
 
+import scala.collection.compat._
+
 import org.objectweb.asm.Opcodes.{INVOKESTATIC, INVOKEVIRTUAL}
 
 abstract class SettableBuilder {
@@ -143,7 +145,7 @@ trait CodeBuilderLike {
     val Ldefault = CodeLabel()
 
     append(discriminant.switch(Ldefault, Lcases))
-    (Lcases, cases).zipped.foreach { case (label, emitCase) =>
+    Lcases.lazyZip(cases).foreach { case (label, emitCase) =>
       define(label)
       emitCase()
       if (isOpenEnded) append(Lexit.goto)

--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -17,6 +17,7 @@ import is.hail.types._
 import is.hail.types.physical._
 import is.hail.utils._
 
+import scala.collection.compat._
 import scala.reflect.ClassTag
 
 import java.io._
@@ -239,7 +240,7 @@ class ServiceBackend(
       jobGroup.state match {
         case Success =>
           runAllKeepFirstError(executor) {
-            (partIdxs, parts.indices).zipped.map { (partIdx, jobIndex) =>
+            partIdxs.lazyZip(parts.indices).map { (partIdx, jobIndex) =>
               (() => readPartitionResult(fs, root, jobIndex), partIdx)
             }
           }

--- a/hail/hail/src/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -7,6 +7,8 @@ import is.hail.types.physical.stypes.{SSettable, SType, SValue}
 import is.hail.types.physical.stypes.interfaces.{SStream, SStreamValue}
 import is.hail.utils._
 
+import scala.collection.compat._
+
 object EmitCodeBuilder {
   def apply(mb: EmitMethodBuilder[_]): EmitCodeBuilder = new EmitCodeBuilder(mb, Code._empty)
 
@@ -119,7 +121,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     s.store(this, v)
 
   def assign(is: IndexedSeq[EmitSettable], ix: IndexedSeq[EmitCode]): Unit =
-    (is, ix).zipped.foreach((s, c) => s.store(this, c))
+    is.lazyZip(ix).foreach((s, c) => s.store(this, c))
 
   def memoizeField(pc: SValue, name: String): SValue = {
     val f = emb.newPField(name, pc.st)

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -20,6 +20,8 @@ import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.virtual._
 import is.hail.utils._
 
+import scala.collection.compat._
+
 import java.io.OutputStream
 
 import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
@@ -78,7 +80,7 @@ package defs {
           false
         } else {
           val other = obj.asInstanceOf[WrappedByteArrays]
-          ba.length == other.ba.length && (ba, other.ba).zipped.forall(java.util.Arrays.equals)
+          ba.length == other.ba.length && ba.lazyZip(other.ba).forall(java.util.Arrays.equals)
         }
       }
     }

--- a/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
@@ -10,6 +10,7 @@ import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.variant._
 
+import scala.collection.compat._
 import scala.collection.compat.immutable.ArraySeq
 
 import org.apache.spark.SparkContext
@@ -343,7 +344,7 @@ object MatrixValue {
     }
 
     val fileData = RVD.writeRowsSplitFiles(ctx, mvs.map(_.rvd), paths, bufferSpec, stageLocally)
-    (mvs, paths, fileData).zipped.foreach { case (mv, path, fd) =>
+    (mvs lazyZip paths lazyZip fileData).foreach { case (mv, path, fd) =>
       mv.finalizeWrite(ctx, path, bufferSpec, fd, consoleInfo = false)
     }
   }

--- a/hail/hail/src/is/hail/expr/ir/Pretty.scala
+++ b/hail/hail/src/is/hail/expr/ir/Pretty.scala
@@ -11,6 +11,7 @@ import is.hail.utils.{space => _, _}
 import is.hail.utils.prettyPrint._
 import is.hail.utils.richUtils.RichIterable
 
+import scala.collection.compat._
 import scala.collection.mutable
 
 import org.json4s.DefaultFormats
@@ -983,12 +984,12 @@ class Pretty(
 
         val head = ir match {
           case MakeStruct(fields) =>
-            val args = (fields.map(_._1), strictChildIdents).zipped.map { (field, value) =>
+            val args = fields.map(_._1).lazyZip(strictChildIdents).map { (field, value) =>
               s"$field: $value"
             }.mkString("(", ", ", ")")
             hsep(text(Pretty.prettyClass(ir) + args) +: (attributes ++ nestedBlocks))
           case InsertFields(_, fields, _) =>
-            val newFields = (fields.map(_._1), strictChildIdents.tail).zipped.map {
+            val newFields = fields.map(_._1).lazyZip(strictChildIdents.tail).map {
               (field, value) => s"$field: $value"
             }.mkString("(", ", ", ")")
             val args = s" ${strictChildIdents.head} $newFields"

--- a/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
@@ -2209,8 +2209,7 @@ object PruneDeadFields {
           requestedType = TStream(dep.elementType),
         )
       case StreamZip(as, names, body, b, errorID) =>
-        val (newAs, newNames) = (as, names)
-          .zipped
+        val (newAs, newNames) = as.lazyZip(names)
           .flatMap { case (a, name) =>
             if (memo.requestedType.contains(a)) Some((rebuildIR(ctx, a, env, memo), name)) else None
           }

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -9,6 +9,7 @@ import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.utils.StackSafe._
 
+import scala.collection.compat._
 import scala.reflect.ClassTag
 
 object TypeCheck {
@@ -409,7 +410,7 @@ object TypeCheck {
           assert(lKeyTyp == rKeyTyp.pointType)
           assert((joinType == "left") || (joinType == "inner"))
         } else {
-          assert((lKey, rKey).zipped.forall { case (lk, rk) =>
+          assert(lKey.lazyZip(rKey).forall { case (lk, rk) =>
             lEltTyp.fieldType(lk) == rEltTyp.fieldType(rk)
           })
         }

--- a/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
@@ -17,6 +17,7 @@ import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.variant.{Locus, ReferenceGenome}
 
+import scala.collection.compat._
 import scala.collection.mutable
 import scala.reflect._
 
@@ -172,10 +173,10 @@ object IRFunctionRegistry {
       case ((typeParametersFound: Seq[Type], valueParameterTypesFound: Seq[Type], _, _), _) =>
         typeParametersFound.length == typeParameters.length && {
           typeParametersFound.foreach(_.clear())
-          (typeParametersFound, typeParameters).zipped.forall(_.unify(_))
+          typeParametersFound.lazyZip(typeParameters).forall(_.unify(_))
         } && valueParameterTypesFound.length == valueParameterTypes.length && {
           valueParameterTypesFound.foreach(_.clear())
-          (valueParameterTypesFound, valueParameterTypes).zipped.forall(_.unify(_))
+          valueParameterTypesFound.lazyZip(valueParameterTypes).forall(_.unify(_))
         }
     }.toSeq match {
       case Seq() => None

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -15,6 +15,8 @@ import is.hail.types.physical.{PCanonicalBinary, PCanonicalTuple}
 import is.hail.types.virtual._
 import is.hail.utils._
 
+import scala.collection.compat._
+
 import org.apache.spark.sql.Row
 
 class LowererUnsupportedOperation(msg: String = null) extends Exception(msg)
@@ -618,7 +620,7 @@ class TableStage(
     require(joinKey <= right.kType.size)
 
     val leftKeyToRightKeyMap =
-      (kType.fieldNames.take(joinKey), right.kType.fieldNames.take(joinKey)).zipped.toMap
+      (kType.fieldNames.take(joinKey) lazyZip right.kType.fieldNames.take(joinKey)).toMap
     val newRightPartitioner = partitioner.coarsen(joinKey).rename(leftKeyToRightKeyMap)
     val repartitionedRight =
       right.repartitionNoShuffle(ec, newRightPartitioner, allowDuplication = true)

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIRHelpers.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIRHelpers.scala
@@ -7,6 +7,8 @@ import is.hail.types.RTable
 import is.hail.types.virtual.TStruct
 import is.hail.utils.FastSeq
 
+import scala.collection.compat._
+
 object LowerTableIRHelpers {
 
   def lowerTableJoin(
@@ -38,7 +40,7 @@ object LowerTableIRHelpers {
       },
       (lEltRef, rEltRef) => {
         MakeStruct(
-          (lKeyFields, rKeyFields).zipped.map { (lKey, rKey) =>
+          lKeyFields.lazyZip(rKeyFields).map { (lKey, rKey) =>
             if (joinType == "outer" && lReq.field(lKey).required && rReq.field(rKey).required)
               lKey -> Coalesce(FastSeq(
                 GetField(lEltRef, lKey),

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -168,7 +168,7 @@ package object ir {
     val accums = inits.map(i => Ref(freshName(), i.typ)).toFastSeq
     StreamFold2(
       stream,
-      (accums, inits).zipped.map((acc, i) => (acc.name, i)),
+      accums.lazyZip(inits).map((acc, i) => (acc.name, i)),
       elt.name,
       seqs.map(f => f(elt, accums)).toFastSeq,
       result(accums),

--- a/hail/hail/src/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/hail/src/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -4,6 +4,8 @@ import is.hail.backend.ExecuteContext
 import is.hail.types.virtual._
 import is.hail.utils._
 
+import scala.collection.compat._
+
 case class FilePartitionInfo(
   metadata: BgenFileMetadata,
   intervals: Array[Interval],
@@ -84,7 +86,7 @@ object BgenRDDPartitions extends Logging {
       val nPartitions = math.min(fileNPartitions(fileIndex), file.nVariants).toInt
       val partNVariants: Array[Long] = partition(file.nVariants, nPartitions)
       val partFirstVariantIndex = partNVariants.scan(0L)(_ + _).init
-      val partLastVariantIndex = (partFirstVariantIndex, partNVariants).zipped.map { (idx, n) =>
+      val partLastVariantIndex = partFirstVariantIndex.lazyZip(partNVariants).map { (idx, n) =>
         idx + n
       }
 

--- a/hail/hail/src/is/hail/rvd/RVDType.scala
+++ b/hail/hail/src/is/hail/rvd/RVDType.scala
@@ -6,6 +6,8 @@ import is.hail.expr.ir.IRParser
 import is.hail.types.physical.{PInterval, PStruct}
 import is.hail.utils._
 
+import scala.collection.compat._
+
 import org.json4s.CustomSerializer
 import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
 
@@ -179,7 +181,7 @@ object RVDType {
     missingEqual: Boolean,
   ): UnsafeOrdering = {
     require(fields1.length == fields2.length)
-    require((fields1, fields2).zipped.forall { case (f1, f2) =>
+    require(fields1.lazyZip(fields2).forall { case (f1, f2) =>
       t1.types(f1) isOfType t2.types(f2)
     })
 

--- a/hail/hail/src/is/hail/types/physical/PCanonicalStruct.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalStruct.scala
@@ -6,6 +6,7 @@ import is.hail.types.virtual.{TStruct, Type}
 import is.hail.utils._
 
 import scala.collection.JavaConverters._
+import scala.collection.compat._
 
 object PCanonicalStruct {
   private val requiredEmpty = PCanonicalStruct(Array.empty[PField], true)
@@ -124,7 +125,7 @@ final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean 
 
   private def deepRenameStruct(t: TStruct): PStruct =
     PCanonicalStruct(
-      (t.fields, this.fields).zipped.map { (tfield, pfield) =>
+      t.fields.lazyZip(this.fields).map { (tfield, pfield) =>
         assert(tfield.index == pfield.index)
         PField(tfield.name, pfield.typ.deepRename(tfield.typ), pfield.index)
       },

--- a/hail/hail/src/is/hail/types/physical/PCanonicalTuple.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalTuple.scala
@@ -3,6 +3,8 @@ package is.hail.types.physical
 import is.hail.types.virtual.{TTuple, Type}
 import is.hail.utils._
 
+import scala.collection.compat._
+
 object PCanonicalTuple {
   def apply(required: Boolean, args: PType*): PCanonicalTuple = PCanonicalTuple(
     args.iterator.zipWithIndex.map { case (t, i) => PTupleField(i, t) }.toIndexedSeq,
@@ -35,7 +37,7 @@ final case class PCanonicalTuple(
 
   private def deepTupleRename(t: TTuple) =
     PCanonicalTuple(
-      (t._types, this._types).zipped.map { (tfield, pfield) =>
+      t._types.lazyZip(this._types).map { (tfield, pfield) =>
         assert(tfield.index == pfield.index)
         PTupleField(pfield.index, pfield.typ.deepRename(tfield.typ))
       },

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
@@ -9,6 +9,8 @@ import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructSettabl
 import is.hail.types.virtual.{TStruct, Type}
 import is.hail.utils._
 
+import scala.collection.compat._
+
 final case class SInsertFieldsStruct(
   virtualType: TStruct,
   parent: SBaseStruct,
@@ -181,6 +183,6 @@ final class SInsertFieldsStructSettable(
   override def store(cb: EmitCodeBuilder, sv: SValue): Unit = sv match {
     case sv: SInsertFieldsStructValue =>
       parent.store(cb, sv.parent)
-      (newFields, sv.newFields).zipped.foreach((settable, value) => cb.assign(settable, value))
+      newFields.lazyZip(sv.newFields).foreach((settable, value) => cb.assign(settable, value))
   }
 }

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -9,6 +9,8 @@ import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.virtual.Type
 import is.hail.utils.{toRichIterable, FastSeq}
 
+import scala.collection.compat._
+
 final case class SNDArrayPointer(pType: PCanonicalNDArray) extends SNDArray {
   require(!pType.required)
 
@@ -157,8 +159,8 @@ final class SNDArrayPointerSettable(
   def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
     case v: SNDArrayPointerValue =>
       cb.assign(a, v.a)
-      (shape, v.shapes).zipped.foreach(cb.assign(_, _))
-      (strides, v.strides).zipped.foreach(cb.assign(_, _))
+      shape.lazyZip(v.shapes).foreach(cb.assign(_, _))
+      strides.lazyZip(v.strides).foreach(cb.assign(_, _))
       cb.assign(firstDataAddress, v.firstDataAddress)
   }
 }

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
@@ -10,6 +10,8 @@ import is.hail.types.physical.stypes.primitives.SInt64
 import is.hail.types.virtual.{TNDArray, Type}
 import is.hail.utils.toRichIterable
 
+import scala.collection.compat._
+
 final case class SNDArraySlice(pType: PCanonicalNDArray) extends SNDArray {
   override def nDims: Int = pType.nDims
 
@@ -130,8 +132,8 @@ final class SNDArraySliceSettable(
 
   override def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
     case v: SNDArraySliceValue =>
-      (shape, v.shapes).zipped.foreach((x, s) => cb.assign(x, s))
-      (strides, v.strides).zipped.foreach((x, s) => cb.assign(x, s))
+      shape.lazyZip(v.shapes).foreach((x, s) => cb.assign(x, s))
+      strides.lazyZip(v.strides).foreach((x, s) => cb.assign(x, s))
       cb.assign(firstDataAddress, v.firstDataAddress)
   }
 }

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SRNGState.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SRNGState.scala
@@ -10,6 +10,8 @@ import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.virtual.{TRNGState, Type}
 import is.hail.utils.FastSeq
 
+import scala.collection.compat._
+
 final case class SRNGStateStaticInfo(
   numWordsInLastBlock: Int,
   hasStaticSplit: Boolean,
@@ -241,8 +243,8 @@ class SCanonicalRNGStateSettable(
       numDynBlocks) with SRNGStateSettable {
   override def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
     case v: SCanonicalRNGStateValue =>
-      (runningSum, v.runningSum).zipped.foreach((x, s) => cb.assign(x, s))
-      (lastDynBlock, v.lastDynBlock).zipped.foreach((x, s) => cb.assign(x, s))
+      runningSum.lazyZip(v.runningSum).foreach((x, s) => cb.assign(x, s))
+      lastDynBlock.lazyZip(v.lastDynBlock).foreach((x, s) => cb.assign(x, s))
       cb.assign(numWordsInLastBlock, v.numWordsInLastBlock)
       cb.assign(hasStaticSplit, v.hasStaticSplit)
       cb.assign(numDynBlocks, v.numDynBlocks)
@@ -371,8 +373,8 @@ class SRNGStateStaticSizeSettable(
 ) extends SRNGStateStaticSizeValue(st, runningSum, lastDynBlock) with SRNGStateSettable {
   override def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
     case v: SRNGStateStaticSizeValue =>
-      (runningSum, v.runningSum).zipped.foreach((x, s) => cb.assign(x, s))
-      (lastDynBlock, v.lastDynBlock).zipped.foreach((x, s) => cb.assign(x, s))
+      runningSum.lazyZip(v.runningSum).foreach((x, s) => cb.assign(x, s))
+      lastDynBlock.lazyZip(v.lastDynBlock).foreach((x, s) => cb.assign(x, s))
   }
 
   override def settableTuple(): IndexedSeq[Settable[_]] =

--- a/hail/hail/src/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -12,6 +12,7 @@ import is.hail.types.physical.stypes.primitives.SInt64Value
 import is.hail.types.virtual.TInt32
 import is.hail.utils.{toRichIterable, valueToRichCodeRegion, FastSeq}
 
+import scala.collection.compat._
 import scala.collection.mutable
 
 object SNDArray {
@@ -1316,7 +1317,7 @@ trait SNDArrayValue extends SValue {
     val shape = this.shapes
     assert(shape.length == otherShape.length)
 
-    (shape, otherShape).zipped.foreach((s1, s2) => b = s1.ceq(s2))
+    shape.lazyZip(otherShape).foreach((s1, s2) => b = s1.ceq(s2))
     b
   }
 

--- a/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
@@ -4,6 +4,8 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 import is.hail.utils._
 
+import scala.collection.compat._
+
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods
 
@@ -79,7 +81,7 @@ abstract class TBaseStruct extends Type {
     forallZippedFields(other)(_.typ == _.typ)
 
   private def forallZippedFields(s: TBaseStruct)(p: (Field, Field) => Boolean): Boolean =
-    (fields, s.fields).zipped.forall(p)
+    fields.lazyZip(s.fields).forall(p)
 
   def truncate(newSize: Int): TBaseStruct
 

--- a/hail/hail/src/is/hail/types/virtual/TStruct.scala
+++ b/hail/hail/src/is/hail/types/virtual/TStruct.scala
@@ -8,6 +8,7 @@ import is.hail.utils.compat._
 import is.hail.utils.compat.immutable.ArraySeq
 
 import scala.collection.JavaConverters._
+import scala.collection.compat._
 import scala.collection.mutable
 
 import org.apache.spark.sql.Row
@@ -81,7 +82,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
   override def unify(concrete: Type): Boolean = concrete match {
     case TStruct(cfields) =>
       fields.length == cfields.length &&
-      (fields, cfields).zipped.forall { case (f, cf) =>
+      fields.lazyZip(cfields).forall { case (f, cf) =>
         f.unify(cf)
       }
     case _ => false

--- a/hail/hail/src/is/hail/types/virtual/TTuple.scala
+++ b/hail/hail/src/is/hail/types/virtual/TTuple.scala
@@ -4,6 +4,8 @@ import is.hail.annotations.ExtendedOrdering
 import is.hail.backend.HailStateManager
 import is.hail.utils._
 
+import scala.collection.compat._
+
 import org.apache.spark.sql.Row
 
 object TTuple {
@@ -47,7 +49,7 @@ final case class TTuple(_types: IndexedSeq[TupleField]) extends TBaseStruct {
   override def unify(concrete: Type): Boolean = concrete match {
     case TTuple(ctypes) =>
       size == ctypes.length &&
-      (types, ctypes).zipped.forall { case (t, ct) =>
+      types.lazyZip(ctypes).forall { case (t, ct) =>
         t.unify(ct.typ)
       }
     case _ => false

--- a/hail/hail/src/is/hail/types/virtual/TUnion.scala
+++ b/hail/hail/src/is/hail/types/virtual/TUnion.scala
@@ -6,6 +6,8 @@ import is.hail.expr.ir.IRParser
 import is.hail.macros.void
 import is.hail.utils._
 
+import scala.collection.compat._
+
 import org.json4s.CustomSerializer
 import org.json4s.JsonAST.JString
 
@@ -59,7 +61,7 @@ final case class TUnion(cases: IndexedSeq[Case]) extends Type {
   override def unify(concrete: Type): Boolean = concrete match {
     case TUnion(cfields) =>
       cases.length == cfields.length &&
-      (cases, cfields).zipped.forall { case (f, cf) =>
+      cases.lazyZip(cfields).forall { case (f, cf) =>
         f.unify(cf)
       }
     case _ => false
@@ -125,7 +127,7 @@ final case class TUnion(cases: IndexedSeq[Case]) extends Type {
     t match {
       case u: TUnion =>
         size == u.size &&
-        (cases, u.cases).zipped.forall(_.typ isIsomorphicTo _.typ)
+        cases.lazyZip(u.cases).forall(_.typ isIsomorphicTo _.typ)
       case _ =>
         false
     }

--- a/hail/hail/src/is/hail/utils/richUtils/RichOrderedSeq.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichOrderedSeq.scala
@@ -1,10 +1,12 @@
 package is.hail.utils.richUtils
 
+import scala.collection.compat._
+
 class RichOrderedSeq[T: Ordering](s: Seq[T]) {
 
   import scala.math.Ordering.Implicits._
 
-  def isIncreasing: Boolean = s.isEmpty || (s, s.tail).zipped.forall(_ < _)
+  def isIncreasing: Boolean = s.isEmpty || s.lazyZip(s.tail).forall(_ < _)
 
-  def isSorted: Boolean = s.isEmpty || (s, s.tail).zipped.forall(_ <= _)
+  def isSorted: Boolean = s.isEmpty || s.lazyZip(s.tail).forall(_ <= _)
 }

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -24,6 +24,7 @@ import is.hail.types.virtual.TIterable.elementType
 import is.hail.utils.{FastSeq, _}
 import is.hail.variant.{Call2, Locus}
 
+import scala.collection.compat._
 import scala.collection.mutable
 
 import org.apache.spark.sql.Row
@@ -2311,7 +2312,7 @@ class IRSuite extends HailSuite {
     ) { (l: IR, r: IR) =>
       bindIRs(l, r) { case Seq(l, r) =>
         MakeStruct(
-          (lKeys, rKeys).zipped.map { (lk, rk) =>
+          lKeys.lazyZip(rKeys).map { (lk, rk) =>
             lk -> Coalesce(IndexedSeq(GetField(l, lk), GetField(r, rk)))
           }
             ++ tcoerce[TStruct](l.typ).fields.filter(f => !lKeys.contains(f.name)).map { f =>

--- a/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
@@ -12,6 +12,8 @@ import is.hail.expr.ir.defs.{
 import is.hail.types.virtual._
 import is.hail.utils._
 
+import scala.collection.compat._
+
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods
 import org.scalatest
@@ -61,7 +63,7 @@ class MatrixIRSuite extends HailSuite {
           (partSize, partIndex) <- partition(10, 3).zipWithIndex
           i <- 0 until partSize
         } yield Row(partIndex.toLong, i.toLong)
-        (0 until 10, uids).zipped.map { (i, uid) =>
+        (0 until 10).lazyZip(uids).map { (i, uid) =>
           Row(i, uid, expectedCols.map { case Row(j, _) => Row(i, j) })
         }
       } else

--- a/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
@@ -14,6 +14,8 @@ import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.variant.Locus
 
+import scala.collection.compat._
+
 import org.apache.spark.sql.Row
 import org.scalatest
 import org.scalatest.{Failed, Succeeded}
@@ -59,7 +61,7 @@ class TableIRSuite extends HailSuite {
       (partSize, partIndex) <- partition(10, 3).zipWithIndex
       i <- 0 until partSize
     } yield Row(partIndex.toLong, i.toLong)
-    val expectedRows = (0 until 10, uids).zipped.map((i, uid) => Row(i, uid))
+    val expectedRows = (0 until 10).lazyZip(uids).map((i, uid) => Row(i, uid))
     val expectedGlobals = Row(57)
 
     assertEvalsTo(TableCollect(read), Row(expectedRows, expectedGlobals))

--- a/hail/hail/test/src/is/hail/scalacheck/ArbitraryGenomicInstances.scala
+++ b/hail/hail/test/src/is/hail/scalacheck/ArbitraryGenomicInstances.scala
@@ -6,6 +6,8 @@ import is.hail.variant._
 import is.hail.variant.Genotype.gqFromPL
 import is.hail.variant.Sex.Sex
 
+import scala.collection.compat._
+
 import org.apache.spark.sql.Row
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
@@ -141,7 +143,7 @@ private[scalacheck] trait ArbitraryGenomicInstances {
         c <- option {
           val min = alleleFrequencies.min
           val weights = alleleFrequencies.map(f => (f / min).toInt)
-          val freq = frequency((weights, (0 until nAlleles).map(const)).zipped.toSeq: _*)
+          val freq = frequency(weights.lazyZip((0 until nAlleles).map(const)).toSeq: _*)
           zip(freq, freq).map { case (gti, gtj) => Call2(gti, gtj) }
         }
 

--- a/hail/hail/test/src/is/hail/scalacheck/GenVal.scala
+++ b/hail/hail/test/src/is/hail/scalacheck/GenVal.scala
@@ -7,6 +7,8 @@ import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.utils.Interval
 
+import scala.collection.compat._
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.scalacheck.{Arbitrary, Gen}
@@ -36,7 +38,7 @@ private[scalacheck] trait GenVal {
         case t: PBaseStruct =>
           for {
             sizes <- partition(t.types.length)
-            values <- sequence((sizes, t.types).zipped.map { case (s, t) =>
+            values <- sequence(sizes.lazyZip(t.types).map { case (s, t) =>
               resize(s, genVal(ctx, t))
             })
           } yield new GenericRow(values)


### PR DESCRIPTION
## Change Description

The `zipped`​ method is deprecated, replaced with `lazyZip`​, e.g. `(foo, bar).zipped.map { (l, r) => ???}`​ is now `foo.lazyZip(bar).map { (l, r) => ???}`​.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP