### PR TITLE
[query] reduce uses of fs.open with compression

### DIFF
--- a/hail/hail/src/is/hail/asm4s/package.scala
+++ b/hail/hail/src/is/hail/asm4s/package.scala
@@ -1,6 +1,10 @@
 package is.hail
 
+import is.hail.utils.richUtils.ByteTrackingOutputStream
+
 import scala.reflect.ClassTag
+
+import java.io.{BufferedInputStream, BufferedOutputStream, InputStream, OutputStream}
 
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.tree._
@@ -386,4 +390,17 @@ package object asm4s {
   implicit def charToCode(c: Char): Code[Char] = const(c)
 
   implicit def byteToCode(b: Byte): Code[Byte] = const(b)
+
+  implicit class RichCodeInputStream(private val c: Code[_ <: InputStream]) extends AnyVal {
+    def buffer: Code[BufferedInputStream] =
+      Code.newInstance[BufferedInputStream, InputStream](c)
+  }
+
+  implicit class RichCodeOutputStream(private val c: Code[_ <: OutputStream]) extends AnyVal {
+    def buffer: Code[BufferedOutputStream] =
+      Code.newInstance[BufferedOutputStream, OutputStream](c)
+
+    def trackBytes: Code[ByteTrackingOutputStream] =
+      Code.newInstance[ByteTrackingOutputStream, OutputStream](c)
+  }
 }

--- a/hail/hail/src/is/hail/expr/ir/Emit.scala
+++ b/hail/hail/src/is/hail/expr/ir/Emit.scala
@@ -3033,7 +3033,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
 
       case ReadValue(path, reader, requestedType) =>
         emitI(path).map(cb) { pv =>
-          val is = cb.memoize(mb.openUnbuffered(pv.asString.loadString(cb), checkCodec = true))
+          val is = cb.memoize(mb.open(pv.asString.loadString(cb), checkCodec = true))
           val decoded = reader.readValue(cb, requestedType, region, is)
           cb += is.invoke[Unit]("close")
           decoded
@@ -3043,7 +3043,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
         emitI(path).flatMap(cb) { case pv: SStringValue =>
           emitI(value).map(cb) { v =>
             val s = stagingFile.map(emitI(_).getOrAssert(cb).asString)
-            val os = cb.memoize(mb.createUnbuffered(s.getOrElse(pv).loadString(cb)))
+            val os = cb.memoize(mb.create(s.getOrElse(pv).loadString(cb)))
             writer.writeValue(cb, v, os)
             cb += os.invoke[Unit]("close")
             s.foreach { stage =>

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -295,21 +295,11 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
   ): EmitMethodBuilder[C] =
     ecb.genEmitMethod[A1, A2, A3, A4, A5, R](baseName)
 
-  def openUnbuffered(path: Code[String], checkCodec: Code[Boolean]): Code[InputStream] =
+  def open(path: Code[String], checkCodec: Code[Boolean]): Code[InputStream] =
     getFS.invoke[String, Boolean, InputStream]("open", path, checkCodec)
 
-  def open(path: Code[String], checkCodec: Code[Boolean]): Code[InputStream] =
-    Code.newInstance[java.io.BufferedInputStream, InputStream](
-      getFS.invoke[String, Boolean, InputStream]("open", path, checkCodec)
-    )
-
-  def createUnbuffered(path: Code[String]): Code[OutputStream] =
-    getFS.invoke[String, OutputStream]("create", path)
-
   def create(path: Code[String]): Code[OutputStream] =
-    Code.newInstance[java.io.BufferedOutputStream, OutputStream](
-      getFS.invoke[String, OutputStream]("create", path)
-    )
+    getFS.invoke[String, OutputStream]("create", path)
 }
 
 final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuilder[C])

--- a/hail/hail/src/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -352,7 +352,7 @@ object EmitStreamDistribute {
       fileArrayIdx < numFilesToWrite,
       cb.assign(fileArrayIdx, fileArrayIdx + 1), {
         val fileName = makeFileName(cb, fileArrayIdx)
-        val ob = cb.memoize(spec.buildCodeOutputBuffer(mb.createUnbuffered(fileName)))
+        val ob = cb.memoize(spec.buildCodeOutputBuffer(mb.create(fileName)))
         cb += outputBuffers.update(fileArrayIdx, ob)
         cb += numElementsPerFile.update(fileArrayIdx, 0)
         cb += numBytesPerFile.update(fileArrayIdx, 0)

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -436,7 +436,7 @@ package defs {
     ): IEmitCode = {
       context.toI(cb).map(cb) { case ctx: SStringValue =>
         val filename = ctx.loadString(cb)
-        val os = cb.memoize(cb.emb.create(filename))
+        val os = cb.memoize(cb.emb.create(filename).buffer)
 
         preConsume(cb, os)
         stream.memoryManagedConsume(region, cb) { cb =>

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -818,7 +818,7 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec, uidFieldName: Str
         override def initialize(cb: EmitCodeBuilder, partitionRegion: Value[Region]): Unit = {
           cb.assign(
             xRowBuf,
-            spec.buildCodeInputBuffer(mb.openUnbuffered(pathString, checkCodec = true)),
+            spec.buildCodeInputBuffer(mb.open(pathString, checkCodec = true)),
           )
           cb.assign(rowIdx, -1L)
         }
@@ -1053,7 +1053,7 @@ case class PartitionNativeIntervalReader(
                     ib,
                     spec.buildCodeInputBuffer(
                       Code.newInstance[ByteTrackingInputStream, InputStream](
-                        cb.emb.openUnbuffered(partPath, false)
+                        cb.emb.open(partPath, false)
                       )
                     ),
                   )
@@ -1264,7 +1264,7 @@ case class PartitionNativeReaderIndexed(
             ib,
             spec.buildCodeInputBuffer(
               Code.newInstance[ByteTrackingInputStream, InputStream](
-                cb.emb.openUnbuffered(partitionPath, false)
+                cb.emb.open(partitionPath, false)
               )
             ),
           )
@@ -1615,7 +1615,7 @@ case class PartitionZippedIndexedNativeReader(
             leftBuffer,
             specLeft.buildCodeInputBuffer(
               Code.newInstance[ByteTrackingInputStream, InputStream](
-                mb.openUnbuffered(
+                mb.open(
                   ctxStruct.loadField(cb, "leftPartitionPath")
                     .getOrAssert(cb)
                     .asString
@@ -1629,7 +1629,7 @@ case class PartitionZippedIndexedNativeReader(
             rightBuffer,
             specRight.buildCodeInputBuffer(
               Code.newInstance[ByteTrackingInputStream, InputStream](
-                mb.openUnbuffered(
+                mb.open(
                   ctxStruct.loadField(cb, "rightPartitionPath")
                     .getOrAssert(cb)
                     .asString

--- a/hail/hail/src/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/hail/src/is/hail/io/avro/AvroPartitionReader.scala
@@ -81,7 +81,7 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
           val mb = cb.emb
           val codeSchema = cb.newLocal("schema", mb.getObject(schema))
           cb.assign(record, Code.newInstance[GenericData.Record, Schema](codeSchema))
-          val is = mb.open(pathString, false)
+          val is = mb.open(pathString, false).buffer
           val datumReader = Code.newInstance[GenericDatumReader[GenericRecord], Schema](codeSchema)
           val dataFileStream = Code.newInstance[
             DataFileStream[GenericRecord],

--- a/hail/hail/src/is/hail/io/bgen/StagedBGENReader.scala
+++ b/hail/hail/src/is/hail/io/bgen/StagedBGENReader.scala
@@ -731,7 +731,10 @@ object BGENFunctions extends RegistryFunctions {
               .concat("-").concat(Code.invokeScalaObject0[String](BGENFunctions.getClass, "uuid")),
           )
           val ob =
-            cb.newLocal[OutputBuffer]("currFile", spec.buildCodeOutputBuffer(mb.create(path)))
+            cb.newLocal[OutputBuffer](
+              "currFile",
+              spec.buildCodeOutputBuffer(mb.create(path).buffer),
+            )
 
           val i = cb.newLocal[Int]("i", 0)
           cb.while_(
@@ -811,7 +814,7 @@ object BGENFunctions extends RegistryFunctions {
           val path = cb.memoize(ctor.getCodeParam[String](1))
           val _size = cb.memoize(ctor.getCodeParam[Int](2))
 
-          cb.assign(ib, spec.buildCodeInputBuffer(mb.open(path, false)))
+          cb.assign(ib, spec.buildCodeInputBuffer(mb.open(path, false).buffer))
           cb.assign(iterSize, _size)
           cb.assign(iterCurrIdx, 0)
         }

--- a/hail/hail/src/is/hail/io/index/StagedIndexReader.scala
+++ b/hail/hail/src/is/hail/io/index/StagedIndexReader.scala
@@ -90,7 +90,7 @@ class StagedIndexReader(
      * but propagated. */
     cb.assign(
       is,
-      Code.newInstance[ByteTrackingInputStream, InputStream](cb.emb.openUnbuffered(
+      Code.newInstance[ByteTrackingInputStream, InputStream](cb.emb.open(
         indexPath.concat("/index"),
         false,
       )),


### PR DESCRIPTION
## Change Description

This PR refactors stream handling in the codebase by introducing buffering and byte tracking utilities as extension methods. It adds `RichCodeInputStream` and `RichCodeOutputStream` classes with methods like `buffer` and `trackBytes` to simplify stream creation and management.

The changes remove direct instantiation of `BufferedInputStream`, `BufferedOutputStream`, and `ByteTrackingOutputStream` throughout the codebase, replacing them with the new extension methods. This standardizes stream handling and makes the code more consistent.

The PR also updates various file operations in `EmitClassBuilder`, `MatrixWriter`, `TableWriter`, and other classes to use these new utilities, ensuring consistent stream handling across the codebase.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP