### PR TITLE
[query] read hail-generated cloud credentails

### DIFF
--- a/hail/hail/src/is/hail/backend/driver/BackendRpc.scala
+++ b/hail/hail/src/is/hail/backend/driver/BackendRpc.scala
@@ -9,17 +9,15 @@ import is.hail.io.plink.LoadPlink
 import is.hail.io.vcf.LoadVCF
 import is.hail.types.virtual.{Kind, TFloat64}
 import is.hail.types.virtual.Kinds._
-import is.hail.utils.{using, BoxedArrayBuilder, ExecutionTimer, FastSeq}
+import is.hail.utils.{jsonToBytes, using, BoxedArrayBuilder, ExecutionTimer, FastSeq}
 import is.hail.utils.ExecutionTimer.Timings
 import is.hail.variant.ReferenceGenome
 
 import scala.util.control.NonFatal
 
 import java.io.ByteArrayOutputStream
-import java.nio.charset.StandardCharsets
 
 import org.json4s.{DefaultFormats, Extraction, Formats, JArray, JValue}
-import org.json4s.jackson.JsonMethods
 
 case class SerializedIRFunction(
   name: String,
@@ -145,9 +143,6 @@ trait BackendRpc {
     } catch {
       case NonFatal(error) => R.failure(env, error)
     }
-
-  def jsonToBytes(v: JValue): Array[Byte] =
-    JsonMethods.compact(v).getBytes(StandardCharsets.UTF_8)
 
   private[this] def withRegisterSerializedFns[A](
     ctx: ExecuteContext,

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -9,6 +9,7 @@ import is.hail.expr.ir.lowering.IrMetadata
 import is.hail.io.fs.{CloudStorageFSConfig, FS, RouterFS}
 import is.hail.io.reference.{IndexedFastaSequenceFile, LiftOver}
 import is.hail.services._
+import is.hail.services.oauth2.CloudCredentials
 import is.hail.types.virtual.Kinds._
 import is.hail.utils._
 import is.hail.utils.ExecutionTimer.Timings
@@ -187,7 +188,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
         name,
         BatchClient(
           DeployConfig.fromConfigFile("/deploy-config/deploy-config.json"),
-          Path.of(scratchDir, "secrets/gsa-key/key.json"),
+          CloudCredentials(Some(Path.of(scratchDir, "secrets/gsa-key/key.json"))),
         ),
         JarUrl(jarLocation),
         BatchConfig.fromConfigFile(Path.of(scratchDir, "batch-config/batch-config.json")),

--- a/hail/hail/src/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/hail/src/is/hail/io/fs/AzureStorageFS.scala
@@ -12,7 +12,6 @@ import is.hail.shadedazure.com.azure.storage.blob.models.{
   BlobItem, BlobRange, BlobStorageException, ListBlobsOptions,
 }
 import is.hail.shadedazure.com.azure.storage.blob.specialized.BlockBlobClient
-import is.hail.utils.FastSeq
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -59,8 +58,8 @@ object AzureStorageFS {
   private val AZURE_HTTPS_URI_REGEX =
     "^https:\\/\\/([a-z0-9_\\-\\.]+)\\.blob\\.core\\.windows\\.net\\/([a-z0-9_\\-\\.]+)(\\/.*)?".r
 
-  val RequiredOAuthScopes: IndexedSeq[String] =
-    FastSeq("https://storage.azure.com/.default")
+  val RequiredOAuthScopes: Array[String] =
+    Array("https://storage.azure.com/.default")
 
   def parseUrl(filename: String): AzureStorageFSURL = {
     AZURE_HTTPS_URI_REGEX

--- a/hail/hail/src/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/hail/src/is/hail/io/fs/GoogleStorageFS.scala
@@ -44,8 +44,8 @@ object GoogleStorageFS {
 
   private[this] val GCS_URI_REGEX = "^gs:\\/\\/([a-z0-9_\\-\\.]+)(\\/.*)?".r
 
-  val RequiredOAuthScopes: IndexedSeq[String] =
-    FastSeq("https://www.googleapis.com/auth/devstorage.read_write")
+  val RequiredOAuthScopes: Array[String] =
+    Array("https://www.googleapis.com/auth/devstorage.read_write")
 
   def parseUrl(filename: String): GoogleStorageFSURL = {
     val scheme = filename.split(":")(0)

--- a/hail/hail/src/is/hail/io/fs/TerraAzureStorageFS.scala
+++ b/hail/hail/src/is/hail/io/fs/TerraAzureStorageFS.scala
@@ -16,8 +16,8 @@ import org.json4s.jackson.JsonMethods
 object TerraAzureStorageFS {
   private val TEN_MINUTES_IN_MS = 10 * 60 * 1000
 
-  val RequiredOAuthScopes: IndexedSeq[String] =
-    FastSeq("https://management.azure.com/.default")
+  val RequiredOAuthScopes: Array[String] =
+    Array("https://management.azure.com/.default")
 }
 
 class TerraAzureStorageFS(credential: AzureCloudCredentials) extends AzureStorageFS(credential) {

--- a/hail/hail/src/is/hail/services/oauth2.scala
+++ b/hail/hail/src/is/hail/services/oauth2.scala
@@ -2,41 +2,57 @@ package is.hail.services
 
 import is.hail.services.oauth2.AzureCloudCredentials.AzureTokenRefreshMinutes
 import is.hail.services.oauth2.AzureCloudCredentials.EnvVars.AzureApplicationCredentials
-import is.hail.services.oauth2.GoogleCloudCredentials.EnvVars.GoogleApplicationCredentials
 import is.hail.shadedazure.com.azure.core.credential.{
   AccessToken, TokenCredential, TokenRequestContext,
 }
 import is.hail.shadedazure.com.azure.identity.{
   ClientSecretCredentialBuilder, DefaultAzureCredentialBuilder,
 }
-import is.hail.utils.{defaultJSONFormats, using}
+import is.hail.utils.{jsonToBytes, using}
 
 import scala.collection.JavaConverters._
 
-import java.io.Serializable
+import java.io.{ByteArrayInputStream, Serializable}
 import java.nio.file.{Files, Path}
 import java.time.OffsetDateTime
 
-import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
-import org.json4s.Formats
+import com.google.auth.oauth2.GoogleCredentials
+import org.json4s.{DefaultFormats, Formats, JValue}
 import org.json4s.jackson.JsonMethods
 
 object oauth2 {
 
   sealed trait CloudCredentials extends Product with Serializable {
     def accessToken: String
+    def scoped(scopes: Array[String]): CloudCredentials
   }
 
-  def CloudCredentials(
-    keyPath: Path,
-    scopes: IndexedSeq[String],
-    env: Map[String, String] = sys.env,
-  ): CloudCredentials =
+  implicit lazy val fmts: Formats = DefaultFormats
+
+  def HailCredentials(env: Map[String, String] = sys.env): Option[CloudCredentials] =
+    for {
+      config <-
+        env
+          .get("XDG_CONFIG_HOME")
+          .map(Path.of(_))
+          .orElse(env.get("HOME").map(Path.of(_, ".config")))
+
+      identity = config.resolve("hail/identity.json").toFile
+      if identity.exists()
+
+      jvalue <- JsonMethods.parseOpt(identity)
+    } yield (jvalue \ "idp").extract[String] match {
+      case "Google" => GoogleCloudCredentials.fromJson(jvalue \ "credentials")
+      case "Microsoft" => AzureCloudCredentials.fromJson(jvalue \ "credentials")
+      case other => throw new IllegalArgumentException(s"Unknown identity provider: '$other'")
+    }
+
+  def CloudCredentials(keyPath: Option[Path], env: Map[String, String] = sys.env)
+    : CloudCredentials =
     env.get("HAIL_CLOUD") match {
-      case Some("gcp") => GoogleCloudCredentials(Some(keyPath), scopes, env)
-      case Some("azure") => AzureCloudCredentials(Some(keyPath), scopes, env)
+      case None | Some("gcp") => GoogleCloudCredentials(keyPath)
+      case Some("azure") => AzureCloudCredentials(keyPath, env)
       case Some(cloud) => throw new IllegalArgumentException(s"Unknown cloud: '$cloud'")
-      case None => throw new IllegalArgumentException(s"HAIL_CLOUD must be set.")
     }
 
   case class GoogleCloudCredentials(value: GoogleCredentials) extends CloudCredentials {
@@ -44,32 +60,34 @@ object oauth2 {
       value.refreshIfExpired()
       value.getAccessToken.getTokenValue
     }
+
+    override def scoped(scopes: Array[String]): GoogleCloudCredentials =
+      GoogleCloudCredentials(value.createScoped(scopes: _*))
   }
 
   object GoogleCloudCredentials {
-    object EnvVars {
-      val GoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
-    }
-
-    def apply(keyPath: Option[Path], scopes: IndexedSeq[String], env: Map[String, String] = sys.env)
-      : GoogleCloudCredentials =
+    def fromJson(jv: JValue): GoogleCloudCredentials =
       GoogleCloudCredentials {
-        val creds: GoogleCredentials =
-          keyPath.orElse(env.get(GoogleApplicationCredentials).map(Path.of(_))) match {
-            case Some(path) =>
-              using(Files.newInputStream(path))(ServiceAccountCredentials.fromStream)
-            case None =>
-              GoogleCredentials.getApplicationDefault
-          }
+        GoogleCredentials.fromStream(
+          new ByteArrayInputStream(jsonToBytes(jv))
+        )
+      }
 
-        creds.createScoped(scopes: _*)
+    def apply(keyPath: Option[Path]): GoogleCloudCredentials =
+      GoogleCloudCredentials {
+        keyPath match {
+          case Some(path) =>
+            using(Files.newInputStream(path))(GoogleCredentials.fromStream)
+          case None =>
+            GoogleCredentials.getApplicationDefault
+        }
       }
   }
 
   sealed trait AzureCloudCredentials extends CloudCredentials {
 
     def value: TokenCredential
-    def scopes: IndexedSeq[String]
+    def scopes: Array[String]
 
     @transient private[this] var token: AccessToken = _
 
@@ -78,11 +96,13 @@ object oauth2 {
       token.getToken
     }
 
+    override def scoped(scopes: Array[String]): AzureCloudCredentials
+
     private[this] def refreshIfRequired(): Unit =
       if (!isExpired) token.getToken
       else synchronized {
         if (isExpired) {
-          token = value.getTokenSync(new TokenRequestContext().setScopes(scopes.asJava))
+          token = value.getTokenSync(new TokenRequestContext().setScopes(scopes.toSeq.asJava))
         }
 
         token.getToken: Unit
@@ -99,33 +119,52 @@ object oauth2 {
       val AzureApplicationCredentials = "AZURE_APPLICATION_CREDENTIALS"
     }
 
+    val DefaultOAuth2Scopes: Array[String] =
+      Array(".default")
+
     private[AzureCloudCredentials] val AzureTokenRefreshMinutes = 5
 
-    def apply(keyPath: Option[Path], scopes: IndexedSeq[String], env: Map[String, String] = sys.env)
-      : AzureCloudCredentials =
+    def fromJson(jv: JValue, scopes: Array[String] = DefaultOAuth2Scopes): AzureCloudCredentials =
+      AzureClientSecretCredentials(
+        clientId = (jv \ "appId").extract[String],
+        tenantId = (jv \ "tenant").extract[String],
+        secret = (jv \ "password").extract[String],
+        scopes = scopes,
+      )
+
+    def apply(keyPath: Option[Path], env: Map[String, String] = sys.env): AzureCloudCredentials =
       keyPath.orElse(env.get(AzureApplicationCredentials).map(Path.of(_))) match {
-        case Some(path) => AzureClientSecretCredentials(path, scopes)
-        case None => AzureDefaultCredentials(scopes)
+        case Some(path) =>
+          using(Files.newInputStream(path)) { in =>
+            fromJson(JsonMethods.parse(in), DefaultOAuth2Scopes)
+          }
+        case None =>
+          AzureDefaultCredentials(DefaultOAuth2Scopes)
       }
   }
 
-  private case class AzureDefaultCredentials(scopes: IndexedSeq[String])
-      extends AzureCloudCredentials {
+  private case class AzureDefaultCredentials(scopes: Array[String]) extends AzureCloudCredentials {
     @transient override lazy val value: TokenCredential =
       new DefaultAzureCredentialBuilder().build()
+
+    override def scoped(scopes: Array[String]): AzureDefaultCredentials =
+      copy(scopes)
   }
 
-  private case class AzureClientSecretCredentials(path: Path, scopes: IndexedSeq[String])
-      extends AzureCloudCredentials {
+  private case class AzureClientSecretCredentials(
+    clientId: String,
+    tenantId: String,
+    secret: String,
+    scopes: Array[String],
+  ) extends AzureCloudCredentials {
     @transient override lazy val value: TokenCredential =
-      using(Files.newInputStream(path)) { is =>
-        implicit val fmts: Formats = defaultJSONFormats
-        val kvs = JsonMethods.parse(is)
-        new ClientSecretCredentialBuilder()
-          .clientId((kvs \ "appId").extract[String])
-          .clientSecret((kvs \ "password").extract[String])
-          .tenantId((kvs \ "tenant").extract[String])
-          .build()
-      }
+      new ClientSecretCredentialBuilder()
+        .clientId(clientId)
+        .clientSecret(secret)
+        .tenantId(tenantId)
+        .build()
+
+    override def scoped(scopes: Array[String]): AzureClientSecretCredentials =
+      copy(scopes = scopes)
   }
 }

--- a/hail/hail/src/is/hail/utils/package.scala
+++ b/hail/hail/src/is/hail/utils/package.scala
@@ -14,6 +14,7 @@ import scala.util.control.NonFatal
 import java.io._
 import java.lang.reflect.Method
 import java.net.{URI, URLClassLoader}
+import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.text.SimpleDateFormat
 import java.util
@@ -30,9 +31,9 @@ import org.apache.hadoop.mapreduce.lib.input.{FileSplit => NewFileSplit}
 import org.apache.log4j.Level
 import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.sql.Row
-import org.json4s.{Extraction, Formats, JObject, NoTypeHints, Serializer}
+import org.json4s.{Extraction, Formats, JObject, JValue, NoTypeHints, Serializer}
 import org.json4s.JsonAST.{JArray, JString}
-import org.json4s.jackson.Serialization
+import org.json4s.jackson.{JsonMethods, Serialization}
 import org.json4s.reflect.TypeInfo
 
 package utils {
@@ -1034,6 +1035,9 @@ package object utils
 
   implicit def evalLazy[A](f: Lazy[A]): A =
     f.force
+
+  def jsonToBytes(v: JValue): Array[Byte] =
+    JsonMethods.compact(v).getBytes(StandardCharsets.UTF_8)
 }
 
 class CancellingExecutorService(delegate: ExecutorService) extends AbstractExecutorService {

--- a/hail/hail/test/src/is/hail/io/fs/AzureStorageFSSuite.scala
+++ b/hail/hail/test/src/is/hail/io/fs/AzureStorageFSSuite.scala
@@ -17,7 +17,10 @@ class AzureStorageFSSuite extends TestNGSuite with FSSuite {
       throw new SkipException("skip")
 
   override lazy val fs: FS =
-    new AzureStorageFS(AzureCloudCredentials(None, AzureStorageFS.RequiredOAuthScopes))
+    new AzureStorageFS(
+      AzureCloudCredentials(None)
+        .scoped(AzureStorageFS.RequiredOAuthScopes)
+    )
 
   @Test def testMakeQualified(): Unit = {
     val qualifiedFileName = "https://account.blob.core.windows.net/container/path"

--- a/hail/hail/test/src/is/hail/io/fs/GoogleStorageFSSuite.scala
+++ b/hail/hail/test/src/is/hail/io/fs/GoogleStorageFSSuite.scala
@@ -17,7 +17,11 @@ class GoogleStorageFSSuite extends TestNGSuite with FSSuite {
       throw new SkipException("skip")
 
   override lazy val fs: FS =
-    new GoogleStorageFS(GoogleCloudCredentials(None, GoogleStorageFS.RequiredOAuthScopes), None)
+    new GoogleStorageFS(
+      GoogleCloudCredentials(None)
+        .scoped(GoogleStorageFS.RequiredOAuthScopes),
+      None,
+    )
 
   @Test def testMakeQualified(): Unit = {
     val qualifiedFileName = "gs://bucket/path"

--- a/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
+++ b/hail/hail/test/src/is/hail/services/BatchClientSuite.scala
@@ -3,6 +3,7 @@ package is.hail.services
 import is.hail.{services, HAIL_REVISION}
 import is.hail.backend.service.Main
 import is.hail.services.JobGroupStates.Failure
+import is.hail.services.oauth2.CloudCredentials
 import is.hail.utils._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -28,7 +29,7 @@ class BatchClientSuite extends TestNGSuite {
     client =
       BatchClient(
         DeployConfig.default,
-        Path.of("/test-gsa-key/key.json"),
+        CloudCredentials(Some(Path.of("/test-gsa-key/key.json"))),
       )
 
     batchId =


### PR DESCRIPTION
General improvements + enables reading hailctl-generated credentials. This will be useful for a later change that runs the batch backend in a py4j session.

This change does not impact the Broad-managed hail batch deployment in GCP.