### PR TITLE
[query] make tests work with mill's sandboxing

### DIFF
--- a/hail/hail/test/src/is/hail/HailSuite.scala
+++ b/hail/hail/test/src/is/hail/HailSuite.scala
@@ -48,7 +48,10 @@ class HailSuite extends TestNGSuite with TestUtils {
   def sc: SparkContext = ctx.backend.asSpark.sc
   def theHailClassLoader: HailClassLoader = ctx.theHailClassLoader
 
-  def getTestResource(localPath: String): String = s"hail/test/resources/$localPath"
+  private[this] lazy val resources: String =
+    sys.env.getOrElse("MILL_TEST_RESOURCE_DIR", "hail/test/resources")
+
+  def getTestResource(localPath: String): String = s"$resources/$localPath"
 
   @BeforeSuite
   def setupBackend(): Unit = {


### PR DESCRIPTION
Mill runs tests in a sandbox directory by default.
This breaks our tests that try to read from test resources.
Use "MILL_TEST_RESOURCE_DIR" to get to test resource directory.

See the following for more information: 
https://mill-build.org/mill/scalalib/testing.html#_running_tests

This change cannot affect the Broad-managed hail batch deployment in GCP.
