### PR TITLE
Refresh cert on deploy

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -337,8 +337,8 @@ steps:
               echo "Certificate is still valid, skipping regeneration"
           else
               echo "Certificate has expired, regenerating certificates while preserving password..."
-              set +x
               echo "Running: EXISTING_PASSWORD=\$(echo \"\$SECRET_JSON\" | jq -r '.data[\"db-root-password\"]' | base64 -d)"
+              set +x
               EXISTING_PASSWORD=$(echo "$SECRET_JSON" | jq -r '.data["db-root-password"]' | base64 -d)
               echo "Running: NAMESPACE={{ default_ns.name }} KEEP_PASSWORD=\"\$EXISTING_PASSWORD\" bash /create_test_db_config.sh"
               NAMESPACE={{ default_ns.name }} KEEP_PASSWORD="$EXISTING_PASSWORD" bash /create_test_db_config.sh


### PR DESCRIPTION
## Change Description
Currently, the `create_test_database_server_config script` in `build.yaml` determines whether to regenerate TLS certificates by checking the most recent timestamp in the Kubernetes secret's `.metadata.managedFields` and checking whether it's over 365 days old. If it is, the script regenerates the secret, otherwise it leaves it as is. However, Kubernetes operations (e.g. an `Update` performed by GoogleContainerEngine) can create new timestamps without actually refreshing the certificate, causing the script to incorrectly believe the certificate is still valid when it has actually expired.

This change replaces the current timestamp-based check with a direct certificate expiration check on the actual certificate stored in the secret, and thus no longer relies on heuristics around timestamp (and, furthermore, means we're not impeded by non-regenerative K8s operations that produce timestamps).

This change has been verified by:
- [Dev deploying the branch](https://batch.hail.is/batches/8368701) and seeing that i) the deploy_test_db job succeeded, and ii) all jobs depending on create_test_database_server_config succeeded.
- Verifying the new command locally in my own namespace:
```
% kubectl get secret database-server-config -n grohlice -o json | jq -r '.data["server-ca.pem"]' | base64 -d | openssl x509 -enddate -checkend 0       
notAfter=Mar  2 17:11:19 2027 GMT
Certificate will not expire
```

## Security Assessment
- This change does not impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has a low security impact

### Impact Description
This change only impacts test database deployments and should not impact the production deployment/databases.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
