### PR TITLE
Ensure that 'top level' files in CODEOWNERS are actually top level

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,6 @@
 
 
 # Files at the top level of the repository:
-CODEOWNERS @hail-is/appsec
-build.yaml @hail-is/appsec
-Makefile @hail-is/appsec
+/CODEOWNERS @hail-is/appsec
+/build.yaml @hail-is/appsec
+/Makefile @hail-is/appsec


### PR DESCRIPTION
## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has no security impact

### Impact Description
This is a change to an file that controls automatic Github review assignment. It does not touch production.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
