### PR TITLE
[terraform] Add network policy support to k8s in gcp and gcp-broad infra

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -175,6 +175,17 @@ resource "google_container_cluster" "vdc" {
   }
 
   timeouts {}
+
+  addons_config {
+    network_policy_config {
+      disabled = false
+    }
+  }
+
+  network_policy {
+    enabled = true
+    provider = "CALICO"
+  }
 }
 
 resource "google_container_node_pool" "vdc_preemptible_pool" {

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -121,6 +121,17 @@ resource "google_container_cluster" "vdc" {
     enabled = false
     autoscaling_profile = "OPTIMIZE_UTILIZATION"
   }
+
+  addons_config {
+    network_policy_config {
+      disabled = false
+    }
+  }
+
+  network_policy {
+    enabled = true
+    provider = "CALICO"
+  }
 }
 
 resource "google_container_node_pool" "vdc_preemptible_pool" {


### PR DESCRIPTION
## Change Description

Closes https://github.com/hail-is/hail-security/issues/46

Enabled network policies in our k8s cluster in GCP.

Note: This is a terraform change, which will need to be manually applied to the GCP infrastructure after approval.

- [ ] Todo: apply the change by going to the k8s cluster settings, and enabling Calico Kubernetes Network Policy on both control plane and nodes

## Security Assessment

Delete all except the correct answer:
This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a medium security impact

### Impact Description

Enables a setting recommended by the CIS scan

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
