### PR TITLE
add login redirects to form-action directive

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -46,6 +46,7 @@ from web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_login_page,
     web_security_headers_swagger,
 )
 
@@ -505,7 +506,7 @@ async def create_user(request: web.Request, _) -> web.Response:
 
 
 @routes.get('/user')
-@web_security_headers
+@web_security_headers_login_page
 @auth.maybe_authenticated_user
 async def user_page(request: web.Request, userdata: Optional[UserData]) -> web.Response:
     context_dict = {'cloud': CLOUD, **({'next_page': request.query['next']} if 'next' in request.query else {})}

--- a/web_common/web_common/__init__.py
+++ b/web_common/web_common/__init__.py
@@ -6,6 +6,7 @@ from .web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_login_page,
     web_security_headers_swagger,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     'setup_aiohttp_jinja2',
     'setup_common_static_routes',
     'web_security_headers',
+    'web_security_headers_login_page',
     'web_security_headers_swagger',
 ]

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -127,7 +127,17 @@ def web_security_headers_swagger(fun):
     )
 
 
-def web_security_header_generator(fun, extra_script: str = '', extra_style: str = '', extra_img: str = ''):
+def web_security_headers_login_page(fun):
+    # Login/signup forms redirect through auth.hail.is/login to the OAuth provider. Chrome follows
+    # the redirect chain when enforcing form-action, so OAuth domains must be allowed.
+    return web_security_header_generator(
+        fun, extra_form_action='https://accounts.google.com https://login.microsoftonline.com'
+    )
+
+
+def web_security_header_generator(
+    fun, extra_script: str = '', extra_style: str = '', extra_img: str = '', extra_form_action: str = ''
+):
     @wraps(fun)
     async def wrapped(request, *args, **kwargs):
         response = await fun(request, *args, **kwargs)
@@ -138,7 +148,7 @@ def web_security_header_generator(fun, extra_script: str = '', extra_style: str 
         script_src = f'script-src \'self\' {extra_script} cdn.jsdelivr.net cdn.plot.ly;'
         img_src = f'img-src \'self\' {extra_img};'
         frame_ancestors = 'frame-ancestors \'self\';'
-        form_action = 'form-action \'self\';'
+        form_action = f"form-action 'self'{' ' + extra_form_action if extra_form_action else ''};"
 
         response.headers['Content-Security-Policy'] = (
             f'{default_src} {font_src} {style_src} {script_src} {img_src} {frame_ancestors} {form_action}'


### PR DESCRIPTION
## Change Description

Restores broken auth login button

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Adds an extra form-action target, on login pages only, to allow redirects to third party login hosts

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
