### PR TITLE
[query] fix flaky batch client scala test

### DIFF
--- a/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
+++ b/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
@@ -198,6 +198,5 @@ class BatchClientSuite extends TestNGSuite {
 
     val jg = client.waitForJobGroup(batchId, jobGroupId)
     jg.state shouldBe services.JobGroupStates.Cancelled
-    jg.complete shouldBe false
   }
 }


### PR DESCRIPTION
The `complete` flag in the `JobGroupResponse` could be `true` or `false` depending on where batch got to when scheduling the jobs. I shouldn't have included this assertion.

This change cannot affect the hail batch service deployed in gcp.