### PR TITLE
[CI] Tidy authorized users list

### DIFF
--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -27,8 +27,6 @@ AUTHORIZED_USERS = [
     User('cjllanwarne', 'chrisl', HAIL_TEAM),
     User('ehigham', 'ehigham', HAIL_TEAM),
     User('grohli', 'grohlice', [SERVICES_TEAM]),
-    User('jkgoodrich', 'jgoodric'),
-    User('konradjk', 'konradk'),
     User('kush-chandra', 'kchandra', HAIL_TEAM),
     User('patrick-schultz', 'pschultz', HAIL_TEAM),
 ]


### PR DESCRIPTION
## Change Description

From the monthly userlist scan. These users have not created testable PRs in over 60 days. We can re-add them later if required.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Removes inactive users from authorized users list in CI

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
