### PR TITLE
[terraform] Add VM metadata for OS Login and Block project-wide SSH

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -80,6 +80,13 @@ resource "google_project_service" "service_networking" {
   timeouts {}
 }
 
+resource "google_compute_project_metadata" "oslogin" {
+  metadata = {
+    enable-oslogin = "TRUE"
+    block-project-ssh-keys = "TRUE"
+  }
+}
+
 resource "google_compute_network" "default" {
   name = "default"
   description = "Default network for the project"

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -84,6 +84,13 @@ resource "google_project_service" "service_networking" {
   service = "servicenetworking.googleapis.com"
 }
 
+resource "google_compute_project_metadata" "oslogin" {
+  metadata = {
+    enable-oslogin = "TRUE"
+    block-project-ssh-keys = "TRUE"
+  }
+}
+
 resource "google_compute_network" "default" {
   name = "default"
 }


### PR DESCRIPTION
## Change Description

Closes https://github.com/hail-is/hail-security/issues/49
Closes https://github.com/hail-is/hail-security/issues/51

Adds "OS Login" and "Block project-wide SSH keys" compute metadata at a project level. Will impact new instances.

Note:
- [ ] Needs applying manually after approval, eg with:
```
gcloud compute project-info add-metadata \
    --metadata enable-oslogin=TRUE,block-project-ssh-keys=TRUE
```

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections are required
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections can be deleted

### Impact Rating

Delete all except the correct answer:
- This change has a medium security impact

### Impact Description

Changes the default SSH login behavior and options for new VMs. No longer supports project-wide ssh keys and requires OS login.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
