### PR TITLE
[query] simplify `ControlX` target access patterns

### DIFF
--- a/hail/hail/src/is/hail/lir/CFG.scala
+++ b/hail/hail/src/is/hail/lir/CFG.scala
@@ -9,8 +9,7 @@ object CFG {
     val pred = Array.fill(nBlocks)(mutable.Set[Int]())
     val succ = Array.fill(nBlocks)(mutable.Set[Int]())
 
-    for (b <- blocks) {
-      val i = blocks.index(b)
+    for (i <- blocks.indices) {
 
       def edgeTo(L: Block): Unit = {
         val j = blocks.index(L)
@@ -19,17 +18,9 @@ object CFG {
         pred(j) += i
       }
 
-      b.last match {
-        case x: GotoX => edgeTo(x.L)
-        case x: IfX =>
-          edgeTo(x.Ltrue)
-          edgeTo(x.Lfalse)
-        case x: SwitchX =>
-          edgeTo(x.Ldefault)
-          x.Lcases.foreach(edgeTo)
-        case _: ReturnX =>
-        case _: ThrowX =>
-      }
+      val x = blocks(i).last.asInstanceOf[ControlX]
+      for (i <- x.targetIndices)
+        edgeTo(x.target(i))
     }
 
     new CFG(blocks.index(m.entry), pred, succ)

--- a/hail/hail/src/is/hail/lir/SimplifyControl.scala
+++ b/hail/hail/src/is/hail/lir/SimplifyControl.scala
@@ -23,8 +23,7 @@ class SimplifyControl(m: Method) {
     val last = L.last.asInstanceOf[ControlX]
 
     if (L.uses.isEmpty && (L ne m.entry)) {
-      var i = 0
-      while (i < last.targetArity()) {
+      for (i <- last.targetIndices) {
         val M = last.target(i)
         last.setTarget(i, null)
 
@@ -34,14 +33,12 @@ class SimplifyControl(m: Method) {
           q += u.parent
         }
 
-        i += 1
       }
 
       return
     }
 
-    var i = 0
-    while (i < last.targetArity()) {
+    for (i <- last.targetIndices) {
       val M = last.target(i)
       val newM = finalTarget(M)
       if (M ne newM) {
@@ -54,7 +51,6 @@ class SimplifyControl(m: Method) {
         }
         q += L
       }
-      i += 1
     }
 
     last match {
@@ -129,11 +125,8 @@ class SimplifyControl(m: Method) {
 
     for (b <- blocks) {
       val last = b.last.asInstanceOf[ControlX]
-      var i = 0
-      while (i < last.targetArity()) {
+      for (i <- last.targetIndices)
         last.setTarget(i, rootFinalTarget(u.find(blocks.index(last.target(i)))))
-        i += 1
-      }
     }
 
     m.setEntry(finalTarget(m.entry))

--- a/hail/hail/src/is/hail/lir/SplitMethod.scala
+++ b/hail/hail/src/is/hail/lir/SplitMethod.scala
@@ -207,8 +207,7 @@ class SplitMethod(
       b.last match {
         case x: SwitchX =>
           var Lunreachable: Block = null
-          var i = 0
-          while (i < x.targetArity()) {
+          for (i <- x.targetIndices) {
             if (x.target(i) == null) {
               if (Lunreachable == null) {
                 Lunreachable = new Block()
@@ -217,7 +216,6 @@ class SplitMethod(
               }
               x.setTarget(i, Lunreachable)
             }
-            i += 1
           }
         case _ =>
       }
@@ -434,15 +432,13 @@ class SplitMethod(
         Lreturn.method = splitM
         Lreturn.append(returnx(load(lidx)))
         val newSwitch = switch(splitMReturnValue, x.Ldefault, x.Lcases)
-        var i = 0
-        while (i < x.targetArity()) {
+        for (i <- x.targetIndices) {
           val L = x.target(i)
           if (regionBlocks(L))
             // null is replaced with throw new SplitUnreachable
             newSwitch.setTarget(i, null)
           else
             x.setTarget(i, Lreturn)
-          i += 1
         }
         newL.append(newSwitch)
       case _: ReturnX =>


### PR DESCRIPTION
While poking around `lir` I noticed a few simplifications and/or
changes that improve readability. There are no functional changes
within.

This change does not affect the broad-managed batch service in gcp. 