### PR TITLE
[QoB] Remove primitive class map from Worker.scala

### DIFF
--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -53,35 +53,11 @@ class WorkerTimer() {
 // the ObjectInputStream to use the correct classloader, but it is not configurable
 // so we override the behavior ourselves.
 // For more context, see: https://github.com/scala/bug/issues/9237#issuecomment-292436652
-object ExplicitClassLoaderInputStream {
-  val primClasses: util.HashMap[String, Class[_]] = {
-    val m = new util.HashMap[String, Class[_]](8, 1.0f)
-    m.put("boolean", Boolean.getClass)
-    m.put("byte", Byte.getClass)
-    m.put("char", Char.getClass)
-    m.put("short", Short.getClass)
-    m.put("int", Int.getClass)
-    m.put("long", Long.getClass)
-    m.put("float", Float.getClass)
-    m.put("double", Double.getClass)
-    m.put("void", Unit.getClass)
-    m
-  }
-}
-
 class ExplicitClassLoaderInputStream(is: InputStream, cl: ClassLoader)
     extends ObjectInputStream(is) {
 
-  override def resolveClass(desc: ObjectStreamClass): Class[_] = {
-    val name = desc.getName
-    try return Class.forName(name, false, cl)
-    catch {
-      case ex: ClassNotFoundException =>
-        val cl = ExplicitClassLoaderInputStream.primClasses.get(name)
-        if (cl != null) return cl
-        else throw ex
-    }
-  }
+  override def resolveClass(desc: ObjectStreamClass): Class[_] =
+    Class.forName(desc.getName, false, cl)
 }
 
 object Worker {


### PR DESCRIPTION
TODO

## Change Description

Fixes #<issue_number> (delete if N/A)

Brief description and justification of what this PR is doing.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections are required
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections can be deleted

### Impact Rating

Delete all except the correct answer:
- This change has a high security impact
- This change has a medium security impact
- This change has a low security impact
- This change has no security impact

### Impact Description

Replace this content with a description of the impact of the change:
- For none/low impact: a quick one/two sentence justification of the rating.
  - Example: "Docs only", "Low-level refactoring of non-security code", etc.
- For medium/high impact: provide a description of the impact and the mitigations in place.
  - Example: "New UI text field added in analogy to existing elements, with input strings escaped and validated against code injection"

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
