### PR TITLE
[terraform] Add GKE master authorized network config

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -166,6 +166,38 @@ resource "google_container_cluster" "vdc" {
     }
   }
 
+  master_authorized_networks_config {
+    # Broad Institute ranges from https://ipinfo.io/AS46964
+    cidr_blocks {
+      cidr_block   = "69.173.64.0/18"
+      display_name = "Broad Institute Range 1"
+    }
+    cidr_blocks {
+      cidr_block   = "69.173.64.0/19"
+      display_name = "Broad Institute Range 2"
+    }
+    cidr_blocks {
+      cidr_block   = "69.173.96.0/19"
+      display_name = "Broad Institute Range 3"
+    }
+    cidr_blocks {
+      cidr_block   = "69.173.95.0/24"
+      display_name = "Broad Institute Range 4"
+    }
+    cidr_blocks {
+      cidr_block   = "69.173.97.0/24"
+      display_name = "Broad Institute Range 5"
+    }
+    cidr_blocks {
+      cidr_block   = "10.0.0.0/8"
+      display_name = "VDC Internal Networks"
+    }
+    cidr_blocks {
+      cidr_block   = "10.128.0.0/9"
+      display_name = "GKE Control Plane and Nodes"
+    }
+  }
+
   cluster_autoscaling {
     # Don't use node auto-provisioning since we manage node pools ourselves
     enabled = false

--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -106,6 +106,25 @@ export GCP_PROJECT=<gcp project name>
    # If set to true, pull the base ubuntu image from Artifact Registry.
    # Otherwise, assumes GCR.
    use_artifact_registry = true
+
+   # Optional: Enable master authorized networks for GKE cluster security
+   # If not set or set to false, the cluster will be accessible from anywhere
+   # If set to true, only the specified networks can access the GKE control plane
+   enable_master_authorized_networks = true
+   master_authorized_networks = [
+     {
+       cidr_block   = "x.x.x.x/32"
+       display_name = "Organizational Network"
+     },
+     {
+       cidr_block   = "10.0.0.0/8"
+       display_name = "Internal Network"
+     },
+     {
+       cidr_block   = "10.128.0.0/9"
+       display_name = "GKE Control Plane and Nodes"
+     }
+   ]
    ```
 
 - You can optionally create a `/tmp/ci_config.json` file to enable CI triggered by GitHub


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/45

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a medium security impact

### Impact Description

Restricts control plane K8S access from "global" to:
- Broad internal networks
- Hail VDC internal networks
- The GKE control plane and nodes directly (should be automatic, but just in case)

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
