### PR TITLE
[ci] More memory for check_hail test

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1746,7 +1746,7 @@ steps:
     image:
       valueFrom: hail_linting_image.image
     resources:
-      memory: 8G
+      memory: 16G
     script: |
       set -ex
       cd /io/repo


### PR DESCRIPTION
## Change Description

This `check_hail` job is ramping up to around 7.8GB (followed by an hour of spinning) fairly regularly. Currently ranked at number 2 on https://ci.hail.is/flaky_tests in the last 14d. Example: [here](https://batch.hail.is/batches/8408235/jobs/147?subtab=charts&tab=attempt&attempt_id=PxY1wv).
Even in good job runs, the memory is extremely close to the max. Example: [here](https://batch.hail.is/batches/8407091/jobs/146?subtab=charts&tab=attempt&attempt_id=PxY1wv).

To resolve: let's give the job the memory it needs.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

Just a test spec fix. Appsec review to confirm the changes to build.yaml are test-case only.


### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
