### PR TITLE
[query] Register hl.stop to be run at exit

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 import sys
 import warnings
@@ -673,6 +674,7 @@ def cite_hail_bibtex():
     return citation(bibtex=True)
 
 
+@atexit.register
 def stop():
     """Stop the currently running Hail session."""
     if Env.is_fully_initialized():


### PR DESCRIPTION
We are observing hangs during exit on dataproc. This can be resolved by ensuring that the context is stopped before exiting. So, we register `hl.stop` with `atexit` to stop the context when the python interpreter exits.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
