### PR TITLE
[query] use new enableBsp feature in mill

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -64,7 +64,7 @@ CLOUD_HAIL_DOCTEST_DATA_DIR = $(CLOUD_HAIL_TEST_RESOURCES_PREFIX)/doctest/data/
 
 # mill integration
 
-MILL := SCALA_VERSION=$(SCALA_VERSION) bash mill
+MILL := bash mill
 MILLOPTS ?=
 
 .PHONY: mill-clean
@@ -82,7 +82,7 @@ ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_JAR): native-lib-prebuilt
 endif
 $(SHADOW_JAR): FORCE
-	$(MILL) $(MILLOPTS) hail[].assembly
+	$(MILL) $(MILLOPTS) hail[$(SCALA_VERSION)].assembly
 
 .PHONY: shadowJar
 shadowJar: $(SHADOW_JAR)
@@ -92,35 +92,35 @@ ifdef HAIL_COMPILE_NATIVES
 $(NON_SHADOW_JAR): native-lib-prebuilt
 endif
 $(NON_SHADOW_JAR): FORCE
-	$(MILL) $(MILLOPTS) hail[].jar
+	$(MILL) $(MILLOPTS) hail[$(SCALA_VERSION)].jar
 
 SHADOW_TEST_JAR := out/hail/$(SCALA_VERSION)/test/assembly.dest/out.jar
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_TEST_JAR): native-lib-prebuilt
 endif
 $(SHADOW_TEST_JAR): FORCE
-	$(MILL) $(MILLOPTS) hail[].test.assembly
+	$(MILL) $(MILLOPTS) hail[$(SCALA_VERSION)].test.assembly
 
 .PHONY: shadowTestJar
 shadowTestJar: $(SHADOW_TEST_JAR)
 
 EXTRA_CLASSPATH := out/hail/$(SCALA_VERSION)/writeRunClasspath.dest/runClasspath
 $(EXTRA_CLASSPATH): FORCE
-	$(MILL) $(MILLOPTS) hail[].writeRunClasspath
+	$(MILL) $(MILLOPTS) hail[$(SCALA_VERSION)].writeRunClasspath
 
 .PHONY: jvm-test
 ifdef HAIL_COMPILE_NATIVES
 jvm-test: native-lib-prebuilt
 endif
 jvm-test:
-	$(MILL) $(MILLOPTS) hail[].test testng.xml
+	$(MILL) $(MILLOPTS) hail[$(SCALA_VERSION)].test testng.xml
 
 .PHONY: services-jvm-test
 ifdef HAIL_COMPILE_NATIVES
 services-jvm-test: native-lib-prebuilt
 endif
 services-jvm-test:
-	$(MILL) $(MILLOPTS) hail[].test testng-services.xml
+	$(MILL) $(MILLOPTS) hail[$(SCALA_VERSION)].test testng-services.xml
 
 .PHONY: fs-jvm-test
 ifdef HAIL_COMPILE_NATIVES
@@ -133,7 +133,7 @@ fs-jvm-test: upload-remote-test-resources
 	HAIL_DEFAULT_NAMESPACE=$(NAMESPACE) \
 	HAIL_FS_TEST_CLOUD_RESOURCES_URI=$(CLOUD_HAIL_TEST_RESOURCES_DIR)fs \
 	HAIL_TEST_STORAGE_URI=$(TEST_STORAGE_URI) \
-	$(MILL) $(MILLOPTS) hail[].test $(realpath testng-fs.xml)
+	$(MILL) $(MILLOPTS) hail[$(SCALA_VERSION)].test $(realpath testng-fs.xml)
 
 # end mill integration
 

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -1,5 +1,4 @@
-//| mill-version: 1.0.4
-//| mill-jvm-version: 11
+//| mill-jvm-version: 17
 package build
 
 import mill.*
@@ -28,6 +27,8 @@ object Env extends Module:
 
 
 trait HailJavaModule extends JavaModule:
+  override def jvmId = "11"
+
   override def javacOptions: T[Seq[String]] = {
     val `java-1.8` =
       if System.getProperty("java.version").startsWith("1.8")

--- a/hail/hail/package.mill
+++ b/hail/hail/package.mill
@@ -11,14 +11,18 @@ import build.Env
 import build.Settings
 import build.HailScalaModule
 
+import millbuild.SupportedScalaVersions
 import millbuild.BuildConfig.*
 import millbuild.BuildMode.*
 import millbuild.MvnCoordinate.*
 
-object `package` extends Cross[RootHailModule](enabledScalaVersions)
+object `package` extends Cross[RootHailModule](SupportedScalaVersions)
 
 trait RootHailModule extends CrossScalaModule, HailScalaModule:
   outer =>
+
+  override def enableBsp: Boolean =
+    millbuild.BuildConfig.bspScalaVersion == crossValue
 
   override def crossScalaVersion: String =
     Settings.scalaMinorVersions(crossValue)
@@ -191,7 +195,7 @@ trait RootHailModule extends CrossScalaModule, HailScalaModule:
       )
 
     override def runMvnDeps: T[Seq[Dep]] =
-      outer.runMvnDeps()
+      outer.runMvnDeps() ++ outer.compileMvnDeps()
 
     override def assemblyRules: Seq[Rule] =
       outer.assemblyRules

--- a/hail/hail/utils/package.mill
+++ b/hail/hail/utils/package.mill
@@ -7,11 +7,15 @@ import mill.scalalib.{CrossScalaModule, Dep}
 import build.Settings
 import build.HailScalaModule
 
+import millbuild.SupportedScalaVersions
 import millbuild.BuildConfig.*
 import millbuild.MvnCoordinate.*
 
-object `package` extends Cross[HailUtils](enabledScalaVersions)
+object `package` extends Cross[HailUtils](SupportedScalaVersions)
 trait HailUtils extends HailScalaModule, CrossScalaModule:
+  override def enableBsp: Boolean =
+    millbuild.BuildConfig.bspScalaVersion == crossValue
+
   override def crossScalaVersion: String =
     Settings.scalaMinorVersions(crossValue)
 

--- a/hail/mill
+++ b/hail/mill
@@ -1,63 +1,14 @@
 #!/usr/bin/env sh
 
-# This is a wrapper script, that automatically selects or downloads Mill from Maven Central or GitHub release pages.
-#
-# This script determines the Mill version to use by trying these sources
-#   - env-variable `MILL_VERSION`
-#   - local file `.mill-version`
-#   - local file `.config/mill-version`
-#   - `mill-version` from YAML fronmatter of current buildfile
-#   - if accessible, find the latest stable version available on Maven Central (https://repo1.maven.org/maven2)
-#   - env-variable `DEFAULT_MILL_VERSION`
-#
-# If a version has the suffix '-native' a native binary will be used.
-# If a version has the suffix '-jvm' an executable jar file will be used, requiring an already installed Java runtime.
-# If no such suffix is found, the script will pick a default based on version and platform.
-#
-# Once a version was determined, it tries to use either
-#    - a system-installed mill, if found and it's version matches
-#    - an already downloaded version under ~/.cache/mill/download
-#
-# If no working mill version was found on the system,
-# this script downloads a binary file from Maven Central or Github Pages (this is version dependent)
-# into a cache location (~/.cache/mill/download).
-#
-# Mill Project URL: https://github.com/com-lihaoyi/mill
-# Script Version: 1.0.0-M1-21-7b6fae-DIRTY892b63e8
-#
-# If you want to improve this script, please also contribute your changes back!
-# This script was generated from: dist/scripts/src/mill.sh
-#
-# Licensed under the Apache License, Version 2.0
-
 set -e
 
-if [ "$1" = "--setup-completions" ] ; then
-  # Need to preserve the first position of those listed options
-  MILL_FIRST_ARG=$1
-  shift
-fi
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="1.1.5"; fi
 
-if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
-  DEFAULT_MILL_VERSION=1.0.3
-fi
+if [ -z "${GITHUB_RELEASE_CDN}" ] ; then GITHUB_RELEASE_CDN=""; fi
 
-
-if [ -z "${GITHUB_RELEASE_CDN}" ] ; then
-  GITHUB_RELEASE_CDN=""
-fi
-
+if [ -z "$MILL_MAIN_CLI" ] ; then MILL_MAIN_CLI="${0}"; fi
 
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
-
-if [ -z "${CURL_CMD}" ] ; then
-  CURL_CMD=curl
-fi
-
-# Explicit commandline argument takes precedence over all other methods
-if [ "$1" = "--mill-version" ] ; then
-    echo "The --mill-version option is no longer supported." 1>&2
-fi
 
 MILL_BUILD_SCRIPT=""
 
@@ -69,259 +20,174 @@ elif [ -f "build.sc" ] ; then
   MILL_BUILD_SCRIPT="build.sc"
 fi
 
-# Please note, that if a MILL_VERSION is already set in the environment,
-# We reuse it's value and skip searching for a value.
+# `s/.*://`:
+#   This is a greedy match that removes everything from the beginning of the line up to (and including) the last
+#   colon (:). This effectively isolates the value part of the declaration.
+#
+#  `s/#.*//`:
+#    This removes any comments at the end of the line.
+#
+#  `s/['\"]//g`:
+#    This removes all single and double quotes from the string, wherever they appear (g is for "global").
+#
+#  `s/^[[:space:]]*//; s/[[:space:]]*$//`:
+#    These two expressions trim any leading or trailing whitespace ([[:space:]] matches spaces and tabs).
+TRIM_VALUE_SED="s/.*://; s/#.*//; s/['\"]//g; s/^[[:space:]]*//; s/[[:space:]]*$//"
 
-# If not already set, read .mill-version file
 if [ -z "${MILL_VERSION}" ] ; then
   if [ -f ".mill-version" ] ; then
     MILL_VERSION="$(tr '\r' '\n' < .mill-version | head -n 1 2> /dev/null)"
   elif [ -f ".config/mill-version" ] ; then
     MILL_VERSION="$(tr '\r' '\n' < .config/mill-version | head -n 1 2> /dev/null)"
+  elif [ -f "build.mill.yaml" ] ; then
+    MILL_VERSION="$(grep -E "mill-version:" "build.mill.yaml" | sed -E "$TRIM_VALUE_SED")"
   elif [ -n "${MILL_BUILD_SCRIPT}" ] ; then
-    MILL_VERSION="$(cat ${MILL_BUILD_SCRIPT} | grep '//[|]  *mill-version:  *' | sed 's;//|  *mill-version:  *;;')"
+    MILL_VERSION="$(grep -E "//\|.*mill-version" "${MILL_BUILD_SCRIPT}" | sed -E "$TRIM_VALUE_SED")"
   fi
 fi
+
+if [ -z "${MILL_VERSION}" ] ; then MILL_VERSION="${DEFAULT_MILL_VERSION}"; fi
 
 MILL_USER_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/mill"
 
-if [ -z "${MILL_DOWNLOAD_PATH}" ] ; then
-  MILL_DOWNLOAD_PATH="${MILL_USER_CACHE_DIR}/download"
-fi
-
-# If not already set, try to fetch newest from Github
-if [ -z "${MILL_VERSION}" ] ; then
-  # TODO: try to load latest version from release page
-  echo "No mill version specified." 1>&2
-  echo "You should provide a version via a '//| mill-version: ' comment or a '.mill-version' file." 1>&2
-
-  mkdir -p "${MILL_DOWNLOAD_PATH}"
-  LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest" 2>/dev/null || (
-    # we might be on OSX or BSD which don't have -d option for touch
-    # but probably a -A [-][[hh]mm]SS
-    touch "${MILL_DOWNLOAD_PATH}/.expire_latest"; touch -A -010000 "${MILL_DOWNLOAD_PATH}/.expire_latest"
-  ) || (
-    # in case we still failed, we retry the first touch command with the intention
-    # to show the (previously suppressed) error message
-    LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest"
-  )
-
-  # POSIX shell variant of bash's -nt operator, see https://unix.stackexchange.com/a/449744/6993
-  # if [ "${MILL_DOWNLOAD_PATH}/.latest" -nt "${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
-  if [ -n "$(find -L "${MILL_DOWNLOAD_PATH}/.latest" -prune -newer "${MILL_DOWNLOAD_PATH}/.expire_latest")" ]; then
-    # we know a current latest version
-    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
-  fi
-
-  if [ -z "${MILL_VERSION}" ] ; then
-    # we don't know a current latest version
-    echo "Retrieving latest mill version ..." 1>&2
-    LANG=C ${CURL_CMD} -s -i -f -I ${MILL_REPO_URL}/releases/latest 2> /dev/null  | grep --ignore-case Location: | sed s'/^.*tag\///' | tr -d '\r\n' > "${MILL_DOWNLOAD_PATH}/.latest"
-    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
-  fi
-
-  if [ -z "${MILL_VERSION}" ] ; then
-    # Last resort
-    MILL_VERSION="${DEFAULT_MILL_VERSION}"
-    echo "Falling back to hardcoded mill version ${MILL_VERSION}" 1>&2
-  else
-    echo "Using mill version ${MILL_VERSION}" 1>&2
-  fi
-fi
+if [ -z "${MILL_FINAL_DOWNLOAD_FOLDER}" ] ; then MILL_FINAL_DOWNLOAD_FOLDER="${MILL_USER_CACHE_DIR}/download"; fi
 
 MILL_NATIVE_SUFFIX="-native"
 MILL_JVM_SUFFIX="-jvm"
-FULL_MILL_VERSION=$MILL_VERSION
 ARTIFACT_SUFFIX=""
-set_artifact_suffix(){
-  if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" = "Linux" ]; then
-    if [ "$(uname -m)" = "aarch64" ]; then
-      ARTIFACT_SUFFIX="-native-linux-aarch64"
-    else
-      ARTIFACT_SUFFIX="-native-linux-amd64"
-    fi
-  elif [ "$(uname)" = "Darwin" ]; then
-    if [ "$(uname -m)" = "arm64" ]; then
-      ARTIFACT_SUFFIX="-native-mac-aarch64"
-    else
-      ARTIFACT_SUFFIX="-native-mac-amd64"
-    fi
+
+# Check if GLIBC version is at least the required version
+# Returns 0 (true) if GLIBC >= required version, 1 (false) otherwise
+check_glibc_version() {
+  required_version="2.39"
+  required_major=$(echo "$required_version" | cut -d. -f1)
+  required_minor=$(echo "$required_version" | cut -d. -f2)
+  # Get GLIBC version from ldd --version (first line contains version like "ldd (GNU libc) 2.31")
+  glibc_version=$(ldd --version 2>/dev/null | head -n 1 | grep -oE '[0-9]+\.[0-9]+$' || echo "")
+  if [ -z "$glibc_version" ]; then
+    # If we can't determine GLIBC version, assume it's too old
+    return 1
+  fi
+  glibc_major=$(echo "$glibc_version" | cut -d. -f1)
+  glibc_minor=$(echo "$glibc_version" | cut -d. -f2)
+  if [ "$glibc_major" -gt "$required_major" ]; then
+    return 0
+  elif [ "$glibc_major" -eq "$required_major" ] && [ "$glibc_minor" -ge "$required_minor" ]; then
+    return 0
   else
-     echo "This native mill launcher supports only Linux and macOS." 1>&2
-     exit 1
+    return 1
+  fi
+}
+
+set_artifact_suffix() {
+  if [ "$(uname -s 2>/dev/null | cut -c 1-5)" = "Linux" ]; then
+    # Native binaries require new enough GLIBC; fall back to JVM launcher if older
+    if ! check_glibc_version; then
+      return
+    fi
+    if [ "$(uname -m)" = "aarch64" ]; then ARTIFACT_SUFFIX="-native-linux-aarch64"
+    else ARTIFACT_SUFFIX="-native-linux-amd64"; fi
+  elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "arm64" ]; then ARTIFACT_SUFFIX="-native-mac-aarch64"
+    else ARTIFACT_SUFFIX="-native-mac-amd64"; fi
+  else
+    echo "This native mill launcher supports only Linux and macOS." 1>&2
+    exit 1
   fi
 }
 
 case "$MILL_VERSION" in
-    *"$MILL_NATIVE_SUFFIX")
-  MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
-  set_artifact_suffix
-  ;;
+  *"$MILL_NATIVE_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
+    set_artifact_suffix
+    ;;
 
-    *"$MILL_JVM_SUFFIX")
+  *"$MILL_JVM_SUFFIX")
     MILL_VERSION=${MILL_VERSION%"$MILL_JVM_SUFFIX"}
-  ;;
+    ;;
 
-    *)
-  case "$MILL_VERSION" in
-    0.1.*) ;;
-    0.2.*) ;;
-    0.3.*) ;;
-    0.4.*) ;;
-    0.5.*) ;;
-    0.6.*) ;;
-    0.7.*) ;;
-    0.8.*) ;;
-    0.9.*) ;;
-    0.10.*) ;;
-    0.11.*) ;;
-    0.12.*) ;;
-    *)
-      set_artifact_suffix
-  esac
-  ;;
+  *)
+    case "$MILL_VERSION" in
+      0.1.* | 0.2.* | 0.3.* | 0.4.* | 0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.* | 0.12.*)
+        ;;
+      *)
+        set_artifact_suffix
+        ;;
+    esac
+    ;;
 esac
 
-MILL="${MILL_DOWNLOAD_PATH}/$MILL_VERSION$ARTIFACT_SUFFIX"
-
-try_to_use_system_mill() {
-  if [ "$(uname)" != "Linux" ]; then
-    return 0
-  fi
-
-  MILL_IN_PATH="$(command -v mill || true)"
-
-  if [ -z "${MILL_IN_PATH}" ]; then
-    return 0
-  fi
-
-  SYSTEM_MILL_FIRST_TWO_BYTES=$(head --bytes=2 "${MILL_IN_PATH}")
-  if [ "${SYSTEM_MILL_FIRST_TWO_BYTES}" = "#!" ]; then
-	  # MILL_IN_PATH is (very likely) a shell script and not the mill
-	  # executable, ignore it.
-	  return 0
-  fi
-
-  SYSTEM_MILL_PATH=$(readlink -e "${MILL_IN_PATH}")
-  SYSTEM_MILL_SIZE=$(stat --format=%s "${SYSTEM_MILL_PATH}")
-  SYSTEM_MILL_MTIME=$(stat --format=%y "${SYSTEM_MILL_PATH}")
-
-  if [ ! -d "${MILL_USER_CACHE_DIR}" ]; then
-    mkdir -p "${MILL_USER_CACHE_DIR}"
-  fi
-
-  SYSTEM_MILL_INFO_FILE="${MILL_USER_CACHE_DIR}/system-mill-info"
-  if [ -f "${SYSTEM_MILL_INFO_FILE}" ]; then
-    parseSystemMillInfo() {
-        LINE_NUMBER="${1}"
-        # Select the line number of the SYSTEM_MILL_INFO_FILE, cut the
-        # variable definition in that line in two halves and return
-        # the value, and finally remove the quotes.
-        sed -n "${LINE_NUMBER}p" "${SYSTEM_MILL_INFO_FILE}" |\
-            cut -d= -f2 |\
-            sed 's/"\(.*\)"/\1/'
-    }
-
-    CACHED_SYSTEM_MILL_PATH=$(parseSystemMillInfo 1)
-    CACHED_SYSTEM_MILL_VERSION=$(parseSystemMillInfo 2)
-    CACHED_SYSTEM_MILL_SIZE=$(parseSystemMillInfo 3)
-    CACHED_SYSTEM_MILL_MTIME=$(parseSystemMillInfo 4)
-
-    if [ "${SYSTEM_MILL_PATH}" = "${CACHED_SYSTEM_MILL_PATH}" ] \
-           && [ "${SYSTEM_MILL_SIZE}" = "${CACHED_SYSTEM_MILL_SIZE}" ] \
-           && [ "${SYSTEM_MILL_MTIME}" = "${CACHED_SYSTEM_MILL_MTIME}" ]; then
-      if [ "${CACHED_SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
-          MILL="${SYSTEM_MILL_PATH}"
-          return 0
-      else
-          return 0
-      fi
-    fi
-  fi
-
-  SYSTEM_MILL_VERSION=$(${SYSTEM_MILL_PATH} --version | head -n1 | sed -n 's/^Mill.*version \(.*\)/\1/p')
-
-  cat <<EOF > "${SYSTEM_MILL_INFO_FILE}"
-CACHED_SYSTEM_MILL_PATH="${SYSTEM_MILL_PATH}"
-CACHED_SYSTEM_MILL_VERSION="${SYSTEM_MILL_VERSION}"
-CACHED_SYSTEM_MILL_SIZE="${SYSTEM_MILL_SIZE}"
-CACHED_SYSTEM_MILL_MTIME="${SYSTEM_MILL_MTIME}"
-EOF
-
-  if [ "${SYSTEM_MILL_VERSION}" = "${MILL_VERSION}" ]; then
-    MILL="${SYSTEM_MILL_PATH}"
-  fi
-}
-try_to_use_system_mill
+MILL="${MILL_FINAL_DOWNLOAD_FOLDER}/$MILL_VERSION$ARTIFACT_SUFFIX"
 
 # If not already downloaded, download it
 if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
   case $MILL_VERSION in
-    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.* )
-      DOWNLOAD_SUFFIX=""
-      DOWNLOAD_FROM_MAVEN=0
+    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.*)
+      MILL_DOWNLOAD_SUFFIX=""
+      MILL_DOWNLOAD_FROM_MAVEN=0
       ;;
-    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M* )
-      DOWNLOAD_SUFFIX="-assembly"
-      DOWNLOAD_FROM_MAVEN=0
+    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M*)
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=0
       ;;
     *)
-      DOWNLOAD_SUFFIX="-assembly"
-      DOWNLOAD_FROM_MAVEN=1
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=1
       ;;
   esac
   case $MILL_VERSION in
-    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11 )
-      DOWNLOAD_EXT="jar"
+    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11)
+      MILL_DOWNLOAD_EXT="jar"
       ;;
-    0.12.* )
-      DOWNLOAD_EXT="exe"
+    0.12.*)
+      MILL_DOWNLOAD_EXT="exe"
       ;;
-    0.* )
-      DOWNLOAD_EXT="jar"
+    0.*)
+      MILL_DOWNLOAD_EXT="jar"
       ;;
     *)
-      DOWNLOAD_EXT="exe"
+      MILL_DOWNLOAD_EXT="exe"
       ;;
   esac
 
-  DOWNLOAD_FILE=$(mktemp mill.XXXXXX)
-  if [ "$DOWNLOAD_FROM_MAVEN" = "1" ] ; then
-    DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.${DOWNLOAD_EXT}"
+  MILL_TEMP_DOWNLOAD_FILE="${MILL_OUTPUT_DIR:-out}/mill-temp-download"
+  mkdir -p "$(dirname "${MILL_TEMP_DOWNLOAD_FILE}")"
+
+  if [ "$MILL_DOWNLOAD_FROM_MAVEN" = "1" ] ; then
+    MILL_DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.${MILL_DOWNLOAD_EXT}"
   else
     MILL_VERSION_TAG=$(echo "$MILL_VERSION" | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
-    DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
+    MILL_DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${MILL_DOWNLOAD_SUFFIX}"
     unset MILL_VERSION_TAG
   fi
 
+
   if [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
-    echo $DOWNLOAD_URL
-    echo $MILL
+    echo "$MILL_DOWNLOAD_URL"
+    echo "$MILL"
     exit 0
   fi
-  # TODO: handle command not found
-  echo "Downloading mill ${MILL_VERSION} from ${DOWNLOAD_URL} ..." 1>&2
-  ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" "${DOWNLOAD_URL}"
-  chmod +x "${DOWNLOAD_FILE}"
-  mkdir -p "${MILL_DOWNLOAD_PATH}"
-  mv "${DOWNLOAD_FILE}" "${MILL}"
 
-  unset DOWNLOAD_FILE
-  unset DOWNLOAD_SUFFIX
-fi
+  echo "Downloading mill ${MILL_VERSION} from ${MILL_DOWNLOAD_URL} ..." 1>&2
+  curl -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"
 
-if [ -z "$MILL_MAIN_CLI" ] ; then
-  MILL_MAIN_CLI="${0}"
+  chmod +x "${MILL_TEMP_DOWNLOAD_FILE}"
+
+  mkdir -p "${MILL_FINAL_DOWNLOAD_FOLDER}"
+  mv "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL}"
+
+  unset MILL_TEMP_DOWNLOAD_FILE
+  unset MILL_DOWNLOAD_SUFFIX
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift
 fi
 
-unset MILL_DOWNLOAD_PATH
+unset MILL_FINAL_DOWNLOAD_FOLDER
 unset MILL_OLD_DOWNLOAD_PATH
 unset OLD_MILL
 unset MILL_VERSION

--- a/hail/mill-build/build.mill
+++ b/hail/mill-build/build.mill
@@ -5,7 +5,7 @@ import mill.api.{PathRef, Task, TaskCtx}
 import mill.meta.MillBuildRootModule
 import mill.scalalib.Dep
 
-import millbuild.BuildMode
+import millbuild.*
 import millbuild.MvnCoordinate.*
 
 import scala.collection.immutable.ArraySeq
@@ -19,9 +19,6 @@ extension [A, F[+X] <: Iterable[X]] (as: F[A])
 
 
 object `package` extends MillBuildRootModule:
-
-  private val SupportedScalaVersions =
-    Set("2.12", "2.12.13", "2.13")
 
   override def mvnDeps: T[Seq[Dep]] =
     Seq(
@@ -45,37 +42,37 @@ object `package` extends MillBuildRootModule:
          |object BuildConfig {
          |  val buildMode =
          |    BuildMode.${buildMode().getOrElse(BuildMode.Release)}
-         |  val enabledScalaVersions =
-         |    ${(enabledScalaVersions() or SupportedScalaVersions.to(ArraySeq)).quoted}
+         |  val bspScalaVersion: String =
+         |    "${bspScalaVersion().getOrElse("2.13")}"
          |}
       """.stripMargin
     )
     super.generatedSources() ++ Seq(PathRef(Task.dest))
   }
 
-  def getConfig(name: String)(implicit ctx: TaskCtx.Env): Seq[String] =
+  def getConfig(name: String)(implicit ctx: TaskCtx.Env): Option[String] =
     ctx.env
       .get(name map { case '-' => '_'; case c => c.toUpper })
       .orElse {
         val path = moduleDir / "config" / name
         Option.when(os.exists(path))(os.read(path))
       }
-      .to(ArraySeq)
-      .flatMap(_.split(',').map(_.strip))
 
-  def enabledScalaVersions: T[Seq[String]] =
+  def bspScalaVersion: T[Option[String]] =
     Task.Input {
-      getConfig("scala-version").tapEach { ver =>
+      val opt = getConfig("scala-version")
+      opt.foreach { ver =>
         require(
           SupportedScalaVersions `contains` ver,
           s"SCALA_VERSION may be one of ${SupportedScalaVersions.quoted.mkString(",")}; found '$ver'."
         )
       }
+      opt
     }
 
   def buildMode: T[Option[BuildMode]] =
     Task.Input {
-      getConfig("hail-build-mode").headOption.map { raw =>
+      getConfig("hail-build-mode").map { raw =>
         try
           BuildMode.valueOf(raw)
         catch {

--- a/hail/mill-build/mill-build/src/package.scala
+++ b/hail/mill-build/mill-build/src/package.scala
@@ -1,0 +1,6 @@
+import scala.collection.immutable.ArraySeq
+
+package millbuild {
+  val SupportedScalaVersions =
+    ArraySeq("2.12", "2.12.13", "2.13")
+}


### PR DESCRIPTION
## Change Description

Mill introduced a new feature to manually enable/disable bsp support for each module. This means we can now have only modules for a single scala version show up in IntelliJ, while all scala versions remain available from the command line (e.g. using the `./mill hail[2.12].compile`).

Changes:

- upgrade mill 1.0.4 -> 1.1.5
- the `scala-version` config file (or `SCALA_VERSION` envvar) now specifies which version of scala will be used by bsp/intellij
- all scala versions are accessible from the command line at all times. The official syntax is now `hail.2_12._`, though the old `hail[2.12]._` still works

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP