### PR TITLE
[devbin] fix pagination in rotate_keys helper

### DIFF
--- a/devbin/rotate_keys.py
+++ b/devbin/rotate_keys.py
@@ -276,12 +276,12 @@ class IAMManager:
     async def all_sa_dicts(self) -> Generator[ServiceAccountDict, None, None]:
         res = await self.iam_client.get('/serviceAccounts')
         next_page_token = res.get('nextPageToken')
-        for acc in res['accounts']:
+        for acc in res.get('accounts', []):
             yield acc
         while next_page_token is not None:
             res = await self.iam_client.get('/serviceAccounts', params={'pageToken': next_page_token})
             next_page_token = res.get('nextPageToken')
-            for acc in res['accounts']:
+            for acc in res.get('accounts', []):
                 yield acc
 
 


### PR DESCRIPTION
## Change Description

Fixes a bug in the rotate_keys script. If the number of keys happens to line up exactly with a page size, we can get a "next page" token but the next page is empty. Empty pages have no `accounts` field, not even an empty one, causing a script crash.

Therefore, be resilient using a get-with-default on the `accounts` field, instead of assuming each page will definitely include the field.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP