### PR TITLE
[query] Teach split_multi_hts to handle haploid genotypes

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -3534,21 +3534,27 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False, vep_root='vep', *, 
     if 'PL' in entry_fields:
         pl = hl.or_missing(
             hl.is_defined(split.PL),
-            (
+            hl.if_else(
+                split.GT.is_diploid(),
                 hl.range(0, 3).map(
                     lambda i: hl.min(
-                        (
-                            hl.range(0, hl.triangle(split.old_alleles.length()))
-                            .filter(
-                                lambda j: hl.downcode(
-                                    hl.unphased_diploid_gt_index_call(j), split.a_index
-                                ).unphased_diploid_gt_index()
-                                == i
-                            )
-                            .map(lambda j: split.PL[j])
+                        hl.range(0, hl.triangle(split.old_alleles.length()))
+                        .filter(
+                            lambda j: hl.downcode(
+                                hl.unphased_diploid_gt_index_call(j), split.a_index
+                            ).unphased_diploid_gt_index()
+                            == i
                         )
+                        .map(lambda j: split.PL[j])
                     )
-                )
+                ),
+                hl.range(0, 2).map(
+                    lambda i: hl.min(
+                        hl.range(0, split.old_alleles.length())
+                        .filter(lambda j: hl.int32(j == split.a_index) == i)
+                        .map(lambda j: split.PL[j])
+                    )
+                ),
             ),
         )
         if 'GQ' in entry_fields:

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1907,22 +1907,13 @@ def test_split_multi_pl_haploid():
             PL=[0, 1000],
         ),
         hl.Struct(
-            locus=hl.Locus(contig='Y', position=10000, reference_genome='GRCh37'),
-            alleles=['A', 'T'],
-            a_index=2,
-            was_split=True,
-            s='S1',
-            GT=hl.Call(alleles=[0], phased=False),
-            PL=[100, 0],
-        ),
-        hl.Struct(
             locus=hl.Locus(contig='Y', position=11000, reference_genome='GRCh37'),
             alleles=['A', 'AT'],
             a_index=1,
             was_split=True,
             s='S1',
             GT=hl.Call(alleles=[0], phased=False),
-            PL=[100, 200],
+            PL=[0, 200],
         ),
         hl.Struct(
             locus=hl.Locus(contig='Y', position=11000, reference_genome='GRCh37'),
@@ -1931,7 +1922,7 @@ def test_split_multi_pl_haploid():
             was_split=True,
             s='S1',
             GT=hl.Call(alleles=[1], phased=False),
-            PL=[100, 0],
+            PL=[73, 0],
         ),
         hl.Struct(
             locus=hl.Locus(contig='Y', position=11000, reference_genome='GRCh37'),
@@ -1940,7 +1931,7 @@ def test_split_multi_pl_haploid():
             was_split=True,
             s='S1',
             GT=hl.Call(alleles=[0], phased=False),
-            PL=[100, 0],
+            PL=[0, 73],
         ),
     ]
     result = mt.entries().collect()

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1869,6 +1869,7 @@ def test_logistic_regression_y_parameter_sanity():
     with pytest.raises(hl.ExpressionException):
         hl.logistic_regression_rows(test='wald', x=mt.prod, y=mt.row_idx, covariates=[1.0]).describe()
 
+
 def test_split_multi_pl_haploid():
     lines = [
         {

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1868,3 +1868,78 @@ def test_logistic_regression_y_parameter_sanity():
 
     with pytest.raises(hl.ExpressionException):
         hl.logistic_regression_rows(test='wald', x=mt.prod, y=mt.row_idx, covariates=[1.0]).describe()
+
+def test_split_multi_pl_haploid():
+    lines = [
+        {
+            'locus': hl.Locus(contig='Y', position=10_000),
+            'alleles': ['A', 'C', 'T'],
+            'entries': [{'GT': hl.Call([1]), 'LPL': [100, 0, 1000]}],
+        },
+        {
+            'locus': hl.Locus(contig='Y', position=11_000),
+            'alleles': ['A', 'AT', 'ATT', 'T'],
+            'entries': [{'GT': hl.Call([2]), 'PL': [100, 200, 0, 73]}],
+        },
+    ]
+    ht = hl.Table.parallelize(lines, key=['locus', 'alleles'])
+    ht = ht.annotate_globals(cols=[hl.Struct(s='S1')])
+    mt = ht._unlocalize_entries('entries', 'cols', ['s'])
+    expected = [
+        hl.Struct(
+            locus=hl.Locus(contig='Y', position=10000, reference_genome='GRCh37'),
+            alleles=['A', 'C'],
+            a_index=1,
+            was_split=True,
+            s='S1',
+            GT=hl.Call(alleles=[1], phased=False),
+            PL=[100, 0],
+        ),
+        hl.Struct(
+            locus=hl.Locus(contig='Y', position=10000, reference_genome='GRCh37'),
+            alleles=['A', 'T'],
+            a_index=2,
+            was_split=True,
+            s='S1',
+            GT=hl.Call(alleles=[0], phased=False),
+            PL=[0, 1000],
+        ),
+        hl.Struct(
+            locus=hl.Locus(contig='Y', position=10000, reference_genome='GRCh37'),
+            alleles=['A', 'T'],
+            a_index=2,
+            was_split=True,
+            s='S1',
+            GT=hl.Call(alleles=[0], phased=False),
+            PL=[100, 0],
+        ),
+        hl.Struct(
+            locus=hl.Locus(contig='Y', position=11000, reference_genome='GRCh37'),
+            alleles=['A', 'AT'],
+            a_index=1,
+            was_split=True,
+            s='S1',
+            GT=hl.Call(alleles=[0], phased=False),
+            PL=[100, 200],
+        ),
+        hl.Struct(
+            locus=hl.Locus(contig='Y', position=11000, reference_genome='GRCh37'),
+            alleles=['A', 'ATT'],
+            a_index=2,
+            was_split=True,
+            s='S1',
+            GT=hl.Call(alleles=[1], phased=False),
+            PL=[100, 0],
+        ),
+        hl.Struct(
+            locus=hl.Locus(contig='Y', position=11000, reference_genome='GRCh37'),
+            alleles=['A', 'T'],
+            a_index=3,
+            was_split=True,
+            s='S1',
+            GT=hl.Call(alleles=[0], phased=False),
+            PL=[100, 0],
+        ),
+    ]
+    result = mt.entries().collect()
+    assert expected == result

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1874,7 +1874,7 @@ def test_split_multi_pl_haploid():
         {
             'locus': hl.Locus(contig='Y', position=10_000),
             'alleles': ['A', 'C', 'T'],
-            'entries': [{'GT': hl.Call([1]), 'LPL': [100, 0, 1000]}],
+            'entries': [{'GT': hl.Call([1]), 'PL': [100, 0, 1000]}],
         },
         {
             'locus': hl.Locus(contig='Y', position=11_000),
@@ -1885,6 +1885,7 @@ def test_split_multi_pl_haploid():
     ht = hl.Table.parallelize(lines, key=['locus', 'alleles'])
     ht = ht.annotate_globals(cols=[hl.Struct(s='S1')])
     mt = ht._unlocalize_entries('entries', 'cols', ['s'])
+    mt = hl.split_multi_hts(mt)
     expected = [
         hl.Struct(
             locus=hl.Locus(contig='Y', position=10000, reference_genome='GRCh37'),


### PR DESCRIPTION
This is the non-sparse version of #15374

Security
--------
This change has no security impact