### PR TITLE
[services] refresh requirements, fixing check_pip_requirements

### DIFF
--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -66,7 +66,7 @@ frozenlist==1.8.0
     #   -c gear/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   aiosignal
-google-api-core==2.29.0
+google-api-core==2.30.0
     # via google-api-python-client
 google-api-python-client==2.190.0
     # via google-cloud-profiler

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -128,7 +128,7 @@ executing==2.2.1
     #   stack-data
 fastjsonschema==2.21.2
     # via nbformat
-filelock==3.24.2
+filelock==3.24.3
     # via virtualenv
 fonttools==4.61.1
     # via matplotlib
@@ -626,7 +626,7 @@ uv==0.9.30
     # via -r hail/python/dev/requirements.txt
 uv-build==0.9.30
     # via -r hail/python/dev/requirements.txt
-virtualenv==20.37.0
+virtualenv==20.38.0
     # via pre-commit
 watchfiles==1.1.1
     # via aiohttp-devtools

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -16,7 +16,7 @@ attrs==25.4.0
     # via aiohttp
 azure-common==1.1.28
     # via azure-mgmt-storage
-azure-core==1.38.1
+azure-core==1.38.2
     # via
     #   azure-identity
     #   azure-mgmt-core
@@ -30,9 +30,9 @@ azure-mgmt-storage==20.1.0
     # via -r hail/python/hailtop/requirements.txt
 azure-storage-blob==12.28.0
     # via -r hail/python/hailtop/requirements.txt
-boto3==1.42.50
+boto3==1.42.53
     # via -r hail/python/hailtop/requirements.txt
-botocore==1.42.50
+botocore==1.42.53
     # via
     #   -r hail/python/hailtop/requirements.txt
     #   boto3

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -34,7 +34,7 @@ azure-common==1.1.28
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   azure-mgmt-storage
-azure-core==1.38.1
+azure-core==1.38.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
@@ -59,11 +59,11 @@ azure-storage-blob==12.28.0
     #   -r hail/python/hailtop/requirements.txt
 bokeh==3.4.3
     # via -r hail/python/requirements.txt
-boto3==1.42.50
+boto3==1.42.53
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-botocore==1.42.50
+botocore==1.42.53
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -258,7 +258,7 @@ pyyaml==6.0.3
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
     #   bokeh
-regex==2026.1.15
+regex==2026.2.19
     # via parsimonious
 requests==2.32.5
     # via


### PR DESCRIPTION
## Change Description

Address an error in check_pip_requirements. Our requirements got invalided because virtualenv 20.37 got yanked after we pinned to it.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Fixes dependency mismatch

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
