### PR TITLE
[batch] Fix test_submit during deploy - part 2

### DIFF
--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -169,7 +169,8 @@ def test_image(submit, tmp_path, client):
 
     b = get_batch_from_json_output(res, client)
     j = b.get_job(1)
-    assert j.status()['spec']['process']['image'] == image, str(j.status())
+    # Assert ends with because we might be going via the dockerhubproxy image:
+    assert j.status()['spec']['process']['image'].endswith(image), str(j.status())
 
 
 def test_image_environment_variable(submit, tmp_path, client):


### PR DESCRIPTION
## Change Description

Fixes another instance of our deploy batch failing because of a rewritten docker image

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Low - to - none. Just updates a test expectation.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
