### PR TITLE
[services] better logging of system permission requirements

### DIFF
--- a/auth/test/test_system_permissions.py
+++ b/auth/test/test_system_permissions.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from hailtop.auth import async_add_role, async_remove_role
+from hailtop.auth import async_add_role, async_get_roles, async_remove_role
 from hailtop.config import get_deploy_config
 from hailtop.utils import external_requests_client_session, retry_response_returning_functions
 
@@ -45,6 +45,15 @@ NO_AUTH_SESSION = external_requests_client_session()
 # Session authenticated as the `test` user (no roles)
 _test_token = _load_test_user_token()
 TEST_USER_SESSION = external_requests_client_session(headers={'Authorization': f'Bearer {_test_token}'})
+
+
+@pytest.fixture(autouse=True, scope='session')
+def reset_test_user_roles():
+    """Strip any roles left on `test` by a previously preempted test run."""
+    existing = asyncio.run(async_get_roles('test'))
+    for role in existing:
+        asyncio.run(async_remove_role('test', role))
+
 
 # ---------------------------------------------------------------------------
 # Permission → endpoint mapping

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -68,7 +68,7 @@ class AccessLogger(AbstractAccessLogger):
         }
 
         userdata_maybe = request.get('userdata', {})
-        userdata_keys = ['username', 'login_id', 'hail_identity', 'system_permissions']
+        userdata_keys = ['username', 'login_id', 'hail_identity']
         extra.update({k: userdata_maybe[k] for k in userdata_keys if k in userdata_maybe})
 
         # Try to get formdata in various ways:
@@ -91,16 +91,11 @@ class AccessLogger(AbstractAccessLogger):
         extra.update({'request_data': {k: request_data[k] for k in request_data.keys() if not k.startswith('_')}})
 
         api_info_maybe = request.get('api_info', {})
-        api_info_keys_and_defaults = {
-            'authenticated_users_only': False,
-            'developers_only': False,
-        }
+        extra['authenticated_users_only'] = api_info_maybe.get('authenticated_users_only', False)
 
-        for k, default in api_info_keys_and_defaults.items():
-            if k in api_info_maybe:
-                extra[k] = api_info_maybe[k]
-            else:
-                extra[k] = default
+        if api_info_maybe.get('system_permissions_required'):
+            extra['system_permissions_required'] = api_info_maybe['system_permissions_required']
+            extra['system_permissions_possessed'] = list(userdata_maybe.get('system_permissions', {}).keys())
 
         self.logger.info(
             f'{request.scheme} {request.method} {request.path} done in {time}s: {response.status}',


### PR DESCRIPTION
## Change Description

- Makes permission-requiring endpoints easier to search for.
- Reduces log noise of user permission logging on endpoints which don't need any permissions
- Remove the old `developers_only` field which is now always false

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Improvement to what we log around permission checks, and how discoverable those logs are

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
