### PR TITLE
[query] get pytests to work w/ batch backend

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1189,7 +1189,7 @@ steps:
       - download_mill_and_maven_deps
   - kind: runImage
     name: test_hail_python
-    numSplits: 28
+    numSplits: 22
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -1361,7 +1361,7 @@ steps:
       - gcp
   - kind: runImage
     name: test_hail_python_local_backend
-    numSplits: 48
+    numSplits: 22
     image:
       valueFrom: hail_run_image.image
     resources:

--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -141,7 +141,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
     val inputURL = argv(5)
     val outputURL = argv(6)
 
-    logger.info(f"${getClass.getName} $PrettyVersion")
+    logger.info(f"Hail $PrettyVersion")
 
     sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 

--- a/hail/hail/src/is/hail/backend/service/Worker.scala
+++ b/hail/hail/src/is/hail/backend/service/Worker.scala
@@ -1,6 +1,6 @@
 package is.hail.backend.service
 
-import is.hail.Revision
+import is.hail.PrettyVersion
 import is.hail.asm4s._
 import is.hail.backend.Backend.PartitionFn
 import is.hail.backend.HailTaskContext
@@ -176,7 +176,7 @@ object Worker extends Logging {
 
     sys.env.get("HAIL_SSL_CONFIG_DIR").foreach(tls.setSSLConfigFromDir)
 
-    logger.info(s"${getClass.getName} $Revision")
+    logger.info(s"Hail $PrettyVersion")
     logger.info(s"running partition $partition root '$root' with scratch directory '$scratchDir'")
 
     timer.start(s"partition $partition")

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -64,11 +64,7 @@ def pytest_collection_modifyitems(items):
             continue
 
         init_fixture_name, priority = (
-            ('uninitialized', 0)
-            if item.get_closest_marker('uninitialized') is not None
-            else ('init_query_on_batch', 1)
-            if backend == 'batch'
-            else ('init_hail', 1)
+            ('uninitialized', 0) if item.get_closest_marker('uninitialized') is not None else ('init_hail', 1)
         )
 
         item.fixturenames.insert(0, init_fixture_name)
@@ -87,29 +83,30 @@ def uninitialized():
         hl_stop_for_test()
 
 
-@pytest.fixture(scope='session')
+def init_hail_scope(fixture_name, config):
+    return 'function' if choose_backend() == 'batch' else 'session'
+
+
+@pytest.fixture(scope=init_hail_scope)
 def init_hail(request):
-    hl_init_for_test(app_name=request.node.name)
+    backend = choose_backend()
+    hl_init_for_test(backend=backend, app_name=request.node.name)
     try:
         yield
     finally:
-        hl_stop_for_test()
-
-
-@pytest.fixture
-def init_query_on_batch(request):
-    hl_stop_for_test()
-    hl_init_for_test(backend='batch', app_name=request.node.name)
-    try:
-        yield
-    finally:
-        new_backend = current_backend()
-        assert isinstance(new_backend, ServiceBackend)
-        batch = new_backend._batch
-        report: Dict[str, CollectReport] = request.node.stash[test_results_key]
-        if any(r.failed for r in report.values()):
-            log.info(f'cancelling failed test batch {batch.id}')
-            hail_event_loop().run_until_complete(batch.cancel())
+        if backend == 'batch':
+            try:
+                new_backend = current_backend()
+                assert isinstance(new_backend, ServiceBackend)
+                batch = new_backend._batch
+                report: Dict[str, CollectReport] = request.node.stash[test_results_key]
+                if any(r.failed for r in report.values()):
+                    log.info(f'cancelling failed test batch {batch.id}')
+                    hail_event_loop().run_until_complete(batch.cancel())
+            finally:
+                hl_stop_for_test()
+        else:
+            hl_stop_for_test()
 
 
 @pytest.fixture(autouse=True)

--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -1,11 +1,12 @@
 import pytest
 
 import hail as hl
+from test.hail.conftest import init_hail_scope
 
 
 class TestAnnotationDB:
-    @pytest.fixture(scope="class")
-    def db_json(self):
+    @pytest.fixture(scope=init_hail_scope)
+    def db_json(self, init_hail):
         t = hl.utils.genomic_range_table(10)
         t = t.annotate(annotation=hl.str(t.locus.position - 1))
         tempdir_manager = hl.TemporaryDirectory()

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -13,6 +13,7 @@ from ..helpers import (
     fails_service_backend,
     qobtest,
     resource,
+    skip_when_service_backend,
     test_timeout,
 )
 
@@ -105,6 +106,7 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(annotated.mean_stats.binary, 0.965, places=3)
         self.assertAlmostEqual(annotated.mean_stats.continuous, 176.528, places=3)
 
+    @skip_when_service_backend
     @test_timeout(local=8 * 60, batch=8 * 60)
     def test_plot_roc_curve(self):
         x = hl.utils.range_table(100).annotate(score1=hl.rand_norm(), score2=hl.rand_norm())

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -13,6 +13,7 @@ from hail import ir
 from hail.expr.functions import _cdf_combine, _error_from_cdf, _result_from_raw_cdf
 from hail.expr.types import tarray, tbool, tcall, tfloat, tfloat32, tfloat64, tint, tint32, tint64, tstr, tstruct
 
+from ..conftest import init_hail_scope
 from ..helpers import assert_evals_to, convert_struct_to_dict, qobtest, resource, test_timeout, with_flags
 
 
@@ -4223,8 +4224,8 @@ def cdf_max_observed_error(cdf):
     return rank_error / cdf.ranks[-1]
 
 
-@pytest.fixture(scope='module', params=(True, False))
-def cdf_test_data(request):
+@pytest.fixture(scope=init_hail_scope, params=(True, False))
+def cdf_test_data(request, init_hail):
     with hl.TemporaryDirectory(ensure_exists=False) as f:
         if request.param:
             t = hl.utils.range_table(1_000_000)

--- a/hail/python/test/hail/fs/test_worker_driver_fs.py
+++ b/hail/python/test/hail/fs/test_worker_driver_fs.py
@@ -4,7 +4,9 @@ import os
 import pytest
 
 import hail as hl
+from hail.utils.java import Env, FatalError
 from hailtop.aiocloud.aioazure import AzureAsyncFS
+from hailtop.httpx import ClientResponseError
 from hailtop.test_utils import run_if_azure, skip_in_azure
 from hailtop.utils import secret_alnum_string
 
@@ -12,27 +14,23 @@ from ..helpers import fails_local_backend, hl_init_for_test, resource, test_time
 
 
 @skip_in_azure
+@pytest.mark.uninitialized
 def test_requester_pays_no_settings():
-    try:
+    with pytest.raises(FatalError, match='Bucket is a requester pays bucket but no user project provided'):
+        hl_init_for_test(gcs_requester_pays_configuration=None)
         hl.import_table('gs://hail-test-requester-pays-fds32/hello')
-    except Exception as exc:
-        assert "Bucket is a requester pays bucket but no user project provided" in str(exc)
-    else:
-        assert False
 
 
 @skip_in_azure
+@pytest.mark.uninitialized
 def test_requester_pays_write_no_settings():
-    random_filename = 'gs://hail-test-requester-pays-fds32/test_requester_pays_on_worker_driver_' + secret_alnum_string(
-        10
-    )
-    try:
+    with pytest.raises(ClientResponseError, match='Bucket is a requester pays bucket but no user project provided'):
+        hl_init_for_test(gcs_requester_pays_configuration=None)
+        random_filename = (
+            'gs://hail-test-requester-pays-fds32/test_requester_pays_on_worker_driver_' + secret_alnum_string(10)
+        )
         hl.utils.range_table(4, n_partitions=4).write(random_filename, overwrite=True)
-    except Exception as exc:
-        assert "Bucket is a requester pays bucket but no user project provided" in str(exc)
-    else:
-        hl.current_backend().fs.rmtree(random_filename)
-        assert False
+        Env.fs().rmtree(random_filename)
 
 
 @skip_in_azure

--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -6,6 +6,7 @@ import pytest
 import hail as hl
 from hail.utils.java import Env, scala_object
 
+from ..conftest import init_hail_scope
 from ..helpers import (
     create_all_values_datasets,
     create_all_values_matrix_table,
@@ -44,12 +45,12 @@ def test_write():
     create_backward_compatibility_files()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope=init_hail_scope)
 def all_values_matrix_table_fixture(init_hail):
     return create_all_values_matrix_table()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope=init_hail_scope)
 def all_values_table_fixture(init_hail):
     return create_all_values_table()
 

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -2378,7 +2378,10 @@ def test_struct_of_arrays_encoding():
         out_path = new_temp_file(extension='mt')
         mt = std_mt.checkpoint(out_path)
         md_path = os.path.join(out_path, 'entries/rows/metadata.json.gz')
-        with gzip.open(md_path) as md_file:
+        with (
+            Env.fs().open(md_path, 'rb') as f,
+            gzip.open(f) as md_file,
+        ):
             md = json.load(md_file)
         etype = md['_codecSpec']['_eType']
         assert 'EStructOfArrays' in etype

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -12,6 +12,7 @@ from hail import ExpressionException, ir
 from hail.utils import new_temp_file
 from hail.utils.java import Env
 
+from ..conftest import init_hail_scope
 from ..helpers import (
     assert_time,
     convert_struct_to_dict,
@@ -569,24 +570,26 @@ class Tests(unittest.TestCase):
         )
 
     def test_interval_product_join_long_key(self):
-        left = hl.utils.range_table(50, n_partitions=8)
-        intervals = hl.utils.range_table(25)
-        intervals = intervals.key_by(
-            interval=hl.interval(
-                1 + (intervals.idx // 5) * 10 + (intervals.idx % 5), (1 + intervals.idx // 5) * 10 - (intervals.idx % 5)
-            ),
-            k2=1,
-        )
-        intervals = intervals.checkpoint('/tmp/bar.ht', overwrite=True)
-        intervals = intervals.annotate(i=intervals.idx % 5)
-        intervals = intervals.key_by('interval')
-        left = left.annotate(interval_matches=intervals.index(left.idx, all_matches=True))
-        self.assertTrue(
-            left.all(
-                hl.sorted(left.interval_matches.map(lambda x: x.i))
-                == hl.range(0, hl.min(left.idx % 10, 10 - left.idx % 10))
+        with hl.TemporaryDirectory(suffix='.ht', ensure_exists=False) as tmpfile:
+            left = hl.utils.range_table(50, n_partitions=8)
+            intervals = hl.utils.range_table(25)
+            intervals = intervals.key_by(
+                interval=hl.interval(
+                    1 + (intervals.idx // 5) * 10 + (intervals.idx % 5),
+                    (1 + intervals.idx // 5) * 10 - (intervals.idx % 5),
+                ),
+                k2=1,
             )
-        )
+            intervals = intervals.checkpoint(tmpfile)
+            intervals = intervals.annotate(i=intervals.idx % 5)
+            intervals = intervals.key_by('interval')
+            left = left.annotate(interval_matches=intervals.index(left.idx, all_matches=True))
+            self.assertTrue(
+                left.all(
+                    hl.sorted(left.interval_matches.map(lambda x: x.i))
+                    == hl.range(0, hl.min(left.idx % 10, 10 - left.idx % 10))
+                )
+            )
 
     def test_join_with_empty(self):
         kt = hl.utils.range_table(10)
@@ -2625,8 +2628,8 @@ def test_order_by_desc():
     assert t._force_count() == 10_000
 
 
-@pytest.fixture(scope="module")
-def query_table_table():
+@pytest.fixture(scope=init_hail_scope)
+def query_table_table(init_hail):
     path = new_temp_file(extension='ht')
     ht = hl.utils.range_table(200, 10)
     ht = ht.filter(ht.idx % 10 == 0)
@@ -2698,8 +2701,8 @@ def test_query_table_randomness(query_table_table):
     assert len(x.r) == x.n
 
 
-@pytest.fixture(scope="module")
-def compound_key_table():
+@pytest.fixture(scope=init_hail_scope)
+def compound_key_table(init_hail):
     path = new_temp_file(extension='ht')
     ht = hl.utils.range_table(200, 10)
     ht = ht.filter(ht.idx % 10 == 0)
@@ -2719,8 +2722,8 @@ def test_query_table_compound_key(compound_key_table, query, expected):
     assert hl.eval(hl.query_table(compound_key_table, query)) == expected
 
 
-@pytest.fixture(scope="module")
-def interval_key_table():
+@pytest.fixture(scope=init_hail_scope)
+def interval_key_table(init_hail):
     path = new_temp_file(extension='ht')
     ht = hl.utils.range_table(200, 10)
     ht = ht.filter(ht.idx % 10 == 0)

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -19,6 +19,7 @@ from hail.utils.java import FatalError
 from hail.utils.linkedlist import LinkedList
 from hail.utils.misc import escape_id, escape_str
 
+from ..conftest import init_hail_scope
 from ..helpers import fails_local_backend, fails_service_backend, qobtest, resource
 
 
@@ -338,7 +339,7 @@ class Tests(unittest.TestCase):
         )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope=init_hail_scope)
 def glob_tests_directory(init_hail):
     with hl.TemporaryDirectory() as dirname:
         touch(dirname + '/abc/ghi/123')


### PR DESCRIPTION
#15465 is an example of a failure that should have been caught by better batch backend test coverage. Enabling all pytests on the batch backend is prohibitively expensive in both time and money. Short of a better testing strategy, this change makes it _possible_ to run all pytests with the batch backend that have not explicitly been marked skip. 

This change does not affect the broad-managed batch service in gcp.