### PR TITLE
[query] implement `HailContext.checkRVDKeys` via flags

### DIFF
--- a/hail/hail/src/is/hail/HailContext.scala
+++ b/hail/hail/src/is/hail/HailContext.scala
@@ -162,8 +162,6 @@ class HailContext private (
 ) {
   def stop(): Unit = HailContext.stop()
 
-  var checkRVDKeys: Boolean = false
-
   def version: String = is.hail.HAIL_PRETTY_VERSION
 
   private[this] def fileAndLineCounts(

--- a/hail/hail/src/is/hail/rvd/RVD.scala
+++ b/hail/hail/src/is/hail/rvd/RVD.scala
@@ -1061,6 +1061,9 @@ class RVD(
 }
 
 object RVD {
+
+  var CheckRvdKeyOrderingForTesting: Boolean = false
+
   def empty(ctx: ExecuteContext, typ: RVDType): RVD =
     RVD.empty(ctx.stateManager, typ)
 
@@ -1313,15 +1316,10 @@ object RVD {
     RVDPartitioner.fromKeySamples(ctx, typ, min, max, samples, nPartitions, partitionKey)
   }
 
-  def apply(
-    typ: RVDType,
-    partitioner: RVDPartitioner,
-    crdd: ContextRDD[Long],
-  ): RVD =
-    if (!HailContext.get.checkRVDKeys)
-      new RVD(typ, partitioner, crdd)
-    else
-      new RVD(typ, partitioner, crdd).checkKeyOrdering()
+  def apply(typ: RVDType, partitioner: RVDPartitioner, crdd: ContextRDD[Long]): RVD = {
+    val rvd = new RVD(typ, partitioner, crdd)
+    if (CheckRvdKeyOrderingForTesting) rvd.checkKeyOrdering() else rvd
+  }
 
   def unify(execCtx: ExecuteContext, rvds: Seq[RVD]): Seq[RVD] = {
     if (rvds.length == 1 || rvds.forall(_.rowPType == rvds.head.rowPType))

--- a/hail/hail/test/src/is/hail/HailSuite.scala
+++ b/hail/hail/test/src/is/hail/HailSuite.scala
@@ -11,6 +11,7 @@ import is.hail.expr.ir.defs.{
 }
 import is.hail.expr.ir.lowering.IrMetadata
 import is.hail.io.fs.{FS, HadoopFS}
+import is.hail.rvd.RVD
 import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
@@ -54,6 +55,7 @@ class HailSuite extends TestNGSuite with TestUtils {
   @BeforeSuite
   def setupHailContext(): Unit = {
     HailContext.configureLogging("/tmp/hail.log", quiet = false, append = false)
+    RVD.CheckRvdKeyOrderingForTesting = true
     val backend = SparkBackend(
       sc = new SparkContext(
         SparkBackend.createSparkConf(
@@ -67,7 +69,6 @@ class HailSuite extends TestNGSuite with TestUtils {
       skipLoggingConfiguration = true,
     )
     HailSuite.hc_ = HailContext(backend)
-    HailSuite.hc_.checkRVDKeys = true
   }
 
   @BeforeClass


### PR DESCRIPTION
As part of my sacred quest to kill `HailContext`, this change moves `checkRVDKeys` out of `HailContext`​.  
This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP