### PR TITLE
[batch] Address localizer performance on smaller files

### DIFF
--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -318,7 +318,8 @@ class SourceCopier:
         success = False
         try:
             try:
-                await self.router_fs.copy_to(srcfile, destfile)
+                size = await srcstat.size()
+                await self.router_fs.copy_to(srcfile, destfile, size=size)
             except NotImplementedError:
                 await self._copy_file_multi_part_main(
                     sema, source_report, srcfile, srcstat, destfile, return_exceptions

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -303,7 +303,7 @@ class AsyncFS(abc.ABC):
     async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         pass
 
-    async def copy_to(self, url: str, dest: str):
+    async def copy_to(self, url: str, dest: str, *, size: Optional[int] = None):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -114,9 +114,9 @@ class RouterAsyncFS(AsyncFS):
         fs = await self._get_fs(url)
         return await fs.open_from(url, start, length=length)
 
-    async def copy_to(self, url: str, dest: str):
+    async def copy_to(self, url: str, dest: str, *, size: Optional[int] = None):
         fs = await self._get_fs(url)
-        return await fs.copy_to(url, dest)
+        return await fs.copy_to(url, dest, size=size)
 
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         fs = await self._get_fs(url)


### PR DESCRIPTION
## Change Description

Updates the localizer to (hopefully) address a regression when we switched to the transfer manager. 

- [ ] Validate this fixes the issues
- [ ] Maybe we can add a test case to prevent future regressions?


Per Claude:

> PR [#15273](https://github.com/hail-is/hail/issues/15273) — Performance Regression Analysis
> 
> The PR replaces the custom chunked copier for GCS-to-local downloads with google-cloud-storage's transfer_manager.download_chunks_concurrently. This works great for large files (the intended fix) but causes severe regressions for small files.
> 
> Observed symptoms
> 
> - 6 files, 6MB total: 2s → 4 minutes
> - Jobs allocated 1GB memory OOM during localization (previously used ~100MB)
> - Large files in manual tests: noticeably faster ✓
> 
> Root cause: thread pool explosion
> 
> download_chunks_concurrently creates a ThreadPoolExecutor(max_workers=32) internally, regardless of file size. For a 1MB file with a 128MB chunk size, the file fits in one chunk — but 32 threads are
> still spawned. With 6 files downloading concurrently, that's 192 threads. Linux default thread stack size is 8MB, so stacks alone consume ~1.5GB, explaining the observed 2.5GB peak vs. ~100MB previously.
> The 4-minute runtime comes from thread creation overhead and scheduler thrashing across 192 threads competing over trivial I/O.
> 
> Secondary bug: filename=dest with file:// prefix
> 
> download_to_file correctly strips the file:// scheme into local_dest for os.makedirs, but then passes the raw dest (e.g. file:///tmp/foo) as filename to transfer_manager, which interprets it as a literal
> local path.
> 
> Recommendation
> 
> Both transfer_manager.download_chunks_concurrently and blob.download_to_filename() are from google-cloud-storage — the fix is just using the right one per file size:
> 
> ```python
> MULTIPART_THRESHOLD = 128 * 1024 * 1024  # one chunk
> 
>   os.makedirs(os.path.dirname(local_dest), exist_ok=True)
> 
>   if blob.size < MULTIPART_THRESHOLD:
>       # Single streaming download — 1 thread, minimal overhead
>       await asyncio.to_thread(blob.download_to_filename, local_dest,
>                               timeout=self._timeout)
>   else:
>       # Parallel chunked download — worthwhile for large files
>       await asyncio.to_thread(
>           transfer_manager.download_chunks_concurrently,
>           blob=blob,
>           filename=local_dest,   # fix: was passing raw dest with file:// prefix
>           chunk_size=MULTIPART_THRESHOLD,
>           download_kwargs={'timeout': self._timeout},
>           max_workers=32,
>       )
> ```
> 
> This preserves the large-file speedup that motivated the PR while restoring original behaviour for small files, and fixes the file:// bug in the same pass. blob.size is available after the bucket.blob() call with a reload(), or can be obtained from the stat that the copier already fetched.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Adds a "return to the status quo ante" clause in GCS file localizer logic, so that small file downloads don't explode the thread pool

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
