### PR TITLE
Revert "[batch] Use gcloud storage to download input files from GCP (#15273)"

### DIFF
--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -16,7 +16,7 @@ aiohttp==3.13.3
     #   -c batch/../hail/python/pinned-requirements.txt
     #   -c batch/../web_common/pinned-requirements.txt
     #   aiodocker
-aiorwlock==1.5.1
+aiorwlock==1.5.0
     # via -r batch/requirements.txt
 aiosignal==1.4.0
     # via

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -67,10 +67,7 @@ frozenlist==1.8.0
     #   aiohttp
     #   aiosignal
 google-api-core==2.30.0
-    # via
-    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
-    #   -c gear/../hail/python/pinned-requirements.txt
-    #   google-api-python-client
+    # via google-api-python-client
 google-api-python-client==2.190.0
     # via google-cloud-profiler
 google-auth==2.48.0
@@ -88,10 +85,7 @@ google-auth-httplib2==0.3.0
 google-cloud-profiler==4.1.0
     # via -r gear/requirements.txt
 googleapis-common-protos==1.72.0
-    # via
-    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
-    #   -c gear/../hail/python/pinned-requirements.txt
-    #   google-api-core
+    # via google-api-core
 httplib2==0.31.2
     # via
     #   google-api-python-client
@@ -132,14 +126,9 @@ propcache==0.4.1
     #   aiohttp
     #   yarl
 proto-plus==1.27.1
-    # via
-    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
-    #   -c gear/../hail/python/pinned-requirements.txt
-    #   google-api-core
+    # via google-api-core
 protobuf==6.33.5
     # via
-    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
-    #   -c gear/../hail/python/pinned-requirements.txt
     #   google-api-core
     #   google-cloud-profiler
     #   googleapis-common-protos

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -317,12 +317,7 @@ class SourceCopier:
     ) -> None:
         success = False
         try:
-            try:
-                await self.router_fs.copy_to(srcfile, destfile)
-            except NotImplementedError:
-                await self._copy_file_multi_part_main(
-                    sema, source_report, srcfile, srcstat, destfile, return_exceptions
-                )
+            await self._copy_file_multi_part_main(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
             success = True
         except Exception as e:
             if return_exceptions:

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -303,9 +303,6 @@ class AsyncFS(abc.ABC):
     async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         pass
 
-    async def copy_to(self, url: str, dest: str):
-        raise NotImplementedError
-
     @abc.abstractmethod
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         pass

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -114,10 +114,6 @@ class RouterAsyncFS(AsyncFS):
         fs = await self._get_fs(url)
         return await fs.open_from(url, start, length=length)
 
-    async def copy_to(self, url: str, dest: str):
-        fs = await self._get_fs(url)
-        return await fs.copy_to(url, dest)
-
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         fs = await self._get_fs(url)
         return await fs.create(url, retry_writes=retry_writes)

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -65,31 +65,12 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-api-core==2.30.0
-    # via
-    #   google-cloud-core
-    #   google-cloud-storage
 google-auth==2.48.0
     # via
     #   -r hail/python/hailtop/requirements.txt
-    #   google-api-core
     #   google-auth-oauthlib
-    #   google-cloud-core
-    #   google-cloud-storage
 google-auth-oauthlib==0.8.0
     # via -r hail/python/hailtop/requirements.txt
-google-cloud-core==2.5.0
-    # via google-cloud-storage
-google-cloud-storage==3.9.0
-    # via -r hail/python/hailtop/requirements.txt
-google-crc32c==1.8.0
-    # via
-    #   google-cloud-storage
-    #   google-resumable-media
-google-resumable-media==2.8.0
-    # via google-cloud-storage
-googleapis-common-protos==1.72.0
-    # via google-api-core
 humanize==4.15.0
     # via -r hail/python/hailtop/requirements.txt
 idna==3.11
@@ -130,13 +111,6 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-proto-plus==1.27.1
-    # via google-api-core
-protobuf==6.33.5
-    # via
-    #   google-api-core
-    #   googleapis-common-protos
-    #   proto-plus
 pyasn1==0.6.2
     # via
     #   pyasn1-modules
@@ -160,8 +134,6 @@ pyyaml==6.0.3
 requests==2.32.5
     # via
     #   azure-core
-    #   google-api-core
-    #   google-cloud-storage
     #   msal
     #   msrest
     #   requests-oauthlib

--- a/hail/python/hailtop/requirements.txt
+++ b/hail/python/hailtop/requirements.txt
@@ -9,7 +9,6 @@ dill>=0.4.0,<0.5
 frozenlist>=1.3.1,<2
 google-auth>=2.14.1,<3
 google-auth-oauthlib>=0.5.2,<1
-google-cloud-storage>=3.8.0
 humanize>=4.0,<5
 janus>=0.6,<1.1
 nest_asyncio>=1.5.8,<2

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -115,44 +115,15 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-api-core==2.30.0
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-cloud-core
-    #   google-cloud-storage
 google-auth==2.48.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-    #   google-api-core
     #   google-auth-oauthlib
-    #   google-cloud-core
-    #   google-cloud-storage
 google-auth-oauthlib==0.8.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-google-cloud-core==2.5.0
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-cloud-storage
-google-cloud-storage==3.9.0
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   -r hail/python/hailtop/requirements.txt
-google-crc32c==1.8.0
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-cloud-storage
-    #   google-resumable-media
-google-resumable-media==2.8.0
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-cloud-storage
-googleapis-common-protos==1.72.0
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-api-core
 humanize==4.15.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
@@ -240,16 +211,6 @@ propcache==0.4.1
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   aiohttp
     #   yarl
-proto-plus==1.27.1
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-api-core
-protobuf==6.33.5
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-api-core
-    #   googleapis-common-protos
-    #   proto-plus
 py4j==0.10.9.7
     # via pyspark
 pyasn1==0.6.2
@@ -304,8 +265,6 @@ requests==2.32.5
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/requirements.txt
     #   azure-core
-    #   google-api-core
-    #   google-cloud-storage
     #   msal
     #   msrest
     #   requests-oauthlib


### PR DESCRIPTION
## Change Description

Rollback localizer changes in #15273 while we diagnose and verify a fix for smaller files / smaller VMs (potentially #15309?)

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Rollback to status quo as of yesterday afternoon

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
