### PR TITLE
[query] remove `Backend` from `HailContext`

### DIFF
--- a/hail/hail/src/is/hail/backend/Backend.scala
+++ b/hail/hail/src/is/hail/backend/Backend.scala
@@ -43,6 +43,18 @@ object Backend {
     assert(t.isFieldDefined(off, 0))
     codec.encode(ctx, elementType, t.loadField(off, 0), os)
   }
+
+  // Currently required by `BackendUtils.collectDArray`
+  private[this] var instance: Backend = _
+
+  def set(b: Backend): Unit =
+    synchronized { instance = b }
+
+  def get: Backend =
+    synchronized {
+      assert(instance != null)
+      instance
+    }
 }
 
 abstract class BroadcastValue[T] { def value: T }

--- a/hail/hail/src/is/hail/backend/BackendUtils.scala
+++ b/hail/hail/src/is/hail/backend/BackendUtils.scala
@@ -1,6 +1,5 @@
 package is.hail.backend
 
-import is.hail.HailContext
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.local.LocalTaskContext
@@ -52,7 +51,7 @@ class BackendUtils(
     val remainingPartitions =
       contexts.indices.filterNot(k => cachedResults.containsOrdered[Int](k, _ < _, _._2))
 
-    val backend = HailContext.get.backend
+    val backend = Backend.get
     val mod = getModule(modID)
     val t = System.nanoTime()
     val (failureOpt, successes) =

--- a/hail/hail/src/is/hail/backend/ExecuteContext.scala
+++ b/hail/hail/src/is/hail/backend/ExecuteContext.scala
@@ -148,11 +148,7 @@ class ExecuteContext(
     f: (HailClassLoader, FS, HailTaskContext, Region) => T
   )(implicit E: Enclosing
   ): T =
-    using(new LocalTaskContext(0, 0)) { tc =>
-      time {
-        f(theHailClassLoader, fs, tc, r)
-      }
-    }
+    using(new LocalTaskContext(0, 0))(tc => time(f(theHailClassLoader, fs, tc, r)))
 
   def createTmpPath(prefix: String, extension: String = null, local: Boolean = false): String =
     tempFileManager.newTmpPath(if (local) localTmpdir else tmpdir, prefix, extension)

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -194,7 +194,8 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
         jobConfig,
       )
 
-    HailContext(backend)
+    HailContext.getOrCreate
+    Backend.set(backend)
     log.info("HailContext initialized.")
 
     // FIXME: when can the classloader be shared? (optimizer benefits!)
@@ -211,7 +212,11 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
           payload,
         )
       )
-    finally HailContext.stop()
+    finally {
+      HailContext.stop()
+      Backend.set(null)
+      backend.close()
+    }
   }
 }
 

--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -55,6 +55,8 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable {
     newFs(CloudStorageFSConfig.fromFlagsAndEnv(None, flags))
   )
 
+  Backend.set(backend)
+
   def pyFs: FS =
     synchronized(tmpFileManager.fs)
 
@@ -284,6 +286,8 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable {
       compiledCodeCache.clear()
       irCache.clear()
       coercerCache.clear()
+      Backend.set(null)
+      backend.close()
     }
 
   private[this] def removeReference(name: String): Unit =

--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -177,8 +177,7 @@ object Worker {
     timer.end("readInputs")
     timer.start("executeFunction")
 
-    // FIXME: workers should not have backends, but some things do need hail contexts
-    HailContext.getOrCreate(new ServiceBackend(null, null, null, null, null))
+    HailContext.getOrCreate
     val result =
       try
         using(new ServiceTaskContext(i)) { htc =>

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -78,7 +78,7 @@ class LocalBackend(Py4JBackend):
             append,
             skip_logging_configuration,
         )
-        jhc = hail_package.HailContext.apply(jbackend)
+        jhc = hail_package.HailContext.apply()
 
         super().__init__(self._gateway.jvm, jbackend, jhc, tmpdir, tmpdir)
         self.gcs_requester_pays_configuration = gcs_requester_pays_configuration

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -117,7 +117,7 @@ class SparkBackend(Py4JBackend):
                 skip_logging_configuration,
                 min_block_size,
             )
-            jhc = hail_package.HailContext.getOrCreate(jbackend)
+            jhc = hail_package.HailContext.getOrCreate()
         else:
             jbackend = hail_package.backend.spark.SparkBackend.apply(
                 jsc,
@@ -130,7 +130,7 @@ class SparkBackend(Py4JBackend):
                 skip_logging_configuration,
                 min_block_size,
             )
-            jhc = hail_package.HailContext.apply(jbackend)
+            jhc = hail_package.HailContext.apply()
 
         self._jsc = jbackend.sc()
         if sc:


### PR DESCRIPTION
Changes the HailContext and Backend relationship by:

1. Removing the direct dependency of HailContext on Backend by:
   - Removing the backend parameter from HailContext constructor
   - Introducing a static Backend.get/set mechanism to access the current backend

2. Ensures proper backend lifecycle management:
   - Moves backend.close() calls to appropriate locations
   - Sets up Backend.set(null) after operations to prevent leaks

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP