### PR TITLE
Codacy config to exclude tests

### DIFF
--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -456,5 +456,3 @@ def test_hail_config_in_environment(submit, tmp_path, client):
 
     for k, v in propagated_config_vars:
         assert configuration_of(k, None, None) == v, str(job_status)
-
-


### PR DESCRIPTION
## Change Description

Codacy flags `assert` even in test code. This config file should make Codacy exclude `test` directories from its scans.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP