### PR TITLE
[compiler] add `HailClassLoader` to `ContextRDD` Element Type

### DIFF
--- a/hail/hail/src/is/hail/asm4s/package.scala
+++ b/hail/hail/src/is/hail/asm4s/package.scala
@@ -72,10 +72,6 @@ package asm4s {
 }
 
 package object asm4s {
-  lazy val theHailClassLoaderForSparkWorkers =
-    // FIXME: how do I ensure this is only created in Spark workers?
-    new HailClassLoader(getClass().getClassLoader())
-
   def genName(tag: String, baseName: String): String = lir.genName(tag, baseName)
 
   def typeInfo[T](implicit tti: TypeInfo[T]): TypeInfo[T] = tti

--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -1,7 +1,6 @@
 package is.hail.backend.spark
 
 import is.hail.annotations._
-import is.hail.asm4s._
 import is.hail.backend._
 import is.hail.backend.Backend.PartitionFn
 import is.hail.collection.compat.immutable.ArraySeq
@@ -270,7 +269,7 @@ class SparkBackend(val spark: SparkSession) extends Backend with Logging {
               : Iterator[Array[Byte]] = {
               val htc = SparkTaskContext.get()
               htc.getRegionPool().scopedRegion { r =>
-                val g = f(theHailClassLoaderForSparkWorkers, new HadoopFS(fsConfig), htc, r)
+                val g = f(unsafeHailClassLoaderForSparkWorkers, new HadoopFS(fsConfig), htc, r)
                 Iterator.single(g(globals, partition.asInstanceOf[RDDPartition].data))
               }
             }

--- a/hail/hail/src/is/hail/backend/spark/package.scala
+++ b/hail/hail/src/is/hail/backend/spark/package.scala
@@ -1,0 +1,9 @@
+package is.hail.backend
+
+import is.hail.asm4s.HailClassLoader
+
+package object spark {
+  // FIXME: how do I ensure this is only created in Spark workers?
+  lazy val unsafeHailClassLoaderForSparkWorkers: HailClassLoader =
+    new HailClassLoader(getClass.getClassLoader)
+}

--- a/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
@@ -286,7 +286,7 @@ case class MatrixValue(
     val fieldIdx = entryType.fieldIdx(entryField)
     val numColsLocal = nCols
 
-    val rows = rvd.mapPartitionsWithIndex { (pi, _, it) =>
+    val rows = rvd.mapPartitionsWithIndex { (pi, _, _, it) =>
       var i = partStartsBc.value(pi)
       it.map { ptr =>
         val data = new Array[Double](numColsLocal)

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -671,9 +671,10 @@ case class PartitionRVDReader(rvd: RVD, uidFieldName: String) extends PartitionR
           cb.assign(curIdx, 0L)
           cb.assign(
             iterator,
-            broadcastRVD.invoke[Int, Region, Region, Iterator[Long]](
+            broadcastRVD.invoke[Int, HailClassLoader, Region, Region, Iterator[Long]](
               "computePartition",
               partIdx.asInt.value,
+              cb.emb.getHailClassLoader,
               region,
               partitionRegion,
             ),

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.{Region, RegionPool, RegionValue}
 import is.hail.asm4s._
 import is.hail.backend.{ExecuteContext, HailTaskContext}
-import is.hail.backend.spark.SparkTaskContext
+import is.hail.backend.spark.{unsafeHailClassLoaderForSparkWorkers, SparkTaskContext}
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.compat.mutable.Growable
@@ -274,7 +274,7 @@ class AggSignatures(val sigs: IndexedSeq[PhysicalAggSig]) {
     : (Array[Byte], Array[Byte]) => Array[Byte] = {
     combOpFSerializedFromRegionPool(ctx, spec) { () =>
       val htc = SparkTaskContext.get()
-      val hcl = theHailClassLoaderForSparkWorkers
+      val hcl = unsafeHailClassLoaderForSparkWorkers
       if (htc == null) {
         throw new UnsupportedOperationException(
           s"Can't get htc. On worker = ${TaskContext.get() != null}"

--- a/hail/hail/src/is/hail/io/CodecSpec.scala
+++ b/hail/hail/src/is/hail/io/CodecSpec.scala
@@ -1,7 +1,7 @@
 package is.hail.io
 
 import is.hail.annotations.{Region, RegionValue}
-import is.hail.asm4s.{theHailClassLoaderForSparkWorkers, Code, HailClassLoader}
+import is.hail.asm4s.{Code, HailClassLoader}
 import is.hail.backend.ExecuteContext
 import is.hail.sparkextras.ContextRDD
 import is.hail.types.encoded.EType
@@ -72,8 +72,8 @@ trait AbstractTypedCodecSpec extends Spec {
     val (pt, dec) = buildDecoder(ctx, requestedType)
     (
       pt,
-      ContextRDD.weaken(bytes).cmapPartitions { (ctx, it) =>
-        RegionValue.fromBytes(theHailClassLoaderForSparkWorkers, dec, ctx.region, it)
+      ContextRDD.weaken(bytes).cmapPartitions { (hcl, ctx, it) =>
+        RegionValue.fromBytes(hcl, dec, ctx.region, it)
       },
     )
   }

--- a/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
@@ -1511,7 +1511,7 @@ object LoadVCF extends Logging {
     skipInvalidLoci: Boolean,
   ): ContextRDD[Long] = {
     val hasRSID = rowPType.hasField("rsid")
-    lines.cmapPartitions { (ctx, it) =>
+    lines.cmapPartitions { (_, ctx, it) =>
       new Iterator[Long] {
         val rvb = ctx.rvb
         var ptr: Long = 0

--- a/hail/hail/src/is/hail/methods/IBD.scala
+++ b/hail/hail/src/is/hail/methods/IBD.scala
@@ -248,7 +248,7 @@ object IBD {
     val sm = ctx.stateManager
 
     val rowPType = input.rvRowPType
-    val unnormalizedIbse = input.rvd.mapPartitions { (ctx, it) =>
+    val unnormalizedIbse = input.rvd.mapPartitions { (_, ctx, it) =>
       val rv = RegionValue(ctx.r)
       val view = HardCallView(rowPType)
       it.map { ptr =>
@@ -260,7 +260,7 @@ object IBD {
 
     val ibse = unnormalizedIbse.normalized
 
-    val chunkedGenotypeMatrix = input.rvd.mapPartitions { (_, it) =>
+    val chunkedGenotypeMatrix = input.rvd.mapPartitions { (_, _, it) =>
       val view = HardCallView(rowPType)
       it.map { ptr =>
         view.set(ptr)
@@ -310,7 +310,7 @@ object IBD {
       })
 
     joined
-      .cmapPartitions { (ctx, it) =>
+      .cmapPartitions { (_, ctx, it) =>
         val rvb = new RegionValueBuilder(sm, ctx.region)
         for {
           ((iChunk, jChunk), ibses) <- it

--- a/hail/hail/src/is/hail/methods/LinearRegression.scala
+++ b/hail/hail/src/is/hail/methods/LinearRegression.scala
@@ -94,7 +94,7 @@ case class LinearRegressionRowsSingle(
     val sm = ctx.stateManager
     val newRVD = mv.rvd.mapPartitionsWithContext(
       rvdType
-    ) { (consumerCtx, it) =>
+    ) { (hcl, consumerCtx, it) =>
       val producerCtx = consumerCtx.freshContext()
       val rvb = new RegionValueBuilder(sm)
 
@@ -108,7 +108,7 @@ case class LinearRegressionRowsSingle(
         i += 1
       }
 
-      it(producerCtx).trueGroupedIterator(rowBlockSize)
+      it(hcl, producerCtx).trueGroupedIterator(rowBlockSize)
         .flatMap { git =>
           var i = 0
           while (git.hasNext) {
@@ -273,7 +273,7 @@ case class LinearRegressionRowsChained(
     val sm = ctx.stateManager
     val newRVD = mv.rvd.mapPartitionsWithContext(
       rvdType
-    ) { (consumerCtx, it) =>
+    ) { (hcl, consumerCtx, it) =>
       val producerCtx = consumerCtx.freshContext()
       val rvb = new RegionValueBuilder(sm)
 
@@ -288,7 +288,7 @@ case class LinearRegressionRowsChained(
         i += 1
       }
 
-      it(producerCtx).trueGroupedIterator(rowBlockSize)
+      it(hcl, producerCtx).trueGroupedIterator(rowBlockSize)
         .flatMap { git =>
           var i = 0
           while (git.hasNext) {

--- a/hail/hail/src/is/hail/methods/LogisticRegression.scala
+++ b/hail/hail/src/is/hail/methods/LogisticRegression.scala
@@ -112,7 +112,7 @@ case class LogisticRegression(
 
     val copiedFieldIndices = (mv.typ.rowKey ++ passThrough).map(mv.rvRowType.fieldIdx(_)).toArray
 
-    val newRVD = mv.rvd.mapPartitions(newRVDType) { (ctx, it) =>
+    val newRVD = mv.rvd.mapPartitions(newRVDType) { (_, ctx, it) =>
       val rvb = ctx.rvb
 
       val missingCompleteCols = new IntArrayBuilder()

--- a/hail/hail/src/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/hail/src/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -77,7 +77,7 @@ case class MatrixExportEntriesByCol(
 
       val fsBc = ctx.fsBc
       val localTempDir = ctx.localTmpdir
-      val partFolders = mv.rvd.crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
+      val partFolders = mv.rvd.crdd.cmapPartitionsWithIndex { (i, _, ctx, it) =>
         val partFolder = partFileBase + partFile(d, i, TaskContext.get())
 
         val filePaths = Array.tabulate(endIdx - startIdx) { j =>

--- a/hail/hail/src/is/hail/methods/Nirvana.scala
+++ b/hail/hail/src/is/hail/methods/Nirvana.scala
@@ -417,7 +417,7 @@ object Nirvana extends Logging {
     val prev = tv.rvd
 
     val annotations = prev
-      .mapPartitions { (_, it) =>
+      .mapPartitions { (_, _, it) =>
         val pb = new ProcessBuilder(cmd.asJava)
         val env = pb.environment()
         if (path.orNull != null)
@@ -470,7 +470,7 @@ object Nirvana extends Logging {
     val nirvanaRVD: RVD = RVD(
       nirvanaRVDType,
       prev.partitioner,
-      ContextRDD.weaken(annotations).cmapPartitions { (rvdContext, it) =>
+      ContextRDD.weaken(annotations).cmapPartitions { (_, rvdContext, it) =>
         val rvb = new RegionValueBuilder(ctx.stateManager, rvdContext.region)
 
         it.map { case (v, nirvana) =>

--- a/hail/hail/src/is/hail/methods/PCA.scala
+++ b/hail/hail/src/is/hail/methods/PCA.scala
@@ -69,7 +69,7 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean)
     val localRowKeySignature = mv.typ.rowKeyStruct.types
 
     val crdd: ContextRDD[Long] = if (computeLoadings) {
-      ContextRDD.weaken(svd.U.rows).cmapPartitions { (ctx, it) =>
+      ContextRDD.weaken(svd.U.rows).cmapPartitions { (_, ctx, it) =>
         val rvb = ctx.rvb
         it.map { ir =>
           rvb.start(rowType)

--- a/hail/hail/src/is/hail/methods/PoissonRegression.scala
+++ b/hail/hail/src/is/hail/methods/PoissonRegression.scala
@@ -90,7 +90,7 @@ case class PoissonRegression(
 
     val copiedFieldIndices = (mv.typ.rowKey ++ passThrough).map(mv.rvRowType.fieldIdx(_)).toArray
 
-    val newRVD = mv.rvd.mapPartitions(newRVDType) { (ctx, it) =>
+    val newRVD = mv.rvd.mapPartitions(newRVDType) { (_, ctx, it) =>
       val rvb = ctx.rvb
 
       val missingCompleteCols = new IntArrayBuilder()

--- a/hail/hail/src/is/hail/methods/Skat.scala
+++ b/hail/hail/src/is/hail/methods/Skat.scala
@@ -352,7 +352,7 @@ case class Skat(
     /* I believe no `boundary` is needed here because `mapPartitions` calls `run` which calls
      * `cleanupRegions`. */
     (
-      mv.rvd.mapPartitions { (ctx, it) =>
+      mv.rvd.mapPartitions { (_, ctx, it) =>
         it.flatMap { ptr =>
           val keyIsDefined = fullRowType.isFieldDefined(ptr, keyIndex)
           val weightIsDefined = fullRowType.isFieldDefined(ptr, weightIndex)

--- a/hail/hail/src/is/hail/methods/VEP.scala
+++ b/hail/hail/src/is/hail/methods/VEP.scala
@@ -88,7 +88,7 @@ class VEP(private val params: VEPParameters, conf: VEPConfiguration)
 
     val csqPattern = "CSQ=[^;^\\t]+".r
     val annotations =
-      inRvd.mapPartitionsWithIndex { (partIdx, _, it) =>
+      inRvd.mapPartitionsWithIndex { (_, partIdx, _, it) =>
         val pb = new ProcessBuilder(cmd.toList.asJava)
         val env = pb.environment()
         for { (k, v) <- conf.env } env.put(k, v)
@@ -211,7 +211,7 @@ class VEP(private val params: VEPParameters, conf: VEPConfiguration)
       RVD(
         inRvd.typ.copy(rowType = vepRowType),
         inRvd.partitioner,
-        ContextRDD.weaken(annotations).cmapPartitions { (ctx, it) =>
+        ContextRDD.weaken(annotations).cmapPartitions { (_, ctx, it) =>
           val rvb = ctx.rvb
 
           it.map { case (v, vep, proc) =>

--- a/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
@@ -87,6 +87,7 @@ object AbstractRVDSpec {
       using(fs.create(partsPath + "/" + filePath)) { os =>
         using(RVDContext.default(execCtx.r.pool)) { ctx =>
           RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(execCtx, rowType))(
+            execCtx.theHailClassLoader,
             ctx,
             rows.iterator.map { a =>
               rowType.unstagedStoreJavaObject(execCtx.stateManager, a, ctx.r)

--- a/hail/hail/src/is/hail/rvd/KeyedRVD.scala
+++ b/hail/hail/src/is/hail/rvd/KeyedRVD.scala
@@ -83,7 +83,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
       joinedType.copy(key = joinedType.key.take(realType.key.length)),
       right.rvd,
       key,
-    ) { (ctx, leftIt, rightIt) =>
+    ) { (_, ctx, leftIt, rightIt) =>
       val sideBuffer = ctx.freshRegion()
       joiner(
         ctx,
@@ -116,7 +116,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
 
         (
           newTyp,
-          (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
+          (_, ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
             f(
               ctx,
               OrderedRVIterator(lTyp, it, ctx, sm)
@@ -143,7 +143,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
 
         (
           newTyp,
-          (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
+          (_, ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
             f(
               ctx,
               OrderedRVIterator(lTyp, it, ctx, sm)
@@ -167,7 +167,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
       joinedType,
       right.rvd,
       key,
-    ) { (ctx, leftIt, rightIt) =>
+    ) { (_, ctx, leftIt, rightIt) =>
       joiner(
         ctx,
         OrderedRVIterator(lTyp, leftIt, ctx, sm).leftJoinDistinct(OrderedRVIterator(
@@ -209,7 +209,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
       this.virtType,
       right.rvd,
       key,
-    ) { (ctx, leftIt, rightIt) =>
+    ) { (_, ctx, leftIt, rightIt) =>
       OrderedRVIterator(lType, leftIt, ctx, sm)
         .merge(OrderedRVIterator(rType, rightIt, ctx, sm))
     }

--- a/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDDRow.scala
+++ b/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDDRow.scala
@@ -7,5 +7,5 @@ import org.apache.spark.sql.Row
 
 class RichContextRDDRow(crdd: ContextRDD[Row]) {
   def toRegionValues(rowType: PStruct): ContextRDD[Long] =
-    crdd.cmapPartitions((ctx, it) => it.copyToRegion(ctx.region, rowType))
+    crdd.cmapPartitions((_, ctx, it) => it.copyToRegion(ctx.region, rowType))
 }

--- a/hail/hail/src/is/hail/sparkextras/implicits/RichRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/implicits/RichRDD.scala
@@ -226,14 +226,14 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     path: String,
     stageLocally: Boolean,
     write: (Iterator[T], OutputStream) => (Long, Long),
-  )(implicit tct: ClassTag[T]
-  ): (Array[FileWriteMetadata]) =
+  )(implicit T: ClassTag[T]
+  ): Array[FileWriteMetadata] =
     ContextRDD.weaken(r).writePartitions(
       ctx,
       path,
       null,
       stageLocally,
-      (_, _) => null,
-      (_, it, os, _) => write(it, os),
+      (_, _, _) => null,
+      (_, _, it, os, _) => write(it, os),
     )
 }


### PR DESCRIPTION
Mostly non-functional change that modifies the alias `ContextRDD.ElementType[A]` from

```scala
RVDContext => Iterator[A]
```

to

```scala
(HailClassLoader, RVDContext) => Iterator[A]
```

By doing so, we eliminate many of the uses of `theHailClassLoaderForSparkWorkers`, some of which were in error.

This change does not affect the broad-managed batch service in GCP.