### PR TITLE
Remove unnecessary accessConfigs parameter from VM config API payload

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -129,7 +129,6 @@ def create_vm_config(
                 'network': 'global/networks/default',
                 'subnetwork': f'regions/{region}/subnetworks/default',
                 'networkTier': 'PREMIUM',
-                'accessConfigs': [{'type': 'ONE_TO_ONE_NAT', 'name': 'external-nat'}],
             }
         ],
         'scheduling': scheduling(),


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/67

Currently, worker VMs are created with external IP addresses. However, there is no operational reason why they actually need those, as we don't actually need/want our workers to be accessible from the public internet. This change updates our worker VM config (sent to GCP for worker creation) to exclude giving an external IP.

## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a medium security impact

### Impact Description

While removing public IPs from our workers makes things generally more secure, this change still relates to changing our worker VM configuration and communication.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
