### PR TITLE
[query] fix max_read_parallelism None-handling

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -155,8 +155,8 @@ class ServiceBackend(Backend):
         driver_memory = configuration_of(ConfigVariable.QUERY_BATCH_DRIVER_MEMORY, driver_memory, None)
         worker_cores = configuration_of(ConfigVariable.QUERY_BATCH_WORKER_CORES, worker_cores, None)
         worker_memory = configuration_of(ConfigVariable.QUERY_BATCH_WORKER_MEMORY, worker_memory, None)
-        max_read_parallelism = configuration_of(
-            ConfigVariable.QUERY_BATCH_BACKEND_MAX_READ_PARALLELISM, str(max_read_parallelism), None
+        max_read_parallelism = maybe(
+            int, configuration_of(ConfigVariable.QUERY_BATCH_BACKEND_MAX_READ_PARALLELISM, max_read_parallelism, None)
         )
 
         if regions == ANY_REGION:


### PR DESCRIPTION
Fixes the following found by claude:

```
a51c7c05e6a9 Edmund Higham [qob] Expose driver maximum read parallelism ([#15322](https://github.com/hail-is/hail/issues/15322))

Severity: 4, Confidence: 5, str(None) produces the string "None" instead of None, breaking default max_read_parallelism configuration.
In service_backend.py lines 158-160, when max_read_parallelism is None (the default), str(None) evaluates to the string "None". 
Since configuration_of checks if explicit_argument is not None, this string passes through and is serialized into JSON for the Scala driver. 
On the Scala side (BatchQueryDriver.scala line 261), the field is typed Option[Int], and json4s will fail to parse "None" as an integer, 
crashing the driver. This affects every user who does NOT explicitly set max_read_parallelism.
```

This change does not affect the broad-managed batch service in gcp.