### PR TITLE
[build] Fix mirror_hailgenetics_images task

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3512,7 +3512,9 @@ steps:
       cd /io/docker/hailgenetics
       export HAIL_PIP_VERSION=$(cat /io/HAIL_PIP_VERSION)
       export DOCKER_PREFIX={{ global.docker_prefix }}
-      {% if global.dockerhub_prefix %}export DOCKERHUB_PREFIX={{ global.dockerhub_prefix }}{% endif %}
+      {% if global.dockerhub_prefix %}
+      export DOCKERHUB_PREFIX={{ global.dockerhub_prefix }}
+      {% endif %}
       bash mirror_images.sh
     inputs:
       - from: /repo/hail/env/HAIL_PIP_VERSION


### PR DESCRIPTION
## Change Description

Fixes the newly-broken mirror_hailgenetics_images task.

The previous jinja2 template was not adding a newline and so becoming:

```
export DOCKERHUB_PREFIX=us-docker.pkg.dev/project/dockerhubproxybash mirror_images.sh
```

This change makes sure a newline appears after the `export DOCKERHUB_PROXY=...` and before the `bash`

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Low impact. Just fixing syntax in a build task, restoring the status quo ante.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
