### PR TITLE
[services] bump base ubuntu to noble-20260324

### DIFF
--- a/dev-docs/services/updating-third-party-images.md
+++ b/dev-docs/services/updating-third-party-images.md
@@ -13,7 +13,7 @@ Not absolutely necessary but installing skopeo will make this go a lot smoother 
 "no space left on device" issues.
 
 ```bash
-$ brew install skopeo
+brew install skopeo
 ```
 
 ### Set the `kubectl` Context
@@ -32,5 +32,5 @@ See [Connecting Docker to Container Registry Credentials](connecting_docker_to_c
 ## Run the following command to update the image:
 
 ```bash
-$ NAMESPACE=default make -C  docker/third-party copy
+NAMESPACE=default make -C  docker/third-party copy
 ```

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_PREFIX={{ global.docker_prefix }}
 ARG SKIP_GCLOUD_PROFILER=false
-FROM $DOCKER_PREFIX/ubuntu:noble-20260217 AS initializer
+FROM $DOCKER_PREFIX/ubuntu:noble-20260324 AS initializer
 
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -19,4 +19,4 @@ ubuntu:18.04
 ubuntu:20.04
 ubuntu:22.04
 ubuntu:24.04
-ubuntu:noble-20260217
+ubuntu:noble-20260324


### PR DESCRIPTION
## Change Description

Updates ubuntu base to noble-20260324

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Ubuntu update

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
