### PR TITLE
[hailtop] changes to make hail work better in hosted jupyter environments

### DIFF
--- a/hail/python/dev/pinned-requirements.txt
+++ b/hail/python/dev/pinned-requirements.txt
@@ -94,7 +94,7 @@ cycler==0.12.1
     # via matplotlib
 debugpy==1.8.21
     # via ipykernel
-decorator==4.4.2
+decorator==5.3.1
     # via
     #   -c hail/python/dev/../pinned-requirements.txt
     #   ipython

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import os
 import subprocess as sp
+import sys
 import time
 import uuid
 import warnings
@@ -221,6 +222,7 @@ class LocalBackend(Backend[None]):
         copied_input_resource_files = set()
         os.makedirs(tmpdir + '/inputs/', exist_ok=True)
 
+        python3 = shq(sys.executable)
         requester_pays_project_json = orjson.dumps(batch.requester_pays_project).decode('utf-8')
 
         def copy_input(job, r):
@@ -233,7 +235,9 @@ class LocalBackend(Backend[None]):
                     if input_scheme != '':
                         transfers_bytes = orjson.dumps([{"from": r._input_path, "to": r._get_path(tmpdir)}])
                         transfers = transfers_bytes.decode('utf-8')
-                        return [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}']
+                        return [
+                            f'{python3} -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(transfers)}'
+                        ]
 
                     absolute_input_path = os.path.realpath(os.path.expanduser(r._input_path))
 
@@ -282,7 +286,9 @@ class LocalBackend(Backend[None]):
                 input_transfers = orjson.dumps(input_transfer_dicts).decode('utf-8')
                 code = new_code_block()
                 code += ["# Write input resources to output destinations"]
-                code += [f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(input_transfers)}']
+                code += [
+                    f'{python3} -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(input_transfers)}'
+                ]
                 code += ['\n']
                 run_code(code)
 
@@ -375,7 +381,7 @@ class LocalBackend(Backend[None]):
                 if output_transfer_dicts:
                     output_transfers = orjson.dumps(output_transfer_dicts).decode('utf-8')
                     code += [
-                        f'python3 -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(output_transfers)}'
+                        f'{python3} -m hailtop.aiotools.copy {shq(requester_pays_project_json)} {shq(output_transfers)}'
                     ]
                 code += ['\n']
 

--- a/hail/python/pinned-requirements.txt
+++ b/hail/python/pinned-requirements.txt
@@ -101,7 +101,7 @@ cryptography==49.0.0
     #   google-auth
     #   msal
     #   pyjwt
-decorator==4.4.2
+decorator==5.3.1
     # via -r hail/python/requirements.txt
 deprecated==1.2.18
     # via -r hail/python/requirements.txt

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -4,7 +4,7 @@
 
 avro>=1.10,<1.12
 bokeh>3.8.2,<4
-decorator<5
+decorator>=5,<6
 Deprecated>=1.2.10,<1.3
 numpy>=2,<3
 pandas>=2,<3


### PR DESCRIPTION
## Change Description

Should make integration into the hosted manifold platform a lot smoother:

- Updates the decorator version imported to avoid collision
- Calls back out to hailtop using the currently running python executable, not system python (so any packages installed in the current env / kernel are still locatable)

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Updates the decorator package. The changes in the `backend` file are only used by the local backend.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
