### PR TITLE
[query] Use pure python for test class finding in generate_splits.py

### DIFF
--- a/hail/generate_splits.py
+++ b/hail/generate_splits.py
@@ -1,6 +1,6 @@
 import os
 import random
-import subprocess as sp
+from pathlib import Path
 from typing import List, TypeVar
 
 T = TypeVar("T")
@@ -23,24 +23,26 @@ def partition(k: int, ls: List[T]) -> List[List[T]]:
     return out
 
 
-sp.run("find hail/test/src \\( -name \"*.scala\" -o -name \"*.java\" \\) -type f > classes", shell=True, check=True)
-
-n_splits = int(os.environ['TESTNG_SPLITS'])
-
-with open('classes', 'r') as f:
-    foo = f.readlines()
-    classes = [
-        x.replace('hail/test/src/', '').replace('.scala\n', '').replace('.java\n', '').replace('/', '.') for x in foo
-    ]
-    classes = [cls for cls in classes if not cls.startswith('is.hail.services') if not cls.startswith('is.hail.io.fs')]
+test_src_root = Path('hail/test/src')
+services_root = test_src_root / 'is/hail/services'
+fs_root = test_src_root / 'is/hail/io/fs'
+classes = [
+    str(Path(dirpath, file).relative_to(test_src_root).with_suffix('')).replace('/', '.')
+    for dirpath, _dirnames, filenames in map(lambda x: (Path(x[0]), *x[1:]), os.walk(test_src_root))
+    for file in filenames
+    if not dirpath.is_relative_to(services_root)
+    and not dirpath.is_relative_to(fs_root)
+    and (file.endswith('.java') or file.endswith('.scala'))
+]
 
 random.shuffle(classes)
 
+n_splits = int(os.environ['TESTNG_SPLITS'])
 splits = partition(n_splits, classes)
 
 for split_index, split in enumerate(splits):
     classes = '\n'.join(f'<class name="{name}"/>' for name in split)
-    with open(f'testng-splits-{split_index}.xml', 'w') as f:
+    with open(f'testng-splits-{split_index}.xml', 'w', encoding='utf-8') as f:
         xml = f"""
 <suite name="SuiteAll" allow-return-values="true" verbose="1">
     <test name="Split{split_index}">


### PR DESCRIPTION
Why shell out when there are perfectly acceptable library functions?

Tested manually by asserting old and new methods of generating the file list produce the same output.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP