### PR TITLE
[query] fix requester-pays in batch backend

### DIFF
--- a/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/BatchQueryDriver.scala
@@ -156,7 +156,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
       using(bootstrapFs.openNoCompression(inputURL)) { is =>
         val input = JsonMethods.parse(is)
         (
-          (input \ "rpc_config").extract[ServiceBackendRPCPayload],
+          (input \ "rpc_config").extract[ServiceBackendRPCConfig],
           (input \ "job_config").extract[BatchJobConfig],
           (input \ "action").extract[Int],
           input \ "payload",
@@ -168,7 +168,7 @@ object BatchQueryDriver extends HttpLikeRpc with Logging {
       RouterFS.buildRoutes(
         fsConfig.copy(
           google = fsConfig.google.map(_.copy(
-            requester_pays_config = rpcConfig.requester_pays_conf
+            requester_pays_config = rpcConfig.requester_pays_config
           ))
         )
       )
@@ -252,10 +252,10 @@ private class HailSocketAPIOutputStream(
 
 case class SequenceConfig(fasta: String, index: String)
 
-case class ServiceBackendRPCPayload(
+case class ServiceBackendRPCConfig(
   tmp_dir: String,
   flags: Map[String, String],
-  requester_pays_conf: Option[RequesterPaysConfig],
+  requester_pays_config: Option[RequesterPaysConfig],
   custom_references: Array[String],
   liftovers: Map[String, Map[String, String]],
   sequences: Map[String, SequenceConfig],
@@ -265,11 +265,12 @@ case class ServiceBackendRPCPayload(
 object RequesterPaysConfigFormats
     extends CustomSerializer[RequesterPaysConfig](implicit fmts =>
       (
-        { case JArray(List(project, buckets)) =>
-          RequesterPaysConfig(
-            project = project.extract[String],
-            buckets = buckets.extract[Option[Set[String]]],
-          )
+        {
+          case JArray(List(project, buckets)) =>
+            RequesterPaysConfig(
+              project = project.extract[String],
+              buckets = buckets.extract[Option[Set[String]]],
+            )
         },
         PartialFunction.empty,
       )

--- a/hail/hail/test/src/is/hail/backend/driver/BatchQueryDriverSpec.scala
+++ b/hail/hail/test/src/is/hail/backend/driver/BatchQueryDriverSpec.scala
@@ -1,0 +1,45 @@
+package is.hail.backend.driver
+
+import is.hail.io.fs.RequesterPaysConfig
+
+import org.json4s._
+import org.testng.annotations.{DataProvider, Test}
+
+class BatchQueryDriverSpec {
+
+  @DataProvider(name = "RequesterPaysConfig")
+  def dataRequesterPaysConfig: Array[Array[Any]] =
+    Array(
+      Array(
+        JNull,
+        None,
+      ),
+      Array(
+        JArray(List(JString("my-project"), JNull)),
+        Some(RequesterPaysConfig("my-project", None)),
+      ),
+      Array(
+        JArray(List(JString("my-project"), JArray(List(JString("my-bucket"))))),
+        Some(RequesterPaysConfig("my-project", Some(Set("my-bucket")))),
+      ),
+    )
+
+  @Test(dataProvider = "RequesterPaysConfig")
+  def testRPCConfigDeserializer(rpjson: JValue, expected: Option[RequesterPaysConfig]): Unit = {
+    val rpcConfig: JObject =
+      JObject(
+        "tmp_dir" -> JString("gs://tmp-bucket/tmp/hail"),
+        "flags" -> JObject(),
+        "requester_pays_config" -> rpjson,
+        "custom_references" -> JArray(List()),
+        "liftovers" -> JObject(List()),
+        "sequences" -> JObject(List()),
+        "max_read_parallelism" -> JNull,
+      )
+
+    implicit val fmts: Formats = DefaultFormats + RequesterPaysConfigFormats
+
+    assert(rpcConfig.extract[ServiceBackendRPCConfig].requester_pays_config == expected)
+  }
+
+}


### PR DESCRIPTION
Caused by a typo in the scala implementation of the `ServiceBackendRPCConfig` in #15331.

This change does not affect the broad-managed batch service in gcp.

Fixes #15465