### PR TITLE
[batch] highlight low / empty billing projects

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1326,6 +1326,7 @@ WHERE billing_project = %s AND state = 'running';
                 (record['billing_project'],),
             )
             async for batch in running_batches:
+                log.warning(f'cancelling running batch {batch["id"]}. Project out of money.')
                 await _cancel_job_group(app, batch['id'], ROOT_JOB_GROUP_ID)
 
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -48,6 +48,7 @@ from hailtop.hail_logging import AccessLogger
 from hailtop.utils import (
     AsyncWorkerPool,
     Notice,
+    cost_str,
     dump_all_stacktraces,
     flatten,
     periodically_call,
@@ -1312,6 +1313,10 @@ async def monitor_billing_limits(app):
         limit = record['limit']
         accrued_cost = record['accrued_cost']
         if limit is not None and accrued_cost >= limit:
+            log.warning(
+                f'billing project {record["billing_project"]} has exceeded its limit; '
+                f'accrued={cost_str(accrued_cost)} limit={cost_str(limit)}; cancelling running batches'
+            )
             running_batches = db.execute_and_fetchall(
                 """
 SELECT id

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2235,6 +2235,7 @@ async def delete_batch(request: web.Request, _, batch_id: int) -> web.Response:
 @catch_ui_error_in_dev
 async def ui_batch(request, userdata, batch_id):
     app = request.app
+    db: Database = app['db']
     batch = await _get_batch(app, batch_id)
 
     q = request.query.get('q', '')
@@ -2267,10 +2268,33 @@ async def ui_batch(request, userdata, batch_id):
             record['cost'] = cost_str(record['cost'])
         batch['cost_breakdown'].sort(key=lambda record: record['resource'])
 
+    bp_records = await query_billing_projects_with_cost(db, billing_project=batch['billing_project'])
+    bp_cost_info = None
+    if bp_records:
+        bp = bp_records[0]
+        limit = bp['limit']
+        accrued = bp['accrued_cost']
+        if limit is not None:
+            fraction = accrued / limit if limit > 0 else 1.0
+            if fraction >= 1.0:
+                bp_level = 'error'
+            elif fraction >= 0.8:
+                bp_level = 'warning'
+            else:
+                bp_level = 'ok'
+        else:
+            bp_level = 'no_limit'
+        bp_cost_info = {
+            'accrued_cost': cost_str(accrued),
+            'limit': cost_str(limit) if limit is not None else None,
+            'level': bp_level,
+        }
+
     page_context = {
         'batch': batch,
         'q': q,
         'last_job_id': last_job_id,
+        'bp_cost_info': bp_cost_info,
     }
     return await render_template('batch', request, userdata, 'batch.html', page_context)
 

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -29,7 +29,33 @@ batch_state_indicator, job_state_indicator, danger_button, submit_button, link, 
         <div class='flex justify-between items-center'>
           <div>
             <div class='font-light text-zinc-500'>Submitted by {{ batch['user'] }}</div>
-            <div class='font-light text-zinc-500'>Billed to {{ batch['billing_project'] }}</div>
+            <div class='font-light text-zinc-500 flex items-center gap-1'>
+              Billed to
+              {% if bp_cost_info %}
+              <span class='relative group cursor-default flex items-center gap-0.5'>
+                <span class='material-symbols-outlined text-base text-zinc-400'>info</span>
+                <span class='underline decoration-dotted decoration-zinc-400'>{{ batch['billing_project'] }}</span>
+                <span class='absolute left-0 bottom-full mb-1 hidden group-hover:block
+                             bg-zinc-800 text-white text-xs rounded px-2 py-1 whitespace-nowrap z-10 pointer-events-none'>
+                  {% if bp_cost_info['level'] == 'error' %}
+                  Billing project over limit:
+                  {% elif bp_cost_info['level'] == 'warning' %}
+                  Billing project nearing limit:
+                  {% else %}
+                  Billing project spend:
+                  {% endif %}
+                  {{ bp_cost_info['accrued_cost'] }}{% if bp_cost_info['limit'] %} / {{ bp_cost_info['limit'] }}{% endif %}
+                </span>
+              </span>
+              {% if bp_cost_info['level'] == 'error' %}
+              <span class='material-symbols-outlined text-base text-red-600'>error</span>
+              {% elif bp_cost_info['level'] == 'warning' %}
+              <span class='material-symbols-outlined text-base text-yellow-500'>warning</span>
+              {% endif %}
+              {% else %}
+              {{ batch['billing_project'] }}
+              {% endif %}
+            </div>
           </div>
           {% if not batch['complete'] and batch['state'] != 'Cancelled' %}
           <form action="{{ base_path }}/batches/{{ batch['id'] }}/cancel" method="post">


### PR DESCRIPTION
## Change Description

Adds hoverable billing project info to the batch details page. 
Adds orange / red warning icons if low (<=20% remaining) or empty (<=0% remaining)

## Examples

### Before changes

Before this change, the billed to <project> element is non-interactive:

<img width="266" height="121" alt="image" src="https://github.com/user-attachments/assets/ddc5612d-d94e-43a3-8658-d4252dee0c2a" />


### Normal operation

With these changes, the billing project name is hoverable. Eg when the billing project has more than 20% funding remaining:

<img width="383" height="181" alt="image" src="https://github.com/user-attachments/assets/4a6cc293-2f30-414c-ae6b-541ba883f36d" />

### Low

When the billing project has between 0 and 20% remaining:

<img width="415" height="159" alt="image" src="https://github.com/user-attachments/assets/14dedefb-8490-4c20-abe2-f7c661dffec8" />

### Over limit

When the billing project is over its limit: 

<img width="384" height="177" alt="image" src="https://github.com/user-attachments/assets/e9e0acc9-6501-481a-8454-a94630a41d30" />


## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Users can already see billing project details if they are members of the billing project. This just puts the information in a more visible - and frequently used location.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
