### PR TITLE
Adding STRAIGHT_JOIN to SELECT in search query sql

### DIFF
--- a/batch/batch/front_end/query/query_v2.py
+++ b/batch/batch/front_end/query/query_v2.py
@@ -294,7 +294,7 @@ def parse_job_group_jobs_query_v2(
         attempts_table_join_str = ''
 
     sql = f"""
-SELECT jobs.*, batches.user, batches.billing_project, batches.format_version, job_attributes.value AS name, cost_t.cost,
+SELECT STRAIGHT_JOIN jobs.*, batches.user, batches.billing_project, batches.format_version, job_attributes.value AS name, cost_t.cost,
   cost_t.cost_breakdown
 FROM jobs
 INNER JOIN batches ON jobs.batch_id = batches.id


### PR DESCRIPTION
## Change Description
Update to a query run when looking at the batches UI page. This change remedies an occasional mysql query planner inefficiency wherein the planner scans over the entire batches table before anything else (e.g., before scanning over the jobs table). Usually this is fine, but on some larger batches this causes the page to take over a minute to load.

Adding `STRAIGHT_JOIN` to the `SELECT` statement forces the planner to read the left table before the right table. Here, this means telling the planner to *always* read the jobs table before the batches table. This avoids any accidentally costly "read the batches table first" plans.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a low security impact

### Impact Description
This change is an update to SQL that deals with the batch database, but it's only a performance update and does not change what information is returned to the user when executed.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
