### PR TITLE
[query] clean-up unused fs methods

### DIFF
--- a/hail/hail/src/is/hail/io/fs/HadoopFS.scala
+++ b/hail/hail/src/is/hail/io/fs/HadoopFS.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 import java.io._
 
 import org.apache.hadoop
-import org.apache.hadoop.fs.{EtagSource, FSDataInputStream, FSDataOutputStream}
+import org.apache.hadoop.fs.{EtagSource, FSDataInputStream, FSDataOutputStream, Path}
 
 class HadoopFileListEntry(fs: hadoop.fs.FileStatus) extends FileListEntry {
   val normalizedPath = fs.getPath
@@ -72,26 +72,26 @@ object HadoopFS {
     }
 }
 
-case class HadoopFSURL(path: String, conf: SerializableHadoopConfiguration) extends FSURL {
-  private[this] val unqualifiedHadoopPath = new hadoop.fs.Path(path)
-  val hadoopFs = unqualifiedHadoopPath.getFileSystem(conf.value)
-  val hadoopPath = hadoopFs.makeQualified(unqualifiedHadoopPath)
+class HadoopFSURL(unqualified: Path, conf: SerializableHadoopConfiguration)
+    extends FSURL[HadoopFSURL] {
+  val hadoopFs = unqualified.getFileSystem(conf.value)
+  val hadoopPath: Path = hadoopFs.makeQualified(unqualified)
 
-  def addPathComponent(c: String): HadoopFSURL = HadoopFSURL(s"${hadoopPath.toString}/$c", conf)
-  def getPath: String = hadoopPath.toString
-  def fromString(s: String): HadoopFSURL = HadoopFSURL(s, conf)
-  override def toString(): String = hadoopPath.toString
+  override def /(c: String): HadoopFSURL =
+    new HadoopFSURL(new Path(unqualified, c), conf)
+
+  override def path: String = hadoopPath.toString
+  override def toString: String = hadoopPath.toString
 }
 
 class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends FS {
   type URL = HadoopFSURL
 
-  override def parseUrl(filename: String): URL = HadoopFSURL(filename, conf)
+  override def parseUrl(filename: String): URL =
+    new HadoopFSURL(new Path(filename), conf)
 
   override def validUrl(filename: String): Boolean =
     Try(getFileSystem(filename)).isSuccess
-
-  def urlAddPathComponent(url: URL, component: String): URL = url.addPathComponent(component)
 
   def getConfiguration(): SerializableHadoopConfiguration = conf
 
@@ -172,7 +172,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
   override def fileStatus(url: URL): FileStatus = {
     val fle = fileListEntry(url)
     if (fle.isDirectory) {
-      throw new FileNotFoundException(url.getPath)
+      throw new FileNotFoundException(url.path)
     }
     fle
   }
@@ -191,9 +191,6 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     val pathFS = ppath.getFileSystem(conf.value)
     pathFS.makeQualified(ppath).toString
   }
-
-  override def deleteOnExit(url: URL): Unit =
-    url.hadoopFs.deleteOnExit(url.hadoopPath): Unit
 
   def supportsScheme(scheme: String): Boolean =
     (scheme == "") || {

--- a/hail/hail/src/is/hail/io/fs/RouterFS.scala
+++ b/hail/hail/src/is/hail/io/fs/RouterFS.scala
@@ -9,19 +9,15 @@ import java.nio.file.Path
 
 import org.apache.hadoop.conf.Configuration
 
-object RouterFSURL {
-  def apply(fs: FS)(_url: fs.URL): RouterFSURL = RouterFSURL(_url, fs)
-}
+class RouterFSURL(val fs: FS, _url: FSURL[_]) extends FSURL[RouterFSURL] {
+  def url: fs.URL = _url.asInstanceOf[fs.URL]
 
-case class RouterFSURL private (_url: FSURL, val fs: FS) extends FSURL {
-  val url = _url.asInstanceOf[fs.URL]
+  override def path: String = _url.path
 
-  def getPath: String = url.getPath
+  override def /(component: String): RouterFSURL =
+    new RouterFSURL(fs, url / component)
 
-  def addPathComponent(component: String): RouterFSURL =
-    RouterFSURL(fs)(fs.urlAddPathComponent(url, component))
-
-  override def toString(): String = url.toString
+  override def toString: String = _url.toString
 }
 
 case class CloudStorageFSConfig(
@@ -86,27 +82,17 @@ class RouterFS(fss: IndexedSeq[FS]) extends FS {
 
   override def parseUrl(filename: String): URL = {
     val fs = lookupFS(filename)
-
-    RouterFSURL(fs)(fs.parseUrl(filename))
+    new RouterFSURL(fs, fs.parseUrl(filename))
   }
 
   override def validUrl(filename: String): Boolean =
     fss.exists(_.validUrl(filename))
 
-  def urlAddPathComponent(url: URL, component: String): URL = url.addPathComponent(component)
-
-  override def openCachedNoCompression(url: URL): SeekableDataInputStream =
-    url.fs.openCachedNoCompression(url.url)
-
-  override def createCachedNoCompression(url: URL): PositionedDataOutputStream =
-    url.fs.createCachedNoCompression(url.url)
-
-  def openNoCompression(url: URL): SeekableDataInputStream = url.fs.openNoCompression(url.url)
-
-  def createNoCompression(url: URL): PositionedDataOutputStream =
+  override def createNoCompression(url: RouterFSURL): PositionedDataOutputStream =
     url.fs.createNoCompression(url.url)
 
-  override def readNoCompression(url: URL): Array[Byte] = url.fs.readNoCompression(url.url)
+  def openNoCompression(url: URL): SeekableDataInputStream =
+    url.fs.openNoCompression(url.url)
 
   override def mkDir(url: URL): Unit = url.fs.mkDir(url.url)
 

--- a/hail/hail/test/src/is/hail/expr/ir/analyses/SemanticHashSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/analyses/SemanticHashSuite.scala
@@ -305,7 +305,7 @@ class SemanticHashSuite extends HailSuite {
     val fs =
       new FakeFS {
         override def eTag(url: FakeURL): Option[String] =
-          throw new FileNotFoundException(url.getPath)
+          throw new FileNotFoundException(url.path)
       }
 
     val ir = importMatrix("gs://fake-bucket/fake-matrix")
@@ -320,12 +320,12 @@ class SemanticHashSuite extends HailSuite {
   private[this] val fakeFs: FS =
     new FakeFS {
       override def eTag(url: FakeURL): Option[String] =
-        Some(url.getPath)
+        Some(url.path)
 
       override def glob(url: FakeURL): Array[FileListEntry] =
         Array(new FileListEntry {
-          override def getPath: String = url.getPath
-          override def getActualUrl: String = url.getPath
+          override def getPath: String = url.path
+          override def getActualUrl: String = url.path
           override def getModificationTime: lang.Long = ???
           override def getLen: Long = ???
           override def isDirectory: Boolean = ???

--- a/hail/hail/test/src/is/hail/io/fs/FSSuite.scala
+++ b/hail/hail/test/src/is/hail/io/fs/FSSuite.scala
@@ -291,9 +291,6 @@ trait FSSuite extends TestNGSuiteLike with TestUtils {
   @Test def testGetCodecExtension(): Unit =
     assert(fs.getCodecExtension("foo.vcf.bgz") == ".bgz")
 
-  @Test def testStripCodecExtension(): Unit =
-    assert(fs.stripCodecExtension("foo.vcf.bgz") == "foo.vcf")
-
   @Test def testReadWriteBytes(): Unit = {
     val f = t()
 
@@ -436,7 +433,7 @@ trait FSSuite extends TestNGSuiteLike with TestUtils {
   @Test def testSeekAfterEOF(): Unit = {
     val prefix = s"$tmpdir/fs-suite/delete-many-files/${java.util.UUID.randomUUID()}"
     val p = s"$prefix/seek_file"
-    using(fs.createCachedNoCompression(p)) { os =>
+    using(fs.createNoCompression(p)) { os =>
       os.write(1)
       os.write(2)
       os.write(3)

--- a/hail/hail/test/src/is/hail/io/fs/FakeFS.scala
+++ b/hail/hail/test/src/is/hail/io/fs/FakeFS.scala
@@ -1,15 +1,14 @@
 package is.hail.io.fs
 
-case class FakeURL(path: String) extends FSURL {
-  def getPath: String = path
-  def getActualUrl: String = path
+class FakeURL(override val path: String) extends FSURL[FakeURL] {
+  override def /(component: String): FakeURL =
+    new FakeURL(f"$path/$component")
 }
 
 abstract class FakeFS extends FS {
   override type URL = FakeURL
   override def validUrl(filename: String): Boolean = ???
-  override def parseUrl(filename: String): FakeURL = FakeURL(filename)
-  override def urlAddPathComponent(url: FakeURL, component: String): FakeURL = ???
+  override def parseUrl(filename: String): FakeURL = new FakeURL(filename)
   override def openNoCompression(url: FakeURL): SeekableDataInputStream = ???
   override def createNoCompression(url: FakeURL): PositionedDataOutputStream = ???
   override def delete(url: FakeURL, recursive: Boolean): Unit = ???

--- a/hail/hail/test/src/is/hail/utils/UtilsSuite.scala
+++ b/hail/hail/test/src/is/hail/utils/UtilsSuite.scala
@@ -59,13 +59,6 @@ class UtilsSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
     assert(Array(1, 1).isSorted)
   }
 
-  @Test def testHadoopStripCodec(): Unit = {
-    assert(fs.stripCodecExtension("file.tsv") == "file.tsv")
-    assert(fs.stripCodecExtension("file.tsv.gz") == "file.tsv")
-    assert(fs.stripCodecExtension("file.tsv.bgz") == "file.tsv")
-    assert(fs.stripCodecExtension("file") == "file")
-  }
-
   @Test def testPairRDDNoDup(): Unit = {
     val answer1 =
       Array((1, (1, Option(1))), (2, (4, Option(2))), (3, (9, Option(3))), (4, (16, Option(4))))


### PR DESCRIPTION
## Change Description

This PR refactors the filesystem abstraction layer to improve the URL handling interface. The main changes include:

- Convert `FSURL` from a trait to an abstract class with a generic type parameter
- Add a standard path component addition operator `/` to replace `addPathComponent`
- Remove redundant methods like `readNoCompression`, `deleteOnExit`, `stripCodecExtension`, and caching-related methods
- Rename `getPath` to simply `path` for cleaner access
- Update implementations in AzureStorageFS, GoogleStorageFS, HadoopFS, and RouterFS to use the new interface

These changes make the filesystem API more consistent and easier to use while removing unnecessary functionality.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP