### PR TITLE
[query] no-sharing in ir functions by construction

### DIFF
--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -1092,7 +1092,7 @@ object Main {
     r += node(
       "ApplyIR",
       in("function", att("String")),
-      in("typeArgs", att("Seq[Type]")),
+      in("typeArgs", att("IndexedSeq[Type]")),
       in("args", child.*),
       in("returnType", att("Type")),
       errorID,
@@ -1102,7 +1102,7 @@ object Main {
     r += node(
       "Apply",
       in("function", att("String")),
-      in("typeArgs", att("Seq[Type]")),
+      in("typeArgs", att("IndexedSeq[Type]")),
       in("args", child.*),
       in("returnType", att("Type")),
       errorID,
@@ -1111,7 +1111,7 @@ object Main {
     r += node(
       "ApplySpecial",
       in("function", att("String")),
-      in("typeArgs", att("Seq[Type]")),
+      in("typeArgs", att("IndexedSeq[Type]")),
       in("args", child.*),
       in("returnType", att("Type")),
       errorID,

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -4,6 +4,8 @@ import is.hail.annotations.Region
 import is.hail.asm4s.Value
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
+import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir.agg.PhysicalAggSig
 import is.hail.expr.ir.functions._
 import is.hail.expr.ir.streams.StreamProducer
@@ -225,13 +227,13 @@ package defs {
   trait AbstractApplyNode[F <: JVMFunction] extends IR {
     def function: String
 
-    def args: Seq[IR]
+    def args: IndexedSeq[IR]
 
     def returnType: Type
 
-    def typeArgs: Seq[Type]
+    def typeArgs: IndexedSeq[Type]
 
-    def argTypes: Seq[Type] = args.map(_.typ)
+    def argTypes: IndexedSeq[Type] = args.map(_.typ)
 
     lazy val implementation: F =
       IRFunctionRegistry.lookupFunctionOrFail(function, returnType, typeArgs, argTypes)
@@ -527,8 +529,6 @@ package defs {
 
   package exts {
 
-    import is.hail.collection.implicits.toRichIterable
-
     abstract class UUID4CompanionExt {
       def apply(): UUID4 = UUID4(genUID())
     }
@@ -770,16 +770,16 @@ package defs {
         aggFoldIR(True()) { accum =>
           ApplySpecial(
             "land",
-            Seq.empty[Type],
-            FastSeq(accum, element),
+            ArraySeq.empty[Type],
+            ArraySeq(accum, element),
             TBoolean,
             ErrorIDs.NO_ERROR,
           )
         } { (accum1, accum2) =>
           ApplySpecial(
             "land",
-            Seq.empty[Type],
-            FastSeq(accum1, accum2),
+            ArraySeq.empty[Type],
+            ArraySeq(accum1, accum2),
             TBoolean,
             ErrorIDs.NO_ERROR,
           )
@@ -873,7 +873,7 @@ package defs {
       lazy val (body, inline): (IR, Boolean) = {
         val ((_, _, _, inline), impl) =
           IRFunctionRegistry.lookupIR(function, typeArgs, args.map(_.typ)).get
-        val body = impl(typeArgs, refs, errorID).deepCopy
+        val body = impl(typeArgs, refs, errorID)
         (body, inline)
       }
 

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -20,6 +20,7 @@ import is.hail.types.virtual._
 import is.hail.utils._
 
 import scala.collection.compat._
+import scala.util.control.ControlThrowable
 
 import org.apache.spark.sql.Row
 
@@ -772,6 +773,25 @@ object Interpret extends Logging {
           }
         }
         ()
+      case TailLoop(name, params, _, body) =>
+        val names = params.map(_._1)
+
+        var vals: IndexedSeq[Any] =
+          params.map(p => interpret(p._2, env, args))
+
+        def go: Any =
+          while (true)
+            try return interpret(body, env.bindIterable(names.zip(vals)), args)
+            catch {
+              case LoopCtrl(`name`, params) =>
+                vals = params
+            }
+
+        go
+
+      case Recur(name, exprs, _) =>
+        throw LoopCtrl(name, exprs.map(e => interpret(e, env, args)))
+
       case MakeStruct(fields) =>
         Row.fromSeq(fields.map { case (_, fieldIR) => interpret(fieldIR, env, args) })
       case SelectFields(old, fields) =>
@@ -1097,4 +1117,6 @@ object Interpret extends Logging {
         uuid4()
     }
   }
+
+  final private case class LoopCtrl(name: Name, args: IndexedSeq[Any]) extends ControlThrowable
 }

--- a/hail/hail/src/is/hail/expr/ir/Parser.scala
+++ b/hail/hail/src/is/hail/expr/ir/Parser.scala
@@ -777,7 +777,7 @@ object IRParser {
 
   def apply_like(
     ctx: ExecuteContext,
-    cons: (String, Seq[Type], IndexedSeq[IR], Type, Int) => IR,
+    cons: (String, IndexedSeq[Type], IndexedSeq[IR], Type, Int) => IR,
   )(
     it: TokenIterator
   ): StackFrame[IR] = {

--- a/hail/hail/src/is/hail/expr/ir/Subst.scala
+++ b/hail/hail/src/is/hail/expr/ir/Subst.scala
@@ -1,25 +1,26 @@
 package is.hail.expr.ir
 
-import is.hail.expr.ir.defs.Ref
+import is.hail.expr.ir.defs.{Atom, Ref}
 
 object Subst {
-  def apply(e: IR): IR = apply(e, BindingEnv.empty[IR])
 
   def apply(e: IR, env: BindingEnv[IR]): IR =
-    subst(e, env)
-
-  private def subst(e: IR, env: BindingEnv[IR]): IR = {
-    if (env.allEmpty)
-      return e
-
-    e match {
+    if (env.allEmpty) e
+    else e match {
       case x @ Ref(name, _) =>
-        env.eval.lookupOption(name).getOrElse(x)
+        env.eval.lookupOption(name)
+          .map {
+            // We don't know how many uses of `y` there might be. For Atom, we
+            // can safely clone `y` knowing work won't be duplicated. If `y` is big
+            // then this is probably a bug and the TreeIR invariant will complain.
+            case y: Atom => y.ir
+            case y => y
+          }
+          .getOrElse(x)
       case _ =>
         e.mapChildrenWithIndex {
-          case (child: IR, i) => subst(child, env.subtract(Bindings.get(e, i)))
+          case (child: IR, i) => Subst(child, env.subtract(Bindings.get(e, i)))
           case (child, _) => child
         }
     }
-  }
 }

--- a/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.functions
 import is.hail.asm4s._
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
-import is.hail.expr.ir._
+import is.hail.expr.ir.{Memoized => M, _}
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.types.physical.{PCanonicalArray, PType}
@@ -13,112 +13,75 @@ import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.{SBooleanValue, SFloat64, SInt32, SInt32Value}
 import is.hail.types.tcoerce
 import is.hail.types.virtual._
+import is.hail.types.virtual.TIterable.elementType
 
 object ArrayFunctions extends RegistryFunctions {
-  val arrayOps: Array[(String, Type, Type, (IR, IR, Int) => IR)] =
+  private[functions] val arrayOps: Array[(String, Type, Type, (IR, IR, Int) => IR)] =
     Array(
-      ("mul", tnum("T"), tv("T"), (ir1: IR, ir2: IR, _) => ApplyBinaryPrimOp(Multiply(), ir1, ir2)),
-      (
-        "div",
-        TInt32,
-        TFloat32,
-        (ir1: IR, ir2: IR, _) => ApplyBinaryPrimOp(FloatingPointDivide(), ir1, ir2),
-      ),
-      (
-        "div",
-        TInt64,
-        TFloat32,
-        (ir1: IR, ir2: IR, _) => ApplyBinaryPrimOp(FloatingPointDivide(), ir1, ir2),
-      ),
-      (
-        "div",
-        TFloat32,
-        TFloat32,
-        (ir1: IR, ir2: IR, _) => ApplyBinaryPrimOp(FloatingPointDivide(), ir1, ir2),
-      ),
-      (
-        "div",
-        TFloat64,
-        TFloat64,
-        (ir1: IR, ir2: IR, _) => ApplyBinaryPrimOp(FloatingPointDivide(), ir1, ir2),
-      ),
-      (
-        "floordiv",
-        tnum("T"),
-        tv("T"),
-        (ir1: IR, ir2: IR, _) =>
-          ApplyBinaryPrimOp(RoundToNegInfDivide(), ir1, ir2),
-      ),
-      ("add", tnum("T"), tv("T"), (ir1: IR, ir2: IR, _) => ApplyBinaryPrimOp(Add(), ir1, ir2)),
-      ("sub", tnum("T"), tv("T"), (ir1: IR, ir2: IR, _) => ApplyBinaryPrimOp(Subtract(), ir1, ir2)),
+      ("mul", tnum("T"), tv("T"), (x, y, _) => x * y),
+      ("div", TInt32, TFloat32, (x, y, _) => x / y),
+      ("div", TInt64, TFloat32, (x, y, _) => x / y),
+      ("div", TFloat32, TFloat32, (x, y, _) => x / y),
+      ("div", TFloat64, TFloat64, (x, y, _) => x / y),
+      ("floordiv", tnum("T"), tv("T"), (x, y, _) => x floorDiv y),
+      ("add", tnum("T"), tv("T"), (x, y, _) => x + y),
+      ("sub", tnum("T"), tv("T"), (x, y, _) => x - y),
       (
         "pow",
         tnum("T"),
         TFloat64,
-        (ir1: IR, ir2: IR, errorID: Int) =>
-          Apply("pow", Seq(), FastSeq(ir1, ir2), TFloat64, errorID),
+        (x, y, errorID) => Apply("pow", ArraySeq(), ArraySeq(x, y), TFloat64, errorID),
       ),
       (
         "mod",
         tnum("T"),
         tv("T"),
-        (ir1: IR, ir2: IR, errorID: Int) =>
-          Apply("mod", Seq(), FastSeq(ir1, ir2), ir2.typ, errorID),
+        (x, y, errorID) => Apply("mod", ArraySeq(), ArraySeq(x, y), y.typ, errorID),
       ),
     )
 
-  def mean(args: Seq[IR]): IR = {
-    val Seq(a) = args
-    val t = tcoerce[TArray](a.typ).elementType
-    val elt = freshName()
-    val n = freshName()
-    val sum = freshName()
-    StreamFold2(
-      ToStream(a),
-      FastSeq((n, I32(0)), (sum, zero(t))),
-      elt,
-      FastSeq(Ref(n, TInt32) + I32(1), Ref(sum, t) + Ref(elt, t)),
-      Cast(Ref(sum, t), TFloat64) / Cast(Ref(n, TInt32), TFloat64),
-    )
-  }
+  private def mean(a: IR): IR =
+    fold2IR(ToStream(a), 0, zero(elementType(a.typ)))(
+      { case (_, Seq(n, _)) => n + 1 },
+      { case (elt, Seq(_, sum)) => sum + elt },
+    ) { case Seq(n, sum) => sum.toD / n.toD }
 
-  def isEmpty(a: IR): IR = ApplyComparisonOp(EQ, ArrayLen(a), I32(0))
+  private[functions] def isEmpty(a: IR): IR =
+    ApplyComparisonOp(EQ, ArrayLen(a), 0)
 
-  def extend(a1: IR, a2: IR): IR = {
-    val uid = freshName()
-    val typ = a1.typ
-    If(
-      IsNA(a1),
-      NA(typ),
-      If(
-        IsNA(a2),
-        NA(typ),
-        ToArray(StreamFlatMap(
-          MakeStream(FastSeq(a1, a2), TStream(typ)),
-          uid,
-          ToStream(Ref(uid, a1.typ)),
-        )),
-      ),
-    )
-  }
+  def extend(a: Atom, b: IR): IR =
+    guardIR(!IsNA(a)) {
+      maybeIR(b)(b => ToArray(flatten(MakeStream(FastSeq(a, b), TStream(a.typ)))))
+    }
 
-  def exists(a: IR, cond: IR => IR): IR = foldIR(ToStream(a), False()) { (acc, elt) =>
-    invoke("lor", TBoolean, acc, cond(elt))
-  }
+  def exists(a: IR, cond: Atom => IR): IR =
+    M.eval {
+      for {
+        a <- a
+        len <- ArrayLen(a)
+      } yield tailLoop(TBoolean, 0) {
+        case (recur, Seq(idx)) =>
+          If(
+            idx >= len,
+            False(),
+            If(bindIR(ArrayRef(a, idx))(cond), True(), recur(ArraySeq(idx + 1))),
+          )
+      }
+    }
 
-  def contains(a: IR, value: IR): IR =
+  def contains(a: IR, value: Atom): IR =
     exists(a, elt => ApplyComparisonOp(EQWithNA, elt, value))
 
   def sum(a: IR): IR = {
     val t = tcoerce[TArray](a.typ).elementType
-    val zero = Cast(I64(0), t)
-    foldIR(ToStream(a), zero)((sum, v) => ApplyBinaryPrimOp(Add(), sum, v))
+    val zero = Cast(0L, t)
+    foldIR(ToStream(a), zero)(_ + _)
   }
 
   def product(a: IR): IR = {
     val t = tcoerce[TArray](a.typ).elementType
     val one = Cast(I64(1), t)
-    foldIR(ToStream(a), one)((product, v) => ApplyBinaryPrimOp(Multiply(), product, v))
+    foldIR(ToStream(a), one)(_ * _)
   }
 
   override def registerAll(): Unit = {
@@ -129,7 +92,7 @@ object ArrayFunctions extends RegistryFunctions {
     )
 
     registerIR2("append", TArray(tv("T")), tv("T"), TArray(tv("T"))) { (_, a, c, _) =>
-      extend(a, MakeArray(FastSeq(c), TArray(c.typ)))
+      extend(a, MakeArray(c))
     }
 
     registerIR2("contains", TArray(tv("T")), tv("T"), TBoolean)((_, a, e, _) => contains(a, e))
@@ -158,59 +121,50 @@ object ArrayFunctions extends RegistryFunctions {
 
     registerIR1("product", TArray(tnum("T")), tv("T"))((_, a, _) => product(a))
 
-    def makeMinMaxOp(op: String): Seq[IR] => IR = { case Seq(a) =>
-      val t = tcoerce[TArray](a.typ).elementType
-      val value = freshName()
-      val first = freshName()
-      val acc = freshName()
-      StreamFold2(
-        ToStream(a),
-        FastSeq((acc, NA(t)), (first, True())),
-        value,
-        FastSeq(
-          If(Ref(first, TBoolean), Ref(value, t), invoke(op, t, Ref(acc, t), Ref(value, t))),
-          False(),
-        ),
-        Ref(acc, t),
-      )
-    }
+    def minmax(s: IR)(pick: (Atom, Atom) => IR): IR =
+      fold2IR(ToStream(s), NA(elementType(s.typ)), True())(
+        { case (elem, Seq(res, first)) => If(first, elem, pick(res, elem)) },
+        (_, _) => False(),
+      ) { case Seq(r, _) => r }
 
-    registerIR("min", ArraySeq(TArray(tnum("T"))), tv("T"), inline = true)((_, a, _) =>
-      makeMinMaxOp("min")(a)
+    registerIR1("min", TArray(tnum("T")), tv("T"), inline = true)((_, a, _) =>
+      minmax(a)((acc, v) => invoke("min", acc.typ, acc, v))
     )
-    registerIR("nanmin", ArraySeq(TArray(tnum("T"))), tv("T"), inline = true)((_, a, _) =>
-      makeMinMaxOp("nanmin")(a)
+    registerIR1("nanmin", TArray(tnum("T")), tv("T"), inline = true)((_, a, _) =>
+      minmax(a)((acc, v) => invoke("nanmin", acc.typ, acc, v))
     )
-    registerIR("max", ArraySeq(TArray(tnum("T"))), tv("T"), inline = true)((_, a, _) =>
-      makeMinMaxOp("max")(a)
+    registerIR1("max", TArray(tnum("T")), tv("T"), inline = true)((_, a, _) =>
+      minmax(a)((acc, v) => invoke("max", acc.typ, acc, v))
     )
-    registerIR("nanmax", ArraySeq(TArray(tnum("T"))), tv("T"), inline = true)((_, a, _) =>
-      makeMinMaxOp("nanmax")(a)
+    registerIR1("nanmax", TArray(tnum("T")), tv("T"), inline = true)((_, a, _) =>
+      minmax(a)((acc, v) => invoke("nanmax", acc.typ, acc, v))
     )
-
-    registerIR("mean", ArraySeq(TArray(tnum("T"))), TFloat64, inline = true)((_, a, _) => mean(a))
+    registerIR1("mean", TArray(tnum("T")), TFloat64, inline = true)((_, a, _) =>
+      mean(a)
+    )
 
     registerIR1("median", TArray(tnum("T")), tv("T")) { (_, array, errorID) =>
-      val t = array.typ.asInstanceOf[TArray].elementType
+      val t = elementType(array.typ)
 
       def div(a: IR, b: IR): IR = ApplyBinaryPrimOp(BinaryOp.defaultDivideOp(t), a, b)
 
       bindIR(ArraySort(filterIR(ToStream(array))(!IsNA(_)))) { a =>
         def ref(i: IR) = ArrayRef(a, i, errorID)
+
         If(
           IsNA(a),
           NA(t),
           bindIR(ArrayLen(a)) { size =>
-            val lastIdx = size - 1
-            val midIdx = lastIdx.floorDiv(2)
             If(
-              size.ceq(0),
+              size ceq 0,
               NA(t),
-              If(
-                invoke("mod", TInt32, size, 2).cne(0),
-                ref(midIdx), // odd number of non-missing elements
-                div(ref(midIdx) + ref(midIdx + 1), Cast(2, t)),
-              ),
+              bindIR((size - 1) floorDiv 2) { midIdx =>
+                If(
+                  invoke("mod", TInt32, size, 2).cne(0),
+                  ref(midIdx), // odd number of non-missing elements
+                  div(ref(midIdx) + ref(midIdx + 1), Literal.coerce(t, 2)),
+                )
+              },
             )
           },
         )
@@ -219,30 +173,19 @@ object ArrayFunctions extends RegistryFunctions {
 
     def argF(a: IR, op: ComparisonOp[Boolean], errorID: Int): IR = {
       val t = tcoerce[TArray](a.typ).elementType
-      val tAccum = TStruct("m" -> t, "midx" -> TInt32)
+      val tAccum = TTuple(t, TInt32)
 
-      def updateAccum(min: IR, midx: IR): IR =
-        MakeStruct(FastSeq("m" -> min, "midx" -> midx))
-
-      GetField(
-        foldIR(StreamRange(I32(0), ArrayLen(a), I32(1)), NA(tAccum)) { (accum, idx) =>
-          bindIRs(ArrayRef(a, idx, errorID), GetField(accum, "m")) { case Seq(value, m) =>
+      GetTupleElement(
+        foldIR(StreamRange(0, ArrayLen(a), 1), NA(tAccum)) { (accum, idx) =>
+          bindIRs(ArrayRef(a, idx, errorID), GetTupleElement(accum, 0)) { case Seq(value, m) =>
             If(
-              IsNA(value),
+              !IsNA(value) && (IsNA(m) || ApplyComparisonOp(op, value, m)),
+              maketuple(value, idx),
               accum,
-              If(
-                IsNA(m),
-                updateAccum(value, idx),
-                If(
-                  ApplyComparisonOp(op, value, m),
-                  updateAccum(value, idx),
-                  accum,
-                ),
-              ),
             )
           }
         },
-        "midx",
+        1,
       )
     }
 
@@ -250,33 +193,25 @@ object ArrayFunctions extends RegistryFunctions {
 
     registerIR1("argmax", TArray(tv("T")), TInt32)((_, a, errorID) => argF(a, GT, errorID))
 
-    def uniqueIndex(a: IR, op: ComparisonOp[Boolean], errorID: Int): IR = {
-      val t = tcoerce[TArray](a.typ).elementType
+    def uniqueIndex(a: Atom, op: ComparisonOp[Boolean], errorID: Int): IR = {
+      val t = elementType(a.typ)
       val tAccum = TStruct("m" -> t, "midx" -> TInt32, "count" -> TInt32)
 
-      def updateAccum(m: IR, midx: IR, count: IR): IR =
-        MakeStruct(FastSeq("m" -> m, "midx" -> midx, "count" -> count))
+      def makeaccum(m: IR, midx: IR, count: IR): IR =
+        makestruct("m" -> m, "midx" -> midx, "count" -> count)
 
-      val fold = foldIR(StreamRange(I32(0), ArrayLen(a), I32(1)), NA(tAccum)) { (accum, idx) =>
+      val fold = foldIR(StreamRange(0, ArrayLen(a), 1), NA(tAccum)) { (accum, idx) =>
         bindIRs(ArrayRef(a, idx, errorID), GetField(accum, "m")) { case Seq(value, m) =>
           If(
             IsNA(value),
             accum,
             If(
-              IsNA(m),
-              updateAccum(value, idx, I32(1)),
+              IsNA(m) || ApplyComparisonOp(op, value, m),
+              makeaccum(value, idx, 1),
               If(
-                ApplyComparisonOp(op, value, m),
-                updateAccum(value, idx, I32(1)),
-                If(
-                  ApplyComparisonOp(EQ, value, m),
-                  updateAccum(
-                    value,
-                    idx,
-                    ApplyBinaryPrimOp(Add(), GetField(accum, "count"), I32(1)),
-                  ),
-                  accum,
-                ),
+                ApplyComparisonOp(EQ, value, m),
+                makeaccum(value, idx, GetField(accum, "count") + 1),
+                accum,
               ),
             ),
           )
@@ -285,7 +220,7 @@ object ArrayFunctions extends RegistryFunctions {
 
       bindIR(fold) { result =>
         If(
-          ApplyComparisonOp(EQ, GetField(result, "count"), I32(1)),
+          ApplyComparisonOp(EQ, GetField(result, "count"), 1),
           GetField(result, "midx"),
           NA(TInt32),
         )
@@ -301,15 +236,11 @@ object ArrayFunctions extends RegistryFunctions {
     )
 
     registerIR2("indexArray", TArray(tv("T")), TInt32, tv("T")) { (_, a, i, errorID) =>
-      ArrayRef(
-        a,
-        If(ApplyComparisonOp(LT, i, I32(0)), ApplyBinaryPrimOp(Add(), ArrayLen(a), i), i),
-        errorID,
-      )
+      ArrayRef(a, If(i < 0, ArrayLen(a) + i, i), errorID)
     }
 
     registerIR1("flatten", TArray(TArray(tv("T"))), TArray(tv("T"))) { (_, a, _) =>
-      ToArray(flatMapIR(ToStream(a))(ToStream(_)))
+      ToArray(flatten(ToStream(a)))
     }
 
     /* Construct an array of length `len`, with the values in `elts` copied to the positions in

--- a/hail/hail/src/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/DictFunctions.scala
@@ -1,51 +1,38 @@
 package is.hail.expr.ir.functions
 
-import is.hail.collection.FastSeq
-import is.hail.expr.ir._
+import is.hail.expr.ir.{Memoized => M, _}
 import is.hail.expr.ir.defs._
 import is.hail.types
 import is.hail.types.virtual._
 
 object DictFunctions extends RegistryFunctions {
-  def contains(dict: IR, key: IR) = {
-    If(
-      IsNA(dict),
-      NA(TBoolean),
-      bindIR(LowerBoundOnOrderedCollection(dict, key, onKey = true)) { i =>
-        If(
-          i.ceq(ArrayLen(CastToArray(dict))),
-          False(),
-          ApplyComparisonOp(
-            EQWithNA,
-            GetField(ArrayRef(CastToArray(dict), i), "key"),
-            key,
-          ),
-        )
-      },
-    )
-  }
+  def contains(dict: Atom, key: Atom): IR =
+    guardIR(!IsNA(dict)) {
+      M.eval {
+        for {
+          i <- LowerBoundOnOrderedCollection(dict, key, onKey = true)
+          a <- CastToArray(dict)
+        } yield (i < ArrayLen(a)) && (GetField(ArrayRef(a, i), "key") ceq key)
+      }
+    }
 
-  def get(dict: IR, key: IR, default: IR): IR = {
-    If(
-      IsNA(dict),
-      NA(default.typ),
-      bindIR(LowerBoundOnOrderedCollection(dict, key, onKey = true)) { i =>
-        If(
-          i.ceq(ArrayLen(CastToArray(dict))),
-          default,
+  def get(dict: Atom, key: Atom, default: IR): IR =
+    guardIR(!IsNA(dict)) {
+      bindIRs(LowerBoundOnOrderedCollection(dict, key, onKey = true), CastToArray(dict)) {
+        case Seq(i, arr) =>
           If(
-            ApplyComparisonOp(
-              EQWithNA,
-              GetField(ArrayRef(CastToArray(dict), i), "key"),
-              key,
-            ),
-            GetField(ArrayRef(CastToArray(dict), i), "value"),
-            default,
-          ),
-        )
-      },
-    )
-  }
+            i ceq ArrayLen(arr),
+            default.deepCopy,
+            bindIR(ArrayRef(arr, i)) { elem =>
+              If(
+                GetField(elem, "key") ceq key,
+                GetField(elem, "value"),
+                default.deepCopy,
+              )
+            },
+          )
+      }
+    }
 
   val tdict = TDict(tv("key"), tv("value"))
 
@@ -80,9 +67,8 @@ object DictFunctions extends RegistryFunctions {
       get(d, k, Die(errormsg, vtype, errorID))
     }
 
-    registerIR1("dictToArray", tdict, TArray(TStruct("key" -> tv("key"), "value" -> tv("value")))) {
-      (_, d, _) =>
-        mapArray(d)(elt => MakeTuple.ordered(FastSeq(GetField(elt, "key"), GetField(elt, "value"))))
+    registerIR1("dictToArray", tdict, TArray(TTuple(tv("key"), tv("value")))) {
+      (_, d, _) => mapArray(d)(elt => maketuple(GetField(elt, "key"), GetField(elt, "value")))
     }
 
     registerIR1("keySet", tdict, TSet(tv("key"))) { (_, d, _) =>

--- a/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/Functions.scala
@@ -9,7 +9,7 @@ import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterable
 import is.hail.experimental.ExperimentalFunctions
 import is.hail.expr.ir._
-import is.hail.expr.ir.defs.{Apply, ApplyIR, ApplySpecial}
+import is.hail.expr.ir.defs.{Apply, ApplyIR, ApplySpecial, Atom}
 import is.hail.io.bgen.BGENFunctions
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{EmitType, SType, SValue}
@@ -27,7 +27,7 @@ import scala.reflect._
 import org.apache.spark.sql.Row
 
 object IRFunctionRegistry {
-  type UserDefinedFnKey = (String, (Type, Seq[Type], Seq[Type]))
+  type UserDefinedFnKey = (String, (Type, IndexedSeq[Type], IndexedSeq[Type]))
 
   private[this] val userAddedFunctions: mutable.Set[UserDefinedFnKey] =
     mutable.HashSet.empty
@@ -39,9 +39,9 @@ object IRFunctionRegistry {
     userAddedFunctions.clear()
   }
 
-  type IRFunctionSignature = (Seq[Type], Seq[Type], Type, Boolean)
-  type IRFunctionImplementation = (Seq[Type], Seq[IR], Int) => IR
-  type ConcreteIRFunctionImplementation = (Seq[IR], Int) => IR
+  type IRFunctionSignature = (IndexedSeq[Type], IndexedSeq[Type], Type, Boolean)
+  type IRFunctionImplementation = (IndexedSeq[Type], IndexedSeq[Atom], Int) => IR
+  type ConcreteIRFunctionImplementation = (IndexedSeq[IR], Int) => IR
 
   val irRegistry: mutable.Map[String, mutable.Map[IRFunctionSignature, IRFunctionImplementation]] =
     new mutable.HashMap()
@@ -59,8 +59,8 @@ object IRFunctionRegistry {
 
   def addIR(
     name: String,
-    typeParameters: Seq[Type],
-    valueParameterTypes: Seq[Type],
+    typeParameters: IndexedSeq[Type],
+    valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
     alwaysInline: Boolean,
     f: IRFunctionImplementation,
@@ -98,7 +98,7 @@ object IRFunctionRegistry {
       valueParameterTypes,
       returnType,
       false,
-      (_, args, _) => Subst(body, BindingEnv.eval(argNames.zip(args): _*)),
+      (_, args, _) => Subst(body.deepCopy, BindingEnv.eval(argNames.zip(args.map(_.ir)): _*)),
     )
     key
   }
@@ -117,8 +117,8 @@ object IRFunctionRegistry {
   def removeIRFunction(
     name: String,
     returnType: Type,
-    typeParameters: Seq[Type],
-    valueParameterTypes: Seq[Type],
+    typeParameters: IndexedSeq[Type],
+    valueParameterTypes: IndexedSeq[Type],
   ): Unit = {
     val m = irRegistry(name)
     m -= ((typeParameters, valueParameterTypes, returnType, false))
@@ -127,8 +127,8 @@ object IRFunctionRegistry {
   private[this] def lookupFunction(
     name: String,
     returnType: Type,
-    typeParameters: Seq[Type],
-    valueParameterTypes: Seq[Type],
+    typeParameters: IndexedSeq[Type],
+    valueParameterTypes: IndexedSeq[Type],
   ): Option[JVMFunction] =
     jvmRegistry.get(name).flatMap { fs =>
       fs.filter(_.unify(typeParameters, valueParameterTypes, returnType)).toSeq match {
@@ -143,8 +143,8 @@ object IRFunctionRegistry {
   def lookupFunctionOrFail(
     name: String,
     returnType: Type,
-    typeParameters: Seq[Type],
-    valueParameterTypes: Seq[Type],
+    typeParameters: IndexedSeq[Type],
+    valueParameterTypes: IndexedSeq[Type],
   ): JVMFunction =
     jvmRegistry.get(name) match {
       case None =>
@@ -168,11 +168,19 @@ object IRFunctionRegistry {
 
   def lookupIR(
     name: String,
-    typeParameters: Seq[Type],
-    valueParameterTypes: Seq[Type],
+    typeParameters: IndexedSeq[Type],
+    valueParameterTypes: IndexedSeq[Type],
   ): Option[(IRFunctionSignature, IRFunctionImplementation)] = {
     irRegistry.getOrElse(name, Map.empty).filter {
-      case ((typeParametersFound: Seq[Type], valueParameterTypesFound: Seq[Type], _, _), _) =>
+      case (
+            (
+              typeParametersFound: IndexedSeq[Type],
+              valueParameterTypesFound: IndexedSeq[Type],
+              _,
+              _,
+            ),
+            _,
+          ) =>
         typeParametersFound.length == typeParameters.length && {
           typeParametersFound.foreach(_.clear())
           typeParametersFound.lazyZip(typeParameters).forall(_.unify(_))
@@ -188,30 +196,30 @@ object IRFunctionRegistry {
     }
   }
 
-  def lookup(name: String, returnType: Type, arguments: Seq[Type])
+  def lookup(name: String, returnType: Type, arguments: IndexedSeq[Type])
     : Option[ConcreteIRFunctionImplementation] =
     lookup(name, returnType, ArraySeq.empty, arguments)
 
   def lookup(
     name: String,
     returnType: Type,
-    typeParameters: Seq[Type],
-    arguments: Seq[Type],
+    typeParameters: IndexedSeq[Type],
+    arguments: IndexedSeq[Type],
   ): Option[ConcreteIRFunctionImplementation] = {
     val validIR: Option[ConcreteIRFunctionImplementation] =
       lookupIR(name, typeParameters, arguments).map { _ => (args, errorID) =>
-        ApplyIR(name, typeParameters, args.toFastSeq, returnType, errorID)
+        ApplyIR(name, typeParameters, args, returnType, errorID)
       }
 
-    val validMethods = lookupFunction(name, returnType, typeParameters, arguments)
-      .map { f =>
-        { (irArguments: Seq[IR], errorID: Int) =>
+    val validMethods =
+      lookupFunction(name, returnType, typeParameters, arguments).map {
+        f => (params: IndexedSeq[IR], errorID: Int) =>
           f match {
             case _: UnseededMissingnessObliviousJVMFunction =>
               Apply(
                 name,
                 typeParameters,
-                irArguments.toFastSeq,
+                params,
                 returnType,
                 errorID,
               )
@@ -219,12 +227,11 @@ object IRFunctionRegistry {
               ApplySpecial(
                 name,
                 typeParameters,
-                irArguments.toFastSeq,
+                params,
                 returnType,
                 errorID,
               )
           }
-        }
       }
 
     (validIR, validMethods) match {
@@ -279,8 +286,8 @@ object IRFunctionRegistry {
 
   private[this] def prettySignature(
     name: String,
-    typeParameterTypes: Seq[Type],
-    valueParameterTypes: Seq[Type],
+    typeParameterTypes: IndexedSeq[Type],
+    valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
   ): String =
     s"$name[${typeParameterTypes.mkString(", ")}](${valueParameterTypes.mkString(", ")}): $returnType"
@@ -459,13 +466,13 @@ abstract class RegistryFunctions {
     name: String,
     valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
-    calculateReturnType: (Type, Seq[SType]) => SType,
+    calculateReturnType: (Type, IndexedSeq[SType]) => SType,
     typeParameters: IndexedSeq[Type] = ArraySeq.empty,
   )(
     impl: (
       Value[Region],
       EmitCodeBuilder,
-      Seq[Type],
+      IndexedSeq[Type],
       SType,
       IndexedSeq[SValue],
       Value[Int],
@@ -478,7 +485,7 @@ abstract class RegistryFunctions {
           r: Value[Region],
           cb: EmitCodeBuilder,
           returnSType: SType,
-          typeParameters: Seq[Type],
+          typeParameters: IndexedSeq[Type],
           errorID: Value[Int],
           args: SValue*
         ): SValue =
@@ -491,10 +498,10 @@ abstract class RegistryFunctions {
     name: String,
     valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
-    calculateReturnType: (Type, Seq[SType]) => SType,
-    typeParameters: IndexedSeq[Type] = FastSeq.empty,
+    calculateReturnType: (Type, IndexedSeq[SType]) => SType,
+    typeParameters: IndexedSeq[Type] = ArraySeq.empty,
   )(
-    impl: (Value[Region], EmitCodeBuilder, SType, Seq[Type], IndexedSeq[SValue]) => Value[_]
+    impl: (Value[Region], EmitCodeBuilder, SType, IndexedSeq[Type], IndexedSeq[SValue]) => Value[_]
   ): Unit = {
     IRFunctionRegistry.addJVMFunction(
       new UnseededMissingnessObliviousJVMFunction(name, typeParameters, valueParameterTypes,
@@ -503,13 +510,17 @@ abstract class RegistryFunctions {
           r: Value[Region],
           cb: EmitCodeBuilder,
           returnSType: SType,
-          typeParameters: Seq[Type],
+          typeParameters: IndexedSeq[Type],
           errorID: Value[Int],
           args: SValue*
         ): SValue = {
-          assert(unify(typeParameters, args.map(_.st.virtualType), returnSType.virtualType))
+          assert(unify(
+            typeParameters,
+            args.toFastSeq.map(_.st.virtualType),
+            returnSType.virtualType,
+          ))
           val returnValue = impl(r, cb, returnSType, typeParameters, args.toFastSeq)
-          returnSType.fromValues(FastSeq(returnValue))
+          returnSType.fromValues(ArraySeq(returnValue))
         }
       }
     )
@@ -517,56 +528,55 @@ abstract class RegistryFunctions {
 
   def registerEmitCode(
     name: String,
-    valueParameterTypes: IndexedSeq[Type],
+    params: IndexedSeq[Type],
     returnType: Type,
-    calculateReturnType: (Type, Seq[EmitType]) => EmitType,
-    typeParameters: IndexedSeq[Type] = FastSeq.empty,
+    calculateReturnType: (Type, IndexedSeq[EmitType]) => EmitType,
+    typParams: IndexedSeq[Type] = ArraySeq.empty,
   )(
-    impl: (EmitMethodBuilder[_], Value[Region], SType, Value[Int], Array[EmitCode]) => EmitCode
-  ): Unit = {
+    impl: (EmitMethodBuilder[_], Value[Region], SType, Value[Int], IndexedSeq[EmitCode]) => EmitCode
+  ): Unit =
     IRFunctionRegistry.addJVMFunction(
-      new UnseededMissingnessAwareJVMFunction(name, typeParameters, valueParameterTypes, returnType,
+      new UnseededMissingnessAwareJVMFunction(name, typParams, params, returnType,
         calculateReturnType) {
         override def apply(
           mb: EmitMethodBuilder[_],
           region: Value[Region],
           rpt: SType,
-          typeParameters: Seq[Type],
+          typeParameters: IndexedSeq[Type],
           errorID: Value[Int],
           args: EmitCode*
         ): EmitCode = {
-          assert(unify(typeParameters, args.map(_.st.virtualType), rpt.virtualType))
-          impl(mb, region, rpt, errorID, args.toArray)
+          assert(unify(typeParameters, args.toFastSeq.map(_.st.virtualType), rpt.virtualType))
+          impl(mb, region, rpt, errorID, args.toFastSeq)
         }
       }
     )
-  }
 
   def registerIEmitCode(
     name: String,
-    valueParameterTypes: IndexedSeq[Type],
+    params: IndexedSeq[Type],
     returnType: Type,
-    calculateReturnType: (Type, Seq[EmitType]) => EmitType,
-    typeParameters: IndexedSeq[Type] = FastSeq.empty,
+    calculateReturnType: (Type, IndexedSeq[EmitType]) => EmitType,
+    typParams: IndexedSeq[Type] = ArraySeq.empty,
   )(
-    impl: (EmitCodeBuilder, Value[Region], SType, Value[Int], Array[EmitCode]) => IEmitCode
+    impl: (EmitCodeBuilder, Value[Region], SType, Value[Int], IndexedSeq[EmitCode]) => IEmitCode
   ): Unit = {
     IRFunctionRegistry.addJVMFunction(
-      new UnseededMissingnessAwareJVMFunction(name, typeParameters, valueParameterTypes, returnType,
+      new UnseededMissingnessAwareJVMFunction(name, typParams, params, returnType,
         calculateReturnType) {
         override def apply(
           cb: EmitCodeBuilder,
           r: Value[Region],
           rpt: SType,
-          typeParameters: Seq[Type],
+          typeParameters: IndexedSeq[Type],
           errorID: Value[Int],
           args: EmitCode*
         ): IEmitCode = {
-          val res = impl(cb, r, rpt, errorID, args.toArray)
-          if (res.emitType != calculateReturnType(rpt.virtualType, args.map(_.emitType)))
+          val res = impl(cb, r, rpt, errorID, args.toFastSeq)
+          if (res.emitType != calculateReturnType(rpt.virtualType, args.toFastSeq.map(_.emitType)))
             throw new RuntimeException(
               s"type mismatch while registering ${this.name}" +
-                s"\n  got ${res.emitType}, got ${calculateReturnType(rpt.virtualType, args.map(_.emitType))}"
+                s"\n  got ${res.emitType}, got ${calculateReturnType(rpt.virtualType, args.toFastSeq.map(_.emitType))}"
             )
           res
         }
@@ -574,7 +584,7 @@ abstract class RegistryFunctions {
           mb: EmitMethodBuilder[_],
           region: Value[Region],
           rpt: SType,
-          typeParameters: Seq[Type],
+          typeParameters: IndexedSeq[Type],
           errorID: Value[Int],
           args: EmitCode*
         ): EmitCode =
@@ -587,7 +597,7 @@ abstract class RegistryFunctions {
     name: String,
     valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
-    calculateReturnType: (Type, Seq[SType]) => SType,
+    calculateReturnType: (Type, IndexedSeq[SType]) => SType,
   )(
     cls: Class[_],
     method: String,
@@ -605,7 +615,7 @@ abstract class RegistryFunctions {
           )(PrimitiveTypeToIRIntermediateClassTag(returnType)),
           rt.settableTupleTypes()(0),
         )
-        rt.fromValues(FastSeq(returnValue))
+        rt.fromValues(ArraySeq(returnValue))
     }
   }
 
@@ -613,7 +623,7 @@ abstract class RegistryFunctions {
     name: String,
     valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
-    calculateReturnType: (Type, Seq[SType]) => SType,
+    calculateReturnType: (Type, IndexedSeq[SType]) => SType,
   )(
     cls: Class[_],
     method: String,
@@ -727,7 +737,7 @@ abstract class RegistryFunctions {
     name: String,
     valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
-    pt: (Type, Seq[SType]) => SType,
+    pt: (Type, IndexedSeq[SType]) => SType,
   )(
     cls: Class[_],
     method: String,
@@ -747,9 +757,9 @@ abstract class RegistryFunctions {
     valueParameterTypes: IndexedSeq[Type],
     returnType: Type,
     inline: Boolean = false,
-    typeParameters: IndexedSeq[Type] = FastSeq.empty,
+    typeParameters: IndexedSeq[Type] = ArraySeq.empty,
   )(
-    f: (Seq[Type], Seq[IR], Int) => IR
+    f: (IndexedSeq[Type], IndexedSeq[Atom], Int) => IR
   ): Unit =
     IRFunctionRegistry.addIR(name, typeParameters, valueParameterTypes, returnType, inline, f)
 
@@ -772,7 +782,7 @@ abstract class RegistryFunctions {
     rt: Type,
     pt: (Type, SType) => SType,
   )(
-    impl: (Value[Region], EmitCodeBuilder, Seq[Type], SType, SValue, Value[Int]) => SValue
+    impl: (Value[Region], EmitCodeBuilder, IndexedSeq[Type], SType, SValue, Value[Int]) => SValue
   ): Unit =
     registerSCode(name, ArraySeq(mt1), rt, unwrappedApply(pt), typeParameters = typeParams) {
       case (r, cb, typeParams, rt, Seq(a1), errorID) => impl(r, cb, typeParams, rt, a1, errorID)
@@ -799,7 +809,15 @@ abstract class RegistryFunctions {
     rt: Type,
     pt: (Type, SType, SType) => SType,
   )(
-    impl: (Value[Region], EmitCodeBuilder, Seq[Type], SType, SValue, SValue, Value[Int]) => SValue
+    impl: (
+      Value[Region],
+      EmitCodeBuilder,
+      IndexedSeq[Type],
+      SType,
+      SValue,
+      SValue,
+      Value[Int],
+    ) => SValue
   ): Unit =
     registerSCode(name, ArraySeq(mt1, mt2), rt, unwrappedApply(pt), typeParameters = typeParams) {
       case (r, cb, typeParams, rt, Seq(a1, a2), errorID) =>
@@ -832,7 +850,7 @@ abstract class RegistryFunctions {
     impl: (
       Value[Region],
       EmitCodeBuilder,
-      Seq[Type],
+      IndexedSeq[Type],
       SType,
       SValue,
       SValue,
@@ -883,7 +901,7 @@ abstract class RegistryFunctions {
     impl: (
       Value[Region],
       EmitCodeBuilder,
-      Seq[Type],
+      IndexedSeq[Type],
       SType,
       SValue,
       SValue,
@@ -1018,7 +1036,7 @@ abstract class RegistryFunctions {
     impl: (EmitCodeBuilder, Value[Region], SType, Value[Int], EmitCode) => IEmitCode
   ): Unit =
     registerIEmitCode(name, ArraySeq(mt1), rt, unwrappedApply(pt)) {
-      case (cb, r, rt, errorID, Array(a1)) =>
+      case (cb, r, rt, errorID, Seq(a1)) =>
         impl(cb, r, rt, errorID, a1)
     }
 
@@ -1032,7 +1050,7 @@ abstract class RegistryFunctions {
     impl: (EmitCodeBuilder, Value[Region], SType, Value[Int], EmitCode, EmitCode) => IEmitCode
   ): Unit =
     registerIEmitCode(name, ArraySeq(mt1, mt2), rt, unwrappedApply(pt)) {
-      case (cb, r, rt, errorID, Array(a1, a2)) =>
+      case (cb, r, rt, errorID, Seq(a1, a2)) =>
         impl(cb, r, rt, errorID, a1, a2)
     }
 
@@ -1055,7 +1073,7 @@ abstract class RegistryFunctions {
     ) => IEmitCode
   ): Unit =
     registerIEmitCode(name, ArraySeq(mt1, mt2, mt3), rt, unwrappedApply(pt)) {
-      case (cb, r, rt, errorID, Array(a1, a2, a3)) =>
+      case (cb, r, rt, errorID, Seq(a1, a2, a3)) =>
         impl(cb, r, rt, errorID, a1, a2, a3)
     }
 
@@ -1080,7 +1098,7 @@ abstract class RegistryFunctions {
     ) => IEmitCode
   ): Unit =
     registerIEmitCode(name, ArraySeq(mt1, mt2, mt3, mt4), rt, unwrappedApply(pt)) {
-      case (cb, r, rt, errorID, Array(a1, a2, a3, a4)) =>
+      case (cb, r, rt, errorID, Seq(a1, a2, a3, a4)) =>
         impl(cb, r, rt, errorID, a1, a2, a3, a4)
     }
 
@@ -1107,7 +1125,7 @@ abstract class RegistryFunctions {
     ) => IEmitCode
   ): Unit =
     registerIEmitCode(name, ArraySeq(mt1, mt2, mt3, mt4, mt5), rt, unwrappedApply(pt)) {
-      case (cb, r, rt, errorID, Array(a1, a2, a3, a4, a5)) =>
+      case (cb, r, rt, errorID, Seq(a1, a2, a3, a4, a5)) =>
         impl(cb, r, rt, errorID, a1, a2, a3, a4, a5)
     }
 
@@ -1136,7 +1154,7 @@ abstract class RegistryFunctions {
     ) => IEmitCode
   ): Unit =
     registerIEmitCode(name, ArraySeq(mt1, mt2, mt3, mt4, mt5, mt6), rt, unwrappedApply(pt)) {
-      case (cb, r, rt, errorID, Array(a1, a2, a3, a4, a5, a6)) =>
+      case (cb, r, rt, errorID, Seq(a1, a2, a3, a4, a5, a6)) =>
         impl(cb, r, rt, errorID, a1, a2, a3, a4, a5, a6)
     }
 
@@ -1150,7 +1168,7 @@ abstract class RegistryFunctions {
     impl: (EmitMethodBuilder[_], Value[Region], SType, Value[Int], EmitCode, EmitCode) => EmitCode
   ): Unit =
     registerEmitCode(name, ArraySeq(mt1, mt2), rt, unwrappedApply(pt)) {
-      case (mb, r, rt, errorID, Array(a1, a2)) => impl(mb, r, rt, errorID, a1, a2)
+      case (mb, r, rt, errorID, Seq(a1, a2)) => impl(mb, r, rt, errorID, a1, a2)
     }
 
   def registerIR1(
@@ -1158,10 +1176,11 @@ abstract class RegistryFunctions {
     mt1: Type,
     returnType: Type,
     typeParameters: IndexedSeq[Type] = ArraySeq.empty,
+    inline: Boolean = false,
   )(
-    f: (Seq[Type], IR, Int) => IR
+    f: (IndexedSeq[Type], Atom, Int) => IR
   ): Unit =
-    registerIR(name, ArraySeq(mt1), returnType, typeParameters = typeParameters) {
+    registerIR(name, ArraySeq(mt1), returnType, inline = inline, typeParameters = typeParameters) {
       case (t, Seq(a1), errorID) => f(t, a1, errorID)
     }
 
@@ -1172,7 +1191,7 @@ abstract class RegistryFunctions {
     returnType: Type,
     typeParameters: IndexedSeq[Type] = ArraySeq.empty,
   )(
-    f: (Seq[Type], IR, IR, Int) => IR
+    f: (IndexedSeq[Type], Atom, Atom, Int) => IR
   ): Unit =
     registerIR(name, ArraySeq(mt1, mt2), returnType, typeParameters = typeParameters) {
       case (t, Seq(a1, a2), errorID) => f(t, a1, a2, errorID)
@@ -1186,44 +1205,29 @@ abstract class RegistryFunctions {
     returnType: Type,
     typeParameters: IndexedSeq[Type] = ArraySeq.empty,
   )(
-    f: (Seq[Type], IR, IR, IR, Int) => IR
+    f: (IndexedSeq[Type], Atom, Atom, Atom, Int) => IR
   ): Unit =
     registerIR(name, ArraySeq(mt1, mt2, mt3), returnType, typeParameters = typeParameters) {
       case (t, Seq(a1, a2, a3), errorID) => f(t, a1, a2, a3, errorID)
-    }
-
-  def registerIR4(
-    name: String,
-    mt1: Type,
-    mt2: Type,
-    mt3: Type,
-    mt4: Type,
-    returnType: Type,
-    typeParameters: IndexedSeq[Type] = ArraySeq.empty,
-  )(
-    f: (Seq[Type], IR, IR, IR, IR, Int) => IR
-  ): Unit =
-    registerIR(name, ArraySeq(mt1, mt2, mt3, mt4), returnType, typeParameters = typeParameters) {
-      case (t, Seq(a1, a2, a3, a4), errorID) => f(t, a1, a2, a3, a4, errorID)
     }
 }
 
 sealed abstract class JVMFunction {
   def name: String
 
-  def typeParameters: Seq[Type]
+  def typeParameters: IndexedSeq[Type]
 
-  def valueParameterTypes: Seq[Type]
+  def valueParameterTypes: IndexedSeq[Type]
 
   def returnType: Type
 
-  def computeReturnEmitType(returnType: Type, valueParameterTypes: Seq[EmitType]): EmitType
+  def computeReturnEmitType(returnType: Type, valueParameterTypes: IndexedSeq[EmitType]): EmitType
 
   def apply(
     mb: EmitMethodBuilder[_],
     region: Value[Region],
     returnType: SType,
-    typeParameters: Seq[Type],
+    typeParameters: IndexedSeq[Type],
     errorID: Value[Int],
     args: EmitCode*
   ): EmitCode
@@ -1231,8 +1235,11 @@ sealed abstract class JVMFunction {
   override def toString: String =
     s"$name[${typeParameters.mkString(", ")}](${valueParameterTypes.mkString(", ")}): $returnType"
 
-  def unify(typeArguments: Seq[Type], valueArgumentTypes: Seq[Type], returnTypeIn: Type)
-    : Boolean = {
+  def unify(
+    typeArguments: IndexedSeq[Type],
+    valueArgumentTypes: IndexedSeq[Type],
+    returnTypeIn: Type,
+  ): Boolean = {
     val concrete = (typeArguments ++ valueArgumentTypes) :+ returnTypeIn
     val types = (typeParameters ++ valueParameterTypes) :+ returnType
     types.length == concrete.length && {
@@ -1244,10 +1251,10 @@ sealed abstract class JVMFunction {
 
 object MissingnessObliviousJVMFunction {
   def returnSType(
-    computeStrictReturnEmitType: (Type, Seq[SType]) => SType
+    computeStrictReturnEmitType: (Type, IndexedSeq[SType]) => SType
   )(
     returnType: Type,
-    valueParameterTypes: Seq[SType],
+    valueParameterTypes: IndexedSeq[SType],
   ): SType =
     if (computeStrictReturnEmitType == null)
       SType.canonical(returnType)
@@ -1257,19 +1264,19 @@ object MissingnessObliviousJVMFunction {
 
 abstract class UnseededMissingnessObliviousJVMFunction(
   override val name: String,
-  override val typeParameters: Seq[Type],
-  override val valueParameterTypes: Seq[Type],
+  override val typeParameters: IndexedSeq[Type],
+  override val valueParameterTypes: IndexedSeq[Type],
   override val returnType: Type,
-  missingnessObliviousComputeReturnType: (Type, Seq[SType]) => SType,
+  missingnessObliviousComputeReturnType: (Type, IndexedSeq[SType]) => SType,
 ) extends JVMFunction {
-  override def computeReturnEmitType(returnType: Type, valueParameterTypes: Seq[EmitType])
+  override def computeReturnEmitType(returnType: Type, valueParameterTypes: IndexedSeq[EmitType])
     : EmitType =
     EmitType(
       computeStrictReturnEmitType(returnType, valueParameterTypes.map(_.st)),
       valueParameterTypes.forall(_.required),
     )
 
-  def computeStrictReturnEmitType(returnType: Type, valueParameterTypes: Seq[SType]): SType =
+  def computeStrictReturnEmitType(returnType: Type, valueParameterTypes: IndexedSeq[SType]): SType =
     MissingnessObliviousJVMFunction.returnSType(missingnessObliviousComputeReturnType)(
       returnType,
       valueParameterTypes,
@@ -1279,7 +1286,7 @@ abstract class UnseededMissingnessObliviousJVMFunction(
     r: Value[Region],
     cb: EmitCodeBuilder,
     returnSType: SType,
-    typeParameters: Seq[Type],
+    typeParameters: IndexedSeq[Type],
     errorID: Value[Int],
     args: SValue*
   ): SValue
@@ -1288,7 +1295,7 @@ abstract class UnseededMissingnessObliviousJVMFunction(
     mb: EmitMethodBuilder[_],
     region: Value[Region],
     returnType: SType,
-    typeParameters: Seq[Type],
+    typeParameters: IndexedSeq[Type],
     errorID: Value[Int],
     args: EmitCode*
   ): EmitCode =
@@ -1302,7 +1309,7 @@ abstract class UnseededMissingnessObliviousJVMFunction(
     r: Value[Region],
     cb: EmitCodeBuilder,
     returnType: SType,
-    typeParameters: Seq[Type],
+    typeParameters: IndexedSeq[Type],
     errorID: Value[Int],
     args: EmitCode*
   ): IEmitCode =
@@ -1310,9 +1317,13 @@ abstract class UnseededMissingnessObliviousJVMFunction(
       apply(r, cb, returnType, typeParameters, errorID, args: _*)
     }
 
-  def getAsMethod[C](cb: EmitClassBuilder[C], rpt: SType, typeParameters: Seq[Type], args: SType*)
-    : EmitMethodBuilder[C] = {
-    val unified = unify(typeParameters, args.map(_.virtualType), rpt.virtualType)
+  def getAsMethod[C](
+    cb: EmitClassBuilder[C],
+    rpt: SType,
+    typeParameters: IndexedSeq[Type],
+    args: SType*
+  ): EmitMethodBuilder[C] = {
+    val unified = unify(typeParameters, args.map(_.virtualType).toFastSeq, rpt.virtualType)
     assert(unified, name)
     val methodbuilder = cb.genEmitMethod(
       name,
@@ -1335,10 +1346,10 @@ abstract class UnseededMissingnessObliviousJVMFunction(
 
 object MissingnessAwareJVMFunction {
   def returnSType(
-    calculateReturnType: (Type, Seq[EmitType]) => EmitType
+    calculateReturnType: (Type, IndexedSeq[EmitType]) => EmitType
   )(
     returnType: Type,
-    valueParameterTypes: Seq[EmitType],
+    valueParameterTypes: IndexedSeq[EmitType],
   ): EmitType =
     if (calculateReturnType == null) EmitType(SType.canonical(returnType), false)
     else calculateReturnType(returnType, valueParameterTypes)
@@ -1346,12 +1357,12 @@ object MissingnessAwareJVMFunction {
 
 abstract class UnseededMissingnessAwareJVMFunction(
   override val name: String,
-  override val typeParameters: Seq[Type],
-  override val valueParameterTypes: Seq[Type],
+  override val typeParameters: IndexedSeq[Type],
+  override val valueParameterTypes: IndexedSeq[Type],
   override val returnType: Type,
-  missingnessAwareComputeReturnSType: (Type, Seq[EmitType]) => EmitType,
+  missingnessAwareComputeReturnSType: (Type, IndexedSeq[EmitType]) => EmitType,
 ) extends JVMFunction {
-  override def computeReturnEmitType(returnType: Type, valueParameterTypes: Seq[EmitType])
+  override def computeReturnEmitType(returnType: Type, valueParameterTypes: IndexedSeq[EmitType])
     : EmitType =
     MissingnessAwareJVMFunction.returnSType(missingnessAwareComputeReturnSType)(
       returnType,
@@ -1362,7 +1373,7 @@ abstract class UnseededMissingnessAwareJVMFunction(
     cb: EmitCodeBuilder,
     r: Value[Region],
     rpt: SType,
-    typeParameters: Seq[Type],
+    typeParameters: IndexedSeq[Type],
     errorID: Value[Int],
     args: EmitCode*
   ): IEmitCode =

--- a/hail/hail/src/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/SetFunctions.scala
@@ -1,24 +1,20 @@
 package is.hail.expr.ir.functions
 
-import is.hail.collection.FastSeq
-import is.hail.expr.ir._
+import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.expr.ir.{Memoized => M, _}
 import is.hail.expr.ir.defs._
 import is.hail.types.virtual._
 
 object SetFunctions extends RegistryFunctions {
-  def contains(set: IR, elem: IR) = {
-    If(
-      IsNA(set),
-      NA(TBoolean),
-      bindIR(LowerBoundOnOrderedCollection(set, elem, onKey = false)) { i =>
-        If(
-          i.ceq(ArrayLen(CastToArray(set))),
-          False(),
-          ApplyComparisonOp(EQWithNA, ArrayRef(CastToArray(set), i), elem),
-        )
-      },
-    )
-  }
+  def contains(set: Atom, elem: Atom): IR =
+    guardIR(!IsNA(set)) {
+      M.eval {
+        for {
+          i <- LowerBoundOnOrderedCollection(set, elem, onKey = false)
+          a <- CastToArray(set)
+        } yield (i < ArrayLen(a)) && (ArrayRef(a, i) ceq elem)
+      }
+    }
 
   override def registerAll(): Unit = {
     registerIR1("toSet", TArray(tv("T")), TSet(tv("T")))((_, a, _) => ToSet(ToStream(a)))
@@ -34,22 +30,17 @@ object SetFunctions extends RegistryFunctions {
     }
 
     registerIR2("add", TSet(tv("T")), tv("T"), TSet(tv("T"))) { (_, s, v, _) =>
-      val t = v.typ
       ToSet(
-        flatMapIR(MakeStream(
-          FastSeq(CastToArray(s), MakeArray(FastSeq(v), TArray(t))),
-          TStream(TArray(t)),
-        ))(ToStream(_))
+        flatten(MakeStream(
+          ArraySeq(CastToArray(s), MakeArray(v)),
+          TStream(TArray(v.typ)),
+        ))
       )
     }
 
     registerIR2("union", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2, _) =>
       val t = s1.typ.asInstanceOf[TSet].elementType
-      ToSet(
-        flatMapIR(
-          MakeStream(FastSeq(CastToArray(s1), CastToArray(s2)), TStream(TArray(t)))
-        )(ToStream(_))
-      )
+      ToSet(flatten(MakeStream(ArraySeq(CastToArray(s1), CastToArray(s2)), TStream(TArray(t)))))
     }
 
     registerIR2("intersection", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2, _) =>
@@ -57,21 +48,29 @@ object SetFunctions extends RegistryFunctions {
     }
 
     registerIR2("difference", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2, _) =>
-      ToSet(
-        filterIR(ToStream(s1))(x => ApplyUnaryPrimOp(Bang, contains(s2, x)))
-      )
+      ToSet(filterIR(ToStream(s1))(!contains(s2, _)))
     }
 
-    registerIR2("isSubset", TSet(tv("T")), TSet(tv("T")), TBoolean) { (_, s, w, errorID) =>
-      foldIR(ToStream(s), True()) { (a, x) =>
-        // FIXME short circuit
-        ApplySpecial(
-          "land",
-          FastSeq(),
-          FastSeq(a, contains(w, x)),
-          TBoolean,
-          errorID,
-        )
+    registerIR2("isSubset", TSet(tv("T")), TSet(tv("T")), TBoolean) { (_, s, w, _) =>
+      guardIR(!(IsNA(s) || IsNA(w))) {
+        M.eval {
+          for {
+            sArray <- CastToArray(s)
+            sLen <- ArrayLen(sArray)
+            wArray <- CastToArray(w)
+            wLen <- ArrayLen(wArray)
+          } yield (sLen <= wLen) && tailLoop(TBoolean, 0) { case (recur, Seq(i)) =>
+            val isElem =
+              M.eval {
+                for {
+                  elem <- ArrayRef(sArray, i)
+                  j <- LowerBoundOnOrderedCollection(wArray, elem, onKey = false)
+                } yield (j < wLen) && (ArrayRef(wArray, j) ceq elem)
+              }
+
+            If(i >= sLen, True(), If(isElem, recur(ArraySeq(i + 1)), False()))
+          }
+        }
       }
     }
 
@@ -80,25 +79,28 @@ object SetFunctions extends RegistryFunctions {
       def div(a: IR, b: IR): IR = ApplyBinaryPrimOp(BinaryOp.defaultDivideOp(t), a, b)
 
       bindIR(CastToArray(s)) { a =>
-        def ref(i: IR) = ArrayRef(a, i)
-        def len: IR = ArrayLen(a)
-        If(
-          IsNA(a),
-          NA(t),
-          bindIR(If(len.ceq(0), len, If(IsNA(ref(len - 1)), len - 1, len))) { size =>
-            val lastIdx = size - 1
-            val midIdx = lastIdx.floorDiv(2)
-            If(
-              size.ceq(0),
-              NA(t),
-              If(
-                invoke("mod", TInt32, size, 2).cne(0),
-                ref(midIdx), // odd number of non-missing elements
-                div(ref(midIdx) + ref(midIdx + 1), Cast(2, t)),
-              ),
-            )
-          },
-        )
+        bindIR(ArrayLen(a)) { len =>
+          def ref(i: IR) = ArrayRef(a, i)
+          If(
+            IsNA(a) || (len ceq 0),
+            NA(t),
+            bindIR(len - 1) { lastIdx =>
+              bindIR(If(IsNA(ref(lastIdx)), lastIdx, len)) { size =>
+                If(
+                  size ceq 0,
+                  NA(t),
+                  bindIR((size - 1) floorDiv 2) { midIdx =>
+                    If(
+                      invoke("mod", TInt32, size, 2) cne 0,
+                      ref(midIdx), // odd number of non-missing elements
+                      div(ref(midIdx) + ref(midIdx + 1), Cast(2, t)),
+                    )
+                  },
+                )
+              }
+            },
+          )
+        }
       }
     }
   }

--- a/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -4,7 +4,6 @@ import is.hail.annotations.Region
 import is.hail.asm4s.{coerce => _, _}
 import is.hail.backend.HailStateManager
 import is.hail.expr.ir._
-import is.hail.expr.ir.defs._
 import is.hail.io.fs.FS
 import is.hail.io.vcf.{LoadVCF, VCFHeaderInfo}
 import is.hail.types.physical.stypes._
@@ -188,10 +187,6 @@ object UtilFunctions extends RegistryFunctions {
   def nanmax_ignore_missing(l: Double, lMissing: Boolean, r: Double, rMissing: Boolean): Double =
     if (lMissing) r else if (rMissing) l else nanmax(l, r)
 
-  def intMin(a: IR, b: IR): IR = If(ApplyComparisonOp(LT, a, b), a, b)
-
-  def intMax(a: IR, b: IR): IR = If(ApplyComparisonOp(GT, a, b), a, b)
-
   def format(f: String, args: Row): String =
     try
       String.format(f, args.toSeq.map(_.asInstanceOf[java.lang.Object]): _*)
@@ -309,8 +304,8 @@ object UtilFunctions extends RegistryFunctions {
     }
 
     Array(TInt32, TInt64).foreach { t =>
-      registerIR2("min", t, t, t)((_, a, b, _) => intMin(a, b))
-      registerIR2("max", t, t, t)((_, a, b, _) => intMax(a, b))
+      registerIR2("min", t, t, t)((_, a, b, _) => minIR(a, b))
+      registerIR2("max", t, t, t)((_, a, b, _) => maxIR(a, b))
     }
 
     Array("min", "max").foreach { name =>

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -252,7 +252,13 @@ class DynamicSparseContexts(
     val startPos = ArrayRef(rowPos, col)
     val endPos = ArrayRef(rowPos, col + 1)
     bindIR(
-      Apply("lowerBound", Seq(), FastSeq(rowIdx, row, startPos, endPos), TInt32, ErrorIDs.NO_ERROR)
+      Apply(
+        "lowerBound",
+        ArraySeq(),
+        FastSeq(rowIdx, row, startPos, endPos),
+        TInt32,
+        ErrorIDs.NO_ERROR,
+      )
     ) { pos =>
       If(
         ArrayRef(rowIdx, pos).ceq(row),

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -6,8 +6,9 @@ import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir._
+import is.hail.expr.ir.{Memoized => M}
 import is.hail.expr.ir.defs._
-import is.hail.expr.ir.functions.{ArrayFunctions, UtilFunctions}
+import is.hail.expr.ir.functions.ArrayFunctions
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.rvd.RVDPartitioner
 import is.hail.sparkextras.implicits.toRichRow
@@ -378,18 +379,17 @@ object LowerDistributedSort extends Logging {
             }) { case (left, right) =>
               ApplyComparisonOp(StructLT(sortFields), left, right)
             }
-            val minArray = MakeArray(GetField(aggResults, "min"))
-            val maxArray = MakeArray(GetField(aggResults, "max"))
+
             val tuplesInSortedOrder =
               tuplesAreSorted(GetField(aggResults, "perPartIntervalTuples"), sortFields)
             bindIR(sortedOversampling) { sortedOversampling =>
               bindIR(ArrayLen(sortedOversampling)) { numSamples =>
                 val sortedSampling = bindIR(
                   /* calculate a 'good' branch factor based on part sizes */
-                  UtilFunctions.intMax(
+                  maxIR(
                     I32(2),
-                    UtilFunctions.intMin(
-                      UtilFunctions.intMin(numSamples, I32(defaultBranchingFactor)),
+                    minIR(
+                      minIR(numSamples, I32(defaultBranchingFactor)),
                       (I64(2L) * GetField(aggResults, "byteSize").floorDiv(
                         I64(sizeCutoff.toLong)
                       )).toI,
@@ -421,13 +421,16 @@ object LowerDistributedSort extends Logging {
                   })
                 }
                 MakeStruct(FastSeq(
-                  "pivotsWithEndpoints" -> ArrayFunctions.extend(
-                    ArrayFunctions.extend(minArray, sortedSampling),
-                    maxArray,
-                  ),
+                  "pivotsWithEndpoints" ->
+                    M.eval {
+                      for {
+                        mins <- MakeArray(GetField(aggResults, "min"))
+                        prefix <- ArrayFunctions.extend(mins, sortedSampling)
+                      } yield ArrayFunctions.extend(prefix, MakeArray(GetField(aggResults, "max")))
+                    },
                   "isSorted" -> ApplySpecial(
                     "land",
-                    Seq.empty[Type],
+                    ArraySeq.empty[Type],
                     FastSeq(GetField(aggResults, "eachPartSorted"), tuplesInSortedOrder),
                     TBoolean,
                     ErrorIDs.NO_ERROR,
@@ -924,7 +927,7 @@ object LowerDistributedSort extends Logging {
       },
       True(),
     ) { case (accum, elt) =>
-      ApplySpecial("land", Seq.empty[Type], FastSeq(accum, elt), TBoolean, ErrorIDs.NO_ERROR)
+      ApplySpecial("land", ArraySeq.empty[Type], FastSeq(accum, elt), TBoolean, ErrorIDs.NO_ERROR)
     }
   }
 }

--- a/hail/hail/src/is/hail/expr/ir/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/package.scala
@@ -54,15 +54,17 @@ package object ir extends CompileOps with LowerPriorityImplicits {
       If(IsNA(pred), False(), pred)
     }
 
-  def invoke(name: String, rt: Type, typeArgs: Seq[Type], errorID: Int, args: IR*): IR =
-    IRFunctionRegistry.lookup(name, rt, typeArgs, args.map(_.typ)) match {
-      case Some(f) => f(args, errorID)
+  def invoke(name: String, rt: Type, typeArgs: IndexedSeq[Type], errorID: Int, args: IR*): IR = {
+    val argSeq = args.toFastSeq
+    IRFunctionRegistry.lookup(name, rt, typeArgs, argSeq.map(_.typ)) match {
+      case Some(f) => f(argSeq, errorID)
       case None => fatal(
           s"no conversion found for $name[${typeArgs.mkString(", ")}](${args.map(_.typ).mkString(", ")}) => $rt"
         )
     }
+  }
 
-  def invoke(name: String, rt: Type, typeArgs: Seq[Type], args: IR*): IR =
+  def invoke(name: String, rt: Type, typeArgs: IndexedSeq[Type], args: IR*): IR =
     invoke(name, rt, typeArgs, ErrorIDs.NO_ERROR, args: _*)
 
   def invoke(name: String, rt: Type, args: IR*): IR =
@@ -92,12 +94,14 @@ package object ir extends CompileOps with LowerPriorityImplicits {
   }
 
   def bindIRs(values: IR*)(body: IndexedSeq[Atom] => IR): IR = {
-    val bindings = values.toFastSeq.map(freshName() -> _)
-    Let(bindings, body(bindings.map(b => Ref(b._1, b._2.typ))))
+    val bindings = values.toFastSeq.map(expr => Binding(freshName(), expr, Scope.EVAL))
+    Block(bindings, body(bindings.map(b => Ref(b.name, b.value.typ))))
   }
 
-  def bindIR(v: IR)(body: Atom => IR): IR =
-    bindIRs(v) { case Seq(ref) => body(ref) }
+  def bindIR(v: IR)(body: Atom => IR): IR = {
+    val ref = Ref(freshName(), v.typ)
+    new Block(ArraySeq(Binding(ref.name, v, Scope.EVAL)), body(ref))
+  }
 
   def relationalBindIR(v: IR)(body: Atom => IR): IR = {
     val ref = RelationalRef(freshName(), v.typ)
@@ -151,6 +155,15 @@ package object ir extends CompileOps with LowerPriorityImplicits {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
     StreamFilter(stream, ref.name, f(ref))
   }
+
+  def maybeIR(ir: IR)(f: Atom => IR): IR =
+    bindIR(ir) { a =>
+      val r = f(a)
+      If(IsNA(a), NA(r.typ), r)
+    }
+
+  def guardIR(condition: IR)(body: IR): IR =
+    If(condition, body, NA(body.typ))
 
   def mapIR(stream: IR)(f: Atom => IR): IR = {
     val ref = Ref(freshName(), tcoerce[TStream](stream.typ).elementType)
@@ -441,24 +454,14 @@ package object ir extends CompileOps with LowerPriorityImplicits {
 
   def strConcat(irs: AnyRef*): IR = {
     assert(irs.nonEmpty)
-    var s: IR = null
-    irs.foreach { xAny =>
-      val x = xAny match {
-        case x: IR => x
-        case x: String => Str(x)
+
+    def str(x: AnyRef): IR =
+      x match {
+        case s: String => Str(s)
+        case ir: IR => if (ir.typ == TString) ir else invoke("str", TString, ir)
       }
 
-      val xstr = if (x.typ == TString)
-        x
-      else
-        invoke("str", TString, x)
-
-      if (s == null)
-        s = xstr
-      else
-        s = invoke("concat", TString, s, xstr)
-    }
-    s
+    irs.tail.foldLeft(str(irs.head))(_ + str(_))
   }
 
   def logIR(result: IR, messages: AnyRef*): IR = ConsoleLog(strConcat(messages: _*), result)

--- a/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/FunctionSuite.scala
@@ -86,22 +86,22 @@ class FunctionSuite extends HailSuite {
     assert(IRFunctionRegistry.lookup(
       "testCodeUnification",
       TInt32,
-      Seq(TInt32, TInt32),
+      ArraySeq(TInt32, TInt32),
     ).isDefined)
     assert(IRFunctionRegistry.lookup(
       "testCodeUnification",
       TInt32,
-      Seq(TInt64, TInt32),
+      ArraySeq(TInt64, TInt32),
     ).isEmpty)
     assert(IRFunctionRegistry.lookup(
       "testCodeUnification",
       TInt64,
-      Seq(TInt32, TInt32),
+      ArraySeq(TInt32, TInt32),
     ).isEmpty)
     assert(IRFunctionRegistry.lookup(
       "testCodeUnification2",
       TArray(TInt32),
-      Seq(TArray(TInt32)),
+      ArraySeq(TArray(TInt32)),
     ).isDefined)
   }
 

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -4268,7 +4268,7 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testSimpleTailLoop(): Unit = {
-    implicit val execStrats = ExecStrategy.compileOnly
+    implicit val execStrats = ExecStrategy.javaOnly
     val triangleSum: IR =
       tailLoop(TInt32, In(0, TInt32), In(1, TInt32)) { case (recur, Seq(x, accum)) =>
         If(x <= 0, accum, recur(FastSeq(x - 1, accum + x)))
@@ -4280,7 +4280,7 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testNestedTailLoop(): Unit = {
-    implicit val execStrats = ExecStrategy.compileOnly
+    implicit val execStrats = ExecStrategy.javaOnly
     val triangleSum: IR = tailLoop(TInt32, In(0, TInt32), I32(0)) { case (recur, Seq(x, accum)) =>
       If(
         x <= 0,

--- a/hail/hail/test/src/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -6,7 +6,7 @@ import is.hail.expr.ir.TestUtils._
 import is.hail.expr.ir.defs.{I32, NA, ToSet, ToStream}
 import is.hail.types.virtual._
 
-import org.testng.annotations.Test
+import org.testng.annotations.{DataProvider, Test}
 
 class SetFunctionsSuite extends HailSuite {
   val naa = NA(TArray(TInt32))
@@ -63,24 +63,22 @@ class SetFunctionsSuite extends HailSuite {
     assertEvalsTo(invoke("add", TSet(TInt32), IRSet(3, 7), NA(TInt32)), Set(null, 3, 7))
   }
 
-  @Test def isSubset(): Unit = {
-    val s = IRSet(3, null, 7)
-    assertEvalsTo(invoke("isSubset", TBoolean, s, invoke("add", TSet(TInt32), s, I32(4))), true)
-    assertEvalsTo(
-      invoke(
-        "isSubset",
-        TBoolean,
-        IRSet(3, 7),
-        invoke("add", TSet(TInt32), IRSet(3, 7), NA(TInt32)),
-      ),
-      true,
+  @DataProvider(name = "IsSubset")
+  def dataIsSubset: Array[Array[Any]] =
+    Array(
+      Array(IRSet(), IRSet(), true),
+      Array(IRSet(1), IRSet(1), true),
+      Array(IRSet(3, null, 7), IRSet(3, null, 7), true),
+      Array(IRSet(3, null, 7), IRSet(3, null, 7, 11), true),
+      Array(IRSet(1, 2, 3), IRSet(1, 2, 4), false),
+      Array(IRSet(1, 2, 3), NA(TSet(TInt32)), null),
+      Array(NA(TSet(TInt32)), IRSet(1, 2, 3), null),
+      Array(NA(TSet(TInt32)), NA(TSet(TInt32)), null),
     )
-    assertEvalsTo(invoke("isSubset", TBoolean, s, invoke("remove", TSet(TInt32), s, I32(3))), false)
-    assertEvalsTo(
-      invoke("isSubset", TBoolean, s, invoke("remove", TSet(TInt32), s, NA(TInt32))),
-      false,
-    )
-  }
+
+  @Test(dataProvider = "IsSubset")
+  def testIsSubset(a: IR, b: IR, isSubset: Any): Unit =
+    assertEvalsTo(invoke("isSubset", TBoolean, a, b), isSubset)
 
   @Test def union(): Unit = {
     assertEvalsTo(invoke("union", TSet(TInt32), IRSet(3, null, 7), IRSet(3, 8)), Set(null, 3, 7, 8))


### PR DESCRIPTION
Partially resolves #13250
Succeeds #15449

This change is one in a series that aims to preserve the TreeIR invariant
throught the various lowerings, culminating in the removal of noSharing.

In this change, IR function implementations:
- use Atoms as parameters
- use IndexedSeq instead of Seq
- fallout in LowerDistibutedSort is addressed

This change does not affect the broad-managed batch service in gcp.