### PR TITLE
[batch] ensure worker VMs are ipv4 only

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -129,6 +129,7 @@ def create_vm_config(
                 'network': 'global/networks/default',
                 'subnetwork': f'regions/{region}/subnetworks/default',
                 'networkTier': 'PREMIUM',
+                'stackType': 'IPV4_ONLY',
             }
         ],
         'scheduling': scheduling(),


### PR DESCRIPTION
## Change Description

Updates worker VMs to only use ipv4 network stacks.

This:
- Makes more sense given that they are now behind an ipv4 only cloudNAT
- Will hopefully prevent a race condition causing some docker accesses to fail

Brief description and justification of what this PR is doing.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Unlikely to have any security impact. At the margins it's an improvement because it reduces the number of interfaces that the VM opens, and forces the expected "ipv4 interface behind a cloud NAT" networking model.


### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
