### PR TITLE
[CI] Catch type errors from status updater so that the main loop doesn't crash

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -425,8 +425,10 @@ class PR(Code):
             await gh_client.post(
                 f'/repos/{self.target_branch.branch.repo.short_str()}/statuses/{self.source_sha}', data=data
             )
-        except gidgethub.HTTPException:
-            log.exception(f'{self.short_str()}: notify github of build state failed due to exception: {data}')
+        except (gidgethub.HTTPException, TypeError) as e:
+            log.exception(
+                f'{self.short_str()}: notify github of build state failed due to exception: {f"/repos/{self.target_branch.branch.repo.short_str()}/statuses/{self.source_sha}"} / {data} / {e}'
+            )
         except aiohttp.client_exceptions.ClientResponseError:
             log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data}')
 


### PR DESCRIPTION
## Change Description

I believe this probably fixes https://github.com/hail-is/hail/issues/15058

Adds another exception type to the guard around github status updating, so that the main loop doesn't crash if we run out of allowed status updates in github.

See follow up #15092 to actually fix the problem.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Adds resilience to CI code, otherwise no changes to running workloads. The only new information being logged if the exception throws is the API URL we were attempting to call, which is already public on github

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
