### PR TITLE
[query] Simplify SType primitives infrastructure

### DIFF
--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SJavaArray.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SJavaArray.scala
@@ -68,7 +68,6 @@ final case class SJavaArrayString(elementRequired: Boolean) extends SContainer {
                 cb += (array(i) = elt.asString.loadString(cb))
               },
             )
-          case (false, false) =>
         }
         new SJavaArrayStringValue(this, array)
     }

--- a/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
@@ -52,11 +52,11 @@ final case class SNDArraySlice(pType: PCanonicalNDArray) extends SNDArray {
     new SNDArraySliceSettable(this, shape, strides, dataFirstElementPointer)
   }
 
-  override def fromValues(settables: IndexedSeq[Value[_]]): SNDArraySliceValue = {
-    assert(settables.length == 2 * nDims + 1)
-    val shape = settables.slice(0, nDims).asInstanceOf[IndexedSeq[Value[Long @unchecked]]]
-    val strides = settables.slice(nDims, 2 * nDims).asInstanceOf[IndexedSeq[Value[Long @unchecked]]]
-    val dataFirstElementPointer = settables.last.asInstanceOf[Value[Long]]
+  override def fromValues(values: IndexedSeq[Value[_]]): SNDArraySliceValue = {
+    assert(values.length == 2 * nDims + 1)
+    val shape = values.slice(0, nDims).asInstanceOf[IndexedSeq[Value[Long @unchecked]]]
+    val strides = values.slice(nDims, 2 * nDims).asInstanceOf[IndexedSeq[Value[Long @unchecked]]]
+    val dataFirstElementPointer = values.last.asInstanceOf[Value[Long]]
     new SNDArraySliceValue(this, shape.map(SizeValueDyn.apply), strides, dataFirstElementPointer)
   }
 

--- a/hail/hail/src/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -1,32 +1,16 @@
 package is.hail.types.physical.stypes.primitives
 
-import is.hail.annotations.Region
 import is.hail.asm4s.{BooleanInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.{PBoolean, PType}
-import is.hail.types.physical.stypes.{SSettable, SType, SValue}
+import is.hail.types.physical.stypes.{SSettable, SValue}
 import is.hail.types.virtual.{TBoolean, Type}
 
 case object SBoolean extends SPrimitive {
   override def ti: TypeInfo[_] = BooleanInfo
 
   override lazy val virtualType: Type = TBoolean
-
-  override def castRename(t: Type): SType = this
-
-  override def _coerceOrCopy(
-    cb: EmitCodeBuilder,
-    region: Value[Region],
-    value: SValue,
-    deepCopy: Boolean,
-  ): SValue =
-    value.st match {
-      case SBoolean =>
-        value
-    }
-
-  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(BooleanInfo)
 
   override def fromSettables(settables: IndexedSeq[Settable[_]]): SBooleanSettable = {
     val IndexedSeq(x: Settable[Boolean @unchecked]) = settables

--- a/hail/hail/src/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -1,31 +1,16 @@
 package is.hail.types.physical.stypes.primitives
 
-import is.hail.annotations.Region
 import is.hail.asm4s.{Code, FloatInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.{PFloat32, PType}
-import is.hail.types.physical.stypes.{SSettable, SType, SValue}
+import is.hail.types.physical.stypes.{SSettable, SValue}
 import is.hail.types.virtual.{TFloat32, Type}
 
 case object SFloat32 extends SPrimitive {
   override def ti: TypeInfo[_] = FloatInfo
 
   override lazy val virtualType: Type = TFloat32
-
-  override def castRename(t: Type): SType = this
-
-  override def _coerceOrCopy(
-    cb: EmitCodeBuilder,
-    region: Value[Region],
-    value: SValue,
-    deepCopy: Boolean,
-  ): SValue =
-    value.st match {
-      case SFloat32 => value
-    }
-
-  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(FloatInfo)
 
   override def fromSettables(settables: IndexedSeq[Settable[_]]): SFloat32Settable = {
     val IndexedSeq(x: Settable[Float @unchecked]) = settables

--- a/hail/hail/src/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -1,12 +1,11 @@
 package is.hail.types.physical.stypes.primitives
 
-import is.hail.annotations.Region
 import is.hail.asm4s.{DoubleInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.asm4s.Code.invokeStatic1
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.{PFloat64, PType}
-import is.hail.types.physical.stypes.{SSettable, SType, SValue}
+import is.hail.types.physical.stypes.{SSettable, SValue}
 import is.hail.types.virtual.{TFloat64, Type}
 
 case object SFloat64 extends SPrimitive {
@@ -14,28 +13,14 @@ case object SFloat64 extends SPrimitive {
 
   override lazy val virtualType: Type = TFloat64
 
-  override def castRename(t: Type): SType = this
-
-  override def _coerceOrCopy(
-    cb: EmitCodeBuilder,
-    region: Value[Region],
-    value: SValue,
-    deepCopy: Boolean,
-  ): SValue =
-    value.st match {
-      case SFloat64 => value
-    }
-
-  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(DoubleInfo)
-
   override def fromSettables(settables: IndexedSeq[Settable[_]]): SFloat64Settable = {
     val IndexedSeq(x: Settable[Double @unchecked]) = settables
     assert(x.ti == DoubleInfo)
     new SFloat64Settable(x)
   }
 
-  override def fromValues(settables: IndexedSeq[Value[_]]): SFloat64Value = {
-    val IndexedSeq(x: Value[Double @unchecked]) = settables
+  override def fromValues(values: IndexedSeq[Value[_]]): SFloat64Value = {
+    val IndexedSeq(x: Value[Double @unchecked]) = values
     assert(x.ti == DoubleInfo)
     new SFloat64Value(x)
   }

--- a/hail/hail/src/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -1,11 +1,10 @@
 package is.hail.types.physical.stypes.primitives
 
-import is.hail.annotations.Region
 import is.hail.asm4s.{IntInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.{PInt32, PType}
-import is.hail.types.physical.stypes.{SSettable, SType, SValue}
+import is.hail.types.physical.stypes.{SSettable, SValue}
 import is.hail.types.virtual.{TInt32, Type}
 
 case object SInt32 extends SPrimitive {
@@ -13,28 +12,14 @@ case object SInt32 extends SPrimitive {
 
   override lazy val virtualType: Type = TInt32
 
-  override def castRename(t: Type): SType = this
-
-  override def _coerceOrCopy(
-    cb: EmitCodeBuilder,
-    region: Value[Region],
-    value: SValue,
-    deepCopy: Boolean,
-  ): SValue =
-    value.st match {
-      case SInt32 => value
-    }
-
-  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(IntInfo)
-
   override def fromSettables(settables: IndexedSeq[Settable[_]]): SInt32Settable = {
     val IndexedSeq(x: Settable[Int @unchecked]) = settables
     assert(x.ti == IntInfo)
     new SInt32Settable(x)
   }
 
-  override def fromValues(settables: IndexedSeq[Value[_]]): SInt32Value = {
-    val IndexedSeq(x: Value[Int @unchecked]) = settables
+  override def fromValues(values: IndexedSeq[Value[_]]): SInt32Value = {
+    val IndexedSeq(x: Value[Int @unchecked]) = values
     assert(x.ti == IntInfo)
     new SInt32Value(x)
   }

--- a/hail/hail/src/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -1,12 +1,11 @@
 package is.hail.types.physical.stypes.primitives
 
-import is.hail.annotations.Region
 import is.hail.asm4s.{LongInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.asm4s.Code.invokeStatic1
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.{PInt64, PType}
-import is.hail.types.physical.stypes.{SSettable, SType, SValue}
+import is.hail.types.physical.stypes.{SSettable, SValue}
 import is.hail.types.virtual.{TInt64, Type}
 
 case object SInt64 extends SPrimitive {
@@ -14,28 +13,14 @@ case object SInt64 extends SPrimitive {
 
   override lazy val virtualType: Type = TInt64
 
-  override def castRename(t: Type): SType = this
-
-  override def _coerceOrCopy(
-    cb: EmitCodeBuilder,
-    region: Value[Region],
-    value: SValue,
-    deepCopy: Boolean,
-  ): SValue =
-    value.st match {
-      case SInt64 => value
-    }
-
-  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(LongInfo)
-
   override def fromSettables(settables: IndexedSeq[Settable[_]]): SInt64Settable = {
     val IndexedSeq(x: Settable[Long @unchecked]) = settables
     assert(x.ti == LongInfo)
     new SInt64Settable(x)
   }
 
-  override def fromValues(settables: IndexedSeq[Value[_]]): SInt64Value = {
-    val IndexedSeq(x: Value[Long @unchecked]) = settables
+  override def fromValues(values: IndexedSeq[Value[_]]): SInt64Value = {
+    val IndexedSeq(x: Value[Long @unchecked]) = values
     assert(x.ti == LongInfo)
     new SInt64Value(x)
   }

--- a/hail/hail/src/is/hail/types/physical/stypes/primitives/SPrimitive.scala
+++ b/hail/hail/src/is/hail/types/physical/stypes/primitives/SPrimitive.scala
@@ -1,11 +1,14 @@
 package is.hail.types.physical.stypes.primitives
 
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.asm4s.implicits._
+import is.hail.collection.FastSeq
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.io.PrefixCoder
 import is.hail.types.{RPrimitive, TypeWithRequiredness}
 import is.hail.types.physical.stypes.{SType, SValue}
+import is.hail.types.virtual.Type
 
 trait SPrimitive extends SType {
   def ti: TypeInfo[_]
@@ -15,6 +18,20 @@ trait SPrimitive extends SType {
   override def copiedType: SType = this
 
   override def containsPointers: Boolean = false
+
+  override def castRename(t: Type): SType = this
+
+  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastSeq(ti)
+
+  override def _coerceOrCopy(
+    cb: EmitCodeBuilder,
+    region: Value[Region],
+    value: SValue,
+    deepCopy: Boolean,
+  ): SValue = {
+    assert(value.st eq this)
+    value
+  }
 }
 
 abstract class SPrimitiveValue extends SValue {


### PR DESCRIPTION
## Summary

Two small, focused simplifications to the SType primitives, plus a parameter renaming along the way.

1. **Consolidate identical `SPrimitive` overrides into the `SPrimitive` trait.** `castRename = this`, `_coerceOrCopy = match-self-or-error`, and `settableTupleTypes = FastSeq(ti)` were identical across `SInt32`, `SInt64`, `SFloat32`, `SFloat64`, `SBoolean`. Moved to the trait; removed from the 5 case objects. Each primitive file shrinks ~15-21 lines.

2. **Delete an unreachable pattern case** in `SJavaArray._coerceOrCopy`. The trailing `case (false, false) =>` (with empty body) was already covered by the preceding `case (false, r) =>`, making it dead.

Plus a small linguistic-antipattern fix bundled with the first commit: rename the misnamed `fromValues(settables: ...)` parameter in 4 files (`SInt32`, `SInt64`, `SFloat64`, `SNDArraySlice`) to match the trait's `values` (the parameter holds Values, not Settables — 22 of 26 implementations already use `values`).

Total: 8 files changed, ~60 lines removed. No behavioral changes. Compiles clean on 2.12 and 2.13.

--------

This is another run of the auto-simplifier we're developing at cc.dev, run after discussion with @patrick-schultz. If you like these changes, will run on more files.