### PR TITLE
[query] `HailContext` is not required in batch

### DIFF
--- a/hail/hail/src/is/hail/HailContext.scala
+++ b/hail/hail/src/is/hail/HailContext.scala
@@ -1,7 +1,6 @@
 package is.hail
 
 import is.hail.backend.spark.SparkBackend
-import is.hail.expr.ir.functions.IRFunctionRegistry
 import is.hail.io.fs.FS
 import is.hail.utils._
 
@@ -37,20 +36,6 @@ object HailContext {
     require(theContext == null)
     checkJavaVersion()
 
-    {
-      import breeze.linalg._
-      import breeze.linalg.operators.{BinaryRegistry, OpMulMatrix}
-
-      implicitly[BinaryRegistry[
-        DenseMatrix[Double],
-        Vector[Double],
-        OpMulMatrix.type,
-        DenseVector[Double],
-      ]].register(
-        DenseMatrix.implOpMulMatrix_DMD_DVD_eq_DVD
-      ): Unit
-    }
-
     theContext = new HailContext
 
     info(s"Running Hail version $HAIL_PRETTY_VERSION")
@@ -60,7 +45,6 @@ object HailContext {
 
   def stop(): Unit =
     synchronized {
-      IRFunctionRegistry.clearUserFunctions()
       theContext = null
     }
 }

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.driver
 
-import is.hail.{HailContext, HailFeatureFlags}
+import is.hail.HailFeatureFlags
 import is.hail.annotations.Memory
 import is.hail.asm4s.HailClassLoader
 import is.hail.backend.{Backend, ExecuteContext, OwningTempFileManager}
@@ -191,9 +191,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
         jobConfig,
       )
 
-    HailContext.getOrCreate: Unit
     Backend.set(backend)
-    log.info("HailContext initialized.")
 
     // FIXME: when can the classloader be shared? (optimizer benefits!)
     try runRpc(
@@ -210,7 +208,6 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
         )
       )
     finally {
-      HailContext.stop()
       Backend.set(null)
       backend.close()
     }

--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -281,6 +281,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable {
       coercerCache.clear()
       Backend.set(null)
       backend.close()
+      IRFunctionRegistry.clearUserFunctions()
     }
 
   private[this] def removeReference(name: String): Unit =

--- a/hail/hail/src/is/hail/backend/local/LocalBackend.scala
+++ b/hail/hail/src/is/hail/backend/local/LocalBackend.scala
@@ -39,6 +39,8 @@ object LocalBackend extends Backend {
     StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
   )
 
+  is.hail.linalg.registerImplOpMulMatrix_DMD_DVD_eq_DVD
+
   def apply(
     logFile: String = "hail.log",
     quiet: Boolean = false,

--- a/hail/hail/src/is/hail/backend/service/Main.scala
+++ b/hail/hail/src/is/hail/backend/service/Main.scala
@@ -17,6 +17,8 @@ object Main {
     StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
   )
 
+  is.hail.linalg.registerImplOpMulMatrix_DMD_DVD_eq_DVD
+
   def main(argv: Array[String]): Unit =
     argv(3) match {
       case WORKER => Worker.main(argv)

--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.service
 
-import is.hail.{HAIL_REVISION, HailContext, HailFeatureFlags}
+import is.hail.{HAIL_REVISION, HailFeatureFlags}
 import is.hail.asm4s._
 import is.hail.backend.HailTaskContext
 import is.hail.io.fs._
@@ -87,7 +87,6 @@ class ExplicitClassLoaderInputStream(is: InputStream, cl: ClassLoader)
 
 object Worker {
   private[this] val log = Logger.getLogger(getClass.getName())
-  private[this] val myRevision = HAIL_REVISION
 
   implicit private[this] val ec = ExecutionContext.fromExecutorService(
     javaConcurrent.Executors.newCachedThreadPool()
@@ -127,7 +126,7 @@ object Worker {
     DeployConfig.set(deployConfig)
     sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 
-    log.info(s"is.hail.backend.service.Worker $myRevision")
+    log.info(s"is.hail.backend.service.Worker $HAIL_REVISION")
     log.info(s"running job $i/$n at root $root with scratch directory '$scratchDir'")
 
     timer.start(s"Job $i/$n")
@@ -176,8 +175,7 @@ object Worker {
     timer.end("readInputs")
     timer.start("executeFunction")
 
-    HailContext.getOrCreate: Unit
-    val result =
+    val result: Either[Throwable, Array[Byte]] =
       try
         using(new ServiceTaskContext(i)) { htc =>
           retryTransientErrors {
@@ -186,8 +184,7 @@ object Worker {
         }
       catch {
         case t: Throwable => Left(t)
-      } finally
-        HailContext.stop()
+      }
 
     timer.end("executeFunction")
     timer.start("writeOutputs")

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -79,6 +79,8 @@ object SparkBackend {
     StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build()
   )
 
+  is.hail.linalg.registerImplOpMulMatrix_DMD_DVD_eq_DVD
+
   private var theSparkBackend: SparkBackend = _
 
   def sparkContext(implicit E: Enclosing): SparkContext =

--- a/hail/hail/src/is/hail/linalg/package.scala
+++ b/hail/hail/src/is/hail/linalg/package.scala
@@ -1,0 +1,16 @@
+package is.hail
+
+import breeze.linalg._
+import breeze.linalg.operators.{BinaryRegistry, OpMulMatrix}
+
+package object linalg {
+  lazy val registerImplOpMulMatrix_DMD_DVD_eq_DVD: Any =
+    implicitly[BinaryRegistry[
+      DenseMatrix[Double],
+      Vector[Double],
+      OpMulMatrix.type,
+      DenseVector[Double],
+    ]].register(
+      DenseMatrix.implOpMulMatrix_DMD_DVD_eq_DVD
+    )
+}


### PR DESCRIPTION
Removes creation of a `HailContext` for QoB.  `HailContext.apply` previously registered a dense matrix operation. For compatibility, this has been moved to a `lazy val` in the newly added `linalg` package object (so that it's registered at most once). Each backend initialises that `lazy val` in a similar way to the `StreamReadConstraints` business.

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

Fixes #15072 