### PR TITLE
[auth] support indirected auth checks with any verb

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -1064,7 +1064,7 @@ async def check_system_permission(request: web.Request, userdata: UserData) -> w
     return json_response({'has_permission': has_permission})
 
 
-@routes.get('/api/v1alpha/verify_system_permission', name='verify_system_permission')
+@routes.route('*', '/api/v1alpha/verify_system_permission', name='verify_system_permission')
 @auth.authenticated_users_only()
 async def verify_system_permission(request: web.Request, userdata: UserData) -> web.Response:
     permission_name = request.query.get('permission')


### PR DESCRIPTION
## Change Description

- Restores access of grafana UI to its data
- Restores post access to developer namespaces

When grafana UI makes POST requests to _get_ grafana data (... 🤦?), we redirect to auth first to `verify_system_permission`, but using the same POST verb, and auth only accepts `GET` permission verifications. So it fails and grafana cannot fetch.

Changing to accept all verbs makes this equivalent to how the old verify_dev_credentials endpoint used to work (but with a specific system permission being checked).

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Allow any http verb to verify system permissions

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
