### PR TITLE
[batch] Improve inactive client UX

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1245,7 +1245,7 @@ python3 -c \'{script}\'""",
         assert status['state'] == 'Success', str((status, b.debug_info()))
     else:
         assert status['state'] == 'Failed', str((status, b.debug_info()))
-        assert 'Unauthorized' in j.log()['main'], (str(j.log()['main']), status)
+        assert 'Not authenticated' in j.log()['main'], (str(j.log()['main']), status)
 
 
 def test_deploy_config_is_mounted_as_readonly(client: BatchClient):

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -17,6 +17,7 @@ from hail.utils import get_env_or_default
 from hail.utils.java import BackendType, Env, choose_backend, warning
 from hail.version import __version__
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration, get_gcs_requester_pays_configuration
+from hailtop.batch_client.aioclient import BatchNotAuthenticatedError
 from hailtop.fs.fs import FS
 from hailtop.hail_event_loop import hail_event_loop
 from hailtop.utils import secret_alnum_string
@@ -592,23 +593,26 @@ async def init_batch(
     from hail.backend.service_backend import ServiceBackend
 
     # FIXME: pass local_tmpdir and use on worker and driver
-    backend = await ServiceBackend.create(
-        billing_project=billing_project,
-        remote_tmpdir=remote_tmpdir,
-        show_progress=show_progress,
-        driver_cores=driver_cores,
-        driver_memory=driver_memory,
-        worker_cores=worker_cores,
-        worker_memory=worker_memory,
-        batch_id=batch_id,
-        name_prefix=name_prefix,
-        credentials_token=token,
-        regions=regions,
-        requester_pays_config=requester_pays_config,
-        gcs_bucket_allow_list=gcs_bucket_allow_list,
-        branching_factor=branching_factor,
-        max_read_parallelism=max_read_parallelism,
-    )
+    try:
+        backend = await ServiceBackend.create(
+            billing_project=billing_project,
+            remote_tmpdir=remote_tmpdir,
+            show_progress=show_progress,
+            driver_cores=driver_cores,
+            driver_memory=driver_memory,
+            worker_cores=worker_cores,
+            worker_memory=worker_memory,
+            batch_id=batch_id,
+            name_prefix=name_prefix,
+            credentials_token=token,
+            regions=regions,
+            requester_pays_config=requester_pays_config,
+            gcs_bucket_allow_list=gcs_bucket_allow_list,
+            branching_factor=branching_factor,
+            max_read_parallelism=max_read_parallelism,
+        )
+    except (BatchNotAuthenticatedError, PermissionError) as e:
+        raise e.with_traceback(None) from None
 
     log = _get_log(log)
     HailContext.create(log, quiet, append, default_reference, global_seed, backend)

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -24,6 +24,7 @@ from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES, hailgenetics_hail_image_for_current_python_version
 from hailtop.batch_client.aioclient import BatchClient as AioBatchClient
+from hailtop.batch_client.aioclient import BatchNotAuthenticatedError
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 from hailtop.config import ConfigVariable, configuration_of, get_deploy_config, get_remote_tmpdir
 from hailtop.utils import async_to_blocking, bounded_gather, parse_docker_image_reference, url_scheme
@@ -538,7 +539,11 @@ class ServiceBackend(Backend[bc.Batch]):
         -------
         A list of the supported cloud regions
         """
-        return async_to_blocking(self._batch_client_sync().supported_regions())
+        try:
+            return async_to_blocking(self._batch_client_sync().supported_regions())
+        except (BatchNotAuthenticatedError, PermissionError) as e:
+            # Reduce stack trace here. Users won't care where this came from. They care they're not authenticated.
+            raise e.with_traceback(None) from None
 
     def default_region(self):
         """
@@ -554,7 +559,11 @@ class ServiceBackend(Backend[bc.Batch]):
         -------
         The default region jobs run in when no regions are specified
         """
-        return async_to_blocking(self._batch_client_sync().default_region())
+        try:
+            return async_to_blocking(self._batch_client_sync().default_region())
+        except (BatchNotAuthenticatedError, PermissionError) as e:
+            # Reduce stack trace here. Users won't care where this came from. They care they're not authenticated.
+            raise e.with_traceback(None) from None
 
     def __init__(
         self,
@@ -622,6 +631,7 @@ class ServiceBackend(Backend[bc.Batch]):
         )
 
         self.__fs = self._requester_pays_fses[None]
+        self.__batch_client: Optional[AioBatchClient] = None
 
         async_to_blocking(self.validate_file(self.remote_tmpdir))
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -631,7 +631,6 @@ class ServiceBackend(Backend[bc.Batch]):
         )
 
         self.__fs = self._requester_pays_fses[None]
-        self.__batch_client: Optional[AioBatchClient] = None
 
         async_to_blocking(self.validate_file(self.remote_tmpdir))
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -575,6 +575,13 @@ class BatchAlreadyCreatedError(Exception):
     pass
 
 
+class BatchNotAuthenticatedError(Exception):
+    def __init__(self):
+        super().__init__(
+            "Not authenticated with Hail Batch.\n\nPlease run:\n\n    hailctl auth login\n\nto obtain credentials. If problems persist, try logging in to the web UI to check account status."
+        )
+
+
 class BatchDebugInfo(TypedDict):
     status: Dict[str, Any]
     jobs: List[JobListEntryV1Alpha]
@@ -1317,21 +1324,27 @@ class BatchClient:
             warnings.warn(f"DEPRECATED: {deprecation_message}")
         return response
 
+    async def _request(self, method: str, path: str, **kwargs) -> aiohttp.ClientResponse:
+        try:
+            resp = await getattr(self._session, method)(self.url + path, headers=self._headers, **kwargs)
+        except httpx.ClientResponseError as err:
+            if err.status == 401:
+                # Replace the generic 401 error with our custom BatchNotAuthenticatedError to give better feedback:
+                raise BatchNotAuthenticatedError() from None
+            raise
+        return await self._warn_if_deprecated(resp)
+
     async def _get(self, path, params=None) -> aiohttp.ClientResponse:
-        return await self._warn_if_deprecated(
-            await self._session.get(self.url + path, params=params, headers=self._headers)
-        )
+        return await self._request('get', path, params=params)
 
     async def _post(self, path, data=None, json=None) -> aiohttp.ClientResponse:
-        return await self._warn_if_deprecated(
-            await self._session.post(self.url + path, data=data, json=json, headers=self._headers)
-        )
+        return await self._request('post', path, data=data, json=json)
 
     async def _patch(self, path) -> aiohttp.ClientResponse:
-        return await self._warn_if_deprecated(await self._session.patch(self.url + path, headers=self._headers))
+        return await self._request('patch', path)
 
     async def _delete(self, path) -> aiohttp.ClientResponse:
-        return await self._warn_if_deprecated(await self._session.delete(self.url + path, headers=self._headers))
+        return await self._request('delete', path)
 
     def reset_billing_project(self, billing_project):
         self.billing_project = billing_project


### PR DESCRIPTION
## Change Description

Wires through the not authenticated message for hailtop.batch users who are unauthenticated or inactive.

Before: See [#Hail Batch support > Hail Batch issue with submission @ 💬](https://hail.zulipchat.com/#narrow/channel/223457-Hail-Batch-support/topic/Hail.20Batch.20issue.20with.20submission/near/575340129)

After: 
```
Traceback (most recent call last):
  File ".../hello.py", line 3, in <module>
    b = hb.Batch('hello test')
        ^^^^^^^^^^^^^^^^^^^^^^
  File ".../hail/python/hailtop/batch/batch.py", line 197, in __init__
    self._backend = ServiceBackend()
                    ^^^^^^^^^^^^^^^^
  File ".../hail/python/hailtop/batch/backend.py", line 645, in __init__
    regions = [ServiceBackend.default_region()]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../hail/python/hailtop/batch/backend.py", line 569, in default_region
    raise e.with_traceback(None) from None
hailtop.batch_client.aioclient.BatchNotAuthenticatedError: Not authenticated with Hail Batch.

Please run:

    hailctl auth login

to obtain credentials. If problems persist, try logging in to the web UI to check account status.
```

Note: It would probably be even better to return the `inactive` state directly via the APIs, so we don't have to say "or try logging in to the web UI", but that's probably a much bigger change

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a low security impact


### Impact Description

Better catching of inactive errors in the client

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
