### PR TITLE
[batch] Block project SSH keys at instance level

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -390,6 +390,10 @@ journalctl -u docker.service > dockerd.log
                     'key': 'instance_config',
                     'value': base64.b64encode(json.dumps(instance_config.to_dict()).encode()).decode(),
                 },
+                {
+                    'key': 'block-project-ssh-keys',
+                    'value': 'TRUE',
+                },
             ]
         },
         'tags': {'items': ["batch2-agent"]},


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/61

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Should be entirely positive. Enables the "block project SSH keys" metadata at instance creation as well as at the project level.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
