### PR TITLE
[CI] Attempt to make gpu testing more reliable

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1510,47 +1510,19 @@ def test_pool_standard_instance_cheapest(client: BatchClient):
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
-# Transitively is not valid for terra
-@skip_in_azure
-async def test_gpu_accesibility_g2(client: BatchClient):
-    b = create_batch(client)._async_batch
-    resources = {'machine_type': "g2-standard-4", 'storage': '100Gi'}
-    j = b.create_job(
-        os.environ['HAIL_GPU_IMAGE'],
-        ['python3', '-c', 'import torch; assert torch.cuda.is_available()'],
-        resources=resources,
-        n_max_attempts=1,
-    )
-    await b.submit()
-    try:
-        status = await asyncio.wait_for(j.wait(), timeout=5 * 60)
-        assert status['state'] == 'Success', str((status, b.debug_info()))
-    except asyncio.TimeoutError:
-        # G2 instances are not always available within a time window
-        # acceptable for CI. This test is permitted to time out
-        # but not otherwise fail
-        pass
-
-
 @skip_in_azure
 async def test_nvidia_driver_accesibility_usage(client: BatchClient):
     b = create_batch(client)._async_batch
     resources = {'machine_type': "g2-standard-4", 'storage': '100Gi'}
     j = b.create_job(
         os.environ['HAIL_GPU_IMAGE'],
-        ['nvidia-smi'],
+        ['/bin/sh', '-c', 'nvidia-smi && python3 -c "import torch; assert torch.cuda.is_available()"'],
         resources=resources,
-        n_max_attempts=1,
+        n_max_attempts=4,
     )
     await b.submit()
-    try:
-        status = await asyncio.wait_for(j.wait(), timeout=5 * 60)
-        assert status['state'] == 'Success', str((status, b.debug_info()))
-    except asyncio.TimeoutError:
-        # G2 instances are not always available within a time window
-        # acceptable for CI. This test is permitted to time out
-        # but not otherwise fail
-        pass
+    status = await asyncio.wait_for(j.wait(), timeout=5 * 60)
+    assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_job_private_instance_preemptible(client: BatchClient):


### PR DESCRIPTION
## Change Description

Attempts to make our current GPU test more reliable by:

- Only requiring us to roll the dice of "will we get a GPU allocated to us" once, not twice
- Allowing up to 4 retries before giving up

Brief description and justification of what this PR is doing.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Internal test shuffling to improve reliability. Should be no functional change.


### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
