### PR TITLE
[compiler] fix check-hail target, bump scala minor versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ pylint-hailtop:
 
 .PHONY: check-hail
 check-hail: check-hail-fast pylint-hailtop
-	cd hail && HAIL_BUILD_MODE=Dev SCALA_VERSION=2.13 $(MILL) $(MILLOPTS) hail[].__.checkFormat + hail[].__.fix --check
+	cd hail && HAIL_BUILD_MODE=Dev $(MILL) $(MILLOPTS) hail.2_13.__.checkFormat + hail.2_13.__.fix --check
 
 .PHONY: check-batch
 check-batch: check-batch-fast pylint-batch

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -16,7 +16,7 @@ import org.typelevel.scalacoptions.*
 object Settings:
   val hailMajorMinorVersion = "0.2"
   val hailPatchVersion = "137"
-  val scalaMinorVersions = Map("2.12" -> "2.12.20", "2.12.13" -> "2.12.13", "2.13" -> "2.13.13")
+  val scalaMinorVersions = Map("2.12" -> "2.12.21", "2.12.13" -> "2.12.13", "2.13" -> "2.13.18")
 
 
 object Env extends Module:

--- a/hail/build.mill
+++ b/hail/build.mill
@@ -16,7 +16,7 @@ import org.typelevel.scalacoptions.*
 object Settings:
   val hailMajorMinorVersion = "0.2"
   val hailPatchVersion = "138"
-  val scalaMinorVersions = Map("2.12" -> "2.12.20", "2.12.13" -> "2.12.13", "2.13" -> "2.13.13")
+  val scalaMinorVersions = Map("2.12" -> "2.12.18", "2.13" -> "2.13.16")
 
 
 object Env extends Module:

--- a/hail/hail/test/src/is/hail/io/IndexSuite.scala
+++ b/hail/hail/test/src/is/hail/io/IndexSuite.scala
@@ -186,7 +186,7 @@ class IndexSuite extends HailSuite {
         stringsWithDups,
         stringsWithDups.indices.map(i => Row()),
         TStruct.empty,
-        branchingFactor = 2,
+        branchingFactor,
       )
       val index = indexReader(file, TStruct.empty)
 


### PR DESCRIPTION
## Change Description

#15175 accidentally broke the `check-hail` make target by making it run with scala 2.12 instead of 2.13. I noticed this when running `./mill hail[2.13].__.fix` locally errored. It looks like the new mill version is using a newer version of semanticdb, which doesn't publish a package for scala 2.13.13. I've resolved this by bumping to the most recent minor versions of both 2.12 and 2.13.

It appears the new semanticdb/scala is also catching a previously uncaught unused variable, which was a genuine bug.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
