### PR TITLE
[query] add `Compiled` alias for compiled functions

### DIFF
--- a/hail/hail/src/is/hail/backend/Backend.scala
+++ b/hail/hail/src/is/hail/backend/Backend.scala
@@ -1,12 +1,10 @@
 package is.hail.backend
 
-import is.hail.asm4s.HailClassLoader
 import is.hail.backend.Backend.PartitionFn
 import is.hail.backend.spark.SparkBackend
-import is.hail.expr.ir.{IR, LoweringAnalyses, SortField, TableIR, TableReader}
+import is.hail.expr.ir.{Compiled, IR, LoweringAnalyses, SortField, TableIR, TableReader}
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.io.{BufferSpec, TypedCodecSpec}
-import is.hail.io.fs.FS
 import is.hail.types.RTable
 import is.hail.types.encoded.EType
 import is.hail.types.physical.PTuple
@@ -45,7 +43,7 @@ object Backend {
     codec.encode(ctx, elementType, t.loadField(off, 0), os)
   }
 
-  type PartitionFn = (Array[Byte], Array[Byte], HailTaskContext, HailClassLoader, FS) => Array[Byte]
+  type PartitionFn = Compiled[(Array[Byte], Array[Byte]) => Array[Byte]]
 }
 
 abstract class BroadcastValue[T] { def value: T }

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -113,7 +113,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
           flags = env.flags,
           irMetadata = new IrMetadata(),
           blockMatrixCache = ImmutableMap.empty,
-          codeCache = ImmutableMap.empty,
+          compileCache = ImmutableMap.empty,
           irCache = ImmutableMap.empty,
           coercerCache = ImmutableMap.empty,
         )(f)

--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -46,7 +46,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
   private[this] val hcl = new HailClassLoader(getClass.getClassLoader)
   private[this] val references = mutable.Map(ReferenceGenome.builtinReferences().toSeq: _*)
   private[this] val blockMatrixCache = mutable.Map[String, linalg.BlockMatrix]()
-  private[this] val compiledCodeCache = new Cache[CodeCacheKey, CompiledFunction[_]](50)
+  private[this] val compiledCodeCache = new Cache[CompileCacheKey, CompiledFunction[_]](50)
   private[this] val irCache = mutable.Map[Int, BaseIR]()
   private[this] val coercerCache = new Cache[Any, LoweredTableReaderCoercer](32)
   private[this] var irID: Int = 0
@@ -347,7 +347,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
           flags = flags,
           irMetadata = new IrMetadata(),
           blockMatrixCache = blockMatrixCache,
-          codeCache = compiledCodeCache,
+          compileCache = compiledCodeCache,
           irCache = irCache,
           coercerCache = coercerCache,
         )(f)

--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -252,7 +252,9 @@ object Worker extends Logging {
           try
             using(new ServiceTaskContext(partition)) { htc =>
               retryTransientErrors {
-                Right(f(globals, context, htc, hcl, fs))
+                htc.getRegionPool().scopedRegion { r =>
+                  Right(f(hcl, fs, htc, r)(globals, context))
+                }
               }
             }
           catch {

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -267,16 +267,13 @@ class SparkBackend(val spark: SparkSession) extends Backend with Logging {
               Array.tabulate(contexts.length)(index => RDDPartition(contexts(index), index))
 
             override def compute(partition: Partition, context: TaskContext)
-              : Iterator[Array[Byte]] =
-              Iterator.single(
-                f(
-                  globals,
-                  partition.asInstanceOf[RDDPartition].data,
-                  SparkTaskContext.get(),
-                  theHailClassLoaderForSparkWorkers,
-                  new HadoopFS(fsConfig),
-                )
-              )
+              : Iterator[Array[Byte]] = {
+              val htc = SparkTaskContext.get()
+              htc.getRegionPool().scopedRegion { r =>
+                val g = f(theHailClassLoaderForSparkWorkers, new HadoopFS(fsConfig), htc, r)
+                Iterator.single(g(globals, partition.asInstanceOf[RDDPartition].data))
+              }
+            }
           }
 
         val todo: IndexedSeq[Int] =

--- a/hail/hail/src/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/hail/src/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -4,7 +4,6 @@ import is.hail.annotations.{Region, SafeRow}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
-import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.{Begin, EncodedLiteral, Literal, MakeTuple, NA}
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.types.physical.PTuple

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -199,15 +199,7 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def backend(): Code[BackendUtils] = ecb.backend()
 
-  def addModule(
-    name: String,
-    mod: (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction3[
-      Region,
-      Array[Byte],
-      Array[Byte],
-      Array[Byte],
-    ],
-  ): Unit =
+  def addModule(name: String, mod: Compiled[BackendUtils.F]): Unit =
     ecb.addModule(name, mod)
 
   def partitionRegion: Settable[Region] = ecb.partitionRegion
@@ -250,8 +242,7 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def threefryRandomEngine: Value[ThreefryRandomEngine] = ecb.threefryRandomEngine
 
-  def resultWithIndex(print: Option[PrintWriter] = None)
-    : (HailClassLoader, FS, HailTaskContext, Region) => C =
+  def resultWithIndex(print: Option[PrintWriter] = None): Compiled[C] =
     ecb.resultWithIndex(print)
 
   def getOrGenEmitMethod(
@@ -465,16 +456,7 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
     Array[AnyRef](baos.toByteArray) ++ preEncodedLiterals.map(_._1.value.ba)
   }
 
-  private[this] val _mods = Array.newBuilder[(
-    String,
-    (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction3[
-      Region,
-      Array[Byte],
-      Array[Byte],
-      Array[Byte],
-    ],
-  )]
-
+  private[this] val _mods = Array.newBuilder[(String, Compiled[BackendUtils.F])]
   private[this] var _backendField: Settable[BackendUtils] = _
 
   private[this] var _aggSigs: IndexedSeq[agg.AggStateSig] = _
@@ -598,15 +580,7 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
   def pool(): Value[RegionPool] =
     poolField
 
-  def addModule(
-    name: String,
-    mod: (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction3[
-      Region,
-      Array[Byte],
-      Array[Byte],
-      Array[Byte],
-    ],
-  ): Unit =
+  def addModule(name: String, mod: Compiled[BackendUtils.F]): Unit =
     _mods += name -> mod
 
   def getHailClassLoader: Code[HailClassLoader] = emodb.getHailClassLoader
@@ -857,8 +831,7 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
     rngField
   }
 
-  def resultWithIndex(print: Option[PrintWriter] = None)
-    : (HailClassLoader, FS, HailTaskContext, Region) => C =
+  def resultWithIndex(print: Option[PrintWriter] = None): Compiled[C] =
     ctx.time {
       makeAddPartitionRegion()
       makeAddHailClassLoader()
@@ -896,7 +869,7 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
       val n = cb.className.replace("/", ".")
       val classesBytes = modb.classesBytes(ctx.shouldWriteIRFiles(), print)
 
-      new ((HailClassLoader, FS, HailTaskContext, Region) => C) with java.io.Serializable {
+      new Compiled[C] with java.io.Serializable {
         @transient @volatile private var theClass: Class[_] = null
 
         override def apply(hcl: HailClassLoader, fs: FS, htc: HailTaskContext, region: Region)

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -8,7 +8,6 @@ import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.{toRichIterable, toRichIterator}
 import is.hail.expr.ir.analyses.PartitionCounts
-import is.hail.expr.ir.compile.{Compile, CompileWithAggregators}
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.{ExecuteRelational, LoweringPipeline}
 import is.hail.io.BufferSpec

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -6,7 +6,6 @@ import is.hail.asm4s.implicits.valueToRichCodeInputBuffer
 import is.hail.backend.{ExecuteContext, HailStateManager, HailTaskContext, TaskFinalizer}
 import is.hail.collection.FastSeq
 import is.hail.collection.implicits.toRichIterable
-import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.{
   BlockMatrixToTableFunction, IntervalFunctions, MatrixToTableFunction, TableToTableFunction,
@@ -1877,7 +1876,7 @@ case class TableNativeZippedReader(
       .typedCodecSpec.encodedType.decodedPType(requestedType.globalType))
 
   def fieldInserter(ctx: ExecuteContext, pLeft: PStruct, pRight: PStruct)
-    : (PStruct, (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction3RegionLongLongLong) = {
+    : (PStruct, Compiled[AsmFunction3RegionLongLongLong]) = {
     val leftRef = Ref(freshName(), pLeft.virtualType)
     val rightRef = Ref(freshName(), pRight.virtualType)
     val (Some(PTypeReferenceSingleCodeType(t: PStruct)), mk) =

--- a/hail/hail/src/is/hail/expr/ir/TableValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableValue.scala
@@ -9,7 +9,6 @@ import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.ir.agg.IndependentExtractedAggs
-import is.hail.expr.ir.compile.{Compile, CompileWithAggregators}
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.{RVDToTableStage, TableStage, TableStageToRVD}
 import is.hail.io.{exportTypes, BufferSpec, ByteArrayDecoder, ByteArrayEncoder, TypedCodecSpec}

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -10,7 +10,6 @@ import is.hail.collection.compat.mutable.Growable
 import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir
 import is.hail.expr.ir._
-import is.hail.expr.ir.compile.CompileWithAggregators
 import is.hail.expr.ir.defs._
 import is.hail.io.BufferSpec
 import is.hail.types.{tcoerce, TypeWithRequiredness, VirtualTypeWithReq}

--- a/hail/hail/src/is/hail/expr/ir/implicits/CompiledOps.scala
+++ b/hail/hail/src/is/hail/expr/ir/implicits/CompiledOps.scala
@@ -1,0 +1,13 @@
+package is.hail.expr.ir.implicits
+
+import is.hail.expr.ir.Compiled
+
+private[implicits] class CompiledOps[A](val fa: Compiled[A]) extends AnyVal {
+  def map[B](f: A => B): Compiled[B] =
+    (hcl, fs, htc, r) =>
+      f(fa(hcl, fs, htc, r))
+
+  def flatMap[B](f: A => Compiled[B]): Compiled[B] =
+    (hcl, fs, htc, r) =>
+      f(fa(hcl, fs, htc, r))(hcl, fs, htc, r)
+}

--- a/hail/hail/src/is/hail/expr/ir/implicits/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/implicits/package.scala
@@ -1,0 +1,6 @@
+package is.hail.expr.ir
+
+package object implicits {
+  @inline implicit def toCompiledOps[A](fa: Compiled[A]): CompiledOps[A] =
+    new CompiledOps[A](fa)
+}

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -6,7 +6,6 @@ import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir._
-import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.{ArrayFunctions, UtilFunctions}
 import is.hail.io.{BufferSpec, TypedCodecSpec}

--- a/hail/hail/src/is/hail/expr/ir/lowering/RVDToTableStage.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/RVDToTableStage.scala
@@ -6,7 +6,6 @@ import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.{AnonymousDependency, SparkTaskContext}
 import is.hail.collection.FastSeq
 import is.hail.expr.ir._
-import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.{
   GetField, In, Let, MakeStruct, ReadPartition, Ref, StreamRange, ToArray,
 }

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.TaskContext
 
-package object ir {
+package object ir extends CompileOps {
   type TokenIterator = BufferedIterator[Token]
   type IEmitCode = IEmitCodeGen[SValue]
 

--- a/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
@@ -1811,7 +1811,7 @@ object MatrixVCFReader extends Logging {
             Array.emptyByteArray,
             files.tail.map(_.getBytes),
             "load_vcf_parse_header",
-          ) { (_, bytes, htc, _, fs) =>
+          ) { (_, fs, _, _) => (_, bytes) =>
             val file = new String(bytes)
 
             val hd = parseHeader(getHeaderLines(fs, file, localFilterAndReplace))

--- a/hail/hail/src/is/hail/utils/Graph.scala
+++ b/hail/hail/src/is/hail/utils/Graph.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.{Region, RegionValueBuilder, UnsafeIndexedSeq}
 import is.hail.asm4s._
 import is.hail.backend.{HailStateManager, HailTaskContext}
 import is.hail.collection.BinaryHeap
+import is.hail.expr.ir.Compiled
 import is.hail.io.fs.FS
 import is.hail.types.physical.PTuple
 import is.hail.variant.ReferenceGenome
@@ -52,7 +53,7 @@ object Graph {
     outerRegion: Region,
     wrappedNodeType: PTuple,
     resultType: PTuple,
-    tieBreaker: (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction3RegionLongLongLong,
+    tieBreaker: Compiled[AsmFunction3RegionLongLongLong],
   ): IndexedSeq[Any] = {
     val nodeType = wrappedNodeType.types.head.virtualType
     val region = outerRegion.getPool().getRegion()

--- a/hail/hail/test/src/is/hail/HailSuite.scala
+++ b/hail/hail/test/src/is/hail/HailSuite.scala
@@ -93,7 +93,7 @@ class HailSuite extends TestNGSuite with TestUtils with Logging {
       flags = HailSuite.flags,
       irMetadata = new IrMetadata(),
       BlockMatrixCache = ImmutableMap.empty,
-      CodeCache = ImmutableMap.empty,
+      CompileCache = ImmutableMap.empty,
       PersistedIrCache = ImmutableMap.empty,
       PersistedCoercerCache = ImmutableMap.empty,
     )

--- a/hail/hail/test/src/is/hail/TestUtils.scala
+++ b/hail/hail/test/src/is/hail/TestUtils.scala
@@ -6,11 +6,10 @@ import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir.{
-  freshName, streamAggIR, BindingEnv, Env, IR, Interpret, MapIR, MatrixIR, MatrixRead, Name,
-  SingleCodeEmitParamType, Subst,
+  freshName, streamAggIR, BindingEnv, Compile, Env, IR, Interpret, MapIR, MatrixIR, MatrixRead,
+  Name, SingleCodeEmitParamType, Subst,
 }
 import is.hail.expr.ir.Optimize.Flags.Optimize
-import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs.{GetField, GetTupleElement, In, MakeTuple, Ref, ToStream}
 import is.hail.expr.ir.lowering.LowererUnsupportedOperation
 import is.hail.io.vcf.MatrixVCFReader

--- a/hail/hail/test/src/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/hail/test/src/is/hail/annotations/StagedConstructorSuite.scala
@@ -2,10 +2,9 @@ package is.hail.annotations
 
 import is.hail.HailSuite
 import is.hail.asm4s._
-import is.hail.backend.{ExecuteContext, HailTaskContext}
+import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
-import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, IEmitCode, RequirednessSuite}
-import is.hail.io.fs.FS
+import is.hail.expr.ir.{Compiled, EmitCode, EmitFunctionBuilder, IEmitCode, RequirednessSuite}
 import is.hail.scalacheck._
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.concrete.SStringPointer
@@ -487,7 +486,7 @@ class StagedConstructorSuite extends HailSuite with ScalaCheckDrivenPropertyChec
   }
 
   def emitCopy(ctx: ExecuteContext, ptype: PType, deepCopy: Boolean)
-    : (HailClassLoader, FS, HailTaskContext, Region) => AsmFunction2[Region, Long, Long] = {
+    : Compiled[AsmFunction2[Region, Long, Long]] = {
     val fb = EmitFunctionBuilder[Region, Long, Long](ctx, "copy")
     fb.emitWithBuilder { cb =>
       val region = fb.getCodeParam[Region](1)

--- a/hail/hail/test/src/is/hail/backend/ServiceBackendSuite.scala
+++ b/hail/hail/test/src/is/hail/backend/ServiceBackendSuite.scala
@@ -34,7 +34,7 @@ class ServiceBackendSuite extends HailSuite with IdiomaticMockito with OptionVal
           contexts,
           "stage1",
           partitions = Some(FastSeq(0)),
-        )((_, bytes, _, _, _) => bytes)
+        )((_, _, _, _) => (_, bytes) => bytes)
 
       failure.foreach(throw _)
 
@@ -102,7 +102,7 @@ class ServiceBackendSuite extends HailSuite with IdiomaticMockito with OptionVal
           Array.emptyByteArray,
           contexts,
           "stage1",
-        )((_, bytes, _, _, _) => bytes)
+        )((_, _, _, _) => (_, bytes) => bytes)
 
       failure.foreach(throw _)
 
@@ -167,7 +167,7 @@ class ServiceBackendSuite extends HailSuite with IdiomaticMockito with OptionVal
           Array.emptyByteArray,
           contexts,
           "stage1",
-        )((_, bytes, _, _, _) => bytes)
+        )((_, _, _, _) => (_, bytes) => bytes)
 
       val (shortMessage, expanded, id) = handleForPython(expectedCause)
       failure.value shouldBe HailWorkerException(failures.head, shortMessage, expanded, id)
@@ -221,7 +221,7 @@ class ServiceBackendSuite extends HailSuite with IdiomaticMockito with OptionVal
           Array.emptyByteArray,
           contexts,
           "stage1",
-        )((_, bytes, _, _, _) => bytes)
+        )((_, _, _, _) => (_, bytes) => bytes)
 
       failure.value shouldBe a[CancellationException]
       result.map(_._2) shouldBe successes

--- a/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
@@ -6,7 +6,6 @@ import is.hail.asm4s._
 import is.hail.collection.FastSeq
 import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir.agg._
-import is.hail.expr.ir.compile.CompileWithAggregators
 import is.hail.expr.ir.defs._
 import is.hail.io.BufferSpec
 import is.hail.types.VirtualTypeWithReq

--- a/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
@@ -7,7 +7,6 @@ import is.hail.asm4s._
 import is.hail.collection.FastSeq
 import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir.agg.{CollectStateSig, PhysicalAggSig, TypedStateSig}
-import is.hail.expr.ir.compile.Compile
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.expr.ir.streams.{EmitStream, StreamUtils}


### PR DESCRIPTION
This is a mostly non-functional change that introduces the type alias
`Compiled[A] = (HailClassLoader, FS, HailTaskContext, Region) => A`.

Lately I've been looking into our use of `RegionPool`s as our memory
reporting (used by our benchmarks) is broken. We're not consistent with
which `RegionPool` to use as `HailTaskContext` and  `ExecuteContext`
contain their own pools. I see the following pattern in some places:

```scala
val (_, f) = Compile(...) 

ctx.scopedExecution { (hcl, fs, htc, r) =>
  f(hcl, fs, htc, r)(r, ...) // returns Long or Unit
}
```

- This had me thinking, why the duplicated `r` argument?
- `r.pool` != `htc.getRegionPool` so which `RegionPool` is `f` using
internally? (spoiler: not `htc`'s which prints memory usage on close)
- `scopedExecution` is a misnoma - `r` is not scoped to the body;
something we're relying on in `CompileAndEvaluate` where the pointer
is read further up the call stack. Something about that bothers me.

Many of the functions returned by `Compile[WithAggregators]` follow
this pattern where the function is initialised with a region and then
invoked with a region, regardless of if that function returns a pointer.
Furthermore, we don't need regions to read off-heap memory addresses
anymore.

My goal is a somewhat lofty - simplify and strengthen region usage
when calling generated functions and RVDs. The following shouldn't
be too controversial as much of the generated code follows this
already:

- The caller should specify the region that the callee should write
its result to.
- The caller manages the lifetime of regions it creates (where possible).
No more complicated business of callees creating `RegionValue`s and
passing off management to someone else.
- If no region is specified, the callee may not return a pointer.
Callees may not make assumptions about the lifetime of regions or
just use the `ExecuteContext`'s region.
- If the callee needs region(s) for scratch usage, it should get them
from the task context.

My goal is that this alias will help identify patterns where we're
using different regions between initialiser and call, then find out
why they need both a partition region and result region. I also what
to find functions where specifying regions has become almost
perfunctory and simplify.

Failing the above, it's fewer keystrokes.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP