### PR TITLE
[release] Fix build.yaml release step

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3503,7 +3503,7 @@ steps:
       GITHUB_OAUTH_HEADER_FILE=/io/github-oauth \
       HAIL_GENETICS_HAIL_IMAGE=docker://{{ hailgenetics_hail_image.image }} \
       HAIL_GENETICS_HAIL_IMAGE_PY_3_10=docker://{{ hailgenetics_hail_image_python_3_10.image }} \
-      HAIL_GENETICS_HAIL_IMAGE_PY_3_11=docker://{{ hailgenetics_hail_image.image }} \  # <- current "default" version
+      HAIL_GENETICS_HAIL_IMAGE_PY_3_11=docker://{{ hailgenetics_hail_image.image }} \
       HAIL_GENETICS_HAIL_IMAGE_PY_3_12=docker://{{ hailgenetics_hail_image_python_3_12.image }} \
       HAIL_GENETICS_HAIL_IMAGE_PY_3_13=docker://{{ hailgenetics_hail_image_python_3_13.image }} \
       HAIL_GENETICS_HAILTOP_IMAGE=docker://{{ hailgenetics_hailtop_image.image }} \


### PR DESCRIPTION
My comment in the script indicating which python image was the "default" broke the command. It's not really necessary, so remove it. The code indicates that `HAIL_GENETICS_HAIL_IMAGE` and `HAIL_GENETICS_HAIL_IMAGE_PY_311` are the same image.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
