### PR TITLE
[query] fix vep misbound parameter

### DIFF
--- a/hail/hail/src/is/hail/methods/VEP.scala
+++ b/hail/hail/src/is/hail/methods/VEP.scala
@@ -88,7 +88,7 @@ class VEP(private val params: VEPParameters, conf: VEPConfiguration)
 
     val csqPattern = "CSQ=[^;^\\t]+".r
     val annotations =
-      inRvd.mapPartitionsWithIndex { (_, partIdx, _, it) =>
+      inRvd.mapPartitionsWithIndex { (partIdx, _, _, it) =>
         val pb = new ProcessBuilder(cmd.toList.asJava)
         val env = pb.environment()
         for { (k, v) <- conf.env } env.put(k, v)


### PR DESCRIPTION
We seem to only test vep on release. Claude found this mistake. Hooray for our ai overlords.
This change does not impact the broad-managed batch service in gcp.