### PR TITLE
[query] Simplify BlockMatrix transpose IR generation

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1303,14 +1303,7 @@ class BlockMatrix:
         if self.n_rows == 1 and self.n_cols == 1:
             return self
 
-        if self.n_rows == 1:
-            index_expr = [0]
-        elif self.n_cols == 1:
-            index_expr = [1]
-        else:
-            index_expr = [1, 0]
-
-        return BlockMatrix(BlockMatrixBroadcast(self._bmir, index_expr, [self.n_cols, self.n_rows], self.block_size))
+        return BlockMatrix(BlockMatrixBroadcast(self._bmir, [1, 0], [self.n_cols, self.n_rows], self.block_size))
 
     def densify(self):
         """Restore all dropped blocks as explicit blocks of zeros.


### PR DESCRIPTION
BlockMatrix IR is a little wierd right now. We often try to treat matricies with a single row/column as a vector. This leads to a lot of additional complexity for little benefit. As as start to simplifying this, always use `[1, 0]` as the index expression to BlockMatrixBroadcast in transpose.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
