### PR TITLE
[scripts] script and docs for manifold platform setup

### DIFF
--- a/user-scripts/manifold/README.md
+++ b/user-scripts/manifold/README.md
@@ -1,0 +1,84 @@
+# Hail on Manifold
+
+## Initial Setup
+
+### Manifold Platform
+
+- Pick a workbench where you have compute environment permissions
+- Create a new compute environment:
+    - Click "Add Environment"
+    - Enter a title
+    - Choose the scipy jupyter notebook image.
+    - Click "Add & Launch"
+    - Wait for it to spin up, then open
+
+### Terminal
+
+Within the newly opend jupyter notebook, open a Terminal tab from the menu.
+
+Download and run the Hail kernel installation script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hail-is/hail/main/user-scripts/manifold/install_hail_kernel.sh | bash
+```
+
+## Using Hail on the Manifold Platform
+
+- Choose a suitable working directory and navigate to it on the left hand side panel:
+  - `/home/jovyan/` - is the default user's home directory and opens by default. It is fine but it probably makes sense
+    to use an explicitly chosen subdirectory.
+  - `/home/jovyan/workspace/username/{project}` - will be preserved and shared across all environments in the workspace.
+  - `/home/jovyan/local/{project}` - anything in `local` will be local to the current environment and not shared with anyone else.
+  
+- Open a new tab, the new kernel might take a few seconds to appear under Notebooks and Console
+- When it appears, open it
+
+### In the notebook
+
+- Set the PATH to include the conda env python (otherwise all the modules will be missing):
+
+```python
+import os, sys
+
+# Prepend the current interpreter's directory to PATH so subprocesses
+# resolve 'python3' to the same conda env Python you're running in
+os.environ['PATH'] = os.path.dirname(sys.executable) + ':' + os.environ['PATH']
+print('done!')
+```
+
+### Example batches
+
+You can now run Hail commands in the notebook:
+
+#### Hello world
+```python
+import hailtop.batch as hb
+
+b = hb.Batch('hello test')
+j = b.new_job('hello task')
+j.command('echo hello')
+b.run()
+```
+
+Using files in the workspace:
+
+- First, create a file in the workspace at `~/workspace/world.txt` with the content "world"
+- Now you can run the script below. It creates a temporary file with the content "hello" and 
+then updates it with the content of the file in the workspace. Finally, it prints the contents of the file.
+
+#### File maker & updater
+```python
+b = hb.Batch('local file updater')
+
+j1 = b.new_job('create_hello')
+j1.command(f'echo "hello" > {j1.ofile}')
+
+j2 = b.new_job('update_world')
+j2.command(f'cat {j1.ofile} > {j2.ofile}; cat ~/workspace/world.txt >> {j2.ofile}')
+b.write_output(j2.ofile, 'output.txt')
+
+j3 = b.new_job('print_result')
+j3.command(f'cat {j2.ofile}')
+
+b.run()
+```

--- a/user-scripts/manifold/README.md
+++ b/user-scripts/manifold/README.md
@@ -27,24 +27,12 @@ curl -fsSL https://raw.githubusercontent.com/hail-is/hail/main/user-scripts/mani
 - Choose a suitable working directory and navigate to it on the left hand side panel:
   - `/home/jovyan/` - is the default user's home directory and opens by default. It is fine but it probably makes sense
     to use an explicitly chosen subdirectory.
-  - `/home/jovyan/workspace/username/{project}` - will be preserved and shared across all environments in the workspace.
+  - `/home/jovyan/workbench/username/{project}` - will be preserved and shared across all environments in the workspace.
   - `/home/jovyan/local/{project}` - anything in `local` will be local to the current environment and not shared with anyone else.
   
-- Open a new tab, the new kernel might take a few seconds to appear under Notebooks and Console
-- When it appears, open it
-
-### In the notebook
-
-- Set the PATH to include the conda env python (otherwise all the modules will be missing):
-
-```python
-import os, sys
-
-# Prepend the current interpreter's directory to PATH so subprocesses
-# resolve 'python3' to the same conda env Python you're running in
-os.environ['PATH'] = os.path.dirname(sys.executable) + ':' + os.environ['PATH']
-print('done!')
-```
+- When navigated to the appropriate directory, open a new tab in the notebook. The new kernel might take a few seconds to appear
+under Notebooks and Console
+- When it appears (it will be called `Python (hail)`), open it 
 
 ### Example batches
 
@@ -60,21 +48,23 @@ j.command('echo hello')
 b.run()
 ```
 
-Using files in the workspace:
-
-- First, create a file in the workspace at `~/workspace/world.txt` with the content "world"
-- Now you can run the script below. It creates a temporary file with the content "hello" and 
-then updates it with the content of the file in the workspace. Finally, it prints the contents of the file.
-
 #### File maker & updater
+
+- First, create a file in the workbench at `~/workbench/world.txt` with the content "world"
+- Now you can run the script below. It creates a temporary file with the content "hello" and 
+then updates it with the content of the file in the workbench. Finally, it prints the contents of the file.
+
+
 ```python
+import hailtop.batch as hb
+
 b = hb.Batch('local file updater')
 
 j1 = b.new_job('create_hello')
 j1.command(f'echo "hello" > {j1.ofile}')
 
 j2 = b.new_job('update_world')
-j2.command(f'cat {j1.ofile} > {j2.ofile}; cat ~/workspace/world.txt >> {j2.ofile}')
+j2.command(f'cat {j1.ofile} > {j2.ofile}; cat ~/workbench/world.txt >> {j2.ofile}')
 b.write_output(j2.ofile, 'output.txt')
 
 j3 = b.new_job('print_result')

--- a/user-scripts/manifold/install_hail_kernel.sh
+++ b/user-scripts/manifold/install_hail_kernel.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# install_hail_kernel.sh
+# -----------------------------------------------------------------------------
+# Sets up (or restores) a PERSISTENT Hail Jupyter kernel on a Manifold compute
+# environment running JupyterLab.
+#
+# WHY THIS IS NEEDED
+#   `conda create -n hail` puts the env on the container's ephemeral layer
+#   (e.g. /opt/conda/envs/hail) and `ipykernel install --user` writes the
+#   kernelspec to ~/.local/share/jupyter (also ephemeral). Both are wiped when
+#   the compute environment restarts, which is why the kernel keeps vanishing.
+#
+# WHAT THIS SCRIPT DOES
+#   1. Picks a directory that survives restarts (a persistent volume).
+#   2. Creates the conda env BY PATH on that volume (the slow, heavy part).
+#   3. Re-registers the kernelspec each run pointing at the persistent python,
+#      and bakes PATH into the kernelspec so the in-notebook PATH hack is no
+#      longer needed.
+#   4. Is idempotent: if the env already exists it skips the rebuild and just
+#      re-registers the kernel in a couple of seconds.
+#
+# USAGE
+#   bash install_hail_kernel.sh                      # create if missing, register
+#   PERSIST_DIR=/your/persistent/path bash install_hail_kernel.sh   # force a path
+#   FORCE_RECREATE=1 bash install_hail_kernel.sh     # delete & rebuild the env
+#
+# AFTER A RESTART
+#   Just run it again. If the env survived it restores in seconds; if not,
+#   the PERSIST_DIR you used was not actually persistent — try another path
+#   (see the printed candidate list) and pass it via PERSIST_DIR=...
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+# ---- Config -----------------------------------------------------------------
+ENV_NAME="hail"
+PY_VERSION="3.11"
+DISPLAY_NAME="Python (hail)"
+
+log() { printf '>> %s\n' "$*"; }
+
+# ---- 1. Choose a persistent base directory ----------------------------------
+# Defaults to ~/local  (i.e. /home/jovyan/local on this environment).
+# Override with PERSIST_DIR=... to use a different volume.
+PERSIST_DIR="${PERSIST_DIR:-$HOME/local}"
+mkdir -p "$PERSIST_DIR"
+ENV_PREFIX="$PERSIST_DIR/conda-envs/$ENV_NAME"
+
+log "Persistent base : $PERSIST_DIR"
+log "Conda env prefix: $ENV_PREFIX"
+log "(If this base does not survive a restart, re-run with PERSIST_DIR=...)"
+
+# ---- 2. Make conda available ------------------------------------------------
+if ! command -v conda >/dev/null 2>&1; then
+  for cbase in /opt/conda "$HOME/miniconda3" "$HOME/anaconda3" "$HOME/miniforge3"; do
+    if [[ -f "$cbase/etc/profile.d/conda.sh" ]]; then
+      # shellcheck disable=SC1091
+      source "$cbase/etc/profile.d/conda.sh"
+      break
+    fi
+  done
+fi
+command -v conda >/dev/null 2>&1 || { echo "ERROR: conda not found on PATH." >&2; exit 1; }
+# shellcheck disable=SC1091
+source "$(conda info --base)/etc/profile.d/conda.sh"
+
+# ---- 3. Create the env (heavy) or restore (fast) ----------------------------
+if [[ "${FORCE_RECREATE:-0}" == "1" && -d "$ENV_PREFIX" ]]; then
+  log "FORCE_RECREATE=1 — removing existing env"
+  conda env remove --prefix "$ENV_PREFIX" -y || true
+fi
+
+mkdir -p "$PERSIST_DIR/conda-envs"
+
+if [[ -x "$ENV_PREFIX/bin/python" ]]; then
+  log "Conda env already present — fast restore path (skipping create/install)."
+  conda activate "$ENV_PREFIX"
+else
+  log "Creating conda env on persistent volume (slow part, ~minutes)…"
+  conda create --prefix "$ENV_PREFIX" "python==$PY_VERSION" -y
+  conda activate "$ENV_PREFIX"
+  log "Installing hail + ipykernel…"
+  pip install hail
+  pip install ipykernel   # a 'decorator' dependency clash may print — safe to ignore
+fi
+
+PYBIN="$ENV_PREFIX/bin/python"
+
+# ---- 4. Register the kernelspec ---------------------------------------------
+# Written by hand so argv points at the persistent python and PATH is baked in,
+# which removes the need for the os.environ['PATH'] = ... step inside notebooks.
+KERNEL_DIR="$HOME/.local/share/jupyter/kernels/$ENV_NAME"
+mkdir -p "$KERNEL_DIR"
+cat > "$KERNEL_DIR/kernel.json" <<JSON
+{
+  "argv": ["$PYBIN", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+  "display_name": "$DISPLAY_NAME",
+  "language": "python",
+  "metadata": { "debugger": true },
+  "env": {
+    "PATH": "$ENV_PREFIX/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  }
+}
+JSON
+log "Kernelspec written: $KERNEL_DIR/kernel.json"
+
+# ---- 4b. Download Hail logo -------------------------------------------------
+HAIL_SVG_URL="https://raw.githubusercontent.com/hail-is/hail/main/graphics/svgs/icons/helix-w.svg"
+if curl -fsSL "$HAIL_SVG_URL" -o "$KERNEL_DIR/logo-svg.svg" 2>/dev/null; then
+  log "Hail logo downloaded (logo-svg.svg)"
+else
+  log "WARN: Could not download Hail logo — kernel will use the default icon"
+fi
+
+# ---- 5. Validate ------------------------------------------------------------
+log "Validating…"
+if "$PYBIN" -c "import hail; print('  hail version:', hail.__version__)"; then
+  :
+else
+  echo "  WARN: 'import hail' failed — check the pip install output above." >&2
+fi
+
+if "$PYBIN" -m hailtop.aiotools.copy --help >/dev/null 2>&1; then
+  log "hailtop CLI OK"
+else
+  echo "  WARN: hailtop.aiotools.copy --help failed." >&2
+fi
+
+log "Registered kernels:"
+jupyter kernelspec list 2>/dev/null | sed 's/^/    /' || true
+
+cat <<EOF
+
+Done.
+  • Open a NEW notebook tab in JupyterLab and pick the "$DISPLAY_NAME" kernel.
+  • No in-notebook PATH setup is needed anymore — it is baked into the kernelspec.
+  • After any compute-environment restart, just re-run:  bash $(basename "$0")
+    If the env survived it restores in seconds. If the kernel is gone again,
+    the persistent path was wrong — re-run with PERSIST_DIR=<a path that persists>.
+EOF

--- a/user-scripts/manifold/install_hail_kernel.sh
+++ b/user-scripts/manifold/install_hail_kernel.sh
@@ -135,7 +135,7 @@ cat <<EOF
 Done.
   • Open a NEW notebook tab in JupyterLab and pick the "$DISPLAY_NAME" kernel.
   • No in-notebook PATH setup is needed anymore — it is baked into the kernelspec.
-  • After any compute-environment restart, just re-run:  bash $(basename "$0")
+  • After any compute-environment restart, just re-run this install.
     If the env survived it restores in seconds. If the kernel is gone again,
     the persistent path was wrong — re-run with PERSIST_DIR=<a path that persists>.
 EOF


### PR DESCRIPTION
## Change Description

Adds a helper script and instructions to get started with a local batch runner in a jupyter environment on the manifold platform.

Note: For testing, you will need to use the temporary install path from my branch, (ie, not hail-is/main yet): 
```sh
curl -fsSL https://raw.githubusercontent.com/cjllanwarne/hail/cjl_manifold_jupyter_installer/user-scripts/manifold/install_hail_kernel.sh | bash
```

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
