### PR TITLE
[query] `Atom` (nee `TrivialIR`) copy-on-use (no-sharing)

### DIFF
--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -73,7 +73,7 @@ trait IRDSL {
 
   type Trait
 
-  val TrivialIR: Trait
+  val Atom: Trait
   val BaseRef: Trait
   def TypedIR(t: String): Trait
   val NDArrayIR: Trait
@@ -118,7 +118,7 @@ object IRDSL_Impl extends IRDSL {
 
   final case class Trait(name: String)
 
-  override val TrivialIR: Trait = Trait("TrivialIR")
+  override val Atom: Trait = Trait("Atom")
   override val BaseRef: Trait = Trait("BaseRef")
   override def TypedIR(typ: String): Trait = Trait(s"TypedIR[$typ]")
   override val NDArrayIR: Trait = Trait("NDArrayIR")
@@ -578,18 +578,18 @@ object Main {
 
     val r = Seq.newBuilder[NodeDef]
 
-    r += node("I32", in("x", att("Int"))).withTraits(TrivialIR)
-    r += node("I64", in("x", att("Long"))).withTraits(TrivialIR)
-    r += node("F32", in("x", att("Float"))).withTraits(TrivialIR)
-    r += node("F64", in("x", att("Double"))).withTraits(TrivialIR)
-    r += node("Str", in("x", att("String"))).withTraits(TrivialIR)
+    r += node("I32", in("x", att("Int"))).withTraits(Atom)
+    r += node("I64", in("x", att("Long"))).withTraits(Atom)
+    r += node("F32", in("x", att("Float"))).withTraits(Atom)
+    r += node("F64", in("x", att("Double"))).withTraits(Atom)
+    r += node("Str", in("x", att("String"))).withTraits(Atom)
       .withPreamble(
         "override def toString(): String = s\"\"\"Str(\"${StringEscapeUtils.escapeString(x)}\")\"\"\""
       ): @nowarn("msg=possible missing interpolator")
-    r += node("True").withTraits(TrivialIR)
-    r += node("False").withTraits(TrivialIR)
-    r += node("Void").withTraits(TrivialIR)
-    r += node("NA", _typ()).withTraits(TrivialIR)
+    r += node("True").withTraits(Atom)
+    r += node("False").withTraits(Atom)
+    r += node("Void").withTraits(Atom)
+    r += node("NA", _typ()).withTraits(Atom)
     r += node("UUID4", in("id", att("String")))
       .withDocstring(
         """WARNING! This node can only be used when trying to append a one-off,
@@ -640,7 +640,7 @@ object Main {
       .withPreamble("override lazy val size: Int = bindings.length + 1")
       .withCompanionExtension
 
-    r += node("Ref", name, _typ().mutable).withTraits(BaseRef)
+    r += node("Ref", name, _typ().mutable).withTraits(BaseRef, Atom)
 
     r += node(
       "TailLoop",
@@ -659,7 +659,7 @@ object Main {
     r += node("Recur", name, in("args", child.*), _typ().mutable).withTraits(BaseRef)
 
     r += node("RelationalLet", name, in("value", child), in("body", child))
-    r += node("RelationalRef", name, _typ()).withTraits(BaseRef)
+    r += node("RelationalRef", name, _typ()).withTraits(BaseRef, Atom)
 
     r += node("ApplyBinaryPrimOp", in("op", att("BinaryOp")), in("l", child), in("r", child))
     r += node("ApplyUnaryPrimOp", in("op", att("UnaryOp")), in("x", child))
@@ -716,9 +716,9 @@ object Main {
 
     r += node("ToSet", in("a", child))
     r += node("ToDict", in("a", child))
-    r += node("ToArray", in("a", child))
-    r += node("CastToArray", in("a", child))
-    r += node("ToStream", in("a", child), mmPerElt)
+    r += node("ToArray", in("a", child)).typed("TArray")
+    r += node("CastToArray", in("a", child)).typed("TArray")
+    r += node("ToStream", in("a", child), mmPerElt).typed("TStream")
     r += node("GroupByKey", in("collection", child))
 
     r += node(
@@ -1082,7 +1082,9 @@ object Main {
     r += node("GetTupleElement", in("o", child), in("idx", att("Int")))
 
     r += node("In", in("i", att("Int")), in("_typ", att("EmitParamType")))
-      .withDocstring("Function input").withCompanionExtension
+      .withTraits(Atom)
+      .withDocstring("Function input")
+      .withCompanionExtension
 
     r += node("Die", in("message", child), in("_typ", att("Type")), errorID).withCompanionExtension
     r += node("ConsoleLog", in("message", child), in("result", child))

--- a/hail/hail/src/is/hail/expr/ir/BaseIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BaseIR.scala
@@ -21,11 +21,11 @@ abstract class BaseIR {
 
   protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BaseIR
 
-  def deepCopy(): this.type =
-    copyWithNewChildren(newChildren = childrenSeq.map(_.deepCopy())).asInstanceOf[this.type]
+  def deepCopy: this.type =
+    copyWithNewChildren(newChildren = childrenSeq.map(_.deepCopy)).asInstanceOf[this.type]
 
   def noSharing(ctx: ExecuteContext): this.type =
-    if (HasIRSharing(ctx, this)) this.deepCopy() else this
+    if (HasIRSharing(ctx, this)) this.deepCopy else this
 
   // For use as a boolean flag by IR passes. Each pass uses a different sentinel value to encode
   // "true" (and anything else is false). As long as we maintain the global invariant that no

--- a/hail/hail/src/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/hail/src/is/hail/expr/ir/ForwardLets.scala
@@ -56,7 +56,7 @@ object ForwardLets {
             env.eval
               .lookupOption(name)
               .map { forwarded =>
-                if (uses.lookup(defs.lookup(x)).count(_.t.name == name) > 1) forwarded.deepCopy()
+                if (uses.lookup(defs.lookup(x)).count(_.t.name == name) > 1) forwarded.deepCopy
                 else forwarded
               }
               .getOrElse(x)

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.annotations.Region
 import is.hail.asm4s.Value
 import is.hail.backend.ExecuteContext
+import is.hail.collection.FastSeq
 import is.hail.expr.ir.agg.PhysicalAggSig
 import is.hail.expr.ir.functions._
 import is.hail.expr.ir.streams.StreamProducer
@@ -27,29 +28,24 @@ import java.io.OutputStream
 import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
 import org.json4s.JsonAST.{JNothing, JString}
 
-trait IR extends BaseIR {
+abstract class IR extends BaseIR {
   private var _typ: Type = null
 
-  override def typ: Type = {
-    if (_typ == null) {
-      try
-        _typ = InferType(this)
-      catch {
-        case e: Throwable => throw new RuntimeException(s"typ: inference failure:", e)
-      }
+  override def typ: Type =
+    if (_typ != null) _typ
+    else {
+      _typ = InferType(this)
       assert(_typ != null)
+      _typ
     }
-    _typ
-  }
 
   override def mapChildren(f: BaseIR => BaseIR): IR = super.mapChildren(f).asInstanceOf[IR]
 
   override def mapChildrenWithIndex(f: (BaseIR, Int) => BaseIR): IR =
     super.mapChildrenWithIndex(f).asInstanceOf[IR]
 
-  override def deepCopy(): this.type = {
-
-    val cp = super.deepCopy()
+  override def deepCopy: this.type = {
+    val cp = super.deepCopy
     if (_typ != null)
       cp._typ = _typ
     cp
@@ -63,14 +59,18 @@ trait IR extends BaseIR {
 
 package defs {
 
-  import is.hail.collection.FastSeq
-
   trait TypedIR[T <: Type] extends IR {
     override def typ: T = tcoerce[T](super.typ)
   }
 
-  // Mark Refs and constants as IRs that are safe to duplicate
-  trait TrivialIR extends IR
+  // Refs and Constants as IRs that are safe to duplicate
+  trait Atom { this: IR =>
+    def ir: IR with Atom = deepCopy
+  }
+
+  object Atom {
+    implicit def atomToIR(a: Atom): IR = a.ir
+  }
 
   class WrappedByteArrays(val ba: Array[Array[Byte]]) {
     override def hashCode(): Int =
@@ -122,7 +122,7 @@ package defs {
 
   case class Binding(name: Name, value: IR, scope: Int = Scope.EVAL)
 
-  trait BaseRef extends IR with TrivialIR {
+  trait BaseRef extends IR {
     def name: Name
     def _typ: Type
   }
@@ -163,7 +163,7 @@ package defs {
         val rightGrouped = mapIR(rightGroupedStream) { group =>
           bindIR(ToArray(group)) { array =>
             bindIR(ArrayRef(array, 0)) { head =>
-              MakeStruct(rKey.map(key => key -> GetField(head, key)) :+ groupField -> array)
+              MakeStruct(rKey.map(key => key -> GetField(head, key)) :+ groupField -> array.ir)
             }
           }
         }
@@ -638,38 +638,23 @@ package defs {
     }
 
     abstract class ArraySortCompanionExt {
-      def apply(a: IR, ascending: IR = True(), onKey: Boolean = false): ArraySort = {
-        val l = freshName()
-        val r = freshName()
-        val atyp = tcoerce[TStream](a.typ)
-        val compare = if (onKey) {
-          val elementType = atyp.elementType.asInstanceOf[TBaseStruct]
-          elementType match {
-            case _: TStruct =>
-              val elt = tcoerce[TStruct](atyp.elementType)
-              ApplyComparisonOp(
-                Compare,
-                GetField(Ref(l, elt), elt.fieldNames(0)),
-                GetField(Ref(r, atyp.elementType), elt.fieldNames(0)),
-              )
-            case _: TTuple =>
-              val elt = tcoerce[TTuple](atyp.elementType)
-              ApplyComparisonOp(
-                Compare,
-                GetTupleElement(Ref(l, elt), elt.fields(0).index),
-                GetTupleElement(Ref(r, atyp.elementType), elt.fields(0).index),
-              )
-          }
-        } else {
-          ApplyComparisonOp(
-            Compare,
-            Ref(l, atyp.elementType),
-            Ref(r, atyp.elementType),
-          )
-        }
+      def apply(a: IR, ascending: IR = True(), onKey: Boolean = false): IR =
+        sortIR(a) { (l, r) =>
+          val compare =
+            if (!onKey) ApplyComparisonOp(Compare, l, r)
+            else l.typ match {
+              case elt: TStruct =>
+                val field = elt.fieldNames(0)
+                ApplyComparisonOp(Compare, GetField(l, field), GetField(r, field))
+              case elt: TTuple =>
+                val index = elt.fields(0).index
+                ApplyComparisonOp(Compare, GetTupleElement(l, index), GetTupleElement(r, index))
+              case telem =>
+                fatal(s"ArraySort(.., onKey = true) requires struct or tuple elements, got $telem")
+            }
 
-        ArraySort(a, l, r, If(ascending, compare < 0, compare > 0))
-      }
+          bindIR(compare)(c => If(ascending, c < 0, c > 0))
+        }
     }
 
     abstract class StreamFold2CompanionExt {
@@ -888,7 +873,7 @@ package defs {
       lazy val (body, inline): (IR, Boolean) = {
         val ((_, _, _, inline), impl) =
           IRFunctionRegistry.lookupIR(function, typeArgs, args.map(_.typ)).get
-        val body = impl(typeArgs, refs, errorID).deepCopy()
+        val body = impl(typeArgs, refs, errorID).deepCopy
         (body, inline)
       }
 

--- a/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.collection.compat.immutable.ArraySeq
-import is.hail.expr.ir.defs.{Let, Ref, TrivialIR}
+import is.hail.expr.ir.defs.{Atom, Let, Ref}
 
 object IRBuilder {
   def scoped(f: IRBuilder => IR): IR = {
@@ -16,15 +16,15 @@ class IRBuilder {
 
   def getBindings: IndexedSeq[(Name, IR)] = bindings.result()
 
-  def memoize(ir: IR): TrivialIR = ir match {
-    case ir: TrivialIR => ir
+  def memoize(ir: IR): Atom = ir match {
+    case ir: Atom => ir
     case _ => strictMemoize(ir)
   }
 
-  def strictMemoize(ir: IR): Ref =
+  def strictMemoize(ir: IR): Atom =
     strictMemoize(ir, freshName())
 
-  def strictMemoize(ir: IR, name: Name): Ref = {
+  def strictMemoize(ir: IR, name: Name): Atom = {
     bindings += name -> ir
     Ref(name, ir.typ)
   }

--- a/hail/hail/src/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/LowerMatrixIR.scala
@@ -109,7 +109,7 @@ object LowerMatrixIR {
   private def bindingsToStruct(bindings: IndexedSeq[(Name, IR)]): MakeStruct =
     MakeStruct(bindings.map { case (n, ir) => n.str -> ir })
 
-  private def unwrapStruct(bindings: IndexedSeq[(Name, IR)], struct: Ref): IndexedSeq[(Name, IR)] =
+  private def unwrapStruct(bindings: IndexedSeq[(Name, IR)], struct: Atom): IndexedSeq[(Name, IR)] =
     bindings.map { case (name, _) => name -> GetField(struct, name.str) }
 
   private[this] def lower(

--- a/hail/hail/src/is/hail/expr/ir/LowerOrInterpretNonCompilable.scala
+++ b/hail/hail/src/is/hail/expr/ir/LowerOrInterpretNonCompilable.scala
@@ -26,7 +26,7 @@ object LowerOrInterpretNonCompilable extends Logging {
         case None =>
           logger.info(s"LowerOrInterpretNonCompilable: whole stage code generation is a go!")
           logger.info(s"lowering result: ${value.getClass.getSimpleName}")
-          val fullyLowered = LowerToDistributedArrayPass(DArrayLowering.All).transform(ctx, value)
+          val fullyLowered = LowerToDistributedArrayPass(DArrayLowering.All)(ctx, value)
             .asInstanceOf[IR]
           logger.info(s"compiling and evaluating result: ${value.getClass.getSimpleName}")
           CompileAndEvaluate.evalToIR(ctx, fullyLowered)

--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -87,7 +87,7 @@ sealed trait MatrixWriterComponents {
   def stage: TableStage
   def setup: IR
   def writePartitionType: Type
-  def writePartition(rows: IR, ctx: Ref): IR
+  def writePartition(rows: IR, ctx: Atom): IR
   def finalizeWrite(parts: IR, globals: IR): IR
 }
 
@@ -223,7 +223,7 @@ object MatrixNativeWriter {
       override def writePartitionType: Type =
         rowWriter.returnType
 
-      override def writePartition(rows: IR, ctx: Ref): IR =
+      override def writePartition(rows: IR, ctx: Atom): IR =
         WritePartition(rows, GetField(ctx, "writeCtx") + UUID4(), rowWriter)
 
       override def finalizeWrite(parts: IR, globals: IR): IR = {
@@ -2575,7 +2575,7 @@ case class MatrixNativeMultiWriter(
             ToArray(mapIR(c.stage.contexts) { ctx =>
               MakeStruct(FastSeq(
                 "matrixId" -> I32(matrixId),
-                "options" -> MakeTuple(emptyUnionIRs.updated(matrixId, matrixId -> ctx)),
+                "options" -> MakeTuple(emptyUnionIRs.updated(matrixId, matrixId -> ctx.ir)),
               ))
             })
           },

--- a/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/hail/src/is/hail/expr/ir/PruneDeadFields.scala
@@ -123,7 +123,7 @@ object PruneDeadFields extends Logging {
   def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR =
     ctx.time {
       try {
-        val irCopy = ir.deepCopy()
+        val irCopy = ir.deepCopy
         val ms = new ComputeMutableState
         irCopy match {
           case mir: MatrixIR =>

--- a/hail/hail/src/is/hail/expr/ir/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/Simplify.scala
@@ -22,7 +22,7 @@ object Simplify {
 
   private[this] def recur(ctx: ExecuteContext, ir: BaseIR): BaseIR =
     ir match {
-      case ir: TrivialIR => ir
+      case ir: Atom => ir
       case ir: IR => simplifyValue(ctx, ir)
       case tir: TableIR => simplifyTable(ctx, tir)
       case mir: MatrixIR => simplifyMatrix(ctx, mir)
@@ -98,66 +98,86 @@ object Simplify {
 
       def isIntegral(t: Type) = t.isInstanceOf[TIntegral]
       def isFloating(t: Type) = t == TFloat32 || t == TFloat64
-      def pure(x: Int): IR = Literal.coerce(typ, x)
 
-      lazy val MinusOne: IR = pure(-1)
-      lazy val Zero: IR = pure(0)
-      lazy val One: IR = pure(1)
+      def pure(x: Int) = Literal.coerce(typ, x)
+      @inline def MinusOne = pure(-1)
+      @inline def Zero = pure(0)
+      @inline def One = pure(1)
+      @inline def Two = pure(2)
 
       ir match {
         case ApplyBinaryPrimOp(op, x, y) =>
           op match {
             case Add() =>
-              if (x == Zero) Some(y)
-              else if (y == Zero) Some(x)
-              else if (isIntegral(typ) && x == y) Some(ApplyBinaryPrimOp(Multiply(), pure(2), x))
+              val `0` = Zero
+              if (x == `0`) Some(y)
+              else if (y == `0`) Some(x)
+              else if (isIntegral(typ) && x == y) Some(ApplyBinaryPrimOp(Multiply(), Two, x))
               else None
 
             case Subtract() =>
-              if (x == Zero) Some(ApplyUnaryPrimOp(Negate, y))
-              else if (y == Zero) Some(x)
-              else if (isIntegral(typ) && x == y) Some(Zero)
+              val `0` = Zero
+              if (x == `0`) Some(ApplyUnaryPrimOp(Negate, y))
+              else if (y == `0`) Some(x)
+              else if (isIntegral(typ) && x == y) Some(`0`)
               else None
 
             case Multiply() =>
-              if (x == One) Some(y)
-              else if (x == MinusOne) Some(ApplyUnaryPrimOp(Negate, y))
-              else if (y == One) Some(x)
-              else if (y == MinusOne) Some(ApplyUnaryPrimOp(Negate, x))
-              else if (isIntegral(typ) && (x == Zero || y == Zero)) Some(Zero)
-              else None
+              val `1` = One
+              if (x == `1`) Some(y)
+              else {
+                val `-1` = MinusOne
+                if (x == `-1`) Some(ApplyUnaryPrimOp(Negate, y))
+                else if (y == `1`) Some(x)
+                else if (y == `-1`) Some(ApplyUnaryPrimOp(Negate, x))
+                else {
+                  val `0` = Zero
+                  if (isIntegral(typ) && (x == `0` || y == `0`)) Some(`0`)
+                  else None
+                }
+              }
 
             case RoundToNegInfDivide() =>
-              if (y == One) Some(x)
+              val `1` = One
+              if (y == `1`) Some(x)
               else if (y == MinusOne) Some(ApplyUnaryPrimOp(Negate, x))
               else if (isIntegral(typ)) {
-                if (x == y) Some(One)
-                else if (x == Zero) Some(Zero)
-                else if (y == Zero) Some(Die("division by zero", ir.typ))
+                val `0` = Zero
+                if (x == y) Some(`1`)
+                else if (x == `0`) Some(x)
+                else if (y == `0`) Some(Die("division by zero", ir.typ))
                 else None
               } else None
 
             case _: LeftShift | _: RightShift | _: LogicalRightShift if isIntegral(typ) =>
-              if (x == Zero) Some(Zero)
-              else if (y == I32(0)) Some(x)
+              if (x == Zero || y == I32(0)) Some(x)
               else None
 
             case BitAnd() if isIntegral(typ) =>
-              if (x == Zero || y == Zero) Some(Zero)
-              else if (x == MinusOne) Some(y)
-              else if (y == MinusOne) Some(x)
-              else None
+              val `0` = Zero
+              if (x == `0` || y == `0`) Some(`0`)
+              else {
+                val `-1` = MinusOne
+                if (x == `-1`) Some(y)
+                else if (y == `-1`) Some(x)
+                else None
+              }
 
             case BitOr() if isIntegral(typ) =>
-              if (x == MinusOne || y == MinusOne) Some(MinusOne)
-              else if (x == Zero) Some(y)
-              else if (y == Zero) Some(x)
-              else None
+              val `-1` = MinusOne
+              if (x == `-1` || y == `-1`) Some(`-1`)
+              else {
+                val `0` = Zero
+                if (x == `0`) Some(y)
+                else if (y == `0`) Some(x)
+                else None
+              }
 
             case BitXOr() if isIntegral(typ) =>
-              if (x == y) Some(Zero)
-              else if (x == Zero) Some(y)
-              else if (y == Zero) Some(x)
+              val `0` = Zero
+              if (x == y) Some(`0`)
+              else if (x == `0`) Some(y)
+              else if (y == `0`) Some(x)
               else None
 
             case _ =>
@@ -527,11 +547,11 @@ object Simplify {
         } // cannot be mapValues, or genUID() gets run for every usage!
 
         def copiedNewFieldRefs(): IndexedSeq[(String, IR)] =
-          fieldNames.map(name => (name, newFieldRefs(name).deepCopy()))
+          fieldNames.map(name => (name, newFieldRefs(name)))
 
         def rewrite(ir1: IR): IR = ir1 match {
           case GetField(Ref(`name`, _), fd) => newFieldRefs.get(fd) match {
-              case Some(r) => r.deepCopy()
+              case Some(r) => r.ir
               case None => GetField(Ref(name, old.typ), fd)
             }
           case ins @ InsertFields(Ref(`name`, _), fields, _) =>

--- a/hail/hail/src/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/hail/src/is/hail/expr/ir/StringTableReader.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
-import is.hail.expr.ir.defs.{Literal, MakeStruct, PartitionReader, ReadPartition, Ref, ToStream}
+import is.hail.expr.ir.defs.{Literal, MakeStruct, PartitionReader, ReadPartition, ToStream}
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage, TableStageDependency}
 import is.hail.expr.ir.streams.StreamProducer
@@ -198,13 +198,12 @@ case class StringTableReader(
       partitioner = RVDPartitioner.unkeyed(ctx.stateManager, lines.nPartitions),
       dependency = TableStageDependency.none,
       contexts = ToStream(Literal.coerce(TArray(lines.contextType), lines.contexts)),
-      body = { partitionContext: Ref =>
+      body = partitionContext =>
         ReadPartition(
           partitionContext,
           requestedType.rowType,
           StringTablePartitionReader(lines, uidFieldName),
-        )
-      },
+        ),
     )
   }
 

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -193,12 +193,12 @@ class AggSignatures(val sigs: IndexedSeq[PhysicalAggSig]) {
       AggStateValue(i, state)
     })
 
-  def initFromSerializedValueOp(statesValue: TrivialIR): IR =
+  def initFromSerializedValueOp(statesValue: Atom): IR =
     Begin(states.zipWithIndex.map { case (state, i) =>
       InitFromSerializedValue(i, GetTupleElement(statesValue, i), state)
     })
 
-  def combOpValues(values: TrivialIR): IR =
+  def combOpValues(values: Atom): IR =
     Begin(sigs.zipWithIndex.map { case (sig, i) =>
       CombOpValue(i, GetTupleElement(values, i), sig)
     })

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.Row
 abstract class BlockMatrixStage(val broadcastVals: IndexedSeq[Ref], val ctxType: Type) {
   def blockContext(idx: (Int, Int)): IR
 
-  def blockBody(ctxRef: Ref): IR
+  def blockBody(ctxRef: Atom): IR
 
   def collectBlocks(
     staticID: String,
@@ -87,7 +87,8 @@ abstract class BlockMatrixStage(val broadcastVals: IndexedSeq[Ref], val ctxType:
       override def blockContext(idx: (Int, Int)): IR =
         makestruct("old" -> outer.blockContext(idx), "new" -> newCtx(idx))
 
-      override def blockBody(ctxRef: Ref): IR = bindIR(GetField(ctxRef, "old"))(outer.blockBody)
+      override def blockBody(ctxRef: Atom): IR =
+        bindIR(GetField(ctxRef, "old"))(outer.blockBody)
     }
   }
 
@@ -96,7 +97,7 @@ abstract class BlockMatrixStage(val broadcastVals: IndexedSeq[Ref], val ctxType:
     new BlockMatrixStage(broadcastVals, outer.ctxType) {
       override def blockContext(idx: (Int, Int)): IR = outer.blockContext(idx)
 
-      override def blockBody(ctxRef: Ref): IR = f(ctxRef, outer.blockBody(ctxRef))
+      override def blockBody(ctxRef: Atom): IR = f(ctxRef, outer.blockBody(ctxRef))
     }
   }
 
@@ -126,7 +127,7 @@ abstract class BlockMatrixStage(val broadcastVals: IndexedSeq[Ref], val ctxType:
         }: _*)
       }
 
-      override def blockBody(ctxRef: Ref): IR = {
+      override def blockBody(ctxRef: Atom): IR = {
         NDArrayConcat(
           ToArray(mapIR(ToStream(ctxRef)) { ctxRows =>
             NDArrayConcat(
@@ -161,7 +162,7 @@ abstract class BlockMatrixStage(val broadcastVals: IndexedSeq[Ref], val ctxType:
 abstract class DynamicBMSContexts {
   def apply(row: IR, col: IR): IR
   def map(ib: IRBuilder)(f: (IR, IR, IR, IR) => IR): DynamicBMSContexts
-  def collect(makeBlock: (Ref, Ref, Ref) => IR): IR
+  def collect(makeBlock: (Atom, Atom, Atom) => IR): IR
 }
 
 object DynamicDenseContexts {
@@ -175,7 +176,7 @@ object DynamicDenseContexts {
   }
 }
 
-case class DynamicDenseContexts(nRows: TrivialIR, nCols: TrivialIR, contexts: TrivialIR)
+case class DynamicDenseContexts(nRows: Atom, nCols: Atom, contexts: Atom)
     extends DynamicBMSContexts {
   def irValue: IR = makestruct("nRows" -> nRows, "nCols" -> nCols, "contexts" -> contexts)
 
@@ -195,7 +196,7 @@ case class DynamicDenseContexts(nRows: TrivialIR, nCols: TrivialIR, contexts: Tr
     )
   }
 
-  override def collect(makeBlock: (Ref, Ref, Ref) => IR): IR = {
+  override def collect(makeBlock: (Atom, Atom, Atom) => IR): IR = {
     NDArrayConcat(
       ToArray(mapIR(rangeIR(nCols)) { j =>
         val colBlocks = mapIR(rangeIR(nRows)) { i =>
@@ -235,15 +236,15 @@ object DynamicSparseContexts {
 }
 
 class DynamicSparseContexts(
-  nRows: TrivialIR,
-  nCols: TrivialIR,
-  rowPos: TrivialIR,
-  rowIdx: TrivialIR,
-  val contexts: TrivialIR,
+  nRows: Atom,
+  nCols: Atom,
+  rowPos: Atom,
+  rowIdx: Atom,
+  val contexts: Atom,
 ) extends DynamicBMSContexts {
   val elementType: Type = contexts.typ.asInstanceOf[TArray].elementType
 
-  def withNewContexts(newContexts: TrivialIR): DynamicSparseContexts =
+  def withNewContexts(newContexts: Atom): DynamicSparseContexts =
     new DynamicSparseContexts(nRows, nCols, rowPos, rowIdx, newContexts)
 
   override def apply(row: IR, col: IR): IR = {
@@ -279,7 +280,7 @@ class DynamicSparseContexts(
     new DynamicSparseContexts(nRows, nCols, rowPos, rowIdx, ib.memoize(newContexts))
   }
 
-  override def collect(makeBlock: (Ref, Ref, Ref) => IR): IR = {
+  override def collect(makeBlock: (Atom, Atom, Atom) => IR): IR = {
     NDArrayConcat(
       ToArray(mapIR(rangeIR(nCols)) { j =>
         val allIdxs = mapIR(rangeIR(nRows))(i => makestruct("idx" -> i))
@@ -358,7 +359,7 @@ abstract class BMSContexts {
 
   def groupedByCol(ib: IRBuilder): BMSContexts
 
-  def collect(makeBlock: (Ref, Ref, Ref) => IR): IR
+  def collect(makeBlock: (Atom, Atom, Atom) => IR): IR
 
   def print(ctx: ExecuteContext): Unit
 }
@@ -375,7 +376,7 @@ case class DenseContexts(sparsity: MatrixSparsity.Dense, dynamic: DynamicDenseCo
     extends BMSContexts {
   override val elementType: Type = contexts.typ.asInstanceOf[TArray].elementType
 
-  override def contexts: TrivialIR = dynamic.contexts
+  override def contexts: IR = dynamic.contexts
 
   override def print(ctx: ExecuteContext): Unit =
     println(
@@ -477,7 +478,7 @@ case class DenseContexts(sparsity: MatrixSparsity.Dense, dynamic: DynamicDenseCo
     DenseContexts(ib, MatrixSparsity.Dense(rowDeps.length, colDeps.length), newContexts)
   }
 
-  override def collect(makeBlock: (Ref, Ref, Ref) => IR): IR = {
+  override def collect(makeBlock: (Atom, Atom, Atom) => IR): IR = {
     NDArrayConcat(
       ToArray(mapIR(rangeIR(nCols)) { j =>
         val colBlocks = mapIR(rangeIR(nRows)) { i =>
@@ -501,7 +502,7 @@ case class SparseContexts(
 ) extends BMSContexts {
   override val elementType: Type = contexts.typ.asInstanceOf[TArray].elementType
 
-  override def contexts: TrivialIR = dynamic.contexts
+  override def contexts: IR = dynamic.contexts
 
   override def print(ctx: ExecuteContext): Unit =
     println(
@@ -604,7 +605,7 @@ case class SparseContexts(
     new SparseContexts(newSparsity, DynamicSparseContexts(ib, newSparsity, newContexts))
   }
 
-  override def collect(makeBlock: (Ref, Ref, Ref) => IR): IR =
+  override def collect(makeBlock: (Atom, Atom, Atom) => IR): IR =
     dynamic.collect(makeBlock)
 }
 
@@ -633,14 +634,14 @@ object BlockMatrixStage2 {
 
   def broadcastVector(ib: IRBuilder, vector: IR, typ: BlockMatrixType, asRowVector: Boolean)
     : BlockMatrixStage2 = {
-    val v: Ref = ib.strictMemoize(vector)
+    val v = ib.strictMemoize(vector)
     val contexts = BMSContexts.tabulate(ib, typ.sparsity)({ (i, j) =>
       val (m, n) = typ.blockShapeIR(i, j)
       val start = (if (asRowVector) j.toL else i.toL) * typ.blockSize.toLong
       makestruct("start" -> start, "shape" -> MakeTuple.ordered(FastSeq[IR](m, n)))
     })
     BlockMatrixStage2(
-      FastSeq(v),
+      FastSeq(v.ir.asInstanceOf[Ref]),
       typ,
       contexts,
       ctx => {
@@ -712,7 +713,7 @@ class BlockMatrixStage2 private (
     new BlockMatrixStage(broadcastVals, ctxType) {
       override def blockContext(idx: (Int, Int)): IR = contexts.dynamic(idx._1, idx._2)
 
-      override def blockBody(ctxRef: Ref): IR =
+      override def blockBody(ctxRef: Atom): IR =
         Let(FastSeq(ctxRefName -> ctxRef), _blockIR)
     }
   }
@@ -754,8 +755,8 @@ class BlockMatrixStage2 private (
           val (m, n) = typ.blockShapeIR(i, j)
           makestruct("oldContext" -> oldContext, "nRows" -> m, "nCols" -> n)
         }
-      def newBlock(context: Ref): IR = {
-        bindIR(GetField(context, "oldContext")) { oldContext =>
+      def newBlock(context: Atom): IR = {
+        bindIR(GetField(context, "oldContext")) { case oldContext: Ref =>
           If(
             IsNA(oldContext),
             MakeNDArray.fill(
@@ -789,8 +790,8 @@ class BlockMatrixStage2 private (
           makestruct("oldContext" -> oldContext, "nRows" -> m, "nCols" -> n)
         }
 
-      def newBlock(context: Ref): IR = {
-        bindIR(GetField(context, "oldContext")) { oldContext =>
+      def newBlock(context: Atom): IR = {
+        bindIR(GetField(context, "oldContext")) { case oldContext: Ref =>
           If(
             IsNA(oldContext),
             MakeNDArray.fill(
@@ -807,7 +808,7 @@ class BlockMatrixStage2 private (
     }
   }
 
-  def mapBody(f: IR => IR): BlockMatrixStage2 = {
+  def mapBody(f: Atom => IR): BlockMatrixStage2 = {
     val newBlockIR = bindIR(_blockIR)(f)
     val newType = typ.copy(elementType = newBlockIR.typ.asInstanceOf[TNDArray].elementType)
     new BlockMatrixStage2(broadcastVals, newType, contexts, ctxRefName, newBlockIR)
@@ -848,7 +849,7 @@ class BlockMatrixStage2 private (
     val newContexts = contexts.zip(ib, other.contexts)
     val ctxRef = Ref(freshName(), newContexts.elementType)
     val newBlockIR =
-      bindIRs(GetTupleElement(ctxRef, 0), GetTupleElement(ctxRef, 1)) { case Seq(l, r) =>
+      bindIRs(GetTupleElement(ctxRef, 0), GetTupleElement(ctxRef, 1)) { case Seq(l: Ref, r: Ref) =>
         f(this.blockIR(l), other.blockIR(r))
       }
     val newType = typ.copy(elementType = newBlockIR.typ.asInstanceOf[TNDArray].elementType)
@@ -910,11 +911,11 @@ class BlockMatrixStage2 private (
         }
         val localKeepRows = GetTupleElement(ctx, 1)
         val localKeepCols = GetTupleElement(ctx, 2)
-        localContexts.collect { (i, j, localContext) =>
+        localContexts.collect({ (i, j, localContext) =>
           bindIRs(ArrayRef(localKeepRows, i), ArrayRef(localKeepCols, j)) { case Seq(rows, cols) =>
             Coalesce(FastSeq(
               // FIXME: assumes blockIR is strict (preserves missing)
-              NDArrayFilter(blockIR(localContext), FastSeq(rows, cols)),
+              NDArrayFilter(blockIR(localContext.asInstanceOf[Ref]), FastSeq(rows, cols)),
               MakeNDArray.fill(
                 zero(typ.elementType),
                 FastSeq(ArrayLen(rows).toL, ArrayLen(cols).toL),
@@ -922,7 +923,7 @@ class BlockMatrixStage2 private (
               ),
             ))
           }
-        }
+        })
       }
     }
 
@@ -937,7 +938,7 @@ class BlockMatrixStage2 private (
       val i = GetTupleElement(ctx, 1)
       val j = GetTupleElement(ctx, 2)
       val diagIndex = (j - i).toL * typ.blockSize.toLong
-      bindIRs(diagIndex, oldCtx) { case Seq(diagIndex, oldCtx) =>
+      bindIRs(diagIndex, oldCtx) { case Seq(diagIndex, oldCtx: Ref) =>
         val localLower = I64(lower) - diagIndex
         val localUpper = I64(upper) - diagIndex
         val (nRowsInBlock, nColsInBlock) = typ.blockShapeIR(i, j)
@@ -978,7 +979,7 @@ class BlockMatrixStage2 private (
       val stops = ToArray(mapIR(ToStream(GetTupleElement(ctx, 4))) { s =>
         minIR(maxIR(s - j.toL * typ.blockSize.toLong, 0L), nCols)
       })
-      bindIRs(oldCtx) { case Seq(oldCtx) =>
+      bindIR(oldCtx) { case oldCtx: Ref =>
         invoke("zero_row_intervals", TNDArray(TFloat64, Nat(2)), blockIR(oldCtx), starts, stops)
       }
     }
@@ -1025,7 +1026,7 @@ class BlockMatrixStage2 private (
     staticID: String,
     dynamicID: IR = NA(TString),
   )(
-    f: (TrivialIR, TrivialIR, TrivialIR) => IR // (ctx, pos, block)
+    f: (Atom, Atom, Atom) => IR // (ctx, pos, block)
   ): IR = {
     val newCtxRef = Ref(freshName(), TTuple(TInt32, ctxType))
     val body = IRBuilder.scoped { bodyIB =>
@@ -1065,11 +1066,11 @@ class BlockMatrixStage2 private (
       case x: SparseContexts => SparseContexts(ib, x.sparsity, blockResults)
     }
 
-    blocks.collect { (i, j, block) =>
+    blocks.collect({ (i, j, block) =>
       val (m, n) = typ.blockShapeIR(i, j)
       val zeroBlock: IR = MakeNDArray.fill(zero(typ.elementType), FastSeq(m, n), False())
       Coalesce(FastSeq(block, zeroBlock))
-    }
+    })
   }
 }
 
@@ -1264,7 +1265,7 @@ object LowerBlockMatrixIR {
           bmir.typ,
           contexts,
           (ctx) =>
-            streamAggIR(mapIR(ToStream(ctx)) { childCtx =>
+            streamAggIR(mapIR(ToStream(ctx)) { case childCtx: Ref =>
               bindIR(NDArrayAgg(loweredChild.blockIR(childCtx), IndexedSeq(0))) { aggedND =>
                 NDArrayReshape(
                   aggedND,
@@ -1289,7 +1290,7 @@ object LowerBlockMatrixIR {
           bmir.typ,
           contexts,
           (ctx) =>
-            streamAggIR(mapIR(ToStream(ctx)) { childCtx =>
+            streamAggIR(mapIR(ToStream(ctx)) { case childCtx: Ref =>
               bindIR(NDArrayAgg(loweredChild.blockIR(childCtx), IndexedSeq(1))) { aggedND =>
                 NDArrayReshape(
                   aggedND,
@@ -1325,7 +1326,7 @@ object LowerBlockMatrixIR {
         })
 
         BlockMatrixStage2(
-          FastSeq(elt),
+          FastSeq(elt.ir.asInstanceOf[Ref]),
           x.typ,
           contexts,
           (ctxRef: Ref) =>
@@ -1494,12 +1495,12 @@ object LowerBlockMatrixIR {
             val localRowSlices = GetTupleElement(ctxRef, 1)
             val localColSlices = GetTupleElement(ctxRef, 2)
 
-            localContexts.collect { (localI, localJ, localContext) =>
+            localContexts.collect({ (localI, localJ, localContext) =>
               bindIRs(ArrayRef(localRowSlices, localI), ArrayRef(localColSlices, localJ)) {
                 case Seq(rowSlice, colSlice) =>
                   Coalesce(FastSeq(
                     NDArraySlice(
-                      childBMS.blockIR(localContext),
+                      childBMS.blockIR(localContext.asInstanceOf[Ref]),
                       MakeTuple.ordered(FastSeq(rowSlice, colSlice)),
                     ),
                     MakeNDArray.fill(
@@ -1509,7 +1510,7 @@ object LowerBlockMatrixIR {
                     ),
                   ))
               }
-            }
+            })
           }
         }
 
@@ -1556,7 +1557,7 @@ object LowerBlockMatrixIR {
             )
           }
 
-          override def blockBody(ctxRef: Ref): IR = {
+          override def blockBody(ctxRef: Atom): IR = {
             val tupleNDArrayStream = ToStream(ctxRef)
             val streamElementName = freshName()
             val streamElementRef =

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -77,7 +77,7 @@ object TableStage {
     val ctxArrays = children.view.zipWithIndex.map { case (child, idx) =>
       ToArray(mapIR(child.contexts) { ctx =>
         MakeTuple.ordered(children.indices.map { idx2 =>
-          if (idx == idx2) ctx else NA(children(idx2).ctxType)
+          if (idx == idx2) ctx.ir else NA(children(idx2).ctxType)
         })
       })
     }.toFastSeq
@@ -91,7 +91,7 @@ object TableStage {
       new RVDPartitioner(ctx.stateManager, keyType, children.flatMap(_.partitioner.rangeBounds))
 
     TableStage(
-      children.flatMap(_.letBindings) :+ globalsRef.name -> newGlobals,
+      children.flatMap(_.letBindings) :+ globalsRef.name -> newGlobals.ir,
       children.flatMap(_.broadcastVals) :+ globalsRef.name -> globalsRef,
       globalsRef,
       newPartitioner,
@@ -260,7 +260,7 @@ class TableStage(
       partitioner,
       dependency,
       newContexts,
-      ctxRef => bindIR(getOldContext(ctxRef))(partition),
+      ctxRef => bindIR(getOldContext(ctxRef))(partition(_)),
     )
   }
 
@@ -1089,7 +1089,7 @@ object LowerTableIR extends Logging {
                   partitioner.rangeBounds.toIndexedSeq,
                 )
                 zipIR(FastSeq(partitionIdx, ToStream(bounds), ctxs), AssertSameLength, errorId)(
-                  MakeTuple.ordered
+                  refs => MakeTuple.ordered(refs.map(_.ir))
                 )
               }
             }
@@ -1325,7 +1325,7 @@ object LowerTableIR extends Logging {
           else
             StreamLen(a)
 
-        def partitionSizeArray(childContexts: Ref): IR = {
+        def partitionSizeArray(childContexts: Atom): IR = {
           PartitionCounts(child) match {
             case Some(partCounts) =>
               var idx = 0
@@ -1378,7 +1378,7 @@ object LowerTableIR extends Logging {
           }
         }
 
-        def answerTuple(partitionSizeArrayRef: Ref): IR =
+        def answerTuple(partitionSizeArrayRef: Atom): IR =
           bindIR(ArrayLen(partitionSizeArrayRef)) { numPartitions =>
             val howManyPartsToKeep = freshName()
             val i = Ref(freshName(), TInt32)
@@ -1461,7 +1461,7 @@ object LowerTableIR extends Logging {
       case TableTail(child, targetNumRows) =>
         val loweredChild = lower(child)
 
-        def partitionSizeArray(childContexts: Ref, totalNumPartitions: Ref): IR = {
+        def partitionSizeArray(childContexts: Atom, totalNumPartitions: Atom): IR = {
           PartitionCounts(child) match {
             case Some(partCounts) =>
               var idx = partCounts.length
@@ -1522,7 +1522,7 @@ object LowerTableIR extends Logging {
 
         /* First element is how many partitions to keep from the right partitionSizeArrayRef, second
          * is how many to keep from first kept element. */
-        def answerTuple(partitionSizeArrayRef: Ref): IR = {
+        def answerTuple(partitionSizeArrayRef: Atom): IR = {
           bindIR(ArrayLen(partitionSizeArrayRef)) { numPartitions =>
             val howManyPartsToDrop = freshName()
             val i = Ref(freshName(), TInt32)
@@ -2029,7 +2029,7 @@ object LowerTableIR extends Logging {
             newPartitioner,
             TableStageDependency.union(repartitioned.map(_.dependency)),
             zipIR(repartitioned.map(_.contexts), ArrayZipBehavior.AssumeSameLength) { ctxRefs =>
-              MakeTuple.ordered(ctxRefs)
+              MakeTuple.ordered(ctxRefs.map(_.ir))
             },
             ctxRef =>
               StreamMultiMerge(
@@ -2071,7 +2071,7 @@ object LowerTableIR extends Logging {
           newPartitioner,
           TableStageDependency.union(repartitioned.map(_.dependency)),
           zipIR(repartitioned.map(_.contexts), ArrayZipBehavior.AssumeSameLength) { ctxRefs =>
-            MakeTuple.ordered(ctxRefs)
+            MakeTuple.ordered(ctxRefs.map(_.ir))
           },
           ctxRef =>
             StreamZipJoin(
@@ -2095,7 +2095,7 @@ object LowerTableIR extends Logging {
 
       case TableExplode(child, path) =>
         lower(child).mapPartition(Some(child.typ.key.takeWhile(k => k != path(0)))) { rows =>
-          flatMapIR(rows) { row: Ref =>
+          flatMapIR(rows) { case row: Ref =>
             val refsBuffer = Array.fill[Ref](path.length + 1)(null)
             val rootsBuffer = Array.fill[IR](path.length)(null)
             var i = 0

--- a/hail/hail/src/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -17,20 +17,15 @@ case class LoweringPipeline(lowerings: LoweringPass*) extends Logging {
       render(s"initial IR")
 
       for (l <- lowerings) {
-        try {
-          x = l(ctx, x)
-          render(s"after ${l.context}")
-        } catch {
-          case e: Throwable =>
-            logger.error(s"error while applying lowering '${l.context}'", e)
-            throw e
-        }
-        try
-          TypeCheck(ctx, x)
-        catch {
-          case e: Throwable =>
-            fatal(s"error after applying ${l.context}", e)
-        }
+        x =
+          try l(ctx, x)
+          catch {
+            case e: Throwable =>
+              logger.error(s"error while applying lowering '${l.context}'", e)
+              throw e
+          }
+        render(s"after ${l.context}")
+        TypeCheck(ctx, x)
       }
 
       x

--- a/hail/hail/src/is/hail/expr/ir/lowering/invariant/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/invariant/package.scala
@@ -41,7 +41,7 @@ package invariant {
         IRTraversal.trace(ir).foreach { case trace @ ir :: _ =>
           if (!invariant(ir)) throw new UnsatisfiedInvariantError(
             s"""Invariant ${E.value} forbids
-               |${trace.take(3).map(Pretty(ctx, _, preserveNames = true)).mkString("\nin\n")}
+               |${trace.take(5).map(Pretty(ctx, _, preserveNames = true)).mkString("\nin\n")}
                |""".stripMargin
           )
         }
@@ -70,10 +70,13 @@ package object invariant {
   implicit def Invariant(p: BaseIR => Boolean)(implicit E: sourcecode.Enclosing): Invariant =
     Fused(p)
 
-  def AnyIR: Invariant =
+  lazy val AnyIR: Invariant =
     new Invariant {
-      override def verify(ctx: ExecuteContext, ir: BaseIR): Unit = ()
+      override private[invariant] def verify(ctx: ExecuteContext, ir: BaseIR): Unit = ()
     }
+
+  def LowerableIR(implicit E: Enclosing): Invariant =
+    TreeIR and NoRedefinedNames
 
   def TreeIR: Invariant = {
     var mark: Int = 0

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -22,7 +22,13 @@ import java.util.UUID
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.TaskContext
 
-package object ir extends CompileOps {
+package ir {
+  trait LowerPriorityImplicits {
+    implicit def irToPrimitiveIR(ir: IR): PrimitiveIR = new PrimitiveIR(ir)
+  }
+}
+
+package object ir extends CompileOps with LowerPriorityImplicits {
   type TokenIterator = BufferedIterator[Token]
   type IEmitCode = IEmitCodeGen[SValue]
 
@@ -62,7 +68,8 @@ package object ir extends CompileOps {
   def invoke(name: String, rt: Type, errorID: Int, args: IR*): IR =
     invoke(name, rt, ArraySeq.empty, errorID, args: _*)
 
-  implicit def irToPrimitiveIR(ir: IR): PrimitiveIR = new PrimitiveIR(ir)
+  implicit def AtomToPrimitive(ir: Atom): PrimitiveIR =
+    new PrimitiveIR(ir)
 
   implicit def intToIR(i: Int): I32 = I32(i)
 
@@ -72,7 +79,7 @@ package object ir extends CompileOps {
 
   implicit def doubleToIR(d: Double): F64 = F64(d)
 
-  implicit def booleanToIR(b: Boolean): TrivialIR = if (b) True() else False()
+  implicit def booleanToIR(b: Boolean): IR with Atom = if (b) True() else False()
 
   def zero(t: Type): IR = t match {
     case TInt32 => I32(0)
@@ -81,66 +88,74 @@ package object ir extends CompileOps {
     case TFloat64 => F64(0d)
   }
 
-  def bindIRs(values: IR*)(body: Seq[Ref] => IR): IR = {
+  def bindIRs(values: IR*)(body: IndexedSeq[Atom] => IR): IR = {
     val bindings = values.toFastSeq.map(freshName() -> _)
     Let(bindings, body(bindings.map(b => Ref(b._1, b._2.typ))))
   }
 
-  def bindIR(v: IR)(body: Ref => IR): IR =
+  def bindIR(v: IR)(body: Atom => IR): IR =
     bindIRs(v) { case Seq(ref) => body(ref) }
 
-  def relationalBindIR(v: IR)(body: RelationalRef => IR): IR = {
+  def relationalBindIR(v: IR)(body: Atom => IR): IR = {
     val ref = RelationalRef(freshName(), v.typ)
     RelationalLet(ref.name, v, body(ref))
   }
 
   def iota(start: IR, step: IR): IR = StreamIota(start, step)
 
-  def dropWhile(v: IR)(f: Ref => IR): IR = {
+  def dropWhile(v: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TStream](v.typ).elementType)
     StreamDropWhile(v, ref.name, f(ref))
   }
 
-  def takeWhile(v: IR)(f: Ref => IR): IR = {
+  def takeWhile(v: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TStream](v.typ).elementType)
     StreamTakeWhile(v, ref.name, f(ref))
   }
 
-  def maxIR(a: IR, b: IR): IR =
-    If(a > b, a, b)
+  def maxIR(A: IR, B: IR): IR =
+    IRBuilder.scoped { r =>
+      val a = r.memoize(A)
+      val b = r.memoize(B)
+      If(a > b, a, b)
+    }
 
-  def minIR(a: IR, b: IR): IR =
-    If(a < b, a, b)
+  def minIR(A: IR, B: IR): IR =
+    IRBuilder.scoped { r =>
+      val a = r.memoize(A)
+      val b = r.memoize(B)
+      If(a < b, a, b)
+    }
 
-  def streamAggIR(stream: IR)(f: Ref => IR): StreamAgg = {
+  def streamAggIR(stream: IR)(f: Atom => IR): StreamAgg = {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     StreamAgg(stream, ref.name, f(ref))
   }
 
-  def streamAggScanIR(stream: IR)(f: Ref => IR): StreamAggScan = {
+  def streamAggScanIR(stream: IR)(f: Atom => IR): StreamAggScan = {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     StreamAggScan(stream, ref.name, f(ref))
   }
 
-  def forIR(stream: IR)(f: Ref => IR): IR = {
+  def forIR(stream: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     StreamFor(stream, ref.name, f(ref))
   }
 
-  def filterIR(stream: IR)(f: Ref => IR): IR = {
+  def filterIR(stream: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     StreamFilter(stream, ref.name, f(ref))
   }
 
-  def mapIR(stream: IR)(f: Ref => IR): IR = {
+  def mapIR(stream: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     StreamMap(stream, ref.name, f(ref))
   }
 
-  def mapArray(array: IR)(f: Ref => IR): IR =
+  def mapArray(array: IR)(f: Atom => IR): IR =
     ToArray(mapIR(ToStream(array))(f))
 
-  def flatMapIR(stream: IR)(f: Ref => IR): IR = {
+  def flatMapIR(stream: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     StreamFlatMap(stream, ref.name, f(ref))
   }
@@ -150,7 +165,7 @@ package object ir extends CompileOps {
       if (elt.typ.isInstanceOf[TStream]) elt else ToStream(elt)
     }
 
-  def foldIR(stream: IR, zero: IR)(f: (Ref, Ref) => IR): StreamFold = {
+  def foldIR(stream: IR, zero: IR)(f: (Atom, Atom) => IR): StreamFold = {
     val elt = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     val accum = Ref(freshName(), zero.typ)
     StreamFold(stream, zero, accum.name, elt.name, f(accum, elt))
@@ -160,9 +175,9 @@ package object ir extends CompileOps {
     stream: IR,
     inits: IR*
   )(
-    seqs: ((Ref, IndexedSeq[Ref]) => IR)*
+    seqs: ((Atom, IndexedSeq[Atom]) => IR)*
   )(
-    result: IndexedSeq[Ref] => IR
+    result: IndexedSeq[Atom] => IR
   ): IR = {
     val elt = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     val accums = inits.toFastSeq.map(i => Ref(freshName(), i.typ))
@@ -175,13 +190,13 @@ package object ir extends CompileOps {
     )
   }
 
-  def streamScanIR(stream: IR, zero: IR)(f: (Ref, Ref) => IR): IR = {
+  def streamScanIR(stream: IR, zero: IR)(f: (Atom, Atom) => IR): IR = {
     val elt = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     val accum = Ref(freshName(), zero.typ)
     StreamScan(stream, zero, accum.name, elt.name, f(accum, elt))
   }
 
-  def sortIR(stream: IR)(f: (Ref, Ref) => IR): IR = {
+  def sortIR(stream: IR)(f: (Atom, Atom) => IR): IR = {
     val t = tcoerce[TStream](stream.typ).elementType
     val l = Ref(freshName(), t)
     val r = Ref(freshName(), t)
@@ -200,7 +215,7 @@ package object ir extends CompileOps {
     requiresMemoryManagement: Boolean = false,
     rightKeyIsDistinct: Boolean = true,
   )(
-    f: (Ref, Ref) => IR
+    f: (Atom, Atom) => IR
   ): IR = {
     val lRef = Ref(freshName(), left.typ.asInstanceOf[TStream].elementType)
     val rRef = Ref(freshName(), right.typ.asInstanceOf[TStream].elementType)
@@ -218,7 +233,7 @@ package object ir extends CompileOps {
     )
   }
 
-  def zipJoin2IR(streams: IndexedSeq[IR], key: IndexedSeq[String])(f: (Ref, Ref) => IR): IR = {
+  def zipJoin2IR(streams: IndexedSeq[IR], key: IndexedSeq[String])(f: (Atom, Atom) => IR): IR = {
     val eltType = tcoerce[TStruct](elementType(streams.head.typ))
     val curKey = Ref(freshName(), eltType.typeAfterSelectNames(key))
     val curVals = Ref(freshName(), TArray(eltType))
@@ -232,7 +247,7 @@ package object ir extends CompileOps {
     rkey: IndexedSeq[String],
     joinType: String,
   )(
-    f: (Ref, Ref) => IR
+    f: (Atom, Atom) => IR
   ): IR = {
     val lRef = Ref(freshName(), left.typ.asInstanceOf[TStream].elementType)
     val rRef = Ref(freshName(), right.typ.asInstanceOf[TStream].elementType)
@@ -254,7 +269,13 @@ package object ir extends CompileOps {
 
   def selectIR(old: IR, fields: String*): SelectFields = SelectFields(old, fields.toFastSeq)
 
-  def zip2(s1: IR, s2: IR, behavior: ArrayZipBehavior.ArrayZipBehavior)(f: (Ref, Ref) => IR): IR = {
+  def zip2(
+    s1: IR,
+    s2: IR,
+    behavior: ArrayZipBehavior.ArrayZipBehavior,
+  )(
+    f: (Atom, Atom) => IR
+  ): IR = {
     val r1 = Ref(freshName(), tcoerce[TStream](s1.typ).elementType)
     val r2 = Ref(freshName(), tcoerce[TStream](s2.typ).elementType)
     StreamZip(FastSeq(s1, s2), FastSeq(r1.name, r2.name), f(r1, r2), behavior)
@@ -276,24 +297,24 @@ package object ir extends CompileOps {
     behavior: ArrayZipBehavior.ArrayZipBehavior,
     errorId: Int = ErrorIDs.NO_ERROR,
   )(
-    f: IndexedSeq[Ref] => IR
+    f: IndexedSeq[Atom] => IR
   ): IR = {
     val refs = ss.map(s => Ref(freshName(), tcoerce[TStream](s.typ).elementType))
     StreamZip(ss, refs.map(_.name), f(refs), behavior, errorId)
   }
 
-  def ndMap(nd: IR)(f: Ref => IR): IR = {
+  def ndMap(nd: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TNDArray](nd.typ).elementType)
     NDArrayMap(nd, ref.name, f(ref))
   }
 
-  def ndMap2(nd1: IR, nd2: IR)(f: (Ref, Ref) => IR): IR = {
+  def ndMap2(nd1: IR, nd2: IR)(f: (Atom, Atom) => IR): IR = {
     val ref1 = Ref(freshName(), tcoerce[TNDArray](nd1.typ).elementType)
     val ref2 = Ref(freshName(), tcoerce[TNDArray](nd2.typ).elementType)
     NDArrayMap2(nd1, nd2, ref1.name, ref2.name, f(ref1, ref2), ErrorIDs.NO_ERROR)
   }
 
-  def bmMap(bm: BlockMatrixIR, needsDense: Boolean)(f: Ref => IR): BlockMatrixMap = {
+  def bmMap(bm: BlockMatrixIR, needsDense: Boolean)(f: Atom => IR): BlockMatrixMap = {
     val ref = Ref(freshName(), bm.typ.elementType)
     BlockMatrixMap(bm, ref.name, f(ref), needsDense)
   }
@@ -303,12 +324,12 @@ package object ir extends CompileOps {
   def maketuple(fields: IR*): MakeTuple =
     MakeTuple(fields.toFastSeq.zipWithIndex.map { case (field, idx) => (idx, field) })
 
-  def aggBindIR(v: IR, isScan: Boolean = false)(body: Ref => IR): IR = {
+  def aggBindIR(v: IR, isScan: Boolean = false)(body: Atom => IR): IR = {
     val ref = Ref(freshName(), v.typ)
     AggLet(ref.name, v, body(ref), isScan = isScan)
   }
 
-  def aggExplodeIR(v: IR, isScan: Boolean = false)(body: Ref => IR): AggExplode = {
+  def aggExplodeIR(v: IR, isScan: Boolean = false)(body: Atom => IR): AggExplode = {
     val r = Ref(freshName(), v.typ.asInstanceOf[TIterable].elementType)
     AggExplode(v, r.name, body(r), isScan)
   }
@@ -318,15 +339,21 @@ package object ir extends CompileOps {
     knownLength: Option[IR] = None,
     isScan: Boolean = false,
   )(
-    body: (Ref, Ref) => IR
+    body: (Atom, Atom) => IR
   ): AggArrayPerElement = {
     val elt = Ref(freshName(), v.typ.asInstanceOf[TIterable].elementType)
     val idx = Ref(freshName(), TInt32)
     AggArrayPerElement(v, elt.name, idx.name, body(elt, idx), knownLength, isScan)
   }
 
-  def aggFoldIR(zero: IR, isScan: Boolean = false)(seqOp: Ref => IR)(combOp: (Ref, Ref) => IR)
-    : AggFold = {
+  def aggFoldIR(
+    zero: IR,
+    isScan: Boolean = false,
+  )(
+    seqOp: Atom => IR
+  )(
+    combOp: (Atom, Atom) => IR
+  ): AggFold = {
     val accum1 = Ref(freshName(), zero.typ)
     val accum2 = Ref(freshName(), zero.typ)
     AggFold(zero, seqOp(accum1), combOp(accum1, accum2), accum1.name, accum2.name, isScan)
@@ -339,7 +366,7 @@ package object ir extends CompileOps {
     dynamicID: IR = NA(TString),
     tsd: Option[TableStageDependency] = None,
   )(
-    body: (Ref, Ref) => IR
+    body: (Atom, Atom) => IR
   ): CollectDistributedArray = {
     val contextRef = Ref(freshName(), contexts.typ.asInstanceOf[TStream].elementType)
     val globalRef = Ref(freshName(), globals.typ)
@@ -356,22 +383,31 @@ package object ir extends CompileOps {
     )
   }
 
-  def tailLoop(resultType: Type, inits: IR*)(f: (IndexedSeq[IR] => IR, IndexedSeq[Ref]) => IR)
-    : IR = {
+  def tailLoop(
+    resultType: Type,
+    inits: IR*
+  )(
+    f: (IndexedSeq[IR] => IR, IndexedSeq[Atom]) => IR
+  ): IR = {
     val loopName = freshName()
     val vars = inits.toFastSeq.map(x => Ref(freshName(), x.typ))
     def recur(vs: IndexedSeq[IR]): IR = Recur(loopName, vs, resultType)
     TailLoop(loopName, vars.map(_.name).zip(inits), resultType, f(recur, vars))
   }
 
-  def mapPartitions(child: TableIR)(f: (Ref, Ref) => IR): TableMapPartitions = {
+  def mapPartitions(child: TableIR)(f: (Atom, Atom) => IR): TableMapPartitions = {
     val globals = Ref(freshName(), child.typ.globalType)
     val part = Ref(freshName(), TStream(child.typ.rowType))
     TableMapPartitions(child, globals.name, part.name, f(globals, part))
   }
 
-  def mapPartitions(child: TableIR, requestedKey: Int, allowedOverlap: Int)(f: (Ref, Ref) => IR)
-    : TableMapPartitions = {
+  def mapPartitions(
+    child: TableIR,
+    requestedKey: Int,
+    allowedOverlap: Int,
+  )(
+    f: (Atom, Atom) => IR
+  ): TableMapPartitions = {
     val globals = Ref(freshName(), child.typ.globalType)
     val part = Ref(freshName(), TStream(child.typ.rowType))
     TableMapPartitions(
@@ -390,7 +426,7 @@ package object ir extends CompileOps {
     partitioner: RVDPartitioner,
     errorID: Int = ErrorIDs.NO_ERROR,
   )(
-    f: (Ref, Ref) => IR
+    f: (Atom, Atom) => IR
   ): TableGen = {
     TypeCheck.coerce[TStream]("contexts", contexts.typ): Unit
     val c = Ref(freshName(), elementType(contexts.typ))

--- a/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
@@ -12,7 +12,7 @@ import is.hail.expr.ir.{
   LowerMatrixIR, MatrixHybridReader, MatrixReader, PartitionNativeIntervalReader, TableNativeReader,
   TableReader,
 }
-import is.hail.expr.ir.defs.{Literal, MakeStruct, PartitionReader, ReadPartition, Ref, ToStream}
+import is.hail.expr.ir.defs.{Literal, MakeStruct, PartitionReader, ReadPartition, ToStream}
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.io._
@@ -620,7 +620,7 @@ class MatrixBGENReader(
           partitioner = partitioner,
           dependency = TableStageDependency.none,
           contexts = ToStream(Literal(TArray(reader.contextType), contexts.result())),
-          (ref: Ref) => ReadPartition(ref, requestedType.rowType, reader),
+          ref => ReadPartition(ref, requestedType.rowType, reader),
         )
 
       case None =>
@@ -654,7 +654,7 @@ class MatrixBGENReader(
           partitioner = partitioner,
           dependency = TableStageDependency.none,
           contexts = ToStream(Literal(TArray(reader.contextType), contexts.result())),
-          (ref: Ref) => ReadPartition(ref, requestedType.rowType, reader),
+          ref => ReadPartition(ref, requestedType.rowType, reader),
         )
     }
   }

--- a/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
@@ -9,7 +9,7 @@ import is.hail.expr.ir.{
   flatMapIR, partFile, IR, PartitionNativeReader, PartitionZippedIndexedNativeReader,
   PartitionZippedNativeReader,
 }
-import is.hail.expr.ir.defs.{Literal, ReadPartition, Ref, ToStream}
+import is.hail.expr.ir.defs.{Literal, ReadPartition, ToStream}
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.io._
 import is.hail.io.fs.FS
@@ -198,15 +198,13 @@ object AbstractRVDSpec {
 
         val contexts = ToStream(Literal(TArray(reader.contextType), contextsValues))
 
-        val body = (ctx: IR) => ReadPartition(ctx, requestedType, reader)
-
-        { (globals: IR) =>
+        { globals =>
           val ts = TableStage(
             globals,
             tmpPartitioner.coarsen(requestedKey.length),
             TableStageDependency.none,
             contexts,
-            body,
+            ctx => ReadPartition(ctx, requestedType, reader),
           )
           if (filterIntervals)
             ts.repartitionNoShuffle(ctx, partitioner, dropEmptyPartitions = true)
@@ -263,16 +261,14 @@ abstract class AbstractRVDSpec {
         },
       ))
 
-      val body = (ctx: IR) =>
-        ReadPartition(ctx, requestedType.rowType, PartitionNativeReader(rSpec, uidFieldName))
-
-      (globals: IR) =>
+      globals =>
         TableStage(
           globals,
           part.coarsen(part.kType.fieldNames.takeWhile(requestedType.rowType.hasField).length),
           TableStageDependency.none,
           contexts,
-          body,
+          ctx =>
+            ReadPartition(ctx, requestedType.rowType, PartitionNativeReader(rSpec, uidFieldName)),
         )
   }
 
@@ -565,18 +561,17 @@ case class IndexedRVDSpec2(
 
       assert(TArray(TArray(reader.contextType)).typeCheck(nestedContexts))
 
-      { (globals: IR) =>
+      globals =>
         TableStage(
           globals,
           newPartitioner,
           TableStageDependency.none,
           contexts = ToStream(Literal(TArray(TArray(reader.contextType)), nestedContexts)),
-          body = (ctxs: Ref) =>
+          body = ctxs =>
             flatMapIR(ToStream(ctxs, true)) { ctx =>
               ReadPartition(ctx, requestedType.rowType, reader)
             },
         )
-      }
 
     case None =>
       super.readTableStage(ctx, path, requestedType, uidFieldName, newPartitioner, filterIntervals)

--- a/hail/hail/test/src/is/hail/HailSuite.scala
+++ b/hail/hail/test/src/is/hail/HailSuite.scala
@@ -171,7 +171,7 @@ class HailSuite extends TestNGSuite with TestUtils with Logging {
     }
 
   def assertEvalsTo(
-    x: IR,
+    x0: IR,
     env: Env[(Any, Type)],
     args: IndexedSeq[(Any, Type)],
     agg: Option[(IndexedSeq[Row], TStruct)],
@@ -179,9 +179,9 @@ class HailSuite extends TestNGSuite with TestUtils with Logging {
   )(implicit execStrats: Set[ExecStrategy]
   ): Unit = {
 
-    TypeCheck(ctx, x, BindingEnv(env.mapValues(_._2), agg = agg.map(_._2.toEnv)))
+    TypeCheck(ctx, x0, BindingEnv(env.mapValues(_._2), agg = agg.map(_._2.toEnv)))
 
-    val t = x.typ
+    val t = x0.typ
     assert(t == TVoid || t.typeCheck(expected), s"$t, $expected")
 
     val filteredExecStrats: Set[ExecStrategy] =
@@ -192,6 +192,7 @@ class HailSuite extends TestNGSuite with TestUtils with Logging {
         execStrats.intersect(ExecStrategy.backendOnly)
       }
 
+    val x = x0.deepCopy
     filteredExecStrats.foreach { implicit strat =>
       try {
         val res =

--- a/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
@@ -24,7 +24,7 @@ import is.hail.variant.Call2
 import org.apache.spark.sql.Row
 import org.scalatest.Inspectors.forAll
 import org.scalatest.enablers.InspectorAsserting.assertingNatureOfAssertion
-import org.testng.annotations.Test
+import org.testng.annotations.{DataProvider, Test}
 
 class EmitStreamSuite extends HailSuite {
 
@@ -46,7 +46,7 @@ class EmitStreamSuite extends HailSuite {
       LongInfo,
     )
     val mb = fb.apply_method
-    val ir = streamIR.deepCopy()
+    val ir = streamIR.deepCopy
 
     val emitContext = EmitContext.analyze(ctx, ir)
 
@@ -145,7 +145,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = EmitFunctionBuilder[Region, Int](ctx, "eval_stream_len")
     val mb = fb.apply_method
     val region = mb.getCodeParam[Region](1)
-    val ir = streamIR.deepCopy()
+    val ir = streamIR.deepCopy
     val emitContext = EmitContext.analyze(ctx, ir)
 
     fb.emitWithBuilder { cb =>
@@ -768,16 +768,23 @@ class EmitStreamSuite extends HailSuite {
     assert(compiled == expected)
   }
 
-  @Test def testEmitScan(): Unit = {
-    val tests: Array[(IR, IndexedSeq[Any])] = Array(
-      streamScanIR(MakeStream(IndexedSeq(), TStream(TInt32)), 9)(_ + _) -> IndexedSeq(9),
-      streamScanIR(mapIR(rangeIR(4))(x => x * x), 1)(_ + _) ->
+  @DataProvider(name = "EmitScan")
+  def emitScanData: Array[Array[Any]] =
+    Array(
+      Array(
+        streamScanIR(MakeStream(IndexedSeq(), TStream(TInt32)), 9)(_ + _),
+        IndexedSeq(9),
+      ),
+      Array(
+        streamScanIR(mapIR(rangeIR(4))(x => x * x), 1)(_ + _),
         IndexedSeq(1, 1 /*1+0*0*/, 2 /*1+1*1*/, 6 /*2+2*2*/, 15 /*6+3*3*/ ),
+      ),
     )
-    forAll(tests) { case (ir, v) =>
-      assert(evalStream(ir) == v, Pretty(ctx, ir))
-      assert(evalStreamLen(ir).contains(v.length), Pretty(ctx, ir))
-    }
+
+  @Test(dataProvider = "EmitScan")
+  def testEmitScan(ir: IR, v: IndexedSeq[Any]): Unit = {
+    assert(evalStream(ir) == v, Pretty(ctx, ir))
+    assert(evalStreamLen(ir).contains(v.length), Pretty(ctx, ir))
   }
 
   @Test def testEmitAggScan(): Unit = {
@@ -936,16 +943,12 @@ class EmitStreamSuite extends HailSuite {
       MakeStream(FastSeq(Str("one"), Str("two"), Str("three"), Str("four")), TStream(TString), true)
 
     assertEvalsTo(
-      foldIR(ToStream(ints, requiresMemoryManagementPerElement = false), I32(-1)) { (acc, elt) =>
-        acc + elt
-      },
+      foldIR(ToStream(ints), I32(-1))((acc, elt) => acc + elt),
       9,
     )
 
     assertEvalsTo(
-      foldIR(ToStream(strsLit, requiresMemoryManagementPerElement = false), Str("")) { (acc, elt) =>
-        invoke("concat", TString, acc, elt)
-      },
+      foldIR(ToStream(strsLit), Str(""))((acc, elt) => invoke("concat", TString, acc, elt)),
       "onetwothreefour",
     )
 

--- a/hail/hail/test/src/is/hail/expr/ir/ForwardLetsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ForwardLetsSuite.scala
@@ -157,7 +157,7 @@ class ForwardLetsSuite extends HailSuite {
     assert(!after.isInstanceOf[Block])
   }
 
-  @DataProvider(name = "TrivialIRCases")
+  @DataProvider(name = "AtomCases")
   def trivalIRCases: Array[Array[Any]] = {
     val pi = Math.atan(1) * 4
 
@@ -218,7 +218,7 @@ class ForwardLetsSuite extends HailSuite {
     )
   }
 
-  @Test(dataProvider = "TrivialIRCases")
+  @Test(dataProvider = "AtomCases")
   def testTrivialCases(input: IR, _expected: IR, reason: String): Unit = {
     val normalize: (ExecuteContext, BaseIR) => BaseIR = NormalizeNames(allowFreeVariables = true)
     val result = normalize(ctx, ForwardLets(ctx, input))

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -644,23 +644,23 @@ class IRSuite extends HailSuite {
     assertEvalsTo(bindIR(NA(TInt32))(x => x), null)
     assertEvalsTo(bindIR(I32(5))(_ => NA(TInt32)), null)
     assertEvalsTo(
-      ToArray(mapIR(bindIR(I32(5))(v => rangeIR(v)))(x => x + I32(2))),
+      ToArray(mapIR(bindIR(I32(5))(v => rangeIR(v)))(x => x + 2)),
       FastSeq(2, 3, 4, 5, 6),
     )
     assertEvalsTo(
       ToArray(mapIR(
         bindIR(I32(2))(q => mapIR(bindIR(q + I32(3))(v => rangeIR(v)))(x => x + q))
-      )(y => y + I32(3))),
+      )(_ + I32(3))),
       FastSeq(5, 6, 7, 8, 9),
     )
 
     // test let binding streams
     assertEvalsTo(
-      bindIR(MakeStream(IndexedSeq(I32(0), I32(5)), TStream(TInt32)))(ToArray),
+      bindIR(MakeStream(IndexedSeq(I32(0), I32(5)), TStream(TInt32)))(ToArray(_)),
       FastSeq(0, 5),
     )
     assertEvalsTo(
-      bindIR(NA(TStream(TInt32)))(ToArray),
+      bindIR(NA(TStream(TInt32)))(ToArray(_)),
       null,
     )
     assertEvalsTo(
@@ -1379,7 +1379,7 @@ class IRSuite extends HailSuite {
     val range6dup = StreamRange(0, 6, 1)
 
     def zip(behavior: ArrayZipBehavior, irs: IR*): IR =
-      zipIR(irs.toFastSeq, behavior)(MakeTuple.ordered)
+      zipIR(irs.toFastSeq, behavior)(irs => MakeTuple.ordered(irs.map(_.ir)))
 
     def zipToTuple(behavior: ArrayZipBehavior, irs: IR*): IR =
       ToArray(zip(behavior, irs: _*))
@@ -1606,7 +1606,10 @@ class IRSuite extends HailSuite {
     val lenOfLet = StreamLen(bindIR(I32(5))(ref =>
       StreamGrouped(
         mapIR(rangeIR(20))(range_element =>
-          InsertFields(MakeStruct(IndexedSeq(("num", range_element + ref))), IndexedSeq(("y", 12)))
+          InsertFields(
+            MakeStruct(IndexedSeq(("num", range_element + ref))),
+            IndexedSeq(("y", 12)),
+          )
         ),
         3,
       )
@@ -1649,7 +1652,7 @@ class IRSuite extends HailSuite {
     assertEvalsTo(StreamLen(StreamDrop(a, 1)), 2)
   }
 
-  def toNestedArray(stream: IR): IR = ToArray(mapIR(stream)(ToArray))
+  def toNestedArray(stream: IR): IR = ToArray(mapIR(stream)(ToArray(_)))
 
   @Test def testStreamGrouped(): Unit = {
     val naa = NA(TStream(TInt32))
@@ -1767,7 +1770,7 @@ class IRSuite extends HailSuite {
     assertEvalsTo(ToArray(filterIR(a)(_ => False())), FastSeq())
     assertEvalsTo(ToArray(filterIR(a)(_ => True())), FastSeq(3, null, 7))
 
-    assertEvalsTo(ToArray(filterIR(a)(IsNA)), FastSeq(null))
+    assertEvalsTo(ToArray(filterIR(a)(IsNA(_))), FastSeq(null))
     assertEvalsTo(ToArray(filterIR(a)(!IsNA(_))), FastSeq(3, 7))
 
     assertEvalsTo(ToArray(filterIR(a)(_ < I32(6))), FastSeq(3))
@@ -1806,18 +1809,18 @@ class IRSuite extends HailSuite {
 
   @Test def testStreamFold(): Unit = {
     assertEvalsTo(foldIR(StreamRange(1, 2, 1), NA(TBoolean))((accum, elt) => IsNA(accum)), true)
-    assertEvalsTo(foldIR(IRStream(1, 2, 3), 0)((accum, elt) => accum + elt), 6)
+    assertEvalsTo(foldIR(IRStream(1, 2, 3), 0)(_ + _), 6)
     assertEvalsTo(
-      foldIR(IRStream(1, 2, 3), NA(TInt32))((accum, elt) => accum + elt),
+      foldIR(IRStream(1, 2, 3), NA(TInt32))(_ + _),
       null,
     )
     assertEvalsTo(
-      foldIR(IRStream(1, null, 3), NA(TInt32))((accum, elt) => accum + elt),
+      foldIR(IRStream(1, null, 3), NA(TInt32))(_ + _),
       null,
     )
-    assertEvalsTo(foldIR(IRStream(1, null, 3), 0)((accum, elt) => accum + elt), null)
+    assertEvalsTo(foldIR(IRStream(1, null, 3), 0)(_ + _), null)
     assertEvalsTo(
-      foldIR(IRStream(1, null, 3), NA(TInt32))((accum, elt) => I32(5) + I32(5)),
+      foldIR(IRStream(1, null, 3), NA(TInt32))((_, _) => I32(5) + I32(5)),
       10,
     )
   }
@@ -1830,15 +1833,9 @@ class IRSuite extends HailSuite {
       I32(0),
       NA(TInt32),
     )(
-      { case (elt, Seq(x, _)) =>
-        elt + x
-      },
-      { case (elt, Seq(_, y)) =>
-        Coalesce(FastSeq(y, elt))
-      },
-    ) { case Seq(x, y) =>
-      MakeStruct(FastSeq(("x", x), ("y", y)))
-    }
+      { case (elt, Seq(x, _)) => elt + x },
+      { case (elt, Seq(_, y)) => Coalesce(FastSeq(y, elt)) },
+    ) { case Seq(x, y) => makestruct("x" -> x, "y" -> y) }
 
     assertEvalsTo(af, FastSeq((FastSeq(1, 2, 3), TArray(TInt32))), Row(6, 1))
   }
@@ -1847,35 +1844,31 @@ class IRSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.javaOnly
 
     assertEvalsTo(
-      ToArray(streamScanIR(StreamRange(1, 4, 1), NA(TBoolean))((accum, elt) => IsNA(accum))),
+      ToArray(streamScanIR(StreamRange(1, 4, 1), NA(TBoolean))((accum, _) => IsNA(accum))),
       FastSeq(null, true, false, false),
     )
     assertEvalsTo(
-      ToArray(streamScanIR(IRStream(1, 2, 3), 0)((accum, elt) => accum + elt)),
+      ToArray(streamScanIR(IRStream(1, 2, 3), 0)(_ + _)),
       FastSeq(0, 1, 3, 6),
     )
     assertEvalsTo(
-      ToArray(streamScanIR(IRStream(1, 2, 3), NA(TInt32))((accum, elt) => accum + elt)),
+      ToArray(streamScanIR(IRStream(1, 2, 3), NA(TInt32))(_ + _)),
       FastSeq(null, null, null, null),
     )
     assertEvalsTo(
-      ToArray(streamScanIR(IRStream(1, null, 3), NA(TInt32))((accum, elt) =>
-        accum + elt
-      )),
+      ToArray(streamScanIR(IRStream(1, null, 3), NA(TInt32))(_ + _)),
       FastSeq(null, null, null, null),
     )
-    assertEvalsTo(ToArray(streamScanIR(NA(TStream(TInt32)), 0)((accum, elt) => accum + elt)), null)
+    assertEvalsTo(ToArray(streamScanIR(NA(TStream(TInt32)), 0)(_ + _)), null)
     assertEvalsTo(
-      ToArray(streamScanIR(MakeStream(IndexedSeq(), TStream(TInt32)), 99)((accum, elt) =>
-        accum + elt
-      )),
+      ToArray(streamScanIR(MakeStream(IndexedSeq(), TStream(TInt32)), 99)(_ + _)),
       FastSeq(99),
     )
     assertEvalsTo(
       ToArray(streamScanIR(
         flatMapIR(rangeIR(5))(_ => MakeStream(IndexedSeq(), TStream(TInt32))),
         99,
-      )((accum, elt) => accum + elt)),
+      )(_ + _)),
       FastSeq(99),
     )
   }
@@ -2419,19 +2412,17 @@ class IRSuite extends HailSuite {
       joinType,
       requiresMemoryManagement = false,
       rightKeyIsDistinct = rightDistinct,
-    ) { (l: IR, r: IR) =>
-      bindIRs(l, r) { case Seq(l, r) =>
-        MakeStruct(
-          lKeys.lazyZip(rKeys).map { (lk, rk) =>
-            lk -> Coalesce(IndexedSeq(GetField(l, lk), GetField(r, rk)))
+    ) { (l, r) =>
+      MakeStruct(
+        lKeys.lazyZip(rKeys).map { (lk, rk) =>
+          lk -> Coalesce(IndexedSeq(GetField(l, lk), GetField(r, rk)))
+        }
+          ++ tcoerce[TStruct](l.typ).fields.filter(f => !lKeys.contains(f.name)).map { f =>
+            f.name -> GetField(l, f.name)
+          } ++ tcoerce[TStruct](r.typ).fields.filter(f => !rKeys.contains(f.name)).map { f =>
+            f.name -> GetField(r, f.name)
           }
-            ++ tcoerce[TStruct](l.typ).fields.filter(f => !lKeys.contains(f.name)).map { f =>
-              f.name -> GetField(l, f.name)
-            } ++ tcoerce[TStruct](r.typ).fields.filter(f => !rKeys.contains(f.name)).map { f =>
-              f.name -> GetField(r, f.name)
-            }
-        )
-      }
+      )
     })
   }
 
@@ -2994,15 +2985,15 @@ class IRSuite extends HailSuite {
             ApplyAggOp(Collect())(
               MakeArray(
                 FastSeq(
-                  x,
-                  elt,
+                  x.ir,
+                  elt.ir,
                   Cast(y, TInt32),
                   Cast(y, TInt32),
                 ), // reference y twice to prevent forwarding
                 TArray(TInt32),
               )
             ),
-            MakeArray(FastSeq(x), TArray(TInt32)),
+            MakeArray(FastSeq(x.ir), TArray(TInt32)),
           )
         }
       }
@@ -4296,7 +4287,7 @@ class IRSuite extends HailSuite {
         tailLoop(TInt32, accum, I32(0)) { case (recur2, Seq(x2, accum2)) =>
           If(x2 <= 0, accum2, recur2(FastSeq(x2 - 5, accum2 + x2)))
         },
-        recur(FastSeq(x - I32(1), accum + x)),
+        recur(FastSeq(x - 1, accum + x)),
       )
     }
 
@@ -4314,7 +4305,7 @@ class IRSuite extends HailSuite {
       If(
         x <= 0,
         accum,
-        recur(FastSeq(x - 1, ndMap(accum)(elt => elt + x))),
+        recur(FastSeq(x - 1, ndMap(accum)(_ + x))),
       )
     }
 
@@ -4333,18 +4324,11 @@ class IRSuite extends HailSuite {
     assert(memUsed == memUsed2)
   }
 
-  @Test def testHasIRSharing(): Unit = {
-    val r = Ref(freshName(), TInt32)
-    val ir1 = MakeTuple.ordered(FastSeq(I64(1), r, r, I32(1)))
-    assert(HasIRSharing(ctx, ir1))
-    assert(!HasIRSharing(ctx, ir1.deepCopy()))
-  }
-
   @Test def testTreeIRInvariant(): Unit = {
     val r = Ref(freshName(), TInt32)
     val ir1 = MakeTuple.ordered(FastSeq(I64(1), r, r, I32(1)))
     assertThrows[UnsatisfiedInvariantError](TreeIR.verify(ctx, ir1))
-    TreeIR.verify(ctx, ir1.deepCopy())
+    TreeIR.verify(ctx, ir1.deepCopy)
   }
 
   @Test def freeVariables(): Unit = {
@@ -4456,12 +4440,13 @@ class IRSuite extends HailSuite {
       true,
     )
 
-    val stream = mapIR(rangeIR(5))(_ => single)
+    def stream = mapIR(rangeIR(5))(_ => single)
 
-    def selfZip(s: IR, n: Int) = zipIR(
-      ArraySeq.fill(n)(s),
-      ArrayZipBehavior.AssumeSameLength,
-    )(MakeArray(_, TArray(TString)))
+    def selfZip(s: => IR, n: Int) =
+      zipIR(
+        ArraySeq.tabulate(n)(_ => s),
+        ArrayZipBehavior.AssumeSameLength,
+      )(elems => MakeArray(elems.map(_.ir), TArray(TString)))
 
     def assertNumDistinct(s: IR, expected: Int) =
       assertEvalsTo(ArrayLen(CastToArray(ToSet(s))), expected)

--- a/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
@@ -82,7 +82,7 @@ class PruneSuite extends HailSuite {
     env: BindingEnv[Type] = BindingEnv.empty,
   ): Unit = {
     TypeCheck(ctx, ir, env)
-    val irCopy = ir.deepCopy()
+    val irCopy = ir.deepCopy
     assert(
       PruneDeadFields.isSupertype(requestedType, irCopy.typ),
       s"not supertype:\n  super: ${requestedType.parsableString()}\n  sub:   ${irCopy.typ.parsableString()}",
@@ -113,7 +113,7 @@ class PruneSuite extends HailSuite {
     env: BindingEnv[Type] = BindingEnv.empty,
   ): Unit = {
     TypeCheck(ctx, ir, env)
-    val irCopy = ir.deepCopy()
+    val irCopy = ir.deepCopy
     val ms = new PruneDeadFields.ComputeMutableState
     val rebuilt = (irCopy match {
       case mir: MatrixIR =>
@@ -878,7 +878,7 @@ class PruneSuite extends HailSuite {
     )
 
   @Test def testStreamMergeMemo(): Unit = {
-    val st2 = st.deepCopy()
+    val st2 = st.deepCopy
     checkMemo(
       StreamMultiMerge(
         IndexedSeq(st, st2),
@@ -891,8 +891,8 @@ class PruneSuite extends HailSuite {
   }
 
   @Test def testStreamZipMemo(): Unit = {
-    val a2 = st.deepCopy()
-    val a3 = st.deepCopy()
+    val a2 = st.deepCopy
+    val a3 = st.deepCopy
     for (
       b <- Array(
         ArrayZipBehavior.ExtendNA,
@@ -1757,8 +1757,8 @@ class PruneSuite extends HailSuite {
   }
 
   @Test def testStreamZipRebuild(): Unit = {
-    val a2 = st.deepCopy()
-    val a3 = st.deepCopy()
+    val a2 = st.deepCopy
+    val a3 = st.deepCopy
     for (
       b <- Array(
         ArrayZipBehavior.ExtendNA,

--- a/hail/hail/test/src/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/RequirednessSuite.scala
@@ -44,7 +44,7 @@ class RequirednessSuite extends HailSuite {
     if (r)
       MakeStream(FastSeq(int(elt), int(required)), tstream)
     else
-      mapIR(NA(tstream))(x => x + int(elt))
+      mapIR(NA(tstream))(_ + int(elt))
 
   def array(r: Boolean, elt: Boolean): IR = ToArray(stream(r, elt))
 
@@ -101,7 +101,7 @@ class RequirednessSuite extends HailSuite {
     "Interval",
     TInterval(point.typ),
     point,
-    point.deepCopy(),
+    point.deepCopy,
     True(),
     if (r) True() else NA(TBoolean),
   )
@@ -261,7 +261,7 @@ class RequirednessSuite extends HailSuite {
     ) { case (recur, Seq(param1, param2)) =>
       If(
         False(), // required
-        MakeArray(FastSeq(param1), tnestedarray), // required
+        MakeArray(FastSeq(param1.ir), tnestedarray), // required
         If(
           param2 <= I32(1), // possibly missing
           recur(FastSeq(array(required, optional), int(required))),
@@ -450,7 +450,7 @@ class RequirednessSuite extends HailSuite {
 
     nodes += Array(
       TableUnion(FastSeq(
-        table.deepCopy(),
+        table.deepCopy,
         TableMapRows(table, insertIR(row, "a" -> nestedarray(optional, optional, required))),
       )),
       rowType.insertFields(FastSeq("a" -> pnestedarray(optional, optional, optional))),
@@ -486,7 +486,7 @@ class RequirednessSuite extends HailSuite {
     val left = TableMapGlobals(
       TableKeyBy(
         TableMapRows(
-          table.deepCopy(),
+          table.deepCopy,
           makestruct(
             "a" -> nestedarray(required, optional, required),
             "b" -> GetField(row, "b"),
@@ -499,7 +499,7 @@ class RequirednessSuite extends HailSuite {
     val right = TableMapGlobals(
       TableKeyBy(
         TableMapRows(
-          table.deepCopy(),
+          table.deepCopy,
           makestruct(
             "a" -> nestedarray(required, required, optional),
             "c" -> GetField(row, "c"),
@@ -556,7 +556,7 @@ class RequirednessSuite extends HailSuite {
 
     val intervalTable = TableKeyBy(
       TableMapRows(
-        table.deepCopy(),
+        table.deepCopy,
         makestruct(
           "a" -> interval(nestedarray(required, required, optional), required),
           "c" -> GetField(row, "c"),
@@ -594,14 +594,14 @@ class RequirednessSuite extends HailSuite {
         FastSeq(
           TableKeyBy(
             TableMapRows(
-              table.deepCopy(),
+              table.deepCopy,
               insertIR(row, "a" -> nestedarray(required, optional, required)),
             ),
             FastSeq("a"),
           ),
           TableKeyBy(
             TableMapRows(
-              table.deepCopy(),
+              table.deepCopy,
               insertIR(row, "a" -> nestedarray(required, required, optional)),
             ),
             FastSeq("a"),

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -355,29 +355,35 @@ class SimplifySuite extends HailSuite {
     tir should simplifyTo(tir)
   }
 
-  @Test def testFilterParallelize(): Unit =
-    forAll(
+  @DataProvider(name = "FilterParallelize")
+  def filterParallelize: Array[Array[Any]] =
+    Array(
       Array(
-        MakeStruct(FastSeq(
-          ("rows", In(0, TArray(TStruct("x" -> TInt32)))),
-          ("global", In(1, TStruct.empty)),
-        )),
-        In(0, TStruct("rows" -> TArray(TStruct("x" -> TInt32)), "global" -> TStruct.empty)),
-      )
-    ) { rowsAndGlobals =>
-      val tp = TableParallelize(rowsAndGlobals, None)
-      val tf = TableFilter(tp, GetField(Ref(TableIR.rowName, tp.typ.rowType), "x") < 100)
+        makestruct(
+          "rows" -> In(0, TArray(TStruct("x" -> TInt32))),
+          "global" -> In(1, TStruct.empty),
+        )
+      ),
+      Array(
+        In(0, TStruct("rows" -> TArray(TStruct("x" -> TInt32)), "global" -> TStruct.empty))
+      ),
+    )
 
-      val rw = Simplify(ctx, tf)
-      TypeCheck(ctx, rw)
-      assert(!Exists(rw, _.isInstanceOf[TableFilter]))
-    }
+  @Test(dataProvider = "FilterParallelize")
+  def testFilterParallelize(rowsAndGlobals: IR): Unit = {
+    val tp = TableParallelize(rowsAndGlobals, None)
+    val tf = TableFilter(tp, GetField(Ref(TableIR.rowName, tp.typ.rowType), "x") < 100)
+
+    val rw = Simplify(ctx, tf)
+    TypeCheck(ctx, rw)
+    assert(!Exists(rw, _.isInstanceOf[TableFilter]))
+  }
 
   @Test def testStreamLenSimplifications(): Unit = {
     val rangeIR = StreamRange(I32(0), I32(10), I32(1))
-    val mapOfRange = mapIR(rangeIR)(range_element => range_element + 5)
+    val mapOfRange = mapIR(rangeIR)(_ + 5)
     val mapBlockedByLet =
-      bindIR(I32(5))(ref => mapIR(rangeIR)(range_element => range_element + ref))
+      bindIR(I32(5))(ref => mapIR(rangeIR)(_ + ref))
 
     assert(Simplify(ctx, StreamLen(rangeIR)) == Simplify(ctx, StreamLen(mapOfRange)))
     assert(Simplify(ctx, StreamLen(mapBlockedByLet)) match {

--- a/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
@@ -1154,7 +1154,7 @@ class TableIRSuite extends HailSuite {
     var tir: TableIR = TableRange(1, 1)
     var ir: IR = rangeIR(5)
     ir = StreamGrouped(ir, 2)
-    ir = ToArray(mapIR(ir)(ToArray))
+    ir = ToArray(mapIR(ir)(ToArray(_)))
     ir = InsertFields(Ref(TableIR.rowName, tir.typ.rowType), FastSeq("foo" -> ir))
     tir = TableMapRows(tir, ir)
     assertEvalsTo(

--- a/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
@@ -6,7 +6,7 @@ import is.hail.collection.FastSeq
 import is.hail.expr.ir._
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs.{
-  ApplyBinaryPrimOp, ErrorIDs, GetField, MakeStream, MakeStruct, Ref, Str, StreamRange,
+  ApplyBinaryPrimOp, Atom, ErrorIDs, GetField, MakeStream, MakeStruct, Ref, Str, StreamRange,
   TableAggregate, TableGetGlobals,
 }
 import is.hail.expr.ir.lowering.{DArrayLowering, LowerTableIR}
@@ -192,7 +192,7 @@ class TableGenSuite extends HailSuite {
   def mkTableGen(
     contexts: Option[IR] = None,
     globals: Option[IR] = None,
-    body: Option[(Ref, Ref) => IR] = None,
+    body: Option[(Atom, Atom) => IR] = None,
     partitioner: Option[RVDPartitioner] = None,
     errorId: Option[Int] = None,
   ): TableGen = {


### PR DESCRIPTION
Partially resolves #13250

Various compiler transforms generate DAGs by using refs and other `TrivialIR`s in more than once place. Many of our analyses require that the IR is a tree and we scatter `noSharing` calls about the code in a fairly ad-hoc manner to unfold the dag. In doing so, we accidentally duplicate work when a shared node is non-trivial.

This change is one in a series that aims to preserve the TreeIR invariant throught the various lowerings, culminating in the removal of `noSharing`.

In this change:

- `TrivialIR` is repurposed as `Atom`, an`IR`mixin rather than extending `IR` itself.
- Uses of `Atom` are implicitly converted to `IR` by a trivial `deepCopy`, satisfying the `TreeIR` invariant.
- Replace `Ref` with `Atom` in ir-helper functions + fix fallout
- Drop `()` from `deepCopy` as it's pure.
- `IR` is an abstract class, not a trait.

Design discussion:

My preference would be

- `Atom` not is not `< IR`
- Add `Val(a: Atom) extends IR`
- Implicitly convert to `IR` for all uses of `Atom`
- Pass `Ref`(which not exends `Atom`) and not have to cast or call `.ir`

I decided against that as i was concerned about memory implications of this layer of indirection.

This change does not affect the broad-managed batch service in gcp.