### PR TITLE
[terraform] Replace excess auth admin roles with custom role

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -479,13 +479,26 @@ module "ukbb" {
   source = "../k8s/ukbb"
 }
 
+resource "google_project_iam_custom_role" "auth_service_account_manager" {
+  role_id     = "authServiceAccountManager"
+  title       = "Auth Service Account Manager"
+  description = "Custom role for auth service with minimal required permissions for service account management"
+  
+  permissions = [
+    "iam.serviceAccounts.create",
+    "iam.serviceAccounts.delete", 
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.list",
+    "iam.serviceAccountKeys.create",
+  ]
+}
+
 module "auth_gsa_secret" {
   source = "./gsa"
   name = "auth"
   project = var.gcp_project
   iam_roles = [
-    "iam.serviceAccountAdmin",
-    "iam.serviceAccountKeyAdmin",
+    "authServiceAccountManager",
     "cloudprofiler.agent",
   ]
 }

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -445,13 +445,26 @@ module "ukbb" {
   source = "../k8s/ukbb"
 }
 
+resource "google_project_iam_custom_role" "auth_service_account_manager" {
+  role_id     = "authServiceAccountManager"
+  title       = "Auth Service Account Manager"
+  description = "Custom role for auth service with minimal required permissions for service account management"
+  
+  permissions = [
+    "iam.serviceAccounts.create",
+    "iam.serviceAccounts.delete", 
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.list",
+    "iam.serviceAccountKeys.create",
+  ]
+}
+
 module "auth_gsa_secret" {
   source = "./gsa_k8s_secret"
   name = "auth"
   project = var.gcp_project
   iam_roles = [
-    "iam.serviceAccountAdmin",
-    "iam.serviceAccountKeyAdmin",
+    "authServiceAccountManager",
     "cloudprofiler.agent",
   ]
 }


### PR DESCRIPTION
## Change Description

Partially resolves https://github.com/hail-is/hail-security/issues/55

Replaces very broad admin grants to the `auth` service with more specific required permissions.

- [ ] Remember to apply the change in production

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Replaces two admin level role grants with 5 specific permissions

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
