### PR TITLE
[compiler] Simplify code generation infrastructure

### DIFF
--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -683,10 +683,10 @@ class MethodBuilder[C](
     if (i == 0 && !isStatic)
       assert(ti == cb.ti, s"$ti != ${cb.ti}")
     else {
-      val static = (!isStatic).toInt
+      val thisOffset = (!isStatic).toInt
       assert(
-        ti == parameterTypeInfo(i - static),
-        s"$ti != ${parameterTypeInfo(i - static)}\n  params: $parameterTypeInfo",
+        ti == parameterTypeInfo(i - thisOffset),
+        s"$ti != ${parameterTypeInfo(i - thisOffset)}\n  params: $parameterTypeInfo",
       )
     }
     new LocalRef(lmethod.getParam(i))

--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -168,12 +168,14 @@ class ModuleBuilder() {
   private var nStaticFieldsOnThisClass: Int = maxFieldsOrMethodsOnClass
   private var staticCls: ClassBuilder[_] = null
 
-  private def incrStaticClassSize(n: Int = 1): Unit =
-    if (nStaticFieldsOnThisClass + n >= maxFieldsOrMethodsOnClass) {
-      nStaticFieldsOnThisClass = n
+  private def incrStaticClassSize(): Unit = {
+    if (nStaticFieldsOnThisClass + 1 >= maxFieldsOrMethodsOnClass) {
+      nStaticFieldsOnThisClass = 0
       staticFieldWrapperIdx += 1
       staticCls = genClass[Unit](s"staticWrapperClass_$staticFieldWrapperIdx")
     }
+    nStaticFieldsOnThisClass += 1
+  }
 
   def genStaticField[T: TypeInfo](name: String = null): StaticFieldRef[T] = {
     incrStaticClassSize()

--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -36,14 +36,8 @@ class Field[T] private (private val lf: lir.Field) extends AnyVal {
 
   def putAny(obj: Code[_], v: Code[_]): Code[Unit] = put(obj, coerce[T](v))
 
-  def put(obj: Code[_], v: Code[T]): Code[Unit] = {
-    obj.end.append(lir.goto(v.start))
-    v.end.append(lir.putField(lf, obj.v, v.v))
-    val newC = new VCode(obj.start, v.end, null)
-    obj.clear()
-    v.clear()
-    newC
-  }
+  def put(obj: Code[_], v: Code[T]): Code[Unit] =
+    Code.void(obj, v, lir.putField(lf, _, _))
 }
 
 object StaticField {
@@ -61,12 +55,8 @@ case class StaticField[T] private (lf: lir.StaticField) extends AnyVal {
 
   def get(): Code[T] = Code(lir.getStaticField(lf))
 
-  def put(v: Code[T]): Code[Unit] = {
-    v.end.append(lir.putStaticField(lf, v.v))
-    val newC = new VCode(v.start, v.end, null)
-    v.clear()
-    newC
-  }
+  def put(v: Code[T]): Code[Unit] =
+    Code.void(v, lir.putStaticField(lf, _))
 }
 
 class ClassesBytes(classesBytes: Array[(String, Array[Byte])]) extends Serializable with Logging {

--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -85,6 +85,25 @@ class ClassesBytes(classesBytes: Array[(String, Array[Byte])]) extends Serializa
   }
 }
 
+class LazyClassFactory[C](
+  classesBytes: ClassesBytes,
+  className: String,
+) extends java.io.Serializable {
+  @transient @volatile private var theClass: Class[_] = null
+
+  def newInstance(hcl: HailClassLoader): C = {
+    if (theClass == null) {
+      this.synchronized {
+        if (theClass == null) {
+          classesBytes.load(hcl)
+          theClass = loadClass(hcl, className)
+        }
+      }
+    }
+    theClass.getDeclaredConstructor().newInstance().asInstanceOf[C]
+  }
+}
+
 class AsmTuple[C](
   val cb: ClassBuilder[C],
   val fields: IndexedSeq[Field[_]],
@@ -479,29 +498,16 @@ class ClassBuilder[C](
   }
 
   def result(writeIRs: Boolean, print: Option[PrintWriter] = None): HailClassLoader => C = {
-    val n = className.replace("/", ".")
-    val classesBytes = modb.classesBytes(writeIRs)
-
     assert(
       TaskContext.get() == null,
       "FunctionBuilder emission should happen on master, but happened on worker",
     )
 
     new (HailClassLoader => C) with java.io.Serializable {
-      @transient @volatile private var theClass: Class[_] = null
+      private val factory =
+        new LazyClassFactory[C](modb.classesBytes(writeIRs), className.replace("/", "."))
 
-      override def apply(hcl: HailClassLoader): C = {
-        if (theClass == null) {
-          this.synchronized {
-            if (theClass == null) {
-              classesBytes.load(hcl)
-              theClass = loadClass(hcl, n)
-            }
-          }
-        }
-
-        theClass.getDeclaredConstructor().newInstance().asInstanceOf[C]
-      }
+      override def apply(hcl: HailClassLoader): C = factory.newInstance(hcl)
     }
   }
 

--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -360,39 +360,37 @@ class ClassBuilder[C](
       m.isStatic == isStatic
     }
 
+  private def addMethod(
+    name: String,
+    parameterTypeInfo: IndexedSeq[TypeInfo[_]],
+    returnTypeInfo: TypeInfo[_],
+    isStatic: Boolean,
+  ): MethodBuilder[C] = {
+    if (lookupMethod(name, parameterTypeInfo, returnTypeInfo, isStatic).isDefined) {
+      val keyword = if (isStatic) "Static method" else "Method"
+      val signature = s"${parameterTypeInfo.mkString("(", ",", ")")} => $returnTypeInfo"
+      throw new DuplicateMemberException(
+        s"$keyword '$name: $signature' already defined in class '$className'."
+      )
+    }
+    val mb = new MethodBuilder[C](this, name, parameterTypeInfo, returnTypeInfo, isStatic)
+    methods += mb
+    mb
+  }
+
   def newMethod(
     name: String,
     parameterTypeInfo: IndexedSeq[TypeInfo[_]],
     returnTypeInfo: TypeInfo[_],
-  ): MethodBuilder[C] = {
-    if (lookupMethod(name, parameterTypeInfo, returnTypeInfo, isStatic = false).isDefined) {
-      val signature = s"${parameterTypeInfo.mkString("(", ",", ")")} => $returnTypeInfo"
-      throw new DuplicateMemberException(
-        s"Method '$name: $signature' already defined in class '$className'."
-      )
-    }
-
-    val mb = new MethodBuilder[C](this, name, parameterTypeInfo, returnTypeInfo)
-    methods += mb
-    mb
-  }
+  ): MethodBuilder[C] =
+    addMethod(name, parameterTypeInfo, returnTypeInfo, isStatic = false)
 
   def newStaticMethod(
     name: String,
     parameterTypeInfo: IndexedSeq[TypeInfo[_]],
     returnTypeInfo: TypeInfo[_],
-  ): MethodBuilder[C] = {
-    if (lookupMethod(name, parameterTypeInfo, returnTypeInfo, isStatic = true).isDefined) {
-      val signature = s"${parameterTypeInfo.mkString("(", ",", ")")} => $returnTypeInfo"
-      throw new DuplicateMemberException(
-        s"Static method '$name: $signature' already defined in class '$className'."
-      )
-    }
-
-    val mb = new MethodBuilder[C](this, name, parameterTypeInfo, returnTypeInfo, isStatic = true)
-    methods += mb
-    mb
-  }
+  ): MethodBuilder[C] =
+    addMethod(name, parameterTypeInfo, returnTypeInfo, isStatic = true)
 
   def newMethod(
     name: String,

--- a/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/hail/src/is/hail/asm4s/ClassBuilder.scala
@@ -95,8 +95,6 @@ class AsmTuple[C](
   def newTuple(elems: IndexedSeq[Code[_]]): Code[C] = Code.newInstance(cb, ctor, elems)
 
   def loadElementsAny(t: Value[_]): IndexedSeq[Value[_]] = fields.map(_.get(coerce[C](t)))
-
-  def loadElements(t: Value[C]): IndexedSeq[Value[_]] = fields.map(_.get(t))
 }
 
 trait WrappedModuleBuilder {

--- a/hail/hail/src/is/hail/asm4s/Code.scala
+++ b/hail/hail/src/is/hail/asm4s/Code.scala
@@ -1090,12 +1090,11 @@ object Code {
   def _empty: Value[Unit] = Value.fromLIR[Unit](null: lir.ValueX)
 
   def _throwAny[T <: java.lang.Throwable]: Thrower[T] = new Thrower[T] {
-    override def apply[U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U] = {
+    override def apply[U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U] =
       if (uti eq UnitInfo)
         Code.void(cerr, lir.throwx(_))
       else
         Code(cerr, lir.insn1(ATHROW, uti))
-    }
   }
 
   private def getEmitLineNum: Int =
@@ -1108,12 +1107,11 @@ object Code {
     _throw[T, U](cerr, getEmitLineNum)
 
   def _throw[T <: java.lang.Throwable, U](cerr: Code[T], lineNumber: Int)(implicit uti: TypeInfo[U])
-    : Code[U] = {
+    : Code[U] =
     if (uti eq UnitInfo)
       Code.void(cerr, lir.throwx(_, lineNumber))
     else
       Code(cerr, lir.insn1(ATHROW, uti, lineNumber))
-  }
 
   def _fatal[U](msg: Code[String])(implicit uti: TypeInfo[U]): Code[U] =
     _fatal[U](msg, getEmitLineNum)

--- a/hail/hail/src/is/hail/asm4s/Code.scala
+++ b/hail/hail/src/is/hail/asm4s/Code.scala
@@ -1091,12 +1091,9 @@ object Code {
 
   def _throwAny[T <: java.lang.Throwable]: Thrower[T] = new Thrower[T] {
     override def apply[U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U] = {
-      if (uti eq UnitInfo) {
-        cerr.end.append(lir.throwx(cerr.v))
-        val newC = new VCode(cerr.start, cerr.end, null)
-        cerr.clear()
-        newC
-      } else
+      if (uti eq UnitInfo)
+        Code.void(cerr, lir.throwx(_))
+      else
         Code(cerr, lir.insn1(ATHROW, uti))
     }
   }
@@ -1112,12 +1109,9 @@ object Code {
 
   def _throw[T <: java.lang.Throwable, U](cerr: Code[T], lineNumber: Int)(implicit uti: TypeInfo[U])
     : Code[U] = {
-    if (uti eq UnitInfo) {
-      cerr.end.append(lir.throwx(cerr.v, lineNumber))
-      val newC = new VCode(cerr.start, cerr.end, null)
-      cerr.clear()
-      newC
-    } else
+    if (uti eq UnitInfo)
+      Code.void(cerr, lir.throwx(_, lineNumber))
+    else
       Code(cerr, lir.insn1(ATHROW, uti, lineNumber))
   }
 
@@ -2066,10 +2060,7 @@ class LocalRef[T](val l: lir.Local) extends Settable[T] {
 
   override def store(rhs: Code[T]): Code[Unit] = {
     assert(rhs.v != null)
-    rhs.end.append(lir.store(l, rhs.v))
-    val newC = new VCode(rhs.start, rhs.end, null)
-    rhs.clear()
-    newC
+    Code.void(rhs, lir.store(l, _))
   }
 }
 

--- a/hail/hail/src/is/hail/asm4s/Code.scala
+++ b/hail/hail/src/is/hail/asm4s/Code.scala
@@ -1138,15 +1138,8 @@ object Code {
       errorId,
     ))
 
-  def _return[T](c: Code[T]): Code[Unit] = {
-    c.end.append(if (c.v != null)
-      lir.returnx(c.v)
-    else
-      lir.returnx())
-    val newC = new VCode(c.start, c.end, null)
-    c.clear()
-    newC
-  }
+  def _return[T](c: Code[T]): Code[Unit] =
+    Code.void(c, v => if (v != null) lir.returnx(v) else lir.returnx())
 
   def _printlns(cs: Code[String]*): Code[Unit] =
     _println(cs.reduce[Code[String]] { case (l, r) => (l.concat(r)) })
@@ -1878,11 +1871,7 @@ class CodeLabel(val L: lir.Block) extends Code[Unit] {
      * clearStack = Thread.currentThread().getStackTrace */
     _start = null
 
-  def goto: Code[Unit] = {
-    val M = new lir.Block()
-    M.append(lir.goto(L))
-    new VCode(M, M, null)
-  }
+  def goto: Code[Unit] = Code.void(lir.goto(L))
 }
 
 object Invokeable {
@@ -2065,11 +2054,7 @@ class LocalRef[T](val l: lir.Local) extends Settable[T] {
 }
 
 class LocalRefInt(val v: LocalRef[Int]) extends AnyRef {
-  def +=(i: Int): Code[Unit] = {
-    val L = new lir.Block()
-    L.append(lir.iincInsn(v.l, i))
-    new VCode(L, L, null)
-  }
+  def +=(i: Int): Code[Unit] = Code.void(lir.iincInsn(v.l, i))
 
   def ++ : Code[Unit] = +=(1)
 }

--- a/hail/hail/src/is/hail/expr/ir/Emit.scala
+++ b/hail/hail/src/is/hail/expr/ir/Emit.scala
@@ -608,6 +608,13 @@ class EmitCode(private val start: CodeLabel, private val iec: IEmitCode) {
 
 object EmitSettable {
   def present(vs: SSettable): EmitSettable = new EmitSettable(None, vs)
+
+  def apply(sb: SettableBuilder, st: SType, required: Boolean, name: String = "anon")
+    : EmitSettable =
+    new EmitSettable(
+      if (required) None else Some(sb.newSettable[Boolean](name + "_missing")),
+      SSettable(sb, st, name),
+    )
 }
 
 class EmitSettable(

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -268,7 +268,7 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
     : EmitMethodBuilder[C] =
     ecb.genEmitMethod[A1, A2, A3, R](baseName)
 
-  def geEmitMethod[A1: TypeInfo, A2: TypeInfo, A3: TypeInfo, A4: TypeInfo, R: TypeInfo](
+  def genEmitMethod[A1: TypeInfo, A2: TypeInfo, A3: TypeInfo, A4: TypeInfo, R: TypeInfo](
     baseName: String
   ): EmitMethodBuilder[C] =
     ecb.genEmitMethod[A1, A2, A3, A4, R](baseName)
@@ -290,7 +290,7 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def open(path: Code[String], checkCodec: Code[Boolean]): Code[InputStream] =
     Code.newInstance[java.io.BufferedInputStream, InputStream](
-      getFS.invoke[String, Boolean, InputStream]("open", path, checkCodec)
+      openUnbuffered(path, checkCodec)
     )
 
   def createUnbuffered(path: Code[String]): Code[OutputStream] =
@@ -298,7 +298,7 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def create(path: Code[String]): Code[OutputStream] =
     Code.newInstance[java.io.BufferedOutputStream, OutputStream](
-      getFS.invoke[String, OutputStream]("create", path)
+      createUnbuffered(path)
     )
 }
 
@@ -973,11 +973,6 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
     : EmitMethodBuilder[C] =
     newStaticEmitMethod(genName("sm", baseName), argsInfo, returnInfo)
 
-  def getUnsafeReader(path: Code[String], checkCodec: Code[Boolean]): Code[InputStream] =
-    getFS.invoke[String, Boolean, InputStream]("unsafeReader", path, checkCodec)
-
-  def getUnsafeWriter(path: Code[String]): Code[OutputStream] =
-    getFS.invoke[String, OutputStream]("unsafeWriter", path)
 }
 
 object EmitFunctionBuilder {

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -85,10 +85,8 @@ class EmitModuleBuilder(val ctx: ExecuteContext, val modb: ModuleBuilder) {
     literalsBuilder.getOrElseUpdate(
       (t, value), {
         val curr = currLitIndex
-        val pt = t.canonicalPType
-        literalsBuilder.update((t, value), (pt, curr))
         currLitIndex += 1
-        (pt, curr)
+        (t.canonicalPType, curr)
       },
     )
   }
@@ -97,10 +95,8 @@ class EmitModuleBuilder(val ctx: ExecuteContext, val modb: ModuleBuilder) {
     encodedLiteralsBuilder.getOrElseUpdate(
       el, {
         val curr = currLitIndex
-        val pt = el.codec.decodedPType()
-        encodedLiteralsBuilder.update(el, (pt, curr))
         currLitIndex += 1
-        (pt, curr)
+        (el.codec.decodedPType(), curr)
       },
     )
   }
@@ -540,15 +536,17 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
     _aggState
   }
 
-  def getSerializedAgg(i: Int): Code[Array[Byte]] = {
+  private def trackSerialized(i: Int): Unit =
     if (_nSerialized <= i)
       _nSerialized = i + 1
+
+  def getSerializedAgg(i: Int): Code[Array[Byte]] = {
+    trackSerialized(i)
     _aggSerialized.load()(i)
   }
 
   def setSerializedAgg(i: Int, b: Code[Array[Byte]]): Code[Unit] = {
-    if (_nSerialized <= i)
-      _nSerialized = i + 1
+    trackSerialized(i)
     _aggSerialized.load().update(i, b)
   }
 

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -17,7 +17,6 @@ import is.hail.types.physical.stypes._
 import is.hail.types.physical.stypes.interfaces.SBaseStruct
 import is.hail.types.virtual.Type
 import is.hail.utils._
-import is.hail.utils.implicits.toRichBoolean
 import is.hail.variant.ReferenceGenome
 
 import scala.collection.mutable
@@ -1153,7 +1152,7 @@ trait FunctionWithAggRegion {
 }
 
 trait FunctionWithHailClassLoader {
-  def addHailClassLoader(fs: HailClassLoader): Unit
+  def addHailClassLoader(hcl: HailClassLoader): Unit
 }
 
 trait FunctionWithFS {
@@ -1178,7 +1177,7 @@ trait FunctionWithLiterals {
 }
 
 trait FunctionWithBackend {
-  def setBackend(spark: BackendUtils): Unit
+  def setBackend(backend: BackendUtils): Unit
 }
 
 class EmitMethodBuilder[C](

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -338,19 +338,13 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
   def newPField(name: String, st: SType): SSettable = newPSettable(fieldBuilder, st, name)
 
   def newEmitField(st: SType, required: Boolean): EmitSettable =
-    new EmitSettable(
-      if (required) None else Some(genFieldThisRef[Boolean]("emitfield_missing")),
-      newPField(st),
-    )
+    EmitSettable(fieldBuilder, st, required)
 
   def newEmitField(name: String, emitType: EmitType): EmitSettable =
     newEmitField(name, emitType.st, emitType.required)
 
   def newEmitField(name: String, st: SType, required: Boolean): EmitSettable =
-    new EmitSettable(
-      if (required) None else Some(genFieldThisRef[Boolean](name + "_missing")),
-      newPField(name, st),
-    )
+    EmitSettable(fieldBuilder, st, required, name)
 
   private[this] type CompareMapKey = (SType, SType)
 
@@ -1263,19 +1257,13 @@ class EmitMethodBuilder[C](
   def newEmitLocal(emitType: EmitType): EmitSettable = newEmitLocal(emitType.st, emitType.required)
 
   def newEmitLocal(st: SType, required: Boolean): EmitSettable =
-    new EmitSettable(
-      if (required) None else Some(newLocal[Boolean]("anon_emitlocal_m")),
-      newPLocal("anon_emitlocal_v", st),
-    )
+    EmitSettable(localBuilder, st, required)
 
   def newEmitLocal(name: String, emitType: EmitType): EmitSettable =
     newEmitLocal(name, emitType.st, emitType.required)
 
   def newEmitLocal(name: String, st: SType, required: Boolean): EmitSettable =
-    new EmitSettable(
-      if (required) None else Some(newLocal[Boolean](name + "_missing")),
-      newPLocal(name, st),
-    )
+    EmitSettable(localBuilder, st, required, name)
 
   def emitWithBuilder[T](f: (EmitCodeBuilder) => Code[T]): Unit =
     emit(EmitCodeBuilder.scopedCode[T](this)(f))

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -676,11 +676,7 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
 
   private def getCodeArgsInfo(argsInfo: IndexedSeq[ParamType], returnInfo: ParamType)
     : (IndexedSeq[TypeInfo[_]], TypeInfo[_], AsmTuple[_]) = {
-    val codeArgsInfo = argsInfo.flatMap {
-      case CodeParamType(ti) => FastSeq(ti)
-      case t: EmitParamType => t.valueTupleTypes
-      case SCodeParamType(pt) => pt.settableTupleTypes()
-    }
+    val codeArgsInfo = argsInfo.flatMap(_.codeTypes)
     val (codeReturnInfo, asmTuple) = returnInfo match {
       case CodeParamType(ti) => ti -> null
       case SCodeParamType(pt) if pt.nSettables == 1 => pt.settableTupleTypes().head -> null
@@ -688,7 +684,7 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
         val asmTuple = modb.tupleClass(pt.settableTupleTypes())
         asmTuple.ti -> asmTuple
       case t: EmitParamType =>
-        val ts = t.valueTupleTypes
+        val ts = t.codeTypes
         if (ts.length == 1)
           ts.head -> null
         else {
@@ -1209,7 +1205,9 @@ class EmitMethodBuilder[C](
   // EmitMethodBuilder methods
 
   // this, ...
-  private val emitParamCodeIndex = emitParamTypes.scanLeft((!mb.isStatic).toInt) {
+  private val thisOffset: Int = if (mb.isStatic) 0 else 1
+
+  private val emitParamCodeIndex = emitParamTypes.scanLeft(thisOffset) {
     case (i, paramType) =>
       i + paramType.nCodes
   }
@@ -1218,20 +1216,18 @@ class EmitMethodBuilder[C](
     if (emitIndex == 0 && !mb.isStatic)
       mb.getArg[T](0)
     else {
-      val static = (!mb.isStatic).toInt
-      assert(emitParamTypes(emitIndex - static).isInstanceOf[CodeParamType])
-      mb.getArg[T](emitParamCodeIndex(emitIndex - static))
+      assert(emitParamTypes(emitIndex - thisOffset).isInstanceOf[CodeParamType])
+      mb.getArg[T](emitParamCodeIndex(emitIndex - thisOffset))
     }
   }
 
   def getSCodeParam(emitIndex: Int): SValue = {
     assert(mb.isStatic || emitIndex != 0)
-    val static = (!mb.isStatic).toInt
-    val _st = emitParamTypes(emitIndex - static).asInstanceOf[SCodeParamType].st
+    val _st = emitParamTypes(emitIndex - thisOffset).asInstanceOf[SCodeParamType].st
     assert(_st.isRealizable)
 
     val ts = _st.settableTupleTypes()
-    val codeIndex = emitParamCodeIndex(emitIndex - static)
+    val codeIndex = emitParamCodeIndex(emitIndex - thisOffset)
 
     _st.fromValues(ts.zipWithIndex.map { case (t, i) =>
       mb.getArg(codeIndex + i)(t)
@@ -1247,14 +1243,13 @@ class EmitMethodBuilder[C](
 
   def getEmitParam(cb: EmitCodeBuilder, emitIndex: Int): EmitValue = {
     assert(mb.isStatic || emitIndex != 0)
-    val static = (!mb.isStatic).toInt
-    val et = emitParamTypes(emitIndex - static) match {
+    val et = emitParamTypes(emitIndex - thisOffset) match {
       case t: EmitParamType => t
       case _ => throw new RuntimeException(
           s"isStatic=${mb.isStatic}, emitIndex=$emitIndex, params=$emitParamTypes"
         )
     }
-    val codeIndex = emitParamCodeIndex(emitIndex - static)
+    val codeIndex = emitParamCodeIndex(emitIndex - thisOffset)
 
     et match {
       case SingleCodeEmitParamType(required, sct) =>
@@ -1264,13 +1259,8 @@ class EmitMethodBuilder[C](
         EmitValue(m, v)
 
       case SCodeEmitParamType(et) =>
-        val ts = et.st.settableTupleTypes()
-
-        val m = if (et.required) None else Some(mb.getArg[Boolean](codeIndex + ts.length))
-        val v = et.st.fromValues(ts.zipWithIndex.map { case (t, i) =>
-          mb.getArg(codeIndex + i)(t)
-        })
-        EmitValue(m, v)
+        val ts = et.settableTupleTypes
+        et.fromValues(ts.zipWithIndex.map { case (t, i) => mb.getArg(codeIndex + i)(t) })
     }
   }
 

--- a/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/EmitClassBuilder.scala
@@ -846,24 +846,15 @@ final class EmitClassBuilder[C](val emodb: EmitModuleBuilder, val cb: ClassBuild
         "FunctionBuilder emission should happen on master, but happened on worker",
       )
 
-      val n = cb.className.replace("/", ".")
-      val classesBytes = modb.classesBytes(ctx.shouldWriteIRFiles(), print)
+      val factory = new LazyClassFactory[C](
+        modb.classesBytes(ctx.shouldWriteIRFiles(), print),
+        cb.className.replace("/", "."),
+      )
 
       new Compiled[C] with java.io.Serializable {
-        @transient @volatile private var theClass: Class[_] = null
-
         override def apply(hcl: HailClassLoader, fs: FS, htc: HailTaskContext, region: Region)
           : C = {
-          if (theClass == null) {
-            this.synchronized {
-              if (theClass == null) {
-                classesBytes.load(hcl)
-                theClass = loadClass(hcl, n)
-              }
-            }
-          }
-
-          val f = theClass.getDeclaredConstructor().newInstance().asInstanceOf[C]
+          val f = factory.newInstance(hcl)
           f.asInstanceOf[FunctionWithHailClassLoader].addHailClassLoader(hcl)
           f.asInstanceOf[FunctionWithFS].addFS(fs)
           f.asInstanceOf[FunctionWithTaskContext].addTaskContext(htc)

--- a/hail/hail/src/is/hail/expr/ir/Param.scala
+++ b/hail/hail/src/is/hail/expr/ir/Param.scala
@@ -28,7 +28,7 @@ trait EmitParamType extends ParamType {
 
   def virtualType: Type
 
-  final lazy override val codeTypes: IndexedSeq[TypeInfo[_]] = {
+  final override lazy val codeTypes: IndexedSeq[TypeInfo[_]] = {
     val ts = definedValueTupleTypes()
     if (required)
       ts

--- a/hail/hail/src/is/hail/expr/ir/Param.scala
+++ b/hail/hail/src/is/hail/expr/ir/Param.scala
@@ -6,17 +6,19 @@ import is.hail.types.physical.stypes.{EmitType, SType, SValue, SingleCodeType}
 import is.hail.types.virtual.Type
 
 sealed trait ParamType {
-  def nCodes: Int
+  def codeTypes: IndexedSeq[TypeInfo[_]]
+
+  def nCodes: Int = codeTypes.length
 }
 
 case class CodeParamType(ti: TypeInfo[_]) extends ParamType {
-  override def nCodes: Int = 1
+  override def codeTypes: IndexedSeq[TypeInfo[_]] = FastSeq(ti)
 
   override def toString: String = s"CodeParam($ti)"
 }
 
 case class SCodeParamType(st: SType) extends ParamType {
-  override def nCodes: Int = st.nSettables
+  override def codeTypes: IndexedSeq[TypeInfo[_]] = st.settableTupleTypes()
 
   override def toString: String = s"SCodeParam($st, $nCodes)"
 }
@@ -26,15 +28,13 @@ trait EmitParamType extends ParamType {
 
   def virtualType: Type
 
-  final lazy val valueTupleTypes: IndexedSeq[TypeInfo[_]] = {
+  final lazy override val codeTypes: IndexedSeq[TypeInfo[_]] = {
     val ts = definedValueTupleTypes()
     if (required)
       ts
     else
       ts :+ BooleanInfo
   }
-
-  final override def nCodes: Int = valueTupleTypes.length
 
   protected def definedValueTupleTypes(): IndexedSeq[TypeInfo[_]]
 }


### PR DESCRIPTION
## Summary

A series of small, independent simplifications to the Scala compiler code generation infrastructure (`Code.scala`, `ClassBuilder.scala`, `EmitClassBuilder.scala`, `Param.scala`, `Emit.scala`). Each commit is a self-contained cleanup.

Total: ~100 lines removed across ~10 commits. No behavioral changes.

--------

This is a demo of an auto-simplifier we're developing at cc.dev, run after discussion with @patrick-schultz . If you like these changes, will run on more files.