### PR TITLE
[query] Fix defined block calculation for BlockMatrixBroadcast.typ

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
@@ -643,12 +643,12 @@ case class BlockMatrixBroadcast(
           case IndexedSeq(0) => // broadcast col vector
             assert(Set(1, shape(0)) == Set(child.typ.nRows, child.typ.nCols))
             BlockMatrixSparsity.constructFromShapeAndFunction(nRowBlocks, nColBlocks)(
-              (i: Int, j: Int) => child.typ.hasBlock(0 -> j)
+              (i: Int, j: Int) => child.typ.hasBlock(i -> 0)
             )
           case IndexedSeq(1) => // broadcast row vector
             assert(Set(1, shape(1)) == Set(child.typ.nRows, child.typ.nCols))
             BlockMatrixSparsity.constructFromShapeAndFunction(nRowBlocks, nColBlocks)(
-              (i: Int, j: Int) => child.typ.hasBlock(i -> 0)
+              (i: Int, j: Int) => child.typ.hasBlock(0 -> j)
             )
           case IndexedSeq(0, 0) => // diagonal as col vector
             assert(shape(0) == 1L)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -496,6 +496,25 @@ def test_block_matrix_elementwise_arithmetic(block_matrix_bindings, x, y):
 
 @pytest.mark.parametrize(
     'x, y',
+    [
+        (
+            np.array([[7.0], [15.0], [19.0]]),
+            np.array([[7.0, 8.0, 9.0]]),
+        ),
+        (
+            np.array([[7.0, 8.0, 9.0]]),
+            np.array([[7.0], [15.0], [19.0]]),
+        ),
+    ],
+)
+def test_sparse_broadcast_add(x, y):
+    bmx = BlockMatrix.from_ndarray(x, block_size=2)._sparsify_blocks([0, 1])
+    bmy = BlockMatrix.from_ndarray(y, block_size=2)
+    _assert_eq(bmx + bmy, x + y)
+
+
+@pytest.mark.parametrize(
+    'x, y',
     [  # division
         ('x / e', 'nx / e'),
         ('c / e', 'nc / e'),


### PR DESCRIPTION
In the sparse case, we were calculating defined blocks for column vectors based on if a column was present and vice versa for rows.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP