### PR TITLE
[batch] fix idempotent create update

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1866,7 +1866,7 @@ FOR UPDATE;
         )
 
         if record:
-            return (record['update_id'], record['start_job_id'], record['start_job_group_id'])
+            return (record['update_id'], record['start_job_group_id'], record['start_job_id'])
 
         # We use FOR UPDATE so that we serialize batch update insertions
         # This is necessary to reserve job id and job group id ranges.


### PR DESCRIPTION
## Change Description

Fixed the order of return values in the `update` function in `front_end.py`. The function was returning `(update_id, start_job_id, start_job_group_id)` but the correct order should be `(update_id, start_job_group_id, start_job_id)`.

## Security Assessment

This change has low impact the Hail Batch instance as deployed by Broad Institute in GCP.

