### PR TITLE
[release] Upgrade twine

### DIFF
--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -8,7 +8,7 @@ COPY gear/pinned-requirements.txt gear-requirements.txt
 RUN hail-pip-install \
       -r hailtop-requirements.txt \
       -r gear-requirements.txt \
-      twine==1.11.0 \
+      'twine>=6.2.0,<7' \
       'Jinja2>3,<4'
 
 FROM golang:1.18 AS skopeo-build


### PR DESCRIPTION
It's been almost seven years. Some transient dependency upgrade broke it. Upgrading it allowed me to manually upload the release to PyPI.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
