### PR TITLE
[services] be more selective about unsafe-inline styles

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -46,6 +46,7 @@ from web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_inline_styles,
     web_security_headers_login_page,
     web_security_headers_swagger,
 )
@@ -251,7 +252,7 @@ async def get_healthcheck(_) -> web.Response:
 
 
 @routes.get('/helloreact')
-@web_security_headers
+@web_security_headers_inline_styles
 @auth.maybe_authenticated_user
 async def hello_react(request: web.Request, userdata) -> web.Response:
     return await render_template('auth', request, userdata, 'hello_react.html', {'use_tailwind': True})

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -60,6 +60,7 @@ from web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_inline_styles,
 )
 
 from ..batch import cancel_job_group_in_db
@@ -485,7 +486,7 @@ FROM user_inst_coll_resources;
 
 
 @routes.get('/quotas')
-@web_security_headers
+@web_security_headers_inline_styles
 @auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
 async def get_quotas(request, userdata):
     if CLOUD != 'gcp':
@@ -575,7 +576,7 @@ def validate_int(session, name, value, predicate, description):
 
 
 @routes.get('/helloreact')
-@web_security_headers
+@web_security_headers_inline_styles
 @auth.authenticated_users_with_permission(SystemPermission.READ_DEPLOYED_SYSTEM_STATE)
 async def hello_react(request: web.Request, userdata) -> web.Response:
     return await render_template('batch-driver', request, userdata, 'hello_react.html', {'use_tailwind': True})

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -80,6 +80,7 @@ from web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_inline_styles,
     web_security_headers_swagger,
 )
 
@@ -2783,7 +2784,7 @@ async def ui_get_jvm_profile(request: web.Request, _, batch_id: int) -> web.Resp
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}')
-@web_security_headers
+@web_security_headers_inline_styles
 @billing_project_users_only()
 @catch_ui_error_in_dev
 async def ui_get_job(request, userdata, batch_id):

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -11,15 +11,15 @@
   {{ table_search("batch-search", base_path ~ "/batches") }}
   <table class='table-fixed w-full' id='batches'>
     <thead>
-      <th class='h-12 bg-slate-200 font-light text-md rounded-tr text-left md:rounded-tr-none' style='width:1rem'></th>
-      <th class='h-12 bg-slate-200 font-light text-md text-center rounded-tl rounded-tr md:rounded-tr-none' style='width:6rem'>ID</th>
+      <th class='h-12 bg-slate-200 font-light text-md rounded-tr text-left md:rounded-tr-none w-4'></th>
+      <th class='h-12 bg-slate-200 font-light text-md text-center rounded-tl rounded-tr md:rounded-tr-none w-24'>ID</th>
       <th class='h-12 bg-slate-200 font-light text-md rounded-tr text-left md:rounded-tr-none'>Batch Name</th>
-      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell' style='width:8rem'>Billing Project</th>
-      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell' style='width:8rem'>Job Statuses</th>
-      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell' style='width:12rem'>Created</th>
-      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell' style='width:12rem'>Completed</th>
-      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell' style='width:8rem'>Duration</th>
-      <th class='h-12 bg-slate-200 font-light text-md text-left hidden md:table-cell rounded-tr' style='width:6rem'>Cost</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell w-32'>Billing Project</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell w-32'>Job Statuses</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell w-48'>Created</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell w-48'>Completed</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden lg:table-cell w-32'>Duration</th>
+      <th class='h-12 bg-slate-200 font-light text-md text-left hidden md:table-cell rounded-tr w-24'>Cost</th>
     </thead>
     <tbody class='border border-collapse border-slate-50'>
       {% for batch in batches %}

--- a/batch/batch/front_end/templates/table_search.html
+++ b/batch/batch/front_end/templates/table_search.html
@@ -49,7 +49,7 @@
     </div>
 
     <!-- Textbox mode (hidden by default) -->
-    <div id='search-textbox-container' class='min-h-32 w-full p-4 bg-slate-200 rounded' style='display: none;'>
+    <div id='search-textbox-container' class='min-h-32 w-full p-4 bg-slate-200 rounded hidden'>
       <textarea id='search-input-box' class='h-32 w-full p-4 bg-white rounded resize whitespace-pre border'
         spellcheck="false" autocorrect="off" placeholder='Enter search query (e.g., "cost > 5.00")'>{% if q %}{{ q }}{% endif %}</textarea>
     </div>

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -268,7 +268,7 @@ async def _populate_historical_pr_context(
 
 
 @routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
-@web_security_headers
+@web_security_headers_inline_styles
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI)
 async def get_pr(request: web.Request, userdata: UserData) -> web.Response:
     watched_branch_index = int(request.match_info['watched_branch_index'])

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -47,6 +47,7 @@ from web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_inline_styles,
     web_security_headers_swagger,
 )
 
@@ -862,7 +863,7 @@ async def get_envoy_configs(request: web.Request, _) -> web.Response:
 
 
 @routes.get('/flaky_tests')
-@web_security_headers
+@web_security_headers_inline_styles
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI)
 async def get_flaky_tests(request: web.Request, userdata: UserData) -> web.Response:
     return await render_template('ci', request, userdata, 'flaky_tests.html', {'use_tailwind': True})

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -43,6 +43,7 @@ from web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_inline_styles,
     web_security_headers_swagger,
 )
 
@@ -171,7 +172,7 @@ async def get_billing(request: web.Request, _) -> web.Response:
 
 
 @routes.get('/billing')
-@web_security_headers
+@web_security_headers_inline_styles
 @auth.authenticated_users_with_permission(SystemPermission.VIEW_MONITORING_DASHBOARDS)
 async def billing(request: web.Request, userdata) -> web.Response:  # pylint: disable=unused-argument
     cost_by_service, compute_cost_breakdown, cost_by_sku_label, time_period_query = await _billing(request)
@@ -459,7 +460,7 @@ async def on_cleanup(app):
 
 
 @routes.get('/helloreact')
-@web_security_headers
+@web_security_headers_inline_styles
 @auth.authenticated_users_with_permission(SystemPermission.VIEW_MONITORING_DASHBOARDS)
 async def hello_react(request: web.Request, userdata) -> web.Response:
     return await render_template('monitoring', request, userdata, 'hello_react.html', {'use_tailwind': True})

--- a/web_common/web_common/__init__.py
+++ b/web_common/web_common/__init__.py
@@ -6,6 +6,7 @@ from .web_common import (
     setup_aiohttp_jinja2,
     setup_common_static_routes,
     web_security_headers,
+    web_security_headers_inline_styles,
     web_security_headers_login_page,
     web_security_headers_swagger,
 )
@@ -18,6 +19,7 @@ __all__ = [
     'setup_aiohttp_jinja2',
     'setup_common_static_routes',
     'web_security_headers',
+    'web_security_headers_inline_styles',
     'web_security_headers_login_page',
     'web_security_headers_swagger',
 ]

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -139,6 +139,10 @@ def web_security_headers_swagger(fun):
     )
 
 
+def web_security_headers_inline_styles(fun):
+    return web_security_header_generator(fun, extra_style="'unsafe-inline'")
+
+
 def web_security_headers_login_page(fun):
     # Login/signup forms redirect through auth.hail.is/login to the OAuth provider. Chrome follows
     # the redirect chain when enforcing form-action, so OAuth domains must be allowed.
@@ -155,7 +159,7 @@ def web_security_header_generator(
         response = await fun(request, *args, **kwargs)
 
         default_src = 'default-src \'self\';'
-        style_src = f'style-src \'self\' \'unsafe-inline\' {extra_style} fonts.googleapis.com fonts.gstatic.com;'
+        style_src = f'style-src \'self\' {extra_style} fonts.googleapis.com fonts.gstatic.com;'
         font_src = 'font-src \'self\' fonts.gstatic.com;'
         script_src = f'script-src \'self\' {extra_script} cdn.jsdelivr.net cdn.plot.ly;'
         img_src = f'img-src \'self\' {extra_img};'


### PR DESCRIPTION
## Change Description

Most pages don't need unsafe inline styles as a CSP. Turn it off by default, reapply only when needed:

- old html pages with plotly components
- old html pages with manual style additions
- new react pages

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP


### Impact Rating

Delete all except the correct answer:
- This change has a low security impact

### Impact Description

Removes unsafe-inline styles except where needed

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
