### PR TITLE
[ci] Use test step inputs and files changed to determine which tests to run

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -826,6 +826,8 @@ steps:
         to: /io/repo/hail
       - from: /repo/.git
         to: /io/repo/.git
+      - from: /repo/README.md
+        to: /io/repo/README.md
     outputs:
       - from: /io/repo/hail/out
         to: /derived/release/hail/out/
@@ -917,6 +919,8 @@ steps:
         to: /io/repo/hail
       - from: /repo/.git
         to: /io/repo/.git
+      - from: /repo/README.md
+        to: /io/repo/README.md
     outputs:
       - from: /io/repo/hail/out
         to: /derived/debug/hail/out

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,6 @@
+alwaysRunSteps:
+  - merge_code
+
 steps:
   - kind: buildImage2
     name: git_make_bash_image

--- a/build.yaml
+++ b/build.yaml
@@ -637,8 +637,10 @@ steps:
     contextPath: /io/repo/docker/vep/
     publishAs: hailgenetics/vep-grch37-85
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/docker/hailgenetics/vep
+        to: /io/repo/docker/hailgenetics/vep
+      - from: /repo/docker/vep
+        to: /io/repo/docker/vep
     dependsOn:
       - merge_code
   - kind: buildImage2
@@ -647,8 +649,10 @@ steps:
     contextPath: /io/repo/docker/vep/
     publishAs: hailgenetics/vep-grch38-95
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/docker/hailgenetics/vep
+        to: /io/repo/docker/hailgenetics/vep
+      - from: /repo/docker/vep
+        to: /io/repo/docker/vep
     dependsOn:
       - merge_code
   - kind: buildImage2
@@ -813,8 +817,8 @@ steps:
       BYTES=$(du build/deploy/dist/hail-*-py3-none-any.whl | awk '{print $1}')
       (( BYTES < 209715200 )) || exit 1
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/hail
+        to: /io/repo/hail
     outputs:
       - from: /io/repo/hail/out
         to: /derived/release/hail/out/
@@ -902,8 +906,8 @@ steps:
 
       time retry make wheel
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/hail
+        to: /io/repo/hail
     outputs:
       - from: /io/repo/hail/out
         to: /derived/debug/hail/out
@@ -933,8 +937,8 @@ steps:
           sleep 5
       fi
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/hail
+        to: /io/repo/hail
       - from: /derived/debug/hail/out
         to: /io/repo/hail/out
     outputs:
@@ -958,8 +962,8 @@ steps:
       time TESTNG_SPLITS=5 python3 generate_splits.py
       time tar czf splits.tar.gz testng-splits-*.xml
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/hail
+        to: /io/repo/hail
     outputs:
       - from: /io/repo/hail/test.tar.gz
         to: /test.tar.gz
@@ -1698,8 +1702,8 @@ steps:
       HAIL_BUILD_MODE='CI'
       time retry sh mill --no-daemon hail[2.13].__.compile
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/hail
+        to: /io/repo/hail
     dependsOn:
       - base_image
       - merge_code
@@ -1744,8 +1748,8 @@ steps:
       memory: standard
       cpu: '2'
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/hail/env/HAIL_PIP_VERSION
+        to: /io/repo/hail/env/HAIL_PIP_VERSION
       - from: /www.tar.gz
         to: /io/www.tar.gz
     outputs:
@@ -3006,8 +3010,28 @@ steps:
       - test
       - dev
     inputs:
-      - from: /repo
-        to: /io/repo
+      - from: /repo/ci
+        to: /io/repo/ci
+      - from: /repo/tls
+        to: /io/repo/tls
+      - from: /repo/pylintrc
+        to: /io/repo/pylintrc
+      - from: /repo/check-sql.sh
+        to: /io/repo/check-sql.sh
+      - from: /repo/pyproject.toml
+        to: /io/repo/pyproject.toml
+      - from: /repo/docker
+        to: /io/repo/docker
+      - from: /repo/gear
+        to: /io/repo/gear
+      - from: /repo/hail/python
+        to: /io/repo/hail/python
+      - from: /repo/hail/Makefile
+        to: /io/repo/hail/Makefile
+      - from: /repo/hail/env_var.mk
+        to: /io/repo/hail/env_var.mk
+      - from: /repo/web_common
+        to: /io/repo/web_common
     dependsOn:
       - default_ns
       - ci_utils_image

--- a/build.yaml
+++ b/build.yaml
@@ -824,6 +824,8 @@ steps:
     inputs:
       - from: /repo/hail
         to: /io/repo/hail
+      - from: /repo/.git
+        to: /io/repo/.git
     outputs:
       - from: /io/repo/hail/out
         to: /derived/release/hail/out/
@@ -913,6 +915,8 @@ steps:
     inputs:
       - from: /repo/hail
         to: /io/repo/hail
+      - from: /repo/.git
+        to: /io/repo/.git
     outputs:
       - from: /io/repo/hail/out
         to: /derived/debug/hail/out
@@ -944,6 +948,8 @@ steps:
     inputs:
       - from: /repo/hail
         to: /io/repo/hail
+      - from: /repo/.git
+        to: /io/repo/.git
       - from: /derived/debug/hail/out
         to: /io/repo/hail/out
     outputs:
@@ -1755,6 +1761,8 @@ steps:
     inputs:
       - from: /repo/hail/env/HAIL_PIP_VERSION
         to: /io/repo/hail/env/HAIL_PIP_VERSION
+      - from: /repo/.git
+        to: /io/repo/.git
       - from: /www.tar.gz
         to: /io/www.tar.gz
     outputs:

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,5 @@
+repoPrefix: /repo
+
 alwaysRunSteps:
   - merge_code
 

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -134,7 +134,8 @@ class BuildConfiguration:
                             visit_dependent(s2)
 
             for step_name in requested_step_names:
-                visit_dependent(name_step[step_name])
+                if step_name in name_step:
+                    visit_dependent(name_step[step_name])
             self.steps = [step for step in runnable_steps if step in visited]
         else:
             self.steps = [step for step in runnable_steps if not step.run_if_requested]

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -134,8 +134,7 @@ class BuildConfiguration:
                             visit_dependent(s2)
 
             for step_name in requested_step_names:
-                if step_name in name_step:
-                    visit_dependent(name_step[step_name])
+                visit_dependent(name_step[step_name])
             self.steps = [step for step in runnable_steps if step in visited]
         else:
             self.steps = [step for step in runnable_steps if not step.run_if_requested]

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -37,17 +37,17 @@ def _is_doc_file(path: str) -> bool:
     return any(lower.endswith(ext) for ext in _DOC_EXTENSIONS)
 
 
-def _repo_input_local_path(from_path: str) -> Optional[str]:
-    """Return the local path from a /repo/... input, or None if not a repo input.
+def _repo_input_local_path(from_path: str, repo_prefix: str = '/repo') -> Optional[str]:
+    """Return the local path from a <repo_prefix>/... input, or None if not a repo input.
 
     '/repo'   -> ''       (matches everything)
     '/repo/x' -> 'x'
     other     -> None
     """
-    if from_path == '/repo':
+    if from_path == repo_prefix:
         return ''
-    if from_path.startswith('/repo/'):
-        return from_path[len('/repo/') :]
+    if from_path.startswith(repo_prefix + '/'):
+        return from_path[len(repo_prefix) + 1 :]
     return None
 
 
@@ -72,15 +72,16 @@ def _find_seed_steps(
     steps: list,
     changed_files: List[str],
     runnable: Callable[[str], bool],
+    repo_prefix: str = '/repo',
 ) -> Set[str]:
-    """Return steps whose /repo/ inputs match any of the changed files."""
+    """Return steps whose repo inputs match any of the changed files."""
     seeds: Set[str] = set()
     for step in steps:
         if not runnable(step['name']):
             continue
         inputs = step.get('inputs') or []
         for inp in inputs:
-            local_path = _repo_input_local_path(inp.get('from', ''))
+            local_path = _repo_input_local_path(inp.get('from', ''), repo_prefix)
             if local_path is None:
                 continue
             if any(_file_matches_input(f, local_path) for f in changed_files):
@@ -114,7 +115,7 @@ def compute_requested_steps(
 ) -> BuildSelectionResult:
     """Return step selection results given a list of changed file paths.
 
-    Finds steps directly affected (those with /repo/ inputs matching changed
+    Finds steps directly affected (those with repo inputs matching changed
     files), then follows dependsOn edges forward to find all transitive
     descendants. Only steps runnable in `scope` and `cloud` are returned; this
     prevents deploy-only or wrong-cloud steps from pulling in unrelated
@@ -125,6 +126,9 @@ def compute_requested_steps(
     alwaysRunSteps in the config are always included whenever changed_files is
     non-empty.
 
+    The repo artifact prefix (e.g. '/repo') is read from the top-level
+    `repoPrefix` field in the config, defaulting to '/repo' if absent.
+
     Returns an empty BuildSelectionResult when changed_files is empty.
     """
     if not changed_files:
@@ -133,6 +137,7 @@ def compute_requested_steps(
     config = yaml.safe_load(config_str)
     steps = config.get('steps', [])
     always_run_steps: List[str] = config.get('alwaysRunSteps', [])
+    repo_prefix: str = config.get('repoPrefix', '/repo')
 
     scopes_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('scopes') for s in steps}
     clouds_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('clouds') for s in steps}
@@ -146,7 +151,7 @@ def compute_requested_steps(
             reverse.setdefault(dep, []).append(step['name'])
 
     code_files = [f for f in changed_files if not _is_doc_file(f)]
-    seeds = _find_seed_steps(steps, code_files, runnable)
+    seeds = _find_seed_steps(steps, code_files, runnable, repo_prefix)
     result = _expand_to_descendants(seeds, reverse, runnable)
     result.update(always_run_steps)
 

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -1,0 +1,143 @@
+"""Change-based test selection helpers.
+
+Derives step selection from each step's `inputs` declarations in build.yaml.
+Steps that directly import changed repository files are seeds; all transitive
+dependents in the dependsOn DAG are included.
+
+This module is intentionally free of cloud/environment imports so it can be
+used in tests and tooling without a running deployment.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Set
+
+import yaml
+
+
+@dataclass
+class BuildSelectionResult:
+    """Result of change-based step selection.
+
+    Attributes:
+        requested_steps: Sorted list of step names that should run.
+    """
+
+    requested_steps: List[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return f'requested_steps={self.requested_steps}'
+
+
+def expand_build_steps(
+    config_str: str,
+    requested_step_names: Sequence[str],
+    cloud: Optional[str] = None,
+    excluded_step_names: Sequence[str] = (),
+) -> List[str]:
+    """Expand a list of requested step names to include all transitive upstream deps.
+
+    Mirrors the logic in BuildConfiguration.visit_dependent, but as a pure
+    function for use in tests and tooling.
+    """
+    config = yaml.safe_load(config_str)
+    steps = config.get('steps', [])
+    excluded = set(excluded_step_names)
+    run_if_requested: Set[str] = {s['name'] for s in steps if s.get('runIfRequested', False)}
+    deps_map: Dict[str, List[str]] = {s['name']: s.get('dependsOn', []) for s in steps}
+    clouds_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('clouds') for s in steps}
+
+    visited: Set[str] = set()
+    frontier = list(requested_step_names)
+    while frontier:
+        cur = frontier.pop()
+        if cur in visited or cur in excluded:
+            continue
+        if cloud is not None:
+            step_clouds = clouds_map.get(cur)
+            if step_clouds is not None and cloud not in step_clouds:
+                continue
+        visited.add(cur)
+        for dep in deps_map.get(cur, []):
+            if dep not in run_if_requested:
+                frontier.append(dep)
+    return sorted(visited)
+
+
+def _repo_input_local_path(from_path: str) -> Optional[str]:
+    """Return the local path from a /repo/... input, or None if not a repo input.
+
+    '/repo'   -> ''       (matches everything)
+    '/repo/x' -> 'x'
+    other     -> None
+    """
+    if from_path == '/repo':
+        return ''
+    if from_path.startswith('/repo/'):
+        return from_path[len('/repo/'):]
+    return None
+
+
+def _file_matches_input(changed_file: str, local_path: str) -> bool:
+    """True if changed_file is at or under local_path."""
+    if local_path == '':
+        return True
+    return changed_file == local_path or changed_file.startswith(local_path + '/')
+
+
+def _in_scope(scopes: Optional[List[str]], scope: str) -> bool:
+    return scopes is None or scope in scopes
+
+
+def compute_requested_steps(
+    config_str: str, changed_files: List[str], scope: str = 'test'
+) -> BuildSelectionResult:
+    """Return step selection results given a list of changed file paths.
+
+    Finds steps directly affected (those with /repo/ inputs matching changed
+    files), then follows dependsOn edges forward to find all transitive
+    descendants. Only steps runnable in `scope` are returned; this prevents
+    deploy-only steps from pulling in unrelated test-scope upstream deps via
+    BuildConfiguration.visit_dependent.
+
+    Returns an empty BuildSelectionResult when changed_files is empty.
+    """
+    if not changed_files:
+        return BuildSelectionResult()
+
+    config = yaml.safe_load(config_str)
+    steps = config.get('steps', [])
+
+    scopes_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('scopes') for s in steps}
+
+    # Build reverse adjacency: step_name -> list of steps that depend on it
+    reverse: Dict[str, List[str]] = {}
+    for step in steps:
+        for dep in step.get('dependsOn', []):
+            reverse.setdefault(dep, []).append(step['name'])
+
+    # Find seed steps: those whose /repo/ inputs match any changed file,
+    # restricted to steps runnable in the target scope.
+    seed_steps: Set[str] = set()
+    for step in steps:
+        if not _in_scope(scopes_map.get(step['name']), scope):
+            continue
+        inputs = step.get('inputs') or []
+        for inp in inputs:
+            local_path = _repo_input_local_path(inp.get('from', ''))
+            if local_path is None:
+                continue
+            if any(_file_matches_input(f, local_path) for f in changed_files):
+                seed_steps.add(step['name'])
+                break
+
+    # BFS forward from seeds to find all in-scope descendants
+    result: Set[str] = set(seed_steps)
+    frontier = list(seed_steps)
+    while frontier:
+        cur = frontier.pop()
+        for dependent in reverse.get(cur, []):
+            if dependent not in result and _in_scope(scopes_map.get(dependent), scope):
+                result.add(dependent)
+                frontier.append(dependent)
+
+    return BuildSelectionResult(requested_steps=sorted(result))

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -78,15 +78,15 @@ def compute_requested_steps(
     changed_files: List[str],
     scope: str = 'test',
     cloud: Optional[str] = None,
-) -> List[str]:
+) -> Set[str]:
     """Select which build steps should be requested, given the changed files in a PR.
 
     set((directly affected steps + their descendants) + alwaysRunSteps)
 
-    Returns an empty list when changed_files is empty.
+    Returns an empty set when changed_files is empty.
     """
     if not changed_files:
-        return []
+        return set()
 
     config = yaml.safe_load(config_str)
     repo_prefix: str = config.get('repoPrefix', '/repo')
@@ -103,4 +103,4 @@ def compute_requested_steps(
     affected_and_descendants = _expand_to_descendants(affected_steps, descendants_map)
     requested_steps = affected_and_descendants | always_run_steps
 
-    return sorted(requested_steps)
+    return requested_steps

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -1,17 +1,6 @@
-from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set
 
 import yaml
-
-
-@dataclass
-class BuildSelectionResult:
-    """The set of build steps selected to run."""
-
-    requested_steps: List[str] = field(default_factory=list)
-
-    def __str__(self) -> str:
-        return f'requested_steps={self.requested_steps}'
 
 
 def _repo_input_local_path(from_path: str, repo_prefix: str = '/repo') -> Optional[str]:
@@ -89,15 +78,15 @@ def compute_requested_steps(
     changed_files: List[str],
     scope: str = 'test',
     cloud: Optional[str] = None,
-) -> BuildSelectionResult:
+) -> List[str]:
     """Select which build steps should be requested, given the changed files in a PR.
 
     set((directly affected steps + their descendants) + alwaysRunSteps)
 
-    Returns an empty result when changed_files is empty.
+    Returns an empty list when changed_files is empty.
     """
     if not changed_files:
-        return BuildSelectionResult()
+        return []
 
     config = yaml.safe_load(config_str)
     repo_prefix: str = config.get('repoPrefix', '/repo')
@@ -114,4 +103,4 @@ def compute_requested_steps(
     affected_and_descendants = _expand_to_descendants(affected_steps, descendants_map)
     requested_steps = affected_and_descendants | always_run_steps
 
-    return BuildSelectionResult(requested_steps=sorted(requested_steps))
+    return sorted(requested_steps)

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, FrozenSet, List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 import yaml
 
@@ -12,15 +12,6 @@ class BuildSelectionResult:
 
     def __str__(self) -> str:
         return f'requested_steps={self.requested_steps}'
-
-
-_DOC_EXTENSIONS: FrozenSet[str] = frozenset({'.md', '.rst'})
-
-
-def _is_doc_file(path: str) -> bool:
-    """True if the file is documentation-only and should not trigger test steps."""
-    lower = path.lower()
-    return any(lower.endswith(ext) for ext in _DOC_EXTENSIONS)
 
 
 def _repo_input_local_path(from_path: str, repo_prefix: str = '/repo') -> Optional[str]:
@@ -110,7 +101,6 @@ def compute_requested_steps(
 
     config = yaml.safe_load(config_str)
     repo_prefix: str = config.get('repoPrefix', '/repo')
-    code_files = [f for f in changed_files if not _is_doc_file(f)]
 
     steps = [s for s in config.get('steps', []) if _valid_step(s, scope, cloud)]
     always_run_steps = set(config.get('alwaysRunSteps', []))
@@ -120,7 +110,7 @@ def compute_requested_steps(
         for dep in step.get('dependsOn', []):
             descendants_map.setdefault(dep, []).append(step['name'])
 
-    affected_steps = _find_affected_steps(steps, code_files, repo_prefix)
+    affected_steps = _find_affected_steps(steps, changed_files, repo_prefix)
     affected_and_descendants = _expand_to_descendants(affected_steps, descendants_map)
     requested_steps = affected_and_descendants | always_run_steps
 

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -24,18 +24,12 @@ def _file_matches_input(changed_file: str, local_path: str) -> bool:
     return changed_file == local_path or changed_file.startswith(local_path + '/')
 
 
-def _in_scope(scopes: Optional[List[str]], scope: str) -> bool:
-    return scopes is None or scope in scopes
-
-
-def _in_cloud(clouds: Optional[List[str]], cloud: Optional[str]) -> bool:
-    if cloud is None or clouds is None:
-        return True
-    return cloud in clouds
-
-
-def _valid_step(step: dict, scope: str, cloud: Optional[str]) -> bool:
-    return _in_scope(step.get('scopes'), scope) and _in_cloud(step.get('clouds'), cloud)
+def _valid_step(step: dict, actual_scope: str, actual_cloud: Optional[str]) -> bool:
+    step_scopes = step.get('scopes')
+    step_clouds = step.get('clouds')
+    return (step_scopes is None or actual_scope in step_scopes) and (
+        step_clouds is None or actual_cloud is None or actual_cloud in step_clouds
+    )
 
 
 def _find_affected_steps(

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -70,23 +70,21 @@ def _expand_to_descendants(
 def compute_requested_steps(
     config_str: str,
     changed_files: List[str],
-    scope: str = 'test',
+    scope: str,
     cloud: Optional[str] = None,
 ) -> Set[str]:
     """Select which build steps should be requested, given the changed files in a PR.
 
     set((directly affected steps + their descendants) + alwaysRunSteps)
-
-    Returns an empty set when changed_files is empty.
     """
-    if not changed_files:
-        return set()
-
     config = yaml.safe_load(config_str)
     repo_prefix: str = config.get('repoPrefix', '/repo')
+    always_run_steps: Set[str] = set(config.get('alwaysRunSteps', []))
+
+    if not changed_files:
+        return always_run_steps
 
     steps = [s for s in config.get('steps', []) if _valid_step(s, scope, cloud)]
-    always_run_steps = set(config.get('alwaysRunSteps', []))
 
     descendants_map: Dict[str, List[str]] = {}
     for step in steps:

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -9,7 +9,7 @@ used in tests and tooling without a running deployment.
 """
 
 from dataclasses import dataclass, field
-from typing import Callable, Dict, FrozenSet, List, Optional, Set
+from typing import Dict, FrozenSet, List, Optional, Set
 
 import yaml
 
@@ -68,17 +68,18 @@ def _in_cloud(clouds: Optional[List[str]], cloud: Optional[str]) -> bool:
     return cloud in clouds
 
 
+def _valid_step(step: dict, scope: str, cloud: Optional[str]) -> bool:
+    return _in_scope(step.get('scopes'), scope) and _in_cloud(step.get('clouds'), cloud)
+
+
 def _find_seed_steps(
     steps: list,
     changed_files: List[str],
-    runnable: Callable[[str], bool],
     repo_prefix: str = '/repo',
 ) -> Set[str]:
     """Return steps whose repo inputs match any of the changed files."""
     seeds: Set[str] = set()
     for step in steps:
-        if not runnable(step['name']):
-            continue
         inputs = step.get('inputs') or []
         for inp in inputs:
             local_path = _repo_input_local_path(inp.get('from', ''), repo_prefix)
@@ -93,15 +94,14 @@ def _find_seed_steps(
 def _expand_to_descendants(
     seeds: Set[str],
     reverse: Dict[str, List[str]],
-    runnable: Callable[[str], bool],
 ) -> Set[str]:
-    """BFS forward from seeds, following dependsOn edges, returning all runnable descendants."""
+    """BFS forward from seeds, following dependsOn edges, returning all descendants."""
     result: Set[str] = set(seeds)
     frontier = list(seeds)
     while frontier:
         cur = frontier.pop()
         for dependent in reverse.get(cur, []):
-            if dependent not in result and runnable(dependent):
+            if dependent not in result:
                 result.add(dependent)
                 frontier.append(dependent)
     return result
@@ -135,15 +135,10 @@ def compute_requested_steps(
         return BuildSelectionResult()
 
     config = yaml.safe_load(config_str)
-    steps = config.get('steps', [])
     always_run_steps: List[str] = config.get('alwaysRunSteps', [])
     repo_prefix: str = config.get('repoPrefix', '/repo')
 
-    scopes_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('scopes') for s in steps}
-    clouds_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('clouds') for s in steps}
-
-    def runnable(name: str) -> bool:
-        return _in_scope(scopes_map.get(name), scope) and _in_cloud(clouds_map.get(name), cloud)
+    steps = [s for s in config.get('steps', []) if _valid_step(s, scope, cloud)]
 
     reverse: Dict[str, List[str]] = {}
     for step in steps:
@@ -151,8 +146,8 @@ def compute_requested_steps(
             reverse.setdefault(dep, []).append(step['name'])
 
     code_files = [f for f in changed_files if not _is_doc_file(f)]
-    seeds = _find_seed_steps(steps, code_files, runnable, repo_prefix)
-    result = _expand_to_descendants(seeds, reverse, runnable)
+    seeds = _find_seed_steps(steps, code_files, repo_prefix)
+    result = _expand_to_descendants(seeds, reverse)
     result.update(always_run_steps)
 
     return BuildSelectionResult(requested_steps=sorted(result))

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -9,7 +9,7 @@ used in tests and tooling without a running deployment.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set
 
 import yaml
 
@@ -59,6 +59,44 @@ def _in_cloud(clouds: Optional[List[str]], cloud: Optional[str]) -> bool:
     return cloud in clouds
 
 
+def _find_seed_steps(
+    steps: list,
+    changed_files: List[str],
+    runnable: Callable[[str], bool],
+) -> Set[str]:
+    """Return steps whose /repo/ inputs match any of the changed files."""
+    seeds: Set[str] = set()
+    for step in steps:
+        if not runnable(step['name']):
+            continue
+        inputs = step.get('inputs') or []
+        for inp in inputs:
+            local_path = _repo_input_local_path(inp.get('from', ''))
+            if local_path is None:
+                continue
+            if any(_file_matches_input(f, local_path) for f in changed_files):
+                seeds.add(step['name'])
+                break
+    return seeds
+
+
+def _expand_to_descendants(
+    seeds: Set[str],
+    reverse: Dict[str, List[str]],
+    runnable: Callable[[str], bool],
+) -> Set[str]:
+    """BFS forward from seeds, following dependsOn edges, returning all runnable descendants."""
+    result: Set[str] = set(seeds)
+    frontier = list(seeds)
+    while frontier:
+        cur = frontier.pop()
+        for dependent in reverse.get(cur, []):
+            if dependent not in result and runnable(dependent):
+                result.add(dependent)
+                frontier.append(dependent)
+    return result
+
+
 def compute_requested_steps(
     config_str: str,
     changed_files: List[str],
@@ -87,35 +125,12 @@ def compute_requested_steps(
     def runnable(name: str) -> bool:
         return _in_scope(scopes_map.get(name), scope) and _in_cloud(clouds_map.get(name), cloud)
 
-    # Build reverse adjacency: step_name -> list of steps that depend on it
     reverse: Dict[str, List[str]] = {}
     for step in steps:
         for dep in step.get('dependsOn', []):
             reverse.setdefault(dep, []).append(step['name'])
 
-    # Find seed steps: those whose /repo/ inputs match any changed file,
-    # restricted to steps runnable in the target scope and cloud.
-    seed_steps: Set[str] = set()
-    for step in steps:
-        if not runnable(step['name']):
-            continue
-        inputs = step.get('inputs') or []
-        for inp in inputs:
-            local_path = _repo_input_local_path(inp.get('from', ''))
-            if local_path is None:
-                continue
-            if any(_file_matches_input(f, local_path) for f in changed_files):
-                seed_steps.add(step['name'])
-                break
-
-    # BFS forward from seeds to find all runnable descendants
-    result: Set[str] = set(seed_steps)
-    frontier = list(seed_steps)
-    while frontier:
-        cur = frontier.pop()
-        for dependent in reverse.get(cur, []):
-            if dependent not in result and runnable(dependent):
-                result.add(dependent)
-                frontier.append(dependent)
+    seeds = _find_seed_steps(steps, changed_files, runnable)
+    result = _expand_to_descendants(seeds, reverse, runnable)
 
     return BuildSelectionResult(requested_steps=sorted(result))

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -1,13 +1,3 @@
-"""Change-based test selection helpers.
-
-Derives step selection from each step's `inputs` declarations in build.yaml.
-Steps that directly import changed repository files are seeds; all transitive
-dependents in the dependsOn DAG are included.
-
-This module is intentionally free of cloud/environment imports so it can be
-used in tests and tooling without a running deployment.
-"""
-
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Set
 
@@ -16,11 +6,7 @@ import yaml
 
 @dataclass
 class BuildSelectionResult:
-    """Result of change-based step selection.
-
-    Attributes:
-        requested_steps: Sorted list of step names that should run.
-    """
+    """The set of build steps selected to run."""
 
     requested_steps: List[str] = field(default_factory=list)
 
@@ -32,13 +18,13 @@ _DOC_EXTENSIONS: FrozenSet[str] = frozenset({'.md', '.rst'})
 
 
 def _is_doc_file(path: str) -> bool:
-    """True if the file has a documentation-only extension that should not trigger test seeds."""
+    """True if the file is documentation-only and should not trigger test steps."""
     lower = path.lower()
     return any(lower.endswith(ext) for ext in _DOC_EXTENSIONS)
 
 
 def _repo_input_local_path(from_path: str, repo_prefix: str = '/repo') -> Optional[str]:
-    """Return the local path from a <repo_prefix>/... input, or None if not a repo input.
+    """Return the repo-relative path for a repo input, or None if not a repo input.
 
     '/repo'   -> ''       (matches everything)
     '/repo/x' -> 'x'
@@ -72,13 +58,13 @@ def _valid_step(step: dict, scope: str, cloud: Optional[str]) -> bool:
     return _in_scope(step.get('scopes'), scope) and _in_cloud(step.get('clouds'), cloud)
 
 
-def _find_seed_steps(
+def _find_affected_steps(
     steps: list,
     changed_files: List[str],
     repo_prefix: str = '/repo',
 ) -> Set[str]:
-    """Return steps whose repo inputs match any of the changed files."""
-    seeds: Set[str] = set()
+    """Return steps with repo inputs that overlap with the changed files."""
+    affected_steps: Set[str] = set()
     for step in steps:
         inputs = step.get('inputs') or []
         for inp in inputs:
@@ -86,24 +72,24 @@ def _find_seed_steps(
             if local_path is None:
                 continue
             if any(_file_matches_input(f, local_path) for f in changed_files):
-                seeds.add(step['name'])
+                affected_steps.add(step['name'])
                 break
-    return seeds
+    return affected_steps
 
 
 def _expand_to_descendants(
-    seeds: Set[str],
-    reverse: Dict[str, List[str]],
+    affected_steps: Set[str],
+    descendants_map: Dict[str, List[str]],
 ) -> Set[str]:
-    """BFS forward from seeds, following dependsOn edges, returning all descendants."""
-    result: Set[str] = set(seeds)
-    frontier = list(seeds)
-    while frontier:
-        cur = frontier.pop()
-        for dependent in reverse.get(cur, []):
+    """Return affected_steps plus all steps that transitively depend on them."""
+    result: Set[str] = set(affected_steps)
+    steps_to_review = set(affected_steps)
+    while steps_to_review:
+        cur = steps_to_review.pop()
+        for dependent in descendants_map.get(cur, []):
             if dependent not in result:
                 result.add(dependent)
-                frontier.append(dependent)
+                steps_to_review.add(dependent)
     return result
 
 
@@ -113,41 +99,29 @@ def compute_requested_steps(
     scope: str = 'test',
     cloud: Optional[str] = None,
 ) -> BuildSelectionResult:
-    """Return step selection results given a list of changed file paths.
+    """Select which build steps should be requested, given the changed files in a PR.
 
-    Finds steps directly affected (those with repo inputs matching changed
-    files), then follows dependsOn edges forward to find all transitive
-    descendants. Only steps runnable in `scope` and `cloud` are returned; this
-    prevents deploy-only or wrong-cloud steps from pulling in unrelated
-    upstream deps via BuildConfiguration.visit_dependent.
+    set((directly affected steps + their descendants) + alwaysRunSteps)
 
-    Doc-only files (.md, .rst) are excluded from seed-matching so that a PR
-    touching only documentation does not trigger test steps. Steps listed under
-    alwaysRunSteps in the config are always included whenever changed_files is
-    non-empty.
-
-    The repo artifact prefix (e.g. '/repo') is read from the top-level
-    `repoPrefix` field in the config, defaulting to '/repo' if absent.
-
-    Returns an empty BuildSelectionResult when changed_files is empty.
+    Returns an empty result when changed_files is empty.
     """
     if not changed_files:
         return BuildSelectionResult()
 
     config = yaml.safe_load(config_str)
-    always_run_steps: List[str] = config.get('alwaysRunSteps', [])
     repo_prefix: str = config.get('repoPrefix', '/repo')
+    code_files = [f for f in changed_files if not _is_doc_file(f)]
 
     steps = [s for s in config.get('steps', []) if _valid_step(s, scope, cloud)]
+    always_run_steps = set(config.get('alwaysRunSteps', []))
 
-    reverse: Dict[str, List[str]] = {}
+    descendants_map: Dict[str, List[str]] = {}
     for step in steps:
         for dep in step.get('dependsOn', []):
-            reverse.setdefault(dep, []).append(step['name'])
+            descendants_map.setdefault(dep, []).append(step['name'])
 
-    code_files = [f for f in changed_files if not _is_doc_file(f)]
-    seeds = _find_seed_steps(steps, code_files, repo_prefix)
-    result = _expand_to_descendants(seeds, reverse)
-    result.update(always_run_steps)
+    affected_steps = _find_affected_steps(steps, code_files, repo_prefix)
+    affected_and_descendants = _expand_to_descendants(affected_steps, descendants_map)
+    requested_steps = affected_and_descendants | always_run_steps
 
-    return BuildSelectionResult(requested_steps=sorted(result))
+    return BuildSelectionResult(requested_steps=sorted(requested_steps))

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -9,7 +9,7 @@ used in tests and tooling without a running deployment.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence, Set
+from typing import Dict, List, Optional, Set
 
 import yaml
 
@@ -28,41 +28,6 @@ class BuildSelectionResult:
         return f'requested_steps={self.requested_steps}'
 
 
-def expand_build_steps(
-    config_str: str,
-    requested_step_names: Sequence[str],
-    cloud: Optional[str] = None,
-    excluded_step_names: Sequence[str] = (),
-) -> List[str]:
-    """Expand a list of requested step names to include all transitive upstream deps.
-
-    Mirrors the logic in BuildConfiguration.visit_dependent, but as a pure
-    function for use in tests and tooling.
-    """
-    config = yaml.safe_load(config_str)
-    steps = config.get('steps', [])
-    excluded = set(excluded_step_names)
-    run_if_requested: Set[str] = {s['name'] for s in steps if s.get('runIfRequested', False)}
-    deps_map: Dict[str, List[str]] = {s['name']: s.get('dependsOn', []) for s in steps}
-    clouds_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('clouds') for s in steps}
-
-    visited: Set[str] = set()
-    frontier = list(requested_step_names)
-    while frontier:
-        cur = frontier.pop()
-        if cur in visited or cur in excluded:
-            continue
-        if cloud is not None:
-            step_clouds = clouds_map.get(cur)
-            if step_clouds is not None and cloud not in step_clouds:
-                continue
-        visited.add(cur)
-        for dep in deps_map.get(cur, []):
-            if dep not in run_if_requested:
-                frontier.append(dep)
-    return sorted(visited)
-
-
 def _repo_input_local_path(from_path: str) -> Optional[str]:
     """Return the local path from a /repo/... input, or None if not a repo input.
 
@@ -73,7 +38,7 @@ def _repo_input_local_path(from_path: str) -> Optional[str]:
     if from_path == '/repo':
         return ''
     if from_path.startswith('/repo/'):
-        return from_path[len('/repo/'):]
+        return from_path[len('/repo/') :]
     return None
 
 
@@ -88,16 +53,25 @@ def _in_scope(scopes: Optional[List[str]], scope: str) -> bool:
     return scopes is None or scope in scopes
 
 
+def _in_cloud(clouds: Optional[List[str]], cloud: Optional[str]) -> bool:
+    if cloud is None or clouds is None:
+        return True
+    return cloud in clouds
+
+
 def compute_requested_steps(
-    config_str: str, changed_files: List[str], scope: str = 'test'
+    config_str: str,
+    changed_files: List[str],
+    scope: str = 'test',
+    cloud: Optional[str] = None,
 ) -> BuildSelectionResult:
     """Return step selection results given a list of changed file paths.
 
     Finds steps directly affected (those with /repo/ inputs matching changed
     files), then follows dependsOn edges forward to find all transitive
-    descendants. Only steps runnable in `scope` are returned; this prevents
-    deploy-only steps from pulling in unrelated test-scope upstream deps via
-    BuildConfiguration.visit_dependent.
+    descendants. Only steps runnable in `scope` and `cloud` are returned; this
+    prevents deploy-only or wrong-cloud steps from pulling in unrelated
+    upstream deps via BuildConfiguration.visit_dependent.
 
     Returns an empty BuildSelectionResult when changed_files is empty.
     """
@@ -108,6 +82,10 @@ def compute_requested_steps(
     steps = config.get('steps', [])
 
     scopes_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('scopes') for s in steps}
+    clouds_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('clouds') for s in steps}
+
+    def runnable(name: str) -> bool:
+        return _in_scope(scopes_map.get(name), scope) and _in_cloud(clouds_map.get(name), cloud)
 
     # Build reverse adjacency: step_name -> list of steps that depend on it
     reverse: Dict[str, List[str]] = {}
@@ -116,10 +94,10 @@ def compute_requested_steps(
             reverse.setdefault(dep, []).append(step['name'])
 
     # Find seed steps: those whose /repo/ inputs match any changed file,
-    # restricted to steps runnable in the target scope.
+    # restricted to steps runnable in the target scope and cloud.
     seed_steps: Set[str] = set()
     for step in steps:
-        if not _in_scope(scopes_map.get(step['name']), scope):
+        if not runnable(step['name']):
             continue
         inputs = step.get('inputs') or []
         for inp in inputs:
@@ -130,13 +108,13 @@ def compute_requested_steps(
                 seed_steps.add(step['name'])
                 break
 
-    # BFS forward from seeds to find all in-scope descendants
+    # BFS forward from seeds to find all runnable descendants
     result: Set[str] = set(seed_steps)
     frontier = list(seed_steps)
     while frontier:
         cur = frontier.pop()
         for dependent in reverse.get(cur, []):
-            if dependent not in result and _in_scope(scopes_map.get(dependent), scope):
+            if dependent not in result and runnable(dependent):
                 result.add(dependent)
                 frontier.append(dependent)
 

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -9,7 +9,7 @@ used in tests and tooling without a running deployment.
 """
 
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, FrozenSet, List, Optional, Set
 
 import yaml
 
@@ -26,6 +26,15 @@ class BuildSelectionResult:
 
     def __str__(self) -> str:
         return f'requested_steps={self.requested_steps}'
+
+
+_DOC_EXTENSIONS: FrozenSet[str] = frozenset({'.md', '.rst'})
+
+
+def _is_doc_file(path: str) -> bool:
+    """True if the file has a documentation-only extension that should not trigger test seeds."""
+    lower = path.lower()
+    return any(lower.endswith(ext) for ext in _DOC_EXTENSIONS)
 
 
 def _repo_input_local_path(from_path: str) -> Optional[str]:
@@ -111,6 +120,11 @@ def compute_requested_steps(
     prevents deploy-only or wrong-cloud steps from pulling in unrelated
     upstream deps via BuildConfiguration.visit_dependent.
 
+    Doc-only files (.md, .rst) are excluded from seed-matching so that a PR
+    touching only documentation does not trigger test steps. Steps listed under
+    alwaysRunSteps in the config are always included whenever changed_files is
+    non-empty.
+
     Returns an empty BuildSelectionResult when changed_files is empty.
     """
     if not changed_files:
@@ -118,6 +132,7 @@ def compute_requested_steps(
 
     config = yaml.safe_load(config_str)
     steps = config.get('steps', [])
+    always_run_steps: List[str] = config.get('alwaysRunSteps', [])
 
     scopes_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('scopes') for s in steps}
     clouds_map: Dict[str, Optional[List[str]]] = {s['name']: s.get('clouds') for s in steps}
@@ -130,7 +145,9 @@ def compute_requested_steps(
         for dep in step.get('dependsOn', []):
             reverse.setdefault(dep, []).append(step['name'])
 
-    seeds = _find_seed_steps(steps, changed_files, runnable)
+    code_files = [f for f in changed_files if not _is_doc_file(f)]
+    seeds = _find_seed_steps(steps, code_files, runnable)
     result = _expand_to_descendants(seeds, reverse, runnable)
+    result.update(always_run_steps)
 
     return BuildSelectionResult(requested_steps=sorted(result))

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -27,8 +27,10 @@ def _file_matches_input(changed_file: str, local_path: str) -> bool:
 def _valid_step(step: dict, actual_scope: str, actual_cloud: Optional[str]) -> bool:
     step_scopes = step.get('scopes')
     step_clouds = step.get('clouds')
-    return (step_scopes is None or actual_scope in step_scopes) and (
-        step_clouds is None or actual_cloud is None or actual_cloud in step_clouds
+    return (
+        not step.get('runIfRequested')
+        and (step_scopes is None or actual_scope in step_scopes)
+        and (step_clouds is None or actual_cloud is None or actual_cloud in step_clouds)
     )
 
 

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -571,13 +571,9 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 build_yaml = f.read()
-            selection = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
-            log.info(
-                f'PR #{self.number} selected steps ({len(selection.requested_steps)}): {selection.requested_steps}'
-            )
-            config = BuildConfiguration(
-                self, build_yaml, scope='test', requested_step_names=selection.requested_steps or ()
-            )
+            requested_steps = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
+            log.info(f'PR #{self.number} selected steps ({len(requested_steps)}): {requested_steps}')
+            config = BuildConfiguration(self, build_yaml, scope='test', requested_step_names=requested_steps or ())
             namespace = config.namespace()
             services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -24,7 +24,7 @@ from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
 from .build import BuildConfiguration, Code
 from .build_selection import compute_requested_steps
 from .constants import AUTHORIZED_USERS, COMPILER_TEAM, GITHUB_CLONE_URL, GITHUB_STATUS_CONTEXT, SERVICES_TEAM
-from .environment import DEPLOY_STEPS
+from .environment import CLOUD, DEPLOY_STEPS
 from .globals import is_test_deployment
 from .utils import GithubStatus, add_deployed_services, github_status
 
@@ -571,8 +571,10 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 build_yaml = f.read()
-            selection = compute_requested_steps(build_yaml, changed_files)
-            log.info(f'PR #{self.number} selected steps ({len(selection.requested_steps)}): {selection.requested_steps}')
+            selection = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
+            log.info(
+                f'PR #{self.number} selected steps ({len(selection.requested_steps)}): {selection.requested_steps}'
+            )
             config = BuildConfiguration(
                 self, build_yaml, scope='test', requested_step_names=selection.requested_steps or ()
             )
@@ -582,6 +584,8 @@ mkdir -p {shq(repo_dir)}
                 test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
 
             services.extend(test_services)
+            # namespace is None when no service deploy steps are selected (e.g. hail-only PRs);
+            # in that case there are no deployed services to register.
             if namespace is not None:
                 tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
                 await add_deployed_services(db, namespace, services, tomorrow)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -571,8 +571,9 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 build_yaml = f.read()
-            requested_steps = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
-            log.info(f'PR #{self.number} selected steps ({len(requested_steps)}): {requested_steps}')
+            requested_steps_set = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
+            requested_steps = list(requested_steps_set)
+            log.info(f'PR #{self.number} selected steps ({len(requested_steps)})')
             config = BuildConfiguration(self, build_yaml, scope='test', requested_step_names=requested_steps or ())
             namespace = config.namespace()
             services = config.deployed_services()

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -22,6 +22,7 @@ from hailtop.config import get_deploy_config
 from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
 
 from .build import BuildConfiguration, Code
+from .build_selection import compute_requested_steps
 from .constants import AUTHORIZED_USERS, COMPILER_TEAM, GITHUB_CLONE_URL, GITHUB_STATUS_CONTEXT, SERVICES_TEAM
 from .environment import DEPLOY_STEPS
 from .globals import is_test_deployment
@@ -561,17 +562,29 @@ mkdir -p {shq(repo_dir)}
             sha_out, _ = await check_shell_output(f'git -C {shq(repo_dir)} rev-parse HEAD')
             self.sha = sha_out.decode('utf-8').strip()
 
+            assert self.target_branch.sha is not None
+            diff_out, _ = await check_shell_output(
+                f'git -C {shq(repo_dir)} diff --name-only {shq(self.target_branch.sha)}...HEAD'
+            )
+            changed_files = [f for f in diff_out.decode('utf-8').strip().split('\n') if f]
+            log.info(f'PR #{self.number} changed files ({len(changed_files)}): {changed_files}')
+
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
-                config = BuildConfiguration(self, f.read(), scope='test')
-                namespace = config.namespace()
-                services = config.deployed_services()
+                build_yaml = f.read()
+            selection = compute_requested_steps(build_yaml, changed_files)
+            log.info(f'PR #{self.number} selected steps ({len(selection.requested_steps)}): {selection.requested_steps}')
+            config = BuildConfiguration(
+                self, build_yaml, scope='test', requested_step_names=selection.requested_steps or ()
+            )
+            namespace = config.namespace()
+            services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
                 test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
 
             services.extend(test_services)
-            tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-            assert namespace is not None
-            await add_deployed_services(db, namespace, services, tomorrow)
+            if namespace is not None:
+                tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+                await add_deployed_services(db, namespace, services, tomorrow)
 
             log.info(f'creating test batch for {self.number}')
             batch = batch_client.create_batch(
@@ -581,7 +594,7 @@ mkdir -p {shq(repo_dir)}
                     'source_branch': self.source_branch.short_str(),
                     'target_branch': self.target_branch.branch.short_str(),
                     'pr': str(self.number),
-                    'namespace': namespace,
+                    'namespace': namespace or '',
                     'source_sha': self.source_sha,
                     'target_sha': self.target_branch.sha,
                     'name': f'PR test #{self.number}: {self.source_branch.name} @ {self.source_sha[:8]} -> {self.target_branch.branch.name} @ {(self.target_branch.sha or "unknown")[:8]}',

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -571,7 +571,7 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 build_yaml = f.read()
-            requested_steps_set = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
+            requested_steps_set = compute_requested_steps(build_yaml, changed_files, scope='test', cloud=CLOUD)
             log.info(f'PR #{self.number} selected steps ({len(requested_steps_set)})')
             config = BuildConfiguration(self, build_yaml, scope='test', requested_step_names=list(requested_steps_set))
             namespace = config.namespace()

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -572,9 +572,10 @@ mkdir -p {shq(repo_dir)}
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 build_yaml = f.read()
             requested_steps_set = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
-            requested_steps = list(requested_steps_set)
-            log.info(f'PR #{self.number} selected steps ({len(requested_steps)})')
-            config = BuildConfiguration(self, build_yaml, scope='test', requested_step_names=requested_steps or ())
+            log.info(f'PR #{self.number} selected steps ({len(requested_steps_set)})')
+            config = BuildConfiguration(
+                self, build_yaml, scope='test', requested_step_names=list(requested_steps_set) or ()
+            )
             namespace = config.namespace()
             services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -598,7 +598,7 @@ mkdir -p {shq(repo_dir)}
                     'source_branch': self.source_branch.short_str(),
                     'target_branch': self.target_branch.branch.short_str(),
                     'pr': str(self.number),
-                    'namespace': namespace or '',
+                    'namespace': namespace or 'N/A',
                     'source_sha': self.source_sha,
                     'target_sha': self.target_branch.sha,
                     'name': f'PR test #{self.number}: {self.source_branch.name} @ {self.source_sha[:8]} -> {self.target_branch.branch.name} @ {(self.target_branch.sha or "unknown")[:8]}',

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -573,9 +573,7 @@ mkdir -p {shq(repo_dir)}
                 build_yaml = f.read()
             requested_steps_set = compute_requested_steps(build_yaml, changed_files, cloud=CLOUD)
             log.info(f'PR #{self.number} selected steps ({len(requested_steps_set)})')
-            config = BuildConfiguration(
-                self, build_yaml, scope='test', requested_step_names=list(requested_steps_set) or ()
-            )
+            config = BuildConfiguration(self, build_yaml, scope='test', requested_step_names=list(requested_steps_set))
             namespace = config.namespace()
             services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -7,9 +7,27 @@ from ci.build_selection import (
     _find_seed_steps,
     _in_cloud,
     _in_scope,
+    _is_doc_file,
     _repo_input_local_path,
     compute_requested_steps,
 )
+
+
+@pytest.mark.parametrize(
+    'path, expected',
+    [
+        ('batch/README.md', True),
+        ('batch/README.MD', True),
+        ('CHANGELOG.rst', True),
+        ('CHANGELOG.RST', True),
+        ('batch/batch/server.py', False),
+        ('foo.py', False),
+        ('notes.md.bak', False),
+        ('README', False),
+    ],
+)
+def test_is_doc_file(path, expected):
+    assert _is_doc_file(path) == expected
 
 
 @pytest.mark.parametrize(
@@ -180,10 +198,12 @@ def test_expand_to_descendants(seeds, reverse, runnable, expected):
 
 
 _SIMPLE_CONFIG = """
+alwaysRunSteps:
+  - merge_code
+
 steps:
   - name: merge_code
-    kind: buildImage
-    scopes: [test, dev]
+    kind: runImage
   - name: check_ci
     kind: runImage
     scopes: [test, dev]
@@ -205,10 +225,12 @@ steps:
 """
 
 _CLOUD_CONFIG = """
+alwaysRunSteps:
+  - merge_code
+
 steps:
   - name: merge_code
-    kind: buildImage
-    scopes: [test]
+    kind: runImage
   - name: test_gcp
     kind: runImage
     scopes: [test]
@@ -231,23 +253,24 @@ steps:
 @pytest.mark.parametrize(
     'config_str, changed_files, scope, cloud, expected_steps',
     [
-        # empty changed_files -> nothing runs
+        # empty changed_files -> nothing runs (not even merge_code)
         (_SIMPLE_CONFIG, [], 'test', None, []),
-        # ci change seeds check_ci; deploy_ci excluded (wrong scope)
-        (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci']),
-        # hail change seeds check_hail
-        (_SIMPLE_CONFIG, ['hail/foo.py'], 'test', None, ['check_hail']),
-        # unrelated change matches nothing
-        (_SIMPLE_CONFIG, ['docs/index.md'], 'test', None, []),
-        # deploy scope: check_ci is scoped to [test,dev] so it's not a seed,
-        # and deploy_ci has no /repo inputs, so nothing is selected
-        (_SIMPLE_CONFIG, ['ci/foo.py'], 'deploy', None, []),
-        # gcp cloud filter — only test_gcp returned
-        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'gcp', ['test_gcp']),
+        # ci change seeds check_ci; merge_code always included
+        (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
+        # hail change seeds check_hail; merge_code always included
+        (_SIMPLE_CONFIG, ['hail/foo.py'], 'test', None, ['check_hail', 'merge_code']),
+        # doc-only change: no seeds, but merge_code still runs
+        (_SIMPLE_CONFIG, ['ci/README.md'], 'test', None, ['merge_code']),
+        # mix of doc and code: code file seeds check_ci, doc file ignored
+        (_SIMPLE_CONFIG, ['ci/README.md', 'ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
+        # deploy scope: check_ci scoped to [test,dev] is not a seed; merge_code always included
+        (_SIMPLE_CONFIG, ['ci/foo.py'], 'deploy', None, ['merge_code']),
+        # gcp cloud filter — test_gcp + merge_code
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'gcp', ['merge_code', 'test_gcp']),
         # azure cloud filter
-        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['test_azure']),
-        # no cloud filter -> both cloud-specific steps returned
-        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['test_azure', 'test_gcp']),
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['merge_code', 'test_azure']),
+        # no cloud filter -> both cloud-specific steps + merge_code
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['merge_code', 'test_azure', 'test_gcp']),
     ],
 )
 def test_compute_requested_steps(config_str, changed_files, scope, cloud, expected_steps):

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -291,4 +291,4 @@ steps:
 )
 def test_compute_requested_steps(config_str, changed_files, scope, cloud, expected_steps):
     result = compute_requested_steps(config_str, changed_files, scope=scope, cloud=cloud)
-    assert result == expected_steps
+    assert result == set(expected_steps)

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -1,7 +1,6 @@
 import pytest
 
 from ci.build_selection import (
-    BuildSelectionResult,
     _expand_to_descendants,
     _file_matches_input,
     _find_affected_steps,
@@ -292,4 +291,4 @@ steps:
 )
 def test_compute_requested_steps(config_str, changed_files, scope, cloud, expected_steps):
     result = compute_requested_steps(config_str, changed_files, scope=scope, cloud=cloud)
-    assert result == BuildSelectionResult(requested_steps=expected_steps)
+    assert result == expected_steps

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -1,0 +1,255 @@
+import pytest
+
+from ci.build_selection import (
+    BuildSelectionResult,
+    _expand_to_descendants,
+    _file_matches_input,
+    _find_seed_steps,
+    _in_cloud,
+    _in_scope,
+    _repo_input_local_path,
+    compute_requested_steps,
+)
+
+
+@pytest.mark.parametrize(
+    'from_path, expected',
+    [
+        ('/repo', ''),
+        ('/repo/ci', 'ci'),
+        ('/repo/hail/python/hail', 'hail/python/hail'),
+        ('/other', None),
+        ('/repo-suffix', None),
+        ('repo', None),
+        ('', None),
+    ],
+)
+def test_repo_input_local_path(from_path, expected):
+    assert _repo_input_local_path(from_path) == expected
+
+
+@pytest.mark.parametrize(
+    'changed_file, local_path, expected',
+    [
+        # empty local_path matches everything
+        ('anything.py', '', True),
+        ('ci/foo.py', '', True),
+        # exact file match
+        ('ci/foo.py', 'ci/foo.py', True),
+        # file under directory
+        ('ci/foo.py', 'ci', True),
+        ('ci/sub/foo.py', 'ci', True),
+        # sibling directory should not match
+        ('ci_extra/foo.py', 'ci', False),
+        # plain prefix without path separator is not a match
+        ('cibuild.py', 'ci', False),
+        # different top-level path
+        ('hail/foo.py', 'ci', False),
+    ],
+)
+def test_file_matches_input(changed_file, local_path, expected):
+    assert _file_matches_input(changed_file, local_path) == expected
+
+
+@pytest.mark.parametrize(
+    'scopes, scope, expected',
+    [
+        (None, 'test', True),
+        (None, 'dev', True),
+        (['test'], 'test', True),
+        (['test', 'dev'], 'test', True),
+        (['dev'], 'test', False),
+        ([], 'test', False),
+    ],
+)
+def test_in_scope(scopes, scope, expected):
+    assert _in_scope(scopes, scope) == expected
+
+
+@pytest.mark.parametrize(
+    'clouds, cloud, expected',
+    [
+        (None, 'gcp', True),
+        (None, None, True),
+        (['gcp'], 'gcp', True),
+        (['gcp', 'azure'], 'gcp', True),
+        (['gcp'], 'azure', False),
+        (['gcp'], None, True),
+        ([], 'gcp', False),
+    ],
+)
+def test_in_cloud(clouds, cloud, expected):
+    assert _in_cloud(clouds, cloud) == expected
+
+
+def _always_runnable(_name: str) -> bool:
+    return True
+
+
+def _never_runnable(_name: str) -> bool:
+    return False
+
+
+@pytest.mark.parametrize(
+    'steps, changed_files, runnable, expected_seeds',
+    [
+        # step with matching /repo/ci input
+        (
+            [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
+            ['ci/foo.py'],
+            _always_runnable,
+            {'check_ci'},
+        ),
+        # /repo matches any changed file
+        (
+            [{'name': 'check_all', 'inputs': [{'from': '/repo', 'to': '/io/repo'}]}],
+            ['anything.py'],
+            _always_runnable,
+            {'check_all'},
+        ),
+        # changed file doesn't match the step's input path
+        (
+            [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
+            ['hail/foo.py'],
+            _always_runnable,
+            set(),
+        ),
+        # step excluded because not runnable
+        (
+            [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
+            ['ci/foo.py'],
+            _never_runnable,
+            set(),
+        ),
+        # step with no inputs is never a seed
+        (
+            [{'name': 'deploy_auth'}],
+            ['ci/foo.py'],
+            _always_runnable,
+            set(),
+        ),
+        # non-/repo input (artifact from another step) is ignored
+        (
+            [{'name': 'test_ci', 'inputs': [{'from': '/io/wheel', 'to': '/wheel'}]}],
+            ['ci/foo.py'],
+            _always_runnable,
+            set(),
+        ),
+        # multiple steps — only the matching one is a seed
+        (
+            [
+                {'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]},
+                {'name': 'check_hail', 'inputs': [{'from': '/repo/hail', 'to': '/io/hail'}]},
+            ],
+            ['ci/foo.py'],
+            _always_runnable,
+            {'check_ci'},
+        ),
+    ],
+)
+def test_find_seed_steps(steps, changed_files, runnable, expected_seeds):
+    assert _find_seed_steps(steps, changed_files, runnable) == expected_seeds
+
+
+@pytest.mark.parametrize(
+    'seeds, reverse, runnable, expected',
+    [
+        # seeds with no dependents
+        ({'A'}, {}, _always_runnable, {'A'}),
+        # single-level descendant
+        ({'A'}, {'A': ['B']}, _always_runnable, {'A', 'B'}),
+        # two-level chain
+        ({'A'}, {'A': ['B'], 'B': ['C']}, _always_runnable, {'A', 'B', 'C'}),
+        # descendant filtered out by runnable
+        ({'A'}, {'A': ['B']}, _never_runnable, {'A'}),
+        # diamond: A -> B, A -> C, B -> D, C -> D
+        (
+            {'A'},
+            {'A': ['B', 'C'], 'B': ['D'], 'C': ['D']},
+            _always_runnable,
+            {'A', 'B', 'C', 'D'},
+        ),
+        # empty seeds
+        (set(), {'A': ['B']}, _always_runnable, set()),
+        # multiple seeds
+        ({'A', 'X'}, {'A': ['B'], 'X': ['Y']}, _always_runnable, {'A', 'B', 'X', 'Y'}),
+    ],
+)
+def test_expand_to_descendants(seeds, reverse, runnable, expected):
+    assert _expand_to_descendants(seeds, reverse, runnable) == expected
+
+
+_SIMPLE_CONFIG = """
+steps:
+  - name: merge_code
+    kind: buildImage
+    scopes: [test, dev]
+  - name: check_ci
+    kind: runImage
+    scopes: [test, dev]
+    inputs:
+      - from: /repo/ci
+        to: /io/ci
+    dependsOn: [merge_code]
+  - name: check_hail
+    kind: runImage
+    scopes: [test, dev]
+    inputs:
+      - from: /repo/hail
+        to: /io/hail
+    dependsOn: [merge_code]
+  - name: deploy_ci
+    kind: deploy
+    scopes: [deploy]
+    dependsOn: [check_ci]
+"""
+
+_CLOUD_CONFIG = """
+steps:
+  - name: merge_code
+    kind: buildImage
+    scopes: [test]
+  - name: test_gcp
+    kind: runImage
+    scopes: [test]
+    clouds: [gcp]
+    inputs:
+      - from: /repo/ci
+        to: /io/ci
+    dependsOn: [merge_code]
+  - name: test_azure
+    kind: runImage
+    scopes: [test]
+    clouds: [azure]
+    inputs:
+      - from: /repo/ci
+        to: /io/ci
+    dependsOn: [merge_code]
+"""
+
+
+@pytest.mark.parametrize(
+    'config_str, changed_files, scope, cloud, expected_steps',
+    [
+        # empty changed_files -> nothing runs
+        (_SIMPLE_CONFIG, [], 'test', None, []),
+        # ci change seeds check_ci; deploy_ci excluded (wrong scope)
+        (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci']),
+        # hail change seeds check_hail
+        (_SIMPLE_CONFIG, ['hail/foo.py'], 'test', None, ['check_hail']),
+        # unrelated change matches nothing
+        (_SIMPLE_CONFIG, ['docs/index.md'], 'test', None, []),
+        # deploy scope: check_ci is scoped to [test,dev] so it's not a seed,
+        # and deploy_ci has no /repo inputs, so nothing is selected
+        (_SIMPLE_CONFIG, ['ci/foo.py'], 'deploy', None, []),
+        # gcp cloud filter — only test_gcp returned
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'gcp', ['test_gcp']),
+        # azure cloud filter
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['test_azure']),
+        # no cloud filter -> both cloud-specific steps returned
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['test_azure', 'test_gcp']),
+    ],
+)
+def test_compute_requested_steps(config_str, changed_files, scope, cloud, expected_steps):
+    result = compute_requested_steps(config_str, changed_files, scope=scope, cloud=cloud)
+    assert result == BuildSelectionResult(requested_steps=expected_steps)

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -4,8 +4,6 @@ from ci.build_selection import (
     _expand_to_descendants,
     _file_matches_input,
     _find_affected_steps,
-    _in_cloud,
-    _in_scope,
     _repo_input_local_path,
     _valid_step,
     compute_requested_steps,
@@ -57,44 +55,15 @@ def test_file_matches_input(changed_file, local_path, expected):
 
 
 @pytest.mark.parametrize(
-    'scopes, scope, expected',
-    [
-        (None, 'test', True),
-        (None, 'dev', True),
-        (['test'], 'test', True),
-        (['test', 'dev'], 'test', True),
-        (['dev'], 'test', False),
-        ([], 'test', False),
-    ],
-)
-def test_in_scope(scopes, scope, expected):
-    assert _in_scope(scopes, scope) == expected
-
-
-@pytest.mark.parametrize(
-    'clouds, cloud, expected',
-    [
-        (None, 'gcp', True),
-        (None, None, True),
-        (['gcp'], 'gcp', True),
-        (['gcp', 'azure'], 'gcp', True),
-        (['gcp'], 'azure', False),
-        (['gcp'], None, True),
-        ([], 'gcp', False),
-    ],
-)
-def test_in_cloud(clouds, cloud, expected):
-    assert _in_cloud(clouds, cloud) == expected
-
-
-@pytest.mark.parametrize(
     'step, scope, cloud, expected',
     [
         ({'scopes': None, 'clouds': None}, 'test', 'gcp', True),
+        ({'scopes': None, 'clouds': None}, 'test', None, True),  # no cloud filter
         ({'scopes': ['test'], 'clouds': None}, 'test', 'gcp', True),
         ({'scopes': ['dev'], 'clouds': None}, 'test', 'gcp', False),
         ({'scopes': None, 'clouds': ['gcp']}, 'test', 'gcp', True),
         ({'scopes': None, 'clouds': ['gcp']}, 'test', 'azure', False),
+        ({'scopes': None, 'clouds': ['gcp']}, 'test', None, True),  # unfiltered cloud matches any
         ({'scopes': ['deploy'], 'clouds': ['gcp']}, 'test', 'gcp', False),
         ({}, 'test', None, True),
     ],

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -31,19 +31,24 @@ def test_is_doc_file(path, expected):
 
 
 @pytest.mark.parametrize(
-    'from_path, expected',
+    'from_path, repo_prefix, expected',
     [
-        ('/repo', ''),
-        ('/repo/ci', 'ci'),
-        ('/repo/hail/python/hail', 'hail/python/hail'),
-        ('/other', None),
-        ('/repo-suffix', None),
-        ('repo', None),
-        ('', None),
+        ('/repo', '/repo', ''),
+        ('/repo/ci', '/repo', 'ci'),
+        ('/repo/hail/python/hail', '/repo', 'hail/python/hail'),
+        ('/other', '/repo', None),
+        ('/repo-suffix', '/repo', None),
+        ('repo', '/repo', None),
+        ('', '/repo', None),
+        # custom prefix
+        ('/src', '/src', ''),
+        ('/src/ci', '/src', 'ci'),
+        ('/repo/ci', '/src', None),
+        ('/src-suffix', '/src', None),
     ],
 )
-def test_repo_input_local_path(from_path, expected):
-    assert _repo_input_local_path(from_path) == expected
+def test_repo_input_local_path(from_path, repo_prefix, expected):
+    assert _repo_input_local_path(from_path, repo_prefix) == expected
 
 
 @pytest.mark.parametrize(
@@ -109,13 +114,14 @@ def _never_runnable(_name: str) -> bool:
 
 
 @pytest.mark.parametrize(
-    'steps, changed_files, runnable, expected_seeds',
+    'steps, changed_files, runnable, repo_prefix, expected_seeds',
     [
         # step with matching /repo/ci input
         (
             [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
             ['ci/foo.py'],
             _always_runnable,
+            '/repo',
             {'check_ci'},
         ),
         # /repo matches any changed file
@@ -123,6 +129,7 @@ def _never_runnable(_name: str) -> bool:
             [{'name': 'check_all', 'inputs': [{'from': '/repo', 'to': '/io/repo'}]}],
             ['anything.py'],
             _always_runnable,
+            '/repo',
             {'check_all'},
         ),
         # changed file doesn't match the step's input path
@@ -130,6 +137,7 @@ def _never_runnable(_name: str) -> bool:
             [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
             ['hail/foo.py'],
             _always_runnable,
+            '/repo',
             set(),
         ),
         # step excluded because not runnable
@@ -137,6 +145,7 @@ def _never_runnable(_name: str) -> bool:
             [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
             ['ci/foo.py'],
             _never_runnable,
+            '/repo',
             set(),
         ),
         # step with no inputs is never a seed
@@ -144,6 +153,7 @@ def _never_runnable(_name: str) -> bool:
             [{'name': 'deploy_auth'}],
             ['ci/foo.py'],
             _always_runnable,
+            '/repo',
             set(),
         ),
         # non-/repo input (artifact from another step) is ignored
@@ -151,6 +161,7 @@ def _never_runnable(_name: str) -> bool:
             [{'name': 'test_ci', 'inputs': [{'from': '/io/wheel', 'to': '/wheel'}]}],
             ['ci/foo.py'],
             _always_runnable,
+            '/repo',
             set(),
         ),
         # multiple steps — only the matching one is a seed
@@ -161,12 +172,29 @@ def _never_runnable(_name: str) -> bool:
             ],
             ['ci/foo.py'],
             _always_runnable,
+            '/repo',
             {'check_ci'},
+        ),
+        # custom repo_prefix: /src/ci matches when prefix is /src
+        (
+            [{'name': 'check_ci', 'inputs': [{'from': '/src/ci', 'to': '/io/ci'}]}],
+            ['ci/foo.py'],
+            _always_runnable,
+            '/src',
+            {'check_ci'},
+        ),
+        # custom repo_prefix: /repo/ci does NOT match when prefix is /src
+        (
+            [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
+            ['ci/foo.py'],
+            _always_runnable,
+            '/src',
+            set(),
         ),
     ],
 )
-def test_find_seed_steps(steps, changed_files, runnable, expected_seeds):
-    assert _find_seed_steps(steps, changed_files, runnable) == expected_seeds
+def test_find_seed_steps(steps, changed_files, runnable, repo_prefix, expected_seeds):
+    assert _find_seed_steps(steps, changed_files, runnable, repo_prefix) == expected_seeds
 
 
 @pytest.mark.parametrize(
@@ -250,6 +278,25 @@ steps:
 """
 
 
+_CUSTOM_PREFIX_CONFIG = """
+repoPrefix: /src
+
+alwaysRunSteps:
+  - merge_code
+
+steps:
+  - name: merge_code
+    kind: runImage
+  - name: check_ci
+    kind: runImage
+    scopes: [test]
+    inputs:
+      - from: /src/ci
+        to: /io/ci
+    dependsOn: [merge_code]
+"""
+
+
 @pytest.mark.parametrize(
     'config_str, changed_files, scope, cloud, expected_steps',
     [
@@ -271,6 +318,8 @@ steps:
         (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['merge_code', 'test_azure']),
         # no cloud filter -> both cloud-specific steps + merge_code
         (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['merge_code', 'test_azure', 'test_gcp']),
+        # custom repoPrefix in config: ci change seeds check_ci
+        (_CUSTOM_PREFIX_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
     ],
 )
 def test_compute_requested_steps(config_str, changed_files, scope, cloud, expected_steps):

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -236,8 +236,8 @@ steps:
 @pytest.mark.parametrize(
     'config_str, changed_files, scope, cloud, expected_steps',
     [
-        # empty changed_files -> nothing runs (not even merge_code)
-        (_SIMPLE_CONFIG, [], 'test', None, []),
+        # empty changed_files -> nothing runs except alwaysRunSteps (ie merge_code)
+        (_SIMPLE_CONFIG, [], 'test', None, {'merge_code'}),
         # ci change affects check_ci; merge_code always included
         (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
         # hail change affects check_hail; merge_code always included

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -4,7 +4,7 @@ from ci.build_selection import (
     BuildSelectionResult,
     _expand_to_descendants,
     _file_matches_input,
-    _find_seed_steps,
+    _find_affected_steps,
     _in_cloud,
     _in_scope,
     _is_doc_file,
@@ -123,7 +123,7 @@ def test_valid_step(step, scope, cloud, expected):
 
 
 @pytest.mark.parametrize(
-    'steps, changed_files, repo_prefix, expected_seeds',
+    'steps, changed_files, repo_prefix, expected_affected_steps',
     [
         # step with matching /repo/ci input
         (
@@ -146,7 +146,7 @@ def test_valid_step(step, scope, cloud, expected):
             '/repo',
             set(),
         ),
-        # step with no inputs is never a seed
+        # step with no inputs is never affected
         (
             [{'name': 'deploy_auth'}],
             ['ci/foo.py'],
@@ -160,7 +160,7 @@ def test_valid_step(step, scope, cloud, expected):
             '/repo',
             set(),
         ),
-        # multiple steps — only the matching one is a seed
+        # multiple steps — only the matching one is affected
         (
             [
                 {'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]},
@@ -186,14 +186,14 @@ def test_valid_step(step, scope, cloud, expected):
         ),
     ],
 )
-def test_find_seed_steps(steps, changed_files, repo_prefix, expected_seeds):
-    assert _find_seed_steps(steps, changed_files, repo_prefix) == expected_seeds
+def test_find_affected_steps(steps, changed_files, repo_prefix, expected_affected_steps):
+    assert _find_affected_steps(steps, changed_files, repo_prefix) == expected_affected_steps
 
 
 @pytest.mark.parametrize(
-    'seeds, reverse, expected',
+    'affected_steps, descendants, expected',
     [
-        # seeds with no dependents
+        # no dependents
         ({'A'}, {}, {'A'}),
         # single-level descendant
         ({'A'}, {'A': ['B']}, {'A', 'B'}),
@@ -201,14 +201,14 @@ def test_find_seed_steps(steps, changed_files, repo_prefix, expected_seeds):
         ({'A'}, {'A': ['B'], 'B': ['C']}, {'A', 'B', 'C'}),
         # diamond: A -> B, A -> C, B -> D, C -> D
         ({'A'}, {'A': ['B', 'C'], 'B': ['D'], 'C': ['D']}, {'A', 'B', 'C', 'D'}),
-        # empty seeds
+        # no affected steps
         (set(), {'A': ['B']}, set()),
-        # multiple seeds
+        # multiple affected steps
         ({'A', 'X'}, {'A': ['B'], 'X': ['Y']}, {'A', 'B', 'X', 'Y'}),
     ],
 )
-def test_expand_to_descendants(seeds, reverse, expected):
-    assert _expand_to_descendants(seeds, reverse) == expected
+def test_expand_to_descendants(affected_steps, descendants, expected):
+    assert _expand_to_descendants(affected_steps, descendants) == expected
 
 
 _SIMPLE_CONFIG = """
@@ -288,15 +288,15 @@ steps:
     [
         # empty changed_files -> nothing runs (not even merge_code)
         (_SIMPLE_CONFIG, [], 'test', None, []),
-        # ci change seeds check_ci; merge_code always included
+        # ci change affects check_ci; merge_code always included
         (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
-        # hail change seeds check_hail; merge_code always included
+        # hail change affects check_hail; merge_code always included
         (_SIMPLE_CONFIG, ['hail/foo.py'], 'test', None, ['check_hail', 'merge_code']),
-        # doc-only change: no seeds, but merge_code still runs
+        # doc-only change: no affected steps, but merge_code still runs
         (_SIMPLE_CONFIG, ['ci/README.md'], 'test', None, ['merge_code']),
-        # mix of doc and code: code file seeds check_ci, doc file ignored
+        # mix of doc and code: code file affects check_ci, doc file ignored
         (_SIMPLE_CONFIG, ['ci/README.md', 'ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
-        # deploy scope: check_ci scoped to [test,dev] is not a seed; merge_code always included
+        # deploy scope: check_ci scoped to [test,dev] is not affected; merge_code always included
         (_SIMPLE_CONFIG, ['ci/foo.py'], 'deploy', None, ['merge_code']),
         # gcp cloud filter — test_gcp + merge_code
         (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'gcp', ['merge_code', 'test_gcp']),
@@ -304,7 +304,7 @@ steps:
         (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['merge_code', 'test_azure']),
         # no cloud filter -> both cloud-specific steps + merge_code
         (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['merge_code', 'test_azure', 'test_gcp']),
-        # custom repoPrefix in config: ci change seeds check_ci
+        # custom repoPrefix in config: ci change affects check_ci
         (_CUSTOM_PREFIX_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
     ],
 )

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -9,6 +9,7 @@ from ci.build_selection import (
     _in_scope,
     _is_doc_file,
     _repo_input_local_path,
+    _valid_step,
     compute_requested_steps,
 )
 
@@ -105,22 +106,29 @@ def test_in_cloud(clouds, cloud, expected):
     assert _in_cloud(clouds, cloud) == expected
 
 
-def _always_runnable(_name: str) -> bool:
-    return True
-
-
-def _never_runnable(_name: str) -> bool:
-    return False
+@pytest.mark.parametrize(
+    'step, scope, cloud, expected',
+    [
+        ({'scopes': None, 'clouds': None}, 'test', 'gcp', True),
+        ({'scopes': ['test'], 'clouds': None}, 'test', 'gcp', True),
+        ({'scopes': ['dev'], 'clouds': None}, 'test', 'gcp', False),
+        ({'scopes': None, 'clouds': ['gcp']}, 'test', 'gcp', True),
+        ({'scopes': None, 'clouds': ['gcp']}, 'test', 'azure', False),
+        ({'scopes': ['deploy'], 'clouds': ['gcp']}, 'test', 'gcp', False),
+        ({}, 'test', None, True),
+    ],
+)
+def test_valid_step(step, scope, cloud, expected):
+    assert _valid_step(step, scope, cloud) == expected
 
 
 @pytest.mark.parametrize(
-    'steps, changed_files, runnable, repo_prefix, expected_seeds',
+    'steps, changed_files, repo_prefix, expected_seeds',
     [
         # step with matching /repo/ci input
         (
             [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
             ['ci/foo.py'],
-            _always_runnable,
             '/repo',
             {'check_ci'},
         ),
@@ -128,7 +136,6 @@ def _never_runnable(_name: str) -> bool:
         (
             [{'name': 'check_all', 'inputs': [{'from': '/repo', 'to': '/io/repo'}]}],
             ['anything.py'],
-            _always_runnable,
             '/repo',
             {'check_all'},
         ),
@@ -136,15 +143,6 @@ def _never_runnable(_name: str) -> bool:
         (
             [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
             ['hail/foo.py'],
-            _always_runnable,
-            '/repo',
-            set(),
-        ),
-        # step excluded because not runnable
-        (
-            [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
-            ['ci/foo.py'],
-            _never_runnable,
             '/repo',
             set(),
         ),
@@ -152,7 +150,6 @@ def _never_runnable(_name: str) -> bool:
         (
             [{'name': 'deploy_auth'}],
             ['ci/foo.py'],
-            _always_runnable,
             '/repo',
             set(),
         ),
@@ -160,7 +157,6 @@ def _never_runnable(_name: str) -> bool:
         (
             [{'name': 'test_ci', 'inputs': [{'from': '/io/wheel', 'to': '/wheel'}]}],
             ['ci/foo.py'],
-            _always_runnable,
             '/repo',
             set(),
         ),
@@ -171,7 +167,6 @@ def _never_runnable(_name: str) -> bool:
                 {'name': 'check_hail', 'inputs': [{'from': '/repo/hail', 'to': '/io/hail'}]},
             ],
             ['ci/foo.py'],
-            _always_runnable,
             '/repo',
             {'check_ci'},
         ),
@@ -179,7 +174,6 @@ def _never_runnable(_name: str) -> bool:
         (
             [{'name': 'check_ci', 'inputs': [{'from': '/src/ci', 'to': '/io/ci'}]}],
             ['ci/foo.py'],
-            _always_runnable,
             '/src',
             {'check_ci'},
         ),
@@ -187,42 +181,34 @@ def _never_runnable(_name: str) -> bool:
         (
             [{'name': 'check_ci', 'inputs': [{'from': '/repo/ci', 'to': '/io/ci'}]}],
             ['ci/foo.py'],
-            _always_runnable,
             '/src',
             set(),
         ),
     ],
 )
-def test_find_seed_steps(steps, changed_files, runnable, repo_prefix, expected_seeds):
-    assert _find_seed_steps(steps, changed_files, runnable, repo_prefix) == expected_seeds
+def test_find_seed_steps(steps, changed_files, repo_prefix, expected_seeds):
+    assert _find_seed_steps(steps, changed_files, repo_prefix) == expected_seeds
 
 
 @pytest.mark.parametrize(
-    'seeds, reverse, runnable, expected',
+    'seeds, reverse, expected',
     [
         # seeds with no dependents
-        ({'A'}, {}, _always_runnable, {'A'}),
+        ({'A'}, {}, {'A'}),
         # single-level descendant
-        ({'A'}, {'A': ['B']}, _always_runnable, {'A', 'B'}),
+        ({'A'}, {'A': ['B']}, {'A', 'B'}),
         # two-level chain
-        ({'A'}, {'A': ['B'], 'B': ['C']}, _always_runnable, {'A', 'B', 'C'}),
-        # descendant filtered out by runnable
-        ({'A'}, {'A': ['B']}, _never_runnable, {'A'}),
+        ({'A'}, {'A': ['B'], 'B': ['C']}, {'A', 'B', 'C'}),
         # diamond: A -> B, A -> C, B -> D, C -> D
-        (
-            {'A'},
-            {'A': ['B', 'C'], 'B': ['D'], 'C': ['D']},
-            _always_runnable,
-            {'A', 'B', 'C', 'D'},
-        ),
+        ({'A'}, {'A': ['B', 'C'], 'B': ['D'], 'C': ['D']}, {'A', 'B', 'C', 'D'}),
         # empty seeds
-        (set(), {'A': ['B']}, _always_runnable, set()),
+        (set(), {'A': ['B']}, set()),
         # multiple seeds
-        ({'A', 'X'}, {'A': ['B'], 'X': ['Y']}, _always_runnable, {'A', 'B', 'X', 'Y'}),
+        ({'A', 'X'}, {'A': ['B'], 'X': ['Y']}, {'A', 'B', 'X', 'Y'}),
     ],
 )
-def test_expand_to_descendants(seeds, reverse, runnable, expected):
-    assert _expand_to_descendants(seeds, reverse, runnable) == expected
+def test_expand_to_descendants(seeds, reverse, expected):
+    assert _expand_to_descendants(seeds, reverse) == expected
 
 
 _SIMPLE_CONFIG = """

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -7,28 +7,10 @@ from ci.build_selection import (
     _find_affected_steps,
     _in_cloud,
     _in_scope,
-    _is_doc_file,
     _repo_input_local_path,
     _valid_step,
     compute_requested_steps,
 )
-
-
-@pytest.mark.parametrize(
-    'path, expected',
-    [
-        ('batch/README.md', True),
-        ('batch/README.MD', True),
-        ('CHANGELOG.rst', True),
-        ('CHANGELOG.RST', True),
-        ('batch/batch/server.py', False),
-        ('foo.py', False),
-        ('notes.md.bak', False),
-        ('README', False),
-    ],
-)
-def test_is_doc_file(path, expected):
-    assert _is_doc_file(path) == expected
 
 
 @pytest.mark.parametrize(
@@ -292,9 +274,9 @@ steps:
         (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
         # hail change affects check_hail; merge_code always included
         (_SIMPLE_CONFIG, ['hail/foo.py'], 'test', None, ['check_hail', 'merge_code']),
-        # doc-only change: no affected steps, but merge_code still runs
-        (_SIMPLE_CONFIG, ['ci/README.md'], 'test', None, ['merge_code']),
-        # mix of doc and code: code file affects check_ci, doc file ignored
+        # README.md under ci/ affects check_ci just like any other file there
+        (_SIMPLE_CONFIG, ['ci/README.md'], 'test', None, ['check_ci', 'merge_code']),
+        # multiple ci/ files both affect check_ci
         (_SIMPLE_CONFIG, ['ci/README.md', 'ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
         # deploy scope: check_ci scoped to [test,dev] is not affected; merge_code always included
         (_SIMPLE_CONFIG, ['ci/foo.py'], 'deploy', None, ['merge_code']),

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -65,6 +65,8 @@ def test_file_matches_input(changed_file, local_path, expected):
         ({'scopes': None, 'clouds': ['gcp']}, 'test', 'azure', False),
         ({'scopes': None, 'clouds': ['gcp']}, 'test', None, True),  # unfiltered cloud matches any
         ({'scopes': ['deploy'], 'clouds': ['gcp']}, 'test', 'gcp', False),
+        ({'runIfRequested': True}, 'test', 'gcp', False),
+        ({'runIfRequested': True}, 'test', None, False),
         ({}, 'test', None, True),
     ],
 )
@@ -214,6 +216,26 @@ steps:
 """
 
 
+_RUN_IF_REQUESTED_CONFIG = """
+alwaysRunSteps:
+  - merge_code
+
+steps:
+  - name: merge_code
+    kind: runImage
+  - name: check_ci
+    kind: runImage
+    scopes: [test]
+    inputs:
+      - from: /repo/ci
+        to: /io/ci
+    dependsOn: [merge_code]
+  - name: create_initial_user
+    kind: runImage
+    runIfRequested: true
+    dependsOn: [merge_code, check_ci]
+"""
+
 _CUSTOM_PREFIX_CONFIG = """
 repoPrefix: /src
 
@@ -254,6 +276,8 @@ steps:
         (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['merge_code', 'test_azure']),
         # no cloud filter -> both cloud-specific steps + merge_code
         (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['merge_code', 'test_azure', 'test_gcp']),
+        # runIfRequested step is never auto-selected as a descendant
+        (_RUN_IF_REQUESTED_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
         # custom repoPrefix in config: ci change affects check_ci
         (_CUSTOM_PREFIX_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
     ],


### PR DESCRIPTION
## Change Description

Alternative approach to #15395. This approach detects which test steps are using any files which have changed in the PR, and requests only those steps - and anything downstream from them. In other words - anything which could be impacted by the change in the files. (Upstream requirements are already calculated by the existing requestedSteps logic)

As a nice side effect, this approach doesn't need us to manually list explicit watchedPaths for tests. We also don't need to have special case handling for clean up actions. We get all of that for free.

## Recommended review strategy

1. Check the implementation of pure functions in build_selection.py, starting with `compute_requested_steps` and working backwards through its call stack.
2. Check the wiring through from github.py
3. Check the test cases adequately cover the new pure functions
4. Check the build.yaml changes pass the smell test. But the real validation of those input changes will be whether the CI test on this PR succeeds or not

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Changes which tests run, based on what actually is being changed in a PR

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
