### PR TITLE
[query] use one finalizer in PartitionNativeIntervalReader

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -940,6 +940,7 @@ case class PartitionNativeIntervalReader(
       val currIdxInPartition = mb.genFieldThisRef[Long]("n_to_read")
       val stopIdxInPartition = mb.genFieldThisRef[Long]("n_to_read")
       val finalizer = mb.genFieldThisRef[TaskFinalizer]("finalizer")
+      cb.assign(finalizer, cb.emb.ecb.getTaskContext.invoke[TaskFinalizer]("newFinalizer"))
 
       val startPartitionIndex = mb.genFieldThisRef[Int]("start_part")
       val currPartitionIdx = mb.genFieldThisRef[Int]("curr_part")
@@ -995,8 +996,6 @@ case class PartitionNativeIntervalReader(
           cb.assign(streamFirst, true)
           cb.assign(currIdxInPartition, 0L)
           cb.assign(stopIdxInPartition, 0L)
-
-          cb.assign(finalizer, cb.emb.ecb.getTaskContext.invoke[TaskFinalizer]("newFinalizer"))
         }
 
         override val elementRegion: Settable[Region] = region


### PR DESCRIPTION
Prevoiusly we were accumulating finalizers on every call to
`StreamProducer.initialize`. The logic in the following snippet
looks like we should be using one finalizer:
```scala
cb.if_(
  indexInitialized, {
    cb += finalizer.invoke[Unit]("clear")
    index.close(cb)
    cb += ib.close()
  },
  cb.assign(indexInitialized, true),
)
```
The problem is that that `finalizer` is not the same one that held
the index and input buffer from the previous stream invocation.