### PR TITLE
[terraform] Make nat maxes higher, powers of 2

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -530,8 +530,8 @@ resource "google_compute_router_nat" "outbound_nat" {
   nat_ip_allocate_option            = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
   enable_dynamic_port_allocation     = true
-  min_ports_per_vm                  = 500
-  max_ports_per_vm                  = 8000
+  min_ports_per_vm                  = 512
+  max_ports_per_vm                  = 16384
 
   log_config {
     enable = true

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -402,8 +402,8 @@ resource "google_compute_router_nat" "outbound_nat" {
   nat_ip_allocate_option            = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
   enable_dynamic_port_allocation     = true
-  min_ports_per_vm                  = 500
-  max_ports_per_vm                  = 8000
+  min_ports_per_vm                  = 512
+  max_ports_per_vm                  = 16384
 
   log_config {
     enable = true


### PR DESCRIPTION
## Change Description

Sets the max connections per VM higher, and makes it a power of 2, as required by the API

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Small config change to un-break the terraform file and give more connection space to VMs

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
