### PR TITLE
[query] simplify `DeployContext`

### DIFF
--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -135,8 +135,6 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
 
     log.info(f"${getClass.getName} $HAIL_PRETTY_VERSION")
 
-    val deployConfig = DeployConfig.fromConfigFile("/deploy-config/deploy-config.json")
-    DeployConfig.set(deployConfig)
     sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 
     val (rpcConfig, jobConfig, action, payload) = {
@@ -187,7 +185,10 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
     val backend =
       new ServiceBackend(
         name,
-        BatchClient(deployConfig, Path.of(scratchDir, "secrets/gsa-key/key.json")),
+        BatchClient(
+          DeployConfig.fromConfigFile("/deploy-config/deploy-config.json"),
+          Path.of(scratchDir, "secrets/gsa-key/key.json"),
+        ),
         JarUrl(jarLocation),
         BatchConfig.fromConfigFile(Path.of(scratchDir, "batch-config/batch-config.json")),
         jobConfig,

--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -175,8 +175,6 @@ object Worker extends Logging {
     val index = argv(6).toInt
     val timer = new WorkerTimer()
 
-    val deployConfig = DeployConfig.fromConfigFile("/deploy-config/deploy-config.json")
-    DeployConfig.set(deployConfig)
     sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 
     log.info(s"${getClass.getName} $HAIL_REVISION")

--- a/hail/hail/src/is/hail/services/DeployConfig.scala
+++ b/hail/hail/src/is/hail/services/DeployConfig.scala
@@ -8,18 +8,7 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods
 
 object DeployConfig {
-  private[this] lazy val default: DeployConfig = fromConfigFile()
-  private[this] var _get: DeployConfig = null
-
-  def set(x: DeployConfig) =
-    _get = x
-
-  def get(): DeployConfig = {
-    if (_get == null) {
-      _get = default
-    }
-    _get
-  }
+  lazy val default: DeployConfig = fromConfigFile()
 
   def fromConfigFile(file0: String = null): DeployConfig = {
     var file = file0

--- a/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
+++ b/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
@@ -25,15 +25,21 @@ class BatchClientSuite extends TestNGSuite {
 
   @BeforeClass
   def createClientAndBatch(): Unit = {
-    client = BatchClient(DeployConfig.get(), Path.of("/test-gsa-key/key.json"))
-    batchId = client.newBatch(
-      BatchRequest(
-        billing_project = "test",
-        n_jobs = 0,
-        token = tokenUrlSafe,
-        attributes = Map("name" -> s"${getClass.getName}"),
+    client =
+      BatchClient(
+        DeployConfig.default,
+        Path.of("/test-gsa-key/key.json"),
       )
-    )
+
+    batchId =
+      client.newBatch(
+        BatchRequest(
+          billing_project = "test",
+          n_jobs = 0,
+          token = tokenUrlSafe,
+          attributes = Map("name" -> s"${getClass.getName}"),
+        )
+      )
   }
 
   @BeforeMethod


### PR DESCRIPTION
This PR refactors the DeployConfig handling to eliminate global state. Instead of using a global singleton with `set()` and `get()` methods, the code now passes DeployConfig instances directly to the components that need them. 

This change has no impact on the Broad-managed hail batch deployment in GCP.