### PR TITLE
[batch] add billing export to csv

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -3085,10 +3085,23 @@ async def ui_get_billing(request, userdata):
         'billing_by_project_user': billing_by_project_user,
         'start': start,
         'end': end,
+        'today': datetime.datetime.now().strftime('%m/%d/%Y'),
+        'is_developer': is_developer,
         'user': userdata['username'],
         'total_cost': total_cost,
     }
     return await render_template('batch', request, userdata, 'billing.html', page_context)
+
+
+@routes.get('/api/v1alpha/billing')
+@auth.authenticated_users_only()
+async def api_get_billing(request, userdata):
+    is_developer = userdata['is_developer'] == 1
+    user = userdata['username'] if not is_developer else None
+    billing, _, _ = await _query_billing(request, user=user)
+    return json_response([
+        {'billing_project': r['billing_project'], 'user': r['user'], 'total_spent': r['cost']} for r in billing
+    ])
 
 
 @routes.get('/billing_projects')

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -3086,7 +3086,6 @@ async def ui_get_billing(request, userdata):
         'start': start,
         'end': end,
         'today': datetime.datetime.now().strftime('%m/%d/%Y'),
-        'is_developer': is_developer,
         'user': userdata['username'],
         'total_cost': total_cost,
     }
@@ -3096,8 +3095,10 @@ async def ui_get_billing(request, userdata):
 @routes.get('/api/v1alpha/billing')
 @auth.authenticated_users_only()
 async def api_get_billing(request, userdata):
-    is_developer = userdata['is_developer'] == 1
-    user = userdata['username'] if not is_developer else None
+    if not userdata['system_permissions'].get(SystemPermission.READ_ALL_BILLING_PROJECTS, False):
+        user = userdata['username']
+    else:
+        user = None
     billing, _, _ = await _query_billing(request, user=user)
     return json_response([
         {'billing_project': r['billing_project'], 'user': r['user'], 'total_spent': r['cost']} for r in billing

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -3,7 +3,7 @@
     if (!exportBtn) return;
 
     var statusEl = document.getElementById('billing-export-status');
-    var basePath = '{{ base_path }}';
+    var basePath = (document.getElementById('billing-js') || {}).dataset?.basePath ?? '';
 
     function toIso(mmddyyyy) {
         if (!mmddyyyy) {

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -1,20 +1,29 @@
 (function () {
     var exportBtn = document.getElementById('billing-export-btn');
-    if (!exportBtn) return;
+    var copyBtn = document.getElementById('billing-copy-btn');
+    if (!exportBtn && !copyBtn) return;
 
     var statusEl = document.getElementById('billing-export-status');
     var basePath = (document.getElementById('billing-js') || {}).dataset?.basePath ?? '';
 
-    function toIso(mmddyyyy) {
-        if (!mmddyyyy) {
-            let now = new Date();
-            return now.getFullYear() + '-'
-                + String(now.getMonth() + 1).padStart(2, '0') + '-'
-                + String(now.getDate()).padStart(2, '0');
+    // Converts a mm/dd/yyyy query-param date string to yyyy-mm-dd for use in filenames.
+    // String manipulation is intentional — Date.toISOString() converts to UTC and can
+    // shift the date backwards in timezones behind UTC.
+    function queryDateToIso8601(mmddyyyy) {
+        try {
+            if (!mmddyyyy) {
+                const now = new Date();
+                yyyy = now.getFullYear();
+                mm = String(now.getMonth() + 1).padStart(2, '0');
+                dd = String(now.getDate()).padStart(2, '0');
+                return `${yyyy}-${mm}-${dd}`;
+            } else {
+                const [mm, dd, yyyy] = mmddyyyy.split('/');
+                return `${yyyy}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`;
+            }
+        } catch (e) {
+            return 'invalid-date-format';
         }
-        var parts = mmddyyyy.split('/');
-        if (parts.length !== 3) return mmddyyyy;
-        return parts[2] + '-' + parts[0] + '-' + parts[1];
     }
 
     function csvEscape(val) {
@@ -70,6 +79,31 @@
         return checked ? checked.value : 'by-project-user';
     }
 
+    function prepareCsvExport(records) {
+        var grouping = getGrouping();
+        var rows, columns, label;
+        if (grouping === 'by-project') {
+            rows = groupByProject(records);
+            columns = ['billing_project', 'total_spent'];
+            label = 'by billing project';
+        } else if (grouping === 'by-user') {
+            rows = groupByUser(records);
+            columns = ['user', 'total_spent'];
+            label = 'by user';
+        } else {
+            rows = groupByProjectUser(records);
+            columns = ['billing_project', 'user', 'total_spent'];
+            label = 'by billing project and user';
+        }
+        var params = new URLSearchParams(window.location.search);
+        var startStr = queryDateToIso8601(params.get('start') || '');
+        var endStr = queryDateToIso8601(params.get('end') || '');
+        return {
+            csvText: toCsv(rows, columns),
+            filename: `Hail billing export ${startStr} to ${endStr} ${label}.csv`,
+        };
+    }
+
     function triggerDownload(csvText, filename) {
         var blob = new Blob([csvText], { type: 'text/csv' });
         var url = URL.createObjectURL(blob);
@@ -82,47 +116,52 @@
         URL.revokeObjectURL(url);
     }
 
-    exportBtn.addEventListener('click', function () {
-        exportBtn.disabled = true;
-        statusEl.textContent = 'Fetching\u2026';
-        statusEl.classList.remove('hidden');
+    function copyToClipboard(csvText) {
+        return navigator.clipboard.writeText(csvText);
+    }
 
-        var query = window.location.search;
-        fetch(basePath + '/api/v1alpha/billing' + query)
+    function fetchBillingRecords() {
+        return fetch(basePath + '/api/v1alpha/billing' + window.location.search)
             .then(function (resp) {
                 if (!resp.ok) throw new Error('HTTP ' + resp.status);
                 return resp.json();
-            })
-            .then(function (records) {
-                var grouping = getGrouping();
-                var rows, columns, label;
-                if (grouping === 'by-project') {
-                    rows = groupByProject(records);
-                    columns = ['billing_project', 'total_spent'];
-                    label = 'by billing project';
-                } else if (grouping === 'by-user') {
-                    rows = groupByUser(records);
-                    columns = ['user', 'total_spent'];
-                    label = 'by user';
-                } else {
-                    rows = groupByProjectUser(records);
-                    columns = ['billing_project', 'user', 'total_spent'];
-                    label = 'by billing project and user';
-                }
+            });
+    }
 
-                var params = new URLSearchParams(window.location.search);
-                var startStr = toIso(params.get('start') || '');
-                var endStr = toIso(params.get('end') || '');
-                var filename = 'Hail billing export ' + startStr + ' to ' + endStr + ' ' + label + '.csv';
+    function withBillingData(btn, action) {
+        btn.disabled = true;
+        statusEl.textContent = 'Fetching\u2026';
+        statusEl.classList.remove('hidden');
 
-                triggerDownload(toCsv(rows, columns), filename);
-                statusEl.classList.add('hidden');
-            })
+        fetchBillingRecords()
+            .then(function (records) { return action(prepareCsvExport(records)); })
             .catch(function (err) {
-                statusEl.textContent = 'Export failed: ' + err.message;
+                statusEl.textContent = 'Failed: ' + err.message;
             })
             .finally(function () {
-                exportBtn.disabled = false;
+                btn.disabled = false;
             });
-    });
+    }
+
+    if (exportBtn) {
+        exportBtn.addEventListener('click', function () {
+            withBillingData(exportBtn, function ({ csvText, filename }) {
+                triggerDownload(csvText, filename);
+                statusEl.classList.add('hidden');
+            });
+        });
+    }
+
+    if (copyBtn) {
+        copyBtn.addEventListener('click', function () {
+            withBillingData(copyBtn, function ({ csvText }) {
+                return copyToClipboard(csvText).then(function () {
+                    statusEl.classList.add('hidden');
+                    var original = copyBtn.textContent;
+                    copyBtn.textContent = '\u2713 Copied!';
+                    setTimeout(function () { copyBtn.textContent = original; }, 2000);
+                });
+            });
+        });
+    }
 })();

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -10,9 +10,9 @@
         try {
             if (!mmddyyyy) {
                 const now = new Date();
-                yyyy = now.getFullYear();
-                mm = String(now.getMonth() + 1).padStart(2, '0');
-                dd = String(now.getDate()).padStart(2, '0');
+                const yyyy = now.getFullYear();
+                const mm = String(now.getMonth() + 1).padStart(2, '0');
+                const dd = String(now.getDate()).padStart(2, '0');
                 return `${yyyy}-${mm}-${dd}`;
             } else {
                 const [mm, dd, yyyy] = mmddyyyy.split('/');

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -27,29 +27,29 @@
 
     function toCsv(rows, columns) {
         var lines = [columns.join(',')];
-        for (var i = 0; i < rows.length; i++) {
-            lines.push(columns.map(function (col) { return csvEscape(rows[i][col]); }).join(','));
-        }
+        rows.forEach(function (row) {
+            lines.push(columns.map(function (col) { return csvEscape(row.get(col)); }).join(','));
+        });
         return lines.join('\n');
     }
 
     function groupByProject(records) {
-        var acc = {};
+        var acc = new Map();
         records.forEach(function (r) {
-            acc[r.billing_project] = (acc[r.billing_project] || 0) + r.total_spent;
+            acc.set(r.billing_project, (acc.get(r.billing_project) || 0) + r.total_spent);
         });
-        return Object.keys(acc).sort().map(function (bp) {
-            return { billing_project: bp, total_spent: acc[bp] };
+        return Array.from(acc.keys()).sort().map(function (bp) {
+            return new Map([['billing_project', bp], ['total_spent', acc.get(bp)]]);
         });
     }
 
     function groupByUser(records) {
-        var acc = {};
+        var acc = new Map();
         records.forEach(function (r) {
-            acc[r.user] = (acc[r.user] || 0) + r.total_spent;
+            acc.set(r.user, (acc.get(r.user) || 0) + r.total_spent);
         });
-        return Object.keys(acc).sort().map(function (u) {
-            return { user: u, total_spent: acc[u] };
+        return Array.from(acc.keys()).sort().map(function (u) {
+            return new Map([['user', u], ['total_spent', acc.get(u)]]);
         });
     }
 
@@ -59,15 +59,15 @@
                 return a.billing_project < b.billing_project ? -1 : 1;
             }
             return a.user < b.user ? -1 : 1;
+        }).map(function (r) {
+            return new Map([['billing_project', r.billing_project], ['user', r.user], ['total_spent', r.total_spent]]);
         });
     }
 
     function getGrouping() {
         var radios = document.querySelectorAll('input[name="export-grouping"]');
-        for (var i = 0; i < radios.length; i++) {
-            if (radios[i].checked) return radios[i].value;
-        }
-        return 'by-project-user';
+        var checked = Array.from(radios).find(function (r) { return r.checked; });
+        return checked ? checked.value : 'by-project-user';
     }
 
     function triggerDownload(csvText, filename) {

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -1,0 +1,128 @@
+(function () {
+    var exportBtn = document.getElementById('billing-export-btn');
+    if (!exportBtn) return;
+
+    var statusEl = document.getElementById('billing-export-status');
+    var basePath = '{{ base_path }}';
+
+    function toIso(mmddyyyy) {
+        if (!mmddyyyy) {
+            var now = new Date();
+            return now.getFullYear() + '-'
+                + String(now.getMonth() + 1).padStart(2, '0') + '-'
+                + String(now.getDate()).padStart(2, '0');
+        }
+        var parts = mmddyyyy.split('/');
+        if (parts.length !== 3) return mmddyyyy;
+        return parts[2] + '-' + parts[0] + '-' + parts[1];
+    }
+
+    function csvEscape(val) {
+        var s = String(val);
+        if (s.indexOf(',') >= 0 || s.indexOf('"') >= 0 || s.indexOf('\n') >= 0) {
+            return '"' + s.replace(/"/g, '""') + '"';
+        }
+        return s;
+    }
+
+    function toCsv(rows, columns) {
+        var lines = [columns.join(',')];
+        for (var i = 0; i < rows.length; i++) {
+            lines.push(columns.map(function (col) { return csvEscape(rows[i][col]); }).join(','));
+        }
+        return lines.join('\n');
+    }
+
+    function groupByProject(records) {
+        var acc = {};
+        records.forEach(function (r) {
+            acc[r.billing_project] = (acc[r.billing_project] || 0) + r.total_spent;
+        });
+        return Object.keys(acc).sort().map(function (bp) {
+            return { billing_project: bp, total_spent: acc[bp] };
+        });
+    }
+
+    function groupByUser(records) {
+        var acc = {};
+        records.forEach(function (r) {
+            acc[r.user] = (acc[r.user] || 0) + r.total_spent;
+        });
+        return Object.keys(acc).sort().map(function (u) {
+            return { user: u, total_spent: acc[u] };
+        });
+    }
+
+    function groupByProjectUser(records) {
+        return records.slice().sort(function (a, b) {
+            if (a.billing_project !== b.billing_project) {
+                return a.billing_project < b.billing_project ? -1 : 1;
+            }
+            return a.user < b.user ? -1 : 1;
+        });
+    }
+
+    function getGrouping() {
+        var radios = document.querySelectorAll('input[name="export-grouping"]');
+        for (var i = 0; i < radios.length; i++) {
+            if (radios[i].checked) return radios[i].value;
+        }
+        return 'by-project-user';
+    }
+
+    function triggerDownload(csvText, filename) {
+        var blob = new Blob([csvText], { type: 'text/csv' });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    exportBtn.addEventListener('click', function () {
+        exportBtn.disabled = true;
+        statusEl.textContent = 'Fetching\u2026';
+        statusEl.classList.remove('hidden');
+
+        var query = window.location.search;
+        fetch(basePath + '/api/v1alpha/billing' + query)
+            .then(function (resp) {
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                return resp.json();
+            })
+            .then(function (records) {
+                var grouping = getGrouping();
+                var rows, columns, label;
+                if (grouping === 'by-project') {
+                    rows = groupByProject(records);
+                    columns = ['billing_project', 'total_spent'];
+                    label = 'by billing project';
+                } else if (grouping === 'by-user') {
+                    rows = groupByUser(records);
+                    columns = ['user', 'total_spent'];
+                    label = 'by user';
+                } else {
+                    rows = groupByProjectUser(records);
+                    columns = ['billing_project', 'user', 'total_spent'];
+                    label = 'by billing project and user';
+                }
+
+                var params = new URLSearchParams(window.location.search);
+                var startStr = toIso(params.get('start') || '');
+                var endStr = toIso(params.get('end') || '');
+                var filename = 'Hail billing export ' + startStr + ' to ' + endStr + ' ' + label + '.csv';
+
+                triggerDownload(toCsv(rows, columns), filename);
+                statusEl.classList.add('hidden');
+            })
+            .catch(function (err) {
+                statusEl.textContent = 'Export failed: ' + err.message;
+            })
+            .finally(function () {
+                exportBtn.disabled = false;
+            });
+    });
+})();

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -6,9 +6,6 @@
     var statusEl = document.getElementById('billing-export-status');
     var basePath = (document.getElementById('billing-js') || {}).dataset?.basePath ?? '';
 
-    // Converts a mm/dd/yyyy query-param date string to yyyy-mm-dd for use in filenames.
-    // String manipulation is intentional — Date.toISOString() converts to UTC and can
-    // shift the date backwards in timezones behind UTC.
     function queryDateToIso8601(mmddyyyy) {
         try {
             if (!mmddyyyy) {

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -7,7 +7,7 @@
 
     function toIso(mmddyyyy) {
         if (!mmddyyyy) {
-            var now = new Date();
+            let now = new Date();
             return now.getFullYear() + '-'
                 + String(now.getMonth() + 1).padStart(2, '0') + '-'
                 + String(now.getDate()).padStart(2, '0');

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -76,8 +76,7 @@
         return checked ? checked.value : 'by-project-user';
     }
 
-    function prepareCsvExport(records) {
-        var grouping = getGrouping();
+    function prepareCsvExport(records, grouping) {
         var rows, columns, label;
         if (grouping === 'by-project') {
             rows = groupByProject(records);
@@ -130,8 +129,9 @@
         statusEl.textContent = 'Fetching\u2026';
         statusEl.classList.remove('hidden');
 
+        var grouping = getGrouping();
         fetchBillingRecords()
-            .then(function (records) { return action(prepareCsvExport(records)); })
+            .then(function (records) { return action(prepareCsvExport(records, grouping)); })
             .catch(function (err) {
                 statusEl.textContent = 'Failed: ' + err.message;
             })

--- a/batch/batch/front_end/static/js/billing.js
+++ b/batch/batch/front_end/static/js/billing.js
@@ -6,21 +6,19 @@
     var statusEl = document.getElementById('billing-export-status');
     var basePath = (document.getElementById('billing-js') || {}).dataset?.basePath ?? '';
 
-    function queryDateToIso8601(mmddyyyy) {
-        try {
-            if (!mmddyyyy) {
-                const now = new Date();
-                const yyyy = now.getFullYear();
-                const mm = String(now.getMonth() + 1).padStart(2, '0');
-                const dd = String(now.getDate()).padStart(2, '0');
-                return `${yyyy}-${mm}-${dd}`;
-            } else {
-                const [mm, dd, yyyy] = mmddyyyy.split('/');
-                return `${yyyy}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`;
-            }
-        } catch (e) {
-            return 'invalid-date-format';
-        }
+    function mmddyyyyToIso8601(mmddyyyy) {
+        const [mm, dd, yyyy] = mmddyyyy.split('/');
+        return `${yyyy}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`;
+    }
+
+    function todayIso8601() {
+        const now = new Date();
+        return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    }
+
+    function firstOfMonthIso8601() {
+        const now = new Date();
+        return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
     }
 
     function csvEscape(val) {
@@ -92,8 +90,8 @@
             label = 'by billing project and user';
         }
         var params = new URLSearchParams(window.location.search);
-        var startStr = queryDateToIso8601(params.get('start') || '');
-        var endStr = queryDateToIso8601(params.get('end') || '');
+        var startStr = params.get('start') ? mmddyyyyToIso8601(params.get('start')) : firstOfMonthIso8601();
+        var endStr   = params.get('end')   ? mmddyyyyToIso8601(params.get('end'))   : todayIso8601();
         return {
             csvText: toCsv(rows, columns),
             filename: `Hail billing export ${startStr} to ${endStr} ${label}.csv`,
@@ -124,16 +122,26 @@
             });
     }
 
+    function showStatus(text) {
+        statusEl.textContent = text;
+        statusEl.classList.remove('hidden');
+    }
+
+    function showDoneThenHide() {
+        showStatus('\u2713 Done');
+        setTimeout(function () { statusEl.classList.add('hidden'); }, 1500);
+    }
+
     function withBillingData(btn, action) {
         btn.disabled = true;
-        statusEl.textContent = 'Fetching\u2026';
-        statusEl.classList.remove('hidden');
+        showStatus('\u29d6 Fetching\u2026');
 
         var grouping = getGrouping();
         fetchBillingRecords()
             .then(function (records) { return action(prepareCsvExport(records, grouping)); })
+            .then(showDoneThenHide)
             .catch(function (err) {
-                statusEl.textContent = 'Failed: ' + err.message;
+                showStatus('Failed: ' + err.message);
             })
             .finally(function () {
                 btn.disabled = false;
@@ -144,7 +152,6 @@
         exportBtn.addEventListener('click', function () {
             withBillingData(exportBtn, function ({ csvText, filename }) {
                 triggerDownload(csvText, filename);
-                statusEl.classList.add('hidden');
             });
         });
     }
@@ -152,12 +159,7 @@
     if (copyBtn) {
         copyBtn.addEventListener('click', function () {
             withBillingData(copyBtn, function ({ csvText }) {
-                return copyToClipboard(csvText).then(function () {
-                    statusEl.classList.add('hidden');
-                    var original = copyBtn.textContent;
-                    copyBtn.textContent = '\u2713 Copied!';
-                    setTimeout(function () { copyBtn.textContent = original; }, 2000);
-                });
+                return copyToClipboard(csvText);
             });
         });
     }

--- a/batch/batch/front_end/templates/billing.html
+++ b/batch/batch/front_end/templates/billing.html
@@ -55,7 +55,7 @@
         {% endif %}
 
         <button id='billing-export-btn'
-          class='bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm'>
+          class='bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm disabled:opacity-50 disabled:cursor-not-allowed'>
           Download CSV
         </button>
         <p id='billing-export-status' class='text-sm text-zinc-500 hidden'></p>

--- a/batch/batch/front_end/templates/billing.html
+++ b/batch/batch/front_end/templates/billing.html
@@ -54,10 +54,16 @@
         </p>
         {% endif %}
 
-        <button id='billing-export-btn'
-          class='bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm disabled:opacity-50 disabled:cursor-not-allowed'>
-          Download CSV
-        </button>
+        <div class='flex gap-2'>
+          <button id='billing-export-btn'
+            class='bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm disabled:opacity-50 disabled:cursor-not-allowed'>
+            Download CSV
+          </button>
+          <button id='billing-copy-btn'
+            class='border border-blue-600 text-blue-600 px-4 py-2 rounded hover:bg-blue-50 text-sm disabled:opacity-50 disabled:cursor-not-allowed'>
+            Copy to Clipboard
+          </button>
+        </div>
         <p id='billing-export-status' class='text-sm text-zinc-500 hidden'></p>
       </div>
     </details>

--- a/batch/batch/front_end/templates/billing.html
+++ b/batch/batch/front_end/templates/billing.html
@@ -2,7 +2,7 @@
 {% extends "layout.html" %}
 {% block title %}Billing{% endblock %}
 {% block content %}
-<div class='flex flex-wrap justify-around md:mt-16'>
+<div class='flex flex-wrap justify-around items-start md:mt-16'>
   <div class='lg:basis-1/3'>
     <form method="GET" action="{{ base_path }}/billing">
       <div class='flex flex-wrap justify-between space-y-2 items-end'>
@@ -33,6 +33,7 @@
         <p class='text-sm text-zinc-500'>
           Dates: <span class='font-medium'>{{ start }}</span> to
           <span class='font-medium'>{{ end or today }}</span>
+          <span class='italic'>({% if end %}currently-running batches excluded{% else %}including currently-running batches{% endif %})</span>
         </p>
 
         {% if is_developer %}
@@ -124,5 +125,5 @@
     </div>
   </div>
 </div>
-<script defer src="{{ base_path }}/batch/static/js/billing.js"></script>
+<script id='billing-js' defer src="{{ base_path }}/batch/static/js/billing.js" data-base-path="{{ base_path }}"></script>
 {% endblock %}

--- a/batch/batch/front_end/templates/billing.html
+++ b/batch/batch/front_end/templates/billing.html
@@ -26,6 +26,40 @@
       MM/DD/YYYY. Leave End empty to include currently running batches. If End is not empty,
       then no currently running batches are included. All dates search for batches that have
       completed within that time interval (inclusive).</p>
+
+    <details class='mt-4 border rounded'>
+      <summary class='p-3 cursor-pointer font-medium select-none'>Export to spreadsheet</summary>
+      <div class='p-4 space-y-3'>
+        <p class='text-sm text-zinc-500'>
+          Dates: <span class='font-medium'>{{ start }}</span> to
+          <span class='font-medium'>{{ end or today }}</span>
+        </p>
+
+        {% if is_developer %}
+        <div class='space-y-1 text-sm'>
+          <label class='flex items-center gap-2 cursor-pointer'>
+            <input type='radio' name='export-grouping' value='by-project' checked> By Billing Project
+          </label>
+          <label class='flex items-center gap-2 cursor-pointer'>
+            <input type='radio' name='export-grouping' value='by-user'> By User
+          </label>
+          <label class='flex items-center gap-2 cursor-pointer'>
+            <input type='radio' name='export-grouping' value='by-project-user'> By Billing Project and User
+          </label>
+        </div>
+        {% else %}
+        <p class='text-sm flex items-center gap-2'>
+          <span class='text-green-600 font-bold'>&#10003;</span> By Billing Project and User
+        </p>
+        {% endif %}
+
+        <button id='billing-export-btn'
+          class='bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 text-sm'>
+          Download CSV
+        </button>
+        <p id='billing-export-status' class='text-sm text-zinc-500 hidden'></p>
+      </div>
+    </details>
   </div>
   <div class='bg-slate-100 border rounded overflow-hidden lg:basis-1/2'>
     <div class='text-xl m-4'>
@@ -90,4 +124,5 @@
     </div>
   </div>
 </div>
+<script defer src="{{ base_path }}/batch/static/js/billing.js"></script>
 {% endblock %}

--- a/batch/batch/front_end/templates/billing.html
+++ b/batch/batch/front_end/templates/billing.html
@@ -36,7 +36,7 @@
           <span class='italic'>({% if end %}currently-running batches excluded{% else %}including currently-running batches{% endif %})</span>
         </p>
 
-        {% if is_developer %}
+        {% if userdata['system_permissions']['read_all_billing_projects'] %}
         <div class='space-y-1 text-sm'>
           <label class='flex items-center gap-2 cursor-pointer'>
             <input type='radio' name='export-grouping' value='by-project' checked> By Billing Project

--- a/batch/batch/front_end/templates/openapi.yaml
+++ b/batch/batch/front_end/templates/openapi.yaml
@@ -755,6 +755,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JobV2ListResponse'
+  '/api/v1alpha/billing':
+    get:
+      summary: "Get billing records"
+      description: >
+        Return per-(billing_project, user) cost records for a date range.
+        Non-developers see only their own records; developers see all.
+        Costs are plain floats in USD. Omitting `end` includes currently-running batches;
+        supplying `end` excludes them.
+      operationId: getBilling
+      tags:
+        - Billing Projects
+      parameters:
+        - name: start
+          in: query
+          description: "Start date in MM/DD/YYYY format (required)."
+          required: true
+          schema:
+            type: string
+            example: "04/01/2026"
+        - name: end
+          in: query
+          description: "End date in MM/DD/YYYY format (inclusive, optional). Omit to include currently-running batches."
+          required: false
+          schema:
+            type: string
+            example: "04/21/2026"
+      responses:
+        '200':
+          description: "Billing records retrieved successfully."
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BillingRecord'
+        '401':
+          description: Unauthorized
   '/api/v1alpha/billing_projects':
     get:
       summary: "List billing projects"
@@ -2251,6 +2288,19 @@ components:
           description: "List of child job groups"
           items:
             $ref: '#/components/schemas/JobGroupResponse'
+
+    BillingRecord:
+      type: object
+      properties:
+        billing_project:
+          type: string
+          description: "The billing project."
+        user:
+          type: string
+          description: "The user."
+        total_spent:
+          type: number
+          description: "Total cost in USD."
 
     CreateJobGroupResponse:
       type: object


### PR DESCRIPTION
## Change Description

- Adds a GET api to fetch billing info
- Adds an export link to the billing page to allow easy download

### Example

New UI element:

<img width="1770" height="591" alt="image" src="https://github.com/user-attachments/assets/48c19c37-0d72-4c2f-86bb-8b8189bd313e" />

Downloaded data in `Hail billing export 2026-04-21 to 2026-04-21 by billing project and user.csv`:
```csv
billing_project,user,total_spent
chrisl-trial,chrisl,0.13632737986124266
```

(the other two options give similar CSVs, with either just the `user` or `project` columns)

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

- The API uses the same auth as the billing.html page to determine what gets presented. The only difference is format.
- Follows the same CSP-friendly pattern to import the javascript which prepares the data as csv

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
