### PR TITLE
[batch] Upgrade pooled vms from n1 to n2 machines

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -13,7 +13,7 @@ from ....file_store import FileStore
 from ....instance_config import InstanceConfig
 from ...resource_utils import unreserved_worker_data_disk_size_gib
 from ...utils import ACCEPTABLE_QUERY_JAR_URL_PREFIX
-from ..resource_utils import GPUConfig, gcp_machine_type_to_parts, machine_type_to_gpu
+from ..resource_utils import GPUConfig, gcp_local_ssd_count, gcp_machine_type_to_parts, machine_type_to_gpu
 
 log = logging.getLogger('create_instance')
 
@@ -62,21 +62,28 @@ def create_vm_config(
     region = instance_config.region_for(zone)
     docker_run_gpu_args = '--runtime=nvidia --gpus all' if machine_type_to_gpu(machine_type_full) else ''
     if local_ssd_data_disk:
-        worker_data_disk = {
-            'type': 'SCRATCH',
-            'autoDelete': True,
-            'interface': 'NVME',
-            'initializeParams': {'diskType': f'zones/{zone}/diskTypes/local-ssd'},
-        }
-        worker_data_disk_name = 'nvme0n1'
+        num_local_ssds = gcp_local_ssd_count(parts.machine_family, cores)
+        worker_data_disks = [
+            {
+                'type': 'SCRATCH',
+                'autoDelete': True,
+                'interface': 'NVME',
+                'initializeParams': {'diskType': f'zones/{zone}/diskTypes/local-ssd'},
+            }
+            for _ in range(num_local_ssds)
+        ]
+        worker_data_disk_name = 'md0' if num_local_ssds > 1 else 'nvme0n1'
     else:
-        worker_data_disk = {
-            'autoDelete': True,
-            'initializeParams': {
-                'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
-                'diskSizeGb': str(data_disk_size_gb),
-            },
-        }
+        num_local_ssds = 0
+        worker_data_disks = [
+            {
+                'autoDelete': True,
+                'initializeParams': {
+                    'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
+                    'diskSizeGb': str(data_disk_size_gb),
+                },
+            }
+        ]
         worker_data_disk_name = 'nvme0n2' if 'g2' in machine_type else 'sdb'
 
     if job_private:
@@ -123,7 +130,7 @@ def create_vm_config(
                     'diskSizeGb': str(boot_disk_size_gb),
                 },
             },
-            worker_data_disk,
+            *worker_data_disks,
         ],
         'networkInterfaces': [
             {
@@ -175,6 +182,7 @@ nohup /bin/bash run.sh >run.log 2>&1 &
 set -x
 
 WORKER_DATA_DISK_NAME="{worker_data_disk_name}"
+NUM_LOCAL_SSDS="{num_local_ssds}"
 UNRESERVED_WORKER_DATA_DISK_SIZE_GB="{unreserved_disk_storage_gb}"
 ACCEPTABLE_QUERY_JAR_URL_PREFIX="{ACCEPTABLE_QUERY_JAR_URL_PREFIX}"
 
@@ -251,6 +259,15 @@ metrics:
 EOF
 
 sudo systemctl restart google-cloud-ops-agent
+
+# combine multiple local SSDs into a single RAID0 array
+if [ "$NUM_LOCAL_SSDS" -gt 1 ]; then
+    DEVICES=""
+    for i in $(seq 1 $NUM_LOCAL_SSDS); do
+        DEVICES="$DEVICES /dev/nvme0n$i"
+    done
+    mdadm --create /dev/md0 --level=0 --raid-devices=$NUM_LOCAL_SSDS $DEVICES --force --run
+fi
 
 # format worker data disk
 sudo mkfs.xfs -m reflink=1 -n ftype=1 /dev/$WORKER_DATA_DISK_NAME

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -125,7 +125,7 @@ def create_vm_config(
                 'autoDelete': True,
                 'initializeParams': {
                     # NB: create a new worker image with gcp-create-worker-image.sh
-                    'sourceImage': f'projects/{project}/global/images/batch-worker-20',
+                    'sourceImage': f'projects/{project}/global/images/batch-worker-grohlice-21',
                     'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
                     'diskSizeGb': str(boot_disk_size_gb),
                 },

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -125,7 +125,7 @@ def create_vm_config(
                 'autoDelete': True,
                 'initializeParams': {
                     # NB: create a new worker image with gcp-create-worker-image.sh
-                    'sourceImage': f'projects/{project}/global/images/batch-worker-grohlice-21',
+                    'sourceImage': f'projects/{project}/global/images/batch-worker-21',
                     'diskType': f'projects/{project}/zones/{zone}/diskTypes/pd-ssd',
                     'diskSizeGb': str(boot_disk_size_gb),
                 },

--- a/batch/batch/cloud/gcp/driver/pricing.py
+++ b/batch/batch/cloud/gcp/driver/pricing.py
@@ -179,6 +179,8 @@ def instance_family_from_sku(sku: dict) -> Optional[str]:
     category = sku['category']
     if category['resourceGroup'] == 'N1Standard':
         return 'n1'
+    if sku['description'].startswith("N2 Instance") or sku['description'].startswith("Spot Preemptible N2 Instance"):
+        return 'n2'
     if sku['description'].startswith("G2 Instance") or sku['description'].startswith("Spot Preemptible G2 Instance"):
         return 'g2'
     if sku['description'].startswith("A2 Instance") or sku['description'].startswith("Spot Preemptible A2 Instance"):
@@ -283,7 +285,7 @@ def process_accelerator_sku(sku: dict, regions: List[str]) -> List[GCPAccelerato
 def process_memory_sku(sku: dict, regions: List[str]) -> List[GCPMemoryPrice]:
     category = sku['category']
     assert category['resourceFamily'] == 'Compute', sku
-    assert 'Ram' in sku['description']
+    assert 'Ram' in sku['description'] or 'Memory' in sku['description']
 
     instance_family = instance_family_from_sku(sku)
     preemptible = preemptible_from_sku(sku)
@@ -392,7 +394,7 @@ async def fetch_prices(
             if 'Core' in sku['description']:
                 for compute_price in process_compute_sku(sku, regions):
                     yield compute_price
-            elif 'Ram' in sku['description']:
+            elif 'Ram' in sku['description'] or 'Memory' in sku['description']:
                 for memory_price in process_memory_sku(sku, regions):
                     yield memory_price
         elif category['resourceFamily'] == 'Storage':

--- a/batch/batch/cloud/gcp/driver/resource_manager.py
+++ b/batch/batch/cloud/gcp/driver/resource_manager.py
@@ -112,7 +112,10 @@ class GCPResourceManager(CloudResourceManager):
         instance_config: InstanceConfig,
     ) -> List[QuantifiedResource]:
         if local_ssd_data_disk:
-            assert data_disk_size_gb % GCP_LOCAL_SSD_PARTITION_SIZE_GIB == 0 and data_disk_size_gb >= GCP_LOCAL_SSD_PARTITION_SIZE_GIB
+            assert (
+                data_disk_size_gb % GCP_LOCAL_SSD_PARTITION_SIZE_GIB == 0
+                and data_disk_size_gb >= GCP_LOCAL_SSD_PARTITION_SIZE_GIB
+            )
 
         resource_rates = self.billing_manager.resource_rates
 

--- a/batch/batch/cloud/gcp/driver/resource_manager.py
+++ b/batch/batch/cloud/gcp/driver/resource_manager.py
@@ -21,6 +21,7 @@ from ....file_store import FileStore
 from ....instance_config import InstanceConfig, QuantifiedResource
 from ..instance_config import GCPSlimInstanceConfig
 from ..resource_utils import (
+    GCP_LOCAL_SSD_PARTITION_SIZE_GIB,
     GCP_MACHINE_FAMILY,
     family_worker_type_cores_to_gcp_machine_type,
     gcp_machine_type_to_cores_and_memory_bytes,
@@ -111,7 +112,7 @@ class GCPResourceManager(CloudResourceManager):
         instance_config: InstanceConfig,
     ) -> List[QuantifiedResource]:
         if local_ssd_data_disk:
-            assert data_disk_size_gb == 375
+            assert data_disk_size_gb % GCP_LOCAL_SSD_PARTITION_SIZE_GIB == 0 and data_disk_size_gb >= GCP_LOCAL_SSD_PARTITION_SIZE_GIB
 
         resource_rates = self.billing_manager.resource_rates
 

--- a/batch/batch/cloud/gcp/instance_config.py
+++ b/batch/batch/cloud/gcp/instance_config.py
@@ -29,7 +29,8 @@ def region_from_location(location: str) -> str:
     # while zones have the form '{region}-{a,b,c,...}' (e.g. 'us-central1-a'). Accept
     # either: return the region unchanged, or strip the trailing zone suffix.
     parts = location.split('-')
-    assert len(parts) in (2, 3), location
+    if len(parts) not in (2, 3):
+        raise ValueError(f'Expected a GCP region or zone, got {location!r}')
     return '-'.join(parts[:2])
 
 

--- a/batch/batch/cloud/gcp/instance_config.py
+++ b/batch/batch/cloud/gcp/instance_config.py
@@ -25,7 +25,12 @@ GCP_INSTANCE_CONFIG_VERSION = 5
 
 
 def region_from_location(location: str) -> str:
-    return location.rsplit('-', maxsplit=1)[0]
+    # GCP regions have the form '{continent}-{direction}{number}' (e.g. 'us-central1'),
+    # while zones have the form '{region}-{a,b,c,...}' (e.g. 'us-central1-a'). Accept
+    # either: return the region unchanged, or strip the trailing zone suffix.
+    parts = location.split('-')
+    assert len(parts) in (2, 3), location
+    return '-'.join(parts[:2])
 
 
 class GCPSlimInstanceConfig(InstanceConfig):

--- a/batch/batch/cloud/gcp/resource_utils.py
+++ b/batch/batch/cloud/gcp/resource_utils.py
@@ -343,8 +343,39 @@ def gcp_is_valid_storage_request(storage_in_gib: int) -> bool:
     return 10 <= storage_in_gib <= GCP_MAX_PERSISTENT_SSD_SIZE_GIB
 
 
-def gcp_local_ssd_size() -> int:
-    return 375
+GCP_LOCAL_SSD_PARTITION_SIZE_GIB = 375
+
+# N2 machines require local SSDs in specific quantities that vary by vCPU count.
+# Verified: n2-standard-16 requires minimum 2 (valid: [0, 2, 4, 8, 16, 24]).
+# Other thresholds are estimated and may need adjustment based on GCP API errors.
+N2_MIN_LOCAL_SSD_COUNT_BY_CORES = {
+    2: 1,
+    4: 1,
+    8: 1,
+    16: 2,
+    32: 2,
+    48: 4,
+    64: 4,
+    80: 8,
+    96: 8,
+    128: 16,
+}
+
+
+def gcp_local_ssd_count(machine_family: str, cores: int) -> int:
+    if machine_family != 'n2':
+        return 1
+    count = N2_MIN_LOCAL_SSD_COUNT_BY_CORES.get(cores)
+    if count is not None:
+        return count
+    for threshold_cores in sorted(N2_MIN_LOCAL_SSD_COUNT_BY_CORES.keys(), reverse=True):
+        if cores >= threshold_cores:
+            return N2_MIN_LOCAL_SSD_COUNT_BY_CORES[threshold_cores]
+    return 1
+
+
+def gcp_local_ssd_size(machine_family: str, cores: int) -> int:
+    return GCP_LOCAL_SSD_PARTITION_SIZE_GIB * gcp_local_ssd_count(machine_family, cores)
 
 
 def machine_type_to_gpu(machine_type: str) -> Optional[str]:

--- a/batch/batch/cloud/gcp/resource_utils.py
+++ b/batch/batch/cloud/gcp/resource_utils.py
@@ -346,18 +346,17 @@ def gcp_is_valid_storage_request(storage_in_gib: int) -> bool:
 GCP_LOCAL_SSD_PARTITION_SIZE_GIB = 375
 
 # N2 machines require local SSDs in specific quantities that vary by vCPU count.
-# Verified: n2-standard-16 requires minimum 2 (valid: [0, 2, 4, 8, 16, 24]).
-# Other thresholds are estimated and may need adjustment based on GCP API errors.
+# Source: https://docs.cloud.google.com/compute/docs/general-purpose-machines#n2-standard
 N2_MIN_LOCAL_SSD_COUNT_BY_CORES = {
     2: 1,
     4: 1,
     8: 1,
     16: 2,
-    32: 2,
-    48: 4,
-    64: 4,
+    32: 4,
+    48: 8,
+    64: 8,
     80: 8,
-    96: 8,
+    96: 16,
     128: 16,
 }
 

--- a/batch/batch/cloud/gcp/resource_utils.py
+++ b/batch/batch/cloud/gcp/resource_utils.py
@@ -6,12 +6,15 @@ log = logging.getLogger('utils')
 
 GCP_MAX_PERSISTENT_SSD_SIZE_GIB = 64 * 1024
 
-GCP_MACHINE_FAMILY = 'n1'
+GCP_MACHINE_FAMILY = 'n2'
 
 MEMORY_PER_CORE_MIB = {
     ('n1', 'standard'): 3840,
     ('n1', 'highmem'): 6656,
     ('n1', 'highcpu'): 924,
+    ('n2', 'standard'): 4096,
+    ('n2', 'highmem'): 8192,
+    ('n2', 'highcpu'): 1024,
 }
 
 
@@ -116,6 +119,45 @@ n1_highcpu_machines = {
     for cores in [2, 4, 8, 16, 32, 64, 96]
 }
 
+# N2 Standard cores: 2 4 8 16 32 48 64 80 96 128
+# N2 Standard mem: 4 * cores GiB
+n2_standard_machines = {
+    f'n2-standard-{cores}': MachineTypeParts(
+        cores=cores,
+        memory=gib_to_bytes(4 * cores),
+        gpu_config=None,
+        machine_family='n2',
+        worker_type='standard',
+    )
+    for cores in [2, 4, 8, 16, 32, 48, 64, 80, 96, 128]
+}
+
+# N2 Highmem cores: 2 4 8 16 32 48 64 80 96
+# N2 Highmem mem: 8 * cores GiB
+n2_highmem_machines = {
+    f'n2-highmem-{cores}': MachineTypeParts(
+        cores=cores,
+        memory=gib_to_bytes(8 * cores),
+        gpu_config=None,
+        machine_family='n2',
+        worker_type='highmem',
+    )
+    for cores in [2, 4, 8, 16, 32, 48, 64, 80, 96]
+}
+
+# N2 Highcpu cores: 2 4 8 16 32 48 64 80 96
+# N2 Highcpu mem: 1024 * cores MiB
+n2_highcpu_machines = {
+    f'n2-highcpu-{cores}': MachineTypeParts(
+        cores=cores,
+        memory=mib_to_bytes(1024 * cores),
+        gpu_config=None,
+        machine_family='n2',
+        worker_type='highcpu',
+    )
+    for cores in [2, 4, 8, 16, 32, 48, 64, 80, 96]
+}
+
 MACHINE_TYPE_TO_PARTS = {
     **n1_standard_t4_machines,
     **n1_highmem_t4_machines,
@@ -123,6 +165,16 @@ MACHINE_TYPE_TO_PARTS = {
     **n1_standard_machines,
     **n1_highmem_machines,
     **n1_highcpu_machines,
+    **n2_standard_machines,
+    **n2_highmem_machines,
+    **n2_highcpu_machines,
+    'n2-highmem-128': MachineTypeParts(
+        cores=128,
+        memory=gib_to_bytes(864),
+        gpu_config=None,
+        machine_family='n2',
+        worker_type='highmem',
+    ),
     'g2-standard-4': MachineTypeParts(
         cores=4,
         memory=gib_to_bytes(16),
@@ -245,9 +297,9 @@ MACHINE_TYPE_TO_PARTS = {
 }
 
 gcp_valid_cores_for_pool_worker_type = {
-    'highcpu': [2, 4, 8, 16, 32, 64, 96],
-    'standard': [1, 2, 4, 8, 16, 32, 64, 96],
-    'highmem': [2, 4, 8, 16, 32, 64, 96],
+    'standard': [2, 4, 8, 16, 32, 48, 64, 80, 96, 128],
+    'highmem': [2, 4, 8, 16, 32, 48, 64, 80, 96],
+    'highcpu': [2, 4, 8, 16, 32, 48, 64, 80, 96],
 }
 
 gcp_valid_machine_types = list(MACHINE_TYPE_TO_PARTS.keys())

--- a/batch/batch/cloud/gcp/resource_utils.py
+++ b/batch/batch/cloud/gcp/resource_utils.py
@@ -298,7 +298,7 @@ MACHINE_TYPE_TO_PARTS = {
 
 gcp_valid_cores_for_pool_worker_type = {
     'standard': [2, 4, 8, 16, 32, 48, 64, 80, 96, 128],
-    'highmem': [2, 4, 8, 16, 32, 48, 64, 80, 96],
+    'highmem': [2, 4, 8, 16, 32, 48, 64, 80, 96, 128],
     'highcpu': [2, 4, 8, 16, 32, 48, 64, 80, 96],
 }
 

--- a/batch/batch/cloud/resource_utils.py
+++ b/batch/batch/cloud/resource_utils.py
@@ -13,6 +13,7 @@ from .azure.resource_utils import (
     azure_valid_machine_types,
 )
 from .gcp.resource_utils import (
+    GCP_MACHINE_FAMILY,
     gcp_is_valid_storage_request,
     gcp_local_ssd_size,
     gcp_machine_type_to_cores_and_memory_bytes,
@@ -115,4 +116,4 @@ def local_ssd_size(cloud: str, worker_type: str, cores: int) -> int:
     if cloud == 'azure':
         return azure_local_ssd_size(worker_type, cores)
     assert cloud == 'gcp', cloud
-    return gcp_local_ssd_size()
+    return gcp_local_ssd_size(GCP_MACHINE_FAMILY, cores)

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -3,6 +3,8 @@ import pytest
 from batch.cloud.azure.resource_utils import MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_AZURE
 from batch.cloud.gcp.resource_utils import (
     MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_GCP,
+)
+from batch.cloud.gcp.resource_utils import (
     gcp_local_ssd_count,
     gcp_local_ssd_size,
     gcp_worker_memory_per_core_mib,

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -139,6 +139,20 @@ def test_region_from_location(location, expected):
     assert region_from_location(location) == expected
 
 
+@pytest.mark.parametrize(
+    "location",
+    [
+        '',
+        'uscentral1',
+        'us-central1-a-b',
+        'us-central1-a-b-c',
+    ],
+)
+def test_region_from_location_rejects_malformed(location):
+    with pytest.raises(ValueError, match='Expected a GCP region or zone'):
+        region_from_location(location)
+
+
 def test_gcp_resource_from_dict():
     name = 'accelerator/l4-nonpreemptible/us-central1/1712657549063'
     gpu_data_dic_single = {'name': name, 'number': 1, 'type': 'gcp_accelerator', 'format_version': 2}

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -33,11 +33,12 @@ def test_memory_str_to_bytes():
 
 
 def test_gcp_worker_memory_per_core_mib():
-    with pytest.raises(AssertionError):
-        assert gcp_worker_memory_per_core_mib('n2', 'standard')
     assert gcp_worker_memory_per_core_mib('n1', 'standard') == 3840
     assert gcp_worker_memory_per_core_mib('n1', 'highmem') == 6656
     assert gcp_worker_memory_per_core_mib('n1', 'highcpu') == 924
+    assert gcp_worker_memory_per_core_mib('n2', 'standard') == 4096
+    assert gcp_worker_memory_per_core_mib('n2', 'highmem') == 8192
+    assert gcp_worker_memory_per_core_mib('n2', 'highcpu') == 1024
 
 
 def test_gcp_machine_memory_per_core_mib():
@@ -48,6 +49,15 @@ def test_gcp_machine_memory_per_core_mib():
             assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 6656
         elif machine_parts.machine_family == 'n1' and machine_parts.worker_type == 'highcpu':
             assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 924
+        elif machine_parts.machine_family == 'n2' and machine_parts.worker_type == 'standard':
+            assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 4096
+        elif machine_parts.machine_family == 'n2' and machine_parts.worker_type == 'highmem':
+            if machine_parts.cores == 128:
+                assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 6912
+            else:
+                assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 8192
+        elif machine_parts.machine_family == 'n2' and machine_parts.worker_type == 'highcpu':
+            assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 1024
         elif machine_parts.machine_family == 'g2' and machine_parts.worker_type == 'standard':
             assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 4096
         elif machine_parts.machine_family == 'a2' and machine_parts.worker_type == 'highgpu':

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -1,8 +1,13 @@
 import pytest
 
 from batch.cloud.azure.resource_utils import MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_AZURE
-from batch.cloud.gcp.resource_utils import MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_GCP
-from batch.cloud.gcp.resource_utils import gcp_local_ssd_count, gcp_local_ssd_size, gcp_worker_memory_per_core_mib, machine_type_to_gpu_num
+from batch.cloud.gcp.resource_utils import (
+    MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_GCP,
+    gcp_local_ssd_count,
+    gcp_local_ssd_size,
+    gcp_worker_memory_per_core_mib,
+    machine_type_to_gpu_num,
+)
 from batch.cloud.gcp.resources import GCPAcceleratorResource, gcp_resource_from_dict
 from batch.cloud.resource_utils import adjust_cores_for_packability
 from batch.utils import rewrite_dockerhub_image

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -88,11 +88,11 @@ def test_gcp_local_ssd_count():
     assert gcp_local_ssd_count('n2', 4) == 1
     assert gcp_local_ssd_count('n2', 8) == 1
     assert gcp_local_ssd_count('n2', 16) == 2
-    assert gcp_local_ssd_count('n2', 32) == 2
-    assert gcp_local_ssd_count('n2', 48) == 4
-    assert gcp_local_ssd_count('n2', 64) == 4
+    assert gcp_local_ssd_count('n2', 32) == 4
+    assert gcp_local_ssd_count('n2', 48) == 8
+    assert gcp_local_ssd_count('n2', 64) == 8
     assert gcp_local_ssd_count('n2', 80) == 8
-    assert gcp_local_ssd_count('n2', 96) == 8
+    assert gcp_local_ssd_count('n2', 96) == 16
     assert gcp_local_ssd_count('n2', 128) == 16
 
 
@@ -100,7 +100,7 @@ def test_gcp_local_ssd_size():
     assert gcp_local_ssd_size('n1', 16) == 375
     assert gcp_local_ssd_size('n2', 2) == 375
     assert gcp_local_ssd_size('n2', 16) == 750
-    assert gcp_local_ssd_size('n2', 48) == 1500
+    assert gcp_local_ssd_size('n2', 48) == 3000
     assert gcp_local_ssd_size('n2', 128) == 6000
 
 

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 from batch.cloud.azure.resource_utils import MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_AZURE
 from batch.cloud.gcp.resource_utils import MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_GCP
-from batch.cloud.gcp.resource_utils import gcp_worker_memory_per_core_mib, machine_type_to_gpu_num
+from batch.cloud.gcp.resource_utils import gcp_local_ssd_count, gcp_local_ssd_size, gcp_worker_memory_per_core_mib, machine_type_to_gpu_num
 from batch.cloud.gcp.resources import GCPAcceleratorResource, gcp_resource_from_dict
 from batch.cloud.resource_utils import adjust_cores_for_packability
 from batch.utils import rewrite_dockerhub_image
@@ -79,6 +79,29 @@ def test_azure_machine_memory_per_core_mib():
             assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 4096
         elif machine_parts.family == 'E':
             assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 8192
+
+
+def test_gcp_local_ssd_count():
+    assert gcp_local_ssd_count('n1', 16) == 1
+    assert gcp_local_ssd_count('n1', 96) == 1
+    assert gcp_local_ssd_count('n2', 2) == 1
+    assert gcp_local_ssd_count('n2', 4) == 1
+    assert gcp_local_ssd_count('n2', 8) == 1
+    assert gcp_local_ssd_count('n2', 16) == 2
+    assert gcp_local_ssd_count('n2', 32) == 2
+    assert gcp_local_ssd_count('n2', 48) == 4
+    assert gcp_local_ssd_count('n2', 64) == 4
+    assert gcp_local_ssd_count('n2', 80) == 8
+    assert gcp_local_ssd_count('n2', 96) == 8
+    assert gcp_local_ssd_count('n2', 128) == 16
+
+
+def test_gcp_local_ssd_size():
+    assert gcp_local_ssd_size('n1', 16) == 375
+    assert gcp_local_ssd_size('n2', 2) == 375
+    assert gcp_local_ssd_size('n2', 16) == 750
+    assert gcp_local_ssd_size('n2', 48) == 1500
+    assert gcp_local_ssd_size('n2', 128) == 6000
 
 
 def test_gcp_resource_from_dict():

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from batch.cloud.azure.resource_utils import MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_AZURE
+from batch.cloud.gcp.instance_config import region_from_location
 from batch.cloud.gcp.resource_utils import (
     MACHINE_TYPE_TO_PARTS as MACHINE_TYPE_TO_PARTS_GCP,
 )
@@ -121,6 +122,21 @@ def test_gcp_local_ssd_count(family, cores, expected):
 )
 def test_gcp_local_ssd_size(family, cores, expected):
     assert gcp_local_ssd_size(family, cores) == expected
+
+
+@pytest.mark.parametrize(
+    "location,expected",
+    [
+        ('us-central1', 'us-central1'),
+        ('us-east1', 'us-east1'),
+        ('northamerica-northeast1', 'northamerica-northeast1'),
+        ('us-central1-a', 'us-central1'),
+        ('us-central1-b', 'us-central1'),
+        ('northamerica-northeast1-a', 'northamerica-northeast1'),
+    ],
+)
+def test_region_from_location(location, expected):
+    assert region_from_location(location) == expected
 
 
 def test_gcp_resource_from_dict():

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -88,27 +88,39 @@ def test_azure_machine_memory_per_core_mib():
             assert int(machine_parts.memory / machine_parts.cores / 1024**2) == 8192
 
 
-def test_gcp_local_ssd_count():
-    assert gcp_local_ssd_count('n1', 16) == 1
-    assert gcp_local_ssd_count('n1', 96) == 1
-    assert gcp_local_ssd_count('n2', 2) == 1
-    assert gcp_local_ssd_count('n2', 4) == 1
-    assert gcp_local_ssd_count('n2', 8) == 1
-    assert gcp_local_ssd_count('n2', 16) == 2
-    assert gcp_local_ssd_count('n2', 32) == 4
-    assert gcp_local_ssd_count('n2', 48) == 8
-    assert gcp_local_ssd_count('n2', 64) == 8
-    assert gcp_local_ssd_count('n2', 80) == 8
-    assert gcp_local_ssd_count('n2', 96) == 16
-    assert gcp_local_ssd_count('n2', 128) == 16
+@pytest.mark.parametrize(
+    "family,cores,expected",
+    [
+        ('n1', 16, 1),
+        ('n1', 96, 1),
+        ('n2', 2, 1),
+        ('n2', 4, 1),
+        ('n2', 8, 1),
+        ('n2', 16, 2),
+        ('n2', 32, 4),
+        ('n2', 48, 8),
+        ('n2', 64, 8),
+        ('n2', 80, 8),
+        ('n2', 96, 16),
+        ('n2', 128, 16),
+    ],
+)
+def test_gcp_local_ssd_count(family, cores, expected):
+    assert gcp_local_ssd_count(family, cores) == expected
 
 
-def test_gcp_local_ssd_size():
-    assert gcp_local_ssd_size('n1', 16) == 375
-    assert gcp_local_ssd_size('n2', 2) == 375
-    assert gcp_local_ssd_size('n2', 16) == 750
-    assert gcp_local_ssd_size('n2', 48) == 3000
-    assert gcp_local_ssd_size('n2', 128) == 6000
+@pytest.mark.parametrize(
+    "family,cores,expected",
+    [
+        ('n1', 16, 375),
+        ('n2', 2, 375),
+        ('n2', 16, 750),
+        ('n2', 48, 3000),
+        ('n2', 128, 6000),
+    ],
+)
+def test_gcp_local_ssd_size(family, cores, expected):
+    assert gcp_local_ssd_size(family, cores) == expected
 
 
 def test_gcp_resource_from_dict():

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -43,6 +43,6 @@ def smallest_machine_type():
     cloud = os.environ['HAIL_CLOUD']
 
     if cloud == 'gcp':
-        return 'n2-standard-2'
+        return 'n1-standard-1'
     assert cloud == 'azure'
     return 'Standard_D2ds_v4'

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -43,6 +43,6 @@ def smallest_machine_type():
     cloud = os.environ['HAIL_CLOUD']
 
     if cloud == 'gcp':
-        return 'n1-standard-1'
+        return 'n2-standard-2'
     assert cloud == 'azure'
     return 'Standard_D2ds_v4'


### PR DESCRIPTION
## Change Description

This PR upgrades the GCP pooled worker VM machine family from N1 to N2. As an implicit part of this PR, N2-family machines are also now available for `job_private` jobs users may submit.

### Billing
SKU and pricing information for N2 resources are added to the resources database as part of this PR. Testing has shown that billing is accurate given resource usage of N2 pooled VMs. 

### Technical difference from N1 machines
**Local SSDs:** N2 machines require a minimum number of local SSD partitions that varies by vCPU count (e.g. 16 cores requires 2, 32 requires 4, up to 16 partitions for 96+ cores). N1 always used a single 375 GiB partition. The VM creation now attaches the correct number of partitions and combines them into a RAID0 array in the startup script when more than one is needed.

**High-end Core:Mem ratio** `n2-highmem-128` has a non-standard memory ratio (864 GiB instead of 8 * 128 = 1024 GiB) and is defined as an explicit override.

### Validation:
SQL output showing the `resources` table in a dev deploy properly populated with N2 pricing information:
```sql
mysql> select * from resources where resource like '%n2%';
+-----------------------------------------------------+---------------------------------+-------------+---------------------+
| resource                                            | rate                            | resource_id | deduped_resource_id |
+-----------------------------------------------------+---------------------------------+-------------+---------------------+
| compute/n2-nonpreemptible/us-central1/1779433200000 |   0.000000000008780833333333336 |         152 |                 152 |
| compute/n2-nonpreemptible/us-east1/1779433200000    |   0.000000000008780833333333336 |         153 |                 153 |
| compute/n2-nonpreemptible/us-east4/1779433200000    |   0.000000000009890277777777778 |          85 |                  85 |
| compute/n2-nonpreemptible/us-west1/1779433200000    |   0.000000000008780833333333336 |         154 |                 154 |
| compute/n2-nonpreemptible/us-west2/1779433200000    |   0.000000000010547222222222221 |         134 |                 134 |
| compute/n2-nonpreemptible/us-west3/1779433200000    |   0.000000000010547222222222221 |         105 |                 105 |
| compute/n2-nonpreemptible/us-west4/1779433200000    |   0.000000000009889722222222222 |          84 |                  84 |
| compute/n2-preemptible/us-central1/1779433200000    |   0.000000000002841666666666667 |          42 |                  42 |
| compute/n2-preemptible/us-east1/1779433200000       |   0.000000000002841666666666667 |          43 |                  43 |
| compute/n2-preemptible/us-east4/1779433200000       |   0.000000000002061111111111111 |         118 |                 118 |
| compute/n2-preemptible/us-west1/1779433200000       |   0.000000000002841666666666667 |          44 |                  44 |
| compute/n2-preemptible/us-west2/1779433200000       |  0.0000000000029750000000000006 |         162 |                 162 |
| compute/n2-preemptible/us-west3/1779433200000       |   0.000000000003769444444444445 |          58 |                  58 |
| compute/n2-preemptible/us-west4/1779433200000       |   0.000000000004400000000000001 |         146 |                 146 |
| memory/n2-nonpreemptible/us-central1/1779433200000  |  0.0000000000011493598090277779 |          93 |                  93 |
| memory/n2-nonpreemptible/us-east1/1779433200000     |  0.0000000000011493598090277779 |          94 |                  94 |
| memory/n2-nonpreemptible/us-east4/1779433200000     |  0.0000000000012942165798611112 |         142 |                 142 |
| memory/n2-nonpreemptible/us-west1/1779433200000     |  0.0000000000011493598090277779 |          95 |                  95 |
| memory/n2-nonpreemptible/us-west2/1779433200000     |  0.0000000000013804796006944447 |          45 |                  45 |
| memory/n2-nonpreemptible/us-west3/1779433200000     |  0.0000000000013804796006944447 |         164 |                 164 |
| memory/n2-nonpreemptible/us-west4/1779433200000     |  0.0000000000012942165798611112 |         201 |                 201 |
| memory/n2-preemptible/us-central1/1779433200000     |  0.0000000000003716362847222223 |          98 |                  98 |
| memory/n2-preemptible/us-east1/1779433200000        |  0.0000000000003716362847222223 |          99 |                  99 |
| memory/n2-preemptible/us-east4/1779433200000        | 0.00000000000027045355902777777 |         136 |                 136 |
| memory/n2-preemptible/us-west1/1779433200000        |  0.0000000000003716362847222223 |         100 |                 100 |
| memory/n2-preemptible/us-west2/1779433200000        |  0.0000000000003911675347222222 |         140 |                 140 |
| memory/n2-preemptible/us-west3/1779433200000        |  0.0000000000004939778645833333 |          97 |                  97 |
| memory/n2-preemptible/us-west4/1779433200000        |  0.0000000000005750868055555555 |         128 |                 128 |
+-----------------------------------------------------+---------------------------------+-------------+---------------------+
```

Test job using VM from pool on a deployment of this branch, showing that it's successfully used a pooled, preemptible n2 machine:
<img width="786" height="666" alt="image" src="https://github.com/user-attachments/assets/3a66b8d8-f79b-4977-a6b9-40ead07036bc" />
<img width="1502" height="958" alt="image" src="https://github.com/user-attachments/assets/a4c53657-538b-4528-9978-ba5ce85a0489" />
Raw SQL output corresponding to the above, in case you don't want to trust a bunch of "<$0.0001" from the UI:
```sql
mysql> select r.* from resources r inner join attempt_resources a on r.deduped_resource_id = a.deduped_resource_id;
+------------------------------------------------------+----------------------------------+-------------+---------------------+
| resource                                             | rate                             | resource_id | deduped_resource_id |
+------------------------------------------------------+----------------------------------+-------------+---------------------+
| service-fee/1                                        |    0.000000000002777777777777778 |           9 |                   9 |
| gcp-support-logs-specs-and-firewall-fees/1           |    0.000000000001388888888888889 |          10 |                  10 |
| ip-fee/preemptible/1024/1                            |   0.0000000000006781684027777778 |          11 |                  11 |
| compute/n2-preemptible/us-central1/1779433200000     |    0.000000000002841666666666667 |          42 |                  42 |
| memory/n2-preemptible/us-central1/1779433200000      |   0.0000000000003716362847222223 |          98 |                  98 |
| disk/pd-ssd/us-central1/1779433200000                |  0.00000000000006312861244201081 |         147 |                 147 |
| disk/local-ssd/preemptible/us-central1/1779433200000 | 0.000000000000010843267548863032 |         184 |                 184 |
+------------------------------------------------------+----------------------------------+-------------+---------------------+
```

Overview of successful regression tests:
<img width="2852" height="1162" alt="image" src="https://github.com/user-attachments/assets/d7a7619d-553d-4ddc-9570-0d377d87c745" />

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections are required

### Impact Rating

Delete all except the correct answer:
- This change has a medium security impact

### Impact Description
This change does not give users any new permissions, etc. when using Hail, but it introduces a new VM type on which users can run their jobs. Additionally, this phases out the n1 family as our default pooled VM resource and fully replaces it with n2 in the pool.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
