### PR TITLE
[batch] Fixes a bad use of id in a log message

### DIFF
--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -706,7 +706,9 @@ LIMIT 300;
 
                 n_prior_attempts = record['n_prior_attempts']
                 n_max_attempts = record['n_max_attempts']
-                log.info(f'Job {id}: {n_prior_attempts} prior attempts out of a maximum of {n_max_attempts}')
+                log.info(
+                    f'Job {(record["batch_id"], record["job_id"])}: {n_prior_attempts} prior attempts out of a maximum of {n_max_attempts}'
+                )
 
                 if n_prior_attempts >= n_max_attempts:
                     await mark_job_errored(


### PR DESCRIPTION
## Change Description

Fixes #15145. We were accidentally using the python built-in `id` function to build logs instead of using the batch/job id that was clearly intended. In job_private where we were at least using the right `id`, the shadowing of a python built-in was unnecessary since the id tuple is trivial to recreate, so do that instead there as well.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Fixes some bad logic while creating a log message (see original bug report)

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
