### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
-*.o
-*~
-.*.crc
-*.pyc
+**/*.o
+**/*~
+**/.*.crc
+**/*.pyc
 **/.mypy_cache/
 **/hail-*.log
 **/__pycache__/


### PR DESCRIPTION
## Change Description

Fixes #15129

This PR fixes minor .dockerignore misconfigurations (#15129). I added `**/` at the beginning of the patterns I thought should match recursively. Please let me know (or directly update my PR) if any other lines should include `**/` as well.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

- This PR includes only minor fixes in the .dockerignore file, which I cannot think of security impact from the change.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
