### PR TITLE
[ci] Increase test timeout to work around presumed system contention

### DIFF
--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -60,7 +60,7 @@ class Tests(unittest.TestCase):
     )
 
     @qobtest
-    @test_timeout(4 * 60)
+    @test_timeout(8 * 60)
     def test_linreg_basic(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'), types={'Pheno': hl.tfloat64}, key='Sample')
         covs = hl.import_table(


### PR DESCRIPTION
## Change Description

Addresses the test failing in https://batch.hail.is/batches/8362516/jobs/172 (`test_hail_python_service_backend_gcp_11`)

This test appears to be unusually susceptible to cluster contention because (1) it's relatively heavyweight and (2) it has a relatively short custom timeout (all tests have a global 10m timeout, this one overrides it with 4m). In the batch above, I am suspicious that a previous preempted attempt left just enough existing work in place that the retry was just a little too slow to finish.

(It might be nicer to cancel previous attempts' jobs at the start of preemption retries, but that's a much bigger change. Hopefully this will reduce flakiness in the test suite with minimal upfront effort)

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact


### Impact Description

Just a test change to hopefully reduce flakiness

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
