### PR TITLE
[query] stop passing requester-pays conf via feature flags

### DIFF
--- a/hail/hail/src/is/hail/HailFeatureFlags.scala
+++ b/hail/hail/src/is/hail/HailFeatureFlags.scala
@@ -5,7 +5,6 @@ import is.hail.backend.service.ServiceBackend
 import is.hail.backend.spark.SparkBackend
 import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir.{agg, Optimize}
-import is.hail.io.fs.RequesterPaysConfig
 import is.hail.types.encoded.EType
 
 import scala.collection.mutable
@@ -43,8 +42,6 @@ object HailFeatureFlags {
     (ExecutionCache.Flags.UseFastRestarts, "HAIL_USE_FAST_RESTARTS" -> null),
     (Optimize.Flags.MaxOptimizerIterations, "HAIL_OPTIMIZER_ITERATIONS" -> null),
     (Optimize.Flags.Optimize, "HAIL_QUERY_OPTIMIZE" -> "1"),
-    (RequesterPaysConfig.Flags.RequesterPaysBuckets, "HAIL_GCS_REQUESTER_PAYS_BUCKETS" -> null),
-    (RequesterPaysConfig.Flags.RequesterPaysProject, "HAIL_GCS_REQUESTER_PAYS_PROJECT" -> null),
     (ServiceBackend.Flags.UseAsyncProfiler, "HAIL_PROFILE" -> null),
     (
       SparkBackend.Flags.MaxStageParallelism,

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -9,7 +9,7 @@ import is.hail.backend.service.ServiceBackend.DefaultMaxReadParallelism
 import is.hail.collection.ImmutableMap
 import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir.lowering.IrMetadata
-import is.hail.io.fs.{CloudStorageFSConfig, FS, RouterFS}
+import is.hail.io.fs.{CloudStorageConfig, FS, RequesterPaysConfig, RouterFS}
 import is.hail.io.reference.{IndexedFastaSequenceFile, LiftOver}
 import is.hail.services._
 import is.hail.services.oauth2.CloudCredentials
@@ -24,7 +24,8 @@ import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
-import org.json4s.JsonAST.JValue
+import org.json4s.{CustomSerializer, DefaultFormats, Formats}
+import org.json4s.JsonAST.{JArray, JValue}
 import org.json4s.jackson.JsonMethods
 
 object BatchQueryDriver extends HttpLikeRpc with Logging {
@@ -125,6 +126,9 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
       ReferenceGenome.addFatalOnCollision(env.references, refs): Unit
   }
 
+  implicit override val fmts: Formats =
+    DefaultFormats + RequesterPaysConfigFormats
+
   def main(argv: Array[String]): Unit = {
     assert(argv.length == 7, argv.toFastSeq)
 
@@ -141,14 +145,13 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
 
     sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 
+    val fsConfig =
+      CloudStorageConfig.readEnv(
+        Some(Path.of(scratchDir, "secrets/gsa-key/key.json"))
+      )
+
     val (rpcConfig, jobConfig, action, payload) = {
-      val bootstrapFs =
-        RouterFS.buildRoutes(
-          CloudStorageFSConfig.fromFlagsAndEnv(
-            Some(Path.of(scratchDir, "secrets/gsa-key/key.json")),
-            HailFeatureFlags.fromEnv(),
-          )
-        )
+      val bootstrapFs = RouterFS.buildRoutes(fsConfig)
 
       using(bootstrapFs.openNoCompression(inputURL)) { is =>
         val input = JsonMethods.parse(is)
@@ -161,15 +164,12 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
       }
     }
 
-    // requester pays config is conveyed in feature flags currently
-    val featureFlags =
-      HailFeatureFlags.fromEnv(rpcConfig.flags)
-
     val fs =
       RouterFS.buildRoutes(
-        CloudStorageFSConfig.fromFlagsAndEnv(
-          Some(Path.of(scratchDir, "secrets/gsa-key/key.json")),
-          featureFlags,
+        fsConfig.copy(
+          google = fsConfig.google.map(_.copy(
+            requester_pays_config = rpcConfig.requester_pays_conf
+          ))
         )
       )
 
@@ -203,7 +203,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
     try runRpc(
         Env(
           backend,
-          featureFlags,
+          HailFeatureFlags.fromEnv(rpcConfig.flags),
           new HailClassLoader(getClass.getClassLoader),
           fs,
           rpcConfig.tmp_dir,
@@ -255,8 +255,22 @@ case class SequenceConfig(fasta: String, index: String)
 case class ServiceBackendRPCPayload(
   tmp_dir: String,
   flags: Map[String, String],
+  requester_pays_conf: Option[RequesterPaysConfig],
   custom_references: Array[String],
   liftovers: Map[String, Map[String, String]],
   sequences: Map[String, SequenceConfig],
   max_read_parallelism: Option[Int],
 )
+
+object RequesterPaysConfigFormats
+    extends CustomSerializer[RequesterPaysConfig](implicit fmts =>
+      (
+        { case JArray(List(project, buckets)) =>
+          RequesterPaysConfig(
+            project = project.extract[String],
+            buckets = buckets.extract[Option[Set[String]]],
+          )
+        },
+        PartialFunction.empty,
+      )
+    )

--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -55,7 +55,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
   private[this] var localTmpdir: String = _
 
   private[this] var tmpFileManager = new OwningTempFileManager(
-    newFs(CloudStorageFSConfig.fromFlagsAndEnv(None, flags))
+    newFs(CloudStorageConfig.readEnv(None))
   )
 
   def pyFs: FS =
@@ -97,7 +97,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     synchronized {
       tmpFileManager.close()
 
-      val cloudfsConf = CloudStorageFSConfig.fromFlagsAndEnv(None, flags)
+      val cloudfsConf = CloudStorageConfig.readEnv(None)
 
       val rpConfig: Option[RequesterPaysConfig] =
         (
@@ -115,7 +115,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
         cloudfsConf.copy(
           google = (cloudfsConf.google, rpConfig) match {
             case (Some(gconf), _) => Some(gconf.copy(requester_pays_config = rpConfig))
-            case (None, Some(_)) => Some(GoogleStorageFSConfig(None, rpConfig))
+            case (None, Some(_)) => Some(GoogleStorageConfig(None, rpConfig))
             case _ => None
           }
         )
@@ -354,7 +354,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
       }
     }
 
-  private[this] def newFs(cloudfsConfig: CloudStorageFSConfig): FS =
+  private[this] def newFs(cloudfsConfig: CloudStorageConfig): FS =
     backend match {
       case s: SparkBackend =>
         val conf = new Configuration(s.sc.hadoopConfiguration)

--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.service
 
-import is.hail.{HailFeatureFlags, Revision}
+import is.hail.Revision
 import is.hail.asm4s._
 import is.hail.backend.Backend.PartitionFn
 import is.hail.backend.HailTaskContext
@@ -184,9 +184,8 @@ object Worker extends Logging {
     val hcl = new HailClassLoader(getClass.getClassLoader)
 
     val fs = RouterFS.buildRoutes(
-      CloudStorageFSConfig.fromFlagsAndEnv(
-        Some(Path.of(scratchDir, "secrets/gsa-key/key.json")),
-        HailFeatureFlags.fromEnv(),
+      CloudStorageConfig.readEnv(
+        Some(Path.of(scratchDir, "secrets/gsa-key/key.json"))
       )
     )
 

--- a/hail/hail/src/is/hail/io/fs/AzureStorageFS.scala
+++ b/hail/hail/src/is/hail/io/fs/AzureStorageFS.scala
@@ -107,7 +107,7 @@ object AzureStorageFileListEntry {
     new BlobStorageFileListEntry(url.toString, null, 0, true)
 }
 
-case class AzureStorageFSConfig(credentials_file: Option[Path])
+case class AzureStorageConfig(credentials_file: Option[Path])
 
 class AzureStorageFS(val credential: AzureCloudCredentials) extends FS {
   type URL = AzureStorageFSURL

--- a/hail/hail/src/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/hail/src/is/hail/io/fs/GoogleStorageFS.scala
@@ -1,12 +1,10 @@
 package is.hail.io.fs
 
-import is.hail.HailFeatureFlags
 import is.hail.collection.FastSeq
 import is.hail.io.fs.FSUtil.dropTrailingSlash
 import is.hail.io.fs.GoogleStorageFS.RequesterPaysFailure
 import is.hail.services.{isTransientError, retryTransientErrors}
 import is.hail.services.oauth2.GoogleCloudCredentials
-import is.hail.utils._
 
 import scala.jdk.CollectionConverters._
 
@@ -108,28 +106,7 @@ object GoogleStorageFileListEntry {
 
 case class RequesterPaysConfig(project: String, buckets: Option[Set[String]])
 
-object RequesterPaysConfig {
-  object Flags {
-    val RequesterPaysProject = "gcs_requester_pays_project"
-    val RequesterPaysBuckets = "gcs_requester_pays_buckets"
-  }
-
-  def fromFlags(flags: HailFeatureFlags): Option[RequesterPaysConfig] =
-    FastSeq(Flags.RequesterPaysProject, Flags.RequesterPaysBuckets).map(flags.lookup) match {
-      case Seq(Some(project), buckets) =>
-        Some(RequesterPaysConfig(project, buckets.map(_.split(",").toSet)))
-      case Seq(None, Some(buckets)) =>
-        fatal(
-          s"'${Flags.RequesterPaysBuckets}' requires '${Flags.RequesterPaysProject}'." +
-            s"Expected: <undefined>" +
-            s"  Actual: '$buckets'"
-        )
-      case _ =>
-        None
-    }
-}
-
-case class GoogleStorageFSConfig(
+case class GoogleStorageConfig(
   credentials_file: Option[Path],
   requester_pays_config: Option[RequesterPaysConfig],
 )

--- a/hail/hail/src/is/hail/io/fs/RouterFS.scala
+++ b/hail/hail/src/is/hail/io/fs/RouterFS.scala
@@ -1,9 +1,8 @@
 package is.hail.io.fs
 
-import is.hail.HailFeatureFlags
 import is.hail.collection.FastSeq
 import is.hail.services.oauth2.{AzureCloudCredentials, GoogleCloudCredentials}
-import is.hail.utils.SerializableHadoopConfiguration
+import is.hail.utils.{fatal, SerializableHadoopConfiguration}
 
 import java.io.Serializable
 import java.nio.file.Path
@@ -21,41 +20,36 @@ class RouterFSURL(val fs: FS, _url: FSURL[_]) extends FSURL[RouterFSURL] {
   override def toString: String = _url.toString
 }
 
-case class CloudStorageFSConfig(
-  azure: Option[AzureStorageFSConfig] = None,
-  google: Option[GoogleStorageFSConfig] = None,
+case class CloudStorageConfig(
+  azure: Option[AzureStorageConfig] = None,
+  google: Option[GoogleStorageConfig] = None,
 ) extends Serializable
 
-object CloudStorageFSConfig {
-  def fromFlagsAndEnv(
-    credentialsFile: Option[Path],
-    flags: HailFeatureFlags,
-    env: Map[String, String] = sys.env,
-  ): CloudStorageFSConfig = {
+object CloudStorageConfig {
+  def readEnv(credentialsFile: Option[Path], env: Map[String, String] = sys.env)
+    : CloudStorageConfig =
     env.get("HAIL_CLOUD") match {
       case Some("azure") =>
-        CloudStorageFSConfig(azure = Some(AzureStorageFSConfig(credentialsFile)))
+        CloudStorageConfig(azure = Some(AzureStorageConfig(credentialsFile)))
       case Some("gcp") | None =>
-        val rpConf = RequesterPaysConfig.fromFlags(flags)
-        CloudStorageFSConfig(google = Some(GoogleStorageFSConfig(credentialsFile, rpConf)))
-      case _ =>
-        CloudStorageFSConfig()
+        CloudStorageConfig(google = Some(GoogleStorageConfig(credentialsFile, None)))
+      case unknown =>
+        fatal(s"unknown cloud vendor: '$unknown'.")
     }
-  }
 }
 
 object RouterFS {
 
-  def buildRoutes(cloudConfig: CloudStorageFSConfig, env: Map[String, String] = sys.env): FS =
+  def buildRoutes(cloudConfig: CloudStorageConfig, env: Map[String, String] = sys.env): FS =
     new RouterFS(
       IndexedSeq.concat(
-        cloudConfig.google.map { case GoogleStorageFSConfig(path, rpConfig) =>
+        cloudConfig.google.map { case GoogleStorageConfig(path, rpConfig) =>
           new GoogleStorageFS(
             GoogleCloudCredentials(path).scoped(GoogleStorageFS.RequiredOAuthScopes),
             rpConfig,
           )
         },
-        cloudConfig.azure.map { case AzureStorageFSConfig(path) =>
+        cloudConfig.azure.map { case AzureStorageConfig(path) =>
           if (env.contains("HAIL_TERRA"))
             new TerraAzureStorageFS(
               AzureCloudCredentials(path, env)

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -9,6 +9,7 @@ from typing import AbstractSet, Any, ClassVar, Dict, List, Mapping, Optional, Se
 
 import orjson
 
+from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
 from hailtop.config.user_config import unchecked_configuration_of
 from hailtop.fs.fs import FS
 
@@ -175,8 +176,6 @@ class Backend(abc.ABC):
         "branching_factor": ("HAIL_BRANCHING_FACTOR", None),
         "cachedir": ("HAIL_CACHE_DIR", None),
         "distributed_scan_comb_op": ("HAIL_DEV_DISTRIBUTED_SCAN_COMB_OP", None),
-        "gcs_requester_pays_buckets": ("HAIL_GCS_REQUESTER_PAYS_BUCKETS", None),
-        "gcs_requester_pays_project": ("HAIL_GCS_REQUESTER_PAYS_PROJECT", None),
         "grouped_aggregate_buffer_size": ("HAIL_GROUPED_AGGREGATE_BUFFER_SIZE", "50"),
         "index_branching_factor": ("HAIL_INDEX_BRANCHING_FACTOR", None),
         "jvm_bytecode_dump": ("HAIL_DEV_JVM_BYTECODE_DUMP", None),
@@ -417,4 +416,14 @@ class Backend(abc.ABC):
     @remote_tmpdir.setter
     @abc.abstractmethod
     def remote_tmpdir(self, dir: str) -> None:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def requester_pays_config(self) -> GCSRequesterPaysConfiguration | None:
+        pass
+
+    @requester_pays_config.setter
+    @abc.abstractmethod
+    def requester_pays_config(self, config: GCSRequesterPaysConfiguration | None):
         pass

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -25,7 +25,7 @@ class LocalBackend(Py4JBackend):
         branching_factor: int | None = None,
         skip_logging_configuration: bool = False,
         jvm_heap_size: str | None = None,
-        gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+        requester_pays_config: Optional[GCSRequesterPaysConfiguration] = None,
     ) -> Py4JBackend:
         max_heap_size = jvm_heap_size or os.getenv('HAIL_LOCAL_BACKEND_HEAP_SIZE')
 
@@ -49,7 +49,7 @@ class LocalBackend(Py4JBackend):
 
                 backend.local_tmpdir = tmpdir
                 backend.remote_tmpdir = tmpdir
-                backend.gcs_requester_pays_configuration = gcs_requester_pays_configuration
+                backend.requester_pays_config = requester_pays_config
                 backend.logger.info(f'Hail {__version__}')
 
                 return backend

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -198,7 +198,7 @@ class Py4JBackend(Backend):
 
         self._jbackend = self._is.hail.backend.driver.Py4JQueryDriver(jbackend)
         self._fs = None
-        self._gcs_requester_pays_config = None
+        self._requester_pays_config = None
 
         # This has to go after creating the SparkSession. Unclear why.
         # Maybe it does its own patch?
@@ -225,7 +225,7 @@ class Py4JBackend(Backend):
     def fs(self) -> FS:
         if self._fs is None:
             self._fs = RouterFS(
-                gcs_kwargs={"gcs_requester_pays_configuration": self.gcs_requester_pays_configuration},
+                gcs_kwargs={"gcs_requester_pays_configuration": self.requester_pays_config},
             )
         return self._fs
 
@@ -256,12 +256,12 @@ class Py4JBackend(Backend):
         self._jbackend.pySetRemoteTmp(tmpdir)
 
     @property
-    def gcs_requester_pays_configuration(self) -> GCSRequesterPaysConfiguration | None:
-        return self._gcs_requester_pays_config
+    def requester_pays_config(self) -> GCSRequesterPaysConfiguration | None:
+        return self._requester_pays_config
 
-    @gcs_requester_pays_configuration.setter
-    def gcs_requester_pays_configuration(self, config: GCSRequesterPaysConfiguration | None):
-        self._gcs_requester_pays_config = config
+    @requester_pays_config.setter
+    def requester_pays_config(self, config: GCSRequesterPaysConfiguration | None):
+        self._requester_pays_config = config
         project, buckets = (None, None) if config is None else (config, None) if isinstance(config, str) else config
         self._jbackend.pySetGcsRequesterPaysConfig(project, buckets)
         # invalidate fs to propagate requester-pays

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -15,13 +15,12 @@ from hail.experimental import read_expression, write_expression
 from hail.utils import FatalError, maybe
 from hail.version import __revision__, __version__
 from hailtop import yamlx
-from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration, get_gcs_requester_pays_configuration
+from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
 from hailtop.aiotools.fs.exceptions import UnexpectedEOFError
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.aiotools.validators import validate_file
 from hailtop.batch_client.aioclient import Batch, BatchClient, JobGroup
 from hailtop.config import ConfigVariable, configuration_of, get_remote_tmpdir
-from hailtop.fs.fs import FS
 from hailtop.fs.router_fs import RouterFS
 from hailtop.hail_event_loop import hail_event_loop
 from hailtop.utils import Timings, am_i_interactive, async_to_blocking, retry_transient_errors
@@ -79,7 +78,8 @@ class SequenceConfig:
 @dataclass
 class ServiceBackendRPCConfig:
     tmp_dir: str
-    flags: Dict[str, str]
+    flags: dict[str, str]
+    requester_pays_config: tuple[str, list[str] | None] | None
     custom_references: List[str]
     liftovers: Dict[str, Dict[str, str]]
     sequences: Dict[str, SequenceConfig]
@@ -116,7 +116,7 @@ class ServiceBackend(Backend):
         name_prefix: Optional[str] = None,
         credentials_token: Optional[str] = None,
         regions: Optional[List[str]] = None,
-        gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+        requester_pays_config: GCSRequesterPaysConfiguration | None = None,
         gcs_bucket_allow_list: Optional[List[str]] = None,
         branching_factor: Optional[int] = None,
         max_read_parallelism: int | None = None,
@@ -129,15 +129,7 @@ class ServiceBackend(Backend):
                 "project or run 'hailctl config set batch/billing_project "
                 "MY_BILLING_PROJECT'"
             )
-        gcs_requester_pays_configuration = get_gcs_requester_pays_configuration(
-            gcs_requester_pays_configuration=gcs_requester_pays_configuration,
-        )
-        async_fs = RouterAsyncFS(
-            gcs_kwargs={'gcs_requester_pays_configuration': gcs_requester_pays_configuration},
-            gcs_bucket_allow_list=gcs_bucket_allow_list,
-        )
-        async_exit_stack.push_async_callback(async_fs.close)
-        sync_fs = RouterFS(async_fs)
+
         if batch_client is None:
             batch_client = await BatchClient.create(billing_project, _token=credentials_token)
             async_exit_stack.push_async_callback(batch_client.close)
@@ -181,23 +173,9 @@ class ServiceBackend(Backend):
         if branching_factor is not None:
             flags['branching_factor'] = str(branching_factor)
 
-        if 'gcs_requester_pays_project' in flags or 'gcs_requester_pays_buckets' in flags:
-            raise ValueError(
-                'Specify neither gcs_requester_pays_project nor gcs_requester_'
-                'pays_buckets in the flags argument to ServiceBackend.create'
-            )
-        if gcs_requester_pays_configuration is not None:
-            if isinstance(gcs_requester_pays_configuration, str):
-                flags['gcs_requester_pays_project'] = gcs_requester_pays_configuration
-            else:
-                assert isinstance(gcs_requester_pays_configuration, tuple)
-                flags['gcs_requester_pays_project'] = gcs_requester_pays_configuration[0]
-                flags['gcs_requester_pays_buckets'] = ','.join(gcs_requester_pays_configuration[1])
-
         sb = ServiceBackend(
             billing_project=billing_project,
-            sync_fs=sync_fs,
-            async_fs=async_fs,
+            bucket_allow_list=gcs_bucket_allow_list,
             batch_client=batch_client,
             batch=(
                 (await batch_client.get_batch(batch_id))
@@ -214,6 +192,7 @@ class ServiceBackend(Backend):
             max_read_parallelism=max_read_parallelism,
             async_exit_stack=async_exit_stack,
         )
+        sb.requester_pays_config = requester_pays_config
         sb._initialize_flags(flags)
         return sb
 
@@ -221,8 +200,7 @@ class ServiceBackend(Backend):
         self,
         *,
         billing_project: str,
-        sync_fs: FS,
-        async_fs: RouterAsyncFS,
+        bucket_allow_list: list[str] | None = None,
         batch_client: BatchClient,
         batch: Batch,
         disable_progress_bar: bool,
@@ -237,8 +215,9 @@ class ServiceBackend(Backend):
     ):
         super(ServiceBackend, self).__init__()
         self.billing_project = billing_project
-        self._sync_fs = sync_fs
-        self._async_fs = async_fs
+        self._router_fs: RouterFS | None = None
+        self._bucket_allow_list = bucket_allow_list
+        self._requester_pays_config = None
         self._batch_client = batch_client
         self._batch = batch
         self._job_group_was_submitted: bool = False
@@ -256,7 +235,7 @@ class ServiceBackend(Backend):
         self._async_exit_stack = async_exit_stack
 
     def validate_file(self, uri: str) -> None:
-        async_to_blocking(validate_file(uri, self._async_fs))
+        async_to_blocking(validate_file(uri, self.fs.afs))
 
     def debug_info(self) -> Dict[str, Any]:
         return {
@@ -273,8 +252,15 @@ class ServiceBackend(Backend):
         }
 
     @property
-    def fs(self) -> FS:
-        return self._sync_fs
+    def fs(self) -> RouterFS:
+        if self._router_fs is None:
+            self._router_fs = RouterFS(
+                RouterAsyncFS(
+                    gcs_kwargs={'gcs_requester_pays_configuration': self._requester_pays_config},
+                    gcs_bucket_allow_list=self._bucket_allow_list,
+                )
+            )
+        return self._router_fs
 
     @property
     def jar_spec(self) -> dict:
@@ -285,11 +271,11 @@ class ServiceBackend(Backend):
         return log
 
     def stop(self):
-        hail_event_loop().run_until_complete(self._stop())
-        super().stop()
+        if self._router_fs is not None:
+            self._router_fs.close()
 
-    async def _stop(self):
-        await self._async_exit_stack.aclose()
+        hail_event_loop().run_until_complete(self._async_exit_stack.aclose())
+        super().stop()
 
     async def _run_on_batch(
         self,
@@ -306,7 +292,7 @@ class ServiceBackend(Backend):
         timings = Timings()
         async with TemporaryDirectory(ensure_exists=False) as iodir:
             with timings.step("write input"):
-                async with await self._async_fs.create(iodir + '/in') as infile:
+                async with await self.fs.afs.create(iodir + '/in') as infile:
                     await infile.write(
                         orjson.dumps({
                             'rpc_config': service_backend_config,
@@ -371,14 +357,14 @@ class ServiceBackend(Backend):
 
     async def _read_output(self, output_uri: str, input_uri: str) -> bytes:
         try:
-            driver_output = await self._async_fs.open(output_uri)
+            driver_output = await self.fs.afs.open(output_uri)
         except FileNotFoundError as exc:
             raise FatalError(
                 'Hail internal error. Please contact the Hail team and provide the following information.\n\n'
                 + yamlx.dump({
                     'service_backend_debug_info': self.debug_info(),
                     'batch_debug_info': await self._batch.debug_info(_jobs_query_string='bad', _max_jobs=10),
-                    'input_uri': await self._async_fs.read(input_uri),
+                    'input_uri': await self.fs.afs.read(input_uri),
                 })
             ) from exc
 
@@ -399,8 +385,8 @@ class ServiceBackend(Backend):
                 + yamlx.dump({
                     'service_backend_debug_info': self.debug_info(),
                     'batch_debug_info': await self._batch.debug_info(_jobs_query_string='bad', _max_jobs=10),
-                    'in': await self._async_fs.read(input_uri),
-                    'out': await self._async_fs.read(output_uri),
+                    'in': await self.fs.afs.read(input_uri),
+                    'out': await self.fs.afs.read(output_uri),
                 })
             ) from exc
 
@@ -426,11 +412,11 @@ class ServiceBackend(Backend):
         }
         sequence_file_mounts = {}
         for rg_name, (fasta_file, index_file) in added_sequences.items():
-            fasta_bucket, fasta_path = self._get_bucket_and_path(fasta_file)
-            index_bucket, index_path = self._get_bucket_and_path(index_file)
+            fasta_bucket, fasta_path = await self._get_bucket_and_path(fasta_file)
+            index_bucket, index_path = await self._get_bucket_and_path(index_file)
             for bucket, blob in [(fasta_bucket, fasta_file), (index_bucket, index_file)]:
                 readonly_fuse_buckets.add(bucket)
-                storage_requirement_bytes += await (await self._async_fs.statfile(blob)).size()
+                storage_requirement_bytes += await (await self.fs.afs.statfile(blob)).size()
             sequence_file_mounts[rg_name] = SequenceConfig(
                 f'/cloudfuse/{fasta_bucket}/{fasta_path}',
                 f'/cloudfuse/{index_bucket}/{index_path}',
@@ -441,6 +427,10 @@ class ServiceBackend(Backend):
             service_backend_config=ServiceBackendRPCConfig(
                 tmp_dir=self.remote_tmpdir,
                 flags=self.flags,
+                requester_pays_config=maybe(
+                    lambda conf: (conf, None) if isinstance(conf, str) else conf,
+                    self._requester_pays_config,
+                ),
                 custom_references=[
                     orjson.dumps(rg._config).decode('utf-8')
                     for rg in self._references.values()
@@ -478,8 +468,8 @@ class ServiceBackend(Backend):
     def remove_sequence(self, name):  # pylint: disable=unused-argument
         pass
 
-    def _get_bucket_and_path(self, blob_uri):
-        url = self._async_fs.parse_url(blob_uri)
+    async def _get_bucket_and_path(self, blob_uri):
+        url = self.fs.afs.parse_url(blob_uri)
         return '/'.join(url.bucket_parts), url.path
 
     def add_liftover(self, name: str, chain_file: str, dest_reference_genome: str):  # pylint: disable=unused-argument
@@ -498,12 +488,6 @@ class ServiceBackend(Backend):
         unknown_flags = set(flags) - self._valid_flags()
         if unknown_flags:
             raise ValueError(f'unknown flags: {", ".join(unknown_flags)}')
-        if 'gcs_requester_pays_project' in flags or 'gcs_requester_pays_buckets' in flags:
-            warnings.warn(
-                'Modifying the requester pays project or buckets at runtime '
-                'using flags is deprecated. Expect this behavior to become '
-                'unsupported soon.'
-            )
         self.flags.update(flags)
 
     def get_flags(self, *flags: str) -> Mapping[str, str]:
@@ -537,3 +521,15 @@ class ServiceBackend(Backend):
     @remote_tmpdir.setter
     def remote_tmpdir(self, tmpdir: str) -> None:
         self._remote_tmpdir = tmpdir
+
+    @property
+    def requester_pays_config(self) -> GCSRequesterPaysConfiguration | None:
+        return self._requester_pays_config
+
+    @requester_pays_config.setter
+    def requester_pays_config(self, config: GCSRequesterPaysConfiguration | None):
+        if self._router_fs is not None:
+            self._router_fs.close()
+            self._router_fs = None
+
+        self._requester_pays_config = config

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from collections.abc import Callable
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import orjson
 import pyspark
@@ -102,7 +102,7 @@ class SparkBackend(Py4JBackend):
         local_tmpdir: str,
         skip_logging_configuration: bool,
         *,
-        gcs_requester_pays_config: Optional[GCSRequesterPaysConfiguration] = None,
+        requester_pays_config: GCSRequesterPaysConfiguration | None = None,
         copy_log_on_error: bool = False,
     ):
         sc = sc or pyspark.SparkContext._active_spark_context
@@ -145,7 +145,7 @@ class SparkBackend(Py4JBackend):
 
         self.remote_tmpdir = tmpdir
         self.local_tmpdir = local_tmpdir
-        self.gcs_requester_pays_configuration = gcs_requester_pays_config
+        self.requester_pays_config = requester_pays_config
         self._copy_log_on_error = copy_log_on_error
 
         self.logger.info(f'Hail {__version__}')
@@ -168,7 +168,7 @@ class SparkBackend(Py4JBackend):
     def router_fs(self) -> RouterFS:
         if self._router_fs is None:
             self._router_fs = RouterFS(
-                gcs_kwargs={"gcs_requester_pays_configuration": self.gcs_requester_pays_configuration},
+                gcs_kwargs={"gcs_requester_pays_configuration": self.requester_pays_config},
             )
         return self._router_fs
 
@@ -179,9 +179,9 @@ class SparkBackend(Py4JBackend):
 
         self._router_fs = router_fs
 
-    @Py4JBackend.gcs_requester_pays_configuration.setter
-    def gcs_requester_pays_configuration(self, config: GCSRequesterPaysConfiguration | None):
-        Py4JBackend.gcs_requester_pays_configuration.__set__(self, config)
+    @Py4JBackend.requester_pays_config.setter
+    def requester_pays_config(self, config: GCSRequesterPaysConfiguration | None):
+        Py4JBackend.requester_pays_config.__set__(self, config)
         self.router_fs = None
 
     def stop(self):

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -369,6 +369,10 @@ def init(
         )
         backend = 'batch'
 
+    requester_pays_config = get_gcs_requester_pays_configuration(
+        gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+    )
+
     if backend == 'batch':
         if os.getenv('HAIL_QUERY_USE_EXPERIMENTAL_BATCH_BACKEND') is not None:
             return hail.experimental.init(
@@ -385,7 +389,7 @@ def init(
                 worker_cores=worker_cores,
                 worker_memory=worker_memory,
                 batch_id=batch_id,
-                gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+                gcs_requester_pays_configuration=requester_pays_config,
                 regions=regions,
                 gcs_bucket_allow_list=gcs_bucket_allow_list,
                 branching_factor=branching_factor,
@@ -406,7 +410,7 @@ def init(
                     worker_memory=worker_memory,
                     batch_id=batch_id,
                     name_prefix=app_name,
-                    gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+                    requester_pays_config=requester_pays_config,
                     regions=regions,
                     gcs_bucket_allow_list=gcs_bucket_allow_list,
                     branching_factor=branching_factor,
@@ -430,7 +434,7 @@ def init(
             default_reference=default_reference,
             global_seed=global_seed,
             skip_logging_configuration=skip_logging_configuration,
-            gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+            requester_pays_config=requester_pays_config,
             copy_log_on_error=copy_spark_log_on_error,
         )
     if backend == 'local':
@@ -442,7 +446,7 @@ def init(
             default_reference=default_reference,
             global_seed=global_seed,
             skip_logging_configuration=skip_logging_configuration,
-            gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+            requester_pays_config=requester_pays_config,
         )
     raise ValueError(f'unknown Hail Query backend: {backend}')
 
@@ -463,7 +467,7 @@ def init(
     spark_conf=nullable(dictof(str, str)),
     skip_logging_configuration=bool,
     local_tmpdir=nullable(str),
-    gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
+    requester_pays_config=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
     copy_log_on_error=nullable(bool),
 )
 def init_spark(
@@ -482,24 +486,18 @@ def init_spark(
     spark_conf=None,
     skip_logging_configuration=False,
     local_tmpdir=None,
-    gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+    requester_pays_config: GCSRequesterPaysConfiguration | None = None,
     copy_log_on_error: bool = False,
 ):
     from hail.backend.spark_backend import SparkBackend
 
     log = _get_log(log)
     tmpdir = _get_tmpdir(tmp_dir)
-    local_tmpdir = _get_local_tmpdir(local_tmpdir)
-
-    app_name = app_name or 'Hail'
-    gcs_requester_pays_configuration = get_gcs_requester_pays_configuration(
-        gcs_requester_pays_configuration=gcs_requester_pays_configuration,
-    )
 
     backend = SparkBackend(
         sc,
         spark_conf,
-        app_name,
+        app_name or 'Hail',
         master,
         local,
         log,
@@ -508,11 +506,12 @@ def init_spark(
         min_block_size,
         branching_factor,
         tmpdir,
-        local_tmpdir,
+        _get_local_tmpdir(local_tmpdir),
         skip_logging_configuration,
-        gcs_requester_pays_config=gcs_requester_pays_configuration,
+        requester_pays_config=requester_pays_config,
         copy_log_on_error=copy_log_on_error,
     )
+
     if not backend.fs.exists(tmpdir):
         backend.fs.mkdir(tmpdir)
 
@@ -536,7 +535,7 @@ def init_spark(
     batch_id=nullable(int),
     name_prefix=nullable(str),
     token=nullable(str),
-    gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
+    requester_pays_config=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
     regions=nullable(sequenceof(str)),
     gcs_bucket_allow_list=nullable(sequenceof(str)),
     branching_factor=nullable(int),
@@ -560,7 +559,7 @@ async def init_batch(
     batch_id: Optional[int] = None,
     name_prefix: Optional[str] = None,
     token: Optional[str] = None,
-    gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+    requester_pays_config: Optional[GCSRequesterPaysConfiguration] = None,
     regions: Optional[List[str]] = None,
     gcs_bucket_allow_list: Optional[List[str]] = None,
     branching_factor: Optional[int] = None,
@@ -581,7 +580,7 @@ async def init_batch(
         name_prefix=name_prefix,
         credentials_token=token,
         regions=regions,
-        gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+        requester_pays_config=requester_pays_config,
         gcs_bucket_allow_list=gcs_bucket_allow_list,
         branching_factor=branching_factor,
         max_read_parallelism=max_read_parallelism,
@@ -601,7 +600,7 @@ async def init_batch(
     global_seed=nullable(int),
     skip_logging_configuration=bool,
     jvm_heap_size=nullable(str),
-    gcs_requester_pays_configuration=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
+    requester_pays_config=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
 )
 def init_local(
     log=None,
@@ -613,7 +612,7 @@ def init_local(
     global_seed=None,
     skip_logging_configuration=False,
     jvm_heap_size=None,
-    gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+    requester_pays_config: GCSRequesterPaysConfiguration | None = None,
 ):
     from hail.backend.local_backend import LocalBackend
 
@@ -629,7 +628,7 @@ def init_local(
         branching_factor,
         skip_logging_configuration,
         jvm_heap_size,
-        gcs_requester_pays_configuration,
+        requester_pays_config,
     )
 
     if not backend.fs.exists(tmpdir):

--- a/hail/python/hail/experimental/context.py
+++ b/hail/python/hail/experimental/context.py
@@ -9,7 +9,7 @@ from hail.context import init as init_
 from hail.utils import maybe
 from hail.utils.java import BackendType, array_of, choose_backend, scala_object
 from hail.version import __version__
-from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
+from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration, get_gcs_requester_pays_configuration
 from hailtop.config import ConfigVariable, configuration_of, get_remote_tmpdir
 
 
@@ -93,7 +93,9 @@ def init(
             backend = LocalBackend(gateway, jbackend, flags)
             backend.remote_tmpdir = remote_tmpdir
             backend.local_tmpdir = tmp_dir
-            backend.gcs_requester_pays_configuration = gcs_requester_pays_configuration
+            backend.requester_pays_config = get_gcs_requester_pays_configuration(
+                gcs_requester_pays_configuration=gcs_requester_pays_configuration,
+            )
 
             backend.logger.info(f'Hail {__version__}')
 

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -20,7 +20,7 @@ from hail.table import Table
 from hail.typecheck import anytype, nullable, numeric, oneof, typecheck
 from hail.utils import FatalError
 from hail.utils.java import Env, info, warning
-from hail.utils.misc import divide_null, guess_cloud_spark_provider, new_temp_file
+from hail.utils.misc import divide_null, guess_cloud_spark_provider, maybe, new_temp_file
 from hailtop import __pip_version__, yamlx
 from hailtop.config import get_deploy_config
 from hailtop.utils import async_to_blocking
@@ -955,8 +955,8 @@ def _service_vep(
     else:
         vep_config = _supported_vep_config(cloud, reference_genome, regions=regions)
 
-    requester_pays_project = backend.flags.get('gcs_requester_pays_project')
-    if requester_pays_project is None and vep_config.data_bucket_is_requester_pays and vep_config.cloud == 'gcp':
+    requester_pays_config = backend.requester_pays_config
+    if requester_pays_config is None and vep_config.data_bucket_is_requester_pays and vep_config.cloud == 'gcp':
         raise ValueError(
             "No requester pays project has been set. "
             "Use hl.init(gcs_requester_pays_configuration='MY_PROJECT') "
@@ -996,7 +996,7 @@ def _service_vep(
                 cloudfuse=[(vep_config.data_bucket, vep_config.data_mount, True)],
                 output_files=[(local_output_file, f'{vep_output_path}/csq-header')],
                 regions=vep_config.regions,
-                requester_pays_project=requester_pays_project,
+                requester_pays_project=maybe(lambda c: c if isinstance(c, str) else c[0], requester_pays_config),
                 env=env,
             )
 
@@ -1039,7 +1039,7 @@ def _service_vep(
                 output_files=[(local_output_file, f'{vep_output_path}/annotations/{part_name}.tsv.gz')],
                 cloudfuse=[(vep_config.data_bucket, vep_config.data_mount, True)],
                 regions=vep_config.regions,
-                requester_pays_project=requester_pays_project,
+                requester_pays_project=requester_pays_config,
                 env=env,
             )
 

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -682,5 +682,5 @@ def chunk(size: int, seq: Sequence[A]) -> Generator[Sequence[A], A, Any]:
         yield seq[pos : pos + size]
 
 
-def maybe(f: Callable[[A], B], ma: Optional[A], default: Optional[B] = None) -> Optional[B]:
+def maybe(f: Callable[[A], B], ma: A | None, default: B | None = None) -> B | None:
     return f(ma) if ma is not None else default

--- a/hail/python/test/hail/backend/test_service_backend.py
+++ b/hail/python/test/hail/backend/test_service_backend.py
@@ -39,7 +39,7 @@ def run_on_batch_mocks(mocker):
     outfile = type('Settable', (object,), {'value': None})
 
     async def write_output(*args, **kwargs):
-        async with await backend._async_fs.create(outfile.value) as f:
+        async with await backend.fs.afs.create(outfile.value) as f:
             payload = hl.ttuple(hl.tint64)._to_encoding([0])
             await f.write(struct.pack('<b', 1))
             await f.write(struct.pack('<i', len(payload)))

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -18,17 +18,18 @@ def hl_init_for_test(**kwargs):
     backend_name = choose_backend(kwargs.get('backend'))
 
     init_kwargs = {
-        **kwargs,
+        'gcs_requester_pays_configuration': GCS_REQUESTER_PAYS_PROJECT,
         'backend': backend_name,
         'global_seed': 0,
+        **kwargs,
     }
 
     if backend_name == 'spark':
         init_kwargs = {
-            **init_kwargs,
             'master': f'local[{HAIL_QUERY_N_CORES}]',
             'min_block_size': 0,
             'quiet': True,
+            **init_kwargs,
         }
 
     hl.init(**init_kwargs)
@@ -223,12 +224,6 @@ def with_flags(**flags):
             hl._set_flags(**prev_flags)
 
     return wrapper
-
-
-def set_gcs_requester_pays_configuration(gcs_project):
-    if gcs_project is not None:
-        return with_flags(gcs_requester_pays_project=gcs_project)
-    return with_flags()
 
 
 def lower_only():

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -10,11 +10,8 @@ from hail.methods.qc import VEPConfigGRCh37Version85, VEPConfigGRCh38Version95
 from ..helpers import (
     get_dataset,
     resource,
-    set_gcs_requester_pays_configuration,
     test_timeout,
 )
-
-GCS_REQUESTER_PAYS_PROJECT = os.environ.get('GCS_REQUESTER_PAYS_PROJECT')
 
 
 class Tests(unittest.TestCase):
@@ -336,7 +333,6 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch37_consequence_true(self):
         gnomad_vep_result = hl.import_vcf(
@@ -359,7 +355,6 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_consequence_true(self):
         gnomad_vep_result = hl.import_vcf(
@@ -384,7 +379,6 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch37_consequence_false(self):
         mt = hl.import_vcf(
@@ -398,7 +392,6 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_consequence_false(self):
         mt = hl.import_vcf(
@@ -412,7 +405,6 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch37_against_dataproc(self):
         mt = hl.import_vcf(resource('sample.vcf.gz'), reference_genome='GRCh37', force_bgz=True, n_partitions=4)
@@ -466,7 +458,6 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_against_dataproc(self):
         dataproc_result = hl.import_table(
@@ -520,7 +511,6 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @set_gcs_requester_pays_configuration(GCS_REQUESTER_PAYS_PROJECT)
     @test_timeout(batch=5 * 60)
     def test_vep_grch38_with_large_positions(self):
         bad_variants = hl.import_table(


### PR DESCRIPTION
Requester pays configuration is now serialised and set with the ServiceBackendRPC payload instead of via the feature flags.

This change does not affect the broad-managed batch service in gcp.