### PR TITLE
[terraform] Switch metadata mode to GKE_METADATA

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -254,6 +254,10 @@ resource "google_container_cluster" "vdc" {
     state    = "ENCRYPTED"
     key_name = google_kms_crypto_key.k8s_secrets_key.id
   }
+  
+  workload_identity_config {
+    workload_pool = "${var.gcp_project}.svc.id.goog"
+  }
 }
 
 resource "google_container_node_pool" "vdc_preemptible_pool" {

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -197,6 +197,10 @@ resource "google_container_cluster" "vdc" {
     state    = "ENCRYPTED"
     key_name = google_kms_crypto_key.k8s_secrets_key.id
   }
+  
+  workload_identity_config {
+    workload_pool = "${var.gcp_project}.svc.id.goog"
+  }
 }
 
 resource "google_container_node_pool" "vdc_preemptible_pool" {


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/56

Sets a metadata server config mode for our GKE node pools.

- [x] Needs applying manually after merging

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact


### Impact Description

Sets a reasonable, restrictive metadata access mode for nodes in the node pool

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
