### PR TITLE
[ci] Resolve slow github polling and hook handling errors

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -1048,7 +1048,8 @@ async def on_startup(app: web.Application):
     exit_stack = AsyncExitStack()
     app[AppKeys.EXIT_STACK] = exit_stack
 
-    client_session = httpx.client_session()
+    # 60s timeout: bulk GitHub GraphQL PR status fetches can take 10-30s.
+    client_session = httpx.client_session(timeout=60)
     exit_stack.push_async_callback(client_session.close)
 
     app[AppKeys.CLIENT_SESSION] = client_session

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -7,7 +7,7 @@ import traceback
 from collections import defaultdict
 from contextlib import AsyncExitStack
 from datetime import timezone
-from typing import Any, Callable, Dict, List, NoReturn, Optional, Set, Tuple, TypedDict
+from typing import Any, Callable, Dict, List, NoReturn, Optional, Set, Tuple, TypedDict, Union
 
 import aiohttp_session  # type: ignore
 import gidgethub
@@ -598,7 +598,7 @@ async def batch_callback_handler(request: web.Request):
 async def deploy_status(request: web.Request, _) -> web.Response:
     batch_client = request.app[AppKeys.BATCH_CLIENT]
 
-    async def get_failure_information(batch):
+    async def get_failure_information(batch: Union[Batch, MergeFailureBatch]) -> Any:
         if isinstance(batch, MergeFailureBatch):
             exc = batch.exception
             return traceback.format_exception(type(exc), value=exc, tb=exc.__traceback__)
@@ -612,19 +612,22 @@ async def deploy_status(request: web.Request, _) -> web.Response:
 
         return await asyncio.gather(*[fetch_job_and_log(j) for j in jobs if j['state'] in ('Error', 'Failed')])
 
-    wb_configs = [
-        {
+    async def wb_config(wb: WatchedBranch) -> Dict[str, Any]:
+        if wb.deploy_state in ('failure', 'checkout_failure'):
+            assert wb.deploy_batch is not None
+            failure_information = await get_failure_information(wb.deploy_batch)
+        else:
+            failure_information = None
+        return {
             'branch': wb.branch.short_str(),
             'sha': wb.sha,
             'deploy_batch_id': wb.deploy_batch.id if wb.deploy_batch and isinstance(wb.deploy_batch, Batch) else None,
             'deploy_state': wb.deploy_state,
             'repo': wb.branch.repo.short_str(),
-            'failure_information': None
-            if wb.deploy_state == 'success'
-            else await get_failure_information(wb.deploy_batch),
+            'failure_information': failure_information,
         }
-        for wb in watched_branches
-    ]
+
+    wb_configs = [await wb_config(wb) for wb in watched_branches]
     return json_response(wb_configs)
 
 

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -684,15 +684,20 @@ class _GitHubGraphQL(Protocol):
     async def post(self, url: str, *, data: Any) -> Any: ...
 
 
+_GITHUB_GRAPHQL_PR_CHUNK_SIZE = 100
+_GITHUB_GRAPHQL_TIMEOUT_SECONDS = 30
+
+
 async def _fetch_pr_github_data(
     gh: _GitHubGraphQL,
     owner: str,
     repo_name: str,
     pr_numbers: List[int],
 ) -> Dict[int, tuple]:
-    """Fetch review decisions and status check rollup for all PRs in a single batched GraphQL query.
+    """Fetch review decisions and status check rollup for all PRs, batched in chunks.
 
-    Uses GraphQL aliases (pr_N: pullRequest(number: N) {{ ... }}) so one round-trip covers all PRs.
+    Uses GraphQL aliases (pr_N: pullRequest(number: N) {{ ... }}) to reduce round-trips.
+    Chunks requests to avoid GitHub query complexity timeouts (~2s per 20-PR chunk vs ~6s for 56).
     Paginates if any PR has more than 20 check contexts, which is not expected in practice.
 
     Returns dict mapping pr_number -> (review_decision: str, check_nodes: List[dict]).
@@ -700,66 +705,77 @@ async def _fetch_pr_github_data(
     """
     accumulated_nodes: Dict[int, List[Dict[str, Any]]] = {n: [] for n in pr_numbers}
     review_decisions: Dict[int, Optional[str]] = {n: None for n in pr_numbers}
-    # remaining maps pr_number -> cursor (None = first page)
-    remaining: Dict[int, Optional[str]] = {n: None for n in pr_numbers}
 
-    while remaining:
+    chunks = [
+        pr_numbers[i : i + _GITHUB_GRAPHQL_PR_CHUNK_SIZE]
+        for i in range(0, len(pr_numbers), _GITHUB_GRAPHQL_PR_CHUNK_SIZE)
+    ]
+    for chunk in chunks:
+        # remaining maps pr_number -> cursor (None = first page)
+        remaining: Dict[int, Optional[str]] = {n: None for n in chunk}
 
-        def build_query(remaining: Dict[int, Optional[str]]) -> str:
-            aliases = []
-            for pr_number, cursor in remaining.items():
-                cursor_arg = f', after: "{cursor}"' if cursor is not None else ''
-                aliases.append(f"""
-                    pr_{pr_number}: pullRequest(number: {pr_number}) {{
-                      reviewDecision
-                      commits(last: 1) {{
-                        nodes {{
-                          commit {{
-                            statusCheckRollup {{
-                              contexts(first: 20{cursor_arg}) {{
-                                nodes {{
-                                  __typename
-                                  ... on CheckRun {{
-                                    name
-                                    conclusion
-                                    isRequired(pullRequestNumber: {pr_number})
+        while remaining:
+
+            def build_query(remaining: Dict[int, Optional[str]]) -> str:
+                aliases = []
+                for pr_number, cursor in remaining.items():
+                    cursor_arg = f', after: "{cursor}"' if cursor is not None else ''
+                    aliases.append(f"""
+                        pr_{pr_number}: pullRequest(number: {pr_number}) {{
+                          reviewDecision
+                          commits(last: 1) {{
+                            nodes {{
+                              commit {{
+                                statusCheckRollup {{
+                                  contexts(first: 20{cursor_arg}) {{
+                                    nodes {{
+                                      __typename
+                                      ... on CheckRun {{
+                                        name
+                                        conclusion
+                                        isRequired(pullRequestNumber: {pr_number})
+                                      }}
+                                      ... on StatusContext {{
+                                        context
+                                        state
+                                        isRequired(pullRequestNumber: {pr_number})
+                                      }}
+                                    }}
+                                    pageInfo {{
+                                      endCursor
+                                      hasNextPage
+                                    }}
                                   }}
-                                  ... on StatusContext {{
-                                    context
-                                    state
-                                    isRequired(pullRequestNumber: {pr_number})
-                                  }}
-                                }}
-                                pageInfo {{
-                                  endCursor
-                                  hasNextPage
                                 }}
                               }}
                             }}
                           }}
                         }}
-                      }}
-                    }}
-                """)
-            return f'query {{ repository(owner: "{owner}", name: "{repo_name}") {{ {"".join(aliases)} }} }}'
+                    """)
+                return f'query {{ repository(owner: "{owner}", name: "{repo_name}") {{ {"".join(aliases)} }} }}'
 
-        repo_data = (await gh.post("/graphql", data={"query": build_query(remaining)}))["data"]["repository"]
+            repo_data = (
+                await asyncio.wait_for(
+                    gh.post("/graphql", data={"query": build_query(remaining)}),
+                    timeout=_GITHUB_GRAPHQL_TIMEOUT_SECONDS,
+                )
+            )["data"]["repository"]
 
-        next_remaining: Dict[int, Optional[str]] = {}
-        for pr_number in list(remaining.keys()):
-            pr_data = repo_data[f"pr_{pr_number}"]
-            if review_decisions[pr_number] is None:
-                raw = pr_data["reviewDecision"]
-                review_decisions[pr_number] = raw if raw is not None else "API_NONE"
-            rollup = pr_data["commits"]["nodes"][0]["commit"]["statusCheckRollup"]
-            if rollup is not None:
-                accumulated_nodes[pr_number].extend(rollup["contexts"]["nodes"])
-                if rollup["contexts"]["pageInfo"]["hasNextPage"]:
-                    next_remaining[pr_number] = rollup["contexts"]["pageInfo"]["endCursor"]
+            next_remaining: Dict[int, Optional[str]] = {}
+            for pr_number in list(remaining.keys()):
+                pr_data = repo_data[f"pr_{pr_number}"]
+                if review_decisions[pr_number] is None:
+                    raw = pr_data["reviewDecision"]
+                    review_decisions[pr_number] = raw if raw is not None else "API_NONE"
+                rollup = pr_data["commits"]["nodes"][0]["commit"]["statusCheckRollup"]
+                if rollup is not None:
+                    accumulated_nodes[pr_number].extend(rollup["contexts"]["nodes"])
+                    if rollup["contexts"]["pageInfo"]["hasNextPage"]:
+                        next_remaining[pr_number] = rollup["contexts"]["pageInfo"]["endCursor"]
 
-        if next_remaining:
-            log.warning(f'_fetch_pr_github_data: pagination required for PRs {list(next_remaining.keys())}')
-        remaining = next_remaining
+            if next_remaining:
+                log.warning(f'_fetch_pr_github_data: pagination required for PRs {list(next_remaining.keys())}')
+            remaining = next_remaining
 
     return {n: (review_decisions[n] or "API_NONE", accumulated_nodes[n]) for n in pr_numbers}
 

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -444,6 +444,8 @@ class PR(Code):
                 assignees.add(select_random_teammate(SERVICES_TEAM).gh_username)
             if ASSIGN_COMPILER in self.body:
                 assignees.add(select_random_teammate(COMPILER_TEAM).gh_username)
+            if not assignees:
+                return
             data = {'assignees': list(assignees)}
             log.info(f'{self.short_str()}: assigning reviewers: {data}')
             try:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -7,7 +7,7 @@ import os
 import random
 import secrets
 from shlex import quote as shq
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, Union
 
 import aiohttp
 import aiohttp.client_exceptions
@@ -441,72 +441,7 @@ class PR(Code):
             except aiohttp.client_exceptions.ClientResponseError:
                 log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data}')
 
-    async def _update_github(self, gh):
-        results = []
-        cursor = None
-        review_decision = None
-
-        def query():
-            return f"""
-                query {{
-                  repository (
-                    owner: "{self.target_branch.branch.repo.owner}",
-                    name: "{self.target_branch.branch.repo.name}"
-                  ) {{
-                    pullRequest (number: {self.number}) {{
-                      reviewDecision
-                      commits (last: 1) {{
-                        nodes {{
-                          commit {{
-                            statusCheckRollup {{
-                              contexts (first: 10{f', after: "{cursor}"' if cursor is not None else ''}) {{
-                                nodes {{
-                                  __typename
-                                  ... on CheckRun {{
-                                    name
-                                    conclusion
-                                    isRequired (pullRequestNumber: {self.number})
-                                  }}
-                                  ... on StatusContext {{
-                                    context
-                                    state
-                                    isRequired (pullRequestNumber: {self.number})
-                                  }}
-                                }}
-                                pageInfo {{
-                                  endCursor
-                                  hasNextPage
-                                }}
-                              }}
-                            }}
-                          }}
-                        }}
-                      }}
-                    }}
-                  }}
-                }}
-            """
-
-        def review_decision_and_commit_status(pull_request, rollup):
-            nonlocal review_decision
-            if review_decision is None:
-                review_decision = (
-                    pull_request["reviewDecision"] if pull_request["reviewDecision"] is not None else "API_NONE"
-                )
-            if rollup is not None:
-                results.extend(rollup["contexts"]["nodes"])
-
-        while (
-            rollup := (
-                pull_request := (await gh.post("/graphql", data={"query": query()}))["data"]["repository"][
-                    "pullRequest"
-                ]
-            )["commits"]["nodes"][0]["commit"]["statusCheckRollup"]
-        ) is not None and rollup["contexts"]["pageInfo"]["hasNextPage"]:
-            cursor = rollup["contexts"]["pageInfo"]["endCursor"]
-            review_decision_and_commit_status(pull_request, rollup)
-        review_decision_and_commit_status(pull_request, rollup)
-
+    def _apply_github_data(self, review_decision: str, check_nodes: List[Dict[str, Any]]):
         if review_decision == 'APPROVED':
             review_state = 'approved'
         elif review_decision == 'CHANGES_REQUESTED':
@@ -528,7 +463,7 @@ class PR(Code):
             self.target_branch.state_changed = True
 
         last_known_github_status = {}
-        for check in results:
+        for check in check_nodes:
             if check["isRequired"]:
                 if (typename := check["__typename"]) == "StatusContext":
                     last_known_github_status[check["context"]] = github_status(check["state"])
@@ -745,6 +680,90 @@ git merge {shq(self.source_sha)} -m 'merge PR'
 """
 
 
+class _GitHubGraphQL(Protocol):
+    async def post(self, url: str, *, data: Any) -> Any: ...
+
+
+async def _fetch_pr_github_data(
+    gh: _GitHubGraphQL,
+    owner: str,
+    repo_name: str,
+    pr_numbers: List[int],
+) -> Dict[int, tuple]:
+    """Fetch review decisions and status check rollup for all PRs in a single batched GraphQL query.
+
+    Uses GraphQL aliases (pr_N: pullRequest(number: N) {{ ... }}) so one round-trip covers all PRs.
+    Paginates if any PR has more than 20 check contexts, which is not expected in practice.
+
+    Returns dict mapping pr_number -> (review_decision: str, check_nodes: List[dict]).
+    review_decision is the raw GraphQL PullRequestReviewDecision value, or "API_NONE" when null.
+    """
+    accumulated_nodes: Dict[int, List[Dict[str, Any]]] = {n: [] for n in pr_numbers}
+    review_decisions: Dict[int, Optional[str]] = {n: None for n in pr_numbers}
+    # remaining maps pr_number -> cursor (None = first page)
+    remaining: Dict[int, Optional[str]] = {n: None for n in pr_numbers}
+
+    while remaining:
+
+        def build_query(remaining: Dict[int, Optional[str]]) -> str:
+            aliases = []
+            for pr_number, cursor in remaining.items():
+                cursor_arg = f', after: "{cursor}"' if cursor is not None else ''
+                aliases.append(f"""
+                    pr_{pr_number}: pullRequest(number: {pr_number}) {{
+                      reviewDecision
+                      commits(last: 1) {{
+                        nodes {{
+                          commit {{
+                            statusCheckRollup {{
+                              contexts(first: 20{cursor_arg}) {{
+                                nodes {{
+                                  __typename
+                                  ... on CheckRun {{
+                                    name
+                                    conclusion
+                                    isRequired(pullRequestNumber: {pr_number})
+                                  }}
+                                  ... on StatusContext {{
+                                    context
+                                    state
+                                    isRequired(pullRequestNumber: {pr_number})
+                                  }}
+                                }}
+                                pageInfo {{
+                                  endCursor
+                                  hasNextPage
+                                }}
+                              }}
+                            }}
+                          }}
+                        }}
+                      }}
+                    }}
+                """)
+            return f'query {{ repository(owner: "{owner}", name: "{repo_name}") {{ {"".join(aliases)} }} }}'
+
+        repo_data = (await gh.post("/graphql", data={"query": build_query(remaining)}))["data"]["repository"]
+
+        next_remaining: Dict[int, Optional[str]] = {}
+        for pr_number in list(remaining.keys()):
+            pr_data = repo_data[f"pr_{pr_number}"]
+            if review_decisions[pr_number] is None:
+                raw = pr_data["reviewDecision"]
+                review_decisions[pr_number] = raw if raw is not None else "API_NONE"
+            rollup = pr_data["commits"]["nodes"][0]["commit"]["statusCheckRollup"]
+            if rollup is not None:
+                accumulated_nodes[pr_number].extend(rollup["contexts"]["nodes"])
+                if rollup["contexts"]["pageInfo"]["hasNextPage"]:
+                    next_remaining[pr_number] = rollup["contexts"]["pageInfo"]["endCursor"]
+
+        if next_remaining:
+            log.warning(f'_fetch_pr_github_data: pagination required for PRs {list(next_remaining.keys())}')
+        remaining = next_remaining
+
+    return {n: (review_decisions[n] or "API_NONE", accumulated_nodes[n]) for n in pr_numbers}
+
+
 class WatchedBranch(Code):
     def __init__(
         self,
@@ -890,8 +909,33 @@ class WatchedBranch(Code):
         for pr in new_prs.values():
             await pr.assign_gh_reviewer_if_requested(gh)
 
-        for pr in new_prs.values():
-            await pr._update_github(gh)
+        if new_prs:
+            pr_github_data = await _fetch_pr_github_data(
+                gh, self.branch.repo.owner, self.branch.repo.name, list(new_prs.keys())
+            )
+
+            summary = []
+            for pr_number, (review_decision, check_nodes) in pr_github_data.items():
+                required_nodes = [c for c in check_nodes if c["isRequired"]]
+                required_statuses = [
+                    github_status(c["conclusion"] if c["__typename"] == "CheckRun" else c["state"])
+                    for c in required_nodes
+                ]
+                if any(s == GithubStatus.FAILURE for s in required_statuses):
+                    check_decision = 'failing'
+                elif required_statuses and all(s == GithubStatus.SUCCESS for s in required_statuses):
+                    check_decision = 'passing'
+                else:
+                    check_decision = 'pending'
+                summary.append((pr_number, review_decision, len(check_nodes), len(required_nodes), check_decision))
+            log.info(
+                f'update github {self.short_str()}: PR data fetched '
+                f'(pr_number, review_decision, total_checks, required_checks, check_decision): {summary}'
+            )
+
+            for pr in new_prs.values():
+                review_decision, check_nodes = pr_github_data[pr.number]
+                pr._apply_github_data(review_decision, check_nodes)
 
     async def _update_deploy(self, batch_client, db: Database):
         assert self.deployable

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -48,6 +48,12 @@ GITHUB_GRAPHQL_REQUEST_LATENCY = pc.Histogram(
     ['chunk_size'],
     buckets=[1, 2, 5, 10, 15, 20, 30, 45, 60],
 )
+WATCHED_BRANCH_UPDATE_LATENCY = pc.Histogram(
+    'ci_watched_branch_update_latency_seconds',
+    'Latency of WatchedBranch update phases',
+    ['phase'],
+    buckets=[0.1, 0.5, 1, 2, 5, 10, 20, 30, 60],
+)
 
 MAX_CONCURRENT_PR_BATCHES = 3
 
@@ -871,6 +877,7 @@ class WatchedBranch(Code):
             log.info(f'already updating {self.short_str()}')
             return
 
+        t_update_start = time.monotonic()
         try:
             log.info(f'start update {self.short_str()}')
             self.updating = True
@@ -890,7 +897,9 @@ class WatchedBranch(Code):
                     if (self.deploy_batch is None or self.deploy_state is not None) and not frozen and self.mergeable:
                         await self.try_to_merge(gh)
         finally:
-            log.info(f'update done {self.short_str()}')
+            t_total = time.monotonic() - t_update_start
+            WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='total').observe(t_total)
+            log.info(f'update done {self.short_str()} in {t_total:.1f}s')
             self.updating = False
 
     async def try_to_merge(self, gh):
@@ -906,6 +915,7 @@ class WatchedBranch(Code):
 
     async def _update_github(self, gh):
         log.info(f'update github {self.short_str()}')
+        t_start = time.monotonic()
 
         repo_ss = self.branch.repo.short_str()
 
@@ -917,6 +927,7 @@ class WatchedBranch(Code):
             self.state_changed = True
 
         new_prs: Dict[int, PR] = {}
+        t_pr_list_start = time.monotonic()
         async for gh_json_pr in gh.getiter(f'/repos/{repo_ss}/pulls?state=open&base={self.branch.name}'):
             number = gh_json_pr['number']
             if number in self.prs:
@@ -925,6 +936,9 @@ class WatchedBranch(Code):
             else:
                 pr = PR.from_gh_json(gh_json_pr, self)
             new_prs[number] = pr
+        t_pr_list_elapsed = time.monotonic() - t_pr_list_start
+        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='pr_list').observe(t_pr_list_elapsed)
+        log.info(f'update github {self.short_str()}: fetched {len(new_prs)} open PRs in {t_pr_list_elapsed:.1f}s')
         for number, pr in self.prs.items():
             if number not in new_prs:
                 pr.decrement_pr_metric()
@@ -960,6 +974,10 @@ class WatchedBranch(Code):
             for pr in new_prs.values():
                 review_decision, check_nodes = pr_github_data[pr.number]
                 pr._apply_github_data(review_decision, check_nodes)
+
+        t_elapsed = time.monotonic() - t_start
+        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='github').observe(t_elapsed)
+        log.info(f'update github {self.short_str()} done in {t_elapsed:.1f}s')
 
     async def _update_deploy(self, batch_client, db: Database):
         assert self.deployable
@@ -1024,6 +1042,7 @@ url: {url}
 
     async def _update_batch(self, batch_client: BatchClient, db: Database):
         log.info(f'update batch {self.short_str()}')
+        t_start = time.monotonic()
 
         if self.deployable:
             await self._update_deploy(batch_client, db)
@@ -1031,8 +1050,13 @@ url: {url}
         for pr in self.prs.values():
             await pr._update_batch(batch_client, db)
 
+        t_elapsed = time.monotonic() - t_start
+        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='batch').observe(t_elapsed)
+        log.info(f'update batch {self.short_str()} done in {t_elapsed:.1f}s')
+
     async def _heal(self, db: Database, batch_client: BatchClient, gh: gh_aiohttp.GitHubAPI, frozen: bool):
         log.info(f'heal {self.short_str()}')
+        t_start = time.monotonic()
 
         if self.deployable:
             await self._heal_deploy(db, batch_client, frozen)
@@ -1073,6 +1097,10 @@ url: {url}
                 attrs = batch.attributes
                 log.info(f'cancel batch {batch.id} for {attrs["pr"]} {attrs["source_sha"]} => {attrs["target_sha"]}')
                 await batch.cancel()
+
+        t_elapsed = time.monotonic() - t_start
+        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='heal').observe(t_elapsed)
+        log.info(f'heal {self.short_str()} done in {t_elapsed:.1f}s')
 
     async def _start_deploy(self, db: Database, batch_client: BatchClient):
         # not deploying

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -6,6 +6,7 @@ import logging
 import os
 import random
 import secrets
+import time
 from shlex import quote as shq
 from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, Union
 
@@ -41,6 +42,12 @@ if os.path.exists("/zulip-config/.zuliprc"):
     zulip_client = zulip.Client(config_file="/zulip-config/.zuliprc")
 
 TRACKED_PRS = pc.Gauge('ci_tracked_prs', 'PRs currently being monitored by CI', ['build_state', 'review_state'])
+GITHUB_GRAPHQL_REQUEST_LATENCY = pc.Histogram(
+    'ci_github_graphql_request_latency_seconds',
+    'Latency of individual GraphQL requests in _fetch_pr_github_data',
+    ['chunk_size'],
+    buckets=[1, 2, 5, 10, 15, 20, 30, 45, 60],
+)
 
 MAX_CONCURRENT_PR_BATCHES = 3
 
@@ -270,8 +277,8 @@ class PR(Code):
         self.developers = developers
 
     def set_build_state(self, build_state):
-        log.info(f'{self.short_str()}: Build state changing from {self.build_state} => {build_state}')
         if build_state != self.build_state:
+            log.info(f'{self.short_str()}: build state changing: {self.build_state} => {build_state}')
             self.decrement_pr_metric()
             self.build_state = build_state
             self.increment_pr_metric()
@@ -709,6 +716,8 @@ async def _fetch_pr_github_data(
         pr_numbers[i : i + _GITHUB_GRAPHQL_PR_CHUNK_SIZE]
         for i in range(0, len(pr_numbers), _GITHUB_GRAPHQL_PR_CHUNK_SIZE)
     ]
+    log.info(f'_fetch_pr_github_data: fetching {len(pr_numbers)} PRs in {len(chunks)} chunk(s)')
+    t_total_start = time.monotonic()
     for chunk in chunks:
         # remaining maps pr_number -> cursor (None = first page)
         remaining: Dict[int, Optional[str]] = {n: None for n in chunk}
@@ -753,7 +762,9 @@ async def _fetch_pr_github_data(
                     """)
                 return f'query {{ repository(owner: "{owner}", name: "{repo_name}") {{ {"".join(aliases)} }} }}'
 
+            t_req_start = time.monotonic()
             repo_data = (await gh.post("/graphql", data={"query": build_query(remaining)}))["data"]["repository"]
+            GITHUB_GRAPHQL_REQUEST_LATENCY.labels(chunk_size=len(remaining)).observe(time.monotonic() - t_req_start)
 
             next_remaining: Dict[int, Optional[str]] = {}
             for pr_number in list(remaining.keys()):
@@ -771,6 +782,9 @@ async def _fetch_pr_github_data(
                 log.warning(f'_fetch_pr_github_data: pagination required for PRs {list(next_remaining.keys())}')
             remaining = next_remaining
 
+    log.info(
+        f'_fetch_pr_github_data: fetched {len(pr_numbers)} PR statuses in {time.monotonic() - t_total_start:.1f}s total'
+    )
     return {n: (review_decisions[n] or "API_NONE", accumulated_nodes[n]) for n in pr_numbers}
 
 

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -445,6 +445,7 @@ class PR(Code):
             if ASSIGN_COMPILER in self.body:
                 assignees.add(select_random_teammate(COMPILER_TEAM).gh_username)
             data = {'assignees': list(assignees)}
+            log.info(f'{self.short_str()}: assigning reviewers: {data}')
             try:
                 await gh_client.post(
                     f'/repos/{self.target_branch.branch.repo.short_str()}/issues/{self.number}/assignees', data=data
@@ -944,8 +945,12 @@ class WatchedBranch(Code):
                 pr.decrement_pr_metric()
         self.prs = new_prs
 
+        t_assign_start = time.monotonic()
         for pr in new_prs.values():
             await pr.assign_gh_reviewer_if_requested(gh)
+        t_assign_elapsed = time.monotonic() - t_assign_start
+        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='assign').observe(t_assign_elapsed)
+        log.info(f'update github {self.short_str()}: assign reviewer loop done in {t_assign_elapsed:.1f}s')
 
         if new_prs:
             pr_github_data = await _fetch_pr_github_data(

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -42,17 +42,9 @@ if os.path.exists("/zulip-config/.zuliprc"):
     zulip_client = zulip.Client(config_file="/zulip-config/.zuliprc")
 
 TRACKED_PRS = pc.Gauge('ci_tracked_prs', 'PRs currently being monitored by CI', ['build_state', 'review_state'])
-GITHUB_GRAPHQL_REQUEST_LATENCY = pc.Histogram(
-    'ci_github_graphql_request_latency_seconds',
-    'Latency of individual GraphQL requests in _fetch_pr_github_data',
-    ['chunk_size'],
-    buckets=[1, 2, 5, 10, 15, 20, 30, 45, 60],
-)
-WATCHED_BRANCH_UPDATE_LATENCY = pc.Histogram(
+WATCHED_BRANCH_UPDATE_LATENCY = pc.Gauge(
     'ci_watched_branch_update_latency_seconds',
-    'Latency of WatchedBranch update phases',
-    ['phase'],
-    buckets=[0.1, 0.5, 1, 2, 5, 10, 20, 30, 60],
+    'Duration of the most recent WatchedBranch update cycle',
 )
 
 MAX_CONCURRENT_PR_BATCHES = 3
@@ -725,8 +717,6 @@ async def _fetch_pr_github_data(
         pr_numbers[i : i + _GITHUB_GRAPHQL_PR_CHUNK_SIZE]
         for i in range(0, len(pr_numbers), _GITHUB_GRAPHQL_PR_CHUNK_SIZE)
     ]
-    log.info(f'_fetch_pr_github_data: fetching {len(pr_numbers)} PRs in {len(chunks)} chunk(s)')
-    t_total_start = time.monotonic()
     for chunk in chunks:
         # remaining maps pr_number -> cursor (None = first page)
         remaining: Dict[int, Optional[str]] = {n: None for n in chunk}
@@ -771,9 +761,7 @@ async def _fetch_pr_github_data(
                     """)
                 return f'query {{ repository(owner: "{owner}", name: "{repo_name}") {{ {"".join(aliases)} }} }}'
 
-            t_req_start = time.monotonic()
             repo_data = (await gh.post("/graphql", data={"query": build_query(remaining)}))["data"]["repository"]
-            GITHUB_GRAPHQL_REQUEST_LATENCY.labels(chunk_size=len(remaining)).observe(time.monotonic() - t_req_start)
 
             next_remaining: Dict[int, Optional[str]] = {}
             for pr_number in list(remaining.keys()):
@@ -791,9 +779,6 @@ async def _fetch_pr_github_data(
                 log.warning(f'_fetch_pr_github_data: pagination required for PRs {list(next_remaining.keys())}')
             remaining = next_remaining
 
-    log.info(
-        f'_fetch_pr_github_data: fetched {len(pr_numbers)} PR statuses in {time.monotonic() - t_total_start:.1f}s total'
-    )
     return {n: (review_decisions[n] or "API_NONE", accumulated_nodes[n]) for n in pr_numbers}
 
 
@@ -901,7 +886,7 @@ class WatchedBranch(Code):
                         await self.try_to_merge(gh)
         finally:
             t_total = time.monotonic() - t_update_start
-            WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='total').observe(t_total)
+            WATCHED_BRANCH_UPDATE_LATENCY.set(t_total)
             log.info(f'update done {self.short_str()} in {t_total:.1f}s')
             self.updating = False
 
@@ -918,7 +903,6 @@ class WatchedBranch(Code):
 
     async def _update_github(self, gh):
         log.info(f'update github {self.short_str()}')
-        t_start = time.monotonic()
 
         repo_ss = self.branch.repo.short_str()
 
@@ -930,7 +914,6 @@ class WatchedBranch(Code):
             self.state_changed = True
 
         new_prs: Dict[int, PR] = {}
-        t_pr_list_start = time.monotonic()
         async for gh_json_pr in gh.getiter(f'/repos/{repo_ss}/pulls?state=open&base={self.branch.name}'):
             number = gh_json_pr['number']
             if number in self.prs:
@@ -939,20 +922,13 @@ class WatchedBranch(Code):
             else:
                 pr = PR.from_gh_json(gh_json_pr, self)
             new_prs[number] = pr
-        t_pr_list_elapsed = time.monotonic() - t_pr_list_start
-        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='pr_list').observe(t_pr_list_elapsed)
-        log.info(f'update github {self.short_str()}: fetched {len(new_prs)} open PRs in {t_pr_list_elapsed:.1f}s')
         for number, pr in self.prs.items():
             if number not in new_prs:
                 pr.decrement_pr_metric()
         self.prs = new_prs
 
-        t_assign_start = time.monotonic()
         for pr in new_prs.values():
             await pr.assign_gh_reviewer_if_requested(gh)
-        t_assign_elapsed = time.monotonic() - t_assign_start
-        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='assign').observe(t_assign_elapsed)
-        log.info(f'update github {self.short_str()}: assign reviewer loop done in {t_assign_elapsed:.1f}s')
 
         if new_prs:
             pr_github_data = await _fetch_pr_github_data(
@@ -981,10 +957,6 @@ class WatchedBranch(Code):
             for pr in new_prs.values():
                 review_decision, check_nodes = pr_github_data[pr.number]
                 pr._apply_github_data(review_decision, check_nodes)
-
-        t_elapsed = time.monotonic() - t_start
-        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='github').observe(t_elapsed)
-        log.info(f'update github {self.short_str()} done in {t_elapsed:.1f}s')
 
     async def _update_deploy(self, batch_client, db: Database):
         assert self.deployable
@@ -1049,7 +1021,6 @@ url: {url}
 
     async def _update_batch(self, batch_client: BatchClient, db: Database):
         log.info(f'update batch {self.short_str()}')
-        t_start = time.monotonic()
 
         if self.deployable:
             await self._update_deploy(batch_client, db)
@@ -1057,13 +1028,8 @@ url: {url}
         for pr in self.prs.values():
             await pr._update_batch(batch_client, db)
 
-        t_elapsed = time.monotonic() - t_start
-        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='batch').observe(t_elapsed)
-        log.info(f'update batch {self.short_str()} done in {t_elapsed:.1f}s')
-
     async def _heal(self, db: Database, batch_client: BatchClient, gh: gh_aiohttp.GitHubAPI, frozen: bool):
         log.info(f'heal {self.short_str()}')
-        t_start = time.monotonic()
 
         if self.deployable:
             await self._heal_deploy(db, batch_client, frozen)
@@ -1104,10 +1070,6 @@ url: {url}
                 attrs = batch.attributes
                 log.info(f'cancel batch {batch.id} for {attrs["pr"]} {attrs["source_sha"]} => {attrs["target_sha"]}')
                 await batch.cancel()
-
-        t_elapsed = time.monotonic() - t_start
-        WATCHED_BRANCH_UPDATE_LATENCY.labels(phase='heal').observe(t_elapsed)
-        log.info(f'heal {self.short_str()} done in {t_elapsed:.1f}s')
 
     async def _start_deploy(self, db: Database, batch_client: BatchClient):
         # not deploying

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -685,7 +685,6 @@ class _GitHubGraphQL(Protocol):
 
 
 _GITHUB_GRAPHQL_PR_CHUNK_SIZE = 100
-_GITHUB_GRAPHQL_TIMEOUT_SECONDS = 30
 
 
 async def _fetch_pr_github_data(
@@ -754,12 +753,7 @@ async def _fetch_pr_github_data(
                     """)
                 return f'query {{ repository(owner: "{owner}", name: "{repo_name}") {{ {"".join(aliases)} }} }}'
 
-            repo_data = (
-                await asyncio.wait_for(
-                    gh.post("/graphql", data={"query": build_query(remaining)}),
-                    timeout=_GITHUB_GRAPHQL_TIMEOUT_SECONDS,
-                )
-            )["data"]["repository"]
+            repo_data = (await gh.post("/graphql", data={"query": build_query(remaining)}))["data"]["repository"]
 
             next_remaining: Dict[int, Optional[str]] = {}
             for pr_number in list(remaining.keys()):

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -131,12 +131,14 @@ class GithubStatus(Enum):
     FAILURE = 'failure'
 
 
-def github_status(state: str) -> GithubStatus:
+def github_status(state: Optional[str]) -> GithubStatus:
     """
     Converts a state for a commit status (https://docs.github.com/en/graphql/reference/enums#statusstate)
     or a conclusion for a check (https://docs.github.com/en/graphql/reference/enums#checkconclusionstate)
     from the GraphQL API to a GithubStatus.
     """
+    if state is None:
+        return GithubStatus.PENDING
     if state in {"PENDING", "EXPECTED", "ACTION_REQUIRED", "STALE"}:
         return GithubStatus.PENDING
     if state in {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE", "SKIPPED"}:

--- a/ci/unit-test/conftest.py
+++ b/ci/unit-test/conftest.py
@@ -1,0 +1,37 @@
+"""Configure the unit-test environment before any ci.* modules are imported.
+
+In CI these values come from the real deployment environment (env vars + /global-config volume
+mount).  Locally they don't exist, so we set safe defaults and mock the config reader.
+"""
+
+import json
+import os
+import unittest.mock
+
+# Env vars read at module-import time by gear.profiling and ci.environment.
+# setdefault leaves real CI values in place.
+os.environ.setdefault('HAIL_SHA', 'test-sha')
+os.environ.setdefault('HAIL_DEFAULT_NAMESPACE', 'default')
+os.environ.setdefault('CLOUD', 'gcp')
+os.environ.setdefault('HAIL_CI_UTILS_IMAGE', 'gcr.io/hail-vdc/ci-utils:test')
+os.environ.setdefault('HAIL_BUILDKIT_IMAGE', 'gcr.io/hail-vdc/buildkit:test')
+os.environ.setdefault('HAIL_CI_STORAGE_URI', 'gs://hail-ci-test/build')
+os.environ.setdefault('HAIL_CI_GITHUB_CONTEXT', 'ci-test')
+
+if not os.path.exists('/global-config'):
+    # Patch gear.cloud_config.read_config_secret so that ci.environment's module-level
+    # get_global_config() call (and the subsequent get_gcp_config() call) succeed locally.
+    _fake_global_config = {
+        'cloud': 'gcp',
+        'docker_prefix': 'gcr.io/hail-vdc',
+        'docker_root_image': 'ubuntu:22.04',
+        'domain': 'hail.is',
+        'kubernetes_server_url': 'https://k8s.example.com',
+        'default_namespace': 'default',
+        # Fields required by GCPConfig.from_global_config
+        'batch_gcp_regions': json.dumps(['us-central1']),
+        'gcp_region': 'us-central1',
+        'gcp_project': 'hail-vdc',
+        'gcp_zone': 'us-central1-a',
+    }
+    unittest.mock.patch('gear.cloud_config.read_config_secret', return_value=_fake_global_config).start()

--- a/ci/unit-test/conftest.py
+++ b/ci/unit-test/conftest.py
@@ -4,6 +4,7 @@ In CI these values come from the real deployment environment (env vars + /global
 mount).  Locally they don't exist, so we set safe defaults and mock the config reader.
 """
 
+import atexit
 import json
 import os
 import unittest.mock
@@ -34,4 +35,6 @@ if not os.path.exists('/global-config'):
         'gcp_project': 'hail-vdc',
         'gcp_zone': 'us-central1-a',
     }
-    unittest.mock.patch('gear.cloud_config.read_config_secret', return_value=_fake_global_config).start()
+    _patcher = unittest.mock.patch('gear.cloud_config.read_config_secret', return_value=_fake_global_config)
+    _patcher.start()
+    atexit.register(_patcher.stop)

--- a/ci/unit-test/pytest.ini
+++ b/ci/unit-test/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/ci/unit-test/test_github_unit.py
+++ b/ci/unit-test/test_github_unit.py
@@ -1,0 +1,277 @@
+"""Unit tests for _fetch_pr_github_data and PR._apply_github_data.
+
+These mock out the GitHub API client so no network access is needed.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ci.github import PR, _fetch_pr_github_data
+from ci.utils import GithubStatus
+
+# ── Mock helpers ─────────────────────────────────────────────────────────────
+
+
+class MockGH:
+    """Records calls and returns pre-canned responses in order."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.call_count = 0
+
+    async def post(self, url: str, *, data: Any) -> Any:  # pylint: disable=unused-argument
+        assert self.call_count < len(self._responses), (
+            f'Unexpected API call #{self.call_count + 1} (only {len(self._responses)} response(s) queued)'
+        )
+        response = self._responses[self.call_count]
+        self.call_count += 1
+        return response
+
+
+def graphql_response(pr_data_by_number: dict) -> dict:
+    return {"data": {"repository": {f"pr_{n}": data for n, data in pr_data_by_number.items()}}}
+
+
+def pr_response(review_decision, check_nodes, *, has_next_page=False, end_cursor=None):
+    """Minimal pullRequest fragment matching the shape _fetch_pr_github_data expects."""
+    return {
+        "reviewDecision": review_decision,
+        "commits": {
+            "nodes": [
+                {
+                    "commit": {
+                        "statusCheckRollup": {
+                            "contexts": {
+                                "nodes": check_nodes,
+                                "pageInfo": {"hasNextPage": has_next_page, "endCursor": end_cursor},
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+    }
+
+
+def pr_response_no_rollup(review_decision):
+    """PR with no CI runs yet — statusCheckRollup is null."""
+    return {
+        "reviewDecision": review_decision,
+        "commits": {"nodes": [{"commit": {"statusCheckRollup": None}}]},
+    }
+
+
+def check_run(name, conclusion, *, is_required=True):
+    return {"__typename": "CheckRun", "name": name, "conclusion": conclusion, "isRequired": is_required}
+
+
+def status_context(context, state, *, is_required=True):
+    return {"__typename": "StatusContext", "context": context, "state": state, "isRequired": is_required}
+
+
+def make_pr(number=123):
+    """Construct a minimal PR with a MagicMock target_branch, bypassing prometheus metrics."""
+    tb = MagicMock()
+    tb.state_changed = False
+    tb.batch_changed = False
+    with patch('ci.github.TRACKED_PRS'):
+        pr = PR(
+            number=number,
+            title='Test PR',
+            body='',
+            source_branch=MagicMock(),
+            source_sha='deadbeef',
+            target_branch=tb,
+            author='testuser',
+            assignees=set(),
+            reviewers=set(),
+            labels=set(),
+            developers=[],
+        )
+    tb.state_changed = False  # reset; constructor sets it
+    return pr
+
+
+# ── _fetch_pr_github_data ─────────────────────────────────────────────────────
+
+
+async def test_single_pr_no_pagination():
+    nodes = [check_run('ci-test', 'SUCCESS'), status_context('lint', 'SUCCESS', is_required=False)]
+    gh = MockGH([graphql_response({123: pr_response('APPROVED', nodes)})])
+
+    result = await _fetch_pr_github_data(gh, 'hail-is', 'hail', [123])
+
+    assert gh.call_count == 1
+    review_decision, check_nodes = result[123]
+    assert review_decision == 'APPROVED'
+    assert check_nodes == nodes
+
+
+async def test_multiple_prs_in_single_request():
+    nodes_a = [check_run('ci-test', 'SUCCESS')]
+    nodes_b = [check_run('ci-test', 'FAILURE')]
+    gh = MockGH([
+        graphql_response({
+            1: pr_response('APPROVED', nodes_a),
+            2: pr_response('REVIEW_REQUIRED', nodes_b),
+        })
+    ])
+
+    result = await _fetch_pr_github_data(gh, 'hail-is', 'hail', [1, 2])
+
+    assert gh.call_count == 1
+    assert result[1] == ('APPROVED', nodes_a)
+    assert result[2] == ('REVIEW_REQUIRED', nodes_b)
+
+
+async def test_pagination_fires_multiple_requests_and_accumulates_nodes():
+    page1 = [check_run('check-a', 'SUCCESS')]
+    page2 = [check_run('check-b', 'FAILURE')]
+    page3 = [check_run('check-c', 'SUCCESS')]
+
+    gh = MockGH([
+        graphql_response({42: pr_response('APPROVED', page1, has_next_page=True, end_cursor='cursor-1')}),
+        # reviewDecision is ignored on subsequent pages (already captured from page 1)
+        graphql_response({42: pr_response(None, page2, has_next_page=True, end_cursor='cursor-2')}),
+        graphql_response({42: pr_response(None, page3, has_next_page=False)}),
+    ])
+
+    result = await _fetch_pr_github_data(gh, 'hail-is', 'hail', [42])
+
+    assert gh.call_count == 3
+    review_decision, check_nodes = result[42]
+    assert review_decision == 'APPROVED'
+    assert check_nodes == page1 + page2 + page3
+
+
+async def test_pagination_only_re_requests_prs_that_need_it():
+    """PRs that finish on page 1 are dropped from subsequent requests; only lagging PRs continue."""
+    page1_pr1 = [check_run('check-a', 'SUCCESS')]
+    page2_pr1 = [check_run('check-b', 'SUCCESS')]
+    page3_pr1 = [check_run('check-c', 'SUCCESS')]
+    nodes_pr2 = [check_run('check-a', 'FAILURE')]
+
+    # Request 1: both PRs. PR 2 finishes; PR 1 needs 2 more pages.
+    # Requests 2 and 3: only PR 1 — mock would error if PR 2 appeared again.
+    gh = MockGH([
+        graphql_response({
+            1: pr_response('APPROVED', page1_pr1, has_next_page=True, end_cursor='cur-1'),
+            2: pr_response('REVIEW_REQUIRED', nodes_pr2, has_next_page=False),
+        }),
+        graphql_response({1: pr_response(None, page2_pr1, has_next_page=True, end_cursor='cur-2')}),
+        graphql_response({1: pr_response(None, page3_pr1, has_next_page=False)}),
+    ])
+
+    result = await _fetch_pr_github_data(gh, 'hail-is', 'hail', [1, 2])
+
+    assert gh.call_count == 3
+    assert result[1] == ('APPROVED', page1_pr1 + page2_pr1 + page3_pr1)
+    assert result[2] == ('REVIEW_REQUIRED', nodes_pr2)
+
+
+async def test_null_review_decision_becomes_api_none():
+    gh = MockGH([graphql_response({5: pr_response(None, [])})])
+
+    result = await _fetch_pr_github_data(gh, 'hail-is', 'hail', [5])
+
+    assert result[5][0] == 'API_NONE'
+
+
+async def test_null_status_rollup_returns_empty_nodes():
+    gh = MockGH([graphql_response({7: pr_response_no_rollup('REVIEW_REQUIRED')})])
+
+    result = await _fetch_pr_github_data(gh, 'hail-is', 'hail', [7])
+
+    review_decision, check_nodes = result[7]
+    assert review_decision == 'REVIEW_REQUIRED'
+    assert check_nodes == []
+
+
+async def test_empty_pr_list_makes_no_request():
+    gh = MockGH([])
+
+    result = await _fetch_pr_github_data(gh, 'hail-is', 'hail', [])
+
+    assert result == {}
+    assert gh.call_count == 0
+
+
+# ── PR._apply_github_data ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    'review_decision,expected_state',
+    [
+        ('APPROVED', 'approved'),
+        ('CHANGES_REQUESTED', 'changes_requested'),
+        ('REVIEW_REQUIRED', 'pending'),
+        ('API_NONE', 'pending'),
+    ],
+)
+def test_review_decision_mapping(review_decision, expected_state):
+    pr = make_pr()
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data(review_decision, [])
+    assert pr.review_state == expected_state
+    assert pr.target_branch.state_changed is True
+
+
+def test_review_state_unchanged_does_not_set_state_changed():
+    pr = make_pr()
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data('APPROVED', [])
+        pr.target_branch.state_changed = False
+        pr._apply_github_data('APPROVED', [])
+    assert pr.target_branch.state_changed is False
+
+
+def test_required_check_run_appears_in_status():
+    pr = make_pr()
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data('APPROVED', [check_run('ci-test', 'SUCCESS', is_required=True)])
+    assert pr.last_known_github_status == {'ci-test': GithubStatus.SUCCESS}
+
+
+def test_required_status_context_appears_in_status():
+    pr = make_pr()
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data('APPROVED', [status_context('ci-status', 'FAILURE', is_required=True)])
+    assert pr.last_known_github_status == {'ci-status': GithubStatus.FAILURE}
+
+
+def test_non_required_checks_are_ignored():
+    pr = make_pr()
+    nodes = [
+        check_run('required', 'SUCCESS', is_required=True),
+        check_run('optional', 'FAILURE', is_required=False),
+        status_context('optional-status', 'FAILURE', is_required=False),
+    ]
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data('APPROVED', nodes)
+    assert list(pr.last_known_github_status.keys()) == ['required']
+
+
+def test_github_status_unchanged_does_not_set_state_changed():
+    pr = make_pr()
+    nodes = [check_run('ci-test', 'SUCCESS', is_required=True)]
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data('APPROVED', nodes)
+        pr.target_branch.state_changed = False
+        pr._apply_github_data('APPROVED', nodes)
+    assert pr.target_branch.state_changed is False
+
+
+def test_check_run_failure_status():
+    pr = make_pr()
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data('APPROVED', [check_run('ci-test', 'FAILURE', is_required=True)])
+    assert pr.last_known_github_status['ci-test'] == GithubStatus.FAILURE
+
+
+def test_check_run_pending_conclusion():
+    pr = make_pr()
+    with patch('ci.github.TRACKED_PRS'):
+        pr._apply_github_data('APPROVED', [check_run('ci-test', 'ACTION_REQUIRED', is_required=True)])
+    assert pr.last_known_github_status['ci-test'] == GithubStatus.PENDING


### PR DESCRIPTION
## Change Description

Two main changes:
- Switch away from a sequence of per-PR per-statuscheck polling which takes ages and runs into an internal CI timeout, and instead do a single graphQL poll that gets all PR review and check information in a single request
- Fix a no-batch-yet bug in the github hook handler which was causing errors to be thrown in logs and status reporting to be delayed in the system.

Additionally, sets up a test framework in CI that can mock out GH to test the polling logic, and provide default environment variables during test runs so that we don't fail because of "global config missing" errors.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Small internal changes in how we poll github and how we manage internal state when we get state update hook calls.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
