### PR TITLE
[query/docs] Clarify liftover guide

### DIFF
--- a/hail/python/hail/docs/cloud/google_cloud.rst
+++ b/hail/python/hail/docs/cloud/google_cloud.rst
@@ -58,6 +58,8 @@ Importantly, to shut down a cluster when done with it, use:
 
     hailctl dataproc stop CLUSTER_NAME
 
+.. _Reading From GCS:
+
 Reading from Google Cloud Storage
 ---------------------------------
 

--- a/hail/python/hail/docs/guides/genetics.rst
+++ b/hail/python/hail/docs/guides/genetics.rst
@@ -56,6 +56,8 @@ Liftover variants from one coordinate system to another
     >>> rg38 = hl.get_reference('GRCh38')  # doctest: +SKIP
     >>> rg37.add_liftover('gs://hail-common/references/grch37_to_grch38.over.chain.gz', rg38)  # doctest: +SKIP
 
+    In order to use the above verbatim, you may need to :ref:`install the GCS connector <Reading from GCS>`.
+
     Then we can liftover the locus coordinates in a Table or MatrixTable (here, `ht`)
     from reference genome ``'GRCh37'`` to ``'GRCh38'``:
 
@@ -448,10 +450,3 @@ Polygenic Score Calculation
 
     :func:`.import_plink`, :func:`.variant_qc`, :func:`.import_table`,
     :func:`.coalesce`, :func:`.case`, :func:`.cond`, :meth:`.Call.n_alt_alleles`
-
-
-
-
-
-
-


### PR DESCRIPTION
The GCS connector or similar needs to be installed to use the guide code verbatim.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
