### PR TITLE
[query] fix ignored spark conf on dataproc

### DIFF
--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -10,6 +10,8 @@ import is.hail.expr.ir._
 import is.hail.expr.ir.analyses.SemanticHash
 import is.hail.expr.ir.lowering._
 import is.hail.io.{BufferSpec, TypedCodecSpec}
+import is.hail.io.compress.{BGzipCodec, BGzipCodecTbi}
+import is.hail.kryo.HailKryoRegistrator
 import is.hail.rvd.RVD
 import is.hail.types._
 import is.hail.types.physical.{PStruct, PTuple}
@@ -24,9 +26,11 @@ import java.io.PrintWriter
 
 import com.fasterxml.jackson.core.StreamReadConstraints
 import org.apache.hadoop
+import org.apache.hadoop.io.compress.{DefaultCodec, GzipCodec}
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
+import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql.SparkSession
 import sourcecode.Enclosing
 
@@ -89,7 +93,7 @@ object SparkBackend extends Logging {
       else theSparkBackend.sc
     }
 
-  def checkSparkCompatibility(jarVersion: String, sparkVersion: String): Unit = {
+  private def checkSparkCompatibility(jarVersion: String, sparkVersion: String): Unit = {
     def majorMinor(version: String): String = version.split("\\.", 3).take(2).mkString(".")
 
     if (majorMinor(jarVersion) != majorMinor(sparkVersion))
@@ -104,62 +108,35 @@ object SparkBackend extends Logging {
       )
   }
 
-  def createSparkConf(appName: String, master: String, local: String, blockSize: Long)
-    : SparkConf = {
-    require(blockSize >= 0)
-
-    checkSparkCompatibility(is.hail.SparkVersion, org.apache.spark.SPARK_VERSION)
-
-    val conf = new SparkConf().setAppName(appName)
-
-    if (master != null) conf.setMaster(master): Unit
-    else if (!conf.contains("spark.master")) conf.setMaster(local): Unit
-
-    conf
-      .set("spark.logConf", "true")
-      .set("spark.kryoserializer.buffer.max", "1g")
-      .set("spark.driver.maxResultSize", "0")
-      .set(
-        "spark.hadoop.io.compression.codecs",
-        "org.apache.hadoop.io.compress.DefaultCodec," +
-          "is.hail.io.compress.BGzipCodec," +
-          "is.hail.io.compress.BGzipCodecTbi," +
-          "org.apache.hadoop.io.compress.GzipCodec",
-      )
-      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-      .set("spark.kryo.registrator", "is.hail.kryo.HailKryoRegistrator")
-      .set(
-        "spark.hadoop.mapreduce.input.fileinputformat.split.minsize",
-        (blockSize * 1024L * 1024L).toString,
-      ): Unit
+  // Used by python and HailSuite before spark session initialisation
+  def pySparkConf: SparkConf = {
+    val config =
+      new SparkConf(loadDefaults = false)
+        .set("spark.logConf", "true")
+        .set("spark.kryoserializer.buffer.max", "1g")
+        .set("spark.driver.maxResultSize", "0")
+        .set("spark.hadoop.io.compression.codecs", CompressionCodecs.mkString(","))
+        .set("spark.serializer", classOf[KryoSerializer].getName)
+        .set("spark.kryo.registrator", classOf[HailKryoRegistrator].getName)
 
     // load additional Spark properties from HAIL_SPARK_PROPERTIES
+    // I (ed) couldn't find any uses of this env var, is it documented?
     sys.env.get("HAIL_SPARK_PROPERTIES").foreach { hailSparkProperties =>
       for (p <- hailSparkProperties.split(",")) {
         p.split("=") match {
           case Array(k, v) =>
             logger.info(s"set Spark property from HAIL_SPARK_PROPERTIES: $k=$v")
-            conf.set(k, v)
+            config.set(k, v)
           case _ =>
-            logger.warn(s"invalid key-value property pair in HAIL_SPARK_PROPERTIES: $p")
+            logger.warn(s"ignoring invalid property in HAIL_SPARK_PROPERTIES: '$p'")
         }
       }
     }
 
-    conf
+    config
   }
 
-  def pySparkSession(
-    appName: String = "Hail",
-    master: String = null,
-    local: String = "local[*]",
-    minBlockSize: Long = 1L,
-  ): SparkSession = {
-    val conf = createSparkConf(appName, master, local, minBlockSize)
-    SparkSession.builder().config(conf).getOrCreate()
-  }
-
-  def checkSparkConfiguration(conf: SparkConf): Unit = {
+  private def checkSparkConfiguration(conf: SparkConf): Unit = {
     val problems = new mutable.ArrayBuffer[String]
 
     val serializer = conf.getOption("spark.serializer")
@@ -183,13 +160,14 @@ object SparkBackend extends Logging {
       )
   }
 
-  private[this] lazy val CompressionCodecs: Array[String] =
-    Array(
-      "org.apache.hadoop.io.compress.DefaultCodec",
-      "is.hail.io.compress.BGzipCodec",
-      "is.hail.io.compress.BGzipCodecTbi",
-      "org.apache.hadoop.io.compress.GzipCodec",
+  private def CompressionCodecs =
+    ArraySeq(
+      classOf[DefaultCodec],
+      classOf[BGzipCodec],
+      classOf[BGzipCodecTbi],
+      classOf[GzipCodec],
     )
+      .map(_.getName)
 
   def getOrCreate(session: SparkSession): SparkBackend =
     synchronized {
@@ -209,8 +187,9 @@ object SparkBackend extends Logging {
   def apply(session: SparkSession): SparkBackend =
     synchronized {
       require(theSparkBackend == null)
+      checkSparkCompatibility(is.hail.SparkVersion, org.apache.spark.SPARK_VERSION)
+
       val sc = session.sparkContext
-      sc.hadoopConfiguration.set("io.compression.codecs", CompressionCodecs.mkString(","))
       checkSparkConfiguration(sc.getConf)
       sc.uiWebUrl.foreach(ui => logger.info(s"SparkUI: $ui"))
       theSparkBackend = new SparkBackend(session)

--- a/hail/hail/test/src/is/hail/HailSuite.scala
+++ b/hail/hail/test/src/is/hail/HailSuite.scala
@@ -61,17 +61,12 @@ class HailSuite extends TestNGSuite with TestUtils with Logging {
     HailSuite.backend_ = SparkBackend(
       SparkSession
         .builder()
-        .config(
-          SparkBackend.createSparkConf(
-            appName = "Hail.TestNG",
-            master = System.getProperty("hail.master"),
-            local = "local[2]",
-            blockSize = 0,
-          )
-        )
+        .appName("HailTest")
+        .master("local[2]")
         .config("spark.unsafe.exceptionOnMemoryLeak", "true")
         .config("spark.ui.showConsoleProgress", "false")
         .config("spark.ui.enabled", "false")
+        .config(SparkBackend.pySparkConf)
         .getOrCreate()
     )
   }

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -3,7 +3,7 @@ import logging
 import os
 import warnings
 import zipfile
-from dataclasses import astuple, dataclass
+from dataclasses import dataclass
 from enum import Enum
 from typing import AbstractSet, Any, ClassVar, Dict, List, Mapping, Optional, Set, Tuple, TypeVar, Union
 
@@ -50,10 +50,7 @@ Error summary: {short_message}""",
 class LocalJarInfo:
     dev: bool
     hail_jar: str
-    extra_classpath: List[str]
-
-    def __iter__(self):
-        return iter(astuple(self))
+    extra_classpath: list[str]
 
 
 def local_jar_information() -> LocalJarInfo:
@@ -288,11 +285,12 @@ class Backend(abc.ABC):
     def initialize_references(self):
         from hail.genetics.reference_genome import ReferenceGenome
 
-        _, jar_path, *_ = local_jar_information()
-        for path_in_jar in BUILTIN_REFERENCE_RESOURCE_PATHS.values():
-            rg_config = orjson.loads(zipfile.ZipFile(jar_path).open(path_in_jar).read())
-            rg = ReferenceGenome._from_config(rg_config, _builtin=True)
-            self._references[rg.name] = rg
+        with zipfile.ZipFile(local_jar_information().hail_jar) as hail_jar:
+            for path_in_jar in BUILTIN_REFERENCE_RESOURCE_PATHS.values():
+                with hail_jar.open(path_in_jar) as f:
+                    rg_config = orjson.loads(f.read())
+                    rg = ReferenceGenome._from_config(rg_config, _builtin=True)
+                    self._references[rg.name] = rg
 
     def remove_reference(self, name):
         del self._references[name]

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional
+from typing import Dict
 
 from py4j.java_gateway import JavaGateway, JavaObject, Py4JJavaError
 
@@ -25,7 +25,8 @@ class LocalBackend(Py4JBackend):
         branching_factor: int | None = None,
         skip_logging_configuration: bool = False,
         jvm_heap_size: str | None = None,
-        requester_pays_config: Optional[GCSRequesterPaysConfiguration] = None,
+        requester_pays_config: GCSRequesterPaysConfiguration | None = None,
+        copy_log_on_error: bool = False,
     ) -> Py4JBackend:
         max_heap_size = jvm_heap_size or os.getenv('HAIL_LOCAL_BACKEND_HEAP_SIZE')
 
@@ -45,7 +46,7 @@ class LocalBackend(Py4JBackend):
                     flags['branching_factor'] = str(branching_factor)
 
                 jbackend = scala_object(_is.hail.backend.local, 'LocalBackend')
-                backend = LocalBackend(gateway, jbackend, flags)
+                backend = LocalBackend(gateway, jbackend, flags, copy_log_on_error)
 
                 backend.local_tmpdir = tmpdir
                 backend.remote_tmpdir = tmpdir
@@ -66,9 +67,10 @@ class LocalBackend(Py4JBackend):
         jgateway: JavaGateway,
         jbackend: JavaObject,
         flags: Dict[str, str],
+        copy_log_on_error: bool,
     ):
         self._gateway = jgateway
-        super().__init__(jgateway.jvm, jbackend, flags)
+        super().__init__(jgateway.jvm, jbackend, flags, copy_log_on_error)
 
     def stop(self):
         super().stop()

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -4,7 +4,7 @@ import http.client
 import logging
 import sys
 import warnings
-from typing import Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 import orjson
 import py4j
@@ -18,8 +18,11 @@ from py4j.java_gateway import (
     launch_gateway,
 )
 
+from hail.backend.backend import ActionTag, Backend, fatal_error_from_java_error_triplet, local_jar_information
 from hail.expr import construct_expr
-from hail.ir import CSERenderer, JavaIR
+from hail.hail_logging import Logger
+from hail.ir import BaseIR, CSERenderer, JavaIR
+from hail.utils import copy_log
 from hail.utils.java import Env, FatalError, scala_object, scala_package_object
 from hail.version import __version__
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
@@ -27,9 +30,6 @@ from hailtop.aiotools.validators import validate_file
 from hailtop.fs.fs import FS
 from hailtop.fs.router_fs import RouterFS
 from hailtop.utils import async_to_blocking, find_spark_home, sync_retry_transient_errors
-
-from ..hail_logging import Logger
-from .backend import ActionTag, Backend, fatal_error_from_java_error_triplet, local_jar_information
 
 # This defaults to 65536 and fails if a header is longer than _MAXLINE
 # The timing json that we output can exceed 65536 bytes so we raise the limit
@@ -42,8 +42,8 @@ _original = None
 
 def start_py4j_gateway(*, max_heap_size: str | None = None) -> JavaGateway:
     spark_home = find_spark_home()
-    _, hail_jar_path, extra_classpath = local_jar_information()
-    extra_classpath = ':'.join([f'{spark_home}/jars/*', hail_jar_path, *extra_classpath])
+    info = local_jar_information()
+    classpath = ':'.join([f'{spark_home}/jars/*', info.hail_jar, *info.extra_classpath])
 
     jvm_opts = []
     if max_heap_size is not None:
@@ -62,7 +62,7 @@ def start_py4j_gateway(*, max_heap_size: str | None = None) -> JavaGateway:
         java_path=None,
         javaopts=jvm_opts,
         jarpath=py4j_jars[0],
-        classpath=extra_classpath,
+        classpath=classpath,
         die_on_exit=True,
     )
 
@@ -183,6 +183,7 @@ class Py4JBackend(Backend):
         jvm: JVMView,
         jbackend: JavaObject,
         flags: Dict[str, str],
+        copy_log_on_error: bool,
     ):
         super().__init__()
         import base64
@@ -195,6 +196,7 @@ class Py4JBackend(Backend):
         self._is = getattr(jvm, 'is')
         self._py4jutils = scala_object(self._is.hail.utils, 'py4jutils')
         self._logger = Log4jLogger(self._py4jutils)
+        self._copy_log_on_error = copy_log_on_error
 
         self._jbackend = self._is.hail.backend.driver.Py4JQueryDriver(jbackend)
         self._fs = None
@@ -270,6 +272,18 @@ class Py4JBackend(Backend):
     @property
     def requires_lowering(self):
         return True
+
+    def execute(self, ir: BaseIR, timed: bool = False) -> Any:
+        try:
+            return super().execute(ir, timed)
+        except Exception as err:
+            if self._copy_log_on_error:
+                try:
+                    copy_log(self.remote_tmpdir)
+                except Exception as fatal:
+                    raise err from fatal
+
+            raise err
 
     def _rpc(self, action, payload) -> Tuple[bytes, Optional[dict]]:
         data = orjson.dumps(payload)

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -105,7 +105,7 @@ class ServiceBackend(Backend):
         *,
         billing_project: Optional[str] = None,
         batch_client: Optional[BatchClient] = None,
-        disable_progress_bar: Optional[bool] = None,
+        show_progress: bool | None = None,
         remote_tmpdir: Optional[str] = None,
         flags: Optional[Dict[str, str]] = None,
         driver_cores: Optional[Union[int, str]] = None,
@@ -162,12 +162,9 @@ class ServiceBackend(Backend):
 
         assert len(regions) > 0, regions
 
-        if disable_progress_bar is None:
-            disable_progress_bar_str = configuration_of(ConfigVariable.QUERY_DISABLE_PROGRESS_BAR, None, None)
-            if disable_progress_bar_str is None:
-                disable_progress_bar = not am_i_interactive()
-            else:
-                disable_progress_bar = len(disable_progress_bar_str) > 0
+        if show_progress is None:
+            str_value = configuration_of(ConfigVariable.QUERY_DISABLE_PROGRESS_BAR, None, None)
+            show_progress = str_value == '0' if str_value is not None else am_i_interactive()
 
         flags = flags or {}
         if branching_factor is not None:
@@ -182,7 +179,7 @@ class ServiceBackend(Backend):
                 if batch_id is not None
                 else batch_client.create_batch(attributes=batch_attributes)
             ),
-            disable_progress_bar=disable_progress_bar,
+            show_progress=show_progress,
             remote_tmpdir=remote_tmpdir,
             driver_cores=driver_cores,
             driver_memory=driver_memory,
@@ -203,7 +200,7 @@ class ServiceBackend(Backend):
         bucket_allow_list: list[str] | None = None,
         batch_client: BatchClient,
         batch: Batch,
-        disable_progress_bar: bool,
+        show_progress: bool,
         remote_tmpdir: str,
         driver_cores: Optional[Union[int, str]],
         driver_memory: Optional[str],
@@ -221,7 +218,7 @@ class ServiceBackend(Backend):
         self._batch_client = batch_client
         self._batch = batch
         self._job_group_was_submitted: bool = False
-        self.disable_progress_bar = disable_progress_bar
+        self.show_progress = show_progress
         self._remote_tmpdir = remote_tmpdir
         self.flags: Dict[str, str] = {}
         self._registered_ir_function_names: Set[str] = set()
@@ -341,7 +338,7 @@ class ServiceBackend(Backend):
                     await asyncio.sleep(0.6)  # it is not possible for the batch to be finished in less than 600ms
                     await self._job_group.wait(
                         description=name,
-                        disable_progress_bar=self.disable_progress_bar,
+                        disable_progress_bar=not self.show_progress,
                         progress=progress,
                     )
                 except KeyboardInterrupt:

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -1,24 +1,24 @@
 import os
 import sys
+import warnings
 from collections.abc import Callable
-from typing import Any, Dict
 
 import orjson
 import pyspark
 import pyspark.sql
-from py4j.java_gateway import JavaGateway
+from pyspark import SparkConf, SparkContext
+from pyspark.sql import SparkSession
 
 from hail.expr.table_type import ttable
-from hail.ir import BaseIR
 from hail.table import Table
-from hail.utils import copy_log
 from hail.utils.java import scala_object
 from hail.version import __version__
 from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
 from hailtop.aiotools.validators import validate_file
+from hailtop.config import ConfigVariable, configuration_of
 from hailtop.fs.fs import FS
 from hailtop.fs.router_fs import RouterFS
-from hailtop.utils import async_to_blocking
+from hailtop.utils import am_i_interactive, async_to_blocking
 
 from ..fs.hadoop_fs import HadoopFS
 from .backend import local_jar_information
@@ -34,69 +34,111 @@ def _append_csv(*xs: str) -> Callable[[str | None], str]:
     return lambda csv: ','.join(xs if csv is None else (csv, *xs))
 
 
-def _get_or_create_pyspark_gateway(
-    sc: pyspark.SparkContext | None,
-    spark_conf: Dict[str, Any] | None = None,
-    local_tmpdir: str | None = None,
-    quiet: bool = False,
-) -> JavaGateway:
-    if sc is not None and not quiet:
-        sys.stderr.write(
-            'pip-installed Hail requires additional configuration options in Spark referring\n'
-            '  to the path to the Hail Python module directory HAIL_DIR,\n'
-            '  e.g. /path/to/python/site-packages/hail:\n'
-            '    spark.jars=HAIL_DIR/backend/hail-all-spark.jar\n'
-            '    spark.driver.extraClassPath=HAIL_DIR/backend/hail-all-spark.jar\n'
-            '    spark.executor.extraClassPath=./hail-all-spark.jar'
-        )
-
-    conf = pyspark.SparkConf()
-    for k, v in (spark_conf or {}).items():
-        conf.set(k, v)
-
-    _, hail_jar, extra_classpath = local_jar_information()
-    jars = [hail_jar]
+def _configure_spark_classpath(conf: SparkConf):
+    info = local_jar_information()
+    classpath = [info.hail_jar, *info.extra_classpath]
 
     if os.environ.get('HAIL_SPARK_MONITOR') or os.environ.get('AZURE_SPARK') == '1':
         import sparkmonitor
 
-        jars = [*jars, os.path.join(os.path.dirname(sparkmonitor.__file__), 'listener.jar')]
+        classpath.append(os.path.join(os.path.dirname(sparkmonitor.__file__), 'listener.jar'))
         _modify_spark_conf(
             conf, 'spark.extraListeners', _append_csv('sparkmonitor.listener.JupyterSparkMonitorListener')
         )
 
-    _modify_spark_conf(conf, 'spark.jars', _append_csv(*jars))
+    _modify_spark_conf(conf, 'spark.jars', _append_csv(*classpath))
     if os.environ.get('AZURE_SPARK') == '1':
         print('AZURE_SPARK environment variable is set to "1", assuming you are in HDInsight.')
         # Setting extraClassPath in HDInsight overrides the classpath entirely so you can't
         # load the Scala standard library. Interestingly, setting extraClassPath is not
         # necessary in HDInsight.
     else:
-        _modify_spark_conf(conf, 'spark.driver.extraClassPath', _append_csv(*jars, *extra_classpath))
-        _modify_spark_conf(conf, 'spark.executor.extraClassPath', _append_csv(hail_jar, *extra_classpath))
+        _modify_spark_conf(conf, 'spark.driver.extraClassPath', _append_csv(*classpath))
+        _modify_spark_conf(conf, 'spark.executor.extraClassPath', _append_csv(*classpath))
+
+
+def _get_or_create_pyspark_session(
+    sc: SparkContext | None,
+    *,
+    spark_conf: dict[str, str] | None = None,
+    app_name: str | None = None,
+    master: str | None = None,
+    local_tmpdir: str | None = None,
+    min_block_size: int | None = None,
+    show_progress: bool | None = None,
+) -> SparkSession:
+    if sc is not None:
+        # We can't modify many conf parameters in an existing SparkContext
+        warnings.warn(
+            'Hail requires additional configuration options in Spark referring\n'
+            '  to the path to the Hail Python module directory HAIL_DIR,\n'
+            '  e.g. /path/to/python/site-packages/hail:\n'
+            '    spark.jars=HAIL_DIR/backend/hail-all-spark.jar\n'
+            '    spark.driver.extraClassPath=HAIL_DIR/backend/hail-all-spark.jar\n'
+            '    spark.executor.extraClassPath=./hail-all-spark.jar'
+        )
+        return SparkSession(sc)
+
+    # How spark is configured depends on the environment in which it's run.
+    #
+    # At present, we don't supply a spark-defaults.conf when users pip-install hail.
+    # When a user executes hail directly in a python shell, therefore, we need to
+    # configure the classpath of the spark driver and workers before we launch the jvm.
+    #
+    # When hail is run in a managed spark environment (like dataproc), however, this
+    # configuration is supplied by a spark-defaults.conf file that we installed on the
+    # master node on cluster creation.
+    conf = SparkConf(loadDefaults=False)
+    _configure_spark_classpath(conf)
+    SparkContext._ensure_initialized(conf=conf)
+
+    jvm = SparkContext._jvm
+    raise_when_mismatched_hail_versions(jvm)
+    JBackend = scala_object(getattr(jvm, 'is').hail.backend.spark, 'SparkBackend')
+
+    # In the case of spark-submit, the python process is run as a child of the jvm
+    # and the conf passed to _ensure_initialized is not used. Some config is defined
+    # in scala as it's required in tests so we merge that with the user-supplied
+    # config from before.
+    conf = SparkConf(_jconf=JBackend.pySparkConf()).setAll(conf.getAll())
+    if spark_conf is not None:
+        conf.setAll(list(spark_conf.items()))
+
+    conf.setIfMissing('spark.app.name', app_name if app_name is not None else 'Hail')
+    conf.setIfMissing('spark.master', master if master is not None else 'local[*]')
 
     if local_tmpdir is not None:
         conf.setIfMissing('spark.local.dir', local_tmpdir.removeprefix('file://'))
 
-    conf.set('spark.ui.showConsoleProgress', str(not quiet).lower())
+    if show_progress is not None:
+        conf.setIfMissing('spark.ui.showConsoleProgress', str(show_progress).lower())
 
-    pyspark.SparkContext._ensure_initialized(instance=sc, conf=conf)
+    if min_block_size is None:
+        min_block_size = 0
+    elif min_block_size < 0:
+        raise ValueError('`min_block_size` cannot be negative')
 
-    return pyspark.SparkContext._gateway
+    conf.setIfMissing(
+        'spark.hadoop.mapreduce.input.fileinputformat.split.minsize',
+        str(min_block_size * 1024 * 1024),
+    )
+
+    return SparkSession.Builder().config(conf=conf).getOrCreate()
 
 
 class SparkBackend(Py4JBackend):
     def __init__(
         self: 'SparkBackend',
         sc: pyspark.SparkContext | None,
-        spark_conf: Dict[str, Any] | None,
+        spark_conf: dict[str, str] | None,
         app_name: str | None,
         master: str | None,
         local: str | None,
         log: str,
         quiet: bool,
         append: bool,
-        min_block_size: int,
+        show_progress: bool | None,
+        min_block_size: int | None,
         branching_factor: int,
         tmpdir: str,
         local_tmpdir: str,
@@ -108,37 +150,39 @@ class SparkBackend(Py4JBackend):
         sc = sc or pyspark.SparkContext._active_spark_context
         self._hail_managed_spark = sc is None
 
-        self._gateway = _get_or_create_pyspark_gateway(sc, spark_conf, local_tmpdir, quiet)
-        jvm = self._gateway.jvm
+        if show_progress is None:
+            str_value = configuration_of(ConfigVariable.QUERY_DISABLE_PROGRESS_BAR, None, None)
+            show_progress = str_value == '0' if str_value is not None else am_i_interactive()
 
-        raise_when_mismatched_hail_versions(jvm)
+        self._spark = _get_or_create_pyspark_session(
+            sc,
+            spark_conf=spark_conf,
+            app_name=app_name,
+            master=master if master is not None else local,
+            local_tmpdir=local_tmpdir,
+            show_progress=show_progress,
+            min_block_size=min_block_size,
+        )
 
+        jvm = self._spark._jvm
         _is = getattr(jvm, 'is')
 
-        py4jutils = scala_object(_is.hail.utils, 'py4jutils')
         if not skip_logging_configuration:
+            py4jutils = scala_object(_is.hail.utils, 'py4jutils')
             py4jutils.pyConfigureLogging(log, quiet, append)
-
-        JSparkBackend = _is.hail.backend.spark.SparkBackend
-        if sc is not None:
-            self._spark = pyspark.sql.SparkSession(sc)
-        else:
-            jspark_session = JSparkBackend.pySparkSession(app_name, master, local, min_block_size)
-            jsc = jvm.JavaSparkContext(jspark_session.sparkContext())
-            sc = pyspark.SparkContext(gateway=self._gateway, jsc=jsc)
-            self._spark = pyspark.sql.SparkSession(sc, jspark_session)
 
         if not quiet:
             sys.stderr.write(f'Running on Apache Spark version {self._spark.version}\n')
             if (uiUrl := self._spark.sparkContext.uiWebUrl) is not None:
                 sys.stderr.write(f'SparkUI available at {uiUrl}\n')
 
-        flags: Dict[str, str] = {}
+        flags: dict[str, str] = {}
         if branching_factor is not None:
             flags['branching_factor'] = str(branching_factor)
 
+        JSparkBackend = _is.hail.backend.spark.SparkBackend
         jbackend = JSparkBackend.getOrCreate(self._spark._jsparkSession)
-        super().__init__(jvm, jbackend, flags)
+        super().__init__(jvm, jbackend, flags, copy_log_on_error)
 
         self._fs = None
         self._router_fs = None
@@ -146,8 +190,6 @@ class SparkBackend(Py4JBackend):
         self.remote_tmpdir = tmpdir
         self.local_tmpdir = local_tmpdir
         self.requester_pays_config = requester_pays_config
-        self._copy_log_on_error = copy_log_on_error
-
         self.logger.info(f'Hail {__version__}')
 
     def validate_file(self, uri: str) -> None:
@@ -188,7 +230,7 @@ class SparkBackend(Py4JBackend):
         if self._hail_managed_spark:
             self._spark.stop()
             super().stop()
-            self._gateway.shutdown()
+            SparkContext._gateway.shutdown()
 
             # clean up pyspark's global state to support
             # re-init with different spark conf
@@ -210,18 +252,6 @@ class SparkBackend(Py4JBackend):
         if flatten:
             t = t.flatten()
         return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._render_ir(t._tir)), self._spark)
-
-    def execute(self, ir: BaseIR, timed: bool = False) -> Any:
-        try:
-            return super().execute(ir, timed)
-        except Exception as err:
-            if self._copy_log_on_error:
-                try:
-                    copy_log(self.remote_tmpdir)
-                except Exception as fatal:
-                    raise err from fatal
-
-            raise err
 
     @property
     def requires_lowering(self):

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -159,11 +159,12 @@ class HailContext(object):
     sc=nullable(SparkContext),
     app_name=nullable(str),
     master=nullable(str),
-    local=str,
+    local=nullable(str),
     log=nullable(str),
     quiet=bool,
+    show_progress=nullable(bool),
     append=bool,
-    min_block_size=int,
+    min_block_size=nullable(int),
     branching_factor=int,
     tmp_dir=nullable(str),
     default_reference=nullable(enumeration(*BUILTIN_REFERENCES)),
@@ -183,16 +184,18 @@ class HailContext(object):
     regions=nullable(sequenceof(str)),
     gcs_bucket_allow_list=nullable(dictof(str, sequenceof(str))),
     copy_spark_log_on_error=nullable(bool),
+    copy_log_on_error=nullable(bool),
 )
 def init(
     sc=None,
     app_name=None,
     master=None,
-    local='local[*]',
+    local=None,
     log=None,
     quiet=False,
+    show_progress=None,
     append=False,
-    min_block_size=0,
+    min_block_size=None,
     branching_factor=50,
     tmp_dir=None,
     default_reference=None,
@@ -212,7 +215,8 @@ def init(
     gcs_requester_pays_configuration: Optional[GCSRequesterPaysConfiguration] = None,
     regions: Optional[List[str]] = None,
     gcs_bucket_allow_list: Optional[Dict[str, List[str]]] = None,
-    copy_spark_log_on_error: bool = False,
+    copy_spark_log_on_error: bool | None = None,
+    copy_log_on_error: bool | None = None,
 ):
     """Initialize and configure Hail.
 
@@ -285,6 +289,8 @@ def init(
         Google Storage, S3, or HDFS.
     quiet : :obj:`bool`
         Print fewer log messages.
+    show_progress: :obj:`bool`, optional
+        Shows the progress of stages in the next line of the console. 'spark' and 'batch' backend only.
     append : :obj:`bool`
         Append to the end of the log file.
     min_block_size : :obj:`int`
@@ -292,8 +298,8 @@ def init(
     branching_factor : :obj:`int`
         Branching factor for tree aggregation.
     tmp_dir : :class:`str`, optional
-        Networked temporary directory.  Must be a network-visible file
-        path.  Defaults to /tmp in the default scheme.
+        Networked temporary directory.  Must be a network-visible file path.
+        Defaults to /tmp in the default scheme.
     default_reference : :class:`str`
         *Deprecated*. Please use :func:`.default_reference` to set the default reference genome
 
@@ -309,7 +315,7 @@ def init(
         Spark Backend only. Skip logging configuration in java and python.
     local_tmpdir : :class:`str`, optional
         Local temporary directory.  Used on driver and executor nodes.
-        Must use the file scheme.  Defaults to TMPDIR, or /tmp.
+        Defaults to TMPDIR, or /tmp
     driver_cores : :class:`str` or :class:`int`, optional
         Batch backend only. Number of cores to use for the driver process. May be 1, 2, 4, or 8. Default is
         1.
@@ -339,7 +345,10 @@ def init(
         A list of buckets that Hail should be permitted to read from or write to, even if their default policy is to
         use "cold" storage. Should look like ``["bucket1", "bucket2"]``.
     copy_spark_log_on_error: :class:`bool`, optional
+        *Deprecated*. Please use `copy_log_on_error`.
         Spark backend only. If `True`, copy the log from the spark driver node to `tmp_dir` on error.
+    copy_log_on_error: :class:`bool`, optional
+        Local-mode only. If `True`, copy the log from the driver node to `tmp_dir` on error.
     """
     if Env._hc:
         if idempotent:
@@ -359,6 +368,13 @@ def init(
         )
     else:
         default_reference = 'GRCh37'
+
+    if copy_spark_log_on_error is not None:
+        warnings.warn('`copy_spark_log_on_error` is deprecated. Please use `copy_log_on_error` instead.')
+        if copy_log_on_error is None:
+            copy_log_on_error = copy_spark_log_on_error
+        else:
+            raise ValueError('Specify at most one of `copy_log_on_error` or `copy_spark_log_on_error`.')
 
     backend = choose_backend(backend)
 
@@ -380,6 +396,7 @@ def init(
                 app_name=app_name,
                 log=log,
                 quiet=quiet,
+                show_progress=show_progress,
                 append=append,
                 tmp_dir=tmp_dir,
                 default_reference=default_reference,
@@ -394,12 +411,14 @@ def init(
                 gcs_bucket_allow_list=gcs_bucket_allow_list,
                 branching_factor=branching_factor,
                 max_read_parallelism=max_read_parallelism,
+                copy_log_on_error=copy_log_on_error,
             )
         else:
             return hail_event_loop().run_until_complete(
                 init_batch(
                     log=log,
                     quiet=quiet,
+                    show_progress=show_progress,
                     append=append,
                     tmpdir=tmp_dir,
                     default_reference=default_reference,
@@ -428,6 +447,7 @@ def init(
             spark_conf=spark_conf,
             log=log,
             quiet=quiet,
+            show_progress=show_progress,
             append=append,
             tmp_dir=tmp_dir,
             local_tmpdir=local_tmpdir,
@@ -435,7 +455,7 @@ def init(
             global_seed=global_seed,
             skip_logging_configuration=skip_logging_configuration,
             requester_pays_config=requester_pays_config,
-            copy_log_on_error=copy_spark_log_on_error,
+            copy_log_on_error=copy_log_on_error,
         )
     if backend == 'local':
         return init_local(
@@ -447,6 +467,7 @@ def init(
             global_seed=global_seed,
             skip_logging_configuration=skip_logging_configuration,
             requester_pays_config=requester_pays_config,
+            copy_log_on_error=copy_log_on_error,
         )
     raise ValueError(f'unknown Hail Query backend: {backend}')
 
@@ -455,11 +476,12 @@ def init(
     sc=nullable(SparkContext),
     app_name=nullable(str),
     master=nullable(str),
-    local=str,
+    local=nullable(str),
     log=nullable(str),
     quiet=bool,
+    show_progress=nullable(bool),
     append=bool,
-    min_block_size=int,
+    min_block_size=nullable(int),
     branching_factor=int,
     tmp_dir=nullable(str),
     default_reference=enumeration(*BUILTIN_REFERENCES),
@@ -474,11 +496,12 @@ def init_spark(
     sc=None,
     app_name=None,
     master=None,
-    local='local[*]',
+    local=None,
     log=None,
     quiet=False,
     append=False,
-    min_block_size=0,
+    show_progress: bool | None = None,
+    min_block_size=None,
     branching_factor=50,
     tmp_dir=None,
     default_reference='GRCh37',
@@ -497,12 +520,13 @@ def init_spark(
     backend = SparkBackend(
         sc,
         spark_conf,
-        app_name or 'Hail',
+        app_name,
         master,
         local,
         log,
         quiet,
         append,
+        show_progress,
         min_block_size,
         branching_factor,
         tmpdir,
@@ -527,7 +551,7 @@ def init_spark(
     tmpdir=nullable(str),
     default_reference=enumeration(*BUILTIN_REFERENCES),
     global_seed=nullable(int),
-    disable_progress_bar=nullable(bool),
+    show_progress=nullable(bool),
     driver_cores=nullable(oneof(str, int)),
     driver_memory=nullable(str),
     worker_cores=nullable(oneof(str, int)),
@@ -551,7 +575,7 @@ async def init_batch(
     tmpdir: Optional[str] = None,
     default_reference: str = 'GRCh37',
     global_seed: Optional[int] = None,
-    disable_progress_bar: Optional[bool] = None,
+    show_progress: bool | None = None,
     driver_cores: Optional[Union[str, int]] = None,
     driver_memory: Optional[str] = None,
     worker_cores: Optional[Union[str, int]] = None,
@@ -571,7 +595,7 @@ async def init_batch(
     backend = await ServiceBackend.create(
         billing_project=billing_project,
         remote_tmpdir=remote_tmpdir,
-        disable_progress_bar=disable_progress_bar,
+        show_progress=show_progress,
         driver_cores=driver_cores,
         driver_memory=driver_memory,
         worker_cores=worker_cores,
@@ -601,6 +625,7 @@ async def init_batch(
     skip_logging_configuration=bool,
     jvm_heap_size=nullable(str),
     requester_pays_config=nullable(oneof(str, sized_tupleof(str, sequenceof(str)))),
+    copy_log_on_error=nullable(bool),
 )
 def init_local(
     log=None,
@@ -613,6 +638,7 @@ def init_local(
     skip_logging_configuration=False,
     jvm_heap_size=None,
     requester_pays_config: GCSRequesterPaysConfiguration | None = None,
+    copy_log_on_error: bool | None = None,
 ):
     from hail.backend.local_backend import LocalBackend
 
@@ -629,6 +655,7 @@ def init_local(
         skip_logging_configuration,
         jvm_heap_size,
         requester_pays_config,
+        copy_log_on_error,
     )
 
     if not backend.fs.exists(tmpdir):
@@ -639,8 +666,7 @@ def init_local(
 
 def _hail_cite_url():
     [tag, sha_prefix] = __version__.split("-")
-    is_devel, *_ = local_jar_information()
-    if not is_devel:
+    if not local_jar_information().dev:
         # pip installed
         return f"https://github.com/hail-is/hail/releases/tag/{tag}"
     return f"https://github.com/hail-is/hail/commit/{sha_prefix}"
@@ -940,10 +966,10 @@ def debug_info():
     if isinstance(Env.backend(), SparkBackend):
         spark_conf = spark_context()._conf.getAll()
 
-    _, hail_jar, classpath = local_jar_information()
+    info = local_jar_information()
     return {
         'version': __version__,
-        'hail_jar': hail_jar,
-        'classpath': classpath,
+        'hail_jar': info.hail_jar,
+        'classpath': info.extra_classpath,
         'spark_conf': spark_conf,
     }

--- a/hail/python/hail/experimental/context.py
+++ b/hail/python/hail/experimental/context.py
@@ -34,6 +34,7 @@ def init(
     jvm_heap_size: str | None = None,
     skip_logging_configuration: bool = False,
     max_read_parallelism: int | None = None,
+    copy_log_on_error: bool | None = None,
     **kwargs,
 ) -> None:
     backend = choose_backend(backend)
@@ -57,6 +58,7 @@ def init(
             gcs_bucket_allow_list=gcs_bucket_allow_list,
             skip_logging_configuration=skip_logging_configuration,
             max_read_parallelism=max_read_parallelism,
+            copy_log_on_error=copy_log_on_error,
             **kwargs,
         )
 
@@ -90,7 +92,7 @@ def init(
             if _optimizer_iterations is not None:
                 flags['optimizer_iterations'] = str(_optimizer_iterations)
 
-            backend = LocalBackend(gateway, jbackend, flags)
+            backend = LocalBackend(gateway, jbackend, flags, copy_log_on_error)
             backend.remote_tmpdir = remote_tmpdir
             backend.local_tmpdir = tmp_dir
             backend.requester_pays_config = get_gcs_requester_pays_configuration(

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -1055,7 +1055,7 @@ def _service_vep(
     try:
         status = b.wait(
             description='vep(...)',
-            disable_progress_bar=backend.disable_progress_bar,
+            disable_progress_bar=not backend.show_progress,
             progress=None,
             starting_job=starting_job_id,
         )

--- a/hail/python/test/hail/backend/test_spark_backend.py
+++ b/hail/python/test/hail/backend/test_spark_backend.py
@@ -1,11 +1,13 @@
 import os
+from typing import Any
 
-import pyspark
 import pytest
+from pyspark import SparkContext
 
 import hail as hl
-from hail.backend.spark_backend import _get_or_create_pyspark_gateway
+from hail.backend.spark_backend import _get_or_create_pyspark_session
 from hail.utils.java import Env
+from hailtop.utils import am_i_interactive
 from test.hail.helpers import hl_init_for_test
 
 pytestmark = [pytest.mark.backend('spark'), pytest.mark.uninitialized]
@@ -17,7 +19,7 @@ def fatal(typ: hl.HailType, msg: str = "") -> hl.Expression:
 
 @pytest.mark.parametrize('copy', [True, False])
 def test_copy_spark_log(tmpdir, copy):
-    hl.init(copy_spark_log_on_error=copy, tmp_dir=str(tmpdir))
+    hl.init(copy_log_on_error=copy, tmp_dir=str(tmpdir))
 
     expr = fatal(hl.tint32)
     with pytest.raises(Exception):
@@ -45,41 +47,78 @@ def test_init_with_existing_spark_context(request):
     The second re-uses the same context.
     """
 
-    gateway = _get_or_create_pyspark_gateway(None, None, quiet=True)
-    JCons = getattr(gateway.jvm, 'is').hail.backend.spark.SparkBackend
-    jspark = JCons.pySparkSession(request.node.name, 'local[1]', None, 0)
-    sc = pyspark.SparkContext(gateway=gateway, jsc=gateway.jvm.JavaSparkContext(jspark.sparkContext()))
-
+    session = _get_or_create_pyspark_session(None, app_name=request.node.name, master='local[1]', show_progress=False)
     try:
+        sc = session.sparkContext
         hl_init_for_test(sc=sc, quiet=True)
         assert sc == Env.spark_session().sparkContext
-
+        hl.utils.range_table(10)._force_count()
         hl.stop()
 
         assert (jsc := getattr(sc, '_jsc', None)) is not None
         assert not jsc.sc().isStopped(), 'SparkBackend.close() should not stop a SparkContext it does not own.'
     finally:
-        sc.stop()
-        gateway.close()
+        session.stop()
+        with SparkContext._lock:
+            SparkContext._gateway.shutdown()
+            SparkContext._gateway = None
+            SparkContext._jvm = None
 
 
-@pytest.mark.parametrize('quiet', [True, False])
-def test_console_progress_bar_quiet(quiet):
-    hl.init(quiet=quiet)
+@pytest.mark.parametrize('show_progress', [True, False])
+def test_show_console_progress_bar(show_progress):
+    hl.init(show_progress=show_progress)
     conf = hl.spark_context().getConf()
-    assert conf.get('spark.ui.showConsoleProgress') == str(not quiet).lower()
+    assert conf.get('spark.ui.showConsoleProgress') == str(show_progress).lower()
 
 
-def test_set_local_dir(tmp_path):
-    hl.init(local_tmpdir=str(tmp_path))
+@pytest.mark.parametrize(
+    'cname,name,default',
+    [
+        ['spark.app.name', 'app_name', 'Hail'],
+        ['spark.master', 'master', 'local[*]'],
+        ['spark.master', 'local', 'local[*]'],
+        ['spark.local.dir', 'local_tmpdir', '/tmp'],
+        ['spark.hadoop.mapreduce.input.fileinputformat.split.minsize', 'min_block_size', '0'],
+        ['spark.ui.showConsoleProgress', 'show_progress', str(am_i_interactive()).lower()],
+    ],
+)
+def test_default_spark_conf(cname: str, name: str, default: str):
+    hl.init(**{name: None})
     conf = hl.spark_context().getConf()
-    assert conf.get('spark.local.dir') == str(tmp_path)
-    assert hl.current_backend().local_tmpdir == f'file://{tmp_path}'
+    assert conf.get(cname) == default
 
 
-def test_set_local_dir_if_missing(tmp_path):
+@pytest.mark.parametrize(
+    'cname,cvalue,name,value',
+    [
+        ['spark.app.name', 'geoff', 'app_name', 'steve'],
+        ['spark.master', 'local[1]', 'master', 'local[*]'],
+        ['spark.master', 'local[1]', 'local', 'local[*]'],
+        ['spark.hadoop.mapreduce.input.fileinputformat.split.minsize', '1', 'min_block_size', 0],
+        ['spark.ui.showConsoleProgress', 'false', 'show_progress', True],
+    ],
+)
+def test_spark_conf_takes_precedence(cname: str, cvalue: str, name: str, value: Any):
+    hl.init(spark_conf={cname: cvalue}, **{name: value})
+    conf = hl.spark_context().getConf()
+    assert conf.get(cname) == cvalue
+
+
+# you can set the spark local dir once per spark context, but you can
+# set hail's temporary directory at any time
+def test_spark_conf_takes_precedence_local_dir_special_case(tmp_path):
     hl.init(spark_conf={'spark.local.dir': str(tmp_path)}, local_tmpdir='/does/not/exist')
     conf = hl.spark_context().getConf()
     assert conf.get('spark.local.dir') == str(tmp_path)
 
-    assert hl.current_backend().local_tmpdir == 'file:///does/not/exist'
+    backend = hl.current_backend()
+    assert backend.local_tmpdir == 'file:///does/not/exist'
+
+    backend.local_tmpdir = '/dev/null'
+    assert backend.local_tmpdir == '/dev/null'
+
+
+def test_min_block_size_pos_int():
+    with pytest.raises(ValueError):
+        hl.init(min_block_size=-1)


### PR DESCRIPTION
Spark configuration defined in the python process was not being applied in dataproc.  
Users noticed that the progress bar wasn't shown following `hailctl dataproc submit`
after d2e6533, which is symptomatic of the larger problem.

Any user-defined spark config, including the progress bar property, was being passed
to `SparkContext._ensure_initialized`. When hail is run directly in a python process,
this initialises the jvm and passes the configuration on the command line. Dataproc 
jobs, however, are invoked with `spark-submit`which runs the python process as a
child of the jvm. Here, `_ensure_initialised` doesn't use the conf, instead connects 
directly with its parent process.

The solution is to configure the `SparkConf` after the JVM has been started and before
the `SparkContext` has been created. Note that in the idempotent init case, a
`SparkContext` already exists and we can't configure it. The `SparkSession` creation
logic is now much simpler.

Previously, I had conflated the `quiet` flag with whether or not to show a progress bar.
I think that was a mistake as its doc relates to logging only. I've created the
`show_progress` flag to dictate whether or not to show a progress bar.  This applies to
both the `spark` and `batch` backend (in non-local mode).

The default value for `show_progress` depends on the execution environment:

- True for interactive shells.
- False otherwise as progress bars mess with logging.

This change also adds support for copying the log-file on error for all backends run
via `py4j`.

This change does not affect the broad-managed batch service in gcp.