### PR TITLE
[auth] Add 'inactive' status to the list of account errors

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -422,9 +422,11 @@ async def callback(request) -> web.Response:
 
         raise web.HTTPFound(creating_url)
 
-    if user['state'] in ('deleting', 'deleted'):
+    if user['state'] in ('deleting', 'deleted', 'inactive'):
         page_context = {'username': user['username'], 'state': user['state'], 'login_id': user['login_id']}
-        return await render_template('auth', request, user, 'account-error.html', page_context)
+        return await render_template(
+            'auth', request, user, 'account-error.html', page_context, status_code=web.HTTPUnauthorized.status_code
+        )
 
     if user['state'] == 'creating':
         if caller == 'signup':

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -83,6 +83,8 @@ async def render_template(
     userdata: Optional[UserData],
     file: str,
     page_context: Dict[str, Any],
+    *,
+    status_code: int = 200,
 ) -> web.Response:
     if request.headers.get('x-hail-return-jinja-context'):
         if userdata and userdata['is_developer']:
@@ -100,7 +102,7 @@ async def render_template(
     context['use_tailwind'] = service in TAILWIND_SERVICES
     context['csrf_token'] = csrf_token
 
-    response = aiohttp_jinja2.render_template(file, request, context)
+    response = aiohttp_jinja2.render_template(file, request, context, status=status_code)
     response.set_cookie('_csrf', csrf_token, secure=True, httponly=True, samesite='strict')
     return response
 


### PR DESCRIPTION
A user reported a 500 when trying to log in on zulip ([#Hail Batch support > unable to log in -- 500 error](https://hail.zulipchat.com/#narrow/channel/223457-Hail-Batch-support/topic/unable.20to.20log.20in.20--.20500.20error/with/563247607)).

We run into this internal server error because we were failing [this](https://github.com/hail-is/hail/blob/5d54486fcac06f6b7b2e8af380f812d1552343fc/auth/auth/auth.py#L438) assertion, as were not handling the 'inactive' status. This change adds the 'inactive' status to the list of errors, and also makes sure to set an http error status when rendering the `account-errors.html` template.

## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has low security impact

### Impact Description
Change the response codes to one portion of the login flow, and make it so that the server doesn't fail when handling login of an inactive user.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
