### PR TITLE
Add form-action directive to CSP

### DIFF
--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -142,9 +142,10 @@ def web_security_header_generator(fun, extra_script: str = '', extra_style: str 
         script_src = f'script-src \'self\' {extra_script} cdn.jsdelivr.net cdn.plot.ly;'
         img_src = f'img-src \'self\' {extra_img};'
         frame_ancestors = 'frame-ancestors \'self\';'
+        form_action = 'form-action \'self\';'
 
         response.headers['Content-Security-Policy'] = (
-            f'{default_src} {font_src} {style_src} {script_src} {img_src} {frame_ancestors}'
+            f'{default_src} {font_src} {style_src} {script_src} {img_src} {frame_ancestors} {form_action}'
         )
         return response
 


### PR DESCRIPTION
## Change Description

Fixes https://github.com/hail-is/hail-security/issues/72
Adds a form-action directive to our CSP to control which domains forms can submit to (in our case, only `self`)

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Tightens up the CSP

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
