### PR TITLE
[make] Fix ubuntu updater

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ install-dev-requirements:
 
 .PHONY: update-hail-ubuntu
 update-hail-ubuntu:
+	@command -v skopeo >/dev/null 2>&1 || { echo 'ERROR: skopeo is required. Install with: brew install skopeo'; exit 1; }
 	python3 update-hail-ubuntu.py
 	$(MAKE) -C docker/third-party copy
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ install-dev-requirements:
 update-hail-ubuntu:
 	@command -v skopeo >/dev/null 2>&1 || { echo 'ERROR: skopeo is required. Install with: brew install skopeo'; exit 1; }
 	python3 update-hail-ubuntu.py
-	$(MAKE) -C docker/third-party copy
+	NAMESPACE=default $(MAKE) -C docker/third-party copy
 
 .PHONY: generate-pip-lockfiles
 generate-pip-lockfiles:

--- a/update-hail-ubuntu.py
+++ b/update-hail-ubuntu.py
@@ -14,7 +14,7 @@ print('Querying Docker Hub for latest ubuntu noble tag...')
 with urllib.request.urlopen(url) as r: # nosec B310 - ignore bandit rule because this url is https
     data = json.loads(r.read())
 
-pattern = re.compile(r'^noble-(\d{8})$')
+pattern = re.compile(r'^noble-(\d{8}(?:\.\d+)?)$')
 tags = [result['name'] for result in data['results'] if pattern.match(result['name'])]
 if not tags:
     print('ERROR: No noble-YYYYMMDD tags found', file=sys.stderr)
@@ -22,7 +22,7 @@ if not tags:
 latest_tag = sorted(tags)[-1]
 
 images_text = IMAGES_FILE.read_text()
-m = re.search(r'^ubuntu:(noble-\d{8})$', images_text, re.MULTILINE)
+m = re.search(r'^ubuntu:(noble-\d{8}(?:\.\d+)?)$', images_text, re.MULTILINE)
 if not m:
     print('ERROR: No ubuntu:noble-YYYYMMDD line found in images.txt', file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
## Change Description

- Fixes the regex check in the dockerhub scan, to accept `.1`s in (eg) `noble-20260509.1`
- Fixes the `NAMESPACE=` in the image copy command, to match the instructions in https://github.com/hail-is/hail/blob/main/dev-docs/services/updating-third-party-images.md
- Makes sure skopeo is installed before beginning the copy. Although "optional"... it's not really.


## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

No impact in production, but modifies a makefile so appsec review is still requested

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
