### PR TITLE
[query] engoodening of the py4j clients

### DIFF
--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.driver
 
-import is.hail.HailFeatureFlags
+import is.hail.{HAIL_PRETTY_VERSION, HailFeatureFlags}
 import is.hail.annotations.Memory
 import is.hail.asm4s.HailClassLoader
 import is.hail.backend.{Backend, ExecuteContext, OwningTempFileManager}
@@ -132,6 +132,8 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
     val name = argv(4)
     val inputURL = argv(5)
     val outputURL = argv(6)
+
+    log.info(f"${getClass.getName} $HAIL_PRETTY_VERSION")
 
     val deployConfig = DeployConfig.fromConfigFile("/deploy-config/deploy-config.json")
     DeployConfig.set(deployConfig)

--- a/hail/hail/src/is/hail/backend/local/LocalBackend.scala
+++ b/hail/hail/src/is/hail/backend/local/LocalBackend.scala
@@ -40,19 +40,8 @@ object LocalBackend extends Backend {
 
   is.hail.linalg.registerImplOpMulMatrix_DMD_DVD_eq_DVD
 
-  def apply(
-    logFile: String = "hail.log",
-    quiet: Boolean = false,
-    append: Boolean = false,
-    skipLoggingConfiguration: Boolean = false,
-  ): LocalBackend.type =
-    synchronized {
-      if (!skipLoggingConfiguration) configureLogging(logFile, quiet, append)
-      logHailVersion()
-      this
-    }
-
-  def broadcast[T: ClassTag](value: T): BroadcastValue[T] = new LocalBroadcastValue[T](value)
+  def broadcast[T: ClassTag](value: T): BroadcastValue[T] =
+    new LocalBroadcastValue[T](value)
 
   private[this] var stageIdx: Int = 0
 

--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -46,8 +46,6 @@ class ServiceBackend(
   jobConfig: BatchJobConfig,
 ) extends Backend {
 
-  logHailVersion()
-
   private[this] var stageCount = 0
 
   private[this] val executor =

--- a/hail/hail/src/is/hail/expr/ir/TableValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableValue.scala
@@ -366,7 +366,7 @@ case class TableValue(ctx: ExecuteContext, typ: TableType, globals: BroadcastRow
   }
 
   def toDF(ctx: ExecuteContext): DataFrame =
-    ctx.backend.asSpark.sparkSession.createDataFrame(
+    ctx.backend.asSpark.spark.createDataFrame(
       rvd.toRows,
       typ.rowType.schema.asInstanceOf[StructType],
     )

--- a/hail/hail/src/is/hail/utils/Py4jUtils.scala
+++ b/hail/hail/src/is/hail/utils/Py4jUtils.scala
@@ -7,11 +7,13 @@ import is.hail.types.virtual.Type
 import scala.collection.JavaConverters._
 
 import java.io.{InputStream, OutputStream}
+import java.util.Properties
 
+import org.apache.log4j.{LogManager, PropertyConfigurator}
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
 
-trait Py4jUtils {
+trait Py4jUtils extends Logging {
   def arrayToArrayList[T](arr: Array[T]): java.util.ArrayList[T] = {
     val list = new java.util.ArrayList[T]()
     for (elem <- arr)
@@ -129,6 +131,39 @@ trait Py4jUtils {
     if (exclusive && fs.exists(path))
       fatal(s"a file already exists at '$path'")
     new HadoopPyWriter(fs.create(path))
+  }
+
+  val LogFormat: String =
+    "%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1}: %p: %m%n"
+
+  def configureLogging(logFile: String, quiet: Boolean, append: Boolean): Unit = {
+    org.apache.log4j.helpers.LogLog.setInternalDebugging(true)
+    org.apache.log4j.helpers.LogLog.setQuietMode(false)
+    val logProps = new Properties()
+
+    // uncomment to see log4j LogLog output:
+    // logProps.put("log4j.debug", "true")
+    logProps.put("log4j.rootLogger", "INFO, logfile")
+    logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
+    logProps.put("log4j.appender.logfile.append", append.toString)
+    logProps.put("log4j.appender.logfile.file", logFile)
+    logProps.put("log4j.appender.logfile.threshold", "INFO")
+    logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
+    logProps.put("log4j.appender.logfile.layout.ConversionPattern", LogFormat)
+
+    if (!quiet) {
+      logProps.put("log4j.logger.Hail", "INFO, HailConsoleAppender, HailSocketAppender")
+      logProps.put("log4j.appender.HailConsoleAppender", "org.apache.log4j.ConsoleAppender")
+      logProps.put("log4j.appender.HailConsoleAppender.target", "System.err")
+      logProps.put("log4j.appender.HailConsoleAppender.layout", "org.apache.log4j.PatternLayout")
+    } else
+      logProps.put("log4j.logger.Hail", "INFO, HailSocketAppender")
+
+    logProps.put("log4j.appender.HailSocketAppender", "is.hail.utils.StringSocketAppender")
+    logProps.put("log4j.appender.HailSocketAppender.layout", "org.apache.log4j.PatternLayout")
+
+    LogManager.resetConfiguration()
+    PropertyConfigurator.configure(logProps)
   }
 
   def addSocketAppender(hostname: String, port: Int): Unit =

--- a/hail/hail/src/is/hail/utils/package.scala
+++ b/hail/hail/src/is/hail/utils/package.scala
@@ -17,7 +17,7 @@ import java.net.{URI, URLClassLoader}
 import java.security.SecureRandom
 import java.text.SimpleDateFormat
 import java.util
-import java.util.{Base64, Date, Properties}
+import java.util.{Base64, Date}
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.PathIOException
 import org.apache.hadoop.mapred.FileSplit
 import org.apache.hadoop.mapreduce.lib.input.{FileSplit => NewFileSplit}
-import org.apache.log4j.{Level, LogManager, PropertyConfigurator}
+import org.apache.log4j.Level
 import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.sql.Row
 import org.json4s.{Extraction, Formats, JObject, NoTypeHints, Serializer}
@@ -114,42 +114,6 @@ package object utils
   type UtilsType = this.type
 
   def utilsPackageClass = getClass
-
-  val LogFormat: String =
-    "%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1}: %p: %m%n"
-
-  def configureLogging(logFile: String, quiet: Boolean, append: Boolean): Unit = {
-    org.apache.log4j.helpers.LogLog.setInternalDebugging(true)
-    org.apache.log4j.helpers.LogLog.setQuietMode(false)
-    val logProps = new Properties()
-
-    // uncomment to see log4j LogLog output:
-    // logProps.put("log4j.debug", "true")
-    logProps.put("log4j.rootLogger", "INFO, logfile")
-    logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
-    logProps.put("log4j.appender.logfile.append", append.toString)
-    logProps.put("log4j.appender.logfile.file", logFile)
-    logProps.put("log4j.appender.logfile.threshold", "INFO")
-    logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
-    logProps.put("log4j.appender.logfile.layout.ConversionPattern", LogFormat)
-
-    if (!quiet) {
-      logProps.put("log4j.logger.Hail", "INFO, HailConsoleAppender, HailSocketAppender")
-      logProps.put("log4j.appender.HailConsoleAppender", "org.apache.log4j.ConsoleAppender")
-      logProps.put("log4j.appender.HailConsoleAppender.target", "System.err")
-      logProps.put("log4j.appender.HailConsoleAppender.layout", "org.apache.log4j.PatternLayout")
-    } else
-      logProps.put("log4j.logger.Hail", "INFO, HailSocketAppender")
-
-    logProps.put("log4j.appender.HailSocketAppender", "is.hail.utils.StringSocketAppender")
-    logProps.put("log4j.appender.HailSocketAppender.layout", "org.apache.log4j.PatternLayout")
-
-    LogManager.resetConfiguration()
-    PropertyConfigurator.configure(logProps)
-  }
-
-  def logHailVersion(): Unit =
-    info(s"Running Hail version $HAIL_PRETTY_VERSION")
 
   def getStderrAndLogOutputStream[T](implicit tct: ClassTag[T]): OutputStream =
     new TeeOutputStream(new LoggerOutputStream(log, Level.ERROR), System.err)

--- a/hail/hail/src/org/apache/spark/ProgressBarBuilder.scala
+++ b/hail/hail/src/org/apache/spark/ProgressBarBuilder.scala
@@ -1,8 +1,0 @@
-package org.apache.spark
-
-import org.apache.spark.ui.ConsoleProgressBar
-
-object ProgressBarBuilder {
-  def build(sc: SparkContext): ConsoleProgressBar =
-    new ConsoleProgressBar(sc)
-}

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -1,172 +1,203 @@
 import os
 import sys
+from collections.abc import Callable
 from typing import Any, Dict, Optional
 
 import orjson
 import pyspark
 import pyspark.sql
+from py4j.java_gateway import JavaGateway
 
 from hail.expr.table_type import ttable
 from hail.ir import BaseIR
-from hail.ir.renderer import CSERenderer
 from hail.table import Table
 from hail.utils import copy_log
+from hail.utils.java import scala_package_object
+from hail.version import __version__
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
-from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
+from hailtop.fs.fs import FS
+from hailtop.fs.router_fs import RouterFS
 from hailtop.utils import async_to_blocking
 
+from ..fs.hadoop_fs import HadoopFS
 from .backend import local_jar_information
-from .py4j_backend import Py4JBackend
+from .py4j_backend import Py4JBackend, connect_logger, raise_when_mismatched_hail_versions
 
 
-def append_to_comma_separated_list(conf: pyspark.SparkConf, k: str, *new_values: str):
-    old = conf.get(k, None)
-    if old is None:
-        conf.set(k, ','.join(new_values))
+def _modify_spark_conf(conf: pyspark.SparkConf, key: str, update: Callable[[str | None], str]):
+    old = conf.get(key, None)
+    conf.set(key, update(old))
+
+
+def _append_csv(*xs: str) -> Callable[[str | None], str]:
+    return lambda csv: ','.join(xs if csv is None else (csv, *xs))
+
+
+def _get_or_create_pyspark_gateway(
+    sc: pyspark.SparkContext | None,
+    spark_conf: Dict[str, Any] | None = None,
+    local_tmpdir: str | None = None,
+    quiet: bool = False,
+) -> JavaGateway:
+    if sc is not None and not quiet:
+        sys.stderr.write(
+            'pip-installed Hail requires additional configuration options in Spark referring\n'
+            '  to the path to the Hail Python module directory HAIL_DIR,\n'
+            '  e.g. /path/to/python/site-packages/hail:\n'
+            '    spark.jars=HAIL_DIR/backend/hail-all-spark.jar\n'
+            '    spark.driver.extraClassPath=HAIL_DIR/backend/hail-all-spark.jar\n'
+            '    spark.executor.extraClassPath=./hail-all-spark.jar'
+        )
+
+    conf = pyspark.SparkConf()
+    for k, v in (spark_conf or {}).items():
+        conf.set(k, v)
+
+    _, hail_jar, extra_classpath = local_jar_information()
+    jars = [hail_jar]
+
+    if os.environ.get('HAIL_SPARK_MONITOR') or os.environ.get('AZURE_SPARK') == '1':
+        import sparkmonitor
+
+        jars = [*jars, os.path.join(os.path.dirname(sparkmonitor.__file__), 'listener.jar')]
+        _modify_spark_conf(
+            conf, 'spark.extraListeners', _append_csv('sparkmonitor.listener.JupyterSparkMonitorListener')
+        )
+
+    _modify_spark_conf(conf, 'spark.jars', _append_csv(*jars))
+    if os.environ.get('AZURE_SPARK') == '1':
+        print('AZURE_SPARK environment variable is set to "1", assuming you are in HDInsight.')
+        # Setting extraClassPath in HDInsight overrides the classpath entirely so you can't
+        # load the Scala standard library. Interestingly, setting extraClassPath is not
+        # necessary in HDInsight.
     else:
-        conf.set(k, old + ',' + ','.join(new_values))
+        _modify_spark_conf(conf, 'spark.driver.extraClassPath', _append_csv(*jars, *extra_classpath))
+        _modify_spark_conf(conf, 'spark.executor.extraClassPath', _append_csv(hail_jar, *extra_classpath))
+
+    if local_tmpdir is not None:
+        conf.setIfMissing('spark.local.dir', local_tmpdir.removeprefix('file://'))
+
+    conf.set('spark.ui.showConsoleProgress', str(not quiet).lower())
+
+    pyspark.SparkContext._ensure_initialized(instance=sc, conf=conf)
+
+    return pyspark.SparkContext._gateway
 
 
 class SparkBackend(Py4JBackend):
     def __init__(
-        self,
-        idempotent,
-        sc,
-        spark_conf,
-        app_name,
-        master,
-        local,
-        log,
-        quiet,
-        append,
-        min_block_size,
-        branching_factor,
-        tmpdir,
-        local_tmpdir,
-        skip_logging_configuration,
+        self: 'SparkBackend',
+        sc: pyspark.SparkContext | None,
+        spark_conf: Dict[str, Any] | None,
+        app_name: str | None,
+        master: str | None,
+        local: str | None,
+        log: str,
+        quiet: bool,
+        append: bool,
+        min_block_size: int,
+        branching_factor: int,
+        tmpdir: str,
+        local_tmpdir: str,
+        skip_logging_configuration: bool,
         *,
         gcs_requester_pays_config: Optional[GCSRequesterPaysConfiguration] = None,
         copy_log_on_error: bool = False,
     ):
-        try:
-            local_jar_info = local_jar_information()
-        except ValueError:
-            local_jar_info = None
+        sc = sc or pyspark.SparkContext._active_spark_context
+        self._hail_managed_spark = sc is None
 
-        if local_jar_info is not None:
-            conf = pyspark.SparkConf()
+        self._gateway = _get_or_create_pyspark_gateway(sc, spark_conf, local_tmpdir, quiet)
+        jvm = self._gateway.jvm
 
-            base_conf = spark_conf or {}
-            for k, v in base_conf.items():
-                conf.set(k, v)
+        raise_when_mismatched_hail_versions(jvm)
 
-            jars = [local_jar_info.path]
-            extra_classpath = local_jar_info.extra_classpath
-
-            if os.environ.get('HAIL_SPARK_MONITOR') or os.environ.get('AZURE_SPARK') == '1':
-                import sparkmonitor
-
-                jars.append(os.path.join(os.path.dirname(sparkmonitor.__file__), 'listener.jar'))
-                append_to_comma_separated_list(
-                    conf, 'spark.extraListeners', 'sparkmonitor.listener.JupyterSparkMonitorListener'
-                )
-
-            append_to_comma_separated_list(conf, 'spark.jars', *jars)
-            if os.environ.get('AZURE_SPARK') == '1':
-                print('AZURE_SPARK environment variable is set to "1", assuming you are in HDInsight.')
-                # Setting extraClassPath in HDInsight overrides the classpath entirely so you can't
-                # load the Scala standard library. Interestingly, setting extraClassPath is not
-                # necessary in HDInsight.
-            else:
-                append_to_comma_separated_list(conf, 'spark.driver.extraClassPath', *jars, *extra_classpath)
-                append_to_comma_separated_list(
-                    conf, 'spark.executor.extraClassPath', './hail-all-spark.jar', *extra_classpath
-                )
-
-            if sc is None:
-                pyspark.SparkContext._ensure_initialized(conf=conf)
-            elif not quiet:
-                sys.stderr.write(
-                    'pip-installed Hail requires additional configuration options in Spark referring\n'
-                    '  to the path to the Hail Python module directory HAIL_DIR,\n'
-                    '  e.g. /path/to/python/site-packages/hail:\n'
-                    '    spark.jars=HAIL_DIR/backend/hail-all-spark.jar\n'
-                    '    spark.driver.extraClassPath=HAIL_DIR/backend/hail-all-spark.jar\n'
-                    '    spark.executor.extraClassPath=./hail-all-spark.jar'
-                )
+        _is = getattr(jvm, 'is')
+        JSparkBackend = _is.hail.backend.spark.SparkBackend
+        if sc is not None:
+            self._spark = pyspark.sql.SparkSession(sc)
         else:
-            pyspark.SparkContext._ensure_initialized()
+            jspark_session = JSparkBackend.pySparkSession(app_name, master, local, min_block_size)
+            jsc = jvm.JavaSparkContext(jspark_session.sparkContext())
+            sc = pyspark.SparkContext(gateway=self._gateway, jsc=jsc)
+            self._spark = pyspark.sql.SparkSession(sc, jspark_session)
 
-        self._gateway = pyspark.SparkContext._gateway
-        jvm = pyspark.SparkContext._jvm
-        assert jvm
-
-        hail_package = getattr(jvm, 'is').hail
-        jsc = sc._jsc.sc() if sc else None
-
-        if idempotent:
-            jbackend = hail_package.backend.spark.SparkBackend.getOrCreate(
-                jsc,
-                app_name,
-                master,
-                local,
-                log,
-                True,
-                append,
-                skip_logging_configuration,
-                min_block_size,
-            )
-        else:
-            jbackend = hail_package.backend.spark.SparkBackend.apply(
-                jsc,
-                app_name,
-                master,
-                local,
-                log,
-                True,
-                append,
-                skip_logging_configuration,
-                min_block_size,
-            )
-
-        self._jsc = jbackend.sc()
-        self.sc = sc if sc else pyspark.SparkContext(gateway=self._gateway, jsc=jvm.JavaSparkContext(self._jsc))
-        self._jspark_session = jbackend.sparkSession().apply()
-        self._spark_session = pyspark.sql.SparkSession(self.sc, self._jspark_session)
-
-        super().__init__(jvm, jbackend, local_tmpdir, tmpdir)
-        self.gcs_requester_pays_configuration = gcs_requester_pays_config
-
-        self._logger = None
+        py4jutils = scala_package_object(_is.hail.utils)
+        if not skip_logging_configuration:
+            py4jutils.configureLogging(log, quiet, append)
 
         if not quiet:
-            sys.stderr.write('Running on Apache Spark version {}\n'.format(self.sc.version))
-            if self._jsc.uiWebUrl().isDefined():
-                sys.stderr.write('SparkUI available at {}\n'.format(self._jsc.uiWebUrl().get()))
+            connect_logger(py4jutils, 'localhost', 12888)
 
-            jbackend.pyStartProgressBar()
+            sys.stderr.write(f'Running on Apache Spark version {self._spark.version}\n')
+            if (uiUrl := self._spark.sparkContext.uiWebUrl) is not None:
+                sys.stderr.write(f'SparkUI available at {uiUrl}\n')
 
         flags: Dict[str, str] = {}
         if branching_factor is not None:
             flags['branching_factor'] = str(branching_factor)
 
-        self._initialize_flags(flags)
+        jbackend = JSparkBackend.getOrCreate(self._spark._jsparkSession)
+        super().__init__(jvm, jbackend, flags)
 
-        self._router_async_fs = RouterAsyncFS(
-            gcs_kwargs={"gcs_requester_pays_configuration": gcs_requester_pays_config}
-        )
+        self._fs = None
+        self._router_fs = None
 
-        self._tmpdir = tmpdir
+        self.remote_tmpdir = tmpdir
+        self.local_tmpdir = local_tmpdir
+        self.gcs_requester_pays_configuration = gcs_requester_pays_config
         self._copy_log_on_error = copy_log_on_error
 
+        self.logger.info(f'Hail {__version__}')
+
     def validate_file(self, uri: str) -> None:
-        async_to_blocking(validate_file(uri, self._router_async_fs))
+        async_to_blocking(validate_file(uri, self.router_fs.afs))
+
+    @property
+    def fs(self) -> FS:
+        if self._fs is None:
+            self._fs = HadoopFS(self._utils_package_object, self._jbackend.pyFs())
+        return self._fs
+
+    @fs.setter
+    def fs(self, fs: FS | None) -> None:
+        assert isinstance(fs, HadoopFS | None)
+        self._fs = fs
+
+    @property
+    def router_fs(self) -> RouterFS:
+        if self._router_fs is None:
+            self._router_fs = RouterFS(
+                gcs_kwargs={"gcs_requester_pays_configuration": self.gcs_requester_pays_configuration},
+            )
+        return self._router_fs
+
+    @router_fs.setter
+    def router_fs(self, router_fs: RouterFS | None) -> None:
+        if self._router_fs is not None:
+            self._router_fs.close()
+
+        self._router_fs = router_fs
+
+    @Py4JBackend.gcs_requester_pays_configuration.setter
+    def gcs_requester_pays_configuration(self, config: GCSRequesterPaysConfiguration | None):
+        Py4JBackend.gcs_requester_pays_configuration.__set__(self, config)
+        self.router_fs = None
 
     def stop(self):
         super().stop()
-        self.sc.stop()
-        self.sc = None
+        if self._hail_managed_spark:
+            self._spark.stop()
+            self._gateway.shutdown()
+
+            # clean up pyspark's global state to support
+            # re-init with different spark conf
+            with pyspark.SparkContext._lock:
+                pyspark.SparkContext._gateway = None
+                pyspark.SparkContext._jvm = None
+
+        self.router_fs = None
 
     def from_spark(self, df, key):
         result_tuple = self._jbackend.pyFromDF(df._jdf, key)
@@ -177,13 +208,7 @@ class SparkBackend(Py4JBackend):
         t = t.expand_types()
         if flatten:
             t = t.flatten()
-        return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._render_ir(t._tir)), self._spark_session)
-
-    def register_ir_function(self, name, type_parameters, argument_names, argument_types, return_type, body):
-        r = CSERenderer()
-        assert not body._ir.uses_randomness
-        code = r(body._ir)
-        self._register_ir_function(name, type_parameters, argument_names, argument_types, return_type, code)
+        return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._render_ir(t._tir)), self._spark)
 
     def execute(self, ir: BaseIR, timed: bool = False) -> Any:
         try:
@@ -191,7 +216,7 @@ class SparkBackend(Py4JBackend):
         except Exception as err:
             if self._copy_log_on_error:
                 try:
-                    copy_log(self._tmpdir)
+                    copy_log(self.remote_tmpdir)
                 except Exception as fatal:
                     raise err from fatal
 

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -31,14 +31,14 @@ def _get_tmpdir(tmpdir):
     return tmpdir
 
 
-def _get_local_tmpdir(local_tmpdir):
+def _get_local_tmpdir(local_tmpdir) -> str:
     local_tmpdir = get_env_or_default(local_tmpdir, 'TMPDIR', 'file:///tmp')
     r = urlparse(local_tmpdir)
     if not r.scheme:
         r = r._replace(scheme='file')
     elif r.scheme != 'file':
         raise ValueError('invalid local_tmpfile: must use scheme file, got scheme {r.scheme}')
-    return urlunparse(r)
+    return str(urlunparse(r))
 
 
 def _get_log(log):
@@ -401,7 +401,6 @@ def init(
             tmp_dir=tmp_dir,
             local_tmpdir=local_tmpdir,
             default_reference=default_reference,
-            idempotent=idempotent,
             global_seed=global_seed,
             skip_logging_configuration=skip_logging_configuration,
             gcs_requester_pays_configuration=gcs_requester_pays_configuration,
@@ -433,7 +432,6 @@ def init(
     branching_factor=int,
     tmp_dir=nullable(str),
     default_reference=enumeration(*BUILTIN_REFERENCES),
-    idempotent=bool,
     global_seed=nullable(int),
     spark_conf=nullable(dictof(str, str)),
     skip_logging_configuration=bool,
@@ -453,7 +451,6 @@ def init_spark(
     branching_factor=50,
     tmp_dir=None,
     default_reference='GRCh37',
-    idempotent=False,
     global_seed=None,
     spark_conf=None,
     skip_logging_configuration=False,
@@ -461,7 +458,6 @@ def init_spark(
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
     copy_log_on_error: bool = False,
 ):
-    from hail.backend.py4j_backend import connect_logger
     from hail.backend.spark_backend import SparkBackend
 
     log = _get_log(log)
@@ -474,7 +470,6 @@ def init_spark(
     )
 
     backend = SparkBackend(
-        idempotent,
         sc,
         spark_conf,
         app_name,
@@ -495,8 +490,6 @@ def init_spark(
         backend.fs.mkdir(tmpdir)
 
     HailContext.create(log, quiet, append, default_reference, global_seed, backend)
-    if not quiet:
-        connect_logger(backend._utils_package_object, 'localhost', 12888)
 
 
 @typecheck(
@@ -593,13 +586,12 @@ def init_local(
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
 ):
     from hail.backend.local_backend import LocalBackend
-    from hail.backend.py4j_backend import connect_logger
 
     log = _get_log(log)
     tmpdir = _get_tmpdir(tmpdir)
 
     jvm_heap_size = get_env_or_default(jvm_heap_size, 'HAIL_LOCAL_BACKEND_HEAP_SIZE', None)
-    backend = LocalBackend(
+    backend = LocalBackend.create(
         tmpdir,
         log,
         quiet,
@@ -614,13 +606,12 @@ def init_local(
         backend.fs.mkdir(tmpdir)
 
     HailContext.create(log, quiet, append, default_reference, global_seed, backend)
-    if not quiet:
-        connect_logger(backend._utils_package_object, 'localhost', 12888)
 
 
 def _hail_cite_url():
     [tag, sha_prefix] = __version__.split("-")
-    if not local_jar_information().development_mode:
+    is_devel, *_ = local_jar_information()
+    if not is_devel:
         # pip installed
         return f"https://github.com/hail-is/hail/releases/tag/{tag}"
     return f"https://github.com/hail-is/hail/commit/{sha_prefix}"
@@ -670,7 +661,7 @@ def spark_context():
     -------
     :class:`pyspark.SparkContext`
     """
-    return Env.spark_backend('spark_context').sc
+    return Env.spark_backend('spark_context')._spark.sparkContext
 
 
 def tmp_dir() -> str:
@@ -919,4 +910,11 @@ def debug_info():
     spark_conf = None
     if isinstance(Env.backend(), SparkBackend):
         spark_conf = spark_context()._conf.getAll()
-    return {'spark_conf': spark_conf, 'local_jar_information': local_jar_information(), 'version': __version__}
+
+    _, hail_jar, classpath = local_jar_information()
+    return {
+        'version': __version__,
+        'hail_jar': hail_jar,
+        'classpath': classpath,
+        'spark_conf': spark_conf,
+    }

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -81,10 +81,8 @@ class Env:
         from hail.backend.py4j_backend import Py4JBackend
 
         b = Env.backend()
-        if isinstance(b, Py4JBackend):
-            return b
-        else:
-            raise NotImplementedError(f"{b.__class__.__name__} doesn't support {op}, only Py4JBackend")
+        assert isinstance(b, Py4JBackend), f"{b.__class__.__name__} doesn't support {op}, only Py4JBackend"
+        return b
 
     @staticmethod
     def spark_backend(op):
@@ -102,7 +100,7 @@ class Env:
 
     @staticmethod
     def spark_session():
-        return Env.backend()._spark_session
+        return Env.spark_backend('Env.spark_session')._spark
 
     _dummy_table = None
 

--- a/hail/python/test/hail/backend/test_spark_backend.py
+++ b/hail/python/test/hail/backend/test_spark_backend.py
@@ -1,17 +1,20 @@
 import os
 
+import pyspark
 import pytest
 
 import hail as hl
-from test.hail.helpers import skip_unless_spark_backend
+from hail.backend.spark_backend import _get_or_create_pyspark_gateway
+from hail.utils.java import Env
+from test.hail.helpers import hl_init_for_test
+
+pytestmark = [pytest.mark.backend('spark'), pytest.mark.uninitialized]
 
 
 def fatal(typ: hl.HailType, msg: str = "") -> hl.Expression:
     return hl.construct_expr(hl.ir.Die(hl.to_expr(msg, hl.tstr)._ir, typ), typ)
 
 
-@pytest.mark.uninitialized
-@pytest.mark.backend('spark')
 @pytest.mark.parametrize('copy', [True, False])
 def test_copy_spark_log(tmpdir, copy):
     hl.init(copy_spark_log_on_error=copy, tmp_dir=str(tmpdir))
@@ -20,8 +23,6 @@ def test_copy_spark_log(tmpdir, copy):
     with pytest.raises(Exception):
         hl.eval(expr)
 
-    from hail.utils.java import Env
-
     hc = Env.hc()
     _, filename = os.path.split(hc._log)
     log = os.path.join(hc._tmpdir, filename)
@@ -29,22 +30,56 @@ def test_copy_spark_log(tmpdir, copy):
     assert Env.fs().exists(log) == copy
 
 
-@skip_unless_spark_backend()
-def test_idempotent_init():
+def test_init_without_existing_spark_context(request):
+    hl_init_for_test(app_name=request.node.name, quiet=True)
+    sc = Env.spark_session().sparkContext
+    hl.stop()
+
+    assert getattr(sc, '_jsc', None) is None, 'SparkBackend.close() did not stop the SparkContext.'
+
+
+def test_init_with_existing_spark_context(request):
     """
     Simulate sharing a spark context across notebook sessions.
     The first notebook successfully initialised hail.
-    The second re-uses the same context and calls init with idempotent=True
+    The second re-uses the same context.
     """
 
-    from hail.backend.py4j_backend import uninstall_exception_handler
-    from hail.utils.java import Env
+    gateway = _get_or_create_pyspark_gateway(None, None, quiet=True)
+    JCons = getattr(gateway.jvm, 'is').hail.backend.spark.SparkBackend
+    jspark = JCons.pySparkSession(request.node.name, 'local[1]', None, 0)
+    sc = pyspark.SparkContext(gateway=gateway, jsc=gateway.jvm.JavaSparkContext(jspark.sparkContext()))
 
-    sc = Env.backend().sc
+    try:
+        hl_init_for_test(sc=sc, quiet=True)
+        assert sc == Env.spark_session().sparkContext
 
-    # Setup globals to simulate new notebook session
-    # please don't do this!
-    Env._hc = None
-    uninstall_exception_handler()
+        hl.stop()
 
-    hl.init(sc, idempotent=True)
+        assert (jsc := getattr(sc, '_jsc', None)) is not None
+        assert not jsc.sc().isStopped(), 'SparkBackend.close() should not stop a SparkContext it does not own.'
+    finally:
+        sc.stop()
+        gateway.close()
+
+
+@pytest.mark.parametrize('quiet', [True, False])
+def test_console_progress_bar_quiet(quiet):
+    hl.init(quiet=quiet)
+    conf = hl.spark_context().getConf()
+    assert conf.get('spark.ui.showConsoleProgress') == str(not quiet).lower()
+
+
+def test_set_local_dir(tmp_path):
+    hl.init(local_tmpdir=str(tmp_path))
+    conf = hl.spark_context().getConf()
+    assert conf.get('spark.local.dir') == str(tmp_path)
+    assert hl.current_backend().local_tmpdir == f'file://{tmp_path}'
+
+
+def test_set_local_dir_if_missing(tmp_path):
+    hl.init(spark_conf={'spark.local.dir': str(tmp_path)}, local_tmpdir='/does/not/exist')
+    conf = hl.spark_context().getConf()
+    assert conf.get('spark.local.dir') == str(tmp_path)
+
+    assert hl.current_backend().local_tmpdir == 'file:///does/not/exist'

--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -6,7 +6,7 @@ import hail as hl
 from hail.backend.backend import Backend
 from hail.backend.spark_backend import SparkBackend
 from hail.utils.java import Env
-from test.hail.helpers import hl_init_for_test, hl_stop_for_test, qobtest, skip_unless_spark_backend, with_flags
+from test.hail.helpers import hl_init_for_test, hl_stop_for_test, qobtest, with_flags
 
 
 def _scala_map_str_to_tuple_str_str_to_dict(scala) -> Dict[str, Tuple[Optional[str], Optional[str]]]:
@@ -60,12 +60,9 @@ def test_get_flags():
     assert list(hl._get_flags('use_new_shuffle')) == ['use_new_shuffle']
 
 
-@skip_unless_spark_backend(reason='requires JVM')
+@pytest.mark.backend('spark', 'local')
 def test_flags_same_in_scala_and_python():
-    b = hl.current_backend()
-    assert isinstance(b, SparkBackend)
-
-    scala_flag_map = _scala_map_str_to_tuple_str_str_to_dict(b._hail_package.HailFeatureFlags.defaults())
+    scala_flag_map = _scala_map_str_to_tuple_str_str_to_dict(Env.hail().HailFeatureFlags.defaults())
     assert scala_flag_map == Backend._flags_env_vars_and_defaults
 
 


### PR DESCRIPTION
This change came about from getting the batch backend to run in a py4j context.
I found the initialisation code in python quite busy and wanted to clean it up.

The goal is to move as much functionality into the python `Py4JBackend`
so that it can accept any scala executor wrapped in the scala `Py4JQueryBackend`
class. This change gets pretty close to that goal with the exception of creating
and managing the lifetime of the jvm and spark context.

The main changes are as follows:

1. `SparkBackend`​ creates a `SparkSession` instead of a `SparkContext`.
Why?
    - Because we need a `SparkSession` to convert to and from data frames in python.
    - You can get the `SparkSession`'s underlying `SparkContext`,
    - You cannot create a `SparkSession` with `SparkContext` directly, and
    - you get warnings about reusing an existing `SparkContext` when doing so.
2. Configures spark progress bar via `SparkConf`​ rather than hacking the scala code.
3. Uses `SparkBackend.getOrCreate`​ from python to use idempotent initialisation by default.
4. Moves logging configuration calls into python
    - I think this is cleaner
5. Warns when setting the local tmpdir when using the `SparkBackend` instead of doing nothing
6. Better support for using an existing `SparkContext`
    - Don't stop a `SparkContext` that we didn't create
    - Use spark's job groups to cancel only those jobs in a stage

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP