### PR TITLE
[terraform] Add batch2agent permissions to gcp terraform, plus migration script fixup

### DIFF
--- a/devbin/migrate-gsa-permissions.sh
+++ b/devbin/migrate-gsa-permissions.sh
@@ -12,13 +12,13 @@ fi
 
 PROJECT=$1
 ADMIN_POD=$(kfind1 admin-pod)
-ACCOUNTS=$(kubectl -n default exec -it $ADMIN_POD -- mysql -NBe "SELECT hail_identity FROM auth.users WHERE state != 'deleted'" | grep -Eo "(\w|-)+@$PROJECT.iam.gserviceaccount.com" | awk '{print $1}')
+ACCOUNTS=$(kubectl -n default exec -i $ADMIN_POD -- mysql -NBe "SELECT hail_identity FROM auth.users WHERE state != 'deleted'" | grep -Eo "(\w|-)+@$PROJECT.iam.gserviceaccount.com" | awk '{print $1}')
 
 echo "Found the following user service accounts in $PROJECT:"
 for ACCOUNT in $ACCOUNTS; do
   echo "    $ACCOUNT"
 done
-confirm 'This script will add the batch user as a service account user to these accounts.'
+confirm 'This script will add batch2-agent as a service account user to these accounts.'
 
 if [ $? -ne 0 ]; then
   exit 0

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -899,6 +899,13 @@ resource "google_service_account_iam_member" "testns_batch_act_as_batch_agent" {
   member             = "serviceAccount:${module.testns_batch_gsa_secret.email}"
 }
 
+# Grant batch2-agent service account permission to act as itself - required for some permission checks
+resource "google_service_account_iam_member" "batch_agent_act_as_batch_agent" {
+  service_account_id = google_service_account.batch_agent.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.batch_agent.email}"
+}
+
 resource "google_service_account" "gke_node_pool" {
   description  = "Service account for GKE node pools"
   display_name = "gke-node-pool"


### PR DESCRIPTION
## Change Description

Small remediation to the `infra/gcp/` terraform to bring it up to date with the `gcp-broad/` version (by adding permission for batch2agent to run work as itself - you can tell why that was missed in the original change).

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

Affects non-Broad-prod terraformed instances only. 