### PR TITLE
[ci] remove wait on spec validation test

### DIFF
--- a/hail/python/test/hailtop/hailctl/batch/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_submit.py
@@ -421,7 +421,6 @@ def test_submit_with_proper_job_settings(submit, tmp_path, client):
             f'{bucket}:/foo:true',
             '-v',
             f'{echo_script}:/',
-            '--wait',
             '-o',
             'json',
             '--quiet',
@@ -440,6 +439,7 @@ def test_submit_with_proper_job_settings(submit, tmp_path, client):
     assert 'gcsfuse' in spec, str(j.status())
     assert 'FOO' in [env['name'] for env in spec['env']], str(j.status())
     assert spec['process']['image'] == os.environ['HAIL_GENETICS_HAIL_IMAGE'], str(j.status())
+    b.cancel()
 
 
 def test_hail_config_in_environment(submit, tmp_path, client):


### PR DESCRIPTION
## Change Description

Fixes a recently flaky test: `test_submit_with_proper_job_settings` in `test_hailtop_python`.

The purpose of the test is to make sure settings specified to hailtop are successfully passed to - and interpreted by - the service. This particular test is flaky because pulling the hailtop image can be slow enough to fail the test. Since this particular test is not validating the test run anyway (the `res.exit_code` checks the CLI exit code, not the job exit code), waiting for the job to complete is unnecessary. It should be sufficient for test to check (1) that the API call can be made (2) that the service interprets and returns the spec fields as expected.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

Test only change
