### PR TITLE
[terraform] Switch GKE node pools to non default SAs

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -193,6 +193,7 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
   node_config {
     spot = true
     machine_type = "n1-standard-2"
+    service_account = google_service_account.gke_node_pool.email
 
     labels = {
       "preemptible" = "true"
@@ -208,14 +209,6 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
       disable-legacy-endpoints = "true"
     }
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append",
-    ]
     tags = []
 
     shielded_instance_config {
@@ -253,6 +246,7 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
   node_config {
     preemptible = false
     machine_type = "n1-standard-2"
+    service_account = google_service_account.gke_node_pool.email
 
     labels = {
       preemptible = "false"
@@ -261,15 +255,6 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
-
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append",
-    ]
 
     tags = []
 
@@ -685,6 +670,27 @@ resource "google_project_iam_member" "batch_agent_iam_member" {
   project = var.gcp_project
   role = "roles/${each.key}"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
+}
+
+resource "google_service_account" "gke_node_pool" {
+  description  = "Service account for GKE node pools"
+  display_name = "gke-node-pool"
+  account_id = "gke-node-pool"
+}
+
+resource "google_project_iam_member" "gke_node_pool_iam_member" {
+  for_each = toset([
+    "storage.objectViewer",
+    "logging.logWriter", 
+    "monitoring.metricWriter",
+    "monitoring.viewer",
+    "autoscaling.metricsWriter",
+    "artifactregistry.reader",
+  ])
+
+  project = var.gcp_project
+  role = "roles/${each.key}"
+  member = "serviceAccount:${google_service_account.gke_node_pool.email}"
 }
 
 resource "google_compute_firewall" "default_allow_internal" {

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -139,6 +139,7 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
   node_config {
     spot = true
     machine_type = "n1-standard-4"
+    service_account = google_service_account.gke_node_pool.email
 
     labels = {
       "preemptible" = "true"
@@ -153,10 +154,6 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
-
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
   }
 }
 
@@ -176,6 +173,7 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
   node_config {
     preemptible = false
     machine_type = "n1-standard-4"
+    service_account = google_service_account.gke_node_pool.email
 
     labels = {
       preemptible = "false"
@@ -184,10 +182,6 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
-
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
   }
 }
 
@@ -644,6 +638,27 @@ resource "google_project_iam_member" "batch_agent_iam_member" {
   project = var.gcp_project
   role = "roles/${each.key}"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
+}
+
+resource "google_service_account" "gke_node_pool" {
+  description  = "Service account for GKE node pools"
+  display_name = "gke-node-pool"
+  account_id = "gke-node-pool"
+}
+
+resource "google_project_iam_member" "gke_node_pool_iam_member" {
+  for_each = toset([
+    "storage.objectViewer",
+    "logging.logWriter", 
+    "monitoring.metricWriter",
+    "monitoring.viewer",
+    "autoscaling.metricsWriter",
+    "artifactregistry.reader",
+  ])
+
+  project = var.gcp_project
+  role = "roles/${each.key}"
+  member = "serviceAccount:${google_service_account.gke_node_pool.email}"
 }
 
 resource "google_compute_firewall" "default_allow_internal" {


### PR DESCRIPTION
## Change Description

Closes https://github.com/hail-is/hail-security/issues/54

Replaces the "default SA with broad oauth scopes" for node pools with a specifically permissioned service account.

Note: 
 - [ ] After merging this change will need to be manually applied:
   - Create the SA
   - Add the specified roles
   - Switch the node pool SAs from default to the new role

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a medium security impact

### Impact Description

Replaces the "default SA with broad oauth scopes" for node pools with a specifically permissioned service account.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
