### PR TITLE
[batch] skip resource ingest (and errors) for DWS type SKUs

### DIFF
--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -378,6 +378,13 @@ async def fetch_prices(
             # therefore, it is safe to skip adding prices for reserved resources.
             continue
 
+        if 'DWS' in sku['description']:
+            # DWS (Dynamic Workload Scheduler) is another example of the same problem as reserved
+            # resources. The hail product names are the same but the SKUs are different. Since we
+            # also don't use DWS, we can skip DWS SKUs too to avoid bringing in the wrong resources
+            # and prices.
+            continue
+
         if 'GPU' in category['resourceGroup']:
             for accelerator_price in process_accelerator_sku(sku, regions):
                 yield accelerator_price


### PR DESCRIPTION
## Change Description

We've been receiving a lot of log errors for "same product name, different SKU". The culprit this time is DWS (Dynamic Workload Scheduler) resources, which is a different way or requesting the same underlying resource with a different SKU. We map them to the same product name as the regular version, then print an error because there's already a product with that name in the DB but a different SKU.

Simple answer is to ignore DWS resources just like we ignore "reserved" resource SKUs, because we don't schedule with DWS either,

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Only impact is deciding not to ingest pricing data from a particular class of GCS resource type.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
