### PR TITLE
[query] Use appropriate delimiters when setting spark conf values

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -60,7 +60,7 @@ def local_jar_information() -> LocalJarInfo:
 
     if (hail_jar := __resource('backend/hail.jar')).is_file():
         warnings.warn('!!! THIS IS A DEVELOPMENT VERSION OF HAIL !!!')
-        return LocalJarInfo(True, str(hail_jar), [__resource_str('backend/extra_classpath')])
+        return LocalJarInfo(True, str(hail_jar), __resource_str('backend/extra_classpath').split(':'))
 
     if (hail_all_spark_jar := __resource('backend/hail-all-spark.jar')).is_file():
         return LocalJarInfo(False, str(hail_all_spark_jar), [])

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -30,31 +30,35 @@ def _modify_spark_conf(conf: pyspark.SparkConf, key: str, update: Callable[[str 
     conf.set(key, update(old))
 
 
-def _append_csv(*xs: str) -> Callable[[str | None], str]:
-    return lambda csv: ','.join(xs if csv is None else (csv, *xs))
+def _append_delimited(*xs: str, sep: str) -> Callable[[str | None], str]:
+    return lambda csv: sep.join(xs if csv is None else (csv, *xs))
 
 
 def _configure_spark_classpath(conf: SparkConf):
     info = local_jar_information()
-    classpath = [info.hail_jar, *info.extra_classpath]
+    extra_classpath = [path for extra_classes in info.extra_classpath for path in extra_classes.split(':')]
+    classpath = [info.hail_jar, *extra_classpath]
 
     if os.environ.get('HAIL_SPARK_MONITOR') or os.environ.get('AZURE_SPARK') == '1':
         import sparkmonitor
 
         classpath.append(os.path.join(os.path.dirname(sparkmonitor.__file__), 'listener.jar'))
         _modify_spark_conf(
-            conf, 'spark.extraListeners', _append_csv('sparkmonitor.listener.JupyterSparkMonitorListener')
+            conf,
+            'spark.extraListeners',
+            _append_delimited('sparkmonitor.listener.JupyterSparkMonitorListener', sep=','),
         )
 
-    _modify_spark_conf(conf, 'spark.jars', _append_csv(*classpath))
+    spark_jars = [path for path in classpath if os.path.splitext(path)[1] == '.jar']
+    _modify_spark_conf(conf, 'spark.jars', _append_delimited(*spark_jars, sep=','))
     if os.environ.get('AZURE_SPARK') == '1':
         print('AZURE_SPARK environment variable is set to "1", assuming you are in HDInsight.')
         # Setting extraClassPath in HDInsight overrides the classpath entirely so you can't
         # load the Scala standard library. Interestingly, setting extraClassPath is not
         # necessary in HDInsight.
     else:
-        _modify_spark_conf(conf, 'spark.driver.extraClassPath', _append_csv(*classpath))
-        _modify_spark_conf(conf, 'spark.executor.extraClassPath', _append_csv(*classpath))
+        _modify_spark_conf(conf, 'spark.driver.extraClassPath', _append_delimited(*classpath, sep=':'))
+        _modify_spark_conf(conf, 'spark.executor.extraClassPath', _append_delimited(*classpath, sep=':'))
 
 
 def _get_or_create_pyspark_session(

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -36,8 +36,7 @@ def _append_delimited(*xs: str, sep: str) -> Callable[[str | None], str]:
 
 def _configure_spark_classpath(conf: SparkConf):
     info = local_jar_information()
-    extra_classpath = [path for extra_classes in info.extra_classpath for path in extra_classes.split(':')]
-    classpath = [info.hail_jar, *extra_classpath]
+    classpath = [info.hail_jar, *info.extra_classpath]
 
     if os.environ.get('HAIL_SPARK_MONITOR') or os.environ.get('AZURE_SPARK') == '1':
         import sparkmonitor


### PR DESCRIPTION
There were a few issues here:
1. Our `extra_classpath` item in `LocalJarInfo` is `list[str]`, but that `list[str]` is just one long string of classpath entries separated by colons.
2. We were then taking this raw value and adding it to `spark.jars` giving one large (16k) string that spark treated as a path, which is almost certainly what caused the file name too long exception in #15389
3. We were also adding extraClassPath entries as csv strings, so we'd end up with a value like `'$HAIL_JAR,/.../spark.jar:$REST_OF_CLASSPATH'`

To fix this, I flatten and separate out the colon separated values in `LocalJarInfo.extra_classpath`, then I only add extra jars that are actually jars (or at least have extension `.jar`). Then I append the appropriate list to the appropriate spark conf parameters with a now configurable separator.

Fixes #15389

Security Assessment
-------------------
* This change has no security impact on the Broad managed batch instance.