### PR TITLE
[ci] Remove azure specific FS tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1140,17 +1140,9 @@ steps:
 
       export HAIL_TEST_GCS_BUCKET={{ global.hail_test_gcs_bucket }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
-      export AZURE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
 
       export HAIL_TEST_S3_BUCKET=hail-test-dy5rg
       export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
-
-      export HAIL_TEST_AZURE_ACCOUNT=hailtest
-      export HAIL_TEST_AZURE_CONTAINER=hail-test-4nxei
-      # Required for SAS testing on Azure
-      export HAIL_TEST_AZURE_RESGRP=hail-dev
-      export HAIL_TEST_AZURE_SUBID=22cd45fe-f996-4c51-af67-ef329d977519
-      export AZURE_APPLICATION_CREDENTIALS=/test-azure-key/credentials.json
 
       python3 -m pytest \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
@@ -1177,10 +1169,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-aws-key
-      - name: test-azure-key
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /test-azure-key
     dependsOn:
       - default_ns
       - hailgenetics_hailtop_image

--- a/hail/python/test/hailtop/inter_cloud/conftest.py
+++ b/hail/python/test/hailtop/inter_cloud/conftest.py
@@ -24,11 +24,7 @@ async def router_filesystem() -> AsyncIterator[Tuple[asyncio.Semaphore, AsyncFS,
         s3_bucket = os.environ['HAIL_TEST_S3_BUCKET']
         s3_base = f's3://{s3_bucket}/tmp/{token}/'
 
-        azure_account = os.environ['HAIL_TEST_AZURE_ACCOUNT']
-        azure_container = os.environ['HAIL_TEST_AZURE_CONTAINER']
-        azure_base = f'https://{azure_account}.blob.core.windows.net/{azure_container}/tmp/{token}/'
-
-        bases = {'file': file_base, 'gs': gs_base, 's3': s3_base, 'azure-https': azure_base}
+        bases = {'file': file_base, 'gs': gs_base, 's3': s3_base}
 
         sema = asyncio.Semaphore(50)
         async with sema:
@@ -38,10 +34,8 @@ async def router_filesystem() -> AsyncIterator[Tuple[asyncio.Semaphore, AsyncFS,
                 functools.partial(fs.rmtree, sema, file_base),
                 functools.partial(fs.rmtree, sema, gs_base),
                 functools.partial(fs.rmtree, sema, s3_base),
-                functools.partial(fs.rmtree, sema, azure_base),
             )
 
         assert not await fs.isdir(file_base)
         assert not await fs.isdir(gs_base)
         assert not await fs.isdir(s3_base)
-        assert not await fs.isdir(azure_base)

--- a/hail/python/test/hailtop/inter_cloud/test_copy.py
+++ b/hail/python/test/hailtop/inter_cloud/test_copy.py
@@ -24,7 +24,7 @@ async def test_spec(request):
     return request.param
 
 
-@pytest.fixture(params=['gs', 's3', 'azure-https'])
+@pytest.fixture(params=['gs', 's3'])
 async def cloud_scheme(request):
     yield request.param
 
@@ -34,19 +34,12 @@ async def cloud_scheme(request):
         'file/file',
         'file/gs',
         'file/s3',
-        'file/azure-https',
         'gs/file',
         'gs/gs',
         'gs/s3',
-        'gs/azure-https',
         's3/file',
         's3/gs',
         's3/s3',
-        's3/azure-https',
-        'azure-https/file',
-        'azure-https/gs',
-        'azure-https/s3',
-        'azure-https/azure-https',
     ]
 )
 async def copy_test_context(request, router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]]):

--- a/hail/python/test/hailtop/inter_cloud/test_delete.py
+++ b/hail/python/test/hailtop/inter_cloud/test_delete.py
@@ -9,7 +9,7 @@ from hailtop.aiotools.fs import AsyncFS
 from .utils import fresh_dir
 
 
-@pytest.fixture(params=['file', 'gs', 's3', 'azure-https'])
+@pytest.fixture(params=['file', 'gs', 's3'])
 async def test_delete_one_file(request, router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]]):
     sema, fs, bases = router_filesystem
     scheme = request.param
@@ -22,7 +22,7 @@ async def test_delete_one_file(request, router_filesystem: Tuple[asyncio.Semapho
     assert not await fs.isfile(url)
 
 
-@pytest.fixture(params=['file', 'gs', 's3', 'azure-https'])
+@pytest.fixture(params=['file', 'gs', 's3'])
 async def test_delete_folder(request, router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]]):
     sema, fs, bases = router_filesystem
     scheme = request.param

--- a/hail/python/test/hailtop/inter_cloud/test_diff.py
+++ b/hail/python/test/hailtop/inter_cloud/test_diff.py
@@ -15,19 +15,12 @@ from .utils import fresh_dir
         'file/file',
         'file/gs',
         'file/s3',
-        'file/azure-https',
         'gs/file',
         'gs/gs',
         'gs/s3',
-        'gs/azure-https',
         's3/file',
         's3/gs',
         's3/s3',
-        's3/azure-https',
-        'azure-https/file',
-        'azure-https/gs',
-        'azure-https/s3',
-        'azure-https/azure-https',
     ]
 )
 async def diff_test_context(request, router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]]):


### PR DESCRIPTION
## Change Description

Removes the broken azure FS checks to unblock CI.

Note: Doesn't go the next logical step further and remove the azure FS code itself. That can be discussed as a follow up. This is just removing the tests that are broken, specifically to unblock CI

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

Removes tests for a backend FS which is not enabled in GCP.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
