### PR TITLE
[batch] inject local ubuntu package mirror

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1154,6 +1154,7 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
 
         always_run = spec.pop('always_run', False)
         n_max_attempts = spec.pop('n_max_attempts', 20)
+        apt_rewrite = spec.pop('apt_rewrite', True)
 
         cloud = spec.get('cloud', CLOUD)
 
@@ -1193,6 +1194,19 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
             if rewritten_image is not None:
                 spec['process']['image'] = rewritten_image
                 log.info(f'Rewrote Docker Hub image {original_image} to {rewritten_image} for job {batch_id}/{job_id}')
+
+        # On GCP, prepend a one-liner to redirect apt traffic to the regional GCE Ubuntu mirror.
+        # This avoids CloudNAT egress and reduces apt-get update cost. HAIL_REGION is injected
+        # into every job container by the worker and resolves to the worker's GCP region at runtime.
+        # Only applies to shell-invoked commands ([shell, '-c', script]). Opt out with apt_rewrite: false.
+        if apt_rewrite and cloud == 'gcp' and spec['process']['type'] == 'docker':
+            command = spec['process']['command']
+            if len(command) == 3 and command[1] == '-c':
+                apt_redirect = (
+                    'sed -i "s|archive\\.ubuntu\\.com|${HAIL_REGION}.gce.archive.ubuntu.com|g"'
+                    ' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true'
+                )
+                spec['process']['command'] = [command[0], command[1], apt_redirect + '\n' + command[2]]
 
         if spec['process']['type'] == 'jvm':
             jvm_requested_cpu = parse_cpu_in_mcpu(resources.get('cpu', BATCH_JOB_DEFAULT_CPU))

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -45,6 +45,7 @@ image_str = str_type
 job_validator = keyed({
     'always_copy_output': bool_type,
     'always_run': bool_type,
+    'apt_rewrite': bool_type,
     'attributes': dictof(str_type),
     'env': listof(keyed({'name': str_type, 'value': str_type})),
     'cloudfuse': listof(

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1830,21 +1830,6 @@ class DockerJob(Job):
 
         assert self.worker.fs
         command = job_spec['process']['command']
-        # On GCP, prepend a one-liner to each job script that replaces the Canonical Ubuntu
-        # mirror with the regional GCE internal mirror. This avoids CloudNAT egress and
-        # halves apt-get update traffic (no duplicate fetches from both sources).
-        # Only applies to shell-invoked commands ([shell, '-c', script]).
-        if CLOUD == 'gcp' and len(command) == 3 and command[1] == '-c':
-            gce_mirror = f'{REGION}.gce.archive.ubuntu.com'
-            # Back up originals first so jobs can restore with:
-            #   mv /etc/apt/sources.list.backup /etc/apt/sources.list
-            apt_redirect = (
-                f"cp /etc/apt/sources.list /etc/apt/sources.list.backup 2>/dev/null || true; "
-                f"for f in /etc/apt/sources.list.d/*.list; do cp \"$f\" \"$f.backup\" 2>/dev/null || true; done; "
-                f"sed -i 's|archive\\.ubuntu\\.com|{gce_mirror}|g' "
-                f"/etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true"
-            )
-            command = [command[0], command[1], apt_redirect + '\n' + command[2]]
         containers['main'] = Container(
             task_manager=self.task_manager,
             fs=self.worker.fs,

--- a/dev-docs/services/apt-mirror.md
+++ b/dev-docs/services/apt-mirror.md
@@ -1,0 +1,66 @@
+# Automatic apt Source Rewriting
+
+On GCP, Hail Batch automatically rewrites apt sources in job containers to use the regional GCE
+Ubuntu mirror instead of the default Canonical mirror (`archive.ubuntu.com`). This reduces
+CloudNAT egress costs and improves `apt-get` performance.
+
+## How It Works
+
+At job submission time, if the job is targeting GCP and uses a shell-invoked command
+(`[shell, '-c', script]`), the batch frontend prepends a `sed` one-liner to the job script that
+rewrites `/etc/apt/sources.list` and all files in `/etc/apt/sources.list.d/`:
+
+```bash
+sed -i "s|archive\.ubuntu\.com|${HAIL_REGION}.gce.archive.ubuntu.com|g" \
+  /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true
+```
+
+`HAIL_REGION` is an environment variable injected into every job container by the worker at
+runtime, containing the GCP region the worker is running in (e.g. `us-central1`). Because it is
+resolved at runtime, the correct regional mirror is used even if a job is retried in a different
+region.
+
+The rewrite is part of the stored job command and is visible in the **Command** section of the
+Batch UI.
+
+## Implementation
+
+The rewrite is applied in `batch/batch/front_end/front_end.py`, in the job processing loop,
+immediately after the Docker Hub image rewriting block. The logic is:
+
+- Only applies when `cloud == 'gcp'`
+- Only applies to `type == 'docker'` processes
+- Only applies to shell-invoked commands (3-element list with `command[1] == '-c'`)
+- Skipped if the job spec includes `apt_rewrite: false`
+
+`HAIL_REGION` is set by the worker in `batch/batch/worker/worker.py` (`hail_extra_env`, alongside
+`HAIL_BATCH_ID`, `HAIL_JOB_ID`, etc.).
+
+## Opting Out
+
+Jobs that need the canonical Canonical mirror can opt out via the `apt_rewrite` job parameter:
+
+**Python batch client (`hailtop.batch`):**
+```python
+j = b.new_job()
+j.apt_rewrite(False)
+```
+
+**Low-level batch client (`hailtop.batch_client`):**
+```python
+batch.create_job(image, command, apt_rewrite=False)
+```
+
+**Raw job spec:**
+```json
+{ "apt_rewrite": false, ... }
+```
+
+## Why Not Worker-Side?
+
+An earlier implementation applied this rewrite in the worker process after receiving the job spec.
+Moving it to the frontend means:
+
+- The rewrite is visible in the Batch UI (Command section), so users can see exactly what runs
+- It follows the same pattern as Docker Hub image rewriting
+- The worker no longer silently mutates the command it was given

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -894,6 +894,7 @@ class ServiceBackend(Backend[bc.Batch]):
                 user_code=user_code,
                 regions=job._regions,
                 always_copy_output=job._always_copy_output,
+                apt_rewrite=job._apt_rewrite,
             )
 
             n_jobs_submitted += 1

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -326,6 +326,29 @@ Container (aka Docker) images are a form of data. In Google Cloud Platform, we r
 your images in a multi-regional artifact registry, which at time of writing, despite being
 "multi-regional", does not incur network charges in the manner described above.
 
+.. _apt-rewrite:
+
+Automatic apt Source Rewriting (GCP)
+-------------------------------------
+
+On GCP, Hail Batch automatically rewrites ``/etc/apt/sources.list`` at the start of each
+shell-invoked job to use the regional GCE Ubuntu mirror (e.g.
+``us-central1.gce.archive.ubuntu.com``) instead of the default Canonical mirror
+(``archive.ubuntu.com``). This reduces CloudNAT egress costs and generally improves
+``apt-get`` performance since the GCE mirror is co-located with your workers.
+
+The rewrite is prepended to your job's command and is visible in the **Command** section of
+the Batch UI.
+
+If your job requires the canonical Canonical mirror — for example, to access a package version
+not yet synced to the GCE mirror — you can opt out:
+
+.. code-block:: python
+
+    >>> j = b.new_job()
+    >>> j.apt_rewrite(False)
+    >>> j.command('apt-get install -y my-package')
+
 
 Using the UI
 ------------

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -81,6 +81,7 @@ class Job:
         self._storage: Optional[str] = None
         self._image: Optional[str] = None
         self._always_run: bool = False
+        self._apt_rewrite: bool = True
         self._n_max_attempts: int = 20
         self._preemptible: Optional[bool] = None
         self._machine_type: Optional[str] = None
@@ -321,6 +322,30 @@ class Job:
         """
 
         self._cpu = opt_str(cores)
+        return self
+
+    def apt_rewrite(self, apt_rewrite: bool = True) -> Self:
+        """
+        Control whether apt sources are rewritten to use the regional GCE Ubuntu mirror.
+
+        On GCP, Hail Batch rewrites ``/etc/apt/sources.list`` to use the regional GCE Ubuntu
+        mirror (e.g. ``us-central1.gce.archive.ubuntu.com``) instead of the default Canonical
+        mirror. This reduces CloudNAT egress costs and improves apt-get performance. The rewrite
+        is visible in the Command section of the Batch UI.
+
+        Set to ``False`` if your job requires the canonical Canonical mirror specifically,
+        e.g. to access a package version not yet synced to the GCE mirror.
+
+        Parameters
+        ----------
+        apt_rewrite:
+            If True (default), rewrite apt sources to the regional GCE mirror on GCP.
+
+        Returns
+        -------
+        Same job object.
+        """
+        self._apt_rewrite = apt_rewrite
         return self
 
     def always_run(self, always_run: bool = True) -> Self:

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -818,6 +818,7 @@ class Batch:
         unconfined: bool = False,
         user_code: Optional[str] = None,
         regions: Optional[List[str]] = None,
+        apt_rewrite: bool = True,
     ) -> Job:
         self._in_update_job_id += 1
 
@@ -908,6 +909,8 @@ class Batch:
             job_spec['user_code'] = user_code
         if regions:
             job_spec['regions'] = regions
+        if not apt_rewrite:
+            job_spec['apt_rewrite'] = False
 
         self._job_specs.append(job_spec)
 

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -182,6 +182,7 @@ class JobGroup:
         user_code: Optional[str] = None,
         regions: Optional[List[str]] = None,
         always_copy_output: bool = False,
+        apt_rewrite: bool = True,
     ) -> Job:
         if parents:
             parents = [parent._async_job for parent in parents]
@@ -209,6 +210,7 @@ class JobGroup:
             unconfined=unconfined,
             user_code=user_code,
             regions=regions,
+            apt_rewrite=apt_rewrite,
         )
 
         return Job(async_job)
@@ -323,6 +325,7 @@ class Batch:
         user_code: Optional[str] = None,
         regions: Optional[List[str]] = None,
         always_copy_output: bool = False,
+        apt_rewrite: bool = True,
     ) -> Job:
         if parents:
             parents = [parent._async_job for parent in parents]
@@ -349,6 +352,7 @@ class Batch:
             unconfined=unconfined,
             user_code=user_code,
             regions=regions,
+            apt_rewrite=apt_rewrite,
         )
 
         return Job(async_job)


### PR DESCRIPTION
## Change Description

For both speed of download and CloudNAT friendliness, add the internal Google ubuntu package mirror to apt sources for all jobs on GCP

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

User jobs get to benefit from a closer package mirror. Standard on google VM images and docker builds, but not for docker images built on non-google starting points.

Hail system pays less in cloud nat ingress

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
