### PR TITLE
[query] reduce ir size by 4N bytes, where N = size(IR)

### DIFF
--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -634,10 +634,8 @@ object Main {
 
     r += node("If", in("cond", child), in("cnsq", child), in("altr", child))
     r += node("Switch", in("x", child), in("default", child), in("cases", child.*))
-      .withPreamble("override lazy val size: Int = 2 + cases.length")
 
     r += node("Block", in("bindings", binding.*), in("body", child))
-      .withPreamble("override lazy val size: Int = bindings.length + 1")
       .withCompanionExtension
 
     r += node("Ref", name, _typ().mutable).withTraits(BaseRef)

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -27,7 +27,7 @@ import java.io.OutputStream
 import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
 import org.json4s.JsonAST.{JNothing, JString}
 
-trait IR extends BaseIR {
+abstract class IR extends BaseIR {
   private var _typ: Type = null
 
   override def typ: Type = {
@@ -55,10 +55,15 @@ trait IR extends BaseIR {
     cp
   }
 
-  lazy val size: Int = 1 + children.map {
-    case x: IR => x.size
-    case _ => 0
-  }.sum
+  val size: Int = {
+    def go(s: Int, ir0: BaseIR): Int =
+      ir0.children.foldLeft(s) {
+        case (s, c: IR) => s + c.size
+        case (s, c: BaseIR) => go(s + 1, c)
+      }
+
+    go(1, this)
+  }
 }
 
 package defs {


### PR DESCRIPTION
Making size a `val`from `lazy val` saves 4 bytes per node.
This change does not affect the broad-managed batch service in gcp.