### PR TITLE
[auth] Fix update to user's last active time

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -880,16 +880,15 @@ async def get_userinfo(request: web.Request, auth_token: str) -> UserData:
             userdata = await get_userinfo_from_login_id_or_hail_identity_id(request, uid)
 
     if userdata:
-        if userdata['state'] == 'active':
-            current_uid = userdata['id']
-            await db.execute_update(
-                """
-    UPDATE users
-    SET last_activated = CURRENT_TIMESTAMP(3)
-    WHERE id = %s;
-    """,
-                current_uid,
-            )
+        current_uid = userdata['id']
+        await db.execute_update(
+            """
+UPDATE users
+SET last_activated = CURRENT_TIMESTAMP(3)
+WHERE id = %s;
+""",
+            current_uid,
+        )
         return userdata
 
     raise web.HTTPUnauthorized()


### PR DESCRIPTION
## Change Description

Currently, we only update a user's last active time if they have an existing active session. However, this excludes some scenarios (ex. calls through the CLI) where the user might not have created a session with a given auth token. This change makes it so when authorizing a call, we will always update the last active time as long as the user is authorized & currently active.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Refactoring where the update to a user's last active time happens. This adds one database update on some authorized calls which didn't have it before.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
