### PR TITLE
[compiler] avoid jackson-databind version conflict

### DIFF
--- a/hail/hail/utils/package.mill
+++ b/hail/hail/utils/package.mill
@@ -22,6 +22,7 @@ trait HailUtils extends HailScalaModule, CrossScalaModule:
 
   override def compileMvnDeps: T[Seq[Dep]] =
     Vector[Dep](
+      `jackson-databind` :: "2.15.2",
       `json4s-jackson` :: "3.7.0-M11",
       `log4j-core`,
       `zstd-jni` :: "1.5.5-4",


### PR DESCRIPTION
## Change Description

For some reason, I was seeing an incompatible version of jackson-databind get loaded when running tests in IntelliJ, though it seems it might have only happened on my machine. Whatever the cause, this is the simplest fix I could find.

Edit: New fix, for real this time (I'm pretty sure).

The cause was that `json4s-jackson` depends on `jackson-databind` 2.12.2. In `utils`, that's the only dependency on `jackson-databind`, so its version resolves to 2.12.2, and that version transitively ends up on the class path in the main hail module.

The best fix I could find was explicitly depending on 2.15.2 it `utils`. I would have assumed pinning the version of `jackson-databind` in `depManagement` would have had the same effect, but apparently not. There's something I'm misunderstanding about how `depManagement` works.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP