### PR TITLE
[services] Add /api/ implementations of all current page queries

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -31,6 +31,7 @@ from gear import (
     monitor_endpoints_middleware,
     setup_aiohttp_session,
     transaction,
+    version_response,
 )
 from gear.auth import AIOHTTPHandler, get_session_id
 from gear.cloud_config import get_global_config
@@ -605,10 +606,30 @@ async def rest_login(request: web.Request) -> web.Response:
     })
 
 
+@routes.get('/api/v1alpha/version')
+@auth.maybe_authenticated_user
+async def get_version(_, userdata: Optional[UserData]) -> web.Response:
+    return version_response(userdata)
+
+
 @routes.get('/api/v1alpha/oauth2-client')
 async def hailctl_oauth_client(request):  # pylint: disable=unused-argument
     idp = IdentityProvider.GOOGLE if CLOUD == 'gcp' else IdentityProvider.MICROSOFT
     return json_response({'idp': idp.value, 'oauth2_client': request.app[AppKeys.HAILCTL_CLIENT_CONFIG]})
+
+
+@routes.get('/api/v1alpha/support')
+async def get_support(request):  # pylint: disable=unused-argument
+    try:
+        global_config = get_global_config()
+        support_email = global_config.get('support_email', '')
+    except (FileNotFoundError, OSError):
+        support_email = ''
+    return json_response({
+        'cloud': CLOUD,
+        'inactive_user_timeout_days': INACTIVE_USER_TIMEOUT_DAYS,
+        'support_email': support_email,
+    })
 
 
 @routes.get('/roles')

--- a/auth/auth/templates/openapi.yaml
+++ b/auth/auth/templates/openapi.yaml
@@ -112,12 +112,6 @@ components:
           type: boolean
           description: "Whether the operation was successful"
 
-  securitySchemes:
-    developerAuth:
-      type: http
-      scheme: bearer
-      description: Hail authentication token (permissions are checked per-endpoint)
-
 paths:
   /api/v1alpha/userinfo:
     get:
@@ -137,8 +131,6 @@ paths:
     get:
       summary: List all users
       tags: [User Management]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: List of users retrieved successfully
@@ -155,8 +147,6 @@ paths:
     get:
       summary: Get user by username
       tags: [User Management]
-      security:
-        - developerAuth: []
       parameters:
         - name: username
           in: path
@@ -175,8 +165,6 @@ paths:
     delete:
       summary: Delete user
       tags: [User Management]
-      security:
-        - developerAuth: []
       parameters:
         - name: username
           in: path
@@ -193,8 +181,6 @@ paths:
     post:
       summary: Create new user
       tags: [User Management]
-      security:
-        - developerAuth: []
       parameters:
         - name: username
           in: path
@@ -290,8 +276,6 @@ paths:
       summary: Verify system permission
       description: Verify that the authenticated user has a specific system permission
       tags: [Authentication]
-      security:
-        - developerAuth: []
       parameters:
         - name: permission
           in: query
@@ -357,8 +341,6 @@ paths:
       summary: Get system roles and permissions for a specific user
       description: Get all system roles and permissions for a specific user by their user ID
       tags: [System Roles]
-      security:
-        - developerAuth: []
       parameters:
         - name: user_id
           in: path
@@ -390,8 +372,6 @@ paths:
       summary: Modify system roles for a specific user
       description: Add or remove a system role for a specific user. The request body must contain exactly one of 'role_addition' or 'role_removal' fields, but not both.
       tags: [System Roles]
-      security:
-        - developerAuth: []
       parameters:
         - name: user_id
           in: path
@@ -469,8 +449,6 @@ paths:
       summary: Get all system role assignments
       description: Get all system roles with their assigned users and permissions
       tags: [System Roles]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: All system role assignments retrieved successfully

--- a/batch/batch/driver/instance_collection/job_private.py
+++ b/batch/batch/driver/instance_collection/job_private.py
@@ -117,7 +117,7 @@ WHERE removed = 0 AND inst_coll = %s;
     def config(self):
         return {
             'name': self.name,
-            'worker_disk_size_gb': self.boot_disk_size_gb,
+            'boot_disk_size_gb': self.boot_disk_size_gb,
             'max_instances': self.max_instances,
             'max_live_instances': self.max_live_instances,
             'max_new_instances_per_autoscaler_loop': self.max_new_instances_per_autoscaler_loop,

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -10,7 +10,7 @@ import warnings
 from collections import defaultdict, namedtuple
 from contextlib import AsyncExitStack
 from functools import wraps
-from typing import Any, Awaitable, Callable, Dict, NoReturn, Set, Tuple
+from typing import Any, Awaitable, Callable, Dict, NoReturn, Optional, Set, Tuple
 
 import aiohttp_session
 import dictdiffer
@@ -41,7 +41,7 @@ from gear import (
 from gear.auth import AIOHTTPHandler, UserData
 from gear.clients import get_cloud_async_fs
 from gear.profiling import install_profiler_if_requested
-from hailtop import aiotools, httpx, uvloopx
+from hailtop import __version__, aiotools, httpx, uvloopx
 from hailtop.batch_client.globals import ROOT_JOB_GROUP_ID
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
@@ -59,6 +59,7 @@ from web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_swagger,
 )
 
 from ..batch import cancel_job_group_in_db
@@ -201,9 +202,191 @@ def active_instances_only(fun: Callable[[web.Request, Instance], Awaitable[web.S
     return wrapped
 
 
+_Pagination = namedtuple('_Pagination', ['offset', 'limit'])
+
+
+def _parse_pagination(request: web.Request) -> _Pagination:
+    try:
+        offset = int(request.rel_url.query.get('offset', 0))
+        if offset < 0:
+            raise ValueError
+    except ValueError as exc:
+        raise web.HTTPBadRequest(reason='offset must be a non-negative integer') from exc
+    limit_str = request.rel_url.query.get('limit')
+    if limit_str is not None:
+        try:
+            limit = int(limit_str)
+            if limit <= 0:
+                raise ValueError
+        except ValueError as exc:
+            raise web.HTTPBadRequest(reason='limit must be a positive integer') from exc
+    else:
+        limit = None
+    return _Pagination(offset=offset, limit=limit)
+
+
+def _apply_pagination(items: list, offset: int, limit: Optional[int]) -> dict:
+    total = len(items)
+    page = items[offset : offset + limit] if limit is not None else items[offset:]
+    more = limit is not None and offset + limit < total
+    return {'items': page, 'total_count': total, 'current_offset': offset, 'more': more}
+
+
+def _log_config_changes(who: str, target: str, before: dict, after: dict) -> None:
+    all_keys = before.keys() | after.keys()
+    changes = [(k, before.get(k), after.get(k)) for k in all_keys if before.get(k) != after.get(k)]
+    if changes:
+        changes_str = ', '.join(f'{k}: {old!r} -> {new!r}' for k, old, new in sorted(changes))
+        log.info(f'{who} updated {target}: {changes_str}')
+    else:
+        log.info(f'{who} updated {target}: no changes')
+
+
+def _validate_pool_config_dict(config: dict, cloud: str, worker_type: str) -> None:
+    boot = config['boot_disk_size_gb']
+    if not isinstance(boot, int) or boot < 10:
+        raise web.HTTPBadRequest(reason='boot_disk_size_gb must be an integer >= 10')
+    if cloud == 'azure' and boot != 30:
+        raise web.HTTPBadRequest(reason='boot_disk_size_gb must be 30 on Azure')
+
+    local_ssd = config['worker_local_ssd_data_disk']
+    if not isinstance(local_ssd, bool):
+        raise web.HTTPBadRequest(reason='worker_local_ssd_data_disk must be a boolean')
+    ext_ssd = config['worker_external_ssd_data_disk_size_gb']
+    if not isinstance(ext_ssd, int) or ext_ssd < 0:
+        raise web.HTTPBadRequest(reason='worker_external_ssd_data_disk_size_gb must be a non-negative integer')
+    if not local_ssd and ext_ssd == 0:
+        raise web.HTTPBadRequest(
+            reason='worker must use a local SSD or worker_external_ssd_data_disk_size_gb must be non-zero'
+        )
+    if local_ssd and ext_ssd > 0:
+        raise web.HTTPBadRequest(
+            reason='worker cannot both use local SSD and have a non-zero worker_external_ssd_data_disk_size_gb'
+        )
+
+    possible_cores = []
+    for cores in possible_cores_from_worker_type(cloud, worker_type):
+        if not local_ssd:
+            possible_cores.append(cores)
+        elif unreserved_worker_data_disk_size_gib(local_ssd_size(cloud, worker_type, cores), cores) >= 0:
+            possible_cores.append(cores)
+
+    worker_cores = config['worker_cores']
+    if worker_cores not in possible_cores:
+        raise web.HTTPBadRequest(reason=f'worker_cores must be one of {possible_cores}')
+    standing_worker_cores = config['standing_worker_cores']
+    if standing_worker_cores not in possible_cores:
+        raise web.HTTPBadRequest(reason=f'standing_worker_cores must be one of {possible_cores}')
+
+    if not local_ssd:
+        if unreserved_worker_data_disk_size_gib(ext_ssd, worker_cores) < 0:
+            min_disk = ext_ssd - unreserved_worker_data_disk_size_gib(ext_ssd, worker_cores)
+            raise web.HTTPBadRequest(reason=f'worker_external_ssd_data_disk_size_gb must be at least {min_disk} GB')
+
+    max_i = config['max_instances']
+    max_live = config['max_live_instances']
+    min_i = config['min_instances']
+    if not isinstance(max_i, int) or max_i < 0:
+        raise web.HTTPBadRequest(reason='max_instances must be a non-negative integer')
+    if not isinstance(max_live, int) or not 0 <= max_live <= max_i:
+        raise web.HTTPBadRequest(reason=f'max_live_instances must be a non-negative integer <= max_instances ({max_i})')
+    if not isinstance(min_i, int) or not 0 <= min_i <= max_live:
+        raise web.HTTPBadRequest(
+            reason=f'min_instances must be a non-negative integer <= max_live_instances ({max_live})'
+        )
+
+    for field in (
+        'max_new_instances_per_autoscaler_loop',
+        'autoscaler_loop_period_secs',
+        'worker_max_idle_time_secs',
+        'standing_worker_max_idle_time_secs',
+        'job_queue_scheduling_window_secs',
+    ):
+        v = config[field]
+        if not isinstance(v, int) or v <= 0:
+            raise web.HTTPBadRequest(reason=f'{field} must be a positive integer')
+
+
+def _validate_jpim_config_dict(config: dict, cloud: str) -> None:
+    boot = config['boot_disk_size_gb']
+    if not isinstance(boot, int) or boot < 10:
+        raise web.HTTPBadRequest(reason='boot_disk_size_gb must be an integer >= 10')
+    if cloud == 'azure' and boot != 30:
+        raise web.HTTPBadRequest(reason='boot_disk_size_gb must be 30 on Azure')
+    for field in (
+        'max_instances',
+        'max_live_instances',
+        'max_new_instances_per_autoscaler_loop',
+        'autoscaler_loop_period_secs',
+        'worker_max_idle_time_secs',
+    ):
+        v = config[field]
+        if not isinstance(v, int) or v <= 0:
+            raise web.HTTPBadRequest(reason=f'{field} must be a positive integer')
+    if config['max_live_instances'] > config['max_instances']:
+        raise web.HTTPBadRequest(reason='max_live_instances must be <= max_instances')
+
+
+def _inst_coll_summary(ic) -> dict:
+    stats = ic.current_worker_version_stats
+    return {
+        'name': ic.name,
+        'all_versions_instances_by_state': dict(ic.all_versions_instances_by_state),
+        'all_versions_cores_mcpu_by_state': dict(ic.all_versions_cores_mcpu_by_state),
+        'max_live_instances': ic.max_live_instances,
+        'max_instances': ic.max_instances,
+        'schedulable_free_cores_mcpu': stats.active_schedulable_free_cores_mcpu,
+        'schedulable_cores_mcpu': stats.cores_mcpu_by_state['active'],
+    }
+
+
+def _instance_to_dict(instance: 'Instance') -> dict:
+    return {
+        'name': instance.name,
+        'inst_coll_name': instance.inst_coll.name,
+        'location': instance.location,
+        'version': instance.version,
+        'state': instance.state,
+        'free_cores_mcpu': instance.free_cores_mcpu,
+        'cores_mcpu': instance.cores_mcpu,
+        'failed_request_count': instance.failed_request_count,
+        'time_created_ms': instance.time_created,
+        'last_updated_ms': instance.last_updated,
+    }
+
+
+async def _set_frozen(app: web.Application, db: Database, freeze: bool) -> dict:
+    await db.execute_update('UPDATE globals SET frozen = %s;', (1 if freeze else 0,))
+    app['frozen'] = freeze
+    return {'frozen': freeze}
+
+
+async def _update_feature_flags(app: web.Application, db: Database, updates: dict) -> dict:
+    known_flags = ('compact_billing_tables', 'oms_agent', 'dockerhub_proxy')
+    set_clauses = ', '.join(f'{flag} = COALESCE(%s, {flag})' for flag in known_flags)
+    args = tuple(updates.get(flag) for flag in known_flags)
+    await db.execute_update(f'UPDATE feature_flags SET {set_clauses};', args)
+    row = await db.select_and_fetchone('SELECT * FROM feature_flags')
+    app['feature_flags'] = row
+    return {'feature_flags': dict(row)}
+
+
 @routes.get('/healthcheck')
 async def get_healthcheck(_) -> web.Response:
     return web.Response()
+
+
+@routes.get('/swagger')
+@web_security_headers_swagger
+async def get_swagger(request: web.Request) -> web.Response:
+    page_context = {'service': 'batch-driver', 'base_path': deploy_config.base_path('batch-driver')}
+    return await render_template('batch-driver', request, None, 'swagger/index.html', page_context)
+
+
+@routes.get('/openapi.yaml')
+async def get_openapi(request: web.Request) -> web.Response:
+    page_context = {'base_path': deploy_config.base_path('batch-driver'), 'spec_version': __version__}
+    return await render_template('batch-driver', request, None, 'openapi.yaml', page_context)
 
 
 @routes.get('/check_invariants')
@@ -225,6 +408,210 @@ async def get_check_invariants(request: web.Request, _) -> web.Response:
         if resource_agg_result
         else None,
     })
+
+
+@routes.get('/api/v1alpha/driver_info')
+@auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
+async def api_get_driver_info(request: web.Request, _) -> web.Response:
+    app = request.app
+    db: Database = app['db']
+    inst_coll_manager: InstanceCollectionManager = app['driver'].inst_coll_manager
+    jpim: JobPrivateInstanceManager = app['driver'].job_private_inst_manager
+
+    ready_cores = await db.select_and_fetchone("""
+SELECT CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu
+FROM user_inst_coll_resources;
+""")
+
+    return json_response({
+        'instance_id': app['instance_id'],
+        'frozen': app['frozen'],
+        'ready_cores_mcpu': ready_cores['ready_cores_mcpu'],
+        'feature_flags': dict(app['feature_flags']),
+        'pools': [_inst_coll_summary(p) for p in inst_coll_manager.pools.values()],
+        'jpim': _inst_coll_summary(jpim),
+        'global_stats': {
+            'n_instances_by_state': dict(inst_coll_manager.global_n_instances_by_state),
+            'cores_mcpu_by_state': dict(inst_coll_manager.global_cores_mcpu_by_state),
+            'schedulable_free_cores_mcpu': inst_coll_manager.global_schedulable_free_cores_mcpu,
+            'schedulable_cores_mcpu': inst_coll_manager.global_schedulable_cores_mcpu,
+        },
+    })
+
+
+@routes.post('/api/v1alpha/freeze')
+@auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
+async def api_freeze(request: web.Request, _: UserData) -> web.Response:
+    if request.app['frozen']:
+        raise web.HTTPConflict(reason='already frozen')
+    return json_response(await _set_frozen(request.app, request.app['db'], True))
+
+
+@routes.post('/api/v1alpha/unfreeze')
+@auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
+async def api_unfreeze(request: web.Request, _: UserData) -> web.Response:
+    if not request.app['frozen']:
+        raise web.HTTPConflict(reason='already unfrozen')
+    return json_response(await _set_frozen(request.app, request.app['db'], False))
+
+
+@routes.patch('/api/v1alpha/feature_flags')
+@auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
+async def api_patch_feature_flags(request: web.Request, userdata: UserData) -> web.Response:
+    body = await request.json()
+    known_flags = {'compact_billing_tables', 'oms_agent', 'dockerhub_proxy'}
+    for k, v in body.items():
+        if k in known_flags and not isinstance(v, bool):
+            raise web.HTTPBadRequest(reason=f'{k} must be a boolean')
+        if k not in known_flags:
+            raise web.HTTPBadRequest(reason=f'unknown feature flag: {k}')
+    updates = {k: v for k, v in body.items() if k in known_flags}
+    before = dict(request.app['feature_flags'])
+    result = await _update_feature_flags(request.app, request.app['db'], updates)
+    _log_config_changes(userdata['username'], 'feature_flags', before, result['feature_flags'])
+    return json_response(result)
+
+
+@routes.get('/api/v1alpha/inst_coll/pool/{pool}')
+@auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
+async def api_get_pool(request: web.Request, _) -> web.Response:
+    inst_coll_manager: InstanceCollectionManager = request.app['driver'].inst_coll_manager
+    pool_name = request.match_info['pool']
+    pool = inst_coll_manager.get_inst_coll(pool_name)
+    if not isinstance(pool, Pool):
+        raise web.HTTPNotFound()
+    return json_response(await _pool_json(pool))
+
+
+@routes.get('/api/v1alpha/inst_coll/pool/{pool}/instances')
+@auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
+async def api_get_pool_instances(request: web.Request, _) -> web.Response:
+    inst_coll_manager: InstanceCollectionManager = request.app['driver'].inst_coll_manager
+    pool_name = request.match_info['pool']
+    pool = inst_coll_manager.get_inst_coll(pool_name)
+    if not isinstance(pool, Pool):
+        raise web.HTTPNotFound()
+    offset, limit = _parse_pagination(request)
+    all_instances = [_instance_to_dict(i) for i in pool.name_instance.values()]
+    return json_response(_apply_pagination(all_instances, offset, limit))
+
+
+@routes.get('/api/v1alpha/inst_coll/jpim')
+@auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
+async def api_get_jpim(request: web.Request, _) -> web.Response:
+    jpim: JobPrivateInstanceManager = request.app['driver'].job_private_inst_manager
+    return json_response(await _jpim_json(jpim))
+
+
+@routes.get('/api/v1alpha/inst_coll/jpim/instances')
+@auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
+async def api_get_jpim_instances(request: web.Request, _) -> web.Response:
+    jpim: JobPrivateInstanceManager = request.app['driver'].job_private_inst_manager
+    offset, limit = _parse_pagination(request)
+    all_instances = [_instance_to_dict(i) for i in jpim.name_instance.values()]
+    return json_response(_apply_pagination(all_instances, offset, limit))
+
+
+@routes.get('/api/v1alpha/user_resources')
+@auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
+async def api_get_user_resources(request: web.Request, _) -> web.Response:
+    return json_response(await _fetch_global_user_resources(request.app['db']))
+
+
+@routes.patch('/api/v1alpha/inst_coll/pool/{pool}')
+@auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
+async def api_patch_pool(request: web.Request, userdata: UserData) -> web.Response:
+    inst_coll_manager: InstanceCollectionManager = request.app['driver'].inst_coll_manager
+    pool_name = request.match_info['pool']
+    pool = inst_coll_manager.get_inst_coll(pool_name)
+    if not isinstance(pool, Pool):
+        raise web.HTTPNotFound()
+
+    body = await request.json()
+    writable = {
+        'boot_disk_size_gb',
+        'worker_local_ssd_data_disk',
+        'worker_external_ssd_data_disk_size_gb',
+        'worker_cores',
+        'standing_worker_cores',
+        'min_instances',
+        'max_instances',
+        'max_live_instances',
+        'max_new_instances_per_autoscaler_loop',
+        'autoscaler_loop_period_secs',
+        'worker_max_idle_time_secs',
+        'standing_worker_max_idle_time_secs',
+        'job_queue_scheduling_window_secs',
+    }
+    unknown = set(body) - writable
+    if unknown:
+        raise web.HTTPBadRequest(reason=f'unknown or read-only fields: {sorted(unknown)}')
+
+    before = pool.config()
+    merged = {**before, **{k: v for k, v in body.items() if k in writable}}
+
+    _validate_pool_config_dict(merged, pool.cloud, pool.worker_type)
+
+    proposed = PoolConfig(
+        name=pool_name,
+        cloud=pool.cloud,
+        worker_type=pool.worker_type,
+        worker_cores=merged['worker_cores'],
+        worker_local_ssd_data_disk=merged['worker_local_ssd_data_disk'],
+        worker_external_ssd_data_disk_size_gb=merged['worker_external_ssd_data_disk_size_gb'],
+        standing_worker_cores=merged['standing_worker_cores'],
+        boot_disk_size_gb=merged['boot_disk_size_gb'],
+        min_instances=merged['min_instances'],
+        max_instances=merged['max_instances'],
+        max_live_instances=merged['max_live_instances'],
+        preemptible=pool.preemptible,
+        max_new_instances_per_autoscaler_loop=merged['max_new_instances_per_autoscaler_loop'],
+        autoscaler_loop_period_secs=merged['autoscaler_loop_period_secs'],
+        worker_max_idle_time_secs=merged['worker_max_idle_time_secs'],
+        standing_worker_max_idle_time_secs=merged['standing_worker_max_idle_time_secs'],
+        job_queue_scheduling_window_secs=merged['job_queue_scheduling_window_secs'],
+    )
+    await proposed.update_database(request.app['db'])
+    pool.configure(proposed)
+
+    after = pool.config()
+    _log_config_changes(userdata['username'], f'pool/{pool_name}', before, after)
+    return json_response(await _pool_json(pool))
+
+
+@routes.patch('/api/v1alpha/inst_coll/jpim')
+@auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
+async def api_patch_jpim(request: web.Request, userdata: UserData) -> web.Response:
+    jpim: JobPrivateInstanceManager = request.app['driver'].job_private_inst_manager
+    body = await request.json()
+    writable = {
+        'boot_disk_size_gb',
+        'max_instances',
+        'max_live_instances',
+        'max_new_instances_per_autoscaler_loop',
+        'autoscaler_loop_period_secs',
+        'worker_max_idle_time_secs',
+    }
+    unknown = set(body) - writable
+    if unknown:
+        raise web.HTTPBadRequest(reason=f'unknown or read-only fields: {sorted(unknown)}')
+
+    before = jpim.config()
+    merged = {**before, **{k: v for k, v in body.items() if k in writable}}
+
+    _validate_jpim_config_dict(merged, jpim.cloud)
+
+    await jpim.configure(
+        boot_disk_size_gb=merged['boot_disk_size_gb'],
+        max_instances=merged['max_instances'],
+        max_live_instances=merged['max_live_instances'],
+        max_new_instances_per_autoscaler_loop=merged['max_new_instances_per_autoscaler_loop'],
+        autoscaler_loop_period_secs=merged['autoscaler_loop_period_secs'],
+        worker_max_idle_time_secs=merged['worker_max_idle_time_secs'],
+    )
+
+    _log_config_changes(userdata['username'], 'jpim', before, jpim.config())
+    return json_response(await _jpim_json(jpim))
 
 
 @routes.patch('/api/v1alpha/batches/{user}/{batch_id}/update')
@@ -300,6 +687,34 @@ async def deactivate_instance_1(instance):
 @add_metadata_to_request
 async def deactivate_instance(_, instance: Instance) -> web.Response:
     await asyncio.shield(deactivate_instance_1(instance))
+    return web.Response()
+
+
+@routes.get('/api/v1alpha/gcp_quotas')
+@auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
+async def api_get_gcp_quotas(request: web.Request, _) -> web.Response:
+    if CLOUD != 'gcp':
+        raise web.HTTPNotFound(reason='quotas are only available on GCP')
+    data = request.app['driver'].get_quotas()
+    if not data:
+        raise web.HTTPServiceUnavailable(reason='quota data not yet available')
+    return json_response({
+        region: {q['metric']: {'limit': q['limit'], 'usage': q['usage']} for q in info['quotas']}
+        for region, info in data.items()
+    })
+
+
+@routes.post('/api/v1alpha/instances/{instance_name}/kill')
+@auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
+async def api_kill_instance(request: web.Request, _) -> web.Response:
+    instance_name = request.match_info['instance_name']
+    inst_coll_manager: InstanceCollectionManager = request.app['driver'].inst_coll_manager
+    instance = inst_coll_manager.get_instance(instance_name)
+    if instance is None:
+        raise web.HTTPNotFound()
+    if instance.state != 'active':
+        raise web.HTTPConflict(reason=f'instance is {instance.state}, not active')
+    await asyncio.shield(instance.kill())
     return web.Response()
 
 
@@ -446,6 +861,52 @@ async def billing_update(request, instance):
     return await asyncio.shield(billing_update_1(request, instance))
 
 
+async def _pool_json(pool: Pool) -> dict:
+    user_resources = await pool.scheduler.compute_fair_share()
+    sorted_user_resources = sorted(
+        user_resources.values(),
+        key=lambda r: r['ready_cores_mcpu'] + r['running_cores_mcpu'],
+        reverse=True,
+    )
+    return {
+        **pool.config(),
+        'status': _inst_coll_summary(pool),
+        'user_resources': sorted_user_resources,
+    }
+
+
+async def _jpim_json(jpim: JobPrivateInstanceManager) -> dict:
+    user_resources = await jpim.compute_fair_share()
+    sorted_user_resources = sorted(
+        user_resources.values(),
+        key=lambda r: r['n_ready_jobs'] + r['n_creating_jobs'] + r['n_running_jobs'],
+        reverse=True,
+    )
+    return {
+        **jpim.config(),
+        'status': _inst_coll_summary(jpim),
+        'user_resources': sorted_user_resources,
+    }
+
+
+async def _fetch_global_user_resources(db: Database) -> list:
+    records = db.execute_and_fetchall("""
+SELECT user,
+  CAST(COALESCE(SUM(n_ready_jobs), 0) AS SIGNED) AS n_ready_jobs,
+  CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu,
+  CAST(COALESCE(SUM(n_running_jobs), 0) AS SIGNED) AS n_running_jobs,
+  CAST(COALESCE(SUM(running_cores_mcpu), 0) AS SIGNED) AS running_cores_mcpu
+FROM user_inst_coll_resources
+GROUP BY user
+HAVING n_ready_jobs + n_running_jobs > 0;
+""")
+    return sorted(
+        [record async for record in records],
+        key=lambda r: r['ready_cores_mcpu'] + r['running_cores_mcpu'],
+        reverse=True,
+    )
+
+
 @routes.get('/')
 @routes.get('')
 @web_security_headers
@@ -582,31 +1043,22 @@ async def hello_react(request: web.Request, userdata) -> web.Response:
 
 @routes.post('/configure-feature-flags')
 @auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
-async def configure_feature_flags(request: web.Request, _) -> NoReturn:
-    app = request.app
-    db: Database = app['db']
+async def configure_feature_flags(request: web.Request, userdata: UserData) -> NoReturn:
     post = await request.post()
-
-    compact_billing_tables = 'compact_billing_tables' in post
-    oms_agent = 'oms_agent' in post
-    dockerhub_proxy = 'dockerhub_proxy' in post
-
-    await db.execute_update(
-        """
-UPDATE feature_flags SET compact_billing_tables = %s, oms_agent = %s, dockerhub_proxy = %s;
-""",
-        (compact_billing_tables, oms_agent, dockerhub_proxy),
-    )
-
-    row = await db.select_and_fetchone('SELECT * FROM feature_flags')
-    app['feature_flags'] = row
-
+    before = dict(request.app['feature_flags'])
+    updates = {
+        'compact_billing_tables': 'compact_billing_tables' in post,
+        'oms_agent': 'oms_agent' in post,
+        'dockerhub_proxy': 'dockerhub_proxy' in post,
+    }
+    result = await _update_feature_flags(request.app, request.app['db'], updates)
+    _log_config_changes(userdata['username'], 'feature_flags', before, result['feature_flags'])
     raise web.HTTPFound(deploy_config.external_url('batch-driver', '/'))
 
 
 @routes.post('/config-update/pool/{pool}')
 @auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
-async def pool_config_update(request: web.Request, _) -> NoReturn:
+async def pool_config_update(request: web.Request, userdata: UserData) -> NoReturn:
     app = request.app
     db: Database = app['db']
     inst_coll_manager: InstanceCollectionManager = app['driver'].inst_coll_manager
@@ -794,8 +1246,10 @@ async def pool_config_update(request: web.Request, _) -> NoReturn:
             )
             raise ConfigError()
 
+        before = pool.config()
         await proposed_pool_config.update_database(db)
         pool.configure(proposed_pool_config)
+        _log_config_changes(userdata['username'], f'pool/{pool_name}', before, pool.config())
 
         set_message(session, f'Updated configuration for {pool}.', 'info')
     except ConfigError:
@@ -811,7 +1265,7 @@ async def pool_config_update(request: web.Request, _) -> NoReturn:
 
 @routes.post('/config-update/jpim')
 @auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
-async def job_private_config_update(request: web.Request, _) -> NoReturn:
+async def job_private_config_update(request: web.Request, userdata: UserData) -> NoReturn:
     app = request.app
     jpim: JobPrivateInstanceManager = app['driver'].job_private_inst_manager
 
@@ -866,6 +1320,7 @@ async def job_private_config_update(request: web.Request, _) -> NoReturn:
             'a positive integer',
         )
 
+        before = jpim.config()
         await jpim.configure(
             boot_disk_size_gb=boot_disk_size_gb,
             max_instances=max_instances,
@@ -874,6 +1329,7 @@ async def job_private_config_update(request: web.Request, _) -> NoReturn:
             autoscaler_loop_period_secs=autoscaler_loop_period_secs,
             worker_max_idle_time_secs=worker_max_idle_time_secs,
         )
+        _log_config_changes(userdata['username'], 'jpim', before, jpim.config())
 
         set_message(session, f'Updated configuration for {jpim}.', 'info')
     except ConfigError:
@@ -903,23 +1359,14 @@ async def get_pool(request, userdata):
         set_message(session, f'Unknown pool {pool_name}.', 'error')
         raise web.HTTPFound(deploy_config.external_url('batch-driver', '/'))
 
-    user_resources = await pool.scheduler.compute_fair_share()
-    user_resources = sorted(
-        user_resources.values(),
-        key=lambda record: record['ready_cores_mcpu'] + record['running_cores_mcpu'],
-        reverse=True,
-    )
-
-    ready_cores_mcpu = sum(record['ready_cores_mcpu'] for record in user_resources)
-
-    pool_config_json = json.dumps(pool.config())
+    data = await _pool_json(pool)
 
     page_context = {
         'pool': pool,
-        'pool_config_json': pool_config_json,
+        'pool_config_json': json.dumps(pool.config()),
         'instances': pool.name_instance.values(),
-        'user_resources': user_resources,
-        'ready_cores_mcpu': ready_cores_mcpu,
+        'user_resources': data['user_resources'],
+        'ready_cores_mcpu': sum(r['ready_cores_mcpu'] for r in data['user_resources']),
     }
 
     return await render_template('batch-driver', request, userdata, 'pool.html', page_context)
@@ -932,24 +1379,15 @@ async def get_job_private_inst_manager(request, userdata):
     app = request.app
     jpim: JobPrivateInstanceManager = app['driver'].job_private_inst_manager
 
-    user_resources = await jpim.compute_fair_share()
-    user_resources = sorted(
-        user_resources.values(),
-        key=lambda record: record['n_ready_jobs'] + record['n_creating_jobs'] + record['n_running_jobs'],
-        reverse=True,
-    )
-
-    n_ready_jobs = sum(record['n_ready_jobs'] for record in user_resources)
-    n_creating_jobs = sum(record['n_creating_jobs'] for record in user_resources)
-    n_running_jobs = sum(record['n_running_jobs'] for record in user_resources)
+    data = await _jpim_json(jpim)
 
     page_context = {
         'jpim': jpim,
         'instances': jpim.name_instance.values(),
-        'user_resources': user_resources,
-        'n_ready_jobs': n_ready_jobs,
-        'n_creating_jobs': n_creating_jobs,
-        'n_running_jobs': n_running_jobs,
+        'user_resources': data['user_resources'],
+        'n_ready_jobs': sum(r['n_ready_jobs'] for r in data['user_resources']),
+        'n_creating_jobs': sum(r['n_creating_jobs'] for r in data['user_resources']),
+        'n_running_jobs': sum(r['n_running_jobs'] for r in data['user_resources']),
     }
 
     return await render_template('batch-driver', request, userdata, 'job_private.html', page_context)
@@ -959,21 +1397,12 @@ async def get_job_private_inst_manager(request, userdata):
 @auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
 async def freeze_batch(request: web.Request, _) -> NoReturn:
     app = request.app
-    db: Database = app['db']
     session = await aiohttp_session.get_session(request)
-
     if app['frozen']:
         set_message(session, 'Batch is already frozen.', 'info')
-        raise web.HTTPFound(deploy_config.external_url('batch-driver', '/'))
-
-    await db.execute_update("""
-UPDATE globals SET frozen = 1;
-""")
-
-    app['frozen'] = True
-
-    set_message(session, 'Froze all instance collections and batch submissions.', 'info')
-
+    else:
+        await _set_frozen(app, app['db'], True)
+        set_message(session, 'Froze all instance collections and batch submissions.', 'info')
     raise web.HTTPFound(deploy_config.external_url('batch-driver', '/'))
 
 
@@ -981,21 +1410,12 @@ UPDATE globals SET frozen = 1;
 @auth.authenticated_users_with_permission(SystemPermission.UPDATE_DEPLOYED_SYSTEM_STATE)
 async def unfreeze_batch(request: web.Request, _) -> NoReturn:
     app = request.app
-    db: Database = app['db']
     session = await aiohttp_session.get_session(request)
-
     if not app['frozen']:
         set_message(session, 'Batch is already unfrozen.', 'info')
-        raise web.HTTPFound(deploy_config.external_url('batch-driver', '/'))
-
-    await db.execute_update("""
-UPDATE globals SET frozen = 0;
-""")
-
-    app['frozen'] = False
-
-    set_message(session, 'Unfroze all instance collections and batch submissions.', 'info')
-
+    else:
+        await _set_frozen(app, app['db'], False)
+        set_message(session, 'Unfroze all instance collections and batch submissions.', 'info')
     raise web.HTTPFound(deploy_config.external_url('batch-driver', '/'))
 
 
@@ -1006,23 +1426,7 @@ async def get_user_resources(request, userdata):
     app = request.app
     db: Database = app['db']
 
-    records = db.execute_and_fetchall("""
-SELECT user,
-  CAST(COALESCE(SUM(n_ready_jobs), 0) AS SIGNED) AS n_ready_jobs,
-  CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu,
-  CAST(COALESCE(SUM(n_running_jobs), 0) AS SIGNED) AS n_running_jobs,
-  CAST(COALESCE(SUM(running_cores_mcpu), 0) AS SIGNED) AS running_cores_mcpu
-FROM user_inst_coll_resources
-GROUP BY user
-HAVING n_ready_jobs + n_running_jobs > 0;
-""")
-
-    user_resources = sorted(
-        [record async for record in records],
-        key=lambda record: record['ready_cores_mcpu'] + record['running_cores_mcpu'],
-        reverse=True,
-    )
-
+    user_resources = await _fetch_global_user_resources(db)
     page_context = {'user_resources': user_resources}
     return await render_template('batch-driver', request, userdata, 'user_resources.html', page_context)
 
@@ -1733,7 +2137,7 @@ SELECT instance_id, frozen FROM globals;
     instance_id = row['instance_id']
     log.info(f'instance_id {instance_id}')
     app['instance_id'] = instance_id
-    app['frozen'] = row['frozen']
+    app['frozen'] = bool(row['frozen'])
 
     row = await db.select_and_fetchone('SELECT * FROM feature_flags')
     app['feature_flags'] = row

--- a/batch/batch/driver/templates/openapi.yaml
+++ b/batch/batch/driver/templates/openapi.yaml
@@ -1,0 +1,646 @@
+openapi: "3.1.0"
+info:
+  version: "{{ spec_version }}"
+  title: Hail Batch Driver
+  contact:
+    name: Contact our support
+    email: hail-team@broadinstitute.org
+    url: https://www.hail.is/gethelp.html
+  license:
+    name: MIT Licence
+    url: https://github.com/hail-is/hail/blob/main/LICENSE
+  description: >
+    Operator API for the Hail Batch Driver service. Requires elevated system
+    permissions (READ_DEPLOYED_SYSTEM_STATE or UPDATE_DEPLOYED_SYSTEM_STATE).
+tags:
+  - name: System
+    description: "System health and diagnostics."
+  - name: Operator
+    description: "Read and mutate live system state. Requires system permissions."
+servers:
+  - url: "{{ base_path }}"
+    description: "Batch Driver service."
+paths:
+  '/healthcheck':
+    get:
+      summary: Healthcheck
+      description: Liveness probe used by Kubernetes.
+      operationId: healthcheck
+      tags: [System]
+      responses:
+        '200':
+          description: Service is healthy.
+
+  '/check_invariants':
+    get:
+      summary: Check invariants
+      description: >
+        Runs consistency checks on user_inst_coll_resources counters against live
+        job state. Returns null fields on success; non-null strings contain error
+        details on failure.
+      operationId: checkInvariants
+      tags: [Operator]
+      responses:
+        '200':
+          description: Invariant check completed (see body for any errors).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  check_incremental_error:
+                    type: [string, 'null']
+                  check_resource_aggregation_error:
+                    type: [string, 'null']
+
+  '/api/v1alpha/driver_info':
+    get:
+      summary: Get driver state
+      description: >
+        Returns global system state: frozen status, total ready cores, feature
+        flags, per-pool and JPIM summaries, and global instance-collection stats.
+        Instance lists are available via the per-collection instances endpoints.
+      operationId: getDriverInfo
+      tags: [Operator]
+      responses:
+        '200':
+          description: Driver state retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DriverInfo'
+
+  '/api/v1alpha/freeze':
+    post:
+      summary: Freeze scheduling
+      description: >
+        Halts all scheduling and batch submissions system-wide. Returns 409 if
+        the system is already frozen.
+      operationId: freeze
+      tags: [Operator]
+      responses:
+        '200':
+          description: System frozen successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  frozen:
+                    type: boolean
+                    example: true
+        '409':
+          description: System is already frozen.
+
+  '/api/v1alpha/unfreeze':
+    post:
+      summary: Unfreeze scheduling
+      description: >
+        Resumes scheduling and batch submissions. Returns 409 if the system is
+        already unfrozen.
+      operationId: unfreeze
+      tags: [Operator]
+      responses:
+        '200':
+          description: System unfrozen successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  frozen:
+                    type: boolean
+                    example: false
+        '409':
+          description: System is already unfrozen.
+
+  '/api/v1alpha/inst_coll/pool/{pool}':
+    get:
+      summary: Get pool state
+      description: >
+        Returns pool configuration, live status (instances and cores by state,
+        schedulable cores), and per-user fair-share breakdown. Instance list
+        is available via the /instances sub-endpoint.
+      operationId: getPool
+      tags: [Operator]
+      parameters:
+        - name: pool
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pool state retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PoolDetail'
+        '404':
+          description: Pool not found.
+    patch:
+      summary: Update pool configuration
+      description: >
+        Partially updates pool configuration. Only the fields provided in the
+        request body are changed; omitted fields retain their current values.
+        Read-only fields (name, worker_type, preemptible) are rejected if
+        included. Returns the full pool state after the update.
+      operationId: patchPool
+      tags: [Operator]
+      parameters:
+        - name: pool
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PoolConfigUpdate'
+      responses:
+        '200':
+          description: Pool updated. Returns full pool state after the update.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PoolDetail'
+        '400':
+          description: Validation error.
+        '404':
+          description: Pool not found.
+
+  '/api/v1alpha/inst_coll/pool/{pool}/instances':
+    get:
+      summary: List pool instances
+      description: Paginated list of live instances for the named pool.
+      operationId: getPoolInstances
+      tags: [Operator]
+      parameters:
+        - name: pool
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Instance list retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstancesPage'
+        '404':
+          description: Pool not found.
+
+  '/api/v1alpha/inst_coll/jpim/instances':
+    get:
+      summary: List JPIM instances
+      description: Paginated list of live instances for the job-private instance manager.
+      operationId: getJpimInstances
+      tags: [Operator]
+      parameters:
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+      responses:
+        '200':
+          description: Instance list retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstancesPage'
+
+  '/api/v1alpha/inst_coll/jpim':
+    patch:
+      summary: Update JPIM configuration
+      description: >
+        Partially updates JPIM configuration. Only the fields provided in the
+        request body are changed. Returns the full JPIM state after the update.
+      operationId: patchJpim
+      tags: [Operator]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JpimConfigUpdate'
+      responses:
+        '200':
+          description: JPIM updated. Returns full JPIM state after the update.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JpimDetail'
+        '400':
+          description: Validation error.
+    get:
+      summary: Get JPIM state
+      description: >
+        Returns job-private instance manager configuration, live status, and
+        per-user breakdown. Instance list is available via the /instances sub-endpoint.
+      operationId: getJpim
+      tags: [Operator]
+      responses:
+        '200':
+          description: JPIM state retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JpimDetail'
+
+  '/api/v1alpha/user_resources':
+    get:
+      summary: Get user resources
+      description: >
+        Returns all users with active work (ready or running jobs), with
+        aggregate ready/running job counts and core counts across all instance
+        collections. Sorted descending by total active cores.
+      operationId: getUserResources
+      tags: [Operator]
+      responses:
+        '200':
+          description: User resources retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserResources'
+
+  '/api/v1alpha/gcp_quotas':
+    get:
+      summary: Get GCP quota usage
+      description: >
+        Returns all GCP quota metrics for each configured region, keyed as
+        `{region: {metric: {limit, usage}}}`. Data is served from a cache
+        refreshed every 60 seconds by the zone monitor. Returns 404 on
+        non-GCP clouds, 503 if the cache has not yet populated.
+      operationId: getGcpQuotas
+      tags: [Operator]
+      responses:
+        '200':
+          description: Quota data retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    properties:
+                      limit:
+                        type: number
+                      usage:
+                        type: number
+        '404':
+          description: Not running on GCP.
+        '503':
+          description: Quota cache not yet populated.
+
+  '/api/v1alpha/instances/{instance_name}/kill':
+    post:
+      summary: Kill instance
+      description: >
+        Kills an active instance. Returns 404 if the instance is not found,
+        409 if the instance is not in the active state.
+      operationId: killInstance
+      tags: [Operator]
+      parameters:
+        - name: instance_name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Kill request issued successfully.
+        '404':
+          description: Instance not found.
+        '409':
+          description: Instance is not active.
+
+  '/api/v1alpha/feature_flags':
+    patch:
+      summary: Update feature flags
+      description: >
+        Partially updates feature flags. Only the fields provided in the request
+        body are changed; omitted fields retain their current values.
+      operationId: patchFeatureFlags
+      tags: [Operator]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeatureFlagsUpdate'
+      responses:
+        '200':
+          description: Feature flags updated. Returns the full set of flags after the update.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  feature_flags:
+                    $ref: '#/components/schemas/FeatureFlags'
+
+components:
+  parameters:
+    offset:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: Number of instances to skip.
+    limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+      description: Maximum number of instances to return. Omit to return all.
+
+
+  schemas:
+    FeatureFlags:
+      type: object
+      properties:
+        compact_billing_tables:
+          type: boolean
+        oms_agent:
+          type: boolean
+        dockerhub_proxy:
+          type: boolean
+
+    FeatureFlagsUpdate:
+      type: object
+      properties:
+        compact_billing_tables:
+          type: boolean
+        oms_agent:
+          type: boolean
+        dockerhub_proxy:
+          type: boolean
+
+    InstCollSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        all_versions_instances_by_state:
+          type: object
+          additionalProperties:
+            type: integer
+        all_versions_cores_mcpu_by_state:
+          type: object
+          additionalProperties:
+            type: integer
+        max_live_instances:
+          type: integer
+        max_instances:
+          type: integer
+        schedulable_free_cores_mcpu:
+          type: integer
+        schedulable_cores_mcpu:
+          type: integer
+
+    Instance:
+      type: object
+      properties:
+        name:
+          type: string
+        inst_coll_name:
+          type: string
+        location:
+          type: string
+        version:
+          type: string
+        state:
+          type: string
+          enum: [pending, active, inactive, deleted]
+        free_cores_mcpu:
+          type: integer
+        cores_mcpu:
+          type: integer
+        failed_request_count:
+          type: integer
+        time_created_ms:
+          type: integer
+        last_updated_ms:
+          type: integer
+
+    GlobalStats:
+      type: object
+      properties:
+        n_instances_by_state:
+          type: object
+          additionalProperties:
+            type: integer
+        cores_mcpu_by_state:
+          type: object
+          additionalProperties:
+            type: integer
+        schedulable_free_cores_mcpu:
+          type: integer
+        schedulable_cores_mcpu:
+          type: integer
+
+    InstancesPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Instance'
+        total_count:
+          type: integer
+          description: Total number of instances across all pages.
+        current_offset:
+          type: integer
+          description: Offset used for this page.
+        more:
+          type: boolean
+          description: Whether more instances exist beyond this page. If true, the next offset is current_offset + len(items).
+
+    UserResources:
+      type: object
+      properties:
+        user:
+          type: string
+        n_ready_jobs:
+          type: integer
+        ready_cores_mcpu:
+          type: integer
+        n_running_jobs:
+          type: integer
+        running_cores_mcpu:
+          type: integer
+
+    PoolUserResources:
+      type: object
+      properties:
+        user:
+          type: string
+        n_ready_jobs:
+          type: integer
+        ready_cores_mcpu:
+          type: integer
+        allocated_cores_mcpu:
+          type: integer
+        n_running_jobs:
+          type: integer
+        running_cores_mcpu:
+          type: integer
+
+    JpimUserResources:
+      type: object
+      properties:
+        user:
+          type: string
+        n_ready_jobs:
+          type: integer
+        n_allocated_jobs:
+          type: integer
+        n_creating_jobs:
+          type: integer
+        n_running_jobs:
+          type: integer
+
+    PoolConfigUpdate:
+      type: object
+      properties:
+        boot_disk_size_gb:
+          type: integer
+        worker_local_ssd_data_disk:
+          type: boolean
+        worker_external_ssd_data_disk_size_gb:
+          type: integer
+        worker_cores:
+          type: integer
+        standing_worker_cores:
+          type: integer
+        min_instances:
+          type: integer
+        max_instances:
+          type: integer
+        max_live_instances:
+          type: integer
+        max_new_instances_per_autoscaler_loop:
+          type: integer
+        autoscaler_loop_period_secs:
+          type: integer
+        worker_max_idle_time_secs:
+          type: integer
+        standing_worker_max_idle_time_secs:
+          type: integer
+        job_queue_scheduling_window_secs:
+          type: integer
+
+    JpimConfigUpdate:
+      type: object
+      properties:
+        boot_disk_size_gb:
+          type: integer
+        max_instances:
+          type: integer
+        max_live_instances:
+          type: integer
+        max_new_instances_per_autoscaler_loop:
+          type: integer
+        autoscaler_loop_period_secs:
+          type: integer
+        worker_max_idle_time_secs:
+          type: integer
+
+    PoolDetail:
+      type: object
+      properties:
+        name:
+          type: string
+        worker_type:
+          type: string
+        worker_cores:
+          type: integer
+        boot_disk_size_gb:
+          type: integer
+        worker_local_ssd_data_disk:
+          type: boolean
+        worker_external_ssd_data_disk_size_gb:
+          type: integer
+        standing_worker_cores:
+          type: integer
+        min_instances:
+          type: integer
+        max_instances:
+          type: integer
+        max_live_instances:
+          type: integer
+        preemptible:
+          type: boolean
+        max_new_instances_per_autoscaler_loop:
+          type: integer
+        autoscaler_loop_period_secs:
+          type: integer
+        standing_worker_max_idle_time_secs:
+          type: integer
+        worker_max_idle_time_secs:
+          type: integer
+        job_queue_scheduling_window_secs:
+          type: integer
+        status:
+          $ref: '#/components/schemas/InstCollSummary'
+        user_resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/PoolUserResources'
+
+    JpimDetail:
+      type: object
+      properties:
+        name:
+          type: string
+        boot_disk_size_gb:
+          type: integer
+        max_instances:
+          type: integer
+        max_live_instances:
+          type: integer
+        max_new_instances_per_autoscaler_loop:
+          type: integer
+        autoscaler_loop_period_secs:
+          type: integer
+        worker_max_idle_time_secs:
+          type: integer
+        status:
+          $ref: '#/components/schemas/InstCollSummary'
+        user_resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/JpimUserResources'
+
+    DriverInfo:
+      type: object
+      properties:
+        instance_id:
+          type: string
+        frozen:
+          type: boolean
+        ready_cores_mcpu:
+          type: integer
+        feature_flags:
+          $ref: '#/components/schemas/FeatureFlags'
+        pools:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstCollSummary'
+        jpim:
+          $ref: '#/components/schemas/InstCollSummary'
+        global_stats:
+          $ref: '#/components/schemas/GlobalStats'

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -43,6 +43,7 @@ from gear import (
     monitor_endpoints_middleware,
     setup_aiohttp_session,
     transaction,
+    version_response,
 )
 from gear.auth import get_session_id, impersonate_user
 from gear.clients import get_cloud_async_fs
@@ -241,8 +242,9 @@ async def get_healthcheck(_) -> web.Response:
 
 
 @routes.get('/api/v1alpha/version')
-async def rest_get_version(_) -> web.Response:
-    return web.Response(text=__version__)
+@auth.maybe_authenticated_user
+async def rest_get_version(_, userdata: Optional[UserData]) -> web.Response:
+    return version_response(userdata)
 
 
 @routes.get('/api/v1alpha/cloud')
@@ -2534,6 +2536,26 @@ async def get_job_resource_usage(request: web.Request, _, batch_id: int) -> web.
     })
 
 
+@routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/jvm_profile')
+@billing_project_users_only()
+async def api_get_jvm_profile(request: web.Request, _, batch_id: int) -> web.Response:
+    job_id = int(request.match_info['job_id'])
+    record = await _get_job_record(request.app, batch_id, job_id)
+    file_store: FileStore = request.app['file_store']
+    batch_format_version = BatchFormatVersion(record['format_version'])
+    attempt_id = attempt_id_from_spec(record)
+
+    if not has_resource_available(record) or record['state'] == 'Running' or attempt_id is None:
+        raise web.HTTPNotFound()
+
+    try:
+        data = await file_store.read_jvm_profile(batch_format_version, batch_id, job_id, attempt_id, 'main')
+    except FileNotFoundError as exc:
+        raise web.HTTPNotFound() from exc
+
+    return web.Response(body=data, content_type='application/octet-stream')
+
+
 def plot_job_durations(container_statuses: dict, batch_id: int, job_id: int):
     data = []
     for step in ['input', 'main', 'output']:
@@ -3135,7 +3157,11 @@ async def get_billing_projects(request, userdata):
     else:
         user = None
 
-    billing_projects = await query_billing_projects_with_cost(db, user=user)
+    status = request.query.get('status')
+    if status is not None and status not in ('open', 'closed'):
+        raise web.HTTPBadRequest(reason=f"Invalid value for status '{status}'; must be 'open' or 'closed'.")
+
+    billing_projects = await query_billing_projects_with_cost(db, user=user, status=status)
     return json_response(billing_projects)
 
 

--- a/batch/batch/front_end/templates/openapi.yaml
+++ b/batch/batch/front_end/templates/openapi.yaml
@@ -682,8 +682,6 @@ paths:
       summary: List batches (v2)
       description: Get a list of batches using v2 query format
       tags: [Batches]
-      security:
-        - developerAuth: []
       parameters:
         - name: q
           in: query
@@ -769,8 +767,8 @@ paths:
       parameters:
         - name: start
           in: query
-          description: "Start date in MM/DD/YYYY format (required)."
-          required: true
+          description: "Start date in MM/DD/YYYY format. Defaults to the first day of the current month."
+          required: false
           schema:
             type: string
             example: "04/01/2026"
@@ -795,10 +793,18 @@ paths:
   '/api/v1alpha/billing_projects':
     get:
       summary: "List billing projects"
-      description: "List billing projects."
+      description: "List billing projects. Optionally filter by status."
       operationId: getBillingProjects
       tags:
         - Billing Projects
+      parameters:
+        - name: status
+          in: query
+          description: "Filter by billing project status. If omitted, returns both open and closed projects."
+          required: false
+          schema:
+            type: string
+            enum: [open, closed]
       responses:
         '200':
           description: "Successfully retrieved the billing projects."
@@ -806,6 +812,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BillingProjectListResponse'
+        '400':
+          description: "Invalid status value."
   '/api/v1alpha/billing_projects/{billing_project}':
     get:
       summary: "Get a billing project"
@@ -832,8 +840,6 @@ paths:
       summary: Create billing project
       description: Create a new billing project
       tags: [Billing]
-      security:
-        - developerAuth: []
       parameters:
         - name: billing_project
           in: path
@@ -956,8 +962,6 @@ paths:
       summary: Delete billing project
       description: Delete an existing billing project
       tags: [Billing]
-      security:
-        - developerAuth: []
       parameters:
         - name: billing_project
           in: path
@@ -984,8 +988,6 @@ paths:
       summary: Edit billing limits
       description: Edit billing limits for a billing project
       tags: [Billing]
-      security:
-        - developerAuth: []
       parameters:
         - name: billing_project
           in: path
@@ -1023,6 +1025,38 @@ paths:
           description: Forbidden - requires developer privileges
         '404':
           description: Billing project not found
+  '/api/v1alpha/batches/{batch_id}/jobs/{job_id}/jvm_profile':
+    get:
+      summary: "Get JVM profile data"
+      description: "Get raw JVM profiling data for a completed job. Only available for jobs run with profiling enabled."
+      operationId: getJvmProfile
+      tags:
+        - Batches API v1Alpha
+      parameters:
+        - name: batch_id
+          in: path
+          description: "The ID of the batch."
+          required: true
+          schema:
+            type: number
+        - name: job_id
+          in: path
+          description: "The ID of the job."
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: "Raw JVM profile data."
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Unauthorized
+        '404':
+          description: "Profile not available (job not complete, profiling not enabled, or profile not yet uploaded)."
   '/batches':
     get:
       summary: "Batches page (UI)"
@@ -1295,8 +1329,6 @@ paths:
       summary: Edit billing limits
       description: Edit billing limits for a billing project
       tags: [Billing]
-      security:
-        - developerAuth: []
       parameters:
         - name: billing_project
           in: path
@@ -1362,8 +1394,6 @@ paths:
       summary: Create billing project
       description: Create a new billing project
       tags: [Billing]
-      security:
-        - developerAuth: []
       parameters:
         - name: billing_project
           in: path

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -144,7 +144,7 @@ class ExceededSharesCounter:
         return f'global {self._global_counter}'
 
 
-async def query_billing_projects_with_cost(db, user=None, billing_project=None) -> List[Dict[str, Any]]:
+async def query_billing_projects_with_cost(db, user=None, billing_project=None, status=None) -> List[Dict[str, Any]]:
     where_conditions = ["billing_projects.`status` != 'deleted'"]
     args = []
 
@@ -155,6 +155,10 @@ async def query_billing_projects_with_cost(db, user=None, billing_project=None) 
     if billing_project:
         where_conditions.append('billing_projects.name_cs = %s')
         args.append(billing_project)
+
+    if status:
+        where_conditions.append('billing_projects.`status` = %s')
+        args.append(status)
 
     if where_conditions:
         where_condition = f'WHERE {" AND ".join(where_conditions)}'
@@ -188,7 +192,7 @@ GROUP BY billing_projects.name, billing_projects.`status`, billing_projects.`lim
 
 
 async def query_billing_projects_without_cost(
-    db: Database, user: Optional[str] = None, billing_project: Optional[str] = None
+    db: Database, user: Optional[str] = None, billing_project: Optional[str] = None, status: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     where_conditions = ["billing_projects.`status` != 'deleted'"]
     args = []
@@ -200,6 +204,10 @@ async def query_billing_projects_without_cost(
     if billing_project:
         where_conditions.append('billing_projects.name_cs = %s')
         args.append(billing_project)
+
+    if status:
+        where_conditions.append('billing_projects.`status` = %s')
+        args.append(status)
 
     if where_conditions:
         where_condition = f'WHERE {" AND ".join(where_conditions)}'

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -33,6 +33,7 @@ from gear import (
     json_response,
     monitor_endpoints_middleware,
     setup_aiohttp_session,
+    version_response,
 )
 from gear.profiling import install_profiler_if_requested
 from hailtop import __version__, aiotools, httpx, uvloopx
@@ -168,6 +169,13 @@ def wb_and_pr_from_request(request: web.Request) -> Tuple[WatchedBranch, PR]:
     return wb, wb.prs[pr_number]
 
 
+def _wb_by_branch(branch_name: str) -> WatchedBranch:
+    for wb in watched_branches:
+        if wb.branch.name == branch_name:
+            return wb
+    raise web.HTTPNotFound()
+
+
 def filter_jobs(jobs):
     filtered: Dict[str, list] = {
         state: []
@@ -198,6 +206,43 @@ async def _populate_batch_context(page_context: Dict[str, Any], batch: Batch) ->
         page_context['logging_queries'] = None
 
 
+async def _active_pr_json(wb: WatchedBranch, pr: PR) -> dict:
+    _do_not_merge = frozenset(('WIP', 'stacked PR'))
+    deploy_batch = wb.deploy_batch
+    blocking_deploy_batch_id = (
+        deploy_batch.id if deploy_batch and isinstance(deploy_batch, Batch) and wb.deploy_state is None else None
+    )
+    batch = pr.batch
+    batch_summary = None
+    if batch and isinstance(batch, Batch):
+        status = await batch.last_known_status()
+        batch_summary = {
+            'id': batch.id,
+            'state': status.get('state'),
+            'cost': status.get('cost'),
+            'artifacts_uri': f'{STORAGE_URI}/build/{batch.attributes["token"]}',
+        }
+    return {
+        'review_approved': pr.review_state == 'approved',
+        'checks_all_pass': len(pr.last_known_github_status) > 0 and pr.build_succeeding_on_all_platforms(),
+        'is_up_to_date': pr.is_up_to_date(),
+        'blocking_labels': [label for label in pr.labels if label in ('WIP', 'stacked PR')],
+        'is_mergeable': pr.is_mergeable(),
+        'prs_ahead_in_queue': [
+            {'number': p.number, 'title': p.title, 'is_merge_candidate': p is wb.merge_candidate}
+            for p in wb.prs_in_merge_priority_order()
+            if p.number != pr.number
+            and p.merge_priority() > pr.merge_priority()
+            and p.review_state == 'approved'
+            and not any(label in _do_not_merge for label in p.labels)
+            and not p.build_failed_on_at_least_one_platform()
+        ],
+        'is_merge_candidate': wb.merge_candidate is not None and wb.merge_candidate.number == pr.number,
+        'blocking_deploy_batch_id': blocking_deploy_batch_id,
+        'batch': batch_summary,
+    }
+
+
 async def _populate_active_pr_context(
     page_context: Dict[str, Any], wb: WatchedBranch, pr_number: int, db: Database
 ) -> None:
@@ -205,33 +250,11 @@ async def _populate_active_pr_context(
     page_context['pr'] = pr
     page_context['active_pr'] = True
     page_context['pr_authorized'] = await pr.authorized(db)
-
-    # Merge eligibility checklist
-    page_context['review_approved'] = pr.review_state == 'approved'
-    page_context['checks_all_pass'] = len(pr.last_known_github_status) > 0 and pr.build_succeeding_on_all_platforms()
-    page_context['is_up_to_date'] = pr.is_up_to_date()
-    page_context['blocking_labels'] = [label for label in pr.labels if label in ('WIP', 'stacked PR')]
-    page_context['is_mergeable'] = pr.is_mergeable()
-
-    # Merge queue: approved, non-blocked, non-failing PRs with higher priority
-    _do_not_merge = frozenset(('WIP', 'stacked PR'))
     page_context['build_failing'] = pr.build_failed_on_at_least_one_platform()
-    page_context['prs_ahead_in_queue'] = [
-        {'number': p.number, 'title': p.title, 'is_merge_candidate': p is wb.merge_candidate}
-        for p in wb.prs_in_merge_priority_order()
-        if p.number != pr.number
-        and p.merge_priority() > pr.merge_priority()
-        and p.review_state == 'approved'
-        and not any(label in _do_not_merge for label in p.labels)
-        and not p.build_failed_on_at_least_one_platform()
-    ]
-    page_context['is_merge_candidate'] = wb.merge_candidate is not None and wb.merge_candidate.number == pr.number
 
-    # Deploy batch blocking next merge (running but not yet complete)
-    deploy_batch = wb.deploy_batch
-    page_context['blocking_deploy_batch_id'] = (
-        deploy_batch.id if deploy_batch and isinstance(deploy_batch, Batch) and wb.deploy_state is None else None
-    )
+    active_data = await _active_pr_json(wb, pr)
+    page_context.update(active_data)
+    page_context.pop('batch', None)
 
     batch = pr.batch
     if batch:
@@ -330,19 +353,15 @@ def storage_uri_to_url(uri: str) -> str:
     return uri
 
 
-async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: UserData):
-    app = request.app
-    session = await aiohttp_session.get_session(request)
-
+async def _retry_pr_core(wb: WatchedBranch, pr: PR, app: web.Application, username: str) -> Optional[str]:
+    """Executes the retry logic. Returns an error message on failure, None on success."""
     if pr.batch is None:
         log.info(f'retry cannot be requested for PR #{pr.number} because it has no batch')
-        set_message(session, f'Retry cannot be requested for PR #{pr.number} because it has no batch.', 'error')
-        return
+        return 'Retry cannot be requested because this PR has no batch.'
 
     if isinstance(pr.batch, MergeFailureBatch):
         log.info(f'retry cannot be requested for PR #{pr.number} because it was a merge failure')
-        set_message(session, f'Retry cannot be requested for PR #{pr.number} because it was a merge failure.', 'error')
-        return
+        return 'Retry cannot be requested because this PR had a merge failure.'
 
     batch_id = pr.batch.id
     db = app[AppKeys.DB]
@@ -363,7 +382,7 @@ async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: Us
                     wb.branch.short_str(),
                     pr.source_branch.name,
                     pr.source_sha,
-                    userdata['username'],
+                    username,
                 ),
             )
 
@@ -373,9 +392,17 @@ async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: Us
     await wb.notify_batch_changed(
         db, app[AppKeys.BATCH_CLIENT], app[AppKeys.GH_CLIENT], app[AppKeys.FROZEN_MERGE_DEPLOY]
     )
-
     log.info(f'retry requested for PR: {pr.number}')
-    set_message(session, f'Retry requested for PR #{pr.number}.', 'info')
+    return None
+
+
+async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: UserData):
+    session = await aiohttp_session.get_session(request)
+    error = await _retry_pr_core(wb, pr, request.app, userdata['username'])
+    if error:
+        set_message(session, error, 'error')
+    else:
+        set_message(session, f'Retry requested for PR #{pr.number}.', 'info')
 
 
 @routes.post('/watched_branches/{watched_branch_index}/pr/{pr_number}/retry')
@@ -593,6 +620,12 @@ async def batch_callback_handler(request: web.Request):
                     )
 
 
+@routes.get('/api/v1alpha/version')
+@auth.maybe_authenticated_user
+async def get_version(_, userdata: Optional[UserData]) -> web.Response:
+    return version_response(userdata)
+
+
 @routes.get('/api/v1alpha/deploy_status')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
 async def deploy_status(request: web.Request, _) -> web.Response:
@@ -749,11 +782,7 @@ UPDATE globals SET frozen_merge_deploy = 0;
     raise web.HTTPFound(deploy_config.external_url('ci', '/'))
 
 
-@routes.get('/namespaces')
-@web_security_headers
-@auth.authenticated_users_with_permission(SystemPermission.READ_CI)
-async def get_active_namespaces(request: web.Request, userdata: UserData) -> web.Response:
-    db = request.app[AppKeys.DB]
+async def _fetch_active_namespaces(db: Database) -> list:
     namespaces = [
         r
         async for r in db.execute_and_fetchall("""
@@ -765,10 +794,15 @@ GROUP BY active_namespaces.namespace""")
     ]
     for ns in namespaces:
         ns['services'] = json.loads(ns['services']) or {}
-    context = {
-        'namespaces': namespaces,
-    }
-    return await render_template('ci', request, userdata, 'namespaces.html', context)
+    return namespaces
+
+
+@routes.get('/namespaces')
+@web_security_headers
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI)
+async def get_active_namespaces(request: web.Request, userdata: UserData) -> web.Response:
+    namespaces = await _fetch_active_namespaces(request.app[AppKeys.DB])
+    return await render_template('ci', request, userdata, 'namespaces.html', {'namespaces': namespaces})
 
 
 @routes.post('/namespaces/{namespace}/services/add')
@@ -793,7 +827,7 @@ WHERE namespace = %s AND service = %s
         set_message(session, 'Service already registered', 'info')
     else:
         await db.execute_insertone(
-            'INSERT INTO deployed_services VALUES (%s, %s)',
+            'INSERT INTO deployed_services (`namespace`, `service`) VALUES (%s, %s)',
             (namespace, service),
         )
 
@@ -810,7 +844,7 @@ async def update_namespaced_service(request: web.Request, _) -> NoReturn:
     post = await request.post()
     rate_limit = post['rate_limit'] or None
 
-    await db.execute_insertone(
+    await db.execute_update(
         """UPDATE deployed_services SET rate_limit_rps = %s WHERE namespace = %s AND service = %s""",
         (rate_limit, namespace, service),
     )
@@ -947,6 +981,278 @@ LIMIT %s
         'cursor': rows[-1]['id'] if has_more else None,
         'has_more': has_more,
     })
+
+
+def _pr_config_json(cfg: PRConfig) -> dict:
+    return {
+        **cfg,
+        'assignees': list(cfg['assignees']),
+        'reviewers': list(cfg['reviewers']),
+        'labels': list(cfg['labels']),
+    }
+
+
+def _wb_config_json(cfg: Dict[str, Any]) -> dict:
+    return {
+        **cfg,
+        'prs': [_pr_config_json(pr) for pr in cfg['prs']],
+        'gh_status_names': list(cfg['gh_status_names']),
+    }
+
+
+@routes.get('/api/v1alpha/watched_branches')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_watched_branches(request: web.Request, _) -> web.Response:
+    result = [
+        {
+            'branch': wb.branch.name,
+            'branch_fqn': wb.branch.short_str(),
+            'repo': wb.branch.repo.short_str(),
+            'sha': wb.sha,
+            'deploy_state': wb.deploy_state,
+            'deploy_batch_id': wb.deploy_batch.id if wb.deploy_batch and isinstance(wb.deploy_batch, Batch) else None,
+            'n_prs': len(wb.prs) if wb.prs else 0,
+            'merge_candidate': wb.merge_candidate.short_str() if wb.merge_candidate else None,
+        }
+        for wb in watched_branches
+    ]
+    return json_response({'branches': result, 'frozen': request.app[AppKeys.FROZEN_MERGE_DEPLOY]})
+
+
+@routes.get('/api/v1alpha/watched_branches/{branch}/prs')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_watched_branch_prs(request: web.Request, _) -> web.Response:
+    wb = _wb_by_branch(request.match_info['branch'])
+    prs = [_pr_config_json(await pr_config(request.app, pr)) for pr in (wb.prs or {}).values()]
+    return json_response(prs)
+
+
+@routes.get('/api/v1alpha/watched_branches/{branch}/prs/{number}')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_watched_branch_pr(request: web.Request, _) -> web.Response:
+    wb = _wb_by_branch(request.match_info['branch'])
+    try:
+        pr_number = int(request.match_info['number'])
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text='PR number must be an integer') from exc
+
+    if wb.prs and pr_number in wb.prs:
+        pr = wb.prs[pr_number]
+        result = _pr_config_json(await pr_config(request.app, pr))
+        result.update(await _active_pr_json(wb, pr))
+        return json_response(result)
+
+    try:
+        gh_pr = await request.app[AppKeys.GH_CLIENT].getitem(f'/repos/{wb.branch.repo.short_str()}/pulls/{pr_number}')
+        return json_response({
+            'number': gh_pr['number'],
+            'title': gh_pr['title'],
+            'labels': [label['name'] for label in gh_pr.get('labels', [])],
+            'merged': gh_pr['merged'],
+            'merge_commit_sha': gh_pr.get('merge_commit_sha') if gh_pr['merged'] else None,
+        })
+    except gidgethub.HTTPException as e:
+        if e.status_code == 404:
+            raise web.HTTPNotFound()
+        log.exception('GitHub API error fetching PR %s', pr_number)
+        raise web.HTTPBadGateway(text='GitHub API error')
+    except ClientError as exc:
+        log.exception('GitHub API network error fetching PR %s', pr_number)
+        raise web.HTTPBadGateway(text='GitHub API unreachable') from exc
+
+
+@routes.get('/api/v1alpha/namespaces')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_namespaces(request: web.Request, _) -> web.Response:
+    namespaces = await _fetch_active_namespaces(request.app[AppKeys.DB])
+    return json_response(namespaces)
+
+
+@routes.get('/api/v1alpha/me')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_me(request: web.Request, userdata: UserData) -> web.Response:
+    user = next(
+        (u for u in AUTHORIZED_USERS if u.hail_username == userdata['username']),
+        None,
+    )
+    if user is None:
+        raise web.HTTPNotFound()
+
+    wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
+    pr_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: is_pr_author(user.gh_username, pr))]
+    review_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: is_pr_reviewer(user.gh_username, pr))]
+    actionable_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: pr_requires_action(user.gh_username, pr))]
+
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
+    dev_deploys_iter = batch_client.list_batches(f'user={user.hail_username} dev_deploy=1', limit=10)
+    dev_deploys = sorted([b async for b in dev_deploys_iter], key=lambda b: b.id, reverse=True)
+
+    return json_response({
+        'hail_username': user.hail_username,
+        'gh_username': user.gh_username,
+        'pr_wbs': pr_wbs,
+        'review_wbs': review_wbs,
+        'actionable_wbs': actionable_wbs,
+        'dev_deploys': [await b.last_known_status() for b in dev_deploys],
+    })
+
+
+@routes.get('/api/v1alpha/authorized_shas')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_authorized_shas(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    rows = [r['sha'] async for r in db.execute_and_fetchall('SELECT sha FROM authorized_shas ORDER BY sha')]
+    return json_response(rows)
+
+
+@routes.get('/api/v1alpha/teams')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_teams(_request: web.Request, _) -> web.Response:
+    result: Dict[str, list] = {team: [] for team in TEAMS}
+    for user in AUTHORIZED_USERS:
+        for team in user.teams:
+            if team in result:
+                result[team].append({'gh_username': user.gh_username, 'hail_username': user.hail_username})
+    return json_response(result)
+
+
+@routes.post('/api/v1alpha/freeze')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_freeze(request: web.Request, _) -> web.Response:
+    app = request.app
+    if app[AppKeys.FROZEN_MERGE_DEPLOY]:
+        raise web.HTTPConflict(text='CI is already frozen.')
+    await app[AppKeys.DB].execute_update('UPDATE globals SET frozen_merge_deploy = 1;')
+    app[AppKeys.FROZEN_MERGE_DEPLOY] = True
+    return json_response({'frozen': True})
+
+
+@routes.post('/api/v1alpha/unfreeze')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_unfreeze(request: web.Request, _) -> web.Response:
+    app = request.app
+    if not app[AppKeys.FROZEN_MERGE_DEPLOY]:
+        raise web.HTTPConflict(text='CI is already unfrozen.')
+    await app[AppKeys.DB].execute_update('UPDATE globals SET frozen_merge_deploy = 0;')
+    app[AppKeys.FROZEN_MERGE_DEPLOY] = False
+    return json_response({'frozen': False})
+
+
+@routes.post('/api/v1alpha/watched_branches/{branch}/prs/{number}/retry')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_retry_pr(request: web.Request, userdata: UserData) -> web.Response:
+    wb = _wb_by_branch(request.match_info['branch'])
+    try:
+        pr_number = int(request.match_info['number'])
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text='PR number must be an integer') from exc
+    if not wb.prs or pr_number not in wb.prs:
+        raise web.HTTPNotFound()
+    pr = wb.prs[pr_number]
+    error = await asyncio.shield(_retry_pr_core(wb, pr, request.app, userdata['username']))
+    if error:
+        raise web.HTTPBadRequest(text=error)
+    return web.Response(status=200)
+
+
+@routes.post('/api/v1alpha/authorize_sha')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_authorize_sha(request: web.Request, _) -> web.Response:
+    params = await json_request(request)
+    sha = str(params.get('sha', '')).strip()
+    if not sha:
+        raise web.HTTPBadRequest(text='sha is required')
+    await request.app[AppKeys.DB].execute_insertone('INSERT INTO authorized_shas (sha) VALUES (%s);', sha)
+    log.info(f'authorized sha: {sha}')
+    return web.Response(status=201)
+
+
+@routes.get('/api/v1alpha/namespaces/{namespace}')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_get_namespace(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    record = await db.select_and_fetchone('SELECT * FROM active_namespaces WHERE namespace = %s', (namespace,))
+    if not record:
+        raise web.HTTPNotFound()
+    return json_response(dict(record))
+
+
+@routes.put('/api/v1alpha/namespaces/{namespace}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_put_namespace(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    existing = await db.execute_and_fetchone('SELECT 1 FROM active_namespaces WHERE namespace = %s', (namespace,))
+    if existing:
+        return json_response({'namespace': namespace})
+    await db.execute_insertone('INSERT INTO active_namespaces (`namespace`) VALUES (%s)', (namespace,))
+    return web.Response(status=201)
+
+
+@routes.delete('/api/v1alpha/namespaces/{namespace}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_delete_namespace(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    await remove_namespace_from_db(db, namespace)
+    return web.Response(status=204)
+
+
+@routes.get('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_get_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    record = await db.select_and_fetchone(
+        'SELECT * FROM deployed_services WHERE namespace = %s AND service = %s', (namespace, service)
+    )
+    if not record:
+        raise web.HTTPNotFound()
+    return json_response(dict(record))
+
+
+@routes.put('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_put_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    existing = await db.select_and_fetchone(
+        'SELECT 1 FROM deployed_services WHERE namespace = %s AND service = %s', (namespace, service)
+    )
+    if existing:
+        return json_response({'namespace': namespace, 'service': service})
+    await db.execute_insertone(
+        'INSERT INTO deployed_services (`namespace`, `service`) VALUES (%s, %s)', (namespace, service)
+    )
+    return web.Response(status=201)
+
+
+@routes.patch('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_update_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    params = await json_request(request)
+    rate_limit_rps = params.get('rate_limit_rps')
+    await db.execute_update(
+        'UPDATE deployed_services SET rate_limit_rps = %s WHERE namespace = %s AND service = %s',
+        (rate_limit_rps, namespace, service),
+    )
+    return web.Response(status=200)
+
+
+@routes.delete('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_delete_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    await db.execute_update('DELETE FROM deployed_services WHERE namespace = %s AND service = %s', (namespace, service))
+    return web.Response(status=204)
 
 
 async def cleanup_expired_namespaces(db: Database):

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -21,6 +21,8 @@ tags:
     description: "Endpoints for managing deployments"
   - name: Namespaces
     description: "Endpoints for managing namespaces and services"
+  - name: PRs
+    description: "Endpoints for pull request data"
   - name: GitHub Integration
     description: "Endpoints for GitHub webhook integration"
   - name: Documentation
@@ -217,11 +219,164 @@ components:
           type: boolean
           description: "Whether more rows exist beyond this page"
 
-  securitySchemes:
-    developerAuth:
-      type: http
-      scheme: bearer
-      description: Developer authentication token
+    WatchedBranchSummary:
+      type: object
+      properties:
+        branch:
+          type: string
+          description: "Branch name (e.g. main). Use this as the {branch} path parameter."
+        branch_fqn:
+          type: string
+          description: "Fully-qualified branch ref (e.g. hail-is/hail:main)."
+        repo:
+          type: string
+          description: "Repository (e.g. hail-is/hail)"
+        sha:
+          type: string
+          nullable: true
+          description: "Current HEAD SHA"
+        deploy_state:
+          type: string
+          nullable: true
+          description: "Latest deploy state"
+        deploy_batch_id:
+          type: integer
+          nullable: true
+          description: "Latest deploy batch ID"
+        n_prs:
+          type: integer
+          description: "Number of active PRs"
+        merge_candidate:
+          type: string
+          nullable: true
+          description: "Current merge candidate branch"
+
+    WatchedBranchesResponse:
+      type: object
+      properties:
+        branches:
+          type: array
+          items:
+            $ref: '#/components/schemas/WatchedBranchSummary'
+        frozen:
+          type: boolean
+          description: "Whether merges and deploys are frozen"
+
+    PRConfig:
+      type: object
+      properties:
+        number:
+          type: integer
+        title:
+          type: string
+        author:
+          type: string
+        source_branch_name:
+          type: string
+        build_state:
+          type: string
+          nullable: true
+        review_state:
+          type: string
+          nullable: true
+        labels:
+          type: array
+          items:
+            type: string
+        out_of_date:
+          type: boolean
+        gh_statuses:
+          type: object
+          additionalProperties:
+            type: string
+        batch_id:
+          type: integer
+          nullable: true
+
+    BatchSummary:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: integer
+        state:
+          type: string
+          nullable: true
+        cost:
+          type: number
+          nullable: true
+        artifacts_uri:
+          type: string
+
+    ActivePRDetail:
+      allOf:
+        - $ref: '#/components/schemas/PRConfig'
+        - type: object
+          properties:
+            review_approved:
+              type: boolean
+            checks_all_pass:
+              type: boolean
+            is_up_to_date:
+              type: boolean
+            blocking_labels:
+              type: array
+              items:
+                type: string
+            is_mergeable:
+              type: boolean
+            prs_ahead_in_queue:
+              type: array
+              items:
+                type: object
+                properties:
+                  number:
+                    type: integer
+                  title:
+                    type: string
+                  is_merge_candidate:
+                    type: boolean
+            is_merge_candidate:
+              type: boolean
+            blocking_deploy_batch_id:
+              type: integer
+              nullable: true
+            batch:
+              $ref: '#/components/schemas/BatchSummary'
+
+    HistoricalPRDetail:
+      type: object
+      properties:
+        number:
+          type: integer
+        title:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        merged:
+          type: boolean
+          nullable: true
+        merge_commit_sha:
+          type: string
+          nullable: true
+
+    TeamMember:
+      type: object
+      properties:
+        gh_username:
+          type: string
+        hail_username:
+          type: string
+          nullable: true
+
+    FreezeResponse:
+      type: object
+      properties:
+        frozen:
+          type: boolean
+
 
 paths:
   '/':
@@ -283,8 +438,6 @@ paths:
       summary: "Retry PR build"
       description: "Request a retry of the CI build for this PR"
       tags: [Deployments]
-      security:
-        - developerAuth: []
       parameters:
         - name: watched_branch_index
           in: path
@@ -356,8 +509,6 @@ paths:
       summary: Get deployment status
       description: Get status of all branch deployments
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Deployment status retrieved successfully
@@ -377,8 +528,6 @@ paths:
       summary: Trigger update
       description: Trigger an update of all watched branches
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Update triggered successfully
@@ -392,8 +541,6 @@ paths:
       summary: Deploy branch for development
       description: Create a development deployment for a specific branch
       tags: [Deployments]
-      security:
-        - developerAuth: []
       requestBody:
         required: true
         content:
@@ -434,8 +581,6 @@ paths:
       summary: List builds
       description: Get a list of CI builds
       tags: [Builds]
-      security:
-        - developerAuth: []
       parameters:
         - name: limit
           in: query
@@ -466,8 +611,6 @@ paths:
       summary: Get build details
       description: Get detailed information about a specific build
       tags: [Builds]
-      security:
-        - developerAuth: []
       parameters:
         - name: build_id
           in: path
@@ -502,8 +645,6 @@ paths:
       summary: Get Envoy configuration
       description: Get Envoy proxy configuration for gateway or internal-gateway
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       parameters:
         - name: proxy
           in: path
@@ -538,8 +679,6 @@ paths:
       summary: Authorize source SHA
       description: Authorize a source SHA for deployment
       tags: [Builds]
-      security:
-        - developerAuth: []
       requestBody:
         required: true
         content:
@@ -563,8 +702,6 @@ paths:
       summary: Freeze merges and deploys
       description: Freeze all merges and deployments
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Successfully froze merges and deploys
@@ -578,8 +715,6 @@ paths:
       summary: Unfreeze merges and deploys
       description: Unfreeze all merges and deployments
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Successfully unfroze merges and deploys
@@ -593,8 +728,6 @@ paths:
       summary: "Namespaces (UI)"
       description: "Render the namespaces page, or (dev only) its supporting jinja context"
       tags: [UI Pages]
-      security:
-        - developerAuth: []
       parameters:
         - name: x-hail-return-jinja-context
           in: header
@@ -617,8 +750,6 @@ paths:
       summary: Add service to namespace
       description: Add a new service to a namespace
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       parameters:
         - name: namespace
           in: path
@@ -649,8 +780,6 @@ paths:
       summary: Edit service in namespace
       description: Edit service configuration in a namespace
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       parameters:
         - name: namespace
           in: path
@@ -688,8 +817,6 @@ paths:
       summary: Add namespace
       description: Add a new namespace
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       requestBody:
         required: true
         content:
@@ -713,8 +840,6 @@ paths:
       summary: "Flaky Test Dashboard (UI)"
       description: "Render the flaky test leaderboard page"
       tags: [Flaky Tests, UI Pages]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: "Successfully rendered the flaky test dashboard"
@@ -731,8 +856,6 @@ paths:
         with cursor-based pagination and an optional date filter.
         The default window is the last 14 days.
       tags: [Flaky Tests]
-      security:
-        - developerAuth: []
       parameters:
         - name: after
           in: query
@@ -813,4 +936,434 @@ paths:
           content:
             application/json:
               schema:
-                type: object 
+                type: object
+
+  /api/v1alpha/watched_branches:
+    get:
+      summary: List watched branches
+      description: "Returns all branches CI is monitoring, plus the current freeze status."
+      tags: [PRs]
+      responses:
+        '200':
+          description: Watched branches retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WatchedBranchesResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /api/v1alpha/watched_branches/{branch}/prs:
+    get:
+      summary: List PRs for a watched branch
+      description: Returns all active PRs for the given branch with build and review state.
+      tags: [PRs]
+      parameters:
+        - name: branch
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "Branch name (e.g. main)"
+      responses:
+        '200':
+          description: PR list retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PRConfig'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Branch not found
+
+  /api/v1alpha/watched_branches/{branch}/prs/{number}:
+    get:
+      summary: Get PR details
+      description: >
+        Returns full details for a single PR. For active PRs (still open against this branch)
+        includes merge eligibility and queue position. For historical PRs fetches from GitHub.
+      tags: [PRs]
+      parameters:
+        - name: branch
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: number
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: PR details retrieved successfully
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ActivePRDetail'
+                  - $ref: '#/components/schemas/HistoricalPRDetail'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Branch or PR not found
+
+  /api/v1alpha/watched_branches/{branch}/prs/{number}/retry:
+    post:
+      summary: Retry PR build
+      description: Requests a CI retry for the PR. Invalidates the current batch and triggers a fresh run.
+      tags: [PRs]
+      parameters:
+        - name: branch
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: number
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Retry requested successfully
+        '400':
+          description: PR has no batch or had a merge failure
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+        '404':
+          description: Branch or PR not found
+
+  /api/v1alpha/namespaces:
+    get:
+      summary: List active namespaces
+      description: Returns all active dev namespaces with their deployed services and rate limits.
+      tags: [Namespaces]
+      responses:
+        '200':
+          description: Namespace list retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NamespaceInfo'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /api/v1alpha/namespaces/{namespace}:
+    get:
+      summary: Get a namespace
+      description: Returns the record for a single active namespace.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Namespace retrieved successfully
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Namespace not found
+    put:
+      summary: Register a namespace (idempotent)
+      description: >
+        Ensures the namespace exists in active_namespaces. Creates it and returns
+        201 if new; returns 200 if it already existed. Safe to call repeatedly.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Namespace already existed
+        '201':
+          description: Namespace registered
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+    delete:
+      summary: Remove a namespace
+      description: Removes the namespace and all its deployed services from the active list.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Namespace removed
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+
+  /api/v1alpha/namespaces/{namespace}/services/{service}:
+    get:
+      summary: Get a namespace service
+      description: Returns the record for a single deployed service in a namespace.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Service retrieved successfully
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Service not found
+    put:
+      summary: Add service to namespace (idempotent)
+      description: >
+        Ensures the service is registered under the namespace. Creates it and
+        returns 201 if new; returns 200 if it already existed.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Service already existed
+        '201':
+          description: Service registered
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+    patch:
+      summary: Update service rate limit
+      description: Sets the rate_limit_rps for a deployed service. Pass null to remove the limit.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                rate_limit_rps:
+                  type: number
+                  nullable: true
+      responses:
+        '200':
+          description: Service updated
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+    delete:
+      summary: Remove a service from a namespace
+      description: Removes the service from the deployed_services table.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Service removed
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+
+  /api/v1alpha/me:
+    get:
+      summary: Current user's CI dashboard data
+      description: >
+        Returns PRs authored by, under review by, and requiring action from the current user,
+        plus their recent dev deploys.
+      tags: [PRs]
+      responses:
+        '200':
+          description: User data retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hail_username:
+                    type: string
+                  gh_username:
+                    type: string
+                  pr_wbs:
+                    type: array
+                    items:
+                      type: object
+                  review_wbs:
+                    type: array
+                    items:
+                      type: object
+                  actionable_wbs:
+                    type: array
+                    items:
+                      type: object
+                  dev_deploys:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - user is not in AUTHORIZED_USERS
+
+  /api/v1alpha/authorized_shas:
+    get:
+      summary: List authorized SHAs
+      description: Returns the list of SHAs that have been manually authorized for CI.
+      tags: [Builds]
+      responses:
+        '200':
+          description: Authorized SHAs retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
+  /api/v1alpha/authorize_sha:
+    post:
+      summary: Authorize a SHA
+      description: Adds a SHA to the authorized_shas table.
+      tags: [Builds]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [sha]
+              properties:
+                sha:
+                  type: string
+      responses:
+        '201':
+          description: SHA authorized
+        '400':
+          description: Missing sha field
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+
+  /api/v1alpha/teams:
+    get:
+      summary: List teams and members
+      description: Returns the full team roster from AUTHORIZED_USERS grouped by team.
+      tags: [PRs]
+      responses:
+        '200':
+          description: Teams retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/TeamMember'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /api/v1alpha/freeze:
+    post:
+      summary: Freeze merges and deploys
+      description: Freezes all CI merges and deployments. Returns 409 if already frozen.
+      tags: [Deployments]
+      responses:
+        '200':
+          description: CI frozen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+        '409':
+          description: Already frozen
+
+  /api/v1alpha/unfreeze:
+    post:
+      summary: Unfreeze merges and deploys
+      description: Unfreezes CI merges and deployments. Returns 409 if already unfrozen.
+      tags: [Deployments]
+      responses:
+        '200':
+          description: CI unfrozen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+        '409':
+          description: Already unfrozen

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -9,7 +9,7 @@ from .auth import (
 from .auth_utils import create_session, insert_user
 from .csrf import check_csrf_token, new_csrf_token
 from .database import Database, Transaction, create_database_pool, resolve_test_db_endpoint, transaction
-from .http_server_utils import json_request, json_response
+from .http_server_utils import json_request, json_response, version_response
 from .k8s_cache import K8sCache
 from .metrics import monitor_endpoints_middleware
 from .session import setup_aiohttp_session
@@ -37,4 +37,5 @@ __all__ = [
     'resolve_test_db_endpoint',
     'setup_aiohttp_session',
     'transaction',
+    'version_response',
 ]

--- a/gear/gear/http_server_utils.py
+++ b/gear/gear/http_server_utils.py
@@ -1,8 +1,15 @@
 from collections.abc import Mapping
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import orjson
 from aiohttp import web
+
+from hailtop import __version__
+
+from .system_permissions import SystemPermission
+
+if TYPE_CHECKING:
+    from .auth import UserData
 
 
 async def json_request(request: web.Request) -> Any:
@@ -19,6 +26,14 @@ async def json_request(request: web.Request) -> Any:
         request['request_data'].update({'raw_data': result})
 
     return result
+
+
+def version_response(userdata: Optional['UserData']) -> web.Response:
+    is_sysadmin = userdata is not None and userdata['system_permissions'].get(
+        SystemPermission.READ_DEPLOYED_SYSTEM_STATE, False
+    )
+    version = __version__ if is_sysadmin else __version__.split('-', maxsplit=1)[0]
+    return web.Response(text=version)
 
 
 def json_response(

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -6,7 +6,7 @@ import logging
 import os
 from collections import defaultdict, namedtuple
 from contextlib import AsyncExitStack
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import aiohttp_session
 import prometheus_client as pc  # type: ignore
@@ -18,9 +18,11 @@ from gear import (
     CommonAiohttpAppKeys,
     Database,
     SystemPermission,
+    UserData,
     json_response,
     setup_aiohttp_session,
     transaction,
+    version_response,
 )
 from hailtop import __version__, aiotools, httpx
 from hailtop.aiocloud import aiogoogle
@@ -149,6 +151,12 @@ async def _billing(request: web.Request):
     return (cost_by_service, compute_cost_breakdown, cost_by_sku_source, time_period_query)
 
 
+@routes.get('/api/v1alpha/version')
+@auth.maybe_authenticated_user
+async def get_version(_, userdata: Optional[UserData]) -> web.Response:
+    return version_response(userdata)
+
+
 @routes.get('/api/v1alpha/billing')
 @auth.authenticated_users_with_permission(SystemPermission.VIEW_MONITORING_DASHBOARDS, redirect=False)
 async def get_billing(request: web.Request, _) -> web.Response:
@@ -244,6 +252,47 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
         )
 
     await insert()
+
+
+@routes.post('/api/v1alpha/billing/fetch')
+@auth.authenticated_users_with_permission(SystemPermission.VIEW_MONITORING_DASHBOARDS, redirect=False)
+async def fetch_billing_json(request: web.Request, _) -> web.Response:
+    date_format = '%m/%Y'
+    try:
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise web.HTTPBadRequest(reason='Request body must be a JSON object.')
+    except web.HTTPBadRequest:
+        raise
+    except Exception:
+        body = {}
+    time_period_raw = body.get('time_period')
+    if time_period_raw is not None and not isinstance(time_period_raw, str):
+        raise web.HTTPBadRequest(reason='time_period must be a string.')
+    time_period_query = time_period_raw or datetime.datetime.now().strftime(date_format)
+    try:
+        time_period = datetime.datetime.strptime(time_period_query, date_format)
+    except ValueError as exc:
+        raise web.HTTPBadRequest(reason='Invalid time_period.') from exc
+
+    db = request.app[AppKeys.DB]
+    bigquery_client = request.app[AppKeys.BQ_CLIENT]
+    await _fetch_billing_month(db, bigquery_client, time_period, full_query=True)
+
+    records = [
+        record
+        async for record in db.execute_and_fetchall(
+            'SELECT * FROM monitoring_billing_data WHERE year = %s AND month = %s;',
+            (time_period.year, time_period.month),
+        )
+    ]
+    cost_by_service, compute_cost_breakdown, cost_by_sku_label = format_data(records)
+    return json_response({
+        'time_period_query': time_period_query,
+        'cost_by_service': cost_by_service,
+        'compute_cost_breakdown': compute_cost_breakdown,
+        'cost_by_sku_label': cost_by_sku_label,
+    })
 
 
 @routes.post('/billing/fetch')

--- a/monitoring/monitoring/templates/openapi.yaml
+++ b/monitoring/monitoring/templates/openapi.yaml
@@ -92,11 +92,6 @@ components:
           description: "Time period for the billing data"
           example: "07/2023"
 
-  securitySchemes:
-    developerAuth:
-      type: http
-      scheme: bearer
-      description: Developer authentication token
 
 paths:
   /api/v1alpha/billing:
@@ -104,8 +99,6 @@ paths:
       summary: Get billing information
       description: Retrieve billing information for a specific time period
       tags: [Billing]
-      security:
-        - developerAuth: []
       parameters:
         - name: time_period
           in: query
@@ -125,6 +118,37 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden - requires developer privileges
+  /api/v1alpha/billing/fetch:
+    post:
+      summary: Trigger billing data refresh
+      description: Force a full BigQuery billing data refresh for the specified month. Defaults to the current month if no time period is provided.
+      tags: [Billing]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                time_period:
+                  type: string
+                  description: Month to refresh in MM/YYYY format. Defaults to current month.
+                  pattern: "^(0[1-9]|1[0-2])/[0-9]{4}$"
+                  example: "07/2023"
+      responses:
+        '200':
+          description: Refresh completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingResponse'
+        '400':
+          description: Invalid time_period format
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires developer privileges
+
   /billing:
     get:
       summary: Get billing information


### PR DESCRIPTION
## Change Description

Completes the REST api endpoint set as a fully featured way to query the system, fetch data, and mutate state.

Motivation:
1. Allow hailctl (with future hailctl tool implementations, or via the hailctl curl fallback) to access all system state.
2. Allow full investigation of the deployed system state with command line commands and scripts.
3. Allow for local UI development against live APIs for rapid prototyping, development and testing without the current 40m build/deploy/test cycle. 
4. Supporting UI elements that combine data from multiple services (eg comparing actual charged billing data from batch with the cloud billing data in monitoring)

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

I'm asserting that there is nothing new that can be done here, since everything is currently possible via the html pages already. But the permissions on each API should be validated and the refactors and we are increasing the surface area of the services even if the functionality is not new.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec