### PR TITLE
[hailctl] Fix container and add attempt when log fetching

### DIFF
--- a/.claude/skills/hail-batch-dev/SKILL.md
+++ b/.claude/skills/hail-batch-dev/SKILL.md
@@ -133,11 +133,11 @@ The spec is the authoritative source — prefer it over any cached list of endpo
 
 **When an endpoint doesn't match the spec** (wrong path, missing params, incorrect response shape), fix the spec too — a drift between implementation and spec is a bug.
 
-## Investigating with the CLI
+## Investigating with the CLI (prefer this for inspection)
 
-Use `hailctl batch` for all job inspection. See `/hail-batch` for the full reference. Key: always use `--container` with `hailctl batch log`, and `--attempt` when a job has been retried.
+The `hailctl batch` CLI works against any namespace via `HAIL_DEFAULT_NAMESPACE`. Prefer it for inspection — see `/hail-batch` for the full command reference.
 
-For listing jobs within a batch, `hailctl curl` is also better than the Python client because the response is paginated and easy to compose with `jq`:
+For listing jobs within a batch, `hailctl curl` is often better than the Python client because the response is paginated and curl makes it easy to inspect pages and compose with `jq`:
 
 ```bash
 # First page of jobs
@@ -294,8 +294,6 @@ CI submits batches to the `ci` billing project. To investigate a CI build failur
 If you hit a gap in the CLI during an investigation (e.g. there's no `hailctl batch jobs BATCH_ID` to list jobs within a batch — you currently need the Python client or `hailctl curl` for that), it may be worth adding the missing command. The CLI lives in `hail/python/hailtop/hailctl/` and is straightforward to extend.
 
 That said, CLI additions should be a **separate PR** from whatever you're currently working on — note it as a follow-up rather than doing it now.
-
-Similarly, if an investigation reveals that a service API endpoint is missing, awkward, or has unhelpful response shape (e.g. no way to filter, missing fields, params that don't do what the spec says), proactively suggest adding or tweaking it. Service API changes also go in a separate PR — but flag them as improvements worth making.
 
 ## Common dev-level failure patterns
 

--- a/.claude/skills/hail-batch-dev/SKILL.md
+++ b/.claude/skills/hail-batch-dev/SKILL.md
@@ -133,11 +133,11 @@ The spec is the authoritative source — prefer it over any cached list of endpo
 
 **When an endpoint doesn't match the spec** (wrong path, missing params, incorrect response shape), fix the spec too — a drift between implementation and spec is a bug.
 
-## Investigating with the CLI (prefer this for inspection)
+## Investigating with hailctl curl (prefer this for inspection)
 
-The `hailctl batch` CLI works against any namespace via `HAIL_DEFAULT_NAMESPACE`. Prefer it for inspection — see `/hail-batch` for the full command reference.
+Use `hailctl curl` as the primary tool for inspecting jobs, logs, and attempts — it's reliable and works for everything. `hailctl batch` subcommands have gaps and version-dependent behaviour. See `/hail-batch` for the full reference including log/attempt endpoints.
 
-For listing jobs within a batch, `hailctl curl` is often better than the Python client because the response is paginated and curl makes it easy to inspect pages and compose with `jq`:
+For listing jobs within a batch, `hailctl curl` is also better than the Python client because the response is paginated and easy to compose with `jq`:
 
 ```bash
 # First page of jobs

--- a/.claude/skills/hail-batch-dev/SKILL.md
+++ b/.claude/skills/hail-batch-dev/SKILL.md
@@ -295,6 +295,8 @@ If you hit a gap in the CLI during an investigation (e.g. there's no `hailctl ba
 
 That said, CLI additions should be a **separate PR** from whatever you're currently working on — note it as a follow-up rather than doing it now.
 
+Similarly, if an investigation reveals that a service API endpoint is missing, awkward, or has unhelpful response shape (e.g. no way to filter, missing fields, params that don't do what the spec says), proactively suggest adding or tweaking it. Service API changes also go in a separate PR — but flag them as improvements worth making.
+
 ## Common dev-level failure patterns
 
 | Symptom | Likely cause | Action |

--- a/.claude/skills/hail-batch-dev/SKILL.md
+++ b/.claude/skills/hail-batch-dev/SKILL.md
@@ -133,9 +133,9 @@ The spec is the authoritative source — prefer it over any cached list of endpo
 
 **When an endpoint doesn't match the spec** (wrong path, missing params, incorrect response shape), fix the spec too — a drift between implementation and spec is a bug.
 
-## Investigating with hailctl curl (prefer this for inspection)
+## Investigating with the CLI
 
-Use `hailctl curl` as the primary tool for inspecting jobs, logs, and attempts — it's reliable and works for everything. `hailctl batch` subcommands have gaps and version-dependent behaviour. See `/hail-batch` for the full reference including log/attempt endpoints.
+Use `hailctl batch` for all job inspection. See `/hail-batch` for the full reference. Key: always use `--container` with `hailctl batch log`, and `--attempt` when a job has been retried.
 
 For listing jobs within a batch, `hailctl curl` is also better than the Python client because the response is paginated and easy to compose with `jq`:
 

--- a/.claude/skills/hail-batch/SKILL.md
+++ b/.claude/skills/hail-batch/SKILL.md
@@ -24,9 +24,7 @@ hailctl auth login
 
 Both are needed. If a user gets auth errors, check which one is missing.
 
-## Investigating batches: use hailctl curl
-
-For inspecting individual jobs and logs, **use `hailctl curl` directly** — it's reliable and works for everything. The `hailctl batch` subcommands (`job`, `log`) are less complete and have version-dependent gaps.
+## Investigating batches
 
 ### List recent batches
 ```bash
@@ -43,22 +41,20 @@ hailctl batch get BATCH_ID -o json
 
 ### Inspect a specific job
 ```bash
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID
+hailctl batch job BATCH_ID JOB_ID
 ```
 
-### Get logs
+### List attempts and get logs
+
+Always specify `--container` when fetching logs — the default (all containers, JSON-wrapped) is hard to read. When a job has been retried, also specify `--attempt` to get the right one.
+
 ```bash
-# All containers (JSON keyed by container name: main, input, output) — deprecated but convenient
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log
+# List attempts to find the attempt_id
+hailctl batch attempts BATCH_ID JOB_ID
 
-# Specific container (preferred)
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log/main
-
-# Specific attempt
-hailctl curl default batch "/api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log/main?attempt_id=ATTEMPT_ID"
-
-# List all attempts (to find attempt_id)
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/attempts
+# Get log for a specific container (almost always what you want)
+hailctl batch log BATCH_ID JOB_ID --container main
+hailctl batch log BATCH_ID JOB_ID --container main --attempt ATTEMPT_ID
 ```
 
 ### Wait for a batch to complete

--- a/.claude/skills/hail-batch/SKILL.md
+++ b/.claude/skills/hail-batch/SKILL.md
@@ -24,9 +24,9 @@ hailctl auth login
 
 Both are needed. If a user gets auth errors, check which one is missing.
 
-## Investigating batches: use the CLI
+## Investigating batches: use hailctl curl
 
-For inspection tasks (checking status, reading logs, diagnosing failures), **always prefer `hailctl batch` CLI commands** — they're simpler and don't require writing Python.
+For inspecting individual jobs and logs, **use `hailctl curl` directly** — it's reliable and works for everything. The `hailctl batch` subcommands (`job`, `log`) are less complete and have version-dependent gaps.
 
 ### List recent batches
 ```bash
@@ -43,22 +43,22 @@ hailctl batch get BATCH_ID -o json
 
 ### Inspect a specific job
 ```bash
-hailctl batch job BATCH_ID JOB_ID           # status + spec (yaml)
+hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID
 ```
 
 ### Get logs
 ```bash
-hailctl batch log BATCH_ID JOB_ID                       # all containers (yaml)
-hailctl batch log BATCH_ID JOB_ID --container main      # just main (raw text)
-hailctl batch log BATCH_ID JOB_ID --container input     # input sidecar
-hailctl batch log BATCH_ID JOB_ID --container output    # output sidecar
-```
+# All containers (JSON keyed by container name: main, input, output) — deprecated but convenient
+hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log
 
-Note: `--container` requires a recent hailtop version. If it fails, fall back to the raw API (container is a path segment):
-```bash
+# Specific container (preferred)
 hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log/main
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log/input
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log/output
+
+# Specific attempt
+hailctl curl default batch "/api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/log/main?attempt_id=ATTEMPT_ID"
+
+# List all attempts (to find attempt_id)
+hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs/JOB_ID/attempts
 ```
 
 ### Wait for a batch to complete

--- a/.claude/skills/hail-batch/SKILL.md
+++ b/.claude/skills/hail-batch/SKILL.md
@@ -24,7 +24,9 @@ hailctl auth login
 
 Both are needed. If a user gets auth errors, check which one is missing.
 
-## Investigating batches
+## Investigating batches: use the CLI
+
+For inspection tasks (checking status, reading logs, diagnosing failures), **always prefer `hailctl batch` CLI commands** — they're simpler and don't require writing Python.
 
 ### List recent batches
 ```bash
@@ -41,20 +43,19 @@ hailctl batch get BATCH_ID -o json
 
 ### Inspect a specific job
 ```bash
-hailctl batch job BATCH_ID JOB_ID
+hailctl batch job BATCH_ID JOB_ID           # status + spec (yaml)
 ```
 
-### List attempts and get logs
+### Get logs
 
-Always specify `--container` when fetching logs — the default (all containers, JSON-wrapped) is hard to read. When a job has been retried, also specify `--attempt` to get the right one.
+Always specify `--container` — the bare command dumps all containers as escaped YAML and is hard to read. If a job has been retried, use `--attempt` to get the right one (defaults to most recent).
 
 ```bash
-# List attempts to find the attempt_id
-hailctl batch attempts BATCH_ID JOB_ID
-
-# Get log for a specific container (almost always what you want)
-hailctl batch log BATCH_ID JOB_ID --container main
-hailctl batch log BATCH_ID JOB_ID --container main --attempt ATTEMPT_ID
+hailctl batch attempts BATCH_ID JOB_ID                              # list attempts + IDs (only if needed)
+hailctl batch log BATCH_ID JOB_ID --container main                  # user code (start here)
+hailctl batch log BATCH_ID JOB_ID --container main --attempt ID     # specific attempt
+hailctl batch log BATCH_ID JOB_ID --container input                 # file copies in
+hailctl batch log BATCH_ID JOB_ID --container output                # file copies out
 ```
 
 ### Wait for a batch to complete

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -284,10 +284,12 @@ class Job:
             tries += 1
             await sleep_before_try(tries)
 
-    async def container_log(self, container_name: str) -> bytes:
+    async def container_log(self, container_name: str, attempt_id: Optional[str] = None) -> bytes:
         self._raise_if_not_submitted()
+        params = {'attempt_id': attempt_id} if attempt_id else {}
         async with await self._client._get(
-            f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/log/{container_name}'
+            f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/log/{container_name}',
+            params=params,
         ) as resp:
             return await resp.read()
 

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -88,8 +88,8 @@ class Job:
     def _wait_for_states(self, *states: str):
         return async_to_blocking(self._async_job._wait_for_states(*states))
 
-    def container_log(self, container_name):
-        return async_to_blocking(self._async_job.container_log(container_name))
+    def container_log(self, container_name, attempt_id=None):
+        return async_to_blocking(self._async_job.container_log(container_name, attempt_id=attempt_id))
 
     def log(self):
         return async_to_blocking(self._async_job.log())

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -103,6 +103,7 @@ def log(
     batch_id: int,
     job_id: int,
     container: Ann[Optional[JobContainer], Opt(help='Container name of the desired job')] = None,
+    attempt: Ann[Optional[str], Opt(help='Attempt ID to retrieve log for (defaults to most recent)')] = None,
     output: StructuredFormatOption = StructuredFormat.YAML,
 ):
     """Get the log for the job with id JOB_ID in the batch with id BATCH_ID."""
@@ -115,9 +116,26 @@ def log(
             return
 
         if container:
-            print(maybe_job.container_log(container))
+            print(maybe_job.container_log(container.value, attempt_id=attempt).decode())
         else:
             print(make_formatter(output)(maybe_job.log()))
+
+
+@app.command()
+def attempts(
+    batch_id: int,
+    job_id: int,
+    output: StructuredFormatOption = StructuredFormat.YAML,
+):
+    """List all attempts for the job with id JOB_ID in the batch with id BATCH_ID."""
+    from hailtop.batch_client.client import BatchClient  # pylint: disable=import-outside-toplevel
+
+    with BatchClient('') as client:
+        maybe_job = get_job_if_exists(client, batch_id, job_id)
+        if maybe_job is None:
+            print(f"Job with ID {job_id} on batch {batch_id} not found")
+            return
+        print(make_formatter(output)(maybe_job.attempts()))
 
 
 @app.command()

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -115,13 +115,17 @@ def log(
     from hailtop.batch_client.client import BatchClient  # pylint: disable=import-outside-toplevel
 
     if attempt is not None and container is None:
-        print("Error: --attempt requires --container to be specified", file=sys.stderr)
-        raise typer.Exit(code=1)
+        raise typer.BadParameter('--attempt requires --container to be specified')
+    if raw and container is None:
+        raise typer.BadParameter('--raw requires --container to be specified')
 
     with BatchClient('') as client:
         maybe_job = get_job_if_exists(client, batch_id, job_id)
         if maybe_job is None:
-            print(f"Job with ID {job_id} on batch {batch_id} not found")
+            msg = f"Job with ID {job_id} on batch {batch_id} not found"
+            if attempt is not None:
+                msg += f", or attempt {attempt!r} does not exist"
+            print(msg)
             return
 
         if container:

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -103,11 +103,20 @@ def log(
     batch_id: int,
     job_id: int,
     container: Ann[Optional[JobContainer], Opt(help='Container name of the desired job')] = None,
-    attempt: Ann[Optional[str], Opt(help='Attempt ID to retrieve log for (defaults to most recent)')] = None,
+    attempt: Ann[
+        Optional[str], Opt(help='Attempt ID to retrieve log for (defaults to most recent); requires --container')
+    ] = None,
     output: StructuredFormatOption = StructuredFormat.YAML,
+    raw: Ann[bool, Opt(help='Write log bytes directly to stdout without decoding')] = False,
 ):
     """Get the log for the job with id JOB_ID in the batch with id BATCH_ID."""
+    import sys  # pylint: disable=import-outside-toplevel
+
     from hailtop.batch_client.client import BatchClient  # pylint: disable=import-outside-toplevel
+
+    if attempt is not None and container is None:
+        print("Error: --attempt requires --container to be specified", file=sys.stderr)
+        raise typer.Exit(code=1)
 
     with BatchClient('') as client:
         maybe_job = get_job_if_exists(client, batch_id, job_id)
@@ -116,7 +125,11 @@ def log(
             return
 
         if container:
-            print(maybe_job.container_log(container.value, attempt_id=attempt).decode())
+            log_bytes = maybe_job.container_log(container.value, attempt_id=attempt)
+            if raw:
+                sys.stdout.buffer.write(log_bytes)
+            else:
+                sys.stdout.write(log_bytes.decode(errors='replace'))
         else:
             print(make_formatter(output)(maybe_job.log()))
 

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -98,6 +98,14 @@ class JobContainer(str, Enum):
     OUTPUT = 'output'
 
 
+def _get_job_or_exit(client, batch_id: int, job_id: int):
+    job = get_job_if_exists(client, batch_id, job_id)
+    if job is None:
+        print(f"Job with ID {job_id} on batch {batch_id} not found")
+        raise typer.Exit(1)
+    return job
+
+
 @app.command()
 def log(
     batch_id: int,
@@ -120,13 +128,7 @@ def log(
         raise typer.BadParameter('--raw requires --container to be specified')
 
     with BatchClient('') as client:
-        maybe_job = get_job_if_exists(client, batch_id, job_id)
-        if maybe_job is None:
-            msg = f"Job with ID {job_id} on batch {batch_id} not found"
-            if attempt is not None:
-                msg += f", or attempt {attempt!r} does not exist"
-            print(msg)
-            return
+        maybe_job = _get_job_or_exit(client, batch_id, job_id)
 
         if container:
             log_bytes = maybe_job.container_log(container.value, attempt_id=attempt)
@@ -148,10 +150,7 @@ def attempts(
     from hailtop.batch_client.client import BatchClient  # pylint: disable=import-outside-toplevel
 
     with BatchClient('') as client:
-        maybe_job = get_job_if_exists(client, batch_id, job_id)
-        if maybe_job is None:
-            print(f"Job with ID {job_id} on batch {batch_id} not found")
-            return
+        maybe_job = _get_job_or_exit(client, batch_id, job_id)
         print(make_formatter(output)(maybe_job.attempts()))
 
 
@@ -184,17 +183,13 @@ def job(batch_id: int, job_id: int, output: StructuredFormatOption = StructuredF
     from hailtop.batch_client.client import BatchClient  # pylint: disable=import-outside-toplevel
 
     with BatchClient('') as client:
-        job = get_job_if_exists(client, batch_id, job_id)
-
-        if job is not None:
-            assert job._status
-            print(
-                make_formatter(output)(
-                    [cast(Dict[str, Any], job._status)]  # https://stackoverflow.com/q/71986632/6823256
-                )
+        job = _get_job_or_exit(client, batch_id, job_id)
+        assert job._status
+        print(
+            make_formatter(output)(
+                [cast(Dict[str, Any], job._status)]  # https://stackoverflow.com/q/71986632/6823256
             )
-        else:
-            print(f"Job with ID {job_id} on batch {batch_id} not found")
+        )
 
 
 @app.command('init', help='Initialize a Hail Batch environment.')


### PR DESCRIPTION
## Change Description

Update hailctl to make log fetching work properly for both containers (previously broken because of enum to-string-ing) and attempts (previously not available), and add a cli command for attempt listing.
Also update the claude skills to make sure `--container` is always used when fetching logs

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

