### PR TITLE
[query] printer/parser rules for StreamBufferedAggregate

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Parser.scala
+++ b/hail/hail/src/is/hail/expr/ir/Parser.scala
@@ -1069,6 +1069,16 @@ object IRParser {
           elem <- ir_value_expr(ctx)(it)
         } yield LowerBoundOnOrderedCollection(col, elem, onKey)
       case "GroupByKey" => ir_value_expr(ctx)(it).map(GroupByKey)
+      case "StreamBufferedAggregate" =>
+        val n = name(it)
+        val aggSigs = p_agg_sigs(ctx)(it)
+        val size = int32_literal(it)
+        for {
+          stream <- ir_value_expr(ctx)(it)
+          init <- ir_value_expr(ctx)(it)
+          key <- ir_value_expr(ctx)(it)
+          seq <- ir_value_expr(ctx)(it)
+        } yield StreamBufferedAggregate(stream, init, key, seq, n, aggSigs, size)
       case "StreamMap" =>
         val n = name(it)
         for {

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -22,6 +22,7 @@ import is.hail.types.physical.stypes.primitives.SInt32
 import is.hail.types.virtual._
 import is.hail.types.virtual.TIterable.elementType
 import is.hail.utils.{FastSeq, _}
+import is.hail.utils.compat.immutable.ArraySeq
 import is.hail.variant.{Call2, Locus}
 
 import scala.collection.compat._
@@ -3429,6 +3430,15 @@ class IRSuite extends HailSuite {
       },
       forIR(st)(_ => Void()) -> Array(st),
       streamAggIR(st)(x => ApplyAggOp(Sum())(Cast(x, TInt64))) -> Array(st),
+      StreamBufferedAggregate(
+        st,
+        Void(),
+        MakeStruct(ArraySeq("l" -> l)),
+        Void(),
+        l.name,
+        ArraySeq(pCollectSig),
+        27,
+      ) -> Array(st),
       streamAggScanIR(st)(x => ApplyScanOp(Sum())(Cast(x, TInt64))) -> Array(st),
       RunAgg(
         Begin(FastSeq(


### PR DESCRIPTION
Adding for completeness.

This operation is used internally by the compiler and isn't exposed to python. We were never getting an assertion from the prettyprinter as this operation is generated and immediately executed in LowerAndExecuteShuffles.

No affect batch.

