### PR TITLE
[compiler] enforce use of `override` keyword using wartremover

### DIFF
--- a/hail/build.mill
+++ b/hail/build.mill
@@ -59,6 +59,11 @@ trait HailScalaModule extends ScalaModule, HailJavaModule, ScalafmtModule, Scala
       `scala-collection-compat` :: "2.13.0",
     )
 
+  def scalacPluginMvnDeps = Seq(
+    mvn"org.wartremover::wartremover:3.4.1",
+    mvn"org.wartremover::wartremover-contrib:2.3.5",
+  )
+
   override def scalacOptions: T[Seq[String]] =
     Task {
       val scalaVersion = this.scalaVersion()
@@ -103,7 +108,8 @@ trait HailScalaModule extends ScalaModule, HailJavaModule, ScalafmtModule, Scala
         ScalacOptions.tokensForVersion(
           ScalaVersion.unsafeFromString(scalaVersion),
           base -- disabled ++ fromBuildMode,
-        )
+      ) :+ "-P:wartremover:only-warn-traverser:org.wartremover.contrib.warts.MissingOverride"
+      //      :+ "-P:wartremover:only-warn-traverser:org.wartremover.contrib.warts.UnsafeInheritance"
 
       val rawOptions =
         if scalaVersion < "2.12" || scalaVersion >= "3"

--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -25,7 +25,7 @@ trait IRDSL {
   protected def oneOrMore[T](x: Type[T]): Type[Seq[T]]
   protected def optional[T](x: Type[T]): Type[Option[T]]
 
-  def name: Type[Name] = att("Name").asInstanceOf[Type[Name]]
+  final def name: Type[Name] = att("Name").asInstanceOf[Type[Name]]
   def child: Type[Child]
   def tableChild: Type[Child]
   def matrixChild: Type[Child]
@@ -81,10 +81,10 @@ trait IRDSL {
 
   // Implicits for common names
 
-  implicit def nameDefaultName(t: Type[Name]): Declaration[Name] =
+  final implicit def nameDefaultName(t: Type[Name]): Declaration[Name] =
     in("name", t)
 
-  implicit def childDefaultName(t: Type[Child]): Declaration[Child] =
+  final implicit def childDefaultName(t: Type[Child]): Declaration[Child] =
     in("child", t)
 }
 
@@ -558,7 +558,7 @@ object IRDSL_Impl extends IRDSL {
       s"object $name extends ${name}CompanionExt\n"
     else ""
 
-    def generateDef: String = companionDef + classDef + "\n"
+    override def generateDef: String = companionDef + classDef + "\n"
   }
 }
 

--- a/hail/hail/package.mill
+++ b/hail/hail/package.mill
@@ -160,9 +160,7 @@ trait RootHailModule extends CrossScalaModule, HailScalaModule:
     )
 
   override def scalacPluginMvnDeps: T[Seq[Dep]] =
-    Seq(
-      `better-monadic-for` :: "0.3.1",
-    )
+    super.scalacPluginMvnDeps() :+ (`better-monadic-for` :: "0.3.1")
 
   def writeRunClasspath: T[PathRef] =
     Task {

--- a/hail/hail/src/is/hail/annotations/BroadcastValue.scala
+++ b/hail/hail/src/is/hail/annotations/BroadcastValue.scala
@@ -99,9 +99,9 @@ trait BroadcastRegionValue extends Logging {
 case class BroadcastRow(ctx: ExecuteContext, value: RegionValue, t: PStruct)
     extends BroadcastRegionValue {
 
-  def javaValue: UnsafeRow = UnsafeRow.readBaseStruct(t, value.region, value.offset)
+  override def javaValue: UnsafeRow = UnsafeRow.readBaseStruct(t, value.region, value.offset)
 
-  def safeJavaValue: Row = SafeRow.read(t, value).asInstanceOf[Row]
+  override def safeJavaValue: Row = SafeRow.read(t, value).asInstanceOf[Row]
 
   def cast(newT: PStruct): BroadcastRow = {
     assert(t.virtualType == newT.virtualType)
@@ -128,9 +128,9 @@ case class BroadcastIndexedSeq(
   t: PArray,
 ) extends BroadcastRegionValue {
 
-  def safeJavaValue: IndexedSeq[Row] = SafeRow.read(t, value).asInstanceOf[IndexedSeq[Row]]
+  override def safeJavaValue: IndexedSeq[Row] = SafeRow.read(t, value).asInstanceOf[IndexedSeq[Row]]
 
-  def javaValue: UnsafeIndexedSeq = new UnsafeIndexedSeq(t, value.region, value.offset)
+  override def javaValue: UnsafeIndexedSeq = new UnsafeIndexedSeq(t, value.region, value.offset)
 
   def cast(newT: PArray): BroadcastIndexedSeq = {
     assert(t.virtualType == newT.virtualType)

--- a/hail/hail/src/is/hail/annotations/ChunkCache.scala
+++ b/hail/hail/src/is/hail/annotations/ChunkCache.scala
@@ -87,7 +87,7 @@ private class ChunkCache(allocator: Long => Long, freer: Long => Unit) {
       }
       // BiConsumer needed to work with scala 2.11.12
       bigChunkCache.forEach(new BiConsumer[Long, LongArrayBuilder]() {
-        def accept(key: Long, value: LongArrayBuilder): Unit =
+        override def accept(key: Long, value: LongArrayBuilder): Unit =
           while (value.size > 0) freeChunkFromMemory(pool, value.pop())
       })
     }

--- a/hail/hail/src/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/hail/src/is/hail/annotations/ExtendedOrdering.scala
@@ -9,7 +9,8 @@ object ExtendedOrdering {
     new ExtendedOrdering {
       val missingEqual = _missingEqual
 
-      def compareNonnull(x: T, y: T): Int = ord.compare(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def compareNonnull(x: T, y: T): Int =
+        ord.compare(x.asInstanceOf[S], y.asInstanceOf[S])
 
       override def ltNonnull(x: T, y: T): Boolean = ord.lt(x.asInstanceOf[S], y.asInstanceOf[S])
 
@@ -24,7 +25,7 @@ object ExtendedOrdering {
     new ExtendedOrdering {
       val missingEqual = _missingEqual
 
-      def compareNonnull(x: T, y: T): Int = {
+      override def compareNonnull(x: T, y: T): Int = {
         val xit = x.asInstanceOf[Iterable[T]].iterator
         val yit = y.asInstanceOf[Iterable[T]].iterator
 
@@ -93,7 +94,7 @@ object ExtendedOrdering {
       // ord can be null if the element type is a TVariable
       val elemOrd = if (ord != null) ord.toOrdering else null
 
-      def compareNonnull(x: T, y: T): Int =
+      override def compareNonnull(x: T, y: T): Int =
         itOrd.compareNonnull(
           x.asInstanceOf[Array[T]].sorted(elemOrd).toFastSeq,
           y.asInstanceOf[Array[T]].sorted(elemOrd).toFastSeq,
@@ -124,7 +125,7 @@ object ExtendedOrdering {
 
       val missingEqual = _missingEqual
 
-      def compareNonnull(x: T, y: T): Int =
+      override def compareNonnull(x: T, y: T): Int =
         saOrd.compareNonnull(
           x.asInstanceOf[Iterable[T]].toArray,
           y.asInstanceOf[Iterable[T]].toArray,
@@ -158,7 +159,7 @@ object ExtendedOrdering {
       private def toArrayOfT(x: T): Array[T] =
         x.asInstanceOf[Map[_, _]].iterator.map { case (k, v) => Row(k, v): T }.toArray
 
-      def compareNonnull(x: T, y: T): Int =
+      override def compareNonnull(x: T, y: T): Int =
         saOrd.compareNonnull(
           toArrayOfT(x),
           toArrayOfT(y),
@@ -384,7 +385,7 @@ abstract class ExtendedOrdering extends Serializable {
 
     override def reverse: ExtendedOrdering = outer
 
-    def compareNonnull(x: T, y: T): Int = outer.compareNonnull(y, x)
+    override def compareNonnull(x: T, y: T): Int = outer.compareNonnull(y, x)
 
     override def ltNonnull(x: T, y: T): Boolean = outer.ltNonnull(y, x)
 
@@ -394,7 +395,7 @@ abstract class ExtendedOrdering extends Serializable {
   }
 
   def toOrdering: Ordering[T] = new Ordering[T] {
-    def compare(x: T, y: T): Int = outer.compare(x, y)
+    override def compare(x: T, y: T): Int = outer.compare(x, y)
 
     override def lt(x: T, y: T): Boolean = outer.lt(x, y)
 

--- a/hail/hail/src/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/hail/src/is/hail/annotations/OrderedRVIterator.scala
@@ -95,7 +95,7 @@ case class OrderedRVIterator(
         }
       }
 
-      def advance(): Unit = {
+      override def advance(): Unit = {
         left.advance()
         setValue()
       }
@@ -190,9 +190,9 @@ case class OrderedRVIterator(
       private val rvb = new RegionValueBuilder(sm, consumerRegion)
       private val rv = RegionValue()
 
-      def hasNext: Boolean = bit.hasNext || q.nonEmpty
+      override def hasNext: Boolean = bit.hasNext || q.nonEmpty
 
-      def next(): RegionValue = {
+      override def next(): RegionValue = {
         if (q.isEmpty) {
           do {
             val rv = bit.next()

--- a/hail/hail/src/is/hail/annotations/Region.scala
+++ b/hail/hail/src/is/hail/annotations/Region.scala
@@ -417,7 +417,7 @@ final class Region protected[annotations] (
   def trackSharedChunk(addr: Long): Unit =
     memory.trackSharedChunk(addr)
 
-  def close(): Unit =
+  override def close(): Unit =
     invalidate()
 
   def addReferenceTo(r: Region): Unit =

--- a/hail/hail/src/is/hail/annotations/RegionMemory.scala
+++ b/hail/hail/src/is/hail/annotations/RegionMemory.scala
@@ -226,7 +226,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     offsetWithinBlock = 0L
   }
 
-  def close(): Unit =
+  override def close(): Unit =
     free()
 
   def numChunks: Int = bigChunks.size

--- a/hail/hail/src/is/hail/annotations/RegionPool.scala
+++ b/hail/hail/src/is/hail/annotations/RegionPool.scala
@@ -173,7 +173,7 @@ final class RegionPool private (strictMemoryCheck: Boolean, threadName: String, 
 
   private[this] var closed: Boolean = false
 
-  def close(): Unit = {
+  override def close(): Unit = {
     if (closed)
       return
     closed = true

--- a/hail/hail/src/is/hail/annotations/UnsafeOrdering.scala
+++ b/hail/hail/src/is/hail/annotations/UnsafeOrdering.scala
@@ -1,8 +1,6 @@
 package is.hail.annotations
 
 abstract class UnsafeOrdering extends Ordering[Long] with Serializable {
-  def compare(o1: Long, o2: Long): Int
-
   def compare(rv1: RegionValue, rv2: RegionValue): Int =
     compare(rv1.offset, rv2.offset)
 

--- a/hail/hail/src/is/hail/annotations/ValueVisitor.scala
+++ b/hail/hail/src/is/hail/annotations/ValueVisitor.scala
@@ -45,50 +45,50 @@ final class PrettyVisitor extends ValueVisitor {
 
   @inline def result(): String = sb.result()
 
-  @inline def visitMissing(t: PType): Unit =
+  @inline override def visitMissing(t: PType): Unit =
     sb.append("NA")
 
-  @inline def visitBoolean(b: Boolean): Unit =
+  @inline override def visitBoolean(b: Boolean): Unit =
     sb.append(b)
 
-  @inline def visitInt32(i: Int): Unit =
+  @inline override def visitInt32(i: Int): Unit =
     sb.append(i)
 
-  @inline def visitInt64(l: Long): Unit =
+  @inline override def visitInt64(l: Long): Unit =
     sb.append(l)
 
-  @inline def visitFloat32(f: Float): Unit =
+  @inline override def visitFloat32(f: Float): Unit =
     sb.append(f)
 
-  @inline def visitFloat64(d: Double): Unit =
+  @inline override def visitFloat64(d: Double): Unit =
     sb.append(d)
 
-  @inline def visitBinary(a: Array[Byte]): Unit =
+  @inline override def visitBinary(a: Array[Byte]): Unit =
     sb.append("bytes...")
 
-  @inline def visitString(s: String): Unit =
+  @inline override def visitString(s: String): Unit =
     sb.append(s)
 
-  @inline def enterStruct(t: PStruct): Unit =
+  @inline override def enterStruct(t: PStruct): Unit =
     sb.append("{")
 
-  def enterField(f: PField): Unit = {
+  override def enterField(f: PField): Unit = {
     if (f.index > 0) sb += ','
     sb += ' ' ++= f.name ++= ": ": Unit
   }
 
-  @inline def leaveField(): Unit = {}
+  @inline override def leaveField(): Unit = {}
 
-  @inline def leaveStruct(): Unit =
+  @inline override def leaveStruct(): Unit =
     sb.append(" }")
 
-  @inline def enterTuple(t: PTuple): Unit =
+  @inline override def enterTuple(t: PTuple): Unit =
     sb.append('(')
 
-  @inline def leaveTuple(): Unit =
+  @inline override def leaveTuple(): Unit =
     sb.append(')')
 
-  def enterArray(t: PContainer, length: Int): Unit = {
+  override def enterArray(t: PContainer, length: Int): Unit = {
     t match {
       case _: PSet => sb.append("Set")
       case _: PDict => sb.append("Dict")
@@ -98,13 +98,13 @@ final class PrettyVisitor extends ValueVisitor {
     sb += '[' ++= length.toString += ';': Unit
   }
 
-  @inline def leaveArray(): Unit =
+  @inline override def leaveArray(): Unit =
     sb.append("]")
 
-  @inline def enterElement(i: Int): Unit = {
+  @inline override def enterElement(i: Int): Unit = {
     if (i > 0) sb += ','
     sb += ' '
   }
 
-  @inline def leaveElement(): Unit = {}
+  @inline override def leaveElement(): Unit = {}
 }

--- a/hail/hail/src/is/hail/annotations/WritableRegionValue.scala
+++ b/hail/hail/src/is/hail/annotations/WritableRegionValue.scala
@@ -125,7 +125,7 @@ class RegionValuePriorityQueue(
     popped.region.close()
   }
 
-  def iterator: Iterator[RegionValue] = queue.iterator
+  override def iterator: Iterator[RegionValue] = queue.iterator
 }
 
 class RegionValueArrayBuffer(val t: PType, region: Region, sm: HailStateManager)
@@ -140,7 +140,7 @@ class RegionValueArrayBuffer(val t: PType, region: Region, sm: HailStateManager)
 
   override def knownSize: Int = idx.length
 
-  def addOne(rv: RegionValue): this.type =
+  override def addOne(rv: RegionValue): this.type =
     this.append(rv.region, rv.offset)
 
   def append(fromRegion: Region, fromOffset: Long): this.type = {
@@ -165,7 +165,7 @@ class RegionValueArrayBuffer(val t: PType, region: Region, sm: HailStateManager)
     this
   }
 
-  def clear(): Unit = {
+  override def clear(): Unit = {
     region.clear()
     idx.clear()
     rvb.clear() // remove
@@ -174,16 +174,16 @@ class RegionValueArrayBuffer(val t: PType, region: Region, sm: HailStateManager)
   private var itIdx = 0
 
   private val it = new Iterator[RegionValue] {
-    def next(): RegionValue = {
+    override def next(): RegionValue = {
       value.setOffset(idx(itIdx))
       itIdx += 1
       value
     }
 
-    def hasNext: Boolean = itIdx < idx.size
+    override def hasNext: Boolean = itIdx < idx.size
   }
 
-  def iterator: Iterator[RegionValue] = {
+  override def iterator: Iterator[RegionValue] = {
     itIdx = 0
     it
   }

--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -209,7 +209,7 @@ class ModuleBuilder() {
 trait WrappedClassBuilder[C] extends WrappedModuleBuilder {
   def cb: ClassBuilder[C]
 
-  def modb: ModuleBuilder = cb.modb
+  override def modb: ModuleBuilder = cb.modb
 
   def className: String = cb.className
 
@@ -499,7 +499,7 @@ class ClassBuilder[C](
     new (HailClassLoader => C) with java.io.Serializable {
       @transient @volatile private var theClass: Class[_] = null
 
-      def apply(hcl: HailClassLoader): C = {
+      override def apply(hcl: HailClassLoader): C = {
         if (theClass == null) {
           this.synchronized {
             if (theClass == null) {
@@ -518,7 +518,7 @@ class ClassBuilder[C](
     new LocalRef[C](new lir.Parameter(null, 0, ti))
 
   val fieldBuilder: SettableBuilder = new SettableBuilder {
-    def newSettable[T](name: String)(implicit tti: TypeInfo[T]): Settable[T] =
+    override def newSettable[T](name: String)(implicit tti: TypeInfo[T]): Settable[T] =
       genFieldThisRef[T](name)
   }
 
@@ -625,7 +625,7 @@ object FunctionBuilder {
 trait WrappedMethodBuilder[C] extends WrappedClassBuilder[C] {
   def mb: MethodBuilder[C]
 
-  def cb: ClassBuilder[C] = mb.cb
+  override def cb: ClassBuilder[C] = mb.cb
 
   def methodName: String = mb.methodName
 
@@ -673,7 +673,8 @@ class MethodBuilder[C](
     cb.lclass.newMethod(methodName, parameterTypeInfo, returnTypeInfo, isStatic)
 
   val localBuilder: SettableBuilder = new SettableBuilder {
-    def newSettable[T](name: String)(implicit tti: TypeInfo[T]): Settable[T] = newLocal[T](name)
+    override def newSettable[T](name: String)(implicit tti: TypeInfo[T]): Settable[T] =
+      newLocal[T](name)
   }
 
   def this_ : Value[C] =

--- a/hail/hail/src/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/CodeBuilder.scala
@@ -286,7 +286,7 @@ trait CodeBuilderLike {
 }
 
 class CodeBuilder(val mb: MethodBuilder[_], var code: Code[Unit]) extends CodeBuilderLike {
-  def isOpenEnded: Boolean =
+  override def isOpenEnded: Boolean =
     code.isOpenEnded
 
   override def append(c: Code[Unit]): Unit = {
@@ -306,7 +306,7 @@ class CodeBuilder(val mb: MethodBuilder[_], var code: Code[Unit]) extends CodeBu
   def uncheckedAppend(c: Code[Unit]): Unit =
     code = Code(code, c)
 
-  def result(): Code[Unit] = {
+  override def result(): Code[Unit] = {
     val tmp = code
     code = Code._empty
     tmp

--- a/hail/hail/src/is/hail/asm4s/GenericTypeInfo.scala
+++ b/hail/hail/src/is/hail/asm4s/GenericTypeInfo.scala
@@ -16,7 +16,7 @@ object GenericTypeInfo {
 final class GenericTypeInfo[T: TypeInfo]() extends MaybeGenericTypeInfo[T] {
   val base = typeInfo[T]
 
-  def castFromGeneric(cb: CodeBuilderLike, _x: Value[_]): Value[T] = {
+  override def castFromGeneric(cb: CodeBuilderLike, _x: Value[_]): Value[T] = {
     val x = coerce[AnyRef](_x)
     base match {
       case _: IntInfo.type =>
@@ -44,7 +44,7 @@ final class GenericTypeInfo[T: TypeInfo]() extends MaybeGenericTypeInfo[T] {
     }
   }
 
-  def castToGeneric(cb: CodeBuilderLike, x: Value[T]): Value[_] = base match {
+  override def castToGeneric(cb: CodeBuilderLike, x: Value[T]): Value[_] = base match {
     case _: IntInfo.type =>
       cb.memoize(Code.boxInt(coerce[Int](x)))
     case _: LongInfo.type =>
@@ -78,8 +78,8 @@ object NotGenericTypeInfo {
 }
 
 final class NotGenericTypeInfo[T: TypeInfo]() extends MaybeGenericTypeInfo[T] {
-  def castFromGeneric(cb: CodeBuilderLike, x: Value[_]): Value[T] = coerce[T](x)
-  def castToGeneric(cb: CodeBuilderLike, x: Value[T]): Value[_] = x
+  override def castFromGeneric(cb: CodeBuilderLike, x: Value[_]): Value[T] = coerce[T](x)
+  override def castToGeneric(cb: CodeBuilderLike, x: Value[T]): Value[_] = x
 
   val base = typeInfo[T]
   val generic = base

--- a/hail/hail/src/is/hail/asm4s/package.scala
+++ b/hail/hail/src/is/hail/asm4s/package.scala
@@ -51,7 +51,7 @@ package asm4s {
     val astoreOp = AASTORE
     val returnOp = ARETURN
 
-    def newArray(): AbstractInsnNode = new TypeInsnNode(ANEWARRAY, iname)
+    override def newArray(): AbstractInsnNode = new TypeInsnNode(ANEWARRAY, iname)
 
     override def uninitializedValue: Value[_] = Code._uncheckednull(this)
   }
@@ -65,7 +65,7 @@ package asm4s {
     val astoreOp = AASTORE
     val returnOp = ARETURN
 
-    def newArray() = new TypeInsnNode(ANEWARRAY, iname)
+    override def newArray() = new TypeInsnNode(ANEWARRAY, iname)
 
     override def uninitializedValue: Value[_] = Code._null[Array[T]](this)
   }
@@ -130,7 +130,7 @@ package object asm4s {
     val returnOp = IRETURN
     val newarrayOp = NEWARRAY
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_BOOLEAN)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_BOOLEAN)
 
     override def uninitializedValue: Value[_] = const(false)
   }
@@ -144,7 +144,7 @@ package object asm4s {
     val returnOp = IRETURN
     val newarrayOp = NEWARRAY
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_BYTE)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_BYTE)
 
     override def uninitializedValue: Value[_] = const(0.toByte)
   }
@@ -158,7 +158,7 @@ package object asm4s {
     val returnOp = IRETURN
     val newarrayOp = NEWARRAY
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_SHORT)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_SHORT)
 
     override def uninitializedValue: Value[_] = const(0.toShort)
   }
@@ -171,7 +171,7 @@ package object asm4s {
     val astoreOp = IASTORE
     val returnOp = IRETURN
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_INT)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_INT)
 
     override def uninitializedValue: Value[_] = const(0)
   }
@@ -185,7 +185,7 @@ package object asm4s {
     val returnOp = LRETURN
     override val slots = 2
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_LONG)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_LONG)
 
     override def uninitializedValue: Value[_] = const(0L)
   }
@@ -198,7 +198,7 @@ package object asm4s {
     val astoreOp = FASTORE
     val returnOp = FRETURN
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_FLOAT)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_FLOAT)
 
     override def uninitializedValue: Value[_] = const(0f)
   }
@@ -212,7 +212,7 @@ package object asm4s {
     val returnOp = DRETURN
     override val slots = 2
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_DOUBLE)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_DOUBLE)
 
     override def uninitializedValue: Value[_] = const(0d)
   }
@@ -226,21 +226,21 @@ package object asm4s {
     val returnOp = IRETURN
     override val slots = 2
 
-    def newArray() = new IntInsnNode(NEWARRAY, T_CHAR)
+    override def newArray() = new IntInsnNode(NEWARRAY, T_CHAR)
 
     override def uninitializedValue: Value[_] = const(0.toChar)
   }
 
   implicit object UnitInfo extends TypeInfo[Unit] {
     val desc = "V"
-    def loadOp = ???
-    def storeOp = ???
-    def aloadOp = ???
-    def astoreOp = ???
+    override def loadOp = ???
+    override def storeOp = ???
+    override def aloadOp = ???
+    override def astoreOp = ???
     val returnOp = RETURN
     override def slots = ???
 
-    def newArray() = ???
+    override def newArray() = ???
 
     override def uninitializedValue: Value[_] = Code._empty
   }
@@ -354,7 +354,7 @@ package object asm4s {
   }
 
   implicit def const(b: Boolean): Value[Boolean] = new Value[Boolean] {
-    def get: Code[Boolean] = new ConstCodeBoolean(b)
+    override def get: Code[Boolean] = new ConstCodeBoolean(b)
   }
 
   implicit def const(i: Int): Value[Int] = _const(i, IntInfo)

--- a/hail/hail/src/is/hail/backend/ExecuteContext.scala
+++ b/hail/hail/src/is/hail/backend/ExecuteContext.scala
@@ -161,7 +161,7 @@ class ExecuteContext(
 
   def shouldLogIR(): Boolean = !shouldNotLogIR()
 
-  def close(): Unit = {
+  override def close(): Unit = {
     tempFileManager.close()
     taskContext.close()
   }

--- a/hail/hail/src/is/hail/backend/HailTaskContext.scala
+++ b/hail/hail/src/is/hail/backend/HailTaskContext.scala
@@ -44,7 +44,7 @@ abstract class HailTaskContext extends AutoCloseable with Logging {
     f
   }
 
-  def close(): Unit = {
+  override def close(): Unit = {
     logger.info(
       s"TaskReport: stage=${stageId()}, partition=${partitionId()}, attempt=${attemptNumber()}, " +
         s"peakBytes=${thePool.getHighestTotalUsage}, peakBytesReadable=${formatSpace(thePool.getHighestTotalUsage)}, " +

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -239,7 +239,7 @@ private class HailSocketAPIOutputStream(
 
   def writeString(s: String): Unit = writeBytes(s.getBytes(StandardCharsets.UTF_8))
 
-  def close(): Unit =
+  override def close(): Unit =
     if (!closed) {
       out.close()
       closed = true

--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -474,7 +474,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
       // Note that simply calling httpServer.start() from a non-daemon thread will spawn a
       // non-daemon thread itself.
       private[this] val thread = new Thread(new Runnable() {
-        def run(): Unit = httpServer.start()
+        override def run(): Unit = httpServer.start()
       })
 
       thread.setDaemon(true)

--- a/hail/hail/src/is/hail/backend/local/LocalBackend.scala
+++ b/hail/hail/src/is/hail/backend/local/LocalBackend.scala
@@ -40,7 +40,7 @@ object LocalBackend extends Backend with Logging {
 
   is.hail.linalg.registerImplOpMulMatrix_DMD_DVD_eq_DVD
 
-  def broadcast[T: ClassTag](value: T): BroadcastValue[T] =
+  override def broadcast[T: ClassTag](value: T): BroadcastValue[T] =
     new LocalBroadcastValue[T](value)
 
   private[this] var stageIdx: Int = 0
@@ -100,9 +100,9 @@ object LocalBackend extends Backend with Logging {
     }
   }
 
-  def defaultParallelism: Int = 1
+  override def defaultParallelism: Int = 1
 
-  def close(): Unit =
+  override def close(): Unit =
     synchronized { stageIdx = 0 }
 
   private[this] def _jvmLowerAndExecute(
@@ -140,7 +140,7 @@ object LocalBackend extends Backend with Logging {
   ): TableReader =
     LowerDistributedSort.distributedSort(ctx, stage, sortFields, rt, nPartitions)
 
-  def tableToTableStage(ctx: ExecuteContext, inputIR: TableIR, analyses: LoweringAnalyses)
+  override def tableToTableStage(ctx: ExecuteContext, inputIR: TableIR, analyses: LoweringAnalyses)
     : TableStage =
     LowerTableIR.applyTable(inputIR, DArrayLowering.All, ctx, analyses)
 }

--- a/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/hail/src/is/hail/backend/service/ServiceBackend.scala
@@ -112,11 +112,11 @@ class ServiceBackend(
       Executors.newFixedThreadPool(MaxAvailableGcsConnections)
     }
 
-  def defaultParallelism: Int = 4
+  override def defaultParallelism: Int = 4
 
-  def broadcast[T: ClassTag](_value: T): BroadcastValue[T] =
+  override def broadcast[T: ClassTag](_value: T): BroadcastValue[T] =
     new BroadcastValue[T] with Serializable {
-      def value: T = _value
+      override def value: T = _value
     }
 
   override def runtimeContext(ctx: ExecuteContext): DriverRuntimeContext =
@@ -409,7 +409,7 @@ class ServiceBackend(
   ): TableReader =
     LowerDistributedSort.distributedSort(ctx, inputStage, sortFields, rt, nPartitions)
 
-  def tableToTableStage(ctx: ExecuteContext, inputIR: TableIR, analyses: LoweringAnalyses)
+  override def tableToTableStage(ctx: ExecuteContext, inputIR: TableIR, analyses: LoweringAnalyses)
     : TableStage =
     LowerTableIR.applyTable(inputIR, DArrayLowering.All, ctx, analyses)
 }

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.SparkSession
 import sourcecode.Enclosing
 
 class SparkBroadcastValue[T](bc: Broadcast[T]) extends BroadcastValue[T] with Serializable {
-  def value: T = bc.value
+  override def value: T = bc.value
 }
 
 object SparkTaskContext {
@@ -231,7 +231,7 @@ class SparkBackend(val spark: SparkSession) extends Backend with Logging {
   val sc: SparkContext =
     spark.sparkContext
 
-  def broadcast[T: ClassTag](value: T): BroadcastValue[T] =
+  override def broadcast[T: ClassTag](value: T): BroadcastValue[T] =
     new SparkBroadcastValue[T](sc.broadcast(value))
 
   override def runtimeContext(ctx: ExecuteContext): DriverRuntimeContext =
@@ -316,12 +316,12 @@ class SparkBackend(val spark: SparkSession) extends Backend with Logging {
       }
     }
 
-  def defaultParallelism: Int =
+  override def defaultParallelism: Int =
     sc.defaultParallelism
 
   override def asSpark(implicit E: Enclosing): SparkBackend = this
 
-  def close(): Unit =
+  override def close(): Unit =
     SparkBackend.synchronized {
       assert(this eq SparkBackend.theSparkBackend)
       SparkBackend.theSparkBackend = null
@@ -424,7 +424,7 @@ class SparkBackend(val spark: SparkSession) extends Backend with Logging {
     RVDTableReader(RVD.unkeyed(rowPType, orderedCRDD), globalsLit, rt)
   }
 
-  def tableToTableStage(ctx: ExecuteContext, inputIR: TableIR, analyses: LoweringAnalyses)
+  override def tableToTableStage(ctx: ExecuteContext, inputIR: TableIR, analyses: LoweringAnalyses)
     : TableStage =
     CanLowerEfficiently(ctx, inputIR) match {
       case Some(failReason) =>

--- a/hail/hail/src/is/hail/compatibility/LegacyBufferSpecs.scala
+++ b/hail/hail/src/is/hail/compatibility/LegacyBufferSpecs.scala
@@ -6,7 +6,7 @@ import is.hail.io.compress.LZ4
 
 final case class LZ4BlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
     extends LZ4BlockBufferSpecCommon {
-  def lz4 = LZ4.hc
-  def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "hc")
-  def typeName = "LZ4BlockBufferSpec"
+  override def lz4 = LZ4.hc
+  override def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "hc")
+  override def typeName = "LZ4BlockBufferSpec"
 }

--- a/hail/hail/src/is/hail/compatibility/LegacyRVDSpecs.scala
+++ b/hail/hail/src/is/hail/compatibility/LegacyRVDSpecs.scala
@@ -109,7 +109,7 @@ trait ShimRVDSpec extends AbstractRVDSpec {
 
   val shim: AbstractRVDSpec
 
-  final def key: IndexedSeq[String] = shim.key
+  final override def key: IndexedSeq[String] = shim.key
 
   override def partitioner(sm: HailStateManager): RVDPartitioner = shim.partitioner(sm)
 
@@ -148,12 +148,12 @@ case class UnpartitionedRVDSpec private (
 ) extends AbstractRVDSpec {
   private val (rowVType: TStruct, rowEType) = LegacyEncodedTypeParser.parseTypeAndEType(rowType)
 
-  def partitioner(sm: HailStateManager): RVDPartitioner =
+  override def partitioner(sm: HailStateManager): RVDPartitioner =
     RVDPartitioner.unkeyed(sm, partFiles.length)
 
-  def key: IndexedSeq[String] = FastSeq()
+  override def key: IndexedSeq[String] = FastSeq()
 
-  def typedCodecSpec: AbstractTypedCodecSpec =
+  override def typedCodecSpec: AbstractTypedCodecSpec =
     TypedCodecSpec(rowEType.setRequired(true), rowVType, codecSpec.child)
 
   val attrs: Map[String, String] = Map.empty
@@ -167,9 +167,9 @@ case class OrderedRVDSpec private (
 ) extends AbstractRVDSpec {
   private val lRvdType = LegacyEncodedTypeParser.parseLegacyRVDType(rvdType)
 
-  def key: IndexedSeq[String] = lRvdType.key
+  override def key: IndexedSeq[String] = lRvdType.key
 
-  def partitioner(sm: HailStateManager): RVDPartitioner = {
+  override def partitioner(sm: HailStateManager): RVDPartitioner = {
     val rangeBoundsType = TArray(TInterval(lRvdType.keyType))
     new RVDPartitioner(
       sm,

--- a/hail/hail/src/is/hail/cxx/RegionValueIterator.scala
+++ b/hail/hail/src/is/hail/cxx/RegionValueIterator.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.RegionValue
 
 class RegionValueIterator(it: Iterator[RegionValue]) extends Iterator[Long] {
 
-  def next(): Long = it.next().offset
+  override def next(): Long = it.next().offset
 
-  def hasNext: Boolean = it.hasNext
+  override def hasNext: Boolean = it.hasNext
 }

--- a/hail/hail/src/is/hail/experimental/ExperimentalFunctions.scala
+++ b/hail/hail/src/is/hail/experimental/ExperimentalFunctions.scala
@@ -8,7 +8,7 @@ import is.hail.types.virtual.{TArray, TFloat64, TInt32, Type}
 
 object ExperimentalFunctions extends RegistryFunctions {
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     val experimentalPackageClass = Class.forName("is.hail.experimental.package$")
 
     registerScalaFunction(

--- a/hail/hail/src/is/hail/expr/Parser.scala
+++ b/hail/hail/src/is/hail/expr/Parser.scala
@@ -86,7 +86,7 @@ object Parser extends JavaTokenParsers {
   def oneOfLiteral(a: IndexedSeq[String]): Parser[String] = new Parser[String] {
     private[this] val root = ParseTrieNode.generate(a)
 
-    def apply(in: Input): ParseResult[String] = {
+    override def apply(in: Input): ParseResult[String] = {
 
       var _in = in
       var node = root

--- a/hail/hail/src/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/hail/src/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -154,7 +154,7 @@ abstract class AbstractMatrixTableSpec extends RelationalSpec {
 
   def entriesSpec: AbstractTableSpec
 
-  def indexed: Boolean = rowsSpec.indexed
+  override def indexed: Boolean = rowsSpec.indexed
 }
 
 object MatrixTableSpec {
@@ -219,17 +219,17 @@ class MatrixTableSpec(
   val rowsSpec: AbstractTableSpec,
   val entriesSpec: AbstractTableSpec,
 ) extends AbstractMatrixTableSpec {
-  def references_rel_path: String = params.references_rel_path
+  override def references_rel_path: String = params.references_rel_path
 
-  def file_version: Int = params.file_version
+  override def file_version: Int = params.file_version
 
-  def hail_version: String = params.hail_version
+  override def hail_version: String = params.hail_version
 
-  def matrix_type: MatrixType = params.matrix_type
+  override def matrix_type: MatrixType = params.matrix_type
 
-  def components: Map[String, ComponentSpec] = params.components
+  override def components: Map[String, ComponentSpec] = params.components
 
-  def toJValue: JValue =
+  override def toJValue: JValue =
     decomposeWithName(params, "MatrixTableSpec")(RelationalSpec.formats)
 }
 

--- a/hail/hail/src/is/hail/expr/ir/AbstractTableSpec.scala
+++ b/hail/hail/src/is/hail/expr/ir/AbstractTableSpec.scala
@@ -29,13 +29,13 @@ sealed abstract class SortOrder {
 }
 
 case object Ascending extends SortOrder {
-  def serialize: Byte = 0.toByte
-  def parsableString(): String = "A"
+  override def serialize: Byte = 0.toByte
+  override def parsableString(): String = "A"
 }
 
 case object Descending extends SortOrder {
-  def serialize: Byte = 1.toByte
-  def parsableString(): String = "D"
+  override def serialize: Byte = 1.toByte
+  override def parsableString(): String = "D"
 }
 
 object SortField {
@@ -59,7 +59,7 @@ abstract class AbstractTableSpec extends RelationalSpec {
 
   def globalsSpec: AbstractRVDSpec
 
-  def indexed: Boolean = rowsSpec.indexed
+  override def indexed: Boolean = rowsSpec.indexed
 }
 
 object TableSpec {
@@ -99,16 +99,16 @@ class TableSpec(
   val globalsSpec: AbstractRVDSpec,
   val rowsSpec: AbstractRVDSpec,
 ) extends AbstractTableSpec {
-  def file_version: Int = params.file_version
+  override def file_version: Int = params.file_version
 
-  def hail_version: String = params.hail_version
+  override def hail_version: String = params.hail_version
 
-  def components: Map[String, ComponentSpec] = params.components
+  override def components: Map[String, ComponentSpec] = params.components
 
-  def references_rel_path: String = params.references_rel_path
+  override def references_rel_path: String = params.references_rel_path
 
-  def table_type: TableType = params.table_type
+  override def table_type: TableType = params.table_type
 
-  def toJValue: JValue =
+  override def toJValue: JValue =
     decomposeWithName(params, "TableSpec")(RelationalSpec.formats)
 }

--- a/hail/hail/src/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/hail/src/is/hail/expr/ir/BinarySearch.scala
@@ -12,7 +12,7 @@ object BinarySearch {
       ltNeedle: IEmitCode => Code[Boolean],
       gtNeedle: IEmitCode => Code[Boolean],
     ): Comparator = new Comparator {
-      def apply(
+      override def apply(
         cb: EmitCodeBuilder,
         elt: IEmitCode,
         ifLtNeedle: => Unit,
@@ -29,7 +29,7 @@ object BinarySearch {
     }
 
     def fromCompare(compare: IEmitCode => Value[Int]): Comparator = new Comparator {
-      def apply(
+      override def apply(
         cb: EmitCodeBuilder,
         elt: IEmitCode,
         ifLtNeedle: => Unit,
@@ -42,7 +42,7 @@ object BinarySearch {
     }
 
     def fromPred(pred: IEmitCode => Code[Boolean]): Comparator = new Comparator {
-      def apply(
+      override def apply(
         cb: EmitCodeBuilder,
         elt: IEmitCode,
         ifLtNeedle: => Unit,

--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -56,12 +56,12 @@ case class BlockMatrixNativeWriter(
   forceRowMajor: Boolean,
   stageLocally: Boolean,
 ) extends BlockMatrixWriter {
-  def pathOpt: Option[String] = Some(path)
+  override def pathOpt: Option[String] = Some(path)
 
-  def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
+  override def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
     bm.write(ctx, path, overwrite, forceRowMajor, stageLocally)
 
-  def loweredTyp: Type = TVoid
+  override def loweredTyp: Type = TVoid
 
   override def lower(
     ctx: ExecuteContext,
@@ -128,9 +128,9 @@ case class BlockMatrixNativeMetadataWriter(
     }
   }
 
-  def annotationType: Type = TArray(TString)
+  override def annotationType: Type = TArray(TString)
 
-  def writeMetadata(
+  override def writeMetadata(
     writeAnnotations: => IEmitCode,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -164,9 +164,9 @@ case class BlockMatrixNativeMetadataWriter(
 }
 
 case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
-  def pathOpt: Option[String] = Some(path)
+  override def pathOpt: Option[String] = Some(path)
 
-  def apply(ctx: ExecuteContext, bm: BlockMatrix): String = {
+  override def apply(ctx: ExecuteContext, bm: BlockMatrix): String = {
     RichDenseMatrixDouble.exportToDoubles(
       ctx.fs,
       path,
@@ -176,7 +176,7 @@ case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
     path
   }
 
-  def loweredTyp: Type = TString
+  override def loweredTyp: Type = TString
 
   override def lower(
     ctx: ExecuteContext,
@@ -191,12 +191,12 @@ case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
 }
 
 case class BlockMatrixPersistWriter(id: String, storageLevel: String) extends BlockMatrixWriter {
-  def pathOpt: Option[String] = None
+  override def pathOpt: Option[String] = None
 
-  def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
+  override def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
     ctx.BlockMatrixCache += id -> bm.persist(storageLevel)
 
-  def loweredTyp: Type = TVoid
+  override def loweredTyp: Type = TVoid
 }
 
 case class BlockMatrixRectanglesWriter(
@@ -206,12 +206,12 @@ case class BlockMatrixRectanglesWriter(
   binary: Boolean,
 ) extends BlockMatrixWriter {
 
-  def pathOpt: Option[String] = Some(path)
+  override def pathOpt: Option[String] = Some(path)
 
-  def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
+  override def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
     bm.exportRectangles(ctx, path, rectangles, delimiter, binary)
 
-  def loweredTyp: Type = TVoid
+  override def loweredTyp: Type = TVoid
 }
 
 abstract class BlockMatrixMultiWriter {
@@ -223,7 +223,7 @@ case class BlockMatrixBinaryMultiWriter(
   overwrite: Boolean,
 ) extends BlockMatrixMultiWriter {
 
-  def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
+  override def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
     BlockMatrix.binaryWriteBlockMatrices(ctx, bms, prefix, overwrite)
 
   def loweredTyp: Type = TVoid
@@ -239,7 +239,7 @@ case class BlockMatrixTextMultiWriter(
   customFilenames: Option[Array[String]],
 ) extends BlockMatrixMultiWriter {
 
-  def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
+  override def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
     BlockMatrix.exportBlockMatrices(
       ctx,
       bms,
@@ -261,7 +261,7 @@ case class BlockMatrixNativeMultiWriter(
   forceRowMajor: Boolean,
 ) extends BlockMatrixMultiWriter {
 
-  def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
+  override def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
     BlockMatrix.writeBlockMatrices(ctx, bms, prefix, overwrite, forceRowMajor)
 
   def loweredTyp: Type = TVoid

--- a/hail/hail/src/is/hail/expr/ir/Compile.scala
+++ b/hail/hail/src/is/hail/expr/ir/Compile.scala
@@ -156,7 +156,7 @@ object CompileIterator {
     private var _stepped = false
     private var _hasNext = false
 
-    def hasNext: Boolean = {
+    override def hasNext: Boolean = {
       if (!_stepped) {
         _hasNext = step()
         _stepped = true
@@ -164,7 +164,7 @@ object CompileIterator {
       _hasNext
     }
 
-    def next(): java.lang.Long = {
+    override def next(): java.lang.Long = {
       if (!hasNext) Iterator.empty.next(): Unit // throw
       _stepped = false
       stepFunction.loadAddress()
@@ -309,7 +309,7 @@ object CompileIterator {
         new LongIteratorWrapper {
           val stepFunction: TMPStepFunction = outerStepFunction
 
-          def step(): Boolean = stepFunction.apply(null, v0, part)
+          override def step(): Boolean = stepFunction.apply(null, v0, part)
         }
       },
     )
@@ -345,7 +345,7 @@ object CompileIterator {
         new LongIteratorWrapper {
           val stepFunction: TableStageToRVDStepFunction = outerStepFunction
 
-          def step(): Boolean = stepFunction.apply(null, v0, v1)
+          override def step(): Boolean = stepFunction.apply(null, v0, v1)
         }
       },
     )

--- a/hail/hail/src/is/hail/expr/ir/Emit.scala
+++ b/hail/hail/src/is/hail/expr/ir/Emit.scala
@@ -2498,7 +2498,7 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
           val M = shapeArray(0)
           val N = shapeArray(1)
           val K = new Value[Long] {
-            def get: Code[Long] = (M < N).mux(M, N)
+            override def get: Code[Long] = (M < N).mux(M, N)
           }
           val LDA = new Value[Long] {
             override def get: Code[Long] =
@@ -3746,7 +3746,7 @@ object NDArrayEmitter {
     val notBroadcasted = 1L
     Array.tabulate(nDims)(dim =>
       new Value[Long] {
-        def get: Code[Long] =
+        override def get: Code[Long] =
           (shapeArray(dim) > 1L).mux(notBroadcasted, broadcasted) * loopVars(dim)
       }
     )
@@ -3757,7 +3757,7 @@ object NDArrayEmitter {
     val notBroadcasted = 1L
     shapeArray.map(shapeElement =>
       new Value[Long] {
-        def get: Code[Long] = (shapeElement > 1L).mux(notBroadcasted, broadcasted)
+        override def get: Code[Long] = (shapeElement > 1L).mux(notBroadcasted, broadcasted)
       }
     )
   }
@@ -3766,7 +3766,7 @@ object NDArrayEmitter {
     : IndexedSeq[Value[Long]] =
     indices.zip(broadcastMask).map { case (index, flag) =>
       new Value[Long] {
-        def get: Code[Long] = index * flag
+        override def get: Code[Long] = index * flag
       }
     }
 

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -135,7 +135,7 @@ trait WrappedEmitModuleBuilder {
 trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
   def ecb: EmitClassBuilder[C]
 
-  def emodb: EmitModuleBuilder = ecb.emodb
+  override def emodb: EmitModuleBuilder = ecb.emodb
 
   def cb: ClassBuilder[C] = ecb.cb
 
@@ -944,7 +944,8 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
       new ((HailClassLoader, FS, HailTaskContext, Region) => C) with java.io.Serializable {
         @transient @volatile private var theClass: Class[_] = null
 
-        def apply(hcl: HailClassLoader, fs: FS, htc: HailTaskContext, region: Region): C = {
+        override def apply(hcl: HailClassLoader, fs: FS, htc: HailTaskContext, region: Region)
+          : C = {
           if (theClass == null) {
             this.synchronized {
               if (theClass == null) {
@@ -1438,7 +1439,7 @@ class EmitMethodBuilder[C](
 trait WrappedEmitMethodBuilder[C] extends WrappedEmitClassBuilder[C] {
   def emb: EmitMethodBuilder[C]
 
-  def ecb: EmitClassBuilder[C] = emb.ecb
+  override def ecb: EmitClassBuilder[C] = emb.ecb
 
   // wrapped MethodBuilder methods
   def mb: MethodBuilder[C] = emb.mb

--- a/hail/hail/src/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -37,10 +37,10 @@ object EmitCodeBuilder {
 }
 
 class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) extends CodeBuilderLike {
-  def isOpenEnded: Boolean =
+  override def isOpenEnded: Boolean =
     code.isOpenEnded
 
-  def mb: MethodBuilder[_] = emb.mb
+  override def mb: MethodBuilder[_] = emb.mb
 
   override def append(c: Code[Unit]): Unit =
     code = Code(code, c)
@@ -54,7 +54,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
       L.clear()
     }
 
-  def result(): Code[Unit] = {
+  override def result(): Code[Unit] = {
     val tmp = code
     code = Code._empty
     tmp

--- a/hail/hail/src/is/hail/expr/ir/Env.scala
+++ b/hail/hail/src/is/hail/expr/ir/Env.scala
@@ -99,7 +99,7 @@ case class BindingEnv[V](
     newEnv
   }
 
-  def extend(bindings: Bindings[V]): BindingEnv[V] = {
+  override def extend(bindings: Bindings[V]): BindingEnv[V] = {
     val Bindings(all, eval, agg, scan, relational, _) = bindings
     var newEnv = modifyWithoutNewBindings(bindings)
     if (all.nonEmpty) {
@@ -150,9 +150,9 @@ case class BindingEnv[V](
   def allEmpty: Boolean =
     eval.isEmpty && agg.forall(_.isEmpty) && scan.forall(_.isEmpty) && relational.isEmpty
 
-  def promoteAgg: BindingEnv[V] = copy(eval = agg.get, agg = None)
+  override def promoteAgg: BindingEnv[V] = copy(eval = agg.get, agg = None)
 
-  def promoteScan: BindingEnv[V] = copy(eval = scan.get, scan = None)
+  override def promoteScan: BindingEnv[V] = copy(eval = scan.get, scan = None)
 
   def promoteScope(scope: Int): BindingEnv[V] = scope match {
     case Scope.EVAL => this
@@ -160,17 +160,17 @@ case class BindingEnv[V](
     case Scope.SCAN => promoteScan
   }
 
-  def noAgg: BindingEnv[V] = copy(agg = None)
+  override def noAgg: BindingEnv[V] = copy(agg = None)
 
-  def noScan: BindingEnv[V] = copy(scan = None)
+  override def noScan: BindingEnv[V] = copy(scan = None)
 
-  def createAgg: BindingEnv[V] =
+  override def createAgg: BindingEnv[V] =
     copy(agg = Some(eval), scan = scan.map(_ => Env.empty))
 
-  def createScan: BindingEnv[V] =
+  override def createScan: BindingEnv[V] =
     copy(scan = Some(eval), agg = agg.map(_ => Env.empty))
 
-  def onlyRelational(keepAggCapabilities: Boolean = false): BindingEnv[V] =
+  override def onlyRelational(keepAggCapabilities: Boolean = false): BindingEnv[V] =
     BindingEnv(
       agg = if (keepAggCapabilities) agg.map(_ => Env.empty) else None,
       scan = if (keepAggCapabilities) scan.map(_ => Env.empty) else None,
@@ -180,18 +180,18 @@ case class BindingEnv[V](
   def bindEval(name: Name, v: V): BindingEnv[V] =
     copy(eval = eval.bind(name, v))
 
-  def bindEval(bindings: (Name, V)*): BindingEnv[V] =
+  override def bindEval(bindings: (Name, V)*): BindingEnv[V] =
     copy(eval = eval.bindIterable(bindings))
 
   def deleteEval(name: Name): BindingEnv[V] = copy(eval = eval.delete(name))
   def deleteEval(names: IndexedSeq[Name]): BindingEnv[V] = copy(eval = eval.delete(names))
 
-  def noEval: BindingEnv[V] = copy(eval = Env.empty)
+  override def noEval: BindingEnv[V] = copy(eval = Env.empty)
 
   def bindAgg(name: Name, v: V): BindingEnv[V] =
     copy(agg = Some(agg.get.bind(name, v)))
 
-  def bindAgg(bindings: (Name, V)*): BindingEnv[V] =
+  override def bindAgg(bindings: (Name, V)*): BindingEnv[V] =
     copy(agg = Some(agg.get.bindIterable(bindings)))
 
   def aggOrEmpty: Env[V] = agg.getOrElse(Env.empty)
@@ -199,13 +199,13 @@ case class BindingEnv[V](
   def bindScan(name: Name, v: V): BindingEnv[V] =
     copy(scan = Some(scan.get.bind(name, v)))
 
-  def bindScan(bindings: (Name, V)*): BindingEnv[V] =
+  override def bindScan(bindings: (Name, V)*): BindingEnv[V] =
     copy(scan = Some(scan.get.bindIterable(bindings)))
 
   def bindRelational(name: Name, v: V): BindingEnv[V] =
     copy(relational = relational.bind(name, v))
 
-  def bindRelational(bindings: (Name, V)*): BindingEnv[V] =
+  override def bindRelational(bindings: (Name, V)*): BindingEnv[V] =
     copy(relational = relational.bind(bindings: _*))
 
   def scanOrEmpty: Env[V] = scan.getOrElse(Env.empty)

--- a/hail/hail/src/is/hail/expr/ir/FreeVariables.scala
+++ b/hail/hail/src/is/hail/expr/ir/FreeVariables.scala
@@ -27,7 +27,7 @@ case class FreeVariableBindingEnv(
   aggVars: Option[FreeVariableEnv],
   scanVars: Option[FreeVariableEnv],
 ) extends GenericBindingEnv[FreeVariableBindingEnv, Type] {
-  def extend(bindings: Bindings[Type]): FreeVariableBindingEnv = {
+  override def extend(bindings: Bindings[Type]): FreeVariableBindingEnv = {
     val Bindings(all, eval, agg, scan, relational, dropEval) = bindings
     var newEnv = this
     if (dropEval) newEnv = newEnv.noEval

--- a/hail/hail/src/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/GenericTableValue.scala
@@ -136,7 +136,7 @@ class PartitionIteratorLongReader(
     }
   }
 
-  def toJValue: JValue =
+  override def toJValue: JValue =
     JObject(
       "category" -> JString("PartitionIteratorLongReader"),
       "fullRowType" -> Extraction.decompose(fullRowType)(PartitionReader.formats),

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -401,11 +401,11 @@ package defs {
   }
 
   abstract class SimplePartitionWriter extends PartitionWriter {
-    def ctxType: Type = TString
+    override def ctxType: Type = TString
 
-    def returnType: Type = TString
+    override def returnType: Type = TString
 
-    def unionTypeRequiredness(
+    override def unionTypeRequiredness(
       r: TypeWithRequiredness,
       ctxType: TypeWithRequiredness,
       streamType: RIterable,
@@ -425,7 +425,7 @@ package defs {
 
     def postConsume(cb: EmitCodeBuilder, os: Value[OutputStream]): Unit = ()
 
-    final def consumeStream(
+    final override def consumeStream(
       ctx: ExecuteContext,
       cb: EmitCodeBuilder,
       stream: StreamProducer,
@@ -463,8 +463,11 @@ package defs {
   }
 
   final case class SimpleMetadataWriter(val annotationType: Type) extends MetadataWriter {
-    def writeMetadata(writeAnnotations: => IEmitCode, cb: EmitCodeBuilder, region: Value[Region])
-      : Unit =
+    override def writeMetadata(
+      writeAnnotations: => IEmitCode,
+      cb: EmitCodeBuilder,
+      region: Value[Region],
+    ): Unit =
       writeAnnotations.consume(cb, {}, _ => ())
   }
 

--- a/hail/hail/src/is/hail/expr/ir/Param.scala
+++ b/hail/hail/src/is/hail/expr/ir/Param.scala
@@ -10,13 +10,13 @@ sealed trait ParamType {
 }
 
 case class CodeParamType(ti: TypeInfo[_]) extends ParamType {
-  def nCodes: Int = 1
+  override def nCodes: Int = 1
 
   override def toString: String = s"CodeParam($ti)"
 }
 
 case class SCodeParamType(st: SType) extends ParamType {
-  def nCodes: Int = st.nSettables
+  override def nCodes: Int = st.nSettables
 
   override def toString: String = s"SCodeParam($st, $nCodes)"
 }
@@ -34,25 +34,25 @@ trait EmitParamType extends ParamType {
       ts :+ BooleanInfo
   }
 
-  final def nCodes: Int = valueTupleTypes.length
+  final override def nCodes: Int = valueTupleTypes.length
 
   protected def definedValueTupleTypes(): IndexedSeq[TypeInfo[_]]
 }
 
 case class SingleCodeEmitParamType(required: Boolean, sct: SingleCodeType) extends EmitParamType {
-  def virtualType: Type = sct.virtualType
+  override def virtualType: Type = sct.virtualType
 
-  def definedValueTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(sct.ti)
+  override def definedValueTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(sct.ti)
 
   override def toString: String = s"SingleCodeEmitParamType($required, $sct)"
 }
 
 case class SCodeEmitParamType(et: EmitType) extends EmitParamType {
-  def required: Boolean = et.required
+  override def required: Boolean = et.required
 
-  def virtualType: Type = et.st.virtualType
+  override def virtualType: Type = et.st.virtualType
 
-  def definedValueTupleTypes(): IndexedSeq[TypeInfo[_]] = et.st.settableTupleTypes()
+  override def definedValueTupleTypes(): IndexedSeq[TypeInfo[_]] = et.st.settableTupleTypes()
 }
 
 sealed trait Param

--- a/hail/hail/src/is/hail/expr/ir/Parser.scala
+++ b/hail/hail/src/is/hail/expr/ir/Parser.scala
@@ -35,23 +35,23 @@ abstract class Token extends Positional {
 }
 
 final case class IdentifierToken(value: String) extends Token {
-  def getName: String = "identifier"
+  override def getName: String = "identifier"
 }
 
 final case class StringToken(value: String) extends Token {
-  def getName: String = "string"
+  override def getName: String = "string"
 }
 
 final case class IntegerToken(value: Long) extends Token {
-  def getName: String = "integer"
+  override def getName: String = "integer"
 }
 
 final case class FloatToken(value: Double) extends Token {
-  def getName: String = "float"
+  override def getName: String = "float"
 }
 
 final case class PunctuationToken(value: String) extends Token {
-  def getName: String = "punctuation"
+  override def getName: String = "punctuation"
 }
 
 object IRLexer extends JavaTokenParsers {
@@ -66,7 +66,7 @@ object IRLexer extends JavaTokenParsers {
 
   def quotedLiteral(delim: Char, what: String): Parser[String] =
     new Parser[String] {
-      def apply(in: Input): ParseResult[String] = {
+      override def apply(in: Input): ParseResult[String] = {
         var r = in
 
         val source = in.source

--- a/hail/hail/src/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/hail/src/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -150,7 +150,7 @@ final class IntMissingArrayBuilder(initialCapacity: Int)
     b(i)
   }
 
-  def ensureCapacity(n: Int): Unit = {
+  override def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = math.max(n, b.length * 2)
       val newb = new Array[Int](newCapacity)
@@ -210,7 +210,7 @@ final class LongMissingArrayBuilder(initialCapacity: Int)
     b(i)
   }
 
-  def ensureCapacity(n: Int): Unit = {
+  override def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = math.max(n, b.length * 2)
       val newb = new Array[Long](newCapacity)
@@ -270,7 +270,7 @@ final class FloatMissingArrayBuilder(initialCapacity: Int)
     b(i)
   }
 
-  def ensureCapacity(n: Int): Unit = {
+  override def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = math.max(n, b.length * 2)
       val newb = new Array[Float](newCapacity)
@@ -330,7 +330,7 @@ final class DoubleMissingArrayBuilder(initialCapacity: Int)
     b(i)
   }
 
-  def ensureCapacity(n: Int): Unit = {
+  override def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = math.max(n, b.length * 2)
       val newb = new Array[Double](newCapacity)
@@ -390,7 +390,7 @@ final class BooleanMissingArrayBuilder(initialCapacity: Int)
     b(i)
   }
 
-  def ensureCapacity(n: Int): Unit = {
+  override def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = math.max(n, b.length * 2)
       val newb = new Array[Boolean](newCapacity)

--- a/hail/hail/src/is/hail/expr/ir/ValueReader.scala
+++ b/hail/hail/src/is/hail/expr/ir/ValueReader.scala
@@ -44,11 +44,15 @@ abstract class ValueReader {
 }
 
 final case class ETypeValueReader(spec: AbstractTypedCodecSpec) extends ValueReader {
-  def unionRequiredness(requestedType: Type, requiredness: TypeWithRequiredness): Unit =
+  override def unionRequiredness(requestedType: Type, requiredness: TypeWithRequiredness): Unit =
     requiredness.fromPType(spec.encodedType.decodedPType(requestedType))
 
-  def readValue(cb: EmitCodeBuilder, t: Type, region: Value[Region], is: Value[InputStream])
-    : SValue = {
+  override def readValue(
+    cb: EmitCodeBuilder,
+    t: Type,
+    region: Value[Region],
+    is: Value[InputStream],
+  ): SValue = {
     val decoder = spec.encodedType.buildDecoder(t, cb.emb.ecb)
     val ib = cb.memoize(spec.buildCodeInputBuffer(is))
     val ret = decoder.apply(cb, region, ib)

--- a/hail/hail/src/is/hail/expr/ir/ValueWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/ValueWriter.scala
@@ -39,7 +39,7 @@ abstract class ValueWriter {
 }
 
 final case class ETypeValueWriter(spec: AbstractTypedCodecSpec) extends ValueWriter {
-  def writeValue(cb: EmitCodeBuilder, value: SValue, os: Value[OutputStream]): Unit = {
+  override def writeValue(cb: EmitCodeBuilder, value: SValue, os: Value[OutputStream]): Unit = {
     val encoder = spec.encodedType.buildEncoder(value.st, cb.emb.ecb)
     val ob = cb.memoize(spec.buildCodeOutputBuffer(os))
     encoder.apply(cb, value, ob)

--- a/hail/hail/src/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -27,11 +27,11 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple)
   private val aoff: Settable[Long] = kb.genFieldThisRef[Long]("arrayrva_aoff")
 
   private def regionOffset(eltIdx: Value[Int]): Value[Int] = new Value[Int] {
-    def get: Code[Int] = (eltIdx + 1) * nStates
+    override def get: Code[Int] = (eltIdx + 1) * nStates
   }
 
   private def statesOffset(eltIdx: Value[Int]): Value[Long] = new Value[Long] {
-    def get: Code[Long] = arrayType.loadElement(typ.loadField(off, 1), eltIdx)
+    override def get: Code[Long] = arrayType.loadElement(typ.loadField(off, 1), eltIdx)
   }
 
   val initContainer: TupleAggregatorState = new TupleAggregatorState(
@@ -39,7 +39,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple)
     nested,
     region,
     new Value[Long] {
-      def get: Code[Long] = typ.loadField(off, 0)
+      override def get: Code[Long] = typ.loadField(off, 0)
     },
   )
 
@@ -118,7 +118,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple)
 
   def store(cb: EmitCodeBuilder): Unit = container.store(cb)
 
-  def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
+  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     val serializers = nested.states.map(_.serialize(codec));
     { (cb: EmitCodeBuilder, ob: Value[OutputBuffer]) =>
       loadInit(cb)
@@ -140,7 +140,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple)
     }
   }
 
-  def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
+  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     val deserializers = nested.states.map(_.deserialize(codec));
     { (cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
       init(
@@ -157,7 +157,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple)
     }
   }
 
-  def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
+  override def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
     init(cb, cb => initContainer.copyFrom(cb, cb.memoize(typ.loadField(src, 0))), initLen = false)
     cb.if_(
       typ.isFieldMissing(cb, src, 1), {
@@ -188,7 +188,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
   val seqOpTypes: Seq[Type] = FastSeq(TInt32)
 
   // inits all things
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     if (knownLength) {
       val Array(len, inits) = init
       state.init(cb, cb => cb += inits.asVoid(), initLen = false)
@@ -205,7 +205,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
   }
 
   // does a length check on arrays
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     assert(seq.length == 1)
     val len = seq.head
     len.toI(cb).consume(
@@ -223,7 +223,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
     )
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -312,12 +312,12 @@ class ArrayElementwiseOpAggregator(nestedAggs: Array[StagedAggregator]) extends 
 
   override def resultEmitType = EmitType(SIndexablePointer(resultPType), false)
 
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit =
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit =
     throw new UnsupportedOperationException(
       "State must be initialized by ArrayElementLengthCheckAggregator."
     )
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(eltIdx, seqOps) = seq
     eltIdx.toI(cb).consume(
       cb,
@@ -336,7 +336,7 @@ class ArrayElementwiseOpAggregator(nestedAggs: Array[StagedAggregator]) extends 
     )
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -347,7 +347,8 @@ class ArrayElementwiseOpAggregator(nestedAggs: Array[StagedAggregator]) extends 
       "State must be combined by ArrayElementLengthCheckAggregator."
     )
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode =
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode =
     throw new UnsupportedOperationException(
       "Result must be defined by ArrayElementLengthCheckAggregator."
     )

--- a/hail/hail/src/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -97,13 +97,14 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
     cb += Region.storeInt(addr, updater(Region.loadInt(addr)))
   }
 
-  def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = { (cb, ob) =>
-    val codecSpec = TypedCodecSpec(kb.ctx, CallStatsState.stateType, codec)
-    codecSpec.encodedType.buildEncoder(CallStatsState.stateType.sType, kb)
-      .apply(cb, CallStatsState.stateType.loadCheapSCode(cb, off), ob)
+  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
+    (cb, ob) =>
+      val codecSpec = TypedCodecSpec(kb.ctx, CallStatsState.stateType, codec)
+      codecSpec.encodedType.buildEncoder(CallStatsState.stateType.sType, kb)
+        .apply(cb, CallStatsState.stateType.loadCheapSCode(cb, off), ob)
   }
 
-  def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
+  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     (cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
       val codecSpec = TypedCodecSpec(kb.ctx, CallStatsState.stateType, codec)
       val decValue = codecSpec.encodedType.buildDecoder(CallStatsState.stateType.virtualType, kb)
@@ -113,7 +114,7 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
       loadNAlleles(cb)
   }
 
-  def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
+  override def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
     cb.assign(
       off,
       CallStatsState.stateType.store(
@@ -137,7 +138,7 @@ class CallStatsAggregator extends StagedAggregator {
   val initOpTypes: Seq[Type] = FastSeq(TInt32)
   val seqOpTypes: Seq[Type] = FastSeq(TCall)
 
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     val Array(nAlleles) = init
     val addr = state.kb.genFieldThisRef[Long]()
     val n = state.kb.genFieldThisRef[Int]()
@@ -175,7 +176,7 @@ class CallStatsAggregator extends StagedAggregator {
       )
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(call) = seq
 
     call.toI(cb).consume(
@@ -203,7 +204,7 @@ class CallStatsAggregator extends StagedAggregator {
     )
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -236,7 +237,8 @@ class CallStatsAggregator extends StagedAggregator {
     )
   }
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode = {
     val rt = CallStatsState.resultPType
     val addr = cb.memoize(rt.allocate(region), "call_stats_aggregator_result_addr")
     rt.stagedInitialize(cb, addr, setMissing = false)

--- a/hail/hail/src/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/CountAggregator.scala
@@ -16,21 +16,21 @@ object CountAggregator extends StagedAggregator {
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type]()
 
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 0)
     assert(state.vtypes.head.r.required)
     val ev = state.fields(0)
     cb.assign(ev, EmitCode.present(cb.emb, primitive(const(0L))))
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     assert(seq.length == 0)
     assert(state.vtypes.head.r.required)
     val ev = state.fields(0)
     cb.assign(ev, EmitCode.present(cb.emb, primitive(cb.memoize(ev.pv.asInt64.value + 1L))))
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -46,7 +46,8 @@ object CountAggregator extends StagedAggregator {
     )
   }
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode = {
     assert(state.vtypes.head.r.required)
     val ev = state.fields(0)
     ev.toI(cb).map(cb)(sv => sv.copyToRegion(cb, region, sv.st))

--- a/hail/hail/src/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
@@ -168,20 +168,20 @@ class ImputeTypeAggregator() extends StagedAggregator {
 
   type State = ImputeTypeState
 
-  def resultEmitType = ImputeTypeState.resultEmitType
+  override def resultEmitType = ImputeTypeState.resultEmitType
 
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 0)
     state.initialize(cb)
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(s) = seq
 
     state.seqOp(cb, s)
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -190,7 +190,8 @@ class ImputeTypeAggregator() extends StagedAggregator {
   ): Unit =
     state.combOp(cb, other)
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode = {
     val emitCodes = Array(
       state.getAnyNonMissing,
       state.getAllDefined,

--- a/hail/hail/src/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -134,7 +134,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
     cb += Region.storeInt(stateType.loadField(state.off, 2), k0)
   }
 
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     val Array(kt, k0t) = init
     kt.toI(cb)
       .consume(
@@ -254,7 +254,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
     )
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(y, x) = seq
     y.toI(cb)
       .consume(
@@ -321,7 +321,7 @@ class LinearRegressionAggregator() extends StagedAggregator {
     )
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -330,7 +330,8 @@ class LinearRegressionAggregator() extends StagedAggregator {
   ): Unit =
     combOpF(state, other)(cb)
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode = {
     val resAddr = cb.newLocal[Long](
       "linear_regression_agg_res",
       Code.invokeScalaObject4[Region, Long, Long, Int, Long](

--- a/hail/hail/src/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -99,7 +99,8 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
     cb.invokeVoid(combOpMethod, cb.this_)
   }
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode =
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode =
     state.get(cb).map(cb)(sv => sv.copyToRegion(cb, region, sv.st))
 }
 

--- a/hail/hail/src/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -14,12 +14,12 @@ class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type](typ.t)
 
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 0)
     state.storeMissing(cb)
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(elt: EmitCode) = seq
     elt.toI(cb)
       .consume(
@@ -29,7 +29,7 @@ class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
       )
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -43,6 +43,7 @@ class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
         sc => state.storeNonmissing(cb, sc),
       )
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode =
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode =
     state.get(cb).map(cb)(sv => sv.copyToRegion(cb, region, sv.st))
 }

--- a/hail/hail/src/is/hail/expr/ir/agg/ReservoirSampleAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/ReservoirSampleAggregator.scala
@@ -33,10 +33,10 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
   private val garbageOffset: Code[Long] => Code[Long] = storageType.loadField(_, 2)
   private val builderStateOffset: Code[Long] => Code[Long] = storageType.loadField(_, 3)
 
-  def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit =
+  override def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit =
     cb += region.getNewRegion(regionSize)
 
-  def createState(cb: EmitCodeBuilder): Unit = {
+  override def createState(cb: EmitCodeBuilder): Unit = {
     cb.assign(rand, Code.newInstance[java.util.Random]())
     cb.if_(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
   }
@@ -70,14 +70,14 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
     )
   }
 
-  def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
+  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     (cb: EmitCodeBuilder, ob: Value[OutputBuffer]) =>
       cb += ob.writeInt(maxSize)
       cb += ob.writeLong(seenSoFar)
       builder.serialize(codec)(cb, ob)
   }
 
-  def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
+  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     (cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
       cb.assign(maxSize, ib.readInt())
       cb.assign(seenSoFar, ib.readLong())
@@ -245,7 +245,7 @@ class ReservoirSampleRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuil
       builder.loadElement(cb, idx).toI(cb)
     }
 
-  def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
+  override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
     cb.assign(maxSize, Region.loadInt(maxSizeOffset(src)))
     cb.assign(seenSoFar, Region.loadLong(elementsSeenOffset(src)))
     cb.assign(garbage, Region.loadLong(garbageOffset(src)))
@@ -262,8 +262,11 @@ class ReservoirSampleAggregator(typ: VirtualTypeWithReq) extends StagedAggregato
   val initOpTypes: Seq[Type] = Array(TInt32)
   val seqOpTypes: Seq[Type] = Array(typ.t)
 
-  protected def _initOp(cb: EmitCodeBuilder, state: ReservoirSampleRVAS, init: Array[EmitCode])
-    : Unit = {
+  override protected def _initOp(
+    cb: EmitCodeBuilder,
+    state: ReservoirSampleRVAS,
+    init: Array[EmitCode],
+  ): Unit = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
     sizeTriplet.toI(cb)
@@ -274,13 +277,16 @@ class ReservoirSampleAggregator(typ: VirtualTypeWithReq) extends StagedAggregato
       )
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: ReservoirSampleRVAS, seq: Array[EmitCode])
-    : Unit = {
+  override protected def _seqOp(
+    cb: EmitCodeBuilder,
+    state: ReservoirSampleRVAS,
+    seq: Array[EmitCode],
+  ): Unit = {
     val Array(elt: EmitCode) = seq
     state.seqOp(cb, elt)
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -288,7 +294,8 @@ class ReservoirSampleAggregator(typ: VirtualTypeWithReq) extends StagedAggregato
     other: ReservoirSampleRVAS,
   ): Unit = state.combine(cb, other)
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode =
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode =
     // deepCopy is handled by state.resultArray
     IEmitCode.present(cb, state.resultArray(cb, region, resultPType))
 }

--- a/hail/hail/src/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -100,9 +100,10 @@ class TakeByRVAS(
     }
   }
 
-  def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit = cb += region.getNewRegion(regionSize)
+  override def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit =
+    cb += region.getNewRegion(regionSize)
 
-  def createState(cb: EmitCodeBuilder): Unit =
+  override def createState(cb: EmitCodeBuilder): Unit =
     cb.if_(
       region.isNull, {
         cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
@@ -193,7 +194,7 @@ class TakeByRVAS(
     })
   }
 
-  def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
+  override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
     maybeGCCode(
       cb,
       { cb =>
@@ -205,7 +206,7 @@ class TakeByRVAS(
     )({ cb => cb.assign(maxGarbage, Region.loadInt(storageType.fieldOffset(src, 4))) })
   }
 
-  def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
+  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     (cb: EmitCodeBuilder, ob: Value[OutputBuffer]) =>
       maybeGCCode(
         cb,
@@ -218,7 +219,7 @@ class TakeByRVAS(
       )(cb => cb += ob.writeInt(maxGarbage), runBefore = true)
   }
 
-  def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
+  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     (cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
       maybeGCCode(
         cb,
@@ -676,7 +677,7 @@ class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithRe
   val initOpTypes: Seq[Type] = Array(TInt32)
   val seqOpTypes: Seq[Type] = Array(valueType.t, keyType.t)
 
-  protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
     sizeTriplet.toI(cb)
@@ -687,12 +688,12 @@ class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithRe
       )
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(value: EmitCode, key: EmitCode) = seq
     state.seqOp(cb, value, key)
   }
 
-  protected def _combOp(
+  override protected def _combOp(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     region: Value[Region],
@@ -700,7 +701,8 @@ class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithRe
     other: TakeByRVAS,
   ): Unit = state.combine(cb, other)
 
-  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode =
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode =
     // state.result does a deep copy
     IEmitCode.present(
       cb,

--- a/hail/hail/src/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
@@ -51,7 +51,7 @@ object ApproxCDFFunctions extends RegistryFunctions {
     unwrapReturn(cb, r, SBaseStructPointer(statePType), row).asBaseStruct
   }
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerSCode3(
       "approxCDFCombine",
       TInt32,

--- a/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -120,7 +120,7 @@ object ArrayFunctions extends RegistryFunctions {
     foldIR(ToStream(a), one)((product, v) => ApplyBinaryPrimOp(Multiply(), product, v))
   }
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerIR1("isEmpty", TArray(tv("T")), TBoolean)((_, a, _) => isEmpty(a))
 
     registerIR2("extend", TArray(tv("T")), TArray(tv("T")), TArray(tv("T")))((_, a, b, _) =>

--- a/hail/hail/src/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/CallFunctions.scala
@@ -12,7 +12,7 @@ import is.hail.variant._
 import scala.reflect.classTag
 
 object CallFunctions extends RegistryFunctions {
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerWrappedScalaFunction1("Call", TString, TCall, (rt: Type, st: SType) => SCanonicalCall)(
       Call.getClass,
       "parse",

--- a/hail/hail/src/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/DictFunctions.scala
@@ -49,7 +49,7 @@ object DictFunctions extends RegistryFunctions {
 
   val tdict = TDict(tv("key"), tv("value"))
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerIR1("isEmpty", tdict, TBoolean)((_, d, _) => ArrayFunctions.isEmpty(CastToArray(d)))
 
     registerIR2("contains", tdict, tv("key"), TBoolean)((_, a, b, _) => contains(a, b))

--- a/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
@@ -1269,7 +1269,7 @@ abstract class UnseededMissingnessObliviousJVMFunction(
     args: SValue*
   ): SValue
 
-  def apply(
+  override def apply(
     r: EmitRegion,
     returnType: SType,
     typeParameters: Seq[Type],

--- a/hail/hail/src/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -9,7 +9,7 @@ import is.hail.types.virtual.{TArray, TFloat64, TInt32, Type}
 
 object GenotypeFunctions extends RegistryFunctions {
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerSCode1("gqFromPL", TArray(tv("N", "int32")), TInt32, (_: Type, _: SType) => SInt32) {
       case (_, cb, _, pl: SIndexableValue, errorID) =>
         val m = cb.newLocal[Int]("m", 99)

--- a/hail/hail/src/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -306,7 +306,7 @@ object IntervalFunctions extends RegistryFunctions {
     BinarySearch.equalRange(cb, array, compare, ltNeedle, gtNeedle, 0, array.loadLength)
   }
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerIEmitCode4(
       "Interval",
       tv("T"),

--- a/hail/hail/src/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -118,7 +118,7 @@ object LocusFunctions extends RegistryFunctions {
         )))
     }
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     val locusClass = Locus.getClass
 
     registerSCode1(

--- a/hail/hail/src/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/MathFunctions.scala
@@ -111,7 +111,7 @@ object MathFunctions extends RegistryFunctions {
 
   val mathPackageClass: Class[_] = Class.forName("scala.math.package$")
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     val thisClass = getClass
     val statsPackageClass = Class.forName("is.hail.stats.package$")
     val jMathClass = classOf[java.lang.Math]

--- a/hail/hail/src/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -111,7 +111,7 @@ object RandomSeededFunctions extends RegistryFunctions {
     )
   }
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerSCode3(
       "rand_unif",
       TRNGState,

--- a/hail/hail/src/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -14,7 +14,7 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
   def rgCode(mb: EmitMethodBuilder[_], rg: String): Code[ReferenceGenome] =
     mb.getReferenceGenome(rg)
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerSCode1t(
       "isValidContig",
       Array(LocusFunctions.tlocus("R")),

--- a/hail/hail/src/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -48,7 +48,7 @@ case class WrappedMatrixToTableFunction(
     function.typ(mType) // MatrixType RVDTypes will go away
   }
 
-  def execute(ctx: ExecuteContext, tv: TableValue): TableValue =
+  override def execute(ctx: ExecuteContext, tv: TableValue): TableValue =
     function.execute(ctx, tv.toMatrixValue(colKey, colsFieldName, entriesFieldName))
 
   override def preservesPartitionCounts: Boolean = function.preservesPartitionCounts
@@ -82,13 +82,13 @@ case class WrappedMatrixToValueFunction(
   colKey: IndexedSeq[String],
 ) extends TableToValueFunction {
 
-  def typ(childType: TableType): Type =
+  override def typ(childType: TableType): Type =
     function.typ(MatrixType.fromTableType(childType, colsFieldName, entriesFieldName, colKey))
 
-  def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit =
+  override def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit =
     function.unionRequiredness(childType, resultType)
 
-  def execute(ctx: ExecuteContext, tv: TableValue): Any =
+  override def execute(ctx: ExecuteContext, tv: TableValue): Any =
     function.execute(ctx, tv.toMatrixValue(colKey, colsFieldName, entriesFieldName))
 }
 

--- a/hail/hail/src/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/SetFunctions.scala
@@ -20,7 +20,7 @@ object SetFunctions extends RegistryFunctions {
     )
   }
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerIR1("toSet", TArray(tv("T")), TSet(tv("T")))((_, a, _) => ToSet(ToStream(a)))
 
     registerIR1("isEmpty", TSet(tv("T")), TBoolean) { (_, s, _) =>

--- a/hail/hail/src/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/StringFunctions.scala
@@ -283,7 +283,7 @@ object StringFunctions extends RegistryFunctions {
       .parse(timeStr)
       .getLong(ChronoField.INSTANT_SECONDS)
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     val thisClass = getClass
 
     registerSCode1("length", TString, TInt32, (_: Type, _: SType) => SInt32) {

--- a/hail/hail/src/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
@@ -10,9 +10,10 @@ import is.hail.utils._
 case class TableCalculateNewPartitions(
   nPartitions: Int
 ) extends TableToValueFunction {
-  def typ(childType: TableType): Type = TArray(TInterval(childType.keyType))
+  override def typ(childType: TableType): Type = TArray(TInterval(childType.keyType))
 
-  def unionRequiredness(childType: types.RTable, resultType: types.TypeWithRequiredness): Unit = {
+  override def unionRequiredness(childType: types.RTable, resultType: types.TypeWithRequiredness)
+    : Unit = {
     val rinterval = types.tcoerce[types.RInterval](
       types.tcoerce[types.RIterable](resultType).elementType
     )
@@ -24,7 +25,7 @@ case class TableCalculateNewPartitions(
     }
   }
 
-  def execute(ctx: ExecuteContext, tv: TableValue): Any = {
+  override def execute(ctx: ExecuteContext, tv: TableValue): Any = {
     val rvd = tv.rvd
     if (rvd.typ.key.isEmpty)
       FastSeq()

--- a/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -201,7 +201,7 @@ object UtilFunctions extends RegistryFunctions {
         )
     }
 
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     val thisClass = getClass
 
     registerSCode4(

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -102,15 +102,17 @@ object LowerDistributedSort extends Logging {
 
     override def isDistinctlyKeyed: Boolean = false // FIXME: No default value
 
-    def rowRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
+    override def rowRequiredness(ctx: ExecuteContext, requestedType: TableType)
+      : VirtualTypeWithReq =
       VirtualTypeWithReq.subset(requestedType.rowType, rt.rowType)
 
-    def globalRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
+    override def globalRequiredness(ctx: ExecuteContext, requestedType: TableType)
+      : VirtualTypeWithReq =
       VirtualTypeWithReq.subset(requestedType.globalType, rt.globalType)
 
     override def toJValue: JValue = JString("LocalSortReader")
 
-    def renderShort(): String = "LocalSortReader"
+    override def renderShort(): String = "LocalSortReader"
 
     override def defaultRender(): String = "LocalSortReader"
 
@@ -982,15 +984,16 @@ case class DistributionSortReader(
 
   override def isDistinctlyKeyed: Boolean = false // FIXME: No default value
 
-  def rowRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
+  override def rowRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
     VirtualTypeWithReq.subset(requestedType.rowType, rt.rowType)
 
-  def globalRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
+  override def globalRequiredness(ctx: ExecuteContext, requestedType: TableType)
+    : VirtualTypeWithReq =
     VirtualTypeWithReq.subset(requestedType.globalType, rt.globalType)
 
   override def toJValue: JValue = JString("DistributionSortReader")
 
-  def renderShort(): String = "DistributionSortReader"
+  override def renderShort(): String = "DistributionSortReader"
 
   override def defaultRender(): String = "DistributionSortReader"
 

--- a/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -61,7 +61,7 @@ case object LowerMatrixToTablePass extends LoweringPass {
   val after: Invariant = NoMatrixIR
   val context: String = "LowerMatrixToTable"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = ir match {
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = ir match {
     case x: IR => LowerMatrixIR(ctx, x)
     case x: TableIR => LowerMatrixIR(ctx, x)
     case x: MatrixIR => LowerMatrixIR(ctx, x)
@@ -74,7 +74,7 @@ case object LiftRelationalValuesToRelationalLets extends LoweringPass {
   val after: Invariant = NoMatrixIR
   val context: String = "LiftRelationalValuesToRelationalLets"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LiftRelationalValues(ir)
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LiftRelationalValues(ir)
 }
 
 case object LegacyInterpretNonCompilablePass extends LoweringPass {
@@ -82,7 +82,8 @@ case object LegacyInterpretNonCompilablePass extends LoweringPass {
   val after: Invariant = NoMatrixIR and NoRelationalLets and CompilableValueIRs
   val context: String = "InterpretNonCompilable"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerOrInterpretNonCompilable(ctx, ir)
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR =
+    LowerOrInterpretNonCompilable(ctx, ir)
 }
 
 case object LowerOrInterpretNonCompilablePass extends LoweringPass {
@@ -90,7 +91,8 @@ case object LowerOrInterpretNonCompilablePass extends LoweringPass {
   val after: Invariant = CompilableIR
   val context: String = "LowerOrInterpretNonCompilable"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerOrInterpretNonCompilable(ctx, ir)
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR =
+    LowerOrInterpretNonCompilable(ctx, ir)
 }
 
 case class LowerToDistributedArrayPass(t: DArrayLowering.Type) extends LoweringPass {
@@ -98,7 +100,8 @@ case class LowerToDistributedArrayPass(t: DArrayLowering.Type) extends LoweringP
   val after: Invariant = CompilableIR
   val context: String = "LowerToDistributedArray"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerToCDA(ir.asInstanceOf[IR], t, ctx)
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR =
+    LowerToCDA(ir.asInstanceOf[IR], t, ctx)
 }
 
 case object InlineApplyIR extends LoweringPass {
@@ -123,7 +126,7 @@ case object LowerArrayAggsToRunAggsPass extends LoweringPass {
   val after: Invariant = EmittableIR
   val context: String = "LowerArrayAggsToRunAggs"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR =
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR =
     ctx.time {
       val x = ir.noSharing(ctx)
       val r = Requiredness(x, ctx)

--- a/hail/hail/src/is/hail/expr/ir/lowering/RVDToTableStage.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/RVDToTableStage.scala
@@ -81,15 +81,16 @@ case class RVDTableReader(rvd: RVD, globals: IR, rt: RTable) extends TableReader
 
   override def isDistinctlyKeyed: Boolean = false
 
-  def rowRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
+  override def rowRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
     VirtualTypeWithReq.subset(requestedType.rowType, rt.rowType)
 
-  def globalRequiredness(ctx: ExecuteContext, requestedType: TableType): VirtualTypeWithReq =
+  override def globalRequiredness(ctx: ExecuteContext, requestedType: TableType)
+    : VirtualTypeWithReq =
     VirtualTypeWithReq.subset(requestedType.globalType, rt.globalType)
 
   override def toJValue: JValue = JString("RVDTableReader")
 
-  def renderShort(): String = "RVDTableReader"
+  override def renderShort(): String = "RVDTableReader"
 
   override def defaultRender(): String = "RVDTableReader"
 

--- a/hail/hail/src/is/hail/expr/ir/orderings/BinaryOrdering.scala
+++ b/hail/hail/src/is/hail/expr/ir/orderings/BinaryOrdering.scala
@@ -13,7 +13,7 @@ object BinaryOrdering {
       val type1: SBinary = t1
       val type2: SBinary = t2
 
-      def _compareNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Int] = {
+      override def _compareNonnull(cb: EmitCodeBuilder, x: SValue, y: SValue): Value[Int] = {
         val xv: SBinaryValue = x.asBinary
         val yv: SBinaryValue = y.asBinary
         val xlen = xv.loadLength(cb)

--- a/hail/hail/src/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/hail/src/is/hail/expr/ir/streams/EmitStream.scala
@@ -422,7 +422,7 @@ object EmitStream {
 
                 val element: EmitCode = EmitCode.fromI(mb)(cb => container.loadElement(cb, idx))
 
-                def close(cb: EmitCodeBuilder): Unit = {}
+                override def close(cb: EmitCodeBuilder): Unit = {}
               }
             )
 
@@ -669,7 +669,7 @@ object EmitStream {
 
                 val element: EmitCode = eltField.load
 
-                def close(cb: EmitCodeBuilder): Unit = {}
+                override def close(cb: EmitCodeBuilder): Unit = {}
               }
             ),
           )
@@ -793,7 +793,7 @@ object EmitStream {
 
                 val element: EmitCode = EmitCode.present(mb, new SInt32Value(curr))
 
-                def close(cb: EmitCodeBuilder): Unit = {}
+                override def close(cb: EmitCodeBuilder): Unit = {}
               }
               SStreamValue(producer)
 
@@ -864,7 +864,7 @@ object EmitStream {
 
                 val element: EmitCode = EmitCode.present(mb, new SInt32Value(curr))
 
-                def close(cb: EmitCodeBuilder): Unit = {}
+                override def close(cb: EmitCodeBuilder): Unit = {}
               }
 
               SStreamValue(producer)
@@ -940,7 +940,7 @@ object EmitStream {
 
                   val element: EmitCode = EmitCode.present(mb, new SInt32Value(curr))
 
-                  def close(cb: EmitCodeBuilder): Unit = {}
+                  override def close(cb: EmitCodeBuilder): Unit = {}
                 }
 
                 SStreamValue(producer)
@@ -1074,7 +1074,7 @@ object EmitStream {
 
                 val element: EmitCode = elementField
 
-                def close(cb: EmitCodeBuilder): Unit = {
+                override def close(cb: EmitCodeBuilder): Unit = {
                   childProducer.close(cb)
                   if (requiresMemoryManagementPerElement)
                     cb += childProducer.elementRegion.invalidate()
@@ -1339,7 +1339,7 @@ object EmitStream {
 
                 val element: EmitCode = bodyResult
 
-                def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
+                override def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
               }
 
               mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))
@@ -1725,7 +1725,7 @@ object EmitStream {
               }
               val element: EmitCode = innerProducer.element
 
-              def close(cb: EmitCodeBuilder): Unit = {
+              override def close(cb: EmitCodeBuilder): Unit = {
                 cb.if_(
                   innerUnclosed, {
                     cb.assign(innerUnclosed, false)
@@ -2935,7 +2935,7 @@ object EmitStream {
 
                     val element: EmitCode = bodyCode
 
-                    def close(cb: EmitCodeBuilder): Unit =
+                    override def close(cb: EmitCodeBuilder): Unit =
                       producers.foreach(_.close(cb))
                   }
 
@@ -3028,7 +3028,7 @@ object EmitStream {
 
                     val element: EmitCode = bodyCode
 
-                    def close(cb: EmitCodeBuilder): Unit =
+                    override def close(cb: EmitCodeBuilder): Unit =
                       producers.foreach(_.close(cb))
                   }
 
@@ -3107,7 +3107,7 @@ object EmitStream {
 
                     val element: EmitCode = bodyCode
 
-                    def close(cb: EmitCodeBuilder): Unit =
+                    override def close(cb: EmitCodeBuilder): Unit =
                       producers.foreach(_.close(cb))
                   }
 
@@ -3854,7 +3854,7 @@ object EmitStream {
               val elementField = mb.newEmitField(elementType)
 
               val producer = new StreamProducer {
-                def method: EmitMethodBuilder[_] = mb
+                override def method: EmitMethodBuilder[_] = mb
 
                 val length: Option[EmitCodeBuilder => Code[Int]] = None
 
@@ -3865,7 +3865,7 @@ object EmitStream {
                 val requiresMemoryManagementPerElement: Boolean =
                   childProducer.requiresMemoryManagementPerElement
 
-                def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+                override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
                   cb.assign(queueSize, emit(maxQueueSize, cb).getOrAssert(cb).asInt32.value)
                   cb.assign(
                     queue,
@@ -3955,7 +3955,7 @@ object EmitStream {
                   cb.goto(childProducer.LproduceElement)
                 }
 
-                def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
+                override def close(cb: EmitCodeBuilder): Unit = childProducer.close(cb)
               }
 
               mb.implementLabel(childProducer.LendOfStream)(cb => cb.goto(producer.LendOfStream))

--- a/hail/hail/src/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/hail/src/is/hail/expr/ir/streams/StreamUtils.scala
@@ -254,7 +254,7 @@ object StreamUtils {
 
     def implInit(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit
 
-    final def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+    final override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
       implInit(cb, outerRegion)
       cb.assign(bracket, Code.newArray[Int](k))
       cb.assign(heads, Code.newArray[Long](k))
@@ -265,7 +265,7 @@ object StreamUtils {
 
     def implClose(cb: EmitCodeBuilder): Unit
 
-    final def close(cb: EmitCodeBuilder): Unit = {
+    final override def close(cb: EmitCodeBuilder): Unit = {
       implClose(cb)
       cb.assign(bracket, Code._null)
       cb.assign(heads, Code._null)

--- a/hail/hail/src/is/hail/io/BufferSpecs.scala
+++ b/hail/hail/src/is/hail/io/BufferSpecs.scala
@@ -89,35 +89,35 @@ trait BufferSpec extends Spec {
 }
 
 final case class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
-  def buildInputBuffer(in: InputStream): InputBuffer =
+  override def buildInputBuffer(in: InputStream): InputBuffer =
     new LEB128InputBuffer(child.buildInputBuffer(in))
 
-  def buildOutputBuffer(out: OutputStream): OutputBuffer =
+  override def buildOutputBuffer(out: OutputStream): OutputBuffer =
     new LEB128OutputBuffer(child.buildOutputBuffer(out))
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
     Code.newInstance[LEB128InputBuffer, InputBuffer](child.buildCodeInputBuffer(in))
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
     Code.newInstance[LEB128OutputBuffer, OutputBuffer](child.buildCodeOutputBuffer(out))
 }
 
 final case class BlockingBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BufferSpec {
   require(blockSize <= (1 << 16))
 
-  def buildInputBuffer(in: InputStream): InputBuffer =
+  override def buildInputBuffer(in: InputStream): InputBuffer =
     new BlockingInputBuffer(blockSize, child.buildInputBuffer(in))
 
-  def buildOutputBuffer(out: OutputStream): OutputBuffer =
+  override def buildOutputBuffer(out: OutputStream): OutputBuffer =
     new BlockingOutputBuffer(blockSize, child.buildOutputBuffer(out))
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
     Code.newInstance[BlockingInputBuffer, Int, InputBlockBuffer](
       blockSize,
       child.buildCodeInputBuffer(in),
     )
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
     Code.newInstance[BlockingOutputBuffer, Int, OutputBlockBuffer](
       blockSize,
       child.buildCodeOutputBuffer(out),
@@ -147,20 +147,20 @@ abstract class LZ4BlockBufferSpecCommon extends BlockBufferSpec {
 
   def child: BlockBufferSpec
 
-  def buildInputBuffer(in: InputStream): InputBlockBuffer =
+  override def buildInputBuffer(in: InputStream): InputBlockBuffer =
     new LZ4InputBlockBuffer(lz4, blockSize, child.buildInputBuffer(in))
 
-  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
     new LZ4OutputBlockBuffer(lz4, blockSize, child.buildOutputBuffer(out))
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[LZ4InputBlockBuffer, LZ4, Int, InputBlockBuffer](
       stagedlz4,
       blockSize,
       child.buildCodeInputBuffer(in),
     )
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
     Code.newInstance[LZ4OutputBlockBuffer, LZ4, Int, OutputBlockBuffer](
       stagedlz4,
       blockSize,
@@ -170,16 +170,16 @@ abstract class LZ4BlockBufferSpecCommon extends BlockBufferSpec {
 
 final case class LZ4HCBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
     extends LZ4BlockBufferSpecCommon {
-  def lz4 = LZ4.hc
-  def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "hc")
-  def typeName = "LZ4HCBlockBufferSpec"
+  override def lz4 = LZ4.hc
+  override def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "hc")
+  override def typeName = "LZ4HCBlockBufferSpec"
 }
 
 final case class LZ4FastBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
     extends LZ4BlockBufferSpecCommon {
-  def lz4 = LZ4.fast
-  def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
-  def typeName = "LZ4FastBlockBufferSpec"
+  override def lz4 = LZ4.fast
+  override def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
+  override def typeName = "LZ4FastBlockBufferSpec"
 }
 
 final case class LZ4SizeBasedBlockBufferSpec(
@@ -196,10 +196,10 @@ final case class LZ4SizeBasedBlockBufferSpec(
   def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
   def typeName = "LZ4SizeBasedBlockBufferSpec"
 
-  def buildInputBuffer(in: InputStream): InputBlockBuffer =
+  override def buildInputBuffer(in: InputStream): InputBlockBuffer =
     new LZ4SizeBasedCompressingInputBlockBuffer(lz4, blockSize, child.buildInputBuffer(in))
 
-  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
     new LZ4SizeBasedCompressingOutputBlockBuffer(
       lz4,
       blockSize,
@@ -207,14 +207,14 @@ final case class LZ4SizeBasedBlockBufferSpec(
       child.buildOutputBuffer(out),
     )
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[LZ4SizeBasedCompressingInputBlockBuffer, LZ4, Int, InputBlockBuffer](
       stagedlz4,
       blockSize,
       child.buildCodeInputBuffer(in),
     )
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
     Code.newInstance[LZ4SizeBasedCompressingOutputBlockBuffer, LZ4, Int, Int, OutputBlockBuffer](
       stagedlz4,
       blockSize,
@@ -227,19 +227,19 @@ final case class ZstdBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
     extends BlockBufferSpec {
   require(blockSize <= (1 << 16))
 
-  def buildInputBuffer(in: InputStream): InputBlockBuffer =
+  override def buildInputBuffer(in: InputStream): InputBlockBuffer =
     new ZstdInputBlockBuffer(blockSize, child.buildInputBuffer(in))
 
-  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
     new ZstdOutputBlockBuffer(blockSize, child.buildOutputBuffer(out))
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[ZstdInputBlockBuffer, Int, InputBlockBuffer](
       blockSize,
       child.buildCodeInputBuffer(in),
     )
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
     Code.newInstance[ZstdOutputBlockBuffer, Int, OutputBlockBuffer](
       blockSize,
       child.buildCodeOutputBuffer(out),
@@ -253,19 +253,19 @@ final case class ZstdSizedBasedBlockBufferSpec(
 ) extends BlockBufferSpec {
   require(blockSize <= (1 << 16))
 
-  def buildInputBuffer(in: InputStream): InputBlockBuffer =
+  override def buildInputBuffer(in: InputStream): InputBlockBuffer =
     new ZstdSizedBasedInputBlockBuffer(blockSize, child.buildInputBuffer(in))
 
-  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
     new ZstdSizedBasedOutputBlockBuffer(blockSize, minCompressionSize, child.buildOutputBuffer(out))
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[ZstdSizedBasedInputBlockBuffer, Int, InputBlockBuffer](
       blockSize,
       child.buildCodeInputBuffer(in),
     )
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
     Code.newInstance[ZstdSizedBasedOutputBlockBuffer, Int, Int, OutputBlockBuffer](
       blockSize,
       minCompressionSize,
@@ -278,14 +278,15 @@ object StreamBlockBufferSpec {
 }
 
 final class StreamBlockBufferSpec extends BlockBufferSpec {
-  def buildInputBuffer(in: InputStream): InputBlockBuffer = new StreamBlockInputBuffer(in)
+  override def buildInputBuffer(in: InputStream): InputBlockBuffer = new StreamBlockInputBuffer(in)
 
-  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new StreamBlockOutputBuffer(out)
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
+    new StreamBlockOutputBuffer(out)
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[StreamBlockInputBuffer, InputStream](in)
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
     Code.newInstance[StreamBlockOutputBuffer, OutputStream](out)
 
   override def equals(other: Any): Boolean = other.isInstanceOf[StreamBlockBufferSpec]
@@ -296,10 +297,10 @@ final class StreamBufferSpec extends BufferSpec {
 
   override def buildOutputBuffer(out: OutputStream): OutputBuffer = new StreamOutputBuffer(out)
 
-  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
+  override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
     Code.newInstance[StreamInputBuffer, InputStream](in)
 
-  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
+  override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
     Code.newInstance[StreamOutputBuffer, OutputStream](out)
 
   override def equals(other: Any): Boolean = other.isInstanceOf[StreamBufferSpec]

--- a/hail/hail/src/is/hail/io/ByteArrayReader.scala
+++ b/hail/hail/src/is/hail/io/ByteArrayReader.scala
@@ -27,7 +27,7 @@ class ByteArrayReader(val arr: Array[Byte]) extends AbstractBinaryReader {
   def seek(pos: Int): Unit =
     position = pos
 
-  def skipBytes(bytes: Long): Long = {
+  override def skipBytes(bytes: Long): Long = {
     require(bytes < Integer.MAX_VALUE)
     position += bytes.toInt
     if (position < length)

--- a/hail/hail/src/is/hail/io/Decoder.scala
+++ b/hail/hail/src/is/hail/io/Decoder.scala
@@ -9,8 +9,6 @@ import is.hail.utils.RestartableByteArrayInputStream
 import java.io._
 
 trait Decoder extends Closeable {
-  def close(): Unit
-
   def ptype: PType
 
   def readRegionValue(region: Region): Long
@@ -26,17 +24,17 @@ final class CompiledDecoder(
   theHailClassLoader: HailClassLoader,
   f: (HailClassLoader) => DecoderAsmFunction,
 ) extends Decoder {
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
-  def readByte(): Byte = in.readByte()
+  override def readByte(): Byte = in.readByte()
 
   private[this] val compiled = f(theHailClassLoader)
 
-  def readRegionValue(r: Region): Long =
+  override def readRegionValue(r: Region): Long =
     compiled(r, in)
 
-  def seek(offset: Long): Unit = in.seek(offset)
+  override def seek(offset: Long): Unit = in.seek(offset)
 }
 
 final class ByteArrayDecoder(

--- a/hail/hail/src/is/hail/io/DoubleInputBuffer.scala
+++ b/hail/hail/src/is/hail/io/DoubleInputBuffer.scala
@@ -10,7 +10,7 @@ final class DoubleInputBuffer(in: InputStream, bufSize: Int) extends Closeable {
   private var end: Int = 0
   private var off: Int = 0
 
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
   def readDoubles(to: Array[Double]): Unit = readDoubles(to, 0, to.length)
@@ -45,7 +45,7 @@ final class DoubleOutputBuffer(out: OutputStream, bufSize: Int) extends Closeabl
   private val buf: Array[Byte] = new Array[Byte](bufSize)
   private var off: Int = 0
 
-  def close(): Unit = {
+  override def close(): Unit = {
     flush()
     out.close()
   }

--- a/hail/hail/src/is/hail/io/Encoder.scala
+++ b/hail/hail/src/is/hail/io/Encoder.scala
@@ -10,7 +10,7 @@ import java.io._
 trait Encoder extends Closeable {
   def flush(): Unit
 
-  def close(): Unit
+  override def close(): Unit
 
   def writeRegionValue(region: Region, offset: Long): Unit
 
@@ -28,10 +28,10 @@ final class CompiledEncoder(
   private[this] var partitionRegion: Region = _
   private[this] val compiled = f(theHailClassLoader)
 
-  def flush(): Unit =
+  override def flush(): Unit =
     out.flush()
 
-  def close(): Unit = {
+  override def close(): Unit = {
     compiled.asInstanceOf[FunctionWithPartitionRegion].setPool(null)
     compiled.asInstanceOf[FunctionWithPartitionRegion].addPartitionRegion(null)
     if (partitionRegion != null) partitionRegion.close()
@@ -45,7 +45,7 @@ final class CompiledEncoder(
     poolSet = true
   }
 
-  def writeRegionValue(r: Region, offset: Long): Unit = {
+  override def writeRegionValue(r: Region, offset: Long): Unit = {
     setScratchPool(r.pool)
     writeRegionValue(offset)
   }
@@ -55,10 +55,10 @@ final class CompiledEncoder(
     compiled(offset, out)
   }
 
-  def writeByte(b: Byte): Unit =
+  override def writeByte(b: Byte): Unit =
     out.writeByte(b)
 
-  def indexOffset(): Long = out.indexOffset()
+  override def indexOffset(): Long = out.indexOffset()
 }
 
 final class ByteArrayEncoder(
@@ -68,7 +68,7 @@ final class ByteArrayEncoder(
   private[this] val baos = new ByteArrayOutputStream()
   private[this] val enc = makeEnc(baos, theHailClassLoader)
 
-  def close(): Unit = {
+  override def close(): Unit = {
     enc.close()
     baos.close()
   }

--- a/hail/hail/src/is/hail/io/HadoopFSDataBinaryReader.scala
+++ b/hail/hail/src/is/hail/io/HadoopFSDataBinaryReader.scala
@@ -10,11 +10,11 @@ class HadoopFSDataBinaryReader(fis: SeekableDataInputStream)
   override def read(byteArray: Array[Byte], hasRead: Int, toRead: Int): Int =
     fis.read(byteArray, hasRead, toRead)
 
-  def close(): Unit = fis.close()
+  override def close(): Unit = fis.close()
 
   def seek(pos: Long): Unit = fis.seek(pos)
 
-  def skipBytes(bytes: Long): Long = fis.skip(bytes)
+  override def skipBytes(bytes: Long): Long = fis.skip(bytes)
 
   def getPosition: Long = fis.getPosition
 }

--- a/hail/hail/src/is/hail/io/IndexBTree.scala
+++ b/hail/hail/src/is/hail/io/IndexBTree.scala
@@ -108,7 +108,7 @@ class IndexBTree(indexFileName: String, fs: FS, branchingFactor: Int = 1024) ext
         )
     }
 
-  def close(): Unit = is.close()
+  override def close(): Unit = is.close()
 
   def calcDepth(): Int =
     IndexBTree.calcDepth(fs.getFileSize(indexFileName) / 8, branchingFactor)

--- a/hail/hail/src/is/hail/io/IndexedBinaryBlockReader.scala
+++ b/hail/hail/src/is/hail/io/IndexedBinaryBlockReader.scala
@@ -44,18 +44,18 @@ abstract class IndexedBinaryBlockReader[T](job: Configuration, split: FileSplit)
     )
   }
 
-  def createKey(): LongWritable = new LongWritable()
+  override def createKey(): LongWritable = new LongWritable()
 
-  def createValue(): T
+  override def createValue(): T
 
-  def getPos: Long = pos
+  override def getPos: Long = pos
 
-  def getProgress: Float =
+  override def getProgress: Float =
     if (partitionStart == end)
       0.0f
     else
       Math.min(1.0f, (pos - partitionStart) / (end - partitionStart).toFloat)
 
-  def close() = bfis.close()
+  override def close() = bfis.close()
 
 }

--- a/hail/hail/src/is/hail/io/IndexedBinaryInputFormat.scala
+++ b/hail/hail/src/is/hail/io/IndexedBinaryInputFormat.scala
@@ -5,6 +5,6 @@ import org.apache.hadoop.mapred._
 
 abstract class IndexedBinaryInputFormat[T] extends FileInputFormat[LongWritable, T] {
 
-  def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter)
+  override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter)
     : RecordReader[LongWritable, T]
 }

--- a/hail/hail/src/is/hail/io/InputBuffers.scala
+++ b/hail/hail/src/is/hail/io/InputBuffers.scala
@@ -11,7 +11,7 @@ import java.util.function.Supplier
 import com.github.luben.zstd.{Zstd, ZstdDecompressCtx}
 
 trait InputBuffer extends Closeable {
-  def close(): Unit
+  override def close(): Unit
 
   def seek(offset: Long): Unit
 
@@ -59,7 +59,7 @@ trait InputBuffer extends Closeable {
 }
 
 trait InputBlockBuffer extends Spec with Closeable {
-  def close(): Unit
+  override def close(): Unit
 
   def seek(offset: Long): Unit
 
@@ -84,11 +84,11 @@ trait InputBlockBuffer extends Spec with Closeable {
 final class StreamInputBuffer(in: InputStream) extends InputBuffer {
   private[this] val buff = new Array[Byte](8)
 
-  def close(): Unit = in.close()
+  override def close(): Unit = in.close()
 
-  def seek(offset: Long) = in.asInstanceOf[ByteTrackingInputStream].seek(offset)
+  override def seek(offset: Long) = in.asInstanceOf[ByteTrackingInputStream].seek(offset)
 
-  def readByte(): Byte = {
+  override def readByte(): Byte = {
     in.readFully(buff, 0, 1)
     Memory.loadByte(buff, 0)
   }
@@ -96,63 +96,63 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
   override def read(buf: Array[Byte], toOff: Int, n: Int): Unit =
     in.readFully(buf, toOff, n)
 
-  def readInt(): Int = {
+  override def readInt(): Int = {
     in.readFully(buff, 0, 4)
     Memory.loadInt(buff, 0)
   }
 
-  def readLong(): Long = {
+  override def readLong(): Long = {
     in.readFully(buff)
     Memory.loadLong(buff, 0)
   }
 
-  def readFloat(): Float = {
+  override def readFloat(): Float = {
     in.readFully(buff, 0, 4)
     Memory.loadFloat(buff, 0)
   }
 
-  def readDouble(): Double = {
+  override def readDouble(): Double = {
     in.readFully(buff)
     Memory.loadDouble(buff, 0)
   }
 
-  def readBytes(toRegion: Region, toOff: Long, n: Int): Unit =
+  override def readBytes(toRegion: Region, toOff: Long, n: Int): Unit =
     Region.storeBytes(toOff, readBytesArray(n))
 
-  def readBytesArray(n: Int): Array[Byte] =
+  override def readBytesArray(n: Int): Array[Byte] =
     Array.tabulate(n)(_ => readByte())
 
-  def skipByte(): Unit = {
+  override def skipByte(): Unit = {
     val bytesRead = in.skip(1)
     assert(bytesRead == 1L)
   }
 
-  def skipInt(): Unit = {
+  override def skipInt(): Unit = {
     val bytesRead = in.skip(4)
     assert(bytesRead == 4L)
   }
 
-  def skipLong(): Unit = {
+  override def skipLong(): Unit = {
     val bytesRead = in.skip(8)
     assert(bytesRead == 8L)
   }
 
-  def skipFloat(): Unit = {
+  override def skipFloat(): Unit = {
     val bytesRead = in.skip(4)
     assert(bytesRead == 4L)
   }
 
-  def skipDouble(): Unit = {
+  override def skipDouble(): Unit = {
     val bytesRead = in.skip(8)
     assert(bytesRead == 8L)
   }
 
-  def skipBytes(n: Int): Unit = {
+  override def skipBytes(n: Int): Unit = {
     val bytesRead = in.skip(n.toLong)
     assert(bytesRead == n)
   }
 
-  def readDoubles(to: Array[Double], off: Int, n: Int): Unit = {
+  override def readDoubles(to: Array[Double], off: Int, n: Int): Unit = {
     var i = 0
     while (i < n) {
       to(off + i) = readDouble()
@@ -162,55 +162,55 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
 }
 
 final class MemoryInputBuffer(mb: MemoryBuffer) extends InputBuffer {
-  def close(): Unit = {}
+  override def close(): Unit = {}
 
-  def seek(offset: Long) = ???
+  override def seek(offset: Long) = ???
 
-  def readByte(): Byte = mb.readByte()
+  override def readByte(): Byte = mb.readByte()
 
-  def readInt(): Int = mb.readInt()
+  override def readInt(): Int = mb.readInt()
 
-  def readLong(): Long = mb.readLong()
+  override def readLong(): Long = mb.readLong()
 
-  def readFloat(): Float = mb.readFloat()
+  override def readFloat(): Float = mb.readFloat()
 
-  def readDouble(): Double = mb.readDouble()
+  override def readDouble(): Double = mb.readDouble()
 
-  def readBytes(toRegion: Region, toOff: Long, n: Int): Unit = mb.readBytes(toOff, n)
+  override def readBytes(toRegion: Region, toOff: Long, n: Int): Unit = mb.readBytes(toOff, n)
 
-  def readBytesArray(n: Int): Array[Byte] = {
+  override def readBytesArray(n: Int): Array[Byte] = {
     val arr = new Array[Byte](n)
     mb.readBytesArray(arr, n)
     arr
   }
 
-  def skipByte(): Unit = mb.skipByte()
+  override def skipByte(): Unit = mb.skipByte()
 
-  def skipInt(): Unit = mb.skipInt()
+  override def skipInt(): Unit = mb.skipInt()
 
-  def skipLong(): Unit = mb.skipLong()
+  override def skipLong(): Unit = mb.skipLong()
 
-  def skipFloat(): Unit = mb.skipFloat()
+  override def skipFloat(): Unit = mb.skipFloat()
 
-  def skipDouble(): Unit = mb.skipDouble()
+  override def skipDouble(): Unit = mb.skipDouble()
 
-  def skipBytes(n: Int): Unit = mb.skipBytes(n)
+  override def skipBytes(n: Int): Unit = mb.skipBytes(n)
 
-  def readDoubles(to: Array[Double], off: Int, n: Int): Unit = ???
+  override def readDoubles(to: Array[Double], off: Int, n: Int): Unit = ???
 }
 
 final class LEB128InputBuffer(in: InputBuffer) extends InputBuffer {
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
-  def seek(offset: Long): Unit = in.seek(offset)
+  override def seek(offset: Long): Unit = in.seek(offset)
 
-  def readByte(): Byte =
+  override def readByte(): Byte =
     in.readByte()
 
   override def read(buf: Array[Byte], toOff: Int, n: Int) = in.read(buf, toOff, n)
 
-  def readInt(): Int = {
+  override def readInt(): Int = {
     var b: Byte = readByte()
     var x: Int = b & 0x7f
     var shift: Int = 7
@@ -222,7 +222,7 @@ final class LEB128InputBuffer(in: InputBuffer) extends InputBuffer {
     x
   }
 
-  def readLong(): Long = {
+  override def readLong(): Long = {
     var b: Byte = readByte()
     var x: Long = b & 0x7fL
     var shift: Int = 7
@@ -234,35 +234,37 @@ final class LEB128InputBuffer(in: InputBuffer) extends InputBuffer {
     x
   }
 
-  def readFloat(): Float = in.readFloat()
+  override def readFloat(): Float = in.readFloat()
 
-  def readDouble(): Double = in.readDouble()
+  override def readDouble(): Double = in.readDouble()
 
-  def readBytes(toRegion: Region, toOff: Long, n: Int): Unit = in.readBytes(toRegion, toOff, n)
+  override def readBytes(toRegion: Region, toOff: Long, n: Int): Unit =
+    in.readBytes(toRegion, toOff, n)
 
-  def readBytesArray(n: Int): Array[Byte] = in.readBytesArray(n)
+  override def readBytesArray(n: Int): Array[Byte] = in.readBytesArray(n)
 
-  def skipByte(): Unit = in.skipByte()
+  override def skipByte(): Unit = in.skipByte()
 
-  def skipInt(): Unit = {
+  override def skipInt(): Unit = {
     var b: Byte = readByte()
     while ((b & 0x80) != 0)
       b = readByte()
   }
 
-  def skipLong(): Unit = {
+  override def skipLong(): Unit = {
     var b: Byte = readByte()
     while ((b & 0x80) != 0)
       b = readByte()
   }
 
-  def skipFloat(): Unit = in.skipFloat()
+  override def skipFloat(): Unit = in.skipFloat()
 
-  def skipDouble(): Unit = in.skipDouble()
+  override def skipDouble(): Unit = in.skipDouble()
 
-  def skipBytes(n: Int): Unit = in.skipBytes(n)
+  override def skipBytes(n: Int): Unit = in.skipBytes(n)
 
-  def readDoubles(to: Array[Double], toOff: Int, n: Int): Unit = in.readDoubles(to, toOff, n)
+  override def readDoubles(to: Array[Double], toOff: Int, n: Int): Unit =
+    in.readDoubles(to, toOff, n)
 }
 
 final class TracingInputBuffer(
@@ -272,11 +274,11 @@ final class TracingInputBuffer(
   private[this] val logfile = new FileOutputStream(filename, true)
   logger.info(s"tracing to $filename")
 
-  def close(): Unit = in.close()
+  override def close(): Unit = in.close()
 
-  def seek(offset: Long): Unit = ???
+  override def seek(offset: Long): Unit = ???
 
-  def readByte(): Byte = {
+  override def readByte(): Byte = {
     val x = in.readByte()
     logfile.write(x.toInt)
     x
@@ -290,53 +292,53 @@ final class TracingInputBuffer(
     }
   }
 
-  def readInt(): Int = {
+  override def readInt(): Int = {
     val bytes = readBytesArray(4)
     Memory.loadInt(bytes, 0)
   }
 
-  def readLong(): Long = {
+  override def readLong(): Long = {
     val bytes = readBytesArray(8)
     Memory.loadLong(bytes, 0)
   }
 
-  def readFloat(): Float = {
+  override def readFloat(): Float = {
     val bytes = readBytesArray(4)
     Memory.loadFloat(bytes, 0)
   }
 
-  def readDouble(): Double = {
+  override def readDouble(): Double = {
     val bytes = readBytesArray(8)
     Memory.loadDouble(bytes, 0)
   }
 
-  def readBytes(toRegion: Region, toOff: Long, n: Int): Unit =
+  override def readBytes(toRegion: Region, toOff: Long, n: Int): Unit =
     Region.storeBytes(toOff, readBytesArray(n))
 
-  def readBytesArray(n: Int): Array[Byte] =
+  override def readBytesArray(n: Int): Array[Byte] =
     Array.tabulate(n)(_ => readByte())
 
   override def skipBoolean(): Unit = skipByte()
 
-  def skipByte(): Unit =
+  override def skipByte(): Unit =
     skipBytes(1)
 
-  def skipInt(): Unit =
+  override def skipInt(): Unit =
     skipBytes(4)
 
-  def skipLong(): Unit =
+  override def skipLong(): Unit =
     skipBytes(8)
 
-  def skipFloat(): Unit =
+  override def skipFloat(): Unit =
     skipBytes(4)
 
-  def skipDouble(): Unit =
+  override def skipDouble(): Unit =
     skipBytes(8)
 
-  @inline def skipBytes(n: Int): Unit =
+  @inline override def skipBytes(n: Int): Unit =
     for (_ <- 0 until n) readByte()
 
-  def readDoubles(to: Array[Double], off: Int, n: Int): Unit = {
+  override def readDoubles(to: Array[Double], off: Int, n: Int): Unit = {
     var i = 0
     while (i < n) {
       to(off + i) = readDouble()
@@ -363,52 +365,52 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
     assert(off + n <= end)
   }
 
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
-  def seek(offset: Long): Unit = {
+  override def seek(offset: Long): Unit = {
     in.seek(offset)
     end = in.readBlock(buf)
     off = (offset & 0xffff).asInstanceOf[Int]
     assert(off <= end)
   }
 
-  def readByte(): Byte = {
+  override def readByte(): Byte = {
     ensure(1)
     val b = Memory.loadByte(buf, off.toLong)
     off += 1
     b
   }
 
-  def readInt(): Int = {
+  override def readInt(): Int = {
     ensure(4)
     val i = Memory.loadInt(buf, off.toLong)
     off += 4
     i
   }
 
-  def readLong(): Long = {
+  override def readLong(): Long = {
     ensure(8)
     val l = Memory.loadLong(buf, off.toLong)
     off += 8
     l
   }
 
-  def readFloat(): Float = {
+  override def readFloat(): Float = {
     ensure(4)
     val f = Memory.loadFloat(buf, off.toLong)
     off += 4
     f
   }
 
-  def readDouble(): Double = {
+  override def readDouble(): Double = {
     ensure(8)
     val d = Memory.loadDouble(buf, off.toLong)
     off += 8
     d
   }
 
-  def readBytes(toRegion: Region, toOff0: Long, n0: Int): Unit = {
+  override def readBytes(toRegion: Region, toOff0: Long, n0: Int): Unit = {
     assert(n0 >= 0)
     var toOff = toOff0
     var n = n0
@@ -445,38 +447,38 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
     }
   }
 
-  def readBytesArray(n: Int): Array[Byte] = {
+  override def readBytesArray(n: Int): Array[Byte] = {
     val arr = new Array[Byte](n)
     read(arr, 0, n)
     arr
   }
 
-  def skipByte(): Unit = {
+  override def skipByte(): Unit = {
     ensure(1)
     off += 1
   }
 
-  def skipInt(): Unit = {
+  override def skipInt(): Unit = {
     ensure(4)
     off += 4
   }
 
-  def skipLong(): Unit = {
+  override def skipLong(): Unit = {
     ensure(8)
     off += 8
   }
 
-  def skipFloat(): Unit = {
+  override def skipFloat(): Unit = {
     ensure(4)
     off += 4
   }
 
-  def skipDouble(): Unit = {
+  override def skipDouble(): Unit = {
     ensure(8)
     off += 8
   }
 
-  def skipBytes(n0: Int): Unit = {
+  override def skipBytes(n0: Int): Unit = {
     var n = n0
     if (off + n > end) {
       n -= (end - off)
@@ -488,7 +490,7 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
     }
   }
 
-  def readDoubles(to: Array[Double], toOff0: Int, n0: Int): Unit = {
+  override def readDoubles(to: Array[Double], toOff0: Int, n0: Int): Unit = {
     assert(toOff0 >= 0)
     assert(n0 >= 0)
     assert(toOff0 <= to.length - n0)
@@ -513,13 +515,14 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
 final class StreamBlockInputBuffer(in: InputStream) extends InputBlockBuffer {
   private[this] val lenBuf = new Array[Byte](4)
 
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
   // this takes a virtual offset and will seek the underlying stream to offset >> 16
-  def seek(offset: Long): Unit = in.asInstanceOf[ByteTrackingInputStream].seek(offset >> 16)
+  override def seek(offset: Long): Unit =
+    in.asInstanceOf[ByteTrackingInputStream].seek(offset >> 16)
 
-  def readBlock(buf: Array[Byte]): Int = {
+  override def readBlock(buf: Array[Byte]): Int = {
     in.readFully(lenBuf, 0, 4)
     val len = Memory.loadInt(lenBuf, 0)
     assert(len >= 0)
@@ -533,10 +536,10 @@ final class LZ4InputBlockBuffer(lz4: LZ4, blockSize: Int, in: InputBlockBuffer)
     extends InputBlockBuffer {
   private[this] val comp = new Array[Byte](4 + lz4.maxCompressedLength(blockSize))
 
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
-  def seek(offset: Long): Unit = in.seek(offset)
+  override def seek(offset: Long): Unit = in.seek(offset)
 
   override def skipBytesReadRemainder(n0: Int, buf: Array[Byte]): Int = {
     var n = n0
@@ -557,7 +560,7 @@ final class LZ4InputBlockBuffer(lz4: LZ4, blockSize: Int, in: InputBlockBuffer)
     return -n
   }
 
-  def readBlock(buf: Array[Byte]): Int = {
+  override def readBlock(buf: Array[Byte]): Int = {
     val blockLen = in.readBlock(comp)
     val result = if (blockLen == -1) {
       -1
@@ -576,12 +579,12 @@ final class LZ4SizeBasedCompressingInputBlockBuffer(lz4: LZ4, blockSize: Int, in
   private[this] val comp = new Array[Byte](8 + lz4.maxCompressedLength(blockSize))
   private[this] var lim = 0
 
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
-  def seek(offset: Long): Unit = in.seek(offset)
+  override def seek(offset: Long): Unit = in.seek(offset)
 
-  def readBlock(buf: Array[Byte]): Int = {
+  override def readBlock(buf: Array[Byte]): Int = {
     val blockLen = in.readBlock(comp)
     val result = if (blockLen == -1) {
       -1
@@ -606,7 +609,7 @@ final class LZ4SizeBasedCompressingInputBlockBuffer(lz4: LZ4, blockSize: Int, in
 
 object ZstdDecompressLib {
   val instance = ThreadLocal.withInitial(new Supplier[ZstdDecompressCtx]() {
-    def get: ZstdDecompressCtx = new ZstdDecompressCtx()
+    override def get: ZstdDecompressCtx = new ZstdDecompressCtx()
   })
 }
 
@@ -614,12 +617,12 @@ final class ZstdInputBlockBuffer(blockSize: Int, in: InputBlockBuffer) extends I
   private[this] val zstd = ZstdDecompressLib.instance.get
   private[this] val comp = new Array[Byte](4 + Zstd.compressBound(blockSize.toLong).toInt)
 
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
-  def seek(offset: Long): Unit = in.seek(offset)
+  override def seek(offset: Long): Unit = in.seek(offset)
 
-  def readBlock(buf: Array[Byte]): Int = {
+  override def readBlock(buf: Array[Byte]): Int = {
     val blockLen = in.readBlock(comp)
     if (blockLen == -1) {
       blockLen
@@ -637,12 +640,12 @@ final class ZstdSizedBasedInputBlockBuffer(blockSize: Int, in: InputBlockBuffer)
   private[this] val zstd = ZstdDecompressLib.instance.get
   private[this] val comp = new Array[Byte](4 + Zstd.compressBound(blockSize.toLong).toInt)
 
-  def close(): Unit =
+  override def close(): Unit =
     in.close()
 
-  def seek(offset: Long): Unit = in.seek(offset)
+  override def seek(offset: Long): Unit = in.seek(offset)
 
-  def readBlock(buf: Array[Byte]): Int = {
+  override def readBlock(buf: Array[Byte]): Int = {
     val blockLen = in.readBlock(comp)
     if (blockLen == -1) {
       blockLen

--- a/hail/hail/src/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/hail/src/is/hail/io/RichContextRDDRegionValue.scala
@@ -204,7 +204,7 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
       new Iterator[Long]() {
         private[this] var cleared: Boolean = false
 
-        def hasNext: Boolean = {
+        override def hasNext: Boolean = {
           if (!cleared) {
             cleared = true
             producerCtx.region.clear()
@@ -212,7 +212,7 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
           it.hasNext
         }
 
-        def next(): Long = {
+        override def next(): Long = {
           if (!cleared) {
             producerCtx.region.clear()
           }
@@ -264,7 +264,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
       new Iterator[RegionValue]() {
         private[this] var cleared: Boolean = false
 
-        def hasNext: Boolean = {
+        override def hasNext: Boolean = {
           if (!cleared) {
             cleared = true
             producerCtx.region.clear()
@@ -272,7 +272,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
           it.hasNext
         }
 
-        def next(): RegionValue = {
+        override def next(): RegionValue = {
           if (!cleared) {
             producerCtx.region.clear()
           }
@@ -297,7 +297,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
       new Iterator[RegionValue]() {
         private[this] var cleared: Boolean = false
 
-        def hasNext: Boolean = {
+        override def hasNext: Boolean = {
           if (!cleared) {
             cleared = true
             ctx.region.clear()
@@ -305,7 +305,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
           it.hasNext
         }
 
-        def next(): RegionValue = {
+        override def next(): RegionValue = {
           if (!cleared) {
             ctx.region.clear()
           }

--- a/hail/hail/src/is/hail/io/TypedCodecSpec.scala
+++ b/hail/hail/src/is/hail/io/TypedCodecSpec.scala
@@ -17,19 +17,20 @@ object TypedCodecSpec {
 
 final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: BufferSpec)
     extends AbstractTypedCodecSpec {
-  def encodedType: EType = _eType
-  def encodedVirtualType: Type = _vType
+  override def encodedType: EType = _eType
+  override def encodedVirtualType: Type = _vType
 
-  def buildEncoder(ctx: ExecuteContext, t: PType): (OutputStream, HailClassLoader) => Encoder = {
+  override def buildEncoder(ctx: ExecuteContext, t: PType)
+    : (OutputStream, HailClassLoader) => Encoder = {
     val bufferToEncoder = encodedType.buildEncoder(ctx, t)
     (out: OutputStream, theHailClassLoader: HailClassLoader) =>
       bufferToEncoder(_bufferSpec.buildOutputBuffer(out), theHailClassLoader)
   }
 
-  def decodedPType(requestedType: Type): PType =
+  override def decodedPType(requestedType: Type): PType =
     encodedType.decodedPType(requestedType)
 
-  def buildDecoder(ctx: ExecuteContext, requestedType: Type)
+  override def buildDecoder(ctx: ExecuteContext, requestedType: Type)
     : (PType, (InputStream, HailClassLoader) => Decoder) = {
     val (rt, bufferToDecoder) = encodedType.buildDecoder(ctx, requestedType)
     (
@@ -45,9 +46,9 @@ final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: Buffer
     pType -> makeDec
   }
 
-  def buildCodeInputBuffer(is: Code[InputStream]): Code[InputBuffer] =
+  override def buildCodeInputBuffer(is: Code[InputStream]): Code[InputBuffer] =
     _bufferSpec.buildCodeInputBuffer(is)
 
-  def buildCodeOutputBuffer(os: Code[OutputStream]): Code[OutputBuffer] =
+  override def buildCodeOutputBuffer(os: Code[OutputStream]): Code[OutputBuffer] =
     _bufferSpec.buildCodeOutputBuffer(os)
 }

--- a/hail/hail/src/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/hail/src/is/hail/io/avro/AvroPartitionReader.scala
@@ -25,7 +25,7 @@ import org.apache.avro.io.DatumReader
 import org.json4s.{Extraction, JValue}
 
 case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends PartitionReader {
-  def contextType: Type = TStruct("partitionPath" -> TString, "partitionIndex" -> TInt64)
+  override def contextType: Type = TStruct("partitionPath" -> TString, "partitionIndex" -> TInt64)
 
   def fullRowTypeWithoutUIDs: TStruct = AvroReader.schemaToType(schema)
 
@@ -78,7 +78,7 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
         override def method: EmitMethodBuilder[_] = cb.emb
         val length: Option[EmitCodeBuilder => Code[Int]] = None
 
-        def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
+        override def initialize(cb: EmitCodeBuilder, outerRegion: Value[Region]): Unit = {
           val mb = cb.emb
           val codeSchema = cb.newLocal("schema", mb.getObject(schema))
           cb.assign(record, Code.newInstance[GenericData.Record, Schema](codeSchema))
@@ -121,14 +121,14 @@ case class AvroPartitionReader(schema: Schema, uidFieldName: String) extends Par
           }
         }
 
-        def close(cb: EmitCodeBuilder): Unit = cb += it.invoke[Unit]("close")
+        override def close(cb: EmitCodeBuilder): Unit = cb += it.invoke[Unit]("close")
       }
 
       SStreamValue(producer)
     }
   }
 
-  def toJValue: JValue = Extraction.decompose(this)(PartitionReader.formats)
+  override def toJValue: JValue = Extraction.decompose(this)(PartitionReader.formats)
 }
 
 object AvroReader {

--- a/hail/hail/src/is/hail/io/avro/AvroTableReader.scala
+++ b/hail/hail/src/is/hail/io/avro/AvroTableReader.scala
@@ -39,9 +39,9 @@ class AvroTableReader(
       RVDPartitioner.unkeyed(stateManager, paths.length)
     }
 
-  def pathsUsed: Seq[String] = paths
+  override def pathsUsed: Seq[String] = paths
 
-  def partitionCounts: Option[IndexedSeq[Long]] = None
+  override def partitionCounts: Option[IndexedSeq[Long]] = None
 
   override def uidType = TTuple(TInt64, TInt64)
 
@@ -66,7 +66,7 @@ class AvroTableReader(
     : VirtualTypeWithReq =
     VirtualTypeWithReq(PCanonicalStruct(required = true))
 
-  def renderShort(): String = defaultRender()
+  override def renderShort(): String = defaultRender()
 
   override def lower(ctx: ExecuteContext, requestedType: TableType): TableStage = {
     val globals = MakeStruct(FastSeq())

--- a/hail/hail/src/is/hail/io/bgen/BgenSettings.scala
+++ b/hail/hail/src/is/hail/io/bgen/BgenSettings.scala
@@ -115,7 +115,7 @@ object BgenSettings {
     ))
 
     new AbstractIndexSpec {
-      def relPath = fatal("relPath called for bgen index spec")
+      override def relPath = fatal("relPath called for bgen index spec")
       val leafCodec = TypedCodecSpec(leafEType, leafVType, bufferSpec)
       val internalNodeCodec = TypedCodecSpec(internalNodeEType, internalNodeVType, bufferSpec)
       val keyType = keyVType

--- a/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
@@ -510,19 +510,19 @@ class MatrixBGENReader(
   filePartitionInfo: IndexedSeq[FilePartitionInfo],
   variants: Option[String],
 ) extends MatrixHybridReader {
-  def pathsUsed: Seq[String] = filePartitionInfo.map(_.metadata.path)
+  override def pathsUsed: Seq[String] = filePartitionInfo.map(_.metadata.path)
 
   lazy val nVariants: Long = filePartitionInfo.map(_.metadata.nVariants).sum
 
-  def rowUIDType = TTuple(TInt64, TInt64)
+  override def rowUIDType = TTuple(TInt64, TInt64)
 
-  def colUIDType = TInt64
+  override def colUIDType = TInt64
 
   private val nSamples = sampleIds.length
 
-  def columnCount: Option[Int] = Some(nSamples)
+  override def columnCount: Option[Int] = Some(nSamples)
 
-  def partitionCounts: Option[IndexedSeq[Long]] = None
+  override def partitionCounts: Option[IndexedSeq[Long]] = None
 
   private var _settings: BgenSettings = _
 
@@ -574,7 +574,7 @@ class MatrixBGENReader(
 
   override def toJValue: JValue = params.toJValue
 
-  def renderShort(): String = defaultRender()
+  override def renderShort(): String = defaultRender()
 
   override def hashCode(): Int = params.hashCode()
 
@@ -672,12 +672,12 @@ case class BgenPartitionReaderWithVariantFilter(
   lazy val uidType = TTuple(TInt64, TInt64)
   lazy val fullRowType: TStruct = MatrixBGENReader.fullTableType(rg).rowType
 
-  def rowRequiredness(requestedType: TStruct): RStruct =
+  override def rowRequiredness(requestedType: TStruct): RStruct =
     StagedBGENReader.rowRequiredness(requestedType)
 
-  def uidFieldName: String = TableReader.uidFieldName
+  override def uidFieldName: String = TableReader.uidFieldName
 
-  def emitStream(
+  override def emitStream(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     mb: EmitMethodBuilder[_],
@@ -830,7 +830,7 @@ case class BgenPartitionReaderWithVariantFilter(
     }
   }
 
-  def toJValue: JValue = Extraction.decompose(this)(PartitionReader.formats)
+  override def toJValue: JValue = Extraction.decompose(this)(PartitionReader.formats)
 }
 
 case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option[String])
@@ -846,12 +846,12 @@ case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option
 
   lazy val fullRowType: TStruct = MatrixBGENReader.fullTableType(rg).rowType
 
-  def rowRequiredness(requestedType: TStruct): RStruct =
+  override def rowRequiredness(requestedType: TStruct): RStruct =
     StagedBGENReader.rowRequiredness(requestedType)
 
-  def uidFieldName: String = TableReader.uidFieldName
+  override def uidFieldName: String = TableReader.uidFieldName
 
-  def emitStream(
+  override def emitStream(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     mb: EmitMethodBuilder[_],
@@ -973,5 +973,5 @@ case class BgenPartitionReader(fileMetadata: Array[BgenFileMetadata], rg: Option
     }
   }
 
-  def toJValue: JValue = Extraction.decompose(this)(PartitionReader.formats)
+  override def toJValue: JValue = Extraction.decompose(this)(PartitionReader.formats)
 }

--- a/hail/hail/src/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/hail/src/is/hail/io/fs/AzureStorageFS.scala
@@ -151,9 +151,9 @@ class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
       case _: IllegalArgumentException => false
     }
 
-  def getConfiguration(): Unit = ()
+  override def getConfiguration(): Unit = ()
 
-  def setConfiguration(config: Any): Unit = {}
+  override def setConfiguration(config: Any): Unit = {}
 
   // ABS errors if you attempt credentialed access for a public container,
   // so we try once with credentials, if that fails use anonymous access for
@@ -190,7 +190,7 @@ class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
     getServiceClient(url).getBlobContainerClient(url.container)
   }
 
-  def openNoCompression(url: URL): SeekableDataInputStream = handlePublicAccessError(url) {
+  override def openNoCompression(url: URL): SeekableDataInputStream = handlePublicAccessError(url) {
     val blobSize = getBlobClient(url).getProperties.getBlobSize
 
     val is: SeekableInputStream = new FSSeekableInputStream {
@@ -238,7 +238,7 @@ class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
     new WrappedSeekableDataInputStream(is)
   }
 
-  def createNoCompression(url: URL): PositionedDataOutputStream = retryTransientErrors {
+  override def createNoCompression(url: URL): PositionedDataOutputStream = retryTransientErrors {
     val blockBlobClient = getBlobClient(url).getBlockBlobClient
 
     val os: PositionedOutputStream = new FSPositionedOutputStream(4 * 1024 * 1024) {
@@ -268,7 +268,7 @@ class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
     new WrappedPositionedDataOutputStream(os)
   }
 
-  def delete(url: URL, recursive: Boolean): Unit = retryTransientErrors {
+  override def delete(url: URL, recursive: Boolean): Unit = retryTransientErrors {
     val blobClient: BlobClient = getBlobClient(url)
 
     if (recursive) {
@@ -294,7 +294,7 @@ class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
     }
   }
 
-  def listDirectory(url: URL): Array[FileListEntry] = handlePublicAccessError(url) {
+  override def listDirectory(url: URL): Array[FileListEntry] = handlePublicAccessError(url) {
     val blobContainerClient: BlobContainerClient = getContainerClient(url)
     val statList: ArrayBuffer[FileListEntry] = ArrayBuffer()
 
@@ -307,7 +307,7 @@ class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
     statList.toArray
   }
 
-  def glob(url: URL): Array[FileListEntry] = handlePublicAccessError(url) {
+  override def glob(url: URL): Array[FileListEntry] = handlePublicAccessError(url) {
     globWithPrefix(prefix = url.withPath(""), path = dropTrailingSlash(url.path))
   }
 
@@ -351,7 +351,7 @@ class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
       Some(getBlobClient(url).getProperties.getETag)
     }
 
-  def makeQualified(filename: String): String = {
+  override def makeQualified(filename: String): String = {
     parseUrl(filename): Unit
     filename
   }

--- a/hail/hail/src/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/hail/src/is/hail/io/fs/GoogleStorageFS.scala
@@ -144,10 +144,10 @@ class GoogleStorageFS(
   override def validUrl(filename: String): Boolean =
     filename.startsWith("gs://")
 
-  def getConfiguration(): Option[RequesterPaysConfig] =
+  override def getConfiguration(): Option[RequesterPaysConfig] =
     requesterPaysConfig
 
-  def setConfiguration(config: Any): Unit =
+  override def setConfiguration(config: Any): Unit =
     requesterPaysConfig = config.asInstanceOf[Option[RequesterPaysConfig]]
 
   private[this] def requesterPaysOptions[T](bucket: String, makeUserProjectOption: String => T)
@@ -186,7 +186,7 @@ class GoogleStorageFS(
       .getService
   }
 
-  def openNoCompression(url: URL): SeekableDataInputStream = retryTransientErrors {
+  override def openNoCompression(url: URL): SeekableDataInputStream = retryTransientErrors {
     val is: SeekableInputStream = new FSSeekableInputStream {
       private[this] var reader: ReadChannel = null
       private[this] var options: Option[Seq[BlobSourceOption]] = None
@@ -248,7 +248,7 @@ class GoogleStorageFS(
     new WrappedSeekableDataInputStream(is)
   }
 
-  def createNoCompression(url: URL): PositionedDataOutputStream = retryTransientErrors {
+  override def createNoCompression(url: URL): PositionedDataOutputStream = retryTransientErrors {
     logger.info(f"createNoCompression: $url")
 
     val blobId = BlobId.of(url.bucket, url.path)
@@ -376,7 +376,7 @@ class GoogleStorageFS(
     if (deleteSource) storage.delete(srcId): Unit
   }
 
-  def delete(url: URL, recursive: Boolean): Unit =
+  override def delete(url: URL, recursive: Boolean): Unit =
     retryTransientErrors[Unit] {
       if (recursive) {
         var page = retryTransientErrors {
@@ -418,7 +418,7 @@ class GoogleStorageFS(
       }
     }
 
-  def glob(url: URL): Array[FileListEntry] = retryTransientErrors {
+  override def glob(url: URL): Array[FileListEntry] = retryTransientErrors {
     globWithPrefix(url.withPath(""), path = dropTrailingSlash(url.path))
   }
 
@@ -500,7 +500,7 @@ class GoogleStorageFS(
       url.bucket,
     )
 
-  def makeQualified(filename: String): String = {
+  override def makeQualified(filename: String): String = {
     if (!filename.startsWith("gs://"))
       throw new IllegalArgumentException(s"Invalid path, expected gs://bucket/path $filename")
     filename

--- a/hail/hail/src/is/hail/io/fs/HadoopFS.scala
+++ b/hail/hail/src/is/hail/io/fs/HadoopFS.scala
@@ -13,21 +13,21 @@ import org.apache.hadoop.fs.{EtagSource, FSDataInputStream, FSDataOutputStream, 
 class HadoopFileListEntry(fs: hadoop.fs.FileStatus) extends FileListEntry {
   val normalizedPath = fs.getPath
 
-  def getPath: String = fs.getPath.toString
+  override def getPath: String = fs.getPath.toString
 
-  def getActualUrl: String = fs.getPath.toString
+  override def getActualUrl: String = fs.getPath.toString
 
-  def getModificationTime: java.lang.Long = fs.getModificationTime
+  override def getModificationTime: java.lang.Long = fs.getModificationTime
 
-  def getLen: Long = fs.getLen
+  override def getLen: Long = fs.getLen
 
-  def isDirectory: Boolean = fs.isDirectory
+  override def isDirectory: Boolean = fs.isDirectory
 
-  def isFile: Boolean = fs.isFile
+  override def isFile: Boolean = fs.isFile
 
-  def isSymlink: Boolean = fs.isSymlink
+  override def isSymlink: Boolean = fs.isSymlink
 
-  def getOwner: String = fs.getOwner
+  override def getOwner: String = fs.getOwner
 }
 
 object HadoopFS {
@@ -47,7 +47,7 @@ object HadoopFS {
           closed = true
         }
 
-      def getPosition: Long = os.getPos
+      override def getPosition: Long = os.getPos
     }
 
   def toSeekableInputStream(is: FSDataInputStream): SeekableInputStream =
@@ -66,9 +66,9 @@ object HadoopFS {
           closed = true
         }
 
-      def seek(pos: Long): Unit = is.seek(pos)
+      override def seek(pos: Long): Unit = is.seek(pos)
 
-      def getPosition: Long = is.getPos
+      override def getPosition: Long = is.getPos
     }
 }
 
@@ -93,19 +93,19 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
   override def validUrl(filename: String): Boolean =
     Try(getFileSystem(filename)).isSuccess
 
-  def getConfiguration(): SerializableHadoopConfiguration = conf
+  override def getConfiguration(): SerializableHadoopConfiguration = conf
 
-  def setConfiguration(_conf: Any): Unit =
+  override def setConfiguration(_conf: Any): Unit =
     conf = _conf.asInstanceOf[SerializableHadoopConfiguration]
 
-  def createNoCompression(url: URL): PositionedDataOutputStream = {
+  override def createNoCompression(url: URL): PositionedDataOutputStream = {
     val os = url.hadoopFs.create(url.hadoopPath)
     new WrappedPositionedDataOutputStream(
       HadoopFS.toPositionedOutputStream(os)
     )
   }
 
-  def openNoCompression(url: URL): SeekableDataInputStream = {
+  override def openNoCompression(url: URL): SeekableDataInputStream = {
     val is =
       try
         url.hadoopFs.open(url.hadoopPath)
@@ -126,7 +126,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
   def getFileSystem(filename: String): hadoop.fs.FileSystem =
     new hadoop.fs.Path(filename).getFileSystem(conf.value)
 
-  def listDirectory(url: URL): Array[FileListEntry] = {
+  override def listDirectory(url: URL): Array[FileListEntry] = {
     val statuses = url.hadoopFs.globStatus(url.hadoopPath)
     if (statuses == null) {
       throw new FileNotFoundException(url.toString)
@@ -147,7 +147,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
   def rmtree(dirname: String): Unit =
     getFileSystem(dirname).delete(new hadoop.fs.Path(dirname), true)
 
-  def delete(url: URL, recursive: Boolean): Unit =
+  override def delete(url: URL, recursive: Boolean): Unit =
     url.hadoopFs.delete(url.hadoopPath, recursive): Unit
 
   override def globAll(filenames: Iterable[String]): Array[FileListEntry] = {
@@ -159,7 +159,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     }.toArray
   }
 
-  def glob(url: URL): Array[FileListEntry] = {
+  override def glob(url: URL): Array[FileListEntry] = {
     var files = url.hadoopFs.globStatus(url.hadoopPath)
     if (files == null)
       files = Array.empty
@@ -177,7 +177,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     fle
   }
 
-  def fileListEntry(url: URL): FileListEntry =
+  override def fileListEntry(url: URL): FileListEntry =
     new HadoopFileListEntry(url.hadoopFs.getFileStatus(url.hadoopPath))
 
   override def eTag(url: URL): Option[String] =
@@ -186,7 +186,7 @@ class HadoopFS(private[this] var conf: SerializableHadoopConfiguration) extends 
     else
       None
 
-  def makeQualified(path: String): String = {
+  override def makeQualified(path: String): String = {
     val ppath = new hadoop.fs.Path(path)
     val pathFS = ppath.getFileSystem(conf.value)
     pathFS.makeQualified(ppath).toString

--- a/hail/hail/src/is/hail/io/fs/RouterFS.scala
+++ b/hail/hail/src/is/hail/io/fs/RouterFS.scala
@@ -91,28 +91,28 @@ class RouterFS(fss: IndexedSeq[FS]) extends FS {
   override def createNoCompression(url: RouterFSURL): PositionedDataOutputStream =
     url.fs.createNoCompression(url.url)
 
-  def openNoCompression(url: URL): SeekableDataInputStream =
+  override def openNoCompression(url: URL): SeekableDataInputStream =
     url.fs.openNoCompression(url.url)
 
   override def mkDir(url: URL): Unit = url.fs.mkDir(url.url)
 
-  def delete(url: URL, recursive: Boolean) = url.fs.delete(url.url, recursive)
+  override def delete(url: URL, recursive: Boolean) = url.fs.delete(url.url, recursive)
 
-  def listDirectory(url: URL): Array[FileListEntry] = url.fs.listDirectory(url.url)
+  override def listDirectory(url: URL): Array[FileListEntry] = url.fs.listDirectory(url.url)
 
-  def glob(url: URL): Array[FileListEntry] = url.fs.glob(url.url)
+  override def glob(url: URL): Array[FileListEntry] = url.fs.glob(url.url)
 
-  def fileStatus(url: URL): FileStatus = url.fs.fileStatus(url.url)
+  override def fileStatus(url: URL): FileStatus = url.fs.fileStatus(url.url)
 
-  def fileListEntry(url: URL): FileListEntry = url.fs.fileListEntry(url.url)
+  override def fileListEntry(url: URL): FileListEntry = url.fs.fileListEntry(url.url)
 
   override def eTag(url: URL): Option[String] = url.fs.eTag(url.url)
 
-  def makeQualified(path: String): String = lookupFS(path).makeQualified(path)
+  override def makeQualified(path: String): String = lookupFS(path).makeQualified(path)
 
-  def getConfiguration(): Any = fss.map(_.getConfiguration())
+  override def getConfiguration(): Any = fss.map(_.getConfiguration())
 
-  def setConfiguration(config: Any): Unit =
+  override def setConfiguration(config: Any): Unit =
     fss.zip(config.asInstanceOf[IndexedSeq[_]]).foreach { case (fs: FS, config: Any) =>
       fs.setConfiguration(config)
     }

--- a/hail/hail/src/is/hail/io/gen/ExportGen.scala
+++ b/hail/hail/src/is/hail/io/gen/ExportGen.scala
@@ -60,7 +60,7 @@ class GenAnnotationView(rowType: PStruct) extends View {
   private var cachedVarid: String = _
   private var cachedRsid: String = _
 
-  def set(offset: Long): Unit = {
+  override def set(offset: Long): Unit = {
     assert(rowType.isFieldDefined(offset, varidIdx))
     assert(rowType.isFieldDefined(offset, rsidIdx))
     this.rsidOffset = rowType.loadField(offset, rsidIdx)

--- a/hail/hail/src/is/hail/io/hadoop/ByteArrayOutputFormat.scala
+++ b/hail/hail/src/is/hail/io/hadoop/ByteArrayOutputFormat.scala
@@ -12,11 +12,11 @@ class ByteArrayOutputFormat extends FileOutputFormat[NullWritable, BytesOnlyWrit
   class ByteArrayRecordWriter(out: DataOutputStream)
       extends RecordWriter[NullWritable, BytesOnlyWritable] {
 
-    def write(key: NullWritable, value: BytesOnlyWritable): Unit =
+    override def write(key: NullWritable, value: BytesOnlyWritable): Unit =
       if (value != null)
         value.write(out)
 
-    def close(reporter: Reporter): Unit =
+    override def close(reporter: Reporter): Unit =
       out.close()
   }
 

--- a/hail/hail/src/is/hail/io/index/IndexReader.scala
+++ b/hail/hail/src/is/hail/io/index/IndexReader.scala
@@ -250,7 +250,7 @@ class IndexReader(
     var localPos = 0
     var leafNode: LeafNode = _
 
-    def next(): LeafChild = {
+    override def next(): LeafChild = {
       assert(hasNext)
 
       if (leafNode == null || localPos >= leafNode.children.length) {
@@ -265,7 +265,7 @@ class IndexReader(
       child
     }
 
-    def hasNext: Boolean = pos < end
+    override def hasNext: Boolean = pos < end
 
     def seek(key: Annotation): Unit = {
       val newPos = lowerBound(key)
@@ -281,7 +281,7 @@ class IndexReader(
   def iterateUntil(key: Annotation): Iterator[LeafChild] =
     iterator(0, lowerBound(key))
 
-  def close(): Unit = {
+  override def close(): Unit = {
     leafDecoder.close()
     internalDecoder.close()
     logger.info(s"Index reader cache queries: ${cacheHits + cacheMisses}")

--- a/hail/hail/src/is/hail/io/index/IndexWriter.scala
+++ b/hail/hail/src/is/hail/io/index/IndexWriter.scala
@@ -121,7 +121,7 @@ class IndexWriter(
 
   def trackedOS(): ByteTrackingOutputStream = comp.trackedOS()
 
-  def close(): Unit = {
+  override def close(): Unit = {
     region.close()
     comp.close()
   }

--- a/hail/hail/src/is/hail/io/plink/LoadPlink.scala
+++ b/hail/hail/src/is/hail/io/plink/LoadPlink.scala
@@ -367,16 +367,16 @@ class MatrixPLINKReader(
   partitioner: RVDPartitioner,
 ) extends MatrixHybridReader {
 
-  def rowUIDType = TInt64
-  def colUIDType = TInt64
+  override def rowUIDType = TInt64
+  override def colUIDType = TInt64
 
-  def pathsUsed: Seq[String] = FastSeq(params.bed, params.bim, params.fam)
+  override def pathsUsed: Seq[String] = FastSeq(params.bed, params.bim, params.fam)
 
   def nSamples: Int = sampleInfo.length
 
   val columnCount: Option[Int] = Some(nSamples)
 
-  def partitionCounts: Option[IndexedSeq[Long]] = None
+  override def partitionCounts: Option[IndexedSeq[Long]] = None
 
   val globals = Row(sampleInfo.zipWithIndex.map { case (s, idx) =>
     Row((0 until s.length).map(s.apply) :+ idx.toLong: _*)
@@ -582,7 +582,7 @@ class MatrixPLINKReader(
     decomposeWithName(params, "MatrixPLINKReader")
   }
 
-  def renderShort(): String = defaultRender()
+  override def renderShort(): String = defaultRender()
 
   override def hashCode(): Int = params.hashCode()
 

--- a/hail/hail/src/is/hail/io/tabix/TabixReader.scala
+++ b/hail/hail/src/is/hail/io/tabix/TabixReader.scala
@@ -26,8 +26,7 @@ class Tabix(
 )
 
 case class TbiPair(var _1: Long, var _2: Long) extends java.lang.Comparable[TbiPair] {
-  @Override
-  def compareTo(other: TbiPair): Int = TbiOrd.compare(this, other)
+  override def compareTo(other: TbiPair): Int = TbiOrd.compare(this, other)
 }
 
 object TbiPair {
@@ -35,7 +34,7 @@ object TbiPair {
 }
 
 object TbiOrd extends Ordering[TbiPair] {
-  def compare(u: TbiPair, v: TbiPair): Int = if (u._1 == v._1) {
+  override def compare(u: TbiPair, v: TbiPair): Int = if (u._1 == v._1) {
     0
   } else if (less64(u._1, v._1)) {
     -1

--- a/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
@@ -1522,7 +1522,7 @@ object LoadVCF extends Logging {
         val abf = new MissingArrayBuilder[Float]
         val abd = new MissingArrayBuilder[Double]
 
-        def hasNext: Boolean = {
+        override def hasNext: Boolean = {
           while (!present && it.hasNext) {
             val lwc = it.next()
             val line = lwc.value
@@ -1583,7 +1583,7 @@ object LoadVCF extends Logging {
           present
         }
 
-        def next(): Long = {
+        override def next(): Long = {
           // call hasNext to advance if necessary
           if (!hasNext)
             throw new java.util.NoSuchElementException()
@@ -1688,9 +1688,9 @@ class PartitionedVCFRDD(
   val contigRemappingBc =
     if (reverseContigMapping.size != 0) sparkContext.broadcast(reverseContigMapping) else null
 
-  protected def getPartitions: Array[Partition] = _partitions
+  override protected def getPartitions: Array[Partition] = _partitions
 
-  def compute(split: Partition, context: TaskContext): Iterator[WithContext[String]] = {
+  override def compute(split: Partition, context: TaskContext): Iterator[WithContext[String]] = {
     val p = split.asInstanceOf[PartitionedVCFPartition]
 
     val chromToQuery = if (contigRemappingBc != null)
@@ -1715,9 +1715,9 @@ class PartitionedVCFRDD(
       private var l = lines.next()
       private var curIdx: Long = lines.getCurIdx()
 
-      def hasNext: Boolean = l != null
+      override def hasNext: Boolean = l != null
 
-      def next(): WithContext[String] = {
+      override def next(): WithContext[String] = {
         assert(l != null)
         val n = l
         l = lines.next()
@@ -1917,8 +1917,8 @@ class MatrixVCFReader(
 
   LoadVCF.warnDuplicates(sampleIDs)
 
-  def rowUIDType = TTuple(TInt64, TInt64)
-  def colUIDType = TInt64
+  override def rowUIDType = TTuple(TInt64, TInt64)
+  override def colUIDType = TInt64
 
   val (infoPType, rowValuePType, formatPType) = header.getPTypes(
     params.arrayElementsRequired,
@@ -1926,7 +1926,7 @@ class MatrixVCFReader(
     params.callFields,
   )
 
-  def fullMatrixTypeWithoutUIDs: MatrixType = MatrixType(
+  override def fullMatrixTypeWithoutUIDs: MatrixType = MatrixType(
     globalType = TStruct.empty,
     colType = TStruct("s" -> TString),
     colKey = Array("s"),
@@ -1958,13 +1958,13 @@ class MatrixVCFReader(
     fullType.key,
   )
 
-  def pathsUsed: Seq[String] = params.files
+  override def pathsUsed: Seq[String] = params.files
 
   def nCols: Int = sampleIDs.length
 
   val columnCount: Option[Int] = Some(nCols)
 
-  def partitionCounts: Option[IndexedSeq[Long]] = None
+  override def partitionCounts: Option[IndexedSeq[Long]] = None
 
   def partitioner(sm: HailStateManager): Option[RVDPartitioner] =
     params.partitionsJSON.map { partitionsJSON =>
@@ -2140,7 +2140,7 @@ class MatrixVCFReader(
     decomposeWithName(params, "MatrixVCFReader")
   }
 
-  def renderShort(): String = defaultRender()
+  override def renderShort(): String = defaultRender()
 
   override def hashCode(): Int = params.hashCode()
 
@@ -2189,7 +2189,7 @@ case class GVCFPartitionReader(
 
   lazy val fullRowType: TStruct = fullRowPType.virtualType
 
-  def rowRequiredness(requestedType: TStruct): RStruct =
+  override def rowRequiredness(requestedType: TStruct): RStruct =
     VirtualTypeWithReq(tcoerce[PStruct](fullRowPType.subsetTo(requestedType))).r.asInstanceOf[
       RStruct
     ]
@@ -2199,7 +2199,7 @@ case class GVCFPartitionReader(
     decomposeWithName(this, "MatrixVCFReader")
   }
 
-  def emitStream(
+  override def emitStream(
     ctx: ExecuteContext,
     cb: EmitCodeBuilder,
     mb: EmitMethodBuilder[_],

--- a/hail/hail/src/is/hail/io/vcf/TabixReadVCFIterator.scala
+++ b/hail/hail/src/is/hail/io/vcf/TabixReadVCFIterator.scala
@@ -48,9 +48,9 @@ class TabixReadVCFIterator(
       private[this] var l = lines.next()
       private[this] var curIdx: Long = lines.getCurIdx()
       private[this] val inner = new Iterator[GenericLine] {
-        def hasNext: Boolean = l != null
+        override def hasNext: Boolean = l != null
 
-        def next(): GenericLine = {
+        override def next(): GenericLine = {
           assert(l != null)
           try {
             val n = l
@@ -85,11 +85,11 @@ class TabixReadVCFIterator(
         start <= pos && pos <= end
       }
 
-      def hasNext: Boolean = inner.hasNext
+      override def hasNext: Boolean = inner.hasNext
 
-      def next(): GenericLine = inner.next()
+      override def next(): GenericLine = inner.next()
 
-      def close(): Unit = lines.close()
+      override def close(): Unit = lines.close()
     }
   }
 

--- a/hail/hail/src/is/hail/linalg/BLAS.scala
+++ b/hail/hail/src/is/hail/linalg/BLAS.scala
@@ -11,7 +11,7 @@ import com.sun.jna.ptr.{DoubleByReference, FloatByReference, IntByReference}
 
 object BLAS extends Logging {
   private[this] val libraryInstance = ThreadLocal.withInitial(new Supplier[BLASLibrary]() {
-    def get() = {
+    override def get() = {
       val standard = Native.load("blas", classOf[BLASLibrary]).asInstanceOf[BLASLibrary]
 
       verificationTest(standard) match {

--- a/hail/hail/src/is/hail/linalg/LAPACK.scala
+++ b/hail/hail/src/is/hail/linalg/LAPACK.scala
@@ -19,7 +19,7 @@ class UnderscoreFunctionMapper extends FunctionMapper {
 // see: https://software.intel.com/content/www/us/en/develop/documentation/mkl-linux-developer-guide/top/language-specific-usage-options/mixed-language-programming-with-the-intel-math-kernel-library/calling-lapack-blas-and-cblas-routines-from-c-c-language-environments.html
 object LAPACK extends Logging {
   private[this] val libraryInstance = ThreadLocal.withInitial(new Supplier[LAPACKLibrary]() {
-    def get() = {
+    override def get() = {
       val mklEnvVar = "HAIL_MKL_PATH"
       val openblasEnvVar = "HAIL_OPENBLAS_PATH"
       val libraryName = if (sys.env.contains(mklEnvVar)) {

--- a/hail/hail/src/is/hail/linalg/MatrixSparsity.scala
+++ b/hail/hail/src/is/hail/linalg/MatrixSparsity.scala
@@ -126,7 +126,7 @@ object MatrixSparsity {
       }
     }
 
-    def newToOldPosNonSubset(newSparsity: Sparse): IndexedSeq[Integer] = {
+    override def newToOldPosNonSubset(newSparsity: Sparse): IndexedSeq[Integer] = {
       if (newSparsity.isEmpty) return ArraySeq.empty
       var cur =
         definedCoords.search(newSparsity.definedCoords.head)(Ordering.by(_.swap)).insertionPoint

--- a/hail/hail/src/is/hail/linalg/RowMatrix.scala
+++ b/hail/hail/src/is/hail/linalg/RowMatrix.scala
@@ -303,11 +303,12 @@ class ReadBlocksAsRowsRDD(
   private val nBlockCols = gp.nBlockCols
   private val blockSize = gp.blockSize
 
-  protected def getPartitions: Array[Partition] = Array.tabulate(partitionStarts.length - 1)(pi =>
-    ReadBlocksAsRowsRDDPartition(pi, partitionStarts(pi), partitionStarts(pi + 1))
-  )
+  override protected def getPartitions: Array[Partition] =
+    Array.tabulate(partitionStarts.length - 1)(pi =>
+      ReadBlocksAsRowsRDDPartition(pi, partitionStarts(pi), partitionStarts(pi + 1))
+    )
 
-  def compute(split: Partition, context: TaskContext): Iterator[(Long, Array[Double])] = {
+  override def compute(split: Partition, context: TaskContext): Iterator[(Long, Array[Double])] = {
     val ReadBlocksAsRowsRDDPartition(_, start, end) =
       split.asInstanceOf[ReadBlocksAsRowsRDDPartition]
 
@@ -315,9 +316,9 @@ class ReadBlocksAsRowsRDD(
     var i = start
 
     new Iterator[(Long, Array[Double])] {
-      def hasNext: Boolean = i < end
+      override def hasNext: Boolean = i < end
 
-      def next(): (Long, Array[Double]) = {
+      override def next(): (Long, Array[Double]) = {
         if (i == start || i % blockSize == 0) {
           val blockRow = (i / blockSize).toInt
           val nRowsInBlock = gp.blockRowNRows(blockRow)

--- a/hail/hail/src/is/hail/lir/Blocks.scala
+++ b/hail/hail/src/is/hail/lir/Blocks.scala
@@ -11,9 +11,9 @@ class Blocks(
 
   def nBlocks: Int = blocks.length
 
-  def length: Int = blocks.length
+  override def length: Int = blocks.length
 
-  def apply(i: Int): Block = blocks(i)
+  override def apply(i: Int): Block = blocks(i)
 
   def index(block: Block): Int = blockIdx.get(block)
 }

--- a/hail/hail/src/is/hail/lir/Locals.scala
+++ b/hail/hail/src/is/hail/lir/Locals.scala
@@ -7,9 +7,9 @@ class Locals(
 
   def nLocals: Int = locals.length
 
-  def length: Int = locals.length
+  override def length: Int = locals.length
 
-  def apply(i: Int): Local = locals(i)
+  override def apply(i: Int): Local = locals(i)
 
   def getIndex(l: Local): Option[Int] = {
     l match {

--- a/hail/hail/src/is/hail/lir/X.scala
+++ b/hail/hail/src/is/hail/lir/X.scala
@@ -137,12 +137,12 @@ abstract class FieldRef {
 
 class Field private[lir] (classx: Classx[_], val name: String, val ti: TypeInfo[_])
     extends FieldRef {
-  def owner: String = classx.name
+  override def owner: String = classx.name
 }
 
 class StaticField private[lir] (classx: Classx[_], val name: String, val ti: TypeInfo[_])
     extends FieldRef {
-  def owner: String = classx.name
+  override def owner: String = classx.name
 }
 
 class FieldLit(
@@ -176,11 +176,11 @@ class Method private[lir] (
 
   def nParameters: Int = parameterTypeInfo.length + (!isStatic).toInt
 
-  def owner: String = classx.name
+  override def owner: String = classx.name
 
-  def desc = s"(${parameterTypeInfo.map(_.desc).mkString})${returnTypeInfo.desc}"
+  override def desc = s"(${parameterTypeInfo.map(_.desc).mkString})${returnTypeInfo.desc}"
 
-  def isInterface: Boolean = false
+  override def isInterface: Boolean = false
 
   private var _entry: Block = _
 
@@ -520,7 +520,7 @@ abstract class StmtX extends X {
   var prev: StmtX = _
   var next: StmtX = _
 
-  def remove(): Unit = {
+  override def remove(): Unit = {
     assert(parent != null)
     if (parent.first == this)
       parent.first = next
@@ -602,7 +602,7 @@ abstract class ValueX extends X {
 
   def ti: TypeInfo[_]
 
-  def remove(): Unit = {
+  override def remove(): Unit = {
     var i = 0
     while (parent.children(i) ne this)
       i += 1
@@ -626,14 +626,14 @@ class GotoX(var lineNumber: Int = 0) extends ControlX {
 
   def setL(newL: Block): Unit = setTarget(0, newL)
 
-  def targetArity(): Int = 1
+  override def targetArity(): Int = 1
 
-  def target(i: Int): Block = {
+  override def target(i: Int): Block = {
     assert(i == 0)
     _L
   }
 
-  def setTarget(i: Int, b: Block): Unit = {
+  override def setTarget(i: Int, b: Block): Unit = {
     assert(i == 0)
     if (_L != null)
       _L.removeUse(this, 0)
@@ -655,9 +655,9 @@ class IfX(val op: Int, var lineNumber: Int = 0) extends ControlX {
 
   def setLfalse(newLfalse: Block): Unit = setTarget(1, newLfalse)
 
-  def targetArity(): Int = 2
+  override def targetArity(): Int = 2
 
-  def target(i: Int): Block = {
+  override def target(i: Int): Block = {
     if (i == 0)
       _Ltrue
     else {
@@ -666,7 +666,7 @@ class IfX(val op: Int, var lineNumber: Int = 0) extends ControlX {
     }
   }
 
-  def setTarget(i: Int, b: Block): Unit = {
+  override def setTarget(i: Int, b: Block): Unit = {
     if (i == 0) {
       if (_Ltrue != null)
         _Ltrue.removeUse(this, 0)
@@ -706,15 +706,15 @@ class SwitchX(var lineNumber: Int = 0) extends ControlX {
       if (block != null) block.addUse(this, i + 1)
   }
 
-  def targetArity(): Int = 1 + _Lcases.length
+  override def targetArity(): Int = 1 + _Lcases.length
 
-  def target(i: Int): Block =
+  override def target(i: Int): Block =
     if (i == 0)
       _Ldefault
     else
       _Lcases(i - 1)
 
-  def setTarget(i: Int, b: Block): Unit = {
+  override def setTarget(i: Int, b: Block): Unit = {
     if (i == 0) {
       if (_Ldefault != null)
         _Ldefault.removeUse(this, 0)
@@ -739,19 +739,19 @@ class PutFieldX(val op: Int, val f: FieldRef, var lineNumber: Int = 0) extends S
 class IincX(var l: Local, val i: Int, var lineNumber: Int = 0) extends StmtX
 
 class ReturnX(var lineNumber: Int = 0) extends ControlX {
-  def targetArity(): Int = 0
+  override def targetArity(): Int = 0
 
-  def target(i: Int): Block = throw new IndexOutOfBoundsException()
+  override def target(i: Int): Block = throw new IndexOutOfBoundsException()
 
-  def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
+  override def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
 }
 
 class ThrowX(var lineNumber: Int = 0) extends ControlX {
-  def targetArity(): Int = 0
+  override def targetArity(): Int = 0
 
-  def target(i: Int): Block = throw new IndexOutOfBoundsException()
+  override def target(i: Int): Block = throw new IndexOutOfBoundsException()
 
-  def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
+  override def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
 }
 
 class StmtOpX(val op: Int, var lineNumber: Int = 0) extends StmtX
@@ -761,7 +761,7 @@ class MethodStmtX(val op: Int, val method: MethodRef, var lineNumber: Int = 0) e
 class TypeInsnX(val op: Int, val ti: TypeInfo[_], var lineNumber: Int = 0) extends ValueX {}
 
 class InsnX(val op: Int, _ti: TypeInfo[_], var lineNumber: Int = 0) extends ValueX {
-  def ti: TypeInfo[_] = {
+  override def ti: TypeInfo[_] = {
     if (_ti != null)
       return _ti
 
@@ -838,15 +838,15 @@ class InsnX(val op: Int, _ti: TypeInfo[_], var lineNumber: Int = 0) extends Valu
 }
 
 class LoadX(var l: Local, var lineNumber: Int = 0) extends ValueX {
-  def ti: TypeInfo[_] = l.ti
+  override def ti: TypeInfo[_] = l.ti
 }
 
 class GetFieldX(val op: Int, val f: FieldRef, var lineNumber: Int = 0) extends ValueX {
-  def ti: TypeInfo[_] = f.ti
+  override def ti: TypeInfo[_] = f.ti
 }
 
 class NewArrayX(val eti: TypeInfo[_], var lineNumber: Int = 0) extends ValueX {
-  def ti: TypeInfo[_] = arrayInfo(eti)
+  override def ti: TypeInfo[_] = arrayInfo(eti)
 }
 
 class NewInstanceX(val ti: TypeInfo[_], val ctor: MethodRef, var lineNumber: Int = 0) extends ValueX
@@ -861,5 +861,5 @@ class LdcX(val a: Any, val ti: TypeInfo[_], var lineNumber: Int = 0) extends Val
 }
 
 class MethodX(val op: Int, val method: MethodRef, var lineNumber: Int = 0) extends ValueX {
-  def ti: TypeInfo[_] = method.returnTypeInfo
+  override def ti: TypeInfo[_] = method.returnTypeInfo
 }

--- a/hail/hail/src/is/hail/methods/ForceCount.scala
+++ b/hail/hail/src/is/hail/methods/ForceCount.scala
@@ -9,7 +9,7 @@ import is.hail.types.virtual.{MatrixType, TInt64, TableType, Type}
 case class ForceCountTable() extends TableToValueFunction {
   override def typ(childType: TableType): Type = TInt64
 
-  def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
+  override def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
 
   override def execute(ctx: ExecuteContext, tv: TableValue): Any = tv.rvd.count()
 }
@@ -17,7 +17,7 @@ case class ForceCountTable() extends TableToValueFunction {
 case class ForceCountMatrixTable() extends MatrixToValueFunction {
   override def typ(childType: MatrixType): Type = TInt64
 
-  def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
+  override def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
 
   override def execute(ctx: ExecuteContext, mv: MatrixValue): Any =
     throw new UnsupportedOperationException

--- a/hail/hail/src/is/hail/methods/IBD.scala
+++ b/hail/hail/src/is/hail/methods/IBD.scala
@@ -388,12 +388,12 @@ case class IBD(
     }
   }
 
-  def preservesPartitionCounts: Boolean = false
+  override def preservesPartitionCounts: Boolean = false
 
-  def typ(childType: MatrixType): TableType =
+  override def typ(childType: MatrixType): TableType =
     TableType(IBD.ibdPType.virtualType, IBD.ibdKey, TStruct.empty)
 
-  def execute(ctx: ExecuteContext, input: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, input: MatrixValue): TableValue = {
     input.requireUniqueSamples("ibd")
     val computeMaf = mafFieldName.map(IBD.generateComputeMaf(input, _))
     val crdd =

--- a/hail/hail/src/is/hail/methods/LinearRegression.scala
+++ b/hail/hail/src/is/hail/methods/LinearRegression.scala
@@ -39,9 +39,9 @@ case class LinearRegressionRowsSingle(
     )
   }
 
-  def preservesPartitionCounts: Boolean = true
+  override def preservesPartitionCounts: Boolean = true
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
     val (y, cov, completeColIdx) =
       RegressionUtils.getPhenosCovCompleteSamples(mv, yFields.toArray, covFields.toArray)
 
@@ -219,9 +219,9 @@ case class LinearRegressionRowsChained(
     )
   }
 
-  def preservesPartitionCounts: Boolean = true
+  override def preservesPartitionCounts: Boolean = true
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
 
     val localData = yFields.map(y =>
       RegressionUtils.getPhenosCovCompleteSamples(mv, y.toArray, covFields.toArray)

--- a/hail/hail/src/is/hail/methods/LocalLDPrune.scala
+++ b/hail/hail/src/is/hail/methods/LocalLDPrune.scala
@@ -305,7 +305,7 @@ case class LocalLDPrune(
       globalType = TStruct.empty,
     )
 
-  def preservesPartitionCounts: Boolean = false
+  override def preservesPartitionCounts: Boolean = false
 
   def makeStream(stream: IR, entriesFieldName: String, nCols: IR): StreamLocalLDPrune = {
     val newRow = mapIR(stream) { row =>
@@ -318,7 +318,7 @@ case class LocalLDPrune(
     StreamLocalLDPrune(newRow, r2Threshold, windowSize, maxQueueSize, nCols)
   }
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
     val nSamples = mv.nCols
     val tableType = typ(mv.typ)
     val ts = TableExecuteIntermediate(mv.toTableValue).asTableStage(ctx).mapPartition(Some(

--- a/hail/hail/src/is/hail/methods/LogisticRegression.scala
+++ b/hail/hail/src/is/hail/methods/LogisticRegression.scala
@@ -31,9 +31,9 @@ case class LogisticRegression(
     )
   }
 
-  def preservesPartitionCounts: Boolean = true
+  override def preservesPartitionCounts: Boolean = true
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
     val logRegTest = LogisticRegressionTest.tests(test)
     val tableType = typ(mv.typ)
     val newRVDType = tableType.canonicalRVDType

--- a/hail/hail/src/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/hail/src/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -22,11 +22,11 @@ case class MatrixExportEntriesByCol(
   headerJsonInFile: Boolean,
   useStringKeyAsFileName: Boolean,
 ) extends MatrixToValueFunction with Logging {
-  def typ(childType: MatrixType): Type = TVoid
+  override def typ(childType: MatrixType): Type = TVoid
 
-  def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
+  override def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): Any = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): Any = {
     val fs = ctx.fs
 
     fs.delete(path, recursive = true) // overwrite by default

--- a/hail/hail/src/is/hail/methods/NPartitions.scala
+++ b/hail/hail/src/is/hail/methods/NPartitions.scala
@@ -9,7 +9,7 @@ import is.hail.types.virtual.{MatrixType, TInt32, TableType, Type}
 case class NPartitionsTable() extends TableToValueFunction {
   override def typ(childType: TableType): Type = TInt32
 
-  def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
+  override def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
 
   override def execute(ctx: ExecuteContext, tv: TableValue): Any = tv.rvd.getNumPartitions
 }
@@ -17,7 +17,7 @@ case class NPartitionsTable() extends TableToValueFunction {
 case class NPartitionsMatrixTable() extends MatrixToValueFunction {
   override def typ(childType: MatrixType): Type = TInt32
 
-  def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
+  override def unionRequiredness(childType: RTable, resultType: TypeWithRequiredness): Unit = ()
 
   override def execute(ctx: ExecuteContext, mv: MatrixValue): Any = mv.rvd.getNumPartitions
 

--- a/hail/hail/src/is/hail/methods/Nirvana.scala
+++ b/hail/hail/src/is/hail/methods/Nirvana.scala
@@ -504,8 +504,8 @@ case class Nirvana(config: String, blockSize: Int = 500000) extends TableToTable
     )
   }
 
-  def preservesPartitionCounts: Boolean = false
+  override def preservesPartitionCounts: Boolean = false
 
-  def execute(ctx: ExecuteContext, tv: TableValue): TableValue =
+  override def execute(ctx: ExecuteContext, tv: TableValue): TableValue =
     Nirvana.annotate(ctx, tv, config, blockSize)
 }

--- a/hail/hail/src/is/hail/methods/PCA.scala
+++ b/hail/hail/src/is/hail/methods/PCA.scala
@@ -27,9 +27,9 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean)
       ),
     )
 
-  def preservesPartitionCounts: Boolean = false
+  override def preservesPartitionCounts: Boolean = false
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
     if (k < 1)
       fatal(s"""requested invalid number of components: $k
                |  Expect componenents >= 1""".stripMargin)

--- a/hail/hail/src/is/hail/methods/PCRelate.scala
+++ b/hail/hail/src/is/hail/methods/PCRelate.scala
@@ -152,10 +152,10 @@ case class PCRelate(
 
   def storageLevel: StorageLevel = PCRelate.defaultStorageLevel
 
-  def typ(bmType: BlockMatrixType, auxType: Type): TableType =
+  override def typ(bmType: BlockMatrixType, auxType: Type): TableType =
     TableType(sig, keys, TStruct.empty)
 
-  def execute(ctx: ExecuteContext, g: M, value: Any): TableValue = {
+  override def execute(ctx: ExecuteContext, g: M, value: Any): TableValue = {
     val pcs = rowsToBDM(value.asInstanceOf[IndexedSeq[IndexedSeq[java.lang.Double]]])
     assert(pcs.rows == g.nCols)
     val r = computeResult(ctx, g, pcs)

--- a/hail/hail/src/is/hail/methods/PoissonRegression.scala
+++ b/hail/hail/src/is/hail/methods/PoissonRegression.scala
@@ -30,9 +30,9 @@ case class PoissonRegression(
     )
   }
 
-  def preservesPartitionCounts: Boolean = true
+  override def preservesPartitionCounts: Boolean = true
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
     val poisRegTest = PoissonRegressionTest.tests(test)
     val tableType = typ(mv.typ)
     val newRVDType = tableType.canonicalRVDType

--- a/hail/hail/src/is/hail/methods/Skat.scala
+++ b/hail/hail/src/is/hail/methods/Skat.scala
@@ -168,9 +168,9 @@ case class Skat(
     TableType(skatSchema, FastSeq("id"), TStruct.empty)
   }
 
-  def preservesPartitionCounts: Boolean = false
+  override def preservesPartitionCounts: Boolean = false
 
-  def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
+  override def execute(ctx: ExecuteContext, mv: MatrixValue): TableValue = {
 
     if (maxSize <= 0 || maxSize > 46340)
       fatal(s"Maximum group size must be in [1, 46340], got $maxSize")

--- a/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
@@ -308,15 +308,15 @@ case class IndexSpec2(
   _annotationType: Type,
   _offsetField: Option[String] = None,
 ) extends AbstractIndexSpec {
-  def relPath: String = _relPath
+  override def relPath: String = _relPath
 
-  def leafCodec: AbstractTypedCodecSpec = _leafCodec
+  override def leafCodec: AbstractTypedCodecSpec = _leafCodec
 
-  def internalNodeCodec: AbstractTypedCodecSpec = _internalNodeCodec
+  override def internalNodeCodec: AbstractTypedCodecSpec = _internalNodeCodec
 
-  def keyType: Type = _keyType
+  override def keyType: Type = _keyType
 
-  def annotationType: Type = _annotationType
+  override def annotationType: Type = _annotationType
 
   override def offsetField: Option[String] = _offsetField
 }
@@ -462,11 +462,11 @@ case class IndexedRVDSpec2(
 
   require(codecSpec2.encodedType.required)
 
-  def typedCodecSpec: AbstractTypedCodecSpec = codecSpec2
+  override def typedCodecSpec: AbstractTypedCodecSpec = codecSpec2
 
-  def indexSpec: AbstractIndexSpec = _indexSpec
+  override def indexSpec: AbstractIndexSpec = _indexSpec
 
-  def partitioner(sm: HailStateManager): RVDPartitioner = {
+  override def partitioner(sm: HailStateManager): RVDPartitioner = {
     val keyType = codecSpec2.encodedVirtualType.asInstanceOf[TStruct].select(key)._1
     val rangeBoundsType = TArray(TInterval(keyType))
     new RVDPartitioner(
@@ -480,9 +480,9 @@ case class IndexedRVDSpec2(
     )
   }
 
-  def partFiles: IndexedSeq[String] = _partFiles
+  override def partFiles: IndexedSeq[String] = _partFiles
 
-  def key: IndexedSeq[String] = _key
+  override def key: IndexedSeq[String] = _key
 
   val attrs: Map[String, String] = _attrs
 
@@ -597,7 +597,7 @@ case class OrderedRVDSpec2(
 
   require(codecSpec2.encodedType.required)
 
-  def partitioner(sm: HailStateManager): RVDPartitioner = {
+  override def partitioner(sm: HailStateManager): RVDPartitioner = {
     val keyType = codecSpec2.encodedVirtualType.asInstanceOf[TStruct].select(key)._1
     val rangeBoundsType = TArray(TInterval(keyType))
     new RVDPartitioner(
@@ -611,11 +611,11 @@ case class OrderedRVDSpec2(
     )
   }
 
-  def partFiles: IndexedSeq[String] = _partFiles
+  override def partFiles: IndexedSeq[String] = _partFiles
 
-  def key: IndexedSeq[String] = _key
+  override def key: IndexedSeq[String] = _key
 
-  def attrs: Map[String, String] = _attrs
+  override def attrs: Map[String, String] = _attrs
 
-  def typedCodecSpec: AbstractTypedCodecSpec = codecSpec2
+  override def typedCodecSpec: AbstractTypedCodecSpec = codecSpec2
 }

--- a/hail/hail/src/is/hail/rvd/RVD.scala
+++ b/hail/hail/src/is/hail/rvd/RVD.scala
@@ -186,9 +186,9 @@ class RVD(
         new Iterator[Long] {
           var first = true
 
-          def hasNext: Boolean = it.hasNext
+          override def hasNext: Boolean = it.hasNext
 
-          def next(): Long = {
+          override def next(): Long = {
             val ptr = it.next()
 
             if (first)
@@ -1016,9 +1016,9 @@ class RVD(
     val sorted: RDD[((Int, Interval), Array[Byte])] = new ShuffledRDD(
       partitionKeyedIntervals,
       new Partitioner {
-        def getPartition(key: Any): Int = key.asInstanceOf[(Int, Interval)]._1
+        override def getPartition(key: Any): Int = key.asInstanceOf[(Int, Interval)]._1
 
-        def numPartitions: Int = nParts
+        override def numPartitions: Int = nParts
       },
     ).setKeyOrdering(Ordering.by[(Int, Interval), Interval](_._2)(intervalOrd))
 
@@ -1188,7 +1188,7 @@ object RVD extends Logging {
     type CRDD = ContextRDD[Long]
 
     val unkeyedCoercer: RVDCoercer = new RVDCoercer(fullType) {
-      def _coerce(typ: RVDType, crdd: CRDD): RVD = {
+      override def _coerce(typ: RVDType, crdd: CRDD): RVD = {
         assert(typ.key.isEmpty)
         unkeyed(typ.rowType, crdd)
       }
@@ -1198,7 +1198,7 @@ object RVD extends Logging {
       return unkeyedCoercer
 
     val emptyCoercer: RVDCoercer = new RVDCoercer(fullType) {
-      def _coerce(typ: RVDType, crdd: CRDD): RVD = empty(execCtx, typ)
+      override def _coerce(typ: RVDType, crdd: CRDD): RVD = empty(execCtx, typ)
     }
 
     val keyInfo = getKeyInfo(execCtx, fullType, partitionKey, keys)
@@ -1243,7 +1243,7 @@ object RVD extends Logging {
           bounds,
         )
 
-        def _coerce(typ: RVDType, crdd: CRDD): RVD =
+        override def _coerce(typ: RVDType, crdd: CRDD): RVD =
           RVD(typ, unfixedPartitioner, orderPartitions(crdd))
             .repartition(execCtx, newPartitioner, shuffle = false)
       }
@@ -1273,7 +1273,7 @@ object RVD extends Logging {
           pkBounds,
         )
 
-        def _coerce(typ: RVDType, crdd: CRDD): RVD = {
+        override def _coerce(typ: RVDType, crdd: CRDD): RVD = {
           RVD(
             typ.copy(key = typ.key.take(partitionKey)),
             unfixedPartitioner,
@@ -1292,7 +1292,7 @@ object RVD extends Logging {
         val newPartitioner =
           calculateKeyRanges(execCtx, this.fullType, keyInfo, keys.getNumPartitions, partitionKey)
 
-        def _coerce(typ: RVDType, crdd: CRDD): RVD =
+        override def _coerce(typ: RVDType, crdd: CRDD): RVD =
           RVD.unkeyed(typ.rowType, crdd)
             .repartition(execCtx, newPartitioner, shuffle = true, filter = false)
       }

--- a/hail/hail/src/is/hail/rvd/RVDContext.scala
+++ b/hail/hail/src/is/hail/rvd/RVDContext.scala
@@ -43,7 +43,7 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
   def rvb = theRvb
 
   // frees the memory associated with this context
-  def close(): Unit = {
+  override def close(): Unit = {
     var e: Exception = null
     children.foreach { child =>
       try

--- a/hail/hail/src/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/hail/src/is/hail/rvd/RVDPartitioner.scala
@@ -114,9 +114,9 @@ class RVDPartitioner(
     val selfBc = broadcast(sc)
 
     new Partitioner {
-      def numPartitions: Int = selfBc.value.numPartitions
+      override def numPartitions: Int = selfBc.value.numPartitions
 
-      def getPartition(key: Any): Int = selfBc.value.lowerBound(key)
+      override def getPartition(key: Any): Int = selfBc.value.lowerBound(key)
     }
   }
 

--- a/hail/hail/src/is/hail/rvd/RVDType.scala
+++ b/hail/hail/src/is/hail/rvd/RVDType.scala
@@ -96,7 +96,7 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String]) extends Seri
       // Left is a point, right is an interval.
       // Returns -1 if point is below interval, 0 if it is inside, and 1 if it
       // is above, always considering missing greatest.
-      def compare(o1: Long, o2: Long): Int = {
+      override def compare(o1: Long, o2: Long): Int = {
 
         val leftDefined = t1.isFieldDefined(o1, f1)
         val rightDefined = t2.isFieldDefined(o2, f2)
@@ -128,10 +128,10 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String]) extends Seri
     val wrv = WritableRegionValue(sm, kType, region)
     val kRowOrdering = kRowOrd(sm)
 
-    def setFiniteValue(representative: RegionValue): Unit =
+    override def setFiniteValue(representative: RegionValue): Unit =
       wrv.setSelect(rowType, kFieldIdx, representative)
 
-    def compareFinite(rv: RegionValue): Int =
+    override def compareFinite(rv: RegionValue): Int =
       kRowOrdering.compare(wrv.value, rv)
   }
 
@@ -188,7 +188,7 @@ object RVDType {
     val nFields = fields1.length
 
     new UnsafeOrdering {
-      def compare(o1: Long, o2: Long): Int = {
+      override def compare(o1: Long, o2: Long): Int = {
         var i = 0
         var hasMissing = false
         while (i < nFields) {

--- a/hail/hail/src/is/hail/services/JSONLogLayout.scala
+++ b/hail/hail/src/is/hail/services/JSONLogLayout.scala
@@ -25,18 +25,19 @@ class DateFormatter {
 
 object JSONLogLayout {
   private val datefmt = ThreadLocal.withInitial(new Supplier[DateFormatter]() {
-    def get() = new DateFormatter()
+    override def get() = new DateFormatter()
   })
 }
 
 class JSONLogLayout extends Layout {
   import JSONLogLayout._
 
-  def ignoresThrowable(): Boolean = false
+  override def ignoresThrowable(): Boolean = false
 
+  @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
   def activateOptions(): Unit = ()
 
-  def format(event: LoggingEvent): String = {
+  override def format(event: LoggingEvent): String = {
     val threadName = event.getThreadName();
     val timestamp = event.getTimeStamp();
     val mdc = event.getProperties();
@@ -55,7 +56,7 @@ class JSONLogLayout extends Layout {
 
     val mdcFields = ArraySeq.newBuilder[JField]
     mdc.forEach(new BiConsumer[Any, Any]() {
-      def accept(key: Any, value: Any): Unit =
+      override def accept(key: Any, value: Any): Unit =
         mdcFields += JField(key.toString, JString(value.toString))
     })
     fields += JField("mdc", JObject(mdcFields.result(): _*))

--- a/hail/hail/src/is/hail/sparkextras/BlockedRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/BlockedRDD.scala
@@ -39,7 +39,7 @@ class BlockedRDD[T](
 
   override def getDependencies: Seq[Dependency[_]] =
     FastSeq(new NarrowDependency(prev) {
-      def getParents(id: Int): Seq[Int] =
+      override def getParents(id: Int): Seq[Int] =
         partitions(id).asInstanceOf[BlockedRDDPartition].range
     })
 

--- a/hail/hail/src/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/ContextRDD.scala
@@ -31,9 +31,9 @@ abstract class Combiner[U] {
 class CommutativeAndAssociativeCombiner[U](zero: => U, combine: (U, U) => U) extends Combiner[U] {
   var state: U = zero
 
-  def combine(i: Int, value0: U): Unit = state = combine(state, value0)
+  override def combine(i: Int, value0: U): Unit = state = combine(state, value0)
 
-  def result(): U = state
+  override def result(): U = state
 }
 
 class AssociativeCombiner[U](zero: => U, combine: (U, U) => U) extends Combiner[U] with Logging {
@@ -44,7 +44,7 @@ class AssociativeCombiner[U](zero: => U, combine: (U, U) => U) extends Combiner[
   // U it holds.
   private val t = new java.util.TreeMap[Int, TreeValue]()
 
-  def combine(i: Int, value0: U): Unit = {
+  override def combine(i: Int, value0: U): Unit = {
     logger.info(s"at result $i, AssociativeCombiner contains ${t.size()} queued results")
     var value = value0
     var end = i
@@ -69,7 +69,7 @@ class AssociativeCombiner[U](zero: => U, combine: (U, U) => U) extends Combiner[
     t.put(i, TreeValue(value, end))
   }
 
-  def result(): U = {
+  override def result(): U = {
     // after 'result' returns, 't' owns no values.
     val n = t.size()
     if (n > 0) {
@@ -295,13 +295,13 @@ class ContextRDD[T: ClassTag](
     f: (RVDContext, T, U) => V
   ): ContextRDD[V] = czipPartitions(that, preservesPartitioning) { (ctx, l, r) =>
     new Iterator[V] {
-      def hasNext = {
+      override def hasNext = {
         val lhn = l.hasNext
         val rhn = r.hasNext
         assert(lhn == rhn)
         lhn
       }
-      def next(): V =
+      override def next(): V =
         f(ctx, l.next(), r.next())
     }
   }
@@ -420,7 +420,7 @@ class ContextRDD[T: ClassTag](
 }
 
 private class CRDDCoalescer(partEnds: Array[Int]) extends PartitionCoalescer with Serializable {
-  def coalesce(maxPartitions: Int, prev: RDD[_]): Array[PartitionGroup] = {
+  override def coalesce(maxPartitions: Int, prev: RDD[_]): Array[PartitionGroup] = {
     assert(maxPartitions == partEnds.length)
     val groups = Array.fill(maxPartitions)(new PartitionGroup())
     val parts = prev.partitions

--- a/hail/hail/src/is/hail/sparkextras/IndexReadRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/IndexReadRDD.scala
@@ -16,7 +16,7 @@ class IndexReadRDD[T: ClassTag](
   @transient val intervalBounds: Option[Array[Interval]],
   f: (IndexedFilePartition, TaskContext) => T,
 ) extends RDD[T](SparkBackend.sparkContext, Nil) {
-  def getPartitions: Array[Partition] =
+  override def getPartitions: Array[Partition] =
     Array.tabulate(partFiles.length) { i =>
       IndexedFilePartition(i, partFiles(i), intervalBounds.map(_(i)))
     }

--- a/hail/hail/src/is/hail/sparkextras/MapPartitionsWithValueRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/MapPartitionsWithValueRDD.scala
@@ -10,7 +10,7 @@ case class MapPartitionsWithValueRDDPartition[V](
   parentPartition: Partition,
   value: V,
 ) extends Partition {
-  def index: Int = parentPartition.index
+  override def index: Int = parentPartition.index
 }
 
 class MapPartitionsWithValueRDD[T: ClassTag, U: ClassTag, V](

--- a/hail/hail/src/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
+++ b/hail/hail/src/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
@@ -46,7 +46,7 @@ class RepartitionedOrderedRDD2 private (
   val typ: RVDType = prev.typ
   val kOrd: ExtendedOrdering = PartitionBoundOrdering(sm, typ.kType.virtualType)
 
-  def getPartitions: Array[Partition] = {
+  override def getPartitions: Array[Partition] = {
     require(newRangeBounds.forall { i =>
       typ.kType.virtualType.relaxedTypeCheck(i.start) && typ.kType.virtualType.relaxedTypeCheck(
         i.end
@@ -109,7 +109,7 @@ class RepartitionedOrderedRDD2 private (
           innerRegion.clear()
         }
 
-        def hasNext: Boolean = {
+        override def hasNext: Boolean = {
           if (pulled)
             return true
 
@@ -126,7 +126,7 @@ class RepartitionedOrderedRDD2 private (
           true
         }
 
-        def next(): Long = {
+        override def next(): Long = {
           // hasNext() must be called before next() to fill `current`
           if (!hasNext)
             throw new NoSuchElementException

--- a/hail/hail/src/is/hail/stats/LeveneHaldane.scala
+++ b/hail/hail/src/is/hail/stats/LeveneHaldane.scala
@@ -21,7 +21,7 @@ class LeveneHaldane(
 ) extends AbstractIntegerDistribution(rng) {
 
   // The probability mass function P(nAB), computing no more than necessary
-  def probability(nAB: Int): Double =
+  override def probability(nAB: Int): Double =
     if (nAB < 0 || nAB > nA || nAB % 2 != nA % 2)
       0.0
     else if (nAB >= mode)
@@ -47,7 +47,7 @@ class LeveneHaldane(
     }
 
   // P(nAB <= n1)
-  def cumulativeProbability(n1: Int): Double =
+  override def cumulativeProbability(n1: Int): Double =
     cumulativeProbability(-1, n1)
 
   // P(nAB > n0)
@@ -81,14 +81,15 @@ class LeveneHaldane(
   }
 
   def nB: Int = 2 * n - nA
-  def getNumericalMean: Double = 1.0 * nA * nB / (2 * n - 1)
+  override def getNumericalMean: Double = 1.0 * nA * nB / (2 * n - 1)
 
-  def getNumericalVariance: Double =
+  override def getNumericalVariance: Double =
     1.0 * nA * nB / (2 * n - 1) * (1 + (nA - 1.0) * (nB - 1) / (2 * n - 3) - 1.0 * nA * nB / (2 * n - 1))
 
-  def isSupportConnected: Boolean = true // interpreted as restricted to the even or odd integers,
-  def getSupportUpperBound: Int = nA
-  def getSupportLowerBound: Int = nA % 2
+  override def isSupportConnected: Boolean =
+    true // interpreted as restricted to the even or odd integers,
+  override def getSupportUpperBound: Int = nA
+  override def getSupportLowerBound: Int = nA % 2
 }
 
 object LeveneHaldane {

--- a/hail/hail/src/is/hail/stats/LogisticRegressionModel.scala
+++ b/hail/hail/src/is/hail/stats/LogisticRegressionModel.scala
@@ -61,7 +61,7 @@ object WaldTest extends GLMTest {
     ("fit", GLMFit.schema),
   )
 
-  def test(
+  override def test(
     X: DenseMatrix[Double],
     y: DenseVector[Double],
     nullFit: GLMFit,
@@ -102,7 +102,7 @@ case class WaldStats(
   z: DenseVector[Double],
   p: DenseVector[Double],
 ) extends GLMStats {
-  def addToRVB(rvb: RegionValueBuilder): Unit = {
+  override def addToRVB(rvb: RegionValueBuilder): Unit = {
     rvb.addDouble(b(-1))
     rvb.addDouble(se(-1))
     rvb.addDouble(z(-1))
@@ -118,7 +118,7 @@ object LikelihoodRatioTest extends GLMTest {
     ("fit", GLMFit.schema),
   )
 
-  def test(
+  override def test(
     X: DenseMatrix[Double],
     y: DenseVector[Double],
     nullFit: GLMFit,
@@ -149,7 +149,7 @@ object LikelihoodRatioTest extends GLMTest {
 }
 
 case class LikelihoodRatioStats(b: DenseVector[Double], chi2: Double, p: Double) extends GLMStats {
-  def addToRVB(rvb: RegionValueBuilder): Unit = {
+  override def addToRVB(rvb: RegionValueBuilder): Unit = {
     rvb.addDouble(b(-1))
     rvb.addDouble(chi2)
     rvb.addDouble(p)
@@ -164,7 +164,7 @@ object LogisticFirthTest extends GLMTest {
     ("fit", GLMFit.schema),
   )
 
-  def test(
+  override def test(
     X: DenseMatrix[Double],
     y: DenseVector[Double],
     nullFit: GLMFit,
@@ -201,7 +201,7 @@ object LogisticFirthTest extends GLMTest {
 }
 
 case class FirthStats(b: DenseVector[Double], chi2: Double, p: Double) extends GLMStats {
-  def addToRVB(rvb: RegionValueBuilder): Unit = {
+  override def addToRVB(rvb: RegionValueBuilder): Unit = {
     rvb.addDouble(b(-1))
     rvb.addDouble(chi2)
     rvb.addDouble(p)
@@ -214,7 +214,7 @@ object LogisticScoreTest extends GLMTest {
     ("p_value", TFloat64),
   )
 
-  def test(
+  override def test(
     X: DenseMatrix[Double],
     y: DenseVector[Double],
     nullFit: GLMFit,
@@ -264,7 +264,7 @@ object LogisticScoreTest extends GLMTest {
 }
 
 case class ScoreStats(chi2: Double, p: Double) extends GLMStats {
-  def addToRVB(rvb: RegionValueBuilder): Unit = {
+  override def addToRVB(rvb: RegionValueBuilder): Unit = {
     rvb.addDouble(chi2)
     rvb.addDouble(p)
   }
@@ -283,7 +283,7 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double])
   val n: Int = X.rows
   val m: Int = X.cols
 
-  def bInterceptOnly(): DenseVector[Double] = {
+  override def bInterceptOnly(): DenseVector[Double] = {
     require(m > 0)
     val b = DenseVector.zeros[Double](m)
     val avg = sum(y) / n
@@ -291,7 +291,7 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double])
     b
   }
 
-  def fit(optNullFit: Option[GLMFit] = None, maxIter: Int, tol: Double): GLMFit = {
+  override def fit(optNullFit: Option[GLMFit] = None, maxIter: Int, tol: Double): GLMFit = {
 
     val b = DenseVector.zeros[Double](m)
     val mu = DenseVector.zeros[Double](n)

--- a/hail/hail/src/is/hail/stats/PoissonRegressionModel.scala
+++ b/hail/hail/src/is/hail/stats/PoissonRegressionModel.scala
@@ -15,7 +15,7 @@ object PoissonScoreTest extends GLMTest {
     ("p_value", TFloat64),
   )
 
-  def test(
+  override def test(
     X: DenseMatrix[Double],
     y: DenseVector[Double],
     nullFit: GLMFit,
@@ -71,7 +71,7 @@ class PoissonRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double])
   val n: Int = X.rows
   val m: Int = X.cols
 
-  def bInterceptOnly(): DenseVector[Double] = {
+  override def bInterceptOnly(): DenseVector[Double] = {
     require(m > 0)
     val b = DenseVector.zeros[Double](m)
     val avg = sum(y) / n
@@ -79,7 +79,7 @@ class PoissonRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double])
     b
   }
 
-  def fit(optNullFit: Option[GLMFit] = None, maxIter: Int, tol: Double): GLMFit = {
+  override def fit(optNullFit: Option[GLMFit] = None, maxIter: Int, tol: Double): GLMFit = {
 
     val b = DenseVector.zeros[Double](m)
     val mu = DenseVector.zeros[Double](n)

--- a/hail/hail/src/is/hail/stats/eigSymD.scala
+++ b/hail/hail/src/is/hail/stats/eigSymD.scala
@@ -17,7 +17,7 @@ object eigSymD extends UFunc {
   type DenseEigSymD = EigSymD[DenseVector[Double], DenseMatrix[Double]]
 
   implicit object eigSymD_DM_Impl extends Impl[DenseMatrix[Double], DenseEigSymD] {
-    def apply(X: DenseMatrix[Double]): DenseEigSymD =
+    override def apply(X: DenseMatrix[Double]): DenseEigSymD =
       doeigSymD(X, rightEigenvectors = true) match {
         case (ev, Some(rev)) => EigSymD(ev, rev)
         case _ => throw new RuntimeException("Shouldn't be here!")
@@ -27,7 +27,7 @@ object eigSymD extends UFunc {
 
   object justEigenvalues extends UFunc {
     implicit object eigSymD_DM_Impl extends Impl[DenseMatrix[Double], DenseVector[Double]] {
-      def apply(X: DenseMatrix[Double]): DenseVector[Double] =
+      override def apply(X: DenseMatrix[Double]): DenseVector[Double] =
         doeigSymD(X, rightEigenvectors = false)._1
     }
 
@@ -84,7 +84,7 @@ object eigSymR extends UFunc {
   type DenseeigSymR = EigSymR[DenseVector[Double], DenseMatrix[Double]]
 
   implicit object eigSymR_DM_Impl extends Impl[DenseMatrix[Double], DenseeigSymR] {
-    def apply(X: DenseMatrix[Double]): DenseeigSymR =
+    override def apply(X: DenseMatrix[Double]): DenseeigSymR =
       doeigSymR(X, rightEigenvectors = true) match {
         case (ev, Some(rev)) => EigSymR(ev, rev)
         case _ => throw new RuntimeException("Shouldn't be here!")
@@ -94,7 +94,7 @@ object eigSymR extends UFunc {
 
   object justEigenvalues extends UFunc {
     implicit object eigSymR_DM_Impl extends Impl[DenseMatrix[Double], DenseVector[Double]] {
-      def apply(X: DenseMatrix[Double]): DenseVector[Double] =
+      override def apply(X: DenseMatrix[Double]): DenseVector[Double] =
         doeigSymR(X, rightEigenvectors = false)._1
     }
 

--- a/hail/hail/src/is/hail/types/Box.scala
+++ b/hail/hail/src/is/hail/types/Box.scala
@@ -4,7 +4,7 @@ import java.util.function._
 
 final case class Box[T](
   b: ThreadLocal[Option[T]] = ThreadLocal.withInitial(
-    new Supplier[Option[T]] { def get = None }
+    new Supplier[Option[T]] { override def get = None }
   ),
   matchCond: (T, T) => Boolean = { (a: T, b: T) => a == b },
 ) {

--- a/hail/hail/src/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/hail/src/is/hail/types/TypeWithRequiredness.scala
@@ -295,22 +295,24 @@ object RPrimitive {
 final case class RPrimitive() extends TypeWithRequiredness {
   val children: IndexedSeq[TypeWithRequiredness] = RPrimitive.children
 
-  def _unionLiteral(a: Annotation): Unit = ()
-  def _matchesPType(pt: PType): Boolean = RPrimitive.typeSupported(pt.virtualType)
-  def _unionPType(pType: PType): Unit = assert(RPrimitive.typeSupported(pType.virtualType))
-  def _unionEmitType(emitType: EmitType) = assert(RPrimitive.typeSupported(emitType.virtualType))
+  override def _unionLiteral(a: Annotation): Unit = ()
+  override def _matchesPType(pt: PType): Boolean = RPrimitive.typeSupported(pt.virtualType)
+  override def _unionPType(pType: PType): Unit = assert(RPrimitive.typeSupported(pType.virtualType))
 
-  def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RPrimitive = {
+  override def _unionEmitType(emitType: EmitType) =
+    assert(RPrimitive.typeSupported(emitType.virtualType))
+
+  override def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RPrimitive = {
     assert(newChildren.isEmpty)
     RPrimitive()
   }
 
-  def canonicalPType(t: Type): PType = {
+  override def canonicalPType(t: Type): PType = {
     assert(RPrimitive.typeSupported(t))
     PType.canonical(t, required)
   }
 
-  def _toString: String = "RPrimitive"
+  override def _toString: String = "RPrimitive"
 }
 
 abstract class RContainer extends TypeWithRequiredness {
@@ -361,26 +363,26 @@ object RIterable {
 case class RIterable(elementType: TypeWithRequiredness, eltRequired: Boolean) extends RContainer {
   override val children: IndexedSeq[TypeWithRequiredness] = FastSeq(elementType)
 
-  def _unionLiteral(a: Annotation): Unit =
+  override def _unionLiteral(a: Annotation): Unit =
     a.asInstanceOf[Iterable[_]].foreach(elt => elementType.unionLiteral(elt))
 
-  def _matchesPType(pt: PType): Boolean =
+  override def _matchesPType(pt: PType): Boolean =
     elementType.matchesPType(tcoerce[PIterable](pt).elementType)
 
-  def _unionPType(pType: PType): Unit =
+  override def _unionPType(pType: PType): Unit =
     elementType.fromPType(pType.asInstanceOf[PIterable].elementType)
 
-  def _unionEmitType(emitType: EmitType): Unit =
+  override def _unionEmitType(emitType: EmitType): Unit =
     elementType.fromEmitType(emitType.st.asInstanceOf[SIndexablePointer].elementEmitType)
 
-  def _toString: String = s"RIterable[${elementType.toString}]"
+  override def _toString: String = s"RIterable[${elementType.toString}]"
 
-  def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RIterable = {
+  override def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RIterable = {
     val IndexedSeq(newElt: TypeWithRequiredness) = newChildren
     RIterable(newElt)
   }
 
-  def canonicalPType(t: Type): PType = {
+  override def canonicalPType(t: Type): PType = {
     val elt = elementType.canonicalPType(tcoerce[TIterable](t).elementType)
     t match {
       case _: TArray => PCanonicalArray(elt, required = required)
@@ -397,11 +399,11 @@ case class RIterable(elementType: TypeWithRequiredness, eltRequired: Boolean) ex
 }
 
 case class RNDArray(elementType: TypeWithRequiredness) extends RContainer {
-  def eltRequired = true
+  override def eltRequired = true
 
   override val children: IndexedSeq[TypeWithRequiredness] = FastSeq(elementType)
 
-  def _unionLiteral(a: Annotation): Unit = {
+  override def _unionLiteral(a: Annotation): Unit = {
     val data = a.asInstanceOf[NDArray].getRowMajorElements()
     data.foreach { elt =>
       if (elt != null)
@@ -409,65 +411,65 @@ case class RNDArray(elementType: TypeWithRequiredness) extends RContainer {
     }
   }
 
-  def _matchesPType(pt: PType): Boolean =
+  override def _matchesPType(pt: PType): Boolean =
     elementType.matchesPType(tcoerce[PNDArray](pt).elementType)
 
-  def _unionPType(pType: PType): Unit =
+  override def _unionPType(pType: PType): Unit =
     elementType.fromPType(pType.asInstanceOf[PNDArray].elementType)
 
-  def _unionEmitType(emitType: EmitType): Unit =
+  override def _unionEmitType(emitType: EmitType): Unit =
     elementType.fromEmitType(emitType.st.asInstanceOf[SNDArray].elementEmitType)
 
-  def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RNDArray = {
+  override def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RNDArray = {
     val IndexedSeq(newElt: TypeWithRequiredness) = newChildren
     RNDArray(newElt)
   }
 
-  def canonicalPType(t: Type): PType = {
+  override def canonicalPType(t: Type): PType = {
     val tnd = tcoerce[TNDArray](t)
     PCanonicalNDArray(elementType.canonicalPType(tnd.elementType), tnd.nDims, required = required)
   }
 
-  def _toString: String = s"RNDArray[${elementType.toString}]"
+  override def _toString: String = s"RNDArray[${elementType.toString}]"
 }
 
 case class RInterval(startType: TypeWithRequiredness, endType: TypeWithRequiredness)
     extends TypeWithRequiredness {
   val children: IndexedSeq[TypeWithRequiredness] = FastSeq(startType, endType)
 
-  def _unionLiteral(a: Annotation): Unit = {
+  override def _unionLiteral(a: Annotation): Unit = {
     startType.unionLiteral(a.asInstanceOf[Interval].start)
     endType.unionLiteral(a.asInstanceOf[Interval].end)
   }
 
-  def _matchesPType(pt: PType): Boolean =
+  override def _matchesPType(pt: PType): Boolean =
     startType.matchesPType(tcoerce[PInterval](pt).pointType) &&
       endType.matchesPType(tcoerce[PInterval](pt).pointType)
 
-  def _unionPType(pType: PType): Unit = {
+  override def _unionPType(pType: PType): Unit = {
     startType.fromPType(pType.asInstanceOf[PInterval].pointType)
     endType.fromPType(pType.asInstanceOf[PInterval].pointType)
   }
 
-  def _unionEmitType(emitType: EmitType): Unit = {
+  override def _unionEmitType(emitType: EmitType): Unit = {
     val sInterval = emitType.st.asInstanceOf[SInterval]
     startType.fromEmitType(sInterval.pointEmitType)
     endType.fromEmitType(sInterval.pointEmitType)
   }
 
-  def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RInterval = {
+  override def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RInterval = {
     val IndexedSeq(newStart: TypeWithRequiredness, newEnd: TypeWithRequiredness) = newChildren
     RInterval(newStart, newEnd)
   }
 
-  def canonicalPType(t: Type): PType = t match {
+  override def canonicalPType(t: Type): PType = t match {
     case TInterval(pointType) =>
       val unified = startType.deepCopy().asInstanceOf[TypeWithRequiredness]
       unified.unionFrom(endType)
       PCanonicalInterval(unified.canonicalPType(pointType), required = required)
   }
 
-  def _toString: String = s"RInterval[${startType.toString}, ${endType.toString}]"
+  override def _toString: String = s"RInterval[${startType.toString}, ${endType.toString}]"
 }
 
 case class RField(name: String, typ: TypeWithRequiredness, index: Int)
@@ -477,7 +479,7 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
   def size: Int = fields.length
   val children: IndexedSeq[TypeWithRequiredness] = fields.map(_.typ)
 
-  def _unionLiteral(a: Annotation): Unit = a match {
+  override def _unionLiteral(a: Annotation): Unit = a match {
     case a: Row => children.lazyZip(a.toSeq).foreach((r, f) => r.unionLiteral(f))
     case (k, v) =>
       // needed to handle the elements of a Map/Dict
@@ -486,13 +488,13 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
       children(1).unionLiteral(v)
   }
 
-  def _matchesPType(pt: PType): Boolean =
+  override def _matchesPType(pt: PType): Boolean =
     tcoerce[PBaseStruct](pt).fields.forall(f => children(f.index).matchesPType(f.typ))
 
-  def _unionPType(pType: PType): Unit =
+  override def _unionPType(pType: PType): Unit =
     pType.asInstanceOf[PBaseStruct].fields.foreach(f => children(f.index).fromPType(f.typ))
 
-  def _unionEmitType(emitType: EmitType): Unit =
+  override def _unionEmitType(emitType: EmitType): Unit =
     emitType.st.asInstanceOf[SBaseStruct].fieldEmitTypes.zipWithIndex.foreach { case (et, idx) =>
       children(idx).fromEmitType(et)
     }
@@ -502,7 +504,7 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
     fields.lazyZip(other.fields).foreach((fd1, fd2) => fd1.typ.unionFrom(fd2.typ))
   }
 
-  def canonicalPType(t: Type): PType = t match {
+  override def canonicalPType(t: Type): PType = t match {
     case ts: TStruct =>
       PCanonicalStruct(
         required = required,
@@ -529,7 +531,7 @@ case class RStruct(fields: IndexedSeq[RField]) extends RBaseStruct {
   def fieldOption(name: String): Option[TypeWithRequiredness] = fieldType.get(name)
   def hasField(name: String): Boolean = fieldType.contains(name)
 
-  def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RStruct = {
+  override def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RStruct = {
     assert(newChildren.length == fields.length)
     RStruct.fromNamesAndTypes(Array.tabulate(fields.length)(i =>
       fields(i).name -> tcoerce[TypeWithRequiredness](newChildren(i))
@@ -539,7 +541,7 @@ case class RStruct(fields: IndexedSeq[RField]) extends RBaseStruct {
   def select(newFields: Array[String]): RStruct =
     RStruct(Array.tabulate(newFields.length)(i => RField(newFields(i), field(newFields(i)), i)))
 
-  def _toString: String =
+  override def _toString: String =
     s"RStruct[${fields.map(f => s"${f.name}: ${f.typ.toString}").mkString(",")}]"
 }
 
@@ -552,14 +554,14 @@ case class RTuple(fields: IndexedSeq[RField]) extends RBaseStruct {
   val fieldType: collection.Map[String, TypeWithRequiredness] = toMapFast(fields)(_.name, _.typ)
   def field(idx: Int): TypeWithRequiredness = fieldType(idx.toString)
 
-  def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RTuple = {
+  override def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RTuple = {
     assert(newChildren.length == fields.length)
     RTuple(fields.lazyZip(newChildren).map { (f, c) =>
       RField(f.name, tcoerce[TypeWithRequiredness](c), f.index)
     })
   }
 
-  def _toString: String =
+  override def _toString: String =
     s"RTuple[${fields.map(f => s"${f.index}: ${f.typ.toString}").mkString(",")}]"
 }
 
@@ -658,7 +660,7 @@ case class RTable(
 
   def changeKey(key: IndexedSeq[String]): RTable = RTable(rowFields, globalFields, key)
 
-  def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RTable = {
+  override def copy(newChildren: IndexedSeq[BaseTypeWithRequiredness]): RTable = {
     assert(newChildren.length == rowFields.length + globalFields.length)
     val newRowFields = rowFields.lazyZip(newChildren.take(rowFields.length)).map {
       case ((n, _), r: TypeWithRequiredness) => n -> r

--- a/hail/hail/src/is/hail/types/encoded/EArray.scala
+++ b/hail/hail/src/is/hail/types/encoded/EArray.scala
@@ -13,7 +13,7 @@ import is.hail.utils._
 
 final case class EArray(val elementType: EType, override val required: Boolean = false)
     extends EContainer {
-  def _decodedSType(requestedType: Type): SType = {
+  override def _decodedSType(requestedType: Type): SType = {
     val elementPType = elementType.decodedPType(requestedType.asInstanceOf[TContainer].elementType)
     requestedType match {
       case _: TSet =>
@@ -193,7 +193,7 @@ final case class EArray(val elementType: EType, override val required: Boolean =
     new SIndexablePointerValue(st, array, len, cb.memoize(arrayType.firstElementOffset(array, len)))
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
     val skip = elementType.buildSkip(cb.emb.ecb)
     val len = cb.newLocal[Int]("len", in.readInt())
     val i = cb.newLocal[Int]("i")
@@ -212,8 +212,8 @@ final case class EArray(val elementType: EType, override val required: Boolean =
     }
   }
 
-  def _asIdent = s"array_of_${elementType.asIdent}"
-  def _toPretty = s"EArray[$elementType]"
+  override def _asIdent = s"array_of_${elementType.asIdent}"
+  override def _toPretty = s"EArray[$elementType]"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit = {
     sb ++= "EArray["
@@ -221,5 +221,5 @@ final case class EArray(val elementType: EType, override val required: Boolean =
     sb += ']'
   }
 
-  def setRequired(newRequired: Boolean): EArray = EArray(elementType, newRequired)
+  override def setRequired(newRequired: Boolean): EArray = EArray(elementType, newRequired)
 }

--- a/hail/hail/src/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/encoded/EBaseStruct.scala
@@ -55,7 +55,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
     )
   }
 
-  def _decodedSType(requestedType: Type): SType = requestedType match {
+  override def _decodedSType(requestedType: Type): SType = requestedType match {
     case t: TInterval =>
       val structPType = decodedPType(t.structRepresentation).asInstanceOf[PStruct]
       val pointType = structPType.field("start").typ
@@ -198,7 +198,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
     }
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
     val mbytes = cb.newLocal[Long]("mbytes", r.allocate(const(1L), const(nMissingBytes.toLong)))
     cb += in.readBytes(r, mbytes, nMissingBytes)
     fields.foreach { f =>
@@ -210,7 +210,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
     }
   }
 
-  def _asIdent: String = {
+  override def _asIdent: String = {
     val sb = new StringBuilder
     sb ++= "struct_of_"
     types.foreachBetween(sb ++= _.asIdent)(sb ++= "AND")
@@ -218,7 +218,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
     sb.result()
   }
 
-  def _toPretty: String = {
+  override def _toPretty: String = {
     val sb = new StringBuilder
     _pretty(sb, 0, compact = true)
     sb.result()
@@ -237,5 +237,5 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       sb += '\n' ++= " " * indent += '}': Unit
     }
 
-  def setRequired(newRequired: Boolean): EBaseStruct = EBaseStruct(fields, newRequired)
+  override def setRequired(newRequired: Boolean): EBaseStruct = EBaseStruct(fields, newRequired)
 }

--- a/hail/hail/src/is/hail/types/encoded/EBinary.scala
+++ b/hail/hail/src/is/hail/types/encoded/EBinary.scala
@@ -61,18 +61,18 @@ class EBinary(override val required: Boolean) extends EType {
     }
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     cb += in.skipBytes(in.readInt())
 
-  def _decodedSType(requestedType: Type): SType = requestedType match {
+  override def _decodedSType(requestedType: Type): SType = requestedType match {
     case TBinary => SBinaryPointer(PCanonicalBinary(false))
     case TString => SStringPointer(PCanonicalString(false))
   }
 
-  def _asIdent = "binary"
-  def _toPretty = "EBinary"
+  override def _asIdent = "binary"
+  override def _toPretty = "EBinary"
 
-  def setRequired(newRequired: Boolean): EBinary = EBinary(newRequired)
+  override def setRequired(newRequired: Boolean): EBinary = EBinary(newRequired)
 }
 
 object EBinary {

--- a/hail/hail/src/is/hail/types/encoded/EBlockMatrixNDArray.scala
+++ b/hail/hail/src/is/hail/types/encoded/EBlockMatrixNDArray.scala
@@ -18,10 +18,10 @@ final case class EBlockMatrixNDArray(
 ) extends EType {
   type DecodedPType = PCanonicalNDArray
 
-  def setRequired(newRequired: Boolean): EBlockMatrixNDArray =
+  override def setRequired(newRequired: Boolean): EBlockMatrixNDArray =
     EBlockMatrixNDArray(elementType, newRequired)
 
-  def _decodedSType(requestedType: Type): SType = {
+  override def _decodedSType(requestedType: Type): SType = {
     val elementPType = elementType.decodedPType(requestedType.asInstanceOf[TNDArray].elementType)
     SNDArrayPointer(PCanonicalNDArray(elementPType, 2, false))
   }
@@ -108,7 +108,7 @@ final case class EBlockMatrixNDArray(
     tFinisher(cb)
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
     val skip = elementType.buildSkip(cb.emb.ecb)
 
     val len = cb.newLocal[Int]("len", in.readInt() * in.readInt())
@@ -120,7 +120,7 @@ final case class EBlockMatrixNDArray(
   override def _asIdent: String =
     s"bm_ndarray_${if (encodeRowMajor) "row" else "column"}_major_of_${elementType.asIdent}"
 
-  def _toPretty = s"ENDArray[$elementType]"
+  override def _toPretty = s"ENDArray[$elementType]"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit = {
     sb ++= "ENDArray["

--- a/hail/hail/src/is/hail/types/encoded/EBoolean.scala
+++ b/hail/hail/src/is/hail/types/encoded/EBoolean.scala
@@ -25,16 +25,16 @@ class EBoolean(override val required: Boolean) extends EType {
   ): SValue =
     new SBooleanValue(cb.memoize(in.readBoolean()))
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     cb += in.skipBoolean()
 
-  def _decodedSType(requestedType: Type): SType = SBoolean
+  override def _decodedSType(requestedType: Type): SType = SBoolean
 
-  def _asIdent = "bool"
+  override def _asIdent = "bool"
 
-  def _toPretty = "EBoolean"
+  override def _toPretty = "EBoolean"
 
-  def setRequired(newRequired: Boolean): EBoolean = EBoolean(newRequired)
+  override def setRequired(newRequired: Boolean): EBoolean = EBoolean(newRequired)
 }
 
 object EBoolean {

--- a/hail/hail/src/is/hail/types/encoded/EDictAsUnsortedArrayOfPairs.scala
+++ b/hail/hail/src/is/hail/types/encoded/EDictAsUnsortedArrayOfPairs.scala
@@ -18,7 +18,7 @@ final case class EDictAsUnsortedArrayOfPairs(
 
   private[this] val arrayRepr = EArray(elementType, required)
 
-  def _decodedSType(requestedType: Type): SType = {
+  override def _decodedSType(requestedType: Type): SType = {
     val elementPType = elementType.decodedPType(requestedType.asInstanceOf[TContainer].elementType)
     requestedType match {
       case _: TDict =>
@@ -27,13 +27,17 @@ final case class EDictAsUnsortedArrayOfPairs(
     }
   }
 
-  def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit =
+  override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit =
     // Anything we have to encode from a region should already be sorted so we don't
     // have to do anything else
     arrayRepr._buildEncoder(cb, v, out)
 
-  def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer])
-    : SValue = {
+  override def _buildDecoder(
+    cb: EmitCodeBuilder,
+    t: Type,
+    region: Value[Region],
+    in: Value[InputBuffer],
+  ): SValue = {
     val tmpRegion = cb.memoize(Region.stagedCreate(Region.REGULAR, region.getPool()), "tmp_region")
 
     val arrayDecoder = arrayRepr.buildDecoder(t, cb.emb.ecb)
@@ -64,12 +68,12 @@ final case class EDictAsUnsortedArrayOfPairs(
     ret
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     arrayRepr._buildSkip(cb, r, in)
 
-  def _asIdent = s"dict_of_${elementType.asIdent}"
-  def _toPretty = s"EDictAsUnsortedArrayOfPairs[$elementType]"
+  override def _asIdent = s"dict_of_${elementType.asIdent}"
+  override def _toPretty = s"EDictAsUnsortedArrayOfPairs[$elementType]"
 
-  def setRequired(newRequired: Boolean): EType =
+  override def setRequired(newRequired: Boolean): EType =
     EDictAsUnsortedArrayOfPairs(elementType, newRequired)
 }

--- a/hail/hail/src/is/hail/types/encoded/EFloat32.scala
+++ b/hail/hail/src/is/hail/types/encoded/EFloat32.scala
@@ -25,16 +25,16 @@ class EFloat32(override val required: Boolean) extends EType {
   ): SValue =
     new SFloat32Value(cb.memoize(in.readFloat()))
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     cb += in.skipFloat()
 
-  def _decodedSType(requestedType: Type): SType = SFloat32
+  override def _decodedSType(requestedType: Type): SType = SFloat32
 
-  def _asIdent = "float32"
+  override def _asIdent = "float32"
 
-  def _toPretty = "EFloat32"
+  override def _toPretty = "EFloat32"
 
-  def setRequired(newRequired: Boolean): EFloat32 = EFloat32(newRequired)
+  override def setRequired(newRequired: Boolean): EFloat32 = EFloat32(newRequired)
 }
 
 object EFloat32 {

--- a/hail/hail/src/is/hail/types/encoded/EFloat64.scala
+++ b/hail/hail/src/is/hail/types/encoded/EFloat64.scala
@@ -25,16 +25,16 @@ class EFloat64(override val required: Boolean) extends EType {
   ): SValue =
     new SFloat64Value(cb.memoize(in.readDouble()))
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     cb += in.skipDouble()
 
-  def _decodedSType(requestedType: Type): SType = SFloat64
+  override def _decodedSType(requestedType: Type): SType = SFloat64
 
-  def _asIdent = "float64"
+  override def _asIdent = "float64"
 
-  def _toPretty = "EFloat64"
+  override def _toPretty = "EFloat64"
 
-  def setRequired(newRequired: Boolean): EFloat64 = EFloat64(newRequired)
+  override def setRequired(newRequired: Boolean): EFloat64 = EFloat64(newRequired)
 }
 
 object EFloat64 {

--- a/hail/hail/src/is/hail/types/encoded/EInt32.scala
+++ b/hail/hail/src/is/hail/types/encoded/EInt32.scala
@@ -45,19 +45,19 @@ class EInt32(override val required: Boolean) extends EType {
     in: Value[InputBuffer],
   ): Code[Int] = in.readInt()
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     cb += in.skipInt()
 
-  def _decodedSType(requestedType: Type): SType = requestedType match {
+  override def _decodedSType(requestedType: Type): SType = requestedType match {
     case TCall => SCanonicalCall
     case _ => SInt32
   }
 
-  def _asIdent = "int32"
+  override def _asIdent = "int32"
 
-  def _toPretty = "EInt32"
+  override def _toPretty = "EInt32"
 
-  def setRequired(newRequired: Boolean): EInt32 = EInt32(newRequired)
+  override def setRequired(newRequired: Boolean): EInt32 = EInt32(newRequired)
 }
 
 object EInt32 {

--- a/hail/hail/src/is/hail/types/encoded/EInt64.scala
+++ b/hail/hail/src/is/hail/types/encoded/EInt64.scala
@@ -25,16 +25,16 @@ class EInt64(override val required: Boolean) extends EType {
   ): SValue =
     new SInt64Value(cb.memoize(in.readLong()))
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     cb += in.skipLong()
 
-  def _decodedSType(requestedType: Type): SType = SInt64
+  override def _decodedSType(requestedType: Type): SType = SInt64
 
-  def _asIdent = "int64"
+  override def _asIdent = "int64"
 
-  def _toPretty = "EInt64"
+  override def _toPretty = "EInt64"
 
-  def setRequired(newRequired: Boolean): EInt64 = EInt64(newRequired)
+  override def setRequired(newRequired: Boolean): EInt64 = EInt64(newRequired)
 }
 
 object EInt64 {

--- a/hail/hail/src/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/hail/src/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -62,7 +62,7 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     pndFinisher(cb)
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
     val skip = elementType.buildSkip(cb.emb.ecb)
 
     val numElements = cb.newLocal[Long](
@@ -73,7 +73,7 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     cb.for_(cb.assign(i, 0L), i < numElements, cb.assign(i, i + 1L), skip(cb, r, in))
   }
 
-  def _decodedSType(requestedType: Type): SType = {
+  override def _decodedSType(requestedType: Type): SType = {
     val requestedTNDArray = requestedType.asInstanceOf[TNDArray]
     val elementPType = elementType.decodedPType(requestedTNDArray.elementType)
     SNDArrayPointer(PCanonicalNDArray(elementPType, requestedTNDArray.nDims, false))

--- a/hail/hail/src/is/hail/types/encoded/ERNGState.scala
+++ b/hail/hail/src/is/hail/types/encoded/ERNGState.scala
@@ -54,7 +54,7 @@ final case class ERNGState(override val required: Boolean, staticInfo: Option[SR
       )
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     staticInfo match {
       case Some(staticInfo) =>
         for (_ <- 0 until (4 + staticInfo.numWordsInLastBlock))
@@ -67,11 +67,11 @@ final case class ERNGState(override val required: Boolean, staticInfo: Option[SR
         cb += in.skipInt()
     }
 
-  def _decodedSType(requestedType: Type): SRNGState = SRNGState(staticInfo)
+  override def _decodedSType(requestedType: Type): SRNGState = SRNGState(staticInfo)
 
-  def _asIdent = "rngstate"
+  override def _asIdent = "rngstate"
 
-  def _toPretty = "ERNGState"
+  override def _toPretty = "ERNGState"
 
-  def setRequired(newRequired: Boolean): ERNGState = ERNGState(newRequired, staticInfo)
+  override def setRequired(newRequired: Boolean): ERNGState = ERNGState(newRequired, staticInfo)
 }

--- a/hail/hail/src/is/hail/types/encoded/EType.scala
+++ b/hail/hail/src/is/hail/types/encoded/EType.scala
@@ -167,7 +167,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
 
   def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit
 
-  final def pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = {
+  final override def pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = {
     if (required)
       sb.append("+")
     _pretty(sb, indent, compact)

--- a/hail/hail/src/is/hail/types/encoded/EUnsortedSet.scala
+++ b/hail/hail/src/is/hail/types/encoded/EUnsortedSet.scala
@@ -14,7 +14,7 @@ final case class EUnsortedSet(val elementType: EType, override val required: Boo
     extends EContainer {
   private[this] val arrayRepr = EArray(elementType, required)
 
-  def _decodedSType(requestedType: Type): SType = {
+  override def _decodedSType(requestedType: Type): SType = {
     val elementPType = elementType.decodedPType(requestedType.asInstanceOf[TContainer].elementType)
     requestedType match {
       case _: TSet =>
@@ -22,13 +22,17 @@ final case class EUnsortedSet(val elementType: EType, override val required: Boo
     }
   }
 
-  def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit =
+  override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit =
     // Anything we have to encode from a region should already be sorted so we don't
     // have to do anything else
     arrayRepr._buildEncoder(cb, v, out)
 
-  def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer])
-    : SValue = {
+  override def _buildDecoder(
+    cb: EmitCodeBuilder,
+    t: Type,
+    region: Value[Region],
+    in: Value[InputBuffer],
+  ): SValue = {
     val tmpRegion = cb.memoize(Region.stagedCreate(Region.REGULAR, region.getPool()), "tmp_region")
 
     val arrayDecoder = arrayRepr.buildDecoder(t, cb.emb.ecb)
@@ -55,10 +59,10 @@ final case class EUnsortedSet(val elementType: EType, override val required: Boo
     ret
   }
 
-  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
+  override def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit =
     arrayRepr._buildSkip(cb, r, in)
 
-  def _asIdent = s"set_of_${elementType.asIdent}"
-  def _toPretty = s"EUnsortedSet[$elementType]"
-  def setRequired(newRequired: Boolean): EType = EUnsortedSet(elementType, newRequired)
+  override def _asIdent = s"set_of_${elementType.asIdent}"
+  override def _toPretty = s"EUnsortedSet[$elementType]"
+  override def setRequired(newRequired: Boolean): EType = EUnsortedSet(elementType, newRequired)
 }

--- a/hail/hail/src/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/hail/src/is/hail/types/physical/PArrayBackedContainer.scala
@@ -96,10 +96,10 @@ trait PArrayBackedContainer extends PContainer {
   override def clearMissingBits(aoff: Long, length: Int) =
     arrayRep.clearMissingBits(aoff, length)
 
-  def contentsByteSize(length: Int): Long =
+  override def contentsByteSize(length: Int): Long =
     arrayRep.contentsByteSize(length)
 
-  def contentsByteSize(length: Code[Int]): Code[Long] =
+  override def contentsByteSize(length: Code[Int]): Code[Long] =
     arrayRep.contentsByteSize(length)
 
   override def initialize(aoff: Long, length: Int, setMissing: Boolean = false) =
@@ -215,5 +215,5 @@ trait PArrayBackedContainer extends PContainer {
 }
 
 trait PCanonicalArrayBackedContainer extends PArrayBackedContainer {
-  def arrayRep: PCanonicalArray
+  override def arrayRep: PCanonicalArray
 }

--- a/hail/hail/src/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/physical/PBaseStruct.scala
@@ -53,7 +53,7 @@ abstract class PBaseStruct extends PType {
 
   def identBase: String
 
-  def _asIdent: String = {
+  override def _asIdent: String = {
     val sb = new StringBuilder
     sb ++= identBase
     sb ++= "_of_"
@@ -79,7 +79,7 @@ abstract class PBaseStruct extends PType {
       types.zip(right.types).map { case (l, r) => l.unsafeOrdering(sm, r) }
 
     new UnsafeOrdering {
-      def compare(o1: Long, o2: Long): Int = {
+      override def compare(o1: Long, o2: Long): Int = {
         var i = 0
         while (i < types.length) {
           val leftDefined = isFieldDefined(o1, i)

--- a/hail/hail/src/is/hail/types/physical/PBinary.scala
+++ b/hail/hail/src/is/hail/types/physical/PBinary.scala
@@ -10,7 +10,7 @@ abstract class PBinary extends PType {
   lazy val virtualType: TBinary.type = TBinary
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
-    def compare(o1: Long, o2: Long): Int = {
+    override def compare(o1: Long, o2: Long): Int = {
       val l1 = loadLength(o1)
       val l2 = loadLength(o2)
 

--- a/hail/hail/src/is/hail/types/physical/PBoolean.scala
+++ b/hail/hail/src/is/hail/types/physical/PBoolean.scala
@@ -15,21 +15,21 @@ case object PBooleanRequired extends PBoolean(true)
 class PBoolean(override val required: Boolean) extends PType with PPrimitive {
   lazy val virtualType: TBoolean.type = TBoolean
 
-  def _asIdent = "bool"
+  override def _asIdent = "bool"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     sb ++= "PBoolean"
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
-    def compare(o1: Long, o2: Long): Int =
+    override def compare(o1: Long, o2: Long): Int =
       java.lang.Boolean.compare(Region.loadBoolean(o1), Region.loadBoolean(o2))
   }
 
   override def byteSize: Long = 1
 
-  def sType: SBoolean.type = SBoolean
+  override def sType: SBoolean.type = SBoolean
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
+  override def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb += Region.storeBoolean(addr, value.asBoolean.value)
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBooleanValue =

--- a/hail/hail/src/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalArray.scala
@@ -15,9 +15,9 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false)
     extends PArray with PCanonicalArrayBackedContainer {
   assert(elementType.isRealizable)
 
-  def arrayRep = this
+  override def arrayRep = this
 
-  def _asIdent = s"array_of_${elementType.asIdent}"
+  override def _asIdent = s"array_of_${elementType.asIdent}"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit = {
     sb ++= "PCArray["
@@ -55,7 +55,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false)
 
   override val byteSize: Long = 8
 
-  def setRequired(required: Boolean): PCanonicalArray =
+  override def setRequired(required: Boolean): PCanonicalArray =
     if (required == this.required) this else PCanonicalArray(elementType, required)
 
   override def loadLength(aoff: Long): Int =
@@ -219,16 +219,16 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false)
       length,
     )
 
-    def hasNext: Boolean = i != length
-    def isDefined: Boolean = isElementDefined(aoff, i)
+    override def hasNext: Boolean = i != length
+    override def isDefined: Boolean = isElementDefined(aoff, i)
 
-    def value: Long =
+    override def value: Long =
       firstElementOffset + i * elementByteSize
 
-    def iterate(): Unit = i += 1
+    override def iterate(): Unit = i += 1
   }
 
-  def elementIterator(aoff: Long, length: Int): Iterator = new Iterator(aoff, length)
+  override def elementIterator(aoff: Long, length: Int): Iterator = new Iterator(aoff, length)
 
   override def allocate(region: Region, length: Int): Long =
     region.allocate(contentsAlignment, contentsByteSize(length))

--- a/hail/hail/src/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalBinary.scala
@@ -13,7 +13,7 @@ case object PCanonicalBinaryOptional extends PCanonicalBinary(false)
 case object PCanonicalBinaryRequired extends PCanonicalBinary(true)
 
 class PCanonicalBinary(val required: Boolean) extends PBinary {
-  def _asIdent = "binary"
+  override def _asIdent = "binary"
 
   override def copiedType: PType = this
 
@@ -53,48 +53,48 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     sb ++= "PCBinary"
 
-  def contentAlignment: Long = 4
+  override def contentAlignment: Long = 4
 
-  def lengthHeaderBytes: Long = 4
+  override def lengthHeaderBytes: Long = 4
 
-  def contentByteSize(length: Int): Long = 4L + length
+  override def contentByteSize(length: Int): Long = 4L + length
 
-  def contentByteSize(length: Code[Int]): Code[Long] = (const(4) + length).toL
+  override def contentByteSize(length: Code[Int]): Code[Long] = (const(4) + length).toL
 
-  def allocate(region: Region, length: Int): Long =
+  override def allocate(region: Region, length: Int): Long =
     region.allocate(contentAlignment, contentByteSize(length))
 
-  def allocate(region: Code[Region], length: Code[Int]): Code[Long] =
+  override def allocate(region: Code[Region], length: Code[Int]): Code[Long] =
     region.allocate(const(contentAlignment), contentByteSize(length))
 
-  def loadLength(boff: Long): Int = Region.loadInt(boff)
+  override def loadLength(boff: Long): Int = Region.loadInt(boff)
 
-  def loadLength(boff: Code[Long]): Code[Int] = Region.loadInt(boff)
+  override def loadLength(boff: Code[Long]): Code[Int] = Region.loadInt(boff)
 
-  def loadBytes(bAddress: Code[Long], length: Code[Int]): Code[Array[Byte]] =
+  override def loadBytes(bAddress: Code[Long], length: Code[Int]): Code[Array[Byte]] =
     Region.loadBytes(this.bytesAddress(bAddress), length)
 
-  def loadBytes(bAddress: Code[Long]): Code[Array[Byte]] =
+  override def loadBytes(bAddress: Code[Long]): Code[Array[Byte]] =
     Code.memoize(bAddress, "pcbin_load_bytes_addr") { bAddress =>
       loadBytes(bAddress, this.loadLength(bAddress))
     }
 
-  def loadBytes(bAddress: Long, length: Int): Array[Byte] =
+  override def loadBytes(bAddress: Long, length: Int): Array[Byte] =
     Region.loadBytes(this.bytesAddress(bAddress), length)
 
-  def loadBytes(bAddress: Long): Array[Byte] =
+  override def loadBytes(bAddress: Long): Array[Byte] =
     this.loadBytes(bAddress, this.loadLength(bAddress))
 
-  def storeLength(boff: Long, len: Int): Unit = Region.storeInt(boff, len)
+  override def storeLength(boff: Long, len: Int): Unit = Region.storeInt(boff, len)
 
-  def storeLength(cb: EmitCodeBuilder, boff: Code[Long], len: Code[Int]): Unit =
+  override def storeLength(cb: EmitCodeBuilder, boff: Code[Long], len: Code[Int]): Unit =
     cb += Region.storeInt(boff, len)
 
-  def bytesAddress(boff: Long): Long = boff + lengthHeaderBytes
+  override def bytesAddress(boff: Long): Long = boff + lengthHeaderBytes
 
-  def bytesAddress(boff: Code[Long]): Code[Long] = boff + lengthHeaderBytes
+  override def bytesAddress(boff: Code[Long]): Code[Long] = boff + lengthHeaderBytes
 
-  def store(addr: Long, bytes: Array[Byte]): Unit = {
+  override def store(addr: Long, bytes: Array[Byte]): Unit = {
     Region.storeInt(addr, bytes.length)
     Region.storeBytes(bytesAddress(addr), bytes)
   }
@@ -163,12 +163,12 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
     }
   }
 
-  def sType: SBinaryPointer = SBinaryPointer(setRequired(false))
+  override def sType: SBinaryPointer = SBinaryPointer(setRequired(false))
 
-  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerValue =
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerValue =
     new SBinaryPointerValue(sType, cb.memoize(addr))
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
+  override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
     : Value[Long] = {
     value.st match {
       case SBinaryPointer(PCanonicalBinary(_)) =>
@@ -191,7 +191,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
     }
   }
 
-  def storeAtAddress(
+  override def storeAtAddress(
     cb: EmitCodeBuilder,
     addr: Code[Long],
     region: Value[Region],
@@ -200,7 +200,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
   ): Unit =
     cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
 
-  def unstagedStoreAtAddress(
+  override def unstagedStoreAtAddress(
     sm: HailStateManager,
     addr: Long,
     region: Region,
@@ -212,10 +212,10 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
     Region.storeAddress(addr, copyFromAddress(sm, region, srcArray, srcAddress, deepCopy))
   }
 
-  def setRequired(required: Boolean): PCanonicalBinary =
+  override def setRequired(required: Boolean): PCanonicalBinary =
     if (required == this.required) this else PCanonicalBinary(required)
 
-  def loadFromNested(addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
+  override def loadFromNested(addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
 
   override def unstagedLoadFromNested(addr: Long): Long = Region.loadAddress(addr)
 

--- a/hail/hail/src/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalCall.scala
@@ -10,7 +10,7 @@ import is.hail.types.physical.stypes.interfaces.SCall
 import is.hail.utils._
 
 final case class PCanonicalCall(required: Boolean = false) extends PCall {
-  def _asIdent = "call"
+  override def _asIdent = "call"
 
   override def copiedType: PType = this
 
@@ -19,13 +19,13 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
 
   val representation: PInt32 = PInt32(required)
 
-  def byteSize: Long = representation.byteSize
+  override def byteSize: Long = representation.byteSize
   override def alignment: Long = representation.alignment
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering =
     representation.unsafeOrdering(sm) // this was a terrible idea
 
-  def setRequired(required: Boolean) =
+  override def setRequired(required: Boolean) =
     if (required == this.required) this else PCanonicalCall(required)
 
   override def unstagedStoreAtAddress(
@@ -62,12 +62,12 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
         representation._copyFromAddress(sm, region, pt.representation, srcAddress, deepCopy)
     }
 
-  def sType: SCall = SCanonicalCall
+  override def sType: SCall = SCanonicalCall
 
-  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCanonicalCallValue =
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCanonicalCallValue =
     new SCanonicalCallValue(cb.memoize(Region.loadInt(addr)))
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
+  override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
     : Value[Long] = {
     value.st match {
       case SCanonicalCall =>
@@ -77,7 +77,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
     }
   }
 
-  def storeAtAddress(
+  override def storeAtAddress(
     cb: EmitCodeBuilder,
     addr: Code[Long],
     region: Value[Region],
@@ -86,7 +86,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
   ): Unit =
     cb += Region.storeInt(addr, value.asCall.canonicalCall(cb))
 
-  def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
+  override def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
 
   override def unstagedLoadFromNested(addr: Long): Long =
     representation.unstagedLoadFromNested(addr)

--- a/hail/hail/src/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalDict.scala
@@ -23,10 +23,10 @@ final case class PCanonicalDict(keyType: PType, valueType: PType, required: Bool
 
   val arrayRep: PCanonicalArray = PCanonicalArray(elementType, required)
 
-  def setRequired(required: Boolean) =
+  override def setRequired(required: Boolean) =
     if (required == this.required) this else PCanonicalDict(keyType, valueType, required)
 
-  def _asIdent = s"dict_of_${keyType.asIdent}AND${valueType.asIdent}"
+  override def _asIdent = s"dict_of_${keyType.asIdent}AND${valueType.asIdent}"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit = {
     sb ++= "PCDict["

--- a/hail/hail/src/is/hail/types/physical/PCanonicalSet.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalSet.scala
@@ -19,10 +19,10 @@ final case class PCanonicalSet(elementType: PType, required: Boolean = false)
     extends PSet with PCanonicalArrayBackedContainer {
   val arrayRep = PCanonicalArray(elementType, required)
 
-  def setRequired(required: Boolean) =
+  override def setRequired(required: Boolean) =
     if (required == this.required) this else PCanonicalSet(elementType, required)
 
-  def _asIdent = s"set_of_${elementType.asIdent}"
+  override def _asIdent = s"set_of_${elementType.asIdent}"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit = {
     sb ++= "PCSet["

--- a/hail/hail/src/is/hail/types/physical/PCanonicalTuple.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalTuple.scala
@@ -20,7 +20,7 @@ final case class PCanonicalTuple(
     tf.index -> idx
   }.toMap
 
-  def setRequired(required: Boolean) =
+  override def setRequired(required: Boolean) =
     if (required == this.required) this else PCanonicalTuple(_types, required)
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = {
@@ -44,7 +44,7 @@ final case class PCanonicalTuple(
       this.required,
     )
 
-  def copiedType: PType = {
+  override def copiedType: PType = {
     val copiedTypes = types.map(_.copiedType)
     if (types.indices.forall(i => types(i).eq(copiedTypes(i))))
       this

--- a/hail/hail/src/is/hail/types/physical/PDict.scala
+++ b/hail/hail/src/is/hail/types/physical/PDict.scala
@@ -9,7 +9,7 @@ abstract class PDict extends PContainer {
   val keyType: PType
   val valueType: PType
 
-  def sType: SContainer
+  override def sType: SContainer
 
-  def elementType: PStruct
+  override def elementType: PStruct
 }

--- a/hail/hail/src/is/hail/types/physical/PFloat32.scala
+++ b/hail/hail/src/is/hail/types/physical/PFloat32.scala
@@ -16,13 +16,13 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override type NType = PFloat32
 
-  def _asIdent = "float32"
+  override def _asIdent = "float32"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     sb ++= "PFloat32"
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
-    def compare(o1: Long, o2: Long): Int =
+    override def compare(o1: Long, o2: Long): Int =
       java.lang.Float.compare(Region.loadFloat(o1), Region.loadFloat(o2))
   }
 
@@ -38,7 +38,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def sType: SType = SFloat32
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
+  override def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeFloat(addr, value.asFloat.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat32Value =

--- a/hail/hail/src/is/hail/types/physical/PFloat64.scala
+++ b/hail/hail/src/is/hail/types/physical/PFloat64.scala
@@ -17,13 +17,13 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override type NType = PFloat64
 
-  def _asIdent = "float64"
+  override def _asIdent = "float64"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     sb ++= "PFloat64"
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
-    def compare(o1: Long, o2: Long): Int =
+    override def compare(o1: Long, o2: Long): Int =
       java.lang.Double.compare(Region.loadDouble(o1), Region.loadDouble(o2))
   }
 
@@ -39,7 +39,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def sType: SType = SFloat64
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
+  override def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeDouble(addr, value.asDouble.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat64Value =

--- a/hail/hail/src/is/hail/types/physical/PInt32.scala
+++ b/hail/hail/src/is/hail/types/physical/PInt32.scala
@@ -13,7 +13,7 @@ case object PInt32Required extends PInt32(true)
 
 class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
   lazy val virtualType: TInt32.type = TInt32
-  def _asIdent = "int32"
+  override def _asIdent = "int32"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     sb ++= "PInt32"
@@ -21,7 +21,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
   override type NType = PInt32
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
-    def compare(o1: Long, o2: Long): Int =
+    override def compare(o1: Long, o2: Long): Int =
       Integer.compare(Region.loadInt(o1), Region.loadInt(o2))
   }
 
@@ -37,7 +37,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
 
   override def sType: SType = SInt32
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
+  override def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeInt(addr, value.asInt.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt32Value =

--- a/hail/hail/src/is/hail/types/physical/PInt64.scala
+++ b/hail/hail/src/is/hail/types/physical/PInt64.scala
@@ -14,7 +14,7 @@ case object PInt64Required extends PInt64(true)
 class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
   lazy val virtualType: TInt64.type = TInt64
 
-  def _asIdent = "int64"
+  override def _asIdent = "int64"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     sb ++= "PInt64"
@@ -22,7 +22,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
   override type NType = PInt64
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = new UnsafeOrdering {
-    def compare(o1: Long, o2: Long): Int =
+    override def compare(o1: Long, o2: Long): Int =
       java.lang.Long.compare(Region.loadLong(o1), Region.loadLong(o2))
   }
 
@@ -38,7 +38,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
 
   override def sType: SType = SInt64
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
+  override def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeLong(addr, value.asLong.value))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt64Value =

--- a/hail/hail/src/is/hail/types/physical/PInterval.scala
+++ b/hail/hail/src/is/hail/types/physical/PInterval.scala
@@ -15,7 +15,7 @@ abstract class PInterval extends PType {
     new UnsafeOrdering {
       private val pOrd = pointType.unsafeOrdering(sm)
 
-      def compare(o1: Long, o2: Long): Int = {
+      override def compare(o1: Long, o2: Long): Int = {
         val sdef1 = startDefined(o1)
         if (sdef1 == startDefined(o2)) {
           val cmp = pOrd.compare(loadStart(o1), loadStart(o2))
@@ -47,7 +47,7 @@ abstract class PInterval extends PType {
     new UnsafeOrdering {
       private val pOrd = pointType.unsafeOrdering(sm)
 
-      def compare(o1: Long, o2: Long): Int = {
+      override def compare(o1: Long, o2: Long): Int = {
         val edef1 = endDefined(o1)
         if (edef1 == endDefined(o2)) {
           val cmp = pOrd.compare(loadEnd(o1), loadEnd(o2))

--- a/hail/hail/src/is/hail/types/physical/PPrimitive.scala
+++ b/hail/hail/src/is/hail/types/physical/PPrimitive.scala
@@ -8,13 +8,11 @@ import is.hail.types.physical.stypes.SValue
 import is.hail.utils._
 
 trait PPrimitive extends PType {
-  def byteSize: Long
-
   def _construct(mb: EmitMethodBuilder[_], region: Value[Region], pc: SValue): SValue = pc
 
   override def containsPointers: Boolean = false
 
-  def _copyFromAddress(
+  override def _copyFromAddress(
     sm: HailStateManager,
     region: Region,
     srcPType: PType,
@@ -30,7 +28,7 @@ trait PPrimitive extends PType {
     addr
   }
 
-  def unstagedStoreAtAddress(
+  override def unstagedStoreAtAddress(
     sm: HailStateManager,
     addr: Long,
     region: Region,
@@ -42,7 +40,7 @@ trait PPrimitive extends PType {
     Region.copyFrom(srcAddress, addr, byteSize)
   }
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
+  override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
     : Value[Long] = {
     val newAddr = cb.memoize(region.allocate(alignment, byteSize))
     storeAtAddress(cb, newAddr, region, value, deepCopy)
@@ -67,7 +65,7 @@ trait PPrimitive extends PType {
     addr
   }
 
-  def setRequired(required: Boolean): PPrimitive = {
+  override def setRequired(required: Boolean): PPrimitive = {
     if (required == this.required)
       this
     else
@@ -80,7 +78,7 @@ trait PPrimitive extends PType {
       }
   }
 
-  def loadFromNested(addr: Code[Long]): Code[Long] = addr
+  override def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
   override def unstagedLoadFromNested(addr: Long): Long = addr
 

--- a/hail/hail/src/is/hail/types/physical/PStruct.scala
+++ b/hail/hail/src/is/hail/types/physical/PStruct.scala
@@ -2,7 +2,7 @@ package is.hail.types.physical
 
 import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructValue}
+import is.hail.types.physical.stypes.interfaces.SBaseStruct
 import is.hail.types.virtual.{Field, TStruct}
 
 import scala.collection.compat._
@@ -35,7 +35,7 @@ trait PStruct extends PBaseStruct {
 
   def rename(m: Map[String, String]): PStruct
 
-  def identBase: String = "struct"
+  override def identBase: String = "struct"
 
   final def selectFields(names: Seq[String]): PCanonicalStruct =
     PCanonicalStruct(required, names.map(f => f -> field(f).typ): _*)
@@ -61,6 +61,4 @@ trait PStruct extends PBaseStruct {
   def setFieldMissing(cb: EmitCodeBuilder, offset: Code[Long], fieldName: String): Unit
 
   def insertFields(fieldsToInsert: IterableOnce[(String, PType)]): PStruct
-
-  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructValue
 }

--- a/hail/hail/src/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/hail/src/is/hail/types/physical/PSubsetStruct.scala
@@ -79,7 +79,7 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String])
   override def fieldOffset(structAddress: Code[Long], fieldIdx: Int): Code[Long] =
     ps.fieldOffset(structAddress, idxMap(fieldIdx))
 
-  def loadField(structAddress: Code[Long], fieldName: String): Code[Long] =
+  override def loadField(structAddress: Code[Long], fieldName: String): Code[Long] =
     ps.loadField(structAddress, fieldName)
 
   override def loadField(structAddress: Long, fieldIdx: Int): Long =
@@ -104,7 +104,7 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String])
   override def setFieldPresent(cb: EmitCodeBuilder, structAddress: Code[Long], fieldIdx: Int)
     : Unit = ???
 
-  def insertFields(fieldsToInsert: IterableOnce[(String, PType)]): PSubsetStruct = ???
+  override def insertFields(fieldsToInsert: IterableOnce[(String, PType)]): PSubsetStruct = ???
 
   override def initialize(structAddress: Long, setMissing: Boolean): Unit =
     ps.initialize(structAddress, setMissing)
@@ -113,10 +113,10 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String])
     : Unit =
     ps.stagedInitialize(cb, structAddress, setMissing)
 
-  def allocate(region: Region): Long =
+  override def allocate(region: Region): Long =
     ps.allocate(region)
 
-  def allocate(region: Code[Region]): Code[Long] =
+  override def allocate(region: Code[Region]): Code[Long] =
     ps.allocate(region)
 
   override def setRequired(required: Boolean): PType =
@@ -140,14 +140,14 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String])
   ): Long =
     throw new UnsupportedOperationException
 
-  def sType: SBaseStruct =
+  override def sType: SBaseStruct =
     SStructView.subset(_fieldNames, ps.sType)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
+  override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
     : Value[Long] =
     throw new UnsupportedOperationException
 
-  def storeAtAddress(
+  override def storeAtAddress(
     cb: EmitCodeBuilder,
     addr: Code[Long],
     region: Value[Region],
@@ -156,10 +156,10 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String])
   ): Unit =
     throw new UnsupportedOperationException
 
-  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructValue =
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructValue =
     throw new UnsupportedOperationException
 
-  def unstagedStoreAtAddress(
+  override def unstagedStoreAtAddress(
     sm: HailStateManager,
     addr: Long,
     region: Region,
@@ -169,7 +169,7 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String])
   ): Unit =
     throw new UnsupportedOperationException
 
-  def loadFromNested(addr: Code[Long]): Code[Long] = addr
+  override def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
   override def unstagedLoadFromNested(addr: Long): Long = addr
 

--- a/hail/hail/src/is/hail/types/physical/PTuple.scala
+++ b/hail/hail/src/is/hail/types/physical/PTuple.scala
@@ -16,5 +16,5 @@ trait PTuple extends PBaseStruct {
 
   lazy val nFields: Int = fields.size
 
-  def identBase: String = "tuple"
+  override def identBase: String = "tuple"
 }

--- a/hail/hail/src/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/hail/src/is/hail/types/physical/PUnrealizable.scala
@@ -14,7 +14,7 @@ trait PUnrealizable extends PType {
 
   override def alignment: Long = unsupported
 
-  protected[physical] def _copyFromAddress(
+  override protected[physical] def _copyFromAddress(
     sm: HailStateManager,
     region: Region,
     srcPType: PType,
@@ -32,7 +32,7 @@ trait PUnrealizable extends PType {
   ): Long =
     unsupported
 
-  def unstagedStoreAtAddress(
+  override def unstagedStoreAtAddress(
     sm: HailStateManager,
     addr: Long,
     region: Region,

--- a/hail/hail/src/is/hail/types/physical/PVoid.scala
+++ b/hail/hail/src/is/hail/types/physical/PVoid.scala
@@ -11,21 +11,21 @@ case object PVoid extends PType with PUnrealizable {
 
   override def sType: SType = SVoid
 
-  def virtualType: Type = TVoid
+  override def virtualType: Type = TVoid
 
   override val required = true
 
-  def _asIdent = "void"
+  override def _asIdent = "void"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     sb ++= "PVoid"
 
-  def setRequired(required: Boolean) = PVoid
+  override def setRequired(required: Boolean) = PVoid
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering =
     throw new NotImplementedError()
 
-  def loadFromNested(addr: Code[Long]): Code[Long] = throw new NotImplementedError()
+  override def loadFromNested(addr: Code[Long]): Code[Long] = throw new NotImplementedError()
 
   override def unstagedLoadFromNested(addr: Long): Long = throw new NotImplementedError()
 }

--- a/hail/hail/src/is/hail/types/physical/StoredSTypePType.scala
+++ b/hail/hail/src/is/hail/types/physical/StoredSTypePType.scala
@@ -117,7 +117,7 @@ case class StoredSTypePType(sType: SType, required: Boolean) extends PType {
 
   override def deepRename(t: Type): PType = StoredSTypePType(sType.castRename(t), required)
 
-  def byteSize: Long = ct.byteSize
+  override def byteSize: Long = ct.byteSize
 
   override def alignment: Long = ct.alignment
 
@@ -137,12 +137,13 @@ case class StoredSTypePType(sType: SType, required: Boolean) extends PType {
 
   override def unsafeOrdering(sm: HailStateManager): UnsafeOrdering = unsupportedCanonicalMethod
 
-  def unstagedLoadFromNested(addr: Long): Long = unsupportedCanonicalMethod
+  override def unstagedLoadFromNested(addr: Long): Long = unsupportedCanonicalMethod
 
-  def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region): Long =
+  override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region)
+    : Long =
     unsupportedCanonicalMethod
 
-  def unstagedStoreJavaObjectAtAddress(
+  override def unstagedStoreJavaObjectAtAddress(
     sm: HailStateManager,
     addr: Long,
     annotation: Annotation,

--- a/hail/hail/src/is/hail/types/physical/stypes/SingleCodeSCode.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/SingleCodeSCode.scala
@@ -46,72 +46,97 @@ sealed trait SingleCodeType {
 }
 
 case object Int32SingleCodeType extends SingleCodeType {
-  def ti: TypeInfo[_] = IntInfo
+  override def ti: TypeInfo[_] = IntInfo
 
   override def loadedSType: SType = SInt32
 
-  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SInt32Value(coerce[Int](c))
+  override def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
+    new SInt32Value(coerce[Int](c))
 
-  def virtualType: Type = TInt32
+  override def virtualType: Type = TInt32
 
-  def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean)
-    : SingleCodeSCode =
+  override def coerceSCode(
+    cb: EmitCodeBuilder,
+    pc: SValue,
+    region: Value[Region],
+    deepCopy: Boolean,
+  ): SingleCodeSCode =
     SingleCodeSCode(this, pc.asInt.value)
 }
 
 case object Int64SingleCodeType extends SingleCodeType {
-  def ti: TypeInfo[_] = LongInfo
+  override def ti: TypeInfo[_] = LongInfo
 
   override def loadedSType: SType = SInt64
 
-  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SInt64Value(coerce[Long](c))
+  override def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
+    new SInt64Value(coerce[Long](c))
 
-  def virtualType: Type = TInt64
+  override def virtualType: Type = TInt64
 
-  def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean)
-    : SingleCodeSCode =
+  override def coerceSCode(
+    cb: EmitCodeBuilder,
+    pc: SValue,
+    region: Value[Region],
+    deepCopy: Boolean,
+  ): SingleCodeSCode =
     SingleCodeSCode(this, pc.asLong.value)
 }
 
 case object Float32SingleCodeType extends SingleCodeType {
-  def ti: TypeInfo[_] = FloatInfo
+  override def ti: TypeInfo[_] = FloatInfo
 
   override def loadedSType: SType = SFloat32
 
-  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SFloat32Value(coerce[Float](c))
+  override def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
+    new SFloat32Value(coerce[Float](c))
 
-  def virtualType: Type = TFloat32
+  override def virtualType: Type = TFloat32
 
-  def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean)
-    : SingleCodeSCode =
+  override def coerceSCode(
+    cb: EmitCodeBuilder,
+    pc: SValue,
+    region: Value[Region],
+    deepCopy: Boolean,
+  ): SingleCodeSCode =
     SingleCodeSCode(this, pc.asFloat.value)
 }
 
 case object Float64SingleCodeType extends SingleCodeType {
-  def ti: TypeInfo[_] = DoubleInfo
+  override def ti: TypeInfo[_] = DoubleInfo
 
   override def loadedSType: SType = SFloat64
 
-  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SFloat64Value(coerce[Double](c))
+  override def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
+    new SFloat64Value(coerce[Double](c))
 
-  def virtualType: Type = TFloat64
+  override def virtualType: Type = TFloat64
 
-  def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean)
-    : SingleCodeSCode =
+  override def coerceSCode(
+    cb: EmitCodeBuilder,
+    pc: SValue,
+    region: Value[Region],
+    deepCopy: Boolean,
+  ): SingleCodeSCode =
     SingleCodeSCode(this, pc.asDouble.value)
 }
 
 case object BooleanSingleCodeType extends SingleCodeType {
-  def ti: TypeInfo[_] = BooleanInfo
+  override def ti: TypeInfo[_] = BooleanInfo
 
   override def loadedSType: SType = SBoolean
 
-  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue = new SBooleanValue(coerce[Boolean](c))
+  override def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
+    new SBooleanValue(coerce[Boolean](c))
 
-  def virtualType: Type = TBoolean
+  override def virtualType: Type = TBoolean
 
-  def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean)
-    : SingleCodeSCode =
+  override def coerceSCode(
+    cb: EmitCodeBuilder,
+    pc: SValue,
+    region: Value[Region],
+    deepCopy: Boolean,
+  ): SingleCodeSCode =
     SingleCodeSCode(this, pc.asBoolean.value)
 }
 
@@ -124,33 +149,41 @@ case class StreamSingleCodeType(
 
   override def loadedSType: SType = SStream(EmitType(eltType.sType, true))
 
-  def virtualType: Type = TStream(eltType.virtualType)
+  override def virtualType: Type = TStream(eltType.virtualType)
 
-  def ti: TypeInfo[_] = classInfo[NoBoxLongIterator]
+  override def ti: TypeInfo[_] = classInfo[NoBoxLongIterator]
 
-  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
+  override def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
     new SStreamConcrete(
       SStreamIteratorLong(eltRequired, eltType, requiresMemoryManagementPerElement),
       coerce[NoBoxLongIterator](c),
     )
 
-  def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean)
-    : SingleCodeSCode =
+  override def coerceSCode(
+    cb: EmitCodeBuilder,
+    pc: SValue,
+    region: Value[Region],
+    deepCopy: Boolean,
+  ): SingleCodeSCode =
     throw new UnsupportedOperationException
 }
 
 case class PTypeReferenceSingleCodeType(pt: PType) extends SingleCodeType {
-  def ti: TypeInfo[_] = LongInfo
+  override def ti: TypeInfo[_] = LongInfo
 
   override def loadedSType: SType = pt.sType
 
-  def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
+  override def loadToSValue(cb: EmitCodeBuilder, c: Value[_]): SValue =
     cb.memoizeField(pt.loadCheapSCode(cb, coerce[Long](c)), "PTypeReferenceSingleCodeType")
 
-  def virtualType: Type = pt.virtualType
+  override def virtualType: Type = pt.virtualType
 
-  def coerceSCode(cb: EmitCodeBuilder, pc: SValue, region: Value[Region], deepCopy: Boolean)
-    : SingleCodeSCode =
+  override def coerceSCode(
+    cb: EmitCodeBuilder,
+    pc: SValue,
+    region: Value[Region],
+    deepCopy: Boolean,
+  ): SingleCodeSCode =
     SingleCodeSCode(this, pt.store(cb, region, pc, deepCopy = deepCopy))
 }
 

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -12,8 +12,12 @@ import is.hail.utils._
 import is.hail.variant._
 
 case object SCanonicalCall extends SCall {
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean)
-    : SValue =
+  override def _coerceOrCopy(
+    cb: EmitCodeBuilder,
+    region: Value[Region],
+    value: SValue,
+    deepCopy: Boolean,
+  ): SValue =
     value.st match {
       case SCanonicalCall => value
     }
@@ -22,25 +26,25 @@ case object SCanonicalCall extends SCall {
 
   override def castRename(t: Type): SType = this
 
-  def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(IntInfo)
+  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(IntInfo)
 
-  def fromSettables(settables: IndexedSeq[Settable[_]]): SCanonicalCallSettable = {
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SCanonicalCallSettable = {
     val IndexedSeq(call: Settable[Int @unchecked]) = settables
     assert(call.ti == IntInfo)
     new SCanonicalCallSettable(call)
   }
 
-  def fromValues(values: IndexedSeq[Value[_]]): SCanonicalCallValue = {
+  override def fromValues(values: IndexedSeq[Value[_]]): SCanonicalCallValue = {
     val IndexedSeq(call: Value[Int @unchecked]) = values
     assert(call.ti == IntInfo)
     new SCanonicalCallValue(call)
   }
 
-  def storageType(): PType = PCanonicalCall(false)
+  override def storageType(): PType = PCanonicalCall(false)
 
-  def copiedType: SType = this
+  override def copiedType: SType = this
 
-  def containsPointers: Boolean = false
+  override def containsPointers: Boolean = false
 
   def constructFromIntRepr(cb: EmitCodeBuilder, c: Code[Int]): SCanonicalCallValue =
     new SCanonicalCallValue(cb.memoize(c))
@@ -59,7 +63,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
     new SCanonicalCallValue(repr)
   }
 
-  def containsAllele(cb: EmitCodeBuilder, allele: Value[Int]): Value[Boolean] =
+  override def containsAllele(cb: EmitCodeBuilder, allele: Value[Int]): Value[Boolean] =
     cb.memoize[Boolean](
       Code.invokeScalaObject2[Int, Int, Boolean](
         Call.getClass,

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -134,9 +134,9 @@ final class SIndexablePointerSettable(
   override val length: Settable[Int],
   override val elementsAddress: Settable[Long],
 ) extends SIndexablePointerValue(st, a, length, elementsAddress) with SSettable {
-  def settableTuple(): IndexedSeq[Settable[_]] = FastSeq(a, length, elementsAddress)
+  override def settableTuple(): IndexedSeq[Settable[_]] = FastSeq(a, length, elementsAddress)
 
-  def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
     case v: SIndexablePointerValue =>
       cb.assign(a, v.a)
       cb.assign(length, v.length)

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -153,10 +153,10 @@ final class SNDArrayPointerSettable(
   override val firstDataAddress: Settable[Long],
 ) extends SNDArrayPointerValue(st, a, shape.map(SizeValueDyn.apply), strides, firstDataAddress)
     with SNDArraySettable {
-  def settableTuple(): IndexedSeq[Settable[_]] =
+  override def settableTuple(): IndexedSeq[Settable[_]] =
     FastSeq(a) ++ shape ++ strides ++ FastSeq(firstDataAddress)
 
-  def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
     case v: SNDArrayPointerValue =>
       cb.assign(a, v.a)
       shape.lazyZip(v.shapes).foreach(cb.assign(_, _))

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
@@ -86,7 +86,8 @@ class SNDArraySliceValue(
   override def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SValue =
     pt.elementType.loadCheapSCode(cb, loadElementAddress(indices, cb))
 
-  def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue = {
+  override def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue])
+    : SNDArrayValue = {
     cb.if_(!hasShape(cb, otherShape), cb._fatal("incompatible shapes"))
     new SNDArraySliceValue(st, otherShape, strides, firstDataAddress)
   }

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -58,13 +58,13 @@ class SStringPointerValue(val st: SStringPointer, val a: Value[Long]) extends SS
   def binaryRepr: SBinaryPointerValue =
     new SBinaryPointerValue(SBinaryPointer(pt.binaryRepresentation), a)
 
-  def loadLength(cb: EmitCodeBuilder): Value[Int] =
+  override def loadLength(cb: EmitCodeBuilder): Value[Int] =
     cb.memoize(pt.loadLength(a))
 
-  def loadString(cb: EmitCodeBuilder): Value[String] =
+  override def loadString(cb: EmitCodeBuilder): Value[String] =
     cb.memoize(pt.loadString(a))
 
-  def toBytes(cb: EmitCodeBuilder): SBinaryPointerValue =
+  override def toBytes(cb: EmitCodeBuilder): SBinaryPointerValue =
     binaryRepr
 
   override def sizeToStoreInBytes(cb: EmitCodeBuilder): SInt64Value =

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SStructView.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SStructView.scala
@@ -106,7 +106,7 @@ final class SStructView(
       ct
     }
 
-  def storageType(): PType = {
+  override def storageType(): PType = {
     val pt = PCanonicalStruct(
       required = false,
       args = rename.fieldNames.zip(fieldEmitTypes.map(_.copiedType.storageType)): _*,

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -169,7 +169,8 @@ case object SUnreachableCall extends SUnreachable with SCall {
 class SUnreachableCallValue extends SUnreachableValue with SCallValue {
   override def unphase(cb: EmitCodeBuilder): SCallValue = this
 
-  def containsAllele(cb: EmitCodeBuilder, allele: Value[Int]): Value[Boolean] = const(false)
+  override def containsAllele(cb: EmitCodeBuilder, allele: Value[Int]): Value[Boolean] =
+    const(false)
 
   override def forEachAllele(cb: EmitCodeBuilder)(alleleCode: Value[Int] => Unit): Unit = {}
 

--- a/hail/hail/src/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -33,7 +33,7 @@ object SBaseStruct {
 }
 
 trait SBaseStruct extends SType {
-  def virtualType: TBaseStruct
+  override def virtualType: TBaseStruct
 
   def size: Int
 
@@ -42,7 +42,7 @@ trait SBaseStruct extends SType {
 
   def fieldIdx(fieldName: String): Int
 
-  def _typeWithRequiredness: TypeWithRequiredness = {
+  override def _typeWithRequiredness: TypeWithRequiredness = {
     virtualType match {
       case ts: TStruct => RStruct.fromNamesAndTypes(ts.fieldNames.zip(fieldEmitTypes).map {
           case (name, et) => (name, et.typeWithRequiredness.r)
@@ -57,7 +57,7 @@ trait SBaseStruct extends SType {
 trait SBaseStructSettable extends SBaseStructValue with SSettable
 
 trait SBaseStructValue extends SValue {
-  def st: SBaseStruct
+  override def st: SBaseStruct
 
   def isFieldMissing(cb: EmitCodeBuilder, fieldIdx: Int): Value[Boolean]
 

--- a/hail/hail/src/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -17,7 +17,7 @@ trait SContainer extends SType {
 }
 
 trait SIndexableValue extends SValue {
-  def st: SContainer
+  override def st: SContainer
 
   def loadLength: Value[Int]
 

--- a/hail/hail/src/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -18,7 +18,7 @@ trait SInterval extends SType {
 }
 
 trait SIntervalValue extends SValue {
-  def st: SInterval
+  override def st: SInterval
 
   def includesStart: Value[Boolean]
 

--- a/hail/hail/src/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -1243,7 +1243,7 @@ object SizeValueStatic {
 }
 
 final class SizeValueDyn(val v: Value[Long]) extends SizeValue {
-  def get: Code[Long] = v.get
+  override def get: Code[Long] = v.get
 
   override def equals(other: Any): Boolean = other match {
     case SizeValueDyn(v2) => v eq v2
@@ -1252,7 +1252,7 @@ final class SizeValueDyn(val v: Value[Long]) extends SizeValue {
 }
 
 final class SizeValueStatic(val v: Long) extends SizeValue {
-  def get: Code[Long] = const(v)
+  override def get: Code[Long] = const(v)
 
   override def equals(other: Any): Boolean = other match {
     case SizeValueStatic(v2) => v == v2
@@ -1261,7 +1261,7 @@ final class SizeValueStatic(val v: Long) extends SizeValue {
 }
 
 trait SNDArrayValue extends SValue {
-  def st: SNDArray
+  override def st: SNDArray
 
   def pt: PNDArray
 

--- a/hail/hail/src/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -95,7 +95,7 @@ object SStreamValue {
 }
 
 trait SStreamValue extends SUnrealizableValue {
-  def st: SStream
+  override def st: SStream
 
   def getProducer(mb: EmitMethodBuilder[_]): StreamProducer
 
@@ -160,7 +160,7 @@ case class SStreamControlFlow(st: SimpleSStream, producer: StreamProducer) exten
     producer
   }
 
-  def valueTuple: IndexedSeq[Value[_]] = throw new NotImplementedError()
+  override def valueTuple: IndexedSeq[Value[_]] = throw new NotImplementedError()
 
   override def defineUnusedLabels(mb: EmitMethodBuilder[_]): Unit = {
     (producer.LendOfStream.isImplemented, producer.LproduceElementDone.isImplemented) match {

--- a/hail/hail/src/is/hail/types/physical/stypes/primitives/SPrimitive.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/primitives/SPrimitive.scala
@@ -11,7 +11,7 @@ trait SPrimitive extends SType {
 
   override def copiedType: SType = this
 
-  def containsPointers: Boolean = false
+  override def containsPointers: Boolean = false
 }
 
 abstract class SPrimitiveValue extends SValue {

--- a/hail/hail/src/is/hail/types/virtual/MatrixType.scala
+++ b/hail/hail/src/is/hail/types/virtual/MatrixType.scala
@@ -154,7 +154,7 @@ case class MatrixType(
     "g" -> entryType,
   )
 
-  def pretty(sb: StringBuilder, indent0: Int = 0, compact: Boolean = false): Unit = {
+  override def pretty(sb: StringBuilder, indent0: Int = 0, compact: Boolean = false): Unit = {
 
     val space: String = if (compact) "" else " "
     val newline: String = if (compact) "" else "\n"

--- a/hail/hail/src/is/hail/types/virtual/TArray.scala
+++ b/hail/hail/src/is/hail/types/virtual/TArray.scala
@@ -12,7 +12,7 @@ final case class TArray(elementType: Type) extends TContainer {
     sb += '>'
   }
 
-  def _toPretty = s"Array[$elementType]"
+  override def _toPretty = s"Array[$elementType]"
 
   override def canCompare(other: Type): Boolean = other match {
     case TArray(otherType) => elementType.canCompare(otherType)
@@ -32,7 +32,7 @@ final case class TArray(elementType: Type) extends TContainer {
     sb += ']'
   }
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[IndexedSeq[_]] &&
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[IndexedSeq[_]] &&
     a.asInstanceOf[IndexedSeq[_]].forall(elementType.typeCheck)
 
   override def _showStr(a: Annotation): String =
@@ -42,7 +42,7 @@ final case class TArray(elementType: Type) extends TContainer {
 
   override def str(a: Annotation): String = JsonMethods.compact(export(a))
 
-  def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.iterableOrdering(elementType.ordering(sm), missingEqual)
 
   override def valueSubsetter(subtype: Type): Any => Any = {

--- a/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
@@ -37,7 +37,7 @@ abstract class TBaseStruct extends Type {
 
   def size: Int
 
-  def _toPretty: String = {
+  override def _toPretty: String = {
     val sb = new StringBuilder
     _pretty(sb, 0, compact = true)
     sb.result()

--- a/hail/hail/src/is/hail/types/virtual/TBinary.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBinary.scala
@@ -4,11 +4,11 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 
 case object TBinary extends Type {
-  def _toPretty = "Binary"
+  override def _toPretty = "Binary"
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Array[Byte]]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Array[Byte]]
 
-  def mkOrdering(sm: HailStateManager, _missingEqual: Boolean = true): ExtendedOrdering =
+  override def mkOrdering(sm: HailStateManager, _missingEqual: Boolean = true): ExtendedOrdering =
     ExtendedOrdering.iterableOrdering(new ExtendedOrdering {
       val missingEqual = _missingEqual
 

--- a/hail/hail/src/is/hail/types/virtual/TBoolean.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBoolean.scala
@@ -4,12 +4,12 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 
 case object TBoolean extends Type {
-  def _toPretty = "Boolean"
+  override def _toPretty = "Boolean"
 
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "bool"
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Boolean]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Boolean]
 
   override def _showStr(a: Annotation): String = if (a.asInstanceOf[Boolean]) "True" else "False"
 

--- a/hail/hail/src/is/hail/types/virtual/TCall.scala
+++ b/hail/hail/src/is/hail/types/virtual/TCall.scala
@@ -5,14 +5,14 @@ import is.hail.backend.HailStateManager
 import is.hail.variant.Call
 
 case object TCall extends Type {
-  def _toPretty = "Call"
+  override def _toPretty = "Call"
 
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "call"
 
   val representation: Type = TInt32
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
 
   override def str(a: Annotation): String =
     if (a == null) "NA" else Call.toString(a.asInstanceOf[Call])

--- a/hail/hail/src/is/hail/types/virtual/TDict.scala
+++ b/hail/hail/src/is/hail/types/virtual/TDict.scala
@@ -27,7 +27,7 @@ final case class TDict(keyType: Type, valueType: Type) extends TContainer {
 
   override def subst() = TDict(keyType.subst(), valueType.subst())
 
-  def _toPretty = s"Dict[$keyType, $valueType]"
+  override def _toPretty = s"Dict[$keyType, $valueType]"
 
   override def pyString(sb: StringBuilder): Unit = {
     sb ++= "dict<"
@@ -45,7 +45,7 @@ final case class TDict(keyType: Type, valueType: Type) extends TContainer {
     sb += ']'
   }
 
-  def _typeCheck(a: Any): Boolean = a == null || (a.isInstanceOf[Map[_, _]] &&
+  override def _typeCheck(a: Any): Boolean = a == null || (a.isInstanceOf[Map[_, _]] &&
     a.asInstanceOf[Map[_, _]].forall { case (k, v) =>
       keyType.typeCheck(k) && valueType.typeCheck(v)
     })

--- a/hail/hail/src/is/hail/types/virtual/TFloat32.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat32.scala
@@ -5,12 +5,12 @@ import is.hail.backend.HailStateManager
 import is.hail.utils._
 
 case object TFloat32 extends TNumeric {
-  def _toPretty = "Float32"
+  override def _toPretty = "Float32"
 
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "float32"
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Float]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Float]
 
   override def _showStr(a: Annotation): String = "%.02e".format(a.asInstanceOf[Float])
 

--- a/hail/hail/src/is/hail/types/virtual/TFloat64.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat64.scala
@@ -10,7 +10,7 @@ case object TFloat64 extends TNumeric {
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "float64"
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Double]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Double]
 
   override def _showStr(a: Annotation): String = "%.02e".format(a.asInstanceOf[Double])
 

--- a/hail/hail/src/is/hail/types/virtual/TInt32.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInt32.scala
@@ -4,12 +4,12 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 
 case object TInt32 extends TIntegral {
-  def _toPretty = "Int32"
+  override def _toPretty = "Int32"
 
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "int32"
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TInt64.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInt64.scala
@@ -4,12 +4,12 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 
 case object TInt64 extends TIntegral {
-  def _toPretty = "Int64"
+  override def _toPretty = "Int64"
 
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "int64"
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Long]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Long]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Long]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TInterval.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInterval.scala
@@ -8,7 +8,7 @@ case class TInterval(pointType: Type) extends Type {
 
   override def children = FastSeq(pointType)
 
-  def _toPretty = s"""Interval[$pointType]"""
+  override def _toPretty = s"""Interval[$pointType]"""
 
   override def pyString(sb: StringBuilder): Unit = {
     sb ++= "interval<"
@@ -22,7 +22,7 @@ case class TInterval(pointType: Type) extends Type {
     sb += ']'
   }
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Interval] && {
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Interval] && {
     val i = a.asInstanceOf[Interval]
     pointType.typeCheck(i.start) && pointType.typeCheck(i.end)
   }

--- a/hail/hail/src/is/hail/types/virtual/TLocus.scala
+++ b/hail/hail/src/is/hail/types/virtual/TLocus.scala
@@ -21,14 +21,14 @@ object TLocus {
 
 case class TLocus(rgName: String) extends Type {
 
-  def _toPretty = s"Locus($rgName)"
+  override def _toPretty = s"Locus($rgName)"
 
   def rg: String = rgName
 
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "locus<" ++= prettyIdentifier(rgName) += '>': Unit
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Locus]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Locus]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering =
     sm.referenceGenomes(rgName).extendedLocusOrdering

--- a/hail/hail/src/is/hail/types/virtual/TNDArray.scala
+++ b/hail/hail/src/is/hail/types/virtual/TNDArray.scala
@@ -46,7 +46,7 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
     sb += '>'
   }
 
-  def _toPretty = s"NDArray[$elementType,$nDims]"
+  override def _toPretty = s"NDArray[$elementType,$nDims]"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit = {
     sb ++= "NDArray["
@@ -105,7 +105,7 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   override def subst(): TNDArray = TNDArray(elementType.subst(), nDimsBase.subst())
 
-  def _typeCheck(a: Annotation): Boolean = a match {
+  override def _typeCheck(a: Annotation): Boolean = a match {
     case nd: NDArray => nd.forall(e => elementType.typeCheck(e))
     case _ => false
   }

--- a/hail/hail/src/is/hail/types/virtual/TRNGState.scala
+++ b/hail/hail/src/is/hail/types/virtual/TRNGState.scala
@@ -8,9 +8,9 @@ case object TRNGState extends Type {
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "rng_state"
 
-  def _typeCheck(a: Any): Boolean = ???
+  override def _typeCheck(a: Any): Boolean = ???
 
-  def mkOrdering(sm: HailStateManager, missingEqual: Boolean)
+  override def mkOrdering(sm: HailStateManager, missingEqual: Boolean)
     : is.hail.annotations.ExtendedOrdering = ???
 
   override def isIsomorphicTo(t: Type): Boolean =

--- a/hail/hail/src/is/hail/types/virtual/TSet.scala
+++ b/hail/hail/src/is/hail/types/virtual/TSet.scala
@@ -6,7 +6,7 @@ import is.hail.backend.HailStateManager
 import org.json4s.jackson.JsonMethods
 
 final case class TSet(elementType: Type) extends TContainer {
-  def _toPretty = s"Set[$elementType]"
+  override def _toPretty = s"Set[$elementType]"
 
   override def pyString(sb: StringBuilder): Unit = {
     sb ++= "set<"
@@ -26,7 +26,7 @@ final case class TSet(elementType: Type) extends TContainer {
 
   override def subst() = TSet(elementType.subst())
 
-  def _typeCheck(a: Any): Boolean =
+  override def _typeCheck(a: Any): Boolean =
     a.isInstanceOf[Set[_]] && a.asInstanceOf[Set[_]].forall(elementType.typeCheck)
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit = {

--- a/hail/hail/src/is/hail/types/virtual/TStream.scala
+++ b/hail/hail/src/is/hail/types/virtual/TStream.scala
@@ -12,7 +12,7 @@ final case class TStream(elementType: Type) extends TIterable {
     sb += '>'
   }
 
-  def _toPretty = s"Stream[$elementType]"
+  override def _toPretty = s"Stream[$elementType]"
 
   override def canCompare(other: Type): Boolean =
     throw new UnsupportedOperationException("Stream comparison is currently undefined.")
@@ -30,7 +30,7 @@ final case class TStream(elementType: Type) extends TIterable {
     sb += ']'
   }
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[IndexedSeq[_]] &&
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[IndexedSeq[_]] &&
     a.asInstanceOf[IndexedSeq[_]].forall(elementType.typeCheck)
 
   override def str(a: Annotation): String = JsonMethods.compact(export(a))

--- a/hail/hail/src/is/hail/types/virtual/TString.scala
+++ b/hail/hail/src/is/hail/types/virtual/TString.scala
@@ -4,14 +4,14 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 
 case object TString extends Type {
-  def _toPretty = "String"
+  override def _toPretty = "String"
 
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "str"
 
   override def _showStr(a: Annotation): String = "\"" + a.asInstanceOf[String] + "\""
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[String]
+  override def _typeCheck(a: Any): Boolean = a.isInstanceOf[String]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[String]], missingEqual)

--- a/hail/hail/src/is/hail/types/virtual/TStruct.scala
+++ b/hail/hail/src/is/hail/types/virtual/TStruct.scala
@@ -65,7 +65,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
     }
   }
 
-  def size: Int = fields.length
+  override def size: Int = fields.length
 
   override def truncate(newSize: Int): TStruct = TStruct(fields.take(newSize))
 

--- a/hail/hail/src/is/hail/types/virtual/TTuple.scala
+++ b/hail/hail/src/is/hail/types/virtual/TTuple.scala
@@ -34,7 +34,7 @@ final case class TTuple(_types: IndexedSeq[TupleField]) extends TBaseStruct {
 
   override lazy val _isCanonical: Boolean = _types.indices.forall(i => i == _types(i).index)
 
-  def size: Int = types.length
+  override def size: Int = types.length
 
   override def truncate(newSize: Int): TTuple =
     TTuple(_types.take(newSize))

--- a/hail/hail/src/is/hail/types/virtual/TVariable.scala
+++ b/hail/hail/src/is/hail/types/virtual/TVariable.scala
@@ -53,7 +53,7 @@ final case class TVariable(name: String, cond: String = null) extends Type {
 
   override def isRealizable = false
 
-  def _typeCheck(a: Any): Boolean =
+  override def _typeCheck(a: Any): Boolean =
     throw new RuntimeException("TVariable is not realizable")
 
   override def unify(concrete: Type): Boolean =

--- a/hail/hail/src/is/hail/types/virtual/TableType.scala
+++ b/hail/hail/src/is/hail/types/virtual/TableType.scala
@@ -55,7 +55,7 @@ case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStr
   lazy val valueType: TStruct = TableType.valueType(rowType, key)
   def valueFieldIdx: Array[Int] = canonicalRVDType.valueFieldIdx
 
-  def pretty(sb: StringBuilder, indent0: Int = 0, compact: Boolean = false): Unit = {
+  override def pretty(sb: StringBuilder, indent0: Int = 0, compact: Boolean = false): Unit = {
 
     val space: String = if (compact) "" else " "
     val padding: String = if (compact) "" else " " * indent0

--- a/hail/hail/src/is/hail/types/virtual/Type.scala
+++ b/hail/hail/src/is/hail/types/virtual/Type.scala
@@ -53,7 +53,7 @@ abstract class Type extends VType with Serializable {
     else
       (this, identity[Annotation])
 
-  final def pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
+  final override def pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit =
     _pretty(sb, indent, compact)
 
   def _toPretty: String

--- a/hail/hail/src/is/hail/utils/AbsoluteFuzzyComparable.scala
+++ b/hail/hail/src/is/hail/utils/AbsoluteFuzzyComparable.scala
@@ -11,13 +11,13 @@ object AbsoluteFuzzyComparable {
     afc.absoluteEq(tolerance, x, y)
 
   implicit object afcDoubles extends AbsoluteFuzzyComparable[Double] {
-    def absoluteEq(tolerance: Double, x: Double, y: Double) = Math.abs(x - y) <= tolerance
+    override def absoluteEq(tolerance: Double, x: Double, y: Double) = Math.abs(x - y) <= tolerance
   }
 
   implicit def afcMaps[K, V](implicit vRFC: AbsoluteFuzzyComparable[V])
     : AbsoluteFuzzyComparable[Map[K, V]] =
     new AbsoluteFuzzyComparable[Map[K, V]] {
-      def absoluteEq(tolerance: Double, x: Map[K, V], y: Map[K, V]) =
+      override def absoluteEq(tolerance: Double, x: Map[K, V], y: Map[K, V]) =
         x.keySet == y.keySet && x.keys.forall(k => vRFC.absoluteEq(tolerance, x(k), y(k)))
     }
 }

--- a/hail/hail/src/is/hail/utils/BufferedAggregatorIterator.scala
+++ b/hail/hail/src/is/hail/utils/BufferedAggregatorIterator.scala
@@ -31,10 +31,10 @@ class BufferedAggregatorIterator[T, V, U, K](
       } else false
   }
 
-  def hasNext: Boolean =
+  override def hasNext: Boolean =
     fb.isValid || buffer.size() > 0
 
-  def next(): (K, U) = {
+  override def next(): (K, U) = {
     if (!hasNext)
       throw new NoSuchElementException
     while (fb.isValid) {

--- a/hail/hail/src/is/hail/utils/Cache.scala
+++ b/hail/hail/src/is/hail/utils/Cache.scala
@@ -66,5 +66,5 @@ class LongToRegionValueCache(capacity: Int) extends Closeable {
     m.clear()
   }
 
-  def close(): Unit = free()
+  override def close(): Unit = free()
 }

--- a/hail/hail/src/is/hail/utils/MultiArray2.scala
+++ b/hail/hail/src/is/hail/utils/MultiArray2.scala
@@ -17,23 +17,23 @@ class MultiArray2[@specialized(Int, Long, Float, Double, Boolean) T](
   class Row(val i: Int) extends IndexedSeq[T] {
     require(i >= 0 && i < n1)
 
-    def apply(j: Int): T = {
+    override def apply(j: Int): T = {
       if (j < 0 || j >= length) throw new ArrayIndexOutOfBoundsException
       a(i * n2 + j)
     }
 
-    def length: Int = n2
+    override def length: Int = n2
   }
 
   class Column(val j: Int) extends IndexedSeq[T] {
     require(j >= 0 && j < n2)
 
-    def apply(i: Int): T = {
+    override def apply(i: Int): T = {
       if (i < 0 || i >= length) throw new ArrayIndexOutOfBoundsException
       a(i * n2 + j)
     }
 
-    def length: Int = n1
+    override def length: Int = n1
   }
 
   def row(i: Int) = new Row(i)
@@ -73,7 +73,7 @@ class MultiArray2[@specialized(Int, Long, Float, Double, Boolean) T](
     new MultiArray2(n1, n2, a.zip(other.a))
   }
 
-  def iterator: Iterator[T] = a.iterator
+  override def iterator: Iterator[T] = a.iterator
 }
 
 object MultiArray2 {

--- a/hail/hail/src/is/hail/utils/NumericImplicits.scala
+++ b/hail/hail/src/is/hail/utils/NumericImplicits.scala
@@ -30,22 +30,22 @@ trait NumericImplicits {
   }
 
   implicit object subBVectorSVector extends OpSub.Impl2[BVector[Double], SVector, BVector[Double]] {
-    def apply(a: BVector[Double], b: SVector): BVector[Double] = a - toBVector(b)
+    override def apply(a: BVector[Double], b: SVector): BVector[Double] = a - toBVector(b)
   }
 
   implicit object subBVectorIndexedRow
       extends OpSub.Impl2[BVector[Double], IndexedRow, IndexedRow] {
-    def apply(a: BVector[Double], b: IndexedRow): IndexedRow =
+    override def apply(a: BVector[Double], b: IndexedRow): IndexedRow =
       IndexedRow(b.index, a - toBVector(b.vector))
   }
 
   implicit object addBVectorSVector extends OpAdd.Impl2[BVector[Double], SVector, BVector[Double]] {
-    def apply(a: BVector[Double], b: SVector): BVector[Double] = a + toBVector(b)
+    override def apply(a: BVector[Double], b: SVector): BVector[Double] = a + toBVector(b)
   }
 
   implicit object addBVectorIndexedRow
       extends OpAdd.Impl2[BVector[Double], IndexedRow, IndexedRow] {
-    def apply(a: BVector[Double], b: IndexedRow): IndexedRow =
+    override def apply(a: BVector[Double], b: IndexedRow): IndexedRow =
       IndexedRow(b.index, a + toBVector(b.vector))
   }
 

--- a/hail/hail/src/is/hail/utils/NumericPair.scala
+++ b/hail/hail/src/is/hail/utils/NumericPair.scala
@@ -13,36 +13,36 @@ trait NumericPairImplicits {
 
   implicit object IntPair extends NumericPair[Int, java.lang.Integer] {
 
-    def box(t: Int): java.lang.Integer = Int.box(t)
+    override def box(t: Int): java.lang.Integer = Int.box(t)
 
-    def unbox(u: java.lang.Integer): Int = Int.unbox(u)
+    override def unbox(u: java.lang.Integer): Int = Int.unbox(u)
 
     val numeric: scala.math.Numeric[Int] = implicitly[Numeric[Int]]
   }
 
   implicit object LongPair extends NumericPair[Long, java.lang.Long] {
 
-    def box(t: Long): java.lang.Long = Long.box(t)
+    override def box(t: Long): java.lang.Long = Long.box(t)
 
-    def unbox(u: java.lang.Long): Long = Long.unbox(u)
+    override def unbox(u: java.lang.Long): Long = Long.unbox(u)
 
     val numeric: scala.math.Numeric[Long] = implicitly[Numeric[Long]]
   }
 
   implicit object FloatPair extends NumericPair[Float, java.lang.Float] {
 
-    def box(t: Float): java.lang.Float = Float.box(t)
+    override def box(t: Float): java.lang.Float = Float.box(t)
 
-    def unbox(u: java.lang.Float): Float = Float.unbox(u)
+    override def unbox(u: java.lang.Float): Float = Float.unbox(u)
 
     val numeric: scala.math.Numeric[Float] = implicitly[Numeric[Float]]
   }
 
   implicit object DoublePair extends NumericPair[Double, java.lang.Double] {
 
-    def box(t: Double): java.lang.Double = Double.box(t)
+    override def box(t: Double): java.lang.Double = Double.box(t)
 
-    def unbox(u: java.lang.Double): Double = Double.unbox(u)
+    override def unbox(u: java.lang.Double): Double = Double.unbox(u)
 
     val numeric: scala.math.Numeric[Double] = implicitly[Numeric[Double]]
   }

--- a/hail/hail/src/is/hail/utils/RelativeFuzzyComparable.scala
+++ b/hail/hail/src/is/hail/utils/RelativeFuzzyComparable.scala
@@ -11,13 +11,13 @@ object RelativeFuzzyComparable {
     afc.relativeEq(tolerance, x, y)
 
   implicit object rfcDoubles extends RelativeFuzzyComparable[Double] {
-    def relativeEq(tolerance: Double, x: Double, y: Double) = D_==(x, y, tolerance)
+    override def relativeEq(tolerance: Double, x: Double, y: Double) = D_==(x, y, tolerance)
   }
 
   implicit def rfcMaps[K, V](implicit vRFC: RelativeFuzzyComparable[V])
     : RelativeFuzzyComparable[Map[K, V]] =
     new RelativeFuzzyComparable[Map[K, V]] {
-      def relativeEq(tolerance: Double, x: Map[K, V], y: Map[K, V]) =
+      override def relativeEq(tolerance: Double, x: Map[K, V], y: Map[K, V]) =
         x.keySet == y.keySet && x.keys.forall(k => vRFC.relativeEq(tolerance, x(k), y(k)))
     }
 }

--- a/hail/hail/src/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/hail/src/is/hail/utils/SpillingCollectIterator.scala
@@ -70,7 +70,7 @@ class SpillingCollectIterator[T: ClassTag] private (
     }
   }
 
-  def hasNext: Boolean = {
+  override def hasNext: Boolean = {
     if (it == null || !it.hasNext) {
       if (i >= files.length) {
         it = null
@@ -100,7 +100,7 @@ class SpillingCollectIterator[T: ClassTag] private (
     it.hasNext
   }
 
-  def next(): T = {
+  override def next(): T = {
     hasNext: Unit
     it.next()
   }

--- a/hail/hail/src/is/hail/utils/package.scala
+++ b/hail/hail/src/is/hail/utils/package.scala
@@ -342,9 +342,9 @@ package object utils
 
   def rowIterator(r: Row): Iterator[Any] = new Iterator[Any] {
     var idx: Int = 0
-    def hasNext: Boolean = idx < r.size
+    override def hasNext: Boolean = idx < r.size
 
-    def next(): Any = {
+    override def next(): Any = {
       val a = r(idx)
       idx += 1
       a
@@ -439,7 +439,7 @@ package object utils
 
   def dictionaryOrdering[T](ords: Ordering[T]*): Ordering[T] = {
     new Ordering[T] {
-      def compare(x: T, y: T): Int = {
+      override def compare(x: T, y: T): Int = {
         var i = 0
         while (i < ords.size) {
           val v = ords(i).compare(x, y)

--- a/hail/hail/src/is/hail/utils/richUtils/ByteTrackingOutputStream.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/ByteTrackingOutputStream.scala
@@ -5,7 +5,7 @@ import java.io.OutputStream
 class ByteTrackingOutputStream(base: OutputStream) extends OutputStream {
   var bytesWritten = 0L
 
-  def write(c: Int): Unit = {
+  override def write(c: Int): Unit = {
     bytesWritten += 1
     base.write(c)
   }

--- a/hail/hail/src/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichContextRDD.scala
@@ -69,7 +69,7 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
       new Iterator[T]() {
         private[this] var cleared: Boolean = false
 
-        def hasNext: Boolean = {
+        override def hasNext: Boolean = {
           if (!cleared) {
             cleared = true
             ctx.region.clear()
@@ -77,7 +77,7 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
           it.hasNext
         }
 
-        def next(): T = {
+        override def next(): T = {
           if (!cleared) {
             ctx.region.clear()
           }

--- a/hail/hail/src/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -85,7 +85,8 @@ private class EmptyPartitionIsAZeroMatrixRDD(blocks: RDD[((Int, Int), BDM[Double
     case Some(p: GridPartitioner) => p
   }
 
-  def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
+  override def compute(split: Partition, context: TaskContext)
+    : Iterator[((Int, Int), BDM[Double])] = {
     val p = split.asInstanceOf[BlockPartition]
     val it = blocks.iterator(split, context)
     if (it.hasNext)
@@ -94,7 +95,7 @@ private class EmptyPartitionIsAZeroMatrixRDD(blocks: RDD[((Int, Int), BDM[Double
       Iterator.single(p.blockCoordinates -> BDM.zeros[Double](p.blockDims._1, p.blockDims._2))
   }
 
-  protected def getPartitions: Array[Partition] =
+  override protected def getPartitions: Array[Partition] =
     blocks.partitions.map { p =>
       new BlockPartition(p.index, gp.blockCoordinates(p.index), gp.blockDims(p.index))
     }.toArray

--- a/hail/hail/src/is/hail/utils/richUtils/RichIterable.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichIterable.scala
@@ -30,40 +30,40 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
     i.iterator.foreachBetween(f)(g)
 
   def intersperse[S >: T](sep: S): Iterable[S] = new Iterable[S] {
-    def iterator = i.iterator.intersperse(sep)
+    override def iterator = i.iterator.intersperse(sep)
   }
 
   def intersperse[S >: T](start: S, sep: S, end: S): Iterable[S] = new Iterable[S] {
-    def iterator = i.iterator.intersperse(start, sep, end)
+    override def iterator = i.iterator.intersperse(start, sep, end)
   }
 
   def +:[S >: T](elt: S): Iterable[S] = new Iterable[S] {
-    def iterator = Iterator.single(elt) ++ i
+    override def iterator = Iterator.single(elt) ++ i
   }
 
   def lazyMapWith[T2, S](i2: Iterable[T2], f: (T, T2) => S): Iterable[S] =
     new Iterable[S] with Serializable {
-      def iterator: Iterator[S] = new Iterator[S] {
+      override def iterator: Iterator[S] = new Iterator[S] {
         val it: Iterator[T] = i.iterator
         val it2: Iterator[T2] = i2.iterator
 
-        def hasNext: Boolean = it.hasNext && it2.hasNext
+        override def hasNext: Boolean = it.hasNext && it2.hasNext
 
-        def next(): S = f(it.next(), it2.next())
+        override def next(): S = f(it.next(), it2.next())
       }
     }
 
   def lazyMapWith2[T2, T3, S](i2: Iterable[T2], i3: Iterable[T3], f: (T, T2, T3) => S)
     : Iterable[S] =
     new Iterable[S] with Serializable {
-      def iterator: Iterator[S] = new Iterator[S] {
+      override def iterator: Iterator[S] = new Iterator[S] {
         val it: Iterator[T] = i.iterator
         val it2: Iterator[T2] = i2.iterator
         val it3: Iterator[T3] = i3.iterator
 
-        def hasNext: Boolean = it.hasNext && it2.hasNext && it3.hasNext
+        override def hasNext: Boolean = it.hasNext && it2.hasNext && it3.hasNext
 
-        def next(): S = f(it.next(), it2.next(), it3.next())
+        override def next(): S = f(it.next(), it2.next(), it3.next())
       }
     }
 
@@ -89,12 +89,12 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
   }
 
   def truncatable(delim: String = ", ", toTake: Int = 10): Truncatable = new Truncatable {
-    def truncate: String = if (i.size > toTake)
+    override def truncate: String = if (i.size > toTake)
       i.take(toTake).mkString(delim) + delim + "..."
     else
       i.mkString(delim)
 
-    def strings: (String, String) = (truncate, i.mkString(delim))
+    override def strings: (String, String) = (truncate, i.mkString(delim))
   }
 
   def counter(): Map[T, Int] = {

--- a/hail/hail/src/is/hail/utils/richUtils/RichIterator.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichIterator.scala
@@ -24,9 +24,9 @@ class RichIterator[T](val it: Iterator[T]) extends AnyVal {
     val bit = it.buffered
     StagingIterator(
       new StateMachine[T] {
-        def value: T = bit.head
-        def isValid = bit.hasNext
-        def advance(): Unit = bit.next(): Unit
+        override def value: T = bit.head
+        override def isValid = bit.hasNext
+        override def advance(): Unit = bit.next(): Unit
       }
     )
   }
@@ -45,9 +45,9 @@ class RichIterator[T](val it: Iterator[T]) extends AnyVal {
 
   def intersperse[S >: T](sep: S): Iterator[S] = new Iterator[S] {
     var nextIsSep = false
-    def hasNext = it.hasNext
+    override def hasNext = it.hasNext
 
-    def next() = {
+    override def next() = {
       val n = if (nextIsSep) sep else it.next()
       nextIsSep = !nextIsSep
       n
@@ -56,9 +56,9 @@ class RichIterator[T](val it: Iterator[T]) extends AnyVal {
 
   def intersperse[S >: T](start: S, sep: S, end: S): Iterator[S] = new Iterator[S] {
     var state = 0
-    def hasNext = state != 4
+    override def hasNext = state != 4
 
-    def next() = {
+    override def next() = {
       state match {
         case 0 =>
           state = if (it.hasNext) 1 else 3
@@ -117,9 +117,9 @@ class RichIterator[T](val it: Iterator[T]) extends AnyVal {
     new Iterator[Iterator[T]] {
       var prev: Iterator[T] = null
 
-      def hasNext: Boolean = it.hasNext
+      override def hasNext: Boolean = it.hasNext
 
-      def next(): Iterator[T] = {
+      override def next(): Iterator[T] = {
         if (!hasNext)
           throw new NoSuchElementException("next on empty iterator")
 
@@ -129,9 +129,9 @@ class RichIterator[T](val it: Iterator[T]) extends AnyVal {
         prev = new Iterator[T] {
           var i = 0
 
-          def hasNext: Boolean = it.hasNext && i < groupSize
+          override def hasNext: Boolean = it.hasNext && i < groupSize
 
-          def next(): T = {
+          override def next(): T = {
             if (!hasNext)
               throw new NoSuchElementException("next on empty iterator")
             i += 1

--- a/hail/hail/src/is/hail/utils/richUtils/RichString.scala
+++ b/hail/hail/src/is/hail/utils/richUtils/RichString.scala
@@ -4,9 +4,9 @@ import is.hail.utils.Truncatable
 
 class RichString(val str: String) extends AnyVal {
   def truncatable(toTake: Int = 60): Truncatable = new Truncatable {
-    def truncate: String = if (str.length > toTake - 3) str.take(toTake) + "..." else str
+    override def truncate: String = if (str.length > toTake - 3) str.take(toTake) + "..." else str
 
-    def strings: (String, String) = (truncate, str)
+    override def strings: (String, String) = (truncate, str)
   }
 
   def equalsCaseInsensitive(other: String): Boolean =

--- a/hail/hail/src/is/hail/variant/Call.scala
+++ b/hail/hail/src/is/hail/variant/Call.scala
@@ -444,9 +444,9 @@ object Call extends Serializable {
     }
 
     new IndexedSeq[Int] with Serializable {
-      def length: Int = nAlleles
+      override def length: Int = nAlleles
 
-      def apply(idx: Int): Int = {
+      override def apply(idx: Int): Int = {
         if (idx < 0 || idx >= nAlleles)
           throw new ArrayIndexOutOfBoundsException(idx)
 

--- a/hail/hail/src/is/hail/variant/ReferenceGenome.scala
+++ b/hail/hail/src/is/hail/variant/ReferenceGenome.scala
@@ -108,7 +108,8 @@ case class ReferenceGenome(
   val locusOrdering = {
     val localContigsIndex = contigsIndex
     new Ordering[Locus] {
-      def compare(x: Locus, y: Locus): Int = ReferenceGenome.compare(localContigsIndex, x, y)
+      override def compare(x: Locus, y: Locus): Int =
+        ReferenceGenome.compare(localContigsIndex, x, y)
     }
   }
 

--- a/hail/hail/src/is/hail/variant/RegionValueVariant.scala
+++ b/hail/hail/src/is/hail/variant/RegionValueVariant.scala
@@ -17,7 +17,7 @@ class RegionValueVariant(rowType: PStruct) extends View {
   private var cachedAlleles: Array[String] = null
   private var cachedLocus: Locus = null
 
-  def set(address: Long): Unit = {
+  override def set(address: Long): Unit = {
     if (!rowType.isFieldDefined(address, locusIdx))
       fatal(s"The row field 'locus' cannot have missing values.")
     if (!rowType.isFieldDefined(address, allelesIdx))

--- a/hail/hail/test/src/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/hail/test/src/is/hail/backend/ServiceBackendSuite.scala
@@ -241,6 +241,8 @@ class ServiceBackendSuite extends HailSuite with IdiomaticMockito with OptionVal
           regions = Array("lunar1"),
         )
 
+      // no idea why this trigger the missing override rule
+      @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
       val batchClient =
         mock[BatchClient]
 

--- a/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
@@ -120,7 +120,7 @@ class EmitStreamSuite extends HailSuite {
         var _eltRegion: Region = _
         var eos: Boolean = _
 
-        def init(outerRegion: Region, eltRegion: Region): Unit = _eltRegion = eltRegion
+        override def init(outerRegion: Region, eltRegion: Region): Unit = _eltRegion = eltRegion
 
         override def next(): Long =
           if (eos || !it.hasNext) {

--- a/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
@@ -25,7 +25,7 @@ class ScalaTestCompanion {
 }
 
 object TestRegisterFunctions extends RegistryFunctions {
-  def registerAll(): Unit = {
+  override def registerAll(): Unit = {
     registerIR1("addone", TInt32, TInt32)((_, a, _) => ApplyBinaryPrimOp(Add(), a, I32(1)))
     registerJavaStaticFunction("compare", Array(TInt32, TInt32), TInt32, null)(
       classOf[java.lang.Integer],

--- a/hail/hail/test/src/is/hail/expr/ir/MissingArrayBuilderSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/MissingArrayBuilderSuite.scala
@@ -11,7 +11,7 @@ import org.testng.annotations.{DataProvider, Test}
 class MissingArrayBuilderSuite extends TestNGSuite {
   def ordering[T <: AnyVal](f: (T, T) => Boolean): AsmFunction2[T, T, Boolean] =
     new AsmFunction2[T, T, Boolean] {
-      def apply(i: T, j: T): Boolean = f(i, j)
+      override def apply(i: T, j: T): Boolean = f(i, j)
     }
 
   def addToArrayBuilder[B <: MissingArrayBuilder, T](

--- a/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
@@ -453,7 +453,7 @@ class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
     val compareGen =
       for {
         elt <- arbitrary[Type]
-        set: Set[Annotation] <- genNonMissingT(ctx, TSet(elt))
+        set <- genNonMissingT[Set[Annotation]](ctx, TSet(elt))
         v <- genNonMissing(ctx, elt)
       } yield (elt, set, v)
 
@@ -509,7 +509,7 @@ class OrderingSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
     val compareGen =
       for {
         tdict <- arbitrary[TDict]
-        dict: Map[Annotation, Annotation] <- genNonMissingT(ctx, tdict, innerRequired = false)
+        dict <- genNonMissingT[Map[Annotation, Annotation]](ctx, tdict, innerRequired = false)
         key <- genNonMissing(ctx, tdict.keyType, innerRequired = false)
       } yield (tdict, dict, key)
 

--- a/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
@@ -202,25 +202,25 @@ class PruneSuite extends HailSuite {
     false,
     false,
     new MatrixReader {
-      def pathsUsed: IndexedSeq[String] = FastSeq()
+      override def pathsUsed: IndexedSeq[String] = FastSeq()
 
       override def columnCount: Option[Int] = None
 
-      def partitionCounts: Option[IndexedSeq[Long]] = None
+      override def partitionCounts: Option[IndexedSeq[Long]] = None
 
-      def rowUIDType = TTuple(TInt64, TInt64)
-      def colUIDType = TTuple(TInt64, TInt64)
+      override def rowUIDType = TTuple(TInt64, TInt64)
+      override def colUIDType = TTuple(TInt64, TInt64)
 
-      def fullMatrixTypeWithoutUIDs: MatrixType = mat.typ
+      override def fullMatrixTypeWithoutUIDs: MatrixType = mat.typ
 
-      def lower(
+      override def lower(
         ctx: ExecuteContext,
         requestedType: MatrixType,
         dropCols: Boolean,
         dropRows: Boolean,
       ): TableIR = ???
 
-      def toJValue: JValue = ???
+      override def toJValue: JValue = ???
 
       override def renderShort(): String = "mr"
     },

--- a/hail/hail/test/src/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -127,8 +127,8 @@ class StagedBlockLinkedListSuite extends HailSuite {
 
     private var ptr = 0L
 
-    def clear(): Unit = ptr = initF(region)
-    def addOne(e: E): this.type = { pushF(region, ptr, e); this }
+    override def clear(): Unit = ptr = initF(region)
+    override def addOne(e: E): this.type = { pushF(region, ptr, e); this }
     def ++=(other: BlockLinkedList[E]): this.type = { appendF(region, ptr, other); this }
     def toIndexedSeq: IndexedSeq[E] = materializeF(region, ptr)
 

--- a/hail/hail/test/src/is/hail/utils/FlipbookIteratorSuite.scala
+++ b/hail/hail/test/src/is/hail/utils/FlipbookIteratorSuite.scala
@@ -34,10 +34,10 @@ class FlipbookIteratorSuite extends HailSuite {
   def boxOrdView[A: Ordering]: OrderingView[Box[A]] = new OrderingView[Box[A]] {
     var value: A = _
 
-    def setFiniteValue(a: Box[A]): Unit =
+    override def setFiniteValue(a: Box[A]): Unit =
       value = a.value
 
-    def compareFinite(a: Box[A]): Int =
+    override def compareFinite(a: Box[A]): Int =
       implicitly[Ordering[A]].compare(value, a.value)
   }
 
@@ -48,18 +48,18 @@ class FlipbookIteratorSuite extends HailSuite {
 
       override def knownSize: Int = buf.size
 
-      def clear(): Unit = buf.clear()
+      override def clear(): Unit = buf.clear()
 
-      def addOne(x: Box[A]) = {
+      override def addOne(x: Box[A]) = {
         buf += x.value
         this
       }
 
-      def iterator: Iterator[Box[A]] = new Iterator[Box[A]] {
+      override def iterator: Iterator[Box[A]] = new Iterator[Box[A]] {
         var i = 0
-        def hasNext = i < buf.size
+        override def hasNext = i < buf.size
 
-        def next() = {
+        override def next() = {
           box.value = buf(i)
           i += 1
           box
@@ -79,7 +79,7 @@ class FlipbookIteratorSuite extends HailSuite {
     val sm = new StateMachine[Box[A]] {
       val value: Box[A] = Box[A]
       var isValid = true
-      def advance(): Unit =
+      override def advance(): Unit =
         if (it.hasNext)
           value.value = it.next()
         else


### PR DESCRIPTION
## Change Description

Use the wartremover scala compiler plugin to enforce using the `override` keyword when implementing/overriding a method from a parent class. This is generally considered a best practice, and e.g. helps with refactoring when deleting a method or changing its signature, as any implementing/overriding methods in child classes will now produce compiler errors.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

