### PR TITLE
[vep] pin test-most version used during vep build

### DIFF
--- a/docker/hailgenetics/vep/grch38/95/Dockerfile
+++ b/docker/hailgenetics/vep/grch38/95/Dockerfile
@@ -71,6 +71,7 @@ RUN export KENT_SRC=$PWD/kent-335_base/src && \
     make clean && make && \
     mkdir -p $VEP_DIR/cpanm && \
     export PERL5LIB=\$PERL5LIB:$HOME/cpanm/lib/perl5 && \
+    cpanm Test::Most@0.38 && \
     cpanm Bio::DB::BigFile
 
 RUN wget https://github.com/samtools/samtools/releases/download/1.22/samtools-1.22.tar.bz2 && \


### PR DESCRIPTION
## Change Description

Resolves CI build errors and re-enables VEP builds by pinning a test library version which broke things for us after a recent update.

```
The failure: hailgenetics_vep_grch38_95_image started failing consistently across all PRs on May 19, blocking CI for every open PR.

  Root cause chain:
  1. Docker Hub published a new ubuntu:22.04 snapshot (jammy-20260509) on May 16
  2. PR #15485 merging on May 19 triggered our CI mirroring process, which pulled the new digest into our registry
  3. This new digest invalidated BuildKit's layer cache for the VEP image — the first time the cache had been cold since the previous ubuntu update in April
  4. With the cache cold, the cpanm Bio::DB::BigFile step ran from scratch, pulling live dependencies from CPAN
  5. Test::Most had been updated from 0.38 to 0.42 on CPAN sometime between April 15 and May 19
  6. Test::Most 0.42 pulls in many more test dependencies and something in that new dependency tree breaks BioPerl 1.7.8's Bio::Root::Version test
  7. cpanm refuses to install BioPerl when its tests fail, so Bio::DB::BigFile (which depends on it) can't install either

  Why it wasn't caught sooner: The layer cache had been warm continuously since at least April 15, so the cpanm step never re-ran. The BioPerl test failure is a latent CPAN compatibility issue, not a regression in our code.

  Fix: Pin Test::Most@0.38 before the cpanm Bio::DB::BigFile call so BioPerl's test suite uses the known-good version.
```

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
