### PR TITLE
[docker] Bump ubuntu base image to noble-20251001

### DIFF
--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKER_PREFIX={{ global.docker_prefix }}
-FROM $DOCKER_PREFIX/ubuntu:noble-20250925
+FROM $DOCKER_PREFIX/ubuntu:noble-20251001
 
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -19,4 +19,4 @@ ubuntu:18.04
 ubuntu:20.04
 ubuntu:22.04
 ubuntu:24.04
-ubuntu:noble-20250925
+ubuntu:noble-20251001


### PR DESCRIPTION
## Change Description

Updates the base image used by services to noble-20251001

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Keeping our dependencies up to date

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
