### PR TITLE
[terraform] enable secure boot in k8s node pools

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -143,7 +143,7 @@ resource "google_container_cluster" "vdc" {
   name = "vdc"
   location = var.gcp_zone
   network = google_compute_network.default.name
-  enable_shielded_nodes = false
+  enable_shielded_nodes = true
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default
@@ -231,7 +231,7 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
 
     shielded_instance_config {
       enable_integrity_monitoring = true
-      enable_secure_boot          = false
+      enable_secure_boot          = true
     }
   }
 
@@ -278,7 +278,7 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
 
     shielded_instance_config {
       enable_integrity_monitoring = true
-      enable_secure_boot          = false
+      enable_secure_boot          = true
     }
   }
 

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -106,6 +106,7 @@ resource "google_container_cluster" "vdc" {
   name = "vdc"
   location = var.gcp_zone
   network = google_compute_network.default.name
+  enable_shielded_nodes = true
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default
@@ -172,6 +173,11 @@ resource "google_container_node_pool" "vdc_preemptible_pool" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
   }
 }
 
@@ -199,6 +205,11 @@ resource "google_container_node_pool" "vdc_nonpreemptible_pool" {
 
     metadata = {
       disable-legacy-endpoints = "true"
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
     }
   }
 }


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/47

Enables secure boot and shielded nodes for node pools and vdc cluster.

Note:
- [x] Apply terraform and validate that it works in a sandbox instance before bringing to production
- [ ] Must be applied manually in production after the PR merges

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Enables secure boot and shielded nodes. Makes sure the kernels being loaded in are properly protected

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
