### PR TITLE
Bump ubuntu base to noble-20260210.1

### DIFF
--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_PREFIX={{ global.docker_prefix }}
 ARG SKIP_GCLOUD_PROFILER=false
-FROM $DOCKER_PREFIX/ubuntu:noble-20260113 AS initializer
+FROM $DOCKER_PREFIX/ubuntu:noble-20260210.1 AS initializer
 
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -19,4 +19,4 @@ ubuntu:18.04
 ubuntu:20.04
 ubuntu:22.04
 ubuntu:24.04
-ubuntu:noble-20260113
+ubuntu:noble-20260210.1


### PR DESCRIPTION
## Change Description

Updates our base ubuntu image to 20260210.1

## Security Assessment


- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
 
### Impact Rating

- This change has a low security impact


### Impact Description

Minor base image version update

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
