### PR TITLE
[gateway] envoy update and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ update-gateways-envoy:
 	$(MAKE) -C gateway deploy
 	$(MAKE) -C internal-gateway deploy
 	@echo ''
+	@echo 'Validate with:'
+	@echo '  kubectl rollout status deployment gateway-deployment && kubectl rollout status deployment internal-gateway-deployment'
+	@echo '  kubectl get deployment gateway-deployment -o jsonpath='\''{.spec.template.spec.containers[0].image}'\'''
+	@echo '  kubectl get deployment internal-gateway-deployment -o jsonpath='\''{.spec.template.spec.containers[0].image}'\'''
 	@echo 'If traffic to hail.is services seems degraded, roll back with:'
 	@echo '  kubectl rollout undo deployment gateway-deployment && kubectl rollout undo deployment internal-gateway-deployment'
 

--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,11 @@ update-gateways-envoy:
 	$(MAKE) -C internal-gateway deploy
 	@echo ''
 	@echo 'Validate with:'
-	@echo '  kubectl rollout status deployment gateway-deployment && kubectl rollout status deployment internal-gateway-deployment'
+	@echo '  kubectl rollout status deployment gateway-deployment && kubectl rollout status deployment internal-gateway'
 	@echo '  kubectl get deployment gateway-deployment -o jsonpath='\''{.spec.template.spec.containers[0].image}'\'''
-	@echo '  kubectl get deployment internal-gateway-deployment -o jsonpath='\''{.spec.template.spec.containers[0].image}'\'''
+	@echo '  kubectl get deployment internal-gateway -o jsonpath='\''{.spec.template.spec.containers[0].image}'\'''
 	@echo 'If traffic to hail.is services seems degraded, roll back with:'
-	@echo '  kubectl rollout undo deployment gateway-deployment && kubectl rollout undo deployment internal-gateway-deployment'
+	@echo '  kubectl rollout undo deployment gateway-deployment && kubectl rollout undo deployment internal-gateway'
 
 .PHONY: generate-pip-lockfiles
 generate-pip-lockfiles:

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,14 @@ update-hail-ubuntu:
 	python3 update-hail-ubuntu.py
 	NAMESPACE=default $(MAKE) -C docker/third-party copy
 
-.PHONY: update-envoy
-update-envoy:
+.PHONY: update-gateways-envoy
+update-gateways-envoy:
 	python3 update-envoy.py
 	$(MAKE) -C gateway deploy
 	$(MAKE) -C internal-gateway deploy
+	@echo ''
+	@echo 'If traffic to hail.is services seems degraded, roll back with:'
+	@echo '  kubectl rollout undo deployment gateway-deployment && kubectl rollout undo deployment internal-gateway-deployment'
 
 .PHONY: generate-pip-lockfiles
 generate-pip-lockfiles:

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,12 @@ update-hail-ubuntu:
 	python3 update-hail-ubuntu.py
 	NAMESPACE=default $(MAKE) -C docker/third-party copy
 
+.PHONY: update-envoy
+update-envoy:
+	python3 update-envoy.py
+	$(MAKE) -C gateway deploy
+	$(MAKE) -C internal-gateway deploy
+
 .PHONY: generate-pip-lockfiles
 generate-pip-lockfiles:
 	./generate-pip-lockfile.sh hail/python/hailtop

--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,11 @@ update-gateways-envoy:
 	python3 update-envoy.py
 	$(MAKE) -C gateway deploy
 	$(MAKE) -C internal-gateway deploy
+	kubectl rollout status deployment gateway-deployment
+	kubectl rollout status deployment internal-gateway
+	kubectl get deployment gateway-deployment -o jsonpath='{.spec.template.spec.containers[0].image}'
+	kubectl get deployment internal-gateway -o jsonpath='{.spec.template.spec.containers[0].image}'
 	@echo ''
-	@echo 'Validate with:'
-	@echo '  kubectl rollout status deployment gateway-deployment && kubectl rollout status deployment internal-gateway'
-	@echo '  kubectl get deployment gateway-deployment -o jsonpath='\''{.spec.template.spec.containers[0].image}'\'''
-	@echo '  kubectl get deployment internal-gateway -o jsonpath='\''{.spec.template.spec.containers[0].image}'\'''
 	@echo 'If traffic to hail.is services seems degraded, roll back with:'
 	@echo '  kubectl rollout undo deployment gateway-deployment && kubectl rollout undo deployment internal-gateway'
 

--- a/dev-docs/services/gateways.md
+++ b/dev-docs/services/gateways.md
@@ -50,7 +50,7 @@ Minor version bumps may contain breaking changes and should be done deliberately
 To update to the latest patch release within the current minor series:
 
 ```bash
-make update-envoy
+make update-gateways-envoy
 ```
 
 This updates the image tag in `gateway/deployment.yaml` and `internal-gateway/deployment.yaml`

--- a/dev-docs/services/gateways.md
+++ b/dev-docs/services/gateways.md
@@ -75,7 +75,7 @@ If something goes wrong, roll back to the previous deployment immediately:
 
 ```bash
 kubectl rollout undo deployment gateway-deployment
-kubectl rollout undo deployment internal-gateway-deployment
+kubectl rollout undo deployment internal-gateway
 ```
 
 Kubernetes retains the previous ReplicaSet so this is instant and zero-downtime.

--- a/dev-docs/services/gateways.md
+++ b/dev-docs/services/gateways.md
@@ -35,3 +35,58 @@ can dynamically load this new configuration as it changes without dropping exist
 You can see CI's current view of the cluster's namespaces/services at ci.hail.is/namespaces
 and can inspect the current Envoy config at ci.hail.is/envoy-config/gateway and
 ci.hail.is/envoy-config/internal-gateway.
+
+## Operations
+
+Both gateways are **unmanaged** — they are not deployed by CI and must be updated manually.
+
+### Updating the Envoy version
+
+Envoy releases quarterly minor versions (`1.33`, `1.34`, …) and patch releases within each series.
+Patch releases are security/bug fixes only and are safe to apply without reviewing breaking changes.
+Minor version bumps may contain breaking changes and should be done deliberately after reading the
+[Envoy version history](https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history).
+
+To update to the latest patch release within the current minor series:
+
+```bash
+make update-envoy
+```
+
+This updates the image tag in `gateway/deployment.yaml` and `internal-gateway/deployment.yaml`
+and deploys both gateways via `kubectl apply`.
+
+### Deploying gateway changes
+
+To apply any change to the gateway (image version, listener config, TLS params, etc.):
+
+```bash
+make -C gateway deploy
+make -C internal-gateway deploy
+```
+
+This renders the Jinja2 templates and runs `kubectl apply`, which triggers a zero-downtime
+rolling update of the gateway pods.
+
+Note: `make -C gateway deploy` does **not** update the xDS routing ConfigMaps — those are
+managed automatically by CI every 10 seconds and do not require a manual deploy.
+
+If something goes wrong, roll back to the previous deployment immediately:
+
+```bash
+kubectl rollout undo deployment gateway-deployment
+kubectl rollout undo deployment internal-gateway-deployment
+```
+
+Kubernetes retains the previous ReplicaSet so this is instant and zero-downtime.
+
+### Renewing TLS certificates
+
+See [letsencrypt.md](letsencrypt.md). After updating the `letsencrypt-config` secret, restart
+the gateway pods to pick up the new certificate:
+
+```bash
+kubectl rollout restart deployment gateway-deployment
+```
+
+This is a pod restart only — it does not change the Envoy image or any config.

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
        - name: gateway
-         image: "{{ global.docker_prefix }}/envoyproxy/envoy:v1.33.0"
+         image: "{{ global.docker_prefix }}/envoyproxy/envoy:v1.33.14"
          command:
            - /usr/local/bin/envoy
            - --config-path

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
        - name: internal-gateway
-         image: "{{ global.docker_prefix }}/envoyproxy/envoy:v1.33.0"
+         image: "{{ global.docker_prefix }}/envoyproxy/envoy:v1.33.14"
          command:
            - /usr/local/bin/envoy
            - --config-path

--- a/update-envoy.py
+++ b/update-envoy.py
@@ -1,55 +1,73 @@
 #!/usr/bin/env python3
+import json
 import re
 import sys
 import urllib.request
-import json
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent
-FILES = [
+DEPLOYMENT_FILES = [
     REPO_ROOT / 'gateway/deployment.yaml',
     REPO_ROOT / 'internal-gateway/deployment.yaml',
 ]
+ENVOY_IMAGE_RE = re.compile(r'envoyproxy/envoy:v(?P<series>\d+\.\d+)\.(?P<patch>\d+)')
 
-pattern = re.compile(r'envoyproxy/envoy:v(\d+\.\d+)\.\d+')
 
-current_version = None
-for f in FILES:
-    m = pattern.search(f.read_text())
-    if m:
-        current_version = m.group(0).split(':v')[1]
-        current_series = m.group(1)
-        break
+def current_envoy_version() -> tuple[str, str]:
+    """Return (series, full_version) parsed from the first deployment file that contains an envoy image tag."""
+    for f in DEPLOYMENT_FILES:
+        if m := ENVOY_IMAGE_RE.search(f.read_text()):
+            return m.group('series'), f"{m.group('series')}.{m.group('patch')}"
+    raise SystemExit('ERROR: Could not find envoy version in deployment files')
 
-if not current_version:
-    print('ERROR: Could not find envoy version in deployment files', file=sys.stderr)
-    sys.exit(1)
 
-print(f'Current version: v{current_version} (series {current_series})')
-print(f'Querying GitHub for latest v{current_series}.x release...')
+def latest_patch_release(series: str) -> str:
+    """Return the latest non-prerelease patch version within the given minor series from GitHub."""
+    url = 'https://api.github.com/repos/envoyproxy/envoy/releases?per_page=50'
+    req = urllib.request.Request(
+        url,
+        headers={'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28'},
+    )
+    with urllib.request.urlopen(req) as r:  # nosec B310
+        releases = json.loads(r.read())
 
-url = f'https://api.github.com/repos/envoyproxy/envoy/releases?per_page=50'
-req = urllib.request.Request(url, headers={'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28'})
-with urllib.request.urlopen(req) as r:  # nosec B310
-    releases = json.loads(r.read())
+    series_re = re.compile(rf'^v{re.escape(series)}\.(\d+)$')
+    patches = [
+        (int(m.group(1)), release['tag_name'])
+        for release in releases
+        if (m := series_re.match(release['tag_name'])) and not release['prerelease']
+    ]
+    if not patches:
+        raise SystemExit(f'ERROR: No releases found for series {series}')
 
-series_pattern = re.compile(rf'^v{re.escape(current_series)}\.(\d+)$')
-matching = [(int(m.group(1)), r['tag_name']) for r in releases if (m := series_pattern.match(r['tag_name'])) and not r['prerelease']]
+    _, latest_tag = max(patches)
+    return latest_tag.lstrip('v')
 
-if not matching:
-    print(f'ERROR: No releases found for series {current_series}', file=sys.stderr)
-    sys.exit(1)
 
-latest_patch, latest_tag = max(matching)
-latest_version = latest_tag.lstrip('v')
+def update_files(old_version: str, new_version: str) -> None:
+    """Replace the envoy image tag in all deployment files."""
+    old_image = f'envoyproxy/envoy:v{old_version}'
+    new_image = f'envoyproxy/envoy:v{new_version}'
+    for f in DEPLOYMENT_FILES:
+        updated = f.read_text().replace(old_image, new_image)
+        f.write_text(updated)
+        print(f'  Updated {f.relative_to(REPO_ROOT)}')
 
-if current_version == latest_version:
-    print(f'Already up to date: v{current_version}')
-    sys.exit(0)
 
-print(f'Updating v{current_version} -> v{latest_version}')
-for f in FILES:
-    text = f.read_text()
-    updated = text.replace(f'envoyproxy/envoy:v{current_version}', f'envoyproxy/envoy:v{latest_version}')
-    f.write_text(updated)
-    print(f'  Updated {f.relative_to(REPO_ROOT)}')
+def main() -> None:
+    series, current_version = current_envoy_version()
+    print(f'Current version: v{current_version} (series {series})')
+    print(f'Querying GitHub for latest v{series}.x release...')
+
+    latest_version = latest_patch_release(series)
+
+    if current_version == latest_version:
+        print(f'Already up to date: v{current_version}')
+        sys.exit(0)
+
+    print(f'Updating v{current_version} -> v{latest_version}')
+    update_files(current_version, latest_version)
+
+
+if __name__ == '__main__':
+    main()

--- a/update-envoy.py
+++ b/update-envoy.py
@@ -28,7 +28,8 @@ def latest_patch_release(series: str) -> str:
         url,
         headers={'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28'},
     )
-    with urllib.request.urlopen(req) as r:  # nosec B310
+    with urllib.request.urlopen(req, timeout=30) as r:  # nosec B310
+
         releases = json.loads(r.read())
 
     series_re = re.compile(rf'^v{re.escape(series)}\.(\d+)$')

--- a/update-envoy.py
+++ b/update-envoy.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import re
+import sys
+import urllib.request
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent
+FILES = [
+    REPO_ROOT / 'gateway/deployment.yaml',
+    REPO_ROOT / 'internal-gateway/deployment.yaml',
+]
+
+pattern = re.compile(r'envoyproxy/envoy:v(\d+\.\d+)\.\d+')
+
+current_version = None
+for f in FILES:
+    m = pattern.search(f.read_text())
+    if m:
+        current_version = m.group(0).split(':v')[1]
+        current_series = m.group(1)
+        break
+
+if not current_version:
+    print('ERROR: Could not find envoy version in deployment files', file=sys.stderr)
+    sys.exit(1)
+
+print(f'Current version: v{current_version} (series {current_series})')
+print(f'Querying GitHub for latest v{current_series}.x release...')
+
+url = f'https://api.github.com/repos/envoyproxy/envoy/releases?per_page=50'
+req = urllib.request.Request(url, headers={'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28'})
+with urllib.request.urlopen(req) as r:  # nosec B310
+    releases = json.loads(r.read())
+
+series_pattern = re.compile(rf'^v{re.escape(current_series)}\.(\d+)$')
+matching = [(int(m.group(1)), r['tag_name']) for r in releases if (m := series_pattern.match(r['tag_name'])) and not r['prerelease']]
+
+if not matching:
+    print(f'ERROR: No releases found for series {current_series}', file=sys.stderr)
+    sys.exit(1)
+
+latest_patch, latest_tag = max(matching)
+latest_version = latest_tag.lstrip('v')
+
+if current_version == latest_version:
+    print(f'Already up to date: v{current_version}')
+    sys.exit(0)
+
+print(f'Updating v{current_version} -> v{latest_version}')
+for f in FILES:
+    text = f.read_text()
+    updated = text.replace(f'envoyproxy/envoy:v{current_version}', f'envoyproxy/envoy:v{latest_version}')
+    f.write_text(updated)
+    print(f'  Updated {f.relative_to(REPO_ROOT)}')


### PR DESCRIPTION
## Change Description

Two changes:
- Update the gateway's envoy version to 1.33.14 (already live, so this is just tracking / for future deployments)
- Add a make target to automate future 

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Gateway patch, plus helper script to ease future patching

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
