### PR TITLE
Update base ubuntu image to noble 20260113

### DIFF
--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_PREFIX={{ global.docker_prefix }}
 ARG SKIP_GCLOUD_PROFILER=false
-FROM $DOCKER_PREFIX/ubuntu:noble-20251013 AS initializer
+FROM $DOCKER_PREFIX/ubuntu:noble-20260113 AS initializer
 
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -19,4 +19,4 @@ ubuntu:18.04
 ubuntu:20.04
 ubuntu:22.04
 ubuntu:24.04
-ubuntu:noble-20251013
+ubuntu:noble-20260113


### PR DESCRIPTION
## Change Description

Keep our base ubuntu image up to date

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a low security impact

### Impact Description

Base OS update, still ubuntu noble 

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
