### PR TITLE
[ci] Add rebuild reason to build history

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -368,6 +368,7 @@ async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: Us
             )
 
     await db.execute_insertone('INSERT INTO invalidated_batches (batch_id) VALUES (%s);', batch_id)
+    pr.pending_build_reason = f'retry by {userdata["username"]}'
     pr.batch = None
     pr.set_build_state(None)
     await wb.notify_batch_changed(

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -260,6 +260,8 @@ class PR(Code):
         # 'error', 'success', 'failure', None
         self.build_state: Optional[str] = None
 
+        self.pending_build_reason: Optional[str] = 'initial build'
+
         self.intended_github_status: GithubStatus = self.github_status_from_build_state()
         self.last_known_github_status: Dict[str, GithubStatus] = {}
 
@@ -350,6 +352,7 @@ class PR(Code):
             self.batch = None
             self.source_sha_failed = None
             self.set_build_state(None)
+            self.pending_build_reason = f'new commit {new_source_sha[:8]}'
             self.target_branch.batch_changed = True
             self.target_branch.state_changed = True
 
@@ -546,6 +549,9 @@ class PR(Code):
     async def _start_build(self, db: Database, batch_client: BatchClient):
         assert await self.authorized(db)
 
+        reason = self.pending_build_reason or 'unknown'
+        self.pending_build_reason = None
+
         # clear current batch
         self.batch = None
         self.set_build_state(None)
@@ -606,6 +612,7 @@ mkdir -p {shq(repo_dir)}
                     'target_sha': self.target_branch.sha,
                     'name': f'PR test #{self.number}: {self.source_branch.name} @ {self.source_sha[:8]} -> {self.target_branch.branch.name} @ {(self.target_branch.sha or "unknown")[:8]}',
                     'batch_type': 'ci/test/pr',
+                    'reason': reason,
                 },
                 callback=CALLBACK_URL,
             )
@@ -699,6 +706,9 @@ mkdir -p {shq(repo_dir)}
             return
 
         if not self.batch or (on_deck and self.batch.attributes['target_sha'] != self.target_branch.sha):
+            if self.batch:
+                old_target = self.batch.attributes['target_sha']
+                self.pending_build_reason = f'target sha updated {old_target[:8]} -> {self.target_branch.sha[:8]}'
             if on_deck or self.target_branch.n_running_batches < MAX_CONCURRENT_PR_BATCHES:
                 self.target_branch.n_running_batches += 1
                 async with repos_lock:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -687,19 +687,14 @@ mkdir -p {shq(repo_dir)}
             self.target_branch.state_changed = True
 
     async def _determine_build_reason(self, batch_client, db: Database) -> str:
-        prior_batches = sorted(
-            [
-                b
-                async for b in batch_client.list_batches(
-                    f'test=1 pr={self.number} target_branch={self.target_branch.branch.short_str()} user:ci'
-                )
-            ],
-            key=lambda b: b.id,
-            reverse=True,
-        )
-        if not prior_batches:
+        most_recent = None
+        async for b in batch_client.list_batches(
+            f'test=1 pr={self.number} target_branch={self.target_branch.branch.short_str()} user:ci',
+            limit=1,
+        ):
+            most_recent = b
+        if most_recent is None:
             return 'initial build'
-        most_recent = prior_batches[0]
         most_recent_status = await most_recent.last_known_status()
         prior_source_sha = most_recent_status.get('attributes', {}).get('source_sha')
         if prior_source_sha and prior_source_sha != self.source_sha:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -915,6 +915,8 @@ class WatchedBranch(Code):
                 pr.update_from_gh_json(gh_json_pr)
             else:
                 pr = PR.from_gh_json(gh_json_pr, self)
+                if self.prs:
+                    pr.pending_build_reason = 'initial build'
             new_prs[number] = pr
         for number, pr in self.prs.items():
             if number not in new_prs:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -260,7 +260,7 @@ class PR(Code):
         # 'error', 'success', 'failure', None
         self.build_state: Optional[str] = None
 
-        self.pending_build_reason: Optional[str] = 'initial build'
+        self.pending_build_reason: str = 'unknown'
 
         self.intended_github_status: GithubStatus = self.github_status_from_build_state()
         self.last_known_github_status: Dict[str, GithubStatus] = {}
@@ -549,8 +549,8 @@ class PR(Code):
     async def _start_build(self, db: Database, batch_client: BatchClient):
         assert await self.authorized(db)
 
-        reason = self.pending_build_reason or 'unknown'
-        self.pending_build_reason = None
+        reason = self.pending_build_reason
+        self.pending_build_reason = 'unknown'
 
         # clear current batch
         self.batch = None
@@ -686,6 +686,28 @@ mkdir -p {shq(repo_dir)}
                 self.source_sha_failed = True
             self.target_branch.state_changed = True
 
+    async def _determine_build_reason(self, batch_client, db: Database) -> str:
+        prior_batches = sorted(
+            [
+                b
+                async for b in batch_client.list_batches(
+                    f'test=1 pr={self.number} target_branch={self.target_branch.branch.short_str()} user:ci'
+                )
+            ],
+            key=lambda b: b.id,
+            reverse=True,
+        )
+        if not prior_batches:
+            return 'initial build'
+        most_recent = prior_batches[0]
+        most_recent_status = await most_recent.last_known_status()
+        prior_source_sha = most_recent_status.get('attributes', {}).get('source_sha')
+        if prior_source_sha and prior_source_sha != self.source_sha:
+            return f'new commit {self.source_sha[:8]}'
+        if await self.is_invalidated_batch(most_recent, db):
+            return 'old batch invalidated'
+        return 'unknown'
+
     async def _heal(self, batch_client, db: Database, on_deck, gh):
         # can't merge target if we don't know what it is
         if self.target_branch.sha is None:
@@ -709,6 +731,8 @@ mkdir -p {shq(repo_dir)}
             if self.batch:
                 old_target = self.batch.attributes['target_sha']
                 self.pending_build_reason = f'target sha updated {old_target[:8]} -> {self.target_branch.sha[:8]}'
+            elif self.pending_build_reason == 'unknown':
+                self.pending_build_reason = await self._determine_build_reason(batch_client, db)
             if on_deck or self.target_branch.n_running_batches < MAX_CONCURRENT_PR_BATCHES:
                 self.target_branch.n_running_batches += 1
                 async with repos_lock:

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -21,6 +21,7 @@
     <tr>
       <th>id</th>
       <th>state</th>
+      <th>reason</th>
     </tr>
   </thead>
   <tbody>
@@ -34,6 +35,7 @@
         {{ batch_state_icon(batch['state']) }} {{ batch['state'] }}
         {% endif %}
       </td>
+      <td>{{ batch.get('attributes', {}).get('reason', '') }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -20,8 +20,9 @@
   <thead>
     <tr>
       <th>id</th>
-      <th>state</th>
       <th>reason</th>
+      <th>started</th>
+      <th>state</th>
     </tr>
   </thead>
   <tbody>
@@ -30,12 +31,13 @@
       <td class="numeric-cell">
         <a rel="noopener" href="{{ batch_base_url }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
       </td>
+      <td>{{ batch.get('attributes', {}).get('reason', '') }}</td>
+      <td>{{ batch.get('time_created', '') }}</td>
       <td>
         {% if 'state' in batch and batch['state'] %}
         {{ batch_state_icon(batch['state']) }} {{ batch['state'] }}
         {% endif %}
       </td>
-      <td>{{ batch.get('attributes', {}).get('reason', '') }}</td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Change Description

Adds a reason against CI runs so we can track why each rebuild was triggered.

Immediate motivation is that I've seen a few batches restart at surprising times without my clicking anything, and I want to see whether there's a bug here or it's happening for some some valid reason. More generally... I've often wanted to be able to see this and this seems like a good time to add it.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Uses existing mechanisms to add some metadata to build batches, and displays that metadata in the build history table per PR to easily track what happened to a particular PR, when, and why. CI page is only visible to developers and admins.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
