### PR TITLE
[query] run tests via mill in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ pylint-hailtop:
 
 .PHONY: check-hail
 check-hail: check-hail-fast pylint-hailtop
-	cd hail && HAIL_BUILD_MODE=Dev SCALA_VERSION=2.13 $(MILL) $(MILLOPTS) hail[].__.checkFormat + hail[].__.fix --check
+	cd hail && HAIL_BUILD_MODE=CI SCALA_VERSION=2.13 $(MILL) $(MILLOPTS) hail.__.checkFormat + hail.__.fix --check
 
 .PHONY: check-batch
 check-batch: check-batch-fast pylint-batch

--- a/build.yaml
+++ b/build.yaml
@@ -789,6 +789,35 @@ steps:
       - merge_code
       - copy_third_party_images
   - kind: runImage
+    name: download_mill_and_maven_deps
+    image:
+      valueFrom: base_image.image
+    resources:
+      memory: standard
+      cpu: '2'
+    script: |
+      set -ex
+      cd /io/repo/hail
+
+      export HAIL_BUILD_MODE=Release
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
+      # force download of mill binary and coursier dependencies
+      sh mill --no-daemon 'hail.__.{prepareOffline,scalaCompilerClasspath,javaHome}'
+      tar -C /io -czf /io/mill-cache.tgz cache
+    inputs:
+      - from: /repo/hail
+        to: /io/repo/hail
+    outputs:
+      - from: /io/mill-cache.tgz
+        to: /mill-cache.tgz
+      - from: /io/repo/hail/out
+        to: /derived/root/hail/out
+    dependsOn:
+      - base_image
+      - merge_code
+  - kind: runImage
     name: build_hail_jar_and_wheel
     image:
       valueFrom: base_image.image
@@ -799,7 +828,12 @@ steps:
       set -ex
       cd /io/repo/hail
 
+      tar -C /io -xzf /io/mill-cache.tgz
+
       export MILLOPTS='--no-daemon' HAIL_BUILD_MODE=Release
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
       time retry sh mill --no-daemon --version
 
       # We've encountered the following sporadic error in CI between `mill`
@@ -828,14 +862,19 @@ steps:
         to: /io/repo/.git
       - from: /repo/README.md
         to: /io/repo/README.md
+      - from: /mill-cache.tgz
+        to: /io/mill-cache.tgz
+      - from: /derived/root/hail/out
+        to: /io/repo/hail/out
     outputs:
-      - from: /io/repo/hail/out
-        to: /derived/release/hail/out/
+      - from: /io/repo/hail/out/hail/2.12/assembly.dest/out.jar
+        to: /derived/release/hail/out/hail/2.12/assembly.dest/out.jar
       - from: /io/repo/hail/build/deploy/dist
         to: /derived/release/hail/build/deploy/dist
     dependsOn:
       - base_image
       - merge_code
+      - download_mill_and_maven_deps
   - kind: runImage
     name: test_install_in_isolation_python3_11
     image:
@@ -903,7 +942,13 @@ steps:
       set -ex
       cd /io/repo/hail
 
-      export MILLOPTS='--no-daemon' HAIL_BUILD_MODE=CI
+      tar -C /io -xzf /io/mill-cache.tgz
+
+      export MILLOPTS='--no-daemon'
+      export HAIL_BUILD_MODE=CI
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
       time retry sh mill --no-daemon --version
 
       # See `build_hail_jar_and_wheel`
@@ -921,6 +966,10 @@ steps:
         to: /io/repo/.git
       - from: /repo/README.md
         to: /io/repo/README.md
+      - from: /mill-cache.tgz
+        to: /io/mill-cache.tgz
+      - from: /derived/root/hail/out
+        to: /io/repo/hail/out
     outputs:
       - from: /io/repo/hail/out
         to: /derived/debug/hail/out
@@ -929,8 +978,9 @@ steps:
     dependsOn:
       - base_image
       - merge_code
+      - download_mill_and_maven_deps
   - kind: runImage
-    name: build_debug_hail_test_jar
+    name: build_debug_hail_test
     image:
       valueFrom: base_image.image
     resources:
@@ -940,15 +990,14 @@ steps:
       set -ex
       cd /io/repo/hail
 
-      export MILLOPTS='--no-daemon' HAIL_BUILD_MODE=CI
-      time retry sh mill --no-daemon --version
+      tar -C /io -xzf /io/mill-cache.tgz
 
-      # See `build_hail_jar_and_wheel`
-      time retry make shadowTestJar
-      if [ ! -f out/hail/2.12/test/assembly.dest/out.jar ]; then
-          echo 'no out.jar found after mill assembly returned. going to sleep'
-          sleep 5
-      fi
+      export HAIL_BUILD_MODE=CI
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
+      export SCALA_VERSION=2.12
+      time sh mill --no-daemon hail[].test.{compile,testForkGrouping}
     inputs:
       - from: /repo/hail
         to: /io/repo/hail
@@ -956,6 +1005,8 @@ steps:
         to: /io/repo/.git
       - from: /derived/debug/hail/out
         to: /io/repo/hail/out
+      - from: /mill-cache.tgz
+        to: /io/mill-cache.tgz
     outputs:
       - from: /io/repo/hail/out
         to: /derived/debug/hail/out
@@ -963,6 +1014,7 @@ steps:
       - base_image
       - merge_code
       - build_hail_debug_jar_and_wheel
+      - download_mill_and_maven_deps
   - kind: runImage
     name: build_hail_test_artifacts
     image:
@@ -974,8 +1026,6 @@ steps:
       time tar czf test.tar.gz -C python test pytest.ini
       time tar czf resources.tar.gz -C hail/test resources
       time tar czf data.tar.gz -C python/hail/docs data
-      time TESTNG_SPLITS=5 python3 generate_splits.py
-      time tar czf splits.tar.gz testng-splits-*.xml
     inputs:
       - from: /repo/hail
         to: /io/repo/hail
@@ -984,8 +1034,6 @@ steps:
         to: /test.tar.gz
       - from: /io/repo/hail/resources.tar.gz
         to: /resources.tar.gz
-      - from: /io/repo/hail/splits.tar.gz
-        to: /splits.tar.gz
       - from: /io/repo/hail/data.tar.gz
         to: /data.tar.gz
     dependsOn:
@@ -1098,22 +1146,26 @@ steps:
       cpu: '2'
     script: |
       set -ex
-      cd /io
-      mkdir -p hail/test
-      tar xzf resources.tar.gz -C hail/test
-      tar xzf splits.tar.gz
-      export HAIL_TEST_SKIP_R=1
-      java -cp hail-test.jar:$SPARK_HOME/jars/* org.testng.TestNG -listener is.hail.LogTestListener testng-splits-$HAIL_RUN_IMAGE_SPLIT_INDEX.xml
+      cd /io/repo/hail
+
+      tar -C /io -xzf /io/mill-cache.tgz
+
+      export HAIL_BUILD_MODE='CI'
+      export NO_COLOR=1
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
+      export SCALA_VERSION=2.12
+      sh mill --no-daemon -j2 hail[].test.testCISplit --split $HAIL_RUN_IMAGE_SPLIT_INDEX --totalSplits 5
     inputs:
-      - from: /resources.tar.gz
-        to: /io/resources.tar.gz
-      - from: /derived/debug/hail/out/hail/2.12/test/assembly.dest/out.jar
-        to: /io/hail-test.jar
-      - from: /splits.tar.gz
-        to: /io/splits.tar.gz
-    outputs:
-      - from: /io/test-output
-        to: /test-output
+      - from: /repo/hail
+        to: /io/repo/hail
+      - from: /repo/.git
+        to: /io/repo/.git
+      - from: /derived/debug/hail/out
+        to: /io/repo/hail/out
+      - from: /mill-cache.tgz
+        to: /io/mill-cache.tgz
     secrets:
       - name: test-gsa-key
         namespace:
@@ -1123,8 +1175,9 @@ steps:
       - default_ns
       - hail_run_image
       - create_test_gsa_keys
-      - build_debug_hail_test_jar
+      - build_debug_hail_test
       - build_hail_test_artifacts
+      - download_mill_and_maven_deps
   - kind: runImage
     name: test_hail_python
     numSplits: 28
@@ -1688,8 +1741,15 @@ steps:
     script: |
       set -ex
       cd /io/repo
+      tar -C /io -xzf /io/mill-cache.tgz
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
+      # This also compiles with scala 2.13, so asserts there are no compiler errors or warnings
       make check-hail
     inputs:
+      - from: /repo/.git
+        to: /io/repo/.git
       - from: /repo/Makefile
         to: /io/repo/Makefile
       - from: /repo/pylintrc
@@ -1700,28 +1760,16 @@ steps:
         to: /io/repo/hail
       - from: /repo/config.mk
         to: /io/repo/config.mk
+      - from: /mill-cache.tgz
+        to: /io/mill-cache.tgz
+      - from: /derived/root/hail/out/hail
+        to: /io/repo/hail/out/hail
+      - from: /derived/root/hail/out/Env
+        to: /io/repo/hail/out/Env
     dependsOn:
       - hail_linting_image
       - merge_code
-  - kind: runImage
-    name: compile_hail_213
-    image:
-      valueFrom: base_image.image
-    resources:
-      memory: standard
-      cpu: '2'
-    script: |
-      set -ex
-      cd /io/repo/hail
-
-      HAIL_BUILD_MODE='CI'
-      time retry sh mill --no-daemon hail[2.13].__.compile
-    inputs:
-      - from: /repo/hail
-        to: /io/repo/hail
-    dependsOn:
-      - base_image
-      - merge_code
+      - download_mill_and_maven_deps
   - kind: runImage
     name: get_pip_versioned_docs
     image:
@@ -3237,7 +3285,7 @@ steps:
       - create_accounts
       - default_ns
       - hail_dev_image
-      - hail_debug_wheel
+      - build_hail_debug_jar_and_wheel
       - deploy_batch
   - kind: runImage
     name: test_hailctl_batch
@@ -3760,11 +3808,9 @@ steps:
     resources:
       memory: standard
       cpu: '2'
+      storage: 6Gi
     script: |
       set -ex
-      cd /io
-      mkdir -p src/test
-      tar xzf resources.tar.gz -C src/test
 
       export HAIL_CLOUD={{ global.cloud }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
@@ -3772,12 +3818,18 @@ steps:
       export HAIL_FS_TEST_CLOUD_RESOURCES_URI={{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/fs
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}
 
+      cd /io/repo/hail
+
+      tar -C /io -xzf /io/mill-cache.tgz
+
+      export HAIL_BUILD_MODE='CI'
+      export NO_COLOR=1
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
+      export SCALA_VERSION=2.12
       set +e
-      java -Xms7500M -Xmx7500M \
-           -cp hail-test.jar:$SPARK_HOME/jars/* \
-           org.testng.TestNG \
-           -listener is.hail.LogTestListener \
-           testng-fs.xml
+      sh mill --no-daemon -j2 hail[].test.test-fs
       exit_code=$?
       set -e
       if [[ $exit_code -eq 2 ]]
@@ -3788,12 +3840,14 @@ steps:
           exit $exit_code
       fi
     inputs:
-      - from: /resources.tar.gz
-        to: /io/resources.tar.gz
-      - from: /derived/debug/hail/out/hail/2.12/test/assembly.dest/out.jar
-        to: /io/hail-test.jar
-      - from: /repo/hail/testng-fs.xml
-        to: /io/testng-fs.xml
+      - from: /repo/hail
+        to: /io/repo/hail
+      - from: /repo/.git
+        to: /io/repo/.git
+      - from: /derived/debug/hail/out
+        to: /io/repo/hail/out
+      - from: /mill-cache.tgz
+        to: /io/mill-cache.tgz
     secrets:
       - name: test-gsa-key
         namespace:
@@ -3805,9 +3859,10 @@ steps:
       - create_certs
       - create_accounts
       - hail_run_image
-      - build_debug_hail_test_jar
+      - build_debug_hail_test
       - build_hail_test_artifacts
       - upload_test_resources_to_blob_storage
+      - download_mill_and_maven_deps
   - kind: runImage
     name: test_hail_services_java
     image:
@@ -3815,27 +3870,33 @@ steps:
     resources:
       memory: standard
       cpu: '2'
+      storage: 6Gi
     script: |
       set -ex
 
       export HAIL_CLOUD={{ global.cloud }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
 
-      cd /io
-      mkdir -p src/test
-      tar xzf resources.tar.gz -C src/test
-      java -Xms7500M -Xmx7500M \
-           -cp hail-test.jar:$SPARK_HOME/jars/* \
-           org.testng.TestNG \
-           -listener is.hail.LogTestListener \
-           testng-services.xml
+      cd /io/repo/hail
+
+      tar -C /io -xzf /io/mill-cache.tgz
+
+      export HAIL_BUILD_MODE='CI'
+      export NO_COLOR=1
+      export COURSIER_CACHE='/io/cache/coursier/v1'
+      export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
+      export MILL_DOWNLOAD_PATH=/io/cache/mill
+      export SCALA_VERSION=2.12
+      sh mill --no-daemon -j2 hail[].test.test-services
     inputs:
-      - from: /resources.tar.gz
-        to: /io/resources.tar.gz
-      - from: /derived/debug/hail/out/hail/2.12/test/assembly.dest/out.jar
-        to: /io/hail-test.jar
-      - from: /repo/hail/testng-services.xml
-        to: /io/testng-services.xml
+      - from: /repo/hail
+        to: /io/repo/hail
+      - from: /repo/.git
+        to: /io/repo/.git
+      - from: /derived/debug/hail/out
+        to: /io/repo/hail/out
+      - from: /mill-cache.tgz
+        to: /io/mill-cache.tgz
     secrets:
       - name: test-gsa-key
         namespace:
@@ -3847,10 +3908,11 @@ steps:
       - create_certs
       - create_accounts
       - hail_run_image
-      - build_debug_hail_test_jar
+      - build_debug_hail_test
       - build_hail_test_artifacts
       - upload_query_jar
       - deploy_batch
+      - download_mill_and_maven_deps
   - kind: runImage
     name: start_hail_benchmark
     scopes:

--- a/hail/hail/package.mill
+++ b/hail/hail/package.mill
@@ -2,6 +2,7 @@ package build.hail
 
 import mill.*
 import mill.api.{BuildCtx, Result}
+import mill.javalib.testrunner.TestResult
 import mill.scalalib.*
 import mill.scalalib.Assembly.*
 import mill.scalalib.TestModule.TestNg
@@ -195,3 +196,53 @@ trait RootHailModule extends CrossScalaModule, HailScalaModule:
 
     override def assemblyRules: Seq[Rule] =
       outer.assemblyRules
+
+    val numCISplits: Int = 5
+
+    // FIXME: we used to run this with `-Xms7500M -Xmx7500M`, will need to split into separate test module
+    // to give it different `forkArgs`
+    def `test-fs`(args: String*): Task.Command[(msg: String, results: Seq[TestResult])] = Task.Command {
+      testTask(
+        Task.Anon {
+          args
+        },
+        Task.Anon {
+          Seq("is.hail.io.fs.*")
+        },
+      )()
+    }
+
+    def `test-services`(args: String*): Task.Command[(msg: String, results: Seq[TestResult])] = Task.Command {
+      testTask(
+        Task.Anon {
+          args
+        },
+        Task.Anon {
+          Seq("is.hail.services.*")
+        },
+      )()
+    }
+
+    def testCISplit(split: Int, totalSplits: Int, seed: Long = 12345L): Task.Command[(msg: String, results: Seq[TestResult])] = {
+      Task.Command {
+        testTask(
+          Task.Anon {
+            Seq.empty
+          }, ciTestGrouping(totalSplits, seed).map(_.apply(split))
+        )()
+      }
+    }
+
+    def ciTestGrouping(numSplits: Int, seed: Long): Task[Seq[Seq[String]]] = Task.Anon {
+      val k = numSplits
+      val classes = discoveredTestClasses().filter { cls =>
+        !cls.startsWith("is.hail.io.fs") && !cls.startsWith("is.hail.services")
+      }
+      val n = classes.length
+      val shuffled = scala.util.Random(seed).shuffle(classes)
+      val offsets = Range(0, k).map(i => (n - i + k - 1) / k).scan(0)(_ + _)
+      assert(offsets.last == n)
+      Range(0, k).map { i =>
+        shuffled.slice(offsets(i), offsets(i + 1))
+      }
+    }

--- a/hail/hail/src-2.12/is/hail/expr/orderings/compat.scala
+++ b/hail/hail/src-2.12/is/hail/expr/orderings/compat.scala
@@ -2,4 +2,5 @@ package is.hail.expr.orderings
 
 object compat {
   val DoubleOrdering = Ordering.Double
+  val FloatOrdering = Ordering.Float
 }

--- a/hail/hail/src-2.13/is/hail/expr/orderings/compat.scala
+++ b/hail/hail/src-2.13/is/hail/expr/orderings/compat.scala
@@ -2,4 +2,5 @@ package is.hail.expr.orderings
 
 object compat {
   val DoubleOrdering = Ordering.Double.IeeeOrdering
+  val FloatOrdering = Ordering.Float.IeeeOrdering
 }

--- a/hail/hail/src/is/hail/types/virtual/TFloat32.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat32.scala
@@ -2,6 +2,7 @@ package is.hail.types.virtual
 
 import is.hail.annotations._
 import is.hail.backend.HailStateManager
+import is.hail.expr.orderings.compat.FloatOrdering
 import is.hail.utils._
 
 case object TFloat32 extends TNumeric {
@@ -33,7 +34,7 @@ case object TFloat32 extends TNumeric {
     })
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Float]], missingEqual)
+    ExtendedOrdering.extendToNull(FloatOrdering, missingEqual)
 
   override def isIsomorphicTo(t: Type): Boolean =
     this == t

--- a/hail/hail/test/src/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/hail/test/src/is/hail/asm4s/ASM4SSuite.scala
@@ -233,43 +233,49 @@ class ASM4SSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
     a
 
   @DataProvider(name = "DoubleComparisonOperator")
-  def doubleComparisonOperator(): Array[(Code[Double], Code[Double]) => Code[Boolean]] =
-    Array(
-      refl(_ < _),
-      refl(_ <= _),
-      refl(_ >= _),
-      refl(_ > _),
-      refl(_ ceq _),
-      refl(_ cne _),
-    )
+  def doubleComparisonOperator(): Array[Array[Any]] =
+    Array[((Code[Double], Code[Double]) => Code[Boolean], (Double, Double) => Boolean)](
+      (refl(_ < _), _ < _),
+      (refl(_ <= _), _ <= _),
+      (refl(_ >= _), _ >= _),
+      (refl(_ > _), _ > _),
+      (refl(_ ceq _), _ == _),
+      (refl(_ cne _), _ != _),
+    ).map(t => Array[Any](t._1, t._2))
 
   @Test(dataProvider = "DoubleComparisonOperator")
-  def nanDoubleAlwaysComparesFalse(op: (Code[Double], Code[Double]) => Code[Boolean]): Unit =
+  def nanDoubleComparisonsMatchIEEE(
+    op: (Code[Double], Code[Double]) => Code[Boolean],
+    javaOp: (Double, Double) => Boolean,
+  ): Unit =
     forAll { (x: Double) =>
       val F = FunctionBuilder[Double, Double, Boolean]("CMP")
       F.emit(op(F.getArg[Double](1), F.getArg[Double](2)))
       val cmp = F.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
-      !cmp(Double.NaN, x)
+      cmp(Double.NaN, x) == javaOp(Double.NaN, x) && cmp(x, Double.NaN) == javaOp(x, Double.NaN)
     }
 
   @DataProvider(name = "FloatComparisonOperator")
-  def floatComparisonOperator(): Array[(Code[Float], Code[Float]) => Code[Boolean]] =
-    Array(
-      refl(_ < _),
-      refl(_ <= _),
-      refl(_ >= _),
-      refl(_ > _),
-      refl(_ ceq _),
-      refl(_ cne _),
-    )
+  def floatComparisonOperator(): Array[Array[Any]] =
+    Array[((Code[Float], Code[Float]) => Code[Boolean], (Float, Float) => Boolean)](
+      (refl(_ < _), _ < _),
+      (refl(_ <= _), _ <= _),
+      (refl(_ >= _), _ >= _),
+      (refl(_ > _), _ > _),
+      (refl(_ ceq _), _ == _),
+      (refl(_ cne _), _ != _),
+    ).map(t => Array[Any](t._1, t._2))
 
   @Test(dataProvider = "FloatComparisonOperator")
-  def nanFloatAlwaysComparesFalse(op: (Code[Float], Code[Float]) => Code[Boolean]): Unit =
+  def nanFloatComparisonsMatchIEEE(
+    op: (Code[Float], Code[Float]) => Code[Boolean],
+    javaOp: (Float, Float) => Boolean,
+  ): Unit =
     forAll { (x: Float) =>
       val F = FunctionBuilder[Float, Float, Boolean]("CMP")
       F.emit(op(F.getArg[Float](1), F.getArg[Float](2)))
       val cmp = F.result(ctx.shouldWriteIRFiles())(theHailClassLoader)
-      !cmp(Float.NaN, x)
+      cmp(Float.NaN, x) == javaOp(Float.NaN, x) && cmp(x, Float.NaN) == javaOp(x, Float.NaN)
     }
 
   @Test def defineOpsAsMethods(): Unit = {

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -681,7 +681,7 @@ class SimplifySuite extends HailSuite {
       ).asInstanceOf[Array[Array[Any]]]
     }
 
-  @Test(dataProvider = "binaryIntegralArithmetic")
+  @Test(dataProvider = "floatingIntegralArithmetic")
   def testBinaryFloatingSimplification(input: IR, expected: IR): Unit =
     input should simplifyTo(expected)
 

--- a/hail/hail/test/src/is/hail/io/fs/FSSuite.scala
+++ b/hail/hail/test/src/is/hail/io/fs/FSSuite.scala
@@ -523,8 +523,9 @@ trait FSSuite extends TestNGSuiteLike with TestUtils {
       case exc: FileAndDirectoryException
           if exc.getMessage() == s"$d/x appears as both file $d/x and directory $d/x/." =>
       case exc: FileAlreadyExistsException
-          if exc.getMessage() == s"Destination exists and is not a directory: $d/x" =>
-      case other => fail(other)
+          if exc.getMessage() == s"Destination exists and is not a directory: $d/x" ||
+            exc.getMessage() == s"Destination exists and is not a directory: /private$d/x" =>
+      case other => fail("unexpected exception", other)
     }
   }
 
@@ -619,7 +620,7 @@ class HadoopFSSuite extends HailSuite with FSSuite {
   override val root: String = "file:/"
 
   override lazy val fsResourcesRoot: String =
-    "file:" + new java.io.File("./src/test/resources/fs").getCanonicalPath
+    "file:" + new java.io.File(getTestResource("fs")).getCanonicalPath
 
   override lazy val tmpdir: String = ctx.tmpdir
 }

--- a/hail/hail/test/src/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/hail/test/src/is/hail/methods/LocalLDPruneSuite.scala
@@ -15,6 +15,7 @@ import org.scalacheck.Gen._
 import org.scalacheck.Prop.forAll
 import org.scalatest
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatestplus.scalacheck.Checkers
 import org.testng.annotations.Test
 
 object LocalLDPruneSuite {
@@ -111,7 +112,7 @@ object LocalLDPruneSuite {
   }
 }
 
-class LocalLDPruneSuite extends HailSuite {
+class LocalLDPruneSuite extends HailSuite with Checkers {
   val memoryPerCoreBytes = 256L * 1024 * 1024
   val nCores = 4
 
@@ -303,7 +304,7 @@ class LocalLDPruneSuite extends HailSuite {
         val bpv = LocalLDPruneSuite.fromCalls(v1)
 
         bpv match {
-          case Some(x) => LocalLDPruneSuite.fromCalls(x.unpack().map(toC2)).get.gs == x.gs
+          case Some(x) => LocalLDPruneSuite.fromCalls(x.unpack().map(toC2)).get.gs sameElements x.gs
           case None => true
         }
       }): Unit
@@ -326,7 +327,10 @@ class LocalLDPruneSuite extends HailSuite {
               val r2BitPacked = LocalLDPrune.computeR2(a, b)
 
               val isSame =
-                D_==(r2BitPacked, r2Breeze) && D_>=(r2BitPacked, 0d) && D_<=(r2BitPacked, 1d)
+                D_==(r2BitPacked, r2Breeze, absTolerance = 1e-30) && D_>=(r2BitPacked, 0d) && D_<=(
+                  r2BitPacked,
+                  1d,
+                )
               if (!isSame) {
                 println(s"breeze=$r2Breeze bitPacked=$r2BitPacked nSamples=$nSamples")
               }
@@ -336,7 +340,7 @@ class LocalLDPruneSuite extends HailSuite {
       }): Unit
   }
 
-  @Test def testRandom(): Unit = Spec.check()
+  @Test def testRandom(): Unit = Spec.properties.foreach { case (_, p) => check(p) }
 
   @Test def testIsLocallyUncorrelated(): Unit = {
     val locallyPrunedVariantsTable =

--- a/hail/hail/test/src/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/hail/hail/test/src/is/hail/variant/ReferenceGenomeSuite.scala
@@ -5,15 +5,15 @@ import is.hail.backend.HailStateManager
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir.EmitFunctionBuilder
 import is.hail.io.reference.{FASTAReader, FASTAReaderConfig, LiftOver}
-import is.hail.scalacheck.{genLocus, genNullable}
+import is.hail.scalacheck.{genLocus, genNonMissing}
 import is.hail.types.virtual.{TInterval, TLocus}
 import is.hail.utils._
 
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory
-import org.scalacheck.Prop.forAll
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.testng.annotations.Test
 
-class ReferenceGenomeSuite extends HailSuite {
+class ReferenceGenomeSuite extends HailSuite with ScalaCheckDrivenPropertyChecks {
 
   @Test def testGRCh37(): Unit = {
     assert(ctx.references.contains(ReferenceGenome.GRCh37))
@@ -142,73 +142,59 @@ class ReferenceGenomeSuite extends HailSuite {
   }
 
   @Test def testFasta(): Unit = {
-    val fastaFile = getTestResource("fake_reference.fasta")
-    val fastaFileGzip = getTestResource("fake_reference.fasta.gz")
-    val indexFile = getTestResource("fake_reference.fasta.fai")
+    // qualifying the paths to avoid a bug: #15368. This dodges the bug by making sure
+    // the paths don't start with "/", which forces FASTAReader.setup to copy and
+    // decompress the files.
+    val fastaFile = ctx.fs.makeQualified(getTestResource("fake_reference.fasta"))
+    val indexFile = ctx.fs.makeQualified(getTestResource("fake_reference.fasta.fai"))
 
     val rg = ReferenceGenome("test", ArraySeq("a", "b", "c"), Map("a" -> 25, "b" -> 15, "c" -> 10))
     ctx.local(references = ctx.references + (rg.name -> rg)) { ctx =>
       val fr = FASTAReaderConfig(ctx.localTmpdir, ctx.fs, rg, fastaFile, indexFile, 3, 5).reader
-      val frGzip =
-        FASTAReaderConfig(ctx.localTmpdir, ctx.fs, rg, fastaFileGzip, indexFile, 3, 5).reader
       val refReaderPath =
         FASTAReader.getLocalFastaFile(ctx.localTmpdir, ctx.fs, fastaFile, indexFile)
-      val refReaderPathGz =
-        FASTAReader.getLocalFastaFile(ctx.localTmpdir, ctx.fs, fastaFileGzip, indexFile)
       val refReader = ReferenceSequenceFileFactory.getReferenceSequenceFile(
         new java.io.File(uriPath(refReaderPath))
       )
-      val refReaderGz = ReferenceSequenceFileFactory.getReferenceSequenceFile(
-        new java.io.File(uriPath(refReaderPathGz))
-      )
 
-      {
-        "cache gives same base as from file" |: forAll(genLocus(rg)) { l =>
-          val contig = l.contig
-          val pos = l.position
-          val expected = refReader.getSubsequenceAt(contig, pos.toLong, pos.toLong).getBaseString
-          val expectedGz =
-            refReaderGz.getSubsequenceAt(contig, pos.toLong, pos.toLong).getBaseString
-          assert(expected == expectedGz, "wat: fasta files don't have the same data")
-          fr.lookup(contig, pos, 0, 0) == expected && frGzip.lookup(contig, pos, 0, 0) == expectedGz
-        }
-      }.check()
+      forAll(genLocus(rg)) { l =>
+        val contig = l.contig
+        val pos = l.position
+        val expected = refReader.getSubsequenceAt(contig, pos.toLong, pos.toLong).getBaseString
+        assert(fr.lookup(contig, pos, 0, 0) == expected)
+      }
 
-      {
-        "interval test" |: forAll(
-          genNullable(ctx, TInterval(TLocus(rg.name))).suchThat(_ != null)
-        ) {
-          case i: Interval =>
-            val start = i.start.asInstanceOf[Locus]
-            val end = i.end.asInstanceOf[Locus]
+      forAll(genNonMissing(ctx, TInterval(TLocus(rg.name)))) {
+        case i: Interval =>
+          val start = i.start.asInstanceOf[Locus]
+          val end = i.end.asInstanceOf[Locus]
 
-            val ordering = TLocus(rg.name).ordering(HailStateManager(Map(rg.name -> rg)))
+          val ordering = TLocus(rg.name).ordering(HailStateManager(Map(rg.name -> rg)))
 
-            def getHtsjdkIntervalSequence: String = {
-              val sb = new StringBuilder
-              var pos = start
-              while (ordering.lteq(pos, end) && pos != null) {
-                val endPos =
-                  if (pos.contig != end.contig) rg.contigLength(pos.contig) else end.position
-                sb ++= refReader.getSubsequenceAt(
-                  pos.contig,
-                  pos.position.toLong,
-                  endPos.toLong,
-                ).getBaseString
-                pos =
-                  if (rg.contigsIndex.get(pos.contig) == rg.contigs.length - 1)
-                    null
-                  else
-                    Locus(rg.contigs(rg.contigsIndex.get(pos.contig) + 1), 1)
-              }
-              sb.result()
+          def getHtsjdkIntervalSequence: String = {
+            val sb = new StringBuilder
+            var pos = start
+            while (ordering.lteq(pos, end) && pos != null) {
+              val endPos =
+                if (pos.contig != end.contig) rg.contigLength(pos.contig) else end.position
+              sb ++= refReader.getSubsequenceAt(
+                pos.contig,
+                pos.position.toLong,
+                endPos.toLong,
+              ).getBaseString
+              pos =
+                if (rg.contigsIndex.get(pos.contig) == rg.contigs.length - 1)
+                  null
+                else
+                  Locus(rg.contigs(rg.contigsIndex.get(pos.contig) + 1), 1)
             }
+            sb.result()
+          }
 
-            fr.lookup(
-              Interval(start, end, includesStart = true, includesEnd = true)
-            ) == getHtsjdkIntervalSequence
-        }
-      }.check()
+          assert(fr.lookup(
+            Interval(start, end, includesStart = true, includesEnd = true)
+          ) == getHtsjdkIntervalSequence)
+      }
 
       assert(fr.lookup("a", 25, 0, 5) == "A")
       assert(fr.lookup("b", 1, 5, 0) == "T")

--- a/hail/hail/utils/src/is/hail/utils/package.scala
+++ b/hail/hail/utils/src/is/hail/utils/package.scala
@@ -232,29 +232,71 @@ package object utils extends ErrorHandling with Logging {
       num / denom
 
   val defaultTolerance = 1e-6
+  val defaultAbsTolerance = java.lang.Double.MIN_NORMAL
 
-  def D_epsilon(a: Double, b: Double, tolerance: Double = defaultTolerance): Double =
-    math.max(java.lang.Double.MIN_NORMAL, tolerance * math.max(math.abs(a), math.abs(b)))
+  def D_epsilon(
+    a: Double,
+    b: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Double =
+    absTolerance + tolerance * math.max(math.abs(a), math.abs(b))
 
-  def D_==(a: Double, b: Double, tolerance: Double = defaultTolerance): Boolean =
-    a == b || math.abs(a - b) <= D_epsilon(a, b, tolerance)
+  // This is more or less the implementation of numpy.isclose
+  def D_==(
+    a: Double,
+    b: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Boolean =
+    a == b || math.abs(a - b) <= D_epsilon(a, b, tolerance, absTolerance)
 
-  def D_!=(a: Double, b: Double, tolerance: Double = defaultTolerance): Boolean =
-    !(a == b) && math.abs(a - b) > D_epsilon(a, b, tolerance)
+  def D_!=(
+    a: Double,
+    b: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Boolean =
+    !(a == b) && math.abs(a - b) > D_epsilon(a, b, tolerance, absTolerance)
 
-  def D_<(a: Double, b: Double, tolerance: Double = defaultTolerance): Boolean =
-    !(a == b) && a - b < -D_epsilon(a, b, tolerance)
+  def D_<(
+    a: Double,
+    b: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Boolean =
+    !(a == b) && a - b < -D_epsilon(a, b, tolerance, absTolerance)
 
-  def D_<=(a: Double, b: Double, tolerance: Double = defaultTolerance): Boolean =
-    (a == b) || a - b <= D_epsilon(a, b, tolerance)
+  def D_<=(
+    a: Double,
+    b: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Boolean =
+    (a == b) || a - b <= D_epsilon(a, b, tolerance, absTolerance)
 
-  def D_>(a: Double, b: Double, tolerance: Double = defaultTolerance): Boolean =
-    !(a == b) && a - b > D_epsilon(a, b, tolerance)
+  def D_>(
+    a: Double,
+    b: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Boolean =
+    !(a == b) && a - b > D_epsilon(a, b, tolerance, absTolerance)
 
-  def D_>=(a: Double, b: Double, tolerance: Double = defaultTolerance): Boolean =
-    (a == b) || a - b >= -D_epsilon(a, b, tolerance)
+  def D_>=(
+    a: Double,
+    b: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Boolean =
+    (a == b) || a - b >= -D_epsilon(a, b, tolerance, absTolerance)
 
-  def D0_==(x: Double, y: Double, tolerance: Double = defaultTolerance): Boolean =
+  def D0_==(
+    x: Double,
+    y: Double,
+    tolerance: Double = defaultTolerance,
+    absTolerance: Double = defaultAbsTolerance,
+  ): Boolean =
     if (x.isNaN)
       y.isNaN
     else if (x.isPosInfinity)
@@ -262,7 +304,7 @@ package object utils extends ErrorHandling with Logging {
     else if (x.isNegInfinity)
       y.isNegInfinity
     else
-      D_==(x, y, tolerance)
+      D_==(x, y, tolerance, absTolerance)
 
   def flushDouble(a: Double): Double =
     if (math.abs(a) < java.lang.Double.MIN_NORMAL) 0.0 else a

--- a/hail/mill-build/build.mill
+++ b/hail/mill-build/build.mill
@@ -21,7 +21,7 @@ extension [A, F[+X] <: Iterable[X]] (as: F[A])
 object `package` extends MillBuildRootModule:
 
   private val SupportedScalaVersions =
-    Set("2.12", "2.12.13", "2.13")
+    Set("2.12", "2.13")
 
   override def mvnDeps: T[Seq[Dep]] =
     Seq(


### PR DESCRIPTION
## Change Description

The primary goal of this change is to have CI run jvm tests using the Mill build system, instead of directly invoking a test runner with a Hail jar. This way:

- We ensure that running tests through Mill actually works. This is important for developers running tests locally who choose not to use IntelliJ, and for coding agents. There were a few tests that were broken running through Mill, which are fixed here.
- The splitting of tests into parallel CI jobs is handled in Mill, agnostic to the test framework/runner, freeing us to change the test framework.

Because we're now running Mill in more CI jobs, the overhead of needing to download all maven dependencies in each such job felt excessive. So this change also introduces a CI job `download_mill_and_maven_deps`, which downloads the mill executable, all JVMs needed, and all maven dependencies, and saves them in a tarball (to preserve executable flags).

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP