### PR TITLE
[docs] allow CI to merge PRs that update github actions

### DIFF
--- a/dev-docs/services/rotating-github-oauth-token.md
+++ b/dev-docs/services/rotating-github-oauth-token.md
@@ -42,6 +42,7 @@ Key settings:
   - Contents: read/write
   - Metadata: read only
   - Pull requests: read/write
+  - Workflows: read/write
 
 
 ## 2. Update the Sops-Encrypted Config


### PR DESCRIPTION
## Change Description

Updates our dev doc listing an additional CI token permission requirement.

This change is necessary to allow CI to merge (reviewed and approved) PRs which update workflow files.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
- But this includes documenting a token permission change, so appsec review requested anyway

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
