### PR TITLE
[query] delete legacy IRandomness

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -8,7 +8,7 @@ import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir._
 import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs._
-import is.hail.expr.ir.functions.{ArrayFunctions, IRRandomness, UtilFunctions}
+import is.hail.expr.ir.functions.{ArrayFunctions, UtilFunctions}
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.rvd.RVDPartitioner
 import is.hail.sparkextras.implicits.toRichRow
@@ -168,7 +168,6 @@ object LowerDistributedSort extends Logging {
   ): TableReader = {
 
     val oversamplingNum = 3
-    val seed = 7L
     val maxBranchingFactor = ctx.getFlag("shuffle_max_branch_factor").toInt
     val defaultBranchingFactor = if (inputStage.numPartitions < maxBranchingFactor) {
       Math.max(2, inputStage.numPartitions)
@@ -246,7 +245,7 @@ object LowerDistributedSort extends Logging {
     )
 
     var i = 0
-    val rand = new IRRandomness(seed)
+    val rand = ThreefryRandomEngine()
 
     /* Loop state keeps track of three things. largeSegments are too big to sort locally so have to
      * broken up.
@@ -786,7 +785,7 @@ object LowerDistributedSort extends Logging {
   }
 
   def howManySamplesPerPartition(
-    rand: IRRandomness,
+    rand: ThreefryRandomEngine,
     totalNumberOfRecords: Long,
     initialNumSamplesToSelect: Int,
     partitionCounts: IndexedSeq[Long],

--- a/hail/hail/test/src/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -108,7 +108,7 @@ class TakeByAggregatorSuite extends HailSuite {
           new TakeByRVAS(VirtualTypeWithReq(PInt32Required), VirtualTypeWithReq(PInt32Required), kb)
         val ab = new agg.StagedArrayBuilder(PInt32Required, kb, argR)
         val rt = PCanonicalArray(tba.valueType)
-        val rng = fb.apply_method.newRNG(0)
+        val rng = fb.apply_method.threefryRandomEngine
 
         fb.emitWithBuilder { cb =>
           tba.createState(cb)

--- a/hail/hail/test/src/is/hail/expr/ir/agg/DownsampleSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/agg/DownsampleSuite.scala
@@ -22,7 +22,7 @@ class DownsampleSuite extends HailSuite {
 
     val stagedPool = fb.newLocal[RegionPool]("pool")
 
-    val rng = fb.newRNG(0)
+    val rng = fb.threefryRandomEngine
     val i = fb.newLocal[Int]()
 
     val x = fb.newLocal[Double]()

--- a/hail/hail/test/src/is/hail/types/physical/PNDArraySuite.scala
+++ b/hail/hail/test/src/is/hail/types/physical/PNDArraySuite.scala
@@ -55,7 +55,11 @@ class PNDArraySuite extends PhysicalTestUtils {
         val T = vecType.constructUninitialized(FastSeq(btwpn), cb, region)
 
         A.coiterateMutate(cb, region) { case Seq(_) =>
-          primitive(cb.memoize(cb.emb.newRNG(0L).invoke[Double]("rnorm")))
+          primitive(cb.memoize(cb.emb.threefryRandomEngine.invoke[Double, Double, Double](
+            "rnorm",
+            0,
+            1,
+          )))
         }
         Acopy.coiterateMutate(cb, region, (A, "A")) { case Seq(_, a) => a }
 
@@ -118,7 +122,11 @@ class PNDArraySuite extends PhysicalTestUtils {
         val T = vecType.constructUninitialized(FastSeq(btn), FastSeq(8), cb, region)
 
         A.coiterateMutate(cb, region) { case Seq(_) =>
-          primitive(cb.memoize(cb.emb.newRNG(0L).invoke[Double]("rnorm")))
+          primitive(cb.memoize(cb.emb.threefryRandomEngine.invoke[Double, Double, Double](
+            "rnorm",
+            0,
+            1,
+          )))
         }
         Acopy.coiterateMutate(cb, region, (A, "A")) { case Seq(_, a) => a }
         SNDArray.geqrt_full(cb, Acopy, Q, R, T, work, blocksize)
@@ -235,7 +243,11 @@ class PNDArraySuite extends PhysicalTestUtils {
         val state = new LocalWhitening(cb, m, w, n, blocksize, region, false)
 
         Aorig.coiterateMutate(cb, region) { case Seq(_) =>
-          primitive(cb.memoize(cb.emb.newRNG(0L).invoke[Double]("rnorm")))
+          primitive(cb.memoize(cb.emb.threefryRandomEngine.invoke[Double, Double, Double](
+            "rnorm",
+            0,
+            1,
+          )))
         }
         A.coiterateMutate(cb, region, (Aorig.slice(cb, Colon, (w, null)), "Aorig")) {
           case Seq(_, a) => a
@@ -323,7 +335,11 @@ class PNDArraySuite extends PhysicalTestUtils {
         val A = matType.constructUninitialized(FastSeq(m, n), cb, region)
 
         Aorig.coiterateMutate(cb, region) { case Seq(_) =>
-          primitive(cb.memoize(cb.emb.newRNG(0L).invoke[Double]("rnorm")))
+          primitive(cb.memoize(cb.emb.threefryRandomEngine.invoke[Double, Double, Double](
+            "rnorm",
+            0,
+            1,
+          )))
         }
         SNDArray.copyMatrix(cb, " ", Aorig, A)
 


### PR DESCRIPTION
IRandomness was used by the previous random implementation.
It's use was limited to tests and distributedSort and can be
replaced with the ThreefryRandomEngine in all cases.

This change does not affect the broad-managed batch service 
in gcp.