### PR TITLE
[query] LiftMeOut is uninterpretable

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Compilable.scala
+++ b/hail/hail/src/is/hail/expr/ir/Compilable.scala
@@ -4,7 +4,6 @@ import is.hail.expr.ir.defs._
 
 object InterpretableButNotCompilable {
   def apply(x: IR): Boolean = x match {
-    case _: LiftMeOut => true
     case _: TableCount => true
     case _: TableGetGlobals => true
     case _: TableCollect => true

--- a/hail/hail/src/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/hail/src/is/hail/expr/ir/FoldConstants.scala
@@ -17,6 +17,7 @@ object FoldConstants {
       {
         case _: Ref |
             _: In |
+            _: LiftMeOut |
             _: RelationalRef |
             _: RelationalLet |
             _: UUID4 |

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -1098,18 +1098,6 @@ object Interpret extends Logging {
         }
 
         wrapped.get(0)
-      case LiftMeOut(child) =>
-        val (Some(PTypeReferenceSingleCodeType(rt)), makeFunction) =
-          Compile[AsmFunction1RegionLong](
-            ctx,
-            FastSeq(),
-            FastSeq(classInfo[Region]),
-            LongInfo,
-            MakeTuple.ordered(FastSeq(child)),
-          )
-        ctx.scopedExecution { (hcl, fs, htc, r) =>
-          SafeRow.read(rt, makeFunction(hcl, fs, htc, r)(r)).asInstanceOf[Row](0)
-        }
       case UUID4(_) =>
         uuid4()
     }

--- a/hail/hail/src/is/hail/expr/ir/lowering/Invariant.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/Invariant.scala
@@ -5,7 +5,7 @@ import is.hail.expr.ir.{
   BaseIR, BlockMatrixIR, Compilable, Emittable, IR, IRTraversal, MatrixIR, RelationalLetMatrixTable,
   RelationalLetTable, TableIR, TableKeyBy, TableKeyByAndAggregate, TableOrderBy,
 }
-import is.hail.expr.ir.defs.{ApplyIR, RelationalLet, RelationalRef}
+import is.hail.expr.ir.defs.{ApplyIR, LiftMeOut, RelationalLet, RelationalRef}
 import is.hail.utils.implicits.toRichPredicate
 
 abstract class Invariant(implicit E: sourcecode.Enclosing) extends (BaseIR => Boolean) {
@@ -45,6 +45,9 @@ object Invariant {
       case _: RelationalRef => false
       case _ => true
     }
+
+  lazy val NoLiftMeOuts: Invariant =
+    Invariant(!_.isInstanceOf[LiftMeOut])
 
   lazy val NoApplyIR: Invariant =
     Invariant(!_.isInstanceOf[ApplyIR])

--- a/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -72,7 +72,7 @@ case object LowerMatrixToTablePass extends LoweringPass {
 
 case object LiftRelationalValuesToRelationalLets extends LoweringPass {
   val before: Invariant = NoMatrixIR
-  val after: Invariant = NoMatrixIR
+  val after: Invariant = NoMatrixIR and NoLiftMeOuts
   val context: String = "LiftRelationalValuesToRelationalLets"
 
   override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LiftRelationalValues(ir)
@@ -176,8 +176,8 @@ case object LowerArrayAggsToRunAggsPass extends LoweringPass {
 }
 
 case class EvalRelationalLetsPass(passesBelow: LoweringPipeline) extends LoweringPass {
-  val before: Invariant = NoMatrixIR
-  val after: Invariant = NoMatrixIR and NoRelationalLets
+  val before: Invariant = NoMatrixIR and NoLiftMeOuts
+  val after: Invariant = before and NoRelationalLets
   val context: String = "EvalRelationalLets"
 
   override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR =

--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -183,7 +183,8 @@ def test_image_environment_variable(submit, tmp_path, client):
 
     b = get_batch_from_json_output(res, client)
     j = b.get_job(1)
-    assert j.status()['spec']['process']['image'] == 'busybox:latest', str(j.status())
+    # Assert ends with because we might be going via the dockerhubproxy image:
+    assert j.status()['spec']['process']['image'].endswith('busybox:latest'), str(j.status())
 
 
 @pytest.mark.xfail(reason='Executable files are not supported.')


### PR DESCRIPTION
Interpreting `LiftMeOut` seems like a bad idea as these get lifted to `ReleationalLet`s. Require that they've been lifted and evaluated before the IR can be interpreted.
This change does not affect the broad-managed batch service in gcp.