### PR TITLE
[query] fix LiftMeOut blockargs

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Pretty.scala
+++ b/hail/hail/src/is/hail/expr/ir/Pretty.scala
@@ -685,6 +685,8 @@ class Pretty(
     def blockArgs(ir: BaseIR, i: Int): Option[IndexedSeq[(Name, String)]] = ir match {
       case If(_, _, _) =>
         if (i > 0) Some(FastSeq()) else None
+      case _: LiftMeOut =>
+        Some(ArraySeq.empty)
       case _: Switch =>
         if (i > 0) Some(FastSeq()) else None
       case TailLoop(name, args, _, _) => if (i == args.length)


### PR DESCRIPTION
LiftMeOut takes a non-strict argument.
This change does not affect the broad-managed batch service in gcp.