### PR TITLE
[batch] docker inspect error reporting

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -571,8 +571,8 @@ class Image:
 
         try:
             image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
-        except Exception:
-            # inspect non-deterministically fails sometimes; retry once
+        except:
+            # inspect non-deterministically fails sometimes
             await asyncio.sleep(1)
             await pull()
             try:
@@ -582,7 +582,7 @@ class Image:
                     f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}); '
                     f'possible causes: insufficient storage (private VMs need at least 3-6x the compressed image size to unpack layers), '
                     f'architecture mismatch (image built for a different CPU arch), or corrupt download'
-                ) from None
+                )
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
 
     async def _ensure_image_is_pulled(

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -569,33 +569,25 @@ class Image:
 
         await pull()
 
-        # After a large image pull, the Docker daemon may still be unpacking layers
-        # when the pull stream ends. Retry inspect with backoff to allow time for
-        # unpacking to complete.
-        inspect_deadline = asyncio.get_event_loop().time() + 60
-        delay = 1
-        while True:
+        try:
+            image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
+        except Exception:
+            # inspect non-deterministically fails sometimes; retry once
+            await asyncio.sleep(1)
+            await pull()
             try:
                 image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
-                break
-            except:
-                if asyncio.get_event_loop().time() > inspect_deadline:
-                    try:
-                        disk_info, _ = await check_exec_output('df', '-h', '--output=avail,used,pcent', '/')
-                        disk_info = disk_info.decode().splitlines()[-1].strip()
-                    except Exception:
-                        disk_info = 'unavailable'
-                    raise DockerInspectError(
-                        f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}) '
-                        f'after repeated retries; disk (avail, used, used%): {disk_info}; '
-                        f'possible causes: insufficient storage (try requesting more), architecture mismatch, corrupt download, or docker daemon error'
-                    ) from None
-                log.warning(
-                    f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}), '
-                    f'retrying in {delay}s (image may still be unpacking)'
-                )
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, 30)
+            except Exception:
+                try:
+                    disk_info, _ = await check_exec_output('df', '-h', '--output=avail,used,pcent', '/')
+                    disk_info = disk_info.decode().splitlines()[-1].strip()
+                except Exception:
+                    disk_info = 'unavailable'
+                raise DockerInspectError(
+                    f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}); '
+                    f'disk (avail, used, used%): {disk_info}; '
+                    f'possible causes: insufficient storage (try requesting more), architecture mismatch, corrupt download, or docker daemon error'
+                ) from None
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
 
     async def _ensure_image_is_pulled(

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -449,6 +449,8 @@ class InvalidImageRepository(Exception):
 
 
 class DockerInspectError(Exception):
+    short_error = 'docker inspect failed after pull; possible causes: insufficient storage, architecture mismatch, corrupt download, or docker daemon error'
+
     def __init__(self, image_ref: str, batch_id: Optional[int], job_id: Optional[int]):
         super().__init__(
             f'docker inspect failed for {image_ref} (batch_id={batch_id}, job_id={job_id}); '
@@ -849,7 +851,7 @@ class Container:
             elif isinstance(e, InvalidImageRepository):
                 self.short_error = 'image repository is invalid'
             elif isinstance(e, DockerInspectError):
-                self.short_error = 'docker inspect failed after pull; possible causes: insufficient storage, architecture mismatch, corrupt download, or docker daemon error'
+                self.short_error = DockerInspectError.short_error
 
             self.state = 'error'
             self.error = traceback.format_exc()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -448,6 +448,10 @@ class InvalidImageRepository(Exception):
     pass
 
 
+class DockerInspectError(Exception):
+    pass
+
+
 class Image:
     @staticmethod
     async def _pull_with_auth_refresh(
@@ -463,11 +467,15 @@ class Image:
         credentials: Optional[Dict[str, str]],
         client_session: httpx.ClientSession,
         pool: concurrent.futures.ThreadPoolExecutor,
+        batch_id: Optional[int] = None,
+        job_id: Optional[int] = None,
     ):
         self.image_name = name
         self.credentials = credentials
         self.client_session = client_session
         self.pool = pool
+        self.batch_id = batch_id
+        self.job_id = job_id
 
         image_ref = parse_docker_image_reference(name)
         if image_ref.tag is None and image_ref.digest is None:
@@ -561,13 +569,33 @@ class Image:
 
         await pull()
 
-        try:
-            image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
-        except:
-            # inspect non-deterministically fails sometimes
-            await asyncio.sleep(1)
-            await pull()
-            image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
+        # After a large image pull, the Docker daemon may still be unpacking layers
+        # when the pull stream ends. Retry inspect with backoff to allow time for
+        # unpacking to complete.
+        inspect_deadline = asyncio.get_event_loop().time() + 60
+        delay = 1
+        while True:
+            try:
+                image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
+                break
+            except:
+                if asyncio.get_event_loop().time() > inspect_deadline:
+                    try:
+                        disk_info, _ = await check_exec_output('df', '-h', '/')
+                        disk_info = disk_info.decode().strip().splitlines()[-1]
+                    except Exception:
+                        disk_info = 'unavailable'
+                    raise DockerInspectError(
+                        f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}) '
+                        f'after repeated retries; disk usage: {disk_info}; '
+                        f'possible causes: insufficient storage (try requesting more), corrupt download, or docker daemon error'
+                    )
+                log.warning(
+                    f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}), '
+                    f'retrying in {delay}s (image may still be unpacking)'
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 30)
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
 
     async def _ensure_image_is_pulled(
@@ -723,7 +751,7 @@ def user_error(e):
         # bucket name and your credentials.\n')
         if b'Bad credentials for bucket' in e.stderr:
             return True
-    if isinstance(e, (ImageNotFound, ImageCannotBePulled, InvalidImageRepository)):
+    if isinstance(e, (ImageNotFound, ImageCannotBePulled, InvalidImageRepository, DockerInspectError)):
         return True
     if isinstance(e, (ContainerTimeoutError, ContainerDeletedError)):
         return True
@@ -832,6 +860,8 @@ class Container:
                 self.short_error = 'image cannot be pulled'
             elif isinstance(e, InvalidImageRepository):
                 self.short_error = 'image repository is invalid'
+            elif isinstance(e, DockerInspectError):
+                self.short_error = 'docker inspect failed after pull; possible causes: insufficient storage, corrupt download, or docker daemon error'
 
             self.state = 'error'
             self.error = traceback.format_exc()
@@ -1833,7 +1863,14 @@ class DockerJob(Job):
             task_manager=self.task_manager,
             fs=self.worker.fs,
             name=self.container_name('main'),
-            image=Image(job_spec['process']['image'], self.credentials, client_session, pool),
+            image=Image(
+                job_spec['process']['image'],
+                self.credentials,
+                client_session,
+                pool,
+                batch_id=self.batch_id,
+                job_id=self.job_id,
+            ),
             scratch_dir=f'{self.scratch}/main',
             command=job_spec['process']['command'],
             cpu_in_mcpu=self.cpu_in_mcpu,

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -589,7 +589,7 @@ class Image:
                         f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}) '
                         f'after repeated retries; disk usage: {disk_info}; '
                         f'possible causes: insufficient storage (try requesting more), corrupt download, or docker daemon error'
-                    )
+                    ) from None
                 log.warning(
                     f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}), '
                     f'retrying in {delay}s (image may still be unpacking)'

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -578,15 +578,10 @@ class Image:
             try:
                 image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
             except Exception:
-                try:
-                    disk_info, _ = await check_exec_output('df', '-h', '--output=avail,used,pcent', '/')
-                    disk_info = disk_info.decode().splitlines()[-1].strip()
-                except Exception:
-                    disk_info = 'unavailable'
                 raise DockerInspectError(
                     f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}); '
-                    f'disk (avail, used, used%): {disk_info}; '
-                    f'possible causes: insufficient storage (try requesting more), architecture mismatch, corrupt download, or docker daemon error'
+                    f'possible causes: insufficient storage (private VMs need at least 3-6x the compressed image size to unpack layers), '
+                    f'architecture mismatch (image built for a different CPU arch), or corrupt download'
                 ) from None
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -583,7 +583,7 @@ class Image:
             try:
                 image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
             except Exception:
-                raise DockerInspectError(self.image_ref_str, self.batch_id, self.job_id)
+                raise DockerInspectError(self.image_ref_str, self.batch_id, self.job_id) from None
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
 
     async def _ensure_image_is_pulled(

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -581,14 +581,14 @@ class Image:
             except:
                 if asyncio.get_event_loop().time() > inspect_deadline:
                     try:
-                        disk_info, _ = await check_exec_output('df', '-h', '/')
-                        disk_info = disk_info.decode().strip().splitlines()[-1]
+                        disk_info, _ = await check_exec_output('df', '-h', '--output=avail,used,pcent', '/')
+                        disk_info = disk_info.decode().splitlines()[-1].strip()
                     except Exception:
                         disk_info = 'unavailable'
                     raise DockerInspectError(
                         f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}) '
-                        f'after repeated retries; disk usage: {disk_info}; '
-                        f'possible causes: insufficient storage (try requesting more), corrupt download, or docker daemon error'
+                        f'after repeated retries; disk (avail, used, used%): {disk_info}; '
+                        f'possible causes: insufficient storage (try requesting more), architecture mismatch, corrupt download, or docker daemon error'
                     ) from None
                 log.warning(
                     f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}), '
@@ -861,7 +861,7 @@ class Container:
             elif isinstance(e, InvalidImageRepository):
                 self.short_error = 'image repository is invalid'
             elif isinstance(e, DockerInspectError):
-                self.short_error = 'docker inspect failed after pull; possible causes: insufficient storage, corrupt download, or docker daemon error'
+                self.short_error = 'docker inspect failed after pull; possible causes: insufficient storage, architecture mismatch, corrupt download, or docker daemon error'
 
             self.state = 'error'
             self.error = traceback.format_exc()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -449,8 +449,6 @@ class InvalidImageRepository(Exception):
 
 
 class DockerInspectError(Exception):
-    short_error = 'docker inspect failed after pull; possible causes: insufficient storage, architecture mismatch, corrupt download, or docker daemon error'
-
     def __init__(self, image_ref: str, batch_id: Optional[int], job_id: Optional[int]):
         super().__init__(
             f'docker inspect failed for {image_ref} (batch_id={batch_id}, job_id={job_id}); '
@@ -851,7 +849,7 @@ class Container:
             elif isinstance(e, InvalidImageRepository):
                 self.short_error = 'image repository is invalid'
             elif isinstance(e, DockerInspectError):
-                self.short_error = DockerInspectError.short_error
+                self.short_error = 'docker inspect failed'
 
             self.state = 'error'
             self.error = traceback.format_exc()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -449,7 +449,12 @@ class InvalidImageRepository(Exception):
 
 
 class DockerInspectError(Exception):
-    pass
+    def __init__(self, image_ref: str, batch_id: Optional[int], job_id: Optional[int]):
+        super().__init__(
+            f'docker inspect failed for {image_ref} (batch_id={batch_id}, job_id={job_id}); '
+            f'possible causes: insufficient storage (private VMs need at least 3-6x the compressed image size to unpack layers), '
+            f'architecture mismatch (image built for a different CPU arch), or corrupt download'
+        )
 
 
 class Image:
@@ -578,11 +583,7 @@ class Image:
             try:
                 image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
             except Exception:
-                raise DockerInspectError(
-                    f'docker inspect failed for {self.image_ref_str} (batch_id={self.batch_id}, job_id={self.job_id}); '
-                    f'possible causes: insufficient storage (private VMs need at least 3-6x the compressed image size to unpack layers), '
-                    f'architecture mismatch (image built for a different CPU arch), or corrupt download'
-                )
+                raise DockerInspectError(self.image_ref_str, self.batch_id, self.job_id)
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
 
     async def _ensure_image_is_pulled(


### PR DESCRIPTION
## Change Description

Improve user feedback when an image inspect fails, including a few of the most common likely causes in the exception string.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Fixed error message string, slightly longer retry before timeout.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
