### PR TITLE
[auth] fix bootstrap_create_accounts for inactive users

### DIFF
--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -33,6 +33,13 @@ async def insert_user_if_not_exists(app, username, login_id, is_developer, is_se
         if row:
             if row['state'] == 'active':
                 return None
+            if row['state'] == 'inactive':
+                # Inactive users don't need recreating, but we should reactivate before we move on
+                await tx.execute_update(
+                    'UPDATE users SET state = "active", last_activated = CURRENT_TIMESTAMP(3) WHERE id = %s;',
+                    (row['id'],),
+                )
+                return None
             return row['id']
 
         hail_credentials_secret_name = f'{username}-gsa-key'


### PR DESCRIPTION
## Change Description

Fixes our `bootstrap_create_accounts` script to be resilient to inactive users.

In this case "create"ing an account that is currently inactive becomes reactivating it.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact


### Impact Description

Making a script resilient be replacing a "create" action with a "reactivate" action, if necessary

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
