### PR TITLE
[query] replace `readRepeatedly` with built-in  `readNBytes`

### DIFF
--- a/hail/hail/src/is/hail/io/plink/LoadPlink.scala
+++ b/hail/hail/src/is/hail/io/plink/LoadPlink.scala
@@ -492,7 +492,7 @@ class MatrixPLINKReader(
               offset = newOffset
             }
 
-            is.readFully(input, 0, input.length)
+            is.readFully(input)
 
             rvb.start(requestedPType)
             rvb.startStruct()

--- a/hail/hail/src/is/hail/utils/richUtils/RichInputStream.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichInputStream.scala
@@ -9,23 +9,7 @@ class RichInputStream(val in: InputStream) extends AnyVal {
     readFully(to, 0, to.length)
 
   def readFully(to: Array[Byte], toOff: Int, n: Int): Unit = {
-    val nRead = readRepeatedly(to, toOff, n)
+    val nRead = in.readNBytes(to, toOff, n)
     if (nRead < n) fatal(s"Premature end of file: expected $n bytes, found $nRead")
   }
-
-  def readRepeatedly(to: Array[Byte], toOff: Int, n: Int): Int = {
-    assert(toOff + n <= to.length)
-    var read = 0
-    var endOfStream = false
-    while (read < n && !endOfStream) {
-      val r = in.read(to, toOff + read, n - read)
-      if (r < 0)
-        endOfStream = true
-      else
-        read += r
-    }
-    read
-  }
-
-  def readRepeatedly(to: Array[Byte]): Int = readRepeatedly(to, 0, to.length)
 }

--- a/hail/hail/test/src/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/hail/test/src/is/hail/io/compress/BGzipCodecSuite.scala
@@ -241,8 +241,8 @@ class BGzipCodecSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
           assert(decompIS.getVirtualOffset() == vOff);
           uncompIS.seek(uOff.toLong + extra)
 
-          val decompRead = decompIS.readRepeatedly(decompData)
-          val uncompRead = uncompIS.readRepeatedly(uncompData)
+          val decompRead = decompIS.readNBytes(decompData, 0, decompData.length)
+          val uncompRead = uncompIS.readNBytes(uncompData, 0, uncompData.length)
 
           assert(
             decompRead == uncompRead,


### PR DESCRIPTION
This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP