### PR TITLE
[query] Replace Deprecated `AnyRefMap` with `HashMap`

### DIFF
--- a/hail/.scalafix.conf
+++ b/hail/.scalafix.conf
@@ -31,5 +31,6 @@ RemoveUnused {
 }
 
 ForbiddenSymbol.symbols = [
-  "scala.collection.compat.immutable.ArraySeq"
+  "scala.collection.mutable.AnyRefMap",
+  "scala.collection.compat.immutable.ArraySeq",
 ]

--- a/hail/hail/src-2.12/is/hail/utils/compat/mutable/package.scala
+++ b/hail/hail/src-2.12/is/hail/utils/compat/mutable/package.scala
@@ -1,6 +1,10 @@
 package is.hail.utils.compat
 
 package object mutable {
+  // scalafix:off ForbiddenSymbol
+  type AnyRefMap[K <: AnyRef, V] = scala.collection.mutable.AnyRefMap[K, V]
+  val AnyRefMap = scala.collection.mutable.AnyRefMap
+
   type Growable[-A] = scala.collection.generic.Growable[A]
   type Shrinkable[-A] = scala.collection.generic.Shrinkable[A]
 }

--- a/hail/hail/src-2.13/is/hail/utils/compat/mutable/package.scala
+++ b/hail/hail/src-2.13/is/hail/utils/compat/mutable/package.scala
@@ -1,6 +1,9 @@
 package is.hail.utils.compat
 
 package object mutable {
+  type AnyRefMap[K, V] = scala.collection.mutable.HashMap[K, V]
+  val AnyRefMap = scala.collection.mutable.HashMap
+
   type Growable[-A] = scala.collection.mutable.Growable[A]
   type GrowableCompat[-A] = Growable[A]
   type Shrinkable[-A] = scala.collection.mutable.Shrinkable[A]

--- a/hail/hail/src/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/hail/src/is/hail/expr/ir/NormalizeNames.scala
@@ -7,7 +7,6 @@ import is.hail.types.virtual.Type
 import is.hail.utils.StackSafe._
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 object NormalizeNames {
   def apply[T <: BaseIR](allowFreeVariables: Boolean = false)(ctx: ExecuteContext, ir: T): T =
@@ -99,7 +98,7 @@ class NormalizeNames(freeVariables: Set[Name]) {
       }
       Recur(newName, args, typ).mapChildrenStackSafe(normalizeIR(_, env))
     case ir =>
-      val bindingsMap = mutable.HashMap.empty[Name, Name]
+      val bindingsMap = is.hail.utils.compat.mutable.AnyRefMap.empty[Name, Name]
       val updateEnv: (BindingEnv[Name], Bindings[Type]) => BindingEnv[Name] =
         if (needsRenaming(ir)) { (env, bindings) =>
           val bindingsNames = bindings.map((name, _) => bindingsMap.getOrElseUpdate(name, gen()))

--- a/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
@@ -1385,7 +1385,7 @@ object PruneDeadFields extends Logging {
         recurMax(ir, 0)
 
       case Block(bindings, _) =>
-        val typeStates = mutable.HashMap.empty[Name, TypeState]
+        val typeStates = is.hail.utils.compat.mutable.AnyRefMap.empty[Name, TypeState]
         recurWithTypeStates(ir, bindings.length, requestedType, typeStates)
         for (i <- bindings.indices.reverse)
           recurWithTypeStates(ir, i, typeStates(bindings(i).name).newType, typeStates)
@@ -1497,7 +1497,7 @@ object PruneDeadFields extends Logging {
 
       case StreamFold2(_, accum, valueName, seq, _) =>
         recur(ir, 2 * accum.length + 1, requestedType)
-        val seqBindings = mutable.HashMap.empty[Name, TypeState]
+        val seqBindings = is.hail.utils.compat.mutable.AnyRefMap.empty[Name, TypeState]
         seq.indices.foreach(i => recurMaxWithTypeStates(ir, accum.length + 1 + i, seqBindings))
         accum.indices.foreach(i => recurMax(ir, i + 1))
         recur(ir, 0, TStream(seqBindings(valueName).newType))
@@ -1607,7 +1607,7 @@ object PruneDeadFields extends Logging {
         recur(ir, 1, requestedType)
 
       case RunAggScan(_, name, _, _, _, _) =>
-        val bindings = mutable.HashMap.empty[Name, TypeState]
+        val bindings = is.hail.utils.compat.mutable.AnyRefMap.empty[Name, TypeState]
 
         recurWithTypeStates(ir, 3, TIterable.elementType(requestedType), bindings)
         recurMaxWithTypeStates(ir, 2, bindings)


### PR DESCRIPTION
Later versions of scalac will issue the following warning:
```
object AnyRefMap in package mutable is deprecated (since 2.13.16): Use scala.collection.mutable.HashMap instead for better performance.
```
Seems fair enough. Spark have also followed suit: 
https://gitmemories.com/apache/spark/issues/48128

This change has no impact on the Broad-managed hail batch deployment in GCP.
