### PR TITLE
[query] move `configureLogging` and `version` out of `HailContext`

### DIFF
--- a/hail/hail/src/is/hail/HailContext.scala
+++ b/hail/hail/src/is/hail/HailContext.scala
@@ -62,7 +62,7 @@ object HailContext {
 
     theContext = new HailContext(backend)
 
-    info(s"Running Hail version ${theContext.version}")
+    info(s"Running Hail version $HAIL_PRETTY_VERSION")
 
     theContext
   }
@@ -79,8 +79,6 @@ class HailContext private (
   var backend: Backend
 ) {
   def stop(): Unit = HailContext.stop()
-
-  def version: String = is.hail.HAIL_PRETTY_VERSION
 
   private[this] def fileAndLineCounts(
     fs: FS,

--- a/hail/hail/src/is/hail/HailContext.scala
+++ b/hail/hail/src/is/hail/HailContext.scala
@@ -6,14 +6,9 @@ import is.hail.expr.ir.functions.IRFunctionRegistry
 import is.hail.io.fs.FS
 import is.hail.utils._
 
-import java.util.Properties
-
-import org.apache.log4j.{LogManager, PropertyConfigurator}
 import org.apache.spark._
 
 object HailContext {
-
-  val logFormat: String = "%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1}: %p: %m%n"
 
   private var theContext: HailContext = _
 
@@ -21,36 +16,6 @@ object HailContext {
     assert(TaskContext.get() == null, "HailContext not available on worker")
     assert(theContext != null, "HailContext not initialized")
     theContext
-  }
-
-  def configureLogging(logFile: String, quiet: Boolean, append: Boolean): Unit = {
-    org.apache.log4j.helpers.LogLog.setInternalDebugging(true)
-    org.apache.log4j.helpers.LogLog.setQuietMode(false)
-    val logProps = new Properties()
-
-    // uncomment to see log4j LogLog output:
-    // logProps.put("log4j.debug", "true")
-    logProps.put("log4j.rootLogger", "INFO, logfile")
-    logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
-    logProps.put("log4j.appender.logfile.append", append.toString)
-    logProps.put("log4j.appender.logfile.file", logFile)
-    logProps.put("log4j.appender.logfile.threshold", "INFO")
-    logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
-    logProps.put("log4j.appender.logfile.layout.ConversionPattern", HailContext.logFormat)
-
-    if (!quiet) {
-      logProps.put("log4j.logger.Hail", "INFO, HailConsoleAppender, HailSocketAppender")
-      logProps.put("log4j.appender.HailConsoleAppender", "org.apache.log4j.ConsoleAppender")
-      logProps.put("log4j.appender.HailConsoleAppender.target", "System.err")
-      logProps.put("log4j.appender.HailConsoleAppender.layout", "org.apache.log4j.PatternLayout")
-    } else
-      logProps.put("log4j.logger.Hail", "INFO, HailSocketAppender")
-
-    logProps.put("log4j.appender.HailSocketAppender", "is.hail.utils.StringSocketAppender")
-    logProps.put("log4j.appender.HailSocketAppender.layout", "org.apache.log4j.PatternLayout")
-
-    LogManager.resetConfiguration()
-    PropertyConfigurator.configure(logProps)
   }
 
   def checkJavaVersion(): Unit = {

--- a/hail/hail/src/is/hail/backend/local/LocalBackend.scala
+++ b/hail/hail/src/is/hail/backend/local/LocalBackend.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.local
 
-import is.hail.{CancellingExecutorService, HailContext}
+import is.hail.CancellingExecutorService
 import is.hail.asm4s._
 import is.hail.backend._
 import is.hail.expr.Validate
@@ -46,7 +46,7 @@ object LocalBackend extends Backend {
     skipLoggingConfiguration: Boolean = false,
   ): LocalBackend.type =
     synchronized {
-      if (!skipLoggingConfiguration) HailContext.configureLogging(logFile, quiet, append)
+      if (!skipLoggingConfiguration) Logging.configureLogging(logFile, quiet, append)
       this
     }
 

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -1,6 +1,5 @@
 package is.hail.backend.spark
 
-import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend._
@@ -199,11 +198,6 @@ object SparkBackend {
     "org.apache.hadoop.io.compress.GzipCodec",
   )
 
-  /** If a SparkBackend has already been initialized, this function returns it regardless of the
-    * parameters with which it was initialized.
-    *
-    * Otherwise, it initializes and returns a new HailContext.
-    */
   def getOrCreate(
     sc: SparkContext = null,
     appName: String = "Hail",

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -260,7 +260,7 @@ object SparkBackend {
       require(theSparkBackend == null)
 
       if (!skipLoggingConfiguration)
-        HailContext.configureLogging(logFile, quiet, append)
+        Logging.configureLogging(logFile, quiet, append)
 
       var sc1 = sc
       if (sc1 == null)

--- a/hail/hail/src/is/hail/utils/Logging.scala
+++ b/hail/hail/src/is/hail/utils/Logging.scala
@@ -1,6 +1,8 @@
 package is.hail.utils
 
-import org.apache.log4j.{LogManager, Logger}
+import java.util.Properties
+
+import org.apache.log4j.{LogManager, Logger, PropertyConfigurator}
 
 object LogHelper {
   // exposed more directly for generated code
@@ -55,4 +57,41 @@ trait Logging {
 
   def error(msg: String): Unit =
     consoleLog.error(msg)
+}
+
+object Logging {
+
+  val LogFormat: String =
+    "%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1}: %p: %m%n"
+
+  def configureLogging(logFile: String, quiet: Boolean, append: Boolean): Unit = {
+    org.apache.log4j.helpers.LogLog.setInternalDebugging(true)
+    org.apache.log4j.helpers.LogLog.setQuietMode(false)
+    val logProps = new Properties()
+
+    // uncomment to see log4j LogLog output:
+    // logProps.put("log4j.debug", "true")
+    logProps.put("log4j.rootLogger", "INFO, logfile")
+    logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
+    logProps.put("log4j.appender.logfile.append", append.toString)
+    logProps.put("log4j.appender.logfile.file", logFile)
+    logProps.put("log4j.appender.logfile.threshold", "INFO")
+    logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
+    logProps.put("log4j.appender.logfile.layout.ConversionPattern", LogFormat)
+
+    if (!quiet) {
+      logProps.put("log4j.logger.Hail", "INFO, HailConsoleAppender, HailSocketAppender")
+      logProps.put("log4j.appender.HailConsoleAppender", "org.apache.log4j.ConsoleAppender")
+      logProps.put("log4j.appender.HailConsoleAppender.target", "System.err")
+      logProps.put("log4j.appender.HailConsoleAppender.layout", "org.apache.log4j.PatternLayout")
+    } else
+      logProps.put("log4j.logger.Hail", "INFO, HailSocketAppender")
+
+    logProps.put("log4j.appender.HailSocketAppender", "is.hail.utils.StringSocketAppender")
+    logProps.put("log4j.appender.HailSocketAppender.layout", "org.apache.log4j.PatternLayout")
+
+    LogManager.resetConfiguration()
+    PropertyConfigurator.configure(logProps)
+  }
+
 }

--- a/hail/hail/src/is/hail/utils/Py4jUtils.scala
+++ b/hail/hail/src/is/hail/utils/Py4jUtils.scala
@@ -1,6 +1,5 @@
 package is.hail.utils
 
-import is.hail.HailContext
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.io.fs.{FS, FileListEntry, FileStatus, SeekableDataInputStream}
 import is.hail.types.virtual.Type
@@ -133,8 +132,7 @@ trait Py4jUtils {
   }
 
   def addSocketAppender(hostname: String, port: Int): Unit =
-    StringSocketAppender.get()
-      .connect(hostname, port, HailContext.logFormat)
+    StringSocketAppender.get().connect(hostname, port, Logging.LogFormat)
 
   def logWarn(msg: String): Unit =
     warn(msg)

--- a/hail/hail/src/is/hail/utils/package.scala
+++ b/hail/hail/src/is/hail/utils/package.scala
@@ -20,10 +20,7 @@ import java.security.SecureRandom
 import java.text.SimpleDateFormat
 import java.util
 import java.util.{Base64, Date}
-import java.util.concurrent.{
-  AbstractExecutorService, Callable, CancellationException, ExecutorCompletionService,
-  ExecutorService, RunnableFuture, TimeUnit,
-}
+import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.google.common.util.concurrent.AbstractFuture
@@ -850,7 +847,7 @@ package object utils
     using(new OutputStreamWriter(fs.create(path + "/README.txt"))) { out =>
       out.write(
         s"""This folder comprises a Hail (www.hail.is) native Table or MatrixTable.
-           |  Written with version ${HailContext.get.version}
+           |  Written with version $HAIL_PRETTY_VERSION
            |  Created at ${dateFormat.format(new Date())}""".stripMargin
       )
     }

--- a/hail/hail/test/src/is/hail/HailSuite.scala
+++ b/hail/hail/test/src/is/hail/HailSuite.scala
@@ -6,9 +6,7 @@ import is.hail.asm4s.HailClassLoader
 import is.hail.backend.{Backend, ExecuteContext, OwningTempFileManager}
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir._
-import is.hail.expr.ir.defs.{
-  BlockMatrixCollect, Cast, MakeTuple, NDArrayRef, Ref, StreamMap, ToArray,
-}
+import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.IrMetadata
 import is.hail.io.fs.{FS, HadoopFS}
 import is.hail.rvd.RVD
@@ -54,7 +52,7 @@ class HailSuite extends TestNGSuite with TestUtils {
 
   @BeforeSuite
   def setupHailContext(): Unit = {
-    HailContext.configureLogging("/tmp/hail.log", quiet = false, append = false)
+    Logging.configureLogging("/tmp/hail.log", quiet = false, append = false)
     RVD.CheckRvdKeyOrderingForTesting = true
     val backend = SparkBackend(
       sc = new SparkContext(

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -210,7 +210,7 @@ class Py4JBackend(Backend):
         # Maybe it does its own patch?
         install_exception_handler()
 
-        jar_version = self._jhc.version()
+        jar_version = scala_package_object(self._hail_package).HAIL_PRETTY_VERSION()
         if jar_version != __version__:
             raise RuntimeError(
                 f"Hail version mismatch between JAR and Python library\n"


### PR DESCRIPTION
`HailContext` jihad:

-  moves logging configuration from `HailContext` to a dedicated `Logging` object.
- removes references to `HailContext.version`​

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP