### PR TITLE
[git] ignore riptide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ services/ui/dist/
 services/ui/node_modules/
 **/static/compiled-js/
 .playwright-mcp/
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/


### PR DESCRIPTION
## Change Description

Auto-generated gitignore update from riptide

Note: in the meantime it's also possible to do this with a personal global gitignore file:

```
touch ~/.gitignore_global
vim ~/.gitignore_global # ... and add content
git config --global core.excludesfile ~/.gitignore_global
```

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP