### PR TITLE
[query] Fix all-ref case in haplotypeFreqEM

### DIFF
--- a/hail/hail/src/is/hail/experimental/package.scala
+++ b/hail/hail/src/is/hail/experimental/package.scala
@@ -55,7 +55,7 @@ package object experimental {
 
     // Needs some non-ref samples to compute
     if (_gtCounts(0) >= nSamples) {
-      return FastSeq(_gtCounts(0).toDouble, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+      return FastSeq(_gtCounts(0).toDouble, 0.0, 0.0, 0.0)
     }
 
     val nHaplotypes = 2.0 * nSamples.toDouble


### PR DESCRIPTION
This function should always return a seq of four values.

Closes #15189

## Security assessment
- This change does not affect broad deployed batch service.