### PR TITLE
[batch] parameterizing `build_python_image` to build from non-slim images

### DIFF
--- a/hail/python/hailtop/batch/docker.py
+++ b/hail/python/hailtop/batch/docker.py
@@ -10,6 +10,7 @@ def build_python_image(
     fullname: str,
     requirements: Optional[List[str]] = None,
     python_version: Optional[str] = None,
+    slim: bool = True,
     _tmp_dir: str = '/tmp',
     *,
     show_docker_output: bool = False,
@@ -38,6 +39,8 @@ def build_python_image(
     python_version:
         String in the format of `major_version.minor_version` (ex: `3.9`). Defaults to
         current version of Python that is running.
+    slim:
+        Whether to use the slim version of the Python image.
     _tmp_dir:
         Location to place local temporary files used while building the image.
     show_docker_output:
@@ -61,7 +64,10 @@ def build_python_image(
             f'Python versions older than 3.9 (you are using {major_version}.{minor_version}) are not supported'
         )
 
-    base_image = f'hailgenetics/python-dill:{major_version}.{minor_version}-slim'
+    if slim:
+        base_image = f'hailgenetics/python-dill:{major_version}.{minor_version}-slim'
+    else:
+        base_image = f'hailgenetics/python-dill:{major_version}.{minor_version}'
 
     docker_path = f'{_tmp_dir}/{secret_alnum_string(6)}/docker'
     try:


### PR DESCRIPTION
## Change Description

Fixes #15082

Currently, `build_python_image` fails for some users if they want to include dependencies that aren't compatible with the underlying Docker image used by `build_python_image` (that is, the image we specify in the `docker build -t...` step). Our default image is always the `slim` version of one of our `hailgenetics/python:dill` images and is rather bare-bones compared to a regular, non-slim image version. There is currently no way for users to specify otherwise.

This change adds a `slim` argument to `build_python_image` (default True), allowing users to specify `False` if the they want to use the standard base image rather than the `slim` version.

## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a medium security impact

### Impact Description
This allows users to build images from hailgenetics/python:dill images that they previously were not able to. However, the actual build execution in this script remains otherwise unchanged.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
