### PR TITLE
[deps] Upgrade to pytest 9

### DIFF
--- a/ci/pinned-requirements.txt
+++ b/ci/pinned-requirements.txt
@@ -45,7 +45,7 @@ pycparser==3.0
     #   -c ci/../hail/python/dev/pinned-requirements.txt
     #   -c ci/../hail/python/pinned-requirements.txt
     #   cffi
-pyjwt==2.11.0
+pyjwt==2.12.0
     # via
     #   -c ci/../hail/python/pinned-requirements.txt
     #   gidgethub

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -70,7 +70,7 @@ google-api-core==2.30.0
     # via google-api-python-client
 google-api-python-client==2.192.0
     # via google-cloud-profiler
-google-auth==2.49.0
+google-auth==2.49.1
     # via
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
@@ -138,7 +138,6 @@ pyasn1==0.6.2
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
@@ -177,11 +176,6 @@ requests==2.32.5
     #   -c gear/../hail/python/pinned-requirements.txt
     #   google-api-core
     #   google-cloud-profiler
-rsa==4.9.1
-    # via
-    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
-    #   -c gear/../hail/python/pinned-requirements.txt
-    #   google-auth
 setuptools==81.0.0
     # via
     #   -c gear/../hail/python/dev/pinned-requirements.txt

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -52,6 +52,8 @@ babel==2.18.0
     # via
     #   jupyterlab-server
     #   sphinx
+backports-asyncio-runner==1.2.0
+    # via pytest-asyncio
 beautifulsoup4==4.14.3
     # via nbconvert
 bleach==6.3.0
@@ -399,6 +401,7 @@ pygments==2.19.2
     #   ipython
     #   jupyter-console
     #   nbconvert
+    #   pytest
     #   sphinx
 pylint==3.3.9
     # via -r hail/python/dev/requirements.txt
@@ -408,7 +411,7 @@ pyproject-hooks==1.2.0
     # via build
 pyright==1.1.408
     # via -r hail/python/dev/requirements.txt
-pytest==7.4.4
+pytest==9.0.2
     # via
     #   -r hail/python/dev/requirements.txt
     #   pytest-asyncio
@@ -419,7 +422,7 @@ pytest==7.4.4
     #   pytest-mock
     #   pytest-timeout
     #   pytest-xdist
-pytest-asyncio==0.21.2
+pytest-asyncio==1.3.0
     # via -r hail/python/dev/requirements.txt
 pytest-forked==1.6.0
     # via pytest-xdist
@@ -615,6 +618,7 @@ typing-extensions==4.15.0
     #   mistune
     #   multidict
     #   pyright
+    #   pytest-asyncio
     #   referencing
     #   virtualenv
 tzdata==2025.3

--- a/hail/python/dev/requirements.txt
+++ b/hail/python/dev/requirements.txt
@@ -11,12 +11,12 @@ uv-build>=0.10.0,<0.11
 curlylint>=0.13.1,<1
 click>=8.1.2,<9
 mock>=5.1,<5.2
-pytest>=7.1.3,<8
+pytest>=9,<10
 pytest-html>=1.20.0,<2
 pytest-xdist>=2.2.1,<3
 pytest-instafail>=0.4.2,<1
 # https://github.com/hail-is/hail/issues/14130
-pytest-asyncio>=0.14.0,<0.23
+pytest-asyncio>=1,<2
 pytest-timestamper>=0.0.9,<1
 pytest-timeout>=2.1,<3
 pytest-mock>=3.14,<4

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -16,7 +16,7 @@ attrs==25.4.0
     # via aiohttp
 azure-common==1.1.28
     # via azure-mgmt-storage
-azure-core==1.38.2
+azure-core==1.38.3
     # via
     #   azure-identity
     #   azure-mgmt-core
@@ -30,9 +30,9 @@ azure-mgmt-storage==20.1.0
     # via -r hail/python/hailtop/requirements.txt
 azure-storage-blob==12.28.0
     # via -r hail/python/hailtop/requirements.txt
-boto3==1.42.66
+boto3==1.42.67
     # via -r hail/python/hailtop/requirements.txt
-botocore==1.42.66
+botocore==1.42.67
     # via
     #   -r hail/python/hailtop/requirements.txt
     #   boto3
@@ -65,7 +65,7 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-auth==2.49.0
+google-auth==2.49.1
     # via
     #   -r hail/python/hailtop/requirements.txt
     #   google-auth-oauthlib
@@ -112,9 +112,7 @@ propcache==0.4.1
     #   aiohttp
     #   yarl
 pyasn1==0.6.2
-    # via
-    #   pyasn1-modules
-    #   rsa
+    # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
 pycares==5.0.1
@@ -123,7 +121,7 @@ pycparser==3.0
     # via cffi
 pygments==2.19.2
     # via rich
-pyjwt==2.11.0
+pyjwt==2.12.0
     # via msal
 python-dateutil==2.9.0.post0
     # via botocore
@@ -145,8 +143,6 @@ rich==12.6.0
     # via
     #   -r hail/python/hailtop/requirements.txt
     #   typer
-rsa==4.9.1
-    # via google-auth
 s3transfer==0.16.0
     # via boto3
 setuptools==81.0.0

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -34,7 +34,7 @@ azure-common==1.1.28
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   azure-mgmt-storage
-azure-core==1.38.2
+azure-core==1.38.3
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   azure-identity
@@ -59,11 +59,11 @@ azure-storage-blob==12.28.0
     #   -r hail/python/hailtop/requirements.txt
 bokeh==3.4.3
     # via -r hail/python/requirements.txt
-boto3==1.42.66
+boto3==1.42.67
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-botocore==1.42.66
+botocore==1.42.67
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -115,7 +115,7 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-auth==2.49.0
+google-auth==2.49.1
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -217,7 +217,6 @@ pyasn1==0.6.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
@@ -234,7 +233,7 @@ pygments==2.19.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   rich
-pyjwt==2.11.0
+pyjwt==2.12.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   msal
@@ -278,10 +277,6 @@ rich==12.6.0
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
     #   typer
-rsa==4.9.1
-    # via
-    #   -c hail/python/hailtop/pinned-requirements.txt
-    #   google-auth
 s3transfer==0.16.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt


### PR DESCRIPTION
I was getting very strange warnings in my environment with pytest 7.x regarding unclosed files. Upgrading seems to have fixed it.

## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

Delete all except the correct answer:
- This change has no security impact

### Impact Description
Dev dependency update

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
