### PR TITLE
[github] Add action linter and fix preexisting linting errors

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,17 @@
+name: Lint GitHub Actions workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+# No permissions for the action (it already runs on a local checkout, and this is a public repo)
+permissions: {}
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint-action@914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint-action@914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12
+      - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca  # v1.7.12

--- a/.github/workflows/create-patch-release.yml
+++ b/.github/workflows/create-patch-release.yml
@@ -29,9 +29,7 @@ jobs:
           sed -Ei 's|(HAIL_PATCH_VERSION := )[[:digit:]]+|\1'"${n}"'|' hail/Makefile
           sed -Ei 's|(hailPatchVersion = ")[[:digit:]]+|\1'"${n}"'|' hail/build.mill
           
-          echo "old=${prefix}.${patch}" >> "${GITHUB_OUTPUT}"
-          echo "new=${prefix}.${n}" >> "${GITHUB_OUTPUT}"
-          echo "fut=${prefix}.$((n + 3))" >> "${GITHUB_OUTPUT}"
+          { echo "old=${prefix}.${patch}"; echo "new=${prefix}.${n}"; echo "fut=${prefix}.$((n + 3))"; } >> "${GITHUB_OUTPUT}"
 
       - name: Generate Changelog Entries
         working-directory: hail
@@ -52,7 +50,7 @@ jobs:
             hail/build.mill \
             hail/Makefile
           
-          git push origin $(git branch --show-current) --force-with-lease
+          git push origin "$(git branch --show-current)" --force-with-lease
 
       - name: Create Pull Request
         env:
@@ -70,7 +68,7 @@ jobs:
             exit 1
           fi
 
-          cat << EOF | gh pr create --base=main --head=$(git branch --show-current) --draft --fill -F -
+          cat << EOF | gh pr create --base=main --head="$(git branch --show-current)" --draft --fill -F -
           Closes #${issue_number}
 
           # Release Checklist (delete before merge)
@@ -92,7 +90,7 @@ jobs:
         run: |
           milestone_number=$(gh api -X POST '/repos/${{ github.repository }}/milestones' \
             -f 'title=${{ steps.version.outputs.fut }}' \
-            -f "due_on=$(date --utc --iso-8601=seconds --date=`date +%Y-%m-01`' +9 months 00:00')" \
+            -f "due_on=$(date --utc --iso-8601=seconds --date="$(date +%Y-%m-01) +9 months 00:00")" \
             --jq '.number')
 
           gh api -X POST '/repos/${{ github.repository }}/issues' \

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # Convert comma-separated list to JSON array
           images=$(echo "$IMAGES" | jq -R -s -c 'split(",")|map(select(length>0)|gsub("\\n";""))')
-          echo "matrix=${images}" >> $GITHUB_OUTPUT
+          echo "matrix=${images}" >> "$GITHUB_OUTPUT"
 
   scan:
     needs: prepare
@@ -113,7 +113,7 @@ jobs:
         id: safe-name
         run: |
           SAFE_NAME=$(echo "${{ matrix.image }}" | tr ':/' '__')
-          echo "name=${SAFE_NAME}" >> $GITHUB_OUTPUT
+          echo "name=${SAFE_NAME}" >> "$GITHUB_OUTPUT"
 
 
       - name: Upload sarif scan results
@@ -154,7 +154,7 @@ jobs:
           cp "$BASE_FILE" combined-results/combined.sarif
 
           # Combine the rest
-          for sarif_file in $(find all-artifacts -name "*.sarif" -type f); do
+          while IFS= read -r sarif_file; do
             if [ "$sarif_file" != "$BASE_FILE" ]; then
               echo "Combining $sarif_file"
               jq -s '
@@ -166,7 +166,7 @@ jobs:
               ' combined-results/combined.sarif "$sarif_file" > combined-results/temp.sarif
               mv combined-results/temp.sarif combined-results/combined.sarif
             fi
-          done
+          done < <(find all-artifacts -name "*.sarif" -type f)
 
       - name: Upload combined SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Change Description

- Adds a github action linter (pinned to a specific release, given no repo permissions) to validate our actions as part of the PR process

Splitting out from #15502 because the lint fixes in other files was distracting from the main purpose of that PR (ie, to get actions working again). 

(Note that this PR will fail until #15502 merges because #15502 fixes a genuine yaml format bug which this linter is now detecting on the main branch.)

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

Requesting appsec review because we're adding a 3rd party github action (with the mitigations mentioned above)

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
