### PR TITLE
[compiler] delete EmitRegion

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/hail/src/is/hail/expr/ir/ArraySorter.scala
@@ -7,9 +7,8 @@ import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TArray, TDict, TSet, Type}
 import is.hail.utils.FastSeq
 
-class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
+class ArraySorter(mb: EmitMethodBuilder[_], r: Value[Region], array: StagedArrayBuilder) {
   val ti: TypeInfo[_] = array.elt.ti
-  val mb: EmitMethodBuilder[_] = r.mb
 
   private[this] var prunedMissing: Boolean = false
 
@@ -191,8 +190,8 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
           array.elt.loadedSType.storageType().setRequired(this.prunedMissing || array.eltRequired)
         )
 
-        arrayType.constructFromElements(cb, r.region, len, deepCopy = false) { (cb, idx) =>
-          array.loadFromIndex(cb, r.region, idx)
+        arrayType.constructFromElements(cb, r, len, deepCopy = false) { (cb, idx) =>
+          array.loadFromIndex(cb, r, idx)
         }
       case td: TDict =>
         PCanonicalDict.coerceArrayCode(toRegion(cb, TArray(td.elementType)))

--- a/hail/hail/src/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -18,7 +18,7 @@ trait BTreeKey {
 
   def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit
 
-  def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, src: Code[Long], dest: Code[Long]): Unit
+  def deepCopy(cb: EmitCodeBuilder, r: Value[Region], src: Code[Long], dest: Code[Long]): Unit
 
   def compKeys(cb: EmitCodeBuilder, k1: EmitValue, k2: EmitValue): Value[Int]
 
@@ -430,7 +430,6 @@ class AppendOnlyBTree(
         val destNode = f.getCodeParam[Long](1)
         val srcNode = f.getCodeParam[Long](2)
 
-        val er = EmitRegion(cb.emb, region)
         val newNode = cb.newLocal[Long]("new_node")
 
         def copyChild(i: Int): Unit = {
@@ -448,7 +447,7 @@ class AppendOnlyBTree(
         (0 until maxElements).foreach { i =>
           cb.if_(
             hasKey(cb, srcNode, i), {
-              key.deepCopy(cb, er, destNode, srcNode)
+              key.deepCopy(cb, region, destNode, srcNode)
               cb.if_(
                 !isLeaf(cb, srcNode), {
                   copyChild(i)

--- a/hail/hail/src/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -3,9 +3,7 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
-import is.hail.expr.ir.{
-  EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion, EmitValue, IEmitCode,
-}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitValue, IEmitCode}
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.io._
 import is.hail.types.VirtualTypeWithReq
@@ -50,7 +48,7 @@ class TypedKey(typ: PType, kb: EmitClassBuilder[_], region: Value[Region]) exten
   override def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit =
     cb += Region.copyFrom(src, dest, storageType.byteSize)
 
-  override def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, dest: Code[Long], src: Code[Long])
+  override def deepCopy(cb: EmitCodeBuilder, r: Value[Region], dest: Code[Long], src: Code[Long])
     : Unit =
     storageType.storeAtAddress(
       cb,

--- a/hail/hail/src/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{
-  EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion, EmitValue, IEmitCode, ParamType,
+  EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitValue, IEmitCode, ParamType,
 }
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
@@ -38,7 +38,7 @@ class DownsampleBTreeKey(binType: PBaseStruct, pointType: PBaseStruct, kb: EmitC
   override def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit =
     cb += Region.copyFrom(src, dest, storageType.byteSize)
 
-  override def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, srcc: Code[Long], dest: Code[Long])
+  override def deepCopy(cb: EmitCodeBuilder, r: Value[Region], srcc: Code[Long], dest: Code[Long])
     : Unit = {
     val src = cb.newLocal[Long]("dsa_deep_copy_src", srcc)
     cb.if_(
@@ -48,7 +48,7 @@ class DownsampleBTreeKey(binType: PBaseStruct, pointType: PBaseStruct, kb: EmitC
     storageType.storeAtAddress(
       cb,
       dest,
-      er.region,
+      r,
       storageType.loadCheapSCode(cb, src),
       deepCopy = true,
     )

--- a/hail/hail/src/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{
-  EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion, EmitValue, IEmitCode, ParamType,
+  EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitValue, IEmitCode, ParamType,
 }
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.io._
@@ -107,8 +107,12 @@ class GroupedBTreeKey(
       deepCopy = false,
     )
 
-  override def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, dest: Code[Long], srcCode: Code[Long])
-    : Unit = {
+  override def deepCopy(
+    cb: EmitCodeBuilder,
+    r: Value[Region],
+    dest: Code[Long],
+    srcCode: Code[Long],
+  ): Unit = {
     val src = cb.newLocal("ga_deep_copy_src", srcCode)
     storageType.storeAtAddress(
       cb,

--- a/hail/hail/src/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
@@ -61,12 +61,12 @@ object ApproxCDFFunctions extends RegistryFunctions {
       (_, _, _, _) => SBaseStructPointer(statePType),
     ) {
       case (r, cb, _, k: SInt32Value, left: SBaseStructValue, right: SBaseStructValue, _) =>
-        val leftState = makeStateManager(cb, r.region, k.value, left)
-        val rightState = makeStateManager(cb, r.region, k.value, right)
+        val leftState = makeStateManager(cb, r, k.value, left)
+        val rightState = makeStateManager(cb, r, k.value, right)
 
         cb += leftState.invoke[ApproxCDFStateManager, Unit]("combOp", rightState)
 
-        fromStateManager(cb, r.region, leftState)
+        fromStateManager(cb, r, leftState)
     }
   }
 }

--- a/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -342,7 +342,7 @@ object ArrayFunctions extends RegistryFunctions {
         )
         val pt = rt.pType.asInstanceOf[PCanonicalArray]
         val (push, finish) =
-          pt.constructFromIndicesUnsafe(cb, er.region, len.value, deepCopy = false)
+          pt.constructFromIndicesUnsafe(cb, er, len.value, deepCopy = false)
         indices.forEachDefined(cb) { case (cb, pos, idx: SInt32Value) =>
           cb.if_(
             idx.value < 0 || idx.value >= len.value,

--- a/hail/hail/src/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/MathFunctions.scala
@@ -341,9 +341,9 @@ object MathFunctions extends RegistryFunctions {
             statsPackageClass,
             "pgenchisq",
             x.value,
-            Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r.region, w)),
-            Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r.region, k)),
-            Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r.region, lam)),
+            Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r, w)),
+            Code.checkcast[IndexedSeq[Int]](svalueToJavaValue(cb, r, k)),
+            Code.checkcast[IndexedSeq[Double]](svalueToJavaValue(cb, r, lam)),
             sigma.value,
             maxIterations.value,
             minAccuracy.value,
@@ -352,7 +352,7 @@ object MathFunctions extends RegistryFunctions {
 
         DaviesAlgorithm.pType.constructFromFields(
           cb,
-          r.region,
+          r,
           FastSeq(
             EmitValue.present(primitive(cb.memoize(res.invoke[Double]("value")))),
             EmitValue.present(primitive(cb.memoize(res.invoke[Int]("nIterations")))),
@@ -439,7 +439,7 @@ object MathFunctions extends RegistryFunctions {
 
       fetStruct.constructFromFields(
         cb,
-        r.region,
+        r,
         FastSeq(
           EmitValue.present(primitive(cb.memoize(res(0)))),
           EmitValue.present(primitive(cb.memoize(res(1)))),
@@ -473,7 +473,7 @@ object MathFunctions extends RegistryFunctions {
 
       chisqStruct.constructFromFields(
         cb,
-        r.region,
+        r,
         FastSeq(
           EmitValue.present(primitive(cb.memoize(res(0)))),
           EmitValue.present(primitive(cb.memoize(res(1)))),
@@ -518,7 +518,7 @@ object MathFunctions extends RegistryFunctions {
 
         chisqStruct.constructFromFields(
           cb,
-          r.region,
+          r,
           FastSeq(
             EmitValue.present(primitive(cb.memoize(res(0)))),
             EmitValue.present(primitive(cb.memoize(res(1)))),
@@ -560,7 +560,7 @@ object MathFunctions extends RegistryFunctions {
 
         hweStruct.constructFromFields(
           cb,
-          r.region,
+          r,
           FastSeq(
             EmitValue.present(primitive(cb.memoize(res(0)))),
             EmitValue.present(primitive(cb.memoize(res(1)))),

--- a/hail/hail/src/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -156,11 +156,11 @@ object RandomSeededFunctions extends RegistryFunctions {
         val result = rt.pType.constructUninitialized(
           FastSeq(SizeValueDyn(nRows.value), SizeValueDyn(nCols.value)),
           cb,
-          r.region,
+          r,
         )
         val rng = cb.emb.getThreefryRNG()
         rngState.copyIntoEngine(cb, rng)
-        result.coiterateMutate(cb, r.region) { _ =>
+        result.coiterateMutate(cb, r) { _ =>
           primitive(cb.memoize(rng.invoke[Double, Double, Double](
             "runif",
             min.asDouble.value,
@@ -236,11 +236,11 @@ object RandomSeededFunctions extends RegistryFunctions {
         val result = rt.pType.constructUninitialized(
           FastSeq(SizeValueDyn(nRows.value), SizeValueDyn(nCols.value)),
           cb,
-          r.region,
+          r,
         )
         val rng = cb.emb.getThreefryRNG()
         rngState.copyIntoEngine(cb, rng)
-        result.coiterateMutate(cb, r.region) { _ =>
+        result.coiterateMutate(cb, r) { _ =>
           primitive(cb.memoize(rng.invoke[Double, Double, Double](
             "rnorm",
             mean.asDouble.value,
@@ -314,7 +314,7 @@ object RandomSeededFunctions extends RegistryFunctions {
           ) =>
         val rng = cb.emb.getThreefryRNG()
         rngState.copyIntoEngine(cb, rng)
-        rt.constructFromElements(cb, r.region, n.value, deepCopy = false) { case (cb, _) =>
+        rt.constructFromElements(cb, r, n.value, deepCopy = false) { case (cb, _) =>
           IEmitCode.present(
             cb,
             primitive(cb.memoize(rng.invoke[Double, Double]("rpois", lambda.value))),
@@ -436,7 +436,7 @@ object RandomSeededFunctions extends RegistryFunctions {
         val rng = cb.emb.getThreefryRNG()
         rngState.copyIntoEngine(cb, rng)
         val (push, finish) = PCanonicalArray(PInt32(required = true))
-          .constructFromFunctions(cb, r.region, colors.loadLength, deepCopy = false)
+          .constructFromFunctions(cb, r, colors.loadLength, deepCopy = false)
         cb.if_(
           colors.hasMissingValues(cb),
           cb._fatal("rand_multi_hyper: colors may not contain missing values"),
@@ -556,7 +556,7 @@ object RandomSeededFunctions extends RegistryFunctions {
         val arrayRt = rt.asInstanceOf[SIndexablePointer]
         val (push, finish) = arrayRt.pType.asInstanceOf[PCanonicalArray].constructFromFunctions(
           cb,
-          r.region,
+          r,
           resultSize,
           false,
         )

--- a/hail/hail/src/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -22,12 +22,12 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
       TBoolean,
       (_: Type, _: SType) => SBoolean,
     ) {
-      case (r, cb, Seq(tlocus: TLocus), _, contig, _) =>
+      case (_, cb, Seq(tlocus: TLocus), _, contig, _) =>
         val scontig = contig.asString.loadString(cb)
-        primitive(cb.memoize(rgCode(r.mb, tlocus.asInstanceOf[TLocus].rg).invoke[String, Boolean](
-          "isValidContig",
-          scontig,
-        )))
+        primitive(cb.memoize(
+          rgCode(cb.emb, tlocus.rg)
+            .invoke[String, Boolean]("isValidContig", scontig)
+        ))
     }
 
     registerSCode2t(
@@ -38,9 +38,9 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
       TBoolean,
       (_: Type, _: SType, _: SType) => SBoolean,
     ) {
-      case (r, cb, Seq(tlocus: TLocus), _, contig, pos, _) =>
+      case (_, cb, Seq(tlocus: TLocus), _, contig, pos, _) =>
         val scontig = contig.asString.loadString(cb)
-        primitive(cb.memoize(rgCode(r.mb, tlocus.rg).invoke[String, Int, Boolean](
+        primitive(cb.memoize(rgCode(cb.emb, tlocus.rg).invoke[String, Int, Boolean](
           "isValidLocus",
           scontig,
           pos.asInt.value,
@@ -61,7 +61,7 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
         val scontig = contig.asString.loadString(cb)
         unwrapReturn(
           cb,
-          r.region,
+          r,
           st,
           rgCode(cb.emb, typeParam.rg).invoke[String, Int, Int, Int, String](
             "getSequence",
@@ -80,9 +80,12 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
       TInt32,
       (_: Type, _: SType) => SInt32,
     ) {
-      case (r, cb, Seq(tlocus: TLocus), _, contig, _) =>
+      case (_, cb, Seq(tlocus: TLocus), _, contig, _) =>
         val scontig = contig.asString.loadString(cb)
-        primitive(cb.memoize(rgCode(r.mb, tlocus.rg).invoke[String, Int]("contigLength", scontig)))
+        primitive(cb.memoize(rgCode(cb.emb, tlocus.rg).invoke[String, Int](
+          "contigLength",
+          scontig,
+        )))
     }
 
     registerIR(

--- a/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -215,14 +215,14 @@ object UtilFunctions extends RegistryFunctions {
         case (_: Type, _: SType, _: SType, _: SType, _: SType) => SBoolean
       },
     ) {
-      case (er, cb, _, l, r, tol, abs, _) =>
+      case (region, cb, _, l, r, tol, abs, _) =>
         assert(
           l.st.virtualType == r.st.virtualType,
           s"\n  lt=${l.st.virtualType}\n  rt=${r.st.virtualType}",
         )
-        val lb = svalueToJavaValue(cb, er.region, l)
-        val rb = svalueToJavaValue(cb, er.region, r)
-        primitive(cb.memoize(er.mb.getType(l.st.virtualType).invoke[
+        val lb = svalueToJavaValue(cb, region, l)
+        val rb = svalueToJavaValue(cb, region, r)
+        primitive(cb.memoize(cb.emb.getType(l.st.virtualType).invoke[
           Any,
           Any,
           Double,
@@ -517,7 +517,7 @@ object UtilFunctions extends RegistryFunctions {
       (_: Type, _: SType, _: SType) => SJavaString,
     ) {
       case (r, cb, st: SJavaString.type, format, args, _) =>
-        val javaObjArgs = Code.checkcast[Row](svalueToJavaValue(cb, r.region, args))
+        val javaObjArgs = Code.checkcast[Row](svalueToJavaValue(cb, r, args))
         val formatted = Code.invokeScalaObject2[String, Row, String](
           thisClass,
           "format",

--- a/hail/hail/src/is/hail/types/encoded/EDictAsUnsortedArrayOfPairs.scala
+++ b/hail/hail/src/is/hail/types/encoded/EDictAsUnsortedArrayOfPairs.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{ArraySorter, EmitCodeBuilder, EmitRegion, StagedArrayBuilder}
+import is.hail.expr.ir.{ArraySorter, EmitCodeBuilder, StagedArrayBuilder}
 import is.hail.io.{InputBuffer, OutputBuffer}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{SType, SValue, SingleCodeType}
@@ -50,7 +50,7 @@ final case class EDictAsUnsortedArrayOfPairs(
       ab.add(cb, ab.elt.coerceSCode(cb, res, region, false).code)
     }
 
-    val sorter = new ArraySorter(EmitRegion(cb.emb, region), ab)
+    val sorter = new ArraySorter(cb.emb, region, ab)
     def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_])
       : Value[Boolean] = {
       val lk = cb.memoize(sct.loadToSValue(cb, l).asBaseStruct.loadField(cb, 0))

--- a/hail/hail/src/is/hail/types/encoded/EUnsortedSet.scala
+++ b/hail/hail/src/is/hail/types/encoded/EUnsortedSet.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{ArraySorter, EmitCodeBuilder, EmitRegion, StagedArrayBuilder}
+import is.hail.expr.ir.{ArraySorter, EmitCodeBuilder, StagedArrayBuilder}
 import is.hail.io.{InputBuffer, OutputBuffer}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{SType, SValue, SingleCodeType}
@@ -45,7 +45,7 @@ final case class EUnsortedSet(val elementType: EType, override val required: Boo
       ab.add(cb, ab.elt.coerceSCode(cb, res, region, false).code)
     }
 
-    val sorter = new ArraySorter(EmitRegion(cb.emb, region), ab)
+    val sorter = new ArraySorter(cb.emb, region, ab)
     def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Value[_], r: Value[_])
       : Value[Boolean] =
       cb.emb.ecb.getOrdering(sct.loadedSType, sct.loadedSType)

--- a/hail/hail/test/src/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -48,7 +48,7 @@ class TestBTreeKey(mb: EmitMethodBuilder[_]) extends BTreeKey {
   override def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit =
     cb += Region.copyFrom(src, dest, storageType.byteSize)
 
-  override def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, src: Code[Long], dest: Code[Long])
+  override def deepCopy(cb: EmitCodeBuilder, r: Value[Region], src: Code[Long], dest: Code[Long])
     : Unit =
     copy(cb, src, dest)
 

--- a/hail/hail/test/src/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -106,8 +106,7 @@ class TakeByAggregatorSuite extends HailSuite {
           new TakeByRVAS(VirtualTypeWithReq(PInt32Required), VirtualTypeWithReq(PInt32Required), kb)
         val ab = new agg.StagedArrayBuilder(PInt32Required, kb, argR)
         val rt = PCanonicalArray(tba.valueType)
-        val er = new EmitRegion(fb.apply_method, argR)
-        val rng = er.mb.newRNG(0)
+        val rng = fb.apply_method.newRNG(0)
 
         fb.emitWithBuilder { cb =>
           tba.createState(cb)


### PR DESCRIPTION
## Change Description

Deletes the vestigial `EmitRegion` class. Once upon a time, it was used to package together a MethodBuilder, and the Region argument to the method (which was usually the first argument). But now it confuses more than it helps, like in the common case where we also pass a CodeBuilder, which itself has a reference to a MethodBuilder.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
