### PR TITLE
[query] fix double ordering in scala 2.13

### DIFF
--- a/hail/hail/src-2.12/is/hail/expr/orderings/compat.scala
+++ b/hail/hail/src-2.12/is/hail/expr/orderings/compat.scala
@@ -1,0 +1,5 @@
+package is.hail.expr.orderings
+
+object compat {
+  val DoubleOrdering = Ordering.Double
+}

--- a/hail/hail/src-2.13/is/hail/expr/orderings/compat.scala
+++ b/hail/hail/src-2.13/is/hail/expr/orderings/compat.scala
@@ -1,0 +1,5 @@
+package is.hail.expr.orderings
+
+object compat {
+  val DoubleOrdering = Ordering.Double.IeeeOrdering
+}

--- a/hail/hail/src/is/hail/types/virtual/TFloat64.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat64.scala
@@ -2,6 +2,7 @@ package is.hail.types.virtual
 
 import is.hail.annotations._
 import is.hail.backend.HailStateManager
+import is.hail.expr.orderings.compat.DoubleOrdering
 import is.hail.utils._
 
 case object TFloat64 extends TNumeric {
@@ -33,7 +34,7 @@ case object TFloat64 extends TNumeric {
     })
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Double]], missingEqual)
+    ExtendedOrdering.extendToNull(DoubleOrdering, missingEqual)
 
   override def isIsomorphicTo(t: Type): Boolean =
     this == t


### PR DESCRIPTION
## Change Description

We're not running tests using scala 2.13 in CI, but I discovered running tests locally that `OrderingSuite.testOrderingArrayDouble` fails. I traced this down to a change in the default double ordering in 2.13: https://www.scala-lang.org/api/current/scala/math/Ordering$$Double$.html.

This PR restores our double ordering to be consistent with 2.12.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
