### PR TITLE
[terraform] Fix role references for new custom roles

### DIFF
--- a/infra/gcp-broad/gsa/main.tf
+++ b/infra/gcp-broad/gsa/main.tf
@@ -22,6 +22,6 @@ resource "google_project_iam_member" "iam_member" {
   for_each = toset(var.iam_roles)
 
   project = var.project
-  role = "roles/${each.key}"
+  role = startswith(each.key, "projects/") ? each.key : "roles/${each.key}"
   member = "serviceAccount:${google_service_account.service_account.email}"
 }

--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -515,7 +515,7 @@ module "auth_gsa_secret" {
   name = "auth"
   project = var.gcp_project
   iam_roles = [
-    "authServiceAccountManager",
+    "projects/${var.gcp_project}/roles/authServiceAccountManager",
     "cloudprofiler.agent",
   ]
 }
@@ -561,7 +561,7 @@ module "batch_gsa_secret" {
   name = "batch"
   project = var.gcp_project
   iam_roles = [
-    "batchComputeManager",
+    "projects/${var.gcp_project}/roles/batchComputeManager",
     "iam.serviceAccountUser",
     "logging.viewer",
     "cloudprofiler.agent",
@@ -579,7 +579,7 @@ module "testns_batch_gsa_secret" {
   name = "testns-batch"
   project = var.gcp_project
   iam_roles = [
-    "batchComputeManager",
+    "projects/${var.gcp_project}/roles/batchComputeManager",
     "iam.serviceAccountUser",
     "logging.viewer",
     "cloudprofiler.agent",
@@ -761,7 +761,6 @@ resource "google_service_account" "batch_agent" {
 
 resource "google_project_iam_member" "batch_agent_iam_member" {
   for_each = toset([
-    "batch2AgentComputeOps",
     "iam.serviceAccountUser",
     "logging.logWriter",
     "storage.objectCreator",
@@ -770,6 +769,12 @@ resource "google_project_iam_member" "batch_agent_iam_member" {
 
   project = var.gcp_project
   role = "roles/${each.key}"
+  member = "serviceAccount:${google_service_account.batch_agent.email}"
+}
+
+resource "google_project_iam_member" "batch_agent_custom_role" {
+  project = var.gcp_project
+  role = "projects/${var.gcp_project}/roles/batch2AgentComputeOps"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
 }
 

--- a/infra/gcp/gsa_k8s_secret/main.tf
+++ b/infra/gcp/gsa_k8s_secret/main.tf
@@ -24,6 +24,6 @@ resource "google_project_iam_member" "iam_member" {
   for_each = toset(var.iam_roles)
 
   project = var.project
-  role = "roles/${each.key}"
+  role = startswith(each.key, "projects/") ? each.key : "roles/${each.key}"
   member = "serviceAccount:${google_service_account.service_account.email}"
 }

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -486,7 +486,7 @@ module "auth_gsa_secret" {
   name = "auth"
   project = var.gcp_project
   iam_roles = [
-    "authServiceAccountManager",
+    "projects/${var.gcp_project}/roles/authServiceAccountManager",
     "cloudprofiler.agent",
   ]
 }
@@ -532,7 +532,7 @@ module "batch_gsa_secret" {
   name = "batch"
   project = var.gcp_project
   iam_roles = [
-    "batchComputeManager",
+    "projects/${var.gcp_project}/roles/batchComputeManager",
     "iam.serviceAccountUser",
     "logging.viewer",
     "storage.admin",
@@ -551,7 +551,7 @@ module "testns_batch_gsa_secret" {
   name = "testns-batch"
   project = var.gcp_project
   iam_roles = [
-    "batchComputeManager",
+    "projects/${var.gcp_project}/roles/batchComputeManager",
     "iam.serviceAccountUser",
     "logging.viewer",
     "cloudprofiler.agent",
@@ -726,7 +726,6 @@ resource "google_service_account" "batch_agent" {
 
 resource "google_project_iam_member" "batch_agent_iam_member" {
   for_each = toset([
-    "batch2AgentComputeOps",
     "iam.serviceAccountUser",
     "logging.logWriter",
     "storage.objectAdmin",
@@ -734,6 +733,12 @@ resource "google_project_iam_member" "batch_agent_iam_member" {
 
   project = var.gcp_project
   role = "roles/${each.key}"
+  member = "serviceAccount:${google_service_account.batch_agent.email}"
+}
+
+resource "google_project_iam_member" "batch_agent_custom_role" {
+  project = var.gcp_project
+  role = "projects/${var.gcp_project}/roles/batch2AgentComputeOps"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
 }
 


### PR DESCRIPTION
## Change Description

Relates to 

Fixes the role references. Previously we were using custom roles as though they were presets, but in fact they need to be project-qualified

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Impact is that the custom roles we previously created should now be applied correctly

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
