### PR TITLE
[query] remove global `Backend` field

### DIFF
--- a/hail/hail/src/is/hail/backend/Backend.scala
+++ b/hail/hail/src/is/hail/backend/Backend.scala
@@ -1,6 +1,7 @@
 package is.hail.backend
 
 import is.hail.asm4s.HailClassLoader
+import is.hail.backend.Backend.PartitionFn
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.{IR, LoweringAnalyses, SortField, TableIR, TableReader}
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
@@ -44,43 +45,31 @@ object Backend {
     codec.encode(ctx, elementType, t.loadField(off, 0), os)
   }
 
-  // Currently required by `BackendUtils.collectDArray`
-  private[this] var instance: Backend = _
-
-  def set(b: Backend): Unit =
-    synchronized { instance = b }
-
-  def get: Backend =
-    synchronized {
-      assert(instance != null)
-      instance
-    }
+  type PartitionFn = (Array[Byte], Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
 }
 
 abstract class BroadcastValue[T] { def value: T }
 
-trait BackendContext {
+abstract class DriverRuntimeContext {
+
   def executionCache: ExecutionCache
+
+  def mapCollectPartitions(
+    globals: Array[Byte],
+    contexts: IndexedSeq[Array[Byte]],
+    stageIdentifier: String,
+    dependency: Option[TableStageDependency] = None,
+    partitions: Option[IndexedSeq[Int]] = None,
+  )(
+    f: PartitionFn
+  ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)])
 }
 
 abstract class Backend extends Closeable {
 
   def defaultParallelism: Int
 
-  def canExecuteParallelTasksOnDriver: Boolean = true
-
   def broadcast[T: ClassTag](value: T): BroadcastValue[T]
-
-  def parallelizeAndComputeWithIndex(
-    backendContext: BackendContext,
-    fs: FS,
-    contexts: IndexedSeq[Array[Byte]],
-    stageIdentifier: String,
-    dependency: Option[TableStageDependency] = None,
-    partitions: Option[IndexedSeq[Int]] = None,
-  )(
-    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
-  ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)])
 
   def asSpark(implicit E: Enclosing): SparkBackend =
     fatal(s"${getClass.getSimpleName}: ${E.value} requires SparkBackend")
@@ -118,5 +107,5 @@ abstract class Backend extends Closeable {
 
   def execute(ctx: ExecuteContext, ir: IR): Either[Unit, (PTuple, Long)]
 
-  def backendContext(ctx: ExecuteContext): BackendContext
+  def runtimeContext(ctx: ExecuteContext): DriverRuntimeContext
 }

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -191,8 +191,6 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
         jobConfig,
       )
 
-    Backend.set(backend)
-
     // FIXME: when can the classloader be shared? (optimizer benefits!)
     try runRpc(
         Env(
@@ -207,10 +205,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
           payload,
         )
       )
-    finally {
-      Backend.set(null)
-      backend.close()
-    }
+    finally backend.close()
   }
 }
 

--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -54,8 +54,6 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable {
     newFs(CloudStorageFSConfig.fromFlagsAndEnv(None, flags))
   )
 
-  Backend.set(backend)
-
   def pyFs: FS =
     synchronized(tmpFileManager.fs)
 
@@ -307,7 +305,6 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable {
       compiledCodeCache.clear()
       irCache.clear()
       coercerCache.clear()
-      Backend.set(null)
       backend.close()
       IRFunctionRegistry.clearUserFunctions()
     }

--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -1,8 +1,8 @@
 package is.hail.backend.service
 
-import is.hail.HailFeatureFlags
-import is.hail.asm4s._
 import is.hail.backend._
+import is.hail.backend.Backend.PartitionFn
+import is.hail.backend.local.LocalTaskContext
 import is.hail.backend.service.ServiceBackend.MaxAvailableGcsConnections
 import is.hail.expr.Validate
 import is.hail.expr.ir.{
@@ -19,6 +19,7 @@ import is.hail.utils._
 
 import scala.collection.compat._
 import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 import java.io._
 import java.nio.charset.StandardCharsets
@@ -46,12 +47,6 @@ class ServiceBackend(
 
   logHailVersion()
 
-  case class Context(
-    remoteTmpDir: String,
-    flags: HailFeatureFlags,
-    override val executionCache: ExecutionCache,
-  ) extends BackendContext
-
   private[this] var stageCount = 0
 
   private[this] val executor =
@@ -66,213 +61,241 @@ class ServiceBackend(
       def value: T = _value
     }
 
-  override def backendContext(ctx: ExecuteContext): BackendContext =
-    Context(
-      remoteTmpDir = ctx.tmpdir,
-      flags = ctx.flags,
-      executionCache = ExecutionCache.fromFlags(ctx.flags, ctx.fs, ctx.tmpdir),
-    )
+  override def runtimeContext(ctx: ExecuteContext): DriverRuntimeContext =
+    new DriverRuntimeContext {
 
-  private[this] def readString(in: DataInputStream): String = {
-    val n = in.readInt()
-    val bytes = new Array[Byte](n)
-    in.read(bytes)
-    new String(bytes, StandardCharsets.UTF_8)
-  }
+      override val executionCache: ExecutionCache =
+        ExecutionCache.fromFlags(ctx.flags, ctx.fs, ctx.tmpdir)
 
-  private[this] def submitJobGroupAndWait(
-    ctx: Context,
-    collection: IndexedSeq[Array[Byte]],
-    token: String,
-    root: String,
-    stageIdentifier: String,
-  ): (JobGroupResponse, Int) = {
-    val defaultProcess =
-      JvmJob(
-        command = null,
-        spec = jarSpec,
-        profile = ctx.flags.get("profile") != null,
-      )
-
-    val defaultJob =
-      JobRequest(
-        always_run = false,
-        process = null,
-        resources = Some(
-          JobResources(
-            preemptible = true,
-            cpu = Some(jobConfig.worker_cores).filter(_ != "None"),
-            memory = Some(jobConfig.worker_memory).filter(_ != "None"),
-            storage = Some(jobConfig.storage).filter(_ != "0Gi"),
-          )
-        ),
-        regions = Some(jobConfig.regions).filter(_.nonEmpty),
-        cloudfuse = Some(jobConfig.cloudfuse_configs).filter(_.nonEmpty),
-      )
-
-    val jobs =
-      collection.indices.map { i =>
-        defaultJob.copy(
-          attributes = Map(
-            "name" -> s"${name}_stage${stageCount}_${stageIdentifier}_job$i",
-            "idx" -> i.toString,
-          ),
-          process = defaultProcess.copy(
-            command = Array(Main.WORKER, root, s"$i", s"${collection.length}")
-          ),
-        )
+      private[this] def readString(in: DataInputStream): String = {
+        val n = in.readInt()
+        val bytes = new Array[Byte](n)
+        in.read(bytes)
+        new String(bytes, StandardCharsets.UTF_8)
       }
 
-    /* When we create a JobGroup with n jobs, Batch gives us the absolute JobGroupId, and the
-     * startJobId for the first job.
-     * This means that all JobId's in the JobGroup will have values in range (startJobId, startJobId
-     * + n).
-     * Therefore, we know the partition index for a given job by using this startJobId offset.
-     *
-     * Why do we do this?
-     * Consider a situation where we're submitting thousands of jobs in a job group.
-     * If one of those jobs fails, we don't want to make thousands of requests to batch to get a
-     * partition index that that job corresponds to. */
-
-    val (jobGroupId, startJobId) =
-      batchClient.newJobGroup(
-        JobGroupRequest(
-          batch_id = batchConfig.batchId,
-          absolute_parent_id = batchConfig.jobGroupId,
-          token = token,
-          cancel_after_n_failures = Some(1),
-          attributes = Map("name" -> stageIdentifier),
-          jobs = jobs,
-        )
-      )
-
-    stageCount += 1
-
-    Thread.sleep(600) // it is not possible for the batch to be finished in less than 600ms
-    val response = batchClient.waitForJobGroup(batchConfig.batchId, jobGroupId)
-    (response, startJobId)
-  }
-
-  private[this] def readPartitionResult(fs: FS, root: String, i: Int): Array[Byte] = {
-    val file = s"$root/result.$i"
-    val bytes = fs.readNoCompression(file)
-    assert(bytes(0) != 0, s"$file is not a valid result.")
-    bytes.slice(1, bytes.length)
-  }
-
-  private[this] def readPartitionError(fs: FS, root: String, i: Int): HailWorkerException = {
-    val file = s"$root/result.$i"
-    val bytes = fs.readNoCompression(file)
-    assert(bytes(0) == 0, s"$file did not contain an error")
-    val errorInformationBytes = bytes.slice(1, bytes.length)
-    val is = new DataInputStream(new ByteArrayInputStream(errorInformationBytes))
-    val shortMessage = readString(is)
-    val expandedMessage = readString(is)
-    val errorId = is.readInt()
-    HailWorkerException(i, shortMessage, expandedMessage, errorId)
-  }
-
-  override def parallelizeAndComputeWithIndex(
-    _backendContext: BackendContext,
-    fs: FS,
-    contexts: IndexedSeq[Array[Byte]],
-    stageIdentifier: String,
-    dependency: Option[TableStageDependency],
-    partitions: Option[IndexedSeq[Int]],
-  )(
-    f: (Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
-  ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) = {
-
-    val backendContext = _backendContext.asInstanceOf[Context]
-
-    val token = tokenUrlSafe
-    val root = s"${backendContext.remoteTmpDir}/parallelizeAndComputeWithIndex/$token"
-    log.info(s"parallelizeAndComputeWithIndex: token='$token', nPartitions=${contexts.length}")
-
-    val uploadFunction = executor.submit[Unit](() =>
-      retryTransientErrors {
-        fs.writePDOS(s"$root/f") { fos =>
-          using(new ObjectOutputStream(fos))(oos => oos.writeObject(f))
-          log.info(s"parallelizeAndComputeWithIndex: $token: uploaded f")
-        }
-      }
-    )
-
-    val (partIdxs, parts) =
-      partitions
-        .map(ps => (ps, ps.map(contexts)))
-        .getOrElse((contexts.indices, contexts))
-
-    val uploadContexts = executor.submit[Unit](() =>
-      retryTransientErrors {
-        fs.writePDOS(s"$root/contexts") { os =>
-          var o = 12L * parts.length // 12L = sizeof(Long) + sizeof(Int)
-          parts.foreach { context =>
-            val len = context.length
-            os.writeLong(o)
-            os.writeInt(len)
-            o += len
-          }
-          parts.foreach(os.write)
-          log.info(s"parallelizeAndComputeWithIndex: $token: wrote ${parts.length} contexts")
-        }
-      }
-    )
-
-    uploadFunction.get()
-    uploadContexts.get()
-
-    val (jobGroup, startJobId) =
-      submitJobGroupAndWait(backendContext, parts, token, root, stageIdentifier)
-    log.info(s"parallelizeAndComputeWithIndex: $token: reading results")
-    val startTime = System.nanoTime()
-
-    def streamSuccessfulPartitionResults: Stream[(Array[Byte], Int)] =
-      for {
-        successes <- batchClient.getJobGroupJobs(
-          jobGroup.batch_id,
-          jobGroup.job_group_id,
-          Some(JobStates.Success),
-        )
-        job <- successes
-        partIdx = job.job_id - startJobId
-      } yield (readPartitionResult(fs, root, partIdx), partIdx)
-
-    val r @ (_, results) =
-      jobGroup.state match {
-        case Success =>
-          runAllKeepFirstError(executor) {
-            partIdxs.lazyZip(parts.indices).map { (partIdx, jobIndex) =>
-              (() => readPartitionResult(fs, root, jobIndex), partIdx)
-            }
-          }
-        case Failure =>
-          val failedEntries = batchClient.getJobGroupJobs(
-            jobGroup.batch_id,
-            jobGroup.job_group_id,
-            Some(JobStates.Failed),
+      private[this] def submitJobGroupAndWait(
+        collection: IndexedSeq[Array[Byte]],
+        token: String,
+        root: String,
+        stageIdentifier: String,
+      ): (JobGroupResponse, Int) = {
+        val defaultProcess =
+          JvmJob(
+            command = null,
+            spec = jarSpec,
+            profile = ctx.flags.get("profile") != null,
           )
-          assert(
-            failedEntries.nonEmpty,
-            s"Job group ${jobGroup.job_group_id} for batch ${batchConfig.batchId} failed, but no failed jobs found.",
+
+        val defaultJob =
+          JobRequest(
+            always_run = false,
+            process = null,
+            resources = Some(
+              JobResources(
+                preemptible = true,
+                cpu = Some(jobConfig.worker_cores).filter(_ != "None"),
+                memory = Some(jobConfig.worker_memory).filter(_ != "None"),
+                storage = Some(jobConfig.storage).filter(_ != "0Gi"),
+              )
+            ),
+            regions = Some(jobConfig.regions).filter(_.nonEmpty),
+            cloudfuse = Some(jobConfig.cloudfuse_configs).filter(_.nonEmpty),
           )
-          val error = readPartitionError(fs, root, failedEntries.head.head.job_id - startJobId)
-          (Some(error), streamSuccessfulPartitionResults.toIndexedSeq)
-        case Cancelled =>
-          val error =
-            new CancellationException(
-              s"Job group ${jobGroup.job_group_id} for batch ${batchConfig.batchId} was cancelled"
+
+        val jobs =
+          collection.indices.map { i =>
+            defaultJob.copy(
+              attributes = Map(
+                "name" -> s"${name}_stage${stageCount}_${stageIdentifier}_job$i",
+                "idx" -> i.toString,
+              ),
+              process = defaultProcess.copy(
+                command = Array(Main.WORKER, root, s"$i", s"${collection.length}")
+              ),
             )
+          }
 
-          (Some(error), streamSuccessfulPartitionResults.toIndexedSeq)
+        /* When we create a JobGroup with n jobs, Batch gives us the absolute JobGroupId, and the
+         * startJobId for the first job.
+         * This means that all JobId's in the JobGroup will have values in range (startJobId,
+         * startJobId + n).
+         * Therefore, we know the partition index for a given job by using this startJobId offset.
+         *
+         * Why do we do this?
+         * Consider a situation where we're submitting thousands of jobs in a job group.
+         * If one of those jobs fails, we don't want to make thousands of requests to batch to get a
+         * partition index that that job corresponds to. */
+
+        val (jobGroupId, startJobId) =
+          batchClient.newJobGroup(
+            JobGroupRequest(
+              batch_id = batchConfig.batchId,
+              absolute_parent_id = batchConfig.jobGroupId,
+              token = token,
+              cancel_after_n_failures = Some(1),
+              attributes = Map("name" -> stageIdentifier),
+              jobs = jobs,
+            )
+          )
+
+        stageCount += 1
+
+        Thread.sleep(600) // it is not possible for the batch to be finished in less than 600ms
+        val response = batchClient.waitForJobGroup(batchConfig.batchId, jobGroupId)
+        (response, startJobId)
       }
 
-    val resultsReadingSeconds = (System.nanoTime() - startTime) / 1000000000.0
-    val rate = results.length / resultsReadingSeconds
-    val byterate = results.map(_._1.length).sum / resultsReadingSeconds / 1024 / 1024
-    log.info(s"all results read. $resultsReadingSeconds s. $rate result/s. $byterate MiB/s.")
-    r
-  }
+      private[this] def readPartitionResult(fs: FS, root: String, i: Int): Array[Byte] = {
+        val file = s"$root/result.$i"
+        val bytes = fs.readNoCompression(file)
+        assert(bytes(0) != 0, s"$file is not a valid result.")
+        bytes.slice(1, bytes.length)
+      }
+
+      private[this] def readPartitionError(fs: FS, root: String, i: Int): HailWorkerException = {
+        val file = s"$root/result.$i"
+        val bytes = fs.readNoCompression(file)
+        assert(bytes(0) == 0, s"$file did not contain an error")
+        val errorInformationBytes = bytes.slice(1, bytes.length)
+        val is = new DataInputStream(new ByteArrayInputStream(errorInformationBytes))
+        val shortMessage = readString(is)
+        val expandedMessage = readString(is)
+        val errorId = is.readInt()
+        HailWorkerException(i, shortMessage, expandedMessage, errorId)
+      }
+
+      override def mapCollectPartitions(
+        globals: Array[Byte],
+        contexts: IndexedSeq[Array[Byte]],
+        stageIdentifier: String,
+        dependency: Option[TableStageDependency],
+        partitions: Option[IndexedSeq[Int]],
+      )(
+        f: PartitionFn
+      ): (Option[Throwable], IndexedSeq[(Array[Byte], Int)]) =
+        partitions.getOrElse(contexts.indices) match {
+          case Seq(k) =>
+            try
+              using(new LocalTaskContext(k, stageCount)) { htc =>
+                (None, FastSeq(f(globals, contexts(k), htc, ctx.theHailClassLoader, ctx.fs) -> k))
+              }
+            catch {
+              case NonFatal(t) => (Some(t), IndexedSeq.empty)
+            } finally stageCount += 1
+
+          case todo =>
+            val token = tokenUrlSafe
+            val root = s"${ctx.tmpdir}/mapCollectPartitions/$token"
+            log.info(s"mapCollectPartitions: token='$token', nPartitions=${todo.length}")
+
+            val uploadGlobals =
+              executor.submit[Unit] { () =>
+                retryTransientErrors {
+                  ctx.fs.writePDOS(s"$root/globals")(_.write(globals))
+                  log.info(s"mapCollectPartitions: $token: uploaded globals")
+                }
+              }
+
+            val uploadFunction =
+              executor.submit[Unit] { () =>
+                val fsConfig: Any =
+                  ctx.fs.getConfiguration()
+
+                val partial: PartitionFn = {
+                  (globals, context, htc, hcl, fs) =>
+                    fs.setConfiguration(fsConfig)
+                    f(globals, context, htc, hcl, fs)
+                }
+
+                retryTransientErrors {
+                  ctx.fs.writePDOS(s"$root/f") { fos =>
+                    using(new ObjectOutputStream(fos))(_.writeObject(partial))
+                    log.info(s"mapCollectPartitions: $token: uploaded function")
+                  }
+                }
+              }
+
+            val parts = todo.map(contexts(_))
+
+            val uploadContexts =
+              executor.submit[Unit] { () =>
+                retryTransientErrors {
+                  ctx.fs.writePDOS(s"$root/contexts") { os =>
+                    var o = 12L * parts.length // 12L = sizeof(Long) + sizeof(Int)
+
+                    for (p <- parts) {
+                      val len = p.length
+                      os.writeLong(o)
+                      os.writeInt(len)
+                      o += len
+                    }
+
+                    for (p <- parts) os.write(p)
+
+                    log.info(s"mapCollectPartitions: $token: wrote ${parts.length} contexts")
+                  }
+                }
+              }
+
+            uploadGlobals.get()
+            uploadFunction.get()
+            uploadContexts.get()
+
+            val (jobGroup, startJobId) = submitJobGroupAndWait(parts, token, root, stageIdentifier)
+            log.info(s"mapCollectPartitions: $token: reading results")
+            val startTime = System.nanoTime()
+
+            def streamSuccessfulPartitionResults: Stream[(Array[Byte], Int)] =
+              for {
+                successes <- batchClient.getJobGroupJobs(
+                  jobGroup.batch_id,
+                  jobGroup.job_group_id,
+                  Some(JobStates.Success),
+                )
+                job <- successes
+                partIdx = job.job_id - startJobId
+              } yield (readPartitionResult(ctx.fs, root, partIdx), partIdx)
+
+            val (failureOpt, results) =
+              jobGroup.state match {
+                case Success =>
+                  runAllKeepFirstError(executor) {
+                    todo.lazyZip(parts.indices).map { (partIdx, jobIndex) =>
+                      (() => readPartitionResult(ctx.fs, root, jobIndex), partIdx)
+                    }
+                  }
+                case Failure =>
+                  val failedEntries =
+                    batchClient.getJobGroupJobs(
+                      jobGroup.batch_id,
+                      jobGroup.job_group_id,
+                      Some(JobStates.Failed),
+                    )
+
+                  assert(
+                    failedEntries.nonEmpty,
+                    s"Job group ${jobGroup.job_group_id} for batch ${batchConfig.batchId} failed, but no failed jobs found.",
+                  )
+                  val error =
+                    readPartitionError(ctx.fs, root, failedEntries.head.head.job_id - startJobId)
+                  (Some(error), streamSuccessfulPartitionResults.toIndexedSeq)
+                case Cancelled =>
+                  val error =
+                    new CancellationException(
+                      s"Job group ${jobGroup.job_group_id} for batch ${batchConfig.batchId} was cancelled"
+                    )
+
+                  (Some(error), streamSuccessfulPartitionResults.toIndexedSeq)
+              }
+
+            val end = (System.nanoTime() - startTime) / 1000000000.0
+            val rate = results.length / end
+            val byterate = results.view.map(_._1.length).sum / end / 1024 / 1024
+            log.info(s"all results read. $end s. $rate result/s. $byterate MiB/s.")
+            (failureOpt, results.sortBy(_._2))
+        }
+    }
 
   override def close(): Unit = {
     if (executor.isEvaluated) executor.shutdownNow()
@@ -285,7 +308,8 @@ class ServiceBackend(
       Validate(ir)
       val queryID = Backend.nextID()
       log.info(s"starting execution of query $queryID of initial size ${IRSize(ir)}")
-      ctx.irMetadata.semhash = SemanticHash(ctx, ir)
+      if (ctx.flags.isDefined(ExecutionCache.Flags.UseFastRestarts))
+        ctx.irMetadata.semhash = SemanticHash(ctx, ir)
       val res = _jvmLowerAndExecute(ctx, ir)
       log.info(s"finished execution of query $queryID")
       res

--- a/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -415,11 +415,6 @@ case object SemanticHash extends Logging {
       fromInt(clz.hashCode())
   }
 
-  object CodeGenSupport {
-    def lift(hash: SemanticHash.Type): Option[SemanticHash.Type] =
-      Some(hash)
-  }
-
 }
 
 case object EncodeTypename {

--- a/hail/hail/test/src/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -89,7 +89,7 @@ object BTreeBackedSet {
 
     val inputBuffer = new StreamBufferSpec().buildInputBuffer(new ByteArrayInputStream(serialized))
     val set = new BTreeBackedSet(ctx, region, n)
-    set.root = fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)(
+    set.root = fb.resultWithIndex()(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, region)(
       region,
       inputBuffer,
     )
@@ -115,7 +115,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       root
     }
 
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
+    fb.resultWithIndex()(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   private val getF = {
@@ -138,7 +138,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       cb.if_(key.isEmpty(cb, elt), key.storeKey(cb, elt, m, v))
       root
     }
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
+    fb.resultWithIndex()(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   private val getResultsF = {
@@ -177,7 +177,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       )
       returnArray
     }
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
+    fb.resultWithIndex()(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   private val bulkStoreF = {
@@ -204,7 +204,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
       ob2.flush()
     }
 
-    fb.resultWithIndex()(HailSuite.theHailClassLoader, ctx.fs, ctx.taskContext, region)
+    fb.resultWithIndex()(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, region)
   }
 
   def clear(): Unit = {


### PR DESCRIPTION
## Change Description

This PR refactors the Backend interface to improve separation of concerns between driver and worker contexts. The key changes include:

1. Removes the static `Backend.instance` singleton pattern in favour of explicit context passing
2. Repurposes `BackendContext`​ as `DriverRuntimeContext` to implement `mapCollectPartitions`​ (formally `parallelizeAndComputeWithIndex`)
3. Removes `canExecuteParallelTasksOnDriver`​ from `Backend`​ - this is now an implementation detail in `mapCollectPartitions`​.
4. Broadcasts globals in a separate file for `ServiceBackend`​
5. Disable all semantic-hash code when it's not featured on

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP