### PR TITLE
[query] ensure theHailClassLoaderForSparkWorkers is only used on spar…

### DIFF
--- a/hail/hail/src/is/hail/asm4s/package.scala
+++ b/hail/hail/src/is/hail/asm4s/package.scala
@@ -1,5 +1,7 @@
 package is.hail
 
+import is.hail.backend.spark.SparkTaskContext
+
 import scala.reflect.ClassTag
 
 import org.objectweb.asm.Opcodes._
@@ -72,9 +74,14 @@ package asm4s {
 }
 
 package object asm4s {
-  lazy val theHailClassLoaderForSparkWorkers =
-    // FIXME: how do I ensure this is only created in Spark workers?
+
+  private[this] lazy val _theHailClassLoaderForSparkWorkers =
     new HailClassLoader(getClass().getClassLoader())
+
+  def theHailClassLoaderForSparkWorkers: HailClassLoader = {
+    val _ = SparkTaskContext.get()
+    _theHailClassLoaderForSparkWorkers
+  }
 
   def genName(tag: String, baseName: String): String = lir.genName(tag, baseName)
 


### PR DESCRIPTION
## Change Description

Modifies the `theHailClassLoaderForSparkWorkers` implementation to ensure it's only created in Spark worker contexts. This replaces the previous implementation which had a FIXME comment about ensuring proper context. The new implementation explicitly checks for a Spark task context before returning the class loader.

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP