### PR TITLE
[monitoring] Add /api/ implementations of remaining html-only queries

### DIFF
--- a/.github/workflows/validate-build-yaml.yml
+++ b/.github/workflows/validate-build-yaml.yml
@@ -1,0 +1,28 @@
+name: Validate build.yaml
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [build.yaml, devbin/check_build_yaml_order.py]
+
+concurrency:
+  group: validate-build-yaml-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-build-yaml:
+    name: Check build.yaml step ordering
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Check build.yaml dependsOn ordering
+        run: python3 devbin/check_build_yaml_order.py

--- a/build.yaml
+++ b/build.yaml
@@ -3045,49 +3045,7 @@ steps:
     timeout: 1500
     dependsOn:
       - auth_image
-  - kind: runImage
-    name: test_system_permissions
-    resources:
-      memory: standard
-      cpu: '0.25'
-    image:
-      valueFrom: auth_image.image
-    script: |
-      set -ex
-      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
-      export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
-      export GOOGLE_APPLICATION_CREDENTIALS=/test-dev-gsa-key/key.json
 
-      hail-pip-install -r /io/dev-requirements.txt
-
-      python3 -m pytest \
-              --log-cli-level=INFO -s -r A -vv --instafail \
-              --durations=50 --timeout=600 \
-              /io/test/test_system_permissions.py
-    inputs:
-      - from: /repo/auth/test
-        to: /io/test
-      - from: /repo/hail/python/dev/pinned-requirements.txt
-        to: /io/dev-requirements.txt
-    timeout: 900
-    secrets:
-      - name: test-tokens
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /user-tokens
-      - name: test-dev-gsa-key
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /test-dev-gsa-key
-    dependsOn:
-      - create_deploy_config
-      - create_accounts
-      - default_ns
-      - deploy_auth
-      - deploy_batch
-      - deploy_ci
-      - deploy_monitoring
-      - auth_image
   - kind: runImage
     name: delete_test_billing_projects
     resources:
@@ -3258,6 +3216,49 @@ steps:
       - deploy_ci_agent
       - create_certs
       - hail_buildkit_image
+  - kind: runImage
+    name: test_system_permissions
+    resources:
+      memory: standard
+      cpu: '0.25'
+    image:
+      valueFrom: auth_image.image
+    script: |
+      set -ex
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+      export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-dev-gsa-key/key.json
+
+      hail-pip-install -r /io/dev-requirements.txt
+
+      python3 -m pytest \
+              --log-cli-level=INFO -s -r A -vv --instafail \
+              --durations=50 --timeout=600 \
+              /io/test/test_system_permissions.py
+    inputs:
+      - from: /repo/auth/test
+        to: /io/test
+      - from: /repo/hail/python/dev/pinned-requirements.txt
+        to: /io/dev-requirements.txt
+    timeout: 900
+    secrets:
+      - name: test-tokens
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /user-tokens
+      - name: test-dev-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-dev-gsa-key
+    dependsOn:
+      - create_deploy_config
+      - create_accounts
+      - default_ns
+      - deploy_auth
+      - deploy_batch
+      - deploy_ci
+      - deploy_monitoring
+      - auth_image
   - kind: runImage
     name: test_ci_unit
     resources:
@@ -3681,158 +3682,6 @@ steps:
     clouds:
       - gcp
   - kind: runImage
-    name: release
-    image:
-      valueFrom: ci_utils_image.image
-    script: |
-      set -ex
-      cd /io
-
-      gcloud auth activate-service-account --key-file=/ci-deploy-0-1--hail-is-hail/ci-deploy-0-1--hail-is-hail.json
-
-      gcloud auth -q configure-docker {{ global.docker_prefix.split('/')[0] }}
-      cat /docker-hub-hailgenetics/password | skopeo login --username hailgenetics --password-stdin docker.io
-
-      cp /pypi-credentials/pypirc $HOME/.pypirc
-      printf 'Authorization: token ' > github-oauth
-      cat /hail-ci-0-1-github-oauth-token/oauth-token >>github-oauth
-      printf '#!/bin/bash\necho ' > git-askpass
-      cat /hail-ci-0-1-github-oauth-token/oauth-token >>git-askpass
-      chmod 755 git-askpass
-      export GIT_ASKPASS=/io/git-askpass
-
-      cd /io/repo/hail
-      export HAIL_PIP_VERSION=$(cat env/HAIL_PIP_VERSION)
-
-      if git ls-remote --exit-code --tags origin $HAIL_PIP_VERSION
-      then
-          echo "tag $HAIL_PIP_VERSION already exists"
-          echo '0' > /io/release-hail-flag
-          exit 0
-      fi
-
-      # #14452 - must build wheel with release `hailtop/hailctl/deploy.yaml`
-      # use `-o` to prevent `mill` from rebuilding the "SHADOW_JAR"
-      make upload-artifacts HAIL_BUILD_MODE=Release DEPLOY_REMOTE=origin \
-        -o out/hail/2.12/assembly.dest/out.jar
-
-      echo Setting arguments and invoking release.sh.
-
-      HAIL_VERSION=$(cat env/HAIL_VERSION) \
-      WHEEL="build/deploy/dist/hail-${HAIL_PIP_VERSION}-py3-none-any.whl" \
-      GIT_VERSION=$(cat env/REVISION) \
-      REMOTE=origin \
-      GITHUB_OAUTH_HEADER_FILE=/io/github-oauth \
-      HAIL_GENETICS_HAIL_IMAGE=docker://{{ hailgenetics_hail_image.image }} \
-      HAIL_GENETICS_HAIL_IMAGE_PY_3_10=docker://{{ hailgenetics_hail_image_python_3_10.image }} \
-      HAIL_GENETICS_HAIL_IMAGE_PY_3_11=docker://{{ hailgenetics_hail_image.image }} \
-      HAIL_GENETICS_HAIL_IMAGE_PY_3_12=docker://{{ hailgenetics_hail_image_python_3_12.image }} \
-      HAIL_GENETICS_HAIL_IMAGE_PY_3_13=docker://{{ hailgenetics_hail_image_python_3_13.image }} \
-      HAIL_GENETICS_HAILTOP_IMAGE=docker://{{ hailgenetics_hailtop_image.image }} \
-      HAIL_GENETICS_VEP_GRCH37_85_IMAGE=docker://{{ hailgenetics_vep_grch37_85_image.image }} \
-      HAIL_GENETICS_VEP_GRCH38_95_IMAGE=docker://{{ hailgenetics_vep_grch38_95_image.image }} \
-      WEBSITE_TAR=/io/www.tar.gz \
-      bash scripts/release.sh
-
-      echo '1' > /io/release-hail-flag
-    inputs:
-      - from: /repo
-        to: /io/repo
-      - from: /derived/release/hail/out/hail/2.12/assembly.dest/out.jar
-        to: /io/repo/hail/out/hail/2.12/assembly.dest/out.jar
-      - from: /www.tar.gz
-        to: /io/www.tar.gz
-    outputs:
-      - from: /io/release-hail-flag
-        to: /release-hail-flag
-    secrets:
-      - name: pypi-credentials
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /pypi-credentials
-      - name: ci-deploy-0-1--hail-is-hail
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /ci-deploy-0-1--hail-is-hail
-      - name: docker-hub-hailgenetics
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /docker-hub-hailgenetics
-      - name: hail-ci-0-1-github-oauth-token
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /hail-ci-0-1-github-oauth-token
-    scopes:
-      - deploy
-      - dev
-    dependsOn:
-      - default_ns
-      - ci_utils_image
-      - merge_code
-      - hailgenetics_hail_image
-      - hailgenetics_hail_image_python_3_10
-      - hailgenetics_hail_image_python_3_12
-      - hailgenetics_hail_image_python_3_13
-      - hailgenetics_hailtop_image
-      - hailgenetics_vep_grch37_85_image
-      - hailgenetics_vep_grch38_95_image
-      - build_hail_jar_and_wheel
-      - test_hail_java
-      - test_hail_python
-      - test_hailtop_python
-      - test_hail_python_local_backend
-      - test_hail_python_service_backend_gcp
-      - test_hail_scala_fs
-      - test_hail_services_java
-      - test_hail_spark_conf_requester_pays_parsing
-      - test_dataproc-37
-      - test_dataproc-38
-      - make_docs
-    clouds:
-      - gcp
-  - kind: runImage
-    name: make_terra_prs
-    image:
-      valueFrom: ci_utils_image.image
-    dependsOn:
-      - default_ns
-      - ci_utils_image
-      - release
-    inputs:
-      - from: /release-hail-flag
-        to: /io/release-hail-flag
-      - from: /repo
-        to: /io/repo
-    secrets:
-      - name: hail-ci-0-1-github-oauth-token
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /hail-ci-0-1-github-oauth-token
-    clouds:
-      - gcp
-    scopes:
-      - deploy
-      - dev
-    script: |
-      set -ex
-      if [[ $(< /io/release-hail-flag) != '1' ]]
-      then
-          echo 'Skipping making terra update prs (no new release published)'
-          exit 0
-      fi
-
-      printf 'Authorization: token ' > github-oauth
-      cat /hail-ci-0-1-github-oauth-token/oauth-token >> /io/github-oauth
-      printf '#!/bin/bash\necho ' > git-askpass
-      cat /hail-ci-0-1-github-oauth-token/oauth-token >> /io/git-askpass
-      chmod 755 /io/git-askpass
-      export GIT_ASKPASS=/io/git-askpass
-
-      cd /io/repo/hail
-      export HAIL_PIP_VERSION=$(cat env/HAIL_PIP_VERSION)
-      export GITHUB_OAUTH_HEADER_FILE=/io/github-oauth
-      bash scripts/make-terra-prs.sh
-  - kind: runImage
     name: mirror_hailgenetics_images
     image: quay.io/skopeo/stable:v1.13.2
     script: |
@@ -4051,6 +3900,158 @@ steps:
       - upload_query_jar
       - deploy_batch
       - download_mill_and_maven_deps
+  - kind: runImage
+    name: release
+    image:
+      valueFrom: ci_utils_image.image
+    script: |
+      set -ex
+      cd /io
+
+      gcloud auth activate-service-account --key-file=/ci-deploy-0-1--hail-is-hail/ci-deploy-0-1--hail-is-hail.json
+
+      gcloud auth -q configure-docker {{ global.docker_prefix.split('/')[0] }}
+      cat /docker-hub-hailgenetics/password | skopeo login --username hailgenetics --password-stdin docker.io
+
+      cp /pypi-credentials/pypirc $HOME/.pypirc
+      printf 'Authorization: token ' > github-oauth
+      cat /hail-ci-0-1-github-oauth-token/oauth-token >>github-oauth
+      printf '#!/bin/bash\necho ' > git-askpass
+      cat /hail-ci-0-1-github-oauth-token/oauth-token >>git-askpass
+      chmod 755 git-askpass
+      export GIT_ASKPASS=/io/git-askpass
+
+      cd /io/repo/hail
+      export HAIL_PIP_VERSION=$(cat env/HAIL_PIP_VERSION)
+
+      if git ls-remote --exit-code --tags origin $HAIL_PIP_VERSION
+      then
+          echo "tag $HAIL_PIP_VERSION already exists"
+          echo '0' > /io/release-hail-flag
+          exit 0
+      fi
+
+      # #14452 - must build wheel with release `hailtop/hailctl/deploy.yaml`
+      # use `-o` to prevent `mill` from rebuilding the "SHADOW_JAR"
+      make upload-artifacts HAIL_BUILD_MODE=Release DEPLOY_REMOTE=origin \
+        -o out/hail/2.12/assembly.dest/out.jar
+
+      echo Setting arguments and invoking release.sh.
+
+      HAIL_VERSION=$(cat env/HAIL_VERSION) \
+      WHEEL="build/deploy/dist/hail-${HAIL_PIP_VERSION}-py3-none-any.whl" \
+      GIT_VERSION=$(cat env/REVISION) \
+      REMOTE=origin \
+      GITHUB_OAUTH_HEADER_FILE=/io/github-oauth \
+      HAIL_GENETICS_HAIL_IMAGE=docker://{{ hailgenetics_hail_image.image }} \
+      HAIL_GENETICS_HAIL_IMAGE_PY_3_10=docker://{{ hailgenetics_hail_image_python_3_10.image }} \
+      HAIL_GENETICS_HAIL_IMAGE_PY_3_11=docker://{{ hailgenetics_hail_image.image }} \
+      HAIL_GENETICS_HAIL_IMAGE_PY_3_12=docker://{{ hailgenetics_hail_image_python_3_12.image }} \
+      HAIL_GENETICS_HAIL_IMAGE_PY_3_13=docker://{{ hailgenetics_hail_image_python_3_13.image }} \
+      HAIL_GENETICS_HAILTOP_IMAGE=docker://{{ hailgenetics_hailtop_image.image }} \
+      HAIL_GENETICS_VEP_GRCH37_85_IMAGE=docker://{{ hailgenetics_vep_grch37_85_image.image }} \
+      HAIL_GENETICS_VEP_GRCH38_95_IMAGE=docker://{{ hailgenetics_vep_grch38_95_image.image }} \
+      WEBSITE_TAR=/io/www.tar.gz \
+      bash scripts/release.sh
+
+      echo '1' > /io/release-hail-flag
+    inputs:
+      - from: /repo
+        to: /io/repo
+      - from: /derived/release/hail/out/hail/2.12/assembly.dest/out.jar
+        to: /io/repo/hail/out/hail/2.12/assembly.dest/out.jar
+      - from: /www.tar.gz
+        to: /io/www.tar.gz
+    outputs:
+      - from: /io/release-hail-flag
+        to: /release-hail-flag
+    secrets:
+      - name: pypi-credentials
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /pypi-credentials
+      - name: ci-deploy-0-1--hail-is-hail
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /ci-deploy-0-1--hail-is-hail
+      - name: docker-hub-hailgenetics
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /docker-hub-hailgenetics
+      - name: hail-ci-0-1-github-oauth-token
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /hail-ci-0-1-github-oauth-token
+    scopes:
+      - deploy
+      - dev
+    dependsOn:
+      - default_ns
+      - ci_utils_image
+      - merge_code
+      - hailgenetics_hail_image
+      - hailgenetics_hail_image_python_3_10
+      - hailgenetics_hail_image_python_3_12
+      - hailgenetics_hail_image_python_3_13
+      - hailgenetics_hailtop_image
+      - hailgenetics_vep_grch37_85_image
+      - hailgenetics_vep_grch38_95_image
+      - build_hail_jar_and_wheel
+      - test_hail_java
+      - test_hail_python
+      - test_hailtop_python
+      - test_hail_python_local_backend
+      - test_hail_python_service_backend_gcp
+      - test_hail_scala_fs
+      - test_hail_services_java
+      - test_hail_spark_conf_requester_pays_parsing
+      - test_dataproc-37
+      - test_dataproc-38
+      - make_docs
+    clouds:
+      - gcp
+  - kind: runImage
+    name: make_terra_prs
+    image:
+      valueFrom: ci_utils_image.image
+    dependsOn:
+      - default_ns
+      - ci_utils_image
+      - release
+    inputs:
+      - from: /release-hail-flag
+        to: /io/release-hail-flag
+      - from: /repo
+        to: /io/repo
+    secrets:
+      - name: hail-ci-0-1-github-oauth-token
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /hail-ci-0-1-github-oauth-token
+    clouds:
+      - gcp
+    scopes:
+      - deploy
+      - dev
+    script: |
+      set -ex
+      if [[ $(< /io/release-hail-flag) != '1' ]]
+      then
+          echo 'Skipping making terra update prs (no new release published)'
+          exit 0
+      fi
+
+      printf 'Authorization: token ' > github-oauth
+      cat /hail-ci-0-1-github-oauth-token/oauth-token >> /io/github-oauth
+      printf '#!/bin/bash\necho ' > git-askpass
+      cat /hail-ci-0-1-github-oauth-token/oauth-token >> /io/git-askpass
+      chmod 755 /io/git-askpass
+      export GIT_ASKPASS=/io/git-askpass
+
+      cd /io/repo/hail
+      export HAIL_PIP_VERSION=$(cat env/HAIL_PIP_VERSION)
+      export GITHUB_OAUTH_HEADER_FILE=/io/github-oauth
+      bash scripts/make-terra-prs.sh
   - kind: runImage
     name: start_hail_benchmark
     scopes:

--- a/devbin/check_build_yaml_order.py
+++ b/devbin/check_build_yaml_order.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Verify that every dependsOn entry in build.yaml refers to a step defined earlier in the file.
+
+Steps are resolved in declaration order at CI startup — a forward reference is silently
+dropped, producing a broken DAG where the dependency is never enforced.
+"""
+import sys
+
+import yaml
+
+
+def main():
+    with open('build.yaml', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+
+    seen: set = set()
+    errors: list = []
+
+    for step in config.get('steps', []):
+        name = step.get('name', '<unnamed>')
+        for dep in step.get('dependsOn', []):
+            if dep not in seen:
+                errors.append(f"  '{name}' dependsOn '{dep}', which is defined later or missing")
+        seen.add(name)
+
+    if errors:
+        print(f"build.yaml ordering errors ({len(errors)} found):")
+        for e in errors:
+            print(e)
+        sys.exit(1)
+
+    print(f"OK: all dependsOn entries in build.yaml refer to earlier-defined steps ({len(seen)} steps checked)")
+
+
+if __name__ == '__main__':
+    main()

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -6,7 +6,7 @@ import logging
 import os
 from collections import defaultdict, namedtuple
 from contextlib import AsyncExitStack
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import aiohttp_session
 import prometheus_client as pc  # type: ignore
@@ -18,9 +18,11 @@ from gear import (
     CommonAiohttpAppKeys,
     Database,
     SystemPermission,
+    UserData,
     json_response,
     setup_aiohttp_session,
     transaction,
+    version_response,
 )
 from hailtop import __version__, aiotools, httpx
 from hailtop.aiocloud import aiogoogle
@@ -149,6 +151,12 @@ async def _billing(request: web.Request):
     return (cost_by_service, compute_cost_breakdown, cost_by_sku_source, time_period_query)
 
 
+@routes.get('/api/v1alpha/version')
+@auth.maybe_authenticated_user
+async def get_version(_, userdata: Optional[UserData]) -> web.Response:
+    return version_response(userdata)
+
+
 @routes.get('/api/v1alpha/billing')
 @auth.authenticated_users_with_permission(SystemPermission.VIEW_MONITORING_DASHBOARDS, redirect=False)
 async def get_billing(request: web.Request, _) -> web.Response:
@@ -244,6 +252,47 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
         )
 
     await insert()
+
+
+@routes.post('/api/v1alpha/billing/fetch')
+@auth.authenticated_users_with_permission(SystemPermission.VIEW_MONITORING_DASHBOARDS, redirect=False)
+async def fetch_billing_json(request: web.Request, _) -> web.Response:
+    date_format = '%m/%Y'
+    try:
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise web.HTTPBadRequest(reason='Request body must be a JSON object.')
+    except web.HTTPBadRequest:
+        raise
+    except Exception:
+        body = {}
+    time_period_raw = body.get('time_period')
+    if time_period_raw is not None and not isinstance(time_period_raw, str):
+        raise web.HTTPBadRequest(reason='time_period must be a string.')
+    time_period_query = time_period_raw or datetime.datetime.now().strftime(date_format)
+    try:
+        time_period = datetime.datetime.strptime(time_period_query, date_format)
+    except ValueError as exc:
+        raise web.HTTPBadRequest(reason='Invalid time_period.') from exc
+
+    db = request.app[AppKeys.DB]
+    bigquery_client = request.app[AppKeys.BQ_CLIENT]
+    await _fetch_billing_month(db, bigquery_client, time_period, full_query=True)
+
+    records = [
+        record
+        async for record in db.execute_and_fetchall(
+            'SELECT * FROM monitoring_billing_data WHERE year = %s AND month = %s;',
+            (time_period.year, time_period.month),
+        )
+    ]
+    cost_by_service, compute_cost_breakdown, cost_by_sku_label = format_data(records)
+    return json_response({
+        'time_period_query': time_period_query,
+        'cost_by_service': cost_by_service,
+        'compute_cost_breakdown': compute_cost_breakdown,
+        'cost_by_sku_label': cost_by_sku_label,
+    })
 
 
 @routes.post('/billing/fetch')

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -258,13 +258,14 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
 @auth.authenticated_users_with_permission(SystemPermission.VIEW_MONITORING_DASHBOARDS, redirect=False)
 async def fetch_billing_json(request: web.Request, _) -> web.Response:
     date_format = '%m/%Y'
-    try:
-        body = await request.json()
+    if request.content_length:
+        try:
+            body = await request.json()
+        except Exception as exc:
+            raise web.HTTPBadRequest(reason='Request body must be valid JSON.') from exc
         if not isinstance(body, dict):
             raise web.HTTPBadRequest(reason='Request body must be a JSON object.')
-    except web.HTTPBadRequest:
-        raise
-    except Exception:
+    else:
         body = {}
     time_period_raw = body.get('time_period')
     if time_period_raw is not None and not isinstance(time_period_raw, str):

--- a/monitoring/monitoring/templates/openapi.yaml
+++ b/monitoring/monitoring/templates/openapi.yaml
@@ -94,6 +94,18 @@ components:
 
 
 paths:
+  /api/v1alpha/version:
+    get:
+      summary: Get version
+      description: Get the current version of the monitoring service
+      tags: [Documentation]
+      responses:
+        '200':
+          description: Version retrieved successfully
+          content:
+            text/plain:
+              schema:
+                type: string
   /api/v1alpha/billing:
     get:
       summary: Get billing information
@@ -115,9 +127,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/BillingResponse'
         '401':
-          description: Unauthorized
+          description: Unauthorized or insufficient permissions
         '403':
-          description: Forbidden - requires developer privileges
+          description: Forbidden - account is inactive
   /api/v1alpha/billing/fetch:
     post:
       summary: Trigger billing data refresh
@@ -145,9 +157,9 @@ paths:
         '400':
           description: Invalid time_period format
         '401':
-          description: Unauthorized
+          description: Unauthorized or insufficient permissions
         '403':
-          description: Forbidden - requires developer privileges
+          description: Forbidden - account is inactive
 
   /billing:
     get:

--- a/monitoring/monitoring/templates/openapi.yaml
+++ b/monitoring/monitoring/templates/openapi.yaml
@@ -92,11 +92,6 @@ components:
           description: "Time period for the billing data"
           example: "07/2023"
 
-  securitySchemes:
-    developerAuth:
-      type: http
-      scheme: bearer
-      description: Developer authentication token
 
 paths:
   /api/v1alpha/billing:
@@ -104,8 +99,6 @@ paths:
       summary: Get billing information
       description: Retrieve billing information for a specific time period
       tags: [Billing]
-      security:
-        - developerAuth: []
       parameters:
         - name: time_period
           in: query
@@ -125,6 +118,37 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden - requires developer privileges
+  /api/v1alpha/billing/fetch:
+    post:
+      summary: Trigger billing data refresh
+      description: Force a full BigQuery billing data refresh for the specified month. Defaults to the current month if no time period is provided.
+      tags: [Billing]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                time_period:
+                  type: string
+                  description: Month to refresh in MM/YYYY format. Defaults to current month.
+                  pattern: "^(0[1-9]|1[0-2])/[0-9]{4}$"
+                  example: "07/2023"
+      responses:
+        '200':
+          description: Refresh completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingResponse'
+        '400':
+          description: Invalid time_period format
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires developer privileges
+
   /billing:
     get:
       summary: Get billing information


### PR DESCRIPTION
Monitoring only spin-off of #15514.

## Change Description

Completes the REST api endpoint set as a fully featured way to query the system, fetch data, and mutate state.
Also adds version_response helper to gear/http_server_utils (to be used by all services).

Motivation:
1. Allow hailctl (with future hailctl tool implementations, or via the hailctl curl fallback) to access all system state.
2. Allow full investigation of the deployed system state with command line commands and scripts.
3. Allow for local UI development against live APIs for rapid prototyping, development and testing without the current 40m build/deploy/test cycle. 
4. Supporting UI elements that combine data from multiple services (eg comparing actual charged billing data from batch with the cloud billing data in monitoring)

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

I'm asserting that there is nothing new that can be done here, since everything is currently possible via the html pages already. But the permissions on each API should be validated, and the refactors are increasing the surface area of the services even if the functionality is not new.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
