### PR TITLE
[terraform] Enable private nodes

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -4,6 +4,10 @@ terraform {
       source = "hashicorp/google"
       version = "7.2.0"
     }
+    google-beta = {
+      source = "hashicorp/google-beta"
+      version = "7.2.0"
+    }
     kubernetes = {
       source = "hashicorp/kubernetes"
       version = "2.8.0"
@@ -503,6 +507,28 @@ resource "google_compute_address" "internal_gateway" {
   address_type = "INTERNAL"
   region = var.gcp_region
 }
+
+# Cloud Router for GKE node outbound NAT
+resource "google_compute_router" "gke_node_outbound_router" {
+  name    = "gke-node-outbound-router"
+  region  = var.gcp_region
+  network = google_compute_network.default.id
+}
+
+# Cloud NAT Gateway for GKE private node outbound internet access
+resource "google_compute_router_nat" "gke_node_outbound_nat" {
+  name                               = "gke-node-outbound-nat"
+  router                            = google_compute_router.gke_node_outbound_router.name
+  region                            = var.gcp_region
+  nat_ip_allocate_option            = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
 
 provider "kubernetes" {
   host = "https://${google_container_cluster.vdc.endpoint}"

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -380,6 +380,27 @@ resource "google_compute_address" "internal_gateway" {
   region = var.gcp_region
 }
 
+# Cloud Router for GKE node outbound NAT
+resource "google_compute_router" "gke_node_outbound_router" {
+  name    = "gke-node-outbound-router"
+  region  = var.gcp_region
+  network = google_compute_network.default.id
+}
+
+# Cloud NAT Gateway for GKE private node outbound internet access
+resource "google_compute_router_nat" "gke_node_outbound_nat" {
+  name                               = "gke-node-outbound-nat"
+  router                            = google_compute_router.gke_node_outbound_router.name
+  region                            = var.gcp_region
+  nat_ip_allocate_option            = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
 provider "kubernetes" {
   host = "https://${google_container_cluster.vdc.endpoint}"
   token = data.google_client_config.provider.access_token


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/43

Switches our clusters to private nodes. Tested in our sandbox instance with no problem once applied.

Note: To make this work, I had to apply the change manually in the gcloud console UI. Terraform was tripping over how to reach the k8s API and wanted to replace the entire cluster. That actually wasn't necessary

- [x] After merging, apply this change manually.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Private nodes are better than ones with public IPs

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
