### PR TITLE
[batch] Break up file chunk reads in copier to avoid timeouts

### DIFF
--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -7,7 +7,6 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
 import humanize
 
 from ...utils import (
-    async_to_blocking,
     bounded_gather2,
     humanize_timedelta_msecs,
     retry_transient_errors,
@@ -248,11 +247,10 @@ class SourceCopier:
                     n = this_part_size
                     while n > 0:
                         bytes_to_write = min(Copier.BUFFER_SIZE, n)
-                        srcf = await self.router_fs.open_from(
+                        async with await self.router_fs.open_from(
                             srcfile, part_number * part_size + (this_part_size - n), length=bytes_to_write
-                        )
-                        b = await srcf.readexactly(bytes_to_write)
-                        await srcf.wait_closed()
+                        ) as srcf:
+                            b = await srcf.readexactly(bytes_to_write)
                         if len(b) == 0:
                             raise UnexpectedEOFError()
                         written = await destf.write(b)

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
 import humanize
 
 from ...utils import (
+    async_to_blocking,
     bounded_gather2,
     humanize_timedelta_msecs,
     retry_transient_errors,
@@ -240,22 +241,24 @@ class SourceCopier:
         return_exceptions: bool,
     ) -> None:
         try:
-            async with self.xfer_sema.acquire_manager(min(Copier.BUFFER_SIZE, this_part_size)):
-                async with await self.router_fs.open_from(
-                    srcfile, part_number * part_size, length=this_part_size
-                ) as srcf:
-                    async with await part_creator.create_part(
-                        part_number, part_number * part_size, size_hint=this_part_size
-                    ) as destf:
-                        n = this_part_size
-                        while n > 0:
-                            b = await srcf.read(min(Copier.BUFFER_SIZE, n))
-                            if len(b) == 0:
-                                raise UnexpectedEOFError()
-                            written = await destf.write(b)
-                            assert written == len(b)
-                            source_report.finish_bytes(written)
-                            n -= len(b)
+            async with self.xfer_sema.acquire_manager(Copier.BUFFER_SIZE):
+                async with await part_creator.create_part(
+                    part_number, part_number * part_size, size_hint=this_part_size
+                ) as destf:
+                    n = this_part_size
+                    while n > 0:
+                        bytes_to_write = min(Copier.BUFFER_SIZE, n)
+                        srcf = await self.router_fs.open_from(
+                            srcfile, part_number * part_size + (this_part_size - n), length=bytes_to_write
+                        )
+                        b = await srcf.readexactly(bytes_to_write)
+                        await srcf.wait_closed()
+                        if len(b) == 0:
+                            raise UnexpectedEOFError()
+                        written = await destf.write(b)
+                        assert written == len(b)
+                        source_report.finish_bytes(written)
+                        n -= bytes_to_write
         except Exception as e:
             if return_exceptions:
                 source_report.set_exception(e)


### PR DESCRIPTION
## Change Description

Fixes #15011 

To download large files with parallelism, the current copier code opens a stream to a GCP blob for each file chunk. The streams stay open while their contents are written to disk in a buffered fashion, so as the number of parallel operations increases, it becomes more likely that a stream's connection will time out before it finishes writing. This change reduces the size of each request & closes the stream while we write.

Measuring timing for file size downloads, there's a significant improvement, though it's slightly less than when using the transfer_manager library:

| File size | Old | New |
|--------|--------|--------|
| 15M | 0.5s | 0.7s |
| 1G | 50s | 7.9s |
| 5G | 100s | 17.5s |
| 10G | 219s | 34s |
| 21G | failed | 61s |
| 54G | failed | 196s |

This avoids the thread explosion problem from the transfer_manager solution & only affects files above a particular size (~0.1G).

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

Changes logic for localizing files larger than 0.1G. The code path for localizing files smaller than 0.1G is unchanged. Jobs that localize files close to this limit which currently pass could be impacted. I manually tested jobs on lowmem VMs and jobs that download ~300 of these smaller files in parallel.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
