### PR TITLE
[query] no-sharing in blockmatrix lowering

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
@@ -163,7 +163,7 @@ class BlockMatrixNativeReader(
     )
     val reader = ETypeValueReader(spec)
 
-    def blockIR(ctx: IR): IR = {
+    def blockIR(ctx: Atom): IR = {
       val path = Apply(
         "concat",
         FastSeq(),
@@ -221,27 +221,25 @@ case class BlockMatrixBinaryReader(path: String, shape: IndexedSeq[Long], blockS
     val nd = evalCtx.memoize(ReadValue(Str(path), reader, TNDArray(TFloat64, nDimsBase = Nat(2))))
 
     val typ = fullType
-    val contexts = BMSContexts.tabulate(evalCtx, typ.sparsity)({ (blockRow, blockCol) =>
+    val contexts = BMSContexts.tabulate(evalCtx, typ.sparsity) { (blockRow, blockCol) =>
       NDArraySlice(
         nd,
-        MakeTuple.ordered(FastSeq(
-          MakeTuple.ordered(FastSeq(
+        maketuple(
+          maketuple(
             blockRow.toL * blockSize.toLong,
             minIR((blockRow + 1).toL * blockSize.toLong, nRows),
             1L,
-          )),
-          MakeTuple.ordered(FastSeq(
+          ),
+          maketuple(
             blockCol.toL * blockSize.toLong,
             minIR((blockCol + 1).toL * blockSize.toLong, nCols),
             1L,
-          )),
-        )),
+          ),
+        ),
       )
-    })
+    }
 
-    def blockIR(ctx: IR) = ctx
-
-    BlockMatrixStage2(FastSeq(), typ, contexts, blockIR)
+    BlockMatrixStage2(FastSeq(), typ, contexts, identity)
   }
 }
 
@@ -299,11 +297,11 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: Name, f: IR, needsDense
     val prev = child.execute(ctx)
 
     val functionArgs = f match {
-      case ApplyUnaryPrimOp(_, arg1) => IndexedSeq(arg1)
+      case ApplyUnaryPrimOp(_, arg1) => FastSeq(arg1)
       case Apply(_, _, args, _, _) => args
-      case ApplyBinaryPrimOp(_, l, r) => IndexedSeq(l, r)
-      case _: Ref => IndexedSeq(f)
-      case Constant(k) => IndexedSeq(k)
+      case ApplyBinaryPrimOp(_, l, r) => FastSeq(l, r)
+      case _: Ref => FastSeq(f)
+      case Constant(k) => FastSeq(k)
     }
 
     assert(
@@ -941,7 +939,7 @@ case class BlockMatrixSlice(child: BlockMatrixIR, slices: IndexedSeq[IndexedSeq[
           if (cbs <= start) outputBlockStart
           else java.lang.Math.max(outputBlockStart, (cbs - start + step - 1) / step)
         kMin < outputBlockEnd && start + kMin * step < (d + 1L) * child.typ.blockSize
-      }.toIndexedSeq
+      }
     }
   }
 

--- a/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
@@ -36,6 +36,7 @@ sealed abstract class Memoized[S] {
 
   def map(f: Atom => IR): Memoized[S] = flatMap(a => pure(f(a)))
   def flatMap(f: Atom => Memoized[S]): Memoized[S] = new Cont(this, f)
+  def >>(m: Memoized[S]): Memoized[S] = flatMap(_ => m)
 }
 
 object Memoized {

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -6,163 +6,25 @@ import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterator
 import is.hail.expr.Nat
 import is.hail.expr.ir._
+import is.hail.expr.ir.{Memoized => M}
 import is.hail.expr.ir.Scope.EVAL
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.GetElement
 import is.hail.linalg.MatrixSparsity
 import is.hail.rvd.RVDPartitioner
-import is.hail.types.{tcoerce, TypeWithRequiredness}
+import is.hail.types.TypeWithRequiredness
 import is.hail.types.virtual._
 
 import org.apache.spark.sql.Row
 
 abstract class BlockMatrixStage(val broadcastVals: IndexedSeq[Ref], val ctxType: Type) {
   def blockContext(idx: (Int, Int)): IR
-
   def blockBody(ctxRef: Atom): IR
-
-  def collectBlocks(
-    staticID: String,
-    dynamicID: IR = NA(TString),
-  )(
-    f: (IR, IR) => IR,
-    blocksToCollect: IndexedSeq[(Int, Int)],
-  ): IR = {
-    val ctxRef = Ref(freshName(), ctxType)
-    val body = f(ctxRef, blockBody(ctxRef))
-    val ctxs = MakeStream(blocksToCollect.map(idx => blockContext(idx)), TStream(ctxRef.typ))
-    val bodyFreeVars = FreeVariables(body, supportsAgg = false, supportsScan = false)
-    val bcFields = broadcastVals.filter { ref =>
-      bodyFreeVars.eval.lookupOption(ref.name).isDefined
-    }
-    val bcVals = MakeStruct(bcFields.map(ref => ref.name.str -> ref))
-    val bcRef = Ref(freshName(), bcVals.typ)
-    val wrappedBody = Let(bcFields.map(ref => ref.name -> GetField(bcRef, ref.name.str)), body)
-    CollectDistributedArray(ctxs, bcVals, ctxRef.name, bcRef.name, wrappedBody, dynamicID, staticID)
-  }
-
-  def collectLocal(typ: BlockMatrixType, staticID: String, dynamicID: IR = NA(TString)): IR = {
-    val blocksRowMajor = ArraySeq.range(0, typ.nRowBlocks).flatMap { i =>
-      ArraySeq.tabulate(typ.nColBlocks)(j => i -> j).filter((typ.hasBlock _).tupled)
-    }
-    val cda = collectBlocks(staticID, dynamicID)((_, b) => b, blocksRowMajor)
-    val blockResults = Ref(freshName(), cda.typ)
-
-    val rows = if (typ.isSparse) {
-      val blockMap = blocksRowMajor.zipWithIndex.toMap
-      MakeArray(
-        ArraySeq.tabulate[IR](typ.nRowBlocks) { i =>
-          NDArrayConcat(
-            MakeArray(
-              ArraySeq.tabulate[IR](typ.nColBlocks) { j =>
-                if (blockMap.contains(i -> j))
-                  ArrayRef(blockResults, i * typ.nColBlocks + j)
-                else {
-                  val (nRows, nCols) = typ.blockShape(i, j)
-                  MakeNDArray.fill(zero(typ.elementType), FastSeq(nRows, nCols), True())
-                }
-              },
-              tcoerce[TArray](cda.typ),
-            ),
-            1,
-          )
-        },
-        tcoerce[TArray](cda.typ),
-      )
-    } else {
-      ToArray(mapIR(rangeIR(I32(typ.nRowBlocks))) { rowIdxRef =>
-        val blocksInOneRow = ToArray(mapIR(rangeIR(I32(typ.nColBlocks))) { colIdxRef =>
-          ArrayRef(blockResults, rowIdxRef * typ.nColBlocks + colIdxRef)
-        })
-        NDArrayConcat(blocksInOneRow, 1)
-      })
-    }
-
-    Let(FastSeq(blockResults.name -> cda), NDArrayConcat(rows, 0))
-  }
-
-  def addContext(newTyp: Type)(newCtx: ((Int, Int)) => IR): BlockMatrixStage = {
-    val outer = this
-    val newCtxType = TStruct("old" -> ctxType, "new" -> newTyp)
-    new BlockMatrixStage(broadcastVals, newCtxType) {
-      override def blockContext(idx: (Int, Int)): IR =
-        makestruct("old" -> outer.blockContext(idx), "new" -> newCtx(idx))
-
-      override def blockBody(ctxRef: Atom): IR =
-        bindIR(GetField(ctxRef, "old"))(outer.blockBody)
-    }
-  }
-
-  def mapBody(f: (IR, IR) => IR): BlockMatrixStage = {
-    val outer = this
-    new BlockMatrixStage(broadcastVals, outer.ctxType) {
-      override def blockContext(idx: (Int, Int)): IR = outer.blockContext(idx)
-
-      override def blockBody(ctxRef: Atom): IR = f(ctxRef, outer.blockBody(ctxRef))
-    }
-  }
-
-  def condenseBlocks(
-    typ: BlockMatrixType,
-    rowBlocks: IndexedSeq[IndexedSeq[Int]],
-    colBlocks: IndexedSeq[IndexedSeq[Int]],
-  ): BlockMatrixStage = {
-    val outer = this
-    val ctxType = TArray(TArray(TTuple(TTuple(TInt64, TInt64), outer.ctxType)))
-    new BlockMatrixStage(outer.broadcastVals, ctxType) {
-      override def blockContext(idx: (Int, Int)): IR = {
-        val i = idx._1
-        val j = idx._2
-        MakeArray(rowBlocks(i).map { ii =>
-          MakeArray(colBlocks(j).map { jj =>
-            if (typ.hasBlock(ii, jj))
-              MakeTuple.ordered(FastSeq(NA(TTuple(TInt64, TInt64)), outer.blockContext(ii -> jj)))
-            else {
-              val (nRows, nCols) = typ.blockShape(ii, jj)
-              MakeTuple.ordered(FastSeq(
-                MakeTuple.ordered(FastSeq(nRows, nCols)),
-                NA(outer.ctxType),
-              ))
-            }
-          }: _*)
-        }: _*)
-      }
-
-      override def blockBody(ctxRef: Atom): IR = {
-        NDArrayConcat(
-          ToArray(mapIR(ToStream(ctxRef)) { ctxRows =>
-            NDArrayConcat(
-              ToArray(mapIR(ToStream(ctxRows)) { shapeOrCtx =>
-                bindIR(GetTupleElement(shapeOrCtx, 1)) { ctx =>
-                  If(
-                    IsNA(ctx),
-                    bindIR(GetTupleElement(shapeOrCtx, 0)) { shape =>
-                      MakeNDArray(
-                        ToArray(mapIR(
-                          rangeIR((GetTupleElement(shape, 0) * GetTupleElement(shape, 1)).toI)
-                        )(_ => zero(typ.elementType))),
-                        shape,
-                        False(),
-                        ErrorIDs.NO_ERROR,
-                      )
-                    },
-                    outer.blockBody(ctx),
-                  )
-                }
-              }),
-              1,
-            )
-          }),
-          0,
-        )
-      }
-    }
-  }
 }
 
 abstract class DynamicBMSContexts {
-  def apply(row: IR, col: IR): IR
-  def map(ib: IRBuilder)(f: (IR, IR, IR, IR) => IR): DynamicBMSContexts
+  def apply(row: Atom, col: Atom): IR
+  def map(ib: IRBuilder)(f: (Atom, Atom, Atom, Atom) => IR): DynamicBMSContexts
   def collect(makeBlock: (Atom, Atom, Atom) => IR): IR
 }
 
@@ -181,9 +43,9 @@ case class DynamicDenseContexts(nRows: Atom, nCols: Atom, contexts: Atom)
     extends DynamicBMSContexts {
   def irValue: IR = makestruct("nRows" -> nRows, "nCols" -> nCols, "contexts" -> contexts)
 
-  override def apply(row: IR, col: IR): IR = ArrayRef(contexts, (col * nRows) + row)
+  override def apply(row: Atom, col: Atom): IR = ArrayRef(contexts, (col * nRows) + row)
 
-  override def map(ib: IRBuilder)(f: (IR, IR, IR, IR) => IR): DynamicDenseContexts = {
+  override def map(ib: IRBuilder)(f: (Atom, Atom, Atom, Atom) => IR): DynamicDenseContexts = {
     DynamicDenseContexts(
       nRows,
       nCols,
@@ -248,14 +110,14 @@ class DynamicSparseContexts(
   def withNewContexts(newContexts: Atom): DynamicSparseContexts =
     new DynamicSparseContexts(nRows, nCols, rowPos, rowIdx, newContexts)
 
-  override def apply(row: IR, col: IR): IR = {
+  override def apply(row: Atom, col: Atom): IR = {
     val startPos = ArrayRef(rowPos, col)
     val endPos = ArrayRef(rowPos, col + 1)
     bindIR(
       Apply(
         "lowerBound",
         ArraySeq(),
-        FastSeq(rowIdx, row, startPos, endPos),
+        ArraySeq(rowIdx, row, startPos, endPos),
         TInt32,
         ErrorIDs.NO_ERROR,
       )
@@ -274,7 +136,7 @@ class DynamicSparseContexts(
     }
   }
 
-  override def map(ib: IRBuilder)(f: (IR, IR, IR, IR) => IR): DynamicSparseContexts = {
+  override def map(ib: IRBuilder)(f: (Atom, Atom, Atom, Atom) => IR): DynamicSparseContexts = {
     val colIdx = flatMapIR(rangeIR(nCols)) { j =>
       mapIR(rangeIR(ArrayRef(rowPos, j), ArrayRef(rowPos, j + 1)))(_ => j)
     }
@@ -317,20 +179,25 @@ object BMSContexts {
       case dense: MatrixSparsity.Dense => DenseContexts(ib, dense, contexts)
     }
 
-  def tabulate(ib: IRBuilder, sparsity: MatrixSparsity)(f: (IR, IR) => IR): BMSContexts = {
-    val definedCoordsIR = sparsity match {
-      case MatrixSparsity.Dense(nRows, nCols) =>
-        flatMapIR(rangeIR(nCols))(j => mapIR(rangeIR(nRows))(i => maketuple(i, j)))
-      case sparsity: MatrixSparsity.Sparse =>
-        ToStream(Literal(TArray(TTuple(TInt32, TInt32)), sparsity.definedCoords.map(Row.fromTuple)))
-    }
+  def tabulate(ib: IRBuilder, sparsity: MatrixSparsity)(f: (Atom, Atom) => IR): BMSContexts = {
+    val definedCoordsIR =
+      sparsity match {
+        case MatrixSparsity.Dense(nRows, nCols) =>
+          flatMapIR(rangeIR(nCols))(j => mapIR(rangeIR(nRows))(i => maketuple(i, j)))
+        case sparsity: MatrixSparsity.Sparse =>
+          ToStream(Literal(
+            TArray(TTuple(TInt32, TInt32)),
+            sparsity.definedCoords.map(Row.fromTuple),
+          ))
+      }
+
     val contexts =
-      ToArray(mapIR(definedCoordsIR) {
-        coords =>
-          bindIRs(GetTupleElement(coords, 0), GetTupleElement(coords, 1)) { case Seq(i, j) =>
-            f(i, j)
-          }
+      ToArray(mapIR(definedCoordsIR) { coords =>
+        bindIRs(GetTupleElement(coords, 0), GetTupleElement(coords, 1)) { case Seq(i, j) =>
+          f(i, j)
+        }
       })
+
     BMSContexts(ib, sparsity, contexts)
   }
 }
@@ -346,14 +213,14 @@ abstract class BMSContexts {
 
   def nCols: Int = sparsity.nCols
 
-  def contexts: IR
+  def contexts: Atom
 
   def transpose(ib: IRBuilder): BMSContexts
 
   def withNewSparsity(ib: IRBuilder, newSparsity: MatrixSparsity): BMSContexts
 
   // body args: (rowIdx, colIdx, position, old context)
-  def map(ib: IRBuilder)(f: (IR, IR, IR, IR) => IR): BMSContexts
+  def map(ib: IRBuilder)(f: (Atom, Atom, Atom, Atom) => IR): BMSContexts
 
   def zip(ib: IRBuilder, other: BMSContexts): BMSContexts
 
@@ -383,7 +250,7 @@ case class DenseContexts(sparsity: MatrixSparsity.Dense, dynamic: DynamicDenseCo
     extends BMSContexts {
   override val elementType: Type = contexts.typ.asInstanceOf[TArray].elementType
 
-  override def contexts: IR = dynamic.contexts
+  override def contexts: Atom = dynamic.contexts
 
   override def print(ctx: ExecuteContext): Unit =
     println(
@@ -398,7 +265,7 @@ case class DenseContexts(sparsity: MatrixSparsity.Dense, dynamic: DynamicDenseCo
     }),
   )
 
-  override def map(ib: IRBuilder)(f: (IR, IR, IR, IR) => IR): DenseContexts =
+  override def map(ib: IRBuilder)(f: (Atom, Atom, Atom, Atom) => IR): DenseContexts =
     DenseContexts(sparsity, dynamic.map(ib)(f))
 
   override def zip(ib: IRBuilder, other: BMSContexts): BMSContexts = {
@@ -424,7 +291,7 @@ case class DenseContexts(sparsity: MatrixSparsity.Dense, dynamic: DynamicDenseCo
 
   override def groupedByCol(ib: IRBuilder): DenseContexts = {
     val groupedContexts = ToArray(mapIR(rangeIR(nCols)) { col =>
-      sliceArrayIR(contexts, col * nRows, (col + 1) * nRows)
+      bindIR(col * nRows)(start => sliceArrayIR(contexts, start, start + nRows))
     })
     DenseContexts(ib, MatrixSparsity.dense(1, nCols), ib.memoize(groupedContexts))
   }
@@ -435,63 +302,70 @@ case class DenseContexts(sparsity: MatrixSparsity.Dense, dynamic: DynamicDenseCo
     colDeps: IndexedSeq[IndexedSeq[Int]],
     typ: BlockMatrixType,
   ): DenseContexts = {
-    val rowDepsLit = Literal(TArray(TArray(TInt32)), rowDeps)
-    val colDepsLit = Literal(TArray(TArray(TInt32)), colDeps)
     assert(rowDeps.nonEmpty || colDeps.nonEmpty)
+    val depsArrayType = TArray(TArray(TInt32))
+    val rowDepsLit = ib.memoize(Literal(depsArrayType, rowDeps))
+    val colDepsLit = ib.memoize(Literal(depsArrayType, colDeps))
     if (rowDeps.isEmpty) {
-      val newContexts = ToArray(flatMapIR(ToStream(colDepsLit)) { localColDeps =>
-        mapIR(rangeIR(nRows)) { i =>
-          IRBuilder.scoped { ib =>
-            val localContexts = ToArray(mapIR(ToStream(localColDeps))(jl => dynamic(i, jl)))
-            DynamicDenseContexts(
-              1,
-              ib.memoize(ArrayLen(localColDeps)),
-              ib.memoize(localContexts),
-            ).irValue
+      val newContexts =
+        ToArray(flatMapIR(ToStream(colDepsLit)) { localColDeps =>
+          bindIR(ArrayLen(localColDeps)) { nLocalColDeps =>
+            mapIR(rangeIR(nRows)) { i =>
+              bindIR(ToArray(mapIR(ToStream(localColDeps))(jl => dynamic(i, jl)))) {
+                localContexts => DynamicDenseContexts(1, nLocalColDeps, localContexts).irValue
+              }
+            }
           }
-        }
-      })
-      return DenseContexts(ib, sparsity.copy(nCols = colDeps.length), newContexts)
-    }
-    if (colDeps.isEmpty) {
-      val newContexts = ToArray(flatMapIR(rangeIR(nCols)) { j =>
-        mapIR(ToStream(rowDepsLit)) { localRowDeps =>
-          IRBuilder.scoped { ib =>
-            val localContexts = ToArray(mapIR(ToStream(localRowDeps))(il => dynamic(il, j)))
-            DynamicDenseContexts(
-              ib.memoize(ArrayLen(localRowDeps)),
-              1,
-              ib.memoize(localContexts),
-            ).irValue
+        })
+
+      DenseContexts(ib, sparsity.copy(nCols = colDeps.length), newContexts)
+    } else if (colDeps.isEmpty) {
+      val newContexts =
+        ToArray(flatMapIR(rangeIR(nCols)) { j =>
+          mapIR(ToStream(rowDepsLit)) { localRowDeps =>
+            M.eval {
+              for {
+                nLocalRowDeps <- ArrayLen(localRowDeps)
+                localContexts <- ToArray(mapIR(ToStream(localRowDeps))(il => dynamic(il, j)))
+              } yield DynamicDenseContexts(nLocalRowDeps, 1, localContexts).irValue
+            }
           }
-        }
-      })
-      return DenseContexts(ib, sparsity.copy(nRows = rowDeps.length), newContexts)
+        })
+
+      DenseContexts(ib, sparsity.copy(nRows = rowDeps.length), newContexts)
+    } else {
+      val newContexts =
+        ToArray(flatMapIR(ToStream(colDepsLit)) { localColDeps =>
+          bindIR(ArrayLen(localColDeps)) { nLocalColDeps =>
+            mapIR(ToStream(rowDepsLit)) { localRowDeps =>
+              M.eval {
+                for {
+                  nLocalRowDeps <- ArrayLen(localRowDeps)
+                  localContexts <-
+                    ToArray(flatMapIR(ToStream(localColDeps)) { jl =>
+                      mapIR(ToStream(localRowDeps))(il => dynamic(il, jl))
+                    })
+                } yield DynamicDenseContexts(nLocalRowDeps, nLocalColDeps, localContexts).irValue
+              }
+            }
+          }
+        })
+
+      DenseContexts(ib, MatrixSparsity.Dense(rowDeps.length, colDeps.length), newContexts)
     }
-    val newContexts = ToArray(flatMapIR(ToStream(colDepsLit)) { localColDeps =>
-      mapIR(ToStream(rowDepsLit)) { localRowDeps =>
-        IRBuilder.scoped { ib =>
-          val localContexts = ToArray(flatMapIR(ToStream(localColDeps)) { jl =>
-            mapIR(ToStream(localRowDeps))(il => dynamic(il, jl))
-          })
-          DynamicDenseContexts(
-            ib.memoize(ArrayLen(localRowDeps)),
-            ib.memoize(ArrayLen(localColDeps)),
-            ib.memoize(localContexts),
-          ).irValue
-        }
-      }
-    })
-    DenseContexts(ib, MatrixSparsity.Dense(rowDeps.length, colDeps.length), newContexts)
   }
 
   override def collect(makeBlock: (Atom, Atom, Atom) => IR): IR = {
     NDArrayConcat(
       ToArray(mapIR(rangeIR(nCols)) { j =>
-        val colBlocks = mapIR(rangeIR(nRows)) { i =>
-          bindIR(ArrayRef(contexts, j * nRows + i))(ctx => makeBlock(i, j, ctx))
+        bindIR(j * nRows) { offset =>
+          NDArrayConcat(
+            ToArray(mapIR(rangeIR(nRows)) { i =>
+              bindIR(ArrayRef(contexts, offset + i))(ctx => makeBlock(i, j, ctx))
+            }),
+            0,
+          )
         }
-        NDArrayConcat(ToArray(colBlocks), 0)
       }),
       1,
     )
@@ -509,7 +383,7 @@ case class SparseContexts(
 ) extends BMSContexts {
   override val elementType: Type = contexts.typ.asInstanceOf[TArray].elementType
 
-  override def contexts: IR = dynamic.contexts
+  override def contexts: Atom = dynamic.contexts
 
   override def print(ctx: ExecuteContext): Unit =
     println(
@@ -524,7 +398,7 @@ case class SparseContexts(
     SparseContexts(ib, sparsity.transpose, newContexts)
   }
 
-  override def map(ib: IRBuilder)(f: (IR, IR, IR, IR) => IR): SparseContexts =
+  override def map(ib: IRBuilder)(f: (Atom, Atom, Atom, Atom) => IR): SparseContexts =
     new SparseContexts(sparsity, dynamic.map(ib)(f))
 
   override def withNewSparsity(ib: IRBuilder, newSparsity: MatrixSparsity): BMSContexts = {
@@ -561,7 +435,7 @@ case class SparseContexts(
 
   override def groupedByCol(ib: IRBuilder): SparseContexts = {
     val rowPos = sparsity.toDCSC.rowPos
-    val rowPosIR = Literal(TArray(TInt32), rowPos)
+    val rowPosIR = ib.memoize(Literal(TArray(TInt32), rowPos))
     val groupedContexts = ToArray(mapIR(rangeIR(rowPos.length - 1)) { colPos =>
       sliceArrayIR(contexts, ArrayRef(rowPosIR, colPos), ArrayRef(rowPosIR, colPos + 1))
     })
@@ -632,7 +506,7 @@ object BlockMatrixStage2 {
   def empty(ib: IRBuilder, eltType: Type): BlockMatrixStage2 = {
     val ctxType = TNDArray(eltType, Nat(2))
     BlockMatrixStage2(
-      IndexedSeq(),
+      FastSeq(),
       BlockMatrixType.dense(eltType, 0, 0, 0),
       DenseContexts(ib, MatrixSparsity.Dense(0, 0), MakeArray(FastSeq(), TArray(ctxType))),
       _ => NA(ctxType),
@@ -642,36 +516,34 @@ object BlockMatrixStage2 {
   def broadcastVector(ib: IRBuilder, vector: IR, typ: BlockMatrixType, asRowVector: Boolean)
     : BlockMatrixStage2 = {
     val v = ib.strictMemoize(vector)
-    val contexts = BMSContexts.tabulate(ib, typ.sparsity)({ (i, j) =>
+    val contexts = BMSContexts.tabulate(ib, typ.sparsity) { (i, j) =>
       val (m, n) = typ.blockShapeIR(i, j)
       val start = (if (asRowVector) j.toL else i.toL) * typ.blockSize.toLong
-      makestruct("start" -> start, "shape" -> MakeTuple.ordered(FastSeq[IR](m, n)))
-    })
+      makestruct("start" -> start, "shape" -> maketuple(m, n))
+    }
     BlockMatrixStage2(
       FastSeq(v.ir.asInstanceOf[Ref]),
       typ,
       contexts,
-      ctx => {
-        bindIRs(GetField(ctx, "shape"), GetField(ctx, "start")) { case Seq(shape, start) =>
-          bindIRs(
-            if (asRowVector) GetTupleElement(shape, 1) else GetTupleElement(shape, 0),
-            if (asRowVector) GetTupleElement(shape, 0) else GetTupleElement(shape, 1),
-          ) { case Seq(len, nRep) =>
-            bindIR(
+      ctx =>
+        M.eval {
+          for {
+            shape <- GetField(ctx, "shape")
+            start <- GetField(ctx, "start")
+            len <- GetTupleElement(shape, if (asRowVector) 1 else 0)
+            axis = if (asRowVector) 0 else 1
+            nRep <- GetTupleElement(shape, axis).toI
+            sliced <-
               NDArrayReshape(
                 NDArraySlice(v, maketuple(maketuple(start, start + len, 1L))),
-                if (asRowVector) maketuple(1L, len) else maketuple(len.toL, 1L),
+                if (asRowVector) maketuple(1L, len) else maketuple(len, 1L),
                 ErrorIDs.NO_ERROR,
               )
-            ) { sliced =>
-              NDArrayConcat(
-                ToArray(mapIR(rangeIR(nRep.toI))(_ => sliced)),
-                if (asRowVector) 0 else 1,
-              )
-            }
-          }
-        }
-      },
+          } yield NDArrayConcat(
+            ToArray(mapIR(rangeIR(nRep))(_ => sliced)),
+            axis,
+          )
+        },
     )
   }
 
@@ -679,11 +551,10 @@ object BlockMatrixStage2 {
     broadcastVals: IndexedSeq[Ref],
     typ: BlockMatrixType,
     contexts: BMSContexts,
-    _blockIR: Ref => IR,
+    _blockIR: Atom => IR,
   ): BlockMatrixStage2 = {
     val ctxRef = Ref(freshName(), contexts.elementType)
     val blockIR = _blockIR(ctxRef)
-
     new BlockMatrixStage2(broadcastVals, typ, contexts, ctxRef.name, blockIR)
   }
 }
@@ -697,50 +568,38 @@ class BlockMatrixStage2 private (
 ) {
   assert(typ.sparsity == contexts.sparsity, s"${typ.sparsity}\n${contexts.sparsity}")
 
-  assert {
-    def literalOrRef(x: IR) = x.isInstanceOf[Literal] || x.isInstanceOf[Ref]
-    contexts.contexts match {
-      case x: MakeStruct => x.fields.forall(f => literalOrRef(f._2))
-      case x => literalOrRef(x)
-    }
-  }
-
   def print(ctx: ExecuteContext): Unit =
     println(s"contexts:\n${contexts.print(ctx)}\nbody($ctxRefName) = ${Pretty(ctx, _blockIR)}")
 
-  def blockIR(ctx: Ref): IR =
-    if (ctx.name == ctxRefName)
-      _blockIR
-    else
-      Let(FastSeq(ctxRefName -> ctx), _blockIR)
+  def blockIR(ctx: IR): IR =
+    Let(FastSeq(ctxRefName -> ctx), _blockIR)
 
   private def ctxType: Type = contexts.elementType
 
-  def toOldBMS: BlockMatrixStage = {
+  def toOldBMS: BlockMatrixStage =
     new BlockMatrixStage(broadcastVals, ctxType) {
       override def blockContext(idx: (Int, Int)): IR = contexts.dynamic(idx._1, idx._2)
-
-      override def blockBody(ctxRef: Atom): IR =
-        Let(FastSeq(ctxRefName -> ctxRef), _blockIR)
+      override def blockBody(ctxRef: Atom): IR = blockIR(ctxRef)
     }
-  }
 
-  private def getBlock(i: IR, j: IR): IR =
-    Let(FastSeq(ctxRefName -> contexts.dynamic(i, j)), _blockIR)
+  def getElement(i: Atom, j: Atom): IR =
+    M.eval {
+      assert(i.typ == TInt64)
+      assert(j.typ == TInt64)
+      val blockSize = typ.blockSize.toLong
+      for {
+        rowBlock <- i floorDiv blockSize
+        colBlock <- j floorDiv blockSize
 
-  def getElement(i: IR, j: IR): IR = {
-    assert(i.typ == TInt64)
-    assert(j.typ == TInt64)
-    val blockSize = typ.blockSize.toLong
-    bindIR(i floorDiv blockSize) { rowBlock =>
-      bindIR(j floorDiv blockSize) { colBlock =>
-        val iInBlock = i - rowBlock * blockSize
-        val jInBlock = j - colBlock * blockSize
+        rowBlockI <- rowBlock.toI
+        colBlockI <- colBlock.toI
 
-        NDArrayRef(getBlock(rowBlock.toI, colBlock.toI), FastSeq(iInBlock, jInBlock), -1)
-      }
+        iInBlock <- i - rowBlock * blockSize
+        jInBlock <- j - colBlock * blockSize
+
+        _ <- ctxRefName -> contexts.dynamic(rowBlockI, colBlockI)
+      } yield NDArrayRef(_blockIR, FastSeq(iInBlock, jInBlock), -1)
     }
-  }
 
   def transposed(ib: IRBuilder): BlockMatrixStage2 = {
     val newBlockIR = NDArrayReindex(_blockIR, FastSeq(1, 0))
@@ -758,12 +617,13 @@ class BlockMatrixStage2 private (
     case contexts: SparseContexts =>
       val newContexts = contexts
         .withNewSparsity(ib, contexts.sparsity.toDense)
-        .map(ib) { (i, j, pos, oldContext) =>
+        .map(ib) { (i, j, _, oldContext) =>
           val (m, n) = typ.blockShapeIR(i, j)
           makestruct("oldContext" -> oldContext, "nRows" -> m, "nCols" -> n)
         }
-      def newBlock(context: Atom): IR = {
-        bindIR(GetField(context, "oldContext")) { case oldContext: Ref =>
+
+      def newBlock(context: Atom): IR =
+        bindIR(GetField(context, "oldContext")) { oldContext =>
           If(
             IsNA(oldContext),
             MakeNDArray.fill(
@@ -774,7 +634,7 @@ class BlockMatrixStage2 private (
             blockIR(oldContext),
           )
         }
-      }
+
       BlockMatrixStage2(broadcastVals, typ.densify, newContexts, newBlock)
   }
 
@@ -792,13 +652,13 @@ class BlockMatrixStage2 private (
       new BlockMatrixStage2(broadcastVals, newType, newContexts, ctxRefName, _blockIR)
     } else {
       val newContexts =
-        contexts.withNewSparsity(ib, newSparsity).map(ib) { (i, j, pos, oldContext) =>
+        contexts.withNewSparsity(ib, newSparsity).map(ib) { (i, j, _, oldContext) =>
           val (m, n) = typ.blockShapeIR(i, j)
           makestruct("oldContext" -> oldContext, "nRows" -> m, "nCols" -> n)
         }
 
-      def newBlock(context: Atom): IR = {
-        bindIR(GetField(context, "oldContext")) { case oldContext: Ref =>
+      def newBlock(context: Atom): IR =
+        bindIR(GetField(context, "oldContext")) { oldContext =>
           If(
             IsNA(oldContext),
             MakeNDArray.fill(
@@ -809,7 +669,6 @@ class BlockMatrixStage2 private (
             blockIR(oldContext),
           )
         }
-      }
 
       BlockMatrixStage2(broadcastVals, newType, newContexts, newBlock)
     }
@@ -826,7 +685,7 @@ class BlockMatrixStage2 private (
     other: BlockMatrixStage2,
     sparsityStrategy: SparsityStrategy,
   )(
-    f: (IR, IR) => IR
+    f: (Atom, Atom) => IR
   ): BlockMatrixStage2 = {
     val (alignedLeft, alignedRight) = (contexts, other.contexts, sparsityStrategy) match {
       case (_: DenseContexts, _: DenseContexts, _) =>
@@ -852,19 +711,25 @@ class BlockMatrixStage2 private (
     alignedLeft.mapBody2Aligned(ib, alignedRight)(f)
   }
 
-  private def mapBody2Aligned(ib: IRBuilder, other: BlockMatrixStage2)(f: (IR, IR) => IR) = {
+  private def mapBody2Aligned(ib: IRBuilder, other: BlockMatrixStage2)(f: (Atom, Atom) => IR) = {
     val newContexts = contexts.zip(ib, other.contexts)
-    val ctxRef = Ref(freshName(), newContexts.elementType)
+    val newCtxName = freshName()
     val newBlockIR =
-      bindIRs(GetTupleElement(ctxRef, 0), GetTupleElement(ctxRef, 1)) { case Seq(l: Ref, r: Ref) =>
-        f(this.blockIR(l), other.blockIR(r))
+      M.eval {
+        val ctx: Atom =
+          Ref(newCtxName, newContexts.elementType)
+
+        for {
+          lBlockIr <- (ctxRefName -> GetTupleElement(ctx, 0)) >> _blockIR
+          rBlockIr <- (other.ctxRefName -> GetTupleElement(ctx, 1)) >> other._blockIR
+        } yield f(lBlockIr, rBlockIr)
       }
     val newType = typ.copy(elementType = newBlockIR.typ.asInstanceOf[TNDArray].elementType)
     new BlockMatrixStage2(
       broadcastVals ++ other.broadcastVals,
       newType,
       newContexts,
-      ctxRef.name,
+      newCtxName,
       newBlockIR,
     )
   }
@@ -902,27 +767,29 @@ class BlockMatrixStage2 private (
     val groupedKeepCols: IndexedSeq[IndexedSeq[IndexedSeq[Long]]] =
       keepCols.grouped(typ.blockSize).map(localIndices).toFastSeq
     val t = TArray(TArray(TArray(TInt64)))
-    val groupedKeepRowsLit = if (keepRows.isEmpty) NA(t) else Literal(t, groupedKeepRows)
-    val groupedKeepColsLit = if (keepCols.isEmpty) NA(t) else Literal(t, groupedKeepCols)
+    val groupedKeepRowsLit =
+      ib.memoize(if (keepRows.isEmpty) NA(t) else Literal(t, groupedKeepRows))
+    val groupedKeepColsLit =
+      ib.memoize(if (keepCols.isEmpty) NA(t) else Literal(t, groupedKeepCols))
     val groupedContexts: BMSContexts =
       contexts.grouped(ib, rowBlockDependents, colBlockDependents, typ)
     val groupedContextsWithIndices = groupedContexts.map(ib) { (i, j, pos, context) =>
       maketuple(context, ArrayRef(groupedKeepRowsLit, i), ArrayRef(groupedKeepColsLit, j))
     }
 
-    def newBody(ctx: Ref): IR = {
+    def newBody(ctx: Atom): IR = {
       IRBuilder.scoped { ib =>
         val localContexts = contexts match {
           case _: DenseContexts => DynamicDenseContexts(ib, GetTupleElement(ctx, 0))
           case _: SparseContexts => DynamicSparseContexts(ib, GetTupleElement(ctx, 0))
         }
-        val localKeepRows = GetTupleElement(ctx, 1)
-        val localKeepCols = GetTupleElement(ctx, 2)
-        localContexts.collect({ (i, j, localContext) =>
+        val localKeepRows = ib.memoize(GetTupleElement(ctx, 1))
+        val localKeepCols = ib.memoize(GetTupleElement(ctx, 2))
+        localContexts.collect { (i, j, localContext) =>
           bindIRs(ArrayRef(localKeepRows, i), ArrayRef(localKeepCols, j)) { case Seq(rows, cols) =>
             Coalesce(FastSeq(
               // FIXME: assumes blockIR is strict (preserves missing)
-              NDArrayFilter(blockIR(localContext.asInstanceOf[Ref]), FastSeq(rows, cols)),
+              NDArrayFilter(blockIR(localContext), FastSeq(rows, cols)),
               MakeNDArray.fill(
                 zero(typ.elementType),
                 FastSeq(ArrayLen(rows).toL, ArrayLen(cols).toL),
@@ -930,7 +797,7 @@ class BlockMatrixStage2 private (
               ),
             ))
           }
-        })
+        }
       }
     }
 
@@ -940,23 +807,22 @@ class BlockMatrixStage2 private (
   def zeroBand(ib: IRBuilder, lower: Long, upper: Long, typ: BlockMatrixType): BlockMatrixStage2 = {
     val ctxs = contexts.map(ib)((i, j, _, context) => maketuple(context, i, j))
 
-    def newBody(ctx: Ref): IR = IRBuilder.scoped { ib =>
-      val oldCtx = GetTupleElement(ctx, 0)
-      val i = GetTupleElement(ctx, 1)
-      val j = GetTupleElement(ctx, 2)
-      val diagIndex = (j - i).toL * typ.blockSize.toLong
-      bindIRs(diagIndex, oldCtx) { case Seq(diagIndex, oldCtx: Ref) =>
-        val localLower = I64(lower) - diagIndex
-        val localUpper = I64(upper) - diagIndex
-        val (nRowsInBlock, nColsInBlock) = typ.blockShapeIR(i, j)
-        val block = blockIR(oldCtx)
-        If(
+    def newBody(ctx: Atom): IR =
+      M.eval {
+        for {
+          i <- GetTupleElement(ctx, 1)
+          j <- GetTupleElement(ctx, 2)
+          diagIndex <- (j - i).toL * typ.blockSize.toLong
+          localLower <- I64(lower) - diagIndex
+          localUpper <- I64(upper) - diagIndex
+          (nRowsInBlock, nColsInBlock) = typ.blockShapeIR(i, j)
+          block <- (ctxRefName -> GetTupleElement(ctx, 0)) >> _blockIR
+        } yield If(
           -localLower >= (nRowsInBlock - 1L) && localUpper >= (nColsInBlock - 1L),
           block,
           invoke("zero_band", TNDArray(TFloat64, Nat(2)), block, localLower, localUpper),
         )
       }
-    }
 
     BlockMatrixStage2(broadcastVals, typ, ctxs, newBody)
   }
@@ -968,28 +834,42 @@ class BlockMatrixStage2 private (
     typ: BlockMatrixType,
   ): BlockMatrixStage2 = {
     val t = TArray(TArray(TInt64))
-    val startsGrouped = Literal(t, starts.grouped(typ.blockSize).toIndexedSeq)
-    val stopsGrouped = Literal(t, stops.grouped(typ.blockSize).toIndexedSeq)
+    val startsGrouped = ib.memoize(Literal(t, starts.grouped(typ.blockSize).to(ArraySeq)))
+    val stopsGrouped = ib.memoize(Literal(t, stops.grouped(typ.blockSize).to(ArraySeq)))
 
     val ctxs = contexts.map(ib) { (i, j, _, context) =>
       maketuple(context, i, j, ArrayRef(startsGrouped, i), ArrayRef(stopsGrouped, i))
     }
 
-    def newBody(ctx: Ref): IR = {
-      val oldCtx = GetTupleElement(ctx, 0)
-      val i = GetTupleElement(ctx, 1)
-      val j = GetTupleElement(ctx, 2)
-      val (_, nCols) = typ.blockShapeIR(i, j)
-      val starts = ToArray(mapIR(ToStream(GetTupleElement(ctx, 3))) { s =>
-        minIR(maxIR(s - j.toL * typ.blockSize.toLong, 0L), nCols)
-      })
-      val stops = ToArray(mapIR(ToStream(GetTupleElement(ctx, 4))) { s =>
-        minIR(maxIR(s - j.toL * typ.blockSize.toLong, 0L), nCols)
-      })
-      bindIR(oldCtx) { case oldCtx: Ref =>
-        invoke("zero_row_intervals", TNDArray(TFloat64, Nat(2)), blockIR(oldCtx), starts, stops)
+    def newBody(ctx: Atom): IR =
+      M.eval {
+        for {
+          block <- (ctxRefName -> GetTupleElement(ctx, 0)) >> _blockIR
+
+          i <- GetTupleElement(ctx, 1)
+          j <- GetTupleElement(ctx, 2)
+
+          (_, nCols) = typ.blockShapeIR(i, j)
+          nColsRef <- nCols
+          colOffset <- j.toL * typ.blockSize.toLong
+
+          starts <-
+            ToArray(mapIR(ToStream(GetTupleElement(ctx, 3))) { s =>
+              minIR(maxIR(s - colOffset, 0L), nColsRef)
+            })
+
+          stops <-
+            ToArray(mapIR(ToStream(GetTupleElement(ctx, 4))) { s =>
+              minIR(maxIR(s - colOffset, 0L), nColsRef)
+            })
+        } yield invoke(
+          "zero_row_intervals",
+          TNDArray(TFloat64, Nat(2)),
+          block,
+          starts,
+          stops,
+        )
       }
-    }
 
     BlockMatrixStage2(broadcastVals, typ, ctxs, newBody)
   }
@@ -1000,34 +880,32 @@ class BlockMatrixStage2 private (
       bodyFreeVars.eval.lookupOption(f).isDefined
     }
 
-    val contextsIR = ToStream(contexts.map(ib) { (rowIdx, colIdx, pos, oldContext) =>
+    val contextsIR = ToStream(contexts.map(ib) { (rowIdx, colIdx, _, oldContext) =>
       maketuple(rowIdx, colIdx, oldContext)
     }.contexts)
 
-    val emptyGlobals = MakeStruct(FastSeq())
-    val globalsId = freshName()
+    val empty = makestruct()
+    val globals = Ref(freshName(), empty.typ)
     val letBindings =
       ib.getBindings
         .map { b => assert(b.scope == EVAL, b.name); b.name -> b.value } :+
-        globalsId -> emptyGlobals
-
-    def tsPartitionFunction(newCtxRef: Ref): IR = {
-      val s = makestruct(
-        "blockRow" -> GetTupleElement(newCtxRef, 0),
-        "blockCol" -> GetTupleElement(newCtxRef, 1),
-        "block" -> Let(FastSeq(ctxRefName -> GetTupleElement(newCtxRef, 2)), _blockIR),
-      )
-      MakeStream(FastSeq(s), TStream(s.typ))
-    }
+        globals.name -> empty
 
     TableStage(
       letBindings,
-      bcFields.map(ref => ref.name -> ref) :+ globalsId -> Ref(globalsId, emptyGlobals.typ),
-      Ref(globalsId, emptyGlobals.typ),
+      bcFields.map(ref => ref.name -> ref) :+ globals.name -> globals.ir,
+      globals,
       RVDPartitioner.unkeyed(ctx.stateManager, bmTyp.nDefinedBlocks),
       TableStageDependency.none,
       contextsIR,
-      tsPartitionFunction,
+      { newCtxRef =>
+        val s = makestruct(
+          "blockRow" -> GetTupleElement(newCtxRef, 0),
+          "blockCol" -> GetTupleElement(newCtxRef, 1),
+          "block" -> Let(FastSeq(ctxRefName -> GetTupleElement(newCtxRef, 2)), _blockIR),
+        )
+        MakeStream(FastSeq(s), TStream(s.typ))
+      },
     )
   }
 
@@ -1038,35 +916,29 @@ class BlockMatrixStage2 private (
   )(
     f: (Atom, Atom, Atom) => IR // (ctx, pos, block)
   ): IR = {
-    val newCtxRef = Ref(freshName(), TTuple(TInt32, ctxType))
-    val body = IRBuilder.scoped { bodyIB =>
-      val pos = bodyIB.memoize(GetTupleElement(newCtxRef, 0))
-      val ctx = bodyIB.strictMemoize(GetTupleElement(newCtxRef, 1), ctxRefName)
-      val block = bodyIB.memoize(_blockIR)
-      f(ctx, pos, block)
+
+    val newContexts =
+      ToStream(
+        contexts
+          .map(ib)((_, _, pos, oldContext) => maketuple(pos, oldContext))
+          .contexts
+      )
+
+    val globals =
+      MakeStruct(broadcastVals.map(ref => ref.name.str -> ref))
+
+    cdaIR(newContexts, globals, staticID, dynamicID) { case (ctxRef, globals) =>
+      IRBuilder.scoped { ib =>
+        broadcastVals.foreach { case Ref(name, _) =>
+          ib.strictMemoize(GetField(globals, name.str), name)
+        }
+
+        val pos = ib.memoize(GetTupleElement(ctxRef, 0))
+        val ctx = ib.strictMemoize(GetTupleElement(ctxRef, 1), name = ctxRefName)
+        val block = ib.memoize(_blockIR)
+        f(ctx, pos, block)
+      }
     }
-
-    val bodyFreeVars = FreeVariables(body, supportsAgg = false, supportsScan = false)
-    val bcFields = broadcastVals.filter { case Ref(f, _) =>
-      bodyFreeVars.eval.lookupOption(f).isDefined
-    }
-    val bcVals = MakeStruct(bcFields.map(ref => ref.name.str -> ref))
-    val bcRef = Ref(freshName(), bcVals.typ)
-    val wrappedBody = Let(bcFields.map(ref => ref.name -> GetField(bcRef, ref.name.str)), body)
-
-    val cdaContexts = ToStream(contexts.map(ib) { (rowIdx, colIdx, pos, oldContext) =>
-      maketuple(pos, oldContext)
-    }.contexts)
-
-    CollectDistributedArray(
-      cdaContexts,
-      bcVals,
-      newCtxRef.name,
-      bcRef.name,
-      wrappedBody,
-      dynamicID,
-      staticID,
-    )
   }
 
   def collectLocal(ib: IRBuilder, staticID: String, dynamicID: IR = NA(TString)): IR = {
@@ -1076,11 +948,11 @@ class BlockMatrixStage2 private (
       case x: SparseContexts => SparseContexts(ib, x.sparsity, blockResults)
     }
 
-    blocks.collect({ (i, j, block) =>
+    blocks.collect { (i, j, block) =>
       val (m, n) = typ.blockShapeIR(i, j)
-      val zeroBlock: IR = MakeNDArray.fill(zero(typ.elementType), FastSeq(m, n), False())
+      val zeroBlock = MakeNDArray.fill(zero(typ.elementType), FastSeq(m, n), False())
       Coalesce(FastSeq(block, zeroBlock))
-    })
+    }
   }
 }
 
@@ -1095,31 +967,34 @@ object LowerBlockMatrixIR {
     def lower(bmir: BlockMatrixIR, ib: IRBuilder) =
       LowerBlockMatrixIR.lower(ib, bmir, typesToLower, ctx, analyses)
 
-    IRBuilder.scoped { ib =>
-      node match {
-        case BlockMatrixCollect(child) =>
-          lower(child, ib).collectLocal(ib, "block_matrix_collect")
-        case BlockMatrixToValueApply(child, GetElement(IndexedSeq(i, j))) =>
-          lower(child, ib).getElement(i, j)
-        case BlockMatrixWrite(child, writer) =>
-          writer.lower(
-            ctx,
-            lower(child, ib),
-            ib,
-            TypeWithRequiredness(child.typ.elementType),
-          ) // FIXME: BlockMatrixIR is currently ignored in Requiredness inference since all eltTypes are +TFloat64
-        case BlockMatrixMultiWrite(_, _) => unimplemented(ctx, node)
-        case node if node.children.exists(_.isInstanceOf[BlockMatrixIR]) =>
-          throw new LowererUnsupportedOperation(
-            s"IR nodes with BlockMatrixIR children need explicit rules: \n${Pretty(ctx, node)}"
-          )
+    val lowered =
+      IRBuilder.scoped { ib =>
+        node match {
+          case BlockMatrixCollect(child) =>
+            lower(child, ib).collectLocal(ib, "block_matrix_collect")
+          case BlockMatrixToValueApply(child, GetElement(Seq(i, j))) =>
+            lower(child, ib).getElement(i, j)
+          case BlockMatrixWrite(child, writer) =>
+            writer.lower(
+              ctx,
+              lower(child, ib),
+              ib,
+              TypeWithRequiredness(child.typ.elementType),
+            ) // FIXME: BlockMatrixIR is currently ignored in Requiredness inference since all eltTypes are +TFloat64
+          case BlockMatrixMultiWrite(_, _) => unimplemented(ctx, node)
+          case node if node.children.exists(_.isInstanceOf[BlockMatrixIR]) =>
+            throw new LowererUnsupportedOperation(
+              s"IR nodes with BlockMatrixIR children need explicit rules: \n${Pretty(ctx, node)}"
+            )
 
-        case node =>
-          throw new LowererUnsupportedOperation(
-            s"Value IRs with no BlockMatrixIR children must be lowered through LowerIR: \n${Pretty(ctx, node)}"
-          )
+          case node =>
+            throw new LowererUnsupportedOperation(
+              s"Value IRs with no BlockMatrixIR children must be lowered through LowerIR: \n${Pretty(ctx, node)}"
+            )
+        }
       }
-    }
+
+    NormalizeNames()(ctx, lowered)
   }
 
   // This lowers a BlockMatrixIR to an unkeyed TableStage with rows of (blockRow, blockCol, block)
@@ -1177,20 +1052,19 @@ object LowerBlockMatrixIR {
       case ValueToBlockMatrix(child, _, _)
           if !child.typ.isInstanceOf[TArray] && !child.typ.isInstanceOf[TNDArray] =>
         val element = LowerToCDA.lower(child, typesToLower, ctx, analyses)
-        val contextsIR = MakeArray(MakeStruct(FastSeq()))
-
-        def blockIR(ctxRef: Ref): IR = MakeNDArray(
-          MakeArray(element),
-          MakeTuple(FastSeq((0, I64(1)), (1, I64(1)))),
-          False(),
-          ErrorIDs.NO_ERROR,
-        )
+        val contextsIR = MakeArray(makestruct())
 
         BlockMatrixStage2(
           FastSeq(),
           bmir.typ,
           BMSContexts(ib, bmir.typ.sparsity, contextsIR),
-          blockIR,
+          _ =>
+            MakeNDArray(
+              MakeArray(element),
+              maketuple(1L, 1L),
+              False(),
+              ErrorIDs.NO_ERROR,
+            ),
         )
 
       case x @ ValueToBlockMatrix(child, _, _) =>
@@ -1198,44 +1072,44 @@ object LowerBlockMatrixIR {
         val nd = ib.memoize(child.typ match {
           case _: TArray => MakeNDArray(
               lowered,
-              MakeTuple.ordered(FastSeq(I64(x.typ.nRows), I64(x.typ.nCols))),
+              maketuple(x.typ.nRows, x.typ.nCols),
               True(),
               ErrorIDs.NO_ERROR,
             )
           case _: TNDArray => lowered
         })
-        val contexts = BMSContexts.tabulate(ib, x.typ.sparsity)({ (rowBlockIdx, colBlockIdx) =>
+        val contexts = BMSContexts.tabulate(ib, x.typ.sparsity) { (rowBlockIdx, colBlockIdx) =>
           val rowStartIdx = rowBlockIdx.toL * I64(x.typ.blockSize.toLong)
           val colStartIdx = colBlockIdx.toL * I64(x.typ.blockSize.toLong)
           val (numRowsBlock, numColsBlock) = x.typ.blockShapeIR(rowBlockIdx, colBlockIdx)
           bindIRs(rowStartIdx, colStartIdx) { case Seq(rowStartIdx, colStartIdx) =>
             NDArraySlice(
               nd,
-              MakeTuple.ordered(FastSeq(
-                MakeTuple.ordered(FastSeq(
+              maketuple(
+                maketuple(
                   rowStartIdx,
                   rowStartIdx + numRowsBlock,
-                  I64(1),
-                )),
-                MakeTuple.ordered(FastSeq(
+                  1L,
+                ),
+                maketuple(
                   colStartIdx,
                   colStartIdx + numColsBlock,
-                  I64(1),
-                )),
-              )),
+                  1L,
+                ),
+              ),
             )
           }
-        })
+        }
 
         BlockMatrixStage2(FastSeq(), x.typ, contexts, identity)
 
       case x @ BlockMatrixRandom(staticUID, gaussian, _, _) =>
-        val contexts = BMSContexts.tabulate(ib, x.typ.sparsity)({ (rowIdx, colIdx) =>
+        val contexts = BMSContexts.tabulate(ib, x.typ.sparsity) { (rowIdx, colIdx) =>
           val (m, n) = x.typ.blockShapeIR(rowIdx, colIdx)
-          MakeTuple.ordered(FastSeq(m, n, rowIdx * x.typ.nColBlocks + colIdx))
-        })
+          maketuple(m, n, rowIdx * x.typ.nColBlocks + colIdx)
+        }
 
-        def bodyIR(ctx: Ref): IR = {
+        def bodyIR(ctx: Atom): IR = {
           val m = GetTupleElement(ctx, 0)
           val n = GetTupleElement(ctx, 1)
           val i = GetTupleElement(ctx, 2)
@@ -1246,26 +1120,25 @@ object LowerBlockMatrixIR {
 
         BlockMatrixStage2(FastSeq(), x.typ, contexts, bodyIR)
 
-      case BlockMatrixAgg(child, IndexedSeq(0, 1) /* axesToSumOut */ ) =>
+      case BlockMatrixAgg(child, Seq(0, 1) /* axesToSumOut */ ) =>
         // Reduce to a single row and column
         val summedChild = lower(child).mapBody { body =>
           NDArrayReshape(
-            NDArrayAgg(body, IndexedSeq(0, 1)),
-            MakeTuple.ordered(FastSeq(I64(1), I64(1))),
+            NDArrayAgg(body, FastSeq(0, 1)),
+            maketuple(1L, 1L),
             ErrorIDs.NO_ERROR,
           )
         }
         val blockResults =
           summedChild.collectBlocks(ib, "block_matrix_agg_axes_0_1")((_, _, block) => block)
         val ndArrayResults = NDArrayConcat(blockResults, 0)
-        val aggResult = NDArrayAgg(ndArrayResults, IndexedSeq(0, 1))
-        val newBlockIR =
-          NDArrayReshape(aggResult, MakeTuple.ordered(FastSeq(I64(1), I64(1))), ErrorIDs.NO_ERROR)
+        val aggResult = NDArrayAgg(ndArrayResults, FastSeq(0, 1))
+        val newBlockIR = ib.memoize(NDArrayReshape(aggResult, maketuple(1L, 1L), ErrorIDs.NO_ERROR))
         val contexts = BMSContexts.tabulate(ib, bmir.typ.sparsity)((_, _) => newBlockIR)
 
         BlockMatrixStage2(FastSeq(), bmir.typ, contexts, identity)
 
-      case BlockMatrixAgg(child, IndexedSeq(0) /* axesToSumOut */ ) =>
+      case BlockMatrixAgg(child, Seq(0) /* axesToSumOut */ ) =>
         // Number of rows goes to 1. Number of cols remains the same.
         val loweredChild = lower(child)
         val contexts = loweredChild.contexts.groupedByCol(ib)
@@ -1274,22 +1147,19 @@ object LowerBlockMatrixIR {
           loweredChild.broadcastVals,
           bmir.typ,
           contexts,
-          (ctx) =>
-            streamAggIR(mapIR(ToStream(ctx)) { case childCtx: Ref =>
-              bindIR(NDArrayAgg(loweredChild.blockIR(childCtx), IndexedSeq(0))) { aggedND =>
+          ctx =>
+            streamAggIR(mapIR(ToStream(ctx)) { childCtx =>
+              bindIR(NDArrayAgg(loweredChild.blockIR(childCtx), FastSeq(0))) { aggedND =>
                 NDArrayReshape(
                   aggedND,
-                  MakeTuple.ordered(FastSeq(
-                    I64(1),
-                    GetTupleElement(NDArrayShape(aggedND), 0),
-                  )),
+                  maketuple(1L, GetTupleElement(NDArrayShape(aggedND), 0)),
                   ErrorIDs.NO_ERROR,
                 )
               }
             })(block => ApplyAggOp(NDArraySum())(block)),
         )
 
-      case BlockMatrixAgg(child, IndexedSeq(1) /* axesToSumOut */ ) =>
+      case BlockMatrixAgg(child, Seq(1) /* axesToSumOut */ ) =>
         // Number of cols goes to 1. Number of rows remains the same.
         val loweredChild = lower(child)
 
@@ -1299,15 +1169,12 @@ object LowerBlockMatrixIR {
           loweredChild.broadcastVals,
           bmir.typ,
           contexts,
-          (ctx) =>
-            streamAggIR(mapIR(ToStream(ctx)) { case childCtx: Ref =>
-              bindIR(NDArrayAgg(loweredChild.blockIR(childCtx), IndexedSeq(1))) { aggedND =>
+          ctx =>
+            streamAggIR(mapIR(ToStream(ctx)) { childCtx =>
+              bindIR(NDArrayAgg(loweredChild.blockIR(childCtx), FastSeq(1))) { aggedND =>
                 NDArrayReshape(
                   aggedND,
-                  MakeTuple.ordered(FastSeq(
-                    GetTupleElement(NDArrayShape(aggedND), 0),
-                    I64(1),
-                  )),
+                  maketuple(GetTupleElement(NDArrayShape(aggedND), 0), 1L),
                   ErrorIDs.NO_ERROR,
                 )
               }
@@ -1324,22 +1191,19 @@ object LowerBlockMatrixIR {
           NDArrayMap2(lBody, rBody, lname, rname, f, ErrorIDs.NO_ERROR)
         })
 
-      case x @ BlockMatrixBroadcast(child, IndexedSeq(), _, _) =>
-        val elt = ib.strictMemoize(IRBuilder.scoped { ib =>
-          val lowered = lower(child, ib)
-          lowered.getElement(0L, 0L)
-        })
+      case x @ BlockMatrixBroadcast(child, Seq(), _, _) =>
+        val elt = ib.strictMemoize(IRBuilder.scoped(ib => lower(child, ib).getElement(0L, 0L)))
 
-        val contexts = BMSContexts.tabulate(ib, x.typ.sparsity)({ (rowIdx, colIdx) =>
+        val contexts = BMSContexts.tabulate(ib, x.typ.sparsity) { (rowIdx, colIdx) =>
           val (i, j) = x.typ.blockShapeIR(rowIdx, colIdx)
           maketuple(i, j)
-        })
+        }
 
         BlockMatrixStage2(
           FastSeq(elt.ir.asInstanceOf[Ref]),
           x.typ,
           contexts,
-          (ctxRef: Ref) =>
+          ctxRef =>
             MakeNDArray.fill(
               elt,
               FastSeq(GetTupleElement(ctxRef, 0), GetTupleElement(ctxRef, 1)),
@@ -1347,19 +1211,18 @@ object LowerBlockMatrixIR {
             ),
         )
 
-      case BlockMatrixBroadcast(child, IndexedSeq(axis), _, _) =>
-        val len = scala.math.max(child.typ.nRows, child.typ.nCols)
+      case BlockMatrixBroadcast(child, Seq(axis), _, _) =>
         val vector = NDArrayReshape(
           IRBuilder.scoped { ib =>
             lower(child, ib).collectLocal(ib, "block_matrix_broadcast_single_axis")
           },
-          MakeTuple.ordered(FastSeq(I64(len))),
+          maketuple(math.max(child.typ.nRows, child.typ.nCols)),
           ErrorIDs.NO_ERROR,
         )
         BlockMatrixStage2.broadcastVector(ib, vector, bmir.typ, asRowVector = axis == 1)
 
-      case x @ BlockMatrixBroadcast(child, IndexedSeq(axis, axis2), _, _)
-          if (axis == axis2) => // diagonal as row/col vector
+      case x @ BlockMatrixBroadcast(child, Seq(axis, axis2), _, _)
+          if axis == axis2 => // diagonal as row/col vector
         val diagLen = math.min(child.typ.nRowBlocks, child.typ.nColBlocks)
         val diagSparsity = MatrixSparsity.Sparse.sorted(
           child.typ.nRowBlocks,
@@ -1370,11 +1233,11 @@ object LowerBlockMatrixIR {
         val diagArray = IRBuilder.scoped { ib =>
           lower(child, ib)
             .withSparsity(ib, diagSparsity)
-            .collectBlocks(ib, "block_matrix_broadcast_diagonal") { (ctx, idx, block) =>
+            .collectBlocks(ib, "block_matrix_broadcast_diagonal") { (_, _, block) =>
               bindIR(NDArrayShape(block)) { shape =>
                 val blockDiagLen = minIR(GetTupleElement(shape, 0), GetTupleElement(shape, 1))
                 ToArray(mapIR(rangeIR(blockDiagLen.toI)) { i =>
-                  NDArrayRef(block, FastSeq(Cast(i, TInt64), Cast(i, TInt64)), ErrorIDs.NO_ERROR)
+                  bindIR(i.toL)(i => NDArrayRef(block, FastSeq(i, i), ErrorIDs.NO_ERROR))
                 })
               }
             }
@@ -1388,10 +1251,10 @@ object LowerBlockMatrixIR {
         )
         BlockMatrixStage2.broadcastVector(ib, diagVector, x.typ, asRowVector = axis == 0)
 
-      case BlockMatrixBroadcast(child, IndexedSeq(1, 0), _, _) => // transpose
+      case BlockMatrixBroadcast(child, Seq(1, 0), _, _) => // transpose
         lower(child).transposed(ib)
 
-      case BlockMatrixBroadcast(child, IndexedSeq(0, 1), _, _) =>
+      case BlockMatrixBroadcast(child, Seq(0, 1), _, _) =>
         lower(child)
 
       case x @ BlockMatrixFilter(child, keep) =>
@@ -1420,7 +1283,7 @@ object LowerBlockMatrixIR {
 
       case x @ BlockMatrixSlice(
             child,
-            IndexedSeq(IndexedSeq(rStart, rEnd @ _, rStep), IndexedSeq(cStart, cEnd @ _, cStep)),
+            Seq(Seq(rStart, _, rStep), Seq(cStart, _, cStep)),
           ) =>
         val rowDependents = x.rowBlockDependents
         val colDependents = x.colBlockDependents
@@ -1462,56 +1325,65 @@ object LowerBlockMatrixIR {
             }
           }
 
-        val sliceType = TTuple(TInt64, TInt64, TInt64)
-        val perBlockRowSlices = computePerBlockSlices(
-          rowDependents,
-          rStart,
-          rStep,
-          x.typ.nRows,
-          child.typ.nRows,
-        )
-        val perBlockColSlices = computePerBlockSlices(
-          colDependents,
-          cStart,
-          cStep,
-          x.typ.nCols,
-          child.typ.nCols,
-        )
-        val perBlockRowSlicesLit = Literal(TArray(TArray(sliceType)), perBlockRowSlices)
-        val perBlockColSlicesLit = Literal(TArray(TArray(sliceType)), perBlockColSlices)
+        val perBlockSlicesType = TArray(TArray(TTuple(TInt64, TInt64, TInt64)))
+        val perBlockRowSlices =
+          ib.memoize(Literal(
+            perBlockSlicesType,
+            computePerBlockSlices(
+              rowDependents,
+              rStart,
+              rStep,
+              x.typ.nRows,
+              child.typ.nRows,
+            ),
+          ))
+
+        val perBlockColSlices =
+          ib.memoize(Literal(
+            perBlockSlicesType,
+            computePerBlockSlices(
+              colDependents,
+              cStart,
+              cStep,
+              x.typ.nCols,
+              child.typ.nCols,
+            ),
+          ))
 
         val groupedContexts = childBMS.contexts.grouped(ib, rowDependents, colDependents, x.typ)
-        val groupedContextsWithSlices = groupedContexts.map(ib) { (i, j, pos, context) =>
+        val groupedContextsWithSlices = groupedContexts.map(ib) { (i, j, _, context) =>
           maketuple(
             context,
-            ArrayRef(perBlockRowSlicesLit, i),
-            ArrayRef(perBlockColSlicesLit, j),
+            ArrayRef(perBlockRowSlices, i),
+            ArrayRef(perBlockColSlices, j),
           )
         }
 
-        def sliceLen(slice: IR): IR = {
-          val start = GetTupleElement(slice, 0)
-          val stop = GetTupleElement(slice, 1)
-          val step = GetTupleElement(slice, 2)
-          (stop - start + step - 1L).floorDiv(step)
-        }
+        def sliceLen(slice: Atom): IR =
+          M.eval {
+            for {
+              start <- GetTupleElement(slice, 0)
+              stop <- GetTupleElement(slice, 1)
+              step <- GetTupleElement(slice, 2)
+            } yield (stop - start + step - 1L) floorDiv step
+          }
 
-        def newBody(ctxRef: Ref): IR = {
+        def newBody(ctxRef: Atom): IR =
           IRBuilder.scoped { ib =>
             val localContexts = childBMS.contexts match {
               case _: DenseContexts => DynamicDenseContexts(ib, GetTupleElement(ctxRef, 0))
               case _: SparseContexts => DynamicSparseContexts(ib, GetTupleElement(ctxRef, 0))
             }
-            val localRowSlices = GetTupleElement(ctxRef, 1)
-            val localColSlices = GetTupleElement(ctxRef, 2)
+            val localRowSlices = ib.memoize(GetTupleElement(ctxRef, 1))
+            val localColSlices = ib.memoize(GetTupleElement(ctxRef, 2))
 
-            localContexts.collect({ (localI, localJ, localContext) =>
+            localContexts.collect { (localI, localJ, localContext) =>
               bindIRs(ArrayRef(localRowSlices, localI), ArrayRef(localColSlices, localJ)) {
                 case Seq(rowSlice, colSlice) =>
                   Coalesce(FastSeq(
                     NDArraySlice(
-                      childBMS.blockIR(localContext.asInstanceOf[Ref]),
-                      MakeTuple.ordered(FastSeq(rowSlice, colSlice)),
+                      childBMS.blockIR(localContext),
+                      maketuple(rowSlice, colSlice),
                     ),
                     MakeNDArray.fill(
                       zero(child.typ.elementType),
@@ -1520,9 +1392,8 @@ object LowerBlockMatrixIR {
                     ),
                   ))
               }
-            })
+            }
           }
-        }
 
         BlockMatrixStage2(childBMS.broadcastVals, x.typ, groupedContextsWithSlices, newBody)
 
@@ -1546,7 +1417,6 @@ object LowerBlockMatrixIR {
       LowerBlockMatrixIR.lower(ib, ir, typesToLower, ctx, analyses).toOldBMS
 
     bmir match {
-
       case BlockMatrixDot(leftIR, rightIR) =>
         val left = lower(leftIR)
         val right = lower(rightIR)
@@ -1554,53 +1424,30 @@ object LowerBlockMatrixIR {
         new BlockMatrixStage(left.broadcastVals ++ right.broadcastVals, newCtxType) {
           override def blockContext(idx: (Int, Int)): IR = {
             val (i, j) = idx
-            MakeArray(
-              ArraySeq.tabulate[Option[IR]](leftIR.typ.nColBlocks) { k =>
-                if (leftIR.typ.hasBlock(i, k) && rightIR.typ.hasBlock(k, j))
-                  Some(MakeTuple.ordered(FastSeq(
-                    left.blockContext(i -> k),
-                    right.blockContext(k -> j),
-                  )))
-                else None
-              }.flatten[IR],
-              newCtxType,
-            )
+
+            val nColBlocks = leftIR.typ.nColBlocks
+            val ctxs = ArraySeq.newBuilder[IR]
+            ctxs.sizeHint(nColBlocks)
+
+            for (k <- 0 until nColBlocks)
+              if (leftIR.typ.hasBlock(i, k) && rightIR.typ.hasBlock(k, j))
+                ctxs += maketuple(left.blockContext(i -> k), right.blockContext(k -> j))
+
+            MakeArray(ctxs.result(), newCtxType)
           }
 
-          override def blockBody(ctxRef: Atom): IR = {
-            val tupleNDArrayStream = ToStream(ctxRef)
-            val streamElementName = freshName()
-            val streamElementRef =
-              Ref(streamElementName, tupleNDArrayStream.typ.asInstanceOf[TStream].elementType)
-            val leftName = freshName()
-            val rightName = freshName()
-            val leftRef = Ref(
-              leftName,
-              tupleNDArrayStream.typ.asInstanceOf[TStream].elementType.asInstanceOf[TTuple].types(0),
-            )
-            val rightRef = Ref(
-              rightName,
-              tupleNDArrayStream.typ.asInstanceOf[TStream].elementType.asInstanceOf[TTuple].types(1),
-            )
-            StreamAgg(
-              tupleNDArrayStream,
-              streamElementName,
-              AggLet(
-                leftName,
-                GetTupleElement(streamElementRef, 0),
-                AggLet(
-                  rightName,
-                  GetTupleElement(streamElementRef, 1),
-                  ApplyAggOp(NDArrayMultiplyAdd())(
-                    left.blockBody(leftRef),
-                    right.blockBody(rightRef),
-                  ),
-                  isScan = false,
-                ),
-                isScan = false,
-              ),
-            )
-          }
+          override def blockBody(ctxRef: Atom): IR =
+            streamAggIR(ToStream(ctxRef)) { elem =>
+              M.agg {
+                for {
+                  lCtx <- GetTupleElement(elem, 0)
+                  rCtx <- GetTupleElement(elem, 1)
+                } yield ApplyAggOp(NDArrayMultiplyAdd())(
+                  left.blockBody(lCtx),
+                  right.blockBody(rCtx),
+                )
+              }
+            }
         }
     }
   }

--- a/hail/hail/src/is/hail/types/virtual/BlockMatrixType.scala
+++ b/hail/hail/src/is/hail/types/virtual/BlockMatrixType.scala
@@ -2,7 +2,7 @@ package is.hail.types.virtual
 
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir._
-import is.hail.expr.ir.defs.{I64, If}
+import is.hail.expr.ir.defs.{Atom, I64, If}
 import is.hail.linalg.{BlockMatrix, MatrixSparsity}
 import is.hail.utils.fatal
 
@@ -62,13 +62,7 @@ case class BlockMatrixType(
 
   def transpose: BlockMatrixType = copy(nRows = nCols, nCols = nRows, sparsity = sparsity.transpose)
 
-  def blockShape(i: Int, j: Int): (Long, Long) = {
-    val r = if (i == nRowBlocks - 1) nRows - (i * blockSize) else blockSize.toLong
-    val c = if (j == nColBlocks - 1) nCols - (j * blockSize) else blockSize.toLong
-    r -> c
-  }
-
-  def blockShapeIR(i: IR, j: IR): (IR, IR) = {
+  def blockShapeIR(i: Atom, j: Atom): (IR, IR) = {
     assert(i.typ == TInt32)
     assert(j.typ == TInt32)
     val r = If(i.ceq(nRowBlocks - 1), I64(nRows) - (i.toL * blockSize.toLong), blockSize.toLong)


### PR DESCRIPTION
Partially resolves https://github.com/hail-is/hail/issues/13250
Succeeds https://github.com/hail-is/hail/pull/15454

This change is one in a series that aims to preserve the TreeIR invariant throught the various lowerings, culminating in the removal of noSharing.

The changes to `BlockMatrix` and `LowerBlockMatrixIR` herein

- uses Atoms to remove duplicate work
- deletes unused code
- uses ir helper functions instead of creating ir directly.

This change does not affect the broad-managed batch service in gcp.