### PR TITLE
[batch] Fix invalid swagger reference

### DIFF
--- a/batch/batch/front_end/templates/openapi.yaml
+++ b/batch/batch/front_end/templates/openapi.yaml
@@ -690,16 +690,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  batches:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Batch'
-                  last_batch_id:
-                    type: integer
-                    nullable: true
-                    description: ID of the last batch in the response, for pagination
+                $ref: '#/components/schemas/BatchListResponse'
         '401':
           description: Unauthorized
         '403':


### PR DESCRIPTION
## Change Description

Noticed during #15065 . We have an invalid object reference that can be replaced by an actual object type.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Very low risk. Just fixing an internal openapi reference that was previously broken

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
