### PR TITLE
[CI] Disable overly flaky GPU test

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1509,7 +1509,7 @@ def test_pool_standard_instance_cheapest(client: BatchClient):
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
-# TODO: This test is too flaky to be run by default.Come up with a way that this test can be tested on demand (eg if we change GPU-y things) but not on
+# TODO (#15116): This test is too flaky to be run by default.Come up with a way that this test can be tested on demand (eg if we change GPU-y things) but not on
 # all unrelated changes.
 #  @skip_in_azure
 # async def test_nvidia_driver_accesibility_usage(client: BatchClient):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,4 +1,3 @@
-import asyncio
 import collections
 import os
 import secrets
@@ -1510,19 +1509,21 @@ def test_pool_standard_instance_cheapest(client: BatchClient):
     assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
-@skip_in_azure
-async def test_nvidia_driver_accesibility_usage(client: BatchClient):
-    b = create_batch(client)._async_batch
-    resources = {'machine_type': "g2-standard-4", 'storage': '100Gi'}
-    j = b.create_job(
-        os.environ['HAIL_GPU_IMAGE'],
-        ['/bin/sh', '-c', 'nvidia-smi && python3 -c "import torch; assert torch.cuda.is_available()"'],
-        resources=resources,
-        n_max_attempts=4,
-    )
-    await b.submit()
-    status = await asyncio.wait_for(j.wait(), timeout=5 * 60)
-    assert status['state'] == 'Success', str((status, b.debug_info()))
+# TODO: This test is too flaky to be run by default.Come up with a way that this test can be tested on demand (eg if we change GPU-y things) but not on
+# all unrelated changes.
+#  @skip_in_azure
+# async def test_nvidia_driver_accesibility_usage(client: BatchClient):
+#     b = create_batch(client)._async_batch
+#     resources = {'machine_type': "g2-standard-4", 'storage': '100Gi'}
+#     j = b.create_job(
+#         os.environ['HAIL_GPU_IMAGE'],
+#         ['/bin/sh', '-c', 'nvidia-smi && python3 -c "import torch; assert torch.cuda.is_available()"'],
+#         resources=resources,
+#         n_max_attempts=4,
+#     )
+#     await b.submit()
+#     status = await asyncio.wait_for(j.wait(), timeout=5 * 60)
+#     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
 def test_job_private_instance_preemptible(client: BatchClient):


### PR DESCRIPTION
## Change Description

Temporarily disable the GPU tests. They fail far too frequently with ZONE EXHAUSTION errors that are nothing to do with the code itself and just an artifact of clouds not being infinite all the time.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

Just a test, no production impact

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
