### PR TITLE
[batch] Use _batch_client() to query supported_regions() and default_region()

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -24,7 +24,6 @@ from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES, hailgenetics_hail_image_for_current_python_version
 from hailtop.batch_client.aioclient import BatchClient as AioBatchClient
-from hailtop.batch_client.client import BatchClient
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 from hailtop.config import ConfigVariable, configuration_of, get_deploy_config, get_remote_tmpdir
 from hailtop.utils import async_to_blocking, bounded_gather, parse_docker_image_reference, url_scheme
@@ -533,13 +532,13 @@ class ServiceBackend(Backend[bc.Batch]):
 
         Examples
         --------
-        >>> regions = service_backend.supported_regions()
+        >>> regions = service_backend.supported_regions()  # doctest: +SKIP
 
         Returns
         -------
         A list of the supported cloud regions
         """
-        return async_to_blocking(async_to_blocking(self._batch_client()).supported_regions())
+        return async_to_blocking(self._batch_client_sync().supported_regions())
 
     def default_region(self):
         """
@@ -549,13 +548,13 @@ class ServiceBackend(Backend[bc.Batch]):
 
         Examples
         --------
-        >>> region = service_backend.default_region()
+        >>> region = service_backend.default_region()  # doctest: +SKIP
 
         Returns
         -------
         The default region jobs run in when no regions are specified
         """
-        return async_to_blocking(async_to_blocking(self._batch_client()).default_region())
+        return async_to_blocking(self._batch_client_sync().default_region())
 
     def __init__(
         self,
@@ -570,6 +569,7 @@ class ServiceBackend(Backend[bc.Batch]):
         gcs_bucket_allow_list: Optional[List[str]] = None,
     ):
         self.__batch_client: Optional[AioBatchClient] = None
+        self._token = token
 
         if len(args) > 2:
             raise TypeError(f'ServiceBackend() takes 2 positional arguments but {len(args)} were given')
@@ -596,7 +596,6 @@ class ServiceBackend(Backend[bc.Batch]):
                 'MY_BILLING_PROJECT`'
             )
         self._billing_project = billing_project
-        self._token = token
 
         self.remote_tmpdir = get_remote_tmpdir('ServiceBackend', bucket=bucket, remote_tmpdir=remote_tmpdir)
 
@@ -642,6 +641,9 @@ class ServiceBackend(Backend[bc.Batch]):
         if self.__batch_client is None:
             self.__batch_client = await AioBatchClient.create(self._billing_project, _token=self._token)
         return self.__batch_client
+
+    def _batch_client_sync(self) -> AioBatchClient:
+        return async_to_blocking(self._batch_client())
 
     @property
     def _fs(self) -> RouterAsyncFS:


### PR DESCRIPTION
## Change Description

As `default_region()` is used in `__init__()`, it needs to work in all scenarios, including those in which credentials are provided via `__init__`'s token parameter. Thus it will need `self._token` so can't be a staticmethod, so it might as well reuse `_batch_client()` and its session.

Do the same with `supported_regions()` for good measure.

Lift `self.__batch_client=None` to the top so it occurs before anything might use `_batch_client()`, e.g., our `self.default_region()` call. This also ensures the `__batch_client` attribute exists within `__del__()` even if `__init__()` raises an exception, preventing a common red herring warning.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Some requests that currently fail due to being entirely unauthenticated will be tried using the authentication token the caller intends to use instead, and will have an opportunity to succeed.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
