### PR TITLE
[query] remove jvm creation from local backend

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -1,120 +1,93 @@
-import glob
 import os
-import sys
-from contextlib import ExitStack
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional
 
-from py4j.java_gateway import GatewayParameters, JavaGateway, launch_gateway
+from py4j.java_gateway import JavaGateway, JavaObject, Py4JJavaError
 
-from hail.ir import finalize_randomness
-from hail.ir.renderer import CSERenderer
+from hail.backend.backend import fatal_error_from_java_error_triplet
+from hail.backend.py4j_backend import Py4JBackend, connect_logger, start_py4j_gateway
+from hail.utils.java import scala_object, scala_package_object
 from hail.version import __version__
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
 from hailtop.aiotools.validators import validate_file
 from hailtop.fs.router_fs import RouterFS
-from hailtop.utils import async_to_blocking, find_spark_home
-
-from ..expr import Expression
-from ..expr.types import HailType
-from ..utils.java import scala_object, scala_package_object
-from .backend import local_jar_information
-from .py4j_backend import Py4JBackend, connect_logger, uninstall_exception_handler
+from hailtop.utils import async_to_blocking
 
 
 class LocalBackend(Py4JBackend):
+    @classmethod
+    def create(
+        cls,
+        tmpdir: str,
+        logfile: str,
+        quiet: bool,
+        append: bool,
+        branching_factor: int | None = None,
+        skip_logging_configuration: bool = False,
+        jvm_heap_size: str | None = None,
+        gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+    ) -> 'LocalBackend':
+        max_heap_size = jvm_heap_size or os.getenv('HAIL_LOCAL_BACKEND_HEAP_SIZE')
+        gateway = start_py4j_gateway(max_heap_size=max_heap_size)
+
+        try:
+            _is = getattr(gateway.jvm, 'is')
+            py4jutils = scala_package_object(_is.hail.utils)
+            try:
+                if not skip_logging_configuration:
+                    py4jutils.configureLogging(logfile, quiet, append)
+
+                if not quiet:
+                    connect_logger(py4jutils, 'localhost', 12888)
+
+                backend = LocalBackend(
+                    gateway,
+                    scala_object(_is.hail.backend.local, 'LocalBackend'),
+                    tmpdir,
+                    tmpdir,
+                    gcs_requester_pays_configuration,
+                    branching_factor,
+                )
+
+                backend.logger.info(f'Hail {__version__}')
+
+                return backend
+            except Py4JJavaError as e:
+                tpl = py4jutils.handleForPython(e.java_exception)
+                deepest, full, error_id = tpl._1(), tpl._2(), tpl._3()
+                raise fatal_error_from_java_error_triplet(deepest, full, error_id) from None
+        except:
+            gateway.shutdown()
+            raise
+
     def __init__(
         self,
-        tmpdir,
-        log,
-        quiet,
-        append,
-        branching_factor,
-        skip_logging_configuration,
-        jvm_heap_size,
-        gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+        jgateway: JavaGateway,
+        jbackend: JavaObject,
+        tmpdir: str,
+        remote_tmpdir: str,
+        gcs_requester_pays_configuration: GCSRequesterPaysConfiguration | None,
+        branching_factor: int | None = None,
+        optimizer_iterations: int | None = None,
     ):
-        self._exit_stack = ExitStack()
+        super().__init__(jgateway.jvm, jbackend, tmpdir, remote_tmpdir)
+        self._gateway = jgateway
 
-        spark_home = find_spark_home()
-        hail_jar_path = os.environ.get('HAIL_JAR')
-        if hail_jar_path is None:
-            try:
-                _, hail_jar_path, extra_classpath = local_jar_information()
-                extra_classpath = ':'.join([f'{spark_home}/jars/*', hail_jar_path, *extra_classpath])
-            except ValueError:
-                raise RuntimeError('local backend requires a packaged jar or HAIL_JAR to be set')
-        else:
-            extra_classpath = ':'.join([f'{spark_home}/jars/*', hail_jar_path])
-
-        jvm_opts = []
-        if jvm_heap_size is not None:
-            jvm_opts.append(f'-Xmx{jvm_heap_size}')
-
-        py4j_jars = glob.glob(f'{spark_home}/jars/py4j-*.jar')
-        if len(py4j_jars) == 0:
-            raise ValueError(f'No py4j JAR found in {spark_home}/jars')
-        if len(py4j_jars) > 1:
-            log.warning(f'found multiple p4yj jars arbitrarily choosing the first one: {py4j_jars}')
-
-        port = launch_gateway(
-            redirect_stdout=sys.stdout,
-            redirect_stderr=sys.stderr,
-            java_path=None,
-            javaopts=jvm_opts,
-            jarpath=py4j_jars[0],
-            classpath=extra_classpath,
-            die_on_exit=True,
-        )
-        self._gateway = JavaGateway(gateway_parameters=GatewayParameters(port=port, auto_convert=True))
-        self._exit_stack.callback(self._gateway.shutdown)
-
-        _is = getattr(self._gateway.jvm, 'is')
-        py4jutils = scala_package_object(_is.hail.utils)
-
-        if not skip_logging_configuration:
-            py4jutils.configureLogging(log, quiet, append)
-
-        if not quiet:
-            connect_logger(py4jutils, 'localhost', 12888)
-
-        py4jutils.log().info(f'Hail {__version__}')
-
-        jbackend = scala_object(_is.hail.backend.local, 'LocalBackend')
-        super().__init__(self._gateway.jvm, jbackend, tmpdir, tmpdir)
-        self.gcs_requester_pays_configuration = gcs_requester_pays_configuration
-        self._fs = None
-
-        flags: Dict[str, str] = {}
+        flags = {}
         if branching_factor is not None:
-            flags['branching_factor'] = str(branching_factor)
+            flags['branching_factor'] = branching_factor
 
+        if optimizer_iterations is not None:
+            flags['optimizer_iterations'] = optimizer_iterations
+
+        self._fs = None
+        self.gcs_requester_pays_configuration = gcs_requester_pays_configuration
         self._initialize_flags(flags)
 
     def validate_file(self, uri: str) -> None:
         async_to_blocking(validate_file(uri, self.fs.afs))
 
-    def register_ir_function(
-        self,
-        name: str,
-        type_parameters: Union[Tuple[HailType, ...], List[HailType]],
-        value_parameter_names: Union[Tuple[str, ...], List[str]],
-        value_parameter_types: Union[Tuple[HailType, ...], List[HailType]],
-        return_type: HailType,
-        body: Expression,
-    ):
-        r = CSERenderer()
-        code = r(finalize_randomness(body._ir))
-        self._register_ir_function(
-            name, type_parameters, value_parameter_names, value_parameter_types, return_type, code
-        )
-
-    def stop(self):
-        super(Py4JBackend, self).stop()
-        self._exit_stack.close()
-        uninstall_exception_handler()
-
     @property
-    def fs(self):
+    def fs(self) -> RouterFS:
         if self._fs is None:
             self._fs = RouterFS(
                 gcs_kwargs={"gcs_requester_pays_configuration": self.gcs_requester_pays_configuration},
@@ -138,3 +111,11 @@ class LocalBackend(Py4JBackend):
     @property
     def requires_lowering(self):
         return True
+
+    def stop(self):
+        super().stop()
+        self._gateway.shutdown()
+
+        if self._fs is not None:
+            self._fs.close()
+            self._fs = None

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -10,7 +10,6 @@ from py4j.java_gateway import JavaGateway
 
 from hail.expr.table_type import ttable
 from hail.ir import BaseIR
-from hail.ir.renderer import CSERenderer
 from hail.table import Table
 from hail.utils import copy_log
 from hail.utils.java import scala_package_object
@@ -154,7 +153,6 @@ class SparkBackend(Py4JBackend):
             flags['branching_factor'] = str(branching_factor)
 
         self._initialize_flags(flags)
-
         self._copy_log_on_error = copy_log_on_error
 
     def validate_file(self, uri: str) -> None:
@@ -211,12 +209,6 @@ class SparkBackend(Py4JBackend):
         if flatten:
             t = t.flatten()
         return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._render_ir(t._tir)), self._spark)
-
-    def register_ir_function(self, name, type_parameters, argument_names, argument_types, return_type, body):
-        r = CSERenderer()
-        assert not body._ir.uses_randomness
-        code = r(body._ir)
-        self._register_ir_function(name, type_parameters, argument_names, argument_types, return_type, code)
 
     def execute(self, ir: BaseIR, timed: bool = False) -> Any:
         try:

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -591,7 +591,7 @@ def init_local(
     tmpdir = _get_tmpdir(tmpdir)
 
     jvm_heap_size = get_env_or_default(jvm_heap_size, 'HAIL_LOCAL_BACKEND_HEAP_SIZE', None)
-    backend = LocalBackend(
+    backend = LocalBackend.create(
         tmpdir,
         log,
         quiet,


### PR DESCRIPTION
1. Introducing a factory method `create()` for constructing `LocalBackend` instances
2. Moving the Py4J gateway initialization logic to a separate function `start_py4j_gateway()`
3. Simplifying the backend initialization process with better error handling
4. Standardizing the `register_ir_function` implementation across backend types

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP