### PR TITLE
[ci] download individual files rather than sync entire repo

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1,4 +1,6 @@
 import abc
+import asyncio
+import base64
 import json
 import logging
 from collections import Counter, defaultdict
@@ -25,6 +27,12 @@ from .globals import is_test_deployment
 from .utils import generate_token
 
 log = logging.getLogger('ci')
+
+
+async def download_repo_file(gh, repo_ss: str, sha: str, path: str) -> str:
+    resp = await gh.getitem(f'/repos/{repo_ss}/contents/{path}?ref={sha}')
+    return base64.b64decode(resp['content']).decode('utf-8')
+
 
 pretty_print_log = "jq -Rr '. as $raw | try \
 (fromjson | if .hail_log == 1 then \
@@ -73,10 +81,6 @@ class Code(abc.ABC):
     @abc.abstractmethod
     def config(self) -> Dict[str, str]:
         pass
-
-    @abc.abstractmethod
-    def repo_dir(self) -> str:
-        """Path to repository on the ci (locally)."""
 
     @abc.abstractmethod
     def checkout_script(self) -> str:
@@ -164,6 +168,9 @@ class BuildConfiguration:
 
             if step.can_run_in_scope(scope):
                 step.cleanup(batch, scope, parent_jobs)
+
+    async def prefetch(self, gh, repo_ss: str, sha: str) -> None:
+        await asyncio.gather(*(step.prefetch(gh, repo_ss, sha) for step in self.steps))
 
     def namespace(self) -> Optional[str]:
         # build.yaml allows for multiple namespaces, but
@@ -260,6 +267,9 @@ class Step(abc.ABC):
 
     @abc.abstractmethod
     def wrapped_job(self) -> list:
+        pass
+
+    async def prefetch(self, gh, repo_ss: str, sha: str) -> None:
         pass
 
     @abc.abstractmethod
@@ -798,6 +808,7 @@ class DeployStep(Step):
         self.link = link
         self.wait = wait
         self.job = None
+        self._content: Optional[str] = None
 
     def wrapped_job(self):
         if self.job:
@@ -824,10 +835,15 @@ class DeployStep(Step):
     def config(self, scope):  # pylint: disable=unused-argument
         return {'token': self.token}
 
+    async def prefetch(self, gh, repo_ss: str, sha: str) -> None:
+        self._content = await download_repo_file(gh, repo_ss, sha, self.config_file)
+
     def build(self, batch, code, scope):
-        with open(f'{code.repo_dir()}/{self.config_file}', 'r', encoding='utf-8') as f:
-            template = jinja2.Template(f.read(), undefined=jinja2.StrictUndefined, trim_blocks=True, lstrip_blocks=True)
-            rendered_config = template.render(**self.input_config(code, scope))
+        assert self._content is not None, f'DeployStep {self.name}: prefetch() must be called before build()'
+        template = jinja2.Template(
+            self._content, undefined=jinja2.StrictUndefined, trim_blocks=True, lstrip_blocks=True
+        )
+        rendered_config = template.render(**self.input_config(code, scope))
 
         script = """\
 set -ex

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -681,7 +681,9 @@ async def dev_deploy_branch(request: web.Request, userdata: UserData) -> web.Res
     batch_client = app[AppKeys.BATCH_CLIENT]
 
     try:
-        batch_id = await unwatched_branch.deploy(app[AppKeys.DB], batch_client, steps, excluded_steps=excluded_steps)
+        batch_id = await unwatched_branch.deploy(
+            app[AppKeys.DB], batch_client, gh, steps, excluded_steps=excluded_steps
+        )
     except asyncio.CancelledError:
         raise
     except Exception as e:  # pylint: disable=broad-except

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -44,6 +44,7 @@ async def prepare_build(gh, code: Code, repo_ss: str, sha: str, scope: str, **kw
     await config.prefetch(gh, repo_ss, sha)
     return config, namespace, services, test_services
 
+
 deploy_config = get_deploy_config()
 
 CALLBACK_URL = deploy_config.url('ci', '/api/v1alpha/batch_callback')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -19,9 +19,9 @@ from gidgethub import aiohttp as gh_aiohttp
 from gear import Database, UserData
 from hailtop.batch_client.aioclient import Batch, BatchClient
 from hailtop.config import get_deploy_config
-from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
+from hailtop.utils import RETRY_FUNCTION_SCRIPT
 
-from .build import BuildConfiguration, Code
+from .build import BuildConfiguration, Code, download_repo_file
 from .constants import AUTHORIZED_USERS, COMPILER_TEAM, GITHUB_CLONE_URL, GITHUB_STATUS_CONTEXT, SERVICES_TEAM
 from .environment import DEPLOY_STEPS
 from .globals import is_test_deployment
@@ -372,9 +372,6 @@ class PR(Code):
         pr.increment_pr_metric()
         return pr
 
-    def repo_dir(self):
-        return self.target_branch.repo_dir()
-
     def config(self):
         assert self.sha is not None
         source_repo = self.source_branch.repo
@@ -541,7 +538,7 @@ class PR(Code):
             self.last_known_github_status = last_known_github_status
             self.target_branch.state_changed = True
 
-    async def _start_build(self, db: Database, batch_client: BatchClient):
+    async def _start_build(self, db: Database, batch_client: BatchClient, gh: gh_aiohttp.GitHubAPI):
         assert await self.authorized(db)
 
         # clear current batch
@@ -551,22 +548,27 @@ class PR(Code):
         batch = None
         try:
             log.info(f'merging for {self.number}')
-            repo_dir = self.repo_dir()
-            await check_shell(f"""
-set -ex
-mkdir -p {shq(repo_dir)}
-(cd {shq(repo_dir)}; {self.checkout_script()})
-""")
+            repo_ss = self.target_branch.branch.repo.short_str()
 
-            sha_out, _ = await check_shell_output(f'git -C {shq(repo_dir)} rev-parse HEAD')
-            self.sha = sha_out.decode('utf-8').strip()
+            # Get the merge commit SHA from GitHub's auto-maintained merge ref.
+            # Returns None if the PR has a merge conflict.
+            pr_data = await gh.getitem(f'/repos/{repo_ss}/pulls/{self.number}')
+            merge_sha = pr_data.get('merge_commit_sha')
+            if not merge_sha:
+                raise Exception(f'PR {self.number} has no merge commit SHA (merge conflict?)')
+            self.sha = merge_sha
 
-            with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
-                config = BuildConfiguration(self, f.read(), scope='test')
-                namespace = config.namespace()
-                services = config.deployed_services()
-            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+            build_yaml, test_build_yaml = await asyncio.gather(
+                download_repo_file(gh, repo_ss, merge_sha, 'build.yaml'),
+                download_repo_file(gh, repo_ss, merge_sha, 'ci/test/resources/build.yaml'),
+            )
+
+            config = BuildConfiguration(self, build_yaml, scope='test')
+            namespace = config.namespace()
+            services = config.deployed_services()
+            test_services = BuildConfiguration(self, test_build_yaml, scope='test').deployed_services()
+
+            await config.prefetch(gh, repo_ss, merge_sha)
 
             services.extend(test_services)
             tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
@@ -675,7 +677,7 @@ mkdir -p {shq(repo_dir)}
             if on_deck or self.target_branch.n_running_batches < MAX_CONCURRENT_PR_BATCHES:
                 self.target_branch.n_running_batches += 1
                 async with repos_lock:
-                    await self._start_build(db, batch_client)
+                    await self._start_build(db, batch_client, gh)
 
     def is_up_to_date(self):
         return self.batch is not None and self.target_branch.sha == self.batch.attributes['target_sha']
@@ -762,9 +764,6 @@ class WatchedBranch(Code):
 
     def short_str(self):
         return f'br-{self.branch.repo.owner}-{self.branch.repo.name}-{self.branch.name}'
-
-    def repo_dir(self):
-        return f'repos/{self.branch.repo.short_str()}'
 
     def config(self):
         assert self.sha is not None
@@ -915,7 +914,7 @@ url: {url}
                     await send_zulip_deploy_failure_message(deploy_failure_message, db, self.sha)
                 self.state_changed = True
 
-    async def _heal_deploy(self, db: Database, batch_client: BatchClient, frozen: bool):
+    async def _heal_deploy(self, db: Database, batch_client: BatchClient, gh: gh_aiohttp.GitHubAPI, frozen: bool):
         assert self.deployable
 
         if not self.sha:
@@ -925,7 +924,7 @@ url: {url}
             self.deploy_batch is None or (self.deploy_state and self.deploy_batch.attributes['sha'] != self.sha)
         ):
             async with repos_lock:
-                await self._start_deploy(db, batch_client)
+                await self._start_deploy(db, batch_client, gh)
 
     async def _update_batch(self, batch_client: BatchClient, db: Database):
         log.info(f'update batch {self.short_str()}')
@@ -940,7 +939,7 @@ url: {url}
         log.info(f'heal {self.short_str()}')
 
         if self.deployable:
-            await self._heal_deploy(db, batch_client, frozen)
+            await self._heal_deploy(db, batch_client, gh, frozen)
 
         merge_candidate = None
         merge_candidate_pri = None
@@ -979,7 +978,7 @@ url: {url}
                 log.info(f'cancel batch {batch.id} for {attrs["pr"]} {attrs["source_sha"]} => {attrs["target_sha"]}')
                 await batch.cancel()
 
-    async def _start_deploy(self, db: Database, batch_client: BatchClient):
+    async def _start_deploy(self, db: Database, batch_client: BatchClient, gh: gh_aiohttp.GitHubAPI):
         # not deploying
         assert not self.deploy_batch or self.deploy_state
 
@@ -989,17 +988,17 @@ url: {url}
         deploy_batch = None
         assert self.sha is not None
         try:
-            repo_dir = self.repo_dir()
-            await check_shell(f"""
-mkdir -p {shq(repo_dir)}
-(cd {shq(repo_dir)}; {self.checkout_script()})
-""")
-            with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
-                config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS, scope='deploy')
-                namespace = config.namespace()
-                services = config.deployed_services()
-            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                test_services = BuildConfiguration(self, f.read(), scope='deploy').deployed_services()
+            repo_ss = self.branch.repo.short_str()
+            build_yaml, test_build_yaml = await asyncio.gather(
+                download_repo_file(gh, repo_ss, self.sha, 'build.yaml'),
+                download_repo_file(gh, repo_ss, self.sha, 'ci/test/resources/build.yaml'),
+            )
+            config = BuildConfiguration(self, build_yaml, requested_step_names=DEPLOY_STEPS, scope='deploy')
+            namespace = config.namespace()
+            services = config.deployed_services()
+            test_services = BuildConfiguration(self, test_build_yaml, scope='deploy').deployed_services()
+
+            await config.prefetch(gh, repo_ss, self.sha)
 
             services.extend(test_services)
             assert namespace is not None
@@ -1074,9 +1073,6 @@ class UnwatchedBranch(Code):
     def short_str(self) -> str:
         return f'br-{self.branch.repo.owner}-{self.branch.repo.name}-{self.branch.name}'
 
-    def repo_dir(self) -> str:
-        return f'repos/{self.branch.repo.short_str()}'
-
     def config(self) -> Dict[str, str]:
         config = {
             'checkout_script': self.checkout_script(),
@@ -1092,26 +1088,32 @@ class UnwatchedBranch(Code):
         return config
 
     async def deploy(
-        self, db: Database, batch_client: BatchClient, steps: Sequence[str], excluded_steps: Sequence[str] = ()
+        self,
+        db: Database,
+        batch_client: BatchClient,
+        gh: gh_aiohttp.GitHubAPI,
+        steps: Sequence[str],
+        excluded_steps: Sequence[str] = (),
     ):
         assert not self.deploy_batch
 
         deploy_batch = None
         try:
-            repo_dir = self.repo_dir()
-            await check_shell(f"""
-mkdir -p {shq(repo_dir)}
-(cd {shq(repo_dir)}; {self.checkout_script()})
-""")
+            repo_ss = self.branch.repo.short_str()
             log.info(f'User {self.user} requested these steps for dev deploy: {steps}')
-            with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
-                config = BuildConfiguration(
-                    self, f.read(), scope='dev', requested_step_names=steps, excluded_step_names=excluded_steps
-                )
-                namespace = config.namespace()
-                services = config.deployed_services()
-            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                test_services = BuildConfiguration(self, f.read(), scope='dev').deployed_services()
+            build_yaml, test_build_yaml = await asyncio.gather(
+                download_repo_file(gh, repo_ss, self.sha, 'build.yaml'),
+                download_repo_file(gh, repo_ss, self.sha, 'ci/test/resources/build.yaml'),
+            )
+            config = BuildConfiguration(
+                self, build_yaml, scope='dev', requested_step_names=steps, excluded_step_names=excluded_steps
+            )
+            namespace = config.namespace()
+            services = config.deployed_services()
+            test_services = BuildConfiguration(self, test_build_yaml, scope='dev').deployed_services()
+
+            await config.prefetch(gh, repo_ss, self.sha)
+
             if namespace is not None:
                 services.extend(test_services)
                 await add_deployed_services(db, namespace, services, None)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -31,6 +31,19 @@ repos_lock = asyncio.Lock()
 
 log = logging.getLogger('ci')
 
+
+async def prepare_build(gh, code: Code, repo_ss: str, sha: str, scope: str, **kwargs):
+    build_yaml, test_build_yaml = await asyncio.gather(
+        download_repo_file(gh, repo_ss, sha, 'build.yaml'),
+        download_repo_file(gh, repo_ss, sha, 'ci/test/resources/build.yaml'),
+    )
+    config = BuildConfiguration(code, build_yaml, scope=scope, **kwargs)
+    namespace = config.namespace()
+    services = config.deployed_services()
+    test_services = BuildConfiguration(code, test_build_yaml, scope=scope).deployed_services()
+    await config.prefetch(gh, repo_ss, sha)
+    return config, namespace, services, test_services
+
 deploy_config = get_deploy_config()
 
 CALLBACK_URL = deploy_config.url('ci', '/api/v1alpha/batch_callback')
@@ -558,17 +571,7 @@ class PR(Code):
                 raise Exception(f'PR {self.number} has no merge commit SHA (merge conflict?)')
             self.sha = merge_sha
 
-            build_yaml, test_build_yaml = await asyncio.gather(
-                download_repo_file(gh, repo_ss, merge_sha, 'build.yaml'),
-                download_repo_file(gh, repo_ss, merge_sha, 'ci/test/resources/build.yaml'),
-            )
-
-            config = BuildConfiguration(self, build_yaml, scope='test')
-            namespace = config.namespace()
-            services = config.deployed_services()
-            test_services = BuildConfiguration(self, test_build_yaml, scope='test').deployed_services()
-
-            await config.prefetch(gh, repo_ss, merge_sha)
+            config, namespace, services, test_services = await prepare_build(gh, self, repo_ss, merge_sha, 'test')
 
             services.extend(test_services)
             tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
@@ -989,16 +992,9 @@ url: {url}
         assert self.sha is not None
         try:
             repo_ss = self.branch.repo.short_str()
-            build_yaml, test_build_yaml = await asyncio.gather(
-                download_repo_file(gh, repo_ss, self.sha, 'build.yaml'),
-                download_repo_file(gh, repo_ss, self.sha, 'ci/test/resources/build.yaml'),
+            config, namespace, services, test_services = await prepare_build(
+                gh, self, repo_ss, self.sha, 'deploy', requested_step_names=DEPLOY_STEPS
             )
-            config = BuildConfiguration(self, build_yaml, requested_step_names=DEPLOY_STEPS, scope='deploy')
-            namespace = config.namespace()
-            services = config.deployed_services()
-            test_services = BuildConfiguration(self, test_build_yaml, scope='deploy').deployed_services()
-
-            await config.prefetch(gh, repo_ss, self.sha)
 
             services.extend(test_services)
             assert namespace is not None
@@ -1101,18 +1097,9 @@ class UnwatchedBranch(Code):
         try:
             repo_ss = self.branch.repo.short_str()
             log.info(f'User {self.user} requested these steps for dev deploy: {steps}')
-            build_yaml, test_build_yaml = await asyncio.gather(
-                download_repo_file(gh, repo_ss, self.sha, 'build.yaml'),
-                download_repo_file(gh, repo_ss, self.sha, 'ci/test/resources/build.yaml'),
+            config, namespace, services, test_services = await prepare_build(
+                gh, self, repo_ss, self.sha, 'dev', requested_step_names=steps, excluded_step_names=excluded_steps
             )
-            config = BuildConfiguration(
-                self, build_yaml, scope='dev', requested_step_names=steps, excluded_step_names=excluded_steps
-            )
-            namespace = config.namespace()
-            services = config.deployed_services()
-            test_services = BuildConfiguration(self, test_build_yaml, scope='dev').deployed_services()
-
-            await config.prefetch(gh, repo_ss, self.sha)
 
             if namespace is not None:
                 services.extend(test_services)


### PR DESCRIPTION
## Change Description

Updates our build generator in ci.py to only download a small set of required files from github (instead of syncing the entire repo and maintaining a local FS copy of the repo - every branch and every fork)

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Swaps a set of git fetch operation with a set of git "sha lookup" and git "download file" operations

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
