### PR TITLE
[services] clean up old deploy images

### DIFF
--- a/devbin/generate_gcp_ar_cleanup_policy.py
+++ b/devbin/generate_gcp_ar_cleanup_policy.py
@@ -126,6 +126,9 @@ def scrape_build_yaml(file_path: str):
 deploy_packages.extend(scrape_build_yaml('build.yaml'))
 deploy_packages.extend(scrape_build_yaml('ci/test/resources/build.yaml'))
 
+# hail-benchmark is pushed by benchmark_in_batch.py at runtime, not a buildImage2 step
+deploy_packages.append('hail-benchmark')
+
 deploy_packages = list(set(deploy_packages))
 
 third_party_packages.sort()

--- a/devbin/generate_gcp_ar_cleanup_policy.py
+++ b/devbin/generate_gcp_ar_cleanup_policy.py
@@ -138,6 +138,7 @@ policies = [
     DeletePolicy('delete_test_deploy', 'tagged', tag_prefixes=['test-deploy-'], older_than='3d'),
     DeletePolicy('delete_pr_cache', 'tagged', tag_prefixes=['cache-pr-'], older_than='7d'),
     DeletePolicy('delete_cache', 'tagged', tag_prefixes=['cache-'], older_than='30d'),
+    DeletePolicy('delete_deploy', 'tagged', tag_prefixes=['deploy-'], older_than='30d'),
     ConditionalKeepPolicy('keep_third_party', 'any', package_name_prefixes=third_party_packages),
     MostRecentVersionKeepPolicy('keep_most_recent_deploy', package_name_prefixes=deploy_packages, keep_count=10),
 ]

--- a/infra/gcp-broad/gcp-ar-cleanup-policy.txt
+++ b/infra/gcp-broad/gcp-ar-cleanup-policy.txt
@@ -74,6 +74,19 @@
         }
     },
     {
+        "name": "delete_deploy",
+        "action": {
+            "type": "Delete"
+        },
+        "condition": {
+            "tagState": "tagged",
+            "tagPrefixes": [
+                "deploy-"
+            ],
+            "olderThan": "30d"
+        }
+    },
+    {
         "name": "keep_third_party",
         "action": {
             "type": "Keep"

--- a/infra/gcp-broad/gcp-ar-cleanup-policy.txt
+++ b/infra/gcp-broad/gcp-ar-cleanup-policy.txt
@@ -126,6 +126,7 @@
                 "create_certs_image",
                 "git-make-bash",
                 "gpu",
+                "hail-benchmark",
                 "hail-buildkit",
                 "hail-dev",
                 "hail-run",


### PR DESCRIPTION
## Change Description

We have a "most recent 10" keep policy on `deploy-` tagged images, but no corresponding delete. Because of this mismatch, all `deploy-` images are preserved forever, and the keep policy is never triggered to save an image from a delete.

Therefore: introduce the delete policy which it looks like we expected when we created the "keep 10" preservation policy. The outcome will be to remove older deploy images which are at least 10 versions behind current.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

No security impact anticipated.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
