### PR TITLE
[batch] Use gcloud to localize large input files from GCS

### DIFF
--- a/batch/pinned-requirements.txt
+++ b/batch/pinned-requirements.txt
@@ -50,7 +50,7 @@ frozenlist==1.8.0
     #   -c batch/../web_common/pinned-requirements.txt
     #   aiohttp
     #   aiosignal
-idna==3.11
+idna==3.12
     # via
     #   -c batch/../gear/pinned-requirements.txt
     #   -c batch/../hail/python/dev/pinned-requirements.txt
@@ -70,7 +70,7 @@ numpy==2.2.6
     #   -c batch/../hail/python/dev/pinned-requirements.txt
     #   -c batch/../hail/python/pinned-requirements.txt
     #   pandas
-packaging==26.0
+packaging==26.1
     # via
     #   -c batch/../gear/pinned-requirements.txt
     #   -c batch/../hail/python/dev/pinned-requirements.txt

--- a/ci/pinned-requirements.txt
+++ b/ci/pinned-requirements.txt
@@ -32,7 +32,7 @@ distro==1.9.0
     # via zulip
 gidgethub==5.4.0
     # via -r ci/requirements.txt
-idna==3.11
+idna==3.12
     # via
     #   -c ci/../gear/pinned-requirements.txt
     #   -c ci/../hail/python/dev/pinned-requirements.txt

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -71,7 +71,6 @@ google-api-core==2.30.3
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
     #   google-api-python-client
-    # via google-api-python-client
 google-api-python-client==2.194.0
     # via google-cloud-profiler
 google-auth==2.49.2
@@ -97,7 +96,7 @@ httplib2==0.31.2
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.11
+idna==3.12
     # via
     #   -c gear/../hail/python/dev/pinned-requirements.txt
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt
@@ -113,7 +112,7 @@ multidict==6.7.1
     #   -c gear/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   yarl
-packaging==26.0
+packaging==26.1
     # via
     #   -c gear/../hail/python/dev/pinned-requirements.txt
     #   -c gear/../hail/python/pinned-requirements.txt
@@ -133,7 +132,10 @@ propcache==0.4.1
     #   aiohttp
     #   yarl
 proto-plus==1.27.2
-    # via google-api-core
+    # via
+    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
+    #   -c gear/../hail/python/pinned-requirements.txt
+    #   google-api-core
 protobuf==7.34.1
     # via
     #   -c gear/../hail/python/hailtop/pinned-requirements.txt

--- a/gear/pinned-requirements.txt
+++ b/gear/pinned-requirements.txt
@@ -67,6 +67,10 @@ frozenlist==1.8.0
     #   aiohttp
     #   aiosignal
 google-api-core==2.30.3
+    # via
+    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
+    #   -c gear/../hail/python/pinned-requirements.txt
+    #   google-api-python-client
     # via google-api-python-client
 google-api-python-client==2.194.0
     # via google-cloud-profiler
@@ -85,7 +89,10 @@ google-auth-httplib2==0.3.1
 google-cloud-profiler==4.1.0
     # via -r gear/requirements.txt
 googleapis-common-protos==1.74.0
-    # via google-api-core
+    # via
+    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
+    #   -c gear/../hail/python/pinned-requirements.txt
+    #   google-api-core
 httplib2==0.31.2
     # via
     #   google-api-python-client
@@ -129,6 +136,8 @@ proto-plus==1.27.2
     # via google-api-core
 protobuf==7.34.1
     # via
+    #   -c gear/../hail/python/hailtop/pinned-requirements.txt
+    #   -c gear/../hail/python/pinned-requirements.txt
     #   google-api-core
     #   google-cloud-profiler
     #   googleapis-common-protos

--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -128,7 +128,7 @@ executing==2.2.1
     #   stack-data
 fastjsonschema==2.21.2
     # via nbformat
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   python-discovery
     #   virtualenv
@@ -149,9 +149,9 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via jupyterlab
-identify==2.6.18
+identify==2.6.19
     # via pre-commit
-idna==3.11
+idna==3.12
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   anyio
@@ -232,7 +232,7 @@ jupyter-core==5.9.1
     #   nbconvert
     #   nbformat
     #   notebook
-jupyter-events==0.12.0
+jupyter-events==0.12.1
     # via jupyter-server
 jupyter-lsp==2.3.1
     # via jupyterlab
@@ -309,7 +309,7 @@ nodeenv==1.10.0
     # via
     #   pre-commit
     #   pyright
-nodejs-wheel-binaries==24.14.1
+nodejs-wheel-binaries==24.15.0
     # via pyright
 notebook==6.5.7
     # via
@@ -326,7 +326,7 @@ numpy==2.2.6
     #   matplotlib
 overrides==7.7.0
     # via jupyter-server
-packaging==26.0
+packaging==26.1
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   build
@@ -631,7 +631,7 @@ uv==0.10.12
     # via -r hail/python/dev/requirements.txt
 uv-build==0.10.12
     # via -r hail/python/dev/requirements.txt
-virtualenv==21.2.1
+virtualenv==21.2.4
     # via pre-commit
 watchfiles==1.1.1
     # via aiohttp-devtools
@@ -651,5 +651,5 @@ yarl==1.23.0
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   aiohttp
-zipp==3.23.0
+zipp==3.23.1
     # via importlib-metadata

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -8,9 +8,13 @@ from types import TracebackType
 from typing import Any, AsyncIterator, Callable, Coroutine, Dict, List, MutableMapping, Optional, Set, Tuple, Type, cast
 
 import aiohttp
+from google.auth.aio.credentials import AnonymousCredentials
+from google.cloud.storage import Client, transfer_manager
+from google.oauth2.credentials import Credentials
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import  # pylint: disable=unused-import
 
 from hailtop import timex
+from hailtop.aiocloud.common import AnonymousCloudCredentials
 from hailtop.aiotools import FeedableAsyncIterable, WriteBuffer
 from hailtop.aiotools.fs import (
     AsyncFS,
@@ -319,10 +323,29 @@ class GoogleStorageClient(GoogleBaseClient):
         if 'timeout' not in kwargs and 'http_session' not in kwargs:
             # Around May 2022, GCS started timing out a lot with our default 5s timeout
             kwargs['timeout'] = aiohttp.ClientTimeout(total=20)
+
+        timeout = kwargs.get('timeout')
+        if isinstance(timeout, aiohttp.ClientTimeout):
+            self._timeout = timeout.total
+        elif isinstance(timeout, (int, float)):
+            self._timeout = timeout
+        else:
+            self._timeout = 20
+
         super().__init__('https://storage.googleapis.com/storage/v1', **kwargs)
         self._gcs_requester_pays_configuration = get_gcs_requester_pays_configuration(
             gcs_requester_pays_configuration=gcs_requester_pays_configuration
         )
+        credentials = kwargs.get('credentials')
+        if isinstance(credentials, GoogleCredentials):
+            access_token = credentials.access_token
+            gcp_credentials = Credentials(token=access_token)
+        elif isinstance(credentials, AnonymousCloudCredentials):
+            gcp_credentials = AnonymousCredentials()
+        else:
+            gcp_credentials = None
+
+        self._client = Client(credentials=gcp_credentials)
 
     async def bucket_info(self, bucket: str) -> Dict[str, Any]:
         """
@@ -414,6 +437,44 @@ class GoogleStorageClient(GoogleBaseClient):
     async def list_objects(self, bucket: str, **kwargs) -> PageIterator:
         self._update_params_with_user_project(kwargs, bucket)
         return PageIterator(self, f'/b/{bucket}/o', kwargs)
+
+    async def download_to_file(self, bucket: str, src: str, dest: str) -> None:
+        if isinstance(self._gcs_requester_pays_configuration, str):
+            user_project = self._gcs_requester_pays_configuration
+        elif isinstance(self._gcs_requester_pays_configuration, tuple):
+            project, buckets = self._gcs_requester_pays_configuration
+            if bucket in buckets:
+                user_project = project
+            else:
+                user_project = None
+        else:
+            user_project = None
+
+        bucket_instance = self._client.bucket(bucket, user_project=user_project)
+        blob = bucket_instance.blob(src)
+        if dest.startswith('file://'):
+            local_dest = urllib.parse.urlparse(dest).path
+        else:
+            local_dest = dest
+        try:
+            await asyncio.to_thread(
+                transfer_manager.download_chunks_concurrently,
+                blob=blob,
+                filename=dest,
+                chunk_size=128 * 1024 * 1024,
+                download_kwargs={'timeout': self._timeout},
+                max_workers=32,
+            )
+        except FileNotFoundError:
+            os.makedirs(os.path.dirname(local_dest), exist_ok=True)
+            await asyncio.to_thread(
+                transfer_manager.download_chunks_concurrently,
+                blob=blob,
+                filename=dest,
+                chunk_size=128 * 1024 * 1024,
+                download_kwargs={'timeout': self._timeout},
+                max_workers=32,
+            )
 
     async def compose(self, bucket: str, names: List[str], destination: str, **kwargs) -> None:
         assert destination
@@ -740,6 +801,13 @@ class GoogleStorageAsyncFS(AsyncFS):
             assert length >= 1
             range_str += str(start + length - 1)
         return await self._storage_client.get_object(fsurl._bucket, fsurl._path, headers={'Range': range_str})
+
+    async def copy_to(self, url: str, dest):
+        if dest.startswith('file://') or '://' not in dest:
+            fsurl = self.parse_url(url, error_if_bucket=True)
+            return await retry_transient_errors(self._storage_client.download_to_file, fsurl._bucket, fsurl._path, dest)
+        else:
+            raise NotImplementedError
 
     async def create(self, url: str, *, retry_writes: bool = True) -> WritableStream:
         fsurl = self.parse_url(url, error_if_bucket=True)

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -26,6 +26,7 @@ import aiohttp
 from google.auth.aio.credentials import AnonymousCredentials
 from google.cloud.storage import Client, transfer_manager
 from google.oauth2.credentials import Credentials
+from jupyter_lsp.virtual_documents_shadow import MAX_WORKERS
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import  # pylint: disable=unused-import
 
 from hailtop import timex
@@ -984,6 +985,23 @@ class GoogleStorageAsyncFS(AsyncFS):
                 raise FileNotFoundError(url) from e
             raise
 
+    async def copy_to_local_2(
+        self,
+        sema: WeightedSemaphore,
+        xfer_sema: WeightedSemaphore,
+        source_report: SourceReport,
+        srcfile: str,
+        srcstat: FileStatus,
+        destfile: str,
+        return_exceptions: bool,
+    ):
+        size = await srcstat.size()
+        if size > self._storage_client.CHUNK_SIZE:
+            with sema.acquire_manager(MAX_WORKERS):
+                await self._copy_single_large_file(xfer_sema, srcfile, destfile, size, source_report, return_exceptions)
+        else:
+            await self._copy_single_local_file(xfer_sema, srcfile, destfile, size, source_report, return_exceptions)
+
     async def copy_to_local(
         self,
         sema: WeightedSemaphore,
@@ -1044,7 +1062,7 @@ class GoogleStorageAsyncFS(AsyncFS):
                     size = await stat.size()
                     filename = await file.url_full()
                     relfilename = filename[len(transfer.src) :].lstrip('/')
-                    if transfer.treat_dest_as == Transfer.DEST_DIR or transfer.treat_dest_as == Transfer.INFER_DEST:
+                    if transfer.treat_dest_as in (Transfer.DEST_DIR, Transfer.INFER_DEST):
                         target_dest = url_join(
                             url_join(transfer.dest, url_basename(transfer.src.rstrip('/'))), relfilename
                         )
@@ -1129,7 +1147,7 @@ class GoogleStorageAsyncFS(AsyncFS):
                 bucket, name = self.get_bucket_and_name(src)
                 report.start_files(1)
                 report.start_bytes(size)
-                await self._storage_client.download_large_file(bucket, name, dest)
+                await retry_transient_errors(self._storage_client.download_large_file, bucket, name, dest)
                 success = True
             except Exception as e:
                 if return_exceptions:

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -1,11 +1,27 @@
 import asyncio
 import datetime
+import functools
 import logging
 import os
 import urllib.parse
+from asyncio import Semaphore
+from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import AsyncExitStack
 from types import TracebackType
-from typing import Any, AsyncIterator, Callable, Coroutine, Dict, List, MutableMapping, Optional, Set, Tuple, Type, cast
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    cast,
+)
 
 import aiohttp
 from google.auth.aio.credentials import AnonymousCredentials
@@ -15,7 +31,7 @@ from multidict import CIMultiDictProxy  # pylint: disable=unused-import  # pylin
 
 from hailtop import timex
 from hailtop.aiocloud.common import AnonymousCloudCredentials
-from hailtop.aiotools import FeedableAsyncIterable, WriteBuffer
+from hailtop.aiotools import FeedableAsyncIterable, Transfer, WeightedSemaphore, WriteBuffer
 from hailtop.aiotools.fs import (
     AsyncFS,
     AsyncFSFactory,
@@ -26,10 +42,18 @@ from hailtop.aiotools.fs import (
     IsABucketError,
     MultiPartCreate,
     ReadableStream,
+    SourceReport,
     UnexpectedEOFError,
     WritableStream,
 )
-from hailtop.utils import OnlineBoundedGather2, TransientError, retry_transient_errors, secret_alnum_string
+from hailtop.utils import (
+    OnlineBoundedGather2,
+    TransientError,
+    blocking_to_async,
+    bounded_gather2,
+    retry_transient_errors,
+    secret_alnum_string,
+)
 
 from ...common.session import BaseSession
 from ..credentials import GoogleCredentials
@@ -319,7 +343,14 @@ class GetObjectStream(ReadableStream):
 
 
 class GoogleStorageClient(GoogleBaseClient):
-    def __init__(self, gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None, **kwargs):
+    CHUNK_SIZE = 8 * 1024 * 1024
+
+    def __init__(
+        self,
+        gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
+        thread_pool: Optional[ThreadPoolExecutor] = None,
+        **kwargs,
+    ):
         if 'timeout' not in kwargs and 'http_session' not in kwargs:
             # Around May 2022, GCS started timing out a lot with our default 5s timeout
             kwargs['timeout'] = aiohttp.ClientTimeout(total=20)
@@ -331,6 +362,10 @@ class GoogleStorageClient(GoogleBaseClient):
             self._timeout = timeout
         else:
             self._timeout = 20
+
+        if not thread_pool:
+            thread_pool = ThreadPoolExecutor()
+        self._thread_pool = thread_pool
 
         super().__init__('https://storage.googleapis.com/storage/v1', **kwargs)
         self._gcs_requester_pays_configuration = get_gcs_requester_pays_configuration(
@@ -438,18 +473,34 @@ class GoogleStorageClient(GoogleBaseClient):
         self._update_params_with_user_project(kwargs, bucket)
         return PageIterator(self, f'/b/{bucket}/o', kwargs)
 
-    async def download_to_file(self, bucket: str, src: str, dest: str) -> None:
-        if isinstance(self._gcs_requester_pays_configuration, str):
-            user_project = self._gcs_requester_pays_configuration
-        elif isinstance(self._gcs_requester_pays_configuration, tuple):
-            project, buckets = self._gcs_requester_pays_configuration
-            if bucket in buckets:
-                user_project = project
-            else:
-                user_project = None
+    async def download_single_file(self, bucket: str, filename: str, dest: str) -> None:
+        user_project = self._get_user_project_for_bucket(bucket)
+        bucket_instance = self._client.bucket(bucket, user_project=user_project)
+        blob = bucket_instance.blob(filename)
+        if dest.startswith('file://'):
+            local_dest = urllib.parse.urlparse(dest).path
         else:
-            user_project = None
+            local_dest = dest
+        try:
+            await blocking_to_async(
+                self._thread_pool,
+                blob.download_to_filename,
+                local_dest,
+                single_shot_download=True,
+                timeout=self._timeout,
+            )
+        except FileNotFoundError:
+            os.makedirs(os.path.dirname(local_dest), exist_ok=True)
+            await blocking_to_async(
+                self._thread_pool,
+                blob.download_to_filename,
+                local_dest,
+                single_shot_download=True,
+                timeout=self._timeout,
+            )
 
+    async def download_large_file(self, bucket: str, src: str, dest: str) -> None:
+        user_project = self._get_user_project_for_bucket(bucket)
         bucket_instance = self._client.bucket(bucket, user_project=user_project)
         blob = bucket_instance.blob(src)
         if dest.startswith('file://'):
@@ -457,23 +508,25 @@ class GoogleStorageClient(GoogleBaseClient):
         else:
             local_dest = dest
         try:
-            await asyncio.to_thread(
+            await blocking_to_async(
+                self._thread_pool,
                 transfer_manager.download_chunks_concurrently,
                 blob=blob,
-                filename=dest,
-                chunk_size=128 * 1024 * 1024,
+                filename=local_dest,
+                chunk_size=self.CHUNK_SIZE,
                 download_kwargs={'timeout': self._timeout},
-                max_workers=32,
+                max_workers=8,
             )
         except FileNotFoundError:
             os.makedirs(os.path.dirname(local_dest), exist_ok=True)
-            await asyncio.to_thread(
+            await blocking_to_async(
+                self._thread_pool,
                 transfer_manager.download_chunks_concurrently,
                 blob=blob,
-                filename=dest,
-                chunk_size=128 * 1024 * 1024,
+                filename=local_dest,
+                chunk_size=self.CHUNK_SIZE,
                 download_kwargs={'timeout': self._timeout},
-                max_workers=32,
+                max_workers=8,
             )
 
     async def compose(self, bucket: str, names: List[str], destination: str, **kwargs) -> None:
@@ -515,6 +568,18 @@ class GoogleStorageClient(GoogleBaseClient):
             project, buckets = config
             if bucket in buckets:
                 params.update({'userProject': project})
+
+    def _get_user_project_for_bucket(self, bucket: str) -> Optional[str]:
+        if isinstance(self._gcs_requester_pays_configuration, str):
+            return self._gcs_requester_pays_configuration
+        elif isinstance(self._gcs_requester_pays_configuration, tuple):
+            project, buckets = self._gcs_requester_pays_configuration
+            if bucket in buckets:
+                return project
+            else:
+                return None
+        else:
+            return None
 
 
 class GetObjectFileStatus(FileStatus):
@@ -802,13 +867,6 @@ class GoogleStorageAsyncFS(AsyncFS):
             range_str += str(start + length - 1)
         return await self._storage_client.get_object(fsurl._bucket, fsurl._path, headers={'Range': range_str})
 
-    async def copy_to(self, url: str, dest):
-        if dest.startswith('file://') or '://' not in dest:
-            fsurl = self.parse_url(url, error_if_bucket=True)
-            return await retry_transient_errors(self._storage_client.download_to_file, fsurl._bucket, fsurl._path, dest)
-        else:
-            raise NotImplementedError
-
     async def create(self, url: str, *, retry_writes: bool = True) -> WritableStream:
         fsurl = self.parse_url(url, error_if_bucket=True)
         params = {'uploadType': 'resumable' if retry_writes else 'media'}
@@ -942,6 +1000,149 @@ class GoogleStorageAsyncFS(AsyncFS):
             if e.status == 404:
                 raise FileNotFoundError(url) from e
             raise
+
+    async def copy_to_local(
+        self,
+        sema: Semaphore,
+        xfer_sema: WeightedSemaphore,
+        transfers: List[Transfer],
+        source_reports: List[SourceReport],
+        *,
+        return_exceptions: bool = False,
+    ):
+        copy_operations = []
+        for transfer, report in zip(transfers, source_reports):
+            assert isinstance(transfer.src, str)
+            if await self.isfile(transfer.src):
+                stat = await self.statfile(transfer.src)
+                size = await stat.size()
+                filename = self.get_bucket_and_name(transfer.src)[1]
+                if transfer.dest.endswith('/') or transfer.treat_dest_as == Transfer.DEST_DIR:
+                    target_dest = (transfer.dest if transfer.dest.endswith('/') else transfer.dest + '/') + filename
+                else:
+                    target_dest = transfer.dest
+                if size > self._storage_client.CHUNK_SIZE:
+                    copy_operations.append(
+                        functools.partial(
+                            self._copy_single_large_file,
+                            sema,
+                            xfer_sema,
+                            transfer.src,
+                            target_dest,
+                            size,
+                            report,
+                            return_exceptions,
+                        )
+                    )
+                else:
+                    copy_operations.append(
+                        functools.partial(
+                            self._copy_single_local_file,
+                            xfer_sema,
+                            transfer.src,
+                            target_dest,
+                            size,
+                            report,
+                            return_exceptions,
+                        )
+                    )
+            else:
+                async for file in await self.listfiles(transfer.src, recursive=True):
+                    stat = await file.status()
+                    size = await stat.size()
+                    filename = file.basename()
+                    target_dest = (transfer.dest if transfer.dest.endswith('/') else transfer.dest + '/') + filename
+                    if size > self._storage_client.CHUNK_SIZE:
+                        copy_operations.append(
+                            functools.partial(
+                                self._copy_single_large_file,
+                                sema,
+                                xfer_sema,
+                                await file.url(),
+                                target_dest,
+                                size,
+                                report,
+                                return_exceptions,
+                            )
+                        )
+                    else:
+                        copy_operations.append(
+                            functools.partial(
+                                self._copy_single_local_file,
+                                xfer_sema,
+                                await file.url(),
+                                target_dest,
+                                size,
+                                report,
+                                return_exceptions,
+                            )
+                        )
+        await bounded_gather2(
+            sema,
+            *copy_operations,
+            cancel_on_error=True,
+        )
+
+    async def _copy_single_local_file(
+        self,
+        xfer_sema: WeightedSemaphore,
+        src: str,
+        dest: str,
+        size: int,
+        report: SourceReport,
+        return_exceptions: bool,
+    ) -> None:
+        async with xfer_sema.acquire_manager(size):
+            bucket, name = self.get_bucket_and_name(src)
+            report.start_files(1)
+            report.start_bytes(size)
+            success = False
+            try:
+                await retry_transient_errors(self._storage_client.download_single_file, bucket, name, dest)
+                success = True
+            except Exception as e:
+                if return_exceptions:
+                    report.set_file_error(src, dest, e)
+                    report.set_exception(e)
+                else:
+                    raise e
+            finally:
+                report.finish_files(1, failed=not success)
+                report.finish_bytes(size)
+
+    async def _copy_single_large_file(
+        self,
+        sema: Semaphore,
+        xfer_sema: WeightedSemaphore,
+        src: str,
+        dest: str,
+        size: int,
+        report: SourceReport,
+        return_exceptions: bool,
+    ) -> None:
+        async with xfer_sema.acquire_manager(self._storage_client.CHUNK_SIZE):
+            success = False
+            threads_acquired = 0
+            try:
+                for _ in range(0, 8):
+                    await sema.acquire()
+                    threads_acquired += 1
+                bucket, name = self.get_bucket_and_name(src)
+                report.start_files(1)
+                report.start_bytes(size)
+                await self._storage_client.download_large_file(bucket, name, dest)
+                success = True
+            except Exception as e:
+                if return_exceptions:
+                    report.set_file_error(src, dest, e)
+                    report.set_exception(e)
+                else:
+                    raise e
+            finally:
+                report.finish_files(1, failed=not success)
+                report.finish_bytes(size)
+                for _ in range(0, threads_acquired):
+                    sema.release()
 
     async def copy_within_gcs(
         self, src: str, dest: str, callback: Optional[Callable[[Dict[str, Any], bool], None]] = None

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -24,6 +24,7 @@ from typing import (
 import aiohttp
 from google.auth.aio.credentials import AnonymousCredentials
 from google.cloud.storage import Client, transfer_manager
+from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import  # pylint: disable=unused-import
 
@@ -51,13 +52,14 @@ from hailtop.aiotools.fs import (
 from hailtop.utils import (
     OnlineBoundedGather2,
     TransientError,
+    async_to_blocking,
     blocking_to_async,
     retry_transient_errors,
     secret_alnum_string,
 )
 
 from ...common.session import BaseSession
-from ..credentials import GoogleCredentials
+from ..credentials import GoogleCredentials, GoogleServiceAccountCredentials
 from ..user_config import GCSRequesterPaysConfiguration, get_gcs_requester_pays_configuration
 from .base_client import GoogleBaseClient
 
@@ -374,8 +376,10 @@ class GoogleStorageClient(GoogleBaseClient):
             gcs_requester_pays_configuration=gcs_requester_pays_configuration
         )
         credentials = kwargs.get('credentials')
-        if isinstance(credentials, GoogleCredentials):
-            access_token = credentials.access_token
+        if isinstance(credentials, GoogleServiceAccountCredentials):
+            gcp_credentials = service_account.Credentials.from_service_account_info(info=credentials.key)
+        elif isinstance(credentials, GoogleCredentials):
+            access_token = async_to_blocking(credentials.access_token())
             gcp_credentials = Credentials(token=access_token)
         elif isinstance(credentials, AnonymousCloudCredentials):
             gcp_credentials = AnonymousCredentials()
@@ -480,8 +484,11 @@ class GoogleStorageClient(GoogleBaseClient):
         bucket_instance = self._client.bucket(bucket, user_project=user_project)
         blob = bucket_instance.blob(filename)
 
-        if not os.path.exists(os.path.dirname(dest)):
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
+        dest_parent = os.path.dirname(dest)
+        if dest_parent:
+            if os.path.exists(dest_parent) and not os.path.isdir(dest_parent):
+                raise NotADirectoryError(dest_parent)
+            os.makedirs(dest_parent, exist_ok=True)
         await blocking_to_async(
             self._thread_pool,
             blob.download_to_filename,
@@ -495,8 +502,11 @@ class GoogleStorageClient(GoogleBaseClient):
         bucket_instance = self._client.bucket(bucket, user_project=user_project)
         blob = bucket_instance.blob(src)
 
-        if not os.path.exists(os.path.dirname(dest)):
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
+        dest_parent = os.path.dirname(dest)
+        if dest_parent:
+            if os.path.exists(dest_parent) and not os.path.isdir(dest_parent):
+                raise NotADirectoryError(dest_parent)
+            os.makedirs(dest_parent, exist_ok=True)
         await blocking_to_async(
             self._thread_pool,
             transfer_manager.download_chunks_concurrently,
@@ -999,11 +1009,15 @@ class GoogleStorageAsyncFS(AsyncFS):
                 xfer_sema = self._xfer_sema
 
             size = await srcstat.size()
+            if destfile.startswith('file://'):
+                local_dest = destfile[len('file://') :]
+            else:
+                local_dest = destfile
             if size > self._storage_client.CHUNK_SIZE:
                 async with sema.acquire_manager(self._storage_client.MAX_WORKERS):
-                    await self._copy_single_large_file(xfer_sema, srcfile, destfile)
+                    await self._copy_single_large_file(xfer_sema, srcfile, local_dest)
             else:
-                await self._copy_single_local_file(xfer_sema, srcfile, destfile, size)
+                await self._copy_single_local_file(xfer_sema, srcfile, local_dest, size)
         else:
             raise NotImplementedError
 
@@ -1024,7 +1038,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         src: str,
         dest: str,
     ) -> None:
-        async with xfer_sema.acquire_manager(self._storage_client.CHUNK_SIZE):
+        async with xfer_sema.acquire_manager(self._storage_client.CHUNK_SIZE * self._storage_client.MAX_WORKERS):
             bucket, name = self.get_bucket_and_name(src)
             await retry_transient_errors(self._storage_client.download_large_file, bucket, name, dest)
 

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -30,7 +30,13 @@ from multidict import CIMultiDictProxy  # pylint: disable=unused-import  # pylin
 
 from hailtop import timex
 from hailtop.aiocloud.common import AnonymousCloudCredentials
-from hailtop.aiotools import FeedableAsyncIterable, Transfer, WeightedSemaphore, WriteBuffer, weighted_bounded_gather2
+from hailtop.aiotools import (
+    FeedableAsyncIterable,
+    Transfer,
+    WeightedSemaphore,
+    WriteBuffer,
+    weighted_bounded_gather2,
+)
 from hailtop.aiotools.fs import (
     AsyncFS,
     AsyncFSFactory,
@@ -51,6 +57,8 @@ from hailtop.utils import (
     blocking_to_async,
     retry_transient_errors,
     secret_alnum_string,
+    url_basename,
+    url_join,
 )
 
 from ...common.session import BaseSession
@@ -476,16 +484,13 @@ class GoogleStorageClient(GoogleBaseClient):
         user_project = self._get_user_project_for_bucket(bucket)
         bucket_instance = self._client.bucket(bucket, user_project=user_project)
         blob = bucket_instance.blob(filename)
-        if dest.startswith('file://'):
-            local_dest = urllib.parse.urlparse(dest).path
-        else:
-            local_dest = dest
 
-        os.makedirs(os.path.dirname(local_dest), exist_ok=True)
+        if not os.path.exists(os.path.dirname(dest)):
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
         await blocking_to_async(
             self._thread_pool,
             blob.download_to_filename,
-            local_dest,
+            dest,
             single_shot_download=True,
             timeout=self._timeout,
         )
@@ -494,17 +499,14 @@ class GoogleStorageClient(GoogleBaseClient):
         user_project = self._get_user_project_for_bucket(bucket)
         bucket_instance = self._client.bucket(bucket, user_project=user_project)
         blob = bucket_instance.blob(src)
-        if dest.startswith('file://'):
-            local_dest = urllib.parse.urlparse(dest).path
-        else:
-            local_dest = dest
 
-        os.makedirs(os.path.dirname(local_dest), exist_ok=True)
+        if not os.path.exists(os.path.dirname(dest)):
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
         await blocking_to_async(
             self._thread_pool,
             transfer_manager.download_chunks_concurrently,
             blob=blob,
-            filename=local_dest,
+            filename=dest,
             chunk_size=self.CHUNK_SIZE,
             download_kwargs={'timeout': self._timeout},
             max_workers=self.MAX_WORKERS,
@@ -999,11 +1001,17 @@ class GoogleStorageAsyncFS(AsyncFS):
             if await self.isfile(transfer.src):
                 stat = await self.statfile(transfer.src)
                 size = await stat.size()
-                filename = self.get_bucket_and_name(transfer.src)[1]
-                if transfer.dest.endswith('/') or transfer.treat_dest_as == Transfer.DEST_DIR:
-                    target_dest = (transfer.dest if transfer.dest.endswith('/') else transfer.dest + '/') + filename
+                filename = url_basename(transfer.src)
+                if transfer.treat_dest_as == Transfer.DEST_DIR or (
+                    transfer.treat_dest_as == Transfer.INFER_DEST and transfer.dest.endswith('/')
+                ):
+                    target_dest = url_join(transfer.dest, filename)
                 else:
                     target_dest = transfer.dest
+
+                if os.path.isdir(target_dest):
+                    raise IsADirectoryError(transfer.dest)
+
                 if size > self._storage_client.CHUNK_SIZE:
                     copy_operations.append(
                         functools.partial(
@@ -1034,14 +1042,24 @@ class GoogleStorageAsyncFS(AsyncFS):
                 async for file in await self.listfiles(transfer.src, recursive=True):
                     stat = await file.status()
                     size = await stat.size()
-                    filename = file.basename()
-                    target_dest = (transfer.dest if transfer.dest.endswith('/') else transfer.dest + '/') + filename
+                    filename = await file.url_full()
+                    relfilename = filename[len(transfer.src) :].lstrip('/')
+                    if transfer.treat_dest_as == Transfer.DEST_DIR or transfer.treat_dest_as == Transfer.INFER_DEST:
+                        target_dest = url_join(
+                            url_join(transfer.dest, url_basename(transfer.src.rstrip('/'))), relfilename
+                        )
+                    else:
+                        target_dest = url_join(transfer.dest, relfilename)
+
+                    if os.path.isfile(target_dest):
+                        raise NotADirectoryError(transfer.dest)
+
                     if size > self._storage_client.CHUNK_SIZE:
                         copy_operations.append(
                             functools.partial(
                                 self._copy_single_large_file,
                                 xfer_sema,
-                                await file.url(),
+                                filename,
                                 target_dest,
                                 size,
                                 report,
@@ -1054,7 +1072,7 @@ class GoogleStorageAsyncFS(AsyncFS):
                             functools.partial(
                                 self._copy_single_local_file,
                                 xfer_sema,
-                                await file.url(),
+                                filename,
                                 target_dest,
                                 size,
                                 report,

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -4,7 +4,6 @@ import functools
 import logging
 import os
 import urllib.parse
-from asyncio import Semaphore
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import AsyncExitStack
 from types import TracebackType
@@ -31,7 +30,7 @@ from multidict import CIMultiDictProxy  # pylint: disable=unused-import  # pylin
 
 from hailtop import timex
 from hailtop.aiocloud.common import AnonymousCloudCredentials
-from hailtop.aiotools import FeedableAsyncIterable, Transfer, WeightedSemaphore, WriteBuffer
+from hailtop.aiotools import FeedableAsyncIterable, Transfer, WeightedSemaphore, WriteBuffer, weighted_bounded_gather2
 from hailtop.aiotools.fs import (
     AsyncFS,
     AsyncFSFactory,
@@ -50,7 +49,6 @@ from hailtop.utils import (
     OnlineBoundedGather2,
     TransientError,
     blocking_to_async,
-    bounded_gather2,
     retry_transient_errors,
     secret_alnum_string,
 )
@@ -344,6 +342,7 @@ class GetObjectStream(ReadableStream):
 
 class GoogleStorageClient(GoogleBaseClient):
     CHUNK_SIZE = 8 * 1024 * 1024
+    MAX_WORKERS = 8
 
     def __init__(
         self,
@@ -481,23 +480,15 @@ class GoogleStorageClient(GoogleBaseClient):
             local_dest = urllib.parse.urlparse(dest).path
         else:
             local_dest = dest
-        try:
-            await blocking_to_async(
-                self._thread_pool,
-                blob.download_to_filename,
-                local_dest,
-                single_shot_download=True,
-                timeout=self._timeout,
-            )
-        except FileNotFoundError:
-            os.makedirs(os.path.dirname(local_dest), exist_ok=True)
-            await blocking_to_async(
-                self._thread_pool,
-                blob.download_to_filename,
-                local_dest,
-                single_shot_download=True,
-                timeout=self._timeout,
-            )
+
+        os.makedirs(os.path.dirname(local_dest), exist_ok=True)
+        await blocking_to_async(
+            self._thread_pool,
+            blob.download_to_filename,
+            local_dest,
+            single_shot_download=True,
+            timeout=self._timeout,
+        )
 
     async def download_large_file(self, bucket: str, src: str, dest: str) -> None:
         user_project = self._get_user_project_for_bucket(bucket)
@@ -507,27 +498,17 @@ class GoogleStorageClient(GoogleBaseClient):
             local_dest = urllib.parse.urlparse(dest).path
         else:
             local_dest = dest
-        try:
-            await blocking_to_async(
-                self._thread_pool,
-                transfer_manager.download_chunks_concurrently,
-                blob=blob,
-                filename=local_dest,
-                chunk_size=self.CHUNK_SIZE,
-                download_kwargs={'timeout': self._timeout},
-                max_workers=8,
-            )
-        except FileNotFoundError:
-            os.makedirs(os.path.dirname(local_dest), exist_ok=True)
-            await blocking_to_async(
-                self._thread_pool,
-                transfer_manager.download_chunks_concurrently,
-                blob=blob,
-                filename=local_dest,
-                chunk_size=self.CHUNK_SIZE,
-                download_kwargs={'timeout': self._timeout},
-                max_workers=8,
-            )
+
+        os.makedirs(os.path.dirname(local_dest), exist_ok=True)
+        await blocking_to_async(
+            self._thread_pool,
+            transfer_manager.download_chunks_concurrently,
+            blob=blob,
+            filename=local_dest,
+            chunk_size=self.CHUNK_SIZE,
+            download_kwargs={'timeout': self._timeout},
+            max_workers=self.MAX_WORKERS,
+        )
 
     async def compose(self, bucket: str, names: List[str], destination: str, **kwargs) -> None:
         assert destination
@@ -1003,7 +984,7 @@ class GoogleStorageAsyncFS(AsyncFS):
 
     async def copy_to_local(
         self,
-        sema: Semaphore,
+        sema: WeightedSemaphore,
         xfer_sema: WeightedSemaphore,
         transfers: List[Transfer],
         source_reports: List[SourceReport],
@@ -1011,6 +992,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         return_exceptions: bool = False,
     ):
         copy_operations = []
+        copy_operation_thread_count = []
         for transfer, report in zip(transfers, source_reports):
             assert isinstance(transfer.src, str)
             if await self.isfile(transfer.src):
@@ -1025,7 +1007,6 @@ class GoogleStorageAsyncFS(AsyncFS):
                     copy_operations.append(
                         functools.partial(
                             self._copy_single_large_file,
-                            sema,
                             xfer_sema,
                             transfer.src,
                             target_dest,
@@ -1034,6 +1015,7 @@ class GoogleStorageAsyncFS(AsyncFS):
                             return_exceptions,
                         )
                     )
+                    copy_operation_thread_count.append(self._storage_client.MAX_WORKERS)
                 else:
                     copy_operations.append(
                         functools.partial(
@@ -1046,6 +1028,7 @@ class GoogleStorageAsyncFS(AsyncFS):
                             return_exceptions,
                         )
                     )
+                    copy_operation_thread_count.append(1)
             else:
                 async for file in await self.listfiles(transfer.src, recursive=True):
                     stat = await file.status()
@@ -1056,7 +1039,6 @@ class GoogleStorageAsyncFS(AsyncFS):
                         copy_operations.append(
                             functools.partial(
                                 self._copy_single_large_file,
-                                sema,
                                 xfer_sema,
                                 await file.url(),
                                 target_dest,
@@ -1065,6 +1047,7 @@ class GoogleStorageAsyncFS(AsyncFS):
                                 return_exceptions,
                             )
                         )
+                        copy_operation_thread_count.append(self._storage_client.MAX_WORKERS)
                     else:
                         copy_operations.append(
                             functools.partial(
@@ -1077,9 +1060,11 @@ class GoogleStorageAsyncFS(AsyncFS):
                                 return_exceptions,
                             )
                         )
-        await bounded_gather2(
+                        copy_operation_thread_count.append(1)
+        await weighted_bounded_gather2(
             sema,
-            *copy_operations,
+            copy_operations,
+            copy_operation_thread_count,
             cancel_on_error=True,
         )
 
@@ -1112,7 +1097,6 @@ class GoogleStorageAsyncFS(AsyncFS):
 
     async def _copy_single_large_file(
         self,
-        sema: Semaphore,
         xfer_sema: WeightedSemaphore,
         src: str,
         dest: str,
@@ -1122,11 +1106,7 @@ class GoogleStorageAsyncFS(AsyncFS):
     ) -> None:
         async with xfer_sema.acquire_manager(self._storage_client.CHUNK_SIZE):
             success = False
-            threads_acquired = 0
             try:
-                for _ in range(0, 8):
-                    await sema.acquire()
-                    threads_acquired += 1
                 bucket, name = self.get_bucket_and_name(src)
                 report.start_files(1)
                 report.start_bytes(size)
@@ -1141,8 +1121,6 @@ class GoogleStorageAsyncFS(AsyncFS):
             finally:
                 report.finish_files(1, failed=not success)
                 report.finish_bytes(size)
-                for _ in range(0, threads_acquired):
-                    sema.release()
 
     async def copy_within_gcs(
         self, src: str, dest: str, callback: Optional[Callable[[Dict[str, Any], bool], None]] = None

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -1,6 +1,5 @@
 import asyncio
 import datetime
-import functools
 import logging
 import os
 import urllib.parse
@@ -26,17 +25,15 @@ import aiohttp
 from google.auth.aio.credentials import AnonymousCredentials
 from google.cloud.storage import Client, transfer_manager
 from google.oauth2.credentials import Credentials
-from jupyter_lsp.virtual_documents_shadow import MAX_WORKERS
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import  # pylint: disable=unused-import
 
 from hailtop import timex
 from hailtop.aiocloud.common import AnonymousCloudCredentials
 from hailtop.aiotools import (
     FeedableAsyncIterable,
-    Transfer,
+    LocalAsyncFS,
     WeightedSemaphore,
     WriteBuffer,
-    weighted_bounded_gather2,
 )
 from hailtop.aiotools.fs import (
     AsyncFS,
@@ -48,7 +45,6 @@ from hailtop.aiotools.fs import (
     IsABucketError,
     MultiPartCreate,
     ReadableStream,
-    SourceReport,
     UnexpectedEOFError,
     WritableStream,
 )
@@ -58,8 +54,6 @@ from hailtop.utils import (
     blocking_to_async,
     retry_transient_errors,
     secret_alnum_string,
-    url_basename,
-    url_join,
 )
 
 from ...common.session import BaseSession
@@ -756,6 +750,8 @@ class GoogleStorageAsyncFS(AsyncFS):
         if bucket_allow_list is None:
             bucket_allow_list = []
         self.allowed_storage_locations = bucket_allow_list
+        self._sema = WeightedSemaphore(self._storage_client.MAX_WORKERS * 10)
+        self._xfer_sema = WeightedSemaphore(self._storage_client.CHUNK_SIZE * 10)
 
     @staticmethod
     def schemes() -> Set[str]:
@@ -985,125 +981,31 @@ class GoogleStorageAsyncFS(AsyncFS):
                 raise FileNotFoundError(url) from e
             raise
 
-    async def copy_to_local_2(
+    async def copy_between_fs(
         self,
-        sema: WeightedSemaphore,
-        xfer_sema: WeightedSemaphore,
-        source_report: SourceReport,
         srcfile: str,
         srcstat: FileStatus,
         destfile: str,
-        return_exceptions: bool,
+        **kwargs,
     ):
-        size = await srcstat.size()
-        if size > self._storage_client.CHUNK_SIZE:
-            with sema.acquire_manager(MAX_WORKERS):
-                await self._copy_single_large_file(xfer_sema, srcfile, destfile, size, source_report, return_exceptions)
-        else:
-            await self._copy_single_local_file(xfer_sema, srcfile, destfile, size, source_report, return_exceptions)
-
-    async def copy_to_local(
-        self,
-        sema: WeightedSemaphore,
-        xfer_sema: WeightedSemaphore,
-        transfers: List[Transfer],
-        source_reports: List[SourceReport],
-        *,
-        return_exceptions: bool = False,
-    ):
-        copy_operations = []
-        copy_operation_thread_count = []
-        for transfer, report in zip(transfers, source_reports):
-            if not isinstance(transfer.src, str):
-                raise TypeError(f'Expected a single source when copying from {transfer.src}')
-            if await self.isfile(transfer.src):
-                stat = await self.statfile(transfer.src)
-                size = await stat.size()
-                filename = url_basename(transfer.src)
-                if transfer.treat_dest_as == Transfer.DEST_DIR or (
-                    transfer.treat_dest_as == Transfer.INFER_DEST and transfer.dest.endswith('/')
-                ):
-                    target_dest = url_join(transfer.dest, filename)
-                else:
-                    target_dest = transfer.dest
-
-                if os.path.isdir(target_dest):
-                    raise IsADirectoryError(transfer.dest)
-
-                if size > self._storage_client.CHUNK_SIZE:
-                    copy_operations.append(
-                        functools.partial(
-                            self._copy_single_large_file,
-                            xfer_sema,
-                            transfer.src,
-                            target_dest,
-                            size,
-                            report,
-                            return_exceptions,
-                        )
-                    )
-                    copy_operation_thread_count.append(self._storage_client.MAX_WORKERS)
-                else:
-                    copy_operations.append(
-                        functools.partial(
-                            self._copy_single_local_file,
-                            xfer_sema,
-                            transfer.src,
-                            target_dest,
-                            size,
-                            report,
-                            return_exceptions,
-                        )
-                    )
-                    copy_operation_thread_count.append(1)
+        if LocalAsyncFS.valid_url(destfile):
+            if kwargs.get('sema'):
+                sema = cast(WeightedSemaphore, kwargs.get('sema'))
             else:
-                async for file in await self.listfiles(transfer.src, recursive=True):
-                    stat = await file.status()
-                    size = await stat.size()
-                    filename = await file.url_full()
-                    relfilename = filename[len(transfer.src) :].lstrip('/')
-                    if transfer.treat_dest_as in (Transfer.DEST_DIR, Transfer.INFER_DEST):
-                        target_dest = url_join(
-                            url_join(transfer.dest, url_basename(transfer.src.rstrip('/'))), relfilename
-                        )
-                    else:
-                        target_dest = url_join(transfer.dest, relfilename)
+                sema = self._sema
+            if kwargs.get('xfer_sema'):
+                xfer_sema = cast(WeightedSemaphore, kwargs.get('xfer_sema'))
+            else:
+                xfer_sema = self._xfer_sema
 
-                    if os.path.isfile(target_dest):
-                        raise NotADirectoryError(transfer.dest)
-
-                    if size > self._storage_client.CHUNK_SIZE:
-                        copy_operations.append(
-                            functools.partial(
-                                self._copy_single_large_file,
-                                xfer_sema,
-                                filename,
-                                target_dest,
-                                size,
-                                report,
-                                return_exceptions,
-                            )
-                        )
-                        copy_operation_thread_count.append(self._storage_client.MAX_WORKERS)
-                    else:
-                        copy_operations.append(
-                            functools.partial(
-                                self._copy_single_local_file,
-                                xfer_sema,
-                                filename,
-                                target_dest,
-                                size,
-                                report,
-                                return_exceptions,
-                            )
-                        )
-                        copy_operation_thread_count.append(1)
-        await weighted_bounded_gather2(
-            sema,
-            copy_operations,
-            copy_operation_thread_count,
-            cancel_on_error=True,
-        )
+            size = await srcstat.size()
+            if size > self._storage_client.CHUNK_SIZE:
+                async with sema.acquire_manager(self._storage_client.MAX_WORKERS):
+                    await self._copy_single_large_file(xfer_sema, srcfile, destfile)
+            else:
+                await self._copy_single_local_file(xfer_sema, srcfile, destfile, size)
+        else:
+            raise NotImplementedError
 
     async def _copy_single_local_file(
         self,
@@ -1111,53 +1013,20 @@ class GoogleStorageAsyncFS(AsyncFS):
         src: str,
         dest: str,
         size: int,
-        report: SourceReport,
-        return_exceptions: bool,
     ) -> None:
         async with xfer_sema.acquire_manager(size):
             bucket, name = self.get_bucket_and_name(src)
-            report.start_files(1)
-            report.start_bytes(size)
-            success = False
-            try:
-                await retry_transient_errors(self._storage_client.download_single_file, bucket, name, dest)
-                success = True
-            except Exception as e:
-                if return_exceptions:
-                    report.set_file_error(src, dest, e)
-                    report.set_exception(e)
-                else:
-                    raise e
-            finally:
-                report.finish_files(1, failed=not success)
-                report.finish_bytes(size)
+            await retry_transient_errors(self._storage_client.download_single_file, bucket, name, dest)
 
     async def _copy_single_large_file(
         self,
         xfer_sema: WeightedSemaphore,
         src: str,
         dest: str,
-        size: int,
-        report: SourceReport,
-        return_exceptions: bool,
     ) -> None:
         async with xfer_sema.acquire_manager(self._storage_client.CHUNK_SIZE):
-            success = False
-            try:
-                bucket, name = self.get_bucket_and_name(src)
-                report.start_files(1)
-                report.start_bytes(size)
-                await retry_transient_errors(self._storage_client.download_large_file, bucket, name, dest)
-                success = True
-            except Exception as e:
-                if return_exceptions:
-                    report.set_file_error(src, dest, e)
-                    report.set_exception(e)
-                else:
-                    raise e
-            finally:
-                report.finish_files(1, failed=not success)
-                report.finish_bytes(size)
+            bucket, name = self.get_bucket_and_name(src)
+            await retry_transient_errors(self._storage_client.download_large_file, bucket, name, dest)
 
     async def copy_within_gcs(
         self, src: str, dest: str, callback: Optional[Callable[[Dict[str, Any], bool], None]] = None

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -994,7 +994,8 @@ class GoogleStorageAsyncFS(AsyncFS):
         copy_operations = []
         copy_operation_thread_count = []
         for transfer, report in zip(transfers, source_reports):
-            assert isinstance(transfer.src, str)
+            if not isinstance(transfer.src, str):
+                raise TypeError(f'Expected a single source when copying from {transfer.src}')
             if await self.isfile(transfer.src):
                 stat = await self.statfile(transfer.src)
                 size = await stat.size()

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -16,7 +16,7 @@ from .fs import (
 from .local_fs import LocalAsyncFS
 from .tasks import BackgroundTaskManager, TaskManagerClosedError
 from .utils import FeedableAsyncIterable, WriteBuffer
-from .weighted_semaphore import WeightedSemaphore
+from .weighted_semaphore import WeightedSemaphore, weighted_bounded_gather2
 
 __all__ = [
     'AsyncFS',
@@ -38,4 +38,5 @@ __all__ = [
     'WriteBuffer',
     'blocking_readable_stream_to_async',
     'blocking_writable_stream_to_async',
+    'weighted_bounded_gather2',
 ]

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -16,7 +16,7 @@ from .fs import (
 from .local_fs import LocalAsyncFS
 from .tasks import BackgroundTaskManager, TaskManagerClosedError
 from .utils import FeedableAsyncIterable, WriteBuffer
-from .weighted_semaphore import WeightedSemaphore, weighted_bounded_gather2
+from .weighted_semaphore import WeightedSemaphore
 
 __all__ = [
     'AsyncFS',
@@ -38,5 +38,4 @@ __all__ = [
     'WriteBuffer',
     'blocking_readable_stream_to_async',
     'blocking_writable_stream_to_async',
-    'weighted_bounded_gather2',
 ]

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List, Literal, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from rich.progress import Progress, TaskID
 
@@ -40,13 +40,11 @@ class GrowingSemaphore(WeightedSemaphore):
                 progress, tid = self.progress_and_tid
                 progress.update(tid, advance=diff)
 
-    async def acquire(self, n: int = 1) -> Literal[True]:
+    async def __aenter__(self) -> 'GrowingSemaphore':
         self.task = asyncio.create_task(self._grow())
-        await super().acquire(n)
-        return True
+        return self
 
-    def release(self, n: int = 1) -> None:
-        super().release(n)
+    def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.task is not None:
             if self.task.done() and not self.task.cancelled():
                 if exc := self.task.exception():

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -40,11 +40,10 @@ class GrowingSemaphore(WeightedSemaphore):
                 progress, tid = self.progress_and_tid
                 progress.update(tid, advance=diff)
 
-    async def __aenter__(self) -> 'GrowingSemaphore':
+    async def __aenter__(self):
         self.task = asyncio.create_task(self._grow())
-        return self
 
-    def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.task is not None:
             if self.task.done() and not self.task.cancelled():
                 if exc := self.task.exception():

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -5,23 +5,23 @@ import logging
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import AsyncContextManager, Dict, List, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 from rich.progress import Progress, TaskID
 
 from .. import uvloopx
 from ..utils.rich_progress_bar import CopyToolProgressBar, make_listener
 from ..utils.utils import sleep_before_try
-from . import Copier, Transfer
+from . import Copier, Transfer, WeightedSemaphore
 from .router_fs import RouterAsyncFS
 
 
-class GrowingSempahore(AsyncContextManager[asyncio.Semaphore]):
+class GrowingSemaphore(WeightedSemaphore):
     def __init__(self, start_max: int, target_max: int, progress_and_tid: Optional[Tuple[Progress, TaskID]]):
+        super().__init__(start_max)
         self.task: Optional[asyncio.Task] = None
         self.target_max = target_max
         self.current_max = start_max
-        self.sema = asyncio.Semaphore(self.current_max)
         self.progress_and_tid = progress_and_tid
 
     async def _grow(self):
@@ -34,28 +34,25 @@ class GrowingSempahore(AsyncContextManager[asyncio.Semaphore]):
             )
             new_max = min(int(self.current_max * 1.5), self.target_max)
             diff = new_max - self.current_max
-            self.sema._value += diff
-            self.sema._wake_up_next()
+            self.release(diff)
             self.current_max = new_max
             if self.progress_and_tid:
                 progress, tid = self.progress_and_tid
                 progress.update(tid, advance=diff)
 
-    async def __aenter__(self) -> asyncio.Semaphore:
+    async def acquire(self, n: int = 1) -> Literal[True]:
         self.task = asyncio.create_task(self._grow())
-        await self.sema.__aenter__()
-        return self.sema
+        await super().acquire(n)
+        return True
 
-    async def __aexit__(self, exc_type, exc, tb):
-        try:
-            await self.sema.__aexit__(exc_type, exc, tb)
-        finally:
-            if self.task is not None:
-                if self.task.done() and not self.task.cancelled():
-                    if exc := self.task.exception():
-                        raise exc
-                else:
-                    self.task.cancel()
+    def release(self, n: int = 1) -> None:
+        super().release(n)
+        if self.task is not None:
+            if self.task.done() and not self.task.cancelled():
+                if exc := self.task.exception():
+                    raise exc
+            else:
+                self.task.cancel()
 
 
 async def copy(
@@ -99,18 +96,18 @@ async def copy(
                     total=max_simultaneous_transfers,
                     visible=verbose,
                 )
-                async with GrowingSempahore(
+                sema = GrowingSemaphore(
                     initial_simultaneous_transfers, max_simultaneous_transfers, (progress, parallelism_tid)
-                ) as sema:
-                    file_tid = progress.add_task(description='files', total=0, visible=verbose)
-                    bytes_tid = progress.add_task(description='bytes', total=0, visible=verbose)
-                    copy_report = await Copier.copy(
-                        fs,
-                        sema,
-                        transfers,
-                        files_listener=make_listener(progress, file_tid),
-                        bytes_listener=make_listener(progress, bytes_tid),
-                    )
+                )
+                file_tid = progress.add_task(description='files', total=0, visible=verbose)
+                bytes_tid = progress.add_task(description='bytes', total=0, visible=verbose)
+                copy_report = await Copier.copy(
+                    fs,
+                    sema,
+                    transfers,
+                    files_listener=make_listener(progress, file_tid),
+                    bytes_listener=make_listener(progress, bytes_tid),
+                )
                 if verbose:
                     copy_report.summarize()
 

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List, Optional, Tuple
+from typing import AsyncContextManager, Dict, List, Optional, Tuple
 
 from rich.progress import Progress, TaskID
 
@@ -16,9 +16,9 @@ from . import Copier, Transfer, WeightedSemaphore
 from .router_fs import RouterAsyncFS
 
 
-class GrowingSemaphore(WeightedSemaphore):
+class GrowingSemaphore(AsyncContextManager[WeightedSemaphore]):
     def __init__(self, start_max: int, target_max: int, progress_and_tid: Optional[Tuple[Progress, TaskID]]):
-        super().__init__(start_max)
+        self.sema = WeightedSemaphore(start_max)
         self.task: Optional[asyncio.Task] = None
         self.target_max = target_max
         self.current_max = start_max
@@ -34,14 +34,15 @@ class GrowingSemaphore(WeightedSemaphore):
             )
             new_max = min(int(self.current_max * 1.5), self.target_max)
             diff = new_max - self.current_max
-            self.release(diff)
+            self.sema.release(diff)
             self.current_max = new_max
             if self.progress_and_tid:
                 progress, tid = self.progress_and_tid
                 progress.update(tid, advance=diff)
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> WeightedSemaphore:
         self.task = asyncio.create_task(self._grow())
+        return self.sema
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.task is not None:
@@ -93,18 +94,18 @@ async def copy(
                     total=max_simultaneous_transfers,
                     visible=verbose,
                 )
-                sema = GrowingSemaphore(
+                async with GrowingSemaphore(
                     initial_simultaneous_transfers, max_simultaneous_transfers, (progress, parallelism_tid)
-                )
-                file_tid = progress.add_task(description='files', total=0, visible=verbose)
-                bytes_tid = progress.add_task(description='bytes', total=0, visible=verbose)
-                copy_report = await Copier.copy(
-                    fs,
-                    sema,
-                    transfers,
-                    files_listener=make_listener(progress, file_tid),
-                    bytes_listener=make_listener(progress, bytes_tid),
-                )
+                ) as sema:
+                    file_tid = progress.add_task(description='files', total=0, visible=verbose)
+                    bytes_tid = progress.add_task(description='bytes', total=0, visible=verbose)
+                    copy_report = await Copier.copy(
+                        fs,
+                        sema,
+                        transfers,
+                        files_listener=make_listener(progress, file_tid),
+                        bytes_listener=make_listener(progress, bytes_tid),
+                    )
                 if verbose:
                     copy_report.summarize()
 

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -76,6 +76,11 @@ async def copy(
         if 'thread_pool' not in local_kwargs:
             local_kwargs['thread_pool'] = thread_pool
 
+        if gcs_kwargs is None:
+            gcs_kwargs = {}
+        if 'thread_pool' not in gcs_kwargs:
+            gcs_kwargs['thread_pool'] = thread_pool
+
         if s3_kwargs is None:
             s3_kwargs = {}
         if 'thread_pool' not in s3_kwargs:

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -317,7 +317,12 @@ class SourceCopier:
     ) -> None:
         success = False
         try:
-            await self._copy_file_multi_part_main(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
+            try:
+                await self.router_fs.copy_to(srcfile, destfile)
+            except NotImplementedError:
+                await self._copy_file_multi_part_main(
+                    sema, source_report, srcfile, srcstat, destfile, return_exceptions
+                )
             success = True
         except Exception as e:
             if return_exceptions:

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -7,14 +7,13 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
 import humanize
 
 from ...utils import (
-    bounded_gather2,
     humanize_timedelta_msecs,
     retry_transient_errors,
     time_msecs,
     url_basename,
     url_join,
 )
-from ..weighted_semaphore import WeightedSemaphore
+from ..weighted_semaphore import WeightedSemaphore, weighted_bounded_gather2
 from .exceptions import FileAndDirectoryError, UnexpectedEOFError
 from .fs import AsyncFS, FileListEntry, FileStatus, MultiPartCreate
 
@@ -264,7 +263,7 @@ class SourceCopier:
 
     async def _copy_file_multi_part_main(
         self,
-        sema: asyncio.Semaphore,
+        sema: WeightedSemaphore,
         source_report: SourceReport,
         srcfile: str,
         srcstat: FileStatus,
@@ -304,11 +303,13 @@ class SourceCopier:
                     return_exceptions,
                 )
 
-            await bounded_gather2(sema, *[functools.partial(f, i) for i in range(n_parts)], cancel_on_error=True)
+            await weighted_bounded_gather2(
+                sema, [functools.partial(f, i) for i in range(n_parts)], cancel_on_error=True
+            )
 
     async def _copy_file_multi_part(
         self,
-        sema: asyncio.Semaphore,
+        sema: WeightedSemaphore,
         source_report: SourceReport,
         srcfile: str,
         srcstat: FileStatus,
@@ -347,7 +348,7 @@ class SourceCopier:
 
     async def copy_as_file(
         self,
-        sema: asyncio.Semaphore,  # pylint: disable=unused-argument
+        sema: WeightedSemaphore,  # pylint: disable=unused-argument
         source_report: SourceReport,
         return_exceptions: bool,
     ):
@@ -379,7 +380,7 @@ class SourceCopier:
         source_report.start_bytes(await srcstat.size())
         await self._copy_file_multi_part(sema, source_report, src, srcstat, full_dest, return_exceptions)
 
-    async def copy_as_dir(self, sema: asyncio.Semaphore, source_report: SourceReport, return_exceptions: bool):
+    async def copy_as_dir(self, sema: WeightedSemaphore, source_report: SourceReport, return_exceptions: bool):
         async def files_iterator() -> AsyncIterator[FileListEntry]:
             return await self.router_fs.listfiles(src, recursive=True)
 
@@ -448,9 +449,9 @@ class SourceCopier:
         copies, bytes_to_copy = await retry_transient_errors(create_copies)
         source_report.start_files(len(copies))
         source_report.start_bytes(bytes_to_copy)
-        await bounded_gather2(sema, *copies, cancel_on_error=True)
+        await weighted_bounded_gather2(sema, copies, cancel_on_error=True)
 
-    async def copy(self, sema: asyncio.Semaphore, source_report: SourceReport, return_exceptions: bool):
+    async def copy(self, sema: WeightedSemaphore, source_report: SourceReport, return_exceptions: bool):
         try:
             # gather with return_exceptions=True to make copy
             # deterministic with respect to exceptions
@@ -496,7 +497,7 @@ class Copier:
     @staticmethod
     async def copy(
         fs: AsyncFS,
-        sema: asyncio.Semaphore,
+        sema: WeightedSemaphore,
         transfer: Union[Transfer, List[Transfer]],
         return_exceptions: bool = False,
         *,
@@ -538,7 +539,7 @@ class Copier:
 
     async def copy_source(
         self,
-        sema: asyncio.Semaphore,
+        sema: WeightedSemaphore,
         transfer: Transfer,
         source_report: SourceReport,
         src: str,
@@ -551,7 +552,7 @@ class Copier:
         await src_copier.copy(sema, source_report, return_exceptions)
 
     async def _copy_one_transfer(
-        self, sema: asyncio.Semaphore, transfer_report: TransferReport, transfer: Transfer, return_exceptions: bool
+        self, sema: WeightedSemaphore, transfer_report: TransferReport, transfer: Transfer, return_exceptions: bool
     ):
         try:
             if transfer.treat_dest_as == Transfer.INFER_DEST:
@@ -570,9 +571,9 @@ class Copier:
                     if transfer.treat_dest_as == Transfer.DEST_IS_TARGET:
                         raise NotADirectoryError(transfer.dest)
 
-                    await bounded_gather2(
+                    await weighted_bounded_gather2(
                         sema,
-                        *[
+                        [
                             functools.partial(self.copy_source, sema, transfer, r, s, dest_type_task, return_exceptions)
                             for r, s in zip(src_report, src)
                         ],
@@ -593,7 +594,7 @@ class Copier:
 
     async def _copy(
         self,
-        sema: asyncio.Semaphore,
+        sema: WeightedSemaphore,
         copy_report: CopyReport,
         transfer: Union[Transfer, List[Transfer]],
         return_exceptions: bool,
@@ -640,9 +641,9 @@ class Copier:
                 return_exceptions=return_exceptions,
             )
 
-            await bounded_gather2(
+            await weighted_bounded_gather2(
                 sema,
-                *[
+                [
                     functools.partial(self._copy_one_transfer, sema, r, t, return_exceptions)
                     for r, t in zip(copier_reports, copier_transfers)
                 ],

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -6,18 +6,15 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
 
 import humanize
 
-from hailtop.aiotools import LocalAsyncFS
-from hailtop.fs.router_fs import RouterFS
-
-from ...aiocloud.aiogoogle import GoogleStorageAsyncFS
 from ...utils import (
+    bounded_gather2,
     humanize_timedelta_msecs,
     retry_transient_errors,
     time_msecs,
     url_basename,
     url_join,
 )
-from ..weighted_semaphore import WeightedSemaphore, weighted_bounded_gather2
+from ..weighted_semaphore import WeightedSemaphore
 from .exceptions import FileAndDirectoryError, UnexpectedEOFError
 from .fs import AsyncFS, FileListEntry, FileStatus, MultiPartCreate
 
@@ -192,7 +189,7 @@ class SourceCopier:
     """
 
     def __init__(
-        self, router_fs: RouterFS, xfer_sema: WeightedSemaphore, src: str, dest: str, treat_dest_as: str, dest_type_task
+        self, router_fs: AsyncFS, xfer_sema: WeightedSemaphore, src: str, dest: str, treat_dest_as: str, dest_type_task
     ):
         self.router_fs = router_fs
         self.xfer_sema = xfer_sema
@@ -307,9 +304,7 @@ class SourceCopier:
                     return_exceptions,
                 )
 
-            await weighted_bounded_gather2(
-                sema, [functools.partial(f, i) for i in range(n_parts)], cancel_on_error=True
-            )
+            await bounded_gather2(sema, *[functools.partial(f, i) for i in range(n_parts)], cancel_on_error=True)
 
     async def _copy_file_multi_part(
         self,
@@ -322,11 +317,15 @@ class SourceCopier:
     ) -> None:
         success = False
         try:
-            if GoogleStorageAsyncFS.valid_url(srcfile) and LocalAsyncFS.valid_url(destfile):
-                await self.router_fs._get_fs(srcfile).copy_to_local_file_2(
-                    sema, self.xfer_sema, source_report, srcfile, srcstat, destfile, return_exceptions
+            try:
+                await self.router_fs.copy_between_fs(
+                    srcfile,
+                    srcstat,
+                    destfile,
+                    sema=sema,
+                    xfer_sema=self.xfer_sema,
                 )
-            else:
+            except NotImplementedError:
                 await self._copy_file_multi_part_main(
                     sema, source_report, srcfile, srcstat, destfile, return_exceptions
                 )
@@ -460,7 +459,7 @@ class SourceCopier:
         copies, bytes_to_copy = await retry_transient_errors(create_copies)
         source_report.start_files(len(copies))
         source_report.start_bytes(bytes_to_copy)
-        await weighted_bounded_gather2(sema, copies, cancel_on_error=True)
+        await bounded_gather2(sema, *copies, cancel_on_error=True)
 
     async def copy(self, sema: WeightedSemaphore, source_report: SourceReport, return_exceptions: bool):
         try:
@@ -582,9 +581,9 @@ class Copier:
                     if transfer.treat_dest_as == Transfer.DEST_IS_TARGET:
                         raise NotADirectoryError(transfer.dest)
 
-                    await weighted_bounded_gather2(
+                    await bounded_gather2(
                         sema,
-                        [
+                        *[
                             functools.partial(self.copy_source, sema, transfer, r, s, dest_type_task, return_exceptions)
                             for r, s in zip(src_report, src)
                         ],
@@ -610,6 +609,7 @@ class Copier:
         transfer: Union[Transfer, List[Transfer]],
         return_exceptions: bool,
     ):
+        '''
         transfer_report = copy_report._transfer_report
         try:
             google_to_local_transfers: List[Transfer] = []
@@ -663,12 +663,20 @@ class Copier:
                 google_to_local_reports,
                 return_exceptions=return_exceptions,
             )
+        '''
+        transfer_report = copy_report._transfer_report
+        try:
+            if isinstance(transfer, Transfer):
+                assert isinstance(transfer_report, TransferReport)
+                await self._copy_one_transfer(sema, transfer_report, transfer, return_exceptions)
+                return
 
-            await weighted_bounded_gather2(
+            assert isinstance(transfer_report, list)
+            await bounded_gather2(
                 sema,
-                [
+                *[
                     functools.partial(self._copy_one_transfer, sema, r, t, return_exceptions)
-                    for r, t in zip(copier_reports, copier_transfers)
+                    for r, t in zip(transfer_report, transfer)
                 ],
                 return_exceptions=return_exceptions,
                 cancel_on_error=True,

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -609,19 +609,16 @@ class Copier:
                 transfer_report if isinstance(transfer_report, list) else [transfer_report],
                 transfer if isinstance(transfer, list) else [transfer],
             ):
-                if isinstance(single_transfer.src, str):
+                if isinstance(single_transfer.src, str) and isinstance(single_report._source_report, SourceReport):
                     if self.router_fs.valid_google_url(single_transfer.src) and self.router_fs.valid_local_url(
                         single_transfer.dest
                     ):
-                        assert isinstance(single_report._source_report, SourceReport)
                         google_to_local_transfers.append(single_transfer)
                         google_to_local_reports.append(single_report._source_report)
                     else:
                         copier_transfers.append(single_transfer)
                         copier_reports.append(single_report)
-                else:
-                    assert isinstance(single_transfer.src, list)
-                    assert isinstance(single_report._source_report, list)
+                elif isinstance(single_report._source_report, List):
                     for source, source_report in zip(single_transfer.src, single_report._source_report):
                         if self.router_fs.valid_google_url(source) and self.router_fs.valid_local_url(
                             single_transfer.dest
@@ -631,10 +628,21 @@ class Copier:
                             )
                             google_to_local_reports.append(source_report)
                         else:
-                            copier_transfers.append(
-                                Transfer(source, single_transfer.dest, treat_dest_as=single_transfer.treat_dest_as)
+                            copier_transfer = Transfer(
+                                source, single_transfer.dest, treat_dest_as=single_transfer.treat_dest_as
                             )
-                            copier_reports.append(single_report)
+                            copier_transfers.append(copier_transfer)
+                            copier_reports.append(
+                                TransferReport(
+                                    copier_transfer,
+                                    files_listener=source_report._files_listener,
+                                    bytes_listener=source_report._bytes_listener,
+                                )
+                            )
+                else:
+                    raise TypeError(
+                        f'Expected {single_transfer.src} to have type {"list" if isinstance(single_report._source_report, List) else "str"}'
+                    )
 
             google_fs = await self.router_fs._get_fs('gs://')
             await google_fs.copy_to_local(

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -317,12 +317,7 @@ class SourceCopier:
     ) -> None:
         success = False
         try:
-            try:
-                await self.router_fs.copy_to(srcfile, destfile)
-            except NotImplementedError:
-                await self._copy_file_multi_part_main(
-                    sema, source_report, srcfile, srcstat, destfile, return_exceptions
-                )
+            await self._copy_file_multi_part_main(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
             success = True
         except Exception as e:
             if return_exceptions:
@@ -605,17 +600,51 @@ class Copier:
     ):
         transfer_report = copy_report._transfer_report
         try:
-            if isinstance(transfer, Transfer):
-                assert isinstance(transfer_report, TransferReport)
-                await self._copy_one_transfer(sema, transfer_report, transfer, return_exceptions)
-                return
+            google_to_local_transfers: List[Transfer] = []
+            google_to_local_reports: List[SourceReport] = []
+            copier_transfers: List[Transfer] = []
+            copier_reports: List[TransferReport] = []
+            for single_report, single_transfer in zip(
+                transfer_report if isinstance(transfer_report, list) else [transfer_report],
+                transfer if isinstance(transfer, list) else [transfer],
+            ):
+                if isinstance(single_transfer.src, str):
+                    if self.router_fs.valid_google_url(single_transfer.src):
+                        assert isinstance(single_report._source_report, SourceReport)
+                        google_to_local_transfers.append(single_transfer)
+                        google_to_local_reports.append(single_report._source_report)
+                    else:
+                        copier_transfers.append(single_transfer)
+                        copier_reports.append(single_report)
+                else:
+                    assert isinstance(single_transfer.src, list)
+                    assert isinstance(single_report._source_report, list)
+                    for source, source_report in zip(single_transfer.src, single_report._source_report):
+                        if self.router_fs.valid_google_url(source):
+                            google_to_local_transfers.append(
+                                Transfer(source, single_transfer.dest, treat_dest_as=single_transfer.treat_dest_as)
+                            )
+                            google_to_local_reports.append(source_report)
+                        else:
+                            copier_transfers.append(
+                                Transfer(source, single_transfer.dest, treat_dest_as=single_transfer.treat_dest_as)
+                            )
+                            copier_reports.append(single_report)
 
-            assert isinstance(transfer_report, list)
+            google_fs = await self.router_fs._get_fs('gs://')
+            await google_fs.copy_to_local(
+                sema,
+                self.xfer_sema,
+                google_to_local_transfers,
+                google_to_local_reports,
+                return_exceptions=return_exceptions,
+            )
+
             await bounded_gather2(
                 sema,
                 *[
                     functools.partial(self._copy_one_transfer, sema, r, t, return_exceptions)
-                    for r, t in zip(transfer_report, transfer)
+                    for r, t in zip(copier_reports, copier_transfers)
                 ],
                 return_exceptions=return_exceptions,
                 cancel_on_error=True,

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
 import humanize
 
 from hailtop.aiotools import LocalAsyncFS
+from hailtop.fs.router_fs import RouterFS
 
 from ...aiocloud.aiogoogle import GoogleStorageAsyncFS
 from ...utils import (
@@ -191,7 +192,7 @@ class SourceCopier:
     """
 
     def __init__(
-        self, router_fs: AsyncFS, xfer_sema: WeightedSemaphore, src: str, dest: str, treat_dest_as: str, dest_type_task
+        self, router_fs: RouterFS, xfer_sema: WeightedSemaphore, src: str, dest: str, treat_dest_as: str, dest_type_task
     ):
         self.router_fs = router_fs
         self.xfer_sema = xfer_sema
@@ -322,9 +323,13 @@ class SourceCopier:
         success = False
         try:
             if GoogleStorageAsyncFS.valid_url(srcfile) and LocalAsyncFS.valid_url(destfile):
-                await self.router_fs._get_fs(srcfile).copy_to_local_file(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
+                await self.router_fs._get_fs(srcfile).copy_to_local_file_2(
+                    sema, self.xfer_sema, source_report, srcfile, srcstat, destfile, return_exceptions
+                )
             else:
-                await self._copy_file_multi_part_main(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
+                await self._copy_file_multi_part_main(
+                    sema, source_report, srcfile, srcstat, destfile, return_exceptions
+                )
             success = True
         except Exception as e:
             if return_exceptions:

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -610,7 +610,9 @@ class Copier:
                 transfer if isinstance(transfer, list) else [transfer],
             ):
                 if isinstance(single_transfer.src, str):
-                    if self.router_fs.valid_google_url(single_transfer.src):
+                    if self.router_fs.valid_google_url(single_transfer.src) and self.router_fs.valid_local_url(
+                        single_transfer.dest
+                    ):
                         assert isinstance(single_report._source_report, SourceReport)
                         google_to_local_transfers.append(single_transfer)
                         google_to_local_reports.append(single_report._source_report)
@@ -621,7 +623,9 @@ class Copier:
                     assert isinstance(single_transfer.src, list)
                     assert isinstance(single_report._source_report, list)
                     for source, source_report in zip(single_transfer.src, single_report._source_report):
-                        if self.router_fs.valid_google_url(source):
+                        if self.router_fs.valid_google_url(source) and self.router_fs.valid_local_url(
+                            single_transfer.dest
+                        ):
                             google_to_local_transfers.append(
                                 Transfer(source, single_transfer.dest, treat_dest_as=single_transfer.treat_dest_as)
                             )

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -6,6 +6,9 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
 
 import humanize
 
+from hailtop.aiotools import LocalAsyncFS
+
+from ...aiocloud.aiogoogle import GoogleStorageAsyncFS
 from ...utils import (
     humanize_timedelta_msecs,
     retry_transient_errors,
@@ -318,7 +321,10 @@ class SourceCopier:
     ) -> None:
         success = False
         try:
-            await self._copy_file_multi_part_main(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
+            if GoogleStorageAsyncFS.valid_url(srcfile) and LocalAsyncFS.valid_url(destfile):
+                await self.router_fs._get_fs(srcfile).copy_to_local_file(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
+            else:
+                await self._copy_file_multi_part_main(sema, source_report, srcfile, srcstat, destfile, return_exceptions)
             success = True
         except Exception as e:
             if return_exceptions:

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -609,61 +609,6 @@ class Copier:
         transfer: Union[Transfer, List[Transfer]],
         return_exceptions: bool,
     ):
-        '''
-        transfer_report = copy_report._transfer_report
-        try:
-            google_to_local_transfers: List[Transfer] = []
-            google_to_local_reports: List[SourceReport] = []
-            copier_transfers: List[Transfer] = []
-            copier_reports: List[TransferReport] = []
-            for single_report, single_transfer in zip(
-                transfer_report if isinstance(transfer_report, list) else [transfer_report],
-                transfer if isinstance(transfer, list) else [transfer],
-            ):
-                if isinstance(single_transfer.src, str) and isinstance(single_report._source_report, SourceReport):
-                    if self.router_fs.valid_google_url(single_transfer.src) and self.router_fs.valid_local_url(
-                        single_transfer.dest
-                    ):
-                        google_to_local_transfers.append(single_transfer)
-                        google_to_local_reports.append(single_report._source_report)
-                    else:
-                        copier_transfers.append(single_transfer)
-                        copier_reports.append(single_report)
-                elif isinstance(single_report._source_report, List):
-                    for source, source_report in zip(single_transfer.src, single_report._source_report):
-                        if self.router_fs.valid_google_url(source) and self.router_fs.valid_local_url(
-                            single_transfer.dest
-                        ):
-                            google_to_local_transfers.append(
-                                Transfer(source, single_transfer.dest, treat_dest_as=single_transfer.treat_dest_as)
-                            )
-                            google_to_local_reports.append(source_report)
-                        else:
-                            copier_transfer = Transfer(
-                                source, single_transfer.dest, treat_dest_as=single_transfer.treat_dest_as
-                            )
-                            copier_transfers.append(copier_transfer)
-                            copier_reports.append(
-                                TransferReport(
-                                    copier_transfer,
-                                    files_listener=source_report._files_listener,
-                                    bytes_listener=source_report._bytes_listener,
-                                )
-                            )
-                else:
-                    raise TypeError(
-                        f'Expected {single_transfer.src} to have type {"list" if isinstance(single_report._source_report, List) else "str"}'
-                    )
-
-            google_fs = await self.router_fs._get_fs('gs://')
-            await google_fs.copy_to_local(
-                sema,
-                self.xfer_sema,
-                google_to_local_transfers,
-                google_to_local_reports,
-                return_exceptions=return_exceptions,
-            )
-        '''
         transfer_report = copy_report._transfer_report
         try:
             if isinstance(transfer, Transfer):

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -303,6 +303,9 @@ class AsyncFS(abc.ABC):
     async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         pass
 
+    async def copy_to(self, url: str, dest: str):
+        raise NotImplementedError
+
     @abc.abstractmethod
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         pass

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -303,9 +303,6 @@ class AsyncFS(abc.ABC):
     async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         pass
 
-    async def copy_to(self, url: str, dest: str):
-        raise NotImplementedError
-
     @abc.abstractmethod
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         pass

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -397,6 +397,15 @@ class AsyncFS(abc.ABC):
             if tasks:
                 await pool.wait(tasks)
 
+    async def copy_between_fs(
+        self,
+        srcfile: str,
+        srcstat: FileStatus,
+        destfile: str,
+        **kwargs,
+    ):
+        raise NotImplementedError
+
     async def touch(self, url: str) -> None:
         async with await self.create(url):
             pass

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -114,6 +114,10 @@ class RouterAsyncFS(AsyncFS):
         fs = await self._get_fs(url)
         return await fs.open_from(url, start, length=length)
 
+    async def copy_to(self, url: str, dest: str):
+        fs = await self._get_fs(url)
+        return await fs.copy_to(url, dest)
+
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         fs = await self._get_fs(url)
         return await fs.create(url, retry_writes=retry_writes)

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -76,14 +76,6 @@ class RouterAsyncFS(AsyncFS):
             or aioaws.S3AsyncFS.valid_url(url)
         )
 
-    @staticmethod
-    def valid_google_url(url) -> bool:
-        return aiogoogle.GoogleStorageAsyncFS.valid_url(url)
-
-    @staticmethod
-    def valid_local_url(url) -> bool:
-        return LocalAsyncFS.valid_url(url)
-
     async def _get_fs(self, url: str):
         if LocalAsyncFS.valid_url(url):
             if self._local_fs is None:
@@ -113,6 +105,16 @@ class RouterAsyncFS(AsyncFS):
                 self._exit_stack.push_async_callback(self._s3_fs.close)
             return self._s3_fs
         raise ValueError(f'no file system found for url {url}')
+
+    async def copy_between_fs(
+        self,
+        srcfile: str,
+        srcstat: FileStatus,
+        destfile: str,
+        **kwargs,
+    ):
+        fs = await self._get_fs(srcfile)
+        await fs.copy_between_fs(srcfile, srcstat, destfile, **kwargs)
 
     async def open(self, url: str) -> ReadableStream:
         fs = await self._get_fs(url)

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -76,6 +76,10 @@ class RouterAsyncFS(AsyncFS):
             or aioaws.S3AsyncFS.valid_url(url)
         )
 
+    @staticmethod
+    def valid_google_url(url) -> bool:
+        return aiogoogle.GoogleStorageAsyncFS.valid_url(url)
+
     async def _get_fs(self, url: str):
         if LocalAsyncFS.valid_url(url):
             if self._local_fs is None:
@@ -113,10 +117,6 @@ class RouterAsyncFS(AsyncFS):
     async def _open_from(self, url: str, start: int, *, length: Optional[int] = None) -> ReadableStream:
         fs = await self._get_fs(url)
         return await fs.open_from(url, start, length=length)
-
-    async def copy_to(self, url: str, dest: str):
-        fs = await self._get_fs(url)
-        return await fs.copy_to(url, dest)
 
     async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         fs = await self._get_fs(url)

--- a/hail/python/hailtop/aiotools/router_fs.py
+++ b/hail/python/hailtop/aiotools/router_fs.py
@@ -80,6 +80,10 @@ class RouterAsyncFS(AsyncFS):
     def valid_google_url(url) -> bool:
         return aiogoogle.GoogleStorageAsyncFS.valid_url(url)
 
+    @staticmethod
+    def valid_local_url(url) -> bool:
+        return LocalAsyncFS.valid_url(url)
+
     async def _get_fs(self, url: str):
         if LocalAsyncFS.valid_url(url):
             if self._local_fs is None:

--- a/hail/python/hailtop/aiotools/weighted_semaphore.py
+++ b/hail/python/hailtop/aiotools/weighted_semaphore.py
@@ -1,12 +1,8 @@
-import asyncio
-import sys
 from asyncio import Event, Semaphore
 from types import TracebackType
-from typing import Awaitable, Callable, List, Literal, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import Literal, Optional, Type, TypeVar, cast
 
 from sortedcontainers import SortedKeyList
-
-from hailtop.utils.utils import WithoutSemaphore
 
 T = TypeVar('T')  # pylint: disable=invalid-name
 
@@ -67,74 +63,3 @@ class WeightedSemaphore(Semaphore):
         self.events.add((n, event))
         await event.wait()
         return True
-
-
-async def weighted_bounded_gather2_raise_exceptions(
-    sema: WeightedSemaphore, pfs: List[Callable[[], Awaitable[T]]], weights: List[int], cancel_on_error: bool = False
-) -> List[T]:
-    """Similar to `bounded_gather2_raise_exceptions`, but uses a
-    weighted semaphore to schedule tasks with different weights.
-    """
-
-    async def run_with_sema(pf: Callable[[], Awaitable[T]], weight: int):
-        async with sema.acquire_manager(weight):
-            return await pf()
-
-    tasks = [asyncio.create_task(run_with_sema(pf, weight)) for pf, weight in zip(pfs, weights)]
-
-    if not cancel_on_error:
-        async with WithoutSemaphore(sema):
-            return await asyncio.gather(*tasks)
-
-    try:
-        async with WithoutSemaphore(sema):
-            return await asyncio.gather(*tasks)
-    finally:
-        _, exc, _ = sys.exc_info()
-        if exc is not None:
-            for task in tasks:
-                if task.done() and not task.cancelled():
-                    exc = task.exception()
-                    if exc:
-                        raise exc
-                else:
-                    task.cancel()
-            if tasks:
-                async with WithoutSemaphore(sema):
-                    await asyncio.wait(tasks)
-
-
-async def weighted_bounded_gather2_return_exceptions(
-    sema: WeightedSemaphore, pfs: List[Callable[[], Awaitable[T]]], weights: List[int]
-) -> List[Union[Tuple[T, None], Tuple[None, Optional[BaseException]]]]:
-    """Similar to `bounded_gather2_return_exceptions`, but uses a
-    weighted semaphore to schedule tasks with different weights.
-    """
-
-    async def run_with_sema_return_exceptions(pf: Callable[[], Awaitable[T]], weight: int):
-        try:
-            async with sema.acquire_manager(weight):
-                return (await pf(), None)
-        except:
-            _, exc, _ = sys.exc_info()
-            return (None, exc)
-
-    tasks = [asyncio.create_task(run_with_sema_return_exceptions(pf, weight)) for pf, weight in zip(pfs, weights)]
-    async with WithoutSemaphore(sema):
-        return await asyncio.gather(*tasks)
-
-
-async def weighted_bounded_gather2(
-    sema: WeightedSemaphore,
-    pfs: List[Callable[[], Awaitable[T]]],
-    weights: Optional[List[int]] = None,
-    return_exceptions: bool = False,
-    cancel_on_error: bool = False,
-) -> List[T]:
-    if not weights:
-        weights = [1] * len(pfs)
-    if return_exceptions:
-        if cancel_on_error:
-            raise ValueError('cannot request return_exceptions and cancel_on_error')
-        return await weighted_bounded_gather2_return_exceptions(sema, pfs, weights)  # type: ignore
-    return await weighted_bounded_gather2_raise_exceptions(sema, pfs, weights, cancel_on_error=cancel_on_error)

--- a/hail/python/hailtop/aiotools/weighted_semaphore.py
+++ b/hail/python/hailtop/aiotools/weighted_semaphore.py
@@ -1,8 +1,14 @@
-from asyncio import Event
+import asyncio
+import sys
+from asyncio import Event, Semaphore
 from types import TracebackType
-from typing import Optional, Type, cast
+from typing import Awaitable, Callable, List, Literal, Optional, Tuple, Type, TypeVar, Union, cast
 
 from sortedcontainers import SortedKeyList
+
+from hailtop.utils.utils import WithoutSemaphore
+
+T = TypeVar('T')  # pylint: disable=invalid-name
 
 
 class _AcquireManager:
@@ -20,23 +26,27 @@ class _AcquireManager:
         self._ws.release(self._n)
 
 
-class WeightedSemaphore:
+class WeightedSemaphore(Semaphore):
     def __init__(self, value: int):
+        super().__init__(value)
         self.max = value
-        self.value = value
+        self._value = value
         self.events = SortedKeyList(key=lambda x: x[0])
 
-    def release(self, n: int) -> None:
-        self.value += n
+    def locked(self):
+        return self._value == 0 or (any(event.is_set() for n, event in self.events))
+
+    def release(self, n: int = 1) -> None:
+        self._value += n
         while self.events:
             _n, _event = self.events[0]
             # cast to int / Event:
             _n = cast(int, _n)
             _event = cast(Event, _event)
 
-            if self.value >= _n:
+            if self._value >= _n:
                 self.events.pop(0)
-                self.value -= _n
+                self._value -= _n
                 _event.set()
             else:
                 break
@@ -44,12 +54,84 @@ class WeightedSemaphore:
     def acquire_manager(self, n: int) -> _AcquireManager:
         return _AcquireManager(self, n)
 
-    async def acquire(self, n: int) -> None:
+    async def acquire(self, n: int = 1) -> Literal[True]:
         assert n <= self.max
-        if self.value >= n:
-            self.value -= n
-            return
+        if self._value >= n:
+            self._value -= n
+            return True
 
         event = Event()
         self.events.add((n, event))
         await event.wait()
+        return True
+
+
+async def weighted_bounded_gather2_raise_exceptions(
+    sema: WeightedSemaphore, pfs: List[Callable[[], Awaitable[T]]], weights: List[int], cancel_on_error: bool = False
+) -> List[T]:
+    """Similar to `bounded_gather2_raise_exceptions`, but uses a
+    weighted semaphore to schedule tasks with different weights.
+    """
+
+    async def run_with_sema(pf: Callable[[], Awaitable[T]], weight: int):
+        async with sema.acquire_manager(weight):
+            return await pf()
+
+    tasks = [asyncio.create_task(run_with_sema(pf, weight)) for pf, weight in zip(pfs, weights)]
+
+    if not cancel_on_error:
+        async with WithoutSemaphore(sema):
+            return await asyncio.gather(*tasks)
+
+    try:
+        async with WithoutSemaphore(sema):
+            return await asyncio.gather(*tasks)
+    finally:
+        _, exc, _ = sys.exc_info()
+        if exc is not None:
+            for task in tasks:
+                if task.done() and not task.cancelled():
+                    exc = task.exception()
+                    if exc:
+                        raise exc
+                else:
+                    task.cancel()
+            if tasks:
+                async with WithoutSemaphore(sema):
+                    await asyncio.wait(tasks)
+
+
+async def weighted_bounded_gather2_return_exceptions(
+    sema: WeightedSemaphore, pfs: List[Callable[[], Awaitable[T]]], weights: List[int]
+) -> List[Union[Tuple[T, None], Tuple[None, Optional[BaseException]]]]:
+    """Similar to `bounded_gather2_return_exceptions`, but uses a
+    weighted semaphore to schedule tasks with different weights.
+    """
+
+    async def run_with_sema_return_exceptions(pf: Callable[[], Awaitable[T]], weight: int):
+        try:
+            async with sema.acquire_manager(weight):
+                return (await pf(), None)
+        except:
+            _, exc, _ = sys.exc_info()
+            return (None, exc)
+
+    tasks = [asyncio.create_task(run_with_sema_return_exceptions(pf, weight)) for pf, weight in zip(pfs, weights)]
+    async with WithoutSemaphore(sema):
+        return await asyncio.gather(*tasks)
+
+
+async def weighted_bounded_gather2(
+    sema: WeightedSemaphore,
+    pfs: List[Callable[[], Awaitable[T]]],
+    weights: Optional[List[int]] = None,
+    return_exceptions: bool = False,
+    cancel_on_error: bool = False,
+) -> List[T]:
+    if not weights:
+        weights = [1] * len(pfs)
+    if return_exceptions:
+        if cancel_on_error:
+            raise ValueError('cannot request return_exceptions and cancel_on_error')
+        return await weighted_bounded_gather2_return_exceptions(sema, pfs, weights)  # type: ignore
+    return await weighted_bounded_gather2_raise_exceptions(sema, pfs, weights, cancel_on_error=cancel_on_error)

--- a/hail/python/hailtop/aiotools/weighted_semaphore.py
+++ b/hail/python/hailtop/aiotools/weighted_semaphore.py
@@ -34,10 +34,13 @@ class WeightedSemaphore(Semaphore):
         self.events = SortedKeyList(key=lambda x: x[0])
 
     def locked(self):
-        return self._value == 0 or (any(event.is_set() for n, event in self.events))
+        return self._value == 0 and (any(not event.is_set() for n, event in (self.events or ())))
 
     def release(self, n: int = 1) -> None:
         self._value += n
+        self._wake_up_next()
+
+    def _wake_up_next(self):
         while self.events:
             _n, _event = self.events[0]
             # cast to int / Event:

--- a/hail/python/hailtop/fs/router_fs.py
+++ b/hail/python/hailtop/fs/router_fs.py
@@ -20,6 +20,7 @@ from hailtop.aiotools.fs import (
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.utils import async_to_blocking, bounded_gather2
 
+from ..aiotools import WeightedSemaphore
 from .fs import FS
 from .stat_result import FileListEntry, FileType
 
@@ -238,7 +239,7 @@ class RouterFS(FS):
         transfer = Transfer(src, dest)
 
         async def _copy():
-            sema = asyncio.Semaphore(max_simultaneous_transfers)
+            sema = WeightedSemaphore(max_simultaneous_transfers)
             await Copier.copy(self.afs, sema, transfer)
 
         return async_to_blocking(_copy())

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -65,12 +65,31 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
+google-api-core==2.30.0
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
 google-auth==2.49.2
     # via
     #   -r hail/python/hailtop/requirements.txt
+    #   google-api-core
     #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-storage
 google-auth-oauthlib==0.8.0
     # via -r hail/python/hailtop/requirements.txt
+google-cloud-core==2.5.0
+    # via google-cloud-storage
+google-cloud-storage==3.9.0
+    # via -r hail/python/hailtop/requirements.txt
+google-crc32c==1.8.0
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.8.0
+    # via google-cloud-storage
+googleapis-common-protos==1.72.0
+    # via google-api-core
 humanize==4.15.0
     # via -r hail/python/hailtop/requirements.txt
 idna==3.11
@@ -113,6 +132,17 @@ propcache==0.4.1
     #   yarl
 pyasn1==0.6.3
     # via pyasn1-modules
+proto-plus==1.27.1
+    # via google-api-core
+protobuf==6.33.5
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
+    #   proto-plus
+pyasn1==0.6.2
+    # via
+    #   pyasn1-modules
+    #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
 pycares==5.0.1
@@ -132,6 +162,8 @@ pyyaml==6.0.3
 requests==2.33.1
     # via
     #   azure-core
+    #   google-api-core
+    #   google-cloud-storage
     #   msal
     #   msrest
     #   requests-oauthlib

--- a/hail/python/hailtop/pinned-requirements.txt
+++ b/hail/python/hailtop/pinned-requirements.txt
@@ -30,9 +30,9 @@ azure-mgmt-storage==20.1.0
     # via -r hail/python/hailtop/requirements.txt
 azure-storage-blob==12.28.0
     # via -r hail/python/hailtop/requirements.txt
-boto3==1.42.87
+boto3==1.42.92
     # via -r hail/python/hailtop/requirements.txt
-botocore==1.42.87
+botocore==1.42.92
     # via
     #   -r hail/python/hailtop/requirements.txt
     #   boto3
@@ -65,7 +65,7 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-api-core==2.30.0
+google-api-core==2.30.3
     # via
     #   google-cloud-core
     #   google-cloud-storage
@@ -78,21 +78,21 @@ google-auth==2.49.2
     #   google-cloud-storage
 google-auth-oauthlib==0.8.0
     # via -r hail/python/hailtop/requirements.txt
-google-cloud-core==2.5.0
+google-cloud-core==2.5.1
     # via google-cloud-storage
-google-cloud-storage==3.9.0
+google-cloud-storage==3.10.1
     # via -r hail/python/hailtop/requirements.txt
 google-crc32c==1.8.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.8.0
+google-resumable-media==2.8.2
     # via google-cloud-storage
-googleapis-common-protos==1.72.0
+googleapis-common-protos==1.74.0
     # via google-api-core
 humanize==4.15.0
     # via -r hail/python/hailtop/requirements.txt
-idna==3.11
+idna==3.12
     # via
     #   requests
     #   yarl
@@ -130,19 +130,15 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-pyasn1==0.6.3
-    # via pyasn1-modules
-proto-plus==1.27.1
+proto-plus==1.27.2
     # via google-api-core
-protobuf==6.33.5
+protobuf==7.34.1
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
-pyasn1==0.6.2
-    # via
-    #   pyasn1-modules
-    #   rsa
+pyasn1==0.6.3
+    # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
 pycares==5.0.1

--- a/hail/python/hailtop/requirements.txt
+++ b/hail/python/hailtop/requirements.txt
@@ -9,6 +9,7 @@ dill>=0.4.0,<0.5
 frozenlist>=1.3.1,<2
 google-auth>=2.14.1,<3
 google-auth-oauthlib>=0.5.2,<1
+google-cloud-storage>=3.8.0
 humanize>=4.0,<5
 janus>=0.6,<1.1
 nest_asyncio>=1.5.8,<2

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -59,11 +59,11 @@ azure-storage-blob==12.28.0
     #   -r hail/python/hailtop/requirements.txt
 bokeh==3.9.0
     # via -r hail/python/requirements.txt
-boto3==1.42.87
+boto3==1.42.92
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-botocore==1.42.87
+botocore==1.42.92
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -115,12 +115,12 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-api-core==2.30.0
+google-api-core==2.30.3
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   google-cloud-core
     #   google-cloud-storage
-google-auth==2.49.1
+google-auth==2.49.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -132,11 +132,11 @@ google-auth-oauthlib==0.8.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-google-cloud-core==2.5.0
+google-cloud-core==2.5.1
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   google-cloud-storage
-google-cloud-storage==3.9.0
+google-cloud-storage==3.10.1
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
@@ -145,11 +145,11 @@ google-crc32c==1.8.0
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   google-cloud-storage
     #   google-resumable-media
-google-resumable-media==2.8.0
+google-resumable-media==2.8.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   google-cloud-storage
-googleapis-common-protos==1.72.0
+googleapis-common-protos==1.74.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   google-api-core
@@ -157,7 +157,7 @@ humanize==4.15.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-idna==3.11
+idna==3.12
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   requests
@@ -202,7 +202,7 @@ multidict==6.7.1
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   aiohttp
     #   yarl
-narwhals==2.19.0
+narwhals==2.20.0
     # via bokeh
 nest-asyncio==1.6.0
     # via
@@ -223,7 +223,7 @@ orjson==3.11.8
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
-packaging==26.0
+packaging==26.1
     # via
     #   bokeh
     #   plotly
@@ -240,11 +240,11 @@ propcache==0.4.1
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   aiohttp
     #   yarl
-proto-plus==1.27.1
+proto-plus==1.27.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   google-api-core
-protobuf==6.33.5
+protobuf==7.34.1
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   google-api-core
@@ -256,7 +256,6 @@ pyasn1==0.6.3
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   pyasn1-modules
-    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -115,15 +115,44 @@ frozenlist==1.8.0
     #   -r hail/python/hailtop/requirements.txt
     #   aiohttp
     #   aiosignal
-google-auth==2.49.2
+google-api-core==2.30.0
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   google-cloud-core
+    #   google-cloud-storage
+google-auth==2.49.1
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
+    #   google-api-core
     #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-storage
 google-auth-oauthlib==0.8.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/hailtop/requirements.txt
+google-cloud-core==2.5.0
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   google-cloud-storage
+google-cloud-storage==3.9.0
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   -r hail/python/hailtop/requirements.txt
+google-crc32c==1.8.0
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.8.0
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.72.0
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   google-api-core
 humanize==4.15.0
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
@@ -211,12 +240,23 @@ propcache==0.4.1
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   aiohttp
     #   yarl
+proto-plus==1.27.1
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   google-api-core
+protobuf==6.33.5
+    # via
+    #   -c hail/python/hailtop/pinned-requirements.txt
+    #   google-api-core
+    #   googleapis-common-protos
+    #   proto-plus
 py4j==0.10.9.7
     # via pyspark
 pyasn1==0.6.3
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   pyasn1-modules
+    #   rsa
 pyasn1-modules==0.4.2
     # via
     #   -c hail/python/hailtop/pinned-requirements.txt
@@ -264,6 +304,8 @@ requests==2.33.1
     #   -c hail/python/hailtop/pinned-requirements.txt
     #   -r hail/python/requirements.txt
     #   azure-core
+    #   google-api-core
+    #   google-cloud-storage
     #   msal
     #   msrest
     #   requests-oauthlib

--- a/hail/python/test/hailtop/inter_cloud/conftest.py
+++ b/hail/python/test/hailtop/inter_cloud/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 import functools
 import os
 import secrets
@@ -6,12 +5,13 @@ from typing import AsyncIterator, Dict, Tuple
 
 import pytest
 
+from hailtop.aiotools import WeightedSemaphore
 from hailtop.aiotools.router_fs import AsyncFS, RouterAsyncFS
 from hailtop.utils import bounded_gather2
 
 
 @pytest.fixture(scope='module')
-async def router_filesystem() -> AsyncIterator[Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]]]:
+async def router_filesystem() -> AsyncIterator[Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]]]:
     token = secrets.token_hex(16)
 
     async with RouterAsyncFS() as fs:
@@ -26,7 +26,7 @@ async def router_filesystem() -> AsyncIterator[Tuple[asyncio.Semaphore, AsyncFS,
 
         bases = {'file': file_base, 'gs': gs_base, 's3': s3_base}
 
-        sema = asyncio.Semaphore(50)
+        sema = WeightedSemaphore(50)
         async with sema:
             yield (sema, fs, bases)
             await bounded_gather2(

--- a/hail/python/test/hailtop/inter_cloud/generate_copy_test_specs.py
+++ b/hail/python/test/hailtop/inter_cloud/generate_copy_test_specs.py
@@ -3,7 +3,7 @@ import pprint
 import secrets
 from concurrent.futures import ThreadPoolExecutor
 
-from hailtop.aiotools import Copier, Transfer
+from hailtop.aiotools import Copier, Transfer, WeightedSemaphore
 from hailtop.aiotools.router_fs import RouterAsyncFS
 
 
@@ -137,7 +137,7 @@ async def copy_test_specs():
                 async with await fs.create(f'{dest_base}keep'):
                     pass
 
-                sema = asyncio.Semaphore(50)
+                sema = WeightedSemaphore(50)
                 async with sema:
                     result = await run_test_spec(sema, fs, config, src_base, dest_base)
                     config['result'] = result

--- a/hail/python/test/hailtop/inter_cloud/test_copy.py
+++ b/hail/python/test/hailtop/inter_cloud/test_copy.py
@@ -1,10 +1,9 @@
-import asyncio
 import secrets
 from typing import AsyncIterator, Dict, List, Tuple
 
 import pytest
 
-from hailtop.aiotools import AsyncFS, Copier, FileAndDirectoryError, FileListEntry, Transfer
+from hailtop.aiotools import AsyncFS, Copier, FileAndDirectoryError, FileListEntry, Transfer, WeightedSemaphore
 from hailtop.utils import url_scheme
 
 from .copy_test_specs import COPY_TEST_SPECS
@@ -42,7 +41,7 @@ async def cloud_scheme(request):
         's3/s3',
     ]
 )
-async def copy_test_context(request, router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]]):
+async def copy_test_context(request, router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]]):
     sema, fs, bases = router_filesystem
 
     [src_scheme, dest_scheme] = request.param.split('/')
@@ -355,7 +354,7 @@ async def test_file_overwrite_dir(copy_test_context):
 
 
 async def test_file_and_directory_error(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
 ):
     sema, fs, bases = router_filesystem
 
@@ -394,7 +393,7 @@ async def collect_files(it: AsyncIterator[FileListEntry]) -> List[str]:
 
 
 async def test_file_and_directory_error_with_slash_empty_file(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
 ):
     sema, fs, bases = router_filesystem
 
@@ -429,7 +428,7 @@ async def test_file_and_directory_error_with_slash_empty_file(
 
 
 async def test_file_and_directory_error_with_slash_non_empty_file_for_google_non_recursive(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]],
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]],
 ):
     _, fs, bases = router_filesystem
 
@@ -446,7 +445,7 @@ async def test_file_and_directory_error_with_slash_non_empty_file_for_google_non
 
 
 async def test_file_and_directory_error_with_slash_non_empty_file(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
 ):
     sema, fs, bases = router_filesystem
 
@@ -489,7 +488,7 @@ async def test_file_and_directory_error_with_slash_non_empty_file(
 
 
 async def test_file_and_directory_error_with_slash_non_empty_file_only_for_google_non_recursive(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]],
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]],
 ):
     sema, fs, bases = router_filesystem
 
@@ -512,7 +511,7 @@ async def test_file_and_directory_error_with_slash_non_empty_file_only_for_googl
 
 
 async def test_file_and_directory_error_with_slash_empty_file_only(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
 ):
     sema, fs, bases = router_filesystem
 
@@ -537,7 +536,7 @@ async def test_file_and_directory_error_with_slash_empty_file_only(
 
 
 async def test_file_and_directory_error_with_slash_non_empty_file_only_google_non_recursive(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]],
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]],
 ):
     _, fs, bases = router_filesystem
 
@@ -553,7 +552,7 @@ async def test_file_and_directory_error_with_slash_non_empty_file_only_google_no
 
 
 async def test_file_and_directory_error_with_slash_non_empty_file_only(
-    router_filesystem: Tuple[asyncio.Semaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
+    router_filesystem: Tuple[WeightedSemaphore, AsyncFS, Dict[str, str]], cloud_scheme: str
 ):
     sema, fs, bases = router_filesystem
 

--- a/web_common/pinned-requirements.txt
+++ b/web_common/pinned-requirements.txt
@@ -39,7 +39,7 @@ frozenlist==1.8.0
     #   -c web_common/../hail/python/pinned-requirements.txt
     #   aiohttp
     #   aiosignal
-idna==3.11
+idna==3.12
     # via
     #   -c web_common/../gear/pinned-requirements.txt
     #   -c web_common/../hail/python/dev/pinned-requirements.txt


### PR DESCRIPTION
## Change Description

Fixes #15011

This is a redo of https://github.com/hail-is/hail/pull/15273 which addresses the scalability issues with that approach:
- We now only use the chunked gcloud downloader if the file is large enough to benefit. Files below the chunk size will be downloaded in a single process, as before.
- Both the gcloud download paths are now bounded by thread count & memory buffer usage, preventing memory errors on lowmem VMs.

The timing improvements for large files remain the same as in the original change, and there is now no spike in latency when downloading hundreds of smaller files.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

This change instantiates a new Google client to download files from GCS buckets. It uses the same local credential files as the existing custom clients we've created. I manually verified the problem cases with the original change now work as intended and am working on adding additional testing for those paths.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
