### PR TITLE
[query] `Memoized`, a monadic ir builder

### DIFF
--- a/hail/hail/bench/src/is/hail/expr/ir/IRBuilderAlternatives.scala
+++ b/hail/hail/bench/src/is/hail/expr/ir/IRBuilderAlternatives.scala
@@ -1,0 +1,166 @@
+package is.hail.expr.ir
+
+import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.expr.ir.Memoized.eval
+import is.hail.expr.ir.Scope.EVAL
+import is.hail.expr.ir.defs._
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.{Scope => JmhScope, _}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(JmhScope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+class MemoizedMapBenchmark {
+
+  @Param(Array("5", "10", "20", "50"))
+  var numBinds: Int = _
+
+  // must not be an Atom
+  private val Zero: IR = I32(0) + 0
+
+  @Benchmark
+  def memoized(): IR = {
+    var x = Memoized.pure[EVAL.type](Zero)
+    for (_ <- 1 until numBinds)
+      x = x.map(_ + 1)
+    eval(x)
+  }
+
+  @Benchmark
+  def directV(): IR = {
+    var x = DirectV.pure(Zero)
+    for (_ <- 1 until numBinds)
+      x = x.map(_ + 1)
+    x.toIR
+  }
+
+  @Benchmark
+  def directL(): IR = {
+    var x = DirectL.pure(Zero)
+    for (_ <- 1 until numBinds)
+      x = x.map(_ + 1)
+    x.toIR
+  }
+
+  @Benchmark
+  def irbuilder(): IR =
+    IRBuilder.scoped { b =>
+      var x = b.strictMemoize(Zero)
+      for (_ <- 1 until numBinds)
+        x = b.strictMemoize(x + 1)
+      x
+    }
+}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(JmhScope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+class MemoizedFlatMapBenchmark {
+
+  // motivation for `go` in benchmarks below:
+  //
+  //   for {
+  //    a <- pure(Zero)
+  //    b <- pure(a + 1)
+  //    c <- pure(b + 1)
+  //  } yield c + 1
+  //
+  //  becomes
+  //
+  //  pure(Zero).flatMap(a =>
+  //    pure(a + 1).flatMap(b =>
+  //      pure(b + 1).map(c =>
+  //        c + 1)))
+
+  @Param(Array("5", "10", "20", "50"))
+  var numBinds: Int = _
+
+  // must not be an Atom
+  private val Zero: IR = I32(0) + 0
+
+  @Benchmark
+  def memoized(): IR = {
+    def go(n: Int): Memoized[EVAL.type] =
+      if (n <= 0) Memoized.pure(Zero)
+      else Memoized.pure(Zero).flatMap(acc => go(n - 1).map(acc + _))
+
+    eval(go(numBinds))
+  }
+
+  @Benchmark
+  def directV(): IR = {
+    def go(n: Int): DirectV =
+      if (n <= 0) DirectV.pure(Zero)
+      else DirectV.pure(Zero).flatMap(acc => go(n - 1).map(acc + _))
+    go(numBinds).toIR
+  }
+
+  @Benchmark
+  def directL(): IR = {
+    def go(n: Int): DirectL =
+      if (n <= 0) DirectL.pure(Zero)
+      else DirectL.pure(Zero).flatMap(acc => go(n - 1).map(acc + _))
+    go(numBinds).toIR
+  }
+
+  @Benchmark
+  def irbuilder(): IR =
+    IRBuilder.scoped { b =>
+      def go(n: Int): IR =
+        if (n <= 0) b.strictMemoize(Zero)
+        else b.strictMemoize(Zero) + go(n - 1)
+
+      go(numBinds)
+    }
+}
+
+final class DirectV(val bindings: Vector[Binding], val body: IR) {
+  def map(f: Atom => IR): DirectV = {
+    val ref = Ref(freshName(), body.typ)
+    new DirectV(bindings :+ Binding(ref.name, body, EVAL), f(ref))
+  }
+
+  def flatMap(f: Atom => DirectV): DirectV = {
+    val ref = Ref(freshName(), body.typ)
+    val res = f(ref)
+    new DirectV(
+      (bindings :+ Binding(ref.name, body, EVAL)) ++ res.bindings,
+      res.body,
+    )
+  }
+
+  def toIR: IR = new Block(bindings, body)
+}
+
+object DirectV {
+  def pure(ir: IR): DirectV =
+    new DirectV(Vector(), ir)
+}
+
+final class DirectL(val rbinds: List[Binding], val body: IR) {
+  def map(f: Atom => IR): DirectL = {
+    val ref = Ref(freshName(), body.typ)
+    new DirectL(Binding(ref.name, body, EVAL) :: rbinds, f(ref))
+  }
+
+  def flatMap(f: Atom => DirectL): DirectL = {
+    val ref = Ref(freshName(), body.typ)
+    val that = f(ref)
+    new DirectL(that.rbinds ::: Binding(ref.name, body, EVAL) :: rbinds, that.body)
+  }
+
+  def toIR: IR = Block(rbinds.reverseIterator.to(ArraySeq), body)
+}
+
+object DirectL {
+  def pure(ir: IR): DirectL =
+    new DirectL(Nil, ir)
+}

--- a/hail/hail/package.mill
+++ b/hail/hail/package.mill
@@ -8,6 +8,8 @@ import mill.scalalib.Assembly.*
 import mill.scalalib.TestModule.TestNg
 import mill.util.{Jvm, VcsVersion}
 
+import contrib.jmh.JmhModule
+
 import build.Env
 import build.Settings
 import build.HailScalaModule
@@ -246,3 +248,36 @@ trait RootHailModule extends CrossScalaModule, HailScalaModule:
         shuffled.slice(offsets(i), offsets(i + 1))
       }
     }
+
+  object bench extends HailScalaModule, JmhModule, CrossValue:
+    override def scalaVersion: T[String] =
+      outer.scalaVersion()
+
+    override def jmhCoreVersion: T[String] =
+      "1.37"
+
+    override def moduleDeps: Seq[JavaModule] =
+      Seq(outer, test)
+
+    override def forkArgs: T[Seq[String]] =
+      Seq("-Xss4m", "-Xmx4096M")
+
+    override def jmhGeneratedSources: T[PathRef] =
+      Task {
+        val dest = Task.ctx().dest
+        val (sourcesDir, _) = generateBenchmarkSources()
+        val sources = os.walk(sourcesDir.path).filter(os.isFile)
+
+        os.proc(
+          Jvm.jdkTool("javac"),
+          "--release", jvmId(),
+          sources.map(_.toString),
+          "-cp",
+          (runClasspath() ++ generatorDeps()).map(_.path.toString).mkString(
+            java.io.File.pathSeparator
+          ),
+          "-d",
+          dest,
+        ).call(dest)
+        PathRef(dest)
+      }

--- a/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/DeprecatedIRBuilder.scala
@@ -385,7 +385,7 @@ object DeprecatedIRBuilder {
     def ~>(body: IRProxy): LambdaProxy = new LambdaProxy(s, body)
   }
 
-  case class BindingProxy(s: Symbol, value: IRProxy, scope: Int)
+  case class BindingProxy(s: Symbol, value: IRProxy, scope: Scope)
 
   private object LetProxy {
     def bind(bindings: IndexedSeq[BindingProxy], body: IRProxy, env: E): IR = {

--- a/hail/hail/src/is/hail/expr/ir/Env.scala
+++ b/hail/hail/src/is/hail/expr/ir/Env.scala
@@ -29,7 +29,7 @@ trait GenericBindingEnv[Self, V] {
 
   def bindScan(bindings: (Name, V)*): Self
 
-  def bindInScope(name: Name, v: V, scope: Int): Self = scope match {
+  def bindInScope(name: Name, v: V, scope: Scope): Self = scope match {
     case Scope.EVAL => bindEval(name -> v)
     case Scope.AGG => bindAgg(name -> v)
     case Scope.SCAN => bindScan(name -> v)
@@ -154,7 +154,7 @@ case class BindingEnv[V](
 
   override def promoteScan: BindingEnv[V] = copy(eval = scan.get, scan = None)
 
-  def promoteScope(scope: Int): BindingEnv[V] = scope match {
+  def promoteScope(scope: Scope): BindingEnv[V] = scope match {
     case Scope.EVAL => this
     case Scope.AGG => promoteAgg
     case Scope.SCAN => promoteScan

--- a/hail/hail/src/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/hail/src/is/hail/expr/ir/ForwardLets.scala
@@ -14,7 +14,7 @@ object ForwardLets {
       val UsesAndDefs(uses, defs, _) = ComputeUsesAndDefs(ir1, errorIfFreeVariables = false)
       val nestingDepth = NestingDepth(ctx, ir1)
 
-      def shouldForward(value: IR, refs: Set[RefEquality[BaseRef]], base: Block, scope: Int)
+      def shouldForward(value: IR, refs: Set[RefEquality[BaseRef]], base: Block, scope: Scope)
         : Boolean =
         IsPure(value) && (
           value.isInstanceOf[Ref] ||

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -120,7 +120,7 @@ package defs {
         Let(xs.init.map(x => (freshName(), x)), xs.last)
   }
 
-  case class Binding(name: Name, value: IR, scope: Int = Scope.EVAL)
+  case class Binding(name: Name, value: IR, scope: Scope = Scope.EVAL)
 
   trait BaseRef extends IR {
     def name: Name

--- a/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
@@ -1,31 +1,88 @@
 package is.hail.expr.ir
 
 import is.hail.collection.compat.immutable.ArraySeq
-import is.hail.expr.ir.defs.{Atom, Let, Ref}
+import is.hail.expr.ir.Scope.{AGG, EVAL, SCAN}
+import is.hail.expr.ir.defs.{Atom, Binding, Block, Ref}
+
+import scala.annotation.tailrec
 
 object IRBuilder {
   def scoped(f: IRBuilder => IR): IR = {
     val builder = new IRBuilder()
     val result = f(builder)
-    Let(builder.getBindings, result)
+    Block(builder.getBindings, result)
   }
 }
 
 class IRBuilder {
-  private val bindings = ArraySeq.newBuilder[(Name, IR)]
+  private val bindings = ArraySeq.newBuilder[Binding]
 
-  def getBindings: IndexedSeq[(Name, IR)] = bindings.result()
+  def getBindings: IndexedSeq[Binding] = bindings.result()
 
-  def memoize(ir: IR): Atom = ir match {
-    case ir: Atom => ir
-    case _ => strictMemoize(ir)
-  }
+  def memoize(ir: IR, scope: Scope = Scope.EVAL): Atom =
+    ir match {
+      case ir: Atom => ir
+      case _ => strictMemoize(ir, scope = scope)
+    }
 
-  def strictMemoize(ir: IR): Atom =
-    strictMemoize(ir, freshName())
-
-  def strictMemoize(ir: IR, name: Name): Atom = {
-    bindings += name -> ir
+  def strictMemoize(ir: IR, name: Name = freshName(), scope: Scope = Scope.EVAL): Atom = {
+    bindings += Binding(name, ir, scope)
     Ref(name, ir.typ)
   }
+}
+
+sealed abstract class Memoized[S] {
+  import Memoized.{Cont, pure}
+
+  def map(f: Atom => IR): Memoized[S] = flatMap(a => pure(f(a)))
+  def flatMap(f: Atom => Memoized[S]): Memoized[S] = new Cont(this, f)
+}
+
+object Memoized {
+
+  def pure[S](ir: IR): Memoized[S] = new Mem[S](ir)
+  def let[S](n: Name, ir: IR): Memoized[S] = new Let[S](n, ir)
+  def defer[S](f: IRBuilder => IR): Memoized[S] = new Suspend(f)
+
+  sealed abstract class HasScope[S](val scope: Scope)
+  implicit object evalScope extends HasScope[EVAL.type](EVAL)
+  implicit object aggScope extends HasScope[AGG.type](AGG)
+  implicit object scanScope extends HasScope[SCAN.type](SCAN)
+
+  def eval(m: Memoized[EVAL.type]): IR = m
+  def agg(m: Memoized[AGG.type]): IR = m
+  def scan(m: Memoized[SCAN.type]): IR = m
+
+  final private class Mem[S](val expr: IR) extends Memoized[S]
+  final private class Let[S](val name: Name, val expr: IR) extends Memoized[S]
+  final private class Cont[S](val m: Memoized[S], val f: Atom => Memoized[S]) extends Memoized[S]
+  final private class Suspend[S](val f: IRBuilder => IR) extends Memoized[S]
+
+  private def run[S](m0: Memoized[S])(b: IRBuilder)(implicit ev: HasScope[S]): IR = {
+    @tailrec def go(m: Memoized[S], stack: List[Atom => Memoized[S]]): IR =
+      m match {
+        case m: Mem[S @unchecked] =>
+          stack match {
+            case Nil => m.expr
+            case k :: rest => go(k(b.memoize(m.expr, scope = ev.scope)), rest)
+          }
+
+        case m: Let[S @unchecked] =>
+          stack match {
+            case Nil => m.expr
+            case k :: rest => go(k(b.strictMemoize(m.expr, m.name, ev.scope)), rest)
+          }
+
+        case m: Cont[S @unchecked] =>
+          go(m.m, m.f :: stack)
+
+        case m: Suspend[S @unchecked] =>
+          go(pure(m.f(b)), stack)
+      }
+
+    go(m0, Nil)
+  }
+
+  implicit def memoizedToIR[S: HasScope](m: Memoized[S]): IR =
+    IRBuilder.scoped(run[S](m))
 }

--- a/hail/hail/src/is/hail/expr/ir/NestingDepth.scala
+++ b/hail/hail/src/is/hail/expr/ir/NestingDepth.scala
@@ -24,7 +24,7 @@ final class NestingDepth(private val memo: Memo[ScopedDepth]) {
   def lookupRef(x: RefEquality[BaseRef]): Int = memo.lookup(x).eval
   def lookupRef(x: BaseRef): Int = memo.lookup(x).eval
 
-  def lookupBinding(x: Block, scope: Int): Int = scope match {
+  def lookupBinding(x: Block, scope: Scope): Int = scope match {
     case Scope.EVAL => memo(x).eval
     case Scope.AGG => memo(x).agg
     case Scope.SCAN => memo(x).scan

--- a/hail/hail/src/is/hail/expr/ir/Pretty.scala
+++ b/hail/hail/src/is/hail/expr/ir/Pretty.scala
@@ -910,7 +910,7 @@ class Pretty(
       bindings: Env[String],
       prefix: String,
       origName: Option[Name],
-      scope: Int = Scope.EVAL,
+      scope: Scope = Scope.EVAL,
     ): (Doc, String) = {
       val (pre, body) = pretty(ir, bindings)
       val ident = prefix + uniqueify(getIdentBase(ir), origName)

--- a/hail/hail/src/is/hail/expr/ir/Scope.scala
+++ b/hail/hail/src/is/hail/expr/ir/Scope.scala
@@ -33,15 +33,26 @@ object UsesScanEnv {
   }
 }
 
+sealed trait Scope {
+  import Scope.{AGG, EVAL, SCAN}
+
+  def toInt: Int =
+    this match {
+      case EVAL => 0
+      case AGG => 1
+      case SCAN => 2
+    }
+}
+
 object Scope {
-  val EVAL: Int = 0
-  val AGG: Int = 1
-  val SCAN: Int = 2
+  case object EVAL extends Scope
+  case object AGG extends Scope
+  case object SCAN extends Scope
 
-  def apply(ir0: BaseIR): Memo[Int] = {
-    val memo = Memo.empty[Int]
+  def apply(ir0: BaseIR): Memo[Scope] = {
+    val memo = Memo.empty[Scope]
 
-    def compute(ir: BaseIR, scope: Int): Unit = {
+    def compute(ir: BaseIR, scope: Scope): Unit = {
       if (ir.isInstanceOf[IR])
         memo.bind(ir, scope)
 

--- a/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
+++ b/hail/hail/src/is/hail/expr/ir/analyses/SemanticHash.scala
@@ -87,7 +87,7 @@ case object SemanticHash extends Logging {
         buffer += a.isScan.toByte
 
       case Block(bindings, _) =>
-        for (b <- bindings) buffer += b.scope.toByte
+        for (b <- bindings) buffer += b.scope.toInt.toByte
 
       case a: AggArrayPerElement =>
         buffer += a.isScan.toByte

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -6,6 +6,7 @@ import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterator
 import is.hail.expr.Nat
 import is.hail.expr.ir._
+import is.hail.expr.ir.Scope.EVAL
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.GetElement
 import is.hail.linalg.MatrixSparsity
@@ -999,7 +1000,10 @@ class BlockMatrixStage2 private (
 
     val emptyGlobals = MakeStruct(FastSeq())
     val globalsId = freshName()
-    val letBindings = ib.getBindings :+ globalsId -> emptyGlobals
+    val letBindings =
+      ib.getBindings
+        .map { b => assert(b.scope == EVAL, b.name); b.name -> b.value } :+
+        globalsId -> emptyGlobals
 
     def tsPartitionFunction(newCtxRef: Ref): IR = {
       val s = makestruct(

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -4,6 +4,7 @@ import is.hail.asm4s._
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterable
+import is.hail.expr.ir.{Memoized => M}
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.IRFunctionRegistry
 import is.hail.expr.ir.lowering.TableStageDependency
@@ -25,6 +26,8 @@ import org.apache.spark.TaskContext
 package ir {
   trait LowerPriorityImplicits {
     implicit def irToPrimitiveIR(ir: IR): PrimitiveIR = new PrimitiveIR(ir)
+    implicit def irToMemoized[S](ir: IR): M[S] = M.pure(ir)
+    implicit def namedIRToMemoized[S](b: (Name, IR)): M[S] = M.let(b._1, b._2)
   }
 }
 
@@ -114,17 +117,19 @@ package object ir extends CompileOps with LowerPriorityImplicits {
   }
 
   def maxIR(A: IR, B: IR): IR =
-    IRBuilder.scoped { r =>
-      val a = r.memoize(A)
-      val b = r.memoize(B)
-      If(a > b, a, b)
+    M.eval {
+      for {
+        a <- A
+        b <- B
+      } yield If(a > b, a, b)
     }
 
   def minIR(A: IR, B: IR): IR =
-    IRBuilder.scoped { r =>
-      val a = r.memoize(A)
-      val b = r.memoize(B)
-      If(a < b, a, b)
+    M.eval {
+      for {
+        a <- A
+        b <- B
+      } yield If(a < b, a, b)
     }
 
   def streamAggIR(stream: IR)(f: Atom => IR): StreamAgg = {

--- a/hail/hail/test/src/is/hail/expr/ir/IRBuilderSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRBuilderSuite.scala
@@ -1,0 +1,66 @@
+package is.hail.expr.ir
+
+import is.hail.HailSuite
+import is.hail.expr.ir.{Memoized => M}
+import is.hail.expr.ir.defs._
+import is.hail.expr.ir.implicits.forTesting.BaseIROps
+import is.hail.types.virtual.TFloat64
+
+import org.testng.annotations.{DataProvider, Test}
+
+class IRBuilderSuite extends HailSuite {
+
+  @DataProvider(name = "ImpFncBuilders")
+  def dataImpFncBuilders: Array[Array[Any]] =
+    Array(
+      Array(
+        IRBuilder.scoped { b =>
+          val x0 = b.memoize(I32(2))
+          val x1 = b.memoize(Cast(x0, TFloat64))
+          val x2 = b.memoize(x1 / F64(2))
+          val x3 = b.strictMemoize(4 * Math.atan(1), name = Name("pi"))
+          val x4 = b.memoize(x3 * x1)
+          val x5 = b.memoize(x2 * x2)
+          val x6 = b.memoize(x3 * x5)
+          makestruct("radius" -> x2, "circumference" -> x4, "area" -> x6)
+        },
+        M.eval {
+          for {
+            x0 <- I32(2)
+            x1 <- Cast(x0, TFloat64)
+            x2 <- x1 / F64(2)
+            x3 <- Name("pi") -> F64(4 * Math.atan(1))
+            x4 <- x3 * x1
+            x5 <- x2 * x2
+            x6 <- x3 * x5
+          } yield makestruct("radius" -> x2, "circumference" -> x4, "area" -> x6)
+        },
+      ),
+      Array(
+        streamAggIR(StreamRange(0, 1, 10)) { elt =>
+          IRBuilder.scoped { b =>
+            val x = b.memoize(elt + 0, scope = Scope.AGG)
+            ApplyAggOp(Count())(x)
+          }
+        },
+        streamAggIR(StreamRange(0, 1, 10)) { elt =>
+          M.agg(for { x <- elt + 0 } yield ApplyAggOp(Count())(x))
+        },
+      ),
+      Array(
+        streamAggScanIR(StreamRange(0, 1, 10)) { elt =>
+          IRBuilder.scoped { b =>
+            val x = b.memoize(elt + 0, scope = Scope.SCAN)
+            ApplyScanOp(Count())(x)
+          }
+        },
+        streamAggScanIR(StreamRange(0, 1, 10)) { elt =>
+          M.scan(for { x <- elt + 0 } yield ApplyScanOp(Count())(x))
+        },
+      ),
+    )
+
+  @Test(dataProvider = "ImpFncBuilders")
+  def testMonadicEquivalence(ib: IR, fn: IR): Unit =
+    assert(ib isAlphaEquiv (ctx, fn))
+}

--- a/hail/mill-build/build.mill
+++ b/hail/mill-build/build.mill
@@ -25,6 +25,7 @@ object `package` extends MillBuildRootModule:
 
   override def mvnDeps: T[Seq[Dep]] =
     Seq(
+      `mill-contrib-jmh` :: "1.0.6",
       `mill-scalafix` :::: "0.6.0",
       `scalac-options` :: "0.1.8",
     )

--- a/hail/mill-build/mill-build/src/MvnCoordinate.scala
+++ b/hail/mill-build/mill-build/src/MvnCoordinate.scala
@@ -283,6 +283,7 @@ object MvnCoordinate:
   val `metrics-jmx` = "io.dropwizard.metrics:metrics-jmx"
   val `metrics-json` = "io.dropwizard.metrics:metrics-json"
   val `metrics-jvm` = "io.dropwizard.metrics:metrics-jvm"
+  val `mill-contrib-jmh` = "com.lihaoyi::mill-contrib-jmh"
   val `mill-scalafix` = "com.goyeau::mill-scalafix"
   val `minlog` = "com.esotericsoftware:minlog"
   val `mockito-scala` = "org.mockito::mockito-scala"


### PR DESCRIPTION
Lately, I've been using `IRBuilder` to help construct irs that do not
share subtrees. I've noticed that it negatively
affects readability through the addition of punctuation and `b.memoize` noise.

To make building IRs more readable, I wanted to write a monadic
ir builder that binds an expression as its effect.
`Memoized`, a `Reader` from `IRBuilder -> IR`, has the syntax:

```scala
def min(X: IR, Y: IR): IR = 
  eval {
    for {
      x <- X
      y <- Y
    } yield If(x < y, x, y)
  }
```

whose equivalent with `IRBuilder` is:

```scala
def min(X: IR, Y: IR): IR = 
  IRBuilder.scoped { b
    val x = b.memoize(X)
    val y = b.memoize(Y)
    If(x < y, x, y)
  }
```

It's not a huge difference in this example but I find it makes the
binding sites clearer, especially as the rhs gets larger.

`Memoized` plays nicely with with `IRBuilder` through `defer` and `run`:

```scala
for {
  x <- ...
  y <- Memoized.defer { ib => 
    // use imperitive style
  }
...
```

Explicitly naming bindings is trivial:

```scala
  pi <- Name("pi") -> F64(4 * Math.atan(1))
```

`Memoized` is parameterised by Scope `S`, providing a clean way of
introducing bindings in any particular scope:

```scala
eval {
  for {
    e1 <- ..
    e2 <- ..
    e3 <- agg {
      for {
        a1 <- ..
        a2 <- ...
      } yield (..)
    }
...  
```

One benefit of the monadic form is that you can't mix lexical scopes by construction. There is no equivalent of:

```scala
IRBuilder.scoped { ib =>
  ... 
  mapIR(stream) { elem => 
    val x = ib.memoize(op elem)
  }
}
```

This change does not affect the broad-managed batch service in gcp.