### PR TITLE
[CI] Resize test dbs

### DIFF
--- a/docker/mysql/db.yaml
+++ b/docker/mysql/db.yaml
@@ -42,7 +42,7 @@ spec:
             periodSeconds: 5
           resources:
             requests:
-              cpu: "1.5"
+              cpu: "1250m"
               memory: "1G"
             limits:
               cpu: "2"

--- a/docker/mysql/db.yaml
+++ b/docker/mysql/db.yaml
@@ -42,6 +42,8 @@ spec:
             periodSeconds: 5
           resources:
             requests:
+              # How we got to 1250m: "it would have been nice to have 2cpus, but all the other cruft on 2 cpu node pool VMs means only 1.47 cpus are guaranteed to be free"
+              # If this is too small, we can consider increasing the node pool VM size to 4cpu and raising this back to 1.5 or 2,
               cpu: "1250m"
               memory: "1G"
             limits:


### PR DESCRIPTION
## Change Description

Makes test DBs schedulable by reducing their required CPU to 1.25 (from 1.5), because of all the new ~cruft~ security apparatus processes that have been added to node pool VMs

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

DB pods are only used in test and developer namespaces, not for the main production services. This change reduces their bare minimum required CPU declaration from 1.5 to 1.25 to accommodate the new processes taking up small CPU segments on all the node pool VMs

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
