### PR TITLE
[query] remove `RichRegex`

### DIFF
--- a/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
@@ -156,6 +156,9 @@ object LoadBgen extends Logging {
       )
   }
 
+  private[this] lazy val EntryPattern =
+    ".*part-[0-9]+(-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?".r.pattern
+
   def getAllFileListEntries(fs: FS, files: Array[String]): Array[FileListEntry] = {
     val badFiles = ArraySeq.newBuilder[String]
 
@@ -172,9 +175,7 @@ object LoadBgen extends Logging {
         if (fileListEntry.isDirectory)
           fs.listDirectory(file)
             .filter(fileListEntry =>
-              ".*part-[0-9]+(-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?".r.matches(
-                fileListEntry.getPath
-              )
+              EntryPattern.matcher(fileListEntry.getPath).matches()
             )
         else
           Array(fileListEntry)
@@ -191,9 +192,6 @@ object LoadBgen extends Logging {
 
     fileListEntries
   }
-
-  def getAllFilePaths(fs: FS, files: Array[String]): Array[String] =
-    getAllFileListEntries(fs, files).map(_.getPath.toString)
 
   def getBgenFileMetadata(
     ctx: ExecuteContext,

--- a/hail/hail/src/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/Implicits.scala
@@ -10,7 +10,6 @@ import is.hail.utils.compat.immutable.ArraySeq
 import scala.collection.compat._
 import scala.collection.mutable
 import scala.reflect.ClassTag
-import scala.util.matching.Regex
 
 import java.io.InputStream
 
@@ -91,8 +90,6 @@ trait Implicits {
 
   implicit def toRichContextRDDLong(r: ContextRDD[Long]): RichContextRDDLong =
     new RichContextRDDLong(r)
-
-  implicit def toRichRegex(r: Regex): RichRegex = new RichRegex(r)
 
   implicit def toRichRow(r: Row): RichRow = new RichRow(r)
 

--- a/hail/hail/src/is/hail/utils/richUtils/RichRegex.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichRegex.scala
@@ -1,7 +1,0 @@
-package is.hail.utils.richUtils
-
-import scala.util.matching.Regex
-
-class RichRegex(r: Regex) {
-  def matches(s: String): Boolean = r.pattern.matcher(s).matches()
-}


### PR DESCRIPTION
While this was convenient for 2.12 (build-in method for 2.13), it was triggering a pattern compilation for every fileListEntry. Lifting the pattern out removes the need for this utility.

This change does not impact the blah blah blah