### PR TITLE
[ci] be selective about which tests run

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1108,6 +1108,7 @@ steps:
     name: test_hail_python
     watchedPaths:
       - hail/python/hail/
+      - hail/python/test/hail/
       - hail/hail/
       - hail/python/hailtop/
     numSplits: 28
@@ -1231,8 +1232,10 @@ steps:
     name: test_hail_python_unchecked_allocator
     watchedPaths:
       - hail/python/hail/
+      - hail/python/test/hail/
       - hail/hail/
       - hail/python/hailtop/
+      - hail/python/test/hailtop/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -1291,6 +1294,7 @@ steps:
     name: test_hail_python_local_backend
     watchedPaths:
       - hail/python/hail/
+      - hail/python/test/hail/
       - hail/hail/
       - hail/python/hailtop/
     numSplits: 48
@@ -2660,6 +2664,7 @@ steps:
     name: test_hail_python_service_backend_gcp
     watchedPaths:
       - hail/python/hail/
+      - hail/python/test/hail/
       - hail/hail/
       - hail/python/hailtop/
       - batch/
@@ -3241,6 +3246,7 @@ steps:
     name: test_hailtop_python
     watchedPaths:
       - hail/python/hailtop/
+      - hail/python/test/hailtop/
       - gear/
       - batch/
     resources:

--- a/build.yaml
+++ b/build.yaml
@@ -5,16 +5,16 @@
 # - The directory entries are superfluous (unwatched files don't cause any tests to be added),
 #   but are here to help document the intent, and make the intent clearer in coverage audits.
 unwatchedPaths:
-  - '*.md'   # documentation; explicitly excluded so it doesn't match dir globs
-  - '*.rst'  # documentation; same reason
+  - '*.md'              # documentation
+  - '*.rst'             # documentation
   - datasets/           # one-off data ETL scripts; not executed by CI
   - infra/              # Terraform infrastructure; manually applied, never CI-tested
   - devbin/             # developer utility scripts; not executed by CI
   - .github/            # GitHub issue templates and Actions workflows; not Hail CI
-  - gateway/            # unmanaged nginx proxy; manually deployed
-  - internal-gateway/   # unmanaged nginx proxy; manually deployed
-  - bootstrap-gateway/  # unmanaged nginx proxy; manually deployed
-  - prometheus/         # monitoring config; manually applied
+  - gateway/            # unmanaged nginx proxy; manually deployed by Make at bootstrap time
+  - internal-gateway/   # unmanaged nginx proxy; manually deployed by Make at bootstrap time
+  - bootstrap-gateway/  # nginx proxy for cluster bootstrap; manually deployed, not used in test runs
+  - prometheus/         # deployed during deploy runs, not test runs
 
 # Files where any change should trigger a full retest of all watched steps.
 # Use this for files that underpin so many things that per-step watching would

--- a/build.yaml
+++ b/build.yaml
@@ -2,9 +2,11 @@ unwatchedPaths:
   - dev-docs/
   - '*.md'
   - CHANGELOG
+  - CODEOWNERS
   - LICENSE
   - .gitignore
   - .github/
+  - .mailmap
 
 alwaysRunSteps:
   - merge_code

--- a/build.yaml
+++ b/build.yaml
@@ -8,6 +8,7 @@ unwatchedPaths:
   - .gitignore
   - .github/
   - .mailmap
+  - devbin/
 
 alwaysRunSteps:
   - merge_code

--- a/build.yaml
+++ b/build.yaml
@@ -747,6 +747,7 @@ steps:
       - merge_code
   - kind: runImage
     name: check_ui
+    description: Run TypeScript type checks and linting (npm run check) for the services/ui frontend; no deployment required.
     watchedPaths:
       - services/ui/
     image: node:20-slim@sha256:a82f40540f5959e0003fb7b3c0f80490def2927be8bdbee7e3e0ac65cce3be92
@@ -1066,6 +1067,7 @@ steps:
       - merge_code
   - kind: runImage
     name: test_hail_java
+    description: Run the Hail JVM integration suite (TestNG) against the compiled Scala debug test JAR; runs in-process.
     watchedPaths:
       - hail/hail/
       - hail/build.mill
@@ -1106,6 +1108,7 @@ steps:
       - build_hail_test_artifacts
   - kind: runImage
     name: test_hail_python
+    description: Run the Hail Python integration suite (pytest) against the debug wheel using an in-process local Spark session.
     watchedPaths:
       - hail/python/hail/
       - hail/python/test/hail/
@@ -1174,6 +1177,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_hailtop_python_fs
+    description: Run the hailtop inter-cloud filesystem integration suite (pytest) against GCS and S3; no deployment required.
     watchedPaths:
       - hail/python/hailtop/
       - gear/
@@ -1230,6 +1234,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_python_unchecked_allocator
+    description: Run the Hail Python integration suite (pytest, unchecked_allocator-marked tests only) against the release wheel using an in-process local Spark session.
     watchedPaths:
       - hail/python/hail/
       - hail/python/test/hail/
@@ -1291,6 +1296,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_python_local_backend
+    description: Run the Hail Python integration suite (pytest) against the debug wheel using the local JVM backend (not Spark).
     watchedPaths:
       - hail/python/hail/
       - hail/python/test/hail/
@@ -1363,6 +1369,7 @@ steps:
       - build_hail_test_artifacts
   - kind: runImage
     name: test_python_docs
+    description: Run the Hail Python doctest suite (pytest --doctest-modules) against the release wheel using an in-process local Spark session.
     watchedPaths:
       - hail/python/hail/docs/
       - hail/python/hail/
@@ -1557,6 +1564,7 @@ steps:
       - hail_ubuntu_image_python_3_13
   - kind: runImage
     name: test_hailgenetics_hail_image
+    description: Smoke-test the Python 3.11 hailgenetics/hail Docker image by verifying the Python version, a basic Hail operation, and scientific library imports (numpy, pandas, sklearn, scipy).
     watchedPaths:
       - hail/hail/
       - hail/python/hail/
@@ -1574,6 +1582,7 @@ steps:
       - hailgenetics_hail_image
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_10
+    description: Smoke-test the Python 3.10 hailgenetics/hail Docker image by verifying the Python version, a basic Hail operation, and scientific library imports.
     watchedPaths:
       - hail/hail/
       - hail/python/hail/
@@ -1591,6 +1600,7 @@ steps:
       - hailgenetics_hail_image_python_3_10
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_12
+    description: Smoke-test the Python 3.12 hailgenetics/hail Docker image by verifying the Python version, a basic Hail operation, and scientific library imports.
     watchedPaths:
       - hail/hail/
       - hail/python/hail/
@@ -1608,6 +1618,7 @@ steps:
       - hailgenetics_hail_image_python_3_12
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_13
+    description: Smoke-test the Python 3.13 hailgenetics/hail Docker image by verifying the Python version, a basic Hail operation, and scientific library imports.
     watchedPaths:
       - hail/hail/
       - hail/python/hail/
@@ -1678,6 +1689,7 @@ steps:
       - hail_ubuntu_image
   - kind: runImage
     name: check_pip_requirements
+    description: Verify that pip dependency pins are consistent and up to date (make check-pip-requirements); no deployment required.
     watchedPaths:
       - hail/python/dev/pinned-requirements.txt
       - pyproject.toml
@@ -1696,6 +1708,7 @@ steps:
       - merge_code
   - kind: runImage
     name: check_services
+    description: Run lint and type checks (ruff, pyright, curlylint via make check-services) across all service packages (auth, batch, ci, gear, monitoring, web_common, hailtop); no deployment required.
     watchedPaths:
       - auth/
       - batch/
@@ -1722,6 +1735,7 @@ steps:
       - merge_code
   - kind: runImage
     name: check_hail
+    description: Run lint and type checks (ruff, pyright, pylint, scalafmt via make check-hail) across the hail Python package and Scala source; no deployment required.
     watchedPaths:
       - hail/
       - pyproject.toml
@@ -1750,6 +1764,7 @@ steps:
       - merge_code
   - kind: runImage
     name: compile_hail_213
+    description: Compile the hail Scala source under Scala 2.13 (Mill) to verify cross-version compatibility; no deployment required.
     watchedPaths:
       - hail/hail/
       - hail/build.mill
@@ -1772,6 +1787,7 @@ steps:
       - merge_code
   - kind: runImage
     name: get_pip_versioned_docs
+    description: Fetch the versioned Hail docs from GCS if the current version tag exists, otherwise package the freshly-built docs; no deployment required.
     watchedPaths:
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
@@ -1977,6 +1993,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_monitoring
+    description: Run the monitoring service integration suite (pytest) against a live deployed monitoring instance.
     watchedPaths:
       - monitoring/
       - gear/
@@ -2020,6 +2037,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_auth_copy_paste_login
+    description: Test the copy-paste login flow (including one-time-use token enforcement) using hailctl and hailtop Python against a live deployed auth instance.
     watchedPaths:
       - auth/
       - gear/
@@ -2086,6 +2104,7 @@ steps:
       - hailgenetics_hailtop_image
   - kind: runImage
     name: test_auth_copy_paste_login_timeout
+    description: Test that copy-paste login tokens expire after 5 minutes using hailctl and hailtop Python against a live deployed auth instance.
     watchedPaths:
       - auth/
       - gear/
@@ -2665,6 +2684,7 @@ steps:
       - create_test_gsa_keys
   - kind: runImage
     name: test_hail_python_service_backend_gcp
+    description: Run the Hail Python integration suite (pytest) against the release wheel using the Batch service backend on GCP; requires a live deployed Batch instance.
     watchedPaths:
       - hail/python/hail/
       - hail/python/test/hail/
@@ -2743,6 +2763,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_spark_conf_requester_pays_parsing
+    description: Run a targeted pytest suite against the release wheel to verify Spark requester-pays configuration parsing.
     watchedPaths:
       - hail/python/hail/
       - hail/hail/
@@ -2823,6 +2844,7 @@ steps:
       - hail_ubuntu_image
   - kind: runImage
     name: test_batch
+    description: Run the Batch service integration suite (pytest) against a live deployed Batch instance.
     watchedPaths:
       - batch/
       - gear/
@@ -2904,6 +2926,7 @@ steps:
       - gpu_image
   - kind: runImage
     name: test_batch_job_private_machines
+    description: Run the Batch integration suite (pytest) for private-machine job configurations against a live deployed Batch instance.
     watchedPaths:
       - batch/
       - gear/
@@ -2982,6 +3005,7 @@ steps:
       - hail_ubuntu_image
   - kind: runImage
     name: test_auth
+    description: Run the auth service integration suite (pytest) against a live deployed auth instance.
     watchedPaths:
       - auth/
       - gear/
@@ -3166,6 +3190,7 @@ steps:
       - hail_buildkit_image
   - kind: runImage
     name: test_ci_unit
+    description: Run the CI service unit suite (pytest) against CI source; no live deployment required.
     watchedPaths:
       - ci/
     resources:
@@ -3199,6 +3224,7 @@ steps:
       - ci_image
   - kind: runImage
     name: test_ci
+    description: Run the CI service integration suite (pytest) against a live deployed CI instance and a temporary test GitHub repo.
     watchedPaths:
       - ci/
       - gear/
@@ -3247,6 +3273,7 @@ steps:
       - create_ci_test_repo
   - kind: runImage
     name: test_hailtop_python
+    description: Run the hailtop Python integration suite (pytest) from the debug wheel, including Batch client tests that require a live deployed Batch instance.
     watchedPaths:
       - hail/python/hailtop/
       - hail/python/test/hailtop/
@@ -3314,6 +3341,7 @@ steps:
       - deploy_batch
   - kind: runImage
     name: test_hailctl_batch
+    description: Run an end-to-end smoke test for hailctl batch submit (submits a Hail query job and verifies output) against a live deployed Batch instance.
     watchedPaths:
       - hail/python/hailtop/
       - batch/
@@ -3411,6 +3439,7 @@ steps:
       - deploy_batch
   - kind: runImage
     name: test_batch_docs
+    description: Run the hailtop Batch Python client doctest suite (pytest --doctest-modules) against a live deployed Batch instance.
     watchedPaths:
       - hail/python/hailtop/
       - batch/
@@ -3809,6 +3838,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_website
+    description: Smoke-test the website service by fetching its root URL via hailctl curl; requires a live deployed website instance.
     watchedPaths:
       - website/
     image:
@@ -3835,6 +3865,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_scala_fs
+    description: Run the Hail Scala filesystem integration suite (TestNG, testng-fs.xml) against the debug test JAR and GCS; requires cloud storage access.
     watchedPaths:
       - hail/hail/
       - hail/build.mill
@@ -3893,6 +3924,7 @@ steps:
       - upload_test_resources_to_blob_storage
   - kind: runImage
     name: test_hail_services_java
+    description: Run the Hail services JVM integration suite (TestNG, testng-services.xml) against the debug test JAR; requires a live deployed Batch instance.
     watchedPaths:
       - hail/hail/
       - hail/build.mill
@@ -4035,6 +4067,7 @@ steps:
       - test_hailctl_batch
   - kind: runImage
     name: test_batch_invariants
+    description: Run the Batch scheduling invariants test (pytest) against a live deployed Batch instance.
     watchedPaths:
       - batch/
       - gear/

--- a/build.yaml
+++ b/build.yaml
@@ -4,6 +4,7 @@ unwatchedPaths:
   - CHANGELOG
   - CODEOWNERS
   - LICENSE
+  - .gitattributes
   - .gitignore
   - .github/
   - .mailmap
@@ -1065,8 +1066,8 @@ steps:
   - kind: runImage
     name: test_hail_java
     watchedPaths:
-      - hail/src/
-      - hail/build.sc
+      - hail/hail/
+      - hail/build.mill
     numSplits: 5
     image:
       valueFrom: hail_run_image.image
@@ -1106,7 +1107,7 @@ steps:
     name: test_hail_python
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
       - hail/python/hailtop/
     numSplits: 28
     image:
@@ -1229,7 +1230,7 @@ steps:
     name: test_hail_python_unchecked_allocator
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
       - hail/python/hailtop/
     image:
       valueFrom: hail_run_image.image
@@ -1289,7 +1290,7 @@ steps:
     name: test_hail_python_local_backend
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
       - hail/python/hailtop/
     numSplits: 48
     image:
@@ -1361,7 +1362,7 @@ steps:
     watchedPaths:
       - hail/python/hail/docs/
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -1550,7 +1551,7 @@ steps:
     name: test_hailgenetics_hail_image
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image.image
     script: |
@@ -1564,7 +1565,7 @@ steps:
     name: test_hailgenetics_hail_image_python_3_10
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_10.image
     script: |
@@ -1578,7 +1579,7 @@ steps:
     name: test_hailgenetics_hail_image_python_3_12
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_12.image
     script: |
@@ -1592,7 +1593,7 @@ steps:
     name: test_hailgenetics_hail_image_python_3_13
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_13.image
     script: |
@@ -1730,8 +1731,8 @@ steps:
   - kind: runImage
     name: compile_hail_213
     watchedPaths:
-      - hail/src/
-      - hail/build.sc
+      - hail/hail/
+      - hail/build.mill
     image:
       valueFrom: base_image.image
     resources:
@@ -2642,7 +2643,7 @@ steps:
     name: test_hail_python_service_backend_gcp
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
       - hail/python/hailtop/
       - batch/
     numSplits: 16
@@ -2719,7 +2720,7 @@ steps:
     name: test_hail_spark_conf_requester_pays_parsing
     watchedPaths:
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
       - hail/scripts/
     image:
       valueFrom: hail_run_image.image
@@ -3807,8 +3808,8 @@ steps:
   - kind: runImage
     name: test_hail_scala_fs
     watchedPaths:
-      - hail/src/
-      - hail/build.sc
+      - hail/hail/
+      - hail/build.mill
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -3865,8 +3866,8 @@ steps:
   - kind: runImage
     name: test_hail_services_java
     watchedPaths:
-      - hail/src/
-      - hail/build.sc
+      - hail/hail/
+      - hail/build.mill
       - batch/
     image:
       valueFrom: hail_run_image.image
@@ -4011,7 +4012,7 @@ steps:
       - hail/python/hailtop/
       - ci/
       - hail/python/hail/
-      - hail/src/
+      - hail/hail/
     image:
       valueFrom: hail_dev_image.image
     script: |

--- a/build.yaml
+++ b/build.yaml
@@ -1235,7 +1235,6 @@ steps:
       - hail/python/test/hail/
       - hail/hail/
       - hail/python/hailtop/
-      - hail/python/test/hailtop/
     image:
       valueFrom: hail_run_image.image
     resources:

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,14 @@
+unwatchedPaths:
+  - dev-docs/
+  - '*.md'
+  - CHANGELOG
+  - LICENSE
+  - .gitignore
+  - .github/
+
+alwaysRunSteps:
+  - merge_code
+
 steps:
   - kind: buildImage2
     name: git_make_bash_image
@@ -732,6 +743,8 @@ steps:
       - merge_code
   - kind: runImage
     name: check_ui
+    watchedPaths:
+      - services/ui/
     image: node:20-slim@sha256:a82f40540f5959e0003fb7b3c0f80490def2927be8bdbee7e3e0ac65cce3be92
     script: |
       set -ex
@@ -1049,6 +1062,9 @@ steps:
       - merge_code
   - kind: runImage
     name: test_hail_java
+    watchedPaths:
+      - hail/src/
+      - hail/build.sc
     numSplits: 5
     image:
       valueFrom: hail_run_image.image
@@ -1086,6 +1102,10 @@ steps:
       - build_hail_test_artifacts
   - kind: runImage
     name: test_hail_python
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
+      - hail/python/hailtop/
     numSplits: 28
     image:
       valueFrom: hail_run_image.image
@@ -1149,6 +1169,9 @@ steps:
       - gcp
   - kind: runImage
     name: test_hailtop_python_fs
+    watchedPaths:
+      - hail/python/hailtop/
+      - gear/
     numSplits: 5
     image:
       valueFrom: hailgenetics_hailtop_image.image
@@ -1202,6 +1225,10 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_python_unchecked_allocator
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
+      - hail/python/hailtop/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -1258,6 +1285,10 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_python_local_backend
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
+      - hail/python/hailtop/
     numSplits: 48
     image:
       valueFrom: hail_run_image.image
@@ -1325,6 +1356,10 @@ steps:
       - build_hail_test_artifacts
   - kind: runImage
     name: test_python_docs
+    watchedPaths:
+      - hail/python/hail/docs/
+      - hail/python/hail/
+      - hail/src/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -1511,6 +1546,9 @@ steps:
       - hail_ubuntu_image_python_3_13
   - kind: runImage
     name: test_hailgenetics_hail_image
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
     image:
       valueFrom: hailgenetics_hail_image.image
     script: |
@@ -1522,6 +1560,9 @@ steps:
       - hailgenetics_hail_image
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_10
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
     image:
       valueFrom: hailgenetics_hail_image_python_3_10.image
     script: |
@@ -1533,6 +1574,9 @@ steps:
       - hailgenetics_hail_image_python_3_10
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_12
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
     image:
       valueFrom: hailgenetics_hail_image_python_3_12.image
     script: |
@@ -1544,6 +1588,9 @@ steps:
       - hailgenetics_hail_image_python_3_12
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_13
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
     image:
       valueFrom: hailgenetics_hail_image_python_3_13.image
     script: |
@@ -1608,6 +1655,9 @@ steps:
       - hail_ubuntu_image
   - kind: runImage
     name: check_pip_requirements
+    watchedPaths:
+      - hail/python/dev/pinned-requirements.txt
+      - pyproject.toml
     image:
       valueFrom: hail_linting_image.image
     script: |
@@ -1623,6 +1673,15 @@ steps:
       - merge_code
   - kind: runImage
     name: check_services
+    watchedPaths:
+      - auth/
+      - batch/
+      - ci/
+      - gear/
+      - monitoring/
+      - web_common/
+      - hail/python/hailtop/
+      - pyproject.toml
     image:
       valueFrom: hail_linting_image.image
     script: |
@@ -1640,6 +1699,10 @@ steps:
       - merge_code
   - kind: runImage
     name: check_hail
+    watchedPaths:
+      - hail/
+      - pyproject.toml
+      - pylintrc
     image:
       valueFrom: hail_linting_image.image
     resources:
@@ -1664,6 +1727,9 @@ steps:
       - merge_code
   - kind: runImage
     name: compile_hail_213
+    watchedPaths:
+      - hail/src/
+      - hail/build.sc
     image:
       valueFrom: base_image.image
     resources:
@@ -1884,6 +1950,9 @@ steps:
       - gcp
   - kind: runImage
     name: test_monitoring
+    watchedPaths:
+      - monitoring/
+      - gear/
     resources:
       memory: standard
       cpu: '0.25'
@@ -1924,6 +1993,10 @@ steps:
       - gcp
   - kind: runImage
     name: test_auth_copy_paste_login
+    watchedPaths:
+      - auth/
+      - gear/
+      - hail/python/hailtop/
     resources:
       memory: standard
       cpu: '0.25'
@@ -1986,6 +2059,10 @@ steps:
       - hailgenetics_hailtop_image
   - kind: runImage
     name: test_auth_copy_paste_login_timeout
+    watchedPaths:
+      - auth/
+      - gear/
+      - hail/python/hailtop/
     resources:
       memory: standard
       cpu: '0.25'
@@ -2561,6 +2638,11 @@ steps:
       - create_test_gsa_keys
   - kind: runImage
     name: test_hail_python_service_backend_gcp
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
+      - hail/python/hailtop/
+      - batch/
     numSplits: 16
     image:
       valueFrom: hail_run_image.image
@@ -2633,6 +2715,10 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_spark_conf_requester_pays_parsing
+    watchedPaths:
+      - hail/python/hail/
+      - hail/src/
+      - hail/scripts/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -2709,6 +2795,10 @@ steps:
       - hail_ubuntu_image
   - kind: runImage
     name: test_batch
+    watchedPaths:
+      - batch/
+      - gear/
+      - hail/python/hailtop/
     numSplits: 5
     image:
       valueFrom: batch_image.image
@@ -2786,6 +2876,10 @@ steps:
       - gpu_image
   - kind: runImage
     name: test_batch_job_private_machines
+    watchedPaths:
+      - batch/
+      - gear/
+      - hail/python/hailtop/
     numSplits: 1
     image:
       valueFrom: batch_image.image
@@ -2860,6 +2954,9 @@ steps:
       - hail_ubuntu_image
   - kind: runImage
     name: test_auth
+    watchedPaths:
+      - auth/
+      - gear/
     numSplits: 1
     image:
       valueFrom: auth_image.image
@@ -3040,6 +3137,8 @@ steps:
       - hail_buildkit_image
   - kind: runImage
     name: test_ci_unit
+    watchedPaths:
+      - ci/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3071,6 +3170,9 @@ steps:
       - ci_image
   - kind: runImage
     name: test_ci
+    watchedPaths:
+      - ci/
+      - gear/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3116,6 +3218,10 @@ steps:
       - create_ci_test_repo
   - kind: runImage
     name: test_hailtop_python
+    watchedPaths:
+      - hail/python/hailtop/
+      - gear/
+      - batch/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3178,6 +3284,9 @@ steps:
       - deploy_batch
   - kind: runImage
     name: test_hailctl_batch
+    watchedPaths:
+      - hail/python/hailtop/
+      - batch/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3272,6 +3381,9 @@ steps:
       - deploy_batch
   - kind: runImage
     name: test_batch_docs
+    watchedPaths:
+      - hail/python/hailtop/
+      - batch/
     image:
       valueFrom: hail_dev_image.image
     script: |
@@ -3666,6 +3778,8 @@ steps:
       - gcp
   - kind: runImage
     name: test_website
+    watchedPaths:
+      - website/
     image:
       valueFrom: hailgenetics_hailtop_image.image
     script: |
@@ -3690,6 +3804,9 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_scala_fs
+    watchedPaths:
+      - hail/src/
+      - hail/build.sc
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -3745,6 +3862,10 @@ steps:
       - upload_test_resources_to_blob_storage
   - kind: runImage
     name: test_hail_services_java
+    watchedPaths:
+      - hail/src/
+      - hail/build.sc
+      - batch/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -3882,6 +4003,13 @@ steps:
       - test_hailctl_batch
   - kind: runImage
     name: test_batch_invariants
+    watchedPaths:
+      - batch/
+      - gear/
+      - hail/python/hailtop/
+      - ci/
+      - hail/python/hail/
+      - hail/src/
     image:
       valueFrom: hail_dev_image.image
     script: |

--- a/build.yaml
+++ b/build.yaml
@@ -1364,6 +1364,10 @@ steps:
       - hail/python/hail/docs/
       - hail/python/hail/
       - hail/hail/
+      - hail/python/requirements.txt
+      - hail/python/pinned-requirements.txt
+      - hail/python/dev/pinned-requirements.txt
+      - hail/python/hailtop/pinned-requirements.txt
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -1761,6 +1765,10 @@ steps:
       - merge_code
   - kind: runImage
     name: get_pip_versioned_docs
+    watchedPaths:
+      - hail/python/requirements.txt
+      - hail/python/pinned-requirements.txt
+      - hail/python/hailtop/pinned-requirements.txt
     image:
       valueFrom: hailgenetics_hail_image.image
     script: |

--- a/build.yaml
+++ b/build.yaml
@@ -1,9 +1,9 @@
 # Files that should never trigger tests regardless of which directory they live
-# in. Doc extensions (*.md, *.rst) need to be listed explicitly so they don't
-# match watchedPaths globs for directories that contain them (e.g. batch/*.md).
-# The directory entries are documentary — they'd be skipped by the
-# default-nothing model anyway, but are listed here to make coverage audits
-# easier and to document the intent.
+# in. 
+# - Doc extensions (*.md, *.rst) are listed explicitly so they don't
+#   trigger tests even within otherwise watched directories (e.g. batch/*.md).
+# - The directory entries are superfluous (unwatched files don't cause any tests to be added),
+#   but are here to help document the intent, and make the intent clearer in coverage audits.
 unwatchedPaths:
   - '*.md'   # documentation; explicitly excluded so it doesn't match dir globs
   - '*.rst'  # documentation; same reason
@@ -14,10 +14,7 @@ unwatchedPaths:
   - gateway/            # unmanaged nginx proxy; manually deployed
   - internal-gateway/   # unmanaged nginx proxy; manually deployed
   - bootstrap-gateway/  # unmanaged nginx proxy; manually deployed
-  - letsencrypt/        # TLS cert renewal scripts; manually run
   - prometheus/         # monitoring config; manually applied
-  - grafana/            # monitoring config; manually applied
-  - admin-pod/          # ops tooling; manually deployed
 
 # Files where any change should trigger a full retest of all watched steps.
 # Use this for files that underpin so many things that per-step watching would
@@ -26,7 +23,6 @@ fullRetestPaths:
   - build.yaml              # CI config itself
   - docker/hail-ubuntu/     # base image for almost every CI step
   - docker/Dockerfile.base  # base for build-artifact and service images
-  - tls/                    # cert infrastructure used by batch/auth service tests
 
 alwaysRunSteps:
   - merge_code
@@ -403,9 +399,12 @@ steps:
       - create_test_database_server_config
   - kind: buildImage2
     name: admin_pod_image
+    description: Build the admin-pod Docker image used for ops tooling (kubectl, gsutil, etc.). Tests Dockerfile but not deployed during tests.
     dockerFile: /io/repo/admin-pod/Dockerfile
     contextPath: /io/repo
     publishAs: admin-pod
+    watchedPaths:
+      - admin-pod/
     inputs:
       - from: /repo/admin-pod
         to: /io/repo/admin-pod
@@ -1875,9 +1874,13 @@ steps:
       - gcp
   - kind: deploy
     name: deploy_grafana
+    description: Deploy Grafana into the test namespace for monitoring dashboards; validates grafana/deployment.yaml via kubectl apply.
     namespace:
       valueFrom: default_ns.name
     config: grafana/deployment.yaml
+    watchedPaths:
+      - grafana/
+      - tls/
     scopes:
       - deploy
       - test
@@ -2026,6 +2029,7 @@ steps:
     watchedPaths:
       - monitoring/
       - gear/
+      - tls/
     resources:
       memory: standard
       cpu: '0.25'
@@ -2071,6 +2075,7 @@ steps:
       - auth/
       - gear/
       - hail/python/hailtop/
+      - tls/
     resources:
       memory: standard
       cpu: '0.25'
@@ -2138,6 +2143,7 @@ steps:
       - auth/
       - gear/
       - hail/python/hailtop/
+      - tls/
     resources:
       memory: standard
       cpu: '0.25'
@@ -2720,6 +2726,7 @@ steps:
       - hail/hail/
       - hail/python/hailtop/
       - batch/
+      - tls/
       - docker/hailgenetics/vep/
     numSplits: 16
     image:
@@ -2880,6 +2887,8 @@ steps:
       - gear/
       - hail/python/hailtop/
       - docker/core-site.xml
+      - letsencrypt/subdomains.txt
+      - tls/
     numSplits: 5
     image:
       valueFrom: batch_image.image
@@ -2963,6 +2972,7 @@ steps:
       - gear/
       - hail/python/hailtop/
       - docker/core-site.xml
+      - tls/
     numSplits: 1
     image:
       valueFrom: batch_image.image
@@ -3260,6 +3270,7 @@ steps:
     watchedPaths:
       - ci/
       - gear/
+      - tls/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3312,6 +3323,7 @@ steps:
       - gear/
       - batch/
       - docker/hailgenetics/hailtop/
+      - tls/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3379,6 +3391,7 @@ steps:
       - hail/python/hailtop/
       - batch/
       - docker/hailgenetics/hail/
+      - tls/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3477,6 +3490,7 @@ steps:
     watchedPaths:
       - hail/python/hailtop/
       - batch/
+      - tls/
     image:
       valueFrom: hail_dev_image.image
     script: |
@@ -3875,6 +3889,7 @@ steps:
     description: Smoke-test the website service by fetching its root URL via hailctl curl; requires a live deployed website instance.
     watchedPaths:
       - website/
+      - tls/
     image:
       valueFrom: hailgenetics_hailtop_image.image
     script: |
@@ -3903,6 +3918,7 @@ steps:
     watchedPaths:
       - hail/hail/
       - hail/build.mill
+      - tls/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -3963,6 +3979,7 @@ steps:
       - hail/hail/
       - hail/build.mill
       - batch/
+      - tls/
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -4107,6 +4124,7 @@ steps:
       - gear/
       - hail/python/hailtop/
       - ci/
+      - tls/
     image:
       valueFrom: hail_dev_image.image
     script: |

--- a/build.yaml
+++ b/build.yaml
@@ -1,14 +1,32 @@
+# Files that should never trigger tests regardless of which directory they live
+# in. Doc extensions (*.md, *.rst) need to be listed explicitly so they don't
+# match watchedPaths globs for directories that contain them (e.g. batch/*.md).
+# The directory entries are documentary — they'd be skipped by the
+# default-nothing model anyway, but are listed here to make coverage audits
+# easier and to document the intent.
 unwatchedPaths:
-  - dev-docs/
-  - '*.md'
-  - CHANGELOG
-  - CODEOWNERS
-  - LICENSE
-  - .gitattributes
-  - .gitignore
-  - .github/
-  - .mailmap
-  - devbin/
+  - '*.md'   # documentation; explicitly excluded so it doesn't match dir globs
+  - '*.rst'  # documentation; same reason
+  - datasets/           # one-off data ETL scripts; not executed by CI
+  - infra/              # Terraform infrastructure; manually applied, never CI-tested
+  - devbin/             # developer utility scripts; not executed by CI
+  - .github/            # GitHub issue templates and Actions workflows; not Hail CI
+  - gateway/            # unmanaged nginx proxy; manually deployed
+  - internal-gateway/   # unmanaged nginx proxy; manually deployed
+  - bootstrap-gateway/  # unmanaged nginx proxy; manually deployed
+  - letsencrypt/        # TLS cert renewal scripts; manually run
+  - prometheus/         # monitoring config; manually applied
+  - grafana/            # monitoring config; manually applied
+  - admin-pod/          # ops tooling; manually deployed
+
+# Files where any change should trigger a full retest of all watched steps.
+# Use this for files that underpin so many things that per-step watching would
+# require duplicating the pattern across most steps.
+fullRetestPaths:
+  - build.yaml              # CI config itself
+  - docker/hail-ubuntu/     # base image for almost every CI step
+  - docker/Dockerfile.base  # base for build-artifact and service images
+  - tls/                    # cert infrastructure used by batch/auth service tests
 
 alwaysRunSteps:
   - merge_code
@@ -1071,6 +1089,9 @@ steps:
     watchedPaths:
       - hail/hail/
       - hail/build.mill
+      - hail/mill-build/
+      - hail/c
+      - hail/prebuilt/
     numSplits: 5
     image:
       valueFrom: hail_run_image.image
@@ -1110,10 +1131,13 @@ steps:
     name: test_hail_python
     description: Run the Hail Python integration suite (pytest) against the debug wheel using an in-process local Spark session.
     watchedPaths:
-      - hail/python/hail/
-      - hail/python/test/hail/
       - hail/hail/
-      - hail/python/hailtop/
+      - hail/build.mill
+      - hail/mill-build/
+      - hail/c
+      - hail/prebuilt/
+      - hail/python/
+      - hail/Makefile
     numSplits: 28
     image:
       valueFrom: hail_run_image.image
@@ -1181,6 +1205,7 @@ steps:
     watchedPaths:
       - hail/python/hailtop/
       - gear/
+      - docker/hailgenetics/hailtop/
     numSplits: 5
     image:
       valueFrom: hailgenetics_hailtop_image.image
@@ -1571,6 +1596,7 @@ steps:
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
       - hail/python/hailtop/pinned-requirements.txt
+      - docker/hailgenetics/hail/
     image:
       valueFrom: hailgenetics_hail_image.image
     script: |
@@ -1589,6 +1615,7 @@ steps:
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
       - hail/python/hailtop/pinned-requirements.txt
+      - docker/hailgenetics/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_10.image
     script: |
@@ -1607,6 +1634,7 @@ steps:
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
       - hail/python/hailtop/pinned-requirements.txt
+      - docker/hailgenetics/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_12.image
     script: |
@@ -1625,6 +1653,7 @@ steps:
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
       - hail/python/hailtop/pinned-requirements.txt
+      - docker/hailgenetics/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_13.image
     script: |
@@ -2691,6 +2720,7 @@ steps:
       - hail/hail/
       - hail/python/hailtop/
       - batch/
+      - docker/hailgenetics/vep/
     numSplits: 16
     image:
       valueFrom: hail_run_image.image
@@ -2849,6 +2879,7 @@ steps:
       - batch/
       - gear/
       - hail/python/hailtop/
+      - docker/core-site.xml
     numSplits: 5
     image:
       valueFrom: batch_image.image
@@ -2931,6 +2962,7 @@ steps:
       - batch/
       - gear/
       - hail/python/hailtop/
+      - docker/core-site.xml
     numSplits: 1
     image:
       valueFrom: batch_image.image
@@ -3279,6 +3311,7 @@ steps:
       - hail/python/test/hailtop/
       - gear/
       - batch/
+      - docker/hailgenetics/hailtop/
     resources:
       memory: standard
       cpu: '0.25'
@@ -3345,6 +3378,7 @@ steps:
     watchedPaths:
       - hail/python/hailtop/
       - batch/
+      - docker/hailgenetics/hail/
     resources:
       memory: standard
       cpu: '0.25'

--- a/build.yaml
+++ b/build.yaml
@@ -1552,6 +1552,9 @@ steps:
     name: test_hailgenetics_hail_image
     watchedPaths:
       - hail/python/hail/
+      - hail/python/requirements.txt
+      - hail/python/pinned-requirements.txt
+      - hail/python/hailtop/pinned-requirements.txt
     image:
       valueFrom: hailgenetics_hail_image.image
     script: |
@@ -1565,6 +1568,9 @@ steps:
     name: test_hailgenetics_hail_image_python_3_10
     watchedPaths:
       - hail/python/hail/
+      - hail/python/requirements.txt
+      - hail/python/pinned-requirements.txt
+      - hail/python/hailtop/pinned-requirements.txt
     image:
       valueFrom: hailgenetics_hail_image_python_3_10.image
     script: |
@@ -1578,6 +1584,9 @@ steps:
     name: test_hailgenetics_hail_image_python_3_12
     watchedPaths:
       - hail/python/hail/
+      - hail/python/requirements.txt
+      - hail/python/pinned-requirements.txt
+      - hail/python/hailtop/pinned-requirements.txt
     image:
       valueFrom: hailgenetics_hail_image_python_3_12.image
     script: |
@@ -1591,6 +1600,9 @@ steps:
     name: test_hailgenetics_hail_image_python_3_13
     watchedPaths:
       - hail/python/hail/
+      - hail/python/requirements.txt
+      - hail/python/pinned-requirements.txt
+      - hail/python/hailtop/pinned-requirements.txt
     image:
       valueFrom: hailgenetics_hail_image_python_3_13.image
     script: |

--- a/build.yaml
+++ b/build.yaml
@@ -1552,7 +1552,6 @@ steps:
     name: test_hailgenetics_hail_image
     watchedPaths:
       - hail/python/hail/
-      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image.image
     script: |
@@ -1566,7 +1565,6 @@ steps:
     name: test_hailgenetics_hail_image_python_3_10
     watchedPaths:
       - hail/python/hail/
-      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_10.image
     script: |
@@ -1580,7 +1578,6 @@ steps:
     name: test_hailgenetics_hail_image_python_3_12
     watchedPaths:
       - hail/python/hail/
-      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_12.image
     script: |
@@ -1594,7 +1591,6 @@ steps:
     name: test_hailgenetics_hail_image_python_3_13
     watchedPaths:
       - hail/python/hail/
-      - hail/hail/
     image:
       valueFrom: hailgenetics_hail_image_python_3_13.image
     script: |
@@ -4015,8 +4011,6 @@ steps:
       - gear/
       - hail/python/hailtop/
       - ci/
-      - hail/python/hail/
-      - hail/hail/
     image:
       valueFrom: hail_dev_image.image
     script: |

--- a/build.yaml
+++ b/build.yaml
@@ -1558,6 +1558,7 @@ steps:
   - kind: runImage
     name: test_hailgenetics_hail_image
     watchedPaths:
+      - hail/hail/
       - hail/python/hail/
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
@@ -1574,6 +1575,7 @@ steps:
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_10
     watchedPaths:
+      - hail/hail/
       - hail/python/hail/
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
@@ -1590,6 +1592,7 @@ steps:
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_12
     watchedPaths:
+      - hail/hail/
       - hail/python/hail/
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt
@@ -1606,6 +1609,7 @@ steps:
   - kind: runImage
     name: test_hailgenetics_hail_image_python_3_13
     watchedPaths:
+      - hail/hail/
       - hail/python/hail/
       - hail/python/requirements.txt
       - hail/python/pinned-requirements.txt

--- a/build.yaml
+++ b/build.yaml
@@ -3018,6 +3018,7 @@ steps:
           valueFrom: default_ns.name
         mountPath: /test-dev-gsa-key
     alwaysRun: true
+    cleanupFor: test_batch
     dependsOn:
       - create_deploy_config
       - create_accounts
@@ -3448,6 +3449,7 @@ steps:
           valueFrom: default_ns.name
         mountPath: /secret/ci-secrets
     alwaysRun: true
+    cleanupFor: create_ci_test_repo
     scopes:
       - test
       - dev
@@ -3991,6 +3993,7 @@ steps:
           valueFrom: default_ns.name
         mountPath: /test-dev-gsa-key
     alwaysRun: true
+    cleanupFor: deploy_batch
     timeout: 300
     dependsOn:
       - create_deploy_config
@@ -4065,6 +4068,7 @@ steps:
     image:
       valueFrom: ci_utils_image.image
     alwaysRun: true
+    cleanupFor: deploy_batch
     script: |
       set -ex
       gcloud -q auth activate-service-account --key-file=/batch-gsa-key/key.json

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -11,6 +11,7 @@ import yaml
 from gear.cloud_config import get_global_config
 from hailtop.utils import RETRY_FUNCTION_SCRIPT, flatten
 
+from .build_selection import expand_build_steps
 from .environment import (
     BUILDKIT_IMAGE,
     CI_UTILS_IMAGE,
@@ -104,38 +105,36 @@ class BuildConfiguration:
         *,
         requested_step_names: Sequence[str] = (),
         excluded_step_names: Sequence[str] = (),
+        include_cleanups: bool = False,
     ):
-        if len(excluded_step_names) > 0 and scope != 'dev':
+        if excluded_step_names and scope != 'dev':
             raise BuildConfigurationError('Excluding build steps is only permitted in a dev scope')
 
-        config = yaml.safe_load(config_str)
         if requested_step_names:
             log.info(f"Constructing build configuration with steps: {requested_step_names}")
+            expanded = set(
+                expand_build_steps(
+                    config_str,
+                    requested_step_names,
+                    cloud=CLOUD,
+                    excluded_step_names=excluded_step_names,
+                    include_cleanups=include_cleanups,
+                )
+            )
+        else:
+            expanded = None
 
-        runnable_steps: List[Step] = []
+        config = yaml.safe_load(config_str)
         name_step: Dict[str, Step] = {}
+        runnable_steps: List[Step] = []
         for step_config in config['steps']:
             step = Step.from_json(StepParameters(code, scope, step_config, name_step))
-            if step.name not in excluded_step_names and step.can_run_in_current_cloud():
+            if step.can_run_in_current_cloud():
                 name_step[step.name] = step
                 runnable_steps.append(step)
 
-        if requested_step_names:
-            # transitively close requested_step_names over dependencies
-            visited = set()
-
-            def visit_dependent(step: Step):
-                if step not in visited and step.name not in excluded_step_names:
-                    if not step.can_run_in_current_cloud():
-                        raise BuildConfigurationError(f'Step {step.name} cannot be run in cloud {CLOUD}')
-                    visited.add(step)
-                    for s2 in step.deps:
-                        if not s2.run_if_requested:
-                            visit_dependent(s2)
-
-            for step_name in requested_step_names:
-                visit_dependent(name_step[step_name])
-            self.steps = [step for step in runnable_steps if step in visited]
+        if expanded is not None:
+            self.steps = [step for step in runnable_steps if step.name in expanded]
         else:
             self.steps = [step for step in runnable_steps if not step.run_if_requested]
 

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -5,33 +5,52 @@ used in unit tests without a running deployment.
 """
 
 import fnmatch
+from dataclasses import dataclass, field
 from typing import List, Set
 
 import yaml
+
+
+@dataclass
+class BuildSelectionResult:
+    """Result of change-based step selection.
+
+    Attributes:
+        requested_steps: Sorted list of step names that should run.
+        full_retest_triggers: Sorted list of changed files that matched no
+            watchedPaths pattern (and therefore caused all watched steps to be
+            included as a fallback).
+    """
+
+    requested_steps: List[str] = field(default_factory=list)
+    full_retest_triggers: List[str] = field(default_factory=list)
 
 
 def _path_matches(changed_file: str, pattern: str) -> bool:
     """Match a changed file path against a watchedPaths/unwatchedPaths pattern.
 
     Patterns ending in '/' match any file under that directory.
-    Otherwise uses fnmatch glob matching.
+    Otherwise uses case-insensitive fnmatch glob matching.
     """
     if pattern.endswith('/'):
-        return changed_file.startswith(pattern) or changed_file == pattern.rstrip('/')
-    return fnmatch.fnmatch(changed_file, pattern)
+        cf = changed_file.lower()
+        p = pattern.lower()
+        return cf.startswith(p) or cf == p.rstrip('/')
+    return fnmatch.fnmatch(changed_file.lower(), pattern.lower())
 
 
-def compute_requested_steps(config_str: str, changed_files: List[str]) -> List[str]:
-    """Return the minimal set of step names to run given a list of changed file paths.
+def compute_requested_steps(config_str: str, changed_files: List[str]) -> BuildSelectionResult:
+    """Return step selection results given a list of changed file paths.
 
     - alwaysRunSteps are always included when changed_files is non-empty.
     - Files matching unwatchedPaths contribute nothing beyond the always-run set.
     - Files matching a step's watchedPaths add that step.
-    - Files matching no step's watchedPaths (fallback) add all watched steps.
-    - Returns [] when changed_files is empty.
+    - Files matching no step's watchedPaths (fallback) add all watched steps and
+      are recorded in full_retest_triggers for observability.
+    - Returns an empty BuildSelectionResult when changed_files is empty.
     """
     if not changed_files:
-        return []
+        return BuildSelectionResult()
 
     config = yaml.safe_load(config_str)
     unwatched: List[str] = config.get('unwatchedPaths', [])
@@ -40,6 +59,7 @@ def compute_requested_steps(config_str: str, changed_files: List[str]) -> List[s
 
     target: Set[str] = set(always_run)
     all_watched_names = {s['name'] for s in watched_steps}
+    fallthrough: List[str] = []
 
     for f in changed_files:
         if any(_path_matches(f, p) for p in unwatched):
@@ -49,5 +69,6 @@ def compute_requested_steps(config_str: str, changed_files: List[str]) -> List[s
             target |= matched
         else:
             target |= all_watched_names  # unknown file → run everything
+            fallthrough.append(f)
 
-    return sorted(target)
+    return BuildSelectionResult(requested_steps=sorted(target), full_retest_triggers=sorted(fallthrough))

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -17,9 +17,9 @@ class BuildSelectionResult:
 
     Attributes:
         requested_steps: Sorted list of step names that should run.
-        full_retest_triggers: Sorted list of changed files that matched no
-            watchedPaths pattern (and therefore caused all watched steps to be
-            included as a fallback).
+        full_retest_triggers: Sorted list of changed files that matched a
+            fullRetestPaths pattern (and therefore caused all watched steps to
+            be included).
     """
 
     requested_steps: List[str] = field(default_factory=list)
@@ -115,10 +115,11 @@ def compute_requested_steps(config_str: str, changed_files: List[str]) -> BuildS
     """Return step selection results given a list of changed file paths.
 
     - alwaysRunSteps are always included when changed_files is non-empty.
-    - Files matching unwatchedPaths contribute nothing beyond the always-run set.
+    - Files matching unwatchedPaths are skipped (explicit no-op list, e.g. doc extensions).
+    - Files matching fullRetestPaths add all watched steps and are recorded in
+      full_retest_triggers for observability.
     - Files matching a step's watchedPaths add that step.
-    - Files matching no step's watchedPaths (fallback) add all watched steps and
-      are recorded in full_retest_triggers for observability.
+    - Files matching none of the above contribute nothing (safe default).
     - Returns an empty BuildSelectionResult when changed_files is empty.
     """
     if not changed_files:
@@ -126,24 +127,25 @@ def compute_requested_steps(config_str: str, changed_files: List[str]) -> BuildS
 
     config = yaml.safe_load(config_str)
     unwatched: List[str] = config.get('unwatchedPaths', [])
+    full_retest: List[str] = config.get('fullRetestPaths', [])
     always_run: List[str] = config.get('alwaysRunSteps', [])
     watched_steps = [s for s in config['steps'] if s.get('watchedPaths')]
 
     target: Set[str] = set(always_run)
     all_watched_names = {s['name'] for s in watched_steps}
-    fallthrough: List[str] = []
+    full_retest_triggers: List[str] = []
 
     for f in changed_files:
         if any(_path_matches(f, p) for p in unwatched):
             continue
+        if any(_path_matches(f, p) for p in full_retest):
+            target |= all_watched_names
+            full_retest_triggers.append(f)
+            continue
         matched = {s['name'] for s in watched_steps if any(_path_matches(f, p) for p in s['watchedPaths'])}
-        if matched:
-            target |= matched
-        else:
-            target |= all_watched_names  # unknown file → run everything
-            fallthrough.append(f)
+        target |= matched  # unknown file → nothing
 
     return BuildSelectionResult(
         requested_steps=sorted(target),
-        full_retest_triggers=sorted(fallthrough),
+        full_retest_triggers=sorted(full_retest_triggers),
     )

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -1,0 +1,53 @@
+"""Change-based test selection helpers.
+
+This module is intentionally free of cloud/environment imports so it can be
+used in unit tests without a running deployment.
+"""
+
+import fnmatch
+from typing import List, Set
+
+import yaml
+
+
+def _path_matches(changed_file: str, pattern: str) -> bool:
+    """Match a changed file path against a watchedPaths/unwatchedPaths pattern.
+
+    Patterns ending in '/' match any file under that directory.
+    Otherwise uses fnmatch glob matching.
+    """
+    if pattern.endswith('/'):
+        return changed_file.startswith(pattern) or changed_file == pattern.rstrip('/')
+    return fnmatch.fnmatch(changed_file, pattern)
+
+
+def compute_requested_steps(config_str: str, changed_files: List[str]) -> List[str]:
+    """Return the minimal set of step names to run given a list of changed file paths.
+
+    - alwaysRunSteps are always included when changed_files is non-empty.
+    - Files matching unwatchedPaths contribute nothing beyond the always-run set.
+    - Files matching a step's watchedPaths add that step.
+    - Files matching no step's watchedPaths (fallback) add all watched steps.
+    - Returns [] when changed_files is empty.
+    """
+    if not changed_files:
+        return []
+
+    config = yaml.safe_load(config_str)
+    unwatched: List[str] = config.get('unwatchedPaths', [])
+    always_run: List[str] = config.get('alwaysRunSteps', [])
+    watched_steps = [s for s in config['steps'] if s.get('watchedPaths')]
+
+    target: Set[str] = set(always_run)
+    all_watched_names = {s['name'] for s in watched_steps}
+
+    for f in changed_files:
+        if any(_path_matches(f, p) for p in unwatched):
+            continue
+        matched = {s['name'] for s in watched_steps if any(_path_matches(f, p) for p in s['watchedPaths'])}
+        if matched:
+            target |= matched
+        else:
+            target |= all_watched_names  # unknown file → run everything
+
+    return sorted(target)

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -6,7 +6,7 @@ used in unit tests without a running deployment.
 
 import fnmatch
 from dataclasses import dataclass, field
-from typing import List, Set
+from typing import Dict, List, Optional, Sequence, Set
 
 import yaml
 
@@ -27,6 +27,75 @@ class BuildSelectionResult:
 
     def __str__(self) -> str:
         return f'requested_steps={self.requested_steps}\nfull_retest_triggers={self.full_retest_triggers}'
+
+
+def _transitive_closure(
+    names: Set[str],
+    deps_map: Dict[str, List[str]],
+    run_if_requested: Set[str],
+    excluded: Set[str],
+    cloud: Optional[str],
+    clouds_map: Dict[str, Optional[List[str]]],
+) -> Set[str]:
+    """Transitively expand names over dependsOn, skipping runIfRequested and wrong-cloud steps."""
+    visited: Set[str] = set()
+    frontier = list(names)
+    while frontier:
+        cur = frontier.pop()
+        if cur in visited or cur in excluded:
+            continue
+        if cloud is not None:
+            step_clouds = clouds_map.get(cur)
+            if step_clouds is not None and cloud not in step_clouds:
+                continue
+        visited.add(cur)
+        for dep in deps_map.get(cur, []):
+            if dep not in run_if_requested:
+                frontier.append(dep)
+    return visited
+
+
+def expand_build_steps(
+    config_str: str,
+    requested_step_names: Sequence[str],
+    cloud: Optional[str] = None,
+    excluded_step_names: Sequence[str] = (),
+    include_cleanups: bool = False,
+) -> List[str]:
+    """Expand a list of requested step names into the full set that should run.
+
+    - Transitively closes requested_step_names over dependsOn (skipping
+      runIfRequested deps and steps not runnable in cloud).
+    - When include_cleanups=True, also adds cleanup steps (those declaring
+      cleanupFor) whose target is transitively reachable from the expanded set.
+    - Returns a sorted list of all step names to include.
+
+    This is a pure function with no cloud/environment imports, suitable for
+    unit tests and for use before BuildConfiguration is constructed.
+    """
+    config = yaml.safe_load(config_str)
+    steps = config.get('steps', [])
+
+    excluded = set(excluded_step_names)
+    run_if_requested: Set[str] = {s['name'] for s in steps if s.get('runIfRequested', False)}
+    deps_map: Dict[str, List[str]] = {s['name']: s.get('dependsOn', []) for s in steps}
+    clouds_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('clouds') for s in steps}
+
+    expanded = _transitive_closure(
+        set(requested_step_names),
+        deps_map,
+        run_if_requested,
+        excluded,
+        cloud,
+        clouds_map,
+    )
+
+    if include_cleanups:
+        # Include cleanup steps whose cleanupFor target is in the expanded set.
+        cleanup_names = {s['name'] for s in steps if s.get('cleanupFor') in expanded}
+        expanded |= cleanup_names
+
+    return sorted(expanded)
 
 
 def _path_matches(changed_file: str, pattern: str) -> bool:
@@ -74,4 +143,7 @@ def compute_requested_steps(config_str: str, changed_files: List[str]) -> BuildS
             target |= all_watched_names  # unknown file → run everything
             fallthrough.append(f)
 
-    return BuildSelectionResult(requested_steps=sorted(target), full_retest_triggers=sorted(fallthrough))
+    return BuildSelectionResult(
+        requested_steps=sorted(target),
+        full_retest_triggers=sorted(fallthrough),
+    )

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -107,7 +107,7 @@ def _path_matches(changed_file: str, pattern: str) -> bool:
     if pattern.endswith('/'):
         cf = changed_file.lower()
         p = pattern.lower()
-        return cf.startswith(p) or cf == p.rstrip('/')
+        return cf.startswith(p)
     return fnmatch.fnmatch(changed_file.lower(), pattern.lower())
 
 

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -25,6 +25,9 @@ class BuildSelectionResult:
     requested_steps: List[str] = field(default_factory=list)
     full_retest_triggers: List[str] = field(default_factory=list)
 
+    def __str__(self) -> str:
+        return f'requested_steps={self.requested_steps}\nfull_retest_triggers={self.full_retest_triggers}'
+
 
 def _path_matches(changed_file: str, pattern: str) -> bool:
     """Match a changed file path against a watchedPaths/unwatchedPaths pattern.

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -576,7 +576,9 @@ mkdir -p {shq(repo_dir)}
                 f'PR {self.number}: changed files={len(changed_files)}, requested steps={selection.requested_steps}'
             )
 
-            config = BuildConfiguration(self, config_str, scope='test', requested_step_names=selection.requested_steps)
+            config = BuildConfiguration(
+                self, config_str, scope='test', requested_step_names=selection.requested_steps, include_cleanups=True
+            )
             namespace = config.namespace()
             services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -13,6 +13,7 @@ import aiohttp
 import aiohttp.client_exceptions
 import gidgethub
 import prometheus_client as pc  # type: ignore
+import yaml
 import zulip
 from gidgethub import aiohttp as gh_aiohttp
 
@@ -22,6 +23,7 @@ from hailtop.config import get_deploy_config
 from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
 
 from .build import BuildConfiguration, Code
+from .build_selection import _path_matches, compute_requested_steps
 from .constants import AUTHORIZED_USERS, COMPILER_TEAM, GITHUB_CLONE_URL, GITHUB_STATUS_CONTEXT, SERVICES_TEAM
 from .environment import DEPLOY_STEPS
 from .globals import is_test_deployment
@@ -562,9 +564,31 @@ mkdir -p {shq(repo_dir)}
             self.sha = sha_out.decode('utf-8').strip()
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
-                config = BuildConfiguration(self, f.read(), scope='test')
-                namespace = config.namespace()
-                services = config.deployed_services()
+                config_str = f.read()
+
+            # Compute which test steps are needed based on changed files
+            assert self.target_branch.sha is not None
+            diff_out, _ = await check_shell_output(
+                f'git -C {shq(repo_dir)} diff --name-only {shq(self.target_branch.sha)} HEAD'
+            )
+            changed_files = diff_out.decode('utf-8').strip().splitlines()
+            requested = compute_requested_steps(config_str, changed_files)
+            log.info(f'PR {self.number}: changed files={len(changed_files)}, requested steps={requested}')
+
+            # Identify files that triggered a full-retest fallback for observability
+            parsed_config = yaml.safe_load(config_str)
+            unwatched_patterns: List[str] = parsed_config.get('unwatchedPaths', [])
+            watched_steps_config = [s for s in parsed_config['steps'] if s.get('watchedPaths')]
+            fallthrough = [
+                f
+                for f in changed_files
+                if not any(_path_matches(f, p) for p in unwatched_patterns)
+                and not any(_path_matches(f, p) for s in watched_steps_config for p in s['watchedPaths'])
+            ]
+
+            config = BuildConfiguration(self, config_str, scope='test', requested_step_names=requested)
+            namespace = config.namespace()
+            services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
                 test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
 
@@ -584,6 +608,7 @@ mkdir -p {shq(repo_dir)}
                     'namespace': namespace,
                     'source_sha': self.source_sha,
                     'target_sha': self.target_branch.sha,
+                    'full_retest_triggers': ','.join(sorted(fallthrough)),
                 },
                 callback=CALLBACK_URL,
             )

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -13,7 +13,6 @@ import aiohttp
 import aiohttp.client_exceptions
 import gidgethub
 import prometheus_client as pc  # type: ignore
-import yaml
 import zulip
 from gidgethub import aiohttp as gh_aiohttp
 
@@ -23,7 +22,7 @@ from hailtop.config import get_deploy_config
 from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
 
 from .build import BuildConfiguration, Code
-from .build_selection import _path_matches, compute_requested_steps
+from .build_selection import compute_requested_steps
 from .constants import AUTHORIZED_USERS, COMPILER_TEAM, GITHUB_CLONE_URL, GITHUB_STATUS_CONTEXT, SERVICES_TEAM
 from .environment import DEPLOY_STEPS
 from .globals import is_test_deployment
@@ -572,21 +571,12 @@ mkdir -p {shq(repo_dir)}
                 f'git -C {shq(repo_dir)} diff --name-only {shq(self.target_branch.sha)} HEAD'
             )
             changed_files = diff_out.decode('utf-8').strip().splitlines()
-            requested = compute_requested_steps(config_str, changed_files)
-            log.info(f'PR {self.number}: changed files={len(changed_files)}, requested steps={requested}')
+            selection = compute_requested_steps(config_str, changed_files)
+            log.info(
+                f'PR {self.number}: changed files={len(changed_files)}, requested steps={selection.requested_steps}'
+            )
 
-            # Identify files that triggered a full-retest fallback for observability
-            parsed_config = yaml.safe_load(config_str)
-            unwatched_patterns: List[str] = parsed_config.get('unwatchedPaths', [])
-            watched_steps_config = [s for s in parsed_config['steps'] if s.get('watchedPaths')]
-            fallthrough = [
-                f
-                for f in changed_files
-                if not any(_path_matches(f, p) for p in unwatched_patterns)
-                and not any(_path_matches(f, p) for s in watched_steps_config for p in s['watchedPaths'])
-            ]
-
-            config = BuildConfiguration(self, config_str, scope='test', requested_step_names=requested)
+            config = BuildConfiguration(self, config_str, scope='test', requested_step_names=selection.requested_steps)
             namespace = config.namespace()
             services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
@@ -608,7 +598,7 @@ mkdir -p {shq(repo_dir)}
                     'namespace': namespace,
                     'source_sha': self.source_sha,
                     'target_sha': self.target_branch.sha,
-                    'full_retest_triggers': ','.join(sorted(fallthrough)),
+                    'full_retest_triggers': ','.join(selection.full_retest_triggers),
                 },
                 callback=CALLBACK_URL,
             )

--- a/ci/unit-test/test_build.py
+++ b/ci/unit-test/test_build.py
@@ -1,4 +1,4 @@
-from ci.build_selection import compute_requested_steps
+from ci.build_selection import BuildSelectionResult, compute_requested_steps
 
 MINIMAL_CONFIG = """
 unwatchedPaths:
@@ -23,39 +23,57 @@ steps:
 
 def test_all_unwatched_files_returns_always_run_only():
     result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/foo.md'])
-    assert result == ['merge_code']
+    assert result.requested_steps == ['merge_code']
+    assert result.full_retest_triggers == []
 
 
 def test_unwatched_glob_pattern_returns_always_run_only():
     result = compute_requested_steps(MINIMAL_CONFIG, ['README.md'])
-    assert result == ['merge_code']
+    assert result.requested_steps == ['merge_code']
+    assert result.full_retest_triggers == []
+
+
+def test_unwatched_glob_matches_nested_md():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['nested/README.md'])
+    assert result.requested_steps == ['merge_code']
+    assert result.full_retest_triggers == []
+
+
+def test_unwatched_glob_matches_uppercase_extension():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['README.MD'])
+    assert result.requested_steps == ['merge_code']
+    assert result.full_retest_triggers == []
 
 
 def test_matched_file_returns_specific_step():
     result = compute_requested_steps(MINIMAL_CONFIG, ['batch/server.py'])
-    assert result == ['merge_code', 'test_batch']
+    assert result.requested_steps == ['merge_code', 'test_batch']
+    assert result.full_retest_triggers == []
 
 
 def test_matched_file_returns_multiple_steps():
     # hailtop is in both test_batch and any step watching it; here only test_batch watches hailtop
     result = compute_requested_steps(MINIMAL_CONFIG, ['hail/python/hailtop/batch/client.py'])
-    assert result == ['merge_code', 'test_batch']
+    assert result.requested_steps == ['merge_code', 'test_batch']
+    assert result.full_retest_triggers == []
 
 
 def test_unknown_file_triggers_all_watched_steps():
     result = compute_requested_steps(MINIMAL_CONFIG, ['some/new/thing.py'])
-    assert result == ['merge_code', 'test_auth', 'test_batch']
+    assert result.requested_steps == ['merge_code', 'test_auth', 'test_batch']
+    assert result.full_retest_triggers == ['some/new/thing.py']
 
 
 def test_mixed_matched_and_unknown_triggers_all():
     # one unknown file → fallback to all watched steps
     result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'some/new/thing.py'])
-    assert result == ['merge_code', 'test_auth', 'test_batch']
+    assert result.requested_steps == ['merge_code', 'test_auth', 'test_batch']
+    assert result.full_retest_triggers == ['some/new/thing.py']
 
 
 def test_empty_changed_files_returns_empty():
     result = compute_requested_steps(MINIMAL_CONFIG, [])
-    assert result == []
+    assert result == BuildSelectionResult()
 
 
 def test_directory_pattern_matches_nested_file():
@@ -67,7 +85,8 @@ steps:
       - hail/src/
 """
     result = compute_requested_steps(config, ['hail/src/main/scala/is/hail/Foo.scala'])
-    assert result == ['test_hail']
+    assert result.requested_steps == ['test_hail']
+    assert result.full_retest_triggers == []
 
 
 def test_directory_pattern_does_not_match_sibling():
@@ -81,32 +100,74 @@ steps:
     # hail/python/ does not start with hail/src/
     result = compute_requested_steps(config, ['hail/python/hail/foo.py'])
     # no watchedPaths match → fallback to all watched steps
-    assert result == ['test_hail']
+    assert result.requested_steps == ['test_hail']
+    assert result.full_retest_triggers == ['hail/python/hail/foo.py']
 
 
 def test_multiple_matched_files_each_different_step():
     result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'auth/y.py'])
-    assert result == ['merge_code', 'test_auth', 'test_batch']
+    assert result.requested_steps == ['merge_code', 'test_auth', 'test_batch']
+    assert result.full_retest_triggers == []
 
 
 def test_mixed_unwatched_and_matched():
     # docs-only file contributes nothing beyond always-run; batch file adds test_batch
     result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/guide.md', 'batch/handler.py'])
-    assert result == ['merge_code', 'test_batch']
+    assert result.requested_steps == ['merge_code', 'test_batch']
+    assert result.full_retest_triggers == []
 
 
 def test_always_run_step_always_selected():
     # merge_code is in alwaysRunSteps — it always appears when changed_files is non-empty
     result = compute_requested_steps(MINIMAL_CONFIG, ['batch/server.py'])
-    assert 'merge_code' in result
+    assert 'merge_code' in result.requested_steps
 
 
 def test_always_run_step_not_in_empty_result():
     # alwaysRunSteps do not appear when changed_files is empty
     result = compute_requested_steps(MINIMAL_CONFIG, [])
-    assert 'merge_code' not in result
+    assert 'merge_code' not in result.requested_steps
+
+
+def test_no_duplicates_when_multiple_files_match_same_step():
+    # batch/x.py and hail/python/hailtop/foo.py both match test_batch — it should appear only once
+    result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'hail/python/hailtop/foo.py'])
+    assert result.requested_steps.count('test_batch') == 1
 
 
 def test_result_is_sorted():
     result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'auth/y.py'])
-    assert result == sorted(result)
+    assert result.requested_steps == sorted(result.requested_steps)
+
+
+def test_full_retest_triggers_are_sorted():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['z/unknown.py', 'a/unknown.py'])
+    assert result.full_retest_triggers == sorted(result.full_retest_triggers)
+
+
+def test_multiple_unknown_files_all_recorded_in_triggers():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['x/foo.py', 'y/bar.py', 'z/baz.py'])
+    assert result.full_retest_triggers == ['x/foo.py', 'y/bar.py', 'z/baz.py']
+
+
+def test_unwatched_files_not_recorded_in_triggers():
+    # Files matching unwatchedPaths are skipped entirely — not counted as fallthrough triggers
+    result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/guide.md', 'README.md'])
+    assert result.full_retest_triggers == []
+
+
+def test_mixed_unwatched_and_unknown_only_unknown_in_triggers():
+    # Unwatched file is silently skipped; unknown file causes full-retest
+    result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/guide.md', 'new/thing.py'])
+    assert result.full_retest_triggers == ['new/thing.py']
+
+
+def test_build_selection_result_defaults():
+    r = BuildSelectionResult()
+    assert r.requested_steps == []
+    assert r.full_retest_triggers == []
+
+
+def test_build_selection_result_equality():
+    assert BuildSelectionResult(['a', 'b'], ['x']) == BuildSelectionResult(['a', 'b'], ['x'])
+    assert BuildSelectionResult(['a'], []) != BuildSelectionResult(['b'], [])

--- a/ci/unit-test/test_build.py
+++ b/ci/unit-test/test_build.py
@@ -1,0 +1,112 @@
+from ci.build_selection import compute_requested_steps
+
+MINIMAL_CONFIG = """
+unwatchedPaths:
+  - dev-docs/
+  - '*.md'
+alwaysRunSteps:
+  - merge_code
+steps:
+  - kind: runImage
+    name: test_batch
+    watchedPaths:
+      - batch/
+      - hail/python/hailtop/
+  - kind: runImage
+    name: test_auth
+    watchedPaths:
+      - auth/
+  - kind: runImage
+    name: merge_code
+"""
+
+
+def test_all_unwatched_files_returns_always_run_only():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/foo.md'])
+    assert result == ['merge_code']
+
+
+def test_unwatched_glob_pattern_returns_always_run_only():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['README.md'])
+    assert result == ['merge_code']
+
+
+def test_matched_file_returns_specific_step():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['batch/server.py'])
+    assert result == ['merge_code', 'test_batch']
+
+
+def test_matched_file_returns_multiple_steps():
+    # hailtop is in both test_batch and any step watching it; here only test_batch watches hailtop
+    result = compute_requested_steps(MINIMAL_CONFIG, ['hail/python/hailtop/batch/client.py'])
+    assert result == ['merge_code', 'test_batch']
+
+
+def test_unknown_file_triggers_all_watched_steps():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['some/new/thing.py'])
+    assert result == ['merge_code', 'test_auth', 'test_batch']
+
+
+def test_mixed_matched_and_unknown_triggers_all():
+    # one unknown file → fallback to all watched steps
+    result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'some/new/thing.py'])
+    assert result == ['merge_code', 'test_auth', 'test_batch']
+
+
+def test_empty_changed_files_returns_empty():
+    result = compute_requested_steps(MINIMAL_CONFIG, [])
+    assert result == []
+
+
+def test_directory_pattern_matches_nested_file():
+    config = """
+steps:
+  - kind: runImage
+    name: test_hail
+    watchedPaths:
+      - hail/src/
+"""
+    result = compute_requested_steps(config, ['hail/src/main/scala/is/hail/Foo.scala'])
+    assert result == ['test_hail']
+
+
+def test_directory_pattern_does_not_match_sibling():
+    config = """
+steps:
+  - kind: runImage
+    name: test_hail
+    watchedPaths:
+      - hail/src/
+"""
+    # hail/python/ does not start with hail/src/
+    result = compute_requested_steps(config, ['hail/python/hail/foo.py'])
+    # no watchedPaths match → fallback to all watched steps
+    assert result == ['test_hail']
+
+
+def test_multiple_matched_files_each_different_step():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'auth/y.py'])
+    assert result == ['merge_code', 'test_auth', 'test_batch']
+
+
+def test_mixed_unwatched_and_matched():
+    # docs-only file contributes nothing beyond always-run; batch file adds test_batch
+    result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/guide.md', 'batch/handler.py'])
+    assert result == ['merge_code', 'test_batch']
+
+
+def test_always_run_step_always_selected():
+    # merge_code is in alwaysRunSteps — it always appears when changed_files is non-empty
+    result = compute_requested_steps(MINIMAL_CONFIG, ['batch/server.py'])
+    assert 'merge_code' in result
+
+
+def test_always_run_step_not_in_empty_result():
+    # alwaysRunSteps do not appear when changed_files is empty
+    result = compute_requested_steps(MINIMAL_CONFIG, [])
+    assert 'merge_code' not in result
+
+
+def test_result_is_sorted():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'auth/y.py'])
+    assert result == sorted(result)

--- a/ci/unit-test/test_build.py
+++ b/ci/unit-test/test_build.py
@@ -2,8 +2,9 @@ from ci.build_selection import BuildSelectionResult, compute_requested_steps, ex
 
 MINIMAL_CONFIG = """
 unwatchedPaths:
-  - dev-docs/
   - '*.md'
+fullRetestPaths:
+  - build.yaml
 alwaysRunSteps:
   - merge_code
 steps:
@@ -22,7 +23,7 @@ steps:
 
 
 def test_all_unwatched_files_returns_always_run_only():
-    result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/foo.md'])
+    result = compute_requested_steps(MINIMAL_CONFIG, ['README.md'])
     assert result.requested_steps == ['merge_code']
     assert result.full_retest_triggers == []
 
@@ -58,17 +59,17 @@ def test_matched_file_returns_multiple_steps():
     assert result.full_retest_triggers == []
 
 
-def test_unknown_file_triggers_all_watched_steps():
+def test_unknown_file_contributes_nothing():
     result = compute_requested_steps(MINIMAL_CONFIG, ['some/new/thing.py'])
-    assert result.requested_steps == ['merge_code', 'test_auth', 'test_batch']
-    assert result.full_retest_triggers == ['some/new/thing.py']
+    assert result.requested_steps == ['merge_code']
+    assert result.full_retest_triggers == []
 
 
-def test_mixed_matched_and_unknown_triggers_all():
-    # one unknown file → fallback to all watched steps
+def test_mixed_matched_and_unknown_only_matched_selected():
+    # unknown file contributes nothing; only the explicitly watched batch/ file adds test_batch
     result = compute_requested_steps(MINIMAL_CONFIG, ['batch/x.py', 'some/new/thing.py'])
-    assert result.requested_steps == ['merge_code', 'test_auth', 'test_batch']
-    assert result.full_retest_triggers == ['some/new/thing.py']
+    assert result.requested_steps == ['merge_code', 'test_batch']
+    assert result.full_retest_triggers == []
 
 
 def test_empty_changed_files_returns_empty():
@@ -97,11 +98,10 @@ steps:
     watchedPaths:
       - hail/src/
 """
-    # hail/python/ does not start with hail/src/
+    # hail/python/ does not start with hail/src/ → contributes nothing
     result = compute_requested_steps(config, ['hail/python/hail/foo.py'])
-    # no watchedPaths match → fallback to all watched steps
-    assert result.requested_steps == ['test_hail']
-    assert result.full_retest_triggers == ['hail/python/hail/foo.py']
+    assert result.requested_steps == []
+    assert result.full_retest_triggers == []
 
 
 def test_multiple_matched_files_each_different_step():
@@ -140,26 +140,41 @@ def test_result_is_sorted():
     assert result.requested_steps == sorted(result.requested_steps)
 
 
+def test_full_retest_path_triggers_all_watched_steps():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['build.yaml'])
+    assert result.requested_steps == ['merge_code', 'test_auth', 'test_batch']
+    assert result.full_retest_triggers == ['build.yaml']
+
+
 def test_full_retest_triggers_are_sorted():
-    result = compute_requested_steps(MINIMAL_CONFIG, ['z/unknown.py', 'a/unknown.py'])
+    config = MINIMAL_CONFIG.replace('  - build.yaml', '  - build.yaml\n  - other.yaml')
+    result = compute_requested_steps(config, ['other.yaml', 'build.yaml'])
     assert result.full_retest_triggers == sorted(result.full_retest_triggers)
 
 
-def test_multiple_unknown_files_all_recorded_in_triggers():
-    result = compute_requested_steps(MINIMAL_CONFIG, ['x/foo.py', 'y/bar.py', 'z/baz.py'])
-    assert result.full_retest_triggers == ['x/foo.py', 'y/bar.py', 'z/baz.py']
+def test_full_retest_path_with_matched_file_deduplicated():
+    # fullRetestPaths file already pulls in all watched steps; matched file adds nothing extra
+    result = compute_requested_steps(MINIMAL_CONFIG, ['build.yaml', 'batch/x.py'])
+    assert result.requested_steps == ['merge_code', 'test_auth', 'test_batch']
+    assert result.full_retest_triggers == ['build.yaml']
 
 
 def test_unwatched_files_not_recorded_in_triggers():
-    # Files matching unwatchedPaths are skipped entirely — not counted as fallthrough triggers
-    result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/guide.md', 'README.md'])
+    # Files matching unwatchedPaths are skipped entirely — not counted as triggers
+    result = compute_requested_steps(MINIMAL_CONFIG, ['README.md', 'CHANGES.md'])
     assert result.full_retest_triggers == []
 
 
-def test_mixed_unwatched_and_unknown_only_unknown_in_triggers():
-    # Unwatched file is silently skipped; unknown file causes full-retest
-    result = compute_requested_steps(MINIMAL_CONFIG, ['dev-docs/guide.md', 'new/thing.py'])
-    assert result.full_retest_triggers == ['new/thing.py']
+def test_unknown_files_not_recorded_in_triggers():
+    # Unknown files contribute nothing and are not recorded
+    result = compute_requested_steps(MINIMAL_CONFIG, ['new/thing.py'])
+    assert result.full_retest_triggers == []
+    assert result.requested_steps == ['merge_code']
+
+
+def test_mixed_unwatched_and_unknown_neither_in_triggers():
+    result = compute_requested_steps(MINIMAL_CONFIG, ['README.md', 'new/thing.py'])
+    assert result.full_retest_triggers == []
 
 
 def test_build_selection_result_defaults():

--- a/ci/unit-test/test_build.py
+++ b/ci/unit-test/test_build.py
@@ -1,4 +1,4 @@
-from ci.build_selection import BuildSelectionResult, compute_requested_steps
+from ci.build_selection import BuildSelectionResult, compute_requested_steps, expand_build_steps
 
 MINIMAL_CONFIG = """
 unwatchedPaths:
@@ -171,3 +171,112 @@ def test_build_selection_result_defaults():
 def test_build_selection_result_equality():
     assert BuildSelectionResult(['a', 'b'], ['x']) == BuildSelectionResult(['a', 'b'], ['x'])
     assert BuildSelectionResult(['a'], []) != BuildSelectionResult(['b'], [])
+
+
+# ---------------------------------------------------------------------------
+# expand_build_steps tests
+# ---------------------------------------------------------------------------
+
+EXPAND_CONFIG = """
+steps:
+  - name: setup
+  - name: test_a
+    watchedPaths: [a/]
+    dependsOn: [setup]
+  - name: test_b
+    watchedPaths: [b/]
+    dependsOn: [setup]
+  - name: cleanup
+    cleanupFor: setup
+    dependsOn: [test_a, test_b]
+"""
+
+
+def test_expand_includes_transitive_deps():
+    result = expand_build_steps(EXPAND_CONFIG, ['test_a'])
+    assert 'setup' in result
+    assert 'test_a' in result
+
+
+def test_expand_no_cleanup_by_default():
+    result = expand_build_steps(EXPAND_CONFIG, ['test_a'])
+    assert 'cleanup' not in result
+
+
+def test_expand_cleanup_included_when_requested():
+    result = expand_build_steps(EXPAND_CONFIG, ['test_a'], include_cleanups=True)
+    assert 'cleanup' in result
+
+
+def test_expand_cleanup_not_included_when_setup_not_reachable():
+    config = """
+steps:
+  - name: other
+    watchedPaths: [other/]
+  - name: setup
+  - name: cleanup
+    cleanupFor: setup
+    dependsOn: [other]
+"""
+    result = expand_build_steps(config, ['other'], include_cleanups=True)
+    assert 'cleanup' not in result
+
+
+def test_expand_chained_cleanups_both_included():
+    config = """
+steps:
+  - name: setup
+  - name: test_a
+    watchedPaths: [a/]
+    dependsOn: [setup]
+  - name: cleanup1
+    cleanupFor: setup
+    dependsOn: [test_a]
+  - name: cleanup2
+    cleanupFor: setup
+    dependsOn: [cleanup1]
+"""
+    result = expand_build_steps(config, ['test_a'], include_cleanups=True)
+    assert 'cleanup1' in result
+    assert 'cleanup2' in result
+
+
+def test_expand_excluded_steps_not_included():
+    result = expand_build_steps(EXPAND_CONFIG, ['test_a', 'test_b'], excluded_step_names=['test_b'])
+    assert 'test_b' not in result
+    assert 'test_a' in result
+
+
+def test_expand_run_if_requested_dep_not_pulled_in():
+    config = """
+steps:
+  - name: infra
+    runIfRequested: true
+  - name: test_a
+    dependsOn: [infra]
+"""
+    result = expand_build_steps(config, ['test_a'])
+    assert 'test_a' in result
+    assert 'infra' not in result
+
+
+def test_expand_cloud_filter_excludes_wrong_cloud():
+    config = """
+steps:
+  - name: gcp_only
+    clouds: [gcp]
+  - name: test_a
+    dependsOn: [gcp_only]
+"""
+    result = expand_build_steps(config, ['test_a'], cloud='azure')
+    assert 'gcp_only' not in result
+
+
+def test_expand_result_is_sorted():
+    result = expand_build_steps(EXPAND_CONFIG, ['test_b', 'test_a'])
+    assert result == sorted(result)
+
+
+def test_expand_empty_requested_returns_empty():
+    result = expand_build_steps(EXPAND_CONFIG, [])
+    assert result == []

--- a/dev-docs/services/ci/README.md
+++ b/dev-docs/services/ci/README.md
@@ -196,6 +196,70 @@ sequenceDiagram
     CI->>Github: Update github check
 ```
 
+## Change-Based Test Selection
+
+### Why
+
+Running the full build.yaml test suite on every PR is expensive. Many PRs touch a single
+service or isolated area (e.g. a batch-only change, a docs fix) and have no need to compile
+the Hail JAR, run Python query tests, or rebuild unrelated service images.
+
+Change-based test selection uses per-step `watchedPaths` annotations in `build.yaml` to
+skip irrelevant test steps automatically. The savings can be significant: a batch-only PR
+skips all JAR compilation and query test steps.
+
+### How it works
+
+Three categories determine what runs:
+
+1. **Unwatched files** — listed in the top-level `unwatchedPaths:` key in `build.yaml`
+   (e.g. `dev-docs/`, `*.md`). A PR that changes only unwatched files runs nothing.
+
+2. **Watched steps** — steps with a `watchedPaths:` list. A changed file that matches any
+   pattern in a step's `watchedPaths` adds that step to the run set.
+
+3. **Unknown files** — changed files that don't match any `unwatchedPaths` pattern and
+   don't match any step's `watchedPaths` patterns. These trigger a fallback: all watched
+   steps run. This is conservative and correct — an unmapped file might affect anything.
+
+`requested_step_names` is passed to `BuildConfiguration`, which transitively closes over
+dependencies automatically. Infrastructure steps (`merge_code`, `deploy_batch`, etc.) have
+no `watchedPaths` and are included automatically as transitive deps when needed.
+
+### The algorithm
+
+```
+for each changed file f:
+    if f matches any unwatchedPaths pattern:
+        skip (contributes nothing)
+    elif f matches at least one step's watchedPaths:
+        add those steps to the run set
+    else:
+        add ALL watched steps (fallback — unknown file)
+```
+
+### How to maintain
+
+**Adding `watchedPaths` to a new test step** — add a `watchedPaths:` list directly under
+the step's `name:` in `build.yaml`. Use directory patterns (ending in `/`) for whole
+directories, and `fnmatch` globs for file patterns. Be conservative: if a test incidentally
+uses a shared library, that library's path belongs in `watchedPaths`.
+
+**Adding to `unwatchedPaths`** — add new inert file types or directories to the top-level
+`unwatchedPaths:` list. Only add entries you are certain can never affect any test.
+
+**Leaving a step unwatched** — infra/setup steps (image builds, namespace creation,
+deployment steps) should have no `watchedPaths`. They are picked up as transitive
+dependencies of whichever test steps are selected.
+
+### Observability
+
+The `full_retest_triggers` batch attribute (visible in the Batch UI under the batch's
+attributes) lists any changed files that fell through to the "run everything" fallback,
+comma-separated. An empty value means all changed files were cleanly mapped.
+
+To see it: open the batch in the Batch UI → Attributes tab → `full_retest_triggers`.
+
 ## Merging PRs
 
 Mergability is determined by:

--- a/devbin/check-pr-test-selection.py
+++ b/devbin/check-pr-test-selection.py
@@ -9,7 +9,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-from ci.build_selection import compute_requested_steps
+import yaml
+
+from ci.build_selection import compute_requested_steps, expand_build_steps
 
 if len(sys.argv) != 2:
     print(f'Usage: {sys.argv[0]} <pr-number>', file=sys.stderr)
@@ -22,4 +24,12 @@ changed_files = subprocess.run(
 ).stdout.strip().splitlines()
 
 config_str = (Path(__file__).parent.parent / 'build.yaml').read_text()
-print(compute_requested_steps(config_str, changed_files))
+selection = compute_requested_steps(config_str, changed_files)
+print(selection)
+
+config = yaml.safe_load(config_str)
+cleanup_names = {s['name'] for s in config['steps'] if s.get('cleanupFor')}
+expanded = expand_build_steps(config_str, selection.requested_steps, include_cleanups=True)
+cleanup = [s for s in expanded if s in cleanup_names]
+if cleanup:
+    print(f'cleanup_steps={cleanup}')

--- a/devbin/check-pr-test-selection.py
+++ b/devbin/check-pr-test-selection.py
@@ -27,26 +27,38 @@ config_str = (Path(__file__).parent.parent / 'build.yaml').read_text()
 selection = compute_requested_steps(config_str, changed_files)
 
 config = yaml.safe_load(config_str)
-cleanup_names = {s['name'] for s in config['steps'] if s.get('cleanupFor')}
-expanded = expand_build_steps(config_str, selection.requested_steps, include_cleanups=True)
-cleanup = [s for s in expanded if s in cleanup_names]
-
-print(f'changed_files={changed_files}')
-print(selection)
-if cleanup:
-    print(f'cleanup_steps={cleanup}')
-
-# Steps with watchedPaths that were not selected — candidates for gap analysis.
+all_cleanup_names = {s['name'] for s in config['steps'] if s.get('cleanupFor')}
 run_if_requested = {s['name'] for s in config['steps'] if s.get('runIfRequested', False)}
+expanded = expand_build_steps(config_str, selection.requested_steps, include_cleanups=True)
 expanded_set = set(expanded)
-excluded_watched = {
-    s['name']: s['watchedPaths']
-    for s in config['steps']
+requested_set = set(selection.requested_steps)
+
+selected_cleanups = sorted(s for s in expanded if s in all_cleanup_names)
+unselected_cleanups = sorted(all_cleanup_names - expanded_set)
+excluded_watched = sorted(
+    s['name'] for s in config['steps']
     if s.get('watchedPaths')
     and s['name'] not in expanded_set
     and s['name'] not in run_if_requested
+)
+dep_only = {
+    s['name'] for s in config['steps']
+    if not s.get('watchedPaths')
+    and not s.get('runIfRequested', False)
+    and s['name'] not in all_cleanup_names
 }
+included_deps = sorted(expanded_set & dep_only - requested_set)
+excluded_deps = sorted(dep_only - expanded_set)
+
+print(f'changed_files={changed_files}')
+print(selection)
+if included_deps:
+    print(f'included_test_dependencies={included_deps}')
+if selected_cleanups:
+    print(f'included_cleanup_steps={selected_cleanups}')
 if excluded_watched:
-    print('excluded_watched_steps (have watchedPaths but not selected):')
-    for name, paths in sorted(excluded_watched.items()):
-        print(f'  {name}: {paths}')
+    print(f'excluded_test_steps_with_watched_paths={excluded_watched}')
+if excluded_deps:
+    print(f'excluded_test_dependencies={excluded_deps}')
+if unselected_cleanups:
+    print(f'excluded_cleanup_steps={unselected_cleanups}')

--- a/devbin/check-pr-test-selection.py
+++ b/devbin/check-pr-test-selection.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Predict which build.yaml test steps would be selected for a given PR.
+
+Usage:
+    python3 devbin/check-pr-test-selection.py <pr-number>
+    python3 devbin/check-pr-test-selection.py 15394
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+repo_root = Path(__file__).parent.parent
+sys.path.insert(0, str(repo_root / 'ci'))
+
+from ci.build_selection import compute_requested_steps  # noqa: E402
+
+
+def get_pr_files(pr_number: int) -> list[str]:
+    result = subprocess.run(
+        ['gh', 'pr', 'view', str(pr_number), '--repo', 'hail-is/hail', '--json', 'files', '--jq', '.files[].path'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip().splitlines()
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f'Usage: {sys.argv[0]} <pr-number>', file=sys.stderr)
+        sys.exit(1)
+
+    pr_number = int(sys.argv[1])
+    changed_files = get_pr_files(pr_number)
+
+    print(f'PR #{pr_number} — {len(changed_files)} changed file(s):')
+    for f in changed_files:
+        print(f'  {f}')
+    print()
+
+    config_str = (repo_root / 'build.yaml').read_text()
+    result = compute_requested_steps(config_str, changed_files)
+
+    print(f'Selected steps ({len(result.requested_steps)}):')
+    for step in result.requested_steps:
+        print(f'  {step}')
+
+    if result.full_retest_triggers:
+        print(f'\nFull-retest triggers ({len(result.full_retest_triggers)}) — unmapped files that forced all steps:')
+        for f in result.full_retest_triggers:
+            print(f'  {f}')
+    else:
+        print('\nNo full-retest triggers — all changed files were cleanly mapped.')
+
+
+if __name__ == '__main__':
+    main()

--- a/devbin/check-pr-test-selection.py
+++ b/devbin/check-pr-test-selection.py
@@ -25,11 +25,28 @@ changed_files = subprocess.run(
 
 config_str = (Path(__file__).parent.parent / 'build.yaml').read_text()
 selection = compute_requested_steps(config_str, changed_files)
-print(selection)
 
 config = yaml.safe_load(config_str)
 cleanup_names = {s['name'] for s in config['steps'] if s.get('cleanupFor')}
 expanded = expand_build_steps(config_str, selection.requested_steps, include_cleanups=True)
 cleanup = [s for s in expanded if s in cleanup_names]
+
+print(f'changed_files={changed_files}')
+print(selection)
 if cleanup:
     print(f'cleanup_steps={cleanup}')
+
+# Steps with watchedPaths that were not selected — candidates for gap analysis.
+run_if_requested = {s['name'] for s in config['steps'] if s.get('runIfRequested', False)}
+expanded_set = set(expanded)
+excluded_watched = {
+    s['name']: s['watchedPaths']
+    for s in config['steps']
+    if s.get('watchedPaths')
+    and s['name'] not in expanded_set
+    and s['name'] not in run_if_requested
+}
+if excluded_watched:
+    print('excluded_watched_steps (have watchedPaths but not selected):')
+    for name, paths in sorted(excluded_watched.items()):
+        print(f'  {name}: {paths}')

--- a/devbin/check-pr-test-selection.py
+++ b/devbin/check-pr-test-selection.py
@@ -3,56 +3,23 @@
 
 Usage:
     python3 devbin/check-pr-test-selection.py <pr-number>
-    python3 devbin/check-pr-test-selection.py 15394
 """
 
 import subprocess
 import sys
 from pathlib import Path
 
-repo_root = Path(__file__).parent.parent
-sys.path.insert(0, str(repo_root / 'ci'))
+from ci.build_selection import compute_requested_steps
 
-from ci.build_selection import compute_requested_steps  # noqa: E402
+if len(sys.argv) != 2:
+    print(f'Usage: {sys.argv[0]} <pr-number>', file=sys.stderr)
+    sys.exit(1)
 
+pr_number = sys.argv[1]
+changed_files = subprocess.run(
+    ['gh', 'pr', 'view', pr_number, '--repo', 'hail-is/hail', '--json', 'files', '--jq', '.files[].path'],
+    capture_output=True, text=True, check=True,
+).stdout.strip().splitlines()
 
-def get_pr_files(pr_number: int) -> list[str]:
-    result = subprocess.run(
-        ['gh', 'pr', 'view', str(pr_number), '--repo', 'hail-is/hail', '--json', 'files', '--jq', '.files[].path'],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.strip().splitlines()
-
-
-def main():
-    if len(sys.argv) != 2:
-        print(f'Usage: {sys.argv[0]} <pr-number>', file=sys.stderr)
-        sys.exit(1)
-
-    pr_number = int(sys.argv[1])
-    changed_files = get_pr_files(pr_number)
-
-    print(f'PR #{pr_number} — {len(changed_files)} changed file(s):')
-    for f in changed_files:
-        print(f'  {f}')
-    print()
-
-    config_str = (repo_root / 'build.yaml').read_text()
-    result = compute_requested_steps(config_str, changed_files)
-
-    print(f'Selected steps ({len(result.requested_steps)}):')
-    for step in result.requested_steps:
-        print(f'  {step}')
-
-    if result.full_retest_triggers:
-        print(f'\nFull-retest triggers ({len(result.full_retest_triggers)}) — unmapped files that forced all steps:')
-        for f in result.full_retest_triggers:
-            print(f'  {f}')
-    else:
-        print('\nNo full-retest triggers — all changed files were cleanly mapped.')
-
-
-if __name__ == '__main__':
-    main()
+config_str = (Path(__file__).parent.parent / 'build.yaml').read_text()
+print(compute_requested_steps(config_str, changed_files))

--- a/devbin/show-watched-paths.py
+++ b/devbin/show-watched-paths.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Show watchedPaths configuration for steps in build.yaml.
+
+Usage:
+    python3 devbin/show-watched-paths.py              # all steps with watchedPaths
+    python3 devbin/show-watched-paths.py step1 step2  # specific steps only
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+config = yaml.safe_load((Path(__file__).parent.parent / 'build.yaml').read_text())
+filter_names = set(sys.argv[1:])
+
+full_retest_paths = config.get('fullRetestPaths', [])
+
+if not filter_names:
+    print('- fullRetestPaths:')
+    for p in full_retest_paths:
+        print(f'    - {p}')
+    print()
+
+for step in config['steps']:
+    name = step['name']
+    paths = step.get('watchedPaths')
+    if not paths:
+        continue
+    if filter_names and name not in filter_names:
+        continue
+    print(f'- {name}:')
+    if desc := step.get('description'):
+        print(f'    - description: {desc}')
+    print('    - watchedPaths:')
+    for p in paths:
+        print(f'        - {p}')


### PR DESCRIPTION
## Change Description

Updates the CI test batch creation process to be more specific about which tests to run:

- Files in the `unwatchedPaths` do not add any test targets
- Files in a test step's `watchedPaths` list add that step (and its upstream dependencies) to the test batch
- Files which are unrecognized (not in `unwatchedPaths` and not in `watchedPaths` for any step): trigger nothing

Note: to check which tests would have been run against a specific PR, there's a devbin helper (which I can delete before the PR merges). Eg this PR would trigger a full rebuild because it modifies build.yaml:

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Updates the deployed CI service with new logic. Reduces the set of tests run, depending on which files are changed.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
