### PR TITLE
[compiler] lower TableKeyByAndAggregate before LowerAndExecuteShuffles

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/DistinctlyKeyed.scala
+++ b/hail/hail/src/is/hail/expr/ir/DistinctlyKeyed.scala
@@ -8,7 +8,7 @@ object DistinctlyKeyed {
       case t: TableRead =>
         memo.bindIf(t.isDistinctlyKeyed, t, ())
 
-      case t @ TableKeyBy(child, keys, _) =>
+      case t @ TableKeyBy(child, keys, _, _) =>
         memo.bindIf(child.typ.key.forall(keys.contains) && memo.contains(child), t, ())
 
       case t @ (_: TableFilter

--- a/hail/hail/src/is/hail/expr/ir/Parser.scala
+++ b/hail/hail/src/is/hail/expr/ir/Parser.scala
@@ -1536,7 +1536,8 @@ object IRParser {
       case "TableKeyBy" =>
         val keys = identifiers(it)
         val isSorted = boolean_literal(it)
-        table_ir(ctx)(it).map(child => TableKeyBy(child, keys, isSorted))
+        val nPartitions = opt(it, int32_literal)
+        table_ir(ctx)(it).map(child => TableKeyBy(child, keys, isSorted, nPartitions))
       case "TableDistinct" => table_ir(ctx)(it).map(TableDistinct)
       case "TableFilter" =>
         for {

--- a/hail/hail/src/is/hail/expr/ir/Pretty.scala
+++ b/hail/hail/src/is/hail/expr/ir/Pretty.scala
@@ -533,8 +533,12 @@ class Pretty(
       single(
         s""""${StringEscapeUtils.escapeString(Serialization.write(writer)(WrappedMatrixNativeMultiWriter.formats))}""""
       )
-    case TableKeyBy(_, keys, isSorted) =>
-      FastSeq(prettyIdentifiers(keys), Pretty.prettyBooleanLiteral(isSorted))
+    case TableKeyBy(_, keys, isSorted, nPartitions) =>
+      FastSeq(
+        prettyIdentifiers(keys),
+        Pretty.prettyBooleanLiteral(isSorted),
+        prettyIntOpt(nPartitions),
+      )
     case TableRange(n, nPartitions) => FastSeq(n.toString, nPartitions.toString)
     case TableRepartition(_, n, strategy) => FastSeq(n.toString, strategy.toString)
     case TableHead(_, n) => single(n.toString)

--- a/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
@@ -533,7 +533,7 @@ object PruneDeadFields extends Logging {
       case TableFilter(child, pred) =>
         val irDep = memoizeAndGetDep(ctx, tir, 1, pred.typ, memo)
         memoizeTableIR(ctx, child, unify(child.typ, requestedType, irDep), memo)
-      case TableKeyBy(child, _, isSorted) =>
+      case TableKeyBy(child, _, isSorted, _) =>
         val reqKey = requestedType.key
         val isPrefix = reqKey.zip(child.typ.key).forall { case (l, r) => l == r }
         val childReqKey = if (isSorted)
@@ -1837,7 +1837,7 @@ object PruneDeadFields extends Logging {
       case TableMapGlobals(child, newGlobals) =>
         val child2 = rebuild(ctx, child, memo)
         TableMapGlobals(child2, rebuildIR(ctx, newGlobals, BindingEnv(child2.typ.globalEnv), memo))
-      case TableKeyBy(child, _, isSorted) =>
+      case TableKeyBy(child, _, isSorted, nPartitions) =>
         var child2 = rebuild(ctx, child, memo)
         val keys2 = requestedType.key
         // fully upcast before shuffle
@@ -1848,7 +1848,7 @@ object PruneDeadFields extends Logging {
             memo.requestedType.lookup(child).asInstanceOf[TableType],
             upcastGlobals = false,
           )
-        TableKeyBy(child2, keys2, isSorted)
+        TableKeyBy(child2, keys2, isSorted, nPartitions)
       case TableOrderBy(child, sortFields) =>
         val child2 =
           if (

--- a/hail/hail/src/is/hail/expr/ir/Requiredness.scala
+++ b/hail/hail/src/is/hail/expr/ir/Requiredness.scala
@@ -391,7 +391,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case TableRange(_, _) =>
 
       // pass through TableIR child
-      case TableKeyBy(child, _, _) => requiredness.unionFrom(lookup(child))
+      case TableKeyBy(child, _, _, _) => requiredness.unionFrom(lookup(child))
       case TableFilter(child, _) => requiredness.unionFrom(lookup(child))
       case TableHead(child, _) => requiredness.unionFrom(lookup(child))
       case TableTail(child, _) => requiredness.unionFrom(lookup(child))

--- a/hail/hail/src/is/hail/expr/ir/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/Simplify.scala
@@ -629,7 +629,7 @@ object Simplify {
       case TableCount(TableUnion(children)) =>
         Some(children.map(TableCount(_): IR).treeReduce(ApplyBinaryPrimOp(Add(), _, _)))
 
-      case TableCount(TableKeyBy(child, _, _)) =>
+      case TableCount(TableKeyBy(child, _, _, _)) =>
         Some(TableCount(child))
 
       case TableCount(TableOrderBy(child, _)) =>
@@ -711,7 +711,7 @@ object Simplify {
       case TableGetGlobals(child) if child.typ.globalType == TStruct.empty =>
         Some(MakeStruct(FastSeq()))
 
-      case TableGetGlobals(TableKeyBy(child, _, _)) =>
+      case TableGetGlobals(TableKeyBy(child, _, _, _)) =>
         Some(TableGetGlobals(child))
 
       case TableGetGlobals(TableFilter(child, _)) =>
@@ -919,8 +919,13 @@ object Simplify {
         Some(child)
 
       // TODO: Write more rules like this to bubble 'TableRename' nodes towards the root.
-      case t @ TableRename(TableKeyBy(child, keys, isSorted), rowMap, globalMap) =>
-        Some(TableKeyBy(TableRename(child, rowMap, globalMap), keys.map(t.rowF), isSorted))
+      case t @ TableRename(TableKeyBy(child, keys, isSorted, nPartitions), rowMap, globalMap) =>
+        Some(TableKeyBy(
+          TableRename(child, rowMap, globalMap),
+          keys.map(t.rowF),
+          isSorted,
+          nPartitions,
+        ))
 
       case TableFilter(t, True()) =>
         Some(t)
@@ -934,13 +939,13 @@ object Simplify {
           ApplySpecial("land", ArraySeq.empty, ArraySeq(p1, p2), TBoolean, ErrorIDs.NO_ERROR),
         ))
 
-      case TableFilter(TableKeyBy(child, key, isSorted), p) =>
-        Some(TableKeyBy(TableFilter(child, p), key, isSorted))
+      case TableFilter(TableKeyBy(child, key, isSorted, nPartitions), p) =>
+        Some(TableKeyBy(TableFilter(child, p), key, isSorted, nPartitions))
 
       case TableFilter(TableRepartition(child, n, strategy), p) =>
         Some(TableRepartition(TableFilter(child, p), n, strategy))
 
-      case TableOrderBy(TableKeyBy(child, _, false), sortFields) =>
+      case TableOrderBy(TableKeyBy(child, _, false, _), sortFields) =>
         Some(TableOrderBy(child, sortFields))
 
       case TableFilter(TableOrderBy(child, sortFields), pred) =>
@@ -978,16 +983,16 @@ object Simplify {
         }
         Some(TableParallelize(newRowsAndGlobal, nPartitions))
 
-      case TableKeyBy(TableOrderBy(child, _), keys, false) =>
-        Some(TableKeyBy(child, keys, false))
+      case TableKeyBy(TableOrderBy(child, _), keys, false, nPartitions) =>
+        Some(TableKeyBy(child, keys, false, nPartitions))
 
-      case TableKeyBy(TableKeyBy(child, _, _), keys, false) =>
-        Some(TableKeyBy(child, keys, false))
+      case TableKeyBy(TableKeyBy(child, _, _, _), keys, false, nPartitions) =>
+        Some(TableKeyBy(child, keys, false, nPartitions))
 
-      case TableKeyBy(TableKeyBy(child, _, true), keys, true) =>
-        Some(TableKeyBy(child, keys, true))
+      case TableKeyBy(TableKeyBy(child, _, true, _), keys, true, nPartitions) =>
+        Some(TableKeyBy(child, keys, true, nPartitions))
 
-      case TableKeyBy(child, key, _) if key == child.typ.key =>
+      case TableKeyBy(child, key, _, _) if key == child.typ.key =>
         Some(child)
 
       case TableMapRows(child, Ref(n, _)) if n == TableIR.rowName =>
@@ -1185,13 +1190,14 @@ object Simplify {
             && child.typ.key.nonEmpty =>
         Some(TableAggregateByKey(child, expr))
 
-      case TableAggregateByKey(x @ TableKeyBy(child, keys, false), expr)
+      case TableAggregateByKey(x @ TableKeyBy(child, keys, false, nPartitions), expr)
           if !x.definitelyDoesNotShuffle =>
         Some(TableKeyByAndAggregate(
           child,
           expr,
           MakeStruct(keys.map(k => k -> GetField(Ref(TableIR.rowName, child.typ.rowType), k))),
           bufferSize = ctx.getFlag("grouped_aggregate_buffer_size").toInt,
+          nPartitions = nPartitions,
         ))
 
       case TableParallelize(TableCollect(child), _) =>

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -2103,8 +2103,12 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
   *     type to the new key. 'isSorted' is ignored.
   *   - Otherwise, if 'isSorted' is false and n < 'keys.length', then shuffle.
   */
-case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolean = false)
-    extends TableIR with PreservesRows {
+case class TableKeyBy(
+  child: TableIR,
+  keys: IndexedSeq[String],
+  isSorted: Boolean = false,
+  nPartitions: Option[Int] = None,
+) extends TableIR with PreservesRows {
   val childrenSeq: IndexedSeq[BaseIR] = ArraySeq(child)
 
   lazy val typ: TableType = child.typ.copy(key = keys)

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -630,7 +630,7 @@ object TypeCheck {
             .intersect(right.typ.globalType.fieldNames.toSet)
             .isEmpty
         )
-      case TableKeyBy(child, keys, _) =>
+      case TableKeyBy(child, keys, _, _) =>
         val fields = child.typ.rowType.fieldNames.toSet
         assert(
           keys.forall(fields.contains),

--- a/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -224,9 +224,10 @@ case object SemanticHash extends Logging {
       case StreamZip(_, _, _, behaviour, _) =>
         buffer ++= Bytes.fromInt(behaviour.id)
 
-      case TableKeyBy(table, keys, _) =>
+      case TableKeyBy(table, keys, _, nPartitions) =>
         val getFieldIndex = table.typ.rowType.fieldIdx
         keys.map(getFieldIndex).foreach(buffer ++= Bytes.fromInt(_))
+        nPartitions.foreach(buffer ++= Bytes.fromInt(_))
 
       case TableKeyByAndAggregate(_, _, _, nPartitions, bufferSize) =>
         nPartitions.foreach {

--- a/hail/hail/src/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/CanLowerEfficiently.scala
@@ -47,7 +47,7 @@ object CanLowerEfficiently {
         case _: TableRepartition => fail(s"TableRepartition has no lowered implementation")
         case _: TableParallelize =>
         case _: TableRange =>
-        case TableKeyBy(_, _, _) =>
+        case TableKeyBy(_, _, _, _) =>
         case _: TableOrderBy =>
         case _: TableFilter =>
         case _: TableHead =>

--- a/hail/hail/src/is/hail/expr/ir/lowering/ExecuteRelational.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/ExecuteRelational.scala
@@ -56,7 +56,7 @@ object ExecuteRelational {
         val leftTS = recur(left).asTableStage(ctx)
         val rightTS = recur(right).asTableStage(ctx)
         TableExecuteIntermediate(LowerTableIRHelpers.lowerTableJoin(ctx, r, ir, leftTS, rightTS))
-      case ir @ TableKeyBy(child, keys, isSorted) =>
+      case ir @ TableKeyBy(child, keys, isSorted, _) =>
         val tv = recur(child).asTableValue(ctx)
         TableValueIntermediate(tv.copy(typ = ir.typ, rvd = tv.rvd.enforceKey(ctx, keys, isSorted)))
       case TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize) =>

--- a/hail/hail/src/is/hail/expr/ir/lowering/Invariant.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/Invariant.scala
@@ -46,6 +46,9 @@ object Invariant {
       case _ => true
     }
 
+  lazy val NoTableKeyByAndAggregate: Invariant =
+    Invariant(!_.isInstanceOf[TableKeyByAndAggregate])
+
   lazy val NoLiftMeOuts: Invariant =
     Invariant(!_.isInstanceOf[LiftMeOut])
 

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerAndExecuteShuffles.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerAndExecuteShuffles.scala
@@ -1,27 +1,24 @@
 package is.hail.expr.ir.lowering
 
 import is.hail.backend.ExecuteContext
-import is.hail.collection.FastSeq
 import is.hail.expr.ir.{Requiredness, _}
-import is.hail.expr.ir.agg.{Extract, PhysicalAggSig, TakeStateSig}
-import is.hail.expr.ir.defs._
 import is.hail.types._
-import is.hail.types.virtual._
 
 object LowerAndExecuteShuffles {
 
-  def apply(ir: BaseIR, ctx: ExecuteContext, passesBelow: LoweringPipeline): BaseIR =
+  def apply(ir: BaseIR, ctx: ExecuteContext): BaseIR =
     ctx.time {
       RewriteBottomUp(
         ir,
         {
-          case t @ TableKeyBy(child, key, _) if !t.definitelyDoesNotShuffle =>
+          case t @ TableKeyBy(child, key, _, nPartitions) if !t.definitelyDoesNotShuffle =>
             val r = Requiredness(child, ctx)
             val reader = ctx.backend.lowerDistributedSort(
               ctx,
               child,
               key.map(k => SortField(k, Ascending)),
               r.lookup(child).asInstanceOf[RTable],
+              nPartitions,
             )
             Some(TableRead(t.typ, false, reader))
 
@@ -35,115 +32,6 @@ object LowerAndExecuteShuffles {
             )
             Some(TableRead(t.typ, false, reader))
 
-          case t @ TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize) =>
-            val newKeyType = newKey.typ.asInstanceOf[TStruct]
-
-            val aggs = Extract(ctx, expr, Requiredness(t, ctx)).independent
-            val aggSigs = aggs.sigs
-
-            var ts = child
-
-            val origGlobalTyp = ts.typ.globalType
-            ts = TableKeyBy(child, IndexedSeq())
-            ts = TableMapGlobals(
-              ts,
-              MakeStruct(FastSeq(
-                ("oldGlobals", Ref(TableIR.globalName, origGlobalTyp)),
-                (
-                  "__initState",
-                  RunAgg(aggs.init, aggSigs.valuesOp, aggSigs.states),
-                ),
-              )),
-            )
-
-            val partiallyAggregated =
-              mapPartitions(ts) { (insGlob, partStream) =>
-                Let(
-                  FastSeq(TableIR.globalName -> GetField(insGlob, "oldGlobals")),
-                  StreamBufferedAggregate(
-                    partStream,
-                    bindIR(GetField(insGlob, "__initState"))(aggSigs.initFromSerializedValueOp),
-                    newKey,
-                    aggs.seqPerElt,
-                    TableIR.rowName,
-                    aggSigs.sigs,
-                    bufferSize,
-                  ),
-                )
-              }.noSharing(ctx)
-
-            val analyses = LoweringAnalyses(partiallyAggregated, ctx)
-            val preShuffleStage = ctx.backend.tableToTableStage(ctx, partiallyAggregated, analyses)
-            // annoying but no better alternative right now
-            val rt = analyses.requirednessAnalysis.lookup(partiallyAggregated).asInstanceOf[RTable]
-            val partiallyAggregatedReader = ctx.backend.lowerDistributedSort(
-              ctx,
-              preShuffleStage,
-              newKeyType.fieldNames.map(k => SortField(k, Ascending)),
-              rt,
-              nPartitions,
-            )
-
-            val takeVirtualSig =
-              TakeStateSig(VirtualTypeWithReq(newKeyType, rt.rowType.select(newKeyType.fieldNames)))
-            val takeAggSig = PhysicalAggSig(Take(), takeVirtualSig)
-            val aggStateSigsPlusTake = aggSigs.states ++ Array(takeVirtualSig)
-
-            val result = ResultOp(aggSigs.nAggs, takeAggSig)
-
-            val shuffleRead =
-              TableRead(partiallyAggregatedReader.fullType, false, partiallyAggregatedReader)
-
-            val tmp = mapPartitions(
-              shuffleRead,
-              newKeyType.size,
-              newKeyType.size - 1,
-            ) { (insGlob, shuffledPartStream) =>
-              Let(
-                FastSeq(TableIR.globalName -> GetField(insGlob, "oldGlobals")),
-                mapIR(StreamGroupByKey(
-                  shuffledPartStream,
-                  newKeyType.fieldNames.toIndexedSeq,
-                  missingEqual = true,
-                )) { groupRef =>
-                  RunAgg(
-                    Begin(FastSeq(
-                      bindIR(GetField(insGlob, "__initState"))(aggSigs.initFromSerializedValueOp),
-                      InitOp(
-                        aggSigs.nAggs,
-                        IndexedSeq(I32(1)),
-                        PhysicalAggSig(Take(), takeVirtualSig),
-                      ),
-                      forIR(groupRef) { elem =>
-                        Begin(FastSeq(
-                          SeqOp(
-                            aggSigs.nAggs,
-                            IndexedSeq(SelectFields(elem, newKeyType.fieldNames)),
-                            PhysicalAggSig(Take(), takeVirtualSig),
-                          ),
-                          bindIR(GetField(elem, "agg"))(aggSigs.combOpValues),
-                        ))
-                      },
-                    )),
-                    bindIRs(aggs.result, result) { case Seq(postAgg, resultFromTake) =>
-                      val keyIRs: IndexedSeq[(String, IR)] =
-                        newKeyType.fieldNames.map(keyName =>
-                          keyName -> GetField(ArrayRef(resultFromTake, 0), keyName)
-                        )
-
-                      MakeStruct(keyIRs ++ expr.typ.asInstanceOf[TStruct].fieldNames.map { f =>
-                        (f, GetField(postAgg, f))
-                      })
-                    },
-                    aggStateSigsPlusTake,
-                  )
-                },
-              )
-            }
-            Some(TableMapGlobals(
-              tmp,
-              GetField(Ref(TableIR.globalName, tmp.typ.globalType), "oldGlobals"),
-            ))
           case _ => None
         },
       )

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1916,7 +1916,7 @@ object LowerTableIR extends Logging {
           )
         }
 
-      case t @ TableKeyBy(child, newKey, _: Boolean) =>
+      case t @ TableKeyBy(child, newKey, _: Boolean, _) =>
         require(t.definitelyDoesNotShuffle)
         val loweredChild = lower(child)
 

--- a/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -3,12 +3,16 @@ package is.hail.expr.ir.lowering
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.expr.ir._
-import is.hail.expr.ir.agg.Extract
+import is.hail.expr.ir.agg.{Extract, PhysicalAggSig, TakeStateSig}
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.expr.ir.defs.{
-  ApplyIR, Begin, Let, RunAgg, RunAggScan, StreamAgg, StreamAggScan, StreamFor,
+  ApplyIR, ArrayRef, Begin, GetField, I32, InitOp, Let, MakeStruct, Ref, ResultOp, RunAgg,
+  RunAggScan, SelectFields, SeqOp, StreamAgg, StreamAggScan, StreamBufferedAggregate, StreamFor,
+  StreamGroupByKey,
 }
 import is.hail.expr.ir.lowering.Invariant._
+import is.hail.types.{RTable, VirtualTypeWithReq}
+import is.hail.types.virtual.TStruct
 import is.hail.utils.implicits.toRichPredicate
 
 final class IrMetadata() {
@@ -184,11 +188,127 @@ case class EvalRelationalLetsPass(passesBelow: LoweringPipeline) extends Lowerin
     EvalRelationalLets(ir, ctx, passesBelow)
 }
 
-case class LowerAndExecuteShufflesPass(passesBelow: LoweringPipeline) extends LoweringPass {
+case object LowerTableKeyByAndAggregatePass extends LoweringPass {
   val before: Invariant = NoRelationalLets and NoMatrixIR
+  val after: Invariant = NoRelationalLets and NoMatrixIR and NoTableKeyByAndAggregate
+  val context: String = "LowerTableKeyByAndAggregate"
+
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = ctx.time {
+    RewriteBottomUp(
+      ir,
+      {
+        case t @ TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize) =>
+          val newKeyType = newKey.typ.asInstanceOf[TStruct]
+
+          val aggs = Extract(ctx, expr, Requiredness(t, ctx)).independent
+          val aggSigs = aggs.sigs
+
+          var ts = child
+
+          val origGlobalTyp = ts.typ.globalType
+          ts = TableKeyBy(child, IndexedSeq())
+          ts = TableMapGlobals(
+            ts,
+            MakeStruct(FastSeq(
+              ("oldGlobals", Ref(TableIR.globalName, origGlobalTyp)),
+              (
+                "__initState",
+                RunAgg(aggs.init, aggSigs.valuesOp, aggSigs.states),
+              ),
+            )),
+          )
+
+          val partiallyAggregated =
+            mapPartitions(ts) { (insGlob, partStream) =>
+              Let(
+                FastSeq(TableIR.globalName -> GetField(insGlob, "oldGlobals")),
+                StreamBufferedAggregate(
+                  partStream,
+                  bindIR(GetField(insGlob, "__initState"))(aggSigs.initFromSerializedValueOp),
+                  newKey,
+                  aggs.seqPerElt,
+                  TableIR.rowName,
+                  aggSigs.sigs,
+                  bufferSize,
+                ),
+              )
+            }.noSharing(ctx)
+
+          val analyses = LoweringAnalyses(partiallyAggregated, ctx)
+          val rt = analyses.requirednessAnalysis.lookup(partiallyAggregated).asInstanceOf[RTable]
+
+          val takeVirtualSig =
+            TakeStateSig(VirtualTypeWithReq(newKeyType, rt.rowType.select(newKeyType.fieldNames)))
+          val takeAggSig = PhysicalAggSig(Take(), takeVirtualSig)
+          val aggStateSigsPlusTake = aggSigs.states ++ Array(takeVirtualSig)
+
+          val result = ResultOp(aggSigs.nAggs, takeAggSig)
+
+          val shuffled = TableKeyBy(
+            partiallyAggregated,
+            newKey.typ.asInstanceOf[TStruct].fieldNames,
+            nPartitions = nPartitions,
+          )
+
+          val tmp =
+            mapPartitions(shuffled, newKeyType.size, newKeyType.size - 1) {
+              (insGlob, shuffledPartStream) =>
+                Let(
+                  FastSeq(TableIR.globalName -> GetField(insGlob, "oldGlobals")),
+                  mapIR(StreamGroupByKey(
+                    shuffledPartStream,
+                    newKeyType.fieldNames.toIndexedSeq,
+                    missingEqual = true,
+                  )) { groupRef =>
+                    RunAgg(
+                      Begin(FastSeq(
+                        bindIR(GetField(insGlob, "__initState"))(aggSigs.initFromSerializedValueOp),
+                        InitOp(
+                          aggSigs.nAggs,
+                          IndexedSeq(I32(1)),
+                          PhysicalAggSig(Take(), takeVirtualSig),
+                        ),
+                        forIR(groupRef) { elem =>
+                          Begin(FastSeq(
+                            SeqOp(
+                              aggSigs.nAggs,
+                              IndexedSeq(SelectFields(elem, newKeyType.fieldNames)),
+                              PhysicalAggSig(Take(), takeVirtualSig),
+                            ),
+                            bindIR(GetField(elem, "agg"))(aggSigs.combOpValues),
+                          ))
+                        },
+                      )),
+                      bindIRs(aggs.result, result) { case Seq(postAgg, resultFromTake) =>
+                        val keyIRs: IndexedSeq[(String, IR)] =
+                          newKeyType.fieldNames.map(keyName =>
+                            keyName -> GetField(ArrayRef(resultFromTake, 0), keyName)
+                          )
+
+                        MakeStruct(keyIRs ++ expr.typ.asInstanceOf[TStruct].fieldNames.map { f =>
+                          (f, GetField(postAgg, f))
+                        })
+                      },
+                      aggStateSigsPlusTake,
+                    )
+                  },
+                )
+            }
+          Some(TableMapGlobals(
+            tmp,
+            GetField(Ref(TableIR.globalName, tmp.typ.globalType), "oldGlobals"),
+          ))
+        case _ => None
+      },
+    )
+  }
+}
+
+case object LowerAndExecuteShufflesPass extends LoweringPass {
+  val before: Invariant = NoRelationalLets and NoMatrixIR and NoTableKeyByAndAggregate
   val after: Invariant = before and LoweredShuffles
   val context: String = "LowerAndExecuteShuffles"
 
   override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR =
-    LowerAndExecuteShuffles(ir, ctx, passesBelow)
+    LowerAndExecuteShuffles(ir, ctx)
 }

--- a/hail/hail/src/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -46,30 +46,24 @@ object LoweringPipeline {
   private[this] def fullLoweringPipeline(context: String, baseTransformer: LoweringPass)
     : LoweringPipeline = {
 
-    val base = LoweringPipeline(
-      baseTransformer,
-      OptimizePass(s"$context, after ${baseTransformer.context}"),
-    )
-
     // recursively lowers and executes
     val withShuffleRewrite =
       LoweringPipeline(
-        LowerAndExecuteShufflesPass(base),
+        LowerTableKeyByAndAggregatePass,
+        LowerAndExecuteShufflesPass,
         OptimizePass(s"$context, after LowerAndExecuteShuffles"),
-      ) + base
+        baseTransformer,
+        OptimizePass(s"$context, after ${baseTransformer.context}"),
+      )
 
     // recursively lowers and executes
-    val withLetEvaluation =
-      LoweringPipeline(
-        LiftRelationalValuesToRelationalLets,
-        EvalRelationalLetsPass(withShuffleRewrite),
-      ) + withShuffleRewrite
-
     LoweringPipeline(
       OptimizePass(s"$context, initial IR"),
       LowerMatrixToTablePass,
       OptimizePass(s"$context, after LowerMatrixToTable"),
-    ) + withLetEvaluation
+      LiftRelationalValuesToRelationalLets,
+      EvalRelationalLetsPass(withShuffleRewrite),
+    ) + withShuffleRewrite
   }
 
   lazy val relationalLowerer: LoweringPipeline =

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -488,7 +488,7 @@ class SimplifySuite extends HailSuite {
 
     val t2 = Simplify(ctx, t)
     assert(t2 match {
-      case TableKeyBy(TableFilter(child, _), _, _) =>
+      case TableKeyBy(TableFilter(child, _), _, _, _) =>
         !Exists(child, _.isInstanceOf[TableFilterIntervals])
       case _ => false
     })

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -278,7 +278,7 @@ class TableKeyBy(TableIR):
         return TableKeyBy(self.child.handle_randomness(uid_field_name), self.keys, self.is_sorted)
 
     def head_str(self):
-        return '({}) {}'.format(' '.join([escape_id(x) for x in self.keys]), self.is_sorted)
+        return '({}) {} {}'.format(' '.join([escape_id(x) for x in self.keys]), self.is_sorted, 'None')
 
     def _eq(self, other):
         return self.keys == other.keys and self.is_sorted == other.is_sorted


### PR DESCRIPTION
## Change Description

This is a step towards simplifying our compilation pipelines. It simplifies the `LowerAndExecuteShuffles` pass to be solely about executing each shuffle in the IR in a separate compute stage, where a shuffle is always represented by a `TableKeyBy `or `TableOrderBy` node.

Previously, the pass also handled `TableKeyByAndAggregate`, which involves complicated lowering logic. Now, that logic is extracted to a new pass `LowerTableKeyByAndAggregate`, which is the same as the old rule in `LowerAndExecuteShuffles`, only instead of directly invoking a distributed sort on the backend, it lowers to `TableKeyBy` to represent the shuffle.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP