### PR TITLE
[auth] fix role buttons in UI

### DIFF
--- a/auth/auth/static/js/roles.js
+++ b/auth/auth/static/js/roles.js
@@ -14,7 +14,7 @@ async function removeRole(username, roleName) {
     }
 
     try {
-        const response = await fetch("{{ base_path }}/api/v1alpha/system_roles/${username}", {
+        const response = await fetch(`{{ base_path }}/api/v1alpha/system_roles/${username}`, {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',
@@ -47,7 +47,7 @@ async function addRole(usernameInputId, roleName) {
     }
 
     try {
-        const response = await fetch("{{ base_path }}/api/v1alpha/system_roles/${username}", {
+        const response = await fetch(`{{ base_path }}/api/v1alpha/system_roles/${username}`, {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Change Description

The remove role buttons in the UI are broken because of a bad string interpolation. Currently all requests are sent to `https://auth.hail.is/api/v1alpha/system_roles/$%7Busername%7D`. Oops!

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Fix a bad string interpolation syntax in the UI

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
