### PR TITLE
[query] Teach gq_from_pl to handle missing entries.

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -4,33 +4,26 @@ import is.hail.asm4s.{coerce => _, _}
 import is.hail.types.{tcoerce => _}
 import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SFloat64, SInt32}
+import is.hail.types.physical.stypes.primitives.{SFloat64, SInt32, SInt32Value}
 import is.hail.types.virtual.{TArray, TFloat64, TInt32, Type}
 
 object GenotypeFunctions extends RegistryFunctions {
 
   override def registerAll(): Unit = {
     registerSCode1("gqFromPL", TArray(tv("N", "int32")), TInt32, (_: Type, _: SType) => SInt32) {
-      case (_, cb, _, pl: SIndexableValue, errorID) =>
+      case (_, cb, _, pl: SIndexableValue, errorID @ _) =>
         val m = cb.newLocal[Int]("m", 99)
         val m2 = cb.newLocal[Int]("m2", 99)
-        val i = cb.newLocal[Int]("i", 0)
 
-        cb.while_(
-          i < pl.loadLength, {
-            val value =
-              pl.loadElement(cb, i).getOrFatal(cb, "PL cannot have missing elements.", errorID)
-            val pli = cb.newLocal[Int]("pli", value.asInt.value)
-            cb.if_(
-              pli < m, {
-                cb.assign(m2, m)
-                cb.assign(m, pli)
-              },
-              cb.if_(pli < m2, cb.assign(m2, pli)),
-            )
-            cb.assign(i, i + 1)
-          },
-        )
+        pl.forEachDefined(cb) { case (cb, _, pli: SInt32Value) =>
+          cb.if_(
+            pli.value < m, {
+              cb.assign(m2, m)
+              cb.assign(m, pli.value)
+            },
+            cb.if_(pli.value < m2, cb.assign(m2, pli.value)),
+          )
+        }
 
         primitive(cb.memoize(m2 - m))
     }

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1870,6 +1870,16 @@ def test_logistic_regression_y_parameter_sanity():
         hl.logistic_regression_rows(test='wald', x=mt.prod, y=mt.row_idx, covariates=[1.0]).describe()
 
 
+def test_gq_from_pl_missing():
+    result = hl.eval(hl.gq_from_pl([450, None, 73, 85, 0, None]))
+    assert result == 73
+
+
+def test_gq_from_pl_all_missing():
+    result = hl.eval(hl.gq_from_pl(hl.literal([None, None, None], hl.tarray(hl.tint32))))
+    assert result == 0
+
+
 def test_split_multi_pl_haploid():
     lines = [
         {


### PR DESCRIPTION
Historically, we have disallowed PL from having missing elements, but with the proliferation of VDS and LPL, it's not the most sound to assign a dummy variable to PL in local to global. This change allows the PL array in gqFromPL to have missing elements. They are skipped essentially like an aggregator, as the algoritm computes the difference between the two smallest values in the list when every present value is clamped between 0 and 99.

Security
--------
This change has no security impact.