### PR TITLE
[query] push `MatrixFilterCols` through `Matrix{Filter|Map}Entries`

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/Simplify.scala
@@ -1434,6 +1434,14 @@ object Simplify {
           )
         )
 
+      // push MatrixFilterCols through MatrixMapEntries / MatrixFilterEntries
+      // so that column-reducing operations run before per-entry work
+      case MatrixFilterCols(MatrixMapEntries(child, newEntries), pred) =>
+        Some(MatrixMapEntries(MatrixFilterCols(child, pred), newEntries))
+
+      case MatrixFilterCols(MatrixFilterEntries(child, entryPred), colPred) =>
+        Some(MatrixFilterEntries(MatrixFilterCols(child, colPred), entryPred))
+
       case MatrixFilterEntries(MatrixFilterEntries(child, pred1), pred2) =>
         Some(MatrixFilterEntries(
           child,

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -359,6 +359,34 @@ class SimplifySuite {
     tir should simplifyTo(tir)
   }
 
+  @Test def testFilterColsPushesThroughMapEntries(implicit ctx: ExecuteContext): Unit = {
+    val reader = MatrixRangeReader(ctx, 5, 5, None)
+    val typ = reader.fullMatrixType
+
+    val newEntries = Ref(MatrixIR.entryName, typ.entryType).insert("x" -> I32(1))
+    val pred = Ref(MatrixIR.colName, typ.colType).get("col_idx") > 0
+
+    val mt = MatrixRead(typ, false, false, reader)
+    val input = MatrixFilterCols(MatrixMapEntries(mt, newEntries), pred)
+    val expected = MatrixMapEntries(MatrixFilterCols(mt, pred), newEntries)
+
+    input should simplifyTo(expected)
+  }
+
+  @Test def testFilterColsPushesThroughFilterEntries(implicit ctx: ExecuteContext): Unit = {
+    val reader = MatrixRangeReader(ctx, 5, 5, None)
+    val typ = reader.fullMatrixType
+
+    val entryPred = True()
+    val colPred = Ref(MatrixIR.colName, typ.colType).get("col_idx") > 0
+
+    val mr = MatrixRead(typ, false, false, reader)
+    val input = MatrixFilterCols(MatrixFilterEntries(mr, entryPred), colPred)
+    val expected = MatrixFilterEntries(MatrixFilterCols(mr, colPred), entryPred)
+
+    input should simplifyTo(expected)
+  }
+
   def testFilterParallelize(): ArraySeq[IR] = ArraySeq(
     makestruct(
       "rows" -> In(0, TArray(TStruct("x" -> TInt32))),


### PR DESCRIPTION
Adds two `Simplify` rules that push `MatrixFilterCols` through `MatrixMapEntries` and `MatrixFilterEntries`, so column reduction runs before per-entry work.

_should_ fix a regression in VDS queries introduced by #14675 (which added a LEN field via `MatrixMapEntries`). The regression occurs because `MatrixFilterCols` sits outside `MatrixMapEntries` after lowering, forcing the entries map to materialize the full entries array for all columns before column filtering subsets it — producing an extra `ToArray` of the entire entries array per row. (to verify)

This change does not affect the broad-managed batch service in gcp.