### PR TITLE
[batch/auth] Fix SQL format specifier

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -55,7 +55,7 @@ async def update_inactive_users(db: Database, user_timeout_days: int):
         """
 UPDATE users
 SET users.state = 'inactive'
-WHERE (users.state = 'active') AND (users.last_activated IS NOT NULL) AND (DATEDIFF(NOW(), users.last_activated) > %d) AND (users.is_service_account = 0);
+WHERE (users.state = 'active') AND (users.last_activated IS NOT NULL) AND (DATEDIFF(NOW(), users.last_activated) > %s) AND (users.is_service_account = 0);
 """,
         (user_timeout_days,),
     )


### PR DESCRIPTION
Stops the server event from constantly failing with "TypeError: %d format: a real number is required, not str".

## Change Description

In a 0.2.136 dev deploy we see the following exception being logged (with headline `in update_inactive_users`) approximately every 30 seconds:

```
Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/hailtop/utils/utils.py", line 915, in retry_long_running
[…]
  File "/opt/venv/lib/python3.11/site-packages/auth/driver/driver.py", line 54, in update_inactive_users
    await db.execute_update(
[…]
  File "/opt/venv/lib/python3.11/site-packages/aiomysql/cursors.py", line 237, in execute
    query = query % self._escape_args(args, conn)
            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: %d format: a real number is required, not str
```

This occurs every 30 seconds because `update_inactive_users()` immediately fails with an exception every time and then is retried without limit by `retry_long_running()`.

I didn't find any clear documentation of whether format specifiers in this SQL are ever supposed to be anything other than `%s` but I did find several other places in the hail codebase where it is `%s` for parameters that appear to be naturally integers. And changing it to `%s` makes the task actually long-running rather than repeatedly aborting.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

The change stops `update_inactive_users()` from immediately aborting. This means that the SQL `UPDATE` and the rest of the code in that function will newly start executing, but this code has already been vetted in PR #14789.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
