### PR TITLE
[compiler] Refactor BlockMatrix sparsity representations in type and lowering

### DIFF
--- a/hail/build.mill
+++ b/hail/build.mill
@@ -113,6 +113,10 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
     mvn"io.github.tanin47::scalafix-forbidden-symbol:1.0.0",
   )
 
+  override def depManagement: T[Seq[Dep]] = Task {
+    Seq(Deps.collection_compat)
+  }
+
   override def javacOptions: T[Seq[String]] = Seq(
     "-Xlint:all",
     "-Werror",
@@ -350,7 +354,7 @@ trait RootHailModule extends CrossScalaModule with HailModule { outer =>
     override def defaultTask(): String = "generate"
 
     override def mvnDeps = Seq(
-      mvn"com.lihaoyi::mainargs:0.6.2",
+      mvn"com.lihaoyi::mainargs:0.7.7",
       mvn"com.lihaoyi::os-lib:0.10.7",
       mvn"com.lihaoyi::sourcecode:0.4.2",
     )

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -512,6 +512,8 @@ package defs {
     def <=(other: IR): IR = ApplyComparisonOp(LTEQ, self, other)
 
     def >=(other: IR): IR = ApplyComparisonOp(GTEQ, self, other)
+
+    def log(messages: AnyRef*): IR = logIR(self, messages: _*)
   }
 
   object ErrorIDs {

--- a/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
@@ -815,6 +815,31 @@ abstract class RegistryFunctions {
       case (r, cb, _, rt, Array(a1, a2, a3), errorID) => impl(r, cb, rt, a1, a2, a3, errorID)
     }
 
+  def registerSCode3t(
+    name: String,
+    typeParams: Array[Type],
+    mt1: Type,
+    mt2: Type,
+    mt3: Type,
+    rt: Type,
+    pt: (Type, SType, SType, SType) => SType,
+  )(
+    impl: (
+      EmitRegion,
+      EmitCodeBuilder,
+      Seq[Type],
+      SType,
+      SValue,
+      SValue,
+      SValue,
+      Value[Int],
+    ) => SValue
+  ): Unit =
+    registerSCode(name, Array(mt1, mt2, mt3), rt, unwrappedApply(pt), typeParams) {
+      case (r, cb, typeParams, rt, Array(a1, a2, a3), errorID) =>
+        impl(r, cb, typeParams, rt, a1, a2, a3, errorID)
+    }
+
   def registerSCode4(
     name: String,
     mt1: Type,

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -44,7 +44,7 @@ package object ir {
     IRFunctionRegistry.lookupUnseeded(name, rt, typeArgs, args.map(_.typ)) match {
       case Some(f) => f(args, errorID)
       case None => fatal(
-          s"no conversion found for $name(${typeArgs.mkString(", ")}, ${args.map(_.typ).mkString(", ")}) => $rt"
+          s"no conversion found for $name[${typeArgs.mkString(", ")}](${args.map(_.typ).mkString(", ")}) => $rt"
         )
     }
 
@@ -409,15 +409,15 @@ package object ir {
         case x: String => Str(x)
       }
 
+      val xstr = if (x.typ == TString)
+        x
+      else
+        invoke("str", TString, x)
+
       if (s == null)
-        s = x
-      else {
-        val xstr = if (x.typ == TString)
-          x
-        else
-          invoke("str", TString, x)
+        s = xstr
+      else
         s = invoke("concat", TString, s, xstr)
-      }
     }
     s
   }

--- a/hail/hail/src/is/hail/linalg/MatrixSparsity.scala
+++ b/hail/hail/src/is/hail/linalg/MatrixSparsity.scala
@@ -1,0 +1,270 @@
+package is.hail.linalg
+
+import is.hail.utils._
+import is.hail.utils.compat._
+import is.hail.utils.compat.immutable.ArraySeq
+
+import scala.collection.Searching._
+import scala.collection.compat._
+
+object MatrixSparsity {
+  def dense(nRows: Int, nCols: Int): MatrixSparsity.Dense =
+    Dense(nRows, nCols)
+
+  def apply(nRows: Int, nCols: Int, definedBlocks: IterableOnce[(Int, Int)])
+    : MatrixSparsity.Sparse =
+    Sparse(nRows, nCols, definedBlocks)
+
+  def union(left: MatrixSparsity, right: MatrixSparsity): MatrixSparsity = {
+    assert(left.nRows == right.nRows && left.nCols == right.nCols)
+    (left, right) match {
+      case (left: MatrixSparsity.Sparse, right: MatrixSparsity.Sparse) =>
+        Sparse(left.nRows, left.nCols, left.blockSet.union(right.blockSet))
+      case _ => MatrixSparsity.dense(left.nRows, left.nCols)
+    }
+  }
+
+  def intersection(left: MatrixSparsity, right: MatrixSparsity): MatrixSparsity = {
+    assert(left.nRows == right.nRows && left.nCols == right.nCols)
+    (left, right) match {
+      case (left: MatrixSparsity.Sparse, right: MatrixSparsity.Sparse) =>
+        Sparse(
+          left.nRows,
+          left.nCols,
+          left.blockSet.intersect(right.blockSet),
+        )
+      case (_, right: MatrixSparsity.Sparse) => right
+      case _ => left
+    }
+  }
+
+  def constructFromShapeAndFunction(nRows: Int, nCols: Int)(exists: (Int, Int) => Boolean)
+    : Sparse = {
+    val builder = ArraySeq.newBuilder[(Int, Int)]
+    for {
+      j <- 0 until nCols
+      i <- 0 until nRows
+      if exists(i, j)
+    } builder += i -> j
+    Sparse.sorted(nRows, nCols, builder.result())
+  }
+
+  def fromLinearCoords(nRows: Int, nCols: Int, definedBlocks: Option[IndexedSeq[Int]])
+    : MatrixSparsity = {
+    definedBlocks.map { blocks =>
+      val blocksCoord = blocks.map { linearIdx =>
+        java.lang.Math.floorDiv(linearIdx, nCols) -> linearIdx % nCols
+      }
+      Sparse(nRows, nCols, blocksCoord)
+    }.getOrElse(dense(nRows, nCols))
+  }
+
+  case class CSC(nRows: Int, nCols: Int, rowPos: IndexedSeq[Int], rowIdx: IndexedSeq[Int])
+
+  case class DCSC(
+    nRows: Int,
+    nCols: Int,
+    colIdx: IndexedSeq[Int],
+    rowPos: IndexedSeq[Int],
+    rowIdx: IndexedSeq[Int],
+  )
+
+  object Sparse {
+    def apply(nRows: Int, nCols: Int, definedBlocks: IterableOnce[(Int, Int)]): Sparse = {
+      val a = Array.from(definedBlocks)
+      new Sparse(nRows, nCols, ArraySeq.unsafeWrapArray(a.sortInPlaceBy(_.swap).array))
+    }
+
+    def apply(nRows: Int, nCols: Int, definedBlocks: ArraySeq[(Int, Int)]): Sparse =
+      Sparse(nRows, nCols, definedBlocks: IterableOnce[(Int, Int)])
+
+    def sorted(nRows: Int, nCols: Int, definedBlocks: ArraySeq[(Int, Int)]): Sparse = {
+      require(definedBlocks.isSorted(Ordering.by(_.swap)))
+      new Sparse(nRows, nCols, definedBlocks)
+    }
+  }
+
+  // Constructor is kept private to enforce the invariant that definedCoords is
+  // in column major order.
+  final case class Sparse private[MatrixSparsity] (
+    nRows: Int,
+    nCols: Int,
+    definedCoords: ArraySeq[(Int, Int)],
+  ) extends MatrixSparsity {
+
+    override def numDefined: Int = definedCoords.length
+    override def isSparse: Boolean = true
+    def nonEmpty: Boolean = definedCoords.nonEmpty
+    def isEmpty: Boolean = definedCoords.isEmpty
+
+    def toDense: Dense = Dense(nRows, nCols)
+
+    def copy(
+      nRows: Int = nRows,
+      nCols: Int = nCols,
+      definedCoords: ArraySeq[(Int, Int)] = definedCoords,
+    ): Sparse =
+      MatrixSparsity(nRows, nCols, definedCoords)
+
+    private[MatrixSparsity] def blockSet: Set[(Int, Int)] = definedCoords.toSet
+
+    override def contains(row: Int, col: Int): Boolean =
+      definedCoords.search(row -> col)(Ordering.by(_.swap)) match {
+        case Found(_) => true
+        case _ => false
+      }
+
+    override def newToOldPos(newSparsity: Sparse): IndexedSeq[Int] = {
+      if (newSparsity.isEmpty) return ArraySeq.empty
+      var cur =
+        definedCoords.search(newSparsity.definedCoords.head)(Ordering.by(_.swap)).insertionPoint
+      newSparsity.definedCoords.map { coords =>
+        val i = definedCoords.indexOf(coords, cur)
+        assert(i >= 0, "newToOld: other sparsity must be a subset of this")
+        cur = i + 1
+        i
+      }
+    }
+
+    def newToOldPosNonSubset(newSparsity: Sparse): IndexedSeq[Integer] = {
+      if (newSparsity.isEmpty) return ArraySeq.empty
+      var cur =
+        definedCoords.search(newSparsity.definedCoords.head)(Ordering.by(_.swap)).insertionPoint
+      val ord: Ordering[(Int, Int)] = Ordering.by(_.swap)
+      newSparsity.definedCoords.map { coords =>
+        cur = cur + definedCoords.segmentLength(ord.lteq(_, coords), cur)
+        if (cur > 0 && definedCoords(cur - 1) == coords) Int.box(cur - 1) else null
+      }
+    }
+
+    def filter(rows: IndexedSeq[Int], cols: IndexedSeq[Int]): Sparse = {
+      require(rows.isSorted)
+      require(cols.isSorted)
+      val newDefined = for {
+        j <- cols.indices.view
+        i <- rows.indices
+        if contains(rows(i), cols(j))
+      } yield i -> j
+      Sparse.sorted(rows.length, cols.length, newDefined.to(ArraySeq))
+    }
+
+    override def condense(
+      rowOverlaps: IndexedSeq[IndexedSeq[Int]],
+      colOverlaps: IndexedSeq[IndexedSeq[Int]],
+    ): Sparse =
+      MatrixSparsity.constructFromShapeAndFunction(rowOverlaps.length, colOverlaps.length) {
+        (i, j) => rowOverlaps(i).exists(ii => colOverlaps(j).exists(jj => contains(ii, jj)))
+      }
+
+    override def condenseCols: Sparse =
+      MatrixSparsity.constructFromShapeAndFunction(1, nCols) { (_, j) =>
+        (0 until nRows).exists(i => contains(i, j))
+      }
+
+    override def condenseRows: Sparse =
+      MatrixSparsity.constructFromShapeAndFunction(nRows, 1) { (i, _) =>
+        (0 until nCols).exists(j => contains(i, j))
+      }
+
+    override lazy val transpose: Sparse =
+      Sparse(nCols, nRows, definedCoords.map { case (i, j) => (j, i) })
+
+    def transposeNewToOld: IndexedSeq[Int] =
+      definedCoords.zipWithIndex.sortBy(_._1).map(_._2)
+
+    override def isSubsetOf(other: MatrixSparsity): Boolean = other match {
+      case _: Dense => true
+      case other: Sparse =>
+        if (isEmpty) return true
+        var cur = other.definedCoords.search(definedCoords.head)(Ordering.by(_.swap)).insertionPoint
+        definedCoords.forall { coords =>
+          val i = other.definedCoords.indexOf(coords, cur)
+          cur = i + 1
+          i > 0
+        }
+    }
+
+    def toCSC: CSC = {
+      val rowPos = (0 to nCols).view.scanLeft(0) { (curPos, j) =>
+        val nextPos = definedCoords.indexWhere(_._2 >= j, curPos)
+        if (nextPos == -1) numDefined else nextPos
+      }.tail.to(ArraySeq)
+      val rowIdx = definedCoords.map(_._1)
+      CSC(nRows, nCols, rowPos, rowIdx)
+    }
+
+    def toDCSC: DCSC = {
+      val rowPos = (0 to numDefined).filter { pos =>
+        pos == 0 || pos == numDefined || definedCoords(pos)._2 != definedCoords(pos - 1)._2
+      }
+      val colIdx = rowPos.view.init.map(definedCoords(_)._2).to(ArraySeq)
+      val rowIdx = definedCoords.map(_._1)
+      DCSC(nRows, nCols, colIdx, rowPos, rowIdx)
+    }
+
+    def definedBlocksColMajorLinear: IndexedSeq[Int] =
+      definedCoords.map { case (i, j) => i + j * nRows }
+  }
+
+  final case class Dense(nRows: Int, nCols: Int) extends MatrixSparsity {
+    override def numDefined: Int = nRows * nCols
+    override def isSparse: Boolean = false
+
+    override def contains(row: Int, col: Int): Boolean =
+      row >= 0 && row < nRows && col >= 0 && col < nCols
+
+    override def condense(
+      rowOverlaps: IndexedSeq[IndexedSeq[Int]],
+      colOverlaps: IndexedSeq[IndexedSeq[Int]],
+    ): Dense =
+      MatrixSparsity.dense(rowOverlaps.length, colOverlaps.length)
+
+    override def condenseCols: Dense =
+      MatrixSparsity.dense(1, nCols)
+
+    override def condenseRows: Dense =
+      MatrixSparsity.dense(nRows, 1)
+
+    override def newToOldPos(newSparsity: Sparse): IndexedSeq[Int] =
+      newSparsity.definedCoords.map { case (i, j) =>
+        j * nRows + i
+      }
+
+    override def newToOldPosNonSubset(newSparsity: Sparse): IndexedSeq[Integer] =
+      newToOldPos(newSparsity).map(Int.box)
+
+    override def transpose: Dense = Dense(nCols, nRows)
+
+    override def isSubsetOf(other: MatrixSparsity): Boolean = other match {
+      case _: Dense => true
+      case other: Sparse => other.numDefined == nRows * nCols
+    }
+
+    override def definedCoords: IndexedSeq[(Int, Int)] =
+      for {
+        j <- 0 until nCols
+        i <- 0 until nRows
+      } yield (i, j)
+  }
+}
+
+abstract class MatrixSparsity {
+  def nRows: Int
+  def nCols: Int
+  def numDefined: Int
+  def isSparse: Boolean
+  def contains(row: Int, col: Int): Boolean
+  def newToOldPos(newSparsity: MatrixSparsity.Sparse): IndexedSeq[Int]
+  def newToOldPosNonSubset(newSparsity: MatrixSparsity.Sparse): IndexedSeq[Integer]
+  def transpose: MatrixSparsity
+
+  def condense(rowOverlaps: IndexedSeq[IndexedSeq[Int]], colOverlaps: IndexedSeq[IndexedSeq[Int]])
+    : MatrixSparsity
+
+  def condenseCols: MatrixSparsity
+  def condenseRows: MatrixSparsity
+
+  def isSubsetOf(other: MatrixSparsity): Boolean
+
+  def definedCoords: IndexedSeq[(Int, Int)]
+}

--- a/hail/hail/src/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalArray.scala
@@ -634,15 +634,13 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false)
     }
 
     def finish(cb: EmitCodeBuilder): SIndexablePointerValue = {
-      cb.if_(
-        currentElementIndex cne length,
-        cb._fatal(
-          "PCanonicalArray.constructFromFunctions push was called the wrong number of times",
-          ": len=",
-          length.toS,
-          ", calls=",
-          currentElementIndex.toS,
-        ),
+      cb._assert(
+        currentElementIndex ceq length,
+        "PCanonicalArray.constructFromFunctions push was called the wrong number of times",
+        ": len=",
+        length.toS,
+        ", calls=",
+        currentElementIndex.toS,
       )
       new SIndexablePointerValue(sType, addr, length, firstElementAddress)
     }
@@ -663,7 +661,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false)
   ) = {
 
     val addr = cb.newLocal[Long]("pcarray_construct2_addr", allocate(region, length))
-    stagedInitialize(cb, addr, length, setMissing = false)
+    stagedInitialize(cb, addr, length, setMissing = true)
     val firstElementAddress =
       cb.newLocal[Long]("pcarray_construct2_first_addr", firstElementOffset(addr, length))
 

--- a/hail/hail/src/is/hail/types/virtual/BlockMatrixType.scala
+++ b/hail/hail/src/is/hail/types/virtual/BlockMatrixType.scala
@@ -1,318 +1,15 @@
 package is.hail.types.virtual
 
 import is.hail.expr.ir._
-import is.hail.expr.ir.defs.{I64, If, Literal, ToStream}
-import is.hail.linalg.BlockMatrix
-import is.hail.utils._
+import is.hail.expr.ir.defs.{I64, If}
+import is.hail.linalg.{BlockMatrix, MatrixSparsity}
+import is.hail.utils.compat._
 import is.hail.utils.compat.immutable.ArraySeq
+import is.hail.utils.fatal
 
-import org.apache.spark.sql.Row
+import scala.collection.compat._
+
 import org.json4s.{JInt, JObject, JString, JValue}
-
-object BlockMatrixSparsity {
-  private val builder = ArraySeq.newBuilder[(Int, Int)]
-
-  val dense: BlockMatrixSparsity = new BlockMatrixSparsity(None: Option[IndexedSeq[(Int, Int)]])
-
-  def apply(definedBlocks: IndexedSeq[(Int, Int)]): BlockMatrixSparsity =
-    BlockMatrixSparsity(Some(definedBlocks))
-
-  def constructFromShapeAndFunction(nRows: Int, nCols: Int)(exists: (Int, Int) => Boolean)
-    : BlockMatrixSparsity = {
-    var i = 0
-    builder.clear()
-    while (i < nRows) {
-      var j = 0
-      while (j < nCols) {
-        if (exists(i, j))
-          builder += i -> j
-        j += 1
-      }
-      i += 1
-    }
-    BlockMatrixSparsity(Some(builder.result().toFastSeq))
-  }
-
-  def fromLinearBlocks(
-    nCols: Long,
-    nRows: Long,
-    blockSize: Int,
-    definedBlocks: Option[IndexedSeq[Int]],
-  ): BlockMatrixSparsity = {
-    val nColBlocks = BlockMatrixType.numBlocks(nCols, blockSize)
-    definedBlocks.map { blocks =>
-      BlockMatrixSparsity(blocks.map { linearIdx =>
-        java.lang.Math.floorDiv(linearIdx, nColBlocks) -> linearIdx % nColBlocks
-      })
-    }.getOrElse(dense)
-  }
-
-  def transposeCSCSparsity(
-    nRows: Int,
-    nCols: Int,
-    rowPos: IndexedSeq[Int],
-    rowIdx: IndexedSeq[Int],
-  ): (IndexedSeq[Int], IndexedSeq[Int], IndexedSeq[Int]) = {
-    val newRowPos = Array.ofDim[Int](nRows + 1)
-    val newRowIdx = Array.ofDim[Int](rowIdx.length)
-    val newToOldPos = Array.ofDim[Int](rowIdx.length)
-
-    // count size of each row
-    var curPos = 0
-    while (curPos < rowIdx.length) {
-      newRowPos(rowIdx(curPos)) += 1
-      curPos += 1
-    }
-
-    // compute prefix sum over row sizes
-    var i = 0
-    var prefixSum = 0
-    while (i < nRows) {
-      val curSum = prefixSum
-      prefixSum += newRowPos(i)
-      newRowPos(i) = curSum
-      i += 1
-    }
-    newRowPos(i) = prefixSum
-
-    // fill in newRowIdx and newToOldPos
-    val curRowPositions = newRowPos.clone()
-    var j = 0
-    while (j < nCols) {
-      curPos = rowPos(j)
-      val endPos = rowPos(j + 1)
-      while (curPos < endPos) {
-        val i = rowIdx(curPos)
-        val newPos = curRowPositions(i)
-        curRowPositions(i) += 1
-        newRowIdx(newPos) = j
-        newToOldPos(newPos) = curPos
-        curPos += 1
-      }
-      j += 1
-    }
-
-    (newRowPos, newRowIdx, newToOldPos)
-  }
-
-  def transposeCSCSparsityIR(
-    nRows: Int,
-    nCols: Int,
-    rowPos: IndexedSeq[Int],
-    rowIdx: IndexedSeq[Int],
-  ): (IR, IR, IR) = {
-    val (newRowPos, newRowIdx, newToOldPos) = transposeCSCSparsity(nRows, nCols, rowPos, rowIdx)
-    val t = TArray(TInt32)
-    (Literal(t, newRowPos), Literal(t, newRowIdx), Literal(t, newToOldPos))
-  }
-
-  def filterCSCSparsity(
-    rowPos: IndexedSeq[Int],
-    rowIdx: IndexedSeq[Int],
-    rowDeps: IndexedSeq[Int],
-    colDeps: IndexedSeq[Int],
-  ): (IndexedSeq[Int], IndexedSeq[Int], IndexedSeq[Int]) = {
-    val newRowPos = new IntArrayBuilder()
-    val newRowIdx = new IntArrayBuilder()
-    val newToOldPos = new IntArrayBuilder()
-
-    var curOutPos = 0
-    for (j <- colDeps) {
-      newRowPos += curOutPos
-      var curLPos = rowPos(j)
-      val endLPos = rowPos(j + 1)
-      var curRPos = 0
-      while (curLPos < endLPos && curRPos < rowDeps.length) {
-        val curLIdx = rowIdx(curLPos)
-        val curRIdx = rowDeps(curRPos)
-        if (curLIdx == curRIdx) {
-          newRowIdx += curLIdx
-          newToOldPos += curOutPos
-          curLPos += 1
-          curRPos += 1
-          curOutPos += 1
-        } else {
-          val c = curLIdx < curRIdx
-          curLPos += c.toInt
-          curRPos += (!c).toInt
-        }
-      }
-    }
-    newRowPos += curOutPos
-
-    (newRowPos.result(), newRowIdx.result(), newToOldPos.result())
-  }
-
-  def groupedCSCSparsity(
-    rowPos: IndexedSeq[Int],
-    rowIdx: IndexedSeq[Int],
-    rowDeps: IndexedSeq[IndexedSeq[Int]],
-    colDeps: IndexedSeq[IndexedSeq[Int]],
-  ): (
-    IndexedSeq[Int],
-    IndexedSeq[Int],
-    IndexedSeq[(IndexedSeq[Int], IndexedSeq[Int], IndexedSeq[Int])],
-  ) = {
-    val newRowPos = new IntArrayBuilder()
-    val newRowIdx = new IntArrayBuilder()
-    val nestedSparsities =
-      new AnyRefArrayBuilder[(IndexedSeq[Int], IndexedSeq[Int], IndexedSeq[Int])]()
-
-    var curOutPos = 0
-    var j = 0
-    while (j < colDeps.length) {
-      newRowPos += curOutPos
-      var i = 0
-      while (i < rowDeps.length) {
-        val nested = filterCSCSparsity(rowPos, rowIdx, rowDeps(i), colDeps(j))
-        if (nested._2.nonEmpty) {
-          newRowIdx += i
-          nestedSparsities += nested
-          curOutPos += 1
-        }
-        i += 1
-      }
-      j += 1
-    }
-    newRowPos += curOutPos
-
-    (newRowPos.result(), newRowIdx.result(), nestedSparsities.result())
-  }
-
-  def groupedCSCSparsityIR(
-    rowPos: IndexedSeq[Int],
-    rowIdx: IndexedSeq[Int],
-    rowDeps: IndexedSeq[IndexedSeq[Int]],
-    colDeps: IndexedSeq[IndexedSeq[Int]],
-  ): (IR, IR, IR) = {
-    val (newRowPos, newRowIdx, nestedSparsities) =
-      groupedCSCSparsity(rowPos, rowIdx, rowDeps, colDeps)
-    val t = TArray(TInt32)
-    (
-      Literal(t, newRowPos),
-      Literal(t, newRowIdx),
-      Literal(TArray(TTuple(t, t, t)), nestedSparsities.map(Row.fromTuple)),
-    )
-  }
-}
-
-case class BlockMatrixSparsity(definedBlocks: Option[IndexedSeq[(Int, Int)]]) {
-  lazy val definedBlocksColMajor: Option[IndexedSeq[(Int, Int)]] = definedBlocks.map { blocks =>
-    blocks.sortWith { case ((i1, j1), (i2, j2)) =>
-      j1 < j2 || (j1 == j2 && i1 < i2)
-    }
-  }
-
-  def definedBlocksCSC(nCols: Int): Option[(IndexedSeq[Int], IndexedSeq[Int])] =
-    definedBlocksColMajor.map { blocks =>
-      var curColIdx = 0
-      var curPos = 0
-      val pos = new Array[Int](nCols + 1)
-      val rowIdx = new IntArrayBuilder()
-
-      pos(0) = 0
-      for ((i, j) <- blocks) {
-        while (curColIdx < j) {
-          pos(curColIdx + 1) = curPos
-          curColIdx += 1
-        }
-        rowIdx += i
-        curPos += 1
-      }
-      while (curColIdx < nCols) {
-        pos(curColIdx + 1) = curPos
-        curColIdx += 1
-      }
-      (pos, rowIdx.result())
-    }
-
-  def definedBlocksCSCIR(nCols: Int): Option[(IR, IR)] =
-    definedBlocksCSC(nCols).map { case (rowPos, rowIdx) =>
-      val t = TArray(TInt32)
-      (Literal(t, rowPos), Literal(t, rowIdx))
-    }
-
-  def definedBlocksColMajorIR: Option[IR] = definedBlocksColMajor.map { blocks =>
-    ToStream(Literal(TArray(TTuple(TInt32, TInt32)), blocks.map(Row.fromTuple)))
-  }
-
-  lazy val definedBlocksRowMajor: Option[IndexedSeq[(Int, Int)]] = definedBlocks.map { blocks =>
-    blocks.sortWith { case ((i1, j1), (i2, j2)) =>
-      i1 < i2 || (i1 == i2 && j1 < j2)
-    }
-  }
-
-  def definedBlocksRowMajorIR: Option[IR] = definedBlocksRowMajor.map { blocks =>
-    ToStream(Literal(TArray(TTuple(TInt32, TInt32)), blocks.map(Row.fromTuple)))
-  }
-
-  def isSparse: Boolean = definedBlocks.isDefined
-  lazy val blockSet: Set[(Int, Int)] = definedBlocks.get.toSet
-  def hasBlock(idx: (Int, Int)): Boolean = definedBlocks.isEmpty || blockSet.contains(idx)
-
-  def condense(blockOverlaps: => (Array[Array[Int]], Array[Array[Int]])): BlockMatrixSparsity = {
-    definedBlocks.map { _ =>
-      val (ro, co) = blockOverlaps
-      BlockMatrixSparsity.constructFromShapeAndFunction(ro.length, co.length) { (i, j) =>
-        ro(i).exists(ii => co(j).exists(jj => hasBlock(ii -> jj)))
-      }
-    }.getOrElse(BlockMatrixSparsity.dense)
-  }
-
-  def allBlocksColMajor(nRowBlocks: Int, nColBlocks: Int): IndexedSeq[(Int, Int)] = {
-    definedBlocksColMajor.getOrElse {
-      val foo = Array.fill[(Int, Int)](nRowBlocks * nColBlocks)(null)
-      var idx = 0
-      var j = 0
-      while (j < nColBlocks) {
-        var i = 0
-        while (i < nRowBlocks) {
-          foo(idx) = i -> j
-          i += 1
-          idx += 1
-        }
-        j += 1
-      }
-      foo
-    }
-  }
-
-  def allBlocksColMajorIR(nRowBlocks: Int, nColBlocks: Int): IR =
-    definedBlocksColMajorIR.getOrElse {
-      flatMapIR(rangeIR(nColBlocks))(j => mapIR(rangeIR(nRowBlocks))(i => maketuple(i, j)))
-    }
-
-  def allBlocksRowMajor(nRowBlocks: Int, nColBlocks: Int): IndexedSeq[(Int, Int)] = {
-    (definedBlocksRowMajor).getOrElse {
-      val foo = Array.fill[(Int, Int)](nRowBlocks * nColBlocks)(null)
-      var idx = 0
-      var i = 0
-      while (i < nRowBlocks) {
-        var j = 0
-        while (j < nColBlocks) {
-          foo(idx) = i -> j
-          j += 1
-          idx += 1
-        }
-        i += 1
-      }
-      foo
-    }
-  }
-
-  def allBlocksRowMajorIR(nRowBlocks: Int, nColBlocks: Int): IR =
-    definedBlocksRowMajorIR.getOrElse {
-      flatMapIR(rangeIR(nRowBlocks))(i => mapIR(rangeIR(nColBlocks))(j => maketuple(i, j)))
-    }
-
-  def transpose: BlockMatrixSparsity =
-    BlockMatrixSparsity(definedBlocks.map(_.map { case (i, j) => (j, i) }))
-
-  override def toString: String =
-    definedBlocks.map { blocks =>
-      blocks.map { case (i, j) => s"($i,$j)" }.mkString("[", ",", "]")
-    }.getOrElse("None")
-}
 
 object BlockMatrixType {
   def numBlocks(n: Long, blockSize: Int): Int =
@@ -320,18 +17,25 @@ object BlockMatrixType {
 
   def getBlockIdx(i: Long, blockSize: Int): Int = java.lang.Math.floorDiv(i, blockSize).toInt
 
-  def dense(elementType: Type, nRows: Long, nCols: Long, blockSize: Int): BlockMatrixType =
-    BlockMatrixType(elementType, nRows, nCols, blockSize, BlockMatrixSparsity.dense)
+  def dense(elementType: Type, nRows: Long, nCols: Long, blockSize: Int): BlockMatrixType = {
+    val nRowBlocks = numBlocks(nRows, blockSize)
+    val nColBlocks = numBlocks(nCols, blockSize)
+    val sparsity = MatrixSparsity.dense(nRowBlocks, nColBlocks)
+    BlockMatrixType(elementType, nRows, nCols, blockSize, sparsity)
+  }
 
   def fromBlockMatrix(value: BlockMatrix): BlockMatrixType = {
-    val sparsity = BlockMatrixSparsity.fromLinearBlocks(
-      value.nRows,
-      value.nCols,
-      value.blockSize,
+    val sparsity = MatrixSparsity.fromLinearCoords(
+      numBlocks(value.nRows, value.blockSize),
+      numBlocks(value.nCols, value.blockSize),
       value.gp.partitionIndexToBlockIndex,
     )
     BlockMatrixType(TFloat64, value.nRows, value.nCols, value.blockSize, sparsity)
   }
+
+  def getBlockDependencies(keep: IterableOnce[IndexedSeq[Long]], blockSize: Int)
+    : IndexedSeq[IndexedSeq[Int]] =
+    keep.iterator.map(_.map(i => (i / blockSize).toInt).distinct).to(ArraySeq)
 }
 
 case class BlockMatrixType(
@@ -339,36 +43,25 @@ case class BlockMatrixType(
   nRows: Long,
   nCols: Long,
   blockSize: Int,
-  sparsity: BlockMatrixSparsity,
+  sparsity: MatrixSparsity,
 ) extends VType {
   require(blockSize >= 0)
+  if (nRows == 0) fatal("block matrix must have at least one row")
+  if (nCols == 0) fatal("block matrix must have at least one column")
 
-  lazy val nRowBlocks: Int = if (blockSize == 0) 0 else BlockMatrixType.numBlocks(nRows, blockSize)
-  lazy val nColBlocks: Int = if (blockSize == 0) 0 else BlockMatrixType.numBlocks(nCols, blockSize)
-  lazy val defaultBlockShape: (Int, Int) = (nRowBlocks, nColBlocks)
+  def nRowBlocks: Int = sparsity.nRows
+  def nColBlocks: Int = sparsity.nCols
 
-  def densify: BlockMatrixType = copy(sparsity = BlockMatrixSparsity(None))
+  def densify: BlockMatrixType = copy(sparsity = MatrixSparsity.Dense(nRowBlocks, nColBlocks))
 
   def getBlockIdx(i: Long): Int = java.lang.Math.floorDiv(i, blockSize).toInt
   def isSparse: Boolean = sparsity.isSparse
 
-  def nDefinedBlocks: Int =
-    if (isSparse) sparsity.definedBlocks.get.length else nRowBlocks * nColBlocks
+  def nDefinedBlocks: Int = sparsity.numDefined
 
-  def hasBlock(idx: (Int, Int)): Boolean =
-    if (isSparse) sparsity.hasBlock(idx)
-    else idx._1 >= 0 && idx._1 < nRowBlocks && idx._2 >= 0 && idx._2 < nColBlocks
+  def hasBlock(row: Int, col: Int): Boolean = sparsity.contains(row, col)
 
   def transpose: BlockMatrixType = copy(nRows = nCols, nCols = nRows, sparsity = sparsity.transpose)
-
-  def allBlocksColMajor: IndexedSeq[(Int, Int)] = sparsity.allBlocksColMajor(nRowBlocks, nColBlocks)
-  def allBlocksColMajorIR: IR = sparsity.allBlocksColMajorIR(nRowBlocks, nColBlocks)
-  def allBlocksRowMajor: IndexedSeq[(Int, Int)] = sparsity.allBlocksRowMajor(nRowBlocks, nColBlocks)
-  def allBlocksRowMajorIR: IR = sparsity.allBlocksRowMajorIR(nRowBlocks, nColBlocks)
-
-  lazy val linearizedDefinedBlocks: Option[IndexedSeq[Int]] = sparsity.definedBlocksColMajor.map {
-    blocks => blocks.map { case (i, j) => i + j * nRowBlocks }
-  }
 
   def blockShape(i: Int, j: Int): (Long, Long) = {
     val r = if (i == nRowBlocks - 1) nRows - (i * blockSize) else blockSize.toLong
@@ -383,24 +76,6 @@ case class BlockMatrixType(
     val c = If(j.ceq(nColBlocks - 1), I64(nCols) - (j.toL * blockSize.toLong), blockSize.toLong)
     r -> c
   }
-
-  private[this] def getBlockDependencies(keep: Array[Array[Long]]): Array[Array[Int]] =
-    keep.map(keeps =>
-      Array.range(
-        BlockMatrixType.getBlockIdx(keeps.head, blockSize),
-        BlockMatrixType.getBlockIdx(keeps.last, blockSize) + 1,
-      )
-    ).toArray
-
-  def rowBlockDependents(keepRows: Array[Array[Long]]): Array[Array[Int]] = if (keepRows.isEmpty)
-    Array.tabulate(nRowBlocks)(i => Array(i))
-  else
-    getBlockDependencies(keepRows)
-
-  def colBlockDependents(keepCols: Array[Array[Long]]): Array[Array[Int]] = if (keepCols.isEmpty)
-    Array.tabulate(nColBlocks)(i => Array(i))
-  else
-    getBlockDependencies(keepCols)
 
   override def pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = {
     val space: String = if (compact) "" else " "

--- a/hail/hail/src/is/hail/utils/richUtils/RichOrderedSeq.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichOrderedSeq.scala
@@ -2,11 +2,12 @@ package is.hail.utils.richUtils
 
 import scala.collection.compat._
 
-class RichOrderedSeq[T: Ordering](s: Seq[T]) {
+class RichOrderedSeq[T](val s: Seq[T]) extends AnyVal {
 
   import scala.math.Ordering.Implicits._
 
-  def isIncreasing: Boolean = s.isEmpty || s.lazyZip(s.tail).forall(_ < _)
+  def isIncreasing(implicit ord: Ordering[T]): Boolean =
+    s.isEmpty || s.lazyZip(s.tail).forall(_ < _)
 
-  def isSorted: Boolean = s.isEmpty || s.lazyZip(s.tail).forall(_ <= _)
+  def isSorted(implicit ord: Ordering[T]): Boolean = s.isEmpty || s.lazyZip(s.tail).forall(_ <= _)
 }

--- a/hail/hail/test/src/is/hail/expr/ir/ArrayFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ArrayFunctionsSuite.scala
@@ -372,4 +372,54 @@ class ArrayFunctionsSuite extends HailSuite {
       expected = true,
     )
   }
+
+  @DataProvider(name = "scatter")
+  def scatterData: Array[Array[Any]] = Array(
+    Array(FastSeq("a", "b", "c"), FastSeq(1, 3, 4), FastSeq(null, "a", null, "b", "c")),
+    Array(FastSeq("a", "b", "c"), FastSeq(2, 0, 3), FastSeq("b", null, "a", "c", null)),
+    Array(FastSeq(), FastSeq(), FastSeq(null, null, null)),
+    Array(FastSeq(), FastSeq(), FastSeq()),
+  )
+
+  @Test(dataProvider = "scatter")
+  def testScatter(elts: IndexedSeq[String], indices: IndexedSeq[Int], expected: IndexedSeq[String])
+    : Unit = {
+    val t1 = TArray(TInt32)
+    val t2 = TArray(TString)
+
+    assertEvalsTo(
+      invoke("scatter", t2, FastSeq(TString), In(0, t2), In(1, t1), expected.length),
+      args = FastSeq(elts -> t2, indices -> t1),
+      expected = expected,
+    )
+  }
+
+  @DataProvider(name = "scatter_errors")
+  def scatterErrorData: Array[Array[Any]] = Array(
+    Array(FastSeq("a", "b", "c"), FastSeq(1, 3, 4), 4, "indices array contained index 4"),
+    Array(
+      FastSeq("a", "b"),
+      FastSeq(1, 3, 4),
+      4,
+      "values and indices arrays have different lengths",
+    ),
+    Array(FastSeq("a", "b", "c"), FastSeq(1, 2, 2), 2, "values array is larger than result length"),
+  )
+
+  @Test(dataProvider = "scatter_errors")
+  def testScatterErrors(
+    elts: IndexedSeq[String],
+    indices: IndexedSeq[Int],
+    length: Int,
+    regex: String,
+  ): Unit = {
+    val t1 = TArray(TInt32)
+    val t2 = TArray(TString)
+
+    assertFatal(
+      invoke("scatter", t2, FastSeq(TString), In(0, t2), In(1, t1), length),
+      args = FastSeq(elts -> t2, indices -> t1),
+      regex = regex,
+    )
+  }
 }

--- a/hail/hail/test/src/is/hail/linalg/MatrixSparsitySuite.scala
+++ b/hail/hail/test/src/is/hail/linalg/MatrixSparsitySuite.scala
@@ -1,0 +1,72 @@
+package is.hail.linalg
+
+import is.hail.utils.compat.immutable.ArraySeq
+
+import org.scalatestplus.testng.TestNGSuite
+import org.testng.annotations.{DataProvider, Test}
+
+class MatrixSparsitySuite extends TestNGSuite {
+  def newToOldReference(from: MatrixSparsity, to: MatrixSparsity): IndexedSeq[Integer] =
+    to.definedCoords.map { coords =>
+      val i = from.definedCoords.indexOf(coords)
+      if (i >= 0) Int.box(i) else null
+    }
+
+  def isSubset(s1: MatrixSparsity, s2: MatrixSparsity): Boolean =
+    s2.definedCoords.toSet.subsetOf(s1.definedCoords.toSet)
+
+  def sparsities_4_3: Iterator[MatrixSparsity] = Iterator(
+    MatrixSparsity.dense(4, 3),
+    MatrixSparsity.apply(4, 3, ArraySeq(1 -> 0, 3 -> 0, 2 -> 1, 0 -> 2, 1 -> 2)),
+    MatrixSparsity.apply(4, 3, ArraySeq(0 -> 0, 1 -> 0, 0 -> 1, 0 -> 2, 1 -> 2)),
+    MatrixSparsity.apply(4, 3, ArraySeq(1 -> 0, 0 -> 2, 1 -> 2)),
+    MatrixSparsity.apply(4, 3, ArraySeq()),
+  )
+
+  @DataProvider(name = "sparsity_pairs_4_3")
+  def sparsityPairs43(): Array[Array[Object]] = (
+    for {
+      s1 <- sparsities_4_3
+      s2 <- sparsities_4_3
+      if s2.isInstanceOf[MatrixSparsity.Sparse]
+    } yield Array[Object](s1, s2)
+  ).toArray
+
+  @DataProvider(name = "sparsity_subset_pairs_4_3")
+  def sparsitySubsetPairs(): Array[Array[Object]] = (
+    for {
+      s1 <- sparsities_4_3
+      s2 <- sparsities_4_3
+      if s2.isInstanceOf[MatrixSparsity.Sparse]
+      if isSubset(s1, s2)
+    } yield Array[Object](s1, s2)
+  ).toArray
+
+  @Test(dataProvider = "sparsity_subset_pairs_4_3")
+  def newToOld(s1: MatrixSparsity, s2: MatrixSparsity.Sparse): Unit =
+    assertResult(newToOldReference(s1, s2))(s1.newToOldPos(s2))
+
+  @Test(dataProvider = "sparsity_pairs_4_3")
+  def newToOldNonSubset(s1: MatrixSparsity, s2: MatrixSparsity.Sparse): Unit =
+    assertResult(newToOldReference(s1, s2))(s1.newToOldPosNonSubset(s2))
+
+  def sparsities_0_0: Iterator[MatrixSparsity] = Iterator(
+    MatrixSparsity.dense(0, 0),
+    MatrixSparsity.apply(0, 0, ArraySeq()),
+  )
+
+  @DataProvider(name = "sparsity_pairs_0_0")
+  def sparsityPairs00(): Array[Array[Object]] = (
+    for {
+      s1 <- sparsities_0_0
+    } yield Array[Object](s1, MatrixSparsity.apply(0, 0, ArraySeq()))
+  ).toArray
+
+  @Test(dataProvider = "sparsity_pairs_0_0")
+  def newToOldDegenerate(s1: MatrixSparsity, s2: MatrixSparsity.Sparse): Unit =
+    assertResult(newToOldReference(s1, s2))(s1.newToOldPos(s2))
+
+  @Test(dataProvider = "sparsity_pairs_0_0")
+  def newToOldNonSubsetDegenerate(s1: MatrixSparsity, s2: MatrixSparsity.Sparse): Unit =
+    assertResult(newToOldReference(s1, s2))(s1.newToOldPosNonSubset(s2))
+}

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1255,7 +1255,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(np.allclose(k, rrm))
 
         one_sample = hl.balding_nichols_model(1, 1, 10)
-        self.assertRaises(FatalError, lambda: hl.realized_relationship_matrix(one_sample.GT))
+        self.assertRaises(FatalError, lambda: hl.realized_relationship_matrix(one_sample.GT).to_numpy())
 
     def test_row_correlation_vs_hardcode(self):
         data = [


### PR DESCRIPTION
## Change Description

The bulk of the changes are in the files `BlockMatrixType.scala`, `MatrixSparsity.scala`, and `LowerBlockMatrixIR.scala`. I suggest starting with those, with the summaries below.

I acknowledge this is a big change containing a lot of non-trivial logic. Please do ask for explanations and clarifications.

### BlockMatrixType and MatrixSparsity
`BlockMatrixType` has a `sparsity`, of type `BlockMatrixSparsity`, which is either dense or a set of present blocks. In this PR I've moved the sparsity representation to `MatrixSparsity`, which is a generic encoding of the sparsity pattern of a sparse matrix. For a `BlockMatrixType`, the sparsity will be a `nBlockRows` by `nBlockCols` `MatrixSparsity`.

Besides moving `BlockMatrixSparsity` to `MatrixSparsity`, and removing references to blocks, the encoding of the sparsity is also streamlined. Before, `BlockMatrixSparsity` held an array of coordinates of present blocks, in an arbitrary order. Methods that need the present blocks in a particular order (usually column major) would need to sort them, and we also built a `Set` of present blocks to handle the `isPresent` query.

Now, `MatrixSparsity` (in the sparse case) enforces that the array of present blocks is always in column major order. This simplifies some of the logic, and lets us handle `isPresent` with binary search (similarly for unions/intersections of sparsity, which now take advantage of the ordering).

In addition, `MatrixSparsity` now knows its dimensions, which `BlockMatrixSparsity` did not. 

I've also gotten rid of all the complicated methods on the CSC (compressed sparse column) encoding (e.g. `transposeCSCSparsity`). Instead, I do all the transformations on the simple coordinate list encoding, and convert to CSC as late as possible.

### LowerBlockMatrixIR
The changes in this file are mostly about a redesign of the `BMSContexts` class. `BMSContexts` bundles together a runtime array of context values (similar to the contexts for a `TableStage`), with a representation of the sparsity pattern, which conceptually maps each context value to the coordinates of its block.

Before, the sparsity pattern was also encoded by runtime values. In the sparse case, this used runtime arrays `rowPos` and `rowIdx` using a CSC encoding. Working with this encoding created a lot of non-trivial runtime logic. But sparsity is completely known at compile time, so all this runtime logic was unnecessary.

There are still cases where we need to work with a CSC encoding of the sparsity at runtime. These cases are now handled by the class `DynamicBMSContexts`, which is essentially the same as the old `BMSContexts`, but now has a minimal interface of three methods. Importantly, these methods are only about consuming a block matrix, not transforming to a new one (like transpose).

The new `BMSContexts` now pairs a statically known `MatrixSparsity` with a `DynamicBMSContexts`. The big change from before is that all methods that produce a new `BMSContexts` now handle all the sparsity logic at compile time, and simply embed the new sparsity in the IR using literals. This typically requires us to also embed an array of ints mapping from old to new positions in the contexts array, which we use at runtime to reorder the contexts as needed.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

