### PR TITLE
Quality: Invalid `SESSION_MAX_AGE_SECS` is silently ignored, causing wrong session lifetime

### DIFF
--- a/gear/gear/auth_utils.py
+++ b/gear/gear/auth_utils.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import secrets
 from typing import Optional
@@ -16,8 +15,10 @@ def max_age():
         if (s := os.getenv('SESSION_MAX_AGE_SECS')) is not None:
             try:
                 MAX_AGE_SECS = int(s)
-            except ValueError:
-                logging.exception("Unable to interpret SESSION_MAX_AGE_SECS as an integer.")
+            except ValueError as e:
+                raise ValueError(f"Invalid SESSION_MAX_AGE_SECS={s!r}; expected integer seconds") from e
+            if MAX_AGE_SECS <= 0:
+                raise ValueError('SESSION_MAX_AGE_SECS must be > 0')
 
     if MAX_AGE_SECS is None:
         # Default value, no env. variable set: 2592000 seconds (30 days)


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`max_age()` catches `ValueError` when `SESSION_MAX_AGE_SECS` is malformed, logs it, and silently falls back to 30 days. This hides configuration mistakes and can materially change authentication behavior (sessions lasting far longer or shorter than intended) without failing fast.


**Severity**: `medium`
**File**: `gear/gear/auth_utils.py`

### Solution
Fail fast on invalid configuration instead of defaulting:
  try:
      MAX_AGE_SECS = int(s)
  except ValueError as e:
      raise ValueError(f"Invalid SESSION_MAX_AGE_SECS={s!r}; expected integer seconds") from e
Optionally also validate positivity:
  if MAX_AGE_SECS <= 0:
      raise ValueError("SESSION_MAX_AGE_SECS must be > 0")

### Changes
- `gear/gear/auth_utils.py` (modified)

## Change Description

Fixes #<issue_number> (delete if N/A)

Brief description and justification of what this PR is doing.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections are required
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections can be deleted

### Impact Rating

Delete all except the correct answer:
- This change has a high security impact
- This change has a medium security impact
- This change has a low security impact
- This change has no security impact

### Impact Description

Replace this content with a description of the impact of the change:
- For none/low impact: a quick one/two sentence justification of the rating.
  - Example: "Docs only", "Low-level refactoring of non-security code", etc.
- For medium/high impact: provide a description of the impact and the mitigations in place.
  - Example: "New UI text field added in analogy to existing elements, with input strings escaped and validated against code injection"

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec


Closes #15366