### PR TITLE
[hailctl] batch jobs query CLI

### DIFF
--- a/.claude/skills/hail-batch/SKILL.md
+++ b/.claude/skills/hail-batch/SKILL.md
@@ -139,23 +139,18 @@ hailctl curl default batch /openapi.yaml
 
 ## Listing jobs within a batch
 
-The `hailctl batch` CLI doesn't have a `jobs` subcommand yet. Use `hailctl curl` instead, which lets you filter and paginate:
-
 ```bash
-# List jobs (first page)
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs
-
-# Filter to failed jobs only
-hailctl curl default batch "/api/v1alpha/batches/BATCH_ID/jobs?q=state%3DFailed"
-
-# Next page — use last_job_id from the previous response
-hailctl curl default batch "/api/v1alpha/batches/BATCH_ID/jobs?last_job_id=42"
-
-# Extract just job_id, state, exit_code with jq
-hailctl curl default batch /api/v1alpha/batches/BATCH_ID/jobs | jq '.jobs[] | {job_id, state, exit_code}'
+hailctl batch jobs BATCH_ID                          # first 50 jobs
+hailctl batch jobs BATCH_ID --state bad              # failed or errored jobs
+hailctl batch jobs BATCH_ID --state bad -o json      # machine-readable
+hailctl batch jobs BATCH_ID --exit-code 137          # OOM kills
+hailctl batch jobs BATCH_ID --name my-step           # by job name
+hailctl batch jobs BATCH_ID --limit 0                # all jobs (no limit)
 ```
 
-The response has a `last_job_id` field when more pages exist — repeat the call with `?last_job_id=<value>` to continue.
+Valid `--state` values: `pending`, `ready`, `creating`, `running`, `live` (ready+creating+running), `cancelled`, `error`, `failed`, `bad` (error+failed), `success`, `done` (all terminal states).
+
+Flags can be combined: `--state bad --exit-code 1` returns jobs that are bad AND have exit code 1.
 
 ## Job states
 
@@ -184,6 +179,6 @@ The response has a `last_job_id` field when more pages exist — repeat the call
 
 When given a batch ID:
 1. Run `hailctl batch get BATCH_ID` — report state, n_jobs, n_succeeded, n_failed, cost
-2. Run `hailctl batch list` with a failure query to find failed jobs, or page through jobs
-3. For each failed job (up to ~5), run `hailctl batch log BATCH_ID JOB_ID --container main`
+2. Run `hailctl batch jobs BATCH_ID --state bad` to find failed/errored jobs
+3. For each bad job (up to ~5), run `hailctl batch log BATCH_ID JOB_ID --container main`
 4. Identify the root cause and suggest next steps

--- a/.claude/skills/hail-batch/SKILL.md
+++ b/.claude/skills/hail-batch/SKILL.md
@@ -146,6 +146,7 @@ hailctl batch jobs BATCH_ID --state bad -o json      # machine-readable
 hailctl batch jobs BATCH_ID --exit-code 137          # OOM kills
 hailctl batch jobs BATCH_ID --name my-step           # by job name
 hailctl batch jobs BATCH_ID --limit 0                # all jobs (no limit)
+hailctl batch jobs BATCH_ID --limit 50 --last-job-id 50  # pagination: next page after job 50
 ```
 
 Valid `--state` values: `pending`, `ready`, `creating`, `running`, `live` (ready+creating+running), `cancelled`, `error`, `failed`, `bad` (error+failed), `success`, `done` (all terminal states).

--- a/build.yaml
+++ b/build.yaml
@@ -3490,6 +3490,35 @@ steps:
       - merge_code
       - deploy_batch
   - kind: runImage
+    name: test_hailctl_unit
+    resources:
+      memory: standard
+      cpu: '0.25'
+    image:
+      valueFrom: hail_dev_image.image
+    script: |
+      set -ex
+      cd /io/repo
+      python3 -m pytest \
+              -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
+              --log-cli-level=INFO \
+              -s \
+              -r A \
+              -vv \
+              --instafail \
+              --durations=50 \
+              --timeout=120 \
+              hail/python/test/hailtop/hailctl/batch/test_jobs_unit.py
+    inputs:
+      - from: /repo/hail/python
+        to: /io/repo/hail/python
+    scopes:
+      - test
+      - dev
+    dependsOn:
+      - merge_code
+      - hail_dev_image
+  - kind: runImage
     name: test_batch_docs
     image:
       valueFrom: hail_dev_image.image

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -433,11 +433,11 @@ class JobGroup:
         q: Optional[str] = None,
         version: Optional[int] = None,
         recursive: bool = False,
+        last_job_id: Optional[int] = None,
     ) -> AsyncIterator[JobListEntryV1Alpha]:
         self._raise_if_not_submitted()
         if version is None:
             version = 1
-        last_job_id = None
         while True:
             params: Dict[str, Any] = {'recursive': str(recursive)}
             if q is not None:
@@ -667,9 +667,14 @@ class Batch:
         self._raise_if_not_created()
         await self._root_job_group.cancel()
 
-    def jobs(self, q: Optional[str] = None, version: Optional[int] = None) -> AsyncIterator[JobListEntryV1Alpha]:
+    def jobs(
+        self,
+        q: Optional[str] = None,
+        version: Optional[int] = None,
+        last_job_id: Optional[int] = None,
+    ) -> AsyncIterator[JobListEntryV1Alpha]:
         self._raise_if_not_created()
-        return self._root_job_group.jobs(q, version, recursive=True)
+        return self._root_job_group.jobs(q, version, recursive=True, last_job_id=last_job_id)
 
     def job_groups(self) -> AsyncIterator[JobGroup]:
         self._raise_if_not_created()

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -274,8 +274,8 @@ class Batch:
     def last_known_status(self):
         return async_to_blocking(self._async_batch.last_known_status())
 
-    def jobs(self, q=None, version=None):
-        return ait_to_blocking(self._async_batch.jobs(q=q, version=version))
+    def jobs(self, q=None, version=None, last_job_id=None):
+        return ait_to_blocking(self._async_batch.jobs(q=q, version=version, last_job_id=last_job_id))
 
     def get_job(self, job_id: int) -> Job:
         j = async_to_blocking(self._async_batch.get_job(job_id))

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -224,7 +224,7 @@ def jobs(
         results = []
         for job in batch.jobs(q=q, version=2):
             results.append(job)
-            if limit > 0 and len(results) >= limit:
+            if 0 < limit <= len(results):
                 break
 
     if results:

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -162,6 +162,77 @@ def job(batch_id: int, job_id: int, output: StructuredFormatOption = StructuredF
             print(f"Job with ID {job_id} on batch {batch_id} not found")
 
 
+_VALID_JOB_STATES = frozenset([
+    'pending',
+    'ready',
+    'creating',
+    'running',
+    'live',
+    'cancelled',
+    'error',
+    'failed',
+    'bad',
+    'success',
+    'done',
+])
+
+
+@app.command()
+def jobs(
+    batch_id: int,
+    state: Ann[
+        Optional[str],
+        Opt(
+            help=(
+                'Filter by job state. One of: pending, ready, creating, running, live, '
+                'cancelled, error, failed, bad, success, done. '
+                '"bad" matches error or failed; "live" matches ready, creating, or running; '
+                '"done" matches cancelled, error, failed, or success.'
+            )
+        ),
+    ] = None,
+    exit_code: Ann[Optional[int], Opt(help='Filter by exit code.')] = None,
+    name: Ann[Optional[str], Opt(help='Filter by job name (attribute).')] = None,
+    limit: Ann[int, Opt(help='Maximum number of jobs to return. 0 means no limit.')] = 50,
+    output: StructuredFormatOption = StructuredFormat.YAML,
+):
+    """List jobs in the batch with id BATCH_ID."""
+    from hailtop.batch_client.client import BatchClient  # pylint: disable=import-outside-toplevel
+
+    if state is not None and state not in _VALID_JOB_STATES:
+        raise typer.BadParameter(
+            f'Invalid state "{state}". Must be one of: {", ".join(sorted(_VALID_JOB_STATES))}',
+            param_hint='--state',
+        )
+
+    terms = []
+    if state is not None:
+        terms.append(f'state={state}')
+    if exit_code is not None:
+        terms.append(f'exit_code={exit_code}')
+    if name is not None:
+        terms.append(f'name={name}')
+
+    q = '\n'.join(terms) if terms else None
+
+    with BatchClient('') as client:
+        batch = get_batch_if_exists(client, batch_id)
+        if batch is None:
+            print(f"Batch with id {batch_id} not found")
+            raise typer.Exit(1)
+
+        results = []
+        for job in batch.jobs(q=q, version=2):
+            results.append(job)
+            if limit > 0 and len(results) >= limit:
+                break
+
+    if results:
+        print(make_formatter(output)(results))
+    else:
+        print('No jobs found.')
+
+
 @app.command('init', help='Initialize a Hail Batch environment.')
 def initialize(verbose: Ann[bool, Opt('--verbose', '-v', help='Print gcloud commands being executed')] = False):
     asyncio.run(async_basic_initialize(verbose=verbose))

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -194,6 +194,7 @@ def jobs(
     exit_code: Ann[Optional[int], Opt(help='Filter by exit code.')] = None,
     name: Ann[Optional[str], Opt(help='Filter by job name (attribute).')] = None,
     limit: Ann[int, Opt(help='Maximum number of jobs to return. 0 means no limit.')] = 50,
+    last_job_id: Ann[Optional[int], Opt(help='Return jobs after this job id (for pagination).')] = None,
     output: StructuredFormatOption = StructuredFormat.YAML,
 ):
     """List jobs in the batch with id BATCH_ID."""
@@ -222,7 +223,7 @@ def jobs(
             raise typer.Exit(1)
 
         results = []
-        for job in batch.jobs(q=q, version=2):
+        for job in batch.jobs(q=q, version=2, last_job_id=last_job_id):
             results.append(job)
             if 0 < limit <= len(results):
                 break

--- a/hail/python/test/hailtop/hailctl/batch/test_jobs_unit.py
+++ b/hail/python/test/hailtop/hailctl/batch/test_jobs_unit.py
@@ -1,0 +1,72 @@
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from hailtop.hailctl.batch import cli
+
+runner = CliRunner()
+
+
+def invoke_jobs(args: List[str]):
+    mock_batch = MagicMock()
+    mock_batch.jobs.return_value = iter([])
+    with patch('hailtop.batch_client.client.BatchClient') as MockClient:
+        MockClient.return_value.__enter__.return_value.get_batch.return_value = mock_batch
+        result = runner.invoke(cli.app, ['jobs', '123', *args], catch_exceptions=False)
+    return result, mock_batch
+
+
+@pytest.mark.parametrize(
+    'args, expected_q, expected_last_job_id',
+    [
+        # fmt: off
+        ([], None, None),
+        (['--state', 'bad'], 'state=bad', None),
+        (['--state', 'live'], 'state=live', None),
+        (['--state', 'done'], 'state=done', None),
+        (['--state', 'failed'], 'state=failed', None),
+        (['--exit-code', '1'], 'exit_code=1', None),
+        (['--name', 'my-job'], 'name=my-job', None),
+        (['--state', 'bad', '--exit-code', '1'], 'state=bad\nexit_code=1', None),
+        (['--state', 'bad', '--name', 'step'], 'state=bad\nname=step', None),
+        (['--exit-code', '137', '--name', 'oom'], 'exit_code=137\nname=oom', None),
+        (['--last-job-id', '50'], None, 50),
+        (['--state', 'bad', '--last-job-id', '99'], 'state=bad', 99),
+        # fmt: on
+    ],
+)
+def test_jobs_query(args, expected_q, expected_last_job_id):
+    result, mock_batch = invoke_jobs(args)
+    assert result.exit_code == 0, result.output
+    mock_batch.jobs.assert_called_once_with(q=expected_q, version=2, last_job_id=expected_last_job_id)
+
+
+@pytest.mark.parametrize('state', ['garbage', 'FAILED', 'Bad', ''])
+def test_invalid_state(state):
+    result, _ = invoke_jobs(['--state', state])
+    assert result.exit_code == 2
+    assert 'Invalid state' in result.output
+
+
+@pytest.mark.parametrize(
+    'args, expected_break_at',
+    [
+        (['--limit', '3'], 3),
+        (['--limit', '1'], 1),
+    ],
+)
+def test_limit(args, expected_break_at):
+    jobs = [{'job_id': i} for i in range(10)]
+    mock_batch = MagicMock()
+    mock_batch.jobs.return_value = iter(jobs)
+    with patch('hailtop.batch_client.client.BatchClient') as MockClient:
+        MockClient.return_value.__enter__.return_value.get_batch.return_value = mock_batch
+        result = runner.invoke(cli.app, ['jobs', '123', *args], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    # output should contain exactly expected_break_at jobs
+    import yaml  # pylint: disable=import-outside-toplevel
+
+    parsed = yaml.safe_load(result.output)
+    assert len(parsed) == expected_break_at


### PR DESCRIPTION
## Change Description

Adds a CLI command to query jobs within a batch. In particular, failed or errored jobs: extremely useful to have when debugging.

Example usage:

`hailctl batch jobs BATCH_ID --state bad`

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

No prod impact - client only change
