### PR TITLE
[batch] Merge wildcard with regular dependency test

### DIFF
--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -293,9 +293,23 @@ def test_input_dependency(client, remote_tmpdir):
     )
     batch.submit()
     tail.wait()
+
     head_status = head.status()
-    assert head._get_exit_code(head_status, 'main') == 0, str((head_status, batch.debug_info()))
+    # The input container doesn't exist so the exit code isn't 0.
     assert head._get_exit_code(head_status, 'input') != 0, str((head_status, batch.debug_info()))
+    # The main container exists and the exit code is 0.
+    assert head._get_exit_code(head_status, 'main') == 0, str((head_status, batch.debug_info()))
+    # The output container for head does not exist and the exit code should be 0.
+    assert head._get_exit_code(head_status, 'output') == 0, str((head_status, batch.debug_info()))
+
+    tail_status = tail.status()
+    # The input container for tail does exist so the exit code should be 0.
+    assert tail._get_exit_code(tail_status, 'input') == 0, str((tail_status, batch.debug_info()))
+    # The main container for tail exists and the exit code is 0.
+    assert tail._get_exit_code(tail_status, 'main') == 0, str((tail_status, batch.debug_info()))
+    # The output container for tail doesn't exists and the exit code shouldn't be 0.
+    assert tail._get_exit_code(tail_status, 'output') != 0, str((tail_status, batch.debug_info()))
+
     tail_log = tail.log()
     assert tail_log['main'] == 'head1\nhead2\n', str((tail_log, batch.debug_info()))
 


### PR DESCRIPTION
## Change Description

Fixes a flaky test suite by combining two near-identical test cases

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has low security impact

### Impact Description

Test expectation change

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
