### PR TITLE
[ui] add namespaced log links

### DIFF
--- a/batch/batch/driver/templates/index.html
+++ b/batch/batch/driver/templates/index.html
@@ -159,6 +159,7 @@
         <th>Failed Requests</th>
         <th>Time Created</th>
         <th>Last Updated</th>
+        <th>Logs</th>
       </tr>
     </thead>
     <tbody>
@@ -173,6 +174,7 @@
         <td class="numeric-cell">{{ instance.failed_request_count }}</td>
         <td>{{ instance.time_created_str() }}</td>
         <td>{{ instance.last_updated_str() }} ago</td>
+        <td><a target="_blank" href="https://console.cloud.google.com/logs/query;query=resource.type%3D%22gce_instance%22%20AND%20labels.%22compute.googleapis.com%2Fresource_name%22%3D%22{{ instance.name }}%22">Logs<i class="material-icons text-icon">open_in_new</i></a></td>
       </tr>
       {% endfor %}
     </tbody>

--- a/batch/batch/driver/templates/job_private.html
+++ b/batch/batch/driver/templates/job_private.html
@@ -98,6 +98,7 @@
     <th>Failed Requests</th>
     <th>Time Created</th>
     <th>Last Updated</th>
+    <th>Logs</th>
   </tr>
   </thead>
   <tbody>
@@ -113,6 +114,7 @@
     <td class="numeric-cell">{{ instance.failed_request_count }}</td>
     <td>{{ instance.time_created_str() }}</td>
     <td>{{ instance.last_updated_str() }} ago</td>
+    <td><a target="_blank" href="https://console.cloud.google.com/logs/query;query=resource.type%3D%22gce_instance%22%20AND%20labels.%22compute.googleapis.com%2Fresource_name%22%3D%22{{ instance.name }}%22">Logs<i class="material-icons text-icon">open_in_new</i></a></td>
   </tr>
   {% endfor %}
   </tbody>

--- a/batch/batch/driver/templates/pool.html
+++ b/batch/batch/driver/templates/pool.html
@@ -127,6 +127,8 @@
     <th>Failed Requests</th>
     <th>Time Created</th>
     <th>Last Updated</th>
+    <th>Logs</th>
+    <th></th>
   </tr>
   </thead>
   <tbody>
@@ -140,6 +142,7 @@
     <td class="numeric-cell">{{ instance.failed_request_count }}</td>
     <td>{{ instance.time_created_str() }}</td>
     <td>{{ instance.last_updated_str() }} ago</td>
+    <td><a target="_blank" href="https://console.cloud.google.com/logs/query;query=resource.type%3D%22gce_instance%22%20AND%20labels.%22compute.googleapis.com%2Fresource_name%22%3D%22{{ instance.name }}%22">Logs<i class="material-icons text-icon">open_in_new</i></a></td>
     <td>
       <form action="{{ base_path }}/instances/{{ instance.name }}/kill" method="post">
         <input type="hidden" name="_csrf" value="{{ csrf_token }}" />

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -61,7 +61,7 @@
       <div class="header-dropdown-menu">
         <div class="monitoring-caret header-dropdown-menu-caret"></div>
         <a class="header-dropdown-menu-link" href="{{ grafana_base_url }}">Grafana</a>
-        <a target="_blank" class="header-dropdown-menu-link" href="https://console.cloud.google.com/logs">
+        <a target="_blank" class="header-dropdown-menu-link" href="https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{ k8s_namespace }}%22">
           Log Viewer<i class="material-icons text-icon">open_in_new</i></a>
         <a class="header-dropdown-menu-link" href="{{ monitoring_base_url }}/billing">Billing</a>
       </div>

--- a/web_common/web_common/templates/new_header.html
+++ b/web_common/web_common/templates/new_header.html
@@ -49,7 +49,7 @@
     {% if userdata['is_developer'] == 1 %}
     {% call header_item("Monitoring", monitoring_base_url) %}
     <a class="block hover:bg-slate-100 px-2 py-1" href="{{ grafana_base_url }}">Grafana</a>
-    <a target="_blank" class="block hover:bg-slate-100 px-2 py-1" href="https://console.cloud.google.com/logs">
+    <a target="_blank" class="block hover:bg-slate-100 px-2 py-1" href="https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22{{ k8s_namespace }}%22">
       Log Viewer<i class="material-icons text-icon">open_in_new</i>
     </a>
     <a class="block hover:bg-slate-100 px-2 py-1" href="{{ monitoring_base_url }}/billing">Billing</a>

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -77,6 +77,7 @@ def base_context(session, userdata, service):
         'ci_base_url': deploy_config.external_url('ci', ''),
         'grafana_base_url': deploy_config.external_url('grafana', ''),
         'monitoring_base_url': deploy_config.external_url('monitoring', ''),
+        'k8s_namespace': deploy_config.default_namespace(),
         'support_email': support_email,
         'userdata': userdata,
     }


### PR DESCRIPTION
## Change Description

Add more helpful log links to the UI, including:

- The Log Viewer link from the header: now includes a default filter to the right k8s namespace
- The instances lists now include links to logs from those instances

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a low security impact


### Impact Description

Updates links for users to follow, by adding well-known and controlled values to the target urls

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
