### PR TITLE
[query] fix ConsoleLog blockargs

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Pretty.scala
+++ b/hail/hail/src/is/hail/expr/ir/Pretty.scala
@@ -719,6 +719,9 @@ class Pretty(
           else None
         case _: Coalesce =>
           some()
+        case _: ConsoleLog =>
+          if (i == 1) some()
+          else None
         case BlockMatrixMap(_, eltName, _, _) =>
           if (i == 1) some(eltName -> "elt")
           else None


### PR DESCRIPTION
Updates the pretty printer to reflect semantics of
`ConsoleLog(message, result)`, which is

- print `message`
- eval result

This does not affect the broad-managed batch deployment in gcp.

