### PR TITLE
[compiler] enforce use of custom ArraySeq over standard library

### DIFF
--- a/hail/.scalafix.conf
+++ b/hail/.scalafix.conf
@@ -4,6 +4,7 @@ rules = [
   ProcedureSyntax
   OrganizeImports
   RemoveUnused
+  ForbiddenSymbol
 ]
 
 OrganizeImports {
@@ -28,3 +29,7 @@ RemoveUnused {
   patternvars = true
   params = true
 }
+
+ForbiddenSymbol.symbols = [
+  "scala.collection.compat.immutable.ArraySeq"
+]

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -101,6 +101,10 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
   def crossValue: String
   override def scalaVersion: T[String] = Task { Settings.scalaMinorVersions(crossValue) }
 
+  override def scalafixIvyDeps: T[Seq[Dep]] = Seq(
+    mvn"io.github.tanin47::scalafix-forbidden-symbol:1.0.0",
+  )
+
   override def javacOptions: T[Seq[String]] = Seq(
     "-Xlint:all",
     "-Werror",
@@ -220,6 +224,10 @@ trait HailModule extends ScalaModule with ScalafmtModule with ScalafixModule { o
 
   trait HailTests extends ScalaTests with TestNg with ScalafmtModule with ScalafixModule {
     override def forkArgs: T[Seq[String]] = Seq("-Xss4m", "-Xmx4096M")
+
+    override def scalafixIvyDeps: T[Seq[Dep]] = Seq(
+      mvn"io.github.tanin47::scalafix-forbidden-symbol:1.0.0",
+    )
 
     override def mvnDeps: T[Seq[Dep]] =
       super.mvnDeps() ++ outer.compileMvnDeps() ++ Seq(

--- a/hail/hail/src-2.12/is/hail/utils/compat/immutable/ArraySeq.scala
+++ b/hail/hail/src-2.12/is/hail/utils/compat/immutable/ArraySeq.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 
 object ArraySeq {
+  // scalafix:off ForbiddenSymbol
   import scala.collection.compat.immutable.{ArraySeq => A}
 
   def empty[T <: AnyRef]: ArraySeq[T] = A.empty

--- a/hail/hail/src-2.12/is/hail/utils/compat/immutable/package.scala
+++ b/hail/hail/src-2.12/is/hail/utils/compat/immutable/package.scala
@@ -1,5 +1,6 @@
 package is.hail.utils.compat
 
 package object immutable {
+  // scalafix:off ForbiddenSymbol
   type ArraySeq[A] = scala.collection.compat.immutable.ArraySeq[A]
 }

--- a/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
@@ -8,10 +8,10 @@ import is.hail.rvd.{AbstractRVDSpec, RVD}
 import is.hail.types.physical.{PArray, PCanonicalStruct, PStruct, PType}
 import is.hail.types.virtual._
 import is.hail.utils._
+import is.hail.utils.compat.immutable.ArraySeq
 import is.hail.variant._
 
 import scala.collection.compat._
-import scala.collection.compat.immutable.ArraySeq
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.Row

--- a/hail/hail/src/is/hail/services/JSONLogLayout.scala
+++ b/hail/hail/src/is/hail/services/JSONLogLayout.scala
@@ -1,6 +1,6 @@
 package is.hail.services
 
-import scala.collection.compat.immutable.ArraySeq
+import is.hail.utils.compat.immutable.ArraySeq
 
 import java.io.StringWriter
 import java.text._

--- a/hail/hail/src/is/hail/utils/Bitstring.scala
+++ b/hail/hail/src/is/hail/utils/Bitstring.scala
@@ -1,6 +1,7 @@
 package is.hail.utils
 
-import scala.collection.compat.immutable.ArraySeq
+import is.hail.utils.compat.immutable.ArraySeq
+
 import scala.collection.mutable
 
 object Bitstring {

--- a/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
@@ -11,8 +11,8 @@ import is.hail.rvd.RVD
 import is.hail.types._
 import is.hail.types.virtual._
 import is.hail.utils._
+import is.hail.utils.compat.immutable.ArraySeq
 
-import scala.collection.compat.immutable.ArraySeq
 import scala.collection.mutable
 
 import org.apache.spark.sql.Row

--- a/hail/hail/test/src/is/hail/utils/IntervalSuite.scala
+++ b/hail/hail/test/src/is/hail/utils/IntervalSuite.scala
@@ -5,8 +5,7 @@ import is.hail.annotations.ExtendedOrdering
 import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.rvd.RVDPartitioner
 import is.hail.types.virtual.{TInt32, TStruct}
-
-import scala.collection.compat.immutable.ArraySeq
+import is.hail.utils.compat.immutable.ArraySeq
 
 import org.apache.spark.sql.Row
 import org.scalatest.Inspectors.forAll


### PR DESCRIPTION
## Change Description

As part of the Scala 2.13 cross compilation work, I added a custom `ArraySeq` object with more efficient implementations of a few methods. This left open the possibility of some files importing the standard library `ArraySeq` and unintentionally missing these optimizations (which is easy to do when letting IntelliJ add imports for you).

This PR adds a third party Scalafix rule, [forbidden symbol](https://github.com/tanin47/scalafix-forbidden-symbol), to forbid naming the standard library `ArraySeq`, except for where our custom version delegates to the standard library.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

