### PR TITLE
[terraform] Remove remaining service account user instances

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -655,7 +655,6 @@ module "batch_gsa_secret" {
   project = var.gcp_project
   iam_roles = [
     "projects/${var.gcp_project}/roles/batchComputeManager",
-    "iam.serviceAccountUser",
     "logging.viewer",
     "cloudprofiler.agent",
   ]
@@ -673,7 +672,6 @@ module "testns_batch_gsa_secret" {
   project = var.gcp_project
   iam_roles = [
     "projects/${var.gcp_project}/roles/batchComputeManager",
-    "iam.serviceAccountUser",
     "logging.viewer",
     "cloudprofiler.agent",
   ]
@@ -868,6 +866,20 @@ resource "google_project_iam_member" "batch_agent_custom_role" {
   project = var.gcp_project
   role = "projects/${var.gcp_project}/roles/batch2AgentComputeOps"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
+}
+
+# Grant batch service account permission to act as batch2-agent service account
+resource "google_service_account_iam_member" "batch_act_as_batch_agent" {
+  service_account_id = google_service_account.batch_agent.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${module.batch_gsa_secret.email}"
+}
+
+# Grant testns-batch service account permission to act as batch2-agent service account
+resource "google_service_account_iam_member" "testns_batch_act_as_batch_agent" {
+  service_account_id = google_service_account.batch_agent.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${module.testns_batch_gsa_secret.email}"
 }
 
 resource "google_service_account" "gke_node_pool" {

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -618,7 +618,6 @@ module "batch_gsa_secret" {
   project = var.gcp_project
   iam_roles = [
     "projects/${var.gcp_project}/roles/batchComputeManager",
-    "iam.serviceAccountUser",
     "logging.viewer",
     "storage.admin",
     "cloudprofiler.agent",
@@ -637,7 +636,6 @@ module "testns_batch_gsa_secret" {
   project = var.gcp_project
   iam_roles = [
     "projects/${var.gcp_project}/roles/batchComputeManager",
-    "iam.serviceAccountUser",
     "logging.viewer",
     "cloudprofiler.agent",
   ]
@@ -824,6 +822,20 @@ resource "google_project_iam_member" "batch_agent_custom_role" {
   project = var.gcp_project
   role = "projects/${var.gcp_project}/roles/batch2AgentComputeOps"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
+}
+
+# Grant batch service account permission to act as batch2-agent service account
+resource "google_service_account_iam_member" "batch_act_as_batch_agent" {
+  service_account_id = google_service_account.batch_agent.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${module.batch_gsa_secret.email}"
+}
+
+# Grant testns-batch service account permission to act as batch2-agent service account
+resource "google_service_account_iam_member" "testns_batch_act_as_batch_agent" {
+  service_account_id = google_service_account.batch_agent.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${module.testns_batch_gsa_secret.email}"
 }
 
 resource "google_service_account" "gke_node_pool" {


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/40

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Remove more instance of SAs being given a project level service account user grant. In this case we only need a single actAs permission.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
