### PR TITLE
[hailctl] unbreak `hailctl dev config set` on first invocation

### DIFF
--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -39,6 +39,14 @@ class DeployConfig:
         }
 
     @classmethod
+    def default_config(cls) -> Dict[str, str]:
+        return {
+            'location': 'external',
+            'default_namespace': 'default',
+            'domain': get_user_config().get('global', 'domain', fallback='hail.is'),
+        }
+
+    @classmethod
     def from_config_file(cls, config_file=None) -> 'DeployConfig':
         config_file = first_extant_file(
             config_file,
@@ -53,11 +61,7 @@ class DeployConfig:
             log.info(f'deploy config location: {config["location"]}')
         else:
             log.info(f'deploy config file not found: {config_file}')
-            config = {
-                'location': 'external',
-                'default_namespace': 'default',
-                'domain': get_user_config().get('global', 'domain', fallback='hail.is'),
-            }
+            config = cls.default_config()
         return cls.from_config(config)
 
     def __init__(self, location: str, default_namespace: str, domain: str, base_path: Optional[str]):

--- a/hail/python/hailtop/hailctl/dev/config.py
+++ b/hail/python/hailtop/hailctl/dev/config.py
@@ -20,9 +20,15 @@ class DevConfigProperty(str, Enum):
 @app.command()
 def set(property: DevConfigProperty, value: str):
     """Set dev config property PROPERTY to value VALUE."""
+    from hailtop.config.deploy_config import DeployConfig  # pylint: disable=import-outside-toplevel
+
     config_file = os.environ.get('HAIL_DEPLOY_CONFIG_FILE', os.path.expanduser('~/.hail/deploy-config.json'))
-    with open(config_file, 'r', encoding='utf-8') as old_config_f:
-        config = orjson.loads(old_config_f.read())
+    if os.path.exists(config_file):
+        with open(config_file, 'r', encoding='utf-8') as old_config_f:
+            config = orjson.loads(old_config_f.read())
+    else:
+        os.makedirs(os.path.dirname(config_file), exist_ok=True)
+        config = DeployConfig.default_config()
 
     config[property] = value
     with open(config_file, 'w', encoding='utf-8') as new_config_f:


### PR DESCRIPTION
## Change Description

Fixes a bug in hailctl that means that `hailctl dev config set` always fails the first time, unless the deploy-config has already been manually seeded beforehand.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

(client library only)