### PR TITLE
[ci] restore CI test runs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2598,7 +2598,7 @@ steps:
       export GOOGLE_APPLICATION_CREDENTIALS=/test-dev-gsa-key/key.json
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       {% for user in code.get("developers", []) %}
-      {% if user['username'] != 'test-dev' %}
+      {% if user['username'] != 'test-dev' and user['login_id'] is not none %}
       hailctl auth create-user \
         --hail-identity {{ user["hail_identity"] }} \
         --hail-credentials-secret-name {{ user["username"] }}-gsa-key \


### PR DESCRIPTION
## Change Description

- Stops trying to recreate system users (picked up because they have _some_ developer-y roles now) during the CI test `add_developers` step

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

No security impact, test run staging only. But changes `build.yaml` so needs an appsec review anyway please

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
